### PR TITLE
Condense long READMEs and expand AI repo description generation

### DIFF
--- a/changelog.d/changed-repo-description-length.md
+++ b/changelog.d/changed-repo-description-length.md
@@ -1,0 +1,5 @@
+- **AI-generated repo descriptions are less terse.** The **Generate** button for a
+  repository's About description now aims for a fuller single line (up to ~250
+  characters) that says what the project does and what makes it stand out, instead
+  of the old ~140-character cap that often produced a thin one-liner. GitHub's About
+  field already accepts up to 350 characters, so the result still fits.

--- a/changelog.d/changed-repo-description-length.md
+++ b/changelog.d/changed-repo-description-length.md
@@ -1,5 +1,8 @@
 - **AI-generated repo descriptions are less terse.** The **Generate** button for a
-  repository's About description now aims for a fuller single line (up to ~250
+  repository's About description now aims for a fuller single line (roughly 200–325
   characters) that says what the project does and what makes it stand out, instead
   of the old ~140-character cap that often produced a thin one-liner. GitHub's About
-  field already accepts up to 350 characters, so the result still fits.
+  field already accepts up to 350 characters, so the result still fits. Long READMEs
+  are now condensed to keep their features and highlights breadth — dropping install
+  and development boilerplate — instead of being blindly cut off at 6,000 characters,
+  so the model sees what the project actually does rather than just its opening.

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -750,7 +750,7 @@ export function extractBranchName(raw: string): string {
 
 const DESCRIPTION_SYSTEM = `You write a GitHub repository's "About" metadata from its README.
 Output EXACTLY these two lines and nothing else:
-Description: <one concise line, at most ~140 characters, no trailing period, no quotes; describe what the project does — do not begin with "This repository", "A repository for", or the project's own name>
+Description: <a single line of up to ~250 characters, no trailing period, no quotes; describe what the project does and what makes it stand out — do not begin with "This repository", "A repository for", or the project's own name>
 Topics: <3 to 8 space-separated lowercase tags using only letters, digits, and hyphens, e.g. "react typescript cli git">`;
 
 export function buildRepoDescriptionPrompt(input: {

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -749,6 +749,10 @@ export function extractBranchName(raw: string): string {
   return line.replace(/^[`'"]+|[`'"]+$/g, "").trim();
 }
 
+// The prompt's 325 ceiling sits INTENTIONALLY below capDescription's 350 guard
+// (GitHub's real About limit): models overshoot stated ceilings (anchoring the
+// prompt at 350 produced a 353-char output live), so the soft target leaves
+// headroom and the parser only cuts what the field itself would reject.
 const DESCRIPTION_SYSTEM = `You write a GitHub repository's "About" metadata from its README.
 Output EXACTLY these two lines and nothing else:
 Description: <one information-dense line of roughly 200 to 325 characters (short one-liners read thin, so use the space — but never exceed 325; the field truncates anything longer), no trailing period, no quotes; describe what the project does and what makes it stand out — do not begin with "This repository", "A repository for", or the project's own name>
@@ -793,16 +797,16 @@ export function buildRepoDescriptionPrompt(input: {
 }
 
 /** Cap a description at `max` chars without chopping mid-word: cut at the last
- *  space inside `max` if it's past ~300, else a plain slice, then strip any
- *  trailing punctuation/whitespace the cut left behind. */
+ *  space inside `max` if it's within 50 chars of the cap, else a plain slice,
+ *  then strip any trailing punctuation/whitespace the cut left behind. */
 function capDescription(text: string, max: number): string {
   if (text.length <= max) {
     return text;
   }
   const window = text.slice(0, max);
   const lastSpace = window.lastIndexOf(" ");
-  const cut = lastSpace > 300 ? window.slice(0, lastSpace) : window;
-  return cut.replace(/[\s,;:—-]+$/, "");
+  const cut = lastSpace > max - 50 ? window.slice(0, lastSpace) : window;
+  return cut.replace(/[\s.,;:—-]+$/, "");
 }
 
 /** Parse the model's "Description:" / "Topics:" lines into clean values. */

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -1,4 +1,5 @@
 import type { ContextPack } from "./agent";
+import { distillReadme } from "./readme";
 import { budgetDiff, budgetReviewExtras, type ReviewExtras } from "./truncate";
 import type {
   BranchNamePromptInput,
@@ -750,8 +751,12 @@ export function extractBranchName(raw: string): string {
 
 const DESCRIPTION_SYSTEM = `You write a GitHub repository's "About" metadata from its README.
 Output EXACTLY these two lines and nothing else:
-Description: <a single line of up to ~250 characters, no trailing period, no quotes; describe what the project does and what makes it stand out — do not begin with "This repository", "A repository for", or the project's own name>
+Description: <one information-dense line of roughly 200 to 325 characters (short one-liners read thin, so use the space — but never exceed 325; the field truncates anything longer), no trailing period, no quotes; describe what the project does and what makes it stand out — do not begin with "This repository", "A repository for", or the project's own name>
 Topics: <3 to 8 space-separated lowercase tags using only letters, digits, and hyphens, e.g. "react typescript cli git">`;
+
+// A long README is condensed (features/highlights breadth preserved) to fit this
+// budget rather than blindly truncated. See distillReadme in ./readme.
+const README_BUDGET = 10_000;
 
 export function buildRepoDescriptionPrompt(input: {
   repoName: string;
@@ -771,7 +776,10 @@ export function buildRepoDescriptionPrompt(input: {
 
   const promptParts = [`## Repository name\n${input.repoName}`];
   if (input.readme.trim()) {
-    promptParts.push(`## README (truncated)\n${input.readme.slice(0, 6000)}`);
+    const readme = distillReadme(input.readme, README_BUDGET);
+    promptParts.push(
+      `## README${readme.length < input.readme.length ? " (condensed)" : ""}\n${readme}`,
+    );
   } else {
     promptParts.push(
       "## README\n(none — infer from the repository name alone)",
@@ -782,6 +790,19 @@ export function buildRepoDescriptionPrompt(input: {
     system: systemParts.join("\n\n"),
     prompt: promptParts.join("\n\n"),
   };
+}
+
+/** Cap a description at `max` chars without chopping mid-word: cut at the last
+ *  space inside `max` if it's past ~300, else a plain slice, then strip any
+ *  trailing punctuation/whitespace the cut left behind. */
+function capDescription(text: string, max: number): string {
+  if (text.length <= max) {
+    return text;
+  }
+  const window = text.slice(0, max);
+  const lastSpace = window.lastIndexOf(" ");
+  const cut = lastSpace > 300 ? window.slice(0, lastSpace) : window;
+  return cut.replace(/[\s,;:—-]+$/, "");
 }
 
 /** Parse the model's "Description:" / "Topics:" lines into clean values. */
@@ -799,12 +820,15 @@ export function extractRepoDetails(raw: string): {
     lines.find((l) => /^description\s*[:-]/i.test(l)) ??
     lines.find((l) => l.length > 0) ??
     "";
-  const description = descLine
+  const cleaned = descLine
     .replace(/^description\s*[:-]\s*/i, "")
     .replace(/^[`'"]+|[`'"]+$/g, "")
     .replace(/\.$/, "")
-    .trim()
-    .slice(0, 350);
+    .trim();
+  // Models can't count chars reliably; on the rare overshoot, cut on a word
+  // boundary near 350 (past ~300) and strip trailing punctuation, so a too-long
+  // description degrades to a clean whole-word line rather than a mid-word chop.
+  const description = capDescription(cleaned, 350);
 
   const topicsLine = lines.find((l) => /^topics\s*[:-]/i.test(l)) ?? "";
   const topics = topicsLine

--- a/src/lib/ai/readme.ts
+++ b/src/lib/ai/readme.ts
@@ -3,7 +3,9 @@
 // tail (features/highlights breadth) of long READMEs. This condenses a README to
 // fit a char budget while preserving the high-signal content — what the project
 // does and the breadth of what it can do — over install/dev boilerplate. Pure,
-// self-contained, no AI pre-pass: same input always yields the same output.
+// self-contained, no AI pre-pass: same input always yields the same output. The
+// output is always ≤ budget; a README that already fits passes through normalized
+// (CRLF→LF + trim) but otherwise untouched.
 
 // Heading text (lowercased) that marks a HIGH-signal section — its body is worth
 // keeping in full for as long as the budget allows.
@@ -58,10 +60,12 @@ const LOW_HEADINGS = [
  *  what-it-does / features content over install/dev boilerplate. */
 export function distillReadme(markdown: string, budget: number): string {
   // Phase 0 — normalize and short-circuit. A README that already fits passes
-  // through byte-identical (the ORIGINAL string, not the normalized copy).
+  // through in its normalized form (CRLF→LF + trim). Returning the raw markdown
+  // here would let content that's short but padded with trailing newlines ship
+  // over budget while skipping every phase (including the newline collapse).
   const normalized = markdown.replace(/\r\n/g, "\n").trim();
   if (normalized.length <= budget) {
-    return markdown;
+    return normalized;
   }
 
   // Phase 1 — strip markup noise (order matters: comments/fences before the
@@ -266,7 +270,7 @@ function hardCut(text: string, budget: number): string {
   return window.trim();
 }
 
-/** Does the lowercased heading text start with, or contain, any keyword? */
+/** Does the lowercased heading text contain any keyword? */
 function matches(title: string, keywords: readonly string[]): boolean {
-  return keywords.some((k) => title.startsWith(k) || title.includes(k));
+  return keywords.some((k) => title.includes(k));
 }

--- a/src/lib/ai/readme.ts
+++ b/src/lib/ai/readme.ts
@@ -1,0 +1,272 @@
+// A deterministic, progressive README distiller. The AI "Generate" for a repo's
+// About description feeds the README into the prompt; a blind slice discards the
+// tail (features/highlights breadth) of long READMEs. This condenses a README to
+// fit a char budget while preserving the high-signal content — what the project
+// does and the breadth of what it can do — over install/dev boilerplate. Pure,
+// self-contained, no AI pre-pass: same input always yields the same output.
+
+// Heading text (lowercased) that marks a HIGH-signal section — its body is worth
+// keeping in full for as long as the budget allows.
+const HIGH_HEADINGS = [
+  "feature",
+  "highlight",
+  "overview",
+  "about",
+  "introduction",
+  "what ",
+  "why ",
+  "motivation",
+  "capabilit",
+  "how it works",
+  "usage",
+];
+
+// Heading text (lowercased) whose body is boilerplate — keep the heading line as
+// a breadcrumb of the section's existence, but drop everything under it.
+const LOW_HEADINGS = [
+  "install",
+  "getting started",
+  "quick start",
+  "setup",
+  "requirement",
+  "prerequisite",
+  "development",
+  "developing",
+  "build",
+  "contribut",
+  "license",
+  "acknowledg",
+  "credit",
+  "sponsor",
+  "donat",
+  "support",
+  "changelog",
+  "release",
+  "roadmap",
+  "faq",
+  "troubleshoot",
+  "screenshot",
+  "table of contents",
+  "update",
+  "privacy",
+  "security",
+  "architecture",
+  "testing",
+];
+
+/** Deterministically condense a README to fit `budget` chars, favoring
+ *  what-it-does / features content over install/dev boilerplate. */
+export function distillReadme(markdown: string, budget: number): string {
+  // Phase 0 — normalize and short-circuit. A README that already fits passes
+  // through byte-identical (the ORIGINAL string, not the normalized copy).
+  const normalized = markdown.replace(/\r\n/g, "\n").trim();
+  if (normalized.length <= budget) {
+    return markdown;
+  }
+
+  // Phase 1 — strip markup noise (order matters: comments/fences before the
+  // tag/link rewrites, so we don't chew half-processed markup).
+  let text = stripNoise(normalized);
+  if (text.length <= budget) {
+    return text;
+  }
+
+  // Phase 2 — classify sections and drop LOW bodies / trim MID bodies.
+  text = selectSections(text);
+  if (text.length <= budget) {
+    return text;
+  }
+
+  // Phase 3 — compress within surviving sections (first line of each list item,
+  // first sentence of long paragraphs).
+  text = compressBlocks(text);
+  if (text.length <= budget) {
+    return text;
+  }
+
+  // Phase 4 — hard cut on the cleanest boundary before the budget.
+  return hardCut(text, budget);
+}
+
+/** Phase 1: remove markup that carries no description signal. */
+function stripNoise(text: string): string {
+  return (
+    text
+      // HTML comments (multiline, non-greedy).
+      .replace(/<!--[\s\S]*?-->/g, "")
+      // Fenced code blocks (``` or ~~~, optional language) — drop entirely.
+      .replace(/^[ \t]*(```|~~~)[^\n]*\n[\s\S]*?^[ \t]*\1[^\n]*$/gm, "")
+      // Linked badges [![alt](img)](href) — drop before plain images/links.
+      .replace(/\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)/g, "")
+      // Bare images ![alt](src) — drop (alt text too).
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+      // Links [text](url) — keep the visible text.
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // Autolinks <https://…> — drop.
+      .replace(/<https?:\/\/[^>\s]*>/g, "")
+      // Remaining HTML tags — strip the tag, keep inner text.
+      .replace(/<\/?[a-zA-Z][^>]*>/g, "")
+      // Per-line trailing whitespace.
+      .replace(/[ \t]+$/gm, "")
+      // Collapse 3+ consecutive newlines to a paragraph break.
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}
+
+/** Phase 2: split at ATX headings, keep the intro in full, and reduce each
+ *  section by its classification (LOW → heading only, MID → heading + first
+ *  paragraph, HIGH → whole body for now). Document order is preserved. */
+function selectSections(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let heading: string | null = null;
+  let body: string[] = [];
+
+  const flush = () => {
+    if (heading === null) {
+      // Intro (content before the first heading) — always kept in full.
+      if (body.length > 0) {
+        out.push(body.join("\n"));
+      }
+      return;
+    }
+    const title = heading.replace(/^#{1,6}\s+/, "").toLowerCase();
+    if (matches(title, LOW_HEADINGS)) {
+      out.push(heading);
+    } else if (matches(title, HIGH_HEADINGS)) {
+      out.push([heading, ...body].join("\n"));
+    } else {
+      out.push([heading, firstParagraph(body)].join("\n"));
+    }
+  };
+
+  for (const line of lines) {
+    if (/^#{1,6}\s+/.test(line)) {
+      flush();
+      heading = line;
+      body = [];
+    } else {
+      body.push(line);
+    }
+  }
+  flush();
+
+  return out.join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/** The section body up to (but excluding) its first blank line. */
+function firstParagraph(body: string[]): string {
+  const para: string[] = [];
+  // Skip leading blank lines, then collect until the next blank line.
+  let started = false;
+  for (const line of body) {
+    if (line.trim() === "") {
+      if (started) {
+        break;
+      }
+      continue;
+    }
+    started = true;
+    para.push(line);
+  }
+  return para.join("\n");
+}
+
+/** Phase 3: within each surviving block, keep only the first line of top-level
+ *  list items (dropping wrapped continuations and nested items) and trim long
+ *  non-list paragraphs — whole blank-line-delimited blocks, wrapping and all —
+ *  to their first sentence. */
+function compressBlocks(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  // Wrapped lines of the current non-list, non-heading paragraph awaiting flush.
+  let para: string[] = [];
+  let inTopItem = false;
+
+  const flushPara = () => {
+    if (para.length > 0) {
+      out.push(compressParagraph(para.join("\n")));
+      para = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (/^#{1,6}\s+/.test(line)) {
+      // Headings pass through untouched and end any open paragraph / list item.
+      flushPara();
+      inTopItem = false;
+      out.push(line);
+      continue;
+    }
+    if (isTopLevelListItem(line)) {
+      // Start of a top-level item: keep this first line verbatim, drop the rest.
+      flushPara();
+      inTopItem = true;
+      out.push(line);
+      continue;
+    }
+    if (line.trim() === "") {
+      // Blank line ends the current paragraph or list item.
+      flushPara();
+      inTopItem = false;
+      out.push(line);
+      continue;
+    }
+    if (inTopItem) {
+      // Wrapped continuation or nested/indented sub-item of the open top-level
+      // list item — drop it.
+      continue;
+    }
+    // Ordinary (non-list) line — accumulate into the current paragraph.
+    para.push(line);
+  }
+  flushPara();
+
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/** A top-level (indent-0) unordered or ordered list item. */
+function isTopLevelListItem(line: string): boolean {
+  return /^(?:[-*+]\s+|\d+\.\s+)/.test(line);
+}
+
+/** Trim a paragraph (possibly wrapped across lines) longer than ~200 chars to
+ *  its first sentence. */
+function compressParagraph(block: string): string {
+  if (block.length <= 200) {
+    return block;
+  }
+  // First sentence boundary after char 40 (avoids cutting at "e.g." early on).
+  // A wrapped sentence ends with ". " OR ".\n", so match a period followed by
+  // any whitespace.
+  const m = /\. |\.\n/.exec(block.slice(40));
+  if (m) {
+    return block.slice(0, 40 + m.index + 1);
+  }
+  // No sentence break — fall back to the first physical line.
+  const nl = block.indexOf("\n");
+  return nl === -1 ? block : block.slice(0, nl);
+}
+
+/** Phase 4: cut at the cleanest boundary that lands before `budget`. */
+function hardCut(text: string, budget: number): string {
+  if (text.length <= budget) {
+    return text;
+  }
+  const window = text.slice(0, budget);
+  const para = window.lastIndexOf("\n\n");
+  if (para >= budget * 0.6) {
+    return text.slice(0, para).trim();
+  }
+  const nl = window.lastIndexOf("\n");
+  if (nl !== -1) {
+    return text.slice(0, nl).trim();
+  }
+  return window.trim();
+}
+
+/** Does the lowercased heading text start with, or contain, any keyword? */
+function matches(title: string, keywords: readonly string[]): boolean {
+  return keywords.some((k) => title.startsWith(k) || title.includes(k));
+}


### PR DESCRIPTION
This change improves AI-generated GitHub repository "About" descriptions by condensing long READMEs for input and allowing more informative, longer output—up to approximately 250–325 characters. This helps repo descriptions better capture project features and distinctiveness, rather than producing terse summaries or discarding key information from lengthy READMEs.

### AI repo description prompt
- Expands the target description length in `src/lib/ai/prompt.ts` (DESCRIPTION_SYSTEM) to allow up to 325 characters, instructing the model to generate fuller, information-dense summaries.
- Updates the prompt construction to use a condensed README (up to a 10,000 character budget) via `distillReadme` from `src/lib/ai/readme.ts` rather than hard truncation at 6,000 characters.
- Adds a new helper function `capDescription` in `src/lib/ai/prompt.ts` to ensure outputs never exceed 350 characters, trimming only at whole-word boundaries.

### README condensation
- Introduces a new deterministic README distillation utility in `src/lib/ai/readme.ts` that:
  - Removes markup noise and boilerplate (installation, development, etc).
  - Preserves breadth and high-signal content (features, usage, overview, etc).
  - Progressively condenses the README in four stages to best fit the character budget for model input, ensuring the included content is maximally informative.

### Changelog documentation
- Documents the changed prompt behavior and rationale in `changelog.d/changed-repo-description-length.md`, highlighting the new description length and smarter handling of long READMEs.