### PR TITLE
Display MCP install permission tier, add MCP prompts, and handle deleted upstream branches correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   branch-mutating tools. The server also exposes GitDesktop's own **AI generation recipes** —
   it hands a connected agent the fully assembled commit-message, PR-description, or
   branch-name prompt (the same context the in-app features build) for the agent to complete
-  with its own model.
+  with its own model — offered as recipe tools *and* as native **MCP prompts**
+  (slash-command-like in clients) for the same three.
 - **Run commands without leaving the app** — every agent session has an integrated
   terminal: a real shell in a resizable bottom dock, toggled with `Ctrl`/`⌘`+`J`. For a
   container session it runs *inside* the session's container — you pick which dev-server

--- a/changelog.d/added-mcp-install-tier-display.md
+++ b/changelog.d/added-mcp-install-tier-display.md
@@ -1,0 +1,6 @@
+- **See which permission tier your global MCP install runs.** In **Settings → MCP servers →
+  Use GitDesktop as an MCP server**, each *Install globally* row (Claude Code / Copilot) now
+  reads out the installed entry's permission tier — e.g. *Installed (local + remote writes)*,
+  or *Installed (read-only)*. When the installed permissions no longer match the checkboxes
+  you've selected, the row switches to a warning and offers **Reinstall** to apply them, so a
+  stale global entry can't keep running old flags unnoticed.

--- a/changelog.d/added-mcp-prompts.md
+++ b/changelog.d/added-mcp-prompts.md
@@ -1,0 +1,6 @@
+- **AI generation recipes are now also MCP prompts.** GitDesktop's MCP server exposes its
+  commit-message, PR-description, and branch-name generation recipes as native MCP prompts
+  (`commit-message`, `pr-description`, `branch-name`) — the slash-command-like primitive many
+  clients surface — alongside the existing recipe tools. Each assembles the *same* fully
+  prepared context and prompt the in-app AI feature builds and hands it to the client's own
+  model to complete. The prompts are read-only and always available, with no opt-in flag.

--- a/changelog.d/changed-mcp-github-review-actions.md
+++ b/changelog.d/changed-mcp-github-review-actions.md
@@ -1,0 +1,6 @@
+- **MCP `approve_pull_request` and `request_changes` now work on GitHub.** Both forge write
+  tools previously dead-ended on GitHub repos with a "goes through the Review menu" error;
+  they now route the GitHub arm through `gh pr review`, so approving and requesting changes on
+  a PR work across GitHub, GitLab, and Bitbucket. (GitHub's `request_changes` requires a
+  non-empty body; the error surfaces if it's omitted, and withdrawing a requested-changes
+  review stays unsupported on GitHub, as `gh` can't do it.)

--- a/changelog.d/changed-review-prompt-verification.md
+++ b/changelog.d/changed-review-prompt-verification.md
@@ -1,0 +1,5 @@
+- **AI PR reviews verify before flagging.** The review now checks the typed contract
+  before reporting a possible null/undefined issue — a field the types declare
+  non-optional (or that every code path visibly sets) is no longer flagged — and it
+  omits a finding relayed from another AI reviewer when it cannot verify that finding
+  against the diff, rather than passing it along with a "could not verify" hedge.

--- a/changelog.d/fixed-branch-gone-upstream-publish.md
+++ b/changelog.d/fixed-branch-gone-upstream-publish.md
@@ -1,0 +1,5 @@
+- **A branch whose remote was deleted now offers "Publish branch."** After a PR
+  merge deletes the remote branch, the sync bar no longer shows stale Push/Pull
+  against the dead ref — it shows **Publish branch**, which recreates the remote
+  branch on push. Undo-commit is available again on such a branch, and amending
+  its tip no longer wrongly demands a force-push.

--- a/changelog.d/fixed-diff-render-flash.md
+++ b/changelog.d/fixed-diff-render-flash.md
@@ -1,0 +1,4 @@
+- Large file diffs no longer flash or re-render while loading. The diff now waits
+  for its syntax-highlighting inputs (the whole-file context reads and any
+  lazily-loaded language grammar) to settle and paints once, instead of showing a
+  brief hunk-only pass that restructured a moment later.

--- a/changelog.d/fixed-header-branch-overflow.md
+++ b/changelog.d/fixed-header-branch-overflow.md
@@ -3,4 +3,5 @@
   horizontal (and cascaded vertical) scrollbars and hiding the sync controls.
   The branch name now truncates with an ellipsis — hover it to see the full
   name — while the icons, detached badge, and Fetch/Pull/Publish controls stay
-  fully visible.
+  fully visible. The truncation order is deliberate: the branch name gives way
+  first, then the CI badge's workflow label, and the repository name last.

--- a/changelog.d/fixed-header-branch-overflow.md
+++ b/changelog.d/fixed-header-branch-overflow.md
@@ -1,0 +1,6 @@
+- **Long branch names no longer overflow the repository header.** A very long
+  current-branch name used to push the header wider than the window, adding
+  horizontal (and cascaded vertical) scrollbars and hiding the sync controls.
+  The branch name now truncates with an ellipsis — hover it to see the full
+  name — while the icons, detached badge, and Fetch/Pull/Publish controls stay
+  fully visible.

--- a/changelog.d/fixed-header-repo-name-truncation.md
+++ b/changelog.d/fixed-header-repo-name-truncation.md
@@ -1,0 +1,5 @@
+- **Long repository names no longer overflow the header.** A repository name
+  or alias longer than the trigger's width used to paint past its box over
+  neighboring controls. It now truncates cleanly with an ellipsis — hover it to
+  see the full name — and at narrow window widths the repository and branch
+  triggers shrink together instead of the branch giving way alone.

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -744,11 +744,12 @@ pub async fn forge_pr_reopen(repo_path: String, number: u64) -> AppResult<()> {
     }
 }
 
-/// Request changes on a merge request (the blocking reviewer state), with an
-/// optional comment. GitLab-only, like the approve/unapprove toggle: GitHub
-/// requests changes through its own Review menu (`gh_pr_review`), and the
-/// frontend gates this on `implemented.mrRequestChanges` (false for GitHub), so
-/// the GitHub arm is never reached — it errors defensively.
+/// Request changes on a merge/pull request (the blocking reviewer state), with a
+/// comment. Wired for all three providers: GitLab/Bitbucket via their reviewer
+/// APIs, GitHub through `gh pr review --request-changes` (`gh_pr_review`), which
+/// requires a non-empty body. The frontend still gates its own control on
+/// `implemented.mrRequestChanges` (false for GitHub, so it uses GitHub's native
+/// Review menu there); this arm serves the MCP `request_changes` tool.
 #[tauri::command]
 pub async fn forge_pr_request_changes(
     repo_path: String,
@@ -762,9 +763,8 @@ pub async fn forge_pr_request_changes(
         Some((Provider::Bitbucket, _)) => {
             bitbucket::request_changes_pr(&repo_path, number, &body).await
         }
-        _ => Err(AppError::InvalidArgument(
-            "GitHub requests changes through the Review menu.".into(),
-        )),
+        _ => crate::github::pr::gh_pr_review(repo_path, number, "request_changes".to_string(), body)
+            .await,
     }
 }
 
@@ -879,16 +879,19 @@ pub async fn forge_pr_approvals(
     }
 }
 
-/// Approve a merge request (a bodyless GitLab reviewer action), behind the
-/// abstraction. GitLab-only — GitHub approves via the review flow.
+/// Approve a merge/pull request (a bodyless reviewer action), behind the
+/// abstraction. Wired for all three providers: GitLab/Bitbucket via their
+/// reviewer APIs, GitHub through `gh pr review --approve` (`gh_pr_review`, no
+/// body). The frontend still gates its own control on `implemented.mrApprove`
+/// (false for GitHub, which uses its native review flow there); this arm serves
+/// the MCP `approve_pull_request` tool.
 #[tauri::command]
 pub async fn forge_pr_approve(repo_path: String, number: u64) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::approve_pr(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::approve_pr(&repo_path, number).await,
-        _ => Err(AppError::InvalidArgument(
-            "GitHub approvals go through the review flow, not this control.".into(),
-        )),
+        _ => crate::github::pr::gh_pr_review(repo_path, number, "approve".to_string(), String::new())
+            .await,
     }
 }
 

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -45,7 +45,8 @@ pub async fn git_branches(repo_path: String) -> AppResult<Vec<Branch>> {
         if name.is_empty() {
             continue;
         }
-        let (upstream_ahead, upstream_behind) = parse_upstream_track(track.unwrap_or(""));
+        let (upstream_ahead, upstream_behind, upstream_gone) =
+            parse_upstream_track(track.unwrap_or(""));
         branches.push(Branch {
             name: name.to_string(),
             is_current: head == Some("*"),
@@ -54,34 +55,38 @@ pub async fn git_branches(repo_path: String) -> AppResult<Vec<Branch>> {
             archived: archived.contains(name),
             upstream_ahead,
             upstream_behind,
+            upstream_gone,
         });
     }
     Ok(branches)
 }
 
-/// Parses git's `%(upstream:track)` field into `(ahead, behind)` counts.
+/// Parses git's `%(upstream:track)` field into `(ahead, behind, gone)`.
 ///
 /// Shapes: `[ahead 1, behind 2]`, `[ahead 1]`, `[behind 2]`, `[gone]`
