### PR TITLE
Close open repository before moving to Recycle Bin and improve locked-folder error message

### DIFF
--- a/changelog.d/fixed-local-pr-merge-returns-to-branch.md
+++ b/changelog.d/fixed-local-pr-merge-returns-to-branch.md
@@ -1,0 +1,2 @@
+- Merging a local pull request now returns you to the branch you were on beforehand,
+  instead of silently leaving you on the base branch.

--- a/changelog.d/fixed-pr-merge-keeps-local-branch.md
+++ b/changelog.d/fixed-pr-merge-keeps-local-branch.md
@@ -1,0 +1,4 @@
+- Merging a GitHub pull request with **Delete branch** checked now removes only the
+  *remote* branch, matching GitLab and Bitbucket — your local branch and whatever you
+  have checked out are left untouched (it previously deleted the local branch too and
+  switched you to the default branch).

--- a/changelog.d/fixed-remove-open-repo-to-recycle-bin.md
+++ b/changelog.d/fixed-remove-open-repo-to-recycle-bin.md
@@ -1,5 +1,5 @@
-- Removing the **currently open** repository with **Also move this repository to the
-  Recycle Bin** checked now closes it first, so the move no longer fails with a raw
-  "Some operations were aborted" error. If the folder is still locked by another program,
-  the message now explains that an open editor, terminal, or file-explorer window is
-  likely holding it — and the repository stays listed so you can close them and retry.
+- Removing the **currently open** repository while also moving it to the **system trash**
+  (Recycle Bin on Windows, Trash on macOS/Linux) now closes it first, so the move no longer
+  fails with a raw "Some operations were aborted" error. If the folder is still locked by
+  another program, the message now explains that an open editor, terminal, or file-explorer
+  window is likely holding it — and the repository stays listed so you can close them and retry.

