### PR TITLE
feat(opt): code-split agent, diff, hooks, and AI providers; narrow mutation invalidation; virtualize blame, unify avatars

### DIFF
--- a/changelog.d/changed-code-split-startup.md
+++ b/changelog.d/changed-code-split-startup.md
@@ -1,0 +1,1 @@
+- **Faster startup.** The app now boots from a much smaller core bundle — agent sessions, diff rendering, the git-hooks editor, and the AI provider SDKs each load on first use instead of on launch.

--- a/changelog.d/changed-consistent-avatars.md
+++ b/changelog.d/changed-consistent-avatars.md
@@ -1,0 +1,3 @@
+- Collaborator and member avatars in Repository Settings now use the standard
+  avatar component, showing a letter fallback when a user has no picture instead
+  of a blank circle.

--- a/changelog.d/changed-narrow-mutation-invalidation.md
+++ b/changelog.d/changed-narrow-mutation-invalidation.md
@@ -1,0 +1,3 @@
+- Snappier UI after issue, pull-request, and Jira actions: closing, editing,
+  commenting, and changing labels/priority/due-date now refresh just the item
+  you touched instead of refetching the whole repository's data.

--- a/changelog.d/fixed-blame-large-files.md
+++ b/changelog.d/fixed-blame-large-files.md
@@ -1,0 +1,3 @@
+- Blaming a very large file no longer freezes the app — the blame view now
+  virtualizes its rows and syntax-highlights only the lines currently on
+  screen, instead of rendering and highlighting every line at once.

--- a/changelog.d/fixed-gl-automerge-poll-hidden-tab.md
+++ b/changelog.d/fixed-gl-automerge-poll-hidden-tab.md
@@ -1,0 +1,3 @@
+- The GitLab auto-merge status poll now pauses while the Pulls tab is hidden,
+  instead of quietly polling the server every 8–30 seconds in the background.
+  Switching back to the Pulls tab refreshes it immediately.

--- a/changelog.d/fixed-keyboard-nav-commands-submodules.md
+++ b/changelog.d/fixed-keyboard-nav-commands-submodules.md
@@ -1,0 +1,3 @@
+- Arrow-key navigation on the custom slash-commands list (Settings) and the
+  submodules list — move between rows with the arrow keys and act on the
+  active row (edit a command, or initialize/update a submodule) with Enter.

--- a/changelog.d/fixed-review-history-lost-update.md
+++ b/changelog.d/fixed-review-history-lost-update.md
@@ -1,0 +1,5 @@
+- Fixed a rare lost update in stored AI review history: when two changes to a
+  PR's reviews landed at nearly the same time — for example an automated review
+  finishing while you edit or delete another review's text — one change could
+  silently overwrite the other. Overlapping writes are now serialized so neither
+  is dropped.

