### PR TITLE
feat(jira): link and surface referenced Jira keys, promote local to Jira, MCP agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,19 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   **priority**, **assignee**, **labels**, Markdown **description**, and **comments**, with
   **View in Jira** link-outs. You can also **create** an issue (summary, description, and an
   issue-type picker), **comment** in Markdown, **close / reopen** by following the project's
-  own workflow (the confirmation names the real resulting status), and **assign / unassign** via
-  user search — actions your Jira permissions don't allow simply don't appear. Connect with
-  an **Atlassian API token** (email + token, validated before saving and kept in your OS
-  keychain), or reuse an existing Bitbucket credential. Especially handy for **Bitbucket** repos, whose native tracker Atlassian
-  retires 2026-08-20.
+  own workflow (the confirmation names the real resulting status) — or jump to any workflow
+  status from the **status menu** on the chip — and **assign / unassign** via
+  user search — actions your Jira permissions don't allow simply don't appear. The linked
+  project's **issue keys** (e.g. `PROJ-123`) are also spotted in the current **branch name**,
+  a commit's message, and a PR's title/description, and surfaced as a compact **referenced
+  Jira issues** row that jumps straight to the issue in the Issues tab. A **local issue** can
+  be **promoted to Jira** too (alongside GitHub / GitLab when both are available) — its
+  comments carry over and the local one closes with a back-link. Agents connected through
+  GitDesktop's **MCP server** get `jira_*` tools to list and read the linked project's issues,
+  and — behind the `--allow-remote-write` opt-in — comment, close/reopen, create, and assign.
+  Connect with an **Atlassian API token** (email + token, validated before saving and kept in
+  your OS keychain), or reuse an existing Bitbucket credential. Especially handy for
+  **Bitbucket** repos, whose native tracker Atlassian retires 2026-08-20.
 - **Delegate a task to an agent** — hand a coding task to an AI agent that works
   in an isolated worktree, so your own checkout is never touched. Follow it
   **step by step** — every file it reads, edits, and command it runs — and

--- a/changelog.d/added-jira-links-promote-mcp.md
+++ b/changelog.d/added-jira-links-promote-mcp.md
@@ -1,0 +1,10 @@
+- **Jira issue links, promote-to-Jira, and agent access.** The linked project's issue keys
+  (e.g. `PROJ-123`) are now spotted in the current branch name, a commit's message, and a PR's
+  title/description, and surfaced as a compact "referenced Jira issues" row that jumps to the
+  issue in the Issues tab. A local issue can be promoted to Jira (alongside GitHub or GitLab
+  when both are available) — its comments carry over and the local one closes with a back-link.
+  And agents connected through GitDesktop's MCP server get `jira_*` tools to list and read the
+  linked project's issues, plus comment, close/reopen, create, and assign behind the
+  `--allow-remote-write` opt-in. The status chip in the Jira issue view is now also a menu
+  (when your permissions allow transitions) for moving an issue to any of its workflow's
+  available statuses, alongside the existing close/reopen quick action.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -80,7 +80,7 @@ const capabilities = [
   },
   {
     label:
-      "Link a Jira Cloud project to any repo — browse issues (status, type, priority, assignee, description & comments) and create, comment on, close/reopen (following the project's workflow), and assign them from the Issues tab, all gated on your Jira permissions; a one-click path for Bitbucket repos after its tracker's 2026 sunset",
+      "Link a Jira Cloud project to any repo — browse issues (status, type, priority, assignee, description & comments) and create, comment on, close/reopen (following the project's workflow), and assign them from the Issues tab, all gated on your Jira permissions; the project's issue keys are spotted in branch names, commits & PR titles and linked back to the Issues tab, a local issue can be promoted to Jira, and agents reach the linked project through GitDesktop's MCP server; a one-click path for Bitbucket repos after its tracker's 2026 sunset",
   },
   { label: "AI code & security review", ai: true },
   { label: "Resolve merge conflicts with AI (review, then accept)", ai: true },

--- a/src-tauri/src/forge/jira.rs
+++ b/src-tauri/src/forge/jira.rs
@@ -1241,22 +1241,28 @@ pub struct JiraTransitionResult {
     pub status_category: String,
 }
 
-/// A workflow transition as `GET /issue/<key>/transitions` returns it — the id we `POST`
-/// and the category of the status it moves the issue *to*.
+/// A workflow transition as `GET /issue/<key>/transitions` returns it — the id we `POST`,
+/// the transition's own display `name` (e.g. "Start Progress"), and the status it moves
+/// the issue *to* (that status's display name + category).
 #[derive(Deserialize, Default)]
 struct JiraTransition {
     #[serde(default)]
     id: Option<String>,
     #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
     to: Option<JiraTransitionTo>,
 }
 
-/// The `to` block of a transition — the destination status's category key. Jira sends
-/// the key as `statusCategory` (camelCase), so this struct MUST rename or `to` never
-/// resolves a category and every transition looks category-less.
+/// The `to` block of a transition — the destination status's display `name` and its
+/// category key. Jira sends the category as `statusCategory` (camelCase), so this struct
+/// MUST rename or `to` never resolves a category and every transition looks
+/// category-less.
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct JiraTransitionTo {
+    #[serde(default)]
+    name: Option<String>,
     #[serde(default)]
     status_category: Option<JiraStatusCategory>,
 }
@@ -1316,6 +1322,48 @@ fn category_of(t: &JiraTransition) -> Option<&str> {
     t.to.as_ref()?.status_category.as_ref()?.key.as_deref()
 }
 
+/// The destination status display name of a transition (`to.name`), or `None` when the
+/// `to` block or its name is absent.
+fn to_status_name_of(t: &JiraTransition) -> Option<&str> {
+    t.to.as_ref()?.name.as_deref()
+}
+
+/// One workflow transition presented to the status picker: the id to POST, the
+/// transition's own name, and the status it leads to.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraTransitionOption {
+    pub id: String,
+    pub name: String,
+    pub to_status_name: String,
+    pub to_status_category: String,
+}
+
+/// Map the parsed transitions onto the picker's [`JiraTransitionOption`] shape, in server
+/// order. Entries missing an id are skipped (a transition we couldn't POST is useless to
+/// offer); every other field degrades to empty. Pure (unit-tested).
+fn transition_options(transitions: &[JiraTransition]) -> Vec<JiraTransitionOption> {
+    transitions
+        .iter()
+        .filter_map(|t| {
+            let id = t.id.clone().filter(|s| !s.is_empty())?;
+            Some(JiraTransitionOption {
+                id,
+                name: t.name.clone().unwrap_or_default(),
+                to_status_name: to_status_name_of(t).unwrap_or("").to_string(),
+                to_status_category: category_of(t).unwrap_or("").to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Whether a transition id is a non-empty run of ASCII digits — Jira transition ids are
+/// numeric strings, and this grammar-validates the id before it is spliced into the POST
+/// body. Pure (testable).
+fn is_valid_transition_id(id: &str) -> bool {
+    !id.is_empty() && id.bytes().all(|b| b.is_ascii_digit())
+}
+
 /// Extract `(statusName, statusCategoryKey)` from an `issue?fields=status` response. Pure.
 fn status_of_issue(issue: &Value) -> (String, String) {
     let fields = issue.get("fields").cloned().unwrap_or(Value::Null);
@@ -1367,9 +1415,21 @@ pub async fn issue_transition(
         ))
     })?;
 
+    post_transition_and_refetch(&creds, key, &transition_id).await
+}
+
+/// POST a chosen transition id for an issue and read back its fresh status. Shared by the
+/// direction-based [`issue_transition`] and the explicit-id [`issue_transition_to`] so the
+/// POST-then-refetch is written once. `key` is assumed already validated; `transition_id`
+/// is assumed already grammar-validated by the caller.
+async fn post_transition_and_refetch(
+    creds: &JiraCredentials,
+    key: &str,
+    transition_id: &str,
+) -> AppResult<JiraTransitionResult> {
     let body = json!({ "transition": { "id": transition_id } });
     send_no_content(
-        &creds,
+        creds,
         reqwest::Method::POST,
         &format!("issue/{key}/transitions"),
         Some(&body),
@@ -1377,12 +1437,53 @@ pub async fn issue_transition(
     .await?;
 
     // Read back the fresh status (the transition response is 204 with no body).
-    let issue: Value = get_json(&creds, &format!("issue/{key}?fields=status"), "issue").await?;
+    let issue: Value = get_json(creds, &format!("issue/{key}?fields=status"), "issue").await?;
     let (status_name, status_category) = status_of_issue(&issue);
     Ok(JiraTransitionResult {
         status_name,
         status_category,
     })
+}
+
+/// The full list of workflow transitions available for an issue right now, for the status
+/// picker. `GET /issue/<key>/transitions`, mapped onto [`JiraTransitionOption`] in server
+/// order (entries missing an id are skipped). The issue key is grammar-validated first.
+pub async fn issue_transitions(site: &str, key: &str) -> AppResult<Vec<JiraTransitionOption>> {
+    let site = normalize_site(site)?;
+    if !is_valid_issue_key(key) {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid Jira issue key: {key}"
+        )));
+    }
+    let creds = load_credentials(&site).await?;
+    let list: JiraTransitionsResponse =
+        get_json(&creds, &format!("issue/{key}/transitions"), "transitions").await?;
+    Ok(transition_options(&list.transitions))
+}
+
+/// Execute a specific workflow transition on an issue by its id (the id comes from
+/// [`issue_transitions`]). The id is grammar-validated (non-empty ASCII digits) BEFORE it
+/// is spliced into the POST body; then the shared POST-then-refetch runs, returning the
+/// issue's fresh status. Unlike [`issue_transition`], the caller supplies the id directly
+/// rather than deriving it from a close/reopen direction.
+pub async fn issue_transition_to(
+    site: &str,
+    key: &str,
+    transition_id: &str,
+) -> AppResult<JiraTransitionResult> {
+    let site = normalize_site(site)?;
+    if !is_valid_issue_key(key) {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid Jira issue key: {key}"
+        )));
+    }
+    if !is_valid_transition_id(transition_id) {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid Jira transition id: {transition_id}"
+        )));
+    }
+    let creds = load_credentials(&site).await?;
+    post_transition_and_refetch(&creds, key, transition_id).await
 }
 
 /// The key + URL of a newly-created issue.
@@ -2060,7 +2161,9 @@ mod tests {
                     status_category: Some(JiraStatusCategory {
                         key: Some((*cat).to_string()),
                     }),
+                    ..Default::default()
                 }),
+                ..Default::default()
             })
             .collect()
     }
@@ -2123,12 +2226,15 @@ mod tests {
             JiraTransition {
                 id: Some("1".into()),
                 to: None,
+                ..Default::default()
             },
             JiraTransition {
                 id: Some("2".into()),
                 to: Some(JiraTransitionTo {
                     status_category: None,
+                    ..Default::default()
                 }),
+                ..Default::default()
             },
             JiraTransition {
                 id: Some("3".into()),
@@ -2136,7 +2242,9 @@ mod tests {
                     status_category: Some(JiraStatusCategory {
                         key: Some("done".into()),
                     }),
+                    ..Default::default()
                 }),
+                ..Default::default()
             },
         ];
         assert_eq!(
@@ -2290,14 +2398,20 @@ mod tests {
         let body = r#"{
             "transitions": [
                 { "id": "11", "name": "Start Progress",
-                  "to": { "statusCategory": { "key": "indeterminate" } } },
+                  "to": { "name": "In Progress", "statusCategory": { "key": "indeterminate" } } },
                 { "id": "21", "name": "Done",
-                  "to": { "statusCategory": { "key": "done" } } }
+                  "to": { "name": "Done", "statusCategory": { "key": "done" } } }
             ]
         }"#;
         let parsed: JiraTransitionsResponse = serde_json::from_str(body).unwrap();
         // The done category must actually deserialize (the crux of bug 1).
         assert_eq!(category_of(&parsed.transitions[1]), Some("done"));