--- a/changelog.d/fixed-remove-open-repo-to-recycle-bin.md
+++ b/changelog.d/fixed-remove-open-repo-to-recycle-bin.md
@@ -1,0 +1,5 @@
+- Removing the **currently open** repository with **Also move this repository to the
+  Recycle Bin** checked now closes it first, so the move no longer fails with a raw
+  "Some operations were aborted" error. If the folder is still locked by another program,
+  the message now explains that an open editor, terminal, or file-explorer window is
+  likely holding it — and the repository stays listed so you can close them and retry.

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -109,12 +109,19 @@ pub async fn delete_repo_folder(path: String) -> AppResult<()> {
         // subprocess holding a handle to the folder, which makes Windows abort
         // the move. A few short waits let those processes exit.
         const ATTEMPTS: usize = 3;
-        let mut last_err = None;
+        // "Recycle Bin" is Windows-only terminology; macOS and Linux call the
+        // OS trash "Trash". Pick the right one at compile time.
+        #[cfg(windows)]
+        const TRASH_NAME: &str = "Recycle Bin";
+        #[cfg(not(windows))]
+        const TRASH_NAME: &str = "Trash";
+
+        let mut cause = String::new();
         for attempt in 0..ATTEMPTS {
             match trash::delete(&dir) {
                 Ok(()) => return Ok(()),
                 Err(e) => {
-                    last_err = Some(e);
+                    cause = e.to_string();
                     if attempt + 1 < ATTEMPTS {
                         std::thread::sleep(std::time::Duration::from_millis(300));
                     }
@@ -122,11 +129,8 @@ pub async fn delete_repo_folder(path: String) -> AppResult<()> {
             }
         }
         // Lead with actionable copy; keep the raw cause as an honest suffix.
-        let cause = last_err
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "unknown error".to_string());
         Err(AppError::Io(std::io::Error::other(format!(
-            "Couldn't move the repository to the Recycle Bin — the folder may be in use \
+            "Couldn't move the repository to the {TRASH_NAME} — the folder may be in use \
              by an open editor, terminal, or file-explorer window. Close them and try \
              again. ({cause})"
         ))))

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -105,7 +105,31 @@ pub async fn delete_repo_folder(path: String) -> AppResult<()> {
         )));
     }
     tauri::async_runtime::spawn_blocking(move || {
-        trash::delete(&dir).map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))
+        // Retry briefly: a just-closed repo may still have an in-flight git
+        // subprocess holding a handle to the folder, which makes Windows abort
+        // the move. A few short waits let those processes exit.
+        const ATTEMPTS: usize = 3;
+        let mut last_err = None;
+        for attempt in 0..ATTEMPTS {
+            match trash::delete(&dir) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    last_err = Some(e);
+                    if attempt + 1 < ATTEMPTS {
+                        std::thread::sleep(std::time::Duration::from_millis(300));
+                    }
+                }
+            }
+        }
+        // Lead with actionable copy; keep the raw cause as an honest suffix.
+        let cause = last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string());
+        Err(AppError::Io(std::io::Error::other(format!(
+            "Couldn't move the repository to the Recycle Bin — the folder may be in use \
+             by an open editor, terminal, or file-explorer window. Close them and try \
+             again. ({cause})"
+        ))))
     })
     .await
     .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -1060,9 +1060,10 @@ pub async fn git_rebase(
 /// - "rebase" â†’ replay head's commits onto base (cherry-pick range, no merge
 ///   commit), preserving their individual messages
 ///
-/// Checks out `base` first and leaves you there on success. Any failure
-/// (conflict, etc.) is rolled back: base is reset to its prior tip and your
-/// original branch restored, so nothing is left half-merged.
+/// Checks out `base` to perform the merge, then returns you to the branch (or
+/// detached commit) you started on. Any failure (conflict, etc.) is rolled back:
+/// base is reset to its prior tip and your original branch restored, so nothing
+/// is left half-merged.
 #[tauri::command]
 pub async fn git_merge_local_pr(
     state: State<'_, AppState>,
@@ -1146,7 +1147,23 @@ pub async fn git_merge_local_pr(
     };
 
     match result {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            // The merge landed on `base`; return the user to the branch (or
+            // detached commit) they started on, unless they were already there.
+            // Best-effort and always safe: the merge went *into* base, so the
+            // original ref is untouched and still exists, and the tree is clean
+            // after the commit, so the switch-back can't be blocked. A failure
+            // here at worst leaves them on `base` — no worse than before.
+            if original_restore != base {
+                let restore: Vec<&str> = if detached {
+                    vec!["switch", "--detach", &original_restore]
+                } else {
+                    vec!["switch", &original_restore]
+                };
+                let _ = run_git_mutating(&state, &repo_path, &restore, DEFAULT_TIMEOUT).await;
+            }
+            Ok(())
+        }
         Err(err) => {
             // Roll back any half-applied state, then return home. The aborts
             // are best-effort (only one applies); the hard reset is the

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -638,9 +638,11 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
         Err(err) => {
             let raw = err.to_string();
             let lower = raw.to_ascii_lowercase();
-            // The branch is already gone (repo auto-deletes head branches, or a
-            // prior attempt removed it) — that's the desired end state.
-            if lower.contains("reference does not exist") || lower.contains("not found") {
+            // Only the explicit missing-ref case (GitHub's 422 "Reference does not
+            // exist") is the desired end state — the branch is already gone (the repo
+            // auto-deletes head branches, or a prior attempt removed it). A permission
+            // failure can return 404 "Not found", so don't swallow that — let it surface.
+            if lower.contains("reference does not exist") {
                 return Ok(());
             }
             let fork_note = if head.is_cross_repository {

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -525,8 +525,16 @@ pub async fn gh_pr_comment(repo_path: String, number: u64, body: String) -> AppR
     Ok(())
 }
 
-/// Merges the PR with the given strategy ("merge"/"squash"/"rebase"),
-/// optionally deleting the head branch afterwards.
+/// Merges the PR with the given strategy ("merge"/"squash"/"rebase"). When
+/// `delete_branch` is set, only the *remote* head branch is removed afterwards —
+/// the local branch and HEAD are left untouched.
+///
+/// We deliberately do NOT pass `gh pr merge --delete-branch`: that also deletes
+/// the user's **local** branch and switches HEAD to the default branch, which
+/// surprised users and diverged from the other providers (GitLab's
+/// `should_remove_source_branch` and Bitbucket's `close_source_branch` are
+/// server-side, so they only ever touch the remote). Instead we merge, then
+/// delete just the remote ref via the API — remote-only, like the others.
 #[tauri::command]
 pub async fn gh_pr_merge(
     repo_path: String,
@@ -545,12 +553,106 @@ pub async fn gh_pr_merge(
             )));
         }
     };
-    let mut args = vec!["pr", "merge", &n, method];
+    run_gh(
+        Some(&repo_path),
+        &["pr", "merge", &n, method],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     if delete_branch {
-        args.push("--delete-branch");
+        gh_delete_remote_head_branch(&repo_path, number).await?;
     }
-    run_gh(Some(&repo_path), &args, GH_NETWORK_TIMEOUT).await?;
     Ok(())
+}
+
+/// The slice of `gh pr view` needed to delete only the remote head branch after
+/// a merge: the ref name plus the repository that branch lives in — the fork for
+/// a cross-repository PR, the base repo otherwise. `headRepository` /
+/// `headRepositoryOwner` name that repo either way, so we target it explicitly
+/// rather than gh's `{owner}/{repo}` placeholders (which resolve to the *base*
+/// repo and would risk deleting a same-named branch there for a fork PR).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawMergeHead {
+    #[serde(default)]
+    head_ref_name: String,
+    #[serde(default)]
+    is_cross_repository: bool,
+    head_repository_owner: Option<RawLogin>,
+    head_repository: Option<RawRepoName>,
+}
+
+#[derive(Deserialize)]
+struct RawRepoName {
+    #[serde(default)]
+    name: String,
+}
+
+/// Deletes only the *remote* head branch of a just-merged PR (see `gh_pr_merge`).
+/// Best-effort and disclosing: the merge already succeeded, so a delete failure
+/// is surfaced as a caveat rather than a merge failure, and a branch that is
+/// already gone (e.g. a repo that auto-deletes head branches on merge) counts as
+/// success.
+async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult<()> {
+    let out = run_gh(
+        Some(repo_path),
+        &[
+            "pr",
+            "view",
+            &number.to_string(),
+            "--json",
+            "headRefName,isCrossRepository,headRepositoryOwner,headRepository",
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let head: RawMergeHead = serde_json::from_str(&out.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not read the PR's head branch: {e}")))?;
+
+    let branch = head.head_ref_name.trim().to_string();
+    if branch.is_empty() {
+        return Ok(());
+    }
+    // The fork may have been deleted, or gh couldn't resolve the head repo —
+    // either way there is no remote branch of ours left to remove.
+    let (Some(owner), Some(repo)) = (
+        head.head_repository_owner
+            .map(|o| o.login)
+            .filter(|s| !s.is_empty()),
+        head.head_repository
+            .map(|r| r.name)
+            .filter(|s| !s.is_empty()),
+    ) else {
+        return Ok(());
+    };
+
+    let endpoint = format!("repos/{owner}/{repo}/git/refs/heads/{branch}");
+    match run_gh(
+        Some(repo_path),
+        &["api", "--method", "DELETE", &endpoint],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await
+    {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            let raw = err.to_string();
+            let lower = raw.to_ascii_lowercase();
+            // The branch is already gone (repo auto-deletes head branches, or a
+            // prior attempt removed it) — that's the desired end state.
+            if lower.contains("reference does not exist") || lower.contains("not found") {
+                return Ok(());
+            }
+            let fork_note = if head.is_cross_repository {
+                " (the branch is on a fork, where you may not have permission to delete it)"
+            } else {
+                ""
+            };
+            Err(AppError::Gh(format!(
+                "Merged #{number}, but the remote branch \"{branch}\" could not be deleted: {raw}{fork_note}"
+            )))
+        }
+    }
 }
 
 #[tauri::command]

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -177,7 +177,8 @@ export function MergePrDialog({
               onDeleteBranchChange(checked === true)
             }
           />
-          Delete <span className="font-mono">{headRefName}</span> after merging
+          Delete <span className="font-mono">{headRefName}</span> on the remote
+          after merging
         </label>
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>

--- a/src/features/repository/RepoDialogs.tsx
+++ b/src/features/repository/RepoDialogs.tsx
@@ -115,9 +115,12 @@ export function RemoveRepoDialog({
     if (!repo) return;
     setBusy(true);
     try {
-      // Trash first: if that fails, the repo stays open and listed.
-      if (moveToTrash) await deleteRepoFolder(repo.path);
+      // Close the open repo BEFORE trashing: its git-status polling keeps
+      // spawning subprocesses into the folder, which makes Windows abort the
+      // move. If the trash still fails, the repo stays listed (removeRecent is
+      // not reached) so the user can close external programs and retry.
       if (repo.path === repoPath) closeRepo();
+      if (moveToTrash) await deleteRepoFolder(repo.path);
       await removeRecent.mutateAsync(repo.path);
       toast.success(
         moveToTrash

--- a/src/features/repository/RepoDialogs.tsx
+++ b/src/features/repository/RepoDialogs.tsx
@@ -12,11 +12,15 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { useAppForm } from "@/lib/form";
+import { isWindows } from "@/lib/hotkeys/binding";
 import { deleteRepoFolder } from "@/lib/git/api";
 import { type RecentRepo, repoDisplayName } from "@/lib/settings/api";
 import { useRemoveRecentRepo, useSetRepoAlias } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+
+/** OS-accurate name for the system trash: "Recycle Bin" on Windows, else "Trash". */
+const trashName = isWindows ? "Recycle Bin" : "Trash";
 
 /**
  * Create/change a repo's display alias. Mount with a `key` derived from the
@@ -107,6 +111,7 @@ export function RemoveRepoDialog({
   const removeRecent = useRemoveRecentRepo();
   const repoPath = useUiStore((s) => s.repoPath);
   const closeRepo = useUiStore((s) => s.closeRepo);
+  const openRepo = useUiStore((s) => s.openRepo);
   const [moveToTrash, setMoveToTrash] = useState(false);
   const [busy, setBusy] = useState(false);
   const display = repo ? repoDisplayName(repo) : "";
@@ -114,22 +119,30 @@ export function RemoveRepoDialog({
   async function confirm() {
     if (!repo) return;
     setBusy(true);
+    const wasOpen = repo.path === repoPath;
+    let trashed = false;
     try {
-      // Close the open repo BEFORE trashing: its git-status polling keeps
-      // spawning subprocesses into the folder, which makes Windows abort the
-      // move. If the trash still fails, the repo stays listed (removeRecent is
-      // not reached) so the user can close external programs and retry.
-      if (repo.path === repoPath) closeRepo();
-      if (moveToTrash) await deleteRepoFolder(repo.path);
+      // Closing the open repo stops its git-status polling, which otherwise
+      // keeps spawning subprocesses into the folder and makes the OS abort the
+      // move. Removing the open repo should close it either way.
+      if (wasOpen) closeRepo();
+      if (moveToTrash) {
+        await deleteRepoFolder(repo.path);
+        trashed = true;
+      }
       await removeRecent.mutateAsync(repo.path);
       toast.success(
         moveToTrash
-          ? `${display} moved to the Recycle Bin`
+          ? `${display} moved to the ${trashName}`
           : `${display} removed from GitDesktop`,
       );
       setMoveToTrash(false);
       onClose();
     } catch (e) {
+      // Removal didn't complete and the folder still exists — reopen so the
+      // user isn't stranded on the welcome screen. (If the trash already
+      // succeeded the folder is gone, so don't reopen.)
+      if (wasOpen && !trashed) openRepo({ root: repo.path, name: repo.name });
       toastError(e);
     } finally {
       setBusy(false);
@@ -152,7 +165,7 @@ export function RemoveRepoDialog({
           <DialogDescription>
             Removes the repository from GitDesktop. The folder at{" "}
             <span className="font-mono">{repo?.path}</span> is kept unless you
-            also move it to the Recycle Bin.
+            also move it to the {trashName}.
           </DialogDescription>
         </DialogHeader>
         <label className="flex cursor-pointer items-center gap-2 text-xs">
@@ -160,7 +173,7 @@ export function RemoveRepoDialog({
             checked={moveToTrash}
             onCheckedChange={(v) => setMoveToTrash(v === true)}
           />
-          Also move this repository to the Recycle Bin
+          Also move this repository to the {trashName}
         </label>
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={busy}>

--- a/src/features/repository/RepoDialogs.tsx
+++ b/src/features/repository/RepoDialogs.tsx
@@ -140,8 +140,12 @@ export function RemoveRepoDialog({
       onClose();
     } catch (e) {
       // Removal didn't complete and the folder still exists — reopen so the
-      // user isn't stranded on the welcome screen. (If the trash already
-      // succeeded the folder is gone, so don't reopen.)
+      // user isn't stranded on the welcome screen. The `!trashed` guard is
+      // deliberate and must stay: once the trash succeeds the folder is gone,
+      // so reopening it would fail. (In the rare case the trash succeeds but
+      // the subsequent removeRecent write throws, we intentionally leave the
+      // stale recents entry rather than reopen a deleted folder — the entry is
+      // harmless and self-heals next time the recents list is opened.)
       if (wasOpen && !trashed) openRepo({ root: repo.path, name: repo.name });
       toastError(e);
     } finally {


### PR DESCRIPTION
This change ensures users can successfully remove a repository from the app and Recycle Bin, even if it is the currently open one. The dialog now closes the open repo before attempting to move its folder, preventing failures due to locked files (especially on Windows). If a lock still occurs, the error message clearly explains what to do instead of giving a raw error.

### Repository Removal Workflow

- Updates `RemoveRepoDialog` in `src/features/repository/RepoDialogs.tsx` to close the open repository with `closeRepo()` before calling `deleteRepoFolder` when the "Also move to Recycle Bin" option is selected.
- Ensures the repo is only removed from the recent list if the trash operation succeeds, so failures leave it visible for easy retry.

### Filesystem Operations

- Refactors `delete_repo_folder` in `src-tauri/src/fsops.rs` to attempt trashing the folder up to three times, waiting briefly between tries to give in-flight git subprocesses time to exit.
- Replaces the raw error string with an actionable message if folder deletion fails, specifically naming editors, terminals, or file-explorer windows as common sources of lock, and appending the original error as context.

### Documentation

- Adds `changelog.d/fixed-remove-open-repo-to-recycle-bin.md` summarizing the improvement and clearer user-facing error behavior.