--- a/src/components/forge-user-avatar.tsx
+++ b/src/components/forge-user-avatar.tsx
@@ -1,30 +1,56 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { ForgeUserRef } from "@/lib/git/types";
+import { cn } from "@/lib/utils";
 
 /**
- * A forge user's avatar for picker rows, chips, and read-only lists (reviewers,
- * assignees). GitLab and Bitbucket supply a real `avatarUrl`, so we use it
- * directly; GitHub doesn't (its user `id` IS the login, and GitHub serves avatars
- * at `<host>/<login>.png`), so we derive it there — pass `ghHost` from
- * `useForgeGhHost(repoPath)`, which is `null` off GitHub. With neither — no URL and
- * off GitHub — the Avatar primitive falls back to the initial, keeping every
- * provider consistent. Mirrors `AuthorAvatar`'s fallback chain.
+ * The canonical forge-user avatar for picker rows, chips, and read-only lists
+ * (reviewers, assignees, collaborators, members, conversation authors). GitLab and
+ * Bitbucket supply a real `avatarUrl`, so we use it directly; GitHub doesn't (its
+ * user `id`/login IS the handle, and GitHub serves avatars at `<host>/<login>.png`),
+ * so we derive it there — pass `ghHost` from `useForgeGhHost(repoPath)` (or the
+ * active-repo hooks), which is `null` off GitHub. With neither — no URL and off
+ * GitHub — the Avatar primitive falls back to the initial, keeping every provider
+ * consistent. This is the single home for the user-avatar initials fallback.
+ *
+ * Callers with a full `ForgeUserRef` pass `user`; callers with a bare login (plus an
+ * optional real avatar URL) pass `login`/`avatarUrl`.
  */
 export function ForgeUserAvatar({
   user,
-  ghHost,
+  login,
+  avatarUrl,
+  ghHost = null,
+  size = "sm",
+  className,
+  decorative = false,
 }: {
-  user: ForgeUserRef;
-  ghHost: string | null;
+  /** A full forge user reference (id + label + avatarUrl). */
+  user?: ForgeUserRef;
+  /** A bare login, when the caller has no `ForgeUserRef`. Ignored if `user` is set. */
+  login?: string;
+  /** The provider's real avatar URL, when known and no `user` is passed. */
+  avatarUrl?: string;
+  /** GitHub host for login-derived avatars; `null`/omitted off GitHub. */
+  ghHost?: string | null;
+  size?: "sm" | "default" | "lg";
+  className?: string;
+  /** Hide the whole avatar from assistive tech when the login is shown as adjacent
+   *  text — otherwise a screen reader announces the fallback letter before the name. */
+  decorative?: boolean;
 }) {
-  const src =
-    user.avatarUrl || (ghHost ? `https://${ghHost}/${user.id}.png?size=48` : "");
+  // Normalize the two calling shapes into a single handle + label + real URL.
+  const handle = user?.id ?? login ?? "";
+  const label = user?.label ?? login ?? "";
+  const realUrl = user?.avatarUrl ?? avatarUrl ?? "";
+  const src = realUrl || (ghHost ? `https://${ghHost}/${handle}.png?size=48` : "");
   return (
-    <Avatar size="sm" className="shrink-0">
-      {src && <AvatarImage src={src} alt={user.label} />}
-      <AvatarFallback>
-        {(user.label || "?").charAt(0).toUpperCase()}
-      </AvatarFallback>
+    <Avatar
+      aria-hidden={decorative || undefined}
+      size={size}
+      className={cn("shrink-0", className)}
+    >
+      {src && <AvatarImage src={src} alt={decorative ? "" : label} />}
+      <AvatarFallback>{(label || "?").charAt(0).toUpperCase()}</AvatarFallback>
     </Avatar>
   );
 }

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -2,7 +2,7 @@ import { useDeferredValue, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffSurface } from "@/features/diff/DiffSurface";
+import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
 import { useBranchDiffFiles, useBranchFileDiff } from "@/lib/git/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { cn } from "@/lib/utils";

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -67,7 +67,9 @@ export function LabelsPopover({
     if (addNames.length > 0 || removeNames.length > 0) {
       editLabels.mutate(
         {
-          target,
+          // `target` is this popover's surface ("issue" | "mr"); it doubles as the
+          // reconcile `kind`. (Discussions use their own view, not this popover.)
+          kind: target,
           number,
           labelableId,
           addIds: ids(addNames),

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -1,8 +1,8 @@
 import { DotsThreeIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useState } from "react";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { MarkdownEditor } from "@/components/markdown-editor";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -71,10 +71,6 @@ export function AuthorAvatar({
   const host = useActiveGhHost();
   const ghHost = useActiveForgeGhHost();
   if (!login) return null;
-  // Prefer the provider's real avatar; otherwise derive from the login only on
-  // GitHub (its login serves at `<host>/<login>.png`). Off GitHub with no avatarUrl,
-  // fall through to the initial rather than requesting a bogus `<glhost>/<login>.png`.
-  const src = avatarUrl || (ghHost ? `https://${ghHost}/${login}.png?size=48` : "");
   return (
     <Button
       variant="ghost"
@@ -83,10 +79,7 @@ export function AuthorAvatar({
       title={`@${login} on ${host}`}
       className="shrink-0 rounded-full hover:opacity-80 cursor-pointer"
     >
-      <Avatar size="sm">
-        {src && <AvatarImage src={src} alt={login} />}
-        <AvatarFallback>{login.charAt(0).toUpperCase()}</AvatarFallback>
-      </Avatar>
+      <ForgeUserAvatar login={login} avatarUrl={avatarUrl} ghHost={ghHost} />
     </Button>
   );
 }

--- a/src/features/diff/DiffSurfaceLazy.tsx
+++ b/src/features/diff/DiffSurfaceLazy.tsx
@@ -11,7 +11,10 @@ import { type ComponentProps, lazy, Suspense } from "react";
 //
 // Prop types are derived from the real components via a type-only import of
 // the module below — types erase at build time, so this does NOT drag the
-// eager module back into the graph.
+// eager module back into the graph. NOTE: `typeof <type-only-imported value>`
+// is a TYPE QUERY and is valid TypeScript (the standard way to take a
+// component's props without a runtime import); only *value*-position use of a
+// type-only import is illegal. `tsc -b` compiles this file clean.
 import type {
   DiffContent as DiffContentImpl,
   DiffSurface as DiffSurfaceImpl,

--- a/src/features/diff/DiffSurfaceLazy.tsx
+++ b/src/features/diff/DiffSurfaceLazy.tsx
@@ -1,0 +1,71 @@
+import { type ComponentProps, lazy, Suspense } from "react";
+
+// @git-diff-view (and DiffSurface's render graph — Shiki wiring, the
+// multi-select workaround, DiffFile building) is heavy and only needed once a
+// diff is actually shown. Loading the real module lazily keeps that whole
+// chunk off the boot path: it splits into its own bundle and loads on first
+// use (tens of ms from local disk in a Tauri app). Every runtime consumer
+// OUTSIDE src/features/diff/ routes through these wrappers so the entry chunk
+// no longer eagerly pulls the library in. Files inside src/features/diff/
+// (DiffViewer &c.) keep importing ./DiffSurface directly.
+//
+// Prop types are derived from the real components via a type-only import of
+// the module below — types erase at build time, so this does NOT drag the
+// eager module back into the graph.
+import type {
+  DiffContent as DiffContentImpl,
+  DiffSurface as DiffSurfaceImpl,
+  GitDiffView as GitDiffViewImpl,
+} from "./DiffSurface";
+
+// Re-export the shared types so consumers keep a single import site — these
+// are erased at build time and pull in no runtime code.
+export type {
+  DiffContentRevs,
+  DiffLineAnchor,
+  LineWidget,
+  SyntaxPrefs,
+} from "./DiffSurface";
+
+// The diff panes these render into already show their own placeholders /
+// skeletons before data arrives (DiffContent itself renders nothing while
+// pending), and the chunk loads in tens of ms — so the least-flashy neutral
+// fallback (nothing) is correct here; a spinner would flash where the app
+// otherwise renders no intermediate state.
+const fallback = null;
+
+const DiffSurfaceLazyImpl = lazy(() =>
+  import("./DiffSurface").then((m) => ({ default: m.DiffSurface })),
+);
+
+export function DiffSurface(props: ComponentProps<typeof DiffSurfaceImpl>) {
+  return (
+    <Suspense fallback={fallback}>
+      <DiffSurfaceLazyImpl {...props} />
+    </Suspense>
+  );
+}
+
+const DiffContentLazyImpl = lazy(() =>
+  import("./DiffSurface").then((m) => ({ default: m.DiffContent })),
+);
+
+export function DiffContent(props: ComponentProps<typeof DiffContentImpl>) {
+  return (
+    <Suspense fallback={fallback}>
+      <DiffContentLazyImpl {...props} />
+    </Suspense>
+  );
+}
+
+const GitDiffViewLazyImpl = lazy(() =>
+  import("./DiffSurface").then((m) => ({ default: m.GitDiffView })),
+);
+
+export function GitDiffView(props: ComponentProps<typeof GitDiffViewImpl>) {
+  return (
+    <Suspense fallback={fallback}>
+      <GitDiffViewLazyImpl {...props} />
+    </Suspense>
+  );
+}

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -311,7 +311,16 @@ export function DiscussionView({
     const addIds = ids([...draftLabels].filter((n) => !applied.has(n)));
     const removeIds = ids([...applied].filter((n) => !draftLabels.has(n)));
     if (addIds.length > 0 || removeIds.length > 0) {
-      editLabels.mutate({ labelableId: d.id, addIds, removeIds }, { onError });
+      editLabels.mutate(
+        {
+          kind: "discussion",
+          number: d.number,
+          labelableId: d.id,
+          addIds,
+          removeIds,
+        },
+        { onError },
+      );
     }
   }
 

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -1,4 +1,6 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
 import hljs from "highlight.js/lib/common";
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -6,10 +8,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { diffLang } from "@/features/diff/diff-lang";
 import { useBlame } from "@/lib/git/queries";
+import type { BlameLine } from "@/lib/git/types";
 import { formatRelativeTime } from "@/lib/time";
 import "@/features/diff/code-highlight.css";
 
@@ -52,6 +54,12 @@ export function BlameDialog({
   const lines = blame.data ?? [];
   const name = path.split("/").pop() ?? path;
   const lang = diffLang(path);
+  // Native scroll container held in STATE (not a ref) so attaching it
+  // re-renders and the child's virtualizer re-initializes with the real node —
+  // a plain ref stays null at the virtualizer's mount effect, so
+  // getVirtualItems() returns [] and no rows paint. See
+  // docs/list-virtualization.md and HistoryPanel's `setScrollEl` wiring.
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -64,7 +72,11 @@ export function BlameDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="min-h-0 flex-1 border">
+        {/* Native overflow scroll container (not the Base-UI ScrollArea) so the
+            virtualizer's getScrollElement gets the real scrollable node — see
+            docs/list-virtualization.md. Fixed-height flex child so getTotalSize
+            resolves (max-h would leave it unbounded → 0). */}
+        <div ref={setScrollEl} className="min-h-0 flex-1 overflow-auto border">
           {blame.isPending ? (
             <div className="flex justify-center p-4">
               <Spinner />
@@ -76,41 +88,83 @@ export function BlameDialog({
           ) : lines.length === 0 ? (
             <p className="p-3 text-xs text-muted-foreground">Empty file.</p>
           ) : (
-            <div className="font-mono text-[11px] leading-relaxed">
-              {lines.map((line, i) => {
-                // Show the commit gutter only when it changes, like git's blame.
-                const newCommit = i === 0 || lines[i - 1].hash !== line.hash;
-                const when = line.time
-                  ? formatRelativeTime(new Date(line.time * 1000).toISOString())
-                  : "";
-                return (
-                  <div
-                    key={line.lineNo}
-                    className="flex items-start hover:bg-muted/40"
-                  >
-                    <span
-                      className="w-40 shrink-0 truncate border-r px-2 text-muted-foreground"
-                      title={
-                        newCommit
-                          ? `${line.hash.slice(0, 7)} · ${line.author} · ${when}\n${line.summary}`
-                          : undefined
-                      }
-                    >
-                      {newCommit
-                        ? `${line.hash.slice(0, 7)} ${line.author}`
-                        : ""}
-                    </span>
-                    <span className="w-10 shrink-0 select-none px-1 text-right text-muted-foreground/70">
-                      {line.lineNo}
-                    </span>
-                    <BlameCode content={line.content} language={lang} />
-                  </div>
-                );
-              })}
-            </div>
+            // Data-gated child: the useVirtualizer call lives here (never in the
+            // dialog host) so (a) BlameDialog keeps compiling under the React
+            // Compiler — useVirtualizer bails its host out — and (b) the
+            // virtualizer only mounts once there are lines, dodging the
+            // variable-height first-row measureElement race
+            // (docs/list-virtualization.md).
+            <BlameLines scrollEl={scrollEl} lines={lines} language={lang} />
           )}
-        </ScrollArea>
+        </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** The virtualized blame rows. Isolated in its own leaf so useVirtualizer
+ *  doesn't bail the dialog host out of the React Compiler, and so it mounts
+ *  only once `lines` is non-empty. hljs highlighting now runs only for the
+ *  mounted (visible) rows — the perf win for very large files. */
+function BlameLines({
+  scrollEl,
+  lines,
+  language,
+}: {
+  scrollEl: HTMLDivElement | null;
+  lines: BlameLine[];
+  language: string | undefined;
+}) {
+  const virtualizer = useVirtualizer({
+    count: lines.length,
+    getScrollElement: () => scrollEl,
+    // Most lines are a single ~18px text row; measureElement corrects any that
+    // wrap (whitespace-pre-wrap on long lines makes rows taller).
+    estimateSize: () => 18,
+    overscan: 24,
+    getItemKey: (index) => lines[index].lineNo,
+  });
+
+  return (
+    <div
+      className="relative w-full font-mono text-[11px] leading-relaxed"
+      style={{ height: `${virtualizer.getTotalSize()}px` }}
+    >
+      {virtualizer.getVirtualItems().map((vi) => {
+        const line = lines[vi.index];
+        // Show the commit gutter only when it changes, like git's blame.
+        // Index-based against the full `lines` array, so it works unchanged
+        // inside virtual rows.
+        const newCommit =
+          vi.index === 0 || lines[vi.index - 1].hash !== line.hash;
+        const when = line.time
+          ? formatRelativeTime(new Date(line.time * 1000).toISOString())
+          : "";
+        return (
+          <div
+            key={vi.key}
+            data-index={vi.index}
+            ref={virtualizer.measureElement}
+            className="absolute top-0 left-0 flex w-full items-start hover:bg-muted/40"
+            style={{ transform: `translateY(${vi.start}px)` }}
+          >
+            <span
+              className="w-40 shrink-0 truncate border-r px-2 text-muted-foreground"
+              title={
+                newCommit
+                  ? `${line.hash.slice(0, 7)} · ${line.author} · ${when}\n${line.summary}`
+                  : undefined
+              }
+            >
+              {newCommit ? `${line.hash.slice(0, 7)} ${line.author}` : ""}
+            </span>
+            <span className="w-10 shrink-0 select-none px-1 text-right text-muted-foreground/70">
+              {line.lineNo}
+            </span>
+            <BlameCode content={line.content} language={language} />
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -14,7 +14,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffSurface, type LineWidget } from "@/features/diff/DiffSurface";
+import { DiffSurface, type LineWidget } from "@/features/diff/DiffSurfaceLazy";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
 import {
   CommitComments,

--- a/src/features/history/FileHistoryDialog.tsx
+++ b/src/features/history/FileHistoryDialog.tsx
@@ -10,7 +10,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffSurface } from "@/features/diff/DiffSurface";
+import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
 import { useCommitFileDiff, useFileLog } from "@/lib/git/queries";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";

--- a/src/features/hooks/HooksDialog.tsx
+++ b/src/features/hooks/HooksDialog.tsx
@@ -1,7 +1,6 @@
 import { CaretDownIcon } from "@phosphor-icons/react";
-import { useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { CodeEditor } from "@/components/code-editor";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -30,6 +29,13 @@ import {
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { HOOK_TEMPLATES } from "./templates";
+
+// CodeMirror is heavy; lazy-load it so its chunk stays off the boot path and
+// only loads when the hooks dialog first opens. The dialog chrome (header,
+// hook list) renders instantly; a skeleton fills the editor area meanwhile.
+const CodeEditor = lazy(() =>
+  import("@/components/code-editor").then((m) => ({ default: m.CodeEditor })),
+);
 
 const DEFAULT_HOOK = "#!/bin/sh\n\n";
 
@@ -289,7 +295,11 @@ export function HooksDialog({
                   </div>
                   <div className="relative min-h-0 flex-1">
                     <div className="absolute inset-0">
-                      <CodeEditor value={draft} onChange={setDraft} />
+                      <Suspense
+                        fallback={<Skeleton className="h-full w-full" />}
+                      >
+                        <CodeEditor value={draft} onChange={setDraft} />
+                      </Suspense>
                     </div>
                   </div>
                   {noShebang && (

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffContent, type LineWidget } from "@/features/diff/DiffSurface";
+import { DiffContent, type LineWidget } from "@/features/diff/DiffSurfaceLazy";
 import { copyText } from "@/lib/clipboard";
 import { splitUnifiedDiff } from "@/lib/git/diff-split";
 import { useCommitComments, usePrCommitDiff } from "@/lib/git/queries";

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -235,10 +235,16 @@ export function RemotePrView({
   const unrequestChangesPr = useUnrequestChangesPr(repoPath);
   // Auto-merge state (GitLab-only): read only for a ready GitLab repo with an open
   // MR (null disables the read for GitHub / closed MRs). It polls server-side so the
-  // view notices the pipeline completing and the auto-merge firing.
+  // view notices the pipeline completing and the auto-merge firing. Gate on the Pulls
+  // tab being active too: the <Activity>-hidden subtree still renders, so the composite
+  // gate is load-bearing — a disabled query (null number) stops the refetchInterval, and
+  // staleTime (5s) means returning to the tab refetches immediately.
+  const repoTab = useUiStore((s) => s.repoTab);
   const mergeState = useGlMrMergeState(
     repoPath,
-    canAutoMerge && details.data?.state === "OPEN" ? number : null,
+    repoTab === "pulls" && canAutoMerge && details.data?.state === "OPEN"
+      ? number
+      : null,
   );
   const armAutoMerge = useGlArmAutoMerge(repoPath);
   const cancelAutoMerge = useGlCancelAutoMerge(repoPath);

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -22,7 +22,7 @@ import {
   DiffContent,
   type DiffLineAnchor,
   type LineWidget,
-} from "@/features/diff/DiffSurface";
+} from "@/features/diff/DiffSurfaceLazy";
 import { TimeTrackingControls } from "@/features/issues/RemoteIssueViewParts";
 import {
   useAddMrSpentTime,

--- a/src/features/repo-settings/CollaboratorsSection.tsx
+++ b/src/features/repo-settings/CollaboratorsSection.tsx
@@ -1,6 +1,7 @@
 import { UserPlusIcon, XIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -264,13 +265,7 @@ function PersonRow({
 }) {
   return (
     <div className="flex items-center gap-2 rounded-md border p-2 text-xs">
-      <div
-        aria-hidden
-        className="size-6 shrink-0 rounded-full bg-muted bg-cover bg-center"
-        style={
-          avatarUrl ? { backgroundImage: `url("${avatarUrl}")` } : undefined
-        }
-      />
+      <ForgeUserAvatar login={login} avatarUrl={avatarUrl} decorative />
       <div className="min-w-0 flex-1">
         <p className="truncate font-medium" title={login}>
           {login}

--- a/src/features/repo-settings/GitLabMembersSection.tsx
+++ b/src/features/repo-settings/GitLabMembersSection.tsx
@@ -1,6 +1,7 @@
 import { UserPlusIcon, XIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -191,14 +192,10 @@ function MemberRow({
 }) {
   return (
     <div className="flex items-center gap-2 rounded-md border p-2 text-xs">
-      <div
-        aria-hidden
-        className="size-6 shrink-0 rounded-full bg-muted bg-cover bg-center"
-        style={
-          member.avatarUrl
-            ? { backgroundImage: `url("${member.avatarUrl}")` }
-            : undefined
-        }
+      <ForgeUserAvatar
+        login={member.username}
+        avatarUrl={member.avatarUrl}
+        decorative
       />
       <div className="min-w-0 flex-1">
         <p className="truncate font-medium" title={member.username}>

--- a/src/features/repository/ConflictResolveView.tsx
+++ b/src/features/repository/ConflictResolveView.tsx
@@ -10,7 +10,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Spinner } from "@/components/ui/spinner";
-import { GitDiffView } from "@/features/diff/DiffSurface";
+import { GitDiffView } from "@/features/diff/DiffSurfaceLazy";
 import { HighlightedCode } from "@/features/diff/HighlightedCode";
 import {
   buildConflictPrompt,

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -22,7 +22,7 @@ import {
   WarningCircleIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -46,7 +46,6 @@ import { RepoAutomationsDialog } from "@/features/automations/RepoAutomationsDia
 import { BranchRulesDialog } from "@/features/branch-rules/BranchRulesDialog";
 import { HooksDialog } from "@/features/hooks/HooksDialog";
 import { RepoJiraDialog } from "@/features/issues/RepoJiraDialog";
-import { RepoSettingsDialog } from "@/features/repo-settings/RepoSettingsDialog";
 import { copyText } from "@/lib/clipboard";
 import {
   forgeRepoUrl,
@@ -77,6 +76,21 @@ import { RemoveRepoDialog, RepoAliasDialog } from "./RepoDialogs";
 import { RepositoryFilesDialog } from "./RepositoryFilesDialog";
 import { SubmodulesDialog } from "./SubmodulesDialog";
 import { WorktreesDialog } from "./WorktreesDialog";
+
+// RepoSettingsDialog's tree pulls in the Shiki highlighter (via parts.tsx →
+// shiki-highlighter's highlightJson), which is heavy and only needed once an
+// admin opens repository settings. Loading it lazily keeps that chunk off the
+// boot path. The dialog is rendered ONLY while open (not always-mounted like
+// the sibling dialogs): a lazy component that is always rendered loads its
+// chunk immediately, defeating the split — the open-gate is what defers the
+// import to first open. Trade-off: the dialog no longer stays mounted across
+// close/reopen, so its remembered rail section resets to "general" each open
+// (see the state note at its render site).
+const RepoSettingsDialog = lazy(() =>
+  import("@/features/repo-settings/RepoSettingsDialog").then((m) => ({
+    default: m.RepoSettingsDialog,
+  })),
+);
 
 export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const gh = useForgeStatus(repoPath);
@@ -418,11 +432,22 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
         onOpenChange={setJiraOpen}
         existingLink={jiraLink.data ?? null}
       />
-      <RepoSettingsDialog
-        repoPath={repoPath}
-        open={repoSettingsOpen}
-        onOpenChange={setRepoSettingsOpen}
-      />
+      {/* Open-gated (unlike the always-mounted siblings above) so its lazy
+          chunk loads on first open, not on boot. `open` stays true while
+          mounted; `onOpenChange(false)` flips the gate, unmounting the subtree
+          — the same immediate-unmount-on-close idiom the other open-gated
+          dialogs in this app use (e.g. ImportMcpDialog). The dialog's remembered
+          rail section (its internal `section` state) no longer persists across
+          close/reopen and resets to "general" each open. */}
+      {repoSettingsOpen && (
+        <Suspense fallback={null}>
+          <RepoSettingsDialog
+            repoPath={repoPath}
+            open={repoSettingsOpen}
+            onOpenChange={setRepoSettingsOpen}
+          />
+        </Suspense>
+      )}
       <BranchRulesDialog
         repoPath={repoPath}
         open={branchRulesOpen}

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -32,7 +32,6 @@ import { CommitBox } from "@/features/commit/CommitBox";
 import { BranchDiffView } from "@/features/compare/BranchDiffView";
 import { ComparePanel } from "@/features/compare/ComparePanel";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffViewer } from "@/features/diff/DiffViewer";
 import { DiscussionsPanel } from "@/features/discussions/DiscussionsPanel";
 import { DiscussionView } from "@/features/discussions/DiscussionView";
 import { CommitDetailView } from "@/features/history/CommitDetailView";
@@ -46,8 +45,6 @@ import { PullRequestsPanel } from "@/features/pulls/PullRequestsPanel";
 import { RemotePrView } from "@/features/pulls/RemotePrView";
 import { useCleanupResolveWorktrees } from "@/features/pulls/useCleanupResolveWorktrees";
 import { useWatchPrHeads } from "@/features/pulls/useWatchPrHeads";
-import { SessionList } from "@/features/sessions/SessionList";
-import { SessionView } from "@/features/sessions/SessionView";
 import { TagDetailView } from "@/features/tags/TagDetailView";
 import { TagsPanel } from "@/features/tags/TagsPanel";
 import {
@@ -77,6 +74,29 @@ const APP_TITLE = import.meta.env.DEV ? "GitDesktop (Dev)" : "GitDesktop";
 const InsightsBoard = lazy(() =>
   import("./insights/InsightsBoard").then((m) => ({
     default: m.InsightsBoard,
+  })),
+);
+
+// The Agent surface (write-capable sessions) is a heavy, AI-only graph; lazy it
+// the same way so its chunk stays off the boot path until the Agent tab is first
+// opened. Gated by `aiEnabled` too — with Hide AI on, it never loads.
+const SessionList = lazy(() =>
+  import("@/features/sessions/SessionList").then((m) => ({
+    default: m.SessionList,
+  })),
+);
+const SessionView = lazy(() =>
+  import("@/features/sessions/SessionView").then((m) => ({
+    default: m.SessionView,
+  })),
+);
+
+// The diff viewer pulls in the @git-diff-view stack; lazy it so that chunk
+// loads with the first diff render rather than on boot. It sits in the default
+// "changes" tab, so the load happens on first paint (tens of ms from disk).
+const DiffViewer = lazy(() =>
+  import("@/features/diff/DiffViewer").then((m) => ({
+    default: m.DiffViewer,
   })),
 );
 
@@ -145,6 +165,11 @@ export function RepositoryView() {
   // its chunk + heavy queries off the boot path until the user opens Insights.
   const [insightsSeen, setInsightsSeen] = useState(false);
   if (repoTab === "insights" && !insightsSeen) setInsightsSeen(true);
+  // Same latch for the (lazy) Agent surface: mount it once its tab is first
+  // opened, then keep it mounted so <Activity> preserves session state. Keeps
+  // the agent chunk off the boot path until the user opens the Agent tab.
+  const [agentSeen, setAgentSeen] = useState(false);
+  if (repoTab === "agent" && !agentSeen) setAgentSeen(true);
 
   // OS notifications for PR/check and workflow-run events while this repo is open.
   usePrNotifications(repoPath ?? "");
@@ -322,13 +347,19 @@ export function RepositoryView() {
           </Activity>
           {aiEnabled && (
             <Activity mode={mode("agent")}>
-              <SessionList repoPath={repoPath} />
+              {agentSeen && (
+                <Suspense fallback={null}>
+                  <SessionList repoPath={repoPath} />
+                </Suspense>
+              )}
             </Activity>
           )}
         </aside>
         <main className="min-w-0 flex-1">
           <Activity mode={mode("changes")}>
-            <DiffViewer repoPath={repoPath} />
+            <Suspense fallback={null}>
+              <DiffViewer repoPath={repoPath} />
+            </Suspense>
           </Activity>
           <Activity mode={mode("history")}>
             {deferredCommitHash ? (
@@ -440,7 +471,11 @@ export function RepositoryView() {
           </Activity>
           {aiEnabled && (
             <Activity mode={mode("agent")}>
-              <SessionView repoPath={repoPath} />
+              {agentSeen && (
+                <Suspense fallback={null}>
+                  <SessionView repoPath={repoPath} />
+                </Suspense>
+              )}
             </Activity>
           )}
         </main>

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffSurface } from "@/features/diff/DiffSurface";
+import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
 import type { ImageRevs } from "@/features/diff/ImageDiff";
 import {
   useOrphanedStashes,

--- a/src/features/repository/SubmodulesDialog.tsx
+++ b/src/features/repository/SubmodulesDialog.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -11,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { useSubmodules, useUpdateSubmodule } from "@/lib/git/queries";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { toastError } from "@/lib/toast";
 
 const STATUS: Record<
@@ -35,6 +37,20 @@ export function SubmodulesDialog({
   const subs = useSubmodules(repoPath);
   const update = useUpdateSubmodule(repoPath);
   const list = subs.data ?? [];
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  // Refetching may shrink `list` while `activeIndex` lingers, so clamp the
+  // stale value (keeping -1 = "nothing active yet") to keep a row focusable.
+  const safeActive =
+    activeIndex >= list.length ? list.length - 1 : activeIndex;
+
+  const onKeyDown = listKeyboardNav<(typeof list)[number]>({
+    items: list,
+    activeIndex: safeActive,
+    onActivate: (_s, to) => setActiveIndex(to),
+    rowKey: (s) => s.path,
+    rowAttr: "data-sub-row",
+  });
 
   function doUpdate(path?: string) {
     update.mutate(path, {
@@ -55,7 +71,12 @@ export function SubmodulesDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-96 overflow-y-auto border">
+        {/* A roving-focus list — arrow keys move between rows, Enter runs the
+            row's Initialize/Update action. */}
+        <div
+          className="max-h-96 overflow-y-auto border"
+          onKeyDown={onKeyDown}
+        >
           {subs.isPending ? (
             <div className="flex justify-center p-4">
               <Spinner />
@@ -65,15 +86,35 @@ export function SubmodulesDialog({
               This repository has no submodules.
             </p>
           ) : (
-            list.map((s) => {
+            list.map((s, i) => {
               const meta = STATUS[s.status] ?? {
                 label: s.status,
                 variant: "outline" as const,
               };
+              const action =
+                s.status === "uninitialized" ? "Initialize" : "Update";
               return (
                 <div
                   key={s.path}
-                  className="flex items-center gap-2 border-b px-3 py-2 text-xs last:border-b-0"
+                  data-sub-row={s.path}
+                  aria-label={`${s.path}, ${meta.label}. Press Enter to ${action.toLowerCase()}.`}
+                  tabIndex={
+                    i === safeActive || (safeActive === -1 && i === 0) ? 0 : -1
+                  }
+                  onFocus={() => setActiveIndex(i)}
+                  onKeyDown={(e) => {
+                    // Only the row itself acts on Enter — not when the child
+                    // Initialize/Update button is focused.
+                    if (
+                      e.key === "Enter" &&
+                      e.target === e.currentTarget &&
+                      !update.isPending
+                    ) {
+                      e.preventDefault();
+                      doUpdate(s.path);
+                    }
+                  }}
+                  className="flex items-center gap-2 border-b px-3 py-2 text-xs outline-none last:border-b-0 focus-visible:ring-1 focus-visible:ring-ring"
                 >
                   <div className="min-w-0 flex-1">
                     <p className="truncate font-mono font-medium">{s.path}</p>
@@ -89,7 +130,7 @@ export function SubmodulesDialog({
                     disabled={update.isPending}
                     onClick={() => doUpdate(s.path)}
                   >
-                    {s.status === "uninitialized" ? "Initialize" : "Update"}
+                    {action}
                   </Button>
                 </div>
               );

--- a/src/features/sessions/AgentTranscript.tsx
+++ b/src/features/sessions/AgentTranscript.tsx
@@ -13,7 +13,7 @@ import {
 import type { UseQueryResult } from "@tanstack/react-query";
 import { type ComponentType, useState } from "react";
 import { Markdown } from "@/components/ui/markdown";
-import { GitDiffView } from "@/features/diff/DiffSurface";
+import { GitDiffView } from "@/features/diff/DiffSurfaceLazy";
 import type { AgentToolKind, TranscriptSegment } from "@/lib/ai/agent";
 import { useSessionFileDiff } from "@/lib/git/queries";
 import type { FileDiff } from "@/lib/git/types";

--- a/src/features/sessions/WorktreeChangesView.tsx
+++ b/src/features/sessions/WorktreeChangesView.tsx
@@ -3,7 +3,7 @@ import { useDeferredValue, useState } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { DiffSurface } from "@/features/diff/DiffSurface";
+import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
 import { gitDiffFile, gitStatus } from "@/lib/git/api";
 import type { ChangeKind, FileEntry } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";

--- a/src/features/settings/CommandsSection.tsx
+++ b/src/features/settings/CommandsSection.tsx
@@ -15,6 +15,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { BUILTIN_COMMANDS } from "@/lib/ai/slash";
 import { withForm } from "@/lib/form";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { CustomCommand } from "@/lib/settings/api";
 import { settingsFormOpts } from "./settings-form";
 
@@ -171,8 +172,22 @@ export const CommandsSection = withForm({
   render: function CommandsSectionRender({ form }) {
     const commands = useSelector(form.store, (s) => s.values.customCommands);
     const [editing, setEditing] = useState<CustomCommand | "new" | null>(null);
+    const [activeIndex, setActiveIndex] = useState(-1);
 
     const list = commands ?? [];
+
+    // Removing rows shrinks `list` but not `activeIndex`, so clamp the stale
+    // value (keeping -1 = "nothing active yet") to keep a row focusable.
+    const safeActive =
+      activeIndex >= list.length ? list.length - 1 : activeIndex;
+
+    const onKeyDown = listKeyboardNav<CustomCommand>({
+      items: list,
+      activeIndex: safeActive,
+      onActivate: (_c, to) => setActiveIndex(to),
+      rowKey: (c) => c.id,
+      rowAttr: "data-cc-row",
+    });
 
     function setCommands(next: CustomCommand[]) {
       form.setFieldValue("customCommands", next);
@@ -234,11 +249,26 @@ export const CommandsSection = withForm({
             in a repo to share them with your team.
           </p>
         ) : (
-          <div className="space-y-2">
-            {list.map((cmd) => (
+          // A roving-focus list — arrow keys move between rows, Enter edits.
+          <div className="space-y-2" onKeyDown={onKeyDown}>
+            {list.map((cmd, i) => (
               <div
                 key={cmd.id}
-                className="flex items-center gap-2 rounded border px-3 py-2"
+                data-cc-row={cmd.id}
+                aria-label={`/${cmd.name}${cmd.description ? `, ${cmd.description}` : ""}. Press Enter to edit.`}
+                tabIndex={
+                  i === safeActive || (safeActive === -1 && i === 0) ? 0 : -1
+                }
+                onFocus={() => setActiveIndex(i)}
+                onKeyDown={(e) => {
+                  // Only the row itself edits on Enter — not when a child
+                  // control (the Edit/Remove buttons) is focused.
+                  if (e.key === "Enter" && e.target === e.currentTarget) {
+                    e.preventDefault();
+                    setEditing(cmd);
+                  }
+                }}
+                className="flex items-center gap-2 rounded border px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
                 <code className="shrink-0 font-mono text-xs font-medium">
                   /{cmd.name}

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { NavRail } from "@/components/NavRail";
 import { Button } from "@/components/ui/button";
@@ -36,10 +36,21 @@ import { InstructionsSection } from "./InstructionsSection";
 import { KeyboardSection } from "./KeyboardSection";
 import { McpServersSection } from "./McpServersSection";
 import { NotificationsSection } from "./NotificationsSection";
-import { SyntaxSection } from "./SyntaxSection";
 import { settingsFormOpts, toDraft } from "./settings-form";
 import { TerminalSection } from "./TerminalSection";
 import { UpdatesSection } from "./UpdatesSection";
+
+// The Syntax panel pulls in the Shiki TextMate highlighter (@git-diff-view +
+// @shikijs/core), which is heavy and only needed once this panel is visited.
+// Loading it lazily keeps that whole chunk off the boot path — its render is
+// already gated on `activePanel === "syntax"`, so the import fires on first
+// visit, not on launch. `lazy` on the named export preserves the `form` prop's
+// full type. The fallback is null: the panel renders instantly once loaded (tens
+// of ms from local disk) and, like the other panels, shows no intermediate
+// state before its data — a spinner would flash where nothing otherwise does.
+const SyntaxSection = lazy(() =>
+  import("./SyntaxSection").then((m) => ({ default: m.SyntaxSection })),
+);
 
 const PANELS = [
   { id: "general", label: "General" },
@@ -273,7 +284,11 @@ export function SettingsScreen() {
                   {repoPath && <RepoIdentitySection repoPath={repoPath} />}
                 </>
               )}
-              {activePanel === "syntax" && <SyntaxSection form={form} />}
+              {activePanel === "syntax" && (
+                <Suspense fallback={null}>
+                  <SyntaxSection form={form} />
+                </Suspense>
+              )}
               {activePanel === "editor" && <EditorSection form={form} />}
               {activePanel === "terminal" && <TerminalSection form={form} />}
               {activePanel === "updates" && <UpdatesSection form={form} />}

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -7,7 +7,7 @@ import {
 } from "ai";
 import { getSecret } from "@/lib/git/api";
 import { errorMessage } from "@/lib/tauri/invoke";
-import { createModel, PROVIDERS_REQUIRING_KEY } from "./providers";
+import { PROVIDERS_REQUIRING_KEY } from "./providers";
 import { httpToolStatusLine } from "./review-tools";
 import type { AiClient, AiSettings, AiStreamRequest } from "./types";
 
@@ -38,6 +38,10 @@ export async function resolveModel(
   if (needsKey && !apiKey) {
     throw new MissingApiKeyError(settings.provider);
   }
+  // The heavy AI-SDK provider packages live in `model-factory` and load only
+  // here, on the first real generation — after the key check above, so the
+  // MissingApiKeyError path never pays for (or surfaces) the import.
+  const { createModel } = await import("./model-factory");
   return createModel(settings, apiKey, allowedHostsOverride);
 }
 

--- a/src/lib/ai/model-factory.ts
+++ b/src/lib/ai/model-factory.ts
@@ -1,0 +1,62 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import type { LanguageModel } from "ai";
+import { createOllama } from "ollama-ai-provider-v2";
+import { guardedFetch } from "./guarded-fetch";
+import { OLLAMA_CLOUD_HOST } from "./providers";
+import type { AiSettings } from "./types";
+
+// All providers go through `guardedFetch` (guarded-fetch.ts) — the Tauri fetch
+// (proxied through Rust, exempt from the webview CORS most AI APIs reject) behind
+// the host allowlist. `allowedHostsOverride` is the unsaved draft list for
+// Settings "Test connection"; omitted elsewhere so the saved list applies.
+//
+// This module owns the four heavyweight AI-SDK provider packages
+// (@ai-sdk/anthropic, @ai-sdk/openai, @openrouter/ai-sdk-provider,
+// ollama-ai-provider-v2). It's kept separate from providers.ts — whose light
+// constants are imported eagerly across the app — and loaded via dynamic
+// import from client.ts so those packages stay off the boot path until an AI
+// generation actually runs.
+export function createModel(
+  settings: AiSettings,
+  apiKey: string | null,
+  allowedHostsOverride?: readonly string[],
+): LanguageModel {
+  const fetch = guardedFetch(allowedHostsOverride);
+  switch (settings.provider) {
+    case "anthropic":
+      return createAnthropic({ apiKey: apiKey ?? "", fetch })(settings.model);
+    case "openai":
+      return createOpenAI({ apiKey: apiKey ?? "", fetch })(settings.model);
+    case "openai-compatible":
+      // Any OpenAI-compatible endpoint (custom base URL). `.chat()` forces the
+      // `/chat/completions` API — third-party endpoints don't implement OpenAI's
+      // Responses API that the default `openai(model)` would target.
+      return createOpenAI({
+        baseURL: settings.openaiCompatibleBaseUrl.replace(/\/$/, ""),
+        apiKey: apiKey ?? "",
+        fetch,
+      }).chat(settings.model);
+    case "openrouter":
+      return createOpenRouter({ apiKey: apiKey ?? "", fetch })(settings.model);
+    case "ollama":
+      return createOllama({
+        baseURL: `${settings.ollamaBaseUrl.replace(/\/$/, "")}/api`,
+        fetch,
+      })(settings.model);
+    case "ollama-cloud":
+      return createOllama({
+        baseURL: `${OLLAMA_CLOUD_HOST}/api`,
+        headers: { Authorization: `Bearer ${apiKey ?? ""}` },
+        fetch,
+      })(settings.model);
+    case "claude-cli":
+    case "codex-cli":
+    case "copilot-cli":
+    case "opencode-cli":
+      // CLI agents run as a subprocess, not through the AI SDK. Callers must
+      // route these through the agent-CLI path before reaching createModel.
+      throw new Error("CLI providers do not use the AI SDK model path");
+  }
+}

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -1,10 +1,4 @@
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createOpenAI } from "@ai-sdk/openai";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import type { LanguageModel } from "ai";
-import { createOllama } from "ollama-ai-provider-v2";
-import { guardedFetch } from "./guarded-fetch";
-import type { AiProviderId, AiSettings } from "./types";
+import type { AiProviderId } from "./types";
 
 export const PROVIDER_LABELS: Record<AiProviderId, string> = {
   anthropic: "Anthropic",
@@ -181,51 +175,4 @@ const PROVIDERS_WITHOUT_DEFAULT_MODEL: readonly AiProviderId[] = ["codex-cli"];
 export function defaultModelForProvider(provider: AiProviderId): string {
   if (PROVIDERS_WITHOUT_DEFAULT_MODEL.includes(provider)) return "";
   return MODEL_SUGGESTIONS[provider][0] ?? "";
-}
-
-// All providers go through `guardedFetch` (guarded-fetch.ts) — the Tauri fetch
-// (proxied through Rust, exempt from the webview CORS most AI APIs reject) behind
-// the host allowlist. `allowedHostsOverride` is the unsaved draft list for
-// Settings "Test connection"; omitted elsewhere so the saved list applies.
-export function createModel(
-  settings: AiSettings,
-  apiKey: string | null,
-  allowedHostsOverride?: readonly string[],
-): LanguageModel {
-  const fetch = guardedFetch(allowedHostsOverride);
-  switch (settings.provider) {
-    case "anthropic":
-      return createAnthropic({ apiKey: apiKey ?? "", fetch })(settings.model);
-    case "openai":
-      return createOpenAI({ apiKey: apiKey ?? "", fetch })(settings.model);
-    case "openai-compatible":
-      // Any OpenAI-compatible endpoint (custom base URL). `.chat()` forces the
-      // `/chat/completions` API — third-party endpoints don't implement OpenAI's
-      // Responses API that the default `openai(model)` would target.
-      return createOpenAI({
-        baseURL: settings.openaiCompatibleBaseUrl.replace(/\/$/, ""),
-        apiKey: apiKey ?? "",
-        fetch,
-      }).chat(settings.model);
-    case "openrouter":
-      return createOpenRouter({ apiKey: apiKey ?? "", fetch })(settings.model);
-    case "ollama":
-      return createOllama({
-        baseURL: `${settings.ollamaBaseUrl.replace(/\/$/, "")}/api`,
-        fetch,
-      })(settings.model);
-    case "ollama-cloud":
-      return createOllama({
-        baseURL: `${OLLAMA_CLOUD_HOST}/api`,
-        headers: { Authorization: `Bearer ${apiKey ?? ""}` },
-        fetch,
-      })(settings.model);
-    case "claude-cli":
-    case "codex-cli":
-    case "copilot-cli":
-    case "opencode-cli":
-      // CLI agents run as a subprocess, not through the AI SDK. Callers must
-      // route these through the agent-CLI path before reaching createModel.
-      throw new Error("CLI providers do not use the AI SDK model path");
-  }
 }

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -478,8 +478,12 @@ async function deliver(
 
   if (event.target.type === "remote") {
     await forgePrComment(event.repoPath, event.target.number, body, true);
+    // Narrow to the PR's own key family (prefix-matches its detail/reactions/
+    // timeline/review-threads) rather than the whole-repo subtree — a posted
+    // conversation comment only touches this PR. Mirrors the local-target path
+    // below, which invalidates just its own store.
     await queryClient.invalidateQueries({
-      queryKey: ["repo", event.repoPath],
+      queryKey: ["repo", event.repoPath, "pr", event.target.number],
     });
     toast.success(`AI ${label} posted on #${event.target.number}`);
     if (notify) {

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -954,6 +954,59 @@ const commitCommentsKey = (repo: string, sha: string) =>
   ["repo", repo, "commit", sha, "comments"] as const;
 
 /**
+ * The shared skeleton behind every optimistic-cache mutation in this file:
+ * cancel in-flight fetches on the target key, snapshot it, apply an optimistic
+ * `setQueryData` patch, roll the snapshot back on error, and reconcile on
+ * settle. The five exported factories below (`useOptimisticCommitCommentMutation`,
+ * `useOptimisticIssueMutation`, `useOptimisticCreateCommentMutation`,
+ * `useOptimisticCommentMutation`, `useOptimisticReviewCommentMutation`) are thin
+ * wrappers over this — they only differ in the *deltas*:
+ *
+ * - `keyFor(args)` — the cache key to patch (derived from the mutation args at
+ *   mutate time, so a mid-flight repo/number/sha switch never corrupts another
+ *   key's cache).
+ * - `patch(prev, args)` — the optimistic `setQueryData` updater.
+ * - `reconcile(queryClient, args)` — the onSettled invalidation. Four factories
+ *   pass a repo-wide invalidate (server-truth reconciliation, matching what
+ *   `useRepoMutation`'s default did before they were made optimistic); the issue
+ *   factory passes a narrow single-issue invalidate.
+ *
+ * `TCache` is the shape stored at the key (a list, a detail object, …); the
+ * rollback context carries the exact key + prior value so onError restores
+ * precisely what onMutate captured.
+ */
+function useOptimisticCacheMutation<TArgs, TData, TCache>(
+  mutationFn: (args: TArgs) => Promise<TData>,
+  keyFor: (args: TArgs) => QueryKey,
+  patch: (prev: TCache | undefined, args: TArgs) => TCache | undefined,
+  reconcile: (
+    queryClient: ReturnType<typeof useQueryClient>,
+    args: TArgs,
+  ) => void,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn,
+    onMutate: async (args: TArgs) => {
+      const key = keyFor(args);
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData<TCache>(key);
+      queryClient.setQueryData<TCache>(key, (data) => patch(data, args));
+      return { prev, key };
+    },
+    onError: (
+      _e: unknown,
+      _args: TArgs,
+      ctx: { prev: TCache | undefined; key: QueryKey } | undefined,
+    ) => {
+      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
+    },
+    onSettled: (_d: TData | undefined, _e: unknown, args: TArgs) =>
+      reconcile(queryClient, args),
+  });
+}
+
+/**
  * Optimistically append a synthetic commit comment to the commit-comments cache,
  * with exact-key rollback — mirroring {@link useOptimisticCreateCommentMutation}
  * for the flat commit-comment list. The synthetic row carries a collision-proof
@@ -1036,32 +1089,22 @@ function useOptimisticCommitCommentMutation<TData>(
     args: { sha: string; commentId: string; body?: string },
   ) => CommitCommentOut | null,
 ) {
-  const queryClient = useQueryClient();
-  return useMutation({
+  return useOptimisticCacheMutation<
+    { sha: string; commentId: string; body?: string },
+    TData,
+    CommitCommentOut[]
+  >(
     mutationFn,
-    onMutate: async (args: {
-      sha: string;
-      commentId: string;
-      body?: string;
-    }) => {
-      const key = commitCommentsKey(repo, args.sha);
-      await queryClient.cancelQueries({ queryKey: key });
-      const prev = queryClient.getQueryData<CommitCommentOut[]>(key);
-      queryClient.setQueryData<CommitCommentOut[]>(key, (list) =>
-        list?.flatMap((c) => {
-          if (c.id !== args.commentId) return [c];
-          const patched = patchComment(c, args);
-          return patched ? [patched] : [];
-        }),
-      );
-      return { prev, key };
-    },
-    onError: (_e, _args, ctx) => {
-      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
-    },
-    onSettled: () =>
+    (args) => commitCommentsKey(repo, args.sha),
+    (list, args) =>
+      list?.flatMap((c) => {
+        if (c.id !== args.commentId) return [c];
+        const patched = patchComment(c, args);
+        return patched ? [patched] : [];
+      }),
+    (queryClient) =>
       void queryClient.invalidateQueries({ queryKey: repoKeys.all(repo) }),
-  });
+  );
 }
 
 export function useEditCommitComment(repo: string) {
@@ -1336,26 +1379,16 @@ function useOptimisticIssueMutation<TArgs extends { number: number }, TData>(
   mutationFn: (args: TArgs) => Promise<TData>,
   patch: (issue: IssueDetails, args: TArgs) => IssueDetails,
 ) {
-  const queryClient = useQueryClient();
-  return useMutation({
+  return useOptimisticCacheMutation<TArgs, TData, IssueDetails>(
     mutationFn,
-    onMutate: async (args: TArgs) => {
-      const key = ["repo", repo, "issue", args.number] as const;
-      await queryClient.cancelQueries({ queryKey: key });
-      const prev = queryClient.getQueryData<IssueDetails>(key);
-      queryClient.setQueryData<IssueDetails>(key, (d) =>
-        d ? patch(d, args) : d,
-      );
-      return { prev, key };
-    },
-    onError: (_e, _args, ctx) => {
-      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
-    },
-    onSettled: (_d, _e, args) =>
-      queryClient.invalidateQueries({
+    (args) => ["repo", repo, "issue", args.number] as const,
+    (d, args) => (d ? patch(d, args) : d),
+    // Narrow reconciliation: only the one issue's detail subtree (not repo-wide).
+    (queryClient, args) =>
+      void queryClient.invalidateQueries({
         queryKey: ["repo", repo, "issue", args.number],
       }),
-  });
+  );
 }
 
 export function useSetIssueAssignees(repo: string) {
@@ -1580,25 +1613,63 @@ export function useSetIssueType(repo: string) {
   );
 }
 
+/**
+ * An issue-lifecycle write (close/reopen/edit/pin/lock/unlock/transfer/delete)
+ * that reconciles NARROWLY on settle instead of the whole-repo default: the one
+ * issue's detail subtree (`["repo", repo, "issue", n]`, prefix-matched so its
+ * reactions/relations/dependencies/development sub-queries refresh too) + every
+ * issue-list state variant (`["repo", repo, "issue-list"]` — the list row shows
+ * state/title/labels/assignees/pinned/locked, and transfer/delete change list
+ * membership). `numberOf` extracts the issue number from the mutation args (the
+ * arg shapes differ — a bare `number` vs `{ number, … }`). No optimistic patch:
+ * these change fields the details view re-reads wholesale, so a scoped refetch is
+ * the reconciliation.
+ */
+function useIssueLifecycleMutation<TArgs, TData>(
+  repo: string,
+  mutationFn: (args: TArgs) => Promise<TData>,
+  numberOf: (args: TArgs) => number,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn,
+    onSettled: (_d, _e, args) =>
+      void Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["repo", repo, "issue-list"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["repo", repo, "issue", numberOf(args)],
+        }),
+      ]),
+  });
+}
+
 export function usePinIssue(repo: string) {
-  return useRepoMutation(repo, (args: { number: number; pinned: boolean }) =>
-    args.pinned
-      ? api.ghIssuePin(repo, args.number)
-      : api.ghIssueUnpin(repo, args.number),
+  return useIssueLifecycleMutation(
+    repo,
+    (args: { number: number; pinned: boolean }) =>
+      args.pinned
+        ? api.ghIssuePin(repo, args.number)
+        : api.ghIssueUnpin(repo, args.number),
+    (args) => args.number,
   );
 }
 
 export function useLockIssue(repo: string) {
-  return useRepoMutation(
+  return useIssueLifecycleMutation(
     repo,
     (args: { number: number; reason: api.LockReason | null }) =>
       api.forgeIssueLock(repo, args.number, args.reason),
+    (args) => args.number,
   );
 }
 
 export function useUnlockIssue(repo: string) {
-  return useRepoMutation(repo, (number: number) =>
-    api.forgeIssueUnlock(repo, number),
+  return useIssueLifecycleMutation(
+    repo,
+    (number: number) => api.forgeIssueUnlock(repo, number),
+    (number) => number,
   );
 }
 
@@ -1911,36 +1982,45 @@ export function useCommentIssue(repo: string) {
 }
 
 export function useCloseIssue(repo: string) {
-  return useRepoMutation(repo, (args: { number: number; reason: string }) =>
-    api.forgeIssueClose(repo, args.number, args.reason),
+  return useIssueLifecycleMutation(
+    repo,
+    (args: { number: number; reason: string }) =>
+      api.forgeIssueClose(repo, args.number, args.reason),
+    (args) => args.number,
   );
 }
 
 export function useReopenIssue(repo: string) {
-  return useRepoMutation(repo, (number: number) =>
-    api.forgeIssueReopen(repo, number),
+  return useIssueLifecycleMutation(
+    repo,
+    (number: number) => api.forgeIssueReopen(repo, number),
+    (number) => number,
   );
 }
 
 export function useEditIssue(repo: string) {
-  return useRepoMutation(
+  return useIssueLifecycleMutation(
     repo,
     (args: { number: number; title: string; body: string }) =>
       api.forgeIssueEdit(repo, args.number, args.title, args.body),
+    (args) => args.number,
   );
 }
 
 export function useTransferIssue(repo: string) {
-  return useRepoMutation(
+  return useIssueLifecycleMutation(
     repo,
     (args: { number: number; destination: string }) =>
       api.forgeIssueTransfer(repo, args.number, args.destination),
+    (args) => args.number,
   );
 }
 
 export function useDeleteIssue(repo: string) {
-  return useRepoMutation(repo, (number: number) =>
-    api.forgeIssueDelete(repo, number),
+  return useIssueLifecycleMutation(
+    repo,
+    (number: number) => api.forgeIssueDelete(repo, number),
+    (number) => number,
   );
 }
 
@@ -1989,9 +2069,9 @@ export function useCreateLinkedBranch(repo: string) {
 }
 
 export function useSetIssueDependency(repo: string) {
-  return useRepoMutation(
-    repo,
-    (args: {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
       number: number;
       relation: IssueRelation;
       target: number;
@@ -2004,7 +2084,18 @@ export function useSetIssueDependency(repo: string) {
         args.target,
         args.add,
       ),
-  );
+    // Cross-issue: a dependency touches BOTH the source's and the target's detail
+    // subtrees (their `dependencies` sub-query is keyed by number) — no list-
+    // membership change, so scope to the two issues' details rather than repo-wide.
+    onSettled: (_d, _e, args) =>
+      void Promise.all(
+        [args.number, args.target].map((n) =>
+          queryClient.invalidateQueries({
+            queryKey: ["repo", repo, "issue", n],
+          }),
+        ),
+      ),
+  });
 }
 
 export function useRemoveSubIssue(repo: string) {
@@ -2028,6 +2119,9 @@ export function useSwitchAccount() {
     mutationFn: (args: { host: string; login: string }) =>
       api.ghSwitchAccount(args.host, args.login),
     // The active account changes what every gh query returns.
+    // Deliberately app-wide (no key filter): the collateral refetch of non-gh
+    // caches is accepted because account switches are rare, and correctness of
+    // every gh-derived answer wins over the narrow-invalidation policy elsewhere.
     onSettled: () => queryClient.invalidateQueries(),
   });
 }
@@ -3489,23 +3583,14 @@ function useOptimisticCreateCommentMutation<TData>(
     asBot?: boolean;
   }) => Promise<TData>,
 ) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (args: {
-      number: number;
-      body: string;
-      author: string;
-      asBot?: boolean;
-    }) => mutationFn(args),
-    onMutate: async (args: {
-      number: number;
-      body: string;
-      author: string;
-      asBot?: boolean;
-    }) => {
-      const key = ["repo", repo, kind, args.number] as const;
-      await queryClient.cancelQueries({ queryKey: key });
-      const prev = queryClient.getQueryData<PrDetails | IssueDetails>(key);
+  return useOptimisticCacheMutation<
+    { number: number; body: string; author: string; asBot?: boolean },
+    TData,
+    PrDetails | IssueDetails
+  >(
+    (args) => mutationFn(args),
+    (args) => ["repo", repo, kind, args.number] as const,
+    (d, args) => {
       const synthetic: PrThreadOut = {
         author: args.author,
         // Optimistic: login-derived (GitHub) / initial until the refetch fills it.
@@ -3519,17 +3604,11 @@ function useOptimisticCreateCommentMutation<TData>(
         isMinimized: false,
         minimizedReason: "",
       };
-      queryClient.setQueryData<PrDetails | IssueDetails>(key, (d) =>
-        d ? { ...d, comments: [...d.comments, synthetic] } : d,
-      );
-      return { prev, key };
+      return d ? { ...d, comments: [...d.comments, synthetic] } : d;
     },
-    onError: (_e, _args, ctx) => {
-      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
-    },
-    onSettled: () =>
+    (queryClient) =>
       void queryClient.invalidateQueries({ queryKey: repoKeys.all(repo) }),
-  });
+  );
 }
 
 /**
@@ -3552,33 +3631,23 @@ function useOptimisticCommentMutation<
   mutationFn: (args: TArgs) => Promise<TData>,
   patchComment: (comment: PrThreadOut, args: TArgs) => PrThreadOut | null,
 ) {
-  const queryClient = useQueryClient();
-  return useMutation({
+  return useOptimisticCacheMutation<TArgs, TData, PrDetails | IssueDetails>(
     mutationFn,
-    onMutate: async (args: TArgs) => {
-      const key = ["repo", repo, kind, args.number] as const;
-      await queryClient.cancelQueries({ queryKey: key });
-      const prev = queryClient.getQueryData<PrDetails | IssueDetails>(key);
-      queryClient.setQueryData<PrDetails | IssueDetails>(key, (d) =>
-        d
-          ? {
-              ...d,
-              comments: d.comments.flatMap((c) => {
-                if (c.id !== args.commentId) return [c];
-                const patched = patchComment(c, args);
-                return patched ? [patched] : [];
-              }),
-            }
-          : d,
-      );
-      return { prev, key };
-    },
-    onError: (_e, _args, ctx) => {
-      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
-    },
-    onSettled: () =>
+    (args) => ["repo", repo, kind, args.number] as const,
+    (d, args) =>
+      d
+        ? {
+            ...d,
+            comments: d.comments.flatMap((c) => {
+              if (c.id !== args.commentId) return [c];
+              const patched = patchComment(c, args);
+              return patched ? [patched] : [];
+            }),
+          }
+        : d,
+    (queryClient) =>
       void queryClient.invalidateQueries({ queryKey: repoKeys.all(repo) }),
-  });
+  );
 }
 
 export function useEditPrComment(repo: string) {
@@ -3639,33 +3708,23 @@ function useOptimisticReviewCommentMutation<
   mutationFn: (args: TArgs) => Promise<TData>,
   patchComment: (comment: PrThreadOut, args: TArgs) => PrThreadOut | null,
 ) {
-  const queryClient = useQueryClient();
-  return useMutation({
+  return useOptimisticCacheMutation<TArgs, TData, ReviewThreadOut[]>(
     mutationFn,
-    onMutate: async (args: TArgs) => {
-      const key = prReviewThreadsKey(repo, args.number);
-      await queryClient.cancelQueries({ queryKey: key });
-      const prev = queryClient.getQueryData<ReviewThreadOut[]>(key);
-      queryClient.setQueryData<ReviewThreadOut[]>(key, (threads) =>
-        threads?.flatMap((t) => {
-          if (!t.comments.some((c) => c.id === args.commentId)) return [t];
-          const comments = t.comments.flatMap((c) => {
-            if (c.id !== args.commentId) return [c];
-            const patched = patchComment(c, args);
-            return patched ? [patched] : [];
-          });
-          // A delete that empties the thread drops the whole card (server does too).
-          return comments.length === 0 ? [] : [{ ...t, comments }];
-        }),
-      );
-      return { prev, key };
-    },
-    onError: (_e, _args, ctx) => {
-      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
-    },
-    onSettled: () =>
+    (args) => prReviewThreadsKey(repo, args.number),
+    (threads, args) =>
+      threads?.flatMap((t) => {
+        if (!t.comments.some((c) => c.id === args.commentId)) return [t];
+        const comments = t.comments.flatMap((c) => {
+          if (c.id !== args.commentId) return [c];
+          const patched = patchComment(c, args);
+          return patched ? [patched] : [];
+        });
+        // A delete that empties the thread drops the whole card (server does too).
+        return comments.length === 0 ? [] : [{ ...t, comments }];
+      }),
+    (queryClient) =>
       void queryClient.invalidateQueries({ queryKey: repoKeys.all(repo) }),
-  });
+  );
 }
 
 export function useEditReviewComment(repo: string) {

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4904,16 +4904,21 @@ export function useEditPr(repo: string) {
   );
 }
 
-/** Add/remove labels on an issue or MR (also used by GitHub-only Discussions).
+/** Add/remove labels on an issue, MR, or GitHub Discussion.
  *  GitHub uses the node-id path (`labelableId` + `addIds`/`removeIds`); GitLab uses
- *  names (`target` + `number` + `addNames`/`removeNames`). The name/target/number
- *  fields are optional so GitHub-only callers (Discussions) stay byte-identical. */
+ *  names (`target` + `number` + `addNames`/`removeNames`). `kind` is the reconcile
+ *  discriminator (the args carry no reliable entity id otherwise); `number` every
+ *  entity has — for the GitHub node-id path it is used only for invalidation, so a
+ *  discussion still sends `0` on the wire (byte-identical to the old default). The
+ *  wire `target` derives from `kind`: issue→"issue", mr→"mr", discussion→"issue"
+ *  (the old default). Reconciles per-kind on settle instead of the whole-repo
+ *  default, since the args now carry a reliable discriminator. */
 export function useEditPrLabels(repo: string) {
-  return useRepoMutation(
-    repo,
-    (args: {
-      target?: "issue" | "mr";
-      number?: number;
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      kind: "issue" | "mr" | "discussion";
+      number: number;
       labelableId: string;
       addIds: string[];
       removeIds: string[];
@@ -4922,15 +4927,41 @@ export function useEditPrLabels(repo: string) {
     }) =>
       api.forgeEditLabels(
         repo,
-        args.target ?? "issue",
-        args.number ?? 0,
+        args.kind === "mr" ? "mr" : "issue",
+        // GitHub Discussions use the node-id path; the wire number is unused and
+        // stays 0 to match the old `args.number ?? 0` default byte-for-byte.
+        args.kind === "discussion" ? 0 : args.number,
         args.labelableId,
         args.addIds,
         args.removeIds,
         args.addNames ?? [],
         args.removeNames ?? [],
       ),
-  );
+    onSettled: (_d, _e, args) => {
+      const keys =
+        args.kind === "issue"
+          ? [
+              ["repo", repo, "issue-list"],
+              ["repo", repo, "issue", args.number],
+            ]
+          : args.kind === "mr"
+            ? [
+                ["repo", repo, "pr", args.number],
+                ["repo", repo, "pr-list"],
+              ]
+            : args.kind === "discussion"
+              ? [
+                  ["repo", repo, "discussion", args.number],
+                  ["repo", repo, "discussion-list"],
+                ]
+              : [repoKeys.all(repo)];
+      return void Promise.all(
+        keys.map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey }),
+        ),
+      );
+    },
+  });
 }
 
 export function useCreatePr(repo: string) {

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -999,6 +999,13 @@ function useOptimisticCacheMutation<TArgs, TData, TCache>(
       _args: TArgs,
       ctx: { prev: TCache | undefined; key: QueryKey } | undefined,
     ) => {
+      // The explicit guard is deliberate: in TanStack Query v5,
+      // setQueryData(key, undefined) BAILS without updating (it does not
+      // remove the entry), so an unguarded call would be a silent no-op, not
+      // a rollback. A future "create from nothing" patch (prev === undefined,
+      // patch returns data) would need removeQueries here instead — but
+      // onSettled's reconcile invalidates immediately after, so there is no
+      // observable window today.
       if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
     },
     onSettled: (_d: TData | undefined, _e: unknown, args: TArgs) =>

--- a/src/lib/jira/queries.ts
+++ b/src/lib/jira/queries.ts
@@ -70,6 +70,33 @@ function invalidateJiraForRepo(
   });
 }
 
+/**
+ * Narrower reconciliation for a single-issue PROPERTY write (due date, priority,
+ * labels, comment create/edit/delete): invalidate just that one issue's detail
+ * key + the repo's jira-issues LIST keys (lists render priority/due/labels, so
+ * they must reconcile). Unlike {@link invalidateJiraForRepo} it does NOT touch
+ * the link key or the whole jira-issue namespace — a property write on one issue
+ * can't affect another issue's detail. `link` supplies the site that keys the
+ * detail entry; when it's absent (unlinked) there's nothing to reconcile beyond
+ * the (empty) list keys. Reserve the broad helper for writes that change list
+ * membership or need cross-issue effects (create, transition, assign).
+ */
+function invalidateJiraIssue(
+  queryClient: ReturnType<typeof useQueryClient>,
+  repo: string,
+  link: JiraLink | null | undefined,
+  issueKey: string,
+) {
+  if (link) {
+    queryClient.invalidateQueries({
+      queryKey: jiraIssueDetailKey(repo, link.siteHost, issueKey),
+    });
+  }
+  queryClient.invalidateQueries({
+    queryKey: ["repo", repo, "jira-issues"],
+  });
+}
+
 export function useSaveJiraLink(repo: string) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -294,7 +321,8 @@ export function useJiraComment(
         d ? { ...d, comments: [...d.comments, comment] } : d,
       );
     },
-    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+    onSettled: (_d, _e, args) =>
+      invalidateJiraIssue(queryClient, repo, link, args.issueKey),
   });
 }
 
@@ -646,7 +674,8 @@ export function useJiraSetDueDate(
       });
     },
     onError: (_e, _args, ctx) => rollbackOptimisticField(queryClient, ctx),
-    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+    onSettled: (_d, _e, args) =>
+      invalidateJiraIssue(queryClient, repo, link, args.issueKey),
   });
 }
 
@@ -681,7 +710,8 @@ export function useJiraSetPriority(
       );
     },
     onError: (_e, _args, ctx) => rollbackOptimisticField(queryClient, ctx),
-    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+    onSettled: (_d, _e, args) =>
+      invalidateJiraIssue(queryClient, repo, link, args.issueKey),
   });
 }
 
@@ -711,7 +741,8 @@ export function useJiraSetLabels(
       );
     },
     onError: (_e, _args, ctx) => rollbackOptimisticField(queryClient, ctx),
-    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+    onSettled: (_d, _e, args) =>
+      invalidateJiraIssue(queryClient, repo, link, args.issueKey),
   });
 }
 
@@ -773,7 +804,8 @@ export function useJiraCommentEdit(
           : d,
       );
     },
-    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+    onSettled: (_d, _e, args) =>
+      invalidateJiraIssue(queryClient, repo, link, args.issueKey),
   });
 }
 
@@ -809,7 +841,8 @@ export function useJiraCommentDelete(
         queryClient.setQueryData(ctx.detailKey, ctx.prevDetail);
       }
     },
-    onSettled: () => invalidateJiraForRepo(queryClient, repo),
+    onSettled: (_d, _e, args) =>
+      invalidateJiraIssue(queryClient, repo, link, args.issueKey),
   });
 }
 

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -50,6 +50,40 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+// Serialize every read-modify-write on this store through one in-process queue.
+// Without it, two overlapping mutations each reload the SAME pre-flush disk snapshot
+// — autoSave persists on a ~100ms debounce, so the first write isn't on disk yet — and
+// the later write drops the earlier one's change (a lost update). Unlike local-prs.json,
+// pr-reviews.json is NOT written by the MCP server; the realistic overlap is entirely
+// in-process — e.g. an automation's review finishing while the user edits or deletes a
+// review's text, or two automation instances finishing close together. Running them one
+// at a time, plus the force-save in writeAll, guarantees each reload sees a current snapshot.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  // Tolerate a missing store file. Asymmetry: `load()` tolerates a missing file
+  // but `reload()` rejects with a raw io error ("The system cannot find the file
+  // specified. (os error 2)") — the file only exists after the first `save()`.
+  // Without this guard the first-ever mutation throws before reaching `save()`,
+  // so the store can never bootstrap; an external delete of the file breaks every
+  // mutation until restart the same way. Fall back to the loaded in-memory state
+  // on ANY reload failure — the serialized op-chain + force-save still protect the
+  // write path.
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing/unreadable file — proceed with in-memory state; the next save()
+    // creates it.
+  }
+}
+
 // Records are keyed by the repo's worktree-stable identity (not its checkout
 // path) so a PR's review history is shared across the main checkout and every
 // worktree. Reads merge in any records still under a legacy checkout-path key
@@ -63,6 +97,10 @@ async function readMerged(repo: string): Promise<PersistedReview[]> {
   return mergeById(primary, legacy);
 }
 
+/** The identity store key for `repo`, folding any legacy checkout-path-keyed
+ *  records onto it once. Call inside the serialized queue (after `reloadRaw`) so
+ *  the fold is ordered with the mutation and a delete can't leave a lingering
+ *  legacy record that would reappear via `readMerged`'s read-merge. */
 async function keyFor(repo: string): Promise<string> {
   const store = await getStore();
   return identityKeyFor<PersistedReview[]>(
@@ -84,6 +122,9 @@ async function writeAll(
 ): Promise<void> {
   const store = await getStore();
   await store.set(key, records);
+  // Flush now instead of on autoSave's debounce, so the next serialized reload can't
+  // re-read a pre-write disk snapshot and drop this change.
+  await store.save();
 }
 
 /** Keeps only the newest `MAX_PER_GROUP` reviews per `(kind, ref, mode)`. */
@@ -134,10 +175,15 @@ export async function saveReview(
   repo: string,
   record: PersistedReview,
 ): Promise<void> {
-  const key = await keyFor(repo);
-  const all = await readByKey(key);
-  const without = all.filter((r) => r.id !== record.id);
-  await writeAll(key, prune([record, ...without]));
+  return serialize(async () => {
+    // Fresh disk state first, then key-fold, then read-modify-write — all inside the
+    // serialized op so an overlapping mutation can't reload a pre-flush snapshot.
+    await reloadRaw();
+    const key = await keyFor(repo);
+    const all = await readByKey(key);
+    const without = all.filter((r) => r.id !== record.id);
+    await writeAll(key, prune([record, ...without]));
+  });
 }
 
 /** Replaces a stored review's text — backs "trim before re-running" so a user
@@ -147,21 +193,27 @@ export async function updateReviewText(
   id: string,
   text: string,
 ): Promise<void> {
-  const key = await keyFor(repo);
-  const all = await readByKey(key);
-  await writeAll(
-    key,
-    all.map((r) => (r.id === id ? { ...r, text } : r)),
-  );
+  return serialize(async () => {
+    await reloadRaw();
+    const key = await keyFor(repo);
+    const all = await readByKey(key);
+    await writeAll(
+      key,
+      all.map((r) => (r.id === id ? { ...r, text } : r)),
+    );
+  });
 }
 
 export async function deleteReview(repo: string, id: string): Promise<void> {
-  const key = await keyFor(repo);
-  const all = await readByKey(key);
-  await writeAll(
-    key,
-    all.filter((r) => r.id !== id),
-  );
+  return serialize(async () => {
+    await reloadRaw();
+    const key = await keyFor(repo);
+    const all = await readByKey(key);
+    await writeAll(
+      key,
+      all.filter((r) => r.id !== id),
+    );
+  });
 }
 
 /** Clears every persisted review for ONE PR (both modes) — scoped so clearing
@@ -171,10 +223,13 @@ export async function clearReviewsFor(
   kind: "remote" | "local",
   ref: string,
 ): Promise<void> {
-  const key = await keyFor(repo);
-  const all = await readByKey(key);
-  await writeAll(
-    key,
-    all.filter((r) => !(r.kind === kind && r.ref === ref)),
-  );
+  return serialize(async () => {
+    await reloadRaw();
+    const key = await keyFor(repo);
+    const all = await readByKey(key);
+    await writeAll(
+      key,
+      all.filter((r) => !(r.kind === kind && r.ref === ref)),
+    );
+  });
 }


### PR DESCRIPTION
This change shrinks startup time and idle memory by deferring heavy modules—agent sessions, diff viewer, git hook editor, AI provider SDKs—behind code splits that load them only on first use. It also dramatically narrows data refresh after mutating issues, PRs, and Jira: post-mutation invalidation now targets only the affected item, not the whole repo, making the UI snappier. Other highlights include a virtualized, on-demand-highlighting blame view for large files and consistent user avatars in settings.

### Performance: code splitting and lazy loading
- Code-splits agent sessions, diff rendering, the git-hooks editor, and all AI provider SDKs (`src/features/repository/RepositoryView.tsx`, `src/features/diff/DiffSurfaceLazy.tsx`, `src/features/hooks/HooksDialog.tsx`, `src/lib/ai/model-factory.ts`, `src/lib/ai/client.ts`, `src/features/repository/RepositoryMenu.tsx`, `src/features/settings/SettingsScreen.tsx`)
- Removes eager imports of AI-SDK providers from `src/lib/ai/providers.ts` (moved to `model-factory.ts`), now loaded dynamically per generation request
- Updates all diff surface and diff viewer consumers throughout the app (e.g. `src/features/compare/BranchDiffView.tsx`, `src/features/history/CommitDetailView.tsx`) to import from the new lazy boundary

### Mutation invalidation: narrower, faster refresh
- Refactors all issue, PR, and Jira mutations to invalidate *only* the specific item mutated, rather than full-repo data (`src/lib/git/queries.ts`, `src/lib/jira/queries.ts`, `src/lib/automations/runner.ts`)
- Extracts new `useOptimisticCacheMutation` helper in `src/lib/git/queries.ts` to DRY optimistic updates and rollback/settle handling across all item-level mutation hooks

### Repo settings and UI: consistent avatars, keyboard navigation
- Replaces hand-written avatar rendering in settings with the canonical `ForgeUserAvatar` component for collaborators and GitLab members (`src/components/forge-user-avatar.tsx`, `src/features/repo-settings/CollaboratorsSection.tsx`, `src/features/repo-settings/GitLabMembersSection.tsx`)
- Unifies fallback behavior: users with no profile picture now show a letter avatar, not a blank
- Makes slash-commands (settings) and submodule lists fully keyboard-accessible: arrow keys move between rows, Enter acts on the focused row (`src/features/settings/CommandsSection.tsx`, `src/features/repository/SubmodulesDialog.tsx`)
- Improves active item tracking and roving tab-index on affected lists

### Blame view: scalable virtualization for large files
- Overhauls `src/features/history/BlameDialog.tsx` to virtualize file lines with `@tanstack/react-virtual`, only syntax-highlighting lines currently on screen
- Prevents hangs/freezes on very large files; only visible rows are rendered and colored
- Switches from ScrollArea to native scroll node to ensure correct input for virtualizer

### Miscellaneous improvements and fixes
- Serializes all persisted review updates in `src/lib/pulls/reviews-history.ts` to prevent lost updates when multiple review writes land in quick succession
- Refactors label and property writes in discussions and Jira so that only the mutated item's details and relevant lists are refreshed, not global Jira link or all issues
- Suspends GitLab auto-merge status polling while the Pulls tab is hidden (`src/features/pulls/RemotePrView.tsx`)

### Documentation and changelog
- Adds extensive, grouped changelog entriessummarizing user-facing impact and fixes (`changelog.d/`)