### PR TITLE
feat(mcp-server,local-prs): MCP server can write .mcp.json, opt-in local PR write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,14 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   each one runs shown so you can vet before adding — or **Import** ones you've already
   configured. Change the selection **mid-session**, too.
 - **Use GitDesktop *as* an MCP server** — the reverse direction: expose this repo's
-  **read-only** git & GitHub tools (status, log, diff, blame, branches, file history/read,
-  PRs, issues, CI logs) to any external MCP client — **Claude Desktop**, **Cursor**,
-  **Claude Code**. **Settings → MCP servers** shows a ready-to-paste config snippet; the
-  app runs as a stdio server (`gitdesktop mcp --repo <path>`), so an agent can *understand*
-  a repo without touching it.
+  **read-only-by-default** git & GitHub tools (status, log, diff, blame, branches, file
+  history/read, PRs, issues, CI logs) to any external MCP client — **Claude Desktop**,
+  **Cursor**, **Claude Code**. **Settings → MCP servers** shows a ready-to-paste config
+  snippet — or **writes it straight into the repo's `.mcp.json`** for you, with a
+  **Shareable** toggle for portable, teammate-committable paths. The app runs as a stdio
+  server (`gitdesktop mcp --repo <path>`), so an agent can *understand* a repo without
+  touching it — and an opt-in **Allow write tools** (`--allow-write`) lets it create,
+  comment on, and approve *this repo's* local PRs when you want it to.
 - **Run commands without leaving the app** — every agent session has an integrated
   terminal: a real shell in a resizable bottom dock, toggled with `Ctrl`/`⌘`+`J`. For a
   container session it runs *inside* the session's container — you pick which dev-server

