### PR TITLE
fix(fsops): remove redundant return statement in macOS terminal launch

### DIFF
--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -297,11 +297,11 @@ fn launch_terminal_unix(path: &str) -> AppResult<()> {
     use std::process::Command;
     #[cfg(target_os = "macos")]
     {
-        return Command::new("open")
+        Command::new("open")
             .args(["-a", "Terminal", path])
             .spawn()
             .map(|_| ())
-            .map_err(AppError::Io);
+            .map_err(AppError::Io)
     }
     #[cfg(not(target_os = "macos"))]
     {


### PR DESCRIPTION
This change streamlines the macOS-specific code for launching Terminal by removing an unnecessary `return` statement. The update addresses a Clippy lint (`needless_return`), improving code readability and maintaining Rust idiomatic style.

- Removes the redundant `return` syntax in `launch_terminal_unix` for the macOS branch in `src-tauri/src/fsops.rs`, changing it to use an implicit return instead.