### PR TITLE
Raise signal and structure of general code review prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,6 +569,14 @@ commit list.
   first-class category, with a carve-out so GitDesktop's own intentional embedding of repo,
   PR, and diff content into its AI prompts isn't mistaken for a vulnerability. Applies to
   both the quick (diff-only) and repo-aware security reviews, on any provider.
+- **Higher-signal AI code reviews.** The general code-review prompt was tightened to
+  raise signal without narrowing its scope. Findings are now ordered by severity with
+  clear definitions for **blocker**, **should-fix**, and **nit**; the real ones must
+  cite the concrete case that triggers them (the input, state, or code path), not just
+  an assertion; and the reviewer is told to include a finding only when it's confident,
+  skip formatting a linter already handles, and never let nits crowd out the real
+  issues. It stays a broad review — correctness, edge cases, security smells,
+  performance, clarity, and tests — and runs on any provider, including local models.
 - **A steadier, tidier agent composer.** The task box (Delegate, Plan, and the
   in-conversation reply) now docks to the bottom of its panel like a terminal: the
   text grows **upward** so the action row and **Send** never drift as you type. The

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -186,13 +186,13 @@ const GENERAL_REVIEW_SYSTEM = `You are a senior software engineer reviewing a pu
 
 Write the review in GitHub-flavored Markdown:
 - Start with a one- or two-sentence summary of what the change does and your overall assessment — is it sound, and is anything blocking?
-- Then list findings, ordered by severity and grouped under \`###\` headings by theme when there are several (e.g. "### Correctness", "### Edge cases", "### Readability", "### Tests"). For each finding give:
+- Then list findings grouped under \`###\` headings by theme when there are several (e.g. "### Correctness", "### Edge cases", "### Readability", "### Tests"), and within each group order them by severity — blockers first, then should-fixes, then nits. For each finding give:
   - a bold severity tag — **blocker** (a real bug, broken behavior, or unsafe change that shouldn't merge as-is), **should-fix** (a genuine problem worth addressing but not merge-blocking), or **nit** (a minor readability/consistency point, optional);
   - the file and the symbol/line it concerns;
   - the problem — and for **blocker**/**should-fix**, the concrete case that makes it real (the input, state, or code path that triggers it, not just an assertion);
   - a concrete suggested fix.
 - Cover real issues across correctness (bugs, logic errors, unhandled edge cases or errors), security smells, performance traps, clarity and naming, and missing or weak tests. Breadth is welcome — but only where each finding is genuinely useful.
-- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't invent missing tests for trivial changes.
+- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't flag missing tests for changes that introduce no new behavior (renames, reformatting, or pure reorganization).
 - Be specific and grounded strictly in the diff — do not invent code, files, or behavior you cannot see. If the change looks solid, say so plainly in a line or two and stop.
 
 No filler: don't summarize what you reviewed, don't pad, don't add compliments — just the assessment and the findings. Do not wrap the whole review in a code fence. Do not restate the entire diff.`;

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -185,12 +185,17 @@ export function buildPrPrompt(input: PrPromptInput): {
 const GENERAL_REVIEW_SYSTEM = `You are a senior software engineer reviewing a pull request. Review ONLY the changes in the provided diff.
 
 Write the review in GitHub-flavored Markdown:
-- Start with a one or two sentence summary of what the change does and your overall assessment.
-- Then list findings, grouped under \`###\` headings by theme when there are several (e.g. "### Correctness", "### Edge cases", "### Readability", "### Tests"). For each finding give a brief severity tag in bold (**blocker**, **should-fix**, or **nit**), name the file (and symbol/line context) it concerns, explain the problem, and suggest a concrete fix.
-- Cover real issues: bugs, logic errors, unhandled edge cases or errors, security smells, performance traps, unclear naming, and missing or weak tests. Prefer a few high-value findings over an exhaustive list of nits.
-- Be specific and grounded strictly in the diff — do not invent code, files, or behavior you cannot see. If the change looks solid, say so plainly and keep it short.
+- Start with a one- or two-sentence summary of what the change does and your overall assessment — is it sound, and is anything blocking?
+- Then list findings, ordered by severity and grouped under \`###\` headings by theme when there are several (e.g. "### Correctness", "### Edge cases", "### Readability", "### Tests"). For each finding give:
+  - a bold severity tag — **blocker** (a real bug, broken behavior, or unsafe change that shouldn't merge as-is), **should-fix** (a genuine problem worth addressing but not merge-blocking), or **nit** (a minor readability/consistency point, optional);
+  - the file and the symbol/line it concerns;
+  - the problem — and for **blocker**/**should-fix**, the concrete case that makes it real (the input, state, or code path that triggers it, not just an assertion);
+  - a concrete suggested fix.
+- Cover real issues across correctness (bugs, logic errors, unhandled edge cases or errors), security smells, performance traps, clarity and naming, and missing or weak tests. Breadth is welcome — but only where each finding is genuinely useful.
+- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't invent missing tests for trivial changes.
+- Be specific and grounded strictly in the diff — do not invent code, files, or behavior you cannot see. If the change looks solid, say so plainly in a line or two and stop.
 
-Do not wrap the whole review in a code fence. Do not restate the entire diff.`;
+No filler: don't summarize what you reviewed, don't pad, don't add compliments — just the assessment and the findings. Do not wrap the whole review in a code fence. Do not restate the entire diff.`;
 
 const SECURITY_REVIEW_SYSTEM = `You are a senior application security engineer performing a focused security review of a pull request. Examine ONLY the changes in the provided diff and report only HIGH-CONFIDENCE, genuinely exploitable vulnerabilities the change INTRODUCES or newly exposes — flag a vulnerability sitting in a changed region even if it predates the change. This is not a general code review: ignore pre-existing issues outside the diff, style, and anything that isn't a concrete, exploitable security risk.
 


### PR DESCRIPTION
This change revises the general AI code review prompt to improve the quality and clarity of automated PR reviews, ensuring issues are flagged only when they are concrete and actionable. The goal is to minimize noise, prioritize high-value findings, and provide clear severity definitions for reviewers and users.

### AI code review logic
- Refines severity definitions in `src/lib/ai/prompt.ts`, making the difference between **blocker**, **should-fix**, and **nit** explicit and requiring findings to cite the concrete trigger (input/state/code path) for real problems.
- Orders findings by severity in `src/lib/ai/prompt.ts` and clarifies grouping under `###` headings, improving signal by instructing the reviewer to favor confident, high-value issues and omit uncertain nits.
- Instructs not to flag trivial formatting or tests, to avoid padding or filler, and never to invent findings outside the diff in `src/lib/ai/prompt.ts`.

### Documentation
- Adds a detailed entry in `CHANGELOG.md` summarizing the new review prompt criteria and intended improvements to review quality.