--- a/changelog.d/added-mcp-server-write-config.md
+++ b/changelog.d/added-mcp-server-write-config.md
@@ -1,0 +1,8 @@
+- **Write GitDesktop's MCP config straight into `.mcp.json`.** The *Use GitDesktop
+  as an MCP server* panel now writes (and merges) its `gitdesktop` entry into your
+  repo's `.mcp.json` for you, preserving any other servers — no more copy-paste.
+  A **Shareable entry** toggle switches between machine-specific absolute paths and
+  portable `${GITDESKTOP_BIN}` / `${CLAUDE_PROJECT_DIR}` paths a teammate can commit,
+  and an **Allow write tools** toggle adds `--allow-write` so agents can create,
+  comment on, approve, and set the status of *this repo's* local PRs — kept off by
+  default, leaving the server read-only.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -47,7 +47,7 @@ const capabilities = [
   { label: "Bring your own MCP servers, opted in per session", ai: true },
   { label: "Point AI at a custom or LAN Ollama / OpenAI-compatible server", ai: true },
   { label: "Browse the official MCP registry to add servers", ai: true },
-  { label: "Use GitDesktop as an MCP server for external AI clients", ai: true },
+  { label: "Use GitDesktop as an MCP server for external AI clients (read-only, or opt-in local-PR write tools)", ai: true },
   { label: "Run agents in a Docker/Podman sandbox (opt-in)", ai: true },
   { label: "Add per-repo tools to the agent container (e.g. Playwright) via a custom image", ai: true },
   { label: "Reviews keep running in the background", ai: true },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -481,10 +481,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -481,8 +481,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -1434,6 +1436,8 @@ name = "gitdesktop"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "chrono",
+ "dirs",
  "keyring",
  "os_info",
  "portable-pty",
@@ -1453,6 +1457,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "trash",
+ "uuid",
  "winreg 0.55.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
 # the tree transitively; declared here as direct deps for the MCP-server code paths.
 dirs = "6"
 uuid = { version = "1", features = ["v4"] }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,14 @@ portable-pty = "0.9"
 # `gitdesktop mcp` subcommand (see main.rs + docs/mcp-server-tier3.md). Linked into
 # the main binary so a shipped app can act as an MCP server with nothing extra to bundle.
 rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
+# Local-PR MCP write core (local_prs.rs): resolve the same app-data dir the store
+# plugin writes (dirs, matching Tauri's BaseDirectory::AppData = dirs::data_dir()),
+# mint record ids (uuid v4, matching the frontend's crypto.randomUUID()), and stamp
+# createdAt in JS `toISOString()` format (chrono RFC3339 millis + Z). All already in
+# the tree transitively; declared here as direct deps for the MCP-server code paths.
+dirs = "6"
+uuid = { version = "1", features = ["v4"] }
+chrono = "0.4"
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -94,6 +94,8 @@ pub enum ReviewEvent {
     /// A chunk of assistant text to append to the rendered review.
     Delta { text: String },
     /// Transient progress note (Tier 2 tool activity, e.g. "Reading files…").
+    // Reserved for Tier-2 progress notes; declared but not emitted yet.
+    #[allow(dead_code)]
     Status { text: String },
     /// One structured tool step for the activity timeline — a normalized `tool`
     /// category (read/search/list/edit/write/run/web-fetch/web-search/other) plus
@@ -537,6 +539,7 @@ fn claude_review_args(
 /// keeps the full conversation AND the worktree's evolving state. Persistence is
 /// ON (no `--no-session-persistence`) so `--resume` can find the transcript; the
 /// system prompt is set only on turn 1 (the resumed session already carries it).
+#[allow(clippy::too_many_arguments)]
 fn claude_session_args(
     model: &str,
     system_prompt: &str,
@@ -718,6 +721,7 @@ fn codex_session_args(
 /// could still escape, so the host tier is "soft" (like Claude); the worktree's git
 /// isolation is the hard guarantee. Multi-turn is deterministic: `--session-id
 /// <uuid>` sets the id on turn 1, `--resume <uuid>` continues it (context retained).
+#[allow(clippy::too_many_arguments)]
 fn copilot_session_args(
     model: &str,
     session_id: &str,
@@ -1536,6 +1540,7 @@ async fn stream_agent(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn agent_review(
     state: tauri::State<'_, AppState>,
     kind: AgentKind,
@@ -1633,6 +1638,7 @@ pub async fn agent_review_cancel(
 /// container-only). Copilot's container authenticates from a `gh auth token` passed by
 /// env, since its login isn't a mountable creds file like the others'.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn agent_session(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -1117,6 +1117,7 @@ fn launch_container_shell(bin: &str, args: &[String], tip: &str) -> AppResult<()
 /// `/workspace` (the bind-mounted worktree), with the seeded claude-home mounted +
 /// (when present) the user's global skills mounted read-only so a nudged skill
 /// resolves; `--rm` tears it down, resource + capability limits harden it.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_run_args(
     runtime: &str,
     agent: &str,

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -4,6 +4,35 @@ use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
 
+/// Best-effort sweep of stale leftover temp files (`.{name}.<pid>.<uuid>.tmp`) from a
+/// prior crash in the write→rename window. Only removes ones older than a minute, so a
+/// concurrent writer's in-flight temp is never touched. All errors are ignored (advisory).
+fn sweep_stale_temps(dir: &Path, file_name: &str) {
+    let prefix = format!(".{file_name}.");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|m| now.duration_since(m).ok())
+            .is_some_and(|age| age.as_secs() >= 60);
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
 /// Write `contents` to `path` atomically: write a uniquely-named temp file in the same
 /// directory, then rename it over the target so a concurrent reader (another GUI or MCP
 /// process) never sees a partial or truncated file. Creates the parent directory if it
@@ -22,6 +51,9 @@ pub fn atomic_write(path: &Path, contents: &[u8]) -> AppResult<()> {
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "tmp".to_string());
+    // Best-effort: clear any temp a prior crash leaked in the write→rename window before
+    // adding our own, so a sensitive dir like a repo root doesn't accumulate strays.
+    sweep_stale_temps(dir, &file_name);
     // Unique temp name (pid + a fresh uuid) so concurrent writers — GUI, MCP, or parallel
     // test threads sharing one pid — can't collide on it.
     let tmp = dir.join(format!(

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -4,6 +4,39 @@ use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
 
+/// Write `contents` to `path` atomically: write a uniquely-named temp file in the same
+/// directory, then rename it over the target so a concurrent reader (another GUI or MCP
+/// process) never sees a partial or truncated file. Creates the parent directory if it
+/// doesn't exist yet.
+///
+/// `std::fs::rename` replaces an existing destination on every platform (on Windows via
+/// `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING`), so this reliably overwrites a file
+/// that's already there. On a genuine IO failure (target locked, permissions) it removes
+/// the temp file rather than leaking it, then surfaces the error.
+pub fn atomic_write(path: &Path, contents: &[u8]) -> AppResult<()> {
+    let dir = path.parent().ok_or_else(|| {
+        AppError::Command(format!("path {} has no parent directory", path.display()))
+    })?;
+    std::fs::create_dir_all(dir)?;
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "tmp".to_string());
+    // Unique temp name (pid + a fresh uuid) so concurrent writers — GUI, MCP, or parallel
+    // test threads sharing one pid — can't collide on it.
+    let tmp = dir.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::write(&tmp, contents)?;
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(AppError::Io(e));
+    }
+    Ok(())
+}
+
 /// Absolute path to the running app executable. Used to build the "Use GitDesktop
 /// as an MCP server" client-config snippet, whose command is `<this exe> mcp`.
 #[tauri::command]

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -705,7 +705,7 @@ pub async fn git_unignore_rules(repo_path: String, rules: Vec<UnignoreRule>) -> 
             next.push_str(ending);
         }
         if has_bom {
-            next.insert_str(0, "\u{feff}");
+            next.insert(0, '\u{feff}');
         }
         tokio::fs::write(&path, next).await.map_err(AppError::Io)?;
     }

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -168,6 +168,7 @@ pub async fn gh_release_view(
 /// exist). `generate_notes` adds GitHub's auto commit-based notes; an explicit
 /// `notes` body is included too. Returns the new release's URL.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn gh_release_create(
     repo_path: String,
     tag: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod github;
 mod health;
 mod hooks;
 mod instructions;
+mod local_prs;
 mod mcp;
 mod mcp_server;
 mod pty;
@@ -513,6 +514,7 @@ pub fn run() {
             secrets::delete_mcp_secret,
             secrets::mcp_secret_exists,
             mcp::discover_mcp_servers,
+            mcp::mcp_json_write,
             instructions::read_repo_instructions,
             instructions::read_repo_ai_ignore,
             instructions::read_repo_branch_rules,

--- a/src-tauri/src/local_prs.rs
+++ b/src-tauri/src/local_prs.rs
@@ -107,32 +107,13 @@ fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
     }
 }
 
-/// Atomically write the store object back: serialize (pretty), write a temp file in
-/// the same directory, then rename over the target so a reader never sees a partial
-/// file. Creates the app-data directory if it doesn't exist yet.
+/// Serialize the store object (pretty) and write it back atomically — temp file in the
+/// same dir + rename over the target (via [`crate::fsops::atomic_write`]) so a reader
+/// never sees a partial file, and an existing store is reliably replaced on all platforms.
 fn write_store(path: &Path, store: &Map<String, Value>) -> AppResult<()> {
-    let dir = path
-        .parent()
-        .ok_or_else(|| AppError::Command(format!("store path {} has no parent", path.display())))?;
-    std::fs::create_dir_all(dir)?;
     let body = serde_json::to_string_pretty(&Value::Object(store.clone()))
         .map_err(|e| AppError::Command(format!("serialize local-prs store: {e}")))?;
-    // Temp file in the SAME dir so the rename is atomic (same filesystem). A unique
-    // suffix (pid + a fresh uuid) keeps concurrent writers — another GUI/MCP process,
-    // or parallel test threads sharing one pid — from colliding on the temp name.
-    let tmp = dir.join(format!(
-        ".{STORE_FILE}.{}.{}.tmp",
-        std::process::id(),
-        uuid::Uuid::new_v4()
-    ));
-    std::fs::write(&tmp, body)?;
-    if let Err(e) = std::fs::rename(&tmp, path) {
-        // On Windows, rename onto an existing file can fail; clean up the temp so we
-        // don't leak it, then surface the error.
-        let _ = std::fs::remove_file(&tmp);
-        return Err(AppError::Io(e));
-    }
-    Ok(())
+    crate::fsops::atomic_write(path, body.as_bytes())
 }
 
 /// Compare two repo-path keys for "same repo" tolerantly: normalize separators to
@@ -218,8 +199,9 @@ where
 {
     let path = store_path()?;
     let mut store = read_store(&path)?;
-    let key = existing_key(&store, repo)
-        .ok_or_else(|| AppError::Command(format!("no local PR with id {id}")))?;
+    let key = existing_key(&store, repo).ok_or_else(|| {
+        AppError::Command(format!("no local PRs found for this repository (id {id})"))
+    })?;
     let list = store
         .get_mut(&key)
         .and_then(Value::as_array_mut)

--- a/src-tauri/src/local_prs.rs
+++ b/src-tauri/src/local_prs.rs
@@ -1,0 +1,421 @@
+//! Local-PR storage core for the MCP server's write tools.
+//!
+//! **Local PRs are GitDesktop's own app-data review artifacts** — no git or remote
+//! writes are involved. The GUI persists them via the Tauri Store plugin
+//! (`src/lib/pulls/local.ts`); this module is the headless mirror the MCP server
+//! (which has NO `AppHandle`) uses to read/modify the SAME file.
+//!
+//! ## Storage-dir mirroring contract (the make-or-break detail)
+//!
+//! The frontend loads the store as `load("local-prs.json", { autoSave: true })`.
+//! `tauri-plugin-store` v2 resolves a relative store path against
+//! `BaseDirectory::AppData` (`resolve_store_path` in the plugin's `store.rs`:
+//! `app.path().resolve(path, BaseDirectory::AppData)`). Tauri's `AppData` resolver
+//! (`tauri`'s `path/desktop.rs::app_data_dir`) is `dirs::data_dir()/<identifier>`,
+//! and our identifier is `com.thebguy.gitdesktop` (tauri.conf.json). So the file is:
+//!
+//! ```text
+//!   Windows: %APPDATA%\com.thebguy.gitdesktop\local-prs.json
+//!            (dirs::data_dir() = the Roaming AppData dir)
+//!   macOS:   ~/Library/Application Support/com.thebguy.gitdesktop/local-prs.json
+//!   Linux:   $XDG_DATA_HOME (or ~/.local/share)/com.thebguy.gitdesktop/local-prs.json
+//! ```
+//!
+//! We resolve it here with the SAME `dirs::data_dir()` the Tauri path layer uses,
+//! joined with the identifier — so the two processes always agree on the file.
+//! (Verified on this machine: `C:\Users\Evan\AppData\Roaming\com.thebguy.gitdesktop\
+//! local-prs.json` exists with the expected `{ [repoPath]: LocalPr[] }` shape.)
+//! Always the real `local-prs.json` name — the frontend's cold-start `coldstart-`
+//! alias is a GUI-only concern the server never participates in.
+//!
+//! ## Value-based round-trip (never drop unknown fields)
+//!
+//! The whole file is read as a `serde_json::Value`, and only the target repo key's
+//! array is mutated — record-by-record as `Value`s. We NEVER deserialize existing
+//! records into a struct and re-serialize them, because that would silently drop any
+//! field a future GUI version adds. NEW records are built from a typed struct (so the
+//! shape is guaranteed correct) then converted to `Value`. Writes are atomic (temp
+//! file in the same dir + rename over the target).
+//!
+//! ## Statelessness
+//!
+//! The GUI holds this store in memory (`autoSave`), so every call here does a FRESH
+//! read → modify → atomic write. We never cache across calls: the contract is
+//! "never write from stale memory".
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::error::{AppError, AppResult};
+
+/// The Tauri bundle identifier — the app-data subdir the store plugin writes under.
+const APP_IDENTIFIER: &str = "com.thebguy.gitdesktop";
+/// The store filename (always the real name; the cold-start alias is GUI-only).
+const STORE_FILE: &str = "local-prs.json";
+
+/// A newly-created local PR, serialized to `Value` for insertion. Mirrors the
+/// frontend `LocalPr` (`src/lib/pulls/local.ts`) camelCase shape for a fresh PR.
+/// Existing records are NEVER routed through this struct — only brand-new ones — so
+/// unknown fields on older records are preserved untouched.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NewLocalPr {
+    id: String,
+    title: String,
+    body: String,
+    base: String,
+    head: String,
+    status: String,
+    approved: bool,
+    labels: Vec<String>,
+    comments: Vec<Value>,
+    created_at: String,
+}
+
+/// Resolve the absolute path of the `local-prs.json` the frontend store writes.
+/// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
+/// (`dirs::data_dir()/<identifier>`) — see the module contract.
+pub fn store_path() -> AppResult<PathBuf> {
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
+}
+
+/// Read the whole store file as a JSON object. A missing file is an empty object;
+/// a present-but-malformed file is a hard error (we must never clobber it).
+fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Command(format!(
+                    "local-prs store at {} is not valid JSON: {e}",
+                    path.display()
+                ))
+            })?;
+            match value {
+                Value::Object(map) => Ok(map),
+                _ => Err(AppError::Command(format!(
+                    "local-prs store at {} is not a JSON object",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(AppError::Io(e)),
+    }
+}
+
+/// Atomically write the store object back: serialize (pretty), write a temp file in
+/// the same directory, then rename over the target so a reader never sees a partial
+/// file. Creates the app-data directory if it doesn't exist yet.
+fn write_store(path: &Path, store: &Map<String, Value>) -> AppResult<()> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| AppError::Command(format!("store path {} has no parent", path.display())))?;
+    std::fs::create_dir_all(dir)?;
+    let body = serde_json::to_string_pretty(&Value::Object(store.clone()))
+        .map_err(|e| AppError::Command(format!("serialize local-prs store: {e}")))?;
+    // Temp file in the SAME dir so the rename is atomic (same filesystem). A unique
+    // suffix (pid + a fresh uuid) keeps concurrent writers — another GUI/MCP process,
+    // or parallel test threads sharing one pid — from colliding on the temp name.
+    let tmp = dir.join(format!(
+        ".{STORE_FILE}.{}.{}.tmp",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::write(&tmp, body)?;
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        // On Windows, rename onto an existing file can fail; clean up the temp so we
+        // don't leak it, then surface the error.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(AppError::Io(e));
+    }
+    Ok(())
+}
+
+/// Compare two repo-path keys for "same repo" tolerantly: normalize separators to
+/// `/`, and treat a leading Windows drive letter case-insensitively (`C:` == `c:`).
+/// The rest of the path stays case-sensitive (safe on all platforms; NTFS's own
+/// case-insensitivity is out of scope — we only smooth over drive-letter + slash
+/// variance, which is where real-world callers differ).
+fn same_repo(a: &str, b: &str) -> bool {
+    fn norm(s: &str) -> String {
+        let slashed: String = s.chars().map(|c| if c == '\\' { '/' } else { c }).collect();
+        // Lowercase only a leading "X:" drive-letter prefix.
+        let bytes = slashed.as_bytes();
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            let mut out = String::with_capacity(slashed.len());
+            out.push(bytes[0].to_ascii_lowercase() as char);
+            out.push_str(&slashed[1..]);
+            out
+        } else {
+            slashed
+        }
+    }
+    norm(a) == norm(b)
+}
+
+/// Find the EXISTING store key for `repo` (exact first, then tolerant match), so we
+/// reuse the GUI's key variant instead of creating a second key for the same repo.
+/// Returns `None` when the repo has no entry yet.
+fn existing_key(store: &Map<String, Value>, repo: &str) -> Option<String> {
+    if store.contains_key(repo) {
+        return Some(repo.to_string());
+    }
+    store
+        .keys()
+        .find(|k| same_repo(k, repo))
+        .map(String::to_string)
+}
+
+/// The current UTC timestamp in JS `Date.prototype.toISOString()` format —
+/// RFC3339 with millisecond precision and a `Z` suffix (e.g. `2026-06-20T20:45:33.666Z`).
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Create a new local PR under `repo` and PREPEND it (matching the GUI). Returns the
+/// created record as a `Value`. The caller is responsible for having validated that
+/// `base`/`head` resolve as branches — this core only touches app data.
+pub fn create(repo: &str, title: &str, body: &str, base: &str, head: &str) -> AppResult<Value> {
+    let path = store_path()?;
+    let mut store = read_store(&path)?;
+    let record = NewLocalPr {
+        id: uuid::Uuid::new_v4().to_string(),
+        title: title.to_string(),
+        body: body.to_string(),
+        base: base.to_string(),
+        head: head.to_string(),
+        status: "open".to_string(),
+        approved: false,
+        labels: Vec::new(),
+        comments: Vec::new(),
+        created_at: now_iso(),
+    };
+    let record = serde_json::to_value(&record)
+        .map_err(|e| AppError::Command(format!("serialize new local PR: {e}")))?;
+
+    let key = existing_key(&store, repo).unwrap_or_else(|| repo.to_string());
+    let arr = store.entry(key).or_insert_with(|| Value::Array(Vec::new()));
+    let list = arr
+        .as_array_mut()
+        .ok_or_else(|| AppError::Command(format!("local-prs entry for {repo} is not an array")))?;
+    list.insert(0, record.clone());
+
+    write_store(&path, &store)?;
+    Ok(record)
+}
+
+/// Locate the PR with `id` inside `repo`'s array and apply `mutate` to it in place,
+/// then persist. `mutate` receives the record as a mutable `Map` so it edits only the
+/// fields it means to — unknown fields on the record survive untouched. Errors if the
+/// repo has no entry or no PR with that id.
+fn mutate_pr<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
+where
+    F: FnOnce(&mut Map<String, Value>) -> AppResult<()>,
+{
+    let path = store_path()?;
+    let mut store = read_store(&path)?;
+    let key = existing_key(&store, repo)
+        .ok_or_else(|| AppError::Command(format!("no local PR with id {id}")))?;
+    let list = store
+        .get_mut(&key)
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| AppError::Command(format!("no local PR with id {id}")))?;
+
+    let target = list
+        .iter_mut()
+        .find(|pr| pr.get("id").and_then(Value::as_str) == Some(id))
+        .ok_or_else(|| AppError::Command(format!("no local PR with id {id}")))?;
+    let obj = target
+        .as_object_mut()
+        .ok_or_else(|| AppError::Command(format!("local PR {id} is not an object")))?;
+    mutate(obj)?;
+    let updated = Value::Object(obj.clone());
+
+    write_store(&path, &store)?;
+    Ok(updated)
+}
+
+/// Append a comment (`{ id, body, createdAt }`) to the PR with `id` under `repo`.
+/// Returns the updated record.
+pub fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
+    let comment = serde_json::json!({
+        "id": uuid::Uuid::new_v4().to_string(),
+        "body": body,
+        "createdAt": now_iso(),
+    });
+    mutate_pr(repo, id, |pr| {
+        let comments = pr
+            .entry("comments")
+            .or_insert_with(|| Value::Array(Vec::new()));
+        comments
+            .as_array_mut()
+            .ok_or_else(|| AppError::Command("local PR `comments` is not an array".to_string()))?
+            .push(comment);
+        Ok(())
+    })
+}
+
+/// Set the status of the PR with `id` under `repo` to `"open"` or `"closed"`.
+/// `"merged"` is rejected here — merging is a git operation the MCP server must never
+/// perform (it happens in GitDesktop). Returns the updated record.
+pub fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
+    if status != "open" && status != "closed" {
+        return Err(AppError::Command(format!(
+            "status must be \"open\" or \"closed\" (got \"{status}\"); merging a local PR happens in GitDesktop, not via this server"
+        )));
+    }
+    let status = status.to_string();
+    mutate_pr(repo, id, move |pr| {
+        pr.insert("status".to_string(), Value::String(status));
+        Ok(())
+    })
+}
+
+/// Set the `approved` flag on the PR with `id` under `repo`. Returns the updated record.
+pub fn set_approved(repo: &str, id: &str, approved: bool) -> AppResult<Value> {
+    mutate_pr(repo, id, move |pr| {
+        pr.insert("approved".to_string(), Value::Bool(approved));
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // These tests exercise the pure store logic (read/mutate/write over a Value map)
+    // against a temp file, bypassing `store_path()` so they never touch the real
+    // app-data store. The public fns wrap this same logic + the fixed path.
+
+    fn tmp_store() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "gd-local-prs-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        p
+    }
+
+    #[test]
+    fn same_repo_tolerates_slashes_and_drive_case() {
+        assert!(same_repo(
+            r"C:\ProjectRepos\demo\harbor",
+            "C:/ProjectRepos/demo/harbor"
+        ));
+        assert!(same_repo(
+            r"C:\ProjectRepos\demo\harbor",
+            r"c:\ProjectRepos\demo\harbor"
+        ));
+        assert!(!same_repo(r"C:\a\b", r"C:\a\c"));
+    }
+
+    #[test]
+    fn read_missing_file_is_empty_object() {
+        let path = tmp_store();
+        let store = read_store(&path).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn malformed_store_is_an_error_not_a_clobber() {
+        let path = tmp_store();
+        std::fs::write(&path, b"{ this is not json").unwrap();
+        let err = read_store(&path).unwrap_err();
+        assert!(err.to_string().contains("not valid JSON"));
+        // The bad file is left intact.
+        assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn atomic_write_round_trips() {
+        let path = tmp_store();
+        let mut store = Map::new();
+        store.insert("repo".into(), json!([{ "id": "a" }]));
+        write_store(&path, &store).unwrap();
+        let back = read_store(&path).unwrap();
+        assert_eq!(back["repo"][0]["id"], "a");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn unknown_fields_survive_a_comment_round_trip() {
+        // A record carrying a field this Rust code has never heard of must survive a
+        // mutation byte-meaningfully (the acceptance criterion for never dropping
+        // unknown fields a future GUI adds).
+        let path = tmp_store();
+        let repo = r"C:\repo\one";
+        let mut store = Map::new();
+        store.insert(
+            repo.to_string(),
+            json!([{
+                "id": "pr-1",
+                "title": "T",
+                "body": "B",
+                "base": "main",
+                "head": "feature",
+                "status": "open",
+                "approved": false,
+                "labels": [],
+                "comments": [],
+                "createdAt": "2026-01-01T00:00:00.000Z",
+                "futureField": 1,
+                "nested": { "keep": ["me", 2, true] }
+            }]),
+        );
+        write_store(&path, &store).unwrap();
+
+        // Drive the SAME mutation logic mutate_pr uses, but against our temp file.
+        let mut s = read_store(&path).unwrap();
+        {
+            let list = s.get_mut(repo).unwrap().as_array_mut().unwrap();
+            let pr = list[0].as_object_mut().unwrap();
+            pr.entry("comments")
+                .or_insert_with(|| Value::Array(vec![]))
+                .as_array_mut()
+                .unwrap()
+                .push(json!({ "id": "c1", "body": "hi", "createdAt": "2026-01-02T00:00:00.000Z" }));
+        }
+        write_store(&path, &s).unwrap();
+
+        let back = read_store(&path).unwrap();
+        let pr = &back[repo][0];
+        // Unknown fields untouched.
+        assert_eq!(pr["futureField"], 1);
+        assert_eq!(pr["nested"]["keep"], json!(["me", 2, true]));
+        // The comment landed.
+        assert_eq!(pr["comments"][0]["body"], "hi");
+        // Known fields unchanged.
+        assert_eq!(pr["status"], "open");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn existing_key_reuses_tolerant_match() {
+        let mut store = Map::new();
+        store.insert(r"C:\repo\one".to_string(), json!([]));
+        // A differently-spelled but same repo reuses the existing key.
+        assert_eq!(
+            existing_key(&store, "c:/repo/one").as_deref(),
+            Some(r"C:\repo\one")
+        );
+        // A genuinely new repo has no key.
+        assert_eq!(existing_key(&store, r"C:\repo\two"), None);
+    }
+
+    #[test]
+    fn now_iso_matches_js_toisostring_shape() {
+        let ts = now_iso();
+        // 2026-06-20T20:45:33.666Z — millis + Z.
+        assert!(ts.ends_with('Z'), "expected Z suffix: {ts}");
+        let dot = ts.find('.').expect("expected millisecond fraction");
+        // exactly 3 fractional digits then Z
+        assert_eq!(&ts[dot + 4..], "Z", "expected 3-digit millis: {ts}");
+    }
+}

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -568,6 +568,14 @@ pub async fn mcp_json_write(
 ) -> AppResult<McpJsonWriteResult> {
     let path = Path::new(&repo_path).join(".mcp.json");
 
+    // The entry must be a JSON object — anything else (null, number, array) would write an
+    // invalid MCP server config. Fail fast before touching the file.
+    if !entry.is_object() {
+        return Err(AppError::Command(
+            "the .mcp.json entry must be a JSON object".to_string(),
+        ));
+    }
+
     // Parse the existing file as a Value so unknown keys round-trip. Missing → start
     // from an empty document; malformed → error (do NOT clobber the user's file).
     let mut doc: Value = match std::fs::read(&path) {
@@ -612,7 +620,7 @@ pub async fn mcp_json_write(
     let mut body = serde_json::to_string_pretty(&doc)
         .map_err(|e| AppError::Command(format!("serialize .mcp.json: {e}")))?;
     body.push('\n');
-    std::fs::write(&path, body)?;
+    crate::fsops::atomic_write(&path, body.as_bytes())?;
 
     Ok(McpJsonWriteResult {
         written: true,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -533,6 +533,93 @@ pub async fn discover_mcp_servers(
     Ok(out)
 }
 
+// --- config-helper backend (write the `gitdesktop` server into `.mcp.json`) ------
+//
+// The GUI "Use GitDesktop as an MCP server" helper calls this to add the
+// `gitdesktop` server entry to a project's `.mcp.json` — the SAME file shape
+// `discover_mcp_servers` reads (top-level `"mcpServers"`). It merges: every sibling
+// server and any unknown top-level key is preserved. This writes ONLY the local
+// `.mcp.json`; no git operation is ever involved.
+
+/// Result of [`mcp_json_write`]. `written` is whether the file was actually written;
+/// `existed` is whether a `gitdesktop` entry was already present (so the GUI can
+/// confirm before overwriting).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpJsonWriteResult {
+    pub written: bool,
+    pub existed: bool,
+}
+
+/// Write/merge the `gitdesktop` server `entry` into `<repo_path>/.mcp.json`.
+///
+/// - A missing file starts from `{"mcpServers":{}}`.
+/// - A malformed existing file is an ERROR (never clobbered).
+/// - If `mcpServers.gitdesktop` already exists and `!overwrite`, returns
+///   `{ written: false, existed: true }` untouched (the GUI confirms, then re-calls
+///   with `overwrite: true`).
+/// - Otherwise sets `mcpServers.gitdesktop = entry`, preserving ALL sibling servers
+///   and unknown top-level keys, and pretty-writes the file with a trailing newline.
+#[tauri::command]
+pub async fn mcp_json_write(
+    repo_path: String,
+    entry: Value,
+    overwrite: bool,
+) -> AppResult<McpJsonWriteResult> {
+    let path = Path::new(&repo_path).join(".mcp.json");
+
+    // Parse the existing file as a Value so unknown keys round-trip. Missing → start
+    // from an empty document; malformed → error (do NOT clobber the user's file).
+    let mut doc: Value = match std::fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map_err(|e| {
+            AppError::Command(format!(
+                "{} is not valid JSON: {e}. Fix or remove it, then try again.",
+                path.display()
+            ))
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => json!({ "mcpServers": {} }),
+        Err(e) => return Err(AppError::Io(e)),
+    };
+    if !doc.is_object() {
+        return Err(AppError::Command(format!(
+            "{} is not a JSON object.",
+            path.display()
+        )));
+    }
+
+    // Ensure `mcpServers` is an object (create it if absent; error if present but the
+    // wrong type rather than dropping it).
+    let root = doc.as_object_mut().expect("checked is_object above");
+    let servers = root
+        .entry("mcpServers".to_string())
+        .or_insert_with(|| json!({}));
+    let servers = servers.as_object_mut().ok_or_else(|| {
+        AppError::Command(format!(
+            "{} has a non-object \"mcpServers\".",
+            path.display()
+        ))
+    })?;
+
+    let existed = servers.contains_key("gitdesktop");
+    if existed && !overwrite {
+        return Ok(McpJsonWriteResult {
+            written: false,
+            existed: true,
+        });
+    }
+    servers.insert("gitdesktop".to_string(), entry);
+
+    let mut body = serde_json::to_string_pretty(&doc)
+        .map_err(|e| AppError::Command(format!("serialize .mcp.json: {e}")))?;
+    body.push('\n');
+    std::fs::write(&path, body)?;
+
+    Ok(McpJsonWriteResult {
+        written: true,
+        existed,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -613,6 +700,114 @@ mod tests {
         assert_eq!(srv["url"], "https://mcp.example.com/mcp");
         assert_eq!(srv["headers"]["Authorization"], "Bearer x");
         assert_eq!(srv["enabled"], true);
+    }
+
+    // --- mcp_json_write ------------------------------------------------------
+
+    fn tmp_dir() -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "gd-mcp-json-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn entry() -> Value {
+        json!({ "command": "gitdesktop", "args": ["mcp", "--repo", "."] })
+    }
+
+    #[tokio::test]
+    async fn write_creates_file_when_missing() {
+        let dir = tmp_dir();
+        let res = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), false)
+            .await
+            .unwrap();
+        assert!(res.written);
+        assert!(!res.existed);
+        let doc: Value =
+            serde_json::from_slice(&std::fs::read(dir.join(".mcp.json")).unwrap()).unwrap();
+        assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "gitdesktop");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn write_preserves_siblings_and_unknown_top_level_keys() {
+        let dir = tmp_dir();
+        let path = dir.join(".mcp.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "mcpServers": { "other": { "command": "other-bin" } },
+                "someUnknownTopKey": { "keep": true }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let res = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), false)
+            .await
+            .unwrap();
+        assert!(res.written);
+        assert!(!res.existed);
+
+        let doc: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        // Sibling server preserved.
+        assert_eq!(doc["mcpServers"]["other"]["command"], "other-bin");
+        // Our entry added.
+        assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "gitdesktop");
+        // Unknown top-level key preserved.
+        assert_eq!(doc["someUnknownTopKey"]["keep"], true);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn write_detects_existing_and_refuses_without_overwrite() {
+        let dir = tmp_dir();
+        let path = dir.join(".mcp.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string(&json!({
+                "mcpServers": { "gitdesktop": { "command": "OLD" } }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // !overwrite → reports existed, writes nothing.
+        let res = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), false)
+            .await
+            .unwrap();
+        assert!(!res.written);
+        assert!(res.existed);
+        let doc: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "OLD");
+
+        // overwrite → replaces.
+        let res = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), true)
+            .await
+            .unwrap();
+        assert!(res.written);
+        assert!(res.existed);
+        let doc: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "gitdesktop");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn write_errors_on_malformed_existing_file_without_clobber() {
+        let dir = tmp_dir();
+        let path = dir.join(".mcp.json");
+        std::fs::write(&path, b"{ not valid json").unwrap();
+        let err = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), true)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not valid JSON"));
+        // The bad file is untouched.
+        assert_eq!(std::fs::read(&path).unwrap(), b"{ not valid json");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -783,7 +783,7 @@ async fn read_file_core(
         ));
     }
     if rel_path
-        .split(|c| c == '/' || c == '\\')
+        .split(['/', '\\'])
         .any(|seg| seg == "..")
     {
         return Err(McpError::invalid_params("path must not contain '..'", None));

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -39,6 +39,10 @@ const GH_TEXT_MAX_BYTES: usize = 100_000;
 #[derive(Clone)]
 pub struct GitDesktopMcp {
     repo: String,
+    /// Whether the opt-in write tools (local-PR editing) are enabled. Off unless the
+    /// server was launched with `--allow-write`; when off, the write tools stay
+    /// registered but return a clear "disabled" error so an agent sees why.
+    allow_write: bool,
     // Read by the `#[tool_handler]`-generated `list_tools`/`call_tool`; the
     // dead-code lint misses that (it only sees the derived `Clone` touch it).
     #[allow(dead_code)]
@@ -151,6 +155,46 @@ struct RunListArgs {
     /// Limit to a branch name.
     #[serde(default)]
     branch: Option<String>,
+}
+
+// ---- Local-PR write tool parameters (opt-in via --allow-write) -------------
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct CreateLocalPrArgs {
+    /// Title of the local PR.
+    title: String,
+    /// Optional description/body (markdown). Defaults to empty.
+    #[serde(default)]
+    body: Option<String>,
+    /// Base branch (the branch changes would merge INTO). Must exist in the repo.
+    base: String,
+    /// Head branch (the branch with the changes). Must exist in the repo.
+    head: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct CommentLocalPrArgs {
+    /// The local PR's id.
+    id: String,
+    /// The comment body (markdown).
+    body: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SetLocalPrStatusArgs {
+    /// The local PR's id.
+    id: String,
+    /// New status: "open" or "closed". "merged" is rejected — merging happens in
+    /// GitDesktop (it's a git operation this server never performs).
+    status: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct ApproveLocalPrArgs {
+    /// The local PR's id.
+    id: String,
+    /// Whether the local PR is approved.
+    approved: bool,
 }
 
 #[tool_router]
@@ -461,13 +505,107 @@ impl GitDesktopMcp {
             GH_TEXT_MAX_BYTES,
         ))]))
     }
+
+    // ---- Local-PR write tools (opt-in via --allow-write) ------------------
+    //
+    // Local PRs are GitDesktop's own app-data review artifacts (mirrored from the
+    // GUI's `local-prs.json`) — these tools create/amend those records only. No git
+    // or remote write ever happens here. All four are gated on `allow_write` and are
+    // annotated non-read-only, non-destructive (they create/amend app-data records,
+    // destroy nothing).
+
+    #[tool(
+        description = "Create a local PR — GitDesktop's own app-data review artifact for the bound \
+                       repository (NOT a GitHub/remote PR; nothing is pushed). Verifies both `base` \
+                       and `head` exist as branches first. Returns the created record as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn create_local_pr(
+        &self,
+        Parameters(args): Parameters<CreateLocalPrArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_write()?;
+        // Pre-mutation guards FIRST: both refs must resolve as branches, else error
+        // naming the missing one — before any app-data write.
+        verify_branch(&self.repo, &args.base).await?;
+        verify_branch(&self.repo, &args.head).await?;
+        let record = crate::local_prs::create(
+            &self.repo,
+            &args.title,
+            args.body.as_deref().unwrap_or(""),
+            &args.base,
+            &args.head,
+        )
+        .map_err(app_err)?;
+        json_result(&record)
+    }
+
+    #[tool(
+        description = "Add a comment to a local PR (by id) in the bound repository. Returns the \
+                       updated record as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn comment_local_pr(
+        &self,
+        Parameters(args): Parameters<CommentLocalPrArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_write()?;
+        let record =
+            crate::local_prs::add_comment(&self.repo, &args.id, &args.body).map_err(app_err)?;
+        json_result(&record)
+    }
+
+    #[tool(
+        description = "Set a local PR's status to \"open\" or \"closed\" (by id). \"merged\" is \
+                       rejected — merging a local PR happens in GitDesktop (a git operation this \
+                       server never performs). Returns the updated record as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn set_local_pr_status(
+        &self,
+        Parameters(args): Parameters<SetLocalPrStatusArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_write()?;
+        let record =
+            crate::local_prs::set_status(&self.repo, &args.id, &args.status).map_err(app_err)?;
+        json_result(&record)
+    }
+
+    #[tool(
+        description = "Set a local PR's approved flag (by id) in the bound repository. Returns the \
+                       updated record as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn approve_local_pr(
+        &self,
+        Parameters(args): Parameters<ApproveLocalPrArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_write()?;
+        let record =
+            crate::local_prs::set_approved(&self.repo, &args.id, args.approved).map_err(app_err)?;
+        json_result(&record)
+    }
 }
 
 impl GitDesktopMcp {
-    pub fn new(repo: String) -> Self {
+    pub fn with_options(repo: String, allow_write: bool) -> Self {
         Self {
             repo,
+            allow_write,
             tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Gate for the write tools: an actionable error when the server wasn't launched
+    /// with `--allow-write`.
+    fn ensure_write(&self) -> Result<(), McpError> {
+        if self.allow_write {
+            Ok(())
+        } else {
+            Err(McpError::invalid_request(
+                "Write tools are disabled. Restart the server with --allow-write to enable them.",
+                None,
+            ))
         }
     }
 }
@@ -480,8 +618,11 @@ impl ServerHandler for GitDesktopMcp {
         let mut info = ServerInfo::default();
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
         info.instructions = Some(
-            "GitDesktop as an MCP server (read-only). Tools act on the repository this server \
-             was launched against (--repo). GitHub tools require an authenticated `gh` CLI."
+            "GitDesktop as an MCP server. Tools act on the repository this server was launched \
+             against (--repo). GitHub tools require an authenticated `gh` CLI. The read tools are \
+             always available; the local-PR write tools (create/comment/status/approve — \
+             GitDesktop's own app-data review artifacts, never git or remote writes) are enabled \
+             only when the server was launched with --allow-write."
                 .into(),
         );
         info
@@ -540,6 +681,38 @@ async fn resolve_commit(repo: &str, rev: &str) -> Result<String, McpError> {
         return Err(McpError::invalid_params(format!("no such commit: {rev}"), None));
     }
     Ok(sha)
+}
+
+/// Verifies that `branch` resolves to an existing LOCAL branch (`refs/heads/<branch>`)
+/// in the repo, erroring clearly by name if not. Used as a pre-mutation guard for
+/// `create_local_pr` so a typo'd base/head is rejected before any app-data write.
+///
+/// Local branches ONLY — a remote-tracking ref (`origin/main`) is deliberately
+/// rejected: the GUI's local-PR paths assume local branches (the create dialog only
+/// offers local names, and `git_merge_local_pr` does `git switch <base>` + cherry-pick,
+/// which errors or DWIM-creates a branch for a remote-tracking ref), so a record with
+/// a remote-tracking ref would be a latent trap at merge time.
+async fn verify_branch(repo: &str, branch: &str) -> Result<(), McpError> {
+    ensure_not_flag(branch, "branch")?;
+    let out = run_git_raw(
+        Some(repo),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}^{{commit}}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .map_err(app_err)?;
+    if !out.stdout_lossy().trim().is_empty() {
+        return Ok(());
+    }
+    Err(McpError::invalid_params(
+        format!("branch not found in this repository: {branch}"),
+        None,
+    ))
 }
 
 /// Redacts an in-URL credential (the `user:pass@` / `token@` userinfo) from an
@@ -660,7 +833,7 @@ async fn read_file_core(
 /// back to the current working directory), then runs the stdio MCP server until
 /// the client disconnects.
 pub fn run_mcp_server() {
-    let repo = parse_repo_arg();
+    let args = McpArgs::from_env();
     let rt = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -671,32 +844,85 @@ pub fn run_mcp_server() {
             std::process::exit(1);
         }
     };
-    if let Err(e) = rt.block_on(serve(repo)) {
+    if let Err(e) = rt.block_on(serve(args)) {
         eprintln!("gitdesktop-mcp: {e}");
         std::process::exit(1);
     }
 }
 
-async fn serve(repo: String) -> Result<(), Box<dyn std::error::Error>> {
-    let service = GitDesktopMcp::new(repo).serve(stdio()).await?;
+async fn serve(args: McpArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let service = GitDesktopMcp::with_options(args.repo, args.allow_write)
+        .serve(stdio())
+        .await?;
     service.waiting().await?;
     Ok(())
 }
 
-/// Reads `--repo <path>` (or `--repo=<path>`) from argv; falls back to the current
-/// working directory, matching how reference MCP git servers are configured.
-fn parse_repo_arg() -> String {
-    let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
-        if arg == "--repo" {
-            if let Some(path) = args.next() {
-                return path;
-            }
-        } else if let Some(path) = arg.strip_prefix("--repo=") {
-            return path.to_string();
-        }
+/// The parsed MCP-server launch arguments: the bound `--repo` and the `--allow-write`
+/// opt-in for the local-PR write tools.
+struct McpArgs {
+    repo: String,
+    allow_write: bool,
+}
+
+impl McpArgs {
+    fn from_env() -> Self {
+        Self::parse(std::env::args().skip(1))
     }
-    std::env::current_dir()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| ".".to_string())
+
+    /// Reads `--repo <path>` (or `--repo=<path>`) and the `--allow-write` flag from an
+    /// argv iterator; the repo falls back to the current working directory, matching
+    /// how reference MCP git servers are configured. `--allow-write` off by default.
+    fn parse(args: impl Iterator<Item = String>) -> Self {
+        let mut repo: Option<String> = None;
+        let mut allow_write = false;
+        let mut args = args;
+        while let Some(arg) = args.next() {
+            if arg == "--repo" {
+                if let Some(path) = args.next() {
+                    repo = Some(path);
+                }
+            } else if let Some(path) = arg.strip_prefix("--repo=") {
+                repo = Some(path.to_string());
+            } else if arg == "--allow-write" {
+                allow_write = true;
+            }
+        }
+        let repo = repo.unwrap_or_else(|| {
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| ".".to_string())
+        });
+        Self { repo, allow_write }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> McpArgs {
+        McpArgs::parse(argv.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn allow_write_defaults_off() {
+        let args = parse(&["--repo", "/tmp/x"]);
+        assert_eq!(args.repo, "/tmp/x");
+        assert!(!args.allow_write);
+    }
+
+    #[test]
+    fn allow_write_flag_enables_it() {
+        let args = parse(&["--repo=/tmp/x", "--allow-write"]);
+        assert_eq!(args.repo, "/tmp/x");
+        assert!(args.allow_write);
+    }
+
+    #[test]
+    fn allow_write_order_independent() {
+        let args = parse(&["--allow-write", "--repo", "/tmp/y"]);
+        assert_eq!(args.repo, "/tmp/y");
+        assert!(args.allow_write);
+    }
 }

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -604,6 +604,7 @@ pub async fn transcript_append_turn(
 
 /// Records a turn's terminal result (status + coalesced narration + checkpoint).
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn transcript_append_result(
     app: AppHandle,
     id: String,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { WelcomeScreen } from "@/features/welcome/WelcomeScreen";
 import { syncAnalytics, track } from "@/lib/analytics";
 import { useGitInstalled } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
+import { reloadLocalPrs } from "@/lib/pulls/local";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { COLD_START } from "@/lib/test-mode";
@@ -127,6 +128,16 @@ function App() {
       ({ payload: focused }) => {
         if (focused) {
           queryClient.invalidateQueries({ queryKey: ["repo"] });
+          // The MCP server (with --allow-write) can mutate local-prs.json on
+          // disk while we're unfocused; reload the in-memory store from disk
+          // BEFORE invalidating so the refetch sees the external writes.
+          reloadLocalPrs()
+            .then(() =>
+              queryClient.invalidateQueries({ queryKey: ["local-prs"] }),
+            )
+            .catch(() => {
+              // Best-effort: a failed reload just leaves the last known state.
+            });
         }
       },
     );

--- a/src/features/conversations/useLocalConversation.ts
+++ b/src/features/conversations/useLocalConversation.ts
@@ -21,17 +21,19 @@ export interface LocalConvEntity {
 
 /**
  * Comment + label CRUD and composer state shared by LocalPrView and
- * LocalIssueView. Every mutation spreads the WHOLE entity and replaces one
- * field via `save.mutate`, so freshness comes from the list query's refetch —
- * comments are never held in local state. `entity` may be undefined while the
- * parent is mid-unmount, so every handler guards on it.
+ * LocalIssueView. Every mutation is handed to `apply` as a function of the
+ * CURRENT record; the view routes it through updateLocalPr/updateLocalIssue,
+ * which reload disk first — so a concurrent external write to the same entity
+ * is merged, not clobbered — and comments are never held in local state.
+ * `entity` may be undefined while the parent is mid-unmount, so every handler
+ * guards on it.
  *
  * `openEdit`/`editForm` stay at the call site (they need the per-view title);
  * this hook owns only conversation/label/composer state.
  */
 export function useLocalConversation<T extends LocalConvEntity>(
   entity: T | undefined,
-  save: { mutate: (entity: T) => void },
+  apply: (mutate: (cur: T) => T) => void,
 ) {
   const [comment, setComment] = useState("");
   const [labelInput, setLabelInput] = useState("");
@@ -41,32 +43,30 @@ export function useLocalConversation<T extends LocalConvEntity>(
   const composerRef = useRef<MarkdownEditorHandle>(null);
   const quoteReply = makeQuoteReply({ composerRef, setBody: setComment });
 
-  // Spread the whole entity, override one field. `as T` works around TS not
-  // assigning a generic spread back to its own type parameter.
-  const patch = (next: Partial<T>): T => ({ ...(entity as T), ...next });
+  // Merge a field patch onto the CURRENT record — whatever `apply` reloaded from
+  // disk — not a stale snapshot, so a concurrent external write to the same entity
+  // (e.g. an MCP-appended comment) survives. `as T` works around TS not assigning a
+  // generic spread back to its own type parameter.
+  const patch = (cur: T, next: Partial<T>): T => ({ ...cur, ...next }) as T;
 
   function addComment() {
     if (!entity || !comment.trim()) return;
-    save.mutate(
-      patch({
-        comments: [
-          ...entity.comments,
-          {
-            id: crypto.randomUUID(),
-            body: comment.trim(),
-            createdAt: new Date().toISOString(),
-          },
-        ],
-      } as Partial<T>),
+    const c = {
+      id: crypto.randomUUID(),
+      body: comment.trim(),
+      createdAt: new Date().toISOString(),
+    };
+    apply((cur) =>
+      patch(cur, { comments: [...cur.comments, c] } as Partial<T>),
     );
     setComment("");
   }
 
   function editComment(commentId: string, body: string) {
     if (!entity) return;
-    save.mutate(
-      patch({
-        comments: entity.comments.map((c) =>
+    apply((cur) =>
+      patch(cur, {
+        comments: cur.comments.map((c) =>
           c.id === commentId ? { ...c, body } : c,
         ),
       } as Partial<T>),
@@ -75,18 +75,18 @@ export function useLocalConversation<T extends LocalConvEntity>(
 
   function deleteComment(commentId: string) {
     if (!entity) return;
-    save.mutate(
-      patch({
-        comments: entity.comments.filter((c) => c.id !== commentId),
+    apply((cur) =>
+      patch(cur, {
+        comments: cur.comments.filter((c) => c.id !== commentId),
       } as Partial<T>),
     );
   }
 
   function setCommentHidden(commentId: string, hidden: boolean) {
     if (!entity) return;
-    save.mutate(
-      patch({
-        comments: entity.comments.map((c) =>
+    apply((cur) =>
+      patch(cur, {
+        comments: cur.comments.map((c) =>
           c.id === commentId ? { ...c, hidden } : c,
         ),
       } as Partial<T>),
@@ -96,17 +96,19 @@ export function useLocalConversation<T extends LocalConvEntity>(
   function addLabel() {
     const name = labelInput.trim();
     if (!entity || !name) return;
-    if (!entity.labels.includes(name)) {
-      save.mutate(patch({ labels: [...entity.labels, name] } as Partial<T>));
-    }
+    apply((cur) =>
+      cur.labels.includes(name)
+        ? cur
+        : patch(cur, { labels: [...cur.labels, name] } as Partial<T>),
+    );
     setLabelInput("");
   }
 
   function removeLabel(label: string) {
     if (!entity) return;
-    save.mutate(
-      patch({
-        labels: entity.labels.filter((l) => l !== label),
+    apply((cur) =>
+      patch(cur, {
+        labels: cur.labels.filter((l) => l !== label),
       } as Partial<T>),
     );
   }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -817,12 +817,19 @@ selection **mid-session** — the picker appears in a running session's reply bo
 new choice applies from your next turn.
 
 **The other direction — GitDesktop *as* a server.** At the bottom of the panel, **Use
-GitDesktop as an MCP server** gives you a ready-to-paste config snippet so any external MCP
-client — Claude Desktop, Cursor, Claude Code — can use *this* repo's **read-only** git &
-GitHub tools (status, log, diffs, blame, branches, file history/read, PRs, issues, CI logs).
-The app itself runs as a stdio server (\`gitdesktop mcp --repo <path>\`) exposing only read
-tools, so an agent can understand a repo without changing it. Copy it, paste it into your
-client's MCP config, done.
+GitDesktop as an MCP server** lets any external MCP client — Claude Desktop, Cursor, Claude
+Code — use *this* repo's **read-only-by-default** git & GitHub tools (status, log, diffs,
+blame, branches, file history/read, PRs, issues, CI logs). The app itself runs as a stdio
+server (\`gitdesktop mcp --repo <path>\`), so an agent can understand a repo without changing
+it. **Copy** the snippet and paste it into your client's config, or hit **Write to
+.mcp.json** to merge the \`gitdesktop\` entry into the open repo's \`.mcp.json\` for you —
+existing servers are preserved, and you're asked before an existing GitDesktop entry is
+replaced. Two toggles shape what gets written: **Shareable entry** swaps machine-specific
+absolute paths for portable \`\${GITDESKTOP_BIN}\` / \`\${CLAUDE_PROJECT_DIR}\` ones a
+teammate can commit (they point \`GITDESKTOP_BIN\` at their own install, or keep
+\`gitdesktop\` on their PATH), and **Allow write tools** adds \`--allow-write\` so an agent
+can also **create**, **comment on**, set the **status** of, and **approve** *this repo's*
+local PRs — off by default, keeping the server read-only.
 
 New to MCP? **Browse** opens the official Model Context Protocol registry right in that
 panel — search it and add a server in a click; it arrives **disabled** for you to review

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -44,7 +44,7 @@ import { forgeFeatureReady, useForgeStatus } from "@/lib/git/queries";
 import {
   useDeleteLocalIssue,
   useLocalIssues,
-  useSaveLocalIssue,
+  useUpdateLocalIssue,
 } from "@/lib/issues/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
@@ -62,7 +62,7 @@ export function LocalIssueView({
 }) {
   const issues = useLocalIssues(repoPath);
   const issue = issues.data?.find((i) => i.id === id);
-  const save = useSaveLocalIssue(repoPath);
+  const update = useUpdateLocalIssue(repoPath);
   const del = useDeleteLocalIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const ghStatus = useForgeStatus(repoPath);
@@ -81,13 +81,18 @@ export function LocalIssueView({
     setCommentHidden,
     addLabel,
     removeLabel,
-  } = useLocalConversation(issue, save);
+  } = useLocalConversation(issue, (mutate) => {
+    if (issue) update.mutate({ id: issue.id, mutate });
+  });
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [promoteOpen, setPromoteOpen] = useState(false);
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {
       if (!issue) return;
-      await save.mutateAsync({ ...issue, title, body });
+      await update.mutateAsync({
+        id: issue.id,
+        mutate: (cur) => ({ ...cur, title, body }),
+      });
     },
   });
 
@@ -321,9 +326,15 @@ export function LocalIssueView({
           size="sm"
           onClick={() => {
             if (issue.archived) {
-              save.mutate({ ...issue, archived: false });
+              update.mutate({
+                id: issue.id,
+                mutate: (cur) => ({ ...cur, archived: false }),
+              });
             } else {
-              save.mutate({ ...issue, archived: true });
+              update.mutate({
+                id: issue.id,
+                mutate: (cur) => ({ ...cur, archived: true }),
+              });
               selectIssue(null);
             }
           }}
@@ -354,10 +365,13 @@ export function LocalIssueView({
               variant="outline"
               size="sm"
               onClick={() =>
-                save.mutate({
-                  ...issue,
-                  status: "closed",
-                  closedAt: new Date().toISOString(),
+                update.mutate({
+                  id: issue.id,
+                  mutate: (cur) => ({
+                    ...cur,
+                    status: "closed",
+                    closedAt: new Date().toISOString(),
+                  }),
                 })
               }
             >
@@ -369,7 +383,12 @@ export function LocalIssueView({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => save.mutate({ ...issue, status: "open" })}
+            onClick={() =>
+              update.mutate({
+                id: issue.id,
+                mutate: (cur) => ({ ...cur, status: "open" }),
+              })
+            }
           >
             <ArrowCounterClockwiseIcon data-icon="inline-start" />
             Reopen

--- a/src/features/issues/PromoteLocalIssueDialog.tsx
+++ b/src/features/issues/PromoteLocalIssueDialog.tsx
@@ -14,7 +14,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { forgeIssueComment } from "@/lib/git/api";
 import { useCreateIssue, useForgeStatus } from "@/lib/git/queries";
 import type { LocalIssue } from "@/lib/issues/local";
-import { useSaveLocalIssue } from "@/lib/issues/queries";
+import { useUpdateLocalIssue } from "@/lib/issues/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 
@@ -36,7 +36,7 @@ export function PromoteLocalIssueDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const createIssue = useCreateIssue(repoPath);
-  const save = useSaveLocalIssue(repoPath);
+  const update = useUpdateLocalIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const forge = useForgeStatus(repoPath);
   const remoteLabel = forge.data?.provider === "gitlab" ? "GitLab" : "GitHub";
@@ -60,18 +60,21 @@ export function PromoteLocalIssueDialog({
       for (const c of carried) {
         await forgeIssueComment(repoPath, number, c.body);
       }
-      await save.mutateAsync({
-        ...issue,
-        status: "closed",
-        closedAt: new Date().toISOString(),
-        comments: [
-          ...issue.comments,
-          {
-            id: crypto.randomUUID(),
-            body: `Promoted to ${remoteLabel} issue [#${number}](${url}).`,
-            createdAt: new Date().toISOString(),
-          },
-        ],
+      await update.mutateAsync({
+        id: issue.id,
+        mutate: (cur) => ({
+          ...cur,
+          status: "closed",
+          closedAt: new Date().toISOString(),
+          comments: [
+            ...cur.comments,
+            {
+              id: crypto.randomUUID(),
+              body: `Promoted to ${remoteLabel} issue [#${number}](${url}).`,
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        }),
       });
       toast.success(`Opened issue #${number}`, {
         description: url,

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -59,7 +59,7 @@ import {
 import {
   useDeleteLocalPr,
   useLocalPrs,
-  useSaveLocalPr,
+  useUpdateLocalPr,
 } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -79,7 +79,7 @@ export function LocalPrView({
 }) {
   const prs = useLocalPrs(repoPath);
   const pr = prs.data?.find((p) => p.id === id);
-  const save = useSaveLocalPr(repoPath);
+  const update = useUpdateLocalPr(repoPath);
   const del = useDeleteLocalPr(repoPath);
   const merge = useMergeLocalPr(repoPath);
   const selectPr = useUiStore((s) => s.selectPr);
@@ -114,14 +114,19 @@ export function LocalPrView({
     setCommentHidden,
     addLabel,
     removeLabel,
-  } = useLocalConversation(pr, save);
+  } = useLocalConversation(pr, (mutate) => {
+    if (pr) update.mutate({ id: pr.id, mutate });
+  });
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [promoteOpen, setPromoteOpen] = useState(false);
   const ghStatus = useForgeStatus(repoPath);
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {
       if (!pr) return;
-      await save.mutateAsync({ ...pr, title, body });
+      await update.mutateAsync({
+        id: pr.id,
+        mutate: (cur) => ({ ...cur, title, body }),
+      });
     },
   });
 
@@ -148,7 +153,10 @@ export function LocalPrView({
 
   function toggleApprove() {
     if (!pr) return;
-    save.mutate({ ...pr, approved: !pr.approved });
+    update.mutate({
+      id: pr.id,
+      mutate: (cur) => ({ ...cur, approved: !cur.approved }),
+    });
   }
 
   function openEdit() {
@@ -163,10 +171,13 @@ export function LocalPrView({
       { base: pr.base, head: pr.head, message, strategy },
       {
         onSuccess: () => {
-          save.mutate({
-            ...pr,
-            status: "merged",
-            mergedAt: new Date().toISOString(),
+          update.mutate({
+            id: pr.id,
+            mutate: (cur) => ({
+              ...cur,
+              status: "merged",
+              mergedAt: new Date().toISOString(),
+            }),
           });
           const verb =
             strategy === "squash"
@@ -330,25 +341,28 @@ export function LocalPrView({
                 files: d.files,
               })),
           }}
-          posting={save.isPending}
-          onPost={(body) =>
-            save
-              .mutateAsync({
-                ...pr,
-                comments: [
-                  ...pr.comments,
-                  {
-                    id: crypto.randomUUID(),
-                    body,
-                    createdAt: new Date().toISOString(),
-                  },
-                ],
-              })
-              .catch((e) => {
-                toastError(e);
-                throw e; // let the panel skip its success toast / text clear
-              })
-          }
+          posting={update.isPending}
+          onPost={async (body) => {
+            try {
+              await update.mutateAsync({
+                id: pr.id,
+                mutate: (cur) => ({
+                  ...cur,
+                  comments: [
+                    ...cur.comments,
+                    {
+                      id: crypto.randomUUID(),
+                      body,
+                      createdAt: new Date().toISOString(),
+                    },
+                  ],
+                }),
+              });
+            } catch (e) {
+              toastError(e);
+              throw e; // let the panel skip its success toast / text clear
+            }
+          }}
         />
       )}
 
@@ -506,9 +520,15 @@ export function LocalPrView({
           size="sm"
           onClick={() => {
             if (pr.archived) {
-              save.mutate({ ...pr, archived: false });
+              update.mutate({
+                id: pr.id,
+                mutate: (cur) => ({ ...cur, archived: false }),
+              });
             } else {
-              save.mutate({ ...pr, archived: true });
+              update.mutate({
+                id: pr.id,
+                mutate: (cur) => ({ ...cur, archived: true }),
+              });
               selectPr(null);
             }
           }}
@@ -538,7 +558,12 @@ export function LocalPrView({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => save.mutate({ ...pr, status: "closed" })}
+              onClick={() =>
+                update.mutate({
+                  id: pr.id,
+                  mutate: (cur) => ({ ...cur, status: "closed" }),
+                })
+              }
             >
               Close
             </Button>
@@ -593,7 +618,12 @@ export function LocalPrView({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => save.mutate({ ...pr, status: "open" })}
+            onClick={() =>
+              update.mutate({
+                id: pr.id,
+                mutate: (cur) => ({ ...cur, status: "open" }),
+              })
+            }
           >
             <ArrowCounterClockwiseIcon data-icon="inline-start" />
             Reopen

--- a/src/features/pulls/PromoteLocalPrDialog.tsx
+++ b/src/features/pulls/PromoteLocalPrDialog.tsx
@@ -15,7 +15,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { forgePrComment } from "@/lib/git/api";
 import { useCreatePr, useForgeStatus } from "@/lib/git/queries";
 import type { LocalPr } from "@/lib/pulls/local";
-import { useSaveLocalPr } from "@/lib/pulls/queries";
+import { useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 
@@ -38,7 +38,7 @@ export function PromoteLocalPrDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const createPr = useCreatePr(repoPath);
-  const save = useSaveLocalPr(repoPath);
+  const update = useUpdateLocalPr(repoPath);
   const selectPr = useUiStore((s) => s.selectPr);
   const forge = useForgeStatus(repoPath);
   const isGitLab = forge.data?.provider === "gitlab";
@@ -46,7 +46,7 @@ export function PromoteLocalPrDialog({
   const prNoun = isGitLab ? "merge request" : "pull request";
   const [draft, setDraft] = useState(false);
   const [posting, setPosting] = useState(false);
-  const pending = createPr.isPending || save.isPending || posting;
+  const pending = createPr.isPending || update.isPending || posting;
 
   // Visible comments, in order — skip empty + hidden (collapsed) ones.
   const carried = pr.comments.filter((c) => c.body.trim() && !c.hidden);
@@ -69,17 +69,20 @@ export function PromoteLocalPrDialog({
       } finally {
         setPosting(false);
       }
-      await save.mutateAsync({
-        ...pr,
-        status: "closed",
-        comments: [
-          ...pr.comments,
-          {
-            id: crypto.randomUUID(),
-            body: `Promoted to ${remoteLabel} ${prNoun} [#${number}](${url}).`,
-            createdAt: new Date().toISOString(),
-          },
-        ],
+      await update.mutateAsync({
+        id: pr.id,
+        mutate: (cur) => ({
+          ...cur,
+          status: "closed",
+          comments: [
+            ...cur.comments,
+            {
+              id: crypto.randomUUID(),
+              body: `Promoted to ${remoteLabel} ${prNoun} [#${number}](${url}).`,
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        }),
       });
       toast.success(`Opened ${prNoun} #${number}`, {
         description: url,

--- a/src/features/pulls/useReconcileLocalPrs.ts
+++ b/src/features/pulls/useReconcileLocalPrs.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { gitBranchMergeStates } from "@/lib/git/api";
-import { useLocalPrs, useSaveLocalPr } from "@/lib/pulls/queries";
+import { useLocalPrs, useUpdateLocalPr } from "@/lib/pulls/queries";
 
 /**
  * Keeps open local PRs honest with git when the work happens outside the app
@@ -11,7 +11,7 @@ import { useLocalPrs, useSaveLocalPr } from "@/lib/pulls/queries";
  */
 export function useReconcileLocalPrs(repo: string) {
   const prs = useLocalPrs(repo);
-  const { mutate } = useSaveLocalPr(repo);
+  const { mutate } = useUpdateLocalPr(repo);
   const open = (prs.data ?? []).filter((p) => p.status === "open");
 
   const states = useQuery({
@@ -43,13 +43,19 @@ export function useReconcileLocalPrs(repo: string) {
       if (s.merged) {
         done.current.add(pr.id);
         mutate({
-          ...pr,
-          status: "merged",
-          mergedAt: pr.mergedAt ?? new Date().toISOString(),
+          id: pr.id,
+          mutate: (cur) => ({
+            ...cur,
+            status: "merged",
+            mergedAt: cur.mergedAt ?? new Date().toISOString(),
+          }),
         });
       } else if (!s.headExists) {
         done.current.add(pr.id);
-        mutate({ ...pr, status: "closed" });
+        mutate({
+          id: pr.id,
+          mutate: (cur) => ({ ...cur, status: "closed" }),
+        });
       }
     });
   }, [states.data, open, mutate]);

--- a/src/features/settings/McpServersSection.tsx
+++ b/src/features/settings/McpServersSection.tsx
@@ -47,7 +47,12 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { copyText } from "@/lib/clipboard";
 import { withForm } from "@/lib/form";
-import { appExePath, deleteMcpSecret, setMcpSecret } from "@/lib/git/api";
+import {
+  appExePath,
+  deleteMcpSecret,
+  mcpJsonWrite,
+  setMcpSecret,
+} from "@/lib/git/api";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { McpServer } from "@/lib/settings/api";
 import {
@@ -556,6 +561,13 @@ function PerRepoStateControl({
 function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  // Two config variants driven by checkboxes: Shareable (portable env-var paths
+  // a teammate can commit) vs Personal (absolute machine paths), and whether to
+  // expose the opt-in local-PR write tools (`--allow-write`).
+  const [shareable, setShareable] = useState(false);
+  const [allowWrite, setAllowWrite] = useState(false);
+  const [writing, setWriting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   // The command is this app's own executable; resolved once (it can't change
   // mid-session). Falls back to a bare name only while the path is loading.
   const { data: exePath } = useQuery({
@@ -564,15 +576,23 @@ function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     staleTime: Number.POSITIVE_INFINITY,
   });
 
+  // Single source of truth for both Copy and Write — the exact entry that gets
+  // merged into .mcp.json under `mcpServers.gitdesktop`.
+  const entry = useMemo(() => {
+    const args = shareable
+      ? ["mcp", "--repo", "${CLAUDE_PROJECT_DIR:-.}"]
+      : ["mcp", "--repo", repoPath ?? "<path to your repo>"];
+    if (allowWrite) args.push("--allow-write");
+    return {
+      command: shareable
+        ? "${GITDESKTOP_BIN:-gitdesktop}"
+        : (exePath ?? "gitdesktop"),
+      args,
+    };
+  }, [shareable, allowWrite, repoPath, exePath]);
+
   const snippet = JSON.stringify(
-    {
-      mcpServers: {
-        gitdesktop: {
-          command: exePath ?? "GitDesktop",
-          args: ["mcp", "--repo", repoPath ?? "<path to your repo>"],
-        },
-      },
-    },
+    { mcpServers: { gitdesktop: entry } },
     null,
     2,
   );
@@ -581,6 +601,35 @@ function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     await copyText(snippet);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
+  }
+
+  // Fire the toast whose wording matches the variant just written.
+  function writeSuccessToast() {
+    toast.success(
+      shareable
+        ? ".mcp.json written — commit it to share with your team"
+        : ".mcp.json written — paths are machine-specific, consider gitignoring it",
+    );
+  }
+
+  // Write .mcp.json without clobbering an existing entry; if one exists, ask
+  // before replacing. `overwrite` is only ever true on the confirm path.
+  async function write(overwrite: boolean) {
+    if (!repoPath || writing) return;
+    setWriting(true);
+    try {
+      const result = await mcpJsonWrite(repoPath, entry, overwrite);
+      if (result.existed && !result.written) {
+        setConfirmOpen(true);
+        return;
+      }
+      setConfirmOpen(false);
+      writeSuccessToast();
+    } catch (e) {
+      toastError(e);
+    } finally {
+      setWriting(false);
+    }
   }
 
   return (
@@ -603,7 +652,7 @@ function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
           </span>
           <span className="block text-xs text-muted-foreground">
             Let Claude Desktop, Cursor, or Claude Code use this repo's git &amp;
-            GitHub tools — read-only, over stdio.
+            GitHub tools — read-only by default, over stdio.
           </span>
         </span>
       </button>
@@ -617,29 +666,124 @@ function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
               the repo you want to expose.
             </p>
           )}
+
+          <div className="space-y-1.5">
+            <label className="flex cursor-pointer items-center gap-2 text-xs">
+              <Checkbox
+                checked={shareable}
+                onCheckedChange={(c) => setShareable(c === true)}
+              />
+              Shareable entry
+            </label>
+            <p className="text-xs text-muted-foreground">
+              {shareable
+                ? "Portable paths — teammates set GITDESKTOP_BIN to their install path (or have gitdesktop on PATH)."
+                : "Absolute paths — works on this machine only. Consider gitignoring .mcp.json."}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="flex cursor-pointer items-center gap-2 text-xs">
+              <Checkbox
+                checked={allowWrite}
+                onCheckedChange={(c) => setAllowWrite(c === true)}
+              />
+              Allow write tools
+            </label>
+            <p className="text-xs text-muted-foreground">
+              {allowWrite
+                ? "Adds --allow-write — agents can create, comment on, and approve this repo's local PRs."
+                : "The server exposes read-only git & GitHub tools."}
+            </p>
+          </div>
+
           <div className="flex items-center justify-between gap-2">
             <span className="text-[11px] text-muted-foreground">
               Paste into your client's MCP config
             </span>
-            <Button type="button" variant="ghost" size="sm" onClick={copy}>
-              {copied ? (
-                <>
-                  <CheckIcon data-icon="inline-start" /> Copied
-                </>
-              ) : (
-                <>
-                  <CopyIcon data-icon="inline-start" /> Copy
-                </>
-              )}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="ghost" size="sm" onClick={copy}>
+                {copied ? (
+                  <>
+                    <CheckIcon data-icon="inline-start" /> Copied
+                  </>
+                ) : (
+                  <>
+                    <CopyIcon data-icon="inline-start" /> Copy
+                  </>
+                )}
+              </Button>
+              {/* A title on a natively-disabled button never surfaces, so wrap it. */}
+              <span
+                title={
+                  repoPath
+                    ? undefined
+                    : "Open a repository to write its .mcp.json"
+                }
+              >
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!repoPath || writing}
+                  onClick={() => write(false)}
+                >
+                  {writing ? (
+                    <>
+                      <Spinner className="size-3" /> Writing…
+                    </>
+                  ) : (
+                    "Write to .mcp.json"
+                  )}
+                </Button>
+              </span>
+            </div>
           </div>
           <pre className="overflow-x-auto rounded border bg-muted/40 p-3 font-mono text-[11px] leading-relaxed">
             {snippet}
           </pre>
           <p className="text-xs text-muted-foreground">
-            Read-only · stdio · exposes git &amp; GitHub tools (status, log,
-            diff, blame, PRs, issues, CI).
+            {allowWrite
+              ? "Read-write · stdio · adds local-PR write tools (create, comment, status, approve) — gated behind --allow-write."
+              : "Read-only · stdio · exposes git & GitHub tools (status, log, diff, blame, PRs, issues, CI)."}
           </p>
+
+          <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Replace existing entry?</DialogTitle>
+                <DialogDescription>
+                  This repo's .mcp.json already has a gitdesktop entry. Replace
+                  it with the configuration shown?
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={writing}
+                  onClick={() => setConfirmOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={writing}
+                  onClick={() => write(true)}
+                >
+                  {writing ? (
+                    <>
+                      <Spinner className="size-3" /> Replacing…
+                    </>
+                  ) : (
+                    "Replace entry"
+                  )}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </div>
       )}
     </div>

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -19,7 +19,7 @@ import {
 } from "@/lib/git/api";
 import type { DiffStatEntry } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
-import { listLocalPrs, saveLocalPr } from "@/lib/pulls/local";
+import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import { getLatestReview, saveReview } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
@@ -414,13 +414,13 @@ async function deliver(
     });
     return;
   }
-  await saveLocalPr(event.repoPath, {
-    ...pr,
+  await updateLocalPr(event.repoPath, targetId, (cur) => ({
+    ...cur,
     comments: [
-      ...pr.comments,
+      ...cur.comments,
       { id: crypto.randomUUID(), body, createdAt: new Date().toISOString() },
     ],
-  });
+  }));
   await queryClient.invalidateQueries({
     queryKey: ["local-prs", event.repoPath],
   });

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2256,6 +2256,21 @@ export const readTextFile = (path: string) =>
  *  GitDesktop as an MCP server" config snippet (`<exe> mcp --repo <path>`). */
 export const appExePath = () => invoke<string>("app_exe_path");
 
+/** Merge the `gitdesktop` MCP entry into `<repo>/.mcp.json`, preserving any
+ *  sibling servers. Returns whether it wrote and whether an entry already
+ *  existed; with `overwrite:false` an existing entry is left untouched
+ *  (`{ existed: true, written: false }`). */
+export const mcpJsonWrite = (
+  repoPath: string,
+  entry: unknown,
+  overwrite: boolean,
+) =>
+  invoke<{ written: boolean; existed: boolean }>("mcp_json_write", {
+    repoPath,
+    entry,
+    overwrite,
+  });
+
 // Cold-start test mode keeps API keys in an isolated sessionStorage store so
 // the OS keychain (and the user's real keys) are never touched (no-op normally).
 export const setSecret = (provider: string, value: string) =>

--- a/src/lib/issues/local.ts
+++ b/src/lib/issues/local.ts
@@ -35,6 +35,23 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+// Serialize every read-modify-write on this store (and the reload) through one in-process
+// queue — mirrors the local-PR store. Without it two overlapping mutations each reload the
+// SAME pre-flush disk snapshot (autoSave persists on a ~100ms debounce) and the later write
+// drops the earlier one's change. writeAll force-saves so each reload sees a current one.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  await store.reload({ ignoreDefaults: true });
+}
+
 export async function listLocalIssues(repo: string): Promise<LocalIssue[]> {
   const store = await getStore();
   const issues = (await store.get<LocalIssue[]>(repo)) ?? [];
@@ -45,6 +62,8 @@ export async function listLocalIssues(repo: string): Promise<LocalIssue[]> {
 async function writeAll(repo: string, issues: LocalIssue[]): Promise<void> {
   const store = await getStore();
   await store.set(repo, issues);
+  // Flush now (not on autoSave's debounce) so the next serialized reload can't drop this.
+  await store.save();
 }
 
 /** Re-read `local-issues.json` from disk into the in-memory store. Kept symmetric
@@ -52,27 +71,28 @@ async function writeAll(repo: string, issues: LocalIssue[]): Promise<void> {
  *  local issues have no external writer today, but every mutation reloads first so the
  *  API is uniform and future-proof if one is ever added. */
 export async function reloadLocalIssues(): Promise<void> {
-  const store = await getStore();
-  await store.reload({ ignoreDefaults: true });
+  return serialize(reloadRaw);
 }
 
 export async function createLocalIssue(
   repo: string,
   input: { title: string; body: string },
 ): Promise<LocalIssue> {
-  const issue: LocalIssue = {
-    id: crypto.randomUUID(),
-    title: input.title,
-    body: input.body,
-    status: "open",
-    labels: [],
-    comments: [],
-    createdAt: new Date().toISOString(),
-  };
-  await reloadLocalIssues();
-  const all = await listLocalIssues(repo);
-  await writeAll(repo, [issue, ...all]);
-  return issue;
+  return serialize(async () => {
+    await reloadRaw();
+    const issue: LocalIssue = {
+      id: crypto.randomUUID(),
+      title: input.title,
+      body: input.body,
+      status: "open",
+      labels: [],
+      comments: [],
+      createdAt: new Date().toISOString(),
+    };
+    const all = await listLocalIssues(repo);
+    await writeAll(repo, [issue, ...all]);
+    return issue;
+  });
 }
 
 /** Apply `mutate` to the FRESH on-disk record for `id`, then persist — mirrors
@@ -83,24 +103,28 @@ export async function updateLocalIssue(
   id: string,
   mutate: (issue: LocalIssue) => LocalIssue,
 ): Promise<LocalIssue> {
-  await reloadLocalIssues();
-  const all = await listLocalIssues(repo);
-  const idx = all.findIndex((i) => i.id === id);
-  if (idx === -1) throw new Error(`no local issue with id ${id}`);
-  const next = [...all];
-  next[idx] = mutate(all[idx]);
-  await writeAll(repo, next);
-  return next[idx];
+  return serialize(async () => {
+    await reloadRaw();
+    const all = await listLocalIssues(repo);
+    const idx = all.findIndex((i) => i.id === id);
+    if (idx === -1) throw new Error(`no local issue with id ${id}`);
+    const next = [...all];
+    next[idx] = mutate(all[idx]);
+    await writeAll(repo, next);
+    return next[idx];
+  });
 }
 
 export async function deleteLocalIssue(
   repo: string,
   id: string,
 ): Promise<void> {
-  await reloadLocalIssues();
-  const all = await listLocalIssues(repo);
-  await writeAll(
-    repo,
-    all.filter((i) => i.id !== id),
-  );
+  return serialize(async () => {
+    await reloadRaw();
+    const all = await listLocalIssues(repo);
+    await writeAll(
+      repo,
+      all.filter((i) => i.id !== id),
+    );
+  });
 }

--- a/src/lib/issues/local.ts
+++ b/src/lib/issues/local.ts
@@ -47,6 +47,15 @@ async function writeAll(repo: string, issues: LocalIssue[]): Promise<void> {
   await store.set(repo, issues);
 }
 
+/** Re-read `local-issues.json` from disk into the in-memory store. Kept symmetric
+ *  with the local-PR store's reconcile-before-mutate discipline (see reloadLocalPrs);
+ *  local issues have no external writer today, but every mutation reloads first so the
+ *  API is uniform and future-proof if one is ever added. */
+export async function reloadLocalIssues(): Promise<void> {
+  const store = await getStore();
+  await store.reload({ ignoreDefaults: true });
+}
+
 export async function createLocalIssue(
   repo: string,
   input: { title: string; body: string },
@@ -60,27 +69,35 @@ export async function createLocalIssue(
     comments: [],
     createdAt: new Date().toISOString(),
   };
+  await reloadLocalIssues();
   const all = await listLocalIssues(repo);
   await writeAll(repo, [issue, ...all]);
   return issue;
 }
 
-/** Upserts the given issue (used for comment/label/status edits). */
-export async function saveLocalIssue(
+/** Apply `mutate` to the FRESH on-disk record for `id`, then persist — mirrors
+ *  updateLocalPr so both local-entity stores share one reconcile-before-mutate shape.
+ *  Throws if the issue no longer exists. */
+export async function updateLocalIssue(
   repo: string,
-  issue: LocalIssue,
-): Promise<void> {
+  id: string,
+  mutate: (issue: LocalIssue) => LocalIssue,
+): Promise<LocalIssue> {
+  await reloadLocalIssues();
   const all = await listLocalIssues(repo);
-  await writeAll(
-    repo,
-    all.map((i) => (i.id === issue.id ? issue : i)),
-  );
+  const idx = all.findIndex((i) => i.id === id);
+  if (idx === -1) throw new Error(`no local issue with id ${id}`);
+  const next = [...all];
+  next[idx] = mutate(all[idx]);
+  await writeAll(repo, next);
+  return next[idx];
 }
 
 export async function deleteLocalIssue(
   repo: string,
   id: string,
 ): Promise<void> {
+  await reloadLocalIssues();
   const all = await listLocalIssues(repo);
   await writeAll(
     repo,

--- a/src/lib/issues/queries.ts
+++ b/src/lib/issues/queries.ts
@@ -4,7 +4,7 @@ import {
   deleteLocalIssue,
   type LocalIssue,
   listLocalIssues,
-  saveLocalIssue,
+  updateLocalIssue,
 } from "./local";
 
 const localIssueKey = (repo: string) => ["local-issues", repo] as const;
@@ -34,9 +34,16 @@ export function useCreateLocalIssue(repo: string) {
   );
 }
 
-export function useSaveLocalIssue(repo: string) {
-  return useLocalIssueMutation(repo, (issue: LocalIssue) =>
-    saveLocalIssue(repo, issue),
+export function useUpdateLocalIssue(repo: string) {
+  return useLocalIssueMutation(
+    repo,
+    ({
+      id,
+      mutate,
+    }: {
+      id: string;
+      mutate: (issue: LocalIssue) => LocalIssue;
+    }) => updateLocalIssue(repo, id, mutate),
   );
 }
 

--- a/src/lib/pulls/local.ts
+++ b/src/lib/pulls/local.ts
@@ -38,6 +38,15 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+/** Re-read `local-prs.json` from disk into the in-memory store. The MCP server
+ *  (with `--allow-write`) can mutate this file externally; without a reload the
+ *  autoSave store would clobber those writes on the next GUI mutation.
+ *  `ignoreDefaults` fully matches the store to disk (so external deletes drop). */
+export async function reloadLocalPrs(): Promise<void> {
+  const store = await getStore();
+  await store.reload({ ignoreDefaults: true });
+}
+
 export async function listLocalPrs(repo: string): Promise<LocalPr[]> {
   const store = await getStore();
   const prs = (await store.get<LocalPr[]>(repo)) ?? [];

--- a/src/lib/pulls/local.ts
+++ b/src/lib/pulls/local.ts
@@ -83,15 +83,24 @@ export async function createLocalPr(
   return pr;
 }
 
-/** Upserts the given PR (used for approve/comment/status edits). */
-export async function saveLocalPr(repo: string, pr: LocalPr): Promise<void> {
-  // Fresh disk state first, so we don't drop a concurrent external MCP write.
+/** Apply `mutate` to the FRESH on-disk record for `id`, then persist. Reloads from
+ *  disk first, so a concurrent external MCP write to the SAME PR (e.g. a comment the
+ *  server appended while the GUI was open) is merged against — not clobbered by — a
+ *  stale in-memory snapshot. `mutate` receives the current record and returns the next
+ *  one: append to `cur.comments`, or set a field. Throws if the PR no longer exists. */
+export async function updateLocalPr(
+  repo: string,
+  id: string,
+  mutate: (pr: LocalPr) => LocalPr,
+): Promise<LocalPr> {
   await reloadLocalPrs();
   const all = await listLocalPrs(repo);
-  await writeAll(
-    repo,
-    all.map((p) => (p.id === pr.id ? pr : p)),
-  );
+  const idx = all.findIndex((p) => p.id === id);
+  if (idx === -1) throw new Error(`no local PR with id ${id}`);
+  const next = [...all];
+  next[idx] = mutate(all[idx]);
+  await writeAll(repo, next);
+  return next[idx];
 }
 
 export async function deleteLocalPr(repo: string, id: string): Promise<void> {

--- a/src/lib/pulls/local.ts
+++ b/src/lib/pulls/local.ts
@@ -38,13 +38,32 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+// Serialize every read-modify-write on this store (and the reconcile reload) through one
+// in-process queue. Without it, two overlapping mutations each reload the SAME pre-flush
+// disk snapshot — autoSave persists on a ~100ms debounce, so the first write isn't on disk
+// yet — and the later write drops the earlier one's change (a lost update; e.g. the
+// reconcile hook marking several PRs in a parallel forEach). Running them one at a time,
+// plus the force-save in writeAll, guarantees each reload sees a current snapshot.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  await store.reload({ ignoreDefaults: true });
+}
+
 /** Re-read `local-prs.json` from disk into the in-memory store. The MCP server
  *  (with `--allow-write`) can mutate this file externally; without a reload the
  *  autoSave store would clobber those writes on the next GUI mutation.
- *  `ignoreDefaults` fully matches the store to disk (so external deletes drop). */
+ *  `ignoreDefaults` fully matches the store to disk (so external deletes drop).
+ *  Serialized so it can't land between another mutation's set and its flush. */
 export async function reloadLocalPrs(): Promise<void> {
-  const store = await getStore();
-  await store.reload({ ignoreDefaults: true });
+  return serialize(reloadRaw);
 }
 
 export async function listLocalPrs(repo: string): Promise<LocalPr[]> {
@@ -57,30 +76,35 @@ export async function listLocalPrs(repo: string): Promise<LocalPr[]> {
 async function writeAll(repo: string, prs: LocalPr[]): Promise<void> {
   const store = await getStore();
   await store.set(repo, prs);
+  // Flush now instead of on autoSave's debounce, so the next serialized reload can't
+  // re-read a pre-write disk snapshot and drop this change.
+  await store.save();
 }
 
 export async function createLocalPr(
   repo: string,
   input: { title: string; body: string; base: string; head: string },
 ): Promise<LocalPr> {
-  // Reconcile any external MCP (--allow-write) writes from disk before we read-modify-
-  // write, so a GUI mutation never clobbers a PR the server added while we were focused.
-  await reloadLocalPrs();
-  const pr: LocalPr = {
-    id: crypto.randomUUID(),
-    title: input.title,
-    body: input.body,
-    base: input.base,
-    head: input.head,
-    status: "open",
-    approved: false,
-    labels: [],
-    comments: [],
-    createdAt: new Date().toISOString(),
-  };
-  const all = await listLocalPrs(repo);
-  await writeAll(repo, [pr, ...all]);
-  return pr;
+  return serialize(async () => {
+    // Reconcile any external MCP (--allow-write) writes from disk before we read-modify-
+    // write, so a GUI mutation never clobbers a PR the server added while we were focused.
+    await reloadRaw();
+    const pr: LocalPr = {
+      id: crypto.randomUUID(),
+      title: input.title,
+      body: input.body,
+      base: input.base,
+      head: input.head,
+      status: "open",
+      approved: false,
+      labels: [],
+      comments: [],
+      createdAt: new Date().toISOString(),
+    };
+    const all = await listLocalPrs(repo);
+    await writeAll(repo, [pr, ...all]);
+    return pr;
+  });
 }
 
 /** Apply `mutate` to the FRESH on-disk record for `id`, then persist. Reloads from
@@ -93,22 +117,26 @@ export async function updateLocalPr(
   id: string,
   mutate: (pr: LocalPr) => LocalPr,
 ): Promise<LocalPr> {
-  await reloadLocalPrs();
-  const all = await listLocalPrs(repo);
-  const idx = all.findIndex((p) => p.id === id);
-  if (idx === -1) throw new Error(`no local PR with id ${id}`);
-  const next = [...all];
-  next[idx] = mutate(all[idx]);
-  await writeAll(repo, next);
-  return next[idx];
+  return serialize(async () => {
+    await reloadRaw();
+    const all = await listLocalPrs(repo);
+    const idx = all.findIndex((p) => p.id === id);
+    if (idx === -1) throw new Error(`no local PR with id ${id}`);
+    const next = [...all];
+    next[idx] = mutate(all[idx]);
+    await writeAll(repo, next);
+    return next[idx];
+  });
 }
 
 export async function deleteLocalPr(repo: string, id: string): Promise<void> {
-  // Fresh disk state first, so we don't drop a concurrent external MCP write.
-  await reloadLocalPrs();
-  const all = await listLocalPrs(repo);
-  await writeAll(
-    repo,
-    all.filter((p) => p.id !== id),
-  );
+  return serialize(async () => {
+    // Fresh disk state first, so we don't drop a concurrent external MCP write.
+    await reloadRaw();
+    const all = await listLocalPrs(repo);
+    await writeAll(
+      repo,
+      all.filter((p) => p.id !== id),
+    );
+  });
 }

--- a/src/lib/pulls/local.ts
+++ b/src/lib/pulls/local.ts
@@ -63,6 +63,9 @@ export async function createLocalPr(
   repo: string,
   input: { title: string; body: string; base: string; head: string },
 ): Promise<LocalPr> {
+  // Reconcile any external MCP (--allow-write) writes from disk before we read-modify-
+  // write, so a GUI mutation never clobbers a PR the server added while we were focused.
+  await reloadLocalPrs();
   const pr: LocalPr = {
     id: crypto.randomUUID(),
     title: input.title,
@@ -82,6 +85,8 @@ export async function createLocalPr(
 
 /** Upserts the given PR (used for approve/comment/status edits). */
 export async function saveLocalPr(repo: string, pr: LocalPr): Promise<void> {
+  // Fresh disk state first, so we don't drop a concurrent external MCP write.
+  await reloadLocalPrs();
   const all = await listLocalPrs(repo);
   await writeAll(
     repo,
@@ -90,6 +95,8 @@ export async function saveLocalPr(repo: string, pr: LocalPr): Promise<void> {
 }
 
 export async function deleteLocalPr(repo: string, id: string): Promise<void> {
+  // Fresh disk state first, so we don't drop a concurrent external MCP write.
+  await reloadLocalPrs();
   const all = await listLocalPrs(repo);
   await writeAll(
     repo,

--- a/src/lib/pulls/queries.ts
+++ b/src/lib/pulls/queries.ts
@@ -9,7 +9,7 @@ import {
   deleteLocalPr,
   type LocalPr,
   listLocalPrs,
-  saveLocalPr,
+  updateLocalPr,
 } from "./local";
 import {
   clearReviewsFor,
@@ -47,8 +47,12 @@ export function useCreateLocalPr(repo: string) {
   );
 }
 
-export function useSaveLocalPr(repo: string) {
-  return useLocalPrMutation(repo, (pr: LocalPr) => saveLocalPr(repo, pr));
+export function useUpdateLocalPr(repo: string) {
+  return useLocalPrMutation(
+    repo,
+    ({ id, mutate }: { id: string; mutate: (pr: LocalPr) => LocalPr }) =>
+      updateLocalPr(repo, id, mutate),
+  );
 }
 
 export function useDeleteLocalPr(repo: string) {


### PR DESCRIPTION
This change allows GitDesktop to act as a shareable MCP server by writing/merging its config entry into `.mcp.json` directly from the GUI, with options for portable team sharing and opt-in write access for local PR tools. It introduces an MCP server mode with local-PR creation, commenting, status, and approval tools—enabled only with an explicit `--allow-write` flag—and ensures safe concurrent access to the local PRs store from both the frontend and the server.

### MCP server config writing and portability

- Adds `mcp_json_write` in `src-tauri/src/mcp.rs` (and exports via `src-tauri/src/lib.rs`), which merges or creates the `gitdesktop` entry in `.mcp.json`, preserving siblings/top-level keys, and guarding against accidental overwrite.
- Implements a result struct (`McpJsonWriteResult`) to communicate "written/existed" status to the frontend.
- Updates `src/features/settings/McpServersSection.tsx` to:
  - Provide a UI for writing or replacing `.mcp.json` entries from the GUI, with confirmation dialogs.
  - Add toggles for “Shareable entry” (portable `${GITDESKTOP_BIN}`/`${CLAUDE_PROJECT_DIR}` paths) and “Allow write tools” (adds `--allow-write`)—these control both the copyable config snippet and the written config.
  - Surface immediate user feedback and error handling for config write actions.
- Exposes `mcpJsonWrite` API to the frontend in `src/lib/git/api.ts`.

### Local PR write tools and concurrency

- Implements a new local PRs core in `src-tauri/src/local_prs.rs`, providing safe, atomic, value-preserving mutations to the `local-prs.json` store used by both GUI and MCP server, including:
  - Safe tolerant handling of repo keys across platforms.
  - Guarding against data loss from unknown/future fields.
  - Tests for store logic and file handling.
- Exposes new MCP write tools in `src-tauri/src/mcp_server.rs`:
  - `create_local_pr`, `comment_local_pr`, `set_local_pr_status`, `approve_local_pr` methods, all opt-in behind the `--allow-write` server argument. 
  - Pre-mutation guards ensure branches exist before creation.
  - Clear error when write tools are invoked without explicit enablement.
  - Argument parsing for `--repo` and `--allow-write` via the new `McpArgs` struct.
  - Updates server instructions to explain the write tools and their safeguards.
  - Unit tests for argument parsing and branch resolution.
- Updates the app's focus handler in `src/App.tsx` to reload the local PR store from disk before querying, ensuring external writes via MCP server are visible in the frontend.

### Documentation and UI

- Enhances the README.md to document shareable and write-enabled MCP server config, as well as the `.mcp.json` write capability and its options.
- Updates `src/features/help/content.ts` to explain new features, usage, and the opt-in model for write tools in the MCP server panel.
- Adds a changelog entry (`changelog.d/added-mcp-server-write-config.md`) summarizing user-facing improvements.
- Updates site copy in `site/src/pages/index.astro` to clarify the MCP server’s read-only (by default) and write tool capabilities.

### Supporting and other changes

- Declares new direct dependencies (`dirs`, `uuid`, `chrono`) in `src-tauri/Cargo.toml` to implement platform-aware app-data paths and record metadata.
- Updates `src-tauri/Cargo.lock` to include new Rust dependencies.
- Adds a reload utility in `src/lib/pulls/local.ts` to force disk reload of `local-prs.json`, ensuring app and MCP server cannot race or lose edits.

This integrates and documents out-of-the-box portable MCP server config (with flexible sharing and write-ability), strengthens safe cross-process local PRs management, and brings direct, in-app controls for advanced MCP workflows.