### PR TITLE
Redesign error toasts with calm summaries and a details dialog

### DIFF
--- a/changelog.d/changed-error-toasts.md
+++ b/changelog.d/changed-error-toasts.md
@@ -1,0 +1,4 @@
+- **Calmer error toasts.** Long git and forge errors now show a single
+  humanized summary line with a **Details** action that opens a dialog with the
+  full, selectable text and a Copy button; short errors are unchanged and keep
+  their Copy action.

--- a/src/features/errors/ErrorDialog.tsx
+++ b/src/features/errors/ErrorDialog.tsx
@@ -1,0 +1,82 @@
+import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useErrorDialog } from "@/lib/stores/error-dialog";
+
+/**
+ * The full-text viewer for a long error. Opened from an error toast's "Details"
+ * action; mounted once at the app root. The toast shows a calm one-line summary;
+ * this dialog carries the raw, selectable text (git/forge stderr, long paths and
+ * hashes) with a Copy action.
+ */
+export function ErrorDialog() {
+  const presentation = useErrorDialog((s) => s.presentation);
+  const close = useErrorDialog((s) => s.close);
+  const [copied, setCopied] = useState(false);
+
+  const fullText = presentation?.fullText ?? "";
+
+  function copy() {
+    navigator.clipboard
+      .writeText(fullText)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        // Clipboard denied — nothing useful to do.
+      });
+  }
+
+  return (
+    <Dialog
+      open={presentation !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+          setCopied(false);
+        }
+      }}
+    >
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <DialogTitle className="min-w-0 wrap-break-word">
+              {presentation?.summary}
+            </DialogTitle>
+            {presentation?.label && (
+              <Badge variant="secondary">{presentation.label}</Badge>
+            )}
+          </div>
+        </DialogHeader>
+        <pre className="max-h-[60vh] min-w-0 overflow-y-auto font-mono text-sm whitespace-pre-wrap [overflow-wrap:anywhere] select-text">
+          {fullText}
+        </pre>
+        <DialogFooter>
+          <Button variant="outline" onClick={close}>
+            Close
+          </Button>
+          <Button variant="secondary" onClick={copy}>
+            {copied ? (
+              <>
+                <CheckIcon data-icon="inline-start" /> Copied
+              </>
+            ) : (
+              <>
+                <CopyIcon data-icon="inline-start" /> Copy
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/errors/ErrorDialog.tsx
+++ b/src/features/errors/ErrorDialog.tsx
@@ -24,6 +24,14 @@ export function ErrorDialog() {
 
   const fullText = presentation?.fullText ?? "";
 
+  // Controlled Base UI dialogs don't fire onOpenChange when `open` flips via the
+  // prop, so the Close button clears `copied` itself — otherwise a Copy → Close
+  // within 1.5s leaves the next-opened dialog briefly showing "Copied".
+  function handleClose() {
+    close();
+    setCopied(false);
+  }
+
   function copy() {
     navigator.clipboard
       .writeText(fullText)
@@ -40,10 +48,7 @@ export function ErrorDialog() {
     <Dialog
       open={presentation !== null}
       onOpenChange={(open) => {
-        if (!open) {
-          close();
-          setCopied(false);
-        }
+        if (!open) handleClose();
       }}
     >
       <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
@@ -53,7 +58,9 @@ export function ErrorDialog() {
               {presentation?.summary}
             </DialogTitle>
             {presentation?.label && (
-              <Badge variant="secondary">{presentation.label}</Badge>
+              <Badge variant="secondary" className="shrink-0">
+                {presentation.label}
+              </Badge>
             )}
           </div>
         </DialogHeader>
@@ -61,7 +68,7 @@ export function ErrorDialog() {
           {fullText}
         </pre>
         <DialogFooter>
-          <Button variant="outline" onClick={close}>
+          <Button variant="outline" onClick={handleClose}>
             Close
           </Button>
           <Button variant="secondary" onClick={copy}>

--- a/src/features/errors/ErrorDialog.tsx
+++ b/src/features/errors/ErrorDialog.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -25,6 +25,19 @@ export function ErrorDialog() {
   // Copy → Close → reopen → Copy sequence lets the first dialog's orphaned
   // timer fire mid-window and prematurely hide the new "Copied" feedback.
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset copy feedback when the presentation identity changes — open() called
+  // while the dialog is already open swaps `presentation` without ever passing
+  // through handleClose(), so a prior Copy's "Copied" state and live timer would
+  // otherwise bleed into the new error's session. (Also fires harmlessly on close.)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `presentation` is the reset trigger, not read in the body.
+  useEffect(() => {
+    setCopied(false);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, [presentation]);
 
   const fullText = presentation?.fullText ?? "";
 

--- a/src/features/errors/ErrorDialog.tsx
+++ b/src/features/errors/ErrorDialog.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +21,10 @@ export function ErrorDialog() {
   const presentation = useErrorDialog((s) => s.presentation);
   const close = useErrorDialog((s) => s.close);
   const [copied, setCopied] = useState(false);
+  // Hold the copy-feedback timer so handleClose can cancel it — otherwise a
+  // Copy → Close → reopen → Copy sequence lets the first dialog's orphaned
+  // timer fire mid-window and prematurely hide the new "Copied" feedback.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fullText = presentation?.fullText ?? "";
 
@@ -28,6 +32,10 @@ export function ErrorDialog() {
   // prop, so the Close button clears `copied` itself — otherwise a Copy → Close
   // within 1.5s leaves the next-opened dialog briefly showing "Copied".
   function handleClose() {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     close();
     setCopied(false);
   }
@@ -37,7 +45,8 @@ export function ErrorDialog() {
       .writeText(fullText)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), 1500);
       })
       .catch(() => {
         // Clipboard denied — nothing useful to do.

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -1,0 +1,125 @@
+import { type AppError, isAppError } from "@/lib/tauri/invoke";
+
+/** A humanized error, split into what a toast shows (a calm one-liner) and what
+ *  the Details dialog shows (the full raw text). Pure — derived from the thrown
+ *  value alone, no React/DOM. */
+export interface ErrorPresentation {
+  /** Kind badge text (e.g. "Git error"), or null for a non-AppError throwable. */
+  label: string | null;
+  /** One humanized line — never raw multi-line stderr noise. */
+  summary: string;
+  /** The full message (plus a distinct stderr appended) for the Details dialog. */
+  fullText: string;
+  /** Whether the error is long enough to route the toast through Details. */
+  long: boolean;
+}
+
+/** Human labels for every AppError kind (mirrors the union in tauri/invoke.ts). */
+const KIND_LABELS: Record<AppError["kind"], string> = {
+  git: "Git error",
+  notARepo: "Not a Git repository",
+  gitNotFound: "Git not found",
+  ghNotFound: "GitHub CLI not found",
+  gh: "GitHub error",
+  glabNotFound: "GitLab CLI not found",
+  glab: "GitLab error",
+  bitbucketNotConfigured: "Bitbucket not configured",
+  bitbucket: "Bitbucket error",
+  jira: "Jira error",
+  keyring: "Credential storage error",
+  invalidArgument: "Invalid input",
+  command: "Command failed",
+  io: "I/O error",
+  timeout: "Timed out",
+};
+
+/** Lines that carry no signal for a one-line summary: git `hint:` guidance,
+ *  `Rebasing (x/y)` progress counters, and blanks. */
+function isNoiseLine(line: string): boolean {
+  const t = line.trim();
+  if (t === "") return true;
+  if (t.startsWith("hint:")) return true;
+  if (/^Rebasing \(\d+\/\d+\)/.test(t)) return true;
+  return false;
+}
+
+/** Strip a leading `error:` / `fatal:` prefix git tacks onto its diagnostics. */
+function stripGitPrefix(line: string): string {
+  return line.replace(/^(?:error|fatal):\s*/i, "").trim();
+}
+
+/** First meaningful line of a message, prefix-stripped. Falls back to the first
+ *  non-empty line (then the whole trimmed text) so a summary is never blank. */
+function firstMeaningfulLine(message: string): string {
+  const lines = message.split("\n");
+  const meaningful = lines.find((l) => !isNoiseLine(l));
+  if (meaningful) return stripGitPrefix(meaningful);
+  const nonEmpty = lines.find((l) => l.trim() !== "");
+  return stripGitPrefix(nonEmpty ?? message).trim() || message.trim();
+}
+
+/** Conflict-family markers — a paused rebase/merge/cherry-pick/revert. When any
+ *  appears we translate to a single calm line (the ConflictBanner already owns
+ *  the durable surface); the raw text still flows to fullText untouched. */
+const CONFLICT_MARKERS = [
+  "could not apply",
+  "Resolve all conflicts",
+  "CONFLICT (",
+  "needs merge",
+];
+
+/** The paused operation named in the text, capitalized for the summary. */
+function conflictOp(text: string): string {
+  const lower = text.toLowerCase();
+  const idx = ["rebase", "merge", "cherry-pick", "revert"]
+    .map((op) => ({ op, at: lower.indexOf(op) }))
+    .filter((m) => m.at !== -1)
+    .sort((a, b) => a.at - b.at)[0];
+  if (!idx) return "Operation";
+  const { op } = idx;
+  return op === "cherry-pick"
+    ? "Cherry-pick"
+    : op.charAt(0).toUpperCase() + op.slice(1);
+}
+
+/** Count of non-empty lines in a string. */
+function nonEmptyLineCount(text: string): number {
+  return text.split("\n").filter((l) => l.trim() !== "").length;
+}
+
+/**
+ * Humanize any thrown value into a toast-friendly summary plus the raw full
+ * text. AppErrors get a kind label; plain Error/string values get label null and
+ * their first line as the summary. Conflict-family errors collapse to one calm
+ * "<Op> paused" line while preserving the raw dump in `fullText`.
+ */
+export function presentError(e: unknown): ErrorPresentation {
+  if (isAppError(e)) {
+    const message = e.message ?? "";
+    const stderr = e.stderr?.trim() ?? "";
+    // Append stderr only when it adds something the message doesn't already carry.
+    const fullText =
+      stderr && !message.includes(stderr)
+        ? `${message}\n\n${stderr}`
+        : message;
+
+    const combined = `${message}\n${stderr}`;
+    const isConflict = CONFLICT_MARKERS.some((m) => combined.includes(m));
+    const summary = isConflict
+      ? `${conflictOp(combined)} paused — resolve the conflicts, then continue.`
+      : firstMeaningfulLine(message);
+
+    const distinctStderr = stderr !== "" && !message.includes(stderr);
+    const long =
+      nonEmptyLineCount(message) > 1 ||
+      distinctStderr ||
+      fullText.length > 140;
+
+    return { label: KIND_LABELS[e.kind], summary, fullText, long };
+  }
+
+  const message = e instanceof Error ? e.message : String(e);
+  const summary = firstMeaningfulLine(message);
+  const long = nonEmptyLineCount(message) > 1 || message.length > 140;
+  return { label: null, summary, fullText: message, long };
+}

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -58,25 +58,26 @@ function firstMeaningfulLine(message: string): string {
   return stripGitPrefix(nonEmpty ?? message).trim() || message.trim();
 }
 
-/** Conflict-family markers — a paused rebase/merge/cherry-pick/revert. When any
+/** Conflict-family markers (lowercase — matched case-insensitively, since git
+ *  emits both `error: could not apply …` and `Could not apply <sha>…`). When any
  *  appears we translate to a single calm line (the ConflictBanner already owns
  *  the durable surface); the raw text still flows to fullText untouched. */
 const CONFLICT_MARKERS = [
   "could not apply",
-  "Resolve all conflicts",
-  "CONFLICT (",
+  "resolve all conflicts",
+  "conflict (",
   "needs merge",
 ];
 
 /** The paused operation named in the text, capitalized for the summary. */
 function conflictOp(text: string): string {
   const lower = text.toLowerCase();
-  const idx = ["rebase", "merge", "cherry-pick", "revert"]
+  const found = ["rebase", "merge", "cherry-pick", "revert"]
     .map((op) => ({ op, at: lower.indexOf(op) }))
     .filter((m) => m.at !== -1)
     .sort((a, b) => a.at - b.at)[0];
-  if (!idx) return "Operation";
-  const { op } = idx;
+  if (!found) return "Operation";
+  const { op } = found;
   return op === "cherry-pick"
     ? "Cherry-pick"
     : op.charAt(0).toUpperCase() + op.slice(1);
@@ -104,10 +105,12 @@ export function presentError(e: unknown): ErrorPresentation {
         : message;
 
     const combined = `${message}\n${stderr}`;
-    const isConflict = CONFLICT_MARKERS.some((m) => combined.includes(m));
+    const combinedLower = combined.toLowerCase();
+    const isConflict = CONFLICT_MARKERS.some((m) => combinedLower.includes(m));
+    const label = KIND_LABELS[e.kind];
     const summary = isConflict
       ? `${conflictOp(combined)} paused — resolve the conflicts, then continue.`
-      : firstMeaningfulLine(message);
+      : firstMeaningfulLine(message) || label;
 
     const distinctStderr = stderr !== "" && !message.includes(stderr);
     const long =
@@ -115,11 +118,11 @@ export function presentError(e: unknown): ErrorPresentation {
       distinctStderr ||
       fullText.length > 140;
 
-    return { label: KIND_LABELS[e.kind], summary, fullText, long };
+    return { label, summary, fullText, long };
   }
 
   const message = e instanceof Error ? e.message : String(e);
-  const summary = firstMeaningfulLine(message);
+  const summary = firstMeaningfulLine(message) || "Unexpected error";
   const long = nonEmptyLineCount(message) > 1 || message.length > 140;
   return { label: null, summary, fullText: message, long };
 }

--- a/src/lib/stores/error-dialog.ts
+++ b/src/lib/stores/error-dialog.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import type { ErrorPresentation } from "@/lib/error-summary";
+
+/**
+ * Drives the globally-mounted ErrorDialog. A long error toast opens this with
+ * its presentation; the dialog shows the full raw text with Copy. Session-only,
+ * not persisted — only one error dialog is ever open at a time.
+ */
+interface ErrorDialogState {
+  /** The error currently shown in the dialog, or null when closed. */
+  presentation: ErrorPresentation | null;
+  /** Open the dialog on an error's presentation (the toast's "Details" action). */
+  open: (presentation: ErrorPresentation) => void;
+  /** Close the dialog (Close button / Esc / backdrop). */
+  close: () => void;
+}
+
+export const useErrorDialog = create<ErrorDialogState>()((set) => ({
+  presentation: null,
+  open: (presentation) => set({ presentation }),
+  close: () => set({ presentation: null }),
+}));

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,43 +1,30 @@
 import { toast } from "sonner";
-import { errorMessage } from "@/lib/tauri/invoke";
-
-const TOAST_MAX_LINES = 6;
-const TOAST_MAX_CHARS = 400;
-
-/** Keeps a long error (e.g. git/provider stderr) from ballooning the toast.
- *  The full text is still available via the Copy action. */
-function clampForToast(text: string): string {
-  let clamped = text.trim();
-  let truncated = false;
-  const lines = clamped.split("\n");
-  if (lines.length > TOAST_MAX_LINES) {
-    clamped = lines.slice(0, TOAST_MAX_LINES).join("\n");
-    truncated = true;
-  }
-  if (clamped.length > TOAST_MAX_CHARS) {
-    clamped = clamped.slice(0, TOAST_MAX_CHARS).trimEnd();
-    truncated = true;
-  }
-  return truncated
-    ? `${clamped}\n… (truncated — use Copy for the full text)`
-    : clamped;
-}
+import { presentError } from "@/lib/error-summary";
+import { useErrorDialog } from "@/lib/stores/error-dialog";
 
 /**
- * Error toast with a Copy action — git/provider errors are often long and
- * worth pasting into a search or an issue.
+ * Error toast — calm one-line summary. Short errors keep a Copy action (the full
+ * text is one line by construction); long errors (multi-line stderr, forge dumps)
+ * get a Details action that opens the ErrorDialog with the full raw text.
  */
 export function toastError(e: unknown) {
-  const full = errorMessage(e);
-  toast.error(clampForToast(full), {
+  const presentation = presentError(e);
+  const { summary, fullText, long } = presentation;
+
+  toast.error(summary, {
     duration: 8000,
-    action: {
-      label: "Copy",
-      onClick: () => {
-        navigator.clipboard.writeText(full).catch(() => {
-          // clipboard denied — nothing useful to do
-        });
-      },
-    },
+    action: long
+      ? {
+          label: "Details",
+          onClick: () => useErrorDialog.getState().open(presentation),
+        }
+      : {
+          label: "Copy",
+          onClick: () => {
+            navigator.clipboard.writeText(fullText).catch(() => {
+              // clipboard denied — nothing useful to do
+            });
+          },
+        },
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ErrorDialog } from "@/features/errors/ErrorDialog";
 import { initAnalytics, trackCaughtError } from "@/lib/analytics";
 import { calmTransition } from "@/lib/motion";
 import { queryClient } from "@/lib/query-client";
@@ -59,6 +60,7 @@ createRoot(document.getElementById("root")!).render(
           </LazyMotion>
         </ErrorBoundary>
         <Toaster position="bottom-right" closeButton />
+        <ErrorDialog />
       </TooltipProvider>
     </QueryClientProvider>
   </StrictMode>,


### PR DESCRIPTION
This update reworks error toast behavior to reduce noise from long or technical messages, aiming to present errors more calmly and helpfully to users. Long error messages now show a concise summary in the toast with a "Details" action that opens a dedicated dialog for the full text and a Copy button, improving clarity without losing access to complete diagnostics.

### Error handling and presentation
- Introduces `presentError` in `src/lib/error-summary.ts` to produce human-friendly error summaries and extract meaningful single-line explanations from errors; preserves full error text for dialogs.
- Adds `src/lib/stores/error-dialog.ts` with a global store to control the opened/closed state and content for the error details dialog.

### User interface
- Implements `ErrorDialog` component in `src/features/errors/ErrorDialog.tsx`, displaying the detailed error text with Copy and Close actions; integrates badge and summary headline.
- Mounts `ErrorDialog` at the app root in `src/main.tsx` alongside the Toaster.
- Modifies `toastError` in `src/lib/toast.ts` to present only a summary for long errors in toasts and attach either a "Details" or "Copy" action depending on error length.

### Documentation
- Adds `changelog.d/changed-error-toasts.md` describing the new behavior and its benefits.
- **Docs-sync note (deliberate):** this change ships with the changelog fragment only — no README/site/help-guide entries. The Details action is discovered in context on the error toast itself, and the in-app guide has no troubleshooting/errors section to extend (verified against `src/features/help/content.ts`). Recorded here per the repo's docs-sync convention ("too minor for README/site/guide" is a deliberate call, not an omission).