### PR TITLE
feat(git,worktrees,ui): promote worktree branch to main workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,10 @@ merges, cherry-picks, history edits, rebases) and, if one is interrupted by a
 crash or restart, surfaces a calm recovery notice naming what was interrupted and
 the exact branch + commit it started from — browsable any time via the *Operation
 history* command; tag management,
-submodule management, and a **worktree manager** (create, switch between, and
-remove linked worktrees, so you can work on several branches in parallel folders
-without stashing).
+submodule management, and a **worktree manager** (create, switch between, promote
+a worktree's branch into your main checkout, and remove linked worktrees, so you
+can work on several branches in parallel folders without stashing — with one-click
+jumps to the main workspace right from the branch switcher).
 
 **Syncing** — fetch / pull / push with ahead/behind indicators; pull is
 `--ff-only`, and divergence routes to a guarded force push with

--- a/changelog.d/added-promote-worktree-to-main.md
+++ b/changelog.d/added-promote-worktree-to-main.md
@@ -1,0 +1,7 @@
+- **Promote a worktree branch to your main workspace.** From the Worktrees dialog (or the
+  command palette), bring the branch you've been working on in a linked worktree into your
+  main checkout in one step — it frees the branch, stashes any uncommitted work in the main
+  workspace so the checkout can't be blocked, and checks the branch out there. The branch
+  switcher also lets you jump straight to the main workspace (or any other worktree) instead
+  of routing through a checked-out branch, and reminds you when a checkout will land in a
+  linked worktree rather than the main one.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -171,7 +171,7 @@ const capabilities = [
       "Change base — rebase a branch onto a different base when it was branched off the wrong one, moving only its own commits",
   },
   { label: "Submodule status & update" },
-  { label: "Worktree manager — create, switch & remove" },
+  { label: "Worktree manager — create, switch, promote & remove" },
   { label: "Command palette + rebindable keys" },
   { label: "Recoverable, recycle-bin discards" },
   { label: "Remembers window size & position" },

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -421,6 +421,11 @@ test, or review several branches at once without stashing or switching.
 - **Delete** a worktree to remove its folder; its branch is kept. A worktree with
   uncommitted changes asks before force-removing. The main worktree, and whichever one
   you're currently in, can't be renamed or deleted — switch away first.
+- **Promote to main workspace** brings a worktree's branch into your main checkout: it
+  removes the worktree (a branch can't be checked out in two at once) and checks that branch
+  out in the main workspace. The worktree must be clean first; any uncommitted work in the
+  main workspace is stashed so the checkout can't be blocked (restore it with *Pop latest
+  stash*). Works even on the worktree you're currently in.
 - **Repair links** (footer) re-connects worktrees if you moved or renamed the repository
   folder in your file manager, which otherwise breaks the path each worktree records.
 
@@ -429,7 +434,11 @@ already in use. The **branch switcher** knows this too: a branch that's checked 
 another worktree is badged, and choosing it offers to open that worktree instead of failing
 with a checkout error. You can also **Remove worktree…** straight from that badged branch's
 right-click menu — the branch stays, and its **Delete…** item un-disables once the worktree
-is gone.
+is gone. When you're in a linked worktree the switcher reminds you that a branch checkout
+lands *there* (not the main workspace) and offers a one-click **Open main workspace**, and its
+**Worktrees** section jumps you straight to any other worktree — no detour through a
+checked-out branch. **Open main workspace** and **Promote this worktree to main workspace**
+are in the command palette too.
 
 A repository's local pull requests, issues, review history, and per-repo settings are shared
 across all its worktrees, so you see the same ones whichever folder you're working in.{{ai}}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -68,11 +68,12 @@ import {
   type MergeRunOptions,
   type PickerMode,
 } from "./BranchMergePickerDialog";
-import { RebaseOntoDialog } from "./RebaseOntoDialog";
 import { CleanupBranchesDialog } from "./CleanupBranchesDialog";
 import { CreateBranchDialog } from "./CreateBranchDialog";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
 import { OperationHistoryDialog } from "./OperationHistoryDialog";