+        // The destination status name (`to.name`) must also deserialize (phase-3 addition).
+        assert_eq!(
+            to_status_name_of(&parsed.transitions[0]),
+            Some("In Progress")
+        );
+        assert_eq!(to_status_name_of(&parsed.transitions[1]), Some("Done"));
         assert_eq!(
             pick_transition_id(&parsed.transitions, "close").unwrap(),
             Some("21".to_string())
@@ -2307,6 +2421,69 @@ mod tests {
             pick_transition_id(&parsed.transitions, "reopen").unwrap(),
             Some("11".to_string())
         );
+    }
+
+    #[test]
+    fn transition_options_maps_live_fixture_in_server_order() {
+        // The status picker consumes ALL transitions (not just close/reopen), mapping each
+        // to {id, name, toStatusName, toStatusCategory} in the order the server returned.
+        let body = r#"{
+            "transitions": [
+                { "id": "11", "name": "Start Progress",
+                  "to": { "name": "In Progress", "statusCategory": { "key": "indeterminate" } } },
+                { "id": "21", "name": "Done",
+                  "to": { "name": "Done", "statusCategory": { "key": "done" } } }
+            ]
+        }"#;
+        let parsed: JiraTransitionsResponse = serde_json::from_str(body).unwrap();
+        let opts = transition_options(&parsed.transitions);
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].id, "11");
+        assert_eq!(opts[0].name, "Start Progress");
+        assert_eq!(opts[0].to_status_name, "In Progress");
+        assert_eq!(opts[0].to_status_category, "indeterminate");
+        assert_eq!(opts[1].id, "21");
+        assert_eq!(opts[1].name, "Done");
+        assert_eq!(opts[1].to_status_name, "Done");
+        assert_eq!(opts[1].to_status_category, "done");
+    }
+
+    #[test]
+    fn transition_options_skips_idless_and_degrades_missing_fields() {
+        // An entry with no id is dropped (can't POST it); missing name/to fields degrade
+        // to empty strings rather than sinking the whole list.
+        let body = r#"{
+            "transitions": [
+                { "name": "No Id Here", "to": { "name": "X", "statusCategory": { "key": "new" } } },
+                { "id": "31" },
+                { "id": "", "name": "Empty Id" }
+            ]
+        }"#;
+        let parsed: JiraTransitionsResponse = serde_json::from_str(body).unwrap();
+        let opts = transition_options(&parsed.transitions);
+        // Only the id-"31" entry survives (idless + empty-id are skipped).
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].id, "31");
+        assert_eq!(opts[0].name, "");
+        assert_eq!(opts[0].to_status_name, "");
+        assert_eq!(opts[0].to_status_category, "");
+    }
+
+    #[test]
+    fn transition_options_empty_when_no_transitions() {
+        assert!(transition_options(&[]).is_empty());
+    }
+
+    #[test]
+    fn valid_transition_id_requires_nonempty_digits() {
+        assert!(is_valid_transition_id("21"));
+        assert!(is_valid_transition_id("10001"));
+        assert!(!is_valid_transition_id("")); // empty
+        assert!(!is_valid_transition_id("2a")); // non-digit
+        assert!(!is_valid_transition_id("a")); // non-digit
+        assert!(!is_valid_transition_id("2 1")); // space
+        assert!(!is_valid_transition_id("-1")); // sign
+        assert!(!is_valid_transition_id("2\"1")); // injection char
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -325,6 +325,27 @@ pub async fn jira_issue_transition(
     jira::issue_transition(&site, &key, &direction).await
 }
 
+/// The full list of workflow transitions available for a Jira issue right now, for the
+/// status picker (`GET /issue/<key>/transitions`, server order).
+#[tauri::command]
+pub async fn jira_issue_transitions(
+    site: String,
+    key: String,
+) -> AppResult<Vec<jira::JiraTransitionOption>> {
+    jira::issue_transitions(&site, &key).await
+}
+
+/// Execute a specific workflow transition on a Jira issue by its id (from
+/// `jira_issue_transitions`). Returns the issue's fresh status after the transition.
+#[tauri::command]
+pub async fn jira_issue_transition_to(
+    site: String,
+    key: String,
+    transition_id: String,
+) -> AppResult<jira::JiraTransitionResult> {
+    jira::issue_transition_to(&site, &key, &transition_id).await
+}
+
 /// Create a Jira issue. Needs `project_key`, `issue_type_id`, and a non-empty `summary`;
 /// `description_md` (markdown → ADF) is optional. Returns the new issue's key + URL.
 #[tauri::command]

--- a/src-tauri/src/jira_links.rs
+++ b/src-tauri/src/jira_links.rs
@@ -1,0 +1,305 @@
+//! Headless reader for the per-repo Jira link store (`jira-links.json`).
+//!
+//! **The Jira link is GitDesktop's own app-data** — a per-repo pointer at a linked
+//! Jira project (`{siteHost, projectKey, projectName}`), never written into the repo
+//! itself. The GUI persists it via the Tauri Store plugin (`src/lib/jira/store.ts`);
+//! this module is the headless mirror the MCP server (which has NO `AppHandle`) uses to
+//! READ the SAME file so its `jira_*` tools resolve the linked project without taking a
+//! `site`/`projectKey` param (the stored link is the single source of truth).
+//!
+//! ## Storage-dir + key mirroring (the make-or-break detail)
+//!
+//! Same contract as [`crate::local_prs`]: the file is
+//! `dirs::data_dir()/<identifier>/jira-links.json` (the `tauri-plugin-store` v2
+//! `BaseDirectory::AppData` resolution), reusing [`crate::local_prs::APP_IDENTIFIER`].
+//! Entries are keyed by the repo's worktree-stable identity
+//! ([`crate::git::repo::repo_identity`] — `git rev-parse --git-common-dir`), so the
+//! link is shared across the main checkout and every worktree. The GUI's read path
+//! ([`getJiraLink`](../src/lib/jira/store.ts)) looks up the identity key first and
+//! falls back to the raw checkout path (a link created under a legacy path key, before
+//! the next GUI mutation folds it onto the identity); this reader mirrors that exact
+//! two-step lookup.
+//!
+//! ## Read-only
+//!
+//! The MCP server NEVER writes this file (linking happens only in the GUI), so — unlike
+//! `local_prs` — there is no create/mutate/atomic-write or fold/migration machinery
+//! here. A missing file, an absent entry, or a malformed entry all read as "no link"
+//! (`None`), never an error, so a hand-edited or partially-corrupt store can't crash a
+//! tool call.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::error::{AppError, AppResult};
+
+/// The store filename (mirrors `src/lib/jira/store.ts`'s `load("jira-links.json")`).
+const STORE_FILE: &str = "jira-links.json";
+
+/// A repo's Jira link, as the headless reader surfaces it. Mirrors the frontend
+/// `JiraLink` (`src/lib/jira/store.ts`) camelCase shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraLinkEntry {
+    /// The Atlassian site host, e.g. `mycompany.atlassian.net`.
+    pub site_host: String,
+    /// The project key, e.g. `PROJ`.
+    pub project_key: String,
+    /// The project's display name.
+    pub project_name: String,
+}
+
+/// Resolve the absolute path of the `jira-links.json` the frontend store writes.
+/// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
+/// (`dirs::data_dir()/<identifier>`) — identical to [`crate::local_prs::store_path`].
+pub fn store_path() -> AppResult<PathBuf> {
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(crate::local_prs::APP_IDENTIFIER).join(STORE_FILE))
+}
+
+/// Read the whole store file as a JSON object. A missing file → an empty object (no
+/// links stored yet). Read-only: a present-but-malformed file surfaces a clear error
+/// (we never look up entries in a file we couldn't parse) — but a well-formed file with
+/// a malformed *entry* is handled per-entry by [`link_from_value`].
+fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Command(format!(
+                    "jira-links store at {} is not valid JSON: {e}",
+                    path.display()
+                ))
+            })?;
+            match value {
+                Value::Object(map) => Ok(map),
+                _ => Err(AppError::Command(format!(
+                    "jira-links store at {} is not a JSON object",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(AppError::Io(e)),
+    }
+}
+
+/// Compare two repo-path keys for "same repo" tolerantly: normalize separators to
+/// `/`, and treat a leading Windows drive letter case-insensitively (`C:` == `c:`).
+/// Mirrors [`crate::local_prs`]'s `same_repo` so the legacy-path fallback matches the
+/// GUI's tolerant key handling (a differently-spelled checkout path still resolves).
+fn same_repo(a: &str, b: &str) -> bool {
+    fn norm(s: &str) -> String {
+        let slashed: String = s.chars().map(|c| if c == '\\' { '/' } else { c }).collect();
+        // Lowercase only a leading "X:" drive-letter prefix.
+        let bytes = slashed.as_bytes();
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            let mut out = String::with_capacity(slashed.len());
+            out.push(bytes[0].to_ascii_lowercase() as char);
+            out.push_str(&slashed[1..]);
+            out
+        } else {
+            slashed
+        }
+    }
+    norm(a) == norm(b)
+}
+
+/// Type-guard one stored value into a [`JiraLinkEntry`] — `None` when it isn't an
+/// object, or any of the three required fields is missing / not a string (per-field
+/// `Value::as_str` guards). A malformed entry reads as "no link" rather than erroring,
+/// mirroring the frontend `asLink` guard.
+fn link_from_value(value: &Value) -> Option<JiraLinkEntry> {
+    let obj = value.as_object()?;
+    let site_host = obj.get("siteHost").and_then(Value::as_str)?.to_string();
+    let project_key = obj.get("projectKey").and_then(Value::as_str)?.to_string();
+    let project_name = obj.get("projectName").and_then(Value::as_str)?.to_string();
+    Some(JiraLinkEntry {
+        site_host,
+        project_key,
+        project_name,
+    })
+}
+
+/// Look up a repo's link in a loaded store map: the identity key first, then — only when
+/// the identity differs from the raw checkout path — the raw path as a tolerant legacy
+/// fallback (a link created under a checkout-path key before the GUI folds it onto the
+/// identity). Pure so the lookup order is unit-testable against a plain map.
+fn lookup(store: &Map<String, Value>, identity: &str, legacy: &str) -> Option<JiraLinkEntry> {
+    // Identity key (exact) first — the canonical, worktree-stable key.
+    if let Some(link) = store.get(identity).and_then(link_from_value) {
+        return Some(link);
+    }
+    // When the resolved identity IS the raw path, there's no separate legacy entry to
+    // check. Otherwise fall back to the checkout path — exact, then slash/drive-tolerant.
+    if identity == legacy {
+        return None;
+    }
+    if let Some(link) = store.get(legacy).and_then(link_from_value) {
+        return Some(link);
+    }
+    store
+        .iter()
+        .find(|(k, _)| same_repo(k, legacy))
+        .and_then(|(_, v)| link_from_value(v))
+}
+
+/// This repo's Jira link, or `None` when it's unlinked (no store file, no entry, or a
+/// malformed entry). Read-only. Resolves the repo's worktree-stable identity
+/// ([`crate::git::repo::repo_identity`]) and looks that up first, then the raw
+/// `repo_path` as a tolerant legacy fallback — mirroring the GUI's `getJiraLink`.
+pub async fn get_link(repo_path: &str) -> AppResult<Option<JiraLinkEntry>> {
+    let identity = crate::git::repo::repo_identity(repo_path).await;
+    let path = store_path()?;
+    let store = read_store(&path)?;
+    Ok(lookup(&store, &identity, repo_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn link_json() -> Value {
+        json!({
+            "siteHost": "acme.atlassian.net",
+            "projectKey": "PROJ",
+            "projectName": "Project X",
+        })
+    }
+
+    fn tmp_store() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "gd-jira-links-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        p
+    }
+
+    #[test]
+    fn read_missing_file_is_empty_object() {
+        let path = tmp_store();
+        let store = read_store(&path).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn read_missing_file_yields_no_link() {
+        // The end-to-end "no store file" case: read_store → empty map → lookup None.
+        let store = read_store(&tmp_store()).unwrap();
+        assert_eq!(lookup(&store, "C:/repo/.git", r"C:\repo"), None);
+    }
+
+    #[test]
+    fn malformed_store_is_an_error_not_a_clobber() {
+        let path = tmp_store();
+        std::fs::write(&path, b"{ this is not json").unwrap();
+        let err = read_store(&path).unwrap_err();
+        assert!(err.to_string().contains("not valid JSON"));
+        // The bad file is left intact (read-only).
+        assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn parses_a_well_formed_entry() {
+        let link = link_from_value(&link_json()).unwrap();
+        assert_eq!(link.site_host, "acme.atlassian.net");
+        assert_eq!(link.project_key, "PROJ");
+        assert_eq!(link.project_name, "Project X");
+    }
+
+    #[test]
+    fn malformed_entry_reads_as_none() {
+        // Not an object.
+        assert!(link_from_value(&json!("nope")).is_none());
+        assert!(link_from_value(&json!(42)).is_none());
+        assert!(link_from_value(&Value::Null).is_none());
+        // Missing a required field.
+        assert!(
+            link_from_value(&json!({ "siteHost": "a.atlassian.net", "projectKey": "P" })).is_none()
+        );
+        // A required field of the wrong type.
+        assert!(link_from_value(&json!({
+            "siteHost": "a.atlassian.net",
+            "projectKey": 7,
+            "projectName": "X"
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn lookup_prefers_the_identity_key() {
+        let identity = "C:/ProjectRepos/demo/harbor/.git";
+        let legacy = r"C:\ProjectRepos\demo\harbor";
+        let mut store = Map::new();
+        store.insert(identity.to_string(), link_json());
+        // A DIFFERENT link under the legacy path must not shadow the identity one.
+        store.insert(
+            legacy.to_string(),
+            json!({ "siteHost": "old.atlassian.net", "projectKey": "OLD", "projectName": "Old" }),
+        );
+        let link = lookup(&store, identity, legacy).unwrap();
+        assert_eq!(link.site_host, "acme.atlassian.net");
+    }
+
+    #[test]
+    fn lookup_falls_back_to_the_legacy_path_key() {
+        // A link created under the checkout path (before a GUI mutation folds it onto
+        // the identity) still resolves — exact match.
+        let identity = "C:/ProjectRepos/demo/harbor/.git";
+        let legacy = r"C:\ProjectRepos\demo\harbor";
+        let mut store = Map::new();
+        store.insert(legacy.to_string(), link_json());
+        let link = lookup(&store, identity, legacy).unwrap();
+        assert_eq!(link.project_key, "PROJ");
+    }
+
+    #[test]
+    fn lookup_legacy_fallback_is_slash_and_drive_tolerant() {
+        // The stored legacy key is spelled differently (slashes + drive case) than the
+        // raw path the server was launched with — the tolerant comparator still matches.
+        let identity = "C:/ProjectRepos/demo/harbor/.git";
+        let stored_legacy = r"C:\ProjectRepos\demo\harbor";
+        let launched_with = "c:/ProjectRepos/demo/harbor";
+        let mut store = Map::new();
+        store.insert(stored_legacy.to_string(), link_json());
+        let link = lookup(&store, identity, launched_with).unwrap();
+        assert_eq!(link.site_host, "acme.atlassian.net");
+    }
+
+    #[test]
+    fn lookup_no_entry_is_none() {
+        let mut store = Map::new();
+        store.insert("C:/other/.git".to_string(), link_json());
+        assert_eq!(lookup(&store, "C:/repo/.git", r"C:\repo"), None);
+    }
+
+    #[test]
+    fn lookup_no_legacy_check_when_identity_equals_path() {
+        // When repo_identity returned the raw path itself (identity == legacy), there's
+        // no distinct legacy entry to consult — a malformed identity entry is just None.
+        let repo = r"C:\repo";
+        let mut store = Map::new();
+        store.insert(repo.to_string(), json!({ "siteHost": "a.atlassian.net" })); // malformed
+        assert_eq!(lookup(&store, repo, repo), None);
+    }
+
+    #[test]
+    fn read_and_lookup_end_to_end_via_temp_file() {
+        let path = tmp_store();
+        let identity = "C:/repo/reads/.git";
+        let mut store = Map::new();
+        store.insert(identity.to_string(), link_json());
+        std::fs::write(&path, serde_json::to_vec(&Value::Object(store)).unwrap()).unwrap();
+
+        let back = read_store(&path).unwrap();
+        let link = lookup(&back, identity, "C:/repo/reads").unwrap();
+        assert_eq!(link.project_key, "PROJ");
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/src-tauri/src/jira_links.rs
+++ b/src-tauri/src/jira_links.rs
@@ -24,9 +24,11 @@
 //!
 //! The MCP server NEVER writes this file (linking happens only in the GUI), so — unlike
 //! `local_prs` — there is no create/mutate/atomic-write or fold/migration machinery
-//! here. A missing file, an absent entry, or a malformed entry all read as "no link"
-//! (`None`), never an error, so a hand-edited or partially-corrupt store can't crash a
-//! tool call.
+//! here. A missing file, an absent entry, or a malformed *entry* all read as "no link"
+//! (`None`), so a single hand-edited or partly-corrupt entry can't crash a tool call. A
+//! malformed store *file* (invalid JSON — genuine corruption of the whole store)
+//! deliberately surfaces an error instead of silently reading as "no link", so real
+//! corruption is visible rather than masked (both behaviors are unit-tested).
 
 use std::path::{Path, PathBuf};
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod github;
 mod health;
 mod hooks;
 mod instructions;
+mod jira_links;
 mod local_issues;
 mod local_prs;
 mod mcp;
@@ -261,6 +262,8 @@ pub fn run() {
             forge::jira_issue_view,
             forge::jira_issue_comment,
             forge::jira_issue_transition,
+            forge::jira_issue_transitions,
+            forge::jira_issue_transition_to,
             forge::jira_issue_create,
             forge::jira_issue_types,
             forge::jira_issue_assign,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -113,10 +113,18 @@ fn pr_system_for(provider: Option<&str>) -> String {
                 "PR"
             };
             PR_SYSTEM
-                .replacen("GitHub pull request", &format!("{host} {}", copy.pr_noun), 1)
+                .replacen(
+                    "GitHub pull request",
+                    &format!("{host} {}", copy.pr_noun),
+                    1,
+                )
                 .replacen("the PR title", &format!("the {} title", copy.pr_noun), 1)
                 .replacen("no \"PR:\"", &format!("no \"{abbrev}:\""), 1)
-                .replacen("human-written PR:", &format!("human-written {}:", copy.pr_noun), 1)
+                .replacen(
+                    "human-written PR:",
+                    &format!("human-written {}:", copy.pr_noun),
+                    1,
+                )
                 .replacen(
                     "issue or PR numbers",
                     &format!("issue or {abbrev} numbers"),
@@ -1083,7 +1091,9 @@ mod tests {
         });
         // System: base + both instruction sections (global trimmed).
         assert!(recipe.system.starts_with("You write git commit messages."));
-        assert!(recipe.system.contains("## Project instructions\nRepo rule."));
+        assert!(recipe
+            .system
+            .contains("## Project instructions\nRepo rule."));
         assert!(recipe.system.contains("## User instructions\nGlobal rule."));
         // Prompt: all the expected headers, in order, plus the closing line.
         assert!(recipe.prompt.contains("## Files changed\nx.rs +1 -1"));
@@ -1174,11 +1184,15 @@ mod tests {
             global_instructions: String::new(),
             provider: Some("github".to_string()),
         });
-        assert!(recipe.system.starts_with("You write GitHub pull request descriptions"));
+        assert!(recipe
+            .system
+            .starts_with("You write GitHub pull request descriptions"));
         assert!(recipe
             .prompt
             .contains("This pull request merges `feature/x` into `main`."));
-        assert!(recipe.prompt.contains("## Commits in this PR\n- feat: thing"));
+        assert!(recipe
+            .prompt
+            .contains("## Commits in this PR\n- feat: thing"));
         // No labels section when the repo has none.
         assert!(!recipe.system.contains("## Labels"));
     }
@@ -1199,7 +1213,9 @@ mod tests {
         });
         assert!(recipe.system.contains("GitLab merge request"));
         assert!(recipe.system.contains("GitLab-flavored Markdown"));
-        assert!(recipe.prompt.contains("This merge request merges `topic` into `main`."));
+        assert!(recipe
+            .prompt
+            .contains("This merge request merges `topic` into `main`."));
         // Labels present (blank entry filtered out).
         assert!(recipe.system.contains("## Labels"));
         assert!(recipe.system.contains("these labels: bug."));
@@ -1282,7 +1298,12 @@ mod tests {
             assert!(is_low_value_path(p), "expected low-value: {p}");
         }
         // Extension branches (suffix-anchored, anywhere in the path).
-        for p in ["a/b.min.js", "x.min.css", "out/bundle.map", "t/__snap__.snap"] {
+        for p in [
+            "a/b.min.js",
+            "x.min.css",
+            "out/bundle.map",
+            "t/__snap__.snap",
+        ] {
             assert!(is_low_value_path(p), "expected low-value: {p}");
         }
         // Real code is NOT low-value (incl. a file merely NAMED like a lockfile part).

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -301,6 +301,33 @@ impl GitDesktopMcp {
     }
 }
 
+/// Reject a Jira issue `key` whose project prefix isn't the LINKED project. The link pins
+/// only the site, so without this a key-taking `jira_*` tool would reach any project on
+/// that site (e.g. `OTHER-456` under a `MYT` link) — wider than the "linked project's
+/// issues" contract. The prefix is everything before the last `-` (matching
+/// `jira::is_valid_issue_key`'s `rsplit_once('-')`), compared case-insensitively. A key
+/// with no `-` (no derivable project) is refused too. Shared by every key-taking tool in
+/// `read_jira`/`write_jira` (not `list_jira_issues`, which is JQL-scoped to the project,
+/// nor `create_jira_issue`, which creates in the linked project). Pure (unit-tested).
+fn ensure_key_in_project(
+    key: &str,
+    link: &crate::jira_links::JiraLinkEntry,
+) -> Result<(), McpError> {
+    let prefix = key.rsplit_once('-').map(|(project, _)| project);
+    let matches = prefix.is_some_and(|p| p.eq_ignore_ascii_case(&link.project_key));
+    if matches {
+        Ok(())
+    } else {
+        Err(McpError::invalid_request(
+            format!(
+                "Key {key} doesn't belong to the linked project {}.",
+                link.project_key
+            ),
+            None,
+        ))
+    }
+}
+
 // The combined per-instance router (built in `with_options`) is what the handler
 // serves — so the `list_tools`/`call_tool`/`get_tool` the macro generates dispatch
 // across every domain module, not just one.
@@ -788,6 +815,31 @@ mod tests {
         assert_eq!(per_module, 116);
     }
 
+    /// `ensure_key_in_project` gates a key-taking Jira tool to the linked project: the
+    /// prefix (before the last `-`) must equal `link.project_key`, case-insensitively.
+    /// A different project (same site) or a key with no `-` is refused, and the error
+    /// names both the key and the linked project.
+    #[test]
+    fn ensure_key_in_project_gates_the_prefix() {
+        let link = crate::jira_links::JiraLinkEntry {
+            site_host: "acme.atlassian.net".to_string(),
+            project_key: "MYT".to_string(),
+            project_name: "My Thing".to_string(),
+        };
+        // Exact match passes.
+        assert!(ensure_key_in_project("MYT-123", &link).is_ok());
+        // Case-insensitive match passes (a lowercased prefix still belongs).
+        assert!(ensure_key_in_project("myt-1", &link).is_ok());
+        // A different project on the same site is refused, naming both.
+        let err = ensure_key_in_project("OTHER-456", &link)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("OTHER-456"), "err: {err}");
+        assert!(err.contains("MYT"), "err: {err}");
+        // A key with no derivable project (no `-`) is refused.
+        assert!(ensure_key_in_project("NODASH", &link).is_err());
+    }
+
     /// The prompt router (separate from the tool router — prompts are NOT tools, so
     /// the count above is unaffected) exposes exactly the three generation-recipe
     /// prompts, by their MCP names. `list_all` returns them sorted by name.
@@ -800,6 +852,9 @@ mod tests {
             .into_iter()
             .map(|p| p.name)
             .collect();
-        assert_eq!(names, vec!["branch-name", "commit-message", "pr-description"]);
+        assert_eq!(
+            names,
+            vec!["branch-name", "commit-message", "pr-description"]
+        );
     }
 }

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -10,8 +10,10 @@
 //!
 //! - [`read_git`]     — local-git read tools (status, log, diffs, blame, read_file, …)
 //! - [`read_forge`]   — forge/CI read tools (PRs, issues, workflow runs/logs)
+//! - [`read_jira`]    — linked-Jira issue read tools (list/get)
 //! - [`write_local`]  — local-PR write tools           (opt-in via `--allow-write`)
 //! - [`write_forge`]  — forge remote-write tools        (opt-in via `--allow-remote-write`)
+//! - [`write_jira`]   — linked-Jira issue write tools   (opt-in via `--allow-remote-write`)
 //! - [`write_git`]    — local-git write tools           (opt-in via `--allow-git-write`)
 //! - [`generate`]     — AI-generation recipe tools
 //!
@@ -26,8 +28,10 @@
 mod generate;
 mod read_forge;
 mod read_git;
+mod read_jira;
 mod write_forge;
 mod write_git;
+mod write_jira;
 mod write_local;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -174,8 +178,10 @@ impl GitDesktopMcp {
             // without touching this expression.
             tool_router: Self::read_git_router()
                 + Self::read_forge_router()
+                + Self::read_jira_router()
                 + Self::write_local_router()
                 + Self::write_forge_router()
+                + Self::write_jira_router()
                 + Self::write_git_router()
                 + Self::generate_router(),
             // The generation recipes are ALSO exposed as MCP prompts. Only one module
@@ -273,6 +279,26 @@ impl GitDesktopMcp {
         }
         Ok(identity)
     }
+
+    /// Resolve the bound repo's linked Jira project (`{siteHost, projectKey,
+    /// projectName}`) from the headless `jira-links.json` store. The `jira_*` tools
+    /// NEVER take a `site`/`projectKey` param — the stored link is the single source of
+    /// truth (an agent must not be able to point them at an arbitrary Jira site), so
+    /// every one resolves through here. A repo with no link returns an actionable error
+    /// telling the user how to create one in GitDesktop (the same call-time pattern the
+    /// Bitbucket-issue tools use — registration stays static).
+    async fn jira_link(&self) -> Result<crate::jira_links::JiraLinkEntry, McpError> {
+        crate::jira_links::get_link(&self.repo)
+            .await
+            .map_err(app_err)?
+            .ok_or_else(|| {
+                McpError::invalid_request(
+                    "This repository has no linked Jira project — link one in GitDesktop \
+                     (repo menu → Link Jira project).",
+                    None,
+                )
+            })
+    }
 }
 
 // The combined per-instance router (built in `with_options`) is what the handler
@@ -297,16 +323,23 @@ impl ServerHandler for GitDesktopMcp {
              `glab` CLI, Bitbucket a stored API token). One exception: Bitbucket's native issue \
              tracker is deprecated, so the issue tools (list/get/create/comment/close/reopen) work \
              on GitHub and GitLab only and return an actionable error on a Bitbucket repo. \
+             Separately, the `jira_*` tools operate on a per-repo LINKED Jira project — a Jira \
+             link is independent of the repo's git host, so those tools work on ANY repo that has \
+             one configured in GitDesktop (GitHub, GitLab, or Bitbucket), and are the issue story \
+             for Bitbucket repos; they read the linked project (site + key) server-side and take \
+             no site/project param, erroring with a link hint when the repo has none. \
              Capabilities are opt-in in an escalating ladder — each tier is a separate flag and \
              enabling one never grants another: (0) READ tools (status, log, diffs, blame, file \
-             history, PRs, issues, CI, releases, discussions) are always available and are the \
-             default. (1) --allow-write enables GitDesktop's own app-data write tools: local PRs \
+             history, PRs, issues, CI, releases, discussions, and linked-Jira issues) are always \
+             available and are the default. (1) --allow-write enables GitDesktop's own app-data \
+             write tools: local PRs \
              AND local issues (create/comment/status and equivalents). These are review artifacts \
              stored in GitDesktop's app data — never git commits and never remote/forge writes. \
              (2) --allow-remote-write enables the full forge remote-write surface under the \
              authenticated forge identity: the PR lifecycle (create/merge/edit), reviewers, \
              labels, assignees and approvals, review threads, CI actions, releases, GitHub \
-             discussions, and issue writes (create/comment/close/reopen). These are REAL, publicly \
+             discussions, issue writes (create/comment/close/reopen), and the linked-Jira issue \
+             writes (comment/transition/create/assign). These are REAL, publicly \
              visible writes to the repository's forge and are not freely reversible. (3) \
              --allow-git-write enables RECOVERABLE local-git mutations of the bound repository \
              (stage/commit/branch/push/…). (4) --allow-destructive is additionally required (on \
@@ -735,22 +768,24 @@ mod tests {
     }
 
     /// The COMBINED router's tool count must equal the sum of the per-module router
-    /// counts, and currently == 110. Deriving each term from the module's own router
+    /// counts, and currently == 116. Deriving each term from the module's own router
     /// means a package growing a module updates both sides of the equality
     /// automatically — this test never needs editing as modules gain tools.
-    /// (The `== 110` literal is the one line a package updates, and only if it
+    /// (The `== 116` literal is the one line a package updates, and only if it
     /// intends to change the current total.)
     #[test]
     fn combined_router_tool_count_is_sum_of_modules() {
         let handler = handler(false, false, false, false);
         let per_module = GitDesktopMcp::read_git_router().list_all().len()
             + GitDesktopMcp::read_forge_router().list_all().len()
+            + GitDesktopMcp::read_jira_router().list_all().len()
             + GitDesktopMcp::write_local_router().list_all().len()
             + GitDesktopMcp::write_forge_router().list_all().len()
+            + GitDesktopMcp::write_jira_router().list_all().len()
             + GitDesktopMcp::write_git_router().list_all().len()
             + GitDesktopMcp::generate_router().list_all().len();
         assert_eq!(handler.tool_router.list_all().len(), per_module);
-        assert_eq!(per_module, 110);
+        assert_eq!(per_module, 116);
     }
 
     /// The prompt router (separate from the tool router — prompts are NOT tools, so

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -199,7 +199,8 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "List issues from the repository's forge (GitHub or GitLab, per its remote; \
-                       Bitbucket issues aren't supported — its native tracker is deprecated). \
+                       Bitbucket issues aren't supported — its native tracker is deprecated; for a \
+                       repo with a linked Jira project, use list_jira_issues instead). \
                        `state` is \"open\" (default) or \"closed\". Without `limit`, returns the \
                        provider default (GitHub ~30; GitLab a full page); pass `limit` to raise or \
                        lower that cap. Per-call ceiling: GitHub 1000, GitLab 100 — a larger \
@@ -223,7 +224,8 @@ impl GitDesktopMcp {
     #[tool(
         description = "Get an issue's full details (title, body, comments, labels, assignees) by \
                        number from the repository's forge (GitHub or GitLab, per its remote; \
-                       Bitbucket issues aren't supported — its native tracker is deprecated). \
+                       Bitbucket issues aren't supported — its native tracker is deprecated; for a \
+                       repo with a linked Jira project, use get_jira_issue instead). \
                        Returns JSON."
     )]
     async fn get_issue(

--- a/src-tauri/src/mcp_server/read_jira.rs
+++ b/src-tauri/src/mcp_server/read_jira.rs
@@ -1,0 +1,79 @@
+//! Jira issue READ tools (always available; no opt-in flag).
+//!
+//! The read half of the Jira `jira_*` tool surface — list and get issues for the
+//! repository's LINKED Jira project. Unlike the `forge_*` issue tools (which dispatch by
+//! the repo's git host), Jira is a per-repo LINKED provider: the linked project
+//! (`{siteHost, projectKey}`) is read server-side from `jira-links.json` via
+//! [`GitDesktopMcp::jira_link`] and is the single source of truth — these tools take NO
+//! `site`/`projectKey` param, so an agent can't point them at an arbitrary Jira site. A
+//! repo with no link returns an actionable "link one in GitDesktop" error. Results wrap
+//! in [`json_result_untrusted`] because Jira summaries, descriptions, and comments are
+//! third-party prose. Credentials are read headlessly from the OS keyring by the shared
+//! [`crate::forge::jira`] cores (never the `#[tauri::command]` wrappers).
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::CallToolResult;
+use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
+
+use super::{app_err, json_result_untrusted, GitDesktopMcp};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct JiraIssueListArgs {
+    /// Which issues to list: "open" (default), "closed", or "all". Mapped through Jira's
+    /// `statusCategory` (open = not Done; closed = Done).
+    #[serde(default)]
+    state: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct JiraIssueKeyArg {
+    /// The Jira issue key, e.g. "PROJ-123".
+    key: String,
+}
+
+#[tool_router(router = read_jira_router, vis = "pub(crate)")]
+impl GitDesktopMcp {
+    #[tool(
+        description = "List issues from the repository's LINKED Jira project. Jira is a per-repo \
+                       linked issue provider (configured in GitDesktop — repo menu → Link Jira \
+                       project), independent of the repo's git host — so this works on ANY repo \
+                       with a Jira link (GitHub, GitLab, or Bitbucket), and errors with a link \
+                       hint when the repo has none. It never takes a site or project — the stored \
+                       link is the single source of truth. `state` is \"open\" (default), \
+                       \"closed\", or \"all\". Returns one page (up to 50, newest-updated first) as \
+                       JSON."
+    )]
+    async fn list_jira_issues(
+        &self,
+        Parameters(args): Parameters<JiraIssueListArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let link = self.jira_link().await?;
+        let issues = crate::forge::jira::issue_list(
+            &link.site_host,
+            &link.project_key,
+            &args.state.unwrap_or_else(|| "open".to_string()),
+        )
+        .await
+        .map_err(app_err)?;
+        json_result_untrusted(&issues)
+    }
+
+    #[tool(
+        description = "Get a Jira issue's full details (summary, status, type, priority, assignee, \
+                       reporter, labels, description, and comments — bodies converted to markdown) \
+                       by key, e.g. \"PROJ-123\", from the repository's LINKED Jira project \
+                       (configured in GitDesktop; errors with a link hint when the repo has none). \
+                       Never takes a site or project — the stored link is the single source of \
+                       truth. Returns JSON."
+    )]
+    async fn get_jira_issue(
+        &self,
+        Parameters(args): Parameters<JiraIssueKeyArg>,
+    ) -> Result<CallToolResult, McpError> {
+        let link = self.jira_link().await?;
+        let issue = crate::forge::jira::issue_view(&link.site_host, &args.key)
+            .await
+            .map_err(app_err)?;
+        json_result_untrusted(&issue)
+    }
+}

--- a/src-tauri/src/mcp_server/read_jira.rs
+++ b/src-tauri/src/mcp_server/read_jira.rs
@@ -15,7 +15,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::CallToolResult;
 use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
 
-use super::{app_err, json_result_untrusted, GitDesktopMcp};
+use super::{app_err, ensure_key_in_project, json_result_untrusted, GitDesktopMcp};
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct JiraIssueListArgs {
@@ -64,13 +64,14 @@ impl GitDesktopMcp {
                        by key, e.g. \"PROJ-123\", from the repository's LINKED Jira project \
                        (configured in GitDesktop; errors with a link hint when the repo has none). \
                        Never takes a site or project — the stored link is the single source of \
-                       truth. Returns JSON."
+                       truth (the key must belong to the linked project). Returns JSON."
     )]
     async fn get_jira_issue(
         &self,
         Parameters(args): Parameters<JiraIssueKeyArg>,
     ) -> Result<CallToolResult, McpError> {
         let link = self.jira_link().await?;
+        ensure_key_in_project(&args.key, &link)?;
         let issue = crate::forge::jira::issue_view(&link.site_host, &args.key)
             .await
             .map_err(app_err)?;

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -395,7 +395,8 @@ impl GitDesktopMcp {
     #[tool(
         description = "Create a real issue in the bound repository's forge (GitHub or GitLab, per \
                        its remote; Bitbucket issues aren't supported — its native tracker is \
-                       deprecated), under the authenticated forge user. NOT reversible without \
+                       deprecated; for a repo with a linked Jira project, use create_jira_issue \
+                       instead), under the authenticated forge user. NOT reversible without \
                        deleting it. Optional labels/assignees are applied by name/login (must \
                        already exist). Returns the created issue ref (number + URL) as JSON. \
                        Requires --allow-remote-write.",
@@ -423,7 +424,8 @@ impl GitDesktopMcp {
     #[tool(
         description = "Post a comment to an issue (by number) in the bound repository's forge \
                        (GitHub or GitLab, per its remote; Bitbucket issues aren't supported — its \
-                       native tracker is deprecated), under the authenticated forge user. \
+                       native tracker is deprecated; for a repo with a linked Jira project, use \
+                       comment_jira_issue instead), under the authenticated forge user. \
                        Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
@@ -443,7 +445,8 @@ impl GitDesktopMcp {
     #[tool(
         description = "Close an issue (by number) in the bound repository's forge (GitHub or \
                        GitLab, per its remote; Bitbucket issues aren't supported — its native \
-                       tracker is deprecated). Reversible via reopen_issue. `reason` is \
+                       tracker is deprecated; for a repo with a linked Jira project, use \
+                       transition_jira_issue instead). Reversible via reopen_issue. `reason` is \
                        \"completed\" (default) or \"not_planned\" (GitHub; GitLab has no close \
                        reason and ignores it). Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
@@ -470,7 +473,8 @@ impl GitDesktopMcp {
     #[tool(
         description = "Reopen a closed issue (by number) in the bound repository's forge (GitHub or \
                        GitLab, per its remote; Bitbucket issues aren't supported — its native \
-                       tracker is deprecated). Requires --allow-remote-write.",
+                       tracker is deprecated; for a repo with a linked Jira project, use \
+                       transition_jira_issue instead). Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn reopen_issue(
@@ -780,7 +784,8 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Set an issue's assignees (by number) in the bound repository's forge (GitHub \
-                       or GitLab, per its remote; Bitbucket issues aren't supported). `assignees` \
+                       or GitLab, per its remote; Bitbucket issues aren't supported; for a repo \
+                       with a linked Jira project, use assign_jira_issue instead). `assignees` \
                        is the FULL desired set of logins — it REPLACES the current assignees (an \
                        empty list clears them). See list_assignable_users. Requires \
                        --allow-remote-write.",

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -592,10 +592,7 @@ impl GitDesktopMcp {
             let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number)
                 .await
                 .map_err(app_err)?;
-            (
-                args.title.unwrap_or(pr.title),
-                args.body.unwrap_or(pr.body),
-            )
+            (args.title.unwrap_or(pr.title), args.body.unwrap_or(pr.body))
         } else {
             (args.title.unwrap(), args.body.unwrap())
         };
@@ -672,9 +669,13 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<RequestReviewersArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_pr_set_reviewers(self.repo.clone(), args.number, args.reviewers.clone())
-            .await
-            .map_err(app_err)?;
+        crate::forge::forge_pr_set_reviewers(
+            self.repo.clone(),
+            args.number,
+            args.reviewers.clone(),
+        )
+        .await
+        .map_err(app_err)?;
         json_result(&serde_json::json!({
             "pull_request": args.number,
             "reviewers": args.reviewers,
@@ -819,10 +820,16 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<SetAssigneesArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_mr_set_assignees(self.repo.clone(), args.number, args.assignees.clone())
-            .await
-            .map_err(app_err)?;
-        json_result(&serde_json::json!({ "pull_request": args.number, "assignees": args.assignees }))
+        crate::forge::forge_mr_set_assignees(
+            self.repo.clone(),
+            args.number,
+            args.assignees.clone(),
+        )
+        .await
+        .map_err(app_err)?;
+        json_result(
+            &serde_json::json!({ "pull_request": args.number, "assignees": args.assignees }),
+        )
     }
 
     #[tool(
@@ -1329,9 +1336,10 @@ impl GitDesktopMcp {
         self.ensure_remote_write()?;
         super::read_forge::ensure_github(&self.repo).await?;
         // add_comment is keyed by the discussion's node id, not its number — resolve it.
-        let discussion = crate::github::discussion::gh_discussion_view(self.repo.clone(), args.number)
-            .await
-            .map_err(app_err)?;
+        let discussion =
+            crate::github::discussion::gh_discussion_view(self.repo.clone(), args.number)
+                .await
+                .map_err(app_err)?;
         // Append the attribution footer so the comment is identifiable as ours.
         let body = format!("{}{GD_COMMENT_FOOTER}", args.body);
         crate::github::discussion::gh_discussion_add_comment(
@@ -1394,9 +1402,10 @@ impl GitDesktopMcp {
         self.ensure_remote_write()?;
         super::read_forge::ensure_github(&self.repo).await?;
         // close is keyed by the discussion's node id — resolve it from the number.
-        let discussion = crate::github::discussion::gh_discussion_view(self.repo.clone(), args.number)
-            .await
-            .map_err(app_err)?;
+        let discussion =
+            crate::github::discussion::gh_discussion_view(self.repo.clone(), args.number)
+                .await
+                .map_err(app_err)?;
         // Empty resolves to "RESOLVED" in the github core; mirror that in the reply.
         let resolved = if args.reason.is_empty() {
             "RESOLVED"
@@ -1428,9 +1437,10 @@ impl GitDesktopMcp {
         self.ensure_remote_write()?;
         super::read_forge::ensure_github(&self.repo).await?;
         // reopen is keyed by the discussion's node id — resolve it from the number.
-        let discussion = crate::github::discussion::gh_discussion_view(self.repo.clone(), args.number)
-            .await
-            .map_err(app_err)?;
+        let discussion =
+            crate::github::discussion::gh_discussion_view(self.repo.clone(), args.number)
+                .await
+                .map_err(app_err)?;
         crate::github::discussion::gh_discussion_reopen(self.repo.clone(), discussion.id)
             .await
             .map_err(app_err)?;
@@ -1504,10 +1514,12 @@ mod tests {
             title: Some("t".into()),
             body: Some("b".into()),
         })));
-        assert_gated!(h.set_pull_request_draft(Parameters(SetPullRequestDraftArgs {
-            number: 1,
-            draft: true,
-        })));
+        assert_gated!(
+            h.set_pull_request_draft(Parameters(SetPullRequestDraftArgs {
+                number: 1,
+                draft: true,
+            }))
+        );
         assert_gated!(h.close_pull_request(Parameters(NumberArg { number: 1 })));
         assert_gated!(h.reopen_pull_request(Parameters(NumberArg { number: 1 })));
         assert_gated!(h.request_reviewers(Parameters(RequestReviewersArgs {
@@ -1530,11 +1542,13 @@ mod tests {
         })));
         assert_gated!(h.approve_pull_request(Parameters(NumberArg { number: 1 })));
         assert_gated!(h.withdraw_pull_request_approval(Parameters(NumberArg { number: 1 })));
-        assert_gated!(h.reply_to_review_thread(Parameters(ReplyToReviewThreadArgs {
-            number: 1,
-            thread_id: "t".into(),
-            body: "b".into(),
-        })));
+        assert_gated!(
+            h.reply_to_review_thread(Parameters(ReplyToReviewThreadArgs {
+                number: 1,
+                thread_id: "t".into(),
+                body: "b".into(),
+            }))
+        );
         assert_gated!(h.resolve_review_thread(Parameters(ResolveReviewThreadArgs {
             number: 1,
             thread_id: "t".into(),
@@ -1604,10 +1618,12 @@ mod tests {
             number: 1,
             body: "b".into(),
         })));
-        assert_gated!(h.mark_discussion_answer(Parameters(MarkDiscussionAnswerArgs {
-            comment_id: "c".into(),
-            answer: true,
-        })));
+        assert_gated!(
+            h.mark_discussion_answer(Parameters(MarkDiscussionAnswerArgs {
+                comment_id: "c".into(),
+                answer: true,
+            }))
+        );
         assert_gated!(h.close_discussion(Parameters(CloseDiscussionArgs {
             number: 1,
             reason: String::new(),
@@ -1632,7 +1648,10 @@ mod tests {
             .expect_err("expected an unknown-reaction rejection");
         let msg = err.to_string();
         assert!(msg.contains("unknown reaction: PARTY"), "got: {msg}");
-        assert!(msg.contains("THUMBS_UP"), "should list valid values, got: {msg}");
+        assert!(
+            msg.contains("THUMBS_UP"),
+            "should list valid values, got: {msg}"
+        );
     }
 
     /// The reaction tools reject an unknown `kind` (not issue/pr) with an actionable
@@ -1649,10 +1668,6 @@ mod tests {
             }))
             .await
             .expect_err("expected an unknown-kind rejection");
-        assert!(
-            err.to_string().contains("kind must be"),
-            "got: {}",
-            err
-        );
+        assert!(err.to_string().contains("kind must be"), "got: {}", err);
     }
 }

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -282,10 +282,15 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<CommitArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_git_write()?;
-        let result =
-            crate::git::commit::git_commit_core(&self.state, self.repo.clone(), args.message, args.body, args.amend)
-                .await
-                .map_err(app_err)?;
+        let result = crate::git::commit::git_commit_core(
+            &self.state,
+            self.repo.clone(),
+            args.message,
+            args.body,
+            args.amend,
+        )
+        .await
+        .map_err(app_err)?;
         json_result(&result)
     }
 
@@ -347,9 +352,13 @@ impl GitDesktopMcp {
         self.ensure_git_write()?;
         ensure_not_flag(&args.name, "branch name")?;
         ensure_not_session_branch(&args.name)?;
-        crate::git::branches::git_checkout_branch_core(&self.state, self.repo.clone(), args.name.clone())
-            .await
-            .map_err(app_err)?;
+        crate::git::branches::git_checkout_branch_core(
+            &self.state,
+            self.repo.clone(),
+            args.name.clone(),
+        )
+        .await
+        .map_err(app_err)?;
         ok_text(format!("switched to {}", args.name))
     }
 
@@ -563,9 +572,10 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_git_write()?;
         ensure_not_flag(&args.sha, "sha")?;
-        let created = crate::git::ops::git_cherry_pick_core(&self.state, self.repo.clone(), args.sha.clone())
-            .await
-            .map_err(app_err)?;
+        let created =
+            crate::git::ops::git_cherry_pick_core(&self.state, self.repo.clone(), args.sha.clone())
+                .await
+                .map_err(app_err)?;
         json_result(&serde_json::json!({ "sha": args.sha, "committed": created }))
     }
 
@@ -656,9 +666,13 @@ impl GitDesktopMcp {
         self.ensure_destructive()?;
         ensure_not_flag(&args.name, "branch name")?;
         ensure_not_session_branch(&args.name)?;
-        crate::git::branches::git_delete_branch_core(&self.state, self.repo.clone(), args.name.clone())
-            .await
-            .map_err(app_err)?;
+        crate::git::branches::git_delete_branch_core(
+            &self.state,
+            self.repo.clone(),
+            args.name.clone(),
+        )
+        .await
+        .map_err(app_err)?;
         ok_text(format!("branch deleted: {}", args.name))
     }
 
@@ -761,7 +775,10 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
-        ok_text(format!("remote branch deleted: {}/{}", args.remote, args.name))
+        ok_text(format!(
+            "remote branch deleted: {}/{}",
+            args.remote, args.name
+        ))
     }
 
     #[tool(
@@ -793,9 +810,14 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_destructive()?;
         ensure_not_flag(&args.name, "tag name")?;
-        crate::git::ops::git_delete_tag_core(&self.state, self.repo.clone(), args.name.clone(), args.remote)
-            .await
-            .map_err(app_err)?;
+        crate::git::ops::git_delete_tag_core(
+            &self.state,
+            self.repo.clone(),
+            args.name.clone(),
+            args.remote,
+        )
+        .await
+        .map_err(app_err)?;
         ok_text(format!("tag deleted: {}", args.name))
     }
 }
@@ -824,20 +846,35 @@ mod tests {
             ($call:expr, $flag:literal) => {{
                 let err = $call.await.expect_err("expected the gate to fire");
                 let msg = err.to_string();
-                assert!(msg.contains($flag), "gate error should name {}, got: {msg}", $flag);
+                assert!(
+                    msg.contains($flag),
+                    "gate error should name {}, got: {msg}",
+                    $flag
+                );
             }};
         }
 
         // Recoverable tools: gated on --allow-git-write.
         assert_gated!(h.stage_files(Parameters(args_stage())), "--allow-git-write");
-        assert_gated!(h.unstage_files(Parameters(args_stage())), "--allow-git-write");
         assert_gated!(
-            h.commit(Parameters(CommitArgs { message: "m".into(), body: None, amend: false })),
+            h.unstage_files(Parameters(args_stage())),
+            "--allow-git-write"
+        );
+        assert_gated!(
+            h.commit(Parameters(CommitArgs {
+                message: "m".into(),
+                body: None,
+                amend: false
+            })),
             "--allow-git-write"
         );
         assert_gated!(h.undo_last_commit(), "--allow-git-write");
         assert_gated!(
-            h.create_branch(Parameters(CreateBranchArgs { name: "b".into(), checkout: false, from: None })),
+            h.create_branch(Parameters(CreateBranchArgs {
+                name: "b".into(),
+                checkout: false,
+                from: None
+            })),
             "--allow-git-write"
         );
         assert_gated!(
@@ -845,18 +882,38 @@ mod tests {
             "--allow-git-write"
         );
         assert_gated!(
-            h.rename_branch(Parameters(RenameBranchArgs { from: "a".into(), to: "b".into() })),
+            h.rename_branch(Parameters(RenameBranchArgs {
+                from: "a".into(),
+                to: "b".into()
+            })),
             "--allow-git-write"
         );
-        assert_gated!(h.push(Parameters(PushArgs { set_upstream: false })), "--allow-git-write");
-        assert_gated!(h.pull(Parameters(PullArgs { mode: None })), "--allow-git-write");
+        assert_gated!(
+            h.push(Parameters(PushArgs {
+                set_upstream: false
+            })),
+            "--allow-git-write"
+        );
+        assert_gated!(
+            h.pull(Parameters(PullArgs { mode: None })),
+            "--allow-git-write"
+        );
         assert_gated!(h.fetch(), "--allow-git-write");
-        assert_gated!(h.stash_push(Parameters(StashPushArgs { paths: vec![] })), "--allow-git-write");
+        assert_gated!(
+            h.stash_push(Parameters(StashPushArgs { paths: vec![] })),
+            "--allow-git-write"
+        );
         assert_gated!(h.stash_pop(), "--allow-git-write");
-        assert_gated!(h.stash_apply(Parameters(StashApplyArgs { index: 0 })), "--allow-git-write");
+        assert_gated!(
+            h.stash_apply(Parameters(StashApplyArgs { index: 0 })),
+            "--allow-git-write"
+        );
         assert_gated!(
             h.merge_branch(Parameters(MergeBranchArgs {
-                branch: "b".into(), squash: false, no_ff: false, strategy: None
+                branch: "b".into(),
+                squash: false,
+                no_ff: false,
+                strategy: None
             })),
             "--allow-git-write"
         );
@@ -864,13 +921,25 @@ mod tests {
             h.rebase_branch(Parameters(RebaseBranchArgs { onto: "b".into() })),
             "--allow-git-write"
         );
-        assert_gated!(h.revert_commit(Parameters(ShaArgs { sha: "abc".into() })), "--allow-git-write");
-        assert_gated!(h.cherry_pick(Parameters(ShaArgs { sha: "abc".into() })), "--allow-git-write");
         assert_gated!(
-            h.create_tag(Parameters(CreateTagArgs { name: "v1".into(), at: "abc".into() })),
+            h.revert_commit(Parameters(ShaArgs { sha: "abc".into() })),
             "--allow-git-write"
         );
-        assert_gated!(h.push_tag(Parameters(TagNameArgs { name: "v1".into() })), "--allow-git-write");
+        assert_gated!(
+            h.cherry_pick(Parameters(ShaArgs { sha: "abc".into() })),
+            "--allow-git-write"
+        );
+        assert_gated!(
+            h.create_tag(Parameters(CreateTagArgs {
+                name: "v1".into(),
+                at: "abc".into()
+            })),
+            "--allow-git-write"
+        );
+        assert_gated!(
+            h.push_tag(Parameters(TagNameArgs { name: "v1".into() })),
+            "--allow-git-write"
+        );
 
         // Destructive tools: both flags missing, so --allow-git-write is named.
         assert_gated!(
@@ -882,15 +951,27 @@ mod tests {
             "--allow-git-write"
         );
         assert_gated!(h.discard_all_changes(), "--allow-git-write");
-        assert_gated!(h.reset_to_commit(Parameters(ShaArgs { sha: "abc".into() })), "--allow-git-write");
-        assert_gated!(h.force_push(), "--allow-git-write");
         assert_gated!(
-            h.delete_remote_branch(Parameters(DeleteRemoteBranchArgs { remote: "origin".into(), name: "b".into() })),
+            h.reset_to_commit(Parameters(ShaArgs { sha: "abc".into() })),
             "--allow-git-write"
         );
-        assert_gated!(h.drop_stash(Parameters(StashIndexArgs { index: 0 })), "--allow-git-write");
+        assert_gated!(h.force_push(), "--allow-git-write");
         assert_gated!(
-            h.delete_tag(Parameters(DeleteTagArgs { name: "v1".into(), remote: false })),
+            h.delete_remote_branch(Parameters(DeleteRemoteBranchArgs {
+                remote: "origin".into(),
+                name: "b".into()
+            })),
+            "--allow-git-write"
+        );
+        assert_gated!(
+            h.drop_stash(Parameters(StashIndexArgs { index: 0 })),
+            "--allow-git-write"
+        );
+        assert_gated!(
+            h.delete_tag(Parameters(DeleteTagArgs {
+                name: "v1".into(),
+                remote: false
+            })),
             "--allow-git-write"
         );
     }
@@ -903,7 +984,9 @@ mod tests {
 
         macro_rules! assert_destructive_gated {
             ($call:expr) => {{
-                let err = $call.await.expect_err("expected the destructive gate to fire");
+                let err = $call
+                    .await
+                    .expect_err("expected the destructive gate to fire");
                 let msg = err.to_string();
                 assert!(
                     msg.contains("--allow-destructive"),
@@ -913,7 +996,9 @@ mod tests {
         }
 
         assert_destructive_gated!(h.delete_branch(Parameters(BranchNameArgs { name: "b".into() })));
-        assert_destructive_gated!(h.discard_changes(Parameters(DiscardChangesArgs { paths: vec![] })));
+        assert_destructive_gated!(
+            h.discard_changes(Parameters(DiscardChangesArgs { paths: vec![] }))
+        );
         assert_destructive_gated!(h.discard_all_changes());
         assert_destructive_gated!(h.reset_to_commit(Parameters(ShaArgs { sha: "abc".into() })));
         assert_destructive_gated!(h.force_push());
@@ -922,7 +1007,10 @@ mod tests {
             name: "b".into(),
         })));
         assert_destructive_gated!(h.drop_stash(Parameters(StashIndexArgs { index: 0 })));
-        assert_destructive_gated!(h.delete_tag(Parameters(DeleteTagArgs { name: "v1".into(), remote: false })));
+        assert_destructive_gated!(h.delete_tag(Parameters(DeleteTagArgs {
+            name: "v1".into(),
+            remote: false
+        })));
     }
 
     /// destructive=true, git_write=false: the destructive tools must error naming the
@@ -1010,7 +1098,10 @@ mod tests {
             }))
             .await
             .expect_err("session branch delete should be refused");
-        assert!(err.to_string().contains("agent-session branch"), "got: {err}");
+        assert!(
+            err.to_string().contains("agent-session branch"),
+            "got: {err}"
+        );
 
         let err = h
             .rename_branch(Parameters(RenameBranchArgs {
@@ -1019,7 +1110,10 @@ mod tests {
             }))
             .await
             .expect_err("session branch rename should be refused");
-        assert!(err.to_string().contains("agent-session branch"), "got: {err}");
+        assert!(
+            err.to_string().contains("agent-session branch"),
+            "got: {err}"
+        );
 
         let err = h
             .delete_remote_branch(Parameters(DeleteRemoteBranchArgs {
@@ -1028,7 +1122,10 @@ mod tests {
             }))
             .await
             .expect_err("session remote branch delete should be refused");
-        assert!(err.to_string().contains("agent-session branch"), "got: {err}");
+        assert!(
+            err.to_string().contains("agent-session branch"),
+            "got: {err}"
+        );
 
         let err = h
             .checkout_branch(Parameters(BranchNameArgs {
@@ -1036,6 +1133,9 @@ mod tests {
             }))
             .await
             .expect_err("session branch checkout should be refused");
-        assert!(err.to_string().contains("agent-session branch"), "got: {err}");
+        assert!(
+            err.to_string().contains("agent-session branch"),
+            "got: {err}"
+        );
     }
 }

--- a/src-tauri/src/mcp_server/write_jira.rs
+++ b/src-tauri/src/mcp_server/write_jira.rs
@@ -1,0 +1,185 @@
+//! Jira issue remote-WRITE tools (opt-in via `--allow-remote-write`).
+//!
+//! The write half of the Jira `jira_*` tool surface — comment, transition (close/reopen),
+//! create, and assign — against the repository's LINKED Jira project. REAL writes to
+//! Jira Cloud under the stored Atlassian credential, so every tool is gated on
+//! `allow_remote_write` (via [`GitDesktopMcp::ensure_remote_write`]) FIRST, then resolves
+//! the linked project server-side (via [`GitDesktopMcp::jira_link`] — the single source
+//! of truth; no `site`/`projectKey` param) and calls the shared [`crate::forge::jira`]
+//! cores (never the `#[tauri::command]` wrappers). All are annotated non-read-only and
+//! non-destructive (mirroring the forge issue-write tools — a Jira write is a mutation,
+//! but none is a trivially-irreversible destructive op). `comment_jira_issue` appends the
+//! shared `GD_COMMENT_FOOTER` attribution.
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::CallToolResult;
+use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
+
+use super::{app_err, json_result, GitDesktopMcp, GD_COMMENT_FOOTER};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct CommentJiraIssueArgs {
+    /// The Jira issue key, e.g. "PROJ-123".
+    key: String,
+    /// The comment body (markdown; converted to Jira's ADF).
+    body: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct TransitionJiraIssueArgs {
+    /// The Jira issue key, e.g. "PROJ-123".
+    key: String,
+    /// "close" moves the issue to a Done-category status; "reopen" moves it back to a
+    /// To-Do (or In-Progress) status. The concrete transition is chosen from the
+    /// project's workflow — ids are never hardcoded.
+    direction: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct CreateJiraIssueArgs {
+    /// The issue summary (title).
+    summary: String,
+    /// Optional issue description (markdown; converted to Jira's ADF). Omit for none.
+    #[serde(default)]
+    description_md: Option<String>,
+    /// Optional issue-type id (from the project's create metadata). Omit to use the
+    /// project's first non-subtask issue type.
+    #[serde(default)]
+    issue_type_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AssignJiraIssueArgs {
+    /// The Jira issue key, e.g. "PROJ-123".
+    key: String,
+    /// The Atlassian accountId to assign. Omit (or null) to UNASSIGN the issue.
+    #[serde(default)]
+    account_id: Option<String>,
+}
+
+#[tool_router(router = write_jira_router, vis = "pub(crate)")]
+impl GitDesktopMcp {
+    #[tool(
+        description = "Post a comment to an issue (by key, e.g. \"PROJ-123\") in the repository's \
+                       LINKED Jira project, under the stored Atlassian identity. The body is \
+                       markdown (converted to Jira's ADF); a \"Posted by GitDesktop\" attribution \
+                       footer is appended automatically. Jira is a per-repo linked provider \
+                       (configured in GitDesktop; errors with a link hint when the repo has none) \
+                       and takes no site/project param. Requires --allow-remote-write. Returns the \
+                       created comment as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn comment_jira_issue(
+        &self,
+        Parameters(args): Parameters<CommentJiraIssueArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_remote_write()?;
+        let link = self.jira_link().await?;
+        let body = format!("{}{GD_COMMENT_FOOTER}", args.body);
+        let comment = crate::forge::jira::issue_comment(&link.site_host, &args.key, &body)
+            .await
+            .map_err(app_err)?;
+        json_result(&comment)
+    }
+
+    #[tool(
+        description = "Close or reopen an issue (by key, e.g. \"PROJ-123\") in the repository's \
+                       LINKED Jira project via its workflow, under the stored Atlassian identity. \
+                       `direction` is \"close\" or \"reopen\"; the concrete workflow transition is \
+                       chosen from the project (ids are never hardcoded), and an actionable error \
+                       is returned when the workflow/permissions offer no suitable transition. \
+                       Jira is a per-repo linked provider (configured in GitDesktop; errors with a \
+                       link hint when the repo has none) and takes no site/project param. Requires \
+                       --allow-remote-write. Returns the issue's resulting status \
+                       (name + category) as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn transition_jira_issue(
+        &self,
+        Parameters(args): Parameters<TransitionJiraIssueArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_remote_write()?;
+        let link = self.jira_link().await?;
+        let result =
+            crate::forge::jira::issue_transition(&link.site_host, &args.key, &args.direction)
+                .await
+                .map_err(app_err)?;
+        json_result(&result)
+    }
+
+    #[tool(
+        description = "Create an issue in the repository's LINKED Jira project, under the stored \
+                       Atlassian identity. Needs a `summary`; `description_md` is optional markdown \
+                       (converted to Jira's ADF). `issue_type_id` is optional — omit it to use the \
+                       project's first non-subtask issue type. Jira is a per-repo linked provider \
+                       (configured in GitDesktop; errors with a link hint when the repo has none) \
+                       and takes no site/project param. NOT reversible without deleting the issue. \
+                       Requires --allow-remote-write. Returns the created issue's key + URL as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn create_jira_issue(
+        &self,
+        Parameters(args): Parameters<CreateJiraIssueArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_remote_write()?;
+        let link = self.jira_link().await?;
+
+        // Resolve the issue type: an explicit id when given, else the project's first
+        // non-subtask type from its create metadata (the CreateJiraIssueDialog default).
+        let issue_type_id = match args.issue_type_id.filter(|s| !s.trim().is_empty()) {
+            Some(id) => id,
+            None => {
+                let types = crate::forge::jira::issue_types(&link.site_host, &link.project_key)
+                    .await
+                    .map_err(app_err)?;
+                types
+                    .into_iter()
+                    .find(|t| !t.subtask)
+                    .map(|t| t.id)
+                    .ok_or_else(|| {
+                        McpError::invalid_request(
+                            "This Jira project has no creatable (non-subtask) issue type — pass \
+                             an issue_type_id explicitly.",
+                            None,
+                        )
+                    })?
+            }
+        };
+
+        let created = crate::forge::jira::issue_create(
+            &link.site_host,
+            &link.project_key,
+            &issue_type_id,
+            &args.summary,
+            args.description_md.as_deref(),
+        )
+        .await
+        .map_err(app_err)?;
+        json_result(&created)
+    }
+
+    #[tool(
+        description = "Assign (or unassign) an issue (by key, e.g. \"PROJ-123\") in the \
+                       repository's LINKED Jira project, under the stored Atlassian identity. Pass \
+                       `account_id` (an Atlassian accountId) to assign; omit it to UNASSIGN. Jira \
+                       is a per-repo linked provider (configured in GitDesktop; errors with a link \
+                       hint when the repo has none) and takes no site/project param. Requires \
+                       --allow-remote-write. Returns a confirmation as JSON.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn assign_jira_issue(
+        &self,
+        Parameters(args): Parameters<AssignJiraIssueArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_remote_write()?;
+        let link = self.jira_link().await?;
+        let account_id = args.account_id.filter(|s| !s.trim().is_empty());
+        crate::forge::jira::issue_assign(&link.site_host, &args.key, account_id.as_deref())
+            .await
+            .map_err(app_err)?;
+        json_result(&serde_json::json!({
+            "key": args.key,
+            "assigned": account_id.is_some(),
+        }))
+    }
+}

--- a/src-tauri/src/mcp_server/write_jira.rs
+++ b/src-tauri/src/mcp_server/write_jira.rs
@@ -15,7 +15,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::CallToolResult;
 use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
 
-use super::{app_err, json_result, GitDesktopMcp, GD_COMMENT_FOOTER};
+use super::{app_err, ensure_key_in_project, json_result, GitDesktopMcp, GD_COMMENT_FOOTER};
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct CommentJiraIssueArgs {
@@ -65,8 +65,8 @@ impl GitDesktopMcp {
                        markdown (converted to Jira's ADF); a \"Posted by GitDesktop\" attribution \
                        footer is appended automatically. Jira is a per-repo linked provider \
                        (configured in GitDesktop; errors with a link hint when the repo has none) \
-                       and takes no site/project param. Requires --allow-remote-write. Returns the \
-                       created comment as JSON.",
+                       and takes no site/project param (the key must belong to the linked \
+                       project). Requires --allow-remote-write. Returns the created comment as JSON.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn comment_jira_issue(
@@ -75,6 +75,7 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
         let link = self.jira_link().await?;
+        ensure_key_in_project(&args.key, &link)?;
         let body = format!("{}{GD_COMMENT_FOOTER}", args.body);
         let comment = crate::forge::jira::issue_comment(&link.site_host, &args.key, &body)
             .await
@@ -89,7 +90,8 @@ impl GitDesktopMcp {
                        chosen from the project (ids are never hardcoded), and an actionable error \
                        is returned when the workflow/permissions offer no suitable transition. \
                        Jira is a per-repo linked provider (configured in GitDesktop; errors with a \
-                       link hint when the repo has none) and takes no site/project param. Requires \
+                       link hint when the repo has none) and takes no site/project param (the key \
+                       must belong to the linked project). Requires \
                        --allow-remote-write. Returns the issue's resulting status \
                        (name + category) as JSON.",
         annotations(read_only_hint = false, destructive_hint = false)
@@ -100,6 +102,7 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
         let link = self.jira_link().await?;
+        ensure_key_in_project(&args.key, &link)?;
         let result =
             crate::forge::jira::issue_transition(&link.site_host, &args.key, &args.direction)
                 .await
@@ -163,7 +166,8 @@ impl GitDesktopMcp {
                        repository's LINKED Jira project, under the stored Atlassian identity. Pass \
                        `account_id` (an Atlassian accountId) to assign; omit it to UNASSIGN. Jira \
                        is a per-repo linked provider (configured in GitDesktop; errors with a link \
-                       hint when the repo has none) and takes no site/project param. Requires \
+                       hint when the repo has none) and takes no site/project param (the key must \
+                       belong to the linked project). Requires \
                        --allow-remote-write. Returns a confirmation as JSON.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
@@ -173,6 +177,7 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
         let link = self.jira_link().await?;
+        ensure_key_in_project(&args.key, &link)?;
         let account_id = args.account_id.filter(|s| !s.trim().is_empty());
         crate::forge::jira::issue_assign(&link.site_host, &args.key, account_id.as_deref())
             .await

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -187,12 +187,9 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_write()?;
         let repo = self.local_issue_key().await?;
-        let record = crate::local_issues::create(
-            &repo,
-            &args.title,
-            args.body.as_deref().unwrap_or(""),
-        )
-        .map_err(app_err)?;
+        let record =
+            crate::local_issues::create(&repo, &args.title, args.body.as_deref().unwrap_or(""))
+                .map_err(app_err)?;
         json_result(&record)
     }
 
@@ -416,10 +413,12 @@ mod tests {
             id: "1".into(),
             body: "b".into(),
         })));
-        assert_gated!(h.set_local_issue_status(Parameters(SetLocalIssueStatusArgs {
-            id: "1".into(),
-            status: "open".into(),
-        })));
+        assert_gated!(
+            h.set_local_issue_status(Parameters(SetLocalIssueStatusArgs {
+                id: "1".into(),
+                status: "open".into(),
+            }))
+        );
     }
 
     /// The local READ tools are UNGATED (the user's own app-data) — with all flags off

--- a/src/features/actions/BranchJiraBadge.tsx
+++ b/src/features/actions/BranchJiraBadge.tsx
@@ -33,8 +33,8 @@ export function BranchJiraBadge({ repoPath }: { repoPath: string }) {
       className="flex min-w-0 shrink-4 items-center gap-1.5 rounded-none px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
       title={
         extra > 0
-          ? `${keys.join(", ")} — view in Issues`
-          : `${first} — view in Issues`
+          ? `${keys.join(", ")} — referenced in the branch name, view in Issues`
+          : `${first} — referenced in the branch name, view in Issues`
       }
       onClick={() => {
         selectIssue({ kind: "jira", id: first });

--- a/src/features/actions/BranchJiraBadge.tsx
+++ b/src/features/actions/BranchJiraBadge.tsx
@@ -1,0 +1,49 @@
+import { KanbanIcon } from "@phosphor-icons/react";
+import { useRepoStatus } from "@/lib/git/queries";
+import { extractJiraKeys } from "@/lib/jira/keys";
+import { useJiraLink } from "@/lib/jira/queries";
+import { useUiStore } from "@/lib/stores/ui";
+
+/**
+ * Glanceable Jira issue reference for the current branch, in the repo header.
+ * Scans the branch name for the linked project's keys (e.g. `PROJ-42` in
+ * `proj-42-fix`); renders nothing when the repo is unlinked, the branch name has
+ * no match, or HEAD is detached (branch name null). Clicking jumps to the Issues
+ * tab with that issue selected. Mirrors `BranchCiBadge` exactly.
+ */
+export function BranchJiraBadge({ repoPath }: { repoPath: string }) {
+  const link = useJiraLink(repoPath).data;
+  const status = useRepoStatus(repoPath);
+  const branch = status.data?.branch.name ?? null;
+  const setRepoTab = useUiStore((s) => s.setRepoTab);
+  const selectIssue = useUiStore((s) => s.selectIssue);
+
+  const keys = link ? extractJiraKeys(branch, link.projectKey) : [];
+  if (keys.length === 0) return null;
+
+  // Compact: the first key, plus a "+N" affordance when the branch names more.
+  const first = keys[0];
+  const extra = keys.length - 1;
+
+  return (
+    <button
+      type="button"
+      // Middle tier of the header shrink cascade, alongside BranchCiBadge — the
+      // key label stays legible while the icon carries the meaning under pressure.
+      className="flex min-w-0 shrink-4 items-center gap-1.5 rounded-none px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      title={
+        extra > 0
+          ? `${keys.join(", ")} — view in Issues`
+          : `${first} — view in Issues`
+      }
+      onClick={() => {
+        selectIssue({ kind: "jira", id: first });
+        setRepoTab("issues");
+      }}
+    >
+      <KanbanIcon className="size-3.5 shrink-0" />
+      <span className="min-w-0 truncate font-mono">{first}</span>
+      {extra > 0 && <span className="shrink-0">+{extra}</span>}
+    </button>
+  );
+}

--- a/src/features/help/HelpScreen.tsx
+++ b/src/features/help/HelpScreen.tsx
@@ -6,7 +6,7 @@ import { Markdown } from "@/components/ui/markdown";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
-import type { ActionId } from "@/lib/hotkeys/registry";
+import { ACTIONS, type ActionId } from "@/lib/hotkeys/registry";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { GUIDE_SECTIONS } from "./content";
@@ -14,6 +14,13 @@ import { GUIDE_SECTIONS } from "./content";
 const BINDING_TOKEN = /\{\{(kbd|key):([a-z0-9+-]+)\}\}/g;
 const AI_BLOCK = /\{\{ai\}\}[\s\S]*?\{\{\/ai\}\}/g;
 const AI_MARKER = /\{\{\/?ai\}\}/g;
+
+// Actions that are palette-only by design (`defaultBinding: null`), so an unset
+// binding reads as "palette" — the chip idiom — rather than "unbound" (which
+// should mean the user deliberately cleared a real default).
+const PALETTE_ONLY: Set<string> = new Set(
+  ACTIONS.filter((a) => a.defaultBinding === null).map((a) => a.id),
+);
 
 /**
  * Resolve a guide body for display: first gate AI passages on `aiEnabled` (strip
@@ -32,7 +39,11 @@ function resolveBody(
   return gated.replace(BINDING_TOKEN, (_match, kind, ref) => {
     if (kind === "key") return formatBinding(ref);
     const binding = bindings.get(ref as ActionId);
-    return binding ? formatBinding(binding) : "unbound";
+    if (binding) return formatBinding(binding);
+    // No live binding: distinguish a deliberately palette-only action from one
+    // the user cleared. A palette-only action never had a key to lose, so
+    // "unbound from the palette" reads wrong — say "palette" (the chip idiom).
+    return PALETTE_ONLY.has(ref) ? "palette" : "unbound";
   });
 }
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -794,9 +794,23 @@ issue links out with **View in Jira**.
 You can work an issue without leaving the tab. **Create** one ({{kbd:create-jira-issue}}
 from the palette) with a summary, Markdown description, and an **issue-type** picker;
 **comment** in Markdown; **close or reopen** it by following the project's own workflow —
-the confirmation names the real resulting status, not a generic "closed"; and **assign or
-unassign** it by searching your project's users. Each action is gated on your Jira
+the confirmation names the real resulting status, not a generic "closed" — or move it to
+any workflow status from the **status menu** on the chip, which lists the transitions your
+role allows by their target status name; and **assign or unassign** it by searching your
+project's users. Each action is gated on your Jira
 permissions, so anything your token and role can't do simply doesn't appear.
+
+**Referenced issues follow your work.** When a **branch name**, a commit's message (in the
+commit detail view), or a pull request's title or description mentions one of the linked
+project's issue keys (e.g. \`PROJ-123\`), GitDesktop shows a compact **referenced Jira
+issues** row there. Click a key to jump to that issue in the **Jira** section of the Issues
+tab. Only the **linked project's** key is matched — no other project and no generic key
+pattern.
+
+You can also **promote a local issue to Jira.** When a repo is linked, the local issue's
+**publish** action offers Jira as a destination (alongside GitHub or GitLab when both are
+available); its comments carry over to the new Jira issue, and the local issue closes with a
+back-link to it.
 
 To connect, add an **Atlassian API token** (your Atlassian account email plus the
 token, validated against the site before it's saved and stored in your OS keychain); if
@@ -807,7 +821,8 @@ credential** with one button instead of re-entering it.
 
 A **local issue** is a private, offline to-do tracked in the app — create, edit, label,
 and close it with no remote. When it's ready to share, **promote** it to a GitHub or
-GitLab issue in one click.
+GitLab issue — or, when the repo has a **linked Jira project**, to a Jira issue — in one
+click.
 {{ai}}
 ## Hand off to an agent
 
@@ -1089,7 +1104,9 @@ diffs, blame, branches, file history/read, PRs, issues, CI logs, labels, milesto
 releases, and a PR's full timeline. The PR, issue, and CI tools work
 across **GitHub, GitLab, and Bitbucket** — they route through GitDesktop's forge layer and
 dispatch by the repo's remote (Bitbucket covers PRs and pipelines, but not issues — its
-native tracker is deprecated). The app itself runs as a stdio server — on macOS and Linux
+native tracker is deprecated). If the repo has a **linked Jira project**, a set of
+\`jira_*\` tools list and read that project's issues too — the tools resolve the repo's
+stored link themselves, so an agent never passes a site or project. The app itself runs as a stdio server — on macOS and Linux
 that's the app binary directly (a Personal config embeds its absolute path), and on Windows a
 dedicated update-safe \`gitdesktop-mcp\` copy (so running servers never block app updates) — so
 an agent can understand a repo without changing it.
@@ -1133,7 +1150,9 @@ authenticated identity (GitHub \`gh\`, GitLab \`glab\`, or a stored Bitbucket to
 **request changes**, or **withdraw** either, **start**, **reply to**, and **resolve** review
 threads, add or remove **reactions**, **rerun/cancel/dispatch** CI, **create/update releases**,
 **create, comment on, close/reopen**, and set the **milestone** of issues, and — on GitHub —
-**create, comment on, answer, and close/reopen discussions**. Issue
+**create, comment on, answer, and close/reopen discussions**. The same flag also unlocks the
+linked Jira project's write \`jira_*\` tools — **comment**, **close/reopen**, **create**, and
+**assign** its issues. Issue
 writes cover GitHub and GitLab (not Bitbucket); discussions are GitHub-only; PR comments cover all three. PR comments an
 agent posts carry a small **Posted by GitDesktop** footer so they're identifiable as
 automated, and on the read side an agent can pull a pull request's full comment set — the

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { DiffSurface, type LineWidget } from "@/features/diff/DiffSurface";
+import { JiraRefRow } from "@/features/issues/JiraRefRow";
 import {
   CommitComments,
   CommitLineComposer,
@@ -296,6 +297,10 @@ export function CommitDetailView({
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
+        <JiraRefRow
+          repoPath={repoPath}
+          text={`${commit.subject}\n${commit.body ?? ""}`}
+        />
       </header>
 
       <div className="flex min-h-0 flex-1">

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -299,7 +299,10 @@ export function CommitDetailView({
         </div>
         <JiraRefRow
           repoPath={repoPath}
-          text={`${commit.subject}\n${commit.body ?? ""}`}
+          sources={[
+            { label: "commit subject", text: commit.subject },
+            { label: "commit message body", text: commit.body },
+          ]}
         />
       </header>
 

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowCounterClockwiseIcon,
   ArrowSquareOutIcon,
+  CaretDownIcon,
   CheckCircleIcon,
   CircleDashedIcon,
 } from "@phosphor-icons/react";
@@ -22,6 +23,13 @@ import {
   ComboboxItem,
   ComboboxList,
 } from "@/components/ui/combobox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Markdown } from "@/components/ui/markdown";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -35,6 +43,8 @@ import {
   useJiraLink,
   useJiraPermissions,
   useJiraTransition,
+  useJiraTransitions,
+  useJiraTransitionTo,
   useJiraUserSearch,
 } from "@/lib/jira/queries";
 import type { JiraLink } from "@/lib/jira/store";
@@ -47,25 +57,133 @@ import { toastError } from "@/lib/toast";
  *  literal modifier (house platform-mod-key rule). */
 const SUBMIT_HINT = formatBinding("mod+enter");
 
-/** The status chip: category picks the open/closed icon+token, the REAL status
- *  name is the text (so meaning is never color-only). `done` → the closed/merged
- *  treatment; anything else → the open/success treatment. */
+/** The category icon + tone shared by the chip and every menu row (so meaning is
+ *  never color-only). `done` → the closed/merged treatment; else open/success. */
+function statusPresentation(category: JiraStatusCategory) {
+  const done = category === "done";
+  return {
+    Icon: done ? CheckCircleIcon : CircleDashedIcon,
+    tone: done ? "text-merged" : "text-success",
+  };
+}
+
+/** The static status chip: category picks the open/closed icon+token, the REAL
+ *  status name is the text. Used read-only, and as the trigger label inside the
+ *  interactive StatusMenu. `interactive` adds the dropdown-affordance chevron. */
 function StatusChip({
   category,
   name,
+  interactive = false,
 }: {
   category: JiraStatusCategory;
   name: string;
+  interactive?: boolean;
 }) {
-  const done = category === "done";
-  const Icon = done ? CheckCircleIcon : CircleDashedIcon;
+  const { Icon, tone } = statusPresentation(category);
   return (
     <span className="inline-flex items-center gap-1 border px-1.5 py-0.5 text-[11px]">
-      <Icon
-        className={`size-3.5 shrink-0 ${done ? "text-merged" : "text-success"}`}
-      />
+      <Icon className={`size-3.5 shrink-0 ${tone}`} />
       {name}
+      {interactive && <CaretDownIcon className="size-3 shrink-0 opacity-60" />}
     </span>
+  );
+}
+
+/**
+ * Interactive status picker: the chip becomes a DropdownMenu trigger. Transitions
+ * are fetched lazily on open (never on mount). Each menu item is a target status
+ * (labeled by its to-status name, dot-toned by category); a self-transition back
+ * to the current status renders as a checked, non-interactive current row.
+ * Selecting one fires the optimistic `jira_issue_transition_to` mutation. Only
+ * rendered when `transitionIssues` is permitted (the static chip covers the rest).
+ */
+function StatusMenu({
+  repoPath,
+  link,
+  issueKey,
+  category,
+  name,
+  busy,
+  transitionTo,
+}: {
+  repoPath: string;
+  link: JiraLink;
+  issueKey: string;
+  category: JiraStatusCategory;
+  name: string;
+  busy: boolean;
+  transitionTo: ReturnType<typeof useJiraTransitionTo>;
+}) {
+  const [open, setOpen] = useState(false);
+  const transitions = useJiraTransitions(repoPath, link, issueKey, open);
+
+  function apply(t: {
+    id: string;
+    toStatusName: string;
+    toStatusCategory: JiraStatusCategory;
+  }) {
+    transitionTo.mutate(
+      {
+        issueKey,
+        transitionId: t.id,
+        toStatusName: t.toStatusName,
+        toStatusCategory: t.toStatusCategory,
+      },
+      {
+        onSuccess: (r) => toast.success(`${issueKey} · ${r.statusName}`),
+        onError: toastError,
+      },
+    );
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger
+        disabled={busy}
+        aria-label={`Status: ${name}. Change status`}
+        className="cursor-pointer rounded-none disabled:cursor-default disabled:opacity-60"
+      >
+        <StatusChip category={category} name={name} interactive />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-44">
+        {transitions.isPending ? (
+          <DropdownMenuItem disabled>Loading transitions…</DropdownMenuItem>
+        ) : transitions.isError ? (
+          <DropdownMenuItem
+            // Base UI item: onClick fires the action (Radix-style onSelect
+            // TYPECHECKS — it's the DOM text-selection event — but never fires
+            // on click); closeOnClick={false} keeps the menu open for retry.
+            closeOnClick={false}
+            onClick={() => transitions.refetch()}
+          >
+            Couldn't load transitions — retry
+          </DropdownMenuItem>
+        ) : (transitions.data ?? []).length === 0 ? (
+          <DropdownMenuItem disabled>No transitions available</DropdownMenuItem>
+        ) : (
+          (transitions.data ?? []).map((t) => {
+            const { Icon, tone } = statusPresentation(t.toStatusCategory);
+            // A self-transition (lands back on the current status) is shown as the
+            // checked, non-interactive current row.
+            const isCurrent = t.toStatusName === name;
+            if (isCurrent) {
+              return (
+                <DropdownMenuCheckboxItem key={t.id} checked disabled>
+                  <Icon className={`size-3.5 shrink-0 ${tone}`} />
+                  {t.toStatusName}
+                </DropdownMenuCheckboxItem>
+              );
+            }
+            return (
+              <DropdownMenuItem key={t.id} onClick={() => apply(t)}>
+                <Icon className={`size-3.5 shrink-0 ${tone}`} />
+                {t.toStatusName}
+              </DropdownMenuItem>
+            );
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -230,6 +348,7 @@ export function JiraIssueView({
 
   const comment = useJiraComment(repoPath, link.data);
   const transition = useJiraTransition(repoPath, link.data);
+  const transitionTo = useJiraTransitionTo(repoPath, link.data);
   const [composeBody, setComposeBody] = useState("");
   const composerRef = useRef<MarkdownEditorHandle>(null);
 
@@ -266,7 +385,8 @@ export function JiraIssueView({
 
   const issue: JiraIssueDetails = details.data;
   const isDone = issue.statusCategory === "done";
-  const busy = comment.isPending || transition.isPending;
+  const busy =
+    comment.isPending || transition.isPending || transitionTo.isPending;
 
   function submitComment() {
     const body = composeBody.trim();
@@ -347,7 +467,22 @@ export function JiraIssueView({
           </Button>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          <StatusChip category={issue.statusCategory} name={issue.statusName} />
+          {canTransition && link.data ? (
+            <StatusMenu
+              repoPath={repoPath}
+              link={link.data}
+              issueKey={issueKey}
+              category={issue.statusCategory}
+              name={issue.statusName}
+              busy={busy}
+              transitionTo={transitionTo}
+            />
+          ) : (
+            <StatusChip
+              category={issue.statusCategory}
+              name={issue.statusName}
+            />
+          )}
           <IssueTypeMeta
             iconUrl={issue.issueTypeIconUrl}
             name={issue.issueTypeName}

--- a/src/features/issues/JiraRefRow.tsx
+++ b/src/features/issues/JiraRefRow.tsx
@@ -1,0 +1,73 @@
+import { KanbanIcon } from "@phosphor-icons/react";
+import { extractJiraKeys } from "@/lib/jira/keys";
+import { useJiraIssues, useJiraLink } from "@/lib/jira/queries";
+import { useUiStore } from "@/lib/stores/ui";
+
+/**
+ * The shared "Jira issues referenced" presentation: one full-width row per
+ * matched key (icon + key + the cached issue title when available), in the house
+ * "related items" idiom (`IssueDevelopment`). Clicking a row selects the issue in
+ * the Jira panel AND switches to the Issues tab — both are required, since
+ * `selectIssue` alone never changes tabs. A bare key with no cached title still
+ * renders and still navigates (the detail view fetches it by key).
+ *
+ * Renders nothing when the repo is unlinked or `text` references no keys — the
+ * omit-when-empty precedent (no persistent empty state).
+ */
+export function JiraRefRow({
+  repoPath,
+  text,
+}: {
+  repoPath: string;
+  /** The git text to scan (e.g. `subject + "\n" + body`). */
+  text: string;
+}) {
+  const link = useJiraLink(repoPath).data;
+  const keys = link ? extractJiraKeys(text, link.projectKey) : [];
+  // Titles are best-effort from whatever list is already cached; "all" is the
+  // broadest filter so it covers open and closed referenced issues. Passing the
+  // link only when there's something to resolve keeps the query disabled (so a
+  // linked repo with no referenced keys fires ZERO Jira calls); when it IS
+  // enabled the panel has usually already warmed this cache.
+  const issues = useJiraIssues(repoPath, keys.length > 0 ? link : null, "all");
+  const selectIssue = useUiStore((s) => s.selectIssue);
+  const setRepoTab = useUiStore((s) => s.setRepoTab);
+
+  if (!link || keys.length === 0) return null;
+
+  const titleFor = (key: string) =>
+    issues.data?.find((i) => i.key === key)?.summary;
+
+  function open(key: string) {
+    // Both calls, always: selectIssue targets the panel selection, setRepoTab
+    // brings the Issues tab forward so the selection is actually visible.
+    selectIssue({ kind: "jira", id: key });
+    setRepoTab("issues");
+  }
+
+  return (
+    <div className="space-y-1">
+      <p className="text-[11px] font-medium text-muted-foreground">
+        Jira issues
+      </p>
+      {keys.map((key) => {
+        const title = titleFor(key);
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => open(key)}
+            className="flex w-full cursor-pointer items-center gap-1.5 text-left text-xs hover:underline"
+            title={title ? `${key} ${title}` : key}
+          >
+            <KanbanIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 font-mono text-muted-foreground">
+              {key}
+            </span>
+            {title && <span className="min-w-0 flex-1 truncate">{title}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/issues/JiraRefRow.tsx
+++ b/src/features/issues/JiraRefRow.tsx
@@ -50,11 +50,11 @@ export function JiraRefRow({
     }
   }
 
-  // Titles are best-effort from whatever list is already cached; "all" is the
-  // broadest filter so it covers open and closed referenced issues. Passing the
-  // link only when there's something to resolve keeps the query disabled (so a
-  // linked repo with no referenced keys fires ZERO Jira calls); when it IS
-  // enabled the panel has usually already warmed this cache.
+  // Titles are best-effort; "all" is the broadest filter so it covers open and
+  // closed referenced issues — note it's a DISTINCT cache key from the panel's
+  // open/closed lists, so the first matched-key render may fetch one small page
+  // cold. Passing the link only when there's something to resolve keeps the
+  // query disabled (a linked repo with no referenced keys fires ZERO Jira calls).
   const issues = useJiraIssues(repoPath, keys.length > 0 ? link : null, "all");
   const selectIssue = useUiStore((s) => s.selectIssue);
   const setRepoTab = useUiStore((s) => s.setRepoTab);

--- a/src/features/issues/JiraRefRow.tsx
+++ b/src/features/issues/JiraRefRow.tsx
@@ -3,6 +3,13 @@ import { extractJiraKeys } from "@/lib/jira/keys";
 import { useJiraIssues, useJiraLink } from "@/lib/jira/queries";
 import { useUiStore } from "@/lib/stores/ui";
 
+/** One place a Jira key can be referenced, with a human label for attribution
+ *  (e.g. `{label: "branch name", text: headRefName}`). */
+export interface JiraRefSource {
+  label: string;
+  text: string | null | undefined;
+}
+
 /**
  * The shared "Jira issues referenced" presentation: one full-width row per
  * matched key (icon + key + the cached issue title when available), in the house
@@ -11,19 +18,38 @@ import { useUiStore } from "@/lib/stores/ui";
  * `selectIssue` alone never changes tabs. A bare key with no cached title still
  * renders and still navigates (the detail view fetches it by key).
  *
- * Renders nothing when the repo is unlinked or `text` references no keys — the
+ * `sources` are scanned in order; a key referenced in several sources is
+ * attributed to the FIRST one it appears in (so callers put the noisier source —
+ * a branch name — LAST, letting title/description attribution win). The overall
+ * row order preserves first-occurrence across all sources.
+ *
+ * Renders nothing when the repo is unlinked or no source references a key — the
  * omit-when-empty precedent (no persistent empty state).
  */
 export function JiraRefRow({
   repoPath,
-  text,
+  sources,
 }: {
   repoPath: string;
-  /** The git text to scan (e.g. `subject + "\n" + body`). */
-  text: string;
+  sources: JiraRefSource[];
 }) {
   const link = useJiraLink(repoPath).data;
-  const keys = link ? extractJiraKeys(text, link.projectKey) : [];
+  // Extract per source in order (reusing extractJiraKeys); first source wins a
+  // key, and overall first-occurrence order is preserved. `attribution` maps each
+  // key → the label of the source it was first seen in.
+  const keys: string[] = [];
+  const attribution = new Map<string, string>();
+  if (link) {
+    for (const source of sources) {
+      for (const key of extractJiraKeys(source.text, link.projectKey)) {
+        if (!attribution.has(key)) {
+          attribution.set(key, source.label);
+          keys.push(key);
+        }
+      }
+    }
+  }
+
   // Titles are best-effort from whatever list is already cached; "all" is the
   // broadest filter so it covers open and closed referenced issues. Passing the
   // link only when there's something to resolve keeps the query disabled (so a
@@ -52,13 +78,20 @@ export function JiraRefRow({
       </p>
       {keys.map((key) => {
         const title = titleFor(key);
+        const source = attribution.get(key);
+        // One title per element: fold the (optional) issue title AND the source
+        // attribution into a single tooltip so neither is lost.
+        const attributionSuffix = source
+          ? ` — referenced in the ${source}`
+          : "";
+        const tooltip = (title ? `${key} ${title}` : key) + attributionSuffix;
         return (
           <button
             key={key}
             type="button"
             onClick={() => open(key)}
             className="flex w-full cursor-pointer items-center gap-1.5 text-left text-xs hover:underline"
-            title={title ? `${key} ${title}` : key}
+            title={tooltip}
           >
             <KanbanIcon className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="shrink-0 font-mono text-muted-foreground">

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -5,9 +5,11 @@ import {
   DotsThreeIcon,
   GithubLogoIcon,
   GitlabLogoIcon,
+  KanbanIcon,
   PencilSimpleIcon,
   TagIcon,
   TrashIcon,
+  UploadSimpleIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
@@ -47,6 +49,7 @@ import {
   useLocalIssues,
   useUpdateLocalIssue,
 } from "@/lib/issues/queries";
+import { useJiraLink, useJiraPermissions } from "@/lib/jira/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
@@ -71,6 +74,14 @@ export function LocalIssueView({
   const del = useDeleteLocalIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const ghStatus = useForgeStatus(repoPath);
+  // Two independent publish gates: the forge's static issue-create capability
+  // and a live per-user Jira permission probe. The Publish affordance shows when
+  // EITHER is available; the dialog itself parameterizes / offers a choice.
+  const canPublishForge = forgeFeatureReady(ghStatus.data, "issueCreate");
+  const jiraLink = useJiraLink(repoPath).data;
+  const jiraPerms = useJiraPermissions(repoPath, jiraLink);
+  const canPublishJira = !!jiraLink && (jiraPerms.data?.createIssues ?? false);
+  const canPublish = canPublishForge || canPublishJira;
   const {
     comment,
     setComment,
@@ -350,20 +361,33 @@ export function LocalIssueView({
         <span className="flex-1" />
         {isOpen && (
           <>
-            {forgeFeatureReady(ghStatus.data, "issueCreate") && (
+            {canPublish && (
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => setPromoteOpen(true)}
-                title={`Open this issue on ${ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}, carrying its comments`}
+                title={
+                  canPublishForge && canPublishJira
+                    ? "Publish this issue to your forge or Jira, carrying its comments"
+                    : canPublishJira
+                      ? "Open this issue in Jira, carrying its comments"
+                      : `Open this issue on ${ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}, carrying its comments`
+                }
               >
-                {ghStatus.data?.provider === "gitlab" ? (
+                {canPublishForge && canPublishJira ? (
+                  <UploadSimpleIcon data-icon="inline-start" />
+                ) : canPublishJira ? (
+                  <KanbanIcon data-icon="inline-start" />
+                ) : ghStatus.data?.provider === "gitlab" ? (
                   <GitlabLogoIcon data-icon="inline-start" />
                 ) : (
                   <GithubLogoIcon data-icon="inline-start" />
                 )}
-                Publish to{" "}
-                {ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}
+                {canPublishForge && canPublishJira
+                  ? "Publish"
+                  : canPublishJira
+                    ? "Publish to Jira"
+                    : `Publish to ${ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}`}
               </Button>
             )}
             <Button

--- a/src/features/issues/PromoteLocalIssueDialog.tsx
+++ b/src/features/issues/PromoteLocalIssueDialog.tsx
@@ -1,6 +1,6 @@
 import { KanbanIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -76,15 +76,35 @@ export function PromoteLocalIssueDialog({
   );
 
   const bothAvailable = canPublishForge && canPublishJira;
-  const [destination, setDestination] = useState<Destination>(
-    canPublishForge ? "forge" : "jira",
-  );
-  // Keep the selection valid as the async gates resolve (e.g. the Jira
-  // permission probe lands after mount). When only one destination is possible,
-  // force it; otherwise default to the forge on first availability.
+  // Init unconditionally to "forge"; the effect below settles the real default
+  // once the async gates resolve (a bare init can't, since both gates are still
+  // pending at mount).
+  const [destination, setDestination] = useState<Destination>("forge");
+  // True once the user has explicitly toggled the destination — after that the
+  // auto-default effect must not override their pick (only the hidden-destination
+  // force-switch below still applies).
+  const userPicked = useRef(false);
+  // Keep the selection sensible as the async gates resolve (the forge status +
+  // Jira permission probes land at different times, often out of order). Two
+  // rules:
+  //   1. Auto-default only while the user hasn't picked: forge-first when both
+  //      are available, jira when only jira is. This is what makes forge win the
+  //      race even if the (cached) Jira gate resolves first.
+  //   2. Force-switch away from a destination whose gate just turned false —
+  //      applies EVEN after a user pick, because a hidden destination must never
+  //      be the one that submits.
   useEffect(() => {
-    if (canPublishForge && !canPublishJira) setDestination("forge");
-    else if (canPublishJira && !canPublishForge) setDestination("jira");
+    if (!userPicked.current) {
+      if (canPublishForge) setDestination("forge");
+      else if (canPublishJira) setDestination("jira");
+      return;
+    }
+    // User has picked: only correct an impossible selection.
+    setDestination((cur) => {
+      if (cur === "forge" && !canPublishForge && canPublishJira) return "jira";
+      if (cur === "jira" && !canPublishJira && canPublishForge) return "forge";
+      return cur;
+    });
   }, [canPublishForge, canPublishJira]);
 
   const [pending, setPending] = useState(false);
@@ -99,6 +119,7 @@ export function PromoteLocalIssueDialog({
   // Explain WHY the Jira submit is dead (never a title on a disabled button):
   // still loading the project's types, or the project has none we can create.
   const jiraLoadingTypes = destination === "jira" && jiraTypes.isPending;
+  const jiraTypesError = destination === "jira" && jiraTypes.isError;
   const jiraNoTypes =
     destination === "jira" &&
     !jiraTypes.isPending &&
@@ -261,7 +282,10 @@ export function PromoteLocalIssueDialog({
                   destination === "forge" && "font-medium",
                 )}
                 aria-pressed={destination === "forge"}
-                onClick={() => setDestination("forge")}
+                onClick={() => {
+                  userPicked.current = true;
+                  setDestination("forge");
+                }}
                 disabled={pending}
               >
                 {remoteLabel}
@@ -273,7 +297,10 @@ export function PromoteLocalIssueDialog({
                   destination === "jira" && "font-medium",
                 )}
                 aria-pressed={destination === "jira"}
-                onClick={() => setDestination("jira")}
+                onClick={() => {
+                  userPicked.current = true;
+                  setDestination("jira");
+                }}
                 disabled={pending}
               >
                 <KanbanIcon data-icon="inline-start" />
@@ -288,6 +315,19 @@ export function PromoteLocalIssueDialog({
             <Spinner data-icon="inline-start" />
             Loading issue types…
           </p>
+        )}
+        {jiraTypesError && (
+          <div className="flex items-center gap-2 border px-3 py-2 text-xs text-muted-foreground">
+            <span className="flex-1">Couldn't load Jira issue types.</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={() => jiraTypes.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
         )}
         {jiraNoTypes && (
           <p className="text-xs text-warning">

--- a/src/features/issues/PromoteLocalIssueDialog.tsx
+++ b/src/features/issues/PromoteLocalIssueDialog.tsx
@@ -1,5 +1,6 @@
+import { KanbanIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,18 +13,35 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { forgeIssueComment } from "@/lib/git/api";
-import { useCreateIssue, useForgeStatus } from "@/lib/git/queries";
+import {
+  forgeFeatureReady,
+  useCreateIssue,
+  useForgeStatus,
+} from "@/lib/git/queries";
 import type { LocalIssue } from "@/lib/issues/local";
 import { useUpdateLocalIssue } from "@/lib/issues/queries";
+import { jiraIssueComment } from "@/lib/jira/api";
+import {
+  useJiraCreateIssue,
+  useJiraIssueTypes,
+  useJiraLink,
+  useJiraPermissions,
+} from "@/lib/jira/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+
+type Destination = "forge" | "jira";
 
 /**
- * Publishes a local issue to the repo's provider (GitHub or GitLab): opens a real
- * issue with the same title/description, **re-posts its comments** (so nothing is
- * lost), then closes the local issue with a link to its successor. Deliberately
- * fires no automations — the local issue's creation was the trigger point, not this.
+ * Publishes a local issue to a real tracker — the repo's forge (GitHub or
+ * GitLab) or the linked Jira project — opening a real issue with the same
+ * title/description, **re-posting its comments** (so nothing is lost), then
+ * closing the local issue with a link to its successor. When both destinations
+ * are available the user picks one; when only one is, that's the whole flow.
+ * Deliberately fires no automations — the local issue's creation was the trigger
+ * point, not this.
  */
 export function PromoteLocalIssueDialog({
   repoPath,
@@ -39,14 +57,55 @@ export function PromoteLocalIssueDialog({
   const createIssue = useCreateIssue(repoPath);
   const update = useUpdateLocalIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
+
   const forge = useForgeStatus(repoPath);
   const remoteLabel = forge.data?.provider === "gitlab" ? "GitLab" : "GitHub";
+  const canPublishForge = forgeFeatureReady(forge.data, "issueCreate");
+
+  const link = useJiraLink(repoPath).data;
+  const jiraPerms = useJiraPermissions(repoPath, link);
+  const canPublishJira = !!link && (jiraPerms.data?.createIssues ?? false);
+  const jiraCreate = useJiraCreateIssue(repoPath, link);
+  // Fetch the project's issue types only while the dialog is open AND Jira is a
+  // possible destination — no picker here, so we auto-resolve the first
+  // creatable (`!subtask`) type, mirroring CreateJiraIssueDialog.
+  const jiraTypes = useJiraIssueTypes(repoPath, link, open && canPublishJira);
+  const creatableTypes = useMemo(
+    () => (jiraTypes.data ?? []).filter((t) => !t.subtask),
+    [jiraTypes.data],
+  );
+
+  const bothAvailable = canPublishForge && canPublishJira;
+  const [destination, setDestination] = useState<Destination>(
+    canPublishForge ? "forge" : "jira",
+  );
+  // Keep the selection valid as the async gates resolve (e.g. the Jira
+  // permission probe lands after mount). When only one destination is possible,
+  // force it; otherwise default to the forge on first availability.
+  useEffect(() => {
+    if (canPublishForge && !canPublishJira) setDestination("forge");
+    else if (canPublishJira && !canPublishForge) setDestination("jira");
+  }, [canPublishForge, canPublishJira]);
+
   const [pending, setPending] = useState(false);
 
   const carried = issue.comments.filter((c) => c.body.trim());
 
-  async function promote() {
-    setPending(true);
+  const targetLabel = destination === "jira" ? "Jira" : remoteLabel;
+  // The auto-resolved Jira type; absent until types load. Its absence disables
+  // the Jira submit so we never fire a create with no type.
+  const jiraTypeId = creatableTypes[0]?.id ?? null;
+  const jiraReady = destination !== "jira" || jiraTypeId !== null;
+  // Explain WHY the Jira submit is dead (never a title on a disabled button):
+  // still loading the project's types, or the project has none we can create.
+  const jiraLoadingTypes = destination === "jira" && jiraTypes.isPending;
+  const jiraNoTypes =
+    destination === "jira" &&
+    !jiraTypes.isPending &&
+    !jiraTypes.isError &&
+    creatableTypes.length === 0;
+
+  async function promoteForge() {
     // Once the remote issue exists, later steps (comment carry-over, closing the
     // local issue) failing must NOT re-arm the submit — retrying would open a
     // duplicate. Track it so the catch can disclose instead of re-running.
@@ -63,28 +122,14 @@ export function PromoteLocalIssueDialog({
         type: null,
       });
       created = { number, url };
-      // Carry the local comments over, in order, so none are lost.
       failedStep = "carrying over comments";
       for (const c of carried) {
         await forgeIssueComment(repoPath, number, c.body);
       }
       failedStep = "closing the local issue";
-      await update.mutateAsync({
-        id: issue.id,
-        mutate: (cur) => ({
-          ...cur,
-          status: "closed",
-          closedAt: new Date().toISOString(),
-          comments: [
-            ...cur.comments,
-            {
-              id: crypto.randomUUID(),
-              body: `Promoted to ${remoteLabel} issue [#${number}](${url}).`,
-              createdAt: new Date().toISOString(),
-            },
-          ],
-        }),
-      });
+      await closeLocalWithBackLink(
+        `Promoted to ${remoteLabel} issue [#${number}](${url}).`,
+      );
       toast.success(`Opened issue #${number}`, {
         description: url,
         action: { label: "View", onClick: () => openUrl(url) },
@@ -97,9 +142,6 @@ export function PromoteLocalIssueDialog({
         toastError(e);
         return;
       }
-      // The remote issue already exists. Close the dialog (leaving it open is a
-      // duplicate factory) and disclose what was created and what failed. The
-      // local issue is left untouched so the user can reconcile manually.
       const { number, url } = created;
       onOpenChange(false);
       toast.error(
@@ -109,6 +151,78 @@ export function PromoteLocalIssueDialog({
           action: { label: "View", onClick: () => openUrl(url) },
         },
       );
+    }
+  }
+
+  async function promoteJira() {
+    if (!link || jiraTypeId === null) return;
+    // Same retry-safety invariant as the forge path, tracked independently per
+    // destination: once the Jira issue exists, a failure in a later step must
+    // disclose rather than re-run (a retry would create a duplicate).
+    let created: { key: string; url: string } | null = null;
+    let failedStep = "finishing up";
+    try {
+      const { key, url } = await jiraCreate.mutateAsync({
+        issueTypeId: jiraTypeId,
+        summary: issue.title,
+        descriptionMd: issue.body.trim() || undefined,
+      });
+      created = { key, url };
+      failedStep = "carrying over comments";
+      for (const c of carried) {
+        await jiraIssueComment(link.siteHost, key, c.body);
+      }
+      failedStep = "closing the local issue";
+      await closeLocalWithBackLink(`Promoted to Jira issue [${key}](${url}).`);
+      toast.success(`Created ${key}`, {
+        description: url,
+        action: { label: "View", onClick: () => openUrl(url) },
+      });
+      onOpenChange(false);
+      selectIssue({ kind: "jira", id: key });
+    } catch (e) {
+      if (created === null) {
+        toastError(e);
+        return;
+      }
+      const { key, url } = created;
+      onOpenChange(false);
+      toast.error(
+        `Created ${key}, but ${failedStep} failed: ${errorMessage(e)}`,
+        {
+          duration: 10000,
+          action: { label: "View", onClick: () => openUrl(url) },
+        },
+      );
+    }
+  }
+
+  // Provider-agnostic final step: close the local issue with a back-link comment
+  // to its successor. Shared by both destinations, unchanged from the original.
+  async function closeLocalWithBackLink(backLink: string) {
+    await update.mutateAsync({
+      id: issue.id,
+      mutate: (cur) => ({
+        ...cur,
+        status: "closed",
+        closedAt: new Date().toISOString(),
+        comments: [
+          ...cur.comments,
+          {
+            id: crypto.randomUUID(),
+            body: backLink,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    });
+  }
+
+  async function promote() {
+    setPending(true);
+    try {
+      if (destination === "jira") await promoteJira();
+      else await promoteForge();
     } finally {
       setPending(false);
     }
@@ -118,9 +232,9 @@ export function PromoteLocalIssueDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Publish this issue to {remoteLabel}?</DialogTitle>
+          <DialogTitle>Publish this issue to {targetLabel}?</DialogTitle>
           <DialogDescription>
-            Opens a new issue on {remoteLabel} with this title and description
+            Opens a new issue on {targetLabel} with this title and description
             {carried.length > 0
               ? ` and re-posts its ${carried.length} comment${
                   carried.length === 1 ? "" : "s"
@@ -130,6 +244,58 @@ export function PromoteLocalIssueDialog({
             Free-form local labels aren't carried over.
           </DialogDescription>
         </DialogHeader>
+
+        {bothAvailable && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">
+              Publish to
+            </p>
+            {/* Segmented toggle: two Tab-focusable buttons with aria-pressed,
+                matching the app's existing segmented-tab idiom (each is its own
+                tab stop; Enter/Space toggles). */}
+            <div className="flex gap-2" aria-label="Publish destination">
+              <Button
+                variant={destination === "forge" ? "secondary" : "outline"}
+                className={cn(
+                  "flex-1",
+                  destination === "forge" && "font-medium",
+                )}
+                aria-pressed={destination === "forge"}
+                onClick={() => setDestination("forge")}
+                disabled={pending}
+              >
+                {remoteLabel}
+              </Button>
+              <Button
+                variant={destination === "jira" ? "secondary" : "outline"}
+                className={cn(
+                  "flex-1",
+                  destination === "jira" && "font-medium",
+                )}
+                aria-pressed={destination === "jira"}
+                onClick={() => setDestination("jira")}
+                disabled={pending}
+              >
+                <KanbanIcon data-icon="inline-start" />
+                Jira
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {jiraLoadingTypes && (
+          <p className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Spinner data-icon="inline-start" />
+            Loading issue types…
+          </p>
+        )}
+        {jiraNoTypes && (
+          <p className="text-xs text-warning">
+            This Jira project has no creatable issue type — create one in Jira
+            or check your project permissions.
+          </p>
+        )}
+
         <DialogFooter>
           <Button
             variant="outline"
@@ -138,9 +304,9 @@ export function PromoteLocalIssueDialog({
           >
             Cancel
           </Button>
-          <Button onClick={promote} disabled={pending}>
+          <Button onClick={promote} disabled={pending || !jiraReady}>
             {pending && <Spinner data-icon="inline-start" />}
-            Publish to {remoteLabel}
+            Publish to {targetLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -344,7 +344,11 @@ export function LocalPrView({
           </div>
           <JiraRefRow
             repoPath={repoPath}
-            text={`${pr.title}\n${pr.body}\n${pr.head}`}
+            sources={[
+              { label: "title", text: pr.title },
+              { label: "description", text: pr.body },
+              { label: "branch name", text: pr.head },
+            ]}
           />
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <span className="font-mono">{pr.head}</span>
@@ -389,7 +393,11 @@ export function LocalPrView({
         </div>
         <JiraRefRow
           repoPath={repoPath}
-          text={`${pr.title}\n${pr.body}\n${pr.head}`}
+          sources={[
+            { label: "title", text: pr.title },
+            { label: "description", text: pr.body },
+            { label: "branch name", text: pr.head },
+          ]}
         />
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span className="font-mono">{pr.head}</span>

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -42,6 +42,7 @@ import { LocalComment } from "@/features/conversations/LocalComment";
 import { useLocalConversation } from "@/features/conversations/useLocalConversation";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { CommitDetailView } from "@/features/history/CommitDetailView";
+import { JiraRefRow } from "@/features/issues/JiraRefRow";
 import { isMergeMethodAllowed } from "@/lib/branch-rules/match";
 import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
 import { copyText } from "@/lib/clipboard";
@@ -341,6 +342,10 @@ export function LocalPrView({
               {pr.status}
             </Badge>
           </div>
+          <JiraRefRow
+            repoPath={repoPath}
+            text={`${pr.title}\n${pr.body}\n${pr.head}`}
+          />
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <span className="font-mono">{pr.head}</span>
             <span>→</span>
@@ -382,6 +387,10 @@ export function LocalPrView({
           )}
           {pr.archived && <Badge variant="secondary">archived</Badge>}
         </div>
+        <JiraRefRow
+          repoPath={repoPath}
+          text={`${pr.title}\n${pr.body}\n${pr.head}`}
+        />
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span className="font-mono">{pr.head}</span>
           <span>→</span>

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -194,6 +194,14 @@ export function LocalPrView({
   // fallen behind base. Non-empty ⇒ offer GitHub's "Update branch".
   const behind = comparison.data?.behind ?? [];
   const fileCount = diffFiles.data?.length;
+  // Shared JiraRefRow sources for both header branches (conflict-takeover +
+  // normal) so the two can't diverge. Branch name LAST so title/description
+  // attribution wins a key that also appears in the branch name.
+  const jiraRefSources = [
+    { label: "title", text: pr.title },
+    { label: "description", text: pr.body },
+    { label: "branch name", text: pr.head },
+  ];
 
   function toggleApprove() {
     if (!pr) return;
@@ -342,14 +350,7 @@ export function LocalPrView({
               {pr.status}
             </Badge>
           </div>
-          <JiraRefRow
-            repoPath={repoPath}
-            sources={[
-              { label: "title", text: pr.title },
-              { label: "description", text: pr.body },
-              { label: "branch name", text: pr.head },
-            ]}
-          />
+          <JiraRefRow repoPath={repoPath} sources={jiraRefSources} />
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <span className="font-mono">{pr.head}</span>
             <span>→</span>
@@ -391,14 +392,7 @@ export function LocalPrView({
           )}
           {pr.archived && <Badge variant="secondary">archived</Badge>}
         </div>
-        <JiraRefRow
-          repoPath={repoPath}
-          sources={[
-            { label: "title", text: pr.title },
-            { label: "description", text: pr.body },
-            { label: "branch name", text: pr.head },
-          ]}
-        />
+        <JiraRefRow repoPath={repoPath} sources={jiraRefSources} />
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span className="font-mono">{pr.head}</span>
           <span>→</span>

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -789,7 +789,11 @@ export function RemotePrView({
         </div>
         <JiraRefRow
           repoPath={repoPath}
-          text={`${pr.title}\n${pr.body}\n${pr.headRefName}`}
+          sources={[
+            { label: "title", text: pr.title },
+            { label: "description", text: pr.body },
+            { label: "branch name", text: pr.headRefName },
+          ]}
         />
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <Badge variant={pr.state === "OPEN" ? "default" : "secondary"}>

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -56,6 +56,7 @@ import {
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import type { LineWidget } from "@/features/diff/DiffSurface";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
+import { JiraRefRow } from "@/features/issues/JiraRefRow";
 import {
   isDeletionBlocked,
   isMergeMethodAllowed,
@@ -786,6 +787,10 @@ export function RemotePrView({
             {remoteLabel}
           </Button>
         </div>
+        <JiraRefRow
+          repoPath={repoPath}
+          text={`${pr.title}\n${pr.body}\n${pr.headRefName}`}
+        />
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <Badge variant={pr.state === "OPEN" ? "default" : "secondary"}>
             {pr.isDraft ? "Draft" : pr.state.toLowerCase()}

--- a/src/features/repository/RepoHeader.tsx
+++ b/src/features/repository/RepoHeader.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftIcon, GearIcon, QuestionIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { BranchCiBadge } from "@/features/actions/BranchCiBadge";
+import { BranchJiraBadge } from "@/features/actions/BranchJiraBadge";
 import { ActivityDock } from "@/features/activity/ActivityDock";
 import { useUiStore } from "@/lib/stores/ui";
 import { BranchSwitcher } from "./BranchSwitcher";
@@ -29,6 +30,7 @@ export function RepoHeader({ repoPath }: { repoPath: string }) {
       <Separator orientation="vertical" className="h-5" />
       <BranchSwitcher repoPath={repoPath} />
       <BranchCiBadge repoPath={repoPath} />
+      <BranchJiraBadge repoPath={repoPath} />
       <div className="flex-1" />
       <SyncControls repoPath={repoPath} />
       <ActivityDock />

--- a/src/lib/jira/api.ts
+++ b/src/lib/jira/api.ts
@@ -12,6 +12,7 @@ import type {
   JiraPermissions,
   JiraProject,
   JiraStoredAccount,
+  JiraTransition,
   JiraTransitionDirection,
   JiraTransitionResult,
 } from "./types";
@@ -98,6 +99,26 @@ export const jiraIssueTransition = (
     site,
     key,
     direction,
+  });
+
+/** The workflow transitions available from the issue's current status (for the
+ *  full status picker). Each carries the status it lands on so the menu can label
+ *  + dot-tone by target status and flip the chip optimistically on select. */
+export const jiraIssueTransitions = (site: string, key: string) =>
+  invoke<JiraTransition[]>("jira_issue_transitions", { site, key });
+
+/** Apply a specific transition by id (the full status picker's counterpart to the
+ *  directional `jiraIssueTransition`); returns the resulting real status name +
+ *  category to update the chip. */
+export const jiraIssueTransitionTo = (
+  site: string,
+  key: string,
+  transitionId: string,
+) =>
+  invoke<JiraTransitionResult>("jira_issue_transition_to", {
+    site,
+    key,
+    transitionId,
   });
 
 /** Create an issue; returns the new key + URL. `descriptionMd` optional (empty

--- a/src/lib/jira/keys.ts
+++ b/src/lib/jira/keys.ts
@@ -1,0 +1,54 @@
+/** Escape a string for safe embedding inside a `RegExp`. The project key is
+ *  grammar-validated at link time, but escaping keeps this util correct for any
+ *  caller and immune to a metacharacter ever slipping through. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Extract the Jira issue keys of the *linked project only* referenced in a piece
+ * of git text (commit message, PR title/body, branch name). Matches
+ * `<PROJECTKEY>-\d+` case-insensitively — never a generic `[A-Z]+-\d+`, which
+ * would false-positive on ISO-8601 dates, UTF-8, and the like. Deduplicated,
+ * ordered by first occurrence.
+ *
+ * Boundary semantics (deliberately NOT plain `\b`, which counts underscore as a
+ * word char and treats a bare `.` like any non-word char):
+ *   - LEFT `(?<![A-Za-z0-9])`: reject a letter/digit prefix (`XMYT-1` → no), but
+ *     ALLOW underscore adjacency — `_` is a common branch-name separator, so
+ *     `feature_MYT-5` must yield MYT-5.
+ *   - RIGHT `(?![A-Za-z])`: reject a letter suffix (`MYT-12a` → no).
+ *   - RIGHT `(?!\.\d)`: reject a version-like `dot+digit` (`MYT-1.2` → no), while
+ *     a sentence-ending period still matches (`fixes MYT-1.` → MYT-1).
+ * Case table (all verified against this regex):
+ *   feature_MYT-5 → MYT-5   |  MYT-5_x → MYT-5      |  feat/myt-2-fix → MYT-2
+ *   fixes MYT-1.  → MYT-1   |  MYT-21  → MYT-21     |  (greedy \d+, no MYT-2)
+ *   XMYT-1 → []  |  MYT-12a → []  |  MYT-1.2 → []  |  2024-01-02 → [] (key ≠ 2024)
+ *
+ * Null/empty text or an empty project key yields an empty array.
+ */
+export function extractJiraKeys(
+  text: string | null | undefined,
+  projectKey: string,
+): string[] {
+  if (!text || !projectKey) return [];
+  // `i` so a lowercased key in a branch name (e.g. `proj-42-fix`) still matches;
+  // `g` to walk every occurrence. Lookarounds implement the boundary table above
+  // (Chromium/WebView2 supports lookbehind).
+  const re = new RegExp(
+    `(?<![A-Za-z0-9])${escapeRegExp(projectKey)}-\\d+(?![A-Za-z])(?!\\.\\d)`,
+    "gi",
+  );
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of text.matchAll(re)) {
+    // Normalize to the canonical upper-case key so `proj-42` and `PROJ-42`
+    // dedupe to one entry (and navigate to the same issue).
+    const key = m[0].toUpperCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(key);
+    }
+  }
+  return out;
+}

--- a/src/lib/jira/queries.ts
+++ b/src/lib/jira/queries.ts
@@ -12,6 +12,8 @@ import {
   jiraIssueCreate,
   jiraIssueList,
   jiraIssueTransition,
+  jiraIssueTransitions,
+  jiraIssueTransitionTo,
   jiraIssueTypes,
   jiraIssueView,
   jiraPermissions,
@@ -28,6 +30,7 @@ import type {
   JiraIssueDetails,
   JiraIssueInfo,
   JiraIssueState,
+  JiraStatusCategory,
   JiraTransitionDirection,
 } from "./types";
 
@@ -256,12 +259,120 @@ export function useJiraComment(
   });
 }
 
-/** Close/reopen via a workflow transition. Optimistic: patches the new status
- *  name + category onto the detail cache AND every list cache for this repo (so
- *  the row's chip flips instantly). Rollback on error restores both. The list
- *  patch may make a row fall out of the active state filter (e.g. closing while
- *  viewing Open) — that's fine: the detail view stays put and invalidation
- *  reconciles the list on settle. */
+/** The available workflow transitions from an issue's current status, for the
+ *  full status picker. Fetched lazily — the caller passes `enabled` (e.g. the
+ *  status menu being open) so nothing is fetched on mount. Site is part of the
+ *  key so a re-link can't serve the prior site's transitions for the same key. */
+export function useJiraTransitions(
+  repo: string,
+  link: JiraLink | null | undefined,
+  key: string,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: [
+      "repo",
+      repo,
+      "jira-transitions",
+      link?.siteHost ?? "",
+      key,
+    ] as const,
+    queryFn: () => jiraIssueTransitions((link as JiraLink).siteHost, key),
+    enabled: !!link && enabled,
+    staleTime: 30_000,
+  });
+}
+
+/** The shared optimistic context for a status change (detail snapshot + every
+ *  patched list cache), so rollback can restore exactly what onMutate touched. */
+type StatusPatchCtx = {
+  detailKey: readonly unknown[] | null;
+  prevDetail: JiraIssueDetails | undefined;
+  lists: [readonly unknown[], JiraIssueInfo[] | undefined][];
+};
+
+/** Optimistically flip an issue's status category (and, when known, its name)
+ *  across the detail cache AND every jira-issues list cache for this repo, so the
+ *  chip + any visible row update instantly. Shared by both transition mutations.
+ *  `name === undefined` (the directional path, which can't know the per-workflow
+ *  target name yet) leaves the existing name; the real values land on success. */
+async function applyOptimisticStatus(
+  queryClient: ReturnType<typeof useQueryClient>,
+  repo: string,
+  link: JiraLink,
+  issueKey: string,
+  category: JiraStatusCategory,
+  name: string | undefined,
+): Promise<StatusPatchCtx> {
+  const detailKey = jiraIssueDetailKey(repo, link.siteHost, issueKey);
+  await queryClient.cancelQueries({ queryKey: detailKey });
+  const prevDetail = queryClient.getQueryData<JiraIssueDetails>(detailKey);
+  if (prevDetail) {
+    queryClient.setQueryData<JiraIssueDetails>(detailKey, {
+      ...prevDetail,
+      statusCategory: category,
+      ...(name !== undefined ? { statusName: name } : {}),
+    });
+  }
+  const lists = queryClient.getQueriesData<JiraIssueInfo[]>({
+    predicate: (q) =>
+      q.queryKey[0] === "repo" &&
+      q.queryKey[1] === repo &&
+      q.queryKey[2] === "jira-issues",
+  });
+  for (const [listKey, list] of lists) {
+    if (!list) continue;
+    queryClient.setQueryData<JiraIssueInfo[]>(
+      listKey,
+      list.map((i) =>
+        i.key === issueKey
+          ? {
+              ...i,
+              statusCategory: category,
+              ...(name !== undefined ? { statusName: name } : {}),
+            }
+          : i,
+      ),
+    );
+  }
+  return { detailKey, prevDetail, lists };
+}
+
+/** Restore the detail + list caches from a StatusPatchCtx (rollback on error). */
+function rollbackOptimisticStatus(
+  queryClient: ReturnType<typeof useQueryClient>,
+  ctx: StatusPatchCtx | undefined,
+) {
+  if (ctx?.detailKey && ctx.prevDetail !== undefined) {
+    queryClient.setQueryData(ctx.detailKey, ctx.prevDetail);
+  }
+  for (const [listKey, list] of ctx?.lists ?? []) {
+    queryClient.setQueryData(listKey, list);
+  }
+}
+
+/** Land the server's REAL status name + category onto the detail cache (success),
+ *  so the chip reads e.g. "Done" not the generic optimistic guess. */
+function landRealStatus(
+  queryClient: ReturnType<typeof useQueryClient>,
+  repo: string,
+  link: JiraLink,
+  issueKey: string,
+  statusName: string,
+  statusCategory: JiraStatusCategory,
+) {
+  const detailKey = jiraIssueDetailKey(repo, link.siteHost, issueKey);
+  queryClient.setQueryData<JiraIssueDetails>(detailKey, (d) =>
+    d ? { ...d, statusName, statusCategory } : d,
+  );
+}
+
+/** Close/reopen via a directional workflow transition. Optimistic: flips the
+ *  category across the detail cache AND every list cache for this repo (so the
+ *  row's chip flips instantly). Rollback on error restores both. The list patch
+ *  may make a row fall out of the active state filter (e.g. closing while viewing
+ *  Open) — that's fine: the detail view stays put and invalidation reconciles the
+ *  list on settle. */
 export function useJiraTransition(
   repo: string,
   link: JiraLink | null | undefined,
@@ -278,61 +389,79 @@ export function useJiraTransition(
         args.direction,
       ),
     onMutate: async (args) => {
-      if (!link) return { detailKey: null, prevDetail: undefined, lists: [] };
-      const detailKey = jiraIssueDetailKey(repo, link.siteHost, args.issueKey);
-      await queryClient.cancelQueries({ queryKey: detailKey });
-      const prevDetail = queryClient.getQueryData<JiraIssueDetails>(detailKey);
+      if (!link) return undefined;
       // We don't yet know the real target status name (it's per-workflow), so
-      // the optimistic patch only flips the category — enough to move the chip's
-      // open/closed treatment; the returned real name lands on success and the
-      // settle invalidation reconciles everything.
-      const category = args.direction === "close" ? "done" : "new";
-      if (prevDetail) {
-        queryClient.setQueryData<JiraIssueDetails>(detailKey, {
-          ...prevDetail,
-          statusCategory: category,
-        });
-      }
-      // Snapshot + patch every jira-issues list cache for this repo (any site /
-      // project / state filter) so a visible row's chip flips too.
-      const lists = queryClient.getQueriesData<JiraIssueInfo[]>({
-        predicate: (q) =>
-          q.queryKey[0] === "repo" &&
-          q.queryKey[1] === repo &&
-          q.queryKey[2] === "jira-issues",
-      });
-      for (const [listKey, list] of lists) {
-        if (!list) continue;
-        queryClient.setQueryData<JiraIssueInfo[]>(
-          listKey,
-          list.map((i) =>
-            i.key === args.issueKey ? { ...i, statusCategory: category } : i,
-          ),
-        );
-      }
-      return { detailKey, prevDetail, lists };
+      // only flip the category (name undefined) — enough to move the chip's
+      // open/closed treatment; the returned real name lands on success.
+      const category: JiraStatusCategory =
+        args.direction === "close" ? "done" : "new";
+      return applyOptimisticStatus(
+        queryClient,
+        repo,
+        link,
+        args.issueKey,
+        category,
+        undefined,
+      );
     },
-    onError: (_e, _args, ctx) => {
-      if (ctx?.detailKey && ctx.prevDetail !== undefined) {
-        queryClient.setQueryData(ctx.detailKey, ctx.prevDetail);
-      }
-      for (const [listKey, list] of ctx?.lists ?? []) {
-        queryClient.setQueryData(listKey, list);
-      }
-    },
+    onError: (_e, _args, ctx) => rollbackOptimisticStatus(queryClient, ctx),
     onSuccess: (result, args) => {
-      // The server told us the REAL new status name — land it on the detail so
-      // the chip reads e.g. "Done", not the generic category guess.
       if (!link) return;
-      const detailKey = jiraIssueDetailKey(repo, link.siteHost, args.issueKey);
-      queryClient.setQueryData<JiraIssueDetails>(detailKey, (d) =>
-        d
-          ? {
-              ...d,
-              statusName: result.statusName,
-              statusCategory: result.statusCategory,
-            }
-          : d,
+      landRealStatus(
+        queryClient,
+        repo,
+        link,
+        args.issueKey,
+        result.statusName,
+        result.statusCategory,
+      );
+    },
+    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+  });
+}
+
+/** Apply a specific transition by id (the full status picker). Same optimistic
+ *  plumbing as `useJiraTransition`, but the caller knows the target from the
+ *  chosen option, so we flip BOTH category and name up front; the server's real
+ *  values still land on success and invalidation reconciles on settle. */
+export function useJiraTransitionTo(
+  repo: string,
+  link: JiraLink | null | undefined,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      issueKey: string;
+      transitionId: string;
+      toStatusName: string;
+      toStatusCategory: JiraStatusCategory;
+    }) =>
+      jiraIssueTransitionTo(
+        (link as JiraLink).siteHost,
+        args.issueKey,
+        args.transitionId,
+      ),
+    onMutate: async (args) => {
+      if (!link) return undefined;
+      return applyOptimisticStatus(
+        queryClient,
+        repo,
+        link,
+        args.issueKey,
+        args.toStatusCategory,
+        args.toStatusName,
+      );
+    },
+    onError: (_e, _args, ctx) => rollbackOptimisticStatus(queryClient, ctx),
+    onSuccess: (result, args) => {
+      if (!link) return;
+      landRealStatus(
+        queryClient,
+        repo,
+        link,
+        args.issueKey,
+        result.statusName,
+        result.statusCategory,
       );
     },
     onSettled: () => invalidateJiraForRepo(queryClient, repo),

--- a/src/lib/jira/types.ts
+++ b/src/lib/jira/types.ts
@@ -108,6 +108,17 @@ export interface JiraTransitionResult {
  *  target category is `done`; `reopen` picks one targeting `new`/`indeterminate`. */
 export type JiraTransitionDirection = "close" | "reopen";
 
+/** One available workflow transition from the issue's current status, as offered
+ *  by the full status picker. `name` is the transition's own name; `toStatusName`
+ *  / `toStatusCategory` describe the status it lands on (what the menu labels and
+ *  dot-tones by, and what the chip flips to optimistically on select). */
+export interface JiraTransition {
+  id: string;
+  name: string;
+  toStatusName: string;
+  toStatusCategory: JiraStatusCategory;
+}
+
 /** The result of creating an issue: the new key + its browser URL. */
 export interface JiraCreatedIssue {
   key: string;


### PR DESCRIPTION
This change enables deep linking and context surfacing for Jira Cloud issues across the app, lets users promote a local issue directly to Jira (alongside GitHub/GitLab), and expands MCP agent access to support listing, reading, and updating linked Jira issues—even for Bitbucket repos whose native tracker is retiring. These features together help users and agents keep issue context visible and actionable wherever work happens.

### Jira key reference extraction and surfacing
- Adds `src/lib/jira/keys.ts` to extract referenced Jira keys (of the linked project) from branch names, commit messages, and PR titles/bodies.
- Surfaces referenced keys in context:
  - `src/features/actions/BranchJiraBadge.tsx` renders a Jira badge for referenced keys in the current branch in `RepoHeader.tsx`.
  - `src/features/issues/JiraRefRow.tsx` presents a unified “Jira issues referenced” row, with clickable navigation to the Issues tab, used in `CommitDetailView.tsx`, `LocalPrView.tsx`, and `RemotePrView.tsx`.
- Updates UI logic and help content to explain this affordance (`README.md`, `site/src/pages/index.astro`, `src/features/help/content.ts`).

### Promote local issues to Jira support
- Updates `src/features/issues/LocalIssueView.tsx` and `src/features/issues/PromoteLocalIssueDialog.tsx` to let users promote a local issue to Jira, carrying over comments, closing the local with a backlink, and offering a choice when forge and Jira are both available.
- Adapts the dialog to fetch available Jira issue types and permissions, mirroring the GitHub/GitLab experience.

### Jira status workflow picker
- Adds workflow transition support in `src-tauri/src/forge/jira.rs` and exposes new Tauri commands in `src-tauri/src/forge/mod.rs` and `src-tauri/src/lib.rs` for fetching available transitions and performing transitions by id.
- Implements `jiraIssueTransitions` and `jiraIssueTransitionTo` API functions in `src/lib/jira/api.ts`.
- Updates `src/features/issues/JiraIssueView.tsx` to present a menu-driven status chip, allowing users to see and move an issue to any permitted workflow status.

### MCP agent Jira support
- Adds a headless reader for Jira project links in `src-tauri/src/jira_links.rs` for agent access.
- Implements agent tool routes for reading (`src-tauri/src/mcp_server/read_jira.rs`) and writing (`src-tauri/src/mcp_server/write_jira.rs`) linked Jira issues, including list, get, comment, close/reopen via workflow, create, and assign.
- Registers and routes these tools in `src-tauri/src/mcp_server/mod.rs`, updating docstrings and capability explanations across help sections (`src/features/help/content.ts`, `README.md`).

### Internal and docs updates
- Documents new features in `changelog.d/added-jira-links-promote-mcp.md`, README, and website page.
- Updates help content and guides for referencing and promoting issues (`src/features/help/HelpScreen.tsx`, `src/features/help/content.ts`).
- Cleans up permission handling, hotkeys, and design details in surrounding components.