### PR TITLE
feat(mcp,ui): add per-client global install status and update-safe MCP launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,15 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   Bitbucket covers PRs and pipelines, but not issues). **Settings → MCP servers** shows a
   ready-to-paste config snippet — or **writes it straight into the repo's `.mcp.json`**
   for you (with a **Shareable** toggle for portable, teammate-committable paths), or
-  **installs it globally** for **Claude Code** or **Copilot** in one click (into the
-  client's user config, available in every project) — plus a
-  one-click **Add to PATH** launcher so the bare `gitdesktop` command resolves in any
-  terminal (adds the app to your user PATH on Windows, or symlinks it into `~/.local/bin`
-  on macOS/Linux — reversible, no admin). The app runs as a stdio server
-  (`gitdesktop mcp --repo <path>`), so an agent can *understand* a repo without touching
-  it. Two **separate, orthogonal** write opt-ins layer on top:
+  **installs it globally** for **Claude Code** or **Copilot** — per-client rows that show
+  each one's live state (installed & pointing at the current launcher, or at an older
+  install with one-click **Reinstall**) and let you **Remove** it, all into the client's
+  user config so it's available in every project — plus a
+  one-click **Add to PATH** launcher so the bare `gitdesktop-mcp` command resolves in any
+  terminal (puts the managed-copy bin dir on your user PATH on Windows, or symlinks
+  `gitdesktop-mcp` into `~/.local/bin` on macOS/Linux — reversible, no admin). The app
+  runs as a stdio server (its own binary on macOS/Linux, an update-safe `gitdesktop-mcp`
+  copy on Windows), so an agent can *understand* a repo without touching it. Two **separate, orthogonal** write opt-ins layer on top:
   **Allow write tools** (`--allow-write`) lets it create, comment on, and approve *this
   repo's* local PRs (GitDesktop's own app-data review artifacts — nothing is pushed);
   **Allow remote write** (`--allow-remote-write`) lets it make *real* forge writes under

--- a/changelog.d/added-mcp-global-install-status.md
+++ b/changelog.d/added-mcp-global-install-status.md
@@ -1,0 +1,6 @@
+- **See and manage your global MCP install per client.** In **Settings → MCP servers →
+  Use GitDesktop as an MCP server**, the *Install globally* section now shows a live row for
+  **Claude Code** and **Copilot**: whether GitDesktop is installed in that client's user
+  config, and whether it points at the current launcher or an older install (with a
+  one-click **Reinstall** to switch it over). Each installed client gets a **Remove** button
+  that takes the entry back out via the client's own CLI.

--- a/changelog.d/fixed-mcp-installer-file-lock.md
+++ b/changelog.d/fixed-mcp-installer-file-lock.md
@@ -1,0 +1,6 @@
+- **MCP server no longer blocks installs or gets killed by updates (Windows).** When you
+  use GitDesktop as an MCP server, the generated config now launches a dedicated
+  `gitdesktop-mcp` copy of the app instead of the installed executable. Running MCP
+  servers no longer lock the installer out with a "Files in Use" dialog, and are no
+  longer silently terminated mid-session by a passive auto-update. **Add to PATH** now
+  points at this launcher and migrates any older install-folder entry automatically.

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -69,15 +69,6 @@ pub fn atomic_write(path: &Path, contents: &[u8]) -> AppResult<()> {
     Ok(())
 }
 
-/// Absolute path to the running app executable. Used to build the "Use GitDesktop
-/// as an MCP server" client-config snippet, whose command is `<this exe> mcp`.
-#[tauri::command]
-pub fn app_exe_path() -> AppResult<String> {
-    std::env::current_exe()
-        .map(|p| p.to_string_lossy().into_owned())
-        .map_err(AppError::Io)
-}
-
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DetectedEditor {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod hooks;
 mod instructions;
 mod local_prs;
 mod mcp;
+mod mcp_launcher;
 mod mcp_server;
 mod oplog;
 mod path_launcher;
@@ -56,6 +57,17 @@ pub fn run() {
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
                 tray::setup_tray(app.handle())?;
                 tray::init_window_title(app.handle());
+                // On Windows, keep the managed MCP launcher copy fresh after an
+                // update — but only if it already exists (lazy: never-used ⇒
+                // never copied). Fire-and-forget so startup never blocks on the
+                // ~50MB copy; a stale copy still serves running sessions.
+                #[cfg(windows)]
+                {
+                    let version = app.package_info().version.to_string();
+                    tauri::async_runtime::spawn_blocking(move || {
+                        mcp_launcher::refresh_if_present(&version);
+                    });
+                }
             }
             Ok(())
         })