+import { PromoteWorktreeDialog } from "./PromoteWorktreeDialog";
+import { RebaseOntoDialog } from "./RebaseOntoDialog";
 import { RenameBranchDialog } from "./RenameBranchDialog";
 import { StashesDialog } from "./StashesDialog";
 import { SwitchWithChangesDialog } from "./SwitchWithChangesDialog";
@@ -81,6 +82,9 @@ import { useOpenWorktree } from "./useOpenRepoByPath";
 /** Lower-cased, forward-slashed path for cross-source comparison — git emits
  *  "/", the app stores "\" on Windows. */
 const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
+
+/** Last path segment (folder name), tolerating either separator. */
+const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
 
 type PrState = "open" | "draft" | "merged" | "closed";
 
@@ -203,6 +207,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     name: string;
     path: string;
   } | null>(null);
+  // The worktree pending a "Promote to main workspace" confirm — set by the
+  // palette action (the Worktrees dialog hosts its own promote flow).
+  const [promoteTarget, setPromoteTarget] = useState<UserWorktree | null>(null);
 
   const head = status.data?.branch;
   const currentName = head?.name ?? null;
@@ -315,6 +322,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     }
     return map;
   }, [userWorktrees.data, activeNorm]);
+  // Cross-worktree navigation (fetched only while open): the main workspace, the
+  // other worktrees you can jump to, and whether you're currently in a linked
+  // (non-main) worktree — where a branch checkout lands here, not in main.
+  const worktreeList = userWorktrees.data ?? [];
+  const currentWorktree = worktreeList.find(
+    (w) => normPath(w.path) === activeNorm,
+  );
+  const mainWorktree = worktreeList.find((w) => w.isMain);
+  const otherWorktrees = worktreeList.filter(
+    (w) => normPath(w.path) !== activeNorm,
+  );
+  const inLinkedWorktree = Boolean(currentWorktree && !currentWorktree.isMain);
+  const currentWorktreeName = currentWorktree
+    ? baseName(currentWorktree.path)
+    : "";
   // Default branch pinned on top, then the rest by most recently committed.
   // Memoized: the compiler won't hoist the `.sort()` copy or the filter
   // allocations, and these recompute on every filter keystroke otherwise.
@@ -733,6 +755,47 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   });
   useHotkeyAction("operation-history", () => setOpHistoryOpen(true));
   useHotkeyAction("discard-all", () => setDiscardAllOpen(true), hasChanges);
+  // Cross-worktree navigation (palette-only). They can fire while the popover is
+  // closed, so they can't rely on the open-gated `userWorktrees` cache — fetch
+  // the worktree list fresh, like the delete-branch off-switch does.
+  useHotkeyAction("open-main-workspace", async () => {
+    setOpen(false);
+    try {
+      const wts = await listUserWorktrees(repoPath);
+      const main = wts.find((w) => w.isMain);
+      if (!main || normPath(main.path) === normPath(repoPath)) {
+        toast.info("You're already in the main workspace.");
+        return;
+      }
+      openWorktree(main.path);
+    } catch (e) {
+      toastError(e);
+    }
+  });
+  useHotkeyAction("promote-worktree-to-main", async () => {
+    setOpen(false);
+    try {
+      const wts = await listUserWorktrees(repoPath);
+      const here = wts.find((w) => normPath(w.path) === normPath(repoPath));
+      if (!here || here.isMain) {
+        toast.info(
+          "Open a linked worktree to promote its branch to the main workspace.",
+        );
+        return;
+      }
+      if (here.isDetached || !here.branch) {
+        toast.info("This worktree has no branch to promote.");
+        return;
+      }
+      if (here.isLocked) {
+        toast.info("This worktree is locked — unlock it before promoting.");
+        return;
+      }
+      setPromoteTarget(here);
+    } catch (e) {
+      toastError(e);
+    }
+  });
 
   // Shared by the visible list and the Archived section.
   const renderBranchRow = (branch: Branch) => {
@@ -1064,6 +1127,30 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               // filter input, a row, or the popup itself (Esc/Tab pass through).
               onKeyDown={onBranchKeyDown}
             >
+              {inLinkedWorktree && (
+                <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-2 text-[11px]">
+                  <TreeStructureIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 text-muted-foreground">
+                    In worktree{" "}
+                    <span className="font-medium text-foreground">
+                      {currentWorktreeName}
+                    </span>{" "}
+                    — a checkout lands here
+                  </span>
+                  {mainWorktree && (
+                    <button
+                      type="button"
+                      className="shrink-0 cursor-pointer font-medium text-primary hover:underline"
+                      onClick={() => {
+                        setOpen(false);
+                        openWorktree(mainWorktree.path);
+                      }}
+                    >
+                      Open main workspace
+                    </button>
+                  )}
+                </div>
+              )}
               <div className="border-b p-2">
                 <Input
                   value={branchFilter}
@@ -1122,6 +1209,44 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   </>
                 )}
               </div>
+              {otherWorktrees.length > 0 && (
+                <div className="border-t py-1">
+                  <p className="px-3 py-1 text-[11px] font-medium text-muted-foreground">
+                    Worktrees
+                  </p>
+                  {otherWorktrees.map((w) => (
+                    <MenuRow
+                      key={w.path}
+                      onClick={() => {
+                        setOpen(false);
+                        openWorktree(w.path);
+                      }}
+                    >
+                      <TreeStructureIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 flex-1 truncate">
+                        {w.isDetached ? "detached HEAD" : w.branch || "—"}
+                      </span>
+                      {w.isMain && (
+                        <Badge variant="secondary" className="shrink-0">
+                          Main
+                        </Badge>
+                      )}
+                      <span
+                        className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground"
+                        onMouseEnter={(e) => {
+                          const el = e.currentTarget;
+                          el.title =
+                            el.scrollWidth > el.clientWidth
+                              ? baseName(w.path)
+                              : "";
+                        }}
+                      >
+                        {baseName(w.path)}
+                      </span>
+                    </MenuRow>
+                  ))}
+                </div>
+              )}
               <div className="border-t py-1">
                 <MenuRow onClick={openCreate}>New branch…</MenuRow>
                 <MenuRow
@@ -1497,6 +1622,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         stashPending={
           stashAll.isPending || checkout.isPending || checkoutRemote.isPending
         }
+      />
+
+      <PromoteWorktreeDialog
+        key={promoteTarget?.path ?? "no-promote"}
+        repoPath={repoPath}
+        worktree={promoteTarget}
+        onClose={() => setPromoteTarget(null)}
       />
     </>
   );

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1246,10 +1246,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                         className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground"
                         onMouseEnter={(e) => {
                           const el = e.currentTarget;
-                          el.title =
-                            el.scrollWidth > el.clientWidth
-                              ? baseName(w.path)
-                              : "";
+                          // Full path is the useful tooltip (the row already
+                          // shows the folder name). removeAttribute, not
+                          // title="", so an unclipped row leaves no empty tooltip.
+                          if (el.scrollWidth > el.clientWidth)
+                            el.title = w.path;
+                          else el.removeAttribute("title");
                         }}
                       >
                         {baseName(w.path)}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -398,6 +398,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     ...visibleBranches,
     ...(showArchived ? archivedBranches : []),
     ...(showRemote ? remoteOnly : []),
+    // The Worktrees section is a selectable list too — key its rows by path so
+    // arrow nav flows from the branch rows straight into it (each row carries a
+    // matching `data-row`). Paths use forward slashes, safe as a data-row value.
+    ...otherWorktrees.map((w) => ({ name: w.path })),
   ];
   const onBranchKeyDown = listKeyboardNav({
     items: navBranches,
@@ -763,8 +767,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     try {
       const wts = await listUserWorktrees(repoPath);
       const main = wts.find((w) => w.isMain);
-      if (!main || normPath(main.path) === normPath(repoPath)) {
-        toast.info("You're already in the main workspace.");
+      if (!main) {
+        toast.error("Couldn't find the main workspace for this repository.");
+        return;
+      }
+      if (normPath(main.path) === normPath(repoPath)) {
+        toast.info("Already in the main workspace.");
         return;
       }
       openWorktree(main.path);
@@ -1215,8 +1223,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     Worktrees
                   </p>
                   {otherWorktrees.map((w) => (
-                    <MenuRow
+                    <button
                       key={w.path}
+                      type="button"
+                      data-row={w.path}
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
                       onClick={() => {
                         setOpen(false);
                         openWorktree(w.path);
@@ -1243,7 +1254,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       >
                         {baseName(w.path)}
                       </span>
-                    </MenuRow>
+                    </button>
                   ))}
                 </div>
               )}

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -1,0 +1,231 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  gitCheckoutBranch,
+  gitStashAll,
+  gitStatus,
+  validateRepo,
+} from "@/lib/git/api";
+import { repoKeys, useUserWorktrees } from "@/lib/git/queries";
+import {
+  pruneWorktrees,
+  removeWorktree,
+  type UserWorktree,
+} from "@/lib/git/worktree";
+import { toastError } from "@/lib/toast";
+import { useOpenWorktree } from "./useOpenRepoByPath";
+
+/** Remove a worktree while keeping its branch, retrying once if the folder is
+ *  momentarily still held. The app has just switched off this worktree, but its
+ *  last in-flight git-status poll (or the OS) can keep the directory busy for a
+ *  beat — and `openRepo`'s switch is deferred by a View Transition, so the app
+ *  may not have fully let go yet. The retry covers that window; a real, lasting
+ *  hold (an editor/terminal in the folder) still surfaces the actionable error. */
+async function removeWorktreeFreeingBranch(repoPath: string, path: string) {
+  try {
+    await removeWorktree(repoPath, path, null, false);
+  } catch (e) {
+    const msg = String((e as { message?: string })?.message ?? e);
+    if (/close any program|in use|being used|invalid argument/i.test(msg)) {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await removeWorktree(repoPath, path, null, false);
+    } else {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Promotes a linked worktree's branch into the MAIN workspace. A branch can only
+ * live in one worktree at a time, so promoting is a composite: free the branch
+ * (remove the worktree, keep the branch) then check it out in the main checkout.
+ *
+ * Guards run BEFORE any mutation so a failure never strands the repo — the
+ * worktree must be clean (we never discard its work), and the main workspace's
+ * own uncommitted changes are stashed first so the checkout can't be blocked.
+ * The main workspace is opened first: there's no filesystem watcher (git status
+ * is polled), so moving the app off the worktree and letting its last poll
+ * settle is what lets the folder delete cleanly — even when you promote the very
+ * worktree you're standing in.
+ */
+export function PromoteWorktreeDialog({
+  repoPath,
+  worktree,
+  onClose,
+}: {
+  repoPath: string;
+  worktree: UserWorktree | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={worktree !== null} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        {worktree && (
+          <PromoteBody
+            repoPath={repoPath}
+            worktree={worktree}
+            onClose={onClose}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PromoteBody({
+  repoPath,
+  worktree,
+  onClose,
+}: {
+  repoPath: string;
+  worktree: UserWorktree;
+  onClose: () => void;
+}) {
+  const worktrees = useUserWorktrees(repoPath);
+  const openWorktree = useOpenWorktree();
+  const queryClient = useQueryClient();
+  const [pending, setPending] = useState(false);
+  // Synchronous re-entry latch: `setPending` is async, so two fast clicks could
+  // both pass the pending check before a re-render — this stops the second.
+  const runningRef = useRef(false);
+
+  const mainPath = (worktrees.data ?? []).find((w) => w.isMain)?.path ?? null;
+
+  // Preconditions, checked fresh while the dialog is open and sharing the app's
+  // status cache (same query key): the worktree must be clean, and we detect the
+  // main workspace's own WIP so we can offer to stash it first. Main is gated on
+  // its path resolving from the worktree list.
+  const wStatus = useQuery({
+    queryKey: repoKeys.status(worktree.path),
+    queryFn: () => gitStatus(worktree.path),
+  });
+  const mStatus = useQuery({
+    queryKey: repoKeys.status(mainPath ?? "__pending__"),
+    queryFn: () => gitStatus(mainPath as string),
+    enabled: Boolean(mainPath),
+  });
+
+  const checking =
+    worktrees.isPending ||
+    wStatus.isPending ||
+    (Boolean(mainPath) && mStatus.isPending);
+  const noMain = !worktrees.isPending && !mainPath;
+  const worktreeDirty = (wStatus.data?.entries.length ?? 0) > 0;
+  const mainDirty = (mStatus.data?.entries.length ?? 0) > 0;
+  const mainBranch = mStatus.data?.branch?.name ?? "the default branch";
+  const blocked =
+    noMain || worktreeDirty || worktree.isLocked || !worktree.branch;
+
+  async function doPromote() {
+    if (!mainPath || !worktree.branch || blocked) return;
+    // Synchronous latch — beat a double-click before `setPending` re-renders.
+    if (runningRef.current) return;
+    runningRef.current = true;
+    const willStash = mainDirty;
+    setPending(true);
+    try {
+      // Verify the main workspace is reachable BEFORE any mutation.
+      // `useOpenWorktree` swallows its own errors (it toasts, never throws), so a
+      // moved/unmounted main path would otherwise let the app stay on the
+      // worktree while we go on to delete it. Throwing here aborts cleanly.
+      await validateRepo(mainPath);
+      // Move the app onto the main workspace — we're about to delete this
+      // worktree's folder, and nothing should keep reading git status inside it.
+      // There's no fs-watcher (status is polled), so switching away stops future
+      // polls; `removeWorktreeFreeingBranch` retries once for any last in-flight
+      // poll that hasn't drained (openRepo's switch is deferred by a transition).
+      await openWorktree(mainPath);
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      // Free the branch: remove the worktree but KEEP the branch (null) — we
+      // check it out in main next. force=false: the clean-tree guard already ran.
+      await removeWorktreeFreeingBranch(mainPath, worktree.path);
+      await pruneWorktrees(mainPath).catch(() => undefined);
+      // The branch's working tree is free now; stash main's own WIP (if any) so
+      // the checkout can't be blocked, then land main on the promoted branch.
+      if (willStash) await gitStashAll(mainPath);
+      await gitCheckoutBranch(mainPath, worktree.branch);
+      await queryClient.invalidateQueries({ queryKey: repoKeys.all(mainPath) });
+      toast.success(
+        willStash
+          ? `Promoted ${worktree.branch} — your main workspace changes were stashed; Pop latest stash brings them back`
+          : `Promoted ${worktree.branch} to your main workspace`,
+      );
+      onClose();
+    } catch (e) {
+      toastError(e);
+      runningRef.current = false;
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Promote to main workspace?</DialogTitle>
+        <DialogDescription>
+          Checks out{" "}
+          <span className="font-mono">{worktree.branch || "this branch"}</span>{" "}
+          in your main workspace and removes this worktree — a branch can only
+          be checked out in one worktree at a time.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <span className="text-muted-foreground">Worktree</span>
+        <span className="truncate font-mono" title={worktree.path}>
+          {worktree.path}
+        </span>
+        <span className="text-muted-foreground">Main workspace</span>
+        <span className="truncate font-mono" title={mainPath ?? undefined}>
+          {mainPath ?? "—"}
+        </span>
+      </div>
+
+      {checking ? (
+        <p className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Spinner /> Checking worktree state…
+        </p>
+      ) : noMain ? (
+        <p className="text-xs text-warning">
+          Couldn't find the main workspace for this repository.
+        </p>
+      ) : worktreeDirty ? (
+        <p className="text-xs text-warning">
+          This worktree has uncommitted changes. Commit or stash them before
+          promoting.
+        </p>
+      ) : worktree.isLocked ? (
+        <p className="text-xs text-warning">
+          This worktree is locked. Unlock it before promoting.
+        </p>
+      ) : mainDirty ? (
+        <p className="text-xs text-info">
+          Your main workspace has uncommitted changes on{" "}
+          <span className="font-mono">{mainBranch}</span> — they'll be stashed
+          first, and Pop latest stash brings them back.
+        </p>
+      ) : null}
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose} disabled={pending}>
+          Cancel
+        </Button>
+        <Button disabled={checking || blocked || pending} onClick={doPromote}>
+          {pending && <Spinner data-icon="inline-start" />}
+          {mainDirty && !blocked ? "Stash & promote" : "Promote"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -124,8 +124,16 @@ function PromoteBody({
   const worktreeDirty = (wStatus.data?.entries.length ?? 0) > 0;
   const mainDirty = (mStatus.data?.entries.length ?? 0) > 0;
   const mainBranch = mStatus.data?.branch?.name ?? "the default branch";
+  // A failed status read must NOT read as "clean": with `data` undefined the
+  // dirty checks silently become false, which would enable Promote with unknown
+  // tree state and could skip the main-WIP stash before the checkout.
+  const statusError = wStatus.isError || (Boolean(mainPath) && mStatus.isError);
   const blocked =
-    noMain || worktreeDirty || worktree.isLocked || !worktree.branch;
+    noMain ||
+    statusError ||
+    worktreeDirty ||
+    worktree.isLocked ||
+    !worktree.branch;
 
   async function doPromote() {
     if (!mainPath || !worktree.branch || blocked) return;
@@ -133,6 +141,11 @@ function PromoteBody({
     if (runningRef.current) return;
     runningRef.current = true;
     const willStash = mainDirty;
+    // Track how far the composite got. Once the worktree is removed we're past
+    // the point of no return: a later failure needs recovery guidance (the
+    // folder is gone, the branch is free but unchecked-out), not git's raw error.
+    let removed = false;
+    let stashed = false;
     setPending(true);
     try {
       // Verify the main workspace is reachable BEFORE any mutation.
@@ -150,10 +163,14 @@ function PromoteBody({
       // Free the branch: remove the worktree but KEEP the branch (null) — we
       // check it out in main next. force=false: the clean-tree guard already ran.
       await removeWorktreeFreeingBranch(mainPath, worktree.path);
+      removed = true;
       await pruneWorktrees(mainPath).catch(() => undefined);
       // The branch's working tree is free now; stash main's own WIP (if any) so
       // the checkout can't be blocked, then land main on the promoted branch.
-      if (willStash) await gitStashAll(mainPath);
+      if (willStash) {
+        await gitStashAll(mainPath);
+        stashed = true;
+      }
       await gitCheckoutBranch(mainPath, worktree.branch);
       await queryClient.invalidateQueries({ queryKey: repoKeys.all(mainPath) });
       toast.success(
@@ -163,7 +180,18 @@ function PromoteBody({
       );
       onClose();
     } catch (e) {
-      toastError(e);
+      if (removed) {
+        // The worktree is already gone and the branch is free but not checked
+        // out — surface the recovery path (with git's error as the detail).
+        toast.error(
+          `Removed the worktree, but couldn't check out ${worktree.branch} in your main workspace — switch to it there manually.${
+            stashed ? " Your changes are stashed — use Pop latest stash." : ""
+          }`,
+          { description: e instanceof Error ? e.message : String(e) },
+        );
+      } else {
+        toastError(e);
+      }
       runningRef.current = false;
       setPending(false);
     }
@@ -195,6 +223,11 @@ function PromoteBody({
       {checking ? (
         <p className="flex items-center gap-2 text-xs text-muted-foreground">
           <Spinner /> Checking worktree state…
+        </p>
+      ) : statusError ? (
+        <p className="text-xs text-warning">
+          Couldn't read the worktree or main workspace state. Close this and try
+          again.
         </p>
       ) : noMain ? (
         <p className="text-xs text-warning">

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -68,13 +68,27 @@ export function PromoteWorktreeDialog({
   worktree: UserWorktree | null;
   onClose: () => void;
 }) {
+  // `pending` lives here (not in PromoteBody) so it gates dismissal: while a
+  // promote runs, Esc / the X / an outside click must NOT tear the dialog down —
+  // the async chain would keep going with the dialog gone (a background recovery
+  // toast; or a second concurrent promote after a quick reopen re-mounts a fresh
+  // re-entry latch). Controlled Base UI funnels every dismissal through
+  // onOpenChange, so gating onClose on !pending blocks them all.
+  const [pending, setPending] = useState(false);
   return (
-    <Dialog open={worktree !== null} onOpenChange={(o) => !o && onClose()}>
+    <Dialog
+      open={worktree !== null}
+      onOpenChange={(o) => {
+        if (!o && !pending) onClose();
+      }}
+    >
       <DialogContent>
         {worktree && (
           <PromoteBody
             repoPath={repoPath}
             worktree={worktree}
+            pending={pending}
+            setPending={setPending}
             onClose={onClose}
           />
         )}
@@ -86,16 +100,19 @@ export function PromoteWorktreeDialog({
 function PromoteBody({
   repoPath,
   worktree,
+  pending,
+  setPending,
   onClose,
 }: {
   repoPath: string;
   worktree: UserWorktree;
+  pending: boolean;
+  setPending: (value: boolean) => void;
   onClose: () => void;
 }) {
   const worktrees = useUserWorktrees(repoPath);
   const openWorktree = useOpenWorktree();
   const queryClient = useQueryClient();
-  const [pending, setPending] = useState(false);
   // Synchronous re-entry latch: `setPending` is async, so two fast clicks could
   // both pass the pending check before a re-render — this stops the second.
   const runningRef = useRef(false);

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -410,17 +410,11 @@ function WorktreeRow({
               removes the worktree (a branch can't live in two) and checks the
               branch out in main. Only for a linked worktree that has a branch. */}
           {!isMain && !isDetached && (
-            <DropdownMenuItem
-              disabled={isLocked}
-              title={
-                isLocked
-                  ? "Unlock this worktree before promoting it"
-                  : undefined
-              }
-              onClick={onPromote}
-            >
+            <DropdownMenuItem disabled={isLocked} onClick={onPromote}>
               <ArrowLineUpIcon />
-              Promote to main workspace…
+              {isLocked
+                ? "Promote to main workspace… (locked)"
+                : "Promote to main workspace…"}
             </DropdownMenuItem>
           )}
           <DropdownMenuItem

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowLineUpIcon,
   CaretLeftIcon,
   DotsThreeVerticalIcon,
   FolderOpenIcon,
@@ -55,6 +56,7 @@ import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
+import { PromoteWorktreeDialog } from "./PromoteWorktreeDialog";
 import { useOpenWorktree } from "./useOpenRepoByPath";
 
 /** Lower-cased, forward-slashed path — git emits "/", the app stores "\" on
@@ -140,6 +142,7 @@ function WorktreeList({
   const [deleteTarget, setDeleteTarget] = useState<UserWorktree | null>(null);
   const [renameTarget, setRenameTarget] = useState<UserWorktree | null>(null);
   const [lockTarget, setLockTarget] = useState<UserWorktree | null>(null);
+  const [promoteTarget, setPromoteTarget] = useState<UserWorktree | null>(null);
 
   const list = worktrees.data ?? [];
   const linkedCount = list.filter((w) => !w.isMain).length;
@@ -202,6 +205,7 @@ function WorktreeList({
                 onLock={() => setLockTarget(w)}
                 onUnlock={() => handleUnlock(w)}
                 onDelete={() => setDeleteTarget(w)}
+                onPromote={() => setPromoteTarget(w)}
               />
             ))
           )}
@@ -266,6 +270,13 @@ function WorktreeList({
         worktree={deleteTarget}
         onClose={() => setDeleteTarget(null)}
       />
+
+      <PromoteWorktreeDialog
+        key={promoteTarget?.path ?? "no-promote"}
+        repoPath={repoPath}
+        worktree={promoteTarget}
+        onClose={() => setPromoteTarget(null)}
+      />
     </>
   );
 }
@@ -280,6 +291,7 @@ function WorktreeRow({
   onLock,
   onUnlock,
   onDelete,
+  onPromote,
 }: {
   worktree: UserWorktree;
   highlighted: boolean;
@@ -290,6 +302,7 @@ function WorktreeRow({
   onLock: () => void;
   onUnlock: () => void;
   onDelete: () => void;
+  onPromote: () => void;
 }) {
   const { path, branch, isMain, isDetached, isLocked, lockReason } = worktree;
 
@@ -393,6 +406,23 @@ function WorktreeRow({
                 Lock…
               </DropdownMenuItem>
             ))}
+          {/* Promote moves this worktree's branch into the main workspace: it
+              removes the worktree (a branch can't live in two) and checks the
+              branch out in main. Only for a linked worktree that has a branch. */}
+          {!isMain && !isDetached && (
+            <DropdownMenuItem
+              disabled={isLocked}
+              title={
+                isLocked
+                  ? "Unlock this worktree before promoting it"
+                  : undefined
+              }
+              onClick={onPromote}
+            >
+              <ArrowLineUpIcon />
+              Promote to main workspace…
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             variant="destructive"
             // Can't delete the main worktree, nor the one you're standing in

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -283,6 +283,18 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "open-main-workspace",
+    label: "Open main workspace",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
+    id: "promote-worktree-to-main",
+    label: "Promote this worktree to main workspace",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
     id: "change-remote-url",
     label: "Change remote URL",
     category: "Repository",


### PR DESCRIPTION
Adds support for promoting a linked worktree's branch directly into the main workspace, allowing users to move a worktree branch into the main checkout in one step. This streamlines workflows when working across multiple worktrees by automating branch transfer, safely stashing main workspace changes if needed, and improving cross-worktree navigation.

### Worktree Promotion Feature
- Adds `PromoteWorktreeDialog.tsx` component for orchestrating "promote to main workspace", including safety checks and automated stashing (`src/features/repository/PromoteWorktreeDialog.tsx`).
- Integrates a "Promote to main workspace" flow in the Worktrees dialog, with corresponding menu option, dialog invocations, and user feedback (`src/features/repository/WorktreesDialog.tsx`).

### Branch Switcher Enhancements
- Updates `BranchSwitcher.tsx` to support one-click navigation to any worktree or direct jump to main workspace, shows current context (in main or linked worktree), and offers promote action via command palette and UI (`src/features/repository/BranchSwitcher.tsx`).
- Enhances worktree awareness in the branch switcher (badging, navigation context, quick switching).

### Hotkey/Command Palette Integration
- Registers new command palette actions and hotkeys for "Open main workspace" and "Promote this worktree to main workspace" (`src/lib/hotkeys/registry.ts`).

### Documentation and Help
- Updates feature descriptions in `README.md`, landing page (`site/src/pages/index.astro`), and user help content (`src/features/help/content.ts`) to document promote workflow and improved navigation.
- Adds a changelog entry explaining the new promote feature and navigation improvements (`changelog.d/added-promote-worktree-to-main.md`).