### PR TITLE
Enforce single-instance lock to prevent duplicate running app processes

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -78,3 +78,9 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+      # Release-only code (`cfg(not(debug_assertions))`: the single-instance
+      # lock, the managed MCP launcher copy) never compiles in the debug-profile
+      # steps above — lint it in release profile so it can't silently rot.
+      - name: Run clippy (release-gated code)
+        run: cargo clippy --release --manifest-path src-tauri/Cargo.toml -- -D warnings

--- a/changelog.d/fixed-single-instance-lock.md
+++ b/changelog.d/fixed-single-instance-lock.md
@@ -1,0 +1,1 @@
+- GitDesktop now enforces a single running instance: launching the app again focuses the existing window — restoring it from the tray if needed — instead of opening a duplicate whose automations could double-fire (e.g. two AI reviews posted on the same PR).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
@@ -4436,6 +4437,21 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,9 @@ tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 tauri-plugin-window-state = "2"
+# Single-instance lock (release builds only — gated at the registration site in
+# lib.rs, since Cargo target tables can't key on `debug_assertions`).
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = { version = "3", features = ["windows-native", "apple-native", "sync-secret-service"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,21 @@ pub use mcp_server::run_mcp_server;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+    // Single-instance lock, release builds only: a second launch defers to the
+    // running instance, whose callback brings the window back (incl. restoring
+    // it from the tray) instead of starting a duplicate — two instances each
+    // running automations double-post (duplicate-AI-review incident, 2026-07-10;
+    // the store plugin caches app-data per process, so instances can't dedup
+    // through the store). Dev is exempt on purpose: the lock keys on the shared
+    // `com.thebguy.gitdesktop` identifier, and dev+prod / two dev builds
+    // (parallel-worktree testing) must keep coexisting. Keep this the FIRST
+    // plugin registered so the check runs before any other init.
+    #[cfg(all(desktop, not(debug_assertions)))]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        tray::show_main_window(app);
+    }));
+    builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,9 @@ pub fn run() {
     // through the store). Dev is exempt on purpose: the lock keys on the shared
     // `com.thebguy.gitdesktop` identifier, and dev+prod / two dev builds
     // (parallel-worktree testing) must keep coexisting. Keep this the FIRST
-    // plugin registered so the check runs before any other init.
+    // plugin registered so the check runs before any other init. The second
+    // launch's argv/cwd are intentionally dropped: v1 is focus-only, and no
+    // CLI repo-open feature exists to forward them to.
     #[cfg(all(desktop, not(debug_assertions)))]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
         tray::show_main_window(app);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,10 @@ fn main() {
     // "Use GitDesktop as an MCP server" config snippet points external clients at,
     // so the shipped app IS the server — nothing extra to bundle. See
     // docs/mcp-server-tier3.md.
+    //
+    // NOTE: this branch must stay ahead of `run()` — release builds register the
+    // single-instance plugin in the Tauri builder there, and `gitdesktop mcp`
+    // child processes must never take (or defer to) that lock.
     if std::env::args().nth(1).as_deref() == Some("mcp") {
         gitdesktop_lib::run_mcp_server();
         return;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -66,6 +66,9 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
 }
 
 pub(crate) fn show_main_window(app: &AppHandle) {
+    // `None` is unreachable today: close-to-tray HIDES "main" (never destroys
+    // it), so the window always exists while the process runs. If the app ever
+    // closes + recreates the window, this silently no-ops — recreate it here.
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.show();
         let _ = window.unminimize();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -65,7 +65,7 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
-fn show_main_window(app: &AppHandle) {
+pub(crate) fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.show();
         let _ = window.unminimize();

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1342,8 +1342,8 @@ there's an equivalent.`,
 Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 
 - **General** — hide AI features, keep running in the **system tray** on close (so
-  background work continues; launching the app again brings that window back), and
-  privacy options.
+  background work continues; launching the app again while it's running —
+  tray-hidden or not — focuses the existing window), and privacy options.
 {{ai}}- **AI** — providers, models, keys, instructions, agent-session isolation
   (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1342,7 +1342,8 @@ there's an equivalent.`,
 Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 
 - **General** — hide AI features, keep running in the **system tray** on close (so
-  background work continues), and privacy options.
+  background work continues; launching the app again brings that window back), and
+  privacy options.
 {{ai}}- **AI** — providers, models, keys, instructions, agent-session isolation
   (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.


### PR DESCRIPTION
This change ensures that only one instance of GitDesktop can run at a time in release builds. Relaunching the app now focuses the existing window—restoring it from the tray if necessary—rather than spawning a duplicate, which previously resulted in duplicate automations (e.g., AI reviews double-posted). The motivation is to prevent reliability issues from concurrent processes and improve user experience and data integrity.

### Backend enforcement (Tauri, Rust)
- Adds `tauri-plugin-single-instance` dependency in `src-tauri/Cargo.toml` and registers it in release builds in `src-tauri/src/lib.rs`.
- Updates `src-tauri/Cargo.lock` to include the new plugin and its dependencies.
- Implements logic in `src-tauri/src/lib.rs` to show the main window of the running instance when a second launch is attempted.
- Restricts single-instance enforcement to release builds; development builds still allow multiple instances for parallel troubleshooting and testing.
- Documents the single-instance approach in a new changelog entry: `changelog.d/fixed-single-instance-lock.md`.

### General integration and tray handling
- Adjusts `src-tauri/src/tray.rs`, making `show_main_window` public within the crate so it can be triggered by the single-instance plugin.
- Notes in `src-tauri/src/main.rs` clarify that MCP server mode, launched via CLI, bypasses the single-instance lock to avoid interfering with background automation.

### Documentation and user guidance
- Updates user docs in `src/features/help/content.ts` to state that relaunching the app brings the original window back (instead of opening a new one) when "minimize to tray" is enabled, clarifying expected behavior.