### PR TITLE
feat(history): show commit-author avatars in History log, detail, and file history

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ its own commits (the wrong base's are left behind), with a preview of exactly
 which commits will move.
 
 **History & advanced** — paged, filterable history with rich commit detail,
-per-file history and line blame, and an at-a-glance marker on every commit that
+commit-author avatars, per-file history and line blame, and an at-a-glance marker on every commit that
 hasn't been pushed yet; cherry-pick (onto the current or another branch) and a
 full **interactive rebase** ⭐ — an *Edit history* editor to reword / squash /
 fixup / drop / reorder unpushed commits behind an atomic replay engine (any

--- a/changelog.d/added-history-commit-avatars.md
+++ b/changelog.d/added-history-commit-avatars.md
@@ -1,0 +1,3 @@
+- **Commit-author avatars in History.** The History log, commit detail, and
+  file-history views now show each author's avatar — derived from GitHub or
+  Gravatar, falling back to their initials.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -141,6 +141,7 @@ const capabilities = [
     ai: true,
   },
   { label: "File history & line blame" },
+  { label: "Commit-author avatars in history" },
   { label: "Unpushed commits flagged in history" },
   { label: "GitHub Actions — runs, jobs & re-run" },
   {

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -284,7 +284,7 @@ pub async fn git_recent_commits(repo_path: String, limit: u32) -> AppResult<Vec<
             "log",
             "-n",
             &limit_arg,
-            "--format=%H%x00%s%x00%an%x00%cI",
+            "--format=%H%x00%s%x00%an%x00%ae%x00%cI",
         ],
         DEFAULT_TIMEOUT,
     )
@@ -298,6 +298,7 @@ pub async fn git_recent_commits(repo_path: String, limit: u32) -> AppResult<Vec<
                 hash: parts.next()?.to_string(),
                 subject: parts.next()?.to_string(),
                 author: parts.next()?.to_string(),
+                author_email: parts.next()?.to_string(),
                 date: parts.next()?.to_string(),
                 tags: Vec::new(),
                 is_merge: false,

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -32,6 +32,7 @@ fn parse_log(text: &str) -> Vec<CommitSummary> {
                 hash: parts.next()?.to_string(),
                 subject: parts.next()?.to_string(),
                 author: parts.next()?.to_string(),
+                author_email: parts.next()?.to_string(),
                 date: parts.next()?.to_string(),
                 tags: Vec::new(),
                 is_merge: false,
@@ -43,7 +44,7 @@ fn parse_log(text: &str) -> Vec<CommitSummary> {
 async fn log_range(repo_path: &str, range: &str) -> AppResult<Vec<CommitSummary>> {
     let out = run_git(
         Some(repo_path),
-        &["log", "--format=%H%x00%s%x00%an%x00%cI", range],
+        &["log", "--format=%H%x00%s%x00%an%x00%ae%x00%cI", range],
         DEFAULT_TIMEOUT,
     )
     .await?;

--- a/src-tauri/src/git/history.rs
+++ b/src-tauri/src/git/history.rs
@@ -48,7 +48,7 @@ pub async fn git_log(
         &limit_arg,
         "--skip",
         &skip_arg,
-        "--format=%H%x00%s%x00%an%x00%cI%x00%D%x00%P",
+        LOG_FORMAT,
     ];
     if let Some(q) = &search {
         // Literal, case-insensitive match against the whole commit message.
@@ -58,8 +58,8 @@ pub async fn git_log(
     Ok(parse_commit_log(&out.stdout_lossy()))
 }
 
-/// The `%H%x00%s%x00%an%x00%cI%x00%D%x00%P` log format, one commit per line.
-const LOG_FORMAT: &str = "--format=%H%x00%s%x00%an%x00%cI%x00%D%x00%P";
+/// The `%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P` log format, one commit per line.
+const LOG_FORMAT: &str = "--format=%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P";
 
 fn parse_commit_log(text: &str) -> Vec<CommitSummary> {
     text.lines()
@@ -69,6 +69,7 @@ fn parse_commit_log(text: &str) -> Vec<CommitSummary> {
                 hash: parts.next()?.to_string(),
                 subject: parts.next()?.to_string(),
                 author: parts.next()?.to_string(),
+                author_email: parts.next()?.to_string(),
                 date: parts.next()?.to_string(),
                 // %D: "HEAD -> main, tag: v1.0, origin/main" — keep the tags.
                 tags: parts

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -139,6 +139,9 @@ pub struct CommitSummary {
     pub hash: String,
     pub subject: String,
     pub author: String,
+    /// Author email (%ae). Drives the History-tab commit avatar (GitHub
+    /// no-reply login or Gravatar); empty when git records no author email.
+    pub author_email: String,
     pub date: String,
     /// Tags pointing at this commit (from %D decorations).
     pub tags: Vec<String>,

--- a/src-tauri/src/mcp_server/read_git.rs
+++ b/src-tauri/src/mcp_server/read_git.rs
@@ -94,7 +94,7 @@ impl GitDesktopMcp {
     }
 
     #[tool(
-        description = "List recent commits (sha, author, date, subject). Supports paging via \
+        description = "List recent commits (sha, author, authorEmail, date, subject). Supports paging via \
                        limit/skip and an optional message/author search filter."
     )]
     async fn log(&self, Parameters(args): Parameters<LogArgs>) -> Result<CallToolResult, McpError> {

--- a/src/components/commit-author-avatar.tsx
+++ b/src/components/commit-author-avatar.tsx
@@ -1,0 +1,31 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useCommitAvatarUrl } from "@/lib/git/commit-avatar";
+import { cn } from "@/lib/utils";
+
+/**
+ * A commit author's avatar for the History surfaces (log list, commit detail,
+ * file history). Derives the image from the author email (GitHub no-reply login
+ * or Gravatar — see `commit-avatar.ts`) and falls back to the author's initial,
+ * so an author with no resolvable avatar looks exactly like the initials
+ * placeholder that preceded this. Mirrors `ForgeUserAvatar`'s fallback chain.
+ */
+export function CommitAuthorAvatar({
+  name,
+  email,
+  size = "sm",
+  className,
+}: {
+  name: string;
+  email: string;
+  size?: "sm" | "default" | "lg";
+  className?: string;
+}) {
+  const src = useCommitAvatarUrl(email);
+  return (
+    <Avatar size={size} className={cn("shrink-0", className)}>
+      {/* Decorative: the author name is always shown as adjacent text. */}
+      {src && <AvatarImage src={src} alt="" />}
+      <AvatarFallback>{(name || "?").charAt(0).toUpperCase()}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/src/components/commit-author-avatar.tsx
+++ b/src/components/commit-author-avatar.tsx
@@ -22,8 +22,10 @@ export function CommitAuthorAvatar({
 }) {
   const src = useCommitAvatarUrl(email);
   return (
-    <Avatar size={size} className={cn("shrink-0", className)}>
-      {/* Decorative: the author name is always shown as adjacent text. */}
+    // Decorative: the author name is always shown as adjacent text, so hide the
+    // whole avatar (image OR initial fallback) from assistive tech — otherwise a
+    // screen reader announces the fallback letter before the name ("A, Alice").
+    <Avatar aria-hidden size={size} className={cn("shrink-0", className)}>
       {src && <AvatarImage src={src} alt="" />}
       <AvatarFallback>{(name || "?").charAt(0).toUpperCase()}</AvatarFallback>
     </Avatar>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -278,7 +278,8 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
     label: "History & git operations",
     body: `# History & git operations
 
-The **History** tab ({{kbd:tab-history}}) is the commit log for the current branch. Click
+The **History** tab ({{kbd:tab-history}}) is the commit log for the current branch — each
+entry shows the author's avatar (from GitHub or Gravatar). Click
 a commit to see its message, author, and full diff; **Shift + ↑ / ↓** extends the
 selection to compare a range.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -279,7 +279,7 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
     body: `# History & git operations
 
 The **History** tab ({{kbd:tab-history}}) is the commit log for the current branch — each
-entry shows the author's avatar (from GitHub or Gravatar). Click
+entry shows the author's avatar (from GitHub or Gravatar, or their initials). Click
 a commit to see its message, author, and full diff; **Shift + ↑ / ↓** extends the
 selection to compare a range.
 

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -1,6 +1,7 @@
 import { CopyIcon, DotsThreeVerticalIcon } from "@phosphor-icons/react";
 import { useDeferredValue, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -222,9 +223,7 @@ export function CommitDetailView({
           </p>
         )}
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <span className="flex size-4 items-center justify-center rounded-full bg-muted text-[9px] uppercase">
-            {commit.author.slice(0, 1)}
-          </span>
+          <CommitAuthorAvatar name={commit.author} email={commit.authorEmail} />
           <span>{commit.author}</span>
           <span>•</span>
           <span>{formatRelativeTime(commit.date)}</span>

--- a/src/features/history/FileHistoryDialog.tsx
+++ b/src/features/history/FileHistoryDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
 import {
   Dialog,
   DialogContent,
@@ -71,16 +72,23 @@ export function FileHistoryDialog({
                       key={c.hash}
                       onClick={() => setSelected(c.hash)}
                       className={cn(
-                        "block w-full border-b px-2.5 py-2 text-left text-xs",
+                        "flex w-full items-start gap-2 border-b px-2.5 py-2 text-left text-xs",
                         c.hash === activeHash
                           ? "bg-accent text-accent-foreground"
                           : "hover:bg-muted/60",
                       )}
                     >
-                      <p className="truncate font-medium">{c.subject}</p>
-                      <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
-                        {c.author} · {formatRelativeTime(c.date)}
-                      </p>
+                      <CommitAuthorAvatar
+                        name={c.author}
+                        email={c.authorEmail}
+                        className="mt-0.5"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium">{c.subject}</p>
+                        <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                          {c.author} · {formatRelativeTime(c.date)}
+                        </p>
+                      </div>
                     </button>
                   ))}
                   {fileLog.hasNextPage && (

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -8,6 +8,7 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { type MouseEvent, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
 import { Button } from "@/components/ui/button";
 import {
   ContextMenu,
@@ -976,7 +977,7 @@ function CommitList({
             ref={virtualizer.measureElement}
             data-hash={commit.hash}
             className={cn(
-              "absolute top-0 left-0 block w-full border-b px-3 py-2 text-left",
+              "absolute top-0 left-0 flex w-full items-start gap-2 border-b px-3 py-2 text-left",
               selected.has(commit.hash) ||
                 (selected.size === 0 && selectedCommitHash === commit.hash)
                 ? "bg-accent text-accent-foreground"
@@ -986,52 +987,56 @@ function CommitList({
             onClick={(e) => onRowClick(e, index, commit.hash)}
             onMouseEnter={() => onHoverPrefetch(commit.hash)}
           >
-            <p className="flex items-center gap-1.5 text-xs font-medium">
-              <span className="min-w-0 truncate" title={commit.subject}>
-                {commit.subject}
-              </span>
-              {commit.tags.slice(0, 2).map((tag) => (
-                <span
-                  key={tag}
-                  className="flex max-w-24 shrink-0 items-center gap-0.5 border px-1 py-px text-[10px] font-normal text-muted-foreground"
-                  title={`tag: ${tag}`}
-                >
-                  <TagIcon className="size-2.5 shrink-0" />
-                  <span className="truncate">{tag}</span>
+            <CommitAuthorAvatar
+              name={commit.author}
+              email={commit.authorEmail}
+              className="mt-0.5"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="flex items-center gap-1.5 text-xs font-medium">
+                <span className="min-w-0 truncate" title={commit.subject}>
+                  {commit.subject}
                 </span>
-              ))}
-              {commit.tags.length > 2 && (
-                <span
-                  className="shrink-0 text-[10px] font-normal text-muted-foreground"
-                  title={commit.tags.join(", ")}
-                >
-                  +{commit.tags.length - 2}
+                {commit.tags.slice(0, 2).map((tag) => (
+                  <span
+                    key={tag}
+                    className="flex max-w-24 shrink-0 items-center gap-0.5 border px-1 py-px text-[10px] font-normal text-muted-foreground"
+                    title={`tag: ${tag}`}
+                  >
+                    <TagIcon className="size-2.5 shrink-0" />
+                    <span className="truncate">{tag}</span>
+                  </span>
+                ))}
+                {commit.tags.length > 2 && (
+                  <span
+                    className="shrink-0 text-[10px] font-normal text-muted-foreground"
+                    title={commit.tags.join(", ")}
+                  >
+                    +{commit.tags.length - 2}
+                  </span>
+                )}
+                {unpushedHashes.has(commit.hash) && (
+                  <span
+                    className="ml-auto flex shrink-0 items-center text-muted-foreground"
+                    title={
+                      upstream
+                        ? `Not pushed yet — ahead of ${upstream}`
+                        : "Not pushed yet"
+                    }
+                    aria-label="Not pushed yet"
+                  >
+                    <ArrowUpIcon className="size-3" weight="bold" />
+                  </span>
+                )}
+              </p>
+              <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <span className="truncate">{commit.author}</span>
+                <span>•</span>
+                <span className="shrink-0">
+                  {formatRelativeTime(commit.date)}
                 </span>
-              )}
-              {unpushedHashes.has(commit.hash) && (
-                <span
-                  className="ml-auto flex shrink-0 items-center text-muted-foreground"
-                  title={
-                    upstream
-                      ? `Not pushed yet — ahead of ${upstream}`
-                      : "Not pushed yet"
-                  }
-                  aria-label="Not pushed yet"
-                >
-                  <ArrowUpIcon className="size-3" weight="bold" />
-                </span>
-              )}
-            </p>
-            <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
-              <span className="flex size-3.5 items-center justify-center rounded-full bg-muted text-[8px] uppercase">
-                {commit.author.slice(0, 1)}
-              </span>
-              <span className="truncate">{commit.author}</span>
-              <span>•</span>
-              <span className="shrink-0">
-                {formatRelativeTime(commit.date)}
-              </span>
-            </p>
+              </p>
+            </div>
           </button>
         );
       })}

--- a/src/lib/git/commit-avatar.ts
+++ b/src/lib/git/commit-avatar.ts
@@ -78,11 +78,18 @@ export function useCommitAvatarUrl(email: string): string {
     let live = true;
     let pending = gravatarPending.get(normalized);
     if (!pending) {
-      pending = computeGravatarUrl(normalized).then((resolved) => {
-        gravatarCache.set(normalized, resolved);
-        gravatarPending.delete(normalized);
-        return resolved;
-      });
+      pending = computeGravatarUrl(normalized)
+        .then((resolved) => {
+          gravatarCache.set(normalized, resolved);
+          gravatarPending.delete(normalized);
+          return resolved;
+        })
+        .catch(() => {
+          // A rejected hash (e.g. crypto.subtle throwing) must clear `pending` too,
+          // or the email is stuck "pending" forever and the rejection goes unhandled.
+          gravatarPending.delete(normalized);
+          return "";
+        });
       gravatarPending.set(normalized, pending);
     }
     pending.then((resolved) => {

--- a/src/lib/git/commit-avatar.ts
+++ b/src/lib/git/commit-avatar.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+
+// Commit-author avatars for the History surfaces.
+//
+// A commit only carries an author name + email locally (never a forge login), so
+// we derive an avatar from the email the way desktop git clients do:
+//   • GitHub no-reply emails embed the login (and the host, for Enterprise), so
+//     the avatar resolves synchronously at `<host>/<login>.png` — nothing is sent
+//     to a third party.
+//   • Everyone else falls back to Gravatar, keyed by a SHA-256 of the email.
+//     `d=404` makes emails with no Gravatar fail the image load, so the caller's
+//     <AvatarFallback> shows the author initial — identical to showing no avatar.
+//
+// SHA-256 hashing is async (Web Crypto), so a module-level cache resolves each
+// distinct email exactly once: the virtualized History list re-renders rows
+// constantly, and we never want to re-hash or flash a resolved avatar back out.
+
+// `ID+login@users.noreply.github.com` and the legacy `login@users.noreply.github.com`.
+// The host is pinned to github.com (never read from the email) and the login is
+// constrained to GitHub's username grammar: a commit author email is untrusted input,
+// and with a null CSP an attacker-chosen host would otherwise beacon on mere view.
+// (GitHub Enterprise no-reply emails fall through to Gravatar / initials.)
+const GH_NOREPLY =
+  /^(?:\d+\+)?([a-z\d][a-z\d-]{0,38})@users\.noreply\.github\.com$/i;
+
+// Resolved Gravatar URLs by lowercased email; a present entry means "hashing done".
+const gravatarCache = new Map<string, string>();
+const gravatarPending = new Map<string, Promise<string>>();
+
+/**
+ * The avatar URL for a commit author's email, `""` when there's nothing to show
+ * (no email / no crypto), or `null` when the answer needs an async Gravatar hash
+ * that hasn't resolved yet — callers show the initial until
+ * {@link useCommitAvatarUrl} fills it in.
+ */
+function commitAvatarUrlSync(email: string): string | null {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return "";
+  const noreply = normalized.match(GH_NOREPLY);
+  if (noreply) {
+    // Login is grammar-constrained above (URL-path-safe chars); host is literal.
+    return `https://github.com/${noreply[1]}.png?size=48`;
+  }
+  return gravatarCache.get(normalized) ?? null;
+}
+
+async function computeGravatarUrl(normalizedEmail: string): Promise<string> {
+  const bytes = new TextEncoder().encode(normalizedEmail);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `https://www.gravatar.com/avatar/${hex}?d=404&s=48`;
+}
+
+/**
+ * The avatar URL for a commit author's email, or `""` while a Gravatar hash is
+ * still pending (or when there's no avatar to derive). Safe to call per row in a
+ * virtualized list — each distinct email is hashed at most once.
+ */
+export function useCommitAvatarUrl(email: string): string {
+  // Lazy init reads the sync answer (no-reply URL, cached Gravatar, or "") once
+  // on mount, so a cache hit paints immediately with no flash. `null` → pending.
+  const [url, setUrl] = useState(() => commitAvatarUrlSync(email) ?? "");
+
+  useEffect(() => {
+    const sync = commitAvatarUrlSync(email);
+    if (sync !== null) {
+      setUrl(sync);
+      return;
+    }
+    // Needs a Gravatar hash. Bail to the initial if Web Crypto is unavailable.
+    if (!globalThis.crypto?.subtle) {
+      setUrl("");
+      return;
+    }
+    const normalized = email.trim().toLowerCase();
+    let live = true;
+    let pending = gravatarPending.get(normalized);
+    if (!pending) {
+      pending = computeGravatarUrl(normalized).then((resolved) => {
+        gravatarCache.set(normalized, resolved);
+        gravatarPending.delete(normalized);
+        return resolved;
+      });
+      gravatarPending.set(normalized, pending);
+    }
+    pending.then((resolved) => {
+      if (live) setUrl(resolved);
+    });
+    return () => {
+      live = false;
+    };
+  }, [email]);
+
+  return url;
+}

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -145,6 +145,8 @@ export interface CommitSummary {
   hash: string;
   subject: string;
   author: string;
+  /** Author email (%ae) — drives the History-tab commit avatar. May be "". */
+  authorEmail: string;
   date: string;
   /** Tags pointing at this commit. */
   tags: string[];


### PR DESCRIPTION
This adds commit-author avatars to the History log, commit detail, and file-history panels, improving visual identification of authors. The avatar is derived from the commit's author email using GitHub no-reply images or Gravatar, with a fallback to initials for unmatched or absent avatars.

### UI and History Features
- Adds `CommitAuthorAvatar` component in `src/components/commit-author-avatar.tsx` for rendering author avatars with a fallback to initials.
- Updates log list renders in `src/features/history/HistoryPanel.tsx` to display author avatars.
- Updates commit detail view in `src/features/history/CommitDetailView.tsx` to use the avatar component.
- Adds avatars to the file history UI in `src/features/history/FileHistoryDialog.tsx`.

### Avatar Resolution Logic
- Implements avatar URL lookup logic in `src/lib/git/commit-avatar.ts`, handling GitHub no-reply and Gravatar with SHA-256 hashing.
- Updates commit types in `src/lib/git/types.ts` to include `authorEmail` field that drives avatar resolution.

### Git Data Layer
- Updates git commit and history queries and parsing in `src-tauri/src/git/commit.rs`, `src-tauri/src/git/compare.rs`, and `src-tauri/src/git/history.rs` to include author email (`%ae`) in responses.
- Extends `CommitSummary` struct in `src-tauri/src/git/types.rs` with an `author_email` field.

### Documentation and Help
- Notes the new avatars feature in `README.md` and `site/src/pages/index.astro`.
- Adds changelog entry in `changelog.d/added-history-commit-avatars.md`.
- Updates in-app help text in `src/features/help/content.ts` to mention author avatars.

### Miscellaneous
- Clarifies documentation string in `src-tauri/src/mcp_server/read_git.rs` to include `authorEmail` in list-commits endpoint.