-/// (upstream deleted), or empty (no upstream, or in sync). `gone`, empty, and
-/// anything unparseable all yield `(0, 0)`.
-fn parse_upstream_track(track: &str) -> (u32, u32) {
+/// (upstream deleted), or empty (no upstream, or in sync). `[gone]` yields
+/// `(0, 0, true)`; empty and anything unparseable yield `(0, 0, false)`.
+/// The `gone` bit lets consumers offer "Publish branch" instead of Push/Pull
+/// against a dead ref, even though `%(upstream:short)` still names the upstream.
+fn parse_upstream_track(track: &str) -> (u32, u32, bool) {
     let inner = track
         .trim()
         .strip_prefix('[')
         .and_then(|s| s.strip_suffix(']'));
     let Some(inner) = inner else {
-        return (0, 0);
+        return (0, 0, false);
     };
-    let (mut ahead, mut behind) = (0u32, 0u32);
+    let (mut ahead, mut behind, mut gone) = (0u32, 0u32, false);
     for part in inner.split(',') {
         let mut words = part.split_whitespace();
         match (words.next(), words.next()) {
             (Some("ahead"), Some(n)) => ahead = n.parse().unwrap_or(0),
             (Some("behind"), Some(n)) => behind = n.parse().unwrap_or(0),
+            (Some("gone"), _) => gone = true,
             _ => {}
         }
     }
-    (ahead, behind)
+    (ahead, behind, gone)
 }
 
 /// Branches that exist on a remote, for the switcher's "Remote" group. Returns
@@ -777,28 +782,29 @@ mod tests {
 
     #[test]
     fn parses_ahead_and_behind() {
-        assert_eq!(parse_upstream_track("[ahead 1, behind 2]"), (1, 2));
+        assert_eq!(parse_upstream_track("[ahead 1, behind 2]"), (1, 2, false));
     }
 
     #[test]
     fn parses_ahead_only() {
-        assert_eq!(parse_upstream_track("[ahead 1]"), (1, 0));
+        assert_eq!(parse_upstream_track("[ahead 1]"), (1, 0, false));
     }
 
     #[test]
     fn parses_behind_only() {
-        assert_eq!(parse_upstream_track("[behind 2]"), (0, 2));
+        assert_eq!(parse_upstream_track("[behind 2]"), (0, 2, false));
     }
 
     #[test]
     fn gone_upstream_is_zero() {
-        assert_eq!(parse_upstream_track("[gone]"), (0, 0));
+        // `[gone]` reports the deleted-upstream bit with zeroed counts.
+        assert_eq!(parse_upstream_track("[gone]"), (0, 0, true));
     }
 
     #[test]
     fn empty_or_unparseable_is_zero() {
-        assert_eq!(parse_upstream_track(""), (0, 0));
-        assert_eq!(parse_upstream_track("   "), (0, 0));
-        assert_eq!(parse_upstream_track("garbage"), (0, 0));
+        assert_eq!(parse_upstream_track(""), (0, 0, false));
+        assert_eq!(parse_upstream_track("   "), (0, 0, false));
+        assert_eq!(parse_upstream_track("garbage"), (0, 0, false));
     }
 }

--- a/src-tauri/src/git/status.rs
+++ b/src-tauri/src/git/status.rs
@@ -54,8 +54,14 @@ pub fn parse_status_v2(text: &str) -> RepoStatus {
         upstream: None,
         ahead: 0,
         behind: 0,
+        upstream_gone: false,
     };
     let mut entries = Vec::new();
+    // Porcelain v2 has no `[gone]` token. When the upstream ref is gone git still
+    // emits `# branch.upstream <name>` but omits `# branch.ab` entirely; a live
+    // upstream always produces a `branch.ab` line (even `+0 -0`). So a present
+    // upstream with no `branch.ab` seen ⇒ gone.
+    let mut saw_ab = false;
 
     let mut tokens = text.split('\0').peekable();
     while let Some(token) = tokens.next() {
@@ -74,6 +80,7 @@ pub fn parse_status_v2(text: &str) -> RepoStatus {
             } else if let Some(upstream) = header.strip_prefix("branch.upstream ") {
                 branch.upstream = Some(upstream.to_string());
             } else if let Some(ab) = header.strip_prefix("branch.ab ") {
+                saw_ab = true;
                 for part in ab.split(' ') {
                     if let Some(a) = part.strip_prefix('+') {
                         branch.ahead = a.parse().unwrap_or(0);
@@ -136,6 +143,8 @@ pub fn parse_status_v2(text: &str) -> RepoStatus {
         }
     }
 
+    branch.upstream_gone = branch.upstream.is_some() && !saw_ab;
+
     RepoStatus { branch, entries }
 }
 
@@ -175,7 +184,35 @@ mod tests {
         assert_eq!(s.branch.upstream.as_deref(), Some("origin/main"));
         assert_eq!(s.branch.ahead, 2);
         assert_eq!(s.branch.behind, 1);
+        // A live upstream always emits a branch.ab line, so it's not gone.
+        assert!(!s.branch.upstream_gone);
         assert!(s.entries.is_empty());
+    }
+
+    #[test]
+    fn upstream_present_without_ab_line_is_gone() {
+        // When the remote branch is deleted, git keeps the upstream header but
+        // drops the branch.ab line entirely — porcelain v2's only "gone" signal.
+        let text = z(&[
+            "# branch.oid abc123",
+            "# branch.head feature",
+            "# branch.upstream origin/feature",
+            "",
+        ]);
+        let s = parse_status_v2(&text);
+        assert_eq!(s.branch.upstream.as_deref(), Some("origin/feature"));
+        assert!(s.branch.upstream_gone);
+        assert_eq!(s.branch.ahead, 0);
+        assert_eq!(s.branch.behind, 0);
+    }
+
+    #[test]
+    fn no_upstream_is_not_gone() {
+        // A branch that never had an upstream must not read as gone.
+        let text = z(&["# branch.oid abc123", "# branch.head feature", ""]);
+        let s = parse_status_v2(&text);
+        assert_eq!(s.branch.upstream, None);
+        assert!(!s.branch.upstream_gone);
     }
 
     #[test]

--- a/src-tauri/src/git/status.rs
+++ b/src-tauri/src/git/status.rs
@@ -13,7 +13,17 @@ pub async fn status_core(repo_path: &str) -> AppResult<RepoStatus> {
         Some(repo_path),
         // -uall lists files inside untracked directories individually
         // instead of collapsing them to "dir/"
+        //
+        // status.aheadBehind=true is pinned defensively: stock git ignores both
+        // the config and --no-ahead-behind for porcelain v2 (verified live on
+        // 2.51.1 — `branch.ab` always emits for a live upstream), but forks that
+        // DO honor the config (large-repo setups often set it false) would
+        // otherwise drop `branch.ab` and make every live upstream read as gone.
+        // `-c` with an unknown key is ignored by any git, so this is
+        // version-safe where an --ahead-behind flag (git ≥ 2.17) is not.
         &[
+            "-c",
+            "status.aheadBehind=true",
             "status",
             "--porcelain=v2",
             "--branch",
@@ -61,6 +71,14 @@ pub fn parse_status_v2(text: &str) -> RepoStatus {
     // emits `# branch.upstream <name>` but omits `# branch.ab` entirely; a live
     // upstream always produces a `branch.ab` line (even `+0 -0`). So a present
     // upstream with no `branch.ab` seen ⇒ gone.
+    //
+    // Invariants this relies on (verified live on git for Windows): porcelain v2
+    // emits `branch.ab` for a live upstream unconditionally — `status.aheadBehind
+    // = false` affects non-porcelain formats only, and `--no-ahead-behind` is
+    // ignored by porcelain v2. Porcelain v2 also has no `branch.status` header.
+    // Belt-and-braces, `status_core` additionally pins `-c status.aheadBehind=
+    // true` on its invocation so even a git fork that honors the config for
+    // porcelain output cannot suppress `branch.ab` and fake a gone upstream.
     let mut saw_ab = false;
 
     let mut tokens = text.split('\0').peekable();

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -45,6 +45,11 @@ pub struct BranchHead {
     pub upstream: Option<String>,
     pub ahead: u32,
     pub behind: u32,
+    /// The upstream is configured (`upstream` is `Some`) but its remote-tracking
+    /// ref is gone (e.g. the branch was deleted on the remote after a PR merge).
+    /// Consumers treat this like "no upstream" for decisions — Publish instead of
+    /// Push/Pull, undo-commit allowed, no force-push demanded on amend.
+    pub upstream_gone: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -69,6 +74,10 @@ pub struct Branch {
     /// Commits on this branch's upstream that it doesn't have (drives
     /// "Update from origin/x" only when there's something to bring down).
     pub upstream_behind: u32,
+    /// The upstream is configured (`upstream` is `Some`) but its remote-tracking
+    /// ref is gone (e.g. the remote branch was deleted after a PR merge). Read as
+    /// "no upstream" for pushed-ness decisions.
+    pub upstream_gone: bool,
 }
 
 /// A branch that exists on a remote but not (yet) as a local branch — offered in

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
-use crate::git::runner::{run_git_mutating, NETWORK_TIMEOUT};
+use crate::git::runner::{run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
 use crate::github::issue::{map_reaction_groups, repo_owner_name, IssueReactions};
 use crate::github::runner::{run_gh, run_gh_input, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
 use crate::state::AppState;
@@ -626,6 +626,26 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
         return Ok(());
     };
 
+    // Best-effort prune of the LOCAL remote-tracking ref for this branch. The
+    // GitHub API delete never touches local git, so `refs/remotes/origin/<branch>`
+    // lingers (marked `[gone]`) until the next pruning fetch — long enough for the
+    // sync bar to keep offering stale Push/Pull. Deleting it now flips the branch
+    // to "Publish" on the next status refresh. Skipped for a cross-repository PR:
+    // a fork's head branch has no `origin` tracking ref of ours to prune. We use
+    // `run_git_raw` (no AppState) for this single atomic ref deletion rather than
+    // threading state through the signature — the same idempotent-prune model
+    // `git_delete_remote_branch_core` already uses.
+    let prune_local_tracking = || async {
+        if !head.is_cross_repository {
+            let _ = run_git_raw(
+                Some(repo_path),
+                &["update-ref", "-d", &format!("refs/remotes/origin/{branch}")],
+                DEFAULT_TIMEOUT,
+            )
+            .await;
+        }
+    };
+
     let endpoint = format!("repos/{owner}/{repo}/git/refs/heads/{branch}");
     match run_gh(
         Some(repo_path),
@@ -634,7 +654,10 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
     )
     .await
     {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            prune_local_tracking().await;
+            Ok(())
+        }
         Err(err) => {
             let raw = err.to_string();
             let lower = raw.to_ascii_lowercase();
@@ -643,6 +666,7 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
             // auto-deletes head branches, or a prior attempt removed it). A permission
             // failure can return 404 "Not found", so don't swallow that — let it surface.
             if lower.contains("reference does not exist") {
+                prune_local_tracking().await;
                 return Ok(());
             }
             let fork_note = if head.is_cross_repository {

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -812,6 +812,11 @@ pub struct McpGlobalClientStatus {
     /// The configured command points at the CURRENT managed launcher path
     /// (path-normalized compare). False for older install paths or custom entries.
     pub current: bool,
+    /// The installed entry's `args` array (string elements only), so the UI can
+    /// show WHICH permission tier is installed and nudge Reinstall on drift.
+    /// `None` when not installed, unreadable, or the args aren't an array — never
+    /// guessed. Non-string elements are dropped, never panicked on.
+    pub args: Option<Vec<String>>,
 }
 
 impl McpGlobalClientStatus {
@@ -820,6 +825,7 @@ impl McpGlobalClientStatus {
             installed: false,
             command: None,
             current: false,
+            args: None,
         }
     }
 }
@@ -852,9 +858,14 @@ fn norm_launcher_path(p: &str) -> String {
 ///
 /// * `mcpServers.gitdesktop` absent (or the shape isn't a map) ⇒ not installed.
 /// * present but `command` isn't a string ⇒ installed, `command: None`,
-///   `current: false`.
+///   `current: false` (args still carried when present).
 /// * present with a string `command` ⇒ installed; `current` iff it path-normal-
 ///   equals `launcher_path`.
+///
+/// `args` carries the entry's `args` array (string elements only) whenever the
+/// entry exists and `args` is an array; non-string junk elements are dropped and
+/// a non-array `args` yields `None`. Untrusted JSON from another CLI's config, so
+/// every element is type-checked — this never panics on shape surprises.
 fn classify_global_entry(config: &Value, launcher_path: &str) -> McpGlobalClientStatus {
     let Some(entry) = config
         .get("mcpServers")
@@ -863,12 +874,20 @@ fn classify_global_entry(config: &Value, launcher_path: &str) -> McpGlobalClient
     else {
         return McpGlobalClientStatus::not_installed();
     };
+    // Only string elements count; a non-array `args` (or a missing one) ⇒ None.
+    let args = entry.get("args").and_then(|v| v.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect::<Vec<String>>()
+    });
     let Some(command) = entry.get("command").and_then(|v| v.as_str()) else {
         // Present but no string command — installed, but we can't classify it.
+        // Still carry args so the UI can read the installed tier.
         return McpGlobalClientStatus {
             installed: true,
             command: None,
             current: false,
+            args,
         };
     };
     let current = norm_launcher_path(command) == norm_launcher_path(launcher_path);
@@ -876,6 +895,7 @@ fn classify_global_entry(config: &Value, launcher_path: &str) -> McpGlobalClient
         installed: true,
         command: Some(command.to_string()),
         current,
+        args,
     }
 }
 
@@ -1192,6 +1212,63 @@ mod tests {
         assert!(s.installed);
         assert_eq!(s.command.as_deref(), Some(LAUNCHER));
         assert!(s.current, "exact match is current");
+        // No args key ⇒ None (not an empty vec).
+        assert_eq!(s.args, None, "missing args ⇒ None");
+    }
+
+    #[test]
+    fn classify_carries_string_args() {
+        let doc = json!({ "mcpServers": { "gitdesktop": {
+            "command": LAUNCHER,
+            "args": ["mcp", "--repo", ".", "--allow-write", "--allow-remote-write"],
+        } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(
+            s.args.as_deref(),
+            Some(
+                [
+                    "mcp".to_string(),
+                    "--repo".to_string(),
+                    ".".to_string(),
+                    "--allow-write".to_string(),
+                    "--allow-remote-write".to_string(),
+                ]
+                .as_slice()
+            ),
+        );
+    }
+
+    #[test]
+    fn classify_args_drops_non_string_junk() {
+        // Untrusted JSON: numbers/objects/nulls mixed into args are dropped, never
+        // panicked on; the surviving strings are carried in order.
+        let doc = json!({ "mcpServers": { "gitdesktop": {
+            "command": LAUNCHER,
+            "args": ["mcp", 42, "--repo", { "x": 1 }, ".", null, "--allow-write"],
+        } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(
+            s.args.as_deref(),
+            Some(
+                [
+                    "mcp".to_string(),
+                    "--repo".to_string(),
+                    ".".to_string(),
+                    "--allow-write".to_string(),
+                ]
+                .as_slice()
+            ),
+        );
+        // A non-array `args` (wrong shape) ⇒ None, not a partial parse.
+        let doc = json!({ "mcpServers": { "gitdesktop": {
+            "command": LAUNCHER,
+            "args": "not-an-array",
+        } } });
+        let s = classify_global_entry(&doc, LAUNCHER);
+        assert!(s.installed);
+        assert_eq!(s.args, None, "non-array args ⇒ None");
     }
 
     #[test]
@@ -1239,12 +1316,28 @@ mod tests {
         assert!(s.installed);
         assert_eq!(s.command, None);
         assert!(!s.current);
-        // command entirely absent ⇒ same (installed, unclassified).
-        let doc = json!({ "mcpServers": { "gitdesktop": { "args": [] } } });
+        // command entirely absent ⇒ same (installed, unclassified) — but args are
+        // still carried so the tier readout survives a command-less entry.
+        let doc = json!({ "mcpServers": { "gitdesktop": {
+            "args": ["mcp", "--repo", ".", "--allow-git-write"],
+        } } });
         let s = classify_global_entry(&doc, LAUNCHER);
         assert!(s.installed);
         assert_eq!(s.command, None);
         assert!(!s.current);
+        assert_eq!(
+            s.args.as_deref(),
+            Some(
+                [
+                    "mcp".to_string(),
+                    "--repo".to_string(),
+                    ".".to_string(),
+                    "--allow-git-write".to_string(),
+                ]
+                .as_slice()
+            ),
+            "command-less entry still carries args",
+        );
     }
 
     #[test]

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -25,8 +25,8 @@
 //! the git cap or budgeting truncated, matching the TS `budgeted.truncated || diffTruncated`.
 
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::CallToolResult;
-use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
+use rmcp::model::{CallToolResult, GetPromptResult, PromptMessage, PromptMessageRole};
+use rmcp::{prompt, prompt_router, schemars, tool, tool_router, ErrorData as McpError};
 
 use super::{app_err, ensure_not_flag, json_result, to_value, GitDesktopMcp};
 use crate::git::types::DiffStatEntry;
@@ -714,6 +714,52 @@ impl GitDesktopMcp {
                        and use the result as the commit message. Errors if nothing is staged."
     )]
     async fn generate_commit_message(&self) -> Result<CallToolResult, McpError> {
+        let recipe = self.build_commit_recipe().await?;
+        json_result(&to_value(&recipe)?)
+    }
+
+    #[tool(
+        description = "Assemble GitDesktop's PR/MR-description generation recipe for a branch range: \
+                       returns { system, prompt, note } — the same provider-aware system + user \
+                       prompt the in-app AI feature builds (three-dot branch diff, the commit \
+                       subjects the PR would introduce, a per-file summary, the repo's available \
+                       labels when any, and project/user instructions). Defaults: base = the repo's \
+                       default branch, head = the current branch. This tool does NOT call a model; \
+                       complete the returned prompt with your own inference."
+    )]
+    async fn generate_pr_description(
+        &self,
+        Parameters(args): Parameters<PrRecipeArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let recipe = self.build_pr_recipe(args).await?;
+        json_result(&to_value(&recipe)?)
+    }
+
+    #[tool(
+        description = "Assemble GitDesktop's branch-name generation recipe from the WHOLE working \
+                       tree (staged + unstaged vs HEAD, plus untracked file names): returns \
+                       { system, prompt, note } — the same system + user prompt the in-app AI feature \
+                       builds (worktree diff, file summary, existing branch names as a convention \
+                       reference, and project/user instructions). This tool does NOT call a model; \
+                       complete the returned prompt with your own inference and use the result as the \
+                       branch name."
+    )]
+    async fn generate_branch_name(&self) -> Result<CallToolResult, McpError> {
+        let recipe = self.build_branch_recipe().await?;
+        json_result(&to_value(&recipe)?)
+    }
+}
+
+// ---- Recipe builders (shared by the recipe TOOLS above and the PROMPTS below) --
+//
+// Each gathers the repository context and assembles the `Recipe`, returning the
+// same `McpError::invalid_request` on the empty-input cases. The tools serialize
+// the recipe as JSON; the prompts render it as a single user PromptMessage. One
+// source of truth so a tool and its twin prompt can never drift.
+impl GitDesktopMcp {
+    /// Gather + assemble the commit-message recipe (STAGED changes). Errors with
+    /// `invalid_request` when nothing is staged.
+    async fn build_commit_recipe(&self) -> Result<Recipe, McpError> {
         let settings = crate::app_store::read_ai_generation_settings();
         let repo_ignore = crate::instructions::read_repo_ai_ignore(self.repo.clone())
             .await
@@ -749,7 +795,7 @@ impl GitDesktopMcp {
             .await
             .map_err(app_err)?;
 
-        let recipe = assemble_commit_recipe(CommitPieces {
+        Ok(assemble_commit_recipe(CommitPieces {
             diff_text: staged.text,
             diff_truncated: staged.truncated,
             files: staged.files,
@@ -757,23 +803,12 @@ impl GitDesktopMcp {
             recent_subjects: commits.into_iter().map(|c| c.subject).collect(),
             repo_instructions,
             global_instructions: settings.global_instructions,
-        });
-        json_result(&to_value(&recipe)?)
+        }))
     }
 
-    #[tool(
-        description = "Assemble GitDesktop's PR/MR-description generation recipe for a branch range: \
-                       returns { system, prompt, note } — the same provider-aware system + user \
-                       prompt the in-app AI feature builds (three-dot branch diff, the commit \
-                       subjects the PR would introduce, a per-file summary, the repo's available \
-                       labels when any, and project/user instructions). Defaults: base = the repo's \
-                       default branch, head = the current branch. This tool does NOT call a model; \
-                       complete the returned prompt with your own inference."
-    )]
-    async fn generate_pr_description(
-        &self,
-        Parameters(args): Parameters<PrRecipeArgs>,
-    ) -> Result<CallToolResult, McpError> {
+    /// Gather + assemble the PR/MR-description recipe for a branch range, applying
+    /// the in-app base/head defaults.
+    async fn build_pr_recipe(&self, args: PrRecipeArgs) -> Result<Recipe, McpError> {
         // Resolve base/head, applying the same defaults the in-app flow uses.
         let base = match args.base {
             Some(b) => b,
@@ -829,7 +864,7 @@ impl GitDesktopMcp {
             .map_err(app_err)?;
         let settings = crate::app_store::read_ai_generation_settings();
 
-        let recipe = assemble_pr_recipe(PrPieces {
+        Ok(assemble_pr_recipe(PrPieces {
             diff_text: diff.text,
             diff_truncated: diff.truncated,
             files: diff.files,
@@ -840,20 +875,12 @@ impl GitDesktopMcp {
             repo_instructions,
             global_instructions: settings.global_instructions,
             provider,
-        });
-        json_result(&to_value(&recipe)?)
+        }))
     }
 
-    #[tool(
-        description = "Assemble GitDesktop's branch-name generation recipe from the WHOLE working \
-                       tree (staged + unstaged vs HEAD, plus untracked file names): returns \
-                       { system, prompt, note } — the same system + user prompt the in-app AI feature \
-                       builds (worktree diff, file summary, existing branch names as a convention \
-                       reference, and project/user instructions). This tool does NOT call a model; \
-                       complete the returned prompt with your own inference and use the result as the \
-                       branch name."
-    )]
-    async fn generate_branch_name(&self) -> Result<CallToolResult, McpError> {
+    /// Gather + assemble the branch-name recipe (WHOLE working tree). Errors with
+    /// `invalid_request` when there are no in-progress changes.
+    async fn build_branch_recipe(&self) -> Result<Recipe, McpError> {
         let settings = crate::app_store::read_ai_generation_settings();
         let repo_ignore = crate::instructions::read_repo_ai_ignore(self.repo.clone())
             .await
@@ -895,7 +922,7 @@ impl GitDesktopMcp {
             .await
             .map_err(app_err)?;
 
-        let recipe = assemble_branch_recipe(BranchPieces {
+        Ok(assemble_branch_recipe(BranchPieces {
             diff_text: diff.text,
             diff_truncated: diff.truncated,
             files: diff.files,
@@ -904,8 +931,75 @@ impl GitDesktopMcp {
             recent_branches: branches,
             repo_instructions,
             global_instructions: settings.global_instructions,
-        });
-        json_result(&to_value(&recipe)?)
+        }))
+    }
+}
+
+/// Render a [`Recipe`] as the single user [`PromptMessage`] an MCP prompt returns:
+/// the system + user prompt joined, described by the recipe's `note`. The client
+/// model completes the assembled prompt (the recipe tools return the same content
+/// as JSON; the prompts hand it to the client as a ready-to-complete message).
+fn recipe_as_prompt(recipe: Recipe) -> GetPromptResult {
+    let Recipe {
+        system,
+        prompt,
+        note,
+    } = recipe;
+    GetPromptResult::new(vec![PromptMessage::new_text(
+        PromptMessageRole::User,
+        format!("{system}\n\n{prompt}"),
+    )])
+    .with_description(note)
+}
+
+// ---- The generation PROMPTS (MCP prompts primitive) ------------------------
+//
+// The same three generation recipes as the tools above, exposed additionally as
+// MCP prompts (slash-command-like in clients). Each assembles GitDesktop's system
+// + user prompt from the repository and returns it as ONE user message for the
+// client's own model to complete — read-only, no writes, no opt-in required. The
+// Rust method names carry a `_prompt` suffix so they don't collide with the recipe
+// tool methods on the same type.
+#[prompt_router(router = "generate_prompt_router", vis = "pub(crate)")]
+impl GitDesktopMcp {
+    #[prompt(
+        name = "commit-message",
+        description = "Assemble GitDesktop's commit-message generation prompt from the currently \
+                       STAGED changes (staged diff, per-file summary, recent commit subjects as a \
+                       style reference, and any project/user instructions) as one ready-to-complete \
+                       message. Your model completes it and the result is the commit message. Errors \
+                       if nothing is staged."
+    )]
+    async fn commit_message_prompt(&self) -> Result<GetPromptResult, McpError> {
+        Ok(recipe_as_prompt(self.build_commit_recipe().await?))
+    }
+
+    #[prompt(
+        name = "pr-description",
+        description = "Assemble GitDesktop's provider-aware PR/MR-description generation prompt for a \
+                       branch range (branch diff, the commit subjects the PR would introduce, a \
+                       per-file summary, the repo's labels when any, and project/user instructions) \
+                       as one ready-to-complete message. Defaults: base = the repo's default branch, \
+                       head = the current branch. Your model completes it and the result is the \
+                       PR/MR title and description."
+    )]
+    async fn pr_description_prompt(
+        &self,
+        Parameters(args): Parameters<PrRecipeArgs>,
+    ) -> Result<GetPromptResult, McpError> {
+        Ok(recipe_as_prompt(self.build_pr_recipe(args).await?))
+    }
+
+    #[prompt(
+        name = "branch-name",
+        description = "Assemble GitDesktop's branch-name generation prompt from the WHOLE working \
+                       tree (staged + unstaged vs HEAD, plus untracked file names; existing branch \
+                       names as a convention reference, and project/user instructions) as one \
+                       ready-to-complete message. Your model completes it and the result is the \
+                       branch name. Errors if there are no in-progress changes."
+    )]
+    async fn branch_name_prompt(&self) -> Result<GetPromptResult, McpError> {
+        Ok(recipe_as_prompt(self.build_branch_recipe().await?))
     }
 }
 

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -33,10 +33,18 @@ mod write_local;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use rmcp::handler::server::router::prompt::PromptRouter;
 use rmcp::handler::server::router::tool::ToolRouter;
-use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::model::{
+    CallToolResult, Content, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo,
+};
+use rmcp::service::RequestContext;
 use rmcp::transport::stdio;
-use rmcp::{schemars, tool_handler, ErrorData as McpError, ServerHandler, ServiceExt};
+use rmcp::{
+    prompt_handler, schemars, tool_handler, ErrorData as McpError, RoleServer, ServerHandler,
+    ServiceExt,
+};
 
 use crate::error::AppError;
 use crate::git::runner::{run_git, run_git_raw, DEFAULT_TIMEOUT};
@@ -103,6 +111,10 @@ pub struct GitDesktopMcp {
     // dead-code lint misses that (it only sees the derived `Clone` touch it).
     #[allow(dead_code)]
     tool_router: ToolRouter<GitDesktopMcp>,
+    // Read by the `#[prompt_handler]`-generated `list_prompts`/`get_prompt`; like
+    // `tool_router`, the dead-code lint only sees the derived `Clone` touch it.
+    #[allow(dead_code)]
+    prompt_router: PromptRouter<GitDesktopMcp>,
 }
 
 // ---- Shared tool parameters -----------------------------------------------
@@ -166,6 +178,11 @@ impl GitDesktopMcp {
                 + Self::write_forge_router()
                 + Self::write_git_router()
                 + Self::generate_router(),
+            // The generation recipes are ALSO exposed as MCP prompts. Only one module
+            // contributes prompts today, so there's no `+` chain here (unlike the
+            // tool router) — a future prompt-contributing module would `+` its own
+            // `PromptRouter` in.
+            prompt_router: Self::generate_prompt_router(),
         }
     }
 
@@ -262,12 +279,16 @@ impl GitDesktopMcp {
 // serves — so the `list_tools`/`call_tool`/`get_tool` the macro generates dispatch
 // across every domain module, not just one.
 #[tool_handler(router = self.tool_router)]
+#[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for GitDesktopMcp {
     fn get_info(&self) -> ServerInfo {
         // ServerInfo (InitializeResult) is #[non_exhaustive] — build from default,
         // then set the fields we care about.
         let mut info = ServerInfo::default();
-        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_prompts()
+            .build();
         info.instructions = Some(
             "GitDesktop as an MCP server. Tools act on the repository this server was launched \
              against (--repo). The PR/issue/CI tools route through GitDesktop's forge abstraction, \
@@ -292,7 +313,10 @@ impl ServerHandler for GitDesktopMcp {
              top of --allow-git-write) for IRRECOVERABLE local-git operations such as \
              discard/reset/force-push. Separately, a small set of generation-recipe tools (which \
              assemble the context and prompt for commit-message / branch-name generation) is \
-             always available and performs no writes."
+             always available and performs no writes. The same three generation recipes \
+             (commit-message, pr-description, branch-name) are ALSO exposed as MCP prompts that \
+             assemble GitDesktop's generation context for the client's own model to complete — \
+             read-only, always available, no opt-in required."
                 .into(),
         );
         info
@@ -727,5 +751,20 @@ mod tests {
             + GitDesktopMcp::generate_router().list_all().len();
         assert_eq!(handler.tool_router.list_all().len(), per_module);
         assert_eq!(per_module, 110);
+    }
+
+    /// The prompt router (separate from the tool router — prompts are NOT tools, so
+    /// the count above is unaffected) exposes exactly the three generation-recipe
+    /// prompts, by their MCP names. `list_all` returns them sorted by name.
+    #[test]
+    fn prompt_router_lists_the_three_generation_prompts() {
+        let handler = handler(false, false, false, false);
+        let names: Vec<String> = handler
+            .prompt_router
+            .list_all()
+            .into_iter()
+            .map(|p| p.name)
+            .collect();
+        assert_eq!(names, vec!["branch-name", "commit-message", "pr-description"]);
     }
 }

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -821,10 +821,9 @@ impl GitDesktopMcp {
     }
 
     #[tool(
-        description = "Approve a pull request (by number) in the bound repository's forge (GitLab \
-                       or Bitbucket, per its remote). GitHub approvals go through the review flow, \
-                       not this control — the forge layer returns an actionable error there. \
-                       Requires --allow-remote-write.",
+        description = "Approve a pull request (by number) in the bound repository's forge — works on \
+                       GitHub, GitLab, and Bitbucket, per its remote (GitHub goes through \
+                       `gh pr review --approve`). Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn approve_pull_request(
@@ -1105,10 +1104,10 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Request changes on a pull request (the blocking reviewer state) in the bound \
-                       repository's forge (GitLab or Bitbucket, per its remote). GitHub requests \
-                       changes through its own Review menu, not this control — the forge layer \
-                       returns an actionable error there. Reversible via withdraw_change_request. \
-                       Requires --allow-remote-write.",
+                       repository's forge — works on GitHub, GitLab, and Bitbucket, per its remote \
+                       (GitHub goes through `gh pr review --request-changes`, which requires a \
+                       non-empty body; the error surfaces if it's omitted). Reversible via \
+                       withdraw_change_request on Bitbucket. Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn request_changes(
@@ -1126,9 +1125,9 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Withdraw the viewer's requested-changes state on a pull request in the bound \
-                       repository's forge (Bitbucket, per its remote). GitLab can only revoke a \
-                       change request on Premium, and GitHub reviews live in its own Review menu — \
-                       the forge layer returns an actionable error there. Requires \
+                       repository's forge (Bitbucket only, per its remote). GitLab can only revoke a \
+                       change request on Premium, and GitHub can't withdraw a requested-changes \
+                       review via gh — the forge layer returns an actionable error there. Requires \
                        --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]

--- a/src/features/actions/BranchCiBadge.tsx
+++ b/src/features/actions/BranchCiBadge.tsx
@@ -29,7 +29,10 @@ export function BranchCiBadge({ repoPath }: { repoPath: string }) {
   return (
     <button
       type="button"
-      className="flex items-center gap-1.5 rounded-none px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      // Middle tier of the header shrink cascade (branch 20 → badge 4 → repo 1):
+      // under space pressure the workflow name compresses after the branch label
+      // but before the repo name; the icon + title tooltip keep the meaning.
+      className="flex min-w-0 shrink-4 items-center gap-1.5 rounded-none px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
       title={`${run.workflowName}: ${statusLabel(run.status, run.conclusion)} — view in Actions`}
       onClick={() => {
         selectRun(run.id);
@@ -41,7 +44,7 @@ export function BranchCiBadge({ repoPath }: { repoPath: string }) {
         conclusion={run.conclusion}
         className="size-3.5"
       />
-      <span className="hidden max-w-32 truncate sm:inline">
+      <span className="hidden min-w-0 max-w-32 truncate sm:inline">
         {run.workflowName}
       </span>
     </button>

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -302,12 +302,17 @@ export function createDiffFile(
 
 /**
  * Reads the full old/new file text for whole-file highlight context (the
- * content-mode path) and returns `{old,new}` to hand {@link createDiffFile}, or
- * `null` when content mode shouldn't apply (no revs, unreadable side, or a diff
- * too big in lines/chars for the renderer to highlight). Gated to small,
- * non-truncated diffs whose files fit the highlight budget. The rev pair MUST
- * match the diff's own old/new. Shared by the read-only diff surface and the
- * staging diff viewer. `diffText`/`filePath` should already be deferred values.
+ * content-mode path) and returns `{ content, pending }`: `content` is
+ * `{old,new}` to hand {@link createDiffFile}, or `null` when content mode
+ * shouldn't apply (no revs, unreadable side, or a diff too big in lines/chars
+ * for the renderer to highlight). `pending` is true only while content mode
+ * WANTS to apply but its whole-file reads haven't settled yet — callers gate on
+ * it to avoid painting an intermediate hunk-only diff that will immediately be
+ * rebuilt into the collapsible content-mode layout once the reads land (the
+ * "diff flash" single-paint fix). Gated to small, non-truncated diffs whose
+ * files fit the highlight budget. The rev pair MUST match the diff's own
+ * old/new. Shared by the read-only diff surface and the staging diff viewer.
+ * `diffText`/`filePath` should already be deferred values.
  */
 export function useFileContent(
   repoPath: string | undefined,
@@ -321,7 +326,7 @@ export function useFileContent(
   // still highlights correctly instead of falling back to the hunk-only,
   // mid-comment-leaking path.
   maxDiffLines: number = DIFF_LINE_CAP,
-): { old: string; new: string } | null {
+): { content: { old: string; new: string } | null; pending: boolean } {
   const oldRev = contentRevs?.oldRev;
   const newRev = contentRevs?.newRev;
   const wantContent =
@@ -374,9 +379,18 @@ export function useFileContent(
     fitsBudget(newText) &&
     covers(newText, maxNewLine) &&
     covers(oldText, maxOldLine);
+  // Content mode wants to apply here but its whole-file reads are still in
+  // flight — the caller should hold the paint rather than build a hunk-only diff
+  // it will immediately restructure once the reads settle. An already-viewed
+  // file settles instantly from the query cache (isPending, not isFetching, so a
+  // background refetch of cached data never re-blanks the pane).
+  const pending = wantContent && (!oldSettled || !newSettled);
   return useMemo(
-    () => (useContent ? { old: oldText, new: newText } : null),
-    [useContent, oldText, newText],
+    () => ({
+      content: useContent ? { old: oldText, new: newText } : null,
+      pending,
+    }),
+    [useContent, oldText, newText, pending],
   );
 }
 
@@ -418,9 +432,13 @@ function RenderedDiff({
   const deferredText = useDeferredValue(text);
   const deferredPath = useDeferredValue(filePath);
 
-  // Whole-file highlight context + collapsible expand for small diffs; null when
-  // it shouldn't apply (big file / unreadable / truncated → capped hunk-only).
-  const content = useFileContent(
+  // Whole-file highlight context + collapsible expand for small diffs; `content`
+  // is null when it shouldn't apply (big file / unreadable / truncated → capped
+  // hunk-only). `contentPending` is true while content mode wants to apply but
+  // its reads are still loading — we hold the whole paint until it settles so the
+  // diff is built ONCE (in its final content-mode layout) rather than painted
+  // hunk-only first and rebuilt when the reads land (the visible "flash").
+  const { content, pending: contentPending } = useFileContent(
     repoPath,
     deferredPath,
     deferredText,
@@ -444,38 +462,70 @@ function RenderedDiff({
 
   // Built-in Shiki grammars (astro/tsx/rust &c.) load lazily to keep them off
   // the startup bundle. The first time a diff needs one it isn't loaded yet, so
-  // createDiffFile falls back to highlight.js / plain; kick off the async load
-  // here and bump this counter when it settles so the memo rebuilds — now with
-  // the grammar registered — and the diff re-renders highlighted.
-  const [grammarReady, setGrammarReady] = useState(0);
+  // rather than build the diff hunk-only-highlighted and rebuild it when the
+  // grammar lands (the visible highlight pop-in), we hold the paint until the
+  // load settles. Track each language's outcome ("ready" or "failed") so a
+  // failed import still releases the gate — a missing grammar must fall back to
+  // highlight.js / plain, never deadlock the pane.
+  const [grammarState, setGrammarState] = useState<
+    Record<string, "ready" | "failed">
+  >({});
   const lang = useMemo(
     () => diffLang(deferredPath, syntaxMap),
     [deferredPath, syntaxMap],
   );
   useEffect(() => {
-    if (!lang || !isBuiltinShikiLang(lang) || isShikiLang(lang)) return;
+    if (
+      !lang ||
+      !isBuiltinShikiLang(lang) ||
+      isShikiLang(lang) ||
+      grammarState[lang] !== undefined
+    )
+      return;
     let cancelled = false;
     ensureBuiltinShikiLang(lang).then((ok) => {
-      if (ok && !cancelled) setGrammarReady((n) => n + 1);
+      if (!cancelled)
+        setGrammarState((s) => ({ ...s, [lang]: ok ? "ready" : "failed" }));
     });
     return () => {
       cancelled = true;
     };
-  }, [lang]);
+  }, [lang, grammarState]);
 
-  // grammarReady is a deliberate rebuild trigger: createDiffFile reads the
+  // A built-in Shiki grammar this diff needs is still loading (never seen a
+  // "ready"/"failed" result for it): hold the paint. `isShikiLang(lang)` already
+  // true means it loaded (this or an earlier diff), so it isn't pending.
+  const grammarPending =
+    !!lang &&
+    isBuiltinShikiLang(lang) &&
+    !isShikiLang(lang) &&
+    !grammarState[lang];
+
+  // grammarState is a deliberate rebuild trigger: createDiffFile reads the
   // now-loaded Shiki grammar via module state (isShikiLang), not a passed value,
-  // so bumping it is what forces the rebuild that picks the grammar up.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: grammarReady is an intentional rebuild trigger, not read directly
+  // so recording the load result is what forces the rebuild that picks the
+  // grammar up (the gate below only lets the first build run once it's settled).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>
-      createDiffFile(
-        deferredPath,
-        shown,
-        { syntaxMap, customLanguages },
-        content ?? undefined,
-      ),
-    [shown, deferredPath, syntaxMap, customLanguages, content, grammarReady],
+      contentPending || grammarPending
+        ? null
+        : createDiffFile(
+            deferredPath,
+            shown,
+            { syntaxMap, customLanguages },
+            content ?? undefined,
+          ),
+    [
+      shown,
+      deferredPath,
+      syntaxMap,
+      customLanguages,
+      content,
+      contentPending,
+      grammarPending,
+      grammarState,
+    ],
   );
 
   // Build the per-side extendData maps from the anchors (keyed by String(line)).
@@ -793,6 +843,12 @@ function RenderedDiff({
     [lineWidget, resolveWidgetRange, syncPreselect],
   );
 
+  // Inputs still settling (whole-file reads or the lazy grammar): render nothing
+  // rather than a hunk-only diff we'd immediately rebuild — the single-paint gate
+  // that removes the flash. Must precede the empty-state placeholder so loading
+  // never masquerades as "No changes to show". Matches DiffContent's own
+  // render-nothing-while-loading design (see the comment there).
+  if (contentPending || grammarPending) return null;
   if (!diffFile) return <DiffPlaceholder message="No changes to show" />;
   return (
     <>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -572,7 +572,11 @@ function StagingDiffView({
   // Whole-file highlight context + expand. The staging view renders every hunk
   // regardless, so let content mode engage for big diffs too — bounded by the
   // file highlight budget, not the read-only surface's 200-line render cap.
-  const content = useFileContent(
+  // `pending` holds the paint until the whole-file reads settle, so the diff is
+  // built once in its final content-mode layout instead of flashing hunk-only
+  // first (the single-paint fix). (No Shiki grammar gating here — this staging
+  // path doesn't lazy-load built-in grammars, a pre-existing gap left as-is.)
+  const { content, pending: contentPending } = useFileContent(
     repoPath,
     deferredPath,
     deferredText,
@@ -580,15 +584,26 @@ function StagingDiffView({
     HIGHLIGHT_MAX_LINES,
   );
   // The whole-file diff (every hunk) — never capped, so all hunks stay stageable.
+  // Null while content reads are pending: don't build an intermediate diff the
+  // arriving reads would immediately restructure.
   const diffFile = useMemo(
     () =>
-      createDiffFile(
-        deferredPath,
-        deferredText,
-        { syntaxMap, customLanguages },
-        content ?? undefined,
-      ),
-    [deferredPath, deferredText, syntaxMap, customLanguages, content],
+      contentPending
+        ? null
+        : createDiffFile(
+            deferredPath,
+            deferredText,
+            { syntaxMap, customLanguages },
+            content ?? undefined,
+          ),
+    [
+      deferredPath,
+      deferredText,
+      syntaxMap,
+      customLanguages,
+      content,
+      contentPending,
+    ],
   );
 
   // The library can expand collapsed context but offers no way back; track when
@@ -674,6 +689,12 @@ function StagingDiffView({
     };
   }, [diffFile, hunks]);
 
+  // Whole-file reads still settling: render nothing rather than build a hunk-only
+  // diff we'd immediately restructure once they land (the single-paint fix). Must
+  // precede the empty-state placeholder so loading never reads as "No changes to
+  // show". All hooks above have already run (rules of hooks); the effects guard
+  // on `!diffFile`, so they no-op while pending and re-bind on the single build.
+  if (contentPending) return null;
   if (!diffFile) return <DiffPlaceholder message="No changes to show" />;
   // A hunk at line 1 has no `@@` separator row to host its buttons (sep=false),
   // so give it a synthetic header bar at the very top instead of overlaying the

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1049,6 +1049,10 @@ project, no per-repo file) via the client's own CLI, with a project-aware \`--re
 single entry follows whatever repo you open. Each row shows its **live state**: already
 installed and pointing at the current launcher, or pointing at an older install (a one-click
 **Reinstall** switches it over) — with **Remove** to take it back out, no confirmation needed.
+An installed row also reads out the entry's **permission tier** (e.g. *Installed (local +
+remote writes)*, or *read-only*), and once you change the permission checkboxes so they no
+longer match the installed entry it flags the mismatch and offers **Reinstall** to apply the
+new selection.
 Two toggles shape what gets written: **Shareable entry** swaps machine-specific
 absolute paths for portable \`\${GITDESKTOP_BIN:-gitdesktop-mcp}\` / \`\${CLAUDE_PROJECT_DIR}\`
 ones a teammate can commit (they point \`GITDESKTOP_BIN\` at their own launcher, or keep
@@ -1099,7 +1103,10 @@ the agent the *same* fully assembled context and prompt the in-app feature build
 staged or branch diff (with the same low-value-file budgeting), recent commit subjects as a
 style reference, your repo and global instructions, and \`.aiignore\` filtering. The tools
 don't call a model; the agent completes the returned prompt with its own inference, so you
-can trigger GitDesktop's generation from any client.
+can trigger GitDesktop's generation from any client. The same three recipes are also exposed
+as native **MCP prompts** (\`commit-message\`, \`pr-description\`, \`branch-name\`) — the
+slash-command-like primitive many clients surface — each handing your model the assembled
+prompt to complete.
 
 New to MCP? **Browse** opens the official Model Context Protocol registry right in that
 panel — search it and add a server in a click; it arrives **disabled** for you to review

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -179,7 +179,9 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
   const head = status.data?.branch;
   const lastCommit = log.data?.pages[0]?.[0];
   const canUndo = Boolean(
-    lastCommit && head && (head.upstream === null || head.ahead > 0),
+    lastCommit &&
+      head &&
+      (head.upstream === null || head.upstreamGone || head.ahead > 0),
   );
 
   async function undoLast() {
@@ -246,12 +248,15 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
   // below it live on `origin/<base>` and are already published, so only the
   // branch's own commits are unpushed. (Queried only in the no-upstream case.)
   // Drives both the rewrite gating below and the per-row "not pushed" marker.
-  const noUpstream = head != null && head.upstream === null;
+  // A gone upstream counts as no upstream so the `unpushedVsRemotes` fallback
+  // engages and the per-row "not pushed" markers reflect what's truly published.
+  const noUpstream =
+    head != null && (head.upstream === null || head.upstreamGone);
   const unpushedVsRemotes = useUnpushedCount(repoPath, noUpstream);
   const unpushedCount = head
-    ? head.upstream
-      ? head.ahead
-      : (unpushedVsRemotes.data ?? 0)
+    ? noUpstream
+      ? (unpushedVsRemotes.data ?? 0)
+      : head.ahead
     : 0;
   // The unpushed set (top `unpushedCount` of the HEAD-order log), for marking
   // rows. Memoized — the React Compiler won't hoist the .slice/.map/new Set.
@@ -737,7 +742,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
               selected={selected}
               selectedCommitHash={selectedCommitHash}
               unpushedHashes={unpushedHashes}
-              upstream={head?.upstream ?? null}
+              upstream={head?.upstreamGone ? null : (head?.upstream ?? null)}
               onRowClick={onRowClick}
               onHoverPrefetch={(hash) =>
                 hoverPrefetch(() => prefetchCommit(hash))

--- a/src/features/history/useAmendCommit.ts
+++ b/src/features/history/useAmendCommit.ts
@@ -48,7 +48,11 @@ export function useAmendWithConfirm(repoPath: string) {
 
   const branch = status.data?.branch;
   const upstream = branch?.upstream ?? null;
-  const needsForcePush = upstream !== null && (branch?.ahead ?? 0) === 0;
+  // A gone upstream (remote branch deleted) reads as no upstream: the commit
+  // isn't on any live remote, so amending it is a plain re-commit, not a
+  // force-push.
+  const needsForcePush =
+    upstream !== null && !branch?.upstreamGone && (branch?.ahead ?? 0) === 0;
 
   function requestAmend(hash: string) {
     // Amending an already-pushed commit means force-pushing it. If a branch

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1029,11 +1029,16 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 className="min-w-0 truncate"
                 // Only expose the full label as a tooltip when it's actually
                 // clipped — measured just-in-time on hover, so no ref needed.
+                // Remove the attribute (not title="") when unclipped: an empty
+                // title="" is still a title in Chromium and would suppress the
+                // Button's own conditional (amending) title above.
                 onMouseEnter={(e) => {
                   const el = e.currentTarget;
-                  if (el)
-                    el.title =
-                      el.scrollWidth > el.clientWidth ? currentLabel : "";
+                  if (el) {
+                    if (el.scrollWidth > el.clientWidth)
+                      el.title = currentLabel;
+                    else el.removeAttribute("title");
+                  }
                 }}
               >
                 {currentLabel}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1011,7 +1011,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             <Button
               variant="ghost"
               size="sm"
-              className="min-w-0 shrink"
+              // Large shrink factor makes the branch label absorb essentially
+              // all header space pressure before the repo name or CI badge give
+              // way (flex removes space proportionally to factor × base size),
+              // so the header cascade collapses branch (20) → CI badge (4) →
+              // repo (1).
+              className="min-w-0 shrink-20"
               disabled={busy || amending}
               title={
                 amending

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1011,6 +1011,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             <Button
               variant="ghost"
               size="sm"
+              className="min-w-0 shrink"
               disabled={busy || amending}
               title={
                 amending
@@ -1019,9 +1020,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               }
             >
               <GitBranchIcon data-icon="inline-start" />
-              {currentLabel}
+              <span
+                className="min-w-0 truncate"
+                // Only expose the full label as a tooltip when it's actually
+                // clipped — measured just-in-time on hover, so no ref needed.
+                onMouseEnter={(e) => {
+                  const el = e.currentTarget;
+                  if (el)
+                    el.title =
+                      el.scrollWidth > el.clientWidth ? currentLabel : "";
+                }}
+              >
+                {currentLabel}
+              </span>
               {head?.detached && (
-                <Badge variant="secondary" className="ml-1">
+                <Badge variant="secondary" className="ml-1 shrink-0">
                   detached
                 </Badge>
               )}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -690,8 +690,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     "update-default-from-upstream",
     () =>
       defaultBranchRow?.upstream &&
+      !defaultBranchRow.upstreamGone &&
       doUpdateFromUpstream(defaultBranchRow.name, defaultBranchRow.upstream),
-    Boolean(defaultBranchRow?.upstream) && !busy,
+    Boolean(defaultBranchRow?.upstream) &&
+      !defaultBranchRow?.upstreamGone &&
+      !busy,
   );
   useHotkeyAction(
     "merge-into-current",
@@ -1458,7 +1461,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         currentLabel={currentLabel}
         defaultBranch={defaultName}
         hasChanges={hasChanges}
-        isPushed={Boolean(head?.upstream)}
+        isPushed={Boolean(head?.upstream) && !head?.upstreamGone}
       />
 
       <SwitchWithChangesDialog

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -58,14 +58,35 @@ export function RepoSwitcher() {
   useHotkeyAction("clone-repository", () => setCloneOpen(true));
   useHotkeyAction("new-repository", () => setCreateOpen(true));
 
+  const repoLabel = alias ?? repoName ?? "Repository";
+
   return (
     <>
       <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger
           render={
-            <Button variant="ghost" size="sm" className="max-w-56 gap-1.5">
-              <span className="truncate text-sm font-medium">
-                {alias ?? repoName ?? "Repository"}
+            <Button
+              variant="ghost"
+              size="sm"
+              // Deliberately NOT shrinkable (the vendored Button's shrink-0
+              // applies): the repo name holds its natural width while the
+              // branch label (shrink-20) and CI badge (shrink-4) absorb header
+              // space pressure — even a tiny flex-shrink share would swap
+              // characters for an ellipsis. max-w-56 still caps long names.
+              className="max-w-56 min-w-0 gap-1.5"
+            >
+              <span
+                className="min-w-0 truncate text-sm font-medium"
+                // Only expose the full name as a tooltip when it's actually
+                // clipped — measured just-in-time on hover, so no ref needed.
+                onMouseEnter={(e) => {
+                  const el = e.currentTarget;
+                  if (el)
+                    el.title =
+                      el.scrollWidth > el.clientWidth ? repoLabel : "";
+                }}
+              >
+                {repoLabel}
               </span>
               <CaretDownIcon className="shrink-0 text-muted-foreground" />
             </Button>

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -79,11 +79,15 @@ export function RepoSwitcher() {
                 className="min-w-0 truncate text-sm font-medium"
                 // Only expose the full name as a tooltip when it's actually
                 // clipped — measured just-in-time on hover, so no ref needed.
+                // Remove the attribute (not title="") when unclipped: an empty
+                // title="" is still a title in Chromium and would suppress any
+                // ancestor tooltip.
                 onMouseEnter={(e) => {
                   const el = e.currentTarget;
-                  if (el)
-                    el.title =
-                      el.scrollWidth > el.clientWidth ? repoLabel : "";
+                  if (el) {
+                    if (el.scrollWidth > el.clientWidth) el.title = repoLabel;
+                    else el.removeAttribute("title");
+                  }
                 }}
               >
                 {repoLabel}

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -67,7 +67,11 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   const readyProviders = usePublishProviders(repoPath, noOrigin);
 
   const head = status.data?.branch;
-  const hasUpstream = Boolean(head?.upstream);
+  // A gone upstream (remote branch deleted, config lingers) reads as "no
+  // upstream": the button flips to "Publish branch" and its push sends
+  // `-u origin HEAD`, recreating the remote branch; Pull disables against the
+  // dead ref.
+  const hasUpstream = Boolean(head?.upstream) && !head?.upstreamGone;
   // amended/rewritten local history: local and remote both have commits the
   // other lacks, so neither pull --ff-only nor a normal push can succeed
   const diverged = Boolean(head && head.ahead > 0 && head.behind > 0);

--- a/src/features/settings/mcp/GitDesktopAsServer.tsx
+++ b/src/features/settings/mcp/GitDesktopAsServer.tsx
@@ -1,6 +1,6 @@
 import { CaretRightIcon, CheckIcon, CopyIcon } from "@phosphor-icons/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -31,6 +31,28 @@ import { toastError } from "@/lib/toast";
  *  `.mcp.json`, or a client's global (all-projects) user config. */
 type InstallTarget = "project" | "claude" | "copilot";
 
+/** The four `--allow-*` permission flags, in ladder order, mapped to their
+ *  human tier label. Drives both the installed-tier readout and the drift
+ *  comparison — every other arg (`mcp`, `--repo`, its value, unknown flags) is
+ *  ignored, so it never counts as a permission or as drift. */
+const ALLOW_FLAG_LABELS: Record<string, string> = {
+  "--allow-write": "local writes",
+  "--allow-remote-write": "remote writes",
+  "--allow-git-write": "git writes",
+  "--allow-destructive": "destructive",
+};
+
+/** The installed entry's permission tier as a readable label, e.g. "local +
+ *  remote writes", or "read-only" when no `--allow-*` flags are present. Reads
+ *  ONLY the known flags out of `args`, in ladder order, so unknown args never
+ *  leak into the label. */
+function tierLabel(installedFlags: string[]): string {
+  const parts = Object.keys(ALLOW_FLAG_LABELS)
+    .filter((flag) => installedFlags.includes(flag))
+    .map((flag) => ALLOW_FLAG_LABELS[flag]);
+  return parts.length ? parts.join(" + ") : "read-only";
+}
+
 /** Bottom-of-section disclosure: the inverse of the rest of this panel. Instead of
  *  consuming MCP servers, expose GitDesktop's OWN read-only git/GitHub tools to
  *  external clients, which run the app as a stdio server via `gitdesktop mcp`.
@@ -50,6 +72,13 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
   // too, so unchecking git-write must also clear destructive).
   const [allowGitWrite, setAllowGitWrite] = useState(false);
   const [allowDestructive, setAllowDestructive] = useState(false);
+  // Dirty-tracking for the four tier checkboxes above (NOT `shareable`): true once
+  // the user has changed any of them this open. The tier checkboxes initialize to
+  // false, so without this a flagged global install would show the drift warning +
+  // "Reinstall" the instant the disclosure opens — a nag before any intent. Reset
+  // to false on each closed→open transition (below) so every open starts pristine;
+  // `drift` gates on it, so drift/Reinstall only surface after a real change.
+  const [tierTouched, setTierTouched] = useState(false);
   // One install at a time: `busyTarget` is which is running, `confirmTarget` which
   // is awaiting a replace-confirm. "project" = this repo's .mcp.json;
   // "claude"/"copilot" = that client's global (all-projects) user config.
@@ -181,6 +210,20 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     setTimeout(() => setCopied(false), 1500);
   }
 
+  // The four `--allow-*` flags the current checkbox selection wants, in ladder
+  // order. Single source of truth for both the emitted global entry and the drift
+  // comparison, so the installed tier and the wanted tier can't diverge.
+  // --allow-destructive requires git-write; gate on both so a stray flag can never
+  // emit (or be compared) without its prerequisite.
+  const wantedAllowFlags = useCallback((): string[] => {
+    const flags: string[] = [];
+    if (allowWrite) flags.push("--allow-write");
+    if (allowRemoteWrite) flags.push("--allow-remote-write");
+    if (allowGitWrite) flags.push("--allow-git-write");
+    if (allowGitWrite && allowDestructive) flags.push("--allow-destructive");
+    return flags;
+  }, [allowWrite, allowRemoteWrite, allowGitWrite, allowDestructive]);
+
   // The entry a GLOBAL (all-projects) install writes: the absolute exe + a DYNAMIC
   // repo so the server follows whatever project the client is in. The repo var is
   // client-specific — Claude Code expands ${CLAUDE_PROJECT_DIR}; Copilot has no
@@ -191,11 +234,8 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
       "mcp",
       "--repo",
       target === "claude" ? "${CLAUDE_PROJECT_DIR:-.}" : ".",
+      ...wantedAllowFlags(),
     ];
-    if (allowWrite) args.push("--allow-write");
-    if (allowRemoteWrite) args.push("--allow-remote-write");
-    if (allowGitWrite) args.push("--allow-git-write");
-    if (allowGitWrite && allowDestructive) args.push("--allow-destructive");
     return { command: launcherPath, args };
   }
 
@@ -303,6 +343,29 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     // Install/Reinstall embed the absolute launcher path, so they additionally
     // gate on the launcher being ready.
     const installReason = rowLoadingReason ?? busyReason ?? launcherDisabledReason;
+    // The known `--allow-*` flags actually installed (order-normalized via the
+    // ladder map; every other arg is ignored). `args` is null for an older
+    // install predating this probe — then we can't read the tier and omit it.
+    const installedFlags =
+      status?.args != null
+        ? Object.keys(ALLOW_FLAG_LABELS).filter((flag) =>
+            (status.args as string[]).includes(flag),
+          )
+        : null;
+    // Drift = the installed permission set differs from the currently-selected
+    // one. Gated on `tierTouched` so a pristine open never nags — the checkboxes
+    // start all-false, which would otherwise read as drift against any flagged
+    // install before the user expresses intent. Only meaningful for a current,
+    // readable install; the stale-path (!current) warning owns the not-current
+    // case and takes precedence.
+    const wanted = wantedAllowFlags();
+    const drift =
+      tierTouched &&
+      status?.installed === true &&
+      status.current &&
+      installedFlags !== null &&
+      (installedFlags.length !== wanted.length ||
+        !wanted.every((flag) => installedFlags.includes(flag)));
     return (
       <div className="space-y-1">
         <div className="flex items-center justify-between gap-2">
@@ -342,11 +405,11 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
                 {installing ? (
                   <>
                     <Spinner className="size-3" />{" "}
-                    {status?.installed && !status.current
+                    {status?.installed && (!status.current || drift)
                       ? "Reinstalling…"
                       : "Adding…"}
                   </>
-                ) : status?.installed && !status.current ? (
+                ) : status?.installed && (!status.current || drift) ? (
                   "Reinstall"
                 ) : (
                   "Install"
@@ -358,15 +421,26 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
         {globalStatusLoading ? (
           <p className="text-xs text-muted-foreground">Checking…</p>
         ) : status?.installed ? (
-          status.current ? (
-            <p className="flex items-center gap-1.5 text-xs text-success">
-              <CheckIcon className="shrink-0" />
-              <span>Installed — uses this launcher.</span>
-            </p>
-          ) : (
+          !status.current ? (
+            // Stale-path warning owns the not-current case and takes precedence
+            // over any drift readout — never show both.
             <p className="text-xs text-warning">
               Installed — points at a different executable (an older install or
               custom entry). Reinstall to use this launcher.
+            </p>
+          ) : drift ? (
+            <p className="text-xs text-warning">
+              Installed ({tierLabel(installedFlags ?? [])}) — differs from the
+              selected permissions. Reinstall to apply them.
+            </p>
+          ) : (
+            <p className="flex items-center gap-1.5 text-xs text-success">
+              <CheckIcon className="shrink-0" />
+              <span>
+                Installed
+                {installedFlags !== null && ` (${tierLabel(installedFlags)})`} —
+                uses this launcher.
+              </span>
             </p>
           )
         ) : (
@@ -401,7 +475,15 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
     <div className="border-t pt-4">
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() =>
+          setOpen((o) => {
+            // Each closed→open transition starts pristine, so a flagged install
+            // shows the calm success line (with its tier readout) rather than the
+            // drift nag until the user actually changes a tier checkbox.
+            if (!o) setTierTouched(false);
+            return !o;
+          })
+        }
         aria-expanded={open}
         aria-controls="gd-as-mcp-config"
         className="flex w-full items-start gap-2 rounded text-left outline-none focus-visible:ring-1 focus-visible:ring-ring"
@@ -451,7 +533,10 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
             <label className="flex cursor-pointer items-center gap-2 text-xs">
               <Checkbox
                 checked={allowWrite}
-                onCheckedChange={(c) => setAllowWrite(c === true)}
+                onCheckedChange={(c) => {
+                  setAllowWrite(c === true);
+                  setTierTouched(true);
+                }}
               />
               Allow write tools
             </label>
@@ -466,7 +551,10 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
             <label className="flex cursor-pointer items-center gap-2 text-xs">
               <Checkbox
                 checked={allowRemoteWrite}
-                onCheckedChange={(c) => setAllowRemoteWrite(c === true)}
+                onCheckedChange={(c) => {
+                  setAllowRemoteWrite(c === true);
+                  setTierTouched(true);
+                }}
               />
               Allow remote write
             </label>
@@ -484,6 +572,7 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
                 onCheckedChange={(c) => {
                   const on = c === true;
                   setAllowGitWrite(on);
+                  setTierTouched(true);
                   // Destructive requires git-write; turning git-write off must
                   // drop it too, so no hidden state can emit --allow-destructive.
                   if (!on) setAllowDestructive(false);
@@ -510,7 +599,10 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
                 <Checkbox
                   checked={allowDestructive}
                   disabled={!allowGitWrite}
-                  onCheckedChange={(c) => setAllowDestructive(c === true)}
+                  onCheckedChange={(c) => {
+                    setAllowDestructive(c === true);
+                    setTierTouched(true);
+                  }}
                 />
                 Allow destructive git writes
               </label>

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -265,7 +265,7 @@ Write the review in GitHub-flavored Markdown:
   - the problem — and for **blocker**/**should-fix**, the concrete case that makes it real (the input, state, or code path that triggers it, not just an assertion);
   - a concrete suggested fix.
 - Cover real issues across correctness (bugs, logic errors, unhandled edge cases or errors), security smells, performance traps, clarity and naming, and missing or weak tests. Breadth is welcome — but only where each finding is genuinely useful.
-- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't flag missing tests for changes that introduce no new behavior (renames, reformatting, or pure reorganization).
+- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't flag missing tests for changes that introduce no new behavior (renames, reformatting, or pure reorganization). Before flagging a possible null/undefined or missing-value issue, check the typed contract: a field the types declare non-optional, or that every code path visibly always sets, is not a finding.
 - Be specific and grounded strictly in the diff — do not invent code, files, or behavior you cannot see. If the change looks solid, say so plainly in a line or two and stop.
 
 No filler: don't summarize what you reviewed, don't pad, don't add compliments — just the assessment and the findings. Do not wrap the whole review in a code fence. Do not restate the entire diff.`;
@@ -337,6 +337,7 @@ You are ALSO given findings that OTHER automated code reviewers (e.g. GitHub Cop
 Re-verify each of their findings against the CURRENT diff and use them like this:
 - If one identifies a real, still-present problem, report it as a normal finding; you MAY add a terse parenthetical credit like "(also flagged by Copilot)" when it independently matches your own conclusion.
 - If one is WRONG, already fixed, or unsupported by the current diff, AND it's the kind of thing a reader might otherwise act on, add a short line briefly dismissing it (e.g. "Copilot flagged X here; not an issue because …"). Triaging their false positives is the most useful thing you can do with them.
+- If you CANNOT verify one against the current diff — the code it concerns isn't shown here — OMIT it entirely. Do not relay it with a "could not verify" hedge, and never add supporting claims of your own that the diff does not show. An unverifiable third-party claim is not a finding.
 - Otherwise (trivial or irrelevant), ignore it silently.
 
 Never present another tool's claim as confirmed unless the current diff proves it, and never invent a finding just to agree or disagree with them.`;

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2724,6 +2724,11 @@ export interface McpGlobalClientStatus {
   /** The configured command resolves to the current managed launcher
    *  (path-normalized) — false for an older install or a custom entry. */
   current: boolean;
+  /** The installed entry's `args` (string elements only), so the UI can read
+   *  WHICH permission tier is installed and nudge Reinstall when it drifts from
+   *  the selected permissions. `null` when not installed, unreadable, or the
+   *  entry predates this probe — never guessed. */
+  args: string[] | null;
 }
 
 export interface McpGlobalStatus {

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -31,6 +31,11 @@ export interface BranchHead {
   upstream: string | null;
   ahead: number;
   behind: number;
+  /** The upstream is configured but its remote-tracking ref is gone (e.g. the
+   *  remote branch was deleted after a PR merge). Treat like "no upstream" for
+   *  decisions: offer Publish over Push/Pull, allow undo-commit, don't demand a
+   *  force-push on amend. */
+  upstreamGone: boolean;
 }
 
 export interface RepoStatus {
@@ -52,6 +57,10 @@ export interface Branch {
   /** Commits this branch is behind its own upstream — drives the
    *  "Update from {upstream}" action. 0 when untracked, gone, or in sync. */
   upstreamBehind: number;
+  /** The upstream is configured but its remote-tracking ref is gone (e.g. the
+   *  remote branch was deleted after a PR merge). Read as "no upstream" for
+   *  pushed-ness decisions. */
+  upstreamGone: boolean;
 }
 
 /** A branch that exists on a remote but not locally — offered in the switcher so


### PR DESCRIPTION
This change adds UI and protocol support to display the installed permission tier for your global MCP server install, exposes all in-app AI generation recipes as native MCP prompts, and makes remote-branch deletion fully reliable—including "gone" upstreams now correctly offer "Publish branch" and no longer trigger force-push requirements or block undo-commit. It also fixes large-file diff flashing/repaints and ensures long branch names never overflow the repo header. These changes streamline working on branches after PR merges, clarify MCP server state, and give every client richer, context-aware model prompts.

### MCP server and permission tier display
- Adds permission tier display (read-only, local writes, remote writes, etc.) to each global MCP install row in `src/features/settings/mcp/GitDesktopAsServer.tsx`
- Adds drift detection: if the installed MCP entry's permissions don't match the checkbox selection, the UI prompts for Reinstall and clearly flags the mismatch (`src/features/settings/mcp/GitDesktopAsServer.tsx`, `src-tauri/src/mcp.rs`)
- Plumbs the installed entry's actual args down from backend to frontend (`src-tauri/src/mcp.rs`, `src/lib/git/api.ts`)

### MCP prompts and generation recipes
- Exposes AI generation recipes (`commit-message`, `pr-description`, `branch-name`) as native MCP prompts—always available, matching the in-app context; see `src-tauri/src/mcp_server/generate.rs` and `src-tauri/src/mcp_server/mod.rs`
- Extends MCP help and README documentation to surface these prompt capabilities (`README.md`, `src/features/help/content.ts`)
- Adds distinct changelog entries for prompt/recipe duality

### Git: Handling deleted upstream branches ("[gone]" remotes)
- Extends branch and status parsing to track when an upstream is configured but the remote branch has been deleted—`upstreamGone`—and propagates this to all consumers (`src-tauri/src/git/branches.rs`, `src-tauri/src/git/status.rs`, `src-tauri/src/git/types.rs`, `src/lib/git/types.ts`)
- Sync bar, branch switcher, and history view now treat a "[gone]" upstream as having no upstream: "Publish branch" is shown, push/pull disables against the dead ref, amending does not force-push, and undo-commit is allowed (`src/features/repository/SyncControls.tsx`, `src/features/repository/BranchSwitcher.tsx`, `src/features/history/HistoryPanel.tsx`, `src/features/history/useAmendCommit.ts`)
- Deleting a merged PR branch on GitHub now removes the local tracking ref immediately, so dead remotes don't linger until the next fetch (`src-tauri/src/github/pr.rs`)

### Diff viewer and UI polish
- Holds rendering of large-file diffs until whole-file context and any lazy-loaded syntax highlighter grammars are loaded, fixing the "flash" or double-paint when opening a large file for diff (`src/features/diff/DiffSurface.tsx`, `src/features/diff/DiffViewer.tsx`)
- Long current-branch names in the repo header now truncate with ellipsis (showing the full name on hover), so header elements never overflow or force scrollbars (`src/features/repository/BranchSwitcher.tsx`)

### Forge and MCP write controls
- Unifies MCP PR approval and request-changes tools across GitHub, GitLab, and Bitbucket: GitHub now uses `gh pr review` under the hood so these actions succeed from MCP for any provider (`src-tauri/src/forge/mod.rs`, `src-tauri/src/mcp_server/write_forge.rs`)
- Updates documentation and annotations for all affected MCP tools and recipes

### AI PR review prompt improvements
- Clarifies AI review system prompts: requires checking typed contracts before null/undefined findings, and omits unverifiable claims relayed from other reviewers, instead of passing through "could not verify" hedges (`src/lib/ai/prompt.ts`)

### Documentation and changelog
- Adds multiple detailed changelog entries summarizing user-facing improvements (`changelog.d/*`)
- Updates README and help copy for new MCP prompt/recipe capabilities (`README.md`, `src/features/help/content.ts`)