@@ -535,7 +547,7 @@ pub fn run() {
             fsops::open_with_program,
             fsops::detect_editors,
             fsops::detect_terminals,
-            fsops::app_exe_path,
+            mcp_launcher::mcp_launcher_path,
             path_launcher::path_launcher_status,
             path_launcher::path_launcher_install,
             path_launcher::path_launcher_remove,
@@ -557,6 +569,8 @@ pub fn run() {
             mcp::discover_mcp_servers,
             mcp::mcp_json_write,
             mcp::mcp_global_install,
+            mcp::mcp_global_status,
+            mcp::mcp_global_remove,
             instructions::read_repo_instructions,
             instructions::read_repo_ai_ignore,
             instructions::read_repo_branch_rules,

--- a/src-tauri/src/local_prs.rs
+++ b/src-tauri/src/local_prs.rs
@@ -51,7 +51,7 @@ use serde_json::{Map, Value};
 use crate::error::{AppError, AppResult};
 
 /// The Tauri bundle identifier — the app-data subdir the store plugin writes under.
-const APP_IDENTIFIER: &str = "com.thebguy.gitdesktop";
+pub(crate) const APP_IDENTIFIER: &str = "com.thebguy.gitdesktop";
 /// The store filename (always the real name; the cold-start alias is GUI-only).
 const STORE_FILE: &str = "local-prs.json";
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -832,16 +832,18 @@ pub struct McpGlobalStatus {
     pub copilot: McpGlobalClientStatus,
 }
 
-/// Path-normalized comparison for the launcher-path check: case-insensitive,
-/// `/` vs `\` insensitive, trailing-separator insensitive. Mirrors
-/// `path_launcher::norm` (which is `#[cfg(windows)]`-private, so it's re-derived
-/// locally here) and additionally folds interior separators so a config written
-/// with `/` still matches a resolved path spelled with `\`.
+/// Path-normalized comparison for the launcher-path check: trailing-separator
+/// insensitive and `/` vs `\` insensitive (unconditional — the separator fold is
+/// applied to both sides, so it stays compare-safe everywhere). Case folding is
+/// gated to case-insensitive filesystems (Windows, macOS); on Linux two paths
+/// differing only in case are genuinely distinct, so case is preserved there.
+/// Mirrors `path_launcher::norm` (which is `#[cfg(windows)]`-private, so it's
+/// re-derived locally here) with the interior-separator fold added.
 fn norm_launcher_path(p: &str) -> String {
-    p.trim()
-        .trim_end_matches(['\\', '/'])
-        .replace('/', "\\")
-        .to_ascii_lowercase()
+    let normalized = p.trim().trim_end_matches(['\\', '/']).replace('/', "\\");
+    #[cfg(any(windows, target_os = "macos"))]
+    let normalized = normalized.to_ascii_lowercase();
+    normalized
 }
 
 /// Classify a client's user-config JSON into an [`McpGlobalClientStatus`] for the
@@ -934,7 +936,7 @@ pub async fn mcp_global_status(app: tauri::AppHandle) -> AppResult<McpGlobalStat
 /// entry that doesn't exist lets the CLI's own behavior/error pass through (the
 /// UI only offers Remove when installed; a race just yields the CLI's message).
 #[tauri::command]
-pub async fn mcp_global_remove(client: String, _app: tauri::AppHandle) -> AppResult<()> {
+pub async fn mcp_global_remove(client: String) -> AppResult<()> {
     let (stdout, stderr, code) = match client.as_str() {
         "claude" => claude_global_remove().await?,
         "copilot" => copilot_global_remove().await?,
@@ -1193,14 +1195,28 @@ mod tests {
     }
 
     #[test]
-    fn classify_current_is_normalization_robust() {
-        // Config command differs from the launcher only by case, separator style,
-        // and a trailing separator — still the current launcher.
-        let configured = r"c:/Users/me/AppData/Local/com.thebguy.gitdesktop/bin/gitdesktop-mcp.exe";
+    fn classify_current_is_separator_and_trailing_robust() {
+        // Config command differs from the launcher only by separator style and a
+        // trailing separator (same case) — matches on every platform.
+        let configured =
+            r"C:/Users/me/AppData/Local/com.thebguy.gitdesktop/bin/gitdesktop-mcp.exe/";
         let doc = json!({ "mcpServers": { "gitdesktop": { "command": configured } } });
         let s = classify_global_entry(&doc, LAUNCHER);
         assert!(s.installed);
-        assert!(s.current, "case/separator differences must still match");
+        assert!(s.current, "separator/trailing differences must still match");
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn classify_current_is_case_robust_on_case_insensitive_fs() {
+        // On case-insensitive filesystems a case-only (plus separator) difference
+        // is still the current launcher. (On Linux those paths are distinct, so
+        // this is gated — see `norm_launcher_path`.)
+        let configured = r"c:/users/ME/appdata/local/com.thebguy.gitdesktop/bin/gitdesktop-mcp.exe";
+        let doc = json!({ "mcpServers": { "gitdesktop": { "command": configured } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert!(s.current, "case differences must match on case-insensitive fs");
     }
 
     #[test]
@@ -1232,7 +1248,25 @@ mod tests {
     }
 
     #[test]
-    fn norm_launcher_path_folds_case_separators_and_trailing() {
+    fn norm_launcher_path_folds_separators_and_trailing() {
+        // Separator style + trailing separator + surrounding whitespace fold
+        // unconditionally, so identically-cased inputs normalize equal on every
+        // platform. (Asserted as an equality invariant rather than a literal,
+        // since the case of the output is platform-dependent.)
+        assert_eq!(
+            norm_launcher_path(r"C:\Foo\Bar\"),
+            norm_launcher_path("C:/Foo/Bar")
+        );
+        assert_eq!(
+            norm_launcher_path("  C:\\Foo/Bar/  "),
+            norm_launcher_path(r"C:\Foo\Bar")
+        );
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn norm_launcher_path_folds_case_on_case_insensitive_fs() {
+        // Case folding is gated to case-insensitive filesystems.
         assert_eq!(
             norm_launcher_path(r"C:\Foo\Bar\"),
             norm_launcher_path(r"c:/foo/bar")

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -717,6 +717,19 @@ pub async fn mcp_global_install(
     }
 }
 
+/// Remove the `gitdesktop` entry from Claude's GLOBAL (user-scope) config via its
+/// own CLI. `-s user` scopes to the user config (where `add-json -s user` writes).
+async fn claude_global_remove() -> AppResult<(String, String, i32)> {
+    run_client_cli("claude", &["mcp", "remove", "gitdesktop", "-s", "user"]).await
+}
+
+/// Remove the `gitdesktop` entry from Copilot's user config via its own CLI.
+/// `copilot mcp remove` takes NO scope flag — it only ever manages the user config
+/// (`~/.copilot/mcp-config.json`), which is exactly where `add` writes.
+async fn copilot_global_remove() -> AppResult<(String, String, i32)> {
+    run_client_cli("copilot", &["mcp", "remove", "gitdesktop"]).await
+}
+
 async fn claude_global_install(
     command: &str,
     args: &[String],
@@ -726,7 +739,7 @@ async fn claude_global_install(
         .map_err(|e| AppError::Command(format!("serialize entry: {e}")))?;
     if overwrite {
         // May or may not exist; a "not found" remove is harmless.
-        let _ = run_client_cli("claude", &["mcp", "remove", "gitdesktop", "-s", "user"]).await;
+        let _ = claude_global_remove().await;
     }
     let (stdout, stderr, code) = run_client_cli(
         "claude",
@@ -758,7 +771,7 @@ async fn copilot_global_install(
         // `copilot mcp remove` takes NO scope flag — it only ever manages the user
         // config (`~/.copilot/mcp-config.json`), which is exactly where `add`
         // writes, so there's no scope to mismatch. A "not found" remove is harmless.
-        let _ = run_client_cli("copilot", &["mcp", "remove", "gitdesktop"]).await;
+        let _ = copilot_global_remove().await;
     }
     // `copilot mcp add gitdesktop -- <command> <args...>` — everything after `--`
     // is the stdio launch command, written to Copilot's user config.
@@ -776,6 +789,167 @@ async fn copilot_global_install(
     }
     Err(AppError::Command(format!(
         "`copilot mcp add` failed: {}",
+        out.trim()
+    )))
+}
+
+// --- global install STATUS + REMOVE ------------------------------------------
+//
+// The Settings "Install globally" buttons write a `gitdesktop` server into a
+// client's user config. These read-only probes let the UI tell whether an entry
+// already exists — and whether it points at the CURRENT managed launcher vs an
+// older install path (old-path entries keep locking the installed exe against
+// updates) — and the remove command lets the UI clear one.
+
+/// Per-client global-install status. See the frozen contract in P4.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpGlobalClientStatus {
+    /// A `gitdesktop` entry exists in this client's global (user) config.
+    pub installed: bool,
+    /// The configured command string, when installed and readable.
+    pub command: Option<String>,
+    /// The configured command points at the CURRENT managed launcher path
+    /// (path-normalized compare). False for older install paths or custom entries.
+    pub current: bool,
+}
+
+impl McpGlobalClientStatus {
+    fn not_installed() -> Self {
+        Self {
+            installed: false,
+            command: None,
+            current: false,
+        }
+    }
+}
+
+/// Global-install status across every supported client.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpGlobalStatus {
+    pub claude: McpGlobalClientStatus,
+    pub copilot: McpGlobalClientStatus,
+}
+
+/// Path-normalized comparison for the launcher-path check: case-insensitive,
+/// `/` vs `\` insensitive, trailing-separator insensitive. Mirrors
+/// `path_launcher::norm` (which is `#[cfg(windows)]`-private, so it's re-derived
+/// locally here) and additionally folds interior separators so a config written
+/// with `/` still matches a resolved path spelled with `\`.
+fn norm_launcher_path(p: &str) -> String {
+    p.trim()
+        .trim_end_matches(['\\', '/'])
+        .replace('/', "\\")
+        .to_ascii_lowercase()
+}
+
+/// Classify a client's user-config JSON into an [`McpGlobalClientStatus`] for the
+/// `gitdesktop` entry. Pure — takes the parsed config `Value` and the current
+/// launcher path so tests need no filesystem or env. Tolerant of untrusted JSON:
+///
+/// * `mcpServers.gitdesktop` absent (or the shape isn't a map) ⇒ not installed.
+/// * present but `command` isn't a string ⇒ installed, `command: None`,
+///   `current: false`.
+/// * present with a string `command` ⇒ installed; `current` iff it path-normal-
+///   equals `launcher_path`.
+fn classify_global_entry(config: &Value, launcher_path: &str) -> McpGlobalClientStatus {
+    let Some(entry) = config
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .and_then(|m| m.get("gitdesktop"))
+    else {
+        return McpGlobalClientStatus::not_installed();
+    };
+    let Some(command) = entry.get("command").and_then(|v| v.as_str()) else {
+        // Present but no string command — installed, but we can't classify it.
+        return McpGlobalClientStatus {
+            installed: true,
+            command: None,
+            current: false,
+        };
+    };
+    let current = norm_launcher_path(command) == norm_launcher_path(launcher_path);
+    McpGlobalClientStatus {
+        installed: true,
+        command: Some(command.to_string()),
+        current,
+    }
+}
+
+/// Read + parse a client's user-config file into a JSON `Value`, tolerantly: a
+/// missing / oversized / unreadable / malformed file yields `None` (⇒ treated as
+/// "not installed" by the caller), never an error. The size guard matches
+/// `collect_discovered` — `~/.claude.json` also holds chat history.
+fn read_global_config(path: &Path) -> Option<Value> {
+    const MAX_BYTES: u64 = 16 * 1024 * 1024;
+    match std::fs::metadata(path) {
+        Ok(m) if m.len() <= MAX_BYTES => {}
+        _ => return None,
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str::<Value>(&text).ok()
+}
+
+/// Read-only status of the `gitdesktop` global (user-scope) MCP install for each
+/// client: whether an entry exists, its configured command, and whether that
+/// command points at the CURRENT managed launcher. Reads config files directly
+/// (Claude `~/.claude.json`, Copilot `~/.copilot/mcp-config.json`) — it does NOT
+/// shell out and, critically, does NOT ensure/create the managed launcher copy
+/// (uses [`mcp_launcher::resolved_launcher_path`], a zero-write path accessor).
+/// Never errors on a missing/malformed config — those read as "not installed".
+#[tauri::command]
+pub async fn mcp_global_status(app: tauri::AppHandle) -> AppResult<McpGlobalStatus> {
+    use tauri::Manager;
+
+    // Zero-write: resolve the launcher path WITHOUT ensuring the copy.
+    let launcher = crate::mcp_launcher::resolved_launcher_path()?
+        .to_string_lossy()
+        .into_owned();
+
+    let (claude, copilot) = match app.path().home_dir() {
+        Ok(home) => {
+            let claude = read_global_config(&home.join(".claude.json"))
+                .map(|cfg| classify_global_entry(&cfg, &launcher))
+                .unwrap_or_else(McpGlobalClientStatus::not_installed);
+            let copilot = read_global_config(&home.join(".copilot").join("mcp-config.json"))
+                .map(|cfg| classify_global_entry(&cfg, &launcher))
+                .unwrap_or_else(McpGlobalClientStatus::not_installed);
+            (claude, copilot)
+        }
+        // No home dir ⇒ nothing to read; report both not-installed rather than error.
+        Err(_) => (
+            McpGlobalClientStatus::not_installed(),
+            McpGlobalClientStatus::not_installed(),
+        ),
+    };
+
+    Ok(McpGlobalStatus { claude, copilot })
+}
+
+/// Remove the `gitdesktop` server from a client's GLOBAL (user-scope) config via
+/// the client's OWN CLI — the same per-client remove invocations the overwrite
+/// path of [`mcp_global_install`] uses. Dispatches on `client` like
+/// `mcp_global_install`; an unknown client is an actionable error. Removing an
+/// entry that doesn't exist lets the CLI's own behavior/error pass through (the
+/// UI only offers Remove when installed; a race just yields the CLI's message).
+#[tauri::command]
+pub async fn mcp_global_remove(client: String, _app: tauri::AppHandle) -> AppResult<()> {
+    let (stdout, stderr, code) = match client.as_str() {
+        "claude" => claude_global_remove().await?,
+        "copilot" => copilot_global_remove().await?,
+        other => {
+            return Err(AppError::Command(format!(
+                "unknown MCP client \"{other}\" (expected \"claude\" or \"copilot\")"
+            )));
+        }
+    };
+    if code == 0 {
+        return Ok(());
+    }
+    let out = format!("{stdout}{stderr}");
+    Err(AppError::Command(format!(
+        "`{client} mcp remove gitdesktop` failed: {}",
         out.trim()
     )))
 }
@@ -988,5 +1162,81 @@ mod tests {
         // Plan (research=false) defines no agent.
         let plan = build_opencode_config(&[], false).unwrap();
         assert!(plan.get("agent").is_none());
+    }
+
+    // --- classify_global_entry ----------------------------------------------
+
+    const LAUNCHER: &str = r"C:\Users\me\AppData\Local\com.thebguy.gitdesktop\bin\gitdesktop-mcp.exe";
+
+    #[test]
+    fn classify_absent_when_no_mcp_servers_or_key() {
+        // Empty doc.
+        let s = classify_global_entry(&json!({}), LAUNCHER);
+        assert!(!s.installed);
+        assert_eq!(s.command, None);
+        assert!(!s.current);
+        // mcpServers present but no gitdesktop.
+        let s = classify_global_entry(&json!({ "mcpServers": { "other": {} } }), LAUNCHER);
+        assert!(!s.installed);
+        // mcpServers wrong shape (array, not map) ⇒ absent.
+        let s = classify_global_entry(&json!({ "mcpServers": [] }), LAUNCHER);
+        assert!(!s.installed);
+    }
+
+    #[test]
+    fn classify_current_when_command_matches_launcher() {
+        let doc = json!({ "mcpServers": { "gitdesktop": { "command": LAUNCHER } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(s.command.as_deref(), Some(LAUNCHER));
+        assert!(s.current, "exact match is current");
+    }
+
+    #[test]
+    fn classify_current_is_normalization_robust() {
+        // Config command differs from the launcher only by case, separator style,
+        // and a trailing separator — still the current launcher.
+        let configured = r"c:/Users/me/AppData/Local/com.thebguy.gitdesktop/bin/gitdesktop-mcp.exe";
+        let doc = json!({ "mcpServers": { "gitdesktop": { "command": configured } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert!(s.current, "case/separator differences must still match");
+    }
+
+    #[test]
+    fn classify_mismatch_for_older_install_path() {
+        // The classic old-path entry: the installed exe, not the managed copy.
+        let old = r"C:\Program Files\gitdesktop\gitdesktop.exe";
+        let doc = json!({ "mcpServers": { "gitdesktop": { "command": old } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(s.command.as_deref(), Some(old));
+        assert!(!s.current, "an older install path is not current");
+    }
+
+    #[test]
+    fn classify_non_string_command_installed_but_unclassified() {
+        // command present but not a string (e.g. a number) ⇒ installed, no command,
+        // not current — never a panic on untrusted JSON.
+        let doc = json!({ "mcpServers": { "gitdesktop": { "command": 42 } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(s.command, None);
+        assert!(!s.current);
+        // command entirely absent ⇒ same (installed, unclassified).
+        let doc = json!({ "mcpServers": { "gitdesktop": { "args": [] } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(s.command, None);
+        assert!(!s.current);
+    }
+
+    #[test]
+    fn norm_launcher_path_folds_case_separators_and_trailing() {
+        assert_eq!(
+            norm_launcher_path(r"C:\Foo\Bar\"),
+            norm_launcher_path(r"c:/foo/bar")
+        );
+        assert_eq!(norm_launcher_path("  C:\\Foo/Bar/  "), r"c:\foo\bar");
     }
 }

--- a/src-tauri/src/mcp_launcher.rs
+++ b/src-tauri/src/mcp_launcher.rs
@@ -1,0 +1,507 @@
+//! Managed copy of the app executable used to run the MCP server.
+//!
+//! The "Use GitDesktop as an MCP server" config points external clients at
+//! `gitdesktop mcp …`, which — until now — ran the *installed* binary
+//! (`C:\Program Files\gitdesktop\gitdesktop.exe`). That has two Windows-only
+//! failure modes:
+//!
+//! * A live MCP server process **locks the install-dir exe**, so an `.msi`
+//!   upgrade fails with "Files in Use".
+//! * The passive NSIS auto-updater does `KillProcess "gitdesktop.exe"`, which
+//!   matches on the **bare filename** — so it silently kills running MCP
+//!   servers.
+//!
+//! Fix: run MCP from a *managed copy* at
+//! `%LOCALAPPDATA%\com.thebguy.gitdesktop\bin\gitdesktop-mcp.exe`. Both
+//! properties are load-bearing — the path (outside the install dir) defeats the
+//! file lock, and the distinct filename defeats kill-by-name.
+//!
+//! This is safe because MCP dispatch is `argv[0]`-independent: `main.rs` checks
+//! only `argv[1] == "mcp"`, and `McpArgs::from_env()` does `.skip(1)`. The copy
+//! therefore behaves exactly like the installed exe when invoked as
+//! `gitdesktop-mcp mcp …`.
+//!
+//! **Management is active** only on Windows *release* builds (or under the
+//! `GD_MCP_LAUNCHER_DIR` override, which exists so dev/live validation can
+//! exercise the machinery). In debug builds, on macOS/Linux, or when there's no
+//! local-data dir, management is INACTIVE and the launcher path is simply
+//! `current_exe()` — dev and Unix behavior are unchanged.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+/// Env override for the managed bin directory. Set → that dir is used as the
+/// managed bin dir in ALL builds (this is how dev/live validation exercises the
+/// copy/refresh machinery without shipping a release build).
+const LAUNCHER_DIR_ENV: &str = "GD_MCP_LAUNCHER_DIR";
+
+/// Launcher filename inside the bin dir — a distinct name so the NSIS
+/// updater's `KillProcess "gitdesktop.exe"` (bare-filename match) can't reap it.
+#[cfg(windows)]
+const LAUNCHER_FILE: &str = "gitdesktop-mcp.exe";
+#[cfg(not(windows))]
+const LAUNCHER_FILE: &str = "gitdesktop-mcp";
+
+/// Staleness marker written beside the launcher after a successful copy.
+const MARKER_FILE: &str = "gitdesktop-mcp.version.json";
+
+/// Records the identity of the source exe that produced the current managed
+/// copy. Its presence at version N is the proof the copy completed — a crash
+/// mid-copy leaves no (or a stale) marker, so the next launch re-copies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Marker {
+    /// The BUNDLE version (`app.package_info().version`), threaded in from the
+    /// command/setup hook. Follows tauri.conf.json → package.json, NOT
+    /// Cargo.toml (which can drift from the shipped bundle version).
+    version: String,
+    /// Byte length of the SOURCE exe at copy time — catches same-version dev
+    /// reinstalls the version string alone wouldn't distinguish.
+    source_len: u64,
+    /// Mtime of the SOURCE exe at copy time, in whole milliseconds since the
+    /// Unix epoch. Complements `source_len` for the same reason.
+    source_mtime_ms: u64,
+}
+
+/// Where the managed launcher lives, and whether we manage it at all.
+enum Resolution {
+    /// Management is active: the launcher is a managed copy in this bin dir.
+    Managed(PathBuf),
+    /// Management is inactive: the "launcher" is just `current_exe()`.
+    Inactive(PathBuf),
+}
+
+/// The managed bin directory, if management is active for this build/env.
+///
+/// Precedence (mirrors `oplog.rs`'s override → real-path resolver):
+/// 1. `GD_MCP_LAUNCHER_DIR` set (non-empty) → that dir (ALL builds).
+/// 2. Windows AND release build → `dirs::data_local_dir()/<identifier>/bin`.
+///    `data_local_dir()` (Local), NOT `data_dir()` (Roaming) — a ~50MB exe must
+///    not roam.
+/// 3. Otherwise (debug, non-Windows, or no local-data dir) → `None`: management
+///    is inactive.
+pub(crate) fn managed_bin_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os(LAUNCHER_DIR_ENV) {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    #[cfg(windows)]
+    if !cfg!(debug_assertions) {
+        return dirs::data_local_dir()
+            .map(|d| d.join(crate::local_prs::APP_IDENTIFIER).join("bin"));
+    }
+    None
+}
+
+/// Resolve the launcher location. Pure w.r.t. app state (no `AppHandle`): reads
+/// the env override / build config and `current_exe()` only.
+fn resolve() -> AppResult<Resolution> {
+    match managed_bin_dir() {
+        Some(dir) => Ok(Resolution::Managed(dir.join(LAUNCHER_FILE))),
+        None => Ok(Resolution::Inactive(current_exe()?)),
+    }
+}
+
+fn current_exe() -> AppResult<PathBuf> {
+    std::env::current_exe().map_err(AppError::Io)
+}
+
+/// The resolved launcher path WITHOUT ensuring/creating the managed copy — a
+/// read-only view over [`resolve`] for callers (e.g. the global-install status
+/// probe) that only need the path to compare against, never to run. Performs
+/// zero filesystem writes; when management is inactive this is `current_exe()`.
+pub(crate) fn resolved_launcher_path() -> AppResult<PathBuf> {
+    match resolve()? {
+        Resolution::Managed(dest) => Ok(dest),
+        Resolution::Inactive(exe) => Ok(exe),
+    }
+}
+
+/// Millis since the Unix epoch for a file's mtime (0 for pre-epoch/unknown, so
+/// the field is always comparable — a mismatch just forces a re-copy, which is
+/// the safe direction).
+fn mtime_ms(meta: &std::fs::Metadata) -> u64 {
+    meta.modified()
+        .ok()
+        .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Build the marker describing `source`'s current on-disk identity at `version`.
+fn marker_for(source: &Path, version: &str) -> AppResult<Marker> {
+    let meta = std::fs::metadata(source).map_err(AppError::Io)?;
+    Ok(Marker {
+        version: version.to_string(),
+        source_len: meta.len(),
+        source_mtime_ms: mtime_ms(&meta),
+    })
+}
+
+/// Read the marker beside `dest`, if present and parseable. A missing or
+/// malformed marker reads as `None` (⇒ stale ⇒ re-copy).
+fn read_marker(dest: &Path) -> Option<Marker> {
+    let path = marker_path(dest);
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn marker_path(dest: &Path) -> PathBuf {
+    dest.with_file_name(MARKER_FILE)
+}
+
+/// Whether the managed copy at `dest` is stale relative to `want`. Stale ⇔ the
+/// dest exe is absent, OR the marker is missing/unparseable, OR any of its three
+/// fields differs from `want`.
+fn is_stale(dest: &Path, want: &Marker) -> bool {
+    if !dest.exists() {
+        return true;
+    }
+    read_marker(dest).as_ref() != Some(want)
+}
+
+/// A unique sibling path of `base` with `suffix` (`tmp`/`old`), in the SAME
+/// directory so a later rename stays same-volume. Mirrors the `fsops` temp-name
+/// idiom (pid + a fresh uuid) so concurrent writers can't collide.
+fn unique_sibling(base: &Path, suffix: &str) -> PathBuf {
+    let stem = base
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "gitdesktop-mcp".to_string());
+    base.with_file_name(format!(
+        ".{stem}.{}.{}.{suffix}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ))
+}
+
+/// Best-effort sweep of `.*.tmp` / `.*.old` strays a prior crash left in `dir`.
+/// Mirrors `fsops::sweep_stale_temps`: advisory, all errors ignored.
+fn sweep_strays(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if name.starts_with('.') && (name.ends_with(".tmp") || name.ends_with(".old")) {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// Copy `source` → `dest` and write the freshness marker, using Windows-safe
+/// file semantics. `dest`'s parent must be the managed bin dir.
+///
+/// Each step exists for a concrete Windows reason (see inline notes). The marker
+/// is written LAST, after the exe rename succeeds, so its presence is proof the
+/// copy completed.
+fn copy_into_place(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
+    let dir = dest
+        .parent()
+        .ok_or_else(|| AppError::Command(format!("{} has no parent directory", dest.display())))?;
+    // 1. Ensure the bin dir exists.
+    std::fs::create_dir_all(dir).map_err(AppError::Io)?;
+    // 2. Sweep prior-crash strays before adding our own.
+    sweep_strays(dir);
+    // 3. Stream-copy the source into a unique same-dir temp (fs::copy streams —
+    //    never reads the ~50MB exe into memory). Same-dir keeps step 5's rename
+    //    same-volume.
+    let tmp = unique_sibling(dest, "tmp");
+    if let Err(e) = std::fs::copy(source, &tmp) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(AppError::Io(e));
+    }
+    // 4. If a dest exe already exists, move it ASIDE first. Two Windows facts
+    //    make this mandatory: (a) `fs::rename` FAILS if the target exists (no
+    //    POSIX overwrite), and (b) a RUNNING image can be renamed/moved but NOT
+    //    deleted or replaced — rename-aside works even while an old MCP server
+    //    is still running that copy.
+    let mut moved_old: Option<PathBuf> = None;
+    if dest.exists() {
+        let old = unique_sibling(dest, "old");
+        if let Err(e) = std::fs::rename(dest, &old) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(AppError::Io(e));
+        }
+        moved_old = Some(old);
+    }
+    // 5. Promote the temp into place.
+    if let Err(e) = std::fs::rename(&tmp, dest) {
+        // Roll back: restore the old exe so a running server keeps a valid path.
+        if let Some(old) = &moved_old {
+            let _ = std::fs::rename(old, dest);
+        }
+        let _ = std::fs::remove_file(&tmp);
+        return Err(AppError::Io(e));
+    }
+    // 6. Write the marker (atomically) — proof the copy completed.
+    let body = serde_json::to_vec(want)
+        .map_err(|e| AppError::Command(format!("serialize launcher marker: {e}")))?;
+    crate::fsops::atomic_write(&marker_path(dest), &body)?;
+    // 7. Best-effort remove of the moved-aside old exe. This succeeds once the
+    //    old process exits; otherwise step 2 sweeps it on a later run.
+    if let Some(old) = moved_old {
+        let _ = std::fs::remove_file(old);
+    }
+    Ok(())
+}
+
+/// Ensure the managed launcher exists and is fresh for `version`, returning its
+/// absolute path.
+///
+/// * Management inactive → returns `current_exe()` immediately (no writes).
+/// * Active and already fresh → returns the dest path (no writes).
+/// * Active and stale/absent → runs the copy recipe, then returns the dest.
+///
+/// On ANY failure while management is active, returns an actionable error —
+/// **never** falls back to the installed exe's path, since a silent fallback
+/// would quietly reintroduce the file-lock/kill-by-name bugs this exists to fix.
+pub fn ensure(version: &str) -> AppResult<PathBuf> {
+    match resolve()? {
+        Resolution::Inactive(exe) => Ok(exe),
+        Resolution::Managed(dest) => {
+            let source = current_exe()?;
+            let want = marker_for(&source, version)?;
+            if !is_stale(&dest, &want) {
+                return Ok(dest);
+            }
+            ensure_in_dir(&source, &dest, &want).map_err(|e| {
+                AppError::Command(format!(
+                    "Couldn't prepare the MCP launcher at {}: {e}. If an antivirus \
+                     quarantined it, restore/allow it and retry.",
+                    dest.display()
+                ))
+            })?;
+            Ok(dest)
+        }
+    }
+}
+
+/// If a managed launcher is already present, re-copy it when stale — otherwise
+/// no-op. Lazy (absent ⇒ no-op, so users who never used MCP never get the copy)
+/// and best-effort (errors swallowed: a stale copy still serves already-running
+/// sessions, and the next launch retries). Never panics, never blocks on I/O
+/// beyond the copy itself.
+pub fn refresh_if_present(version: &str) {
+    let Ok(Resolution::Managed(dest)) = resolve() else {
+        return;
+    };
+    let Ok(source) = current_exe() else {
+        return;
+    };
+    let Ok(want) = marker_for(&source, version) else {
+        return;
+    };
+    refresh_dest_if_stale(&source, &dest, &want);
+}
+
+/// The env-free core of [`refresh_if_present`], parameterized on
+/// `source`/`dest`/`want` so tests drive it against a temp dir without touching
+/// process-global env. No-ops when `dest` is absent (lazy: never used ⇒ nothing
+/// to refresh), re-copies when stale, and swallows copy errors best-effort (a
+/// stale copy still serves already-running sessions; the next launch retries).
+fn refresh_dest_if_stale(source: &Path, dest: &Path, want: &Marker) {
+    if !dest.exists() {
+        return; // lazy: never used ⇒ nothing to refresh
+    }
+    if is_stale(dest, want) {
+        let _ = ensure_in_dir(source, dest, want);
+    }
+}
+
+/// The re-copy core, parameterized on `source`/`dest`/`want` so tests drive it
+/// against a temp dir without touching process-global env or the real bin dir.
+fn ensure_in_dir(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
+    copy_into_place(source, dest, want)
+}
+
+/// Absolute path of the MCP launcher executable, ensuring (create/refresh) the
+/// managed copy first when management is active. Runs the (potentially ~50MB)
+/// copy in `spawn_blocking` so the main thread never stalls.
+#[tauri::command]
+pub async fn mcp_launcher_path(app: tauri::AppHandle) -> AppResult<String> {
+    let version = app.package_info().version.to_string();
+    let path = tauri::async_runtime::spawn_blocking(move || ensure(&version))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-mcp-launcher-test-{}-{}-{}",
+            tag,
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    #[test]
+    fn marker_json_roundtrips() {
+        let m = Marker {
+            version: "1.2.3".into(),
+            source_len: 52_428_800,
+            source_mtime_ms: 1_700_000_000_123,
+        };
+        let bytes = serde_json::to_vec(&m).unwrap();
+        // camelCase on the wire.
+        let s = String::from_utf8(bytes.clone()).unwrap();
+        assert!(s.contains("\"sourceLen\""), "expected camelCase: {s}");
+        assert!(s.contains("\"sourceMtimeMs\""), "expected camelCase: {s}");
+        let back: Marker = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(back, m);
+    }
+
+    /// Set up a temp bin dir with a copied launcher + marker and return
+    /// (dir, dest, source, base_marker).
+    fn seeded() -> (PathBuf, PathBuf, PathBuf, Marker) {
+        let dir = scratch_dir("seed");
+        std::fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join(LAUNCHER_FILE);
+        // Copy the test binary itself as the "source" exe — a real file.
+        let source = current_exe().unwrap();
+        let want = marker_for(&source, "9.9.9").unwrap();
+        ensure_in_dir(&source, &dest, &want).unwrap();
+        (dir, dest, source, want)
+    }
+
+    #[test]
+    fn stale_when_marker_missing() {
+        let dir = scratch_dir("nomarker");
+        std::fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join(LAUNCHER_FILE);
+        // exe present but no marker file at all.
+        std::fs::write(&dest, b"exe").unwrap();
+        let want = marker_for(&current_exe().unwrap(), "1.0.0").unwrap();
+        assert!(is_stale(&dest, &want));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn fresh_when_all_fields_match() {
+        let (dir, dest, _source, want) = seeded();
+        assert!(!is_stale(&dest, &want), "just-copied should be fresh");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn stale_when_version_differs() {
+        let (dir, dest, _source, want) = seeded();
+        let other = Marker {
+            version: "0.0.1".into(),
+            ..want
+        };
+        assert!(is_stale(&dest, &other));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn stale_when_source_len_differs() {
+        let (dir, dest, _source, want) = seeded();
+        let other = Marker {
+            source_len: want.source_len + 1,
+            ..want.clone()
+        };
+        assert!(is_stale(&dest, &other));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn stale_when_source_mtime_differs() {
+        let (dir, dest, _source, want) = seeded();
+        let other = Marker {
+            source_mtime_ms: want.source_mtime_ms.wrapping_add(1),
+            ..want.clone()
+        };
+        assert!(is_stale(&dest, &other));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ensure_in_dir_creates_exe_and_marker() {
+        let dir = scratch_dir("create");
+        std::fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join(LAUNCHER_FILE);
+        let source = current_exe().unwrap();
+        let want = marker_for(&source, "3.1.4").unwrap();
+
+        assert!(!dest.exists());
+        ensure_in_dir(&source, &dest, &want).unwrap();
+        assert!(dest.exists(), "launcher exe materialized");
+        assert!(marker_path(&dest).exists(), "marker written");
+        assert_eq!(read_marker(&dest).as_ref(), Some(&want));
+        // The copy is byte-identical to the source.
+        assert_eq!(
+            std::fs::metadata(&dest).unwrap().len(),
+            std::fs::metadata(&source).unwrap().len()
+        );
+
+        // Second call with the same marker is a no-op: nothing is stale, so the
+        // recipe isn't re-run. (Guarded via is_stale, mirroring `ensure`.)
+        assert!(!is_stale(&dest, &want));
+        // Re-running the recipe anyway still succeeds and leaves a valid copy.
+        ensure_in_dir(&source, &dest, &want).unwrap();
+        assert!(dest.exists());
+        assert_eq!(read_marker(&dest).as_ref(), Some(&want));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn refresh_dest_if_stale_noops_when_dest_absent() {
+        // Lazy: a never-copied launcher must not be materialized by a refresh.
+        // Drive the real production core against a temp dir and assert NO
+        // filesystem writes appear (neither the exe nor the marker).
+        let dir = scratch_dir("refresh-absent");
+        std::fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join(LAUNCHER_FILE);
+        let source = current_exe().unwrap();
+        let want = marker_for(&source, "1.0.0").unwrap();
+
+        assert!(!dest.exists());
+        refresh_dest_if_stale(&source, &dest, &want);
+        assert!(!dest.exists(), "absent dest ⇒ no exe written");
+        assert!(
+            !marker_path(&dest).exists(),
+            "absent dest ⇒ no marker written"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn refresh_dest_if_stale_recopies_when_stale() {
+        // Seed a copy, then hand a DIFFERENT want marker (a bumped version) so
+        // the present-but-stale branch fires. The refresh must re-copy and the
+        // on-disk marker must now match the new want.
+        let (dir, dest, source, base) = seeded();
+        assert!(dest.exists());
+        let bumped = Marker {
+            version: "10.0.0".into(),
+            ..base.clone()
+        };
+        assert!(is_stale(&dest, &bumped), "bumped version is stale");
+
+        refresh_dest_if_stale(&source, &dest, &bumped);
+        assert!(dest.exists(), "re-copied launcher still present");
+        assert_eq!(
+            read_marker(&dest).as_ref(),
+            Some(&bumped),
+            "marker updated to the new want"
+        );
+        assert!(!is_stale(&dest, &bumped), "no longer stale after refresh");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src-tauri/src/mcp_launcher.rs
+++ b/src-tauri/src/mcp_launcher.rs
@@ -212,7 +212,10 @@ fn copy_into_place(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
     sweep_strays(dir);
     // 3. Stream-copy the source into a unique same-dir temp (fs::copy streams —
     //    never reads the ~50MB exe into memory). Same-dir keeps step 5's rename
-    //    same-volume.
+    //    same-volume. fs::copy's documented contract also copies the source's
+    //    PERMISSION BITS on every platform (Unix impl fchmods the destination),
+    //    so under the `GD_MCP_LAUNCHER_DIR` override on Unix the copy inherits
+    //    the source exe's +x — no explicit chmod needed.
     let tmp = unique_sibling(dest, "tmp");
     if let Err(e) = std::fs::copy(source, &tmp) {
         let _ = std::fs::remove_file(&tmp);

--- a/src-tauri/src/path_launcher.rs
+++ b/src-tauri/src/path_launcher.rs
@@ -1,17 +1,19 @@
-//! One-click "add `gitdesktop` to your PATH" launcher.
+//! One-click "add `gitdesktop-mcp` to your PATH" launcher.
 //!
 //! The "Use GitDesktop as an MCP server" config points external clients at the
-//! command `gitdesktop mcp …`. That bare command only resolves if the app's
-//! executable is reachable on the shell's `PATH` — otherwise users must hardcode
+//! command `gitdesktop-mcp mcp …`. That bare command only resolves if the
+//! launcher is reachable on the shell's `PATH` — otherwise users must hardcode
 //! an absolute path (Personal variant) or set `GITDESKTOP_BIN` (Shareable
 //! variant). This module makes the bare command work in one click:
 //!
-//! * **Windows** — append the app's own directory to the *user* `PATH`
+//! * **Windows** — append the managed launcher's bin dir (holding
+//!   `gitdesktop-mcp.exe`, see `mcp_launcher.rs`) to the *user* `PATH`
 //!   (`HKCU\Environment`, no admin) and broadcast `WM_SETTINGCHANGE` so new
-//!   terminals pick it up without a logout. The command `gitdesktop` resolves to
-//!   `GitDesktop.exe` case-insensitively.
-//! * **macOS / Linux** — symlink `gitdesktop` → the app binary into
-//!   `~/.local/bin` (the lowercase name matters; Unix is case-sensitive).
+//!   terminals pick it up without a logout. A legacy install-dir entry from a
+//!   pre-launcher version is migrated away in the same write.
+//! * **macOS / Linux** — symlink `gitdesktop-mcp` → the app binary into
+//!   `~/.local/bin` (management is inactive on Unix; the name still matches the
+//!   shareable config's fallback). A legacy `gitdesktop` link we own is migrated.
 //!
 //! Every install is reversible via [`path_launcher_remove`], and we only ever
 //! remove what we created (a user-`PATH` entry we added / a symlink we own).
@@ -20,12 +22,12 @@ use crate::error::{AppError, AppResult};
 use serde::Serialize;
 use std::path::PathBuf;
 
-/// State of the `gitdesktop` command-line launcher, surfaced in Settings →
+/// State of the `gitdesktop-mcp` command-line launcher, surfaced in Settings →
 /// "Use GitDesktop as an MCP server".
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PathLauncherStatus {
-    /// `gitdesktop` resolves in a newly-opened terminal (from the *persisted*
+    /// `gitdesktop-mcp` resolves in a newly-opened terminal (from the *persisted*
     /// PATH — the registry on Windows / `$PATH` on Unix — not this process's
     /// possibly-stale environment).
     pub on_path: bool,
@@ -56,8 +58,16 @@ pub fn path_launcher_status() -> AppResult<PathLauncherStatus> {
 }
 
 #[tauri::command]
-pub fn path_launcher_install() -> AppResult<PathLauncherStatus> {
-    install_impl()
+pub fn path_launcher_install(app: tauri::AppHandle) -> AppResult<PathLauncherStatus> {
+    let _version = app.package_info().version.to_string();
+    #[cfg(windows)]
+    {
+        install_impl(&_version)
+    }
+    #[cfg(not(windows))]
+    {
+        install_impl()
+    }
 }
 
 #[tauri::command]
@@ -74,15 +84,36 @@ mod platform {
     use winreg::types::FromRegValue;
     use winreg::{RegKey, RegValue};
 
-    /// The app's own directory — adding it to PATH makes `GitDesktop.exe`
-    /// resolvable as the (case-insensitive) command `gitdesktop`.
-    fn exe_dir() -> AppResult<String> {
+    /// The directory we put on PATH. When the managed MCP launcher is active,
+    /// this is its bin dir (`%LOCALAPPDATA%\…\bin`, holding only
+    /// `gitdesktop-mcp.exe` and its `gitdesktop-mcp.version.json` marker — no
+    /// bare-`gitdesktop` copy exists), so the resolvable command is
+    /// `gitdesktop-mcp`. Otherwise the app's own install directory (dev builds
+    /// keep today's behavior). Adding it to PATH makes the launcher resolvable
+    /// case-insensitively.
+    fn launcher_dir() -> AppResult<String> {
+        if let Some(dir) = crate::mcp_launcher::managed_bin_dir() {
+            return Ok(dir.to_string_lossy().into_owned());
+        }
+        install_dir()
+    }
+
+    /// The app's own install directory (`current_exe()`'s parent). This is the
+    /// OLD launcher dir a pre-migration install would have added to PATH; we
+    /// treat it as removable-by-us and detect it for migration.
+    fn install_dir() -> AppResult<String> {
         let exe = exe_path()?;
         exe.parent()
             .map(|p| p.to_string_lossy().into_owned())
-            .ok_or_else(|| {
-                AppError::Command("could not determine the app's directory".into())
-            })
+            .ok_or_else(|| AppError::Command("could not determine the app's directory".into()))
+    }
+
+    /// The old install-dir PATH entry to migrate away from — `Some` only when
+    /// management is active AND the install dir differs from the managed dir
+    /// (i.e. there is a genuinely distinct legacy entry to reconcile).
+    fn old_entry(new_dir: &str) -> Option<String> {
+        let old = install_dir().ok()?;
+        (norm(&old) != norm(new_dir)).then_some(old)
     }
 
     /// Normalize a PATH entry for case-insensitive comparison (Windows paths are
@@ -142,13 +173,12 @@ mod platform {
     /// reads as empty + `REG_EXPAND_SZ` (the type Windows uses to create PATH).
     /// Takes the key as a parameter so it round-trips against a scratch key in
     /// tests without ever touching the live `HKCU\Environment`.
-    pub(super) fn read_path_value(
-        env: &RegKey,
-    ) -> AppResult<(String, winreg::enums::RegType)> {
+    pub(super) fn read_path_value(env: &RegKey) -> AppResult<(String, winreg::enums::RegType)> {
         match env.get_raw_value("Path") {
             Ok(raw) => {
-                let s = String::from_reg_value(&raw)
-                    .map_err(|e| AppError::Command(format!("reading PATH from the registry: {e}")))?;
+                let s = String::from_reg_value(&raw).map_err(|e| {
+                    AppError::Command(format!("reading PATH from the registry: {e}"))
+                })?;
                 Ok((s, raw.vtype))
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -225,22 +255,52 @@ mod platform {
     }
 
     pub(super) fn status_impl() -> AppResult<PathLauncherStatus> {
-        let dir = exe_dir()?;
+        let dir = launcher_dir()?;
         let (user_path, _) = read_path_value(&open_user_env(KEY_READ)?)?;
+        // A leftover pre-migration entry pointing at the install folder means the
+        // shared MCP config's bare `gitdesktop` command still resolves to the
+        // install-dir exe (locks the .msi, killed by name). Nudge the user to
+        // re-run Add to PATH, which migrates it.
+        let warning = old_entry(&dir)
+            .filter(|old| path_contains(&user_path, old))
+            .map(|_| {
+                "An earlier Add to PATH entry still points at the app's install folder. \
+                 Add to PATH again to migrate it. Shared configs using the bare \
+                 `gitdesktop` command need updating to `gitdesktop-mcp`."
+                    .to_string()
+            });
         Ok(PathLauncherStatus {
             on_path: persisted_path_contains_exe_dir(&dir),
             managed: path_contains(&user_path, &dir),
             target: dir,
-            warning: None,
+            warning,
             note: None,
         })
     }
 
-    pub(super) fn install_impl() -> AppResult<PathLauncherStatus> {
-        let dir = exe_dir()?;
+    pub(super) fn install_impl(version: &str) -> AppResult<PathLauncherStatus> {
+        let dir = launcher_dir()?;
+        // Materialize the managed launcher copy FIRST — putting an empty dir on
+        // PATH is useless. On dev builds (management inactive) this is a no-op
+        // returning the install-dir exe. Ensure errors propagate.
+        crate::mcp_launcher::ensure(version)?;
         let env = open_user_env(KEY_READ | KEY_WRITE)?;
         let (current, vtype) = read_path_value(&env)?;
-        if let Some(next) = path_with_dir_added(&current, &dir) {
+        // Add the new dir and, in the SAME write, migrate away the old install-
+        // dir entry if it's present.
+        let mut next = current.clone();
+        let mut changed = false;
+        if let Some(added) = path_with_dir_added(&next, &dir) {
+            next = added;
+            changed = true;
+        }
+        if let Some(old) = old_entry(&dir) {
+            if path_contains(&next, &old) {
+                next = path_with_dir_removed(&next, &old);
+                changed = true;
+            }
+        }
+        if changed {
             write_path_value(&env, &next, vtype)?;
             broadcast_env_change();
         }
@@ -249,18 +309,29 @@ mod platform {
             managed: true,
             target: dir,
             warning: None,
-            note: Some(
-                "Added to your PATH — open a new terminal to use gitdesktop.".into(),
-            ),
+            note: Some("Added to your PATH — open a new terminal to use gitdesktop.".into()),
         })
     }
 
     pub(super) fn remove_impl() -> AppResult<PathLauncherStatus> {
-        let dir = exe_dir()?;
+        let dir = launcher_dir()?;
         let env = open_user_env(KEY_READ | KEY_WRITE)?;
         let (current, vtype) = read_path_value(&env)?;
-        if path_contains(&current, &dir) {
-            let next = path_with_dir_removed(&current, &dir);
+        // Remove BOTH the new dir and any leftover old install-dir entry — both
+        // are entries GitDesktop added, so both are ours to reverse.
+        let mut next = current.clone();
+        let mut changed = false;
+        if path_contains(&next, &dir) {
+            next = path_with_dir_removed(&next, &dir);
+            changed = true;
+        }
+        if let Some(old) = old_entry(&dir) {
+            if path_contains(&next, &old) {
+                next = path_with_dir_removed(&next, &old);
+                changed = true;
+            }
+        }
+        if changed {
             write_path_value(&env, &next, vtype)?;
             broadcast_env_change();
         }
@@ -281,12 +352,27 @@ mod platform {
 
     /// Preferred user bin directory — on `$PATH` in virtually all modern shells.
     fn user_bin_dir() -> AppResult<PathBuf> {
-        let home = std::env::var_os("HOME")
-            .ok_or_else(|| AppError::Command("HOME is not set".into()))?;
+        let home =
+            std::env::var_os("HOME").ok_or_else(|| AppError::Command("HOME is not set".into()))?;
         Ok(PathBuf::from(home).join(".local").join("bin"))
     }
 
+    /// The canonical launcher symlink. Named `gitdesktop-mcp` to match the
+    /// shareable client-config command `${GITDESKTOP_BIN:-gitdesktop-mcp}`
+    /// (`GitDesktopAsServer.tsx`), so a config authored on any platform — and
+    /// committed into a team repo — resolves on a teammate who used Add to PATH.
+    /// The symlink still targets the app binary directly: MCP dispatch is
+    /// argv[0]-independent (`main.rs` checks `argv[1]`), so `gitdesktop-mcp mcp …`
+    /// works regardless of the link name.
     fn link_path() -> AppResult<PathBuf> {
+        Ok(user_bin_dir()?.join("gitdesktop-mcp"))
+    }
+
+    /// The legacy launcher symlink from before the rename (`gitdesktop`). We
+    /// migrate it away — but only when it's ours (targets *this* exe) — so a
+    /// shared config's bare `gitdesktop-mcp` fallback isn't shadowed by a stale
+    /// `gitdesktop`-named link that no longer matches.
+    fn legacy_link_path() -> AppResult<PathBuf> {
         Ok(user_bin_dir()?.join("gitdesktop"))
     }
 
@@ -298,21 +384,24 @@ mod platform {
         std::env::split_paths(&path).any(|p| p == dir)
     }
 
-    /// Whether some `gitdesktop` is resolvable on `$PATH` (a file or a symlink).
+    /// Whether some `gitdesktop-mcp` is resolvable on `$PATH` (a file or a
+    /// symlink).
     fn gitdesktop_on_path() -> bool {
         let Some(path) = std::env::var_os("PATH") else {
             return false;
         };
         std::env::split_paths(&path).any(|dir| {
-            let cand = dir.join("gitdesktop");
+            let cand = dir.join("gitdesktop-mcp");
             std::fs::symlink_metadata(&cand)
                 .map(|m| m.file_type().is_symlink() || m.file_type().is_file())
                 .unwrap_or(false)
         })
     }
 
-    /// Whether our symlink exists and points at *this* binary.
-    fn managed(link: &Path, exe: &Path) -> bool {
+    /// Whether `link` is a symlink pointing at *this* binary (our ownership
+    /// test, shared by status/install/remove for both the canonical and legacy
+    /// links).
+    fn owned_by_us(link: &Path, exe: &Path) -> bool {
         std::fs::symlink_metadata(link)
             .map(|m| m.file_type().is_symlink())
             .unwrap_or(false)
@@ -323,8 +412,18 @@ mod platform {
         let exe = exe_path()?;
         let bin = user_bin_dir()?;
         let link = link_path()?;
-        let is_managed = managed(&link, &exe);
-        let warning = if is_managed && !dir_on_path(&bin) {
+        let is_managed = owned_by_us(&link, &exe);
+        // A leftover legacy `gitdesktop` link we own means an earlier install
+        // used the old name; nudge the user to re-run Add to PATH (which
+        // migrates it) so the shared config's `gitdesktop-mcp` fallback resolves.
+        let legacy_present = owned_by_us(&legacy_link_path()?, &exe);
+        let warning = if legacy_present {
+            Some(
+                "An earlier Add to PATH link still uses the old `gitdesktop` name. \
+                 Add to PATH again to migrate it."
+                    .to_string(),
+            )
+        } else if is_managed && !dir_on_path(&bin) {
             Some(format!(
                 "{} may not be on your PATH — add it to your shell profile, or use the Shareable entry's GITDESKTOP_BIN.",
                 bin.display()
@@ -372,12 +471,18 @@ mod platform {
             Err(e) => return Err(AppError::Io(e)),
         }
         symlink(&exe, &link).map_err(AppError::Io)?;
+        // Migrate away the legacy `gitdesktop` link when it's ours (ownership-
+        // checked) — mirrors the Windows old-entry migration in the same action.
+        let legacy = legacy_link_path()?;
+        if owned_by_us(&legacy, &exe) {
+            let _ = std::fs::remove_file(&legacy);
+        }
         let mut status = status_impl()?;
         status.note = Some(if dir_on_path(&bin) {
-            format!("Linked gitdesktop into {}.", bin.display())
+            format!("Linked gitdesktop-mcp into {}.", bin.display())
         } else {
             format!(
-                "Linked gitdesktop into {} — add that folder to your PATH to use it.",
+                "Linked gitdesktop-mcp into {} — add that folder to your PATH to use it.",
                 bin.display()
             )
         });
@@ -389,8 +494,8 @@ mod platform {
         let link = link_path()?;
         match std::fs::symlink_metadata(&link) {
             // Only remove OUR launcher — a symlink pointing at *this* binary
-            // (the same ownership test `managed()`/status use). Never delete a
-            // gitdesktop symlink the user aimed at a different install, and
+            // (the same ownership test `owned_by_us()`/status use). Never delete a
+            // gitdesktop-mcp symlink the user aimed at a different install, and
             // never a real file they placed here.
             Ok(meta) if meta.file_type().is_symlink() => {
                 if std::fs::read_link(&link).map(|t| t == exe).unwrap_or(false) {
@@ -410,8 +515,16 @@ mod platform {
             }
             _ => {} // already gone
         }
+        // Also remove the legacy `gitdesktop` link when it's ours (ownership-
+        // checked) — both are links GitDesktop created, so both are ours to
+        // reverse. Best-effort: a legacy link owned by a different install is
+        // left untouched.
+        let legacy = legacy_link_path()?;
+        if owned_by_us(&legacy, &exe) {
+            let _ = std::fs::remove_file(&legacy);
+        }
         let mut status = status_impl()?;
-        status.note = Some("Removed the gitdesktop launcher.".into());
+        status.note = Some("Removed the gitdesktop-mcp launcher.".into());
         Ok(status)
     }
 }
@@ -482,10 +595,7 @@ mod windows_path_tests {
         // Removing an absent dir is a no-op.
         assert_eq!(path_with_dir_removed(r"C:\Windows", DIR), r"C:\Windows");
         // Removing our dir never introduces a `;;` of its own.
-        assert_eq!(
-            path_with_dir_removed(&format!(r"A;{DIR};B"), DIR),
-            "A;B"
-        );
+        assert_eq!(path_with_dir_removed(&format!(r"A;{DIR};B"), DIR), "A;B");
     }
 }
 
@@ -513,7 +623,10 @@ mod windows_registry_tests {
         write_path_value(&key, seeded, REG_EXPAND_SZ).expect("seed write");
         let (val, vtype) = read_path_value(&key).expect("read seeded");
         assert_eq!(val, seeded, "%VAR% must survive the round-trip unexpanded");
-        assert!(matches!(vtype, REG_EXPAND_SZ), "type preserved: got {vtype:?}");
+        assert!(
+            matches!(vtype, REG_EXPAND_SZ),
+            "type preserved: got {vtype:?}"
+        );
 
         // Append our dir at the same type — the actual install mutation.
         let dir = r"C:\Users\me\AppData\Local\GitDesktop";
@@ -528,6 +641,7 @@ mod windows_registry_tests {
         let (_, sz_type) = read_path_value(&key).expect("read sz");
         assert!(matches!(sz_type, REG_SZ), "type honored: got {sz_type:?}");
 
-        hkcu.delete_subkey_all(SCRATCH).expect("cleanup scratch key");
+        hkcu.delete_subkey_all(SCRATCH)
+            .expect("cleanup scratch key");
     }
 }

--- a/src-tauri/src/path_launcher.rs
+++ b/src-tauri/src/path_launcher.rs
@@ -309,7 +309,7 @@ mod platform {
             managed: true,
             target: dir,
             warning: None,
-            note: Some("Added to your PATH — open a new terminal to use gitdesktop.".into()),
+            note: Some("Added to your PATH — open a new terminal to use gitdesktop-mcp.".into()),
         })
     }
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1030,27 +1030,32 @@ Code — use *this* repo's **read-only-by-default** git & forge tools (status, l
 blame, branches, file history/read, PRs, issues, CI logs). The PR, issue, and CI tools work
 across **GitHub, GitLab, and Bitbucket** — they route through GitDesktop's forge layer and
 dispatch by the repo's remote (Bitbucket covers PRs and pipelines, but not issues — its
-native tracker is deprecated). The app itself runs as a stdio server
-(\`gitdesktop mcp --repo <path>\`), so an agent can understand a repo without changing it.
+native tracker is deprecated). The app itself runs as a stdio server — on macOS and Linux
+that's the app binary directly (\`gitdesktop mcp --repo <path>\`), and on Windows a dedicated
+update-safe copy named \`gitdesktop-mcp\` (so running servers never block app updates) — so an
+agent can understand a repo without changing it.
 **Copy** the snippet and paste it into your client's config, or hit **Write to
 .mcp.json** to merge the \`gitdesktop\` entry into the open repo's \`.mcp.json\` for you —
 existing servers are preserved, and you're asked before an existing GitDesktop entry is
 replaced. Or **install it globally** for **Claude Code** or **Copilot** — a one-click
 button that adds \`gitdesktop\` to that client's user config (so it's in *every* project, no
 per-repo file) via the client's own CLI, with a project-aware \`--repo\` so the single entry
-follows whatever repo you open. Two toggles shape what gets written: **Shareable entry** swaps machine-specific
-absolute paths for portable \`\${GITDESKTOP_BIN}\` / \`\${CLAUDE_PROJECT_DIR}\` ones a
-teammate can commit (they point \`GITDESKTOP_BIN\` at their own install, or keep
-\`gitdesktop\` on their PATH), and **Allow write tools** adds \`--allow-write\` so an agent
+follows whatever repo you open. Each client shows its **live state**: already installed and
+pointing at the current launcher, or pointing at an older install (a one-click **Reinstall**
+switches it over) — with **Remove** to take it back out, no confirmation needed. Two toggles shape what gets written: **Shareable entry** swaps machine-specific
+absolute paths for portable \`\${GITDESKTOP_BIN:-gitdesktop-mcp}\` / \`\${CLAUDE_PROJECT_DIR}\`
+ones a teammate can commit (they point \`GITDESKTOP_BIN\` at their own launcher, or keep
+\`gitdesktop-mcp\` on their PATH), and **Allow write tools** adds \`--allow-write\` so an agent
 can also **create**, **comment on**, set the **status** of, and **approve** *this repo's*
 local PRs (GitDesktop's own app-data review artifacts — nothing is pushed).
 
-To make the bare \`gitdesktop\` command actually resolve in a terminal (so the **Shareable
+To make the bare launcher command actually resolve in a terminal (so the **Shareable
 entry** works with no hardcoded path and no \`GITDESKTOP_BIN\`), use the **Command-line
-launcher** at the bottom of the disclosure: **Add to PATH** appends the app to your user
-PATH on Windows (open a new terminal afterward) or symlinks \`gitdesktop\` into
-\`~/.local/bin\` on macOS/Linux, and **Remove** undoes exactly that — no admin needed either
-way.
+launcher** at the bottom of the disclosure: **Add to PATH** puts the launcher's folder on
+your user PATH on Windows so \`gitdesktop-mcp\` resolves, or symlinks \`gitdesktop-mcp\` into
+\`~/.local/bin\` on macOS/Linux (open a new terminal afterward on Windows), and **Remove**
+undoes exactly that — no admin needed either way. On both platforms, re-running it also
+migrates any older \`gitdesktop\`-named entry a previous version left behind.
 
 Separately, **Allow remote write** adds \`--allow-remote-write\` — a distinct opt-in that
 lets an agent make **real forge writes** in this repo under your authenticated identity

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1031,18 +1031,19 @@ blame, branches, file history/read, PRs, issues, CI logs). The PR, issue, and CI
 across **GitHub, GitLab, and Bitbucket** — they route through GitDesktop's forge layer and
 dispatch by the repo's remote (Bitbucket covers PRs and pipelines, but not issues — its
 native tracker is deprecated). The app itself runs as a stdio server — on macOS and Linux
-that's the app binary directly (\`gitdesktop mcp --repo <path>\`), and on Windows a dedicated
-update-safe copy named \`gitdesktop-mcp\` (so running servers never block app updates) — so an
-agent can understand a repo without changing it.
+that's the app binary directly (a Personal config embeds its absolute path), and on Windows a
+dedicated update-safe \`gitdesktop-mcp\` copy (so running servers never block app updates) — so
+an agent can understand a repo without changing it.
 **Copy** the snippet and paste it into your client's config, or hit **Write to
 .mcp.json** to merge the \`gitdesktop\` entry into the open repo's \`.mcp.json\` for you —
 existing servers are preserved, and you're asked before an existing GitDesktop entry is
-replaced. Or **install it globally** for **Claude Code** or **Copilot** — a one-click
-button that adds \`gitdesktop\` to that client's user config (so it's in *every* project, no
-per-repo file) via the client's own CLI, with a project-aware \`--repo\` so the single entry
-follows whatever repo you open. Each client shows its **live state**: already installed and
-pointing at the current launcher, or pointing at an older install (a one-click **Reinstall**
-switches it over) — with **Remove** to take it back out, no confirmation needed. Two toggles shape what gets written: **Shareable entry** swaps machine-specific
+replaced. Or **install it globally** for **Claude Code** or **Copilot** — a per-client row
+for each adds the \`gitdesktop\` entry to that client's user config (so it's in *every*
+project, no per-repo file) via the client's own CLI, with a project-aware \`--repo\` so the
+single entry follows whatever repo you open. Each row shows its **live state**: already
+installed and pointing at the current launcher, or pointing at an older install (a one-click
+**Reinstall** switches it over) — with **Remove** to take it back out, no confirmation needed.
+Two toggles shape what gets written: **Shareable entry** swaps machine-specific
 absolute paths for portable \`\${GITDESKTOP_BIN:-gitdesktop-mcp}\` / \`\${CLAUDE_PROJECT_DIR}\`
 ones a teammate can commit (they point \`GITDESKTOP_BIN\` at their own launcher, or keep
 \`gitdesktop-mcp\` on their PATH), and **Allow write tools** adds \`--allow-write\` so an agent

--- a/src/features/settings/mcp/GitDesktopAsServer.tsx
+++ b/src/features/settings/mcp/GitDesktopAsServer.tsx
@@ -15,9 +15,11 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { copyText } from "@/lib/clipboard";
 import {
-  appExePath,
   mcpGlobalInstall,
+  mcpGlobalRemove,
+  mcpGlobalStatus,
   mcpJsonWrite,
+  mcpLauncherPath,
   type PathLauncherStatus,
   pathLauncherInstall,
   pathLauncherRemove,
@@ -50,6 +52,11 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
   const [confirmTarget, setConfirmTarget] = useState<InstallTarget | null>(
     null,
   );
+  // Which global client is mid-removal — parallel to `busyTarget` (which tracks
+  // installs) so per-row Install/Reinstall/Remove disable each other.
+  const [removingClient, setRemovingClient] = useState<
+    "claude" | "copilot" | null
+  >(null);
   // The command-line launcher: is `gitdesktop` on PATH, and did we put it there?
   // Only fetched while the disclosure is open (it reads the registry / $PATH).
   const queryClient = useQueryClient();
@@ -59,13 +66,53 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     enabled: open,
   });
   const [pathBusy, setPathBusy] = useState(false);
-  // The command is this app's own executable; resolved once (it can't change
-  // mid-session). Falls back to a bare name only while the path is loading.
-  const { data: exePath } = useQuery({
-    queryKey: ["app-exe-path"],
-    queryFn: appExePath,
+  // The command is the managed MCP launcher (an update-safe copy of the app
+  // that isn't file-locked by the installed binary). Resolving it ensures the
+  // copy exists, so only fetch it once the disclosure is open — opening is the
+  // lazy-create trigger; merely mounting Settings must not write the copy.
+  const {
+    data: launcherPath,
+    isPending: launcherPathPending,
+    error: launcherPathError,
+  } = useQuery({
+    queryKey: ["mcp-launcher-path"],
+    queryFn: mcpLauncherPath,
     staleTime: Number.POSITIVE_INFINITY,
+    enabled: open,
   });
+  // Per-client global-install state (Claude Code / Copilot): is `gitdesktop` in
+  // each client's user config, and does it point at the CURRENT launcher? Only
+  // fetched while the disclosure is open (it shells out to each CLI). Refetched
+  // after any successful install/reinstall/remove so the rows stay authoritative.
+  const { data: globalStatus, isLoading: globalStatusLoading } = useQuery({
+    queryKey: ["mcp-global-status"],
+    queryFn: mcpGlobalStatus,
+    enabled: open,
+  });
+  // Actionable message when the launcher can't be prepared (e.g. antivirus
+  // quarantine) — surface it, never emit a config against a wrong/absent path.
+  const launcherErrorMessage = launcherPathError
+    ? launcherPathError instanceof Error
+      ? launcherPathError.message
+      : String(launcherPathError)
+    : null;
+  // No config that embeds the absolute launcher path may be emitted until that
+  // path resolves: writing a stale/absent path silently keeps locking the old
+  // binary. The global installs (Claude Code / Copilot) ALWAYS embed it, so they
+  // gate on this unconditionally.
+  const launcherDisabledReason = launcherPathPending
+    ? "Preparing the MCP launcher…"
+    : launcherErrorMessage;
+  // Copy / Write emit `entry`, whose command in SHAREABLE mode is the constant
+  // `${GITDESKTOP_BIN:-gitdesktop-mcp}` — independent of the local launcher, so a
+  // pending/failed local ensure must not block the one path that provably works.
+  // Only personal mode embeds the absolute path and thus needs the launcher gate.
+  const entryDisabledReason = shareable ? null : launcherDisabledReason;
+  // The replace-confirm re-runs the SAME emit as the button that opened it, so it
+  // must share that button's gate: `project` follows the shareable-aware entry
+  // gate; the global targets always embed the launcher path.
+  const confirmDisabledReason =
+    confirmTarget === "project" ? entryDisabledReason : launcherDisabledReason;
 
   // Single source of truth for both Copy and Write — the exact entry that gets
   // merged into .mcp.json under `mcpServers.gitdesktop`.
@@ -76,15 +123,21 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     if (allowWrite) args.push("--allow-write");
     if (allowRemoteWrite) args.push("--allow-remote-write");
     return {
-      command: shareable
-        ? "${GITDESKTOP_BIN:-gitdesktop}"
-        : (exePath ?? "gitdesktop"),
+      command: shareable ? "${GITDESKTOP_BIN:-gitdesktop-mcp}" : launcherPath,
       args,
     };
-  }, [shareable, allowWrite, allowRemoteWrite, repoPath, exePath]);
+  }, [shareable, allowWrite, allowRemoteWrite, repoPath, launcherPath]);
 
+  // The snippet is display-only: while the launcher path is still resolving,
+  // `entry.command` is undefined, so show a muted "…" placeholder rather than a
+  // JSON object with a missing command line. Emission (Copy/Write) is disabled
+  // in that state, so the real `entry` — never the placeholder — is what writes.
   const snippet = JSON.stringify(
-    { mcpServers: { gitdesktop: entry } },
+    {
+      mcpServers: {
+        gitdesktop: { ...entry, command: entry.command ?? "…" },
+      },
+    },
     null,
     2,
   );
@@ -118,10 +171,13 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     ];
     if (allowWrite) args.push("--allow-write");
     if (allowRemoteWrite) args.push("--allow-remote-write");
-    return { command: exePath ?? "gitdesktop", args };
+    return { command: launcherPath, args };
   }
 
-  function installSuccessToast(target: InstallTarget) {
+  // `replaced` = an existing entry was overwritten (reinstall/migrate), so the
+  // global toast reads honestly instead of "Added". Project (.mcp.json) toasts
+  // are unaffected by this distinction.
+  function installSuccessToast(target: InstallTarget, replaced: boolean) {
     if (target === "project") {
       toast.success(
         shareable
@@ -132,7 +188,9 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     }
     const client = target === "claude" ? "Claude Code" : "Copilot";
     toast.success(
-      `Added gitdesktop to ${client} — available in all your projects (restart the client).`,
+      replaced
+        ? `Updated gitdesktop in ${client} — points at this launcher now (restart the client).`
+        : `Added gitdesktop to ${client} — available in all your projects (restart the client).`,
     );
   }
 
@@ -148,6 +206,10 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
         result = await mcpJsonWrite(repoPath as string, entry, overwrite);
       } else {
         const { command, args } = globalEntry(target);
+        // A global install embeds the absolute launcher path; if it hasn't
+        // resolved yet (or failed to prepare) there's nothing safe to write.
+        // The buttons are gated on this too — this is the type-level backstop.
+        if (command === undefined) return;
         result = await mcpGlobalInstall(target, command, args, overwrite);
       }
       if (result.existed && !result.written) {
@@ -155,12 +217,140 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
         return;
       }
       setConfirmTarget(null);
-      installSuccessToast(target);
+      installSuccessToast(target, result.existed);
+      // A global install/reinstall changed a client's user config — refetch the
+      // per-client rows so their installed/current state reflects it.
+      if (target !== "project") {
+        queryClient.invalidateQueries({ queryKey: ["mcp-global-status"] });
+      }
     } catch (e) {
       toastError(e);
     } finally {
       setBusyTarget(null);
     }
+  }
+
+  // Remove the global `gitdesktop` entry from a client's user config — one-click
+  // and reversible (re-installable), so no confirm dialog (matches the launcher
+  // section's Remove). Refetches the rows on success.
+  async function removeGlobal(client: "claude" | "copilot") {
+    if (removingClient || busyTarget) return;
+    setRemovingClient(client);
+    try {
+      await mcpGlobalRemove(client);
+      toast.success(
+        `Removed gitdesktop from ${client === "claude" ? "Claude Code" : "Copilot"}.`,
+      );
+      queryClient.invalidateQueries({ queryKey: ["mcp-global-status"] });
+    } catch (e) {
+      toastError(e);
+    } finally {
+      setRemovingClient(null);
+    }
+  }
+
+  // One per-client global-install status row (Claude Code / Copilot), mirroring
+  // the Command-line launcher section's idiom below: a label + contextual action
+  // on the right, a status line underneath. Install/Reinstall embed the absolute
+  // launcher path so they gate on `launcherDisabledReason`; Remove doesn't need
+  // the path (it must work even when the launcher errored) and only blocks while
+  // an install/remove for this row is in flight.
+  function globalRow(client: "claude" | "copilot") {
+    const label = client === "claude" ? "Claude Code" : "Copilot";
+    const status = globalStatus?.[client];
+    const installing = busyTarget === client;
+    const removing = removingClient === client;
+    // Any global install/remove (either row) disables every row's actions, so a
+    // second op can't race a config write. Install/Reinstall additionally need
+    // the launcher path; Remove does not (it must work in the AV-error case).
+    const anyBusy = busyTarget !== null || removingClient !== null;
+    // Until the status query resolves, the row's action label ("Install" vs
+    // "Reinstall") isn't yet known, so hold every action rather than show a
+    // possibly-wrong one next to the "Checking…" line.
+    const rowLoadingReason = globalStatusLoading
+      ? "Checking the current install state…"
+      : null;
+    const busyReason = anyBusy
+      ? "Waiting for the current operation to finish."
+      : null;
+    // Remove doesn't embed the launcher path, so it's exempt from that gate.
+    const removeReason = rowLoadingReason ?? busyReason;
+    // Install/Reinstall embed the absolute launcher path, so they additionally
+    // gate on the launcher being ready.
+    const installReason = rowLoadingReason ?? busyReason ?? launcherDisabledReason;
+    return (
+      <div className="space-y-1" key={client}>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs font-medium">{label}</span>
+          <div className="flex items-center gap-2">
+            {status?.installed && (
+              // A title on a natively-disabled button never surfaces, so wrap it.
+              <span title={removeReason ?? undefined}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={removeReason !== null}
+                  onClick={() => removeGlobal(client)}
+                >
+                  {removing ? (
+                    <>
+                      <Spinner className="size-3" /> Removing…
+                    </>
+                  ) : (
+                    "Remove"
+                  )}
+                </Button>
+              </span>
+            )}
+            {/* A title on a natively-disabled button never surfaces, so wrap it.
+                Install (new) and Reinstall (migrate a stale/other entry) share
+                the same overwrite-confirm-on-existing flow. */}
+            <span title={installReason ?? undefined}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={installReason !== null}
+                onClick={() => install(client, false)}
+              >
+                {installing ? (
+                  <>
+                    <Spinner className="size-3" />{" "}
+                    {status?.installed && !status.current
+                      ? "Reinstalling…"
+                      : "Adding…"}
+                  </>
+                ) : status?.installed && !status.current ? (
+                  "Reinstall"
+                ) : (
+                  "Install"
+                )}
+              </Button>
+            </span>
+          </div>
+        </div>
+        {globalStatusLoading ? (
+          <p className="text-xs text-muted-foreground">Checking…</p>
+        ) : status?.installed ? (
+          status.current ? (
+            <p className="flex items-center gap-1.5 text-xs text-success">
+              <CheckIcon className="shrink-0" />
+              <span>Installed — uses this launcher.</span>
+            </p>
+          ) : (
+            <p className="text-xs text-warning">
+              Installed — points at a different executable (an older install or
+              custom entry). Reinstall to use this launcher.
+            </p>
+          )
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Not in {label}'s user config.
+          </p>
+        )}
+      </div>
+    );
   }
 
   // Run an install/remove and fold the authoritative result back into the cache.
@@ -227,7 +417,7 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
             </label>
             <p className="text-xs text-muted-foreground">
               {shareable
-                ? "Portable paths — teammates set GITDESKTOP_BIN to their install path, or add gitdesktop to their PATH (see below)."
+                ? "Portable paths — teammates set GITDESKTOP_BIN to their launcher path, or add gitdesktop-mcp to their PATH (see below)."
                 : "Absolute paths — works on this machine only. Consider gitignoring .mcp.json."}
             </p>
           </div>
@@ -267,30 +457,43 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
               Paste into your client's MCP config
             </span>
             <div className="flex items-center gap-2">
-              <Button type="button" variant="ghost" size="sm" onClick={copy}>
-                {copied ? (
-                  <>
-                    <CheckIcon data-icon="inline-start" /> Copied
-                  </>
-                ) : (
-                  <>
-                    <CopyIcon data-icon="inline-start" /> Copy
-                  </>
-                )}
-              </Button>
               {/* A title on a natively-disabled button never surfaces, so wrap it. */}
+              <span title={entryDisabledReason ?? undefined}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={entryDisabledReason !== null}
+                  onClick={copy}
+                >
+                  {copied ? (
+                    <>
+                      <CheckIcon data-icon="inline-start" /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <CopyIcon data-icon="inline-start" /> Copy
+                    </>
+                  )}
+                </Button>
+              </span>
               <span
                 title={
-                  repoPath
+                  entryDisabledReason ??
+                  (repoPath
                     ? undefined
-                    : "Open a repository to write its .mcp.json"
+                    : "Open a repository to write its .mcp.json")
                 }
               >
                 <Button
                   type="button"
                   variant="outline"
                   size="sm"
-                  disabled={!repoPath || busyTarget !== null}
+                  disabled={
+                    !repoPath ||
+                    busyTarget !== null ||
+                    entryDisabledReason !== null
+                  }
                   onClick={() => install("project", false)}
                 >
                   {busyTarget === "project" ? (
@@ -304,55 +507,33 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
               </span>
             </div>
           </div>
+          {launcherErrorMessage && (
+            <p className="text-xs text-warning">
+              Couldn't prepare the MCP launcher: {launcherErrorMessage}
+            </p>
+          )}
           <pre className="overflow-x-auto rounded border bg-muted/40 p-3 font-mono text-[11px] leading-relaxed">
             {snippet}
           </pre>
           <p className="text-xs text-muted-foreground">{modeNote}</p>
+          <p className="text-xs text-muted-foreground">
+            Older configs that point at the app executable keep working —
+            re-emitting here switches them to the update-safe launcher.
+          </p>
 
-          {/* Install globally — one click into a client's user config (all
+          {/* Install globally — per-client rows into a client's user config (all
               projects), via its own CLI. Uses a project-aware --repo so a single
-              global entry follows whatever repo the client opens. */}
-          <div className="mt-1 space-y-1.5 border-t pt-3">
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-xs font-medium">
-                Install globally — all projects
-              </span>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={busyTarget !== null}
-                  onClick={() => install("claude", false)}
-                >
-                  {busyTarget === "claude" ? (
-                    <>
-                      <Spinner className="size-3" /> Adding…
-                    </>
-                  ) : (
-                    "Claude Code"
-                  )}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={busyTarget !== null}
-                  onClick={() => install("copilot", false)}
-                >
-                  {busyTarget === "copilot" ? (
-                    <>
-                      <Spinner className="size-3" /> Adding…
-                    </>
-                  ) : (
-                    "Copilot"
-                  )}
-                </Button>
-              </div>
-            </div>
+              global entry follows whatever repo the client opens. Each row shows
+              installed state and offers Install / Reinstall / Remove. */}
+          <div className="mt-1 space-y-2 border-t pt-3">
+            <span className="text-xs font-medium">
+              Install globally — all projects
+            </span>
+            {globalRow("claude")}
+            {globalRow("copilot")}
             <p className="text-xs text-muted-foreground">
-              Adds gitdesktop to the client's user config via its CLI, so it's
-              in every project — no per-repo{" "}
+              Adds gitdesktop to the client's user config via its CLI, so it's in
+              every project — no per-repo{" "}
               <code className="font-mono">.mcp.json</code>. The write toggles
               above carry over.
             </p>
@@ -408,13 +589,13 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
                 <p className="flex items-center gap-1.5 text-xs text-success">
                   <CheckIcon className="shrink-0" />
                   <span>
-                    gitdesktop is on your PATH
+                    gitdesktop-mcp is on your PATH
                     {!launcher.managed && " — added outside GitDesktop"}
                   </span>
                 </p>
               ) : (
                 <p className="text-xs text-muted-foreground">
-                  Make <code className="font-mono">gitdesktop</code> runnable
+                  Make <code className="font-mono">gitdesktop-mcp</code> runnable
                   from any terminal, so the command above works without a full
                   path.
                 </p>
@@ -452,20 +633,27 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
                 >
                   Cancel
                 </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={busyTarget !== null}
-                  onClick={() => confirmTarget && install(confirmTarget, true)}
-                >
-                  {busyTarget !== null ? (
-                    <>
-                      <Spinner className="size-3" /> Replacing…
-                    </>
-                  ) : (
-                    "Replace entry"
-                  )}
-                </Button>
+                {/* A title on a natively-disabled button never surfaces, so wrap it. */}
+                <span title={confirmDisabledReason ?? undefined}>
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={
+                      busyTarget !== null || confirmDisabledReason !== null
+                    }
+                    onClick={() =>
+                      confirmTarget && install(confirmTarget, true)
+                    }
+                  >
+                    {busyTarget !== null ? (
+                      <>
+                        <Spinner className="size-3" /> Replacing…
+                      </>
+                    ) : (
+                      "Replace entry"
+                    )}
+                  </Button>
+                </span>
               </DialogFooter>
             </DialogContent>
           </Dialog>

--- a/src/features/settings/mcp/GitDesktopAsServer.tsx
+++ b/src/features/settings/mcp/GitDesktopAsServer.tsx
@@ -81,8 +81,9 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     enabled: open,
   });
   // Per-client global-install state (Claude Code / Copilot): is `gitdesktop` in
-  // each client's user config, and does it point at the CURRENT launcher? Only
-  // fetched while the disclosure is open (it shells out to each CLI). Refetched
+  // each client's user config, and does it point at the CURRENT launcher? A
+  // read-only probe of each client's config file (no CLI spawn, no launcher
+  // ensure); only fetched while the disclosure is open. Refetched
   // after any successful install/reinstall/remove so the rows stay authoritative.
   const { data: globalStatus, isLoading: globalStatusLoading } = useQuery({
     queryKey: ["mcp-global-status"],
@@ -279,7 +280,7 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     // gate on the launcher being ready.
     const installReason = rowLoadingReason ?? busyReason ?? launcherDisabledReason;
     return (
-      <div className="space-y-1" key={client}>
+      <div className="space-y-1">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs font-medium">{label}</span>
           <div className="flex items-center gap-2">

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2648,15 +2648,17 @@ export const readAgentCommands = (repoPath: string, agent: string) =>
 export const readTextFile = (path: string) =>
   invoke<string>("read_text_file", { path });
 
-/** Absolute path to the running app executable — the command for the "use
- *  GitDesktop as an MCP server" config snippet (`<exe> mcp --repo <path>`). */
-export const appExePath = () => invoke<string>("app_exe_path");
+/** Absolute path to the managed MCP launcher executable — ensures the
+ *  update-safe copy exists (Windows) before returning. The command for the
+ *  "use GitDesktop as an MCP server" config (`<launcher> mcp --repo <path>`). */
+export const mcpLauncherPath = () => invoke<string>("mcp_launcher_path");
 
-/** State of the `gitdesktop` command-line launcher (Settings → MCP servers).
- *  Windows adds the app dir to the user PATH; macOS/Linux symlink into
- *  ~/.local/bin. See src-tauri/src/path_launcher.rs. */
+/** State of the `gitdesktop-mcp` command-line launcher (Settings → MCP servers).
+ *  Windows puts the managed launcher's bin dir on the user PATH (migrating any
+ *  older app-dir entry); macOS/Linux symlink `gitdesktop-mcp` into ~/.local/bin.
+ *  See src-tauri/src/path_launcher.rs. */
 export interface PathLauncherStatus {
-  /** `gitdesktop` resolves in a newly-opened terminal (persisted PATH). */
+  /** `gitdesktop-mcp` resolves in a newly-opened terminal (persisted PATH). */
   onPath: boolean;
   /** We installed it, so Remove can undo it (false when on PATH by other means). */
   managed: boolean;
@@ -2711,6 +2713,33 @@ export const mcpGlobalInstall = (
     args,
     overwrite,
   });
+
+/** Whether a client's GLOBAL (user-scope) config has a `gitdesktop` server, and
+ *  whether its configured command points at the CURRENT managed launcher. */
+export interface McpGlobalClientStatus {
+  /** A `gitdesktop` server exists in this client's user config. */
+  installed: boolean;
+  /** The configured command, or null when not installed (for display). */
+  command: string | null;
+  /** The configured command resolves to the current managed launcher
+   *  (path-normalized) — false for an older install or a custom entry. */
+  current: boolean;
+}
+
+export interface McpGlobalStatus {
+  claude: McpGlobalClientStatus;
+  copilot: McpGlobalClientStatus;
+}
+
+/** Read-only probe of the global `gitdesktop` install state for both clients,
+ *  via each CLI. Never creates the managed launcher copy. See src-tauri/src/mcp.rs. */
+export const mcpGlobalStatus = () =>
+  invoke<McpGlobalStatus>("mcp_global_status");
+
+/** Remove the `gitdesktop` server from a client's GLOBAL (user-scope) config via
+ *  that client's own CLI. Errors carry actionable messages (e.g. CLI not found). */
+export const mcpGlobalRemove = (client: "claude" | "copilot") =>
+  invoke<null>("mcp_global_remove", { client });
 
 // Cold-start test mode keeps API keys in an isolated sessionStorage store so
 // the OS keychain (and the user's real keys) are never touched (no-op normally).

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2732,7 +2732,8 @@ export interface McpGlobalStatus {
 }
 
 /** Read-only probe of the global `gitdesktop` install state for both clients,
- *  via each CLI. Never creates the managed launcher copy. See src-tauri/src/mcp.rs. */
+ *  by reading each client's config file directly (no CLI spawn). Never creates
+ *  the managed launcher copy. See src-tauri/src/mcp.rs. */
 export const mcpGlobalStatus = () =>
   invoke<McpGlobalStatus>("mcp_global_status");
 


### PR DESCRIPTION
This change adds per-client global install status for Claude Code and Copilot in Settings, letting users see, reinstall, or remove each client entry, and switches all MCP configuration and command-line entrypoints to use an update-safe `gitdesktop-mcp` launcher. The new launcher solves update-file-lock and upgrade-kill issues on Windows by running MCP from a managed copy outside the install directory, ensuring updates are always safe and live status is never stale.

### MCP launcher: update safety and platform integration
- Adds `src-tauri/src/mcp_launcher.rs` providing a managed `gitdesktop-mcp` launcher copy, with atomic copy & version tracking, only on Windows release builds (env override for dev/tests).
- Updates `src-tauri/src/lib.rs` to refresh the managed launcher after each app update.
- All MCP config now refers to `gitdesktop-mcp` (not `gitdesktop`), switching config emission logic in all clusters.

### Global install status and management
- Implements new API in `src-tauri/src/mcp.rs`:
  - Adds `mcp_global_status` and `mcp_global_remove` Tauri commands to enumerate/read and remove per-client user-config MCP installs via the relevant CLI.
  - Adds tolerant config parsing and normalization to robustly detect command paths and installation status.
- Frontend (`src/features/settings/mcp/GitDesktopAsServer.tsx`, `src/lib/git/api.ts`):
  - Surfaces per-client global install status, showing live state, and new Reinstall/Remove controls.
  - All config emits respect the new launcher and path/command conventions.
  - Adds global install/remove logic for both Claude and Copilot.
- Documentation: Updates help and onboarding copy (`README.md`, `src/features/help/content.ts`) to refer to the new MCP launcher name, global install management flow, and launcher path expectations.

### Command-line launcher and PATH handling
- Updates `src-tauri/src/path_launcher.rs` to operate on `gitdesktop-mcp` consistently:
  - Windows: puts managed bin dir on the user PATH, automatically migrates old install-dir entries, and only removes what was previously created.
  - macOS/Linux: symlinks `gitdesktop-mcp` into `~/.local/bin` (auto-migrates previous `gitdesktop` symlinks).
- Frontend UI and logic to match (`src/lib/git/api.ts`, `src/features/settings/mcp/GitDesktopAsServer.tsx`): new launcher path accessors and copy/install flows, migrated everywhere relevant.

### Changelog and support artifacts
- Adds `changelog.d/added-mcp-global-install-status.md` covering the new global install status view and management.
- Adds `changelog.d/fixed-mcp-installer-file-lock.md` documenting the fix for file locks and update safety.

### Miscellaneous/internal
- Removes dead or obsolete code in `src-tauri/src/fsops.rs` (the previous `app_exe_path`).
- Refactors/exports constants in `src-tauri/src/local_prs.rs` as needed for cross-module coordination.