### PR TITLE
feat(repo-settings, git): enhance Description and Topics fields, optimize remote URL caching, and cap MCP review diff hunks

### DIFF
--- a/changelog.d/added-completed-reviewers-bitbucket.md
+++ b/changelog.d/added-completed-reviewers-bitbucket.md
@@ -1,0 +1,4 @@
+- **Bitbucket PR reviewers who've acted now show as completed chips.** On a Bitbucket
+  pull request, participants who have approved or requested changes now appear as
+  read-only completed-reviewer chips carrying their verdict, and drop off the
+  pending-request list so they no longer double-render as still-pending.

--- a/changelog.d/added-completed-reviewers-gitlab.md
+++ b/changelog.d/added-completed-reviewers-gitlab.md
@@ -1,0 +1,4 @@
+- **GitLab MR reviewers who've acted now show as completed chips.** On a GitLab merge
+  request, reviewers who have approved or requested changes now appear as read-only
+  completed-reviewer chips carrying their verdict, and drop off the pending-request list
+  so they no longer double-render as still-pending.

--- a/changelog.d/added-completed-reviewers.md
+++ b/changelog.d/added-completed-reviewers.md
@@ -1,0 +1,5 @@
+- **See finished reviewers in the PR Reviewers section.** The Reviewers rail now shows
+  reviewers who've already reviewed as read-only chips carrying their verdict — a check for
+  approved, an X for changes requested, a speech bubble for commented — so a completed
+  review (including **Copilot**'s) stays visible after the reviewer drops off the
+  pending-request list. State is conveyed by icon shape plus the word, never color alone.

--- a/changelog.d/changed-forge-origin-url-cache.md
+++ b/changelog.d/changed-forge-origin-url-cache.md
@@ -1,0 +1,1 @@
+- Forge views feel snappier. Repeated origin-remote lookups from the many forge queries a pull-request or merge-request view fires are now served from a short-lived in-memory cache instead of re-shelling out to `git` each time — noticeably fewer process spawns on Windows.

--- a/changelog.d/changed-mcp-comment-output.md
+++ b/changelog.d/changed-mcp-comment-output.md
@@ -1,0 +1,4 @@
+- The MCP `list_pull_request_comments` tool now caps each review thread's diff
+  hunk to its last few lines, so a comment on a brand-new file no longer drags
+  the whole file into the response. Pass `include_diff_hunk: false` to drop the
+  hunks entirely when you only need the threads' structure.

--- a/changelog.d/changed-repo-settings-fields.md
+++ b/changelog.d/changed-repo-settings-fields.md
@@ -1,0 +1,11 @@
+- **Repository settings: friendlier Description and Topics fields.** In *Settings →
+  General*, the **Description** is now a multi-line box so a long "About" wraps
+  instead of clipping mid-word (GitHub and GitLab; Bitbucket already did). **Topics**
+  are now removable chips with an inline add-box: type a topic and press **Enter** or
+  comma to add it. On GitHub, each token is normalized to a valid topic as you add it and
+  the chip shows exactly what will be saved — so `C++` becomes `c` and `React_Native`
+  becomes `react-native`, and pasted or space-separated text lands as clean chips instead
+  of being silently mangled on save; the field caps at 20 with a live count. On
+  GitLab, topics keep their case and spaces, so "React Native" stays one topic. Chips are
+  fully keyboard-navigable — arrow between them, remove the focused one with Enter or its
+  ✕, and Backspace in an empty add-box removes the last one.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -32,7 +32,8 @@ use crate::forge::http::{
     self, BbCredentials, BB_HOST, KEY_DISPLAY_NAME, KEY_EMAIL, KEY_TOKEN, KEY_USERNAME,
 };
 use crate::forge::model::{
-    Capabilities, ForgeRepo, ForgeRepoList, ForgeStatus, ForgeUserRef, Implemented, Provider,
+    Capabilities, CompletedReviewerOut, ForgeRepo, ForgeRepoList, ForgeStatus, ForgeUserRef,
+    Implemented, Provider,
 };
 use crate::forge::Forge;
 use crate::github::actions::{RunDetail, RunJob, WorkflowRun};
@@ -527,6 +528,13 @@ struct BbPr {
     /// commenters/approvers who were never asked to review.
     #[serde(default)]
     reviewers: Vec<BbUser>,
+    /// The participant list (present on the unfielded single-PR GET, avatars and
+    /// all). Carries each participant's approval `state`, so `view_pr` derives the
+    /// completed reviewers (approved / changes-requested) from it without a second
+    /// fetch. Distinct from `reviewers`: this also includes commenters/approvers
+    /// who were never formally asked to review.
+    #[serde(default, deserialize_with = "null_to_default")]
+    participants: Vec<BbParticipant>,
 }
 
 /// Best display login for a Bitbucket user: display_name else nickname (other users
@@ -937,7 +945,9 @@ fn commit_author(c: &BbCommit) -> String {
 /// `PrDetails`. Reviews are left empty: the frontend renders `reviews` generically
 /// (author + body + state), but a Bitbucket "approved" participant has no body/state
 /// text to show — so like GitLab's `view_pr` this returns `Vec::new()` rather than
-/// bare author lines. Assignees/labels are always empty (Bitbucket has neither).
+/// bare author lines. Participants who acted DO surface as `completed_reviewers`
+/// (verdict chips) instead, derived from participant state. Assignees/labels are
+/// always empty (Bitbucket has neither).
 pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
     let creds = http::load_credentials().await?;
     let (ws, slug) = workspace_slug(repo_path).await?;
@@ -1075,6 +1085,15 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         .unwrap_or_default()
     };
 
+    // Completed reviewers = participants who acted (approved or requested changes),
+    // derived from participant state (Bitbucket has no GitHub-style review objects).
+    // These are DISPLAYED separately from the pending reviewers; the frontend de-dups
+    // the display so an acted reviewer doesn't render as both a pending and a completed
+    // chip. `reviewers` below stays the FULL assigned set on purpose — it feeds the
+    // reviewers picker's full-replacement PUT, so dropping an acted reviewer here would
+    // silently un-assign them on the next reviewer edit.
+    let completed_reviewers = completed_reviewers_from(&pr.participants);
+
     Ok(PrDetails {
         // No node ids on Bitbucket.
         id: String::new(),
@@ -1115,6 +1134,7 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
                 })
             })
             .collect(),
+        completed_reviewers,
     })
 }
 
@@ -2898,6 +2918,42 @@ fn build_approval_state(
         approvals_left: 0,
         viewer_requested_changes,
     }
+}
+
+/// The completed reviewers of a PR — every participant who cast a verdict — derived
+/// from participant `state`. Bitbucket has no GitHub-style review objects, so a
+/// participant's `state` (`"approved"` / `"changes_requested"` / null) IS the verdict:
+/// `"approved"` → `"APPROVED"`, `"changes_requested"` → `"CHANGES_REQUESTED"`.
+/// Commenters who never acted carry `state: null` (and any unrecognized state) and are
+/// skipped, as are participants with no resolvable braced uuid. Identity = braced uuid
+/// (the one field present on participant objects), matching the reviewers picker so the
+/// caller can subtract these from the pending reviewer list. Pure (testable).
+fn completed_reviewers_from(participants: &[BbParticipant]) -> Vec<CompletedReviewerOut> {
+    participants
+        .iter()
+        .filter_map(|p| {
+            let state = match p.state.as_deref() {
+                Some("approved") => "APPROVED",
+                Some("changes_requested") => "CHANGES_REQUESTED",
+                // Commenters (null) and any unrecognized state didn't cast a verdict.
+                _ => return None,
+            };
+            let u = p.user.as_ref()?;
+            let id = u.uuid.clone().unwrap_or_default();
+            if id.is_empty() {
+                return None;
+            }
+            Some(CompletedReviewerOut {
+                user: ForgeUserRef {
+                    id,
+                    label: user_login(u),
+                    avatar_url: user_avatar(u),
+                    is_bot: false,
+                },
+                state: state.to_string(),
+            })
+        })
+        .collect()
 }
 
 /// The viewer's + the PR's approval state (`GET …/pullrequests/{n}` participants). The
@@ -5527,6 +5583,45 @@ mod tests {
         assert!(!state.viewer_requested_changes);
         // The approver is not the viewer, so their nickname (not the login) is used.
         assert_eq!(state.approved_by, vec!["someone".to_string()]);
+    }
+
+    #[test]
+    fn completed_reviewers_maps_states_avatars_and_skips_commenters() {
+        // approved → APPROVED (with avatar), changes_requested → CHANGES_REQUESTED,
+        // null (a commenter) → skipped, unrecognized state → skipped.
+        let ps = participants(
+            r#"{"participants":[
+                {"user":{"uuid":"{app}","display_name":"Approver",
+                         "links":{"avatar":{"href":"https://avatars/app.png"}}},
+                 "approved":true,"state":"approved"},
+                {"user":{"uuid":"{cr}","nickname":"Reviewer"},
+                 "approved":false,"state":"changes_requested"},
+                {"user":{"uuid":"{c}","nickname":"Commenter"},"approved":false,"state":null},
+                {"user":{"uuid":"{u}","nickname":"Unknown"},"approved":false,"state":"weird"}
+            ]}"#,
+        );
+        let out = completed_reviewers_from(&ps);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].user.id, "{app}");
+        assert_eq!(out[0].user.label, "Approver");
+        assert_eq!(out[0].user.avatar_url, "https://avatars/app.png");
+        assert!(!out[0].user.is_bot);
+        assert_eq!(out[0].state, "APPROVED");
+        assert_eq!(out[1].user.id, "{cr}");
+        assert_eq!(out[1].user.label, "Reviewer");
+        assert_eq!(out[1].state, "CHANGES_REQUESTED");
+    }
+
+    #[test]
+    fn completed_reviewers_skips_participant_with_no_uuid() {
+        // A participant with a verdict but no braced uuid can't round-trip, so it's
+        // dropped rather than emitted with an empty id.
+        let ps = participants(
+            r#"{"participants":[
+                {"user":{"nickname":"NoUuid"},"approved":true,"state":"approved"}
+            ]}"#,
+        );
+        assert!(completed_reviewers_from(&ps).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -3681,6 +3681,9 @@ pub async fn rename_repo(state: &crate::state::AppState, repo_path: &str, new_na
                  set it to {new_url} manually. ({e})"
             )));
         }
+        // origin now points at the new slug — drop any cached (stale) URL so a forge query
+        // within the TTL re-resolves it instead of hitting the old, now-404 URL.
+        crate::git::remote::invalidate_remote_url_cache(repo_path, "origin");
     }
     Ok(())
 }

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -7,7 +7,9 @@
 //! methods, each delegating to the matching `gh_*` function.
 
 use crate::error::AppResult;
-use crate::forge::model::{Capabilities, ForgeRepo, ForgeRepoList, ForgeStatus, Implemented, Provider};
+use crate::forge::model::{
+    Capabilities, ForgeRepo, ForgeRepoList, ForgeStatus, Implemented, Provider,
+};
 use crate::forge::Forge;
 use crate::github::pr::{gh_list_repos, gh_status, GhRepo, GhStatus};
 
@@ -125,11 +127,7 @@ pub async fn commit_comment_create(
     crate::github::pr::commit_comment_create(repo_path, sha, body, path, position).await
 }
 
-pub async fn commit_comment_edit(
-    repo_path: &str,
-    comment_id: &str,
-    body: &str,
-) -> AppResult<()> {
+pub async fn commit_comment_edit(repo_path: &str, comment_id: &str, body: &str) -> AppResult<()> {
     crate::github::pr::commit_comment_edit(repo_path, comment_id, body).await
 }
 
@@ -570,23 +568,21 @@ pub async fn assignable_users(
 ) -> AppResult<Vec<crate::forge::model::ForgeUserRef>> {
     // GitHub carries no avatar in the assignees endpoint; the picker derives it
     // from the login (id), so leave `avatar_url` empty and let the frontend fill it.
-    Ok(crate::github::issue::gh_assignable_users(repo_path.to_string())
-        .await?
-        .into_iter()
-        .map(|l| crate::forge::model::ForgeUserRef {
-            id: l.clone(),
-            label: l,
-            avatar_url: String::new(),
-            is_bot: false,
-        })
-        .collect())
+    Ok(
+        crate::github::issue::gh_assignable_users(repo_path.to_string())
+            .await?
+            .into_iter()
+            .map(|l| crate::forge::model::ForgeUserRef {
+                id: l.clone(),
+                label: l,
+                avatar_url: String::new(),
+                is_bot: false,
+            })
+            .collect(),
+    )
 }
 
-pub async fn set_pr_reviewers(
-    repo_path: &str,
-    number: u64,
-    reviewers: &[String],
-) -> AppResult<()> {
+pub async fn set_pr_reviewers(repo_path: &str, number: u64, reviewers: &[String]) -> AppResult<()> {
     crate::github::pr::set_pr_reviewers(repo_path, number, reviewers).await
 }
 

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -25,8 +25,8 @@ use crate::github::pr::{
     PrCommitOut, PrDetails, PrFileOut, PrInfo, PrListLabel, PrPollInfo, PrRef, PrThreadOut,
     PrTimelineEventOut, RepoLabel, ReviewSubmitOut, ReviewThreadOut,
 };
-use crate::state::AppState;
 use crate::github::release::{ReleaseAsset, ReleaseDetails, ReleaseInfo};
+use crate::state::AppState;
 
 /// GitLab via the `glab` CLI. Carries the repo's host (gitlab.com today; a
 /// self-managed host list arrives with the Settings → Accounts work).
@@ -151,7 +151,10 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
         .unwrap_or_default();
     let out = run_glab(
         None,
-        &["api", "projects?membership=true&order_by=last_activity_at&per_page=100"],
+        &[
+            "api",
+            "projects?membership=true&order_by=last_activity_at&per_page=100",
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await?;
@@ -201,7 +204,8 @@ use crate::forge::encode_query_value;
 
 /// The project's full path (`group/name`) from the repo's origin remote.
 async fn project_path(repo_path: &str) -> AppResult<String> {
-    let url = crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await?;
+    let url =
+        crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await?;
     crate::forge::remote_path(&url).ok_or_else(|| {
         AppError::Glab("could not determine the GitLab project from the origin remote".into())
     })
@@ -628,7 +632,11 @@ fn gl_build_line_range(
     start: u64,
     line: u64,
 ) -> serde_json::Value {
-    let line_field = if side == "old" { "old_line" } else { "new_line" };
+    let line_field = if side == "old" {
+        "old_line"
+    } else {
+        "new_line"
+    };
     let make_ref = |ln: u64| {
         let mut r = serde_json::json!({ "type": side, line_field: ln });
         if let Some((old_pos, new_pos)) = gl_diff_line_refs(file_diff, side, ln) {
@@ -731,7 +739,10 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
     // Core fields + changed files in one call.
     let out = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/merge_requests/{number}/changes")],
+        &[
+            "api",
+            &format!("projects/{enc}/merge_requests/{number}/changes"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await?;
@@ -763,7 +774,10 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
     // so reverse to oldest-first (matching gh's GraphQL order).
     let mut commits: Vec<PrCommitOut> = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/merge_requests/{number}/commits?per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/merge_requests/{number}/commits?per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -791,7 +805,10 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
     // real file/line context instead of leaking into the flat conversation list.
     let comments: Vec<PrThreadOut> = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/merge_requests/{number}/notes?sort=asc&per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/merge_requests/{number}/notes?sort=asc&per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -1077,7 +1094,10 @@ pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<PrTimeli
 async fn fetch_mr_changes(repo_path: &str, enc: &str, number: u64) -> Vec<GlabChange> {
     let out = match run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/merge_requests/{number}/changes")],
+        &[
+            "api",
+            &format!("projects/{enc}/merge_requests/{number}/changes"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -1095,7 +1115,10 @@ async fn fetch_mr_changes(repo_path: &str, enc: &str, number: u64) -> Vec<GlabCh
 async fn fetch_commit_changes(repo_path: &str, enc: &str, sha: &str) -> Vec<GlabChange> {
     let out = match run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/repository/commits/{sha}/diff?per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/repository/commits/{sha}/diff?per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -1145,7 +1168,10 @@ pub async fn diff_pr(repo_path: &str, number: u64) -> AppResult<String> {
     let enc = encode_project(&project_path(repo_path).await?);
     let out = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/merge_requests/{number}/changes")],
+        &[
+            "api",
+            &format!("projects/{enc}/merge_requests/{number}/changes"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await?;
@@ -1167,7 +1193,9 @@ pub async fn diff_pr(repo_path: &str, number: u64) -> AppResult<String> {
 /// before any network call.
 fn validate_commit_sha(sha: &str) -> AppResult<()> {
     if sha.is_empty() || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
-        return Err(AppError::InvalidArgument(format!("invalid commit id: {sha}")));
+        return Err(AppError::InvalidArgument(format!(
+            "invalid commit id: {sha}"
+        )));
     }
     Ok(())
 }
@@ -1181,7 +1209,10 @@ pub async fn commit_diff(repo_path: &str, sha: &str) -> AppResult<String> {
     let enc = encode_project(&project_path(repo_path).await?);
     let out = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/repository/commits/{sha}/diff?per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/repository/commits/{sha}/diff?per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await?;
@@ -1289,7 +1320,10 @@ pub async fn commit_comments(repo_path: &str, sha: &str) -> AppResult<Vec<Commit
     let viewer = current_user_login(repo_path).await;
     let out = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/repository/commits/{sha}/discussions?per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/repository/commits/{sha}/discussions?per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await?;
@@ -1351,7 +1385,8 @@ async fn commit_parent_sha(repo_path: &str, enc: &str, sha: &str) -> AppResult<S
         .map_err(|e| AppError::Glab(format!("could not parse the GitLab commit: {e}")))?;
     c.parent_ids.into_iter().next().ok_or_else(|| {
         AppError::InvalidArgument(
-            "can't anchor a comment on this commit — it has no parent commit to diff against.".into(),
+            "can't anchor a comment on this commit — it has no parent commit to diff against."
+                .into(),
         )
     })
 }
@@ -1440,8 +1475,7 @@ pub async fn commit_comment_edit(
     validate_commit_sha(sha)?;
     let (did, nid) = parse_commit_comment_id(comment_id)?;
     let enc = encode_project(&project_path(repo_path).await?);
-    let endpoint =
-        format!("projects/{enc}/repository/commits/{sha}/discussions/{did}/notes/{nid}");
+    let endpoint = format!("projects/{enc}/repository/commits/{sha}/discussions/{did}/notes/{nid}");
     let body_arg = format!("body={body}");
     run_glab(
         Some(repo_path),
@@ -1454,16 +1488,11 @@ pub async fn commit_comment_edit(
 
 /// Delete a commit comment (`DELETE …/commits/{sha}/discussions/{did}/notes/{nid}`).
 /// Composite-id parse runs BEFORE the request.
-pub async fn commit_comment_delete(
-    repo_path: &str,
-    sha: &str,
-    comment_id: &str,
-) -> AppResult<()> {
+pub async fn commit_comment_delete(repo_path: &str, sha: &str, comment_id: &str) -> AppResult<()> {
     validate_commit_sha(sha)?;
     let (did, nid) = parse_commit_comment_id(comment_id)?;
     let enc = encode_project(&project_path(repo_path).await?);
-    let endpoint =
-        format!("projects/{enc}/repository/commits/{sha}/discussions/{did}/notes/{nid}");
+    let endpoint = format!("projects/{enc}/repository/commits/{sha}/discussions/{did}/notes/{nid}");
     run_glab(
         Some(repo_path),
         &["api", "--method", "DELETE", &endpoint],
@@ -1658,9 +1687,10 @@ pub async fn edit_mr(repo_path: &str, number: u64, title: &str, body: &str) -> A
 /// Parse a comment id (a note id, sent as a string over IPC) to the numeric id
 /// GitLab's notes endpoint takes — a pre-mutation guard, before any network call.
 fn parse_note_id(comment_id: &str) -> AppResult<u64> {
-    comment_id.trim().parse::<u64>().map_err(|_| {
-        AppError::InvalidArgument(format!("invalid comment id: {comment_id}"))
-    })
+    comment_id
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| AppError::InvalidArgument(format!("invalid comment id: {comment_id}")))
 }
 
 /// Edit a merge request note's body (`PUT …/merge_requests/{n}/notes/{id}`).
@@ -1813,7 +1843,10 @@ pub async fn pr_approvals(repo_path: &str, number: u64) -> AppResult<ApprovalSta
     let enc = encode_project(&project_path(repo_path).await?);
     let out = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/merge_requests/{number}/approvals")],
+        &[
+            "api",
+            &format!("projects/{enc}/merge_requests/{number}/approvals"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await?;
@@ -1889,14 +1922,22 @@ struct GlabGqlRequestChangesErrors {
 }
 
 /// Replace the MR's reviewers with `ids` (`0` clears — the assignees CSV shape).
-async fn set_mr_reviewer_ids(repo_path: &str, enc: &str, number: u64, ids: &[u64]) -> AppResult<()> {
+async fn set_mr_reviewer_ids(
+    repo_path: &str,
+    enc: &str,
+    number: u64,
+    ids: &[u64],
+) -> AppResult<()> {
     let endpoint = format!("projects/{enc}/merge_requests/{number}");
     let ids_arg = format!(
         "reviewer_ids={}",
         if ids.is_empty() {
             "0".to_string()
         } else {
-            ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(",")
+            ids.iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
         }
     );
     run_glab(
@@ -2114,7 +2155,14 @@ async fn merge_mr_inner(
     let squash_arg = format!("squash={squash}");
     let remove_arg = format!("should_remove_source_branch={delete_branch}");
     let mut args = vec![
-        "api", "--method", "PUT", &endpoint, "-f", &squash_arg, "-f", &remove_arg,
+        "api",
+        "--method",
+        "PUT",
+        &endpoint,
+        "-f",
+        &squash_arg,
+        "-f",
+        &remove_arg,
     ];
     // Only guard on a non-empty SHA — an empty `sha=` would itself be rejected.
     let sha_arg;
@@ -2422,7 +2470,10 @@ pub async fn view_issue(repo_path: &str, number: u64) -> AppResult<IssueDetails>
     // Comments — drop GitLab's system notes (auto "changed the milestone", etc.).
     let comments: Vec<PrThreadOut> = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/issues/{number}/notes?sort=asc&per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/issues/{number}/notes?sort=asc&per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -2619,11 +2670,7 @@ pub async fn edit_issue_comment(
 
 /// Delete an issue note (`DELETE …/issues/{n}/notes/{id}`). Comment-id parse runs
 /// BEFORE the request.
-pub async fn delete_issue_comment(
-    repo_path: &str,
-    number: u64,
-    comment_id: &str,
-) -> AppResult<()> {
+pub async fn delete_issue_comment(repo_path: &str, number: u64, comment_id: &str) -> AppResult<()> {
     let note_id = parse_note_id(comment_id)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let endpoint = format!("projects/{enc}/issues/{number}/notes/{note_id}");
@@ -2772,9 +2819,8 @@ pub async fn delete_issue(repo_path: &str, number: u64) -> AppResult<()> {
 /// group milestone, and the global-id write accepts either kind).
 pub async fn list_milestones(repo_path: &str) -> AppResult<Vec<Milestone>> {
     let enc = encode_project(&project_path(repo_path).await?);
-    let endpoint = format!(
-        "projects/{enc}/milestones?state=active&include_ancestor_groups=true&per_page=100"
-    );
+    let endpoint =
+        format!("projects/{enc}/milestones?state=active&include_ancestor_groups=true&per_page=100");
     let out = run_glab(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT).await?;
     let milestones: Vec<GlabMilestone> = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Glab(format!("could not parse GitLab milestones: {e}")))?;
@@ -3040,7 +3086,13 @@ async fn award_read(
     let viewer = data.current_user.map(|u| u.username).unwrap_or_default();
     let target = data
         .project
-        .and_then(|p| if target_field == "issue" { p.issue } else { p.merge_request })
+        .and_then(|p| {
+            if target_field == "issue" {
+                p.issue
+            } else {
+                p.merge_request
+            }
+        })
         .ok_or_else(|| AppError::Glab("GitLab returned no such issue/MR".into()))?;
     let body = tally_awards(
         target.award_emoji.map(|a| a.nodes).unwrap_or_default(),
@@ -3128,9 +3180,17 @@ struct GlabNotePosition {
 /// last arm labels `"old"` because the path came from the old side). Pure/testable.
 fn gl_thread_anchor(position: &GlabNotePosition) -> (String, u32, &'static str) {
     if position.new_line.is_some() && !position.new_path.is_empty() {
-        (position.new_path.clone(), position.new_line.unwrap_or(0), "new")
+        (
+            position.new_path.clone(),
+            position.new_line.unwrap_or(0),
+            "new",
+        )
     } else if position.old_line.is_some() && !position.old_path.is_empty() {
-        (position.old_path.clone(), position.old_line.unwrap_or(0), "old")
+        (
+            position.old_path.clone(),
+            position.old_line.unwrap_or(0),
+            "old",
+        )
     } else if !position.new_path.is_empty() {
         (position.new_path.clone(), 0, "new")
     } else {
@@ -3172,7 +3232,11 @@ struct GlabLineRangeRef {
 /// for the old side, the new part for the new side). `None` when neither yields a
 /// value — a garbage or absent `line_code` and no explicit field. Pure (testable).
 fn gl_range_ref_line(r: &GlabLineRangeRef, side: &str) -> Option<u32> {
-    let explicit = if side == "old" { r.old_line } else { r.new_line };
+    let explicit = if side == "old" {
+        r.old_line
+    } else {
+        r.new_line
+    };
     if explicit.is_some() {
         return explicit;
     }
@@ -3299,9 +3363,8 @@ async fn fetch_mr_discussions(
 ) -> AppResult<Vec<GlabDiscussion>> {
     let mut all: Vec<GlabDiscussion> = Vec::new();
     for page in 1..=5u32 {
-        let endpoint = format!(
-            "projects/{enc}/merge_requests/{number}/discussions?per_page=100&page={page}"
-        );
+        let endpoint =
+            format!("projects/{enc}/merge_requests/{number}/discussions?per_page=100&page={page}");
         let out = run_glab(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT).await?;
         let batch: Vec<GlabDiscussion> = match serde_json::from_str(&out.stdout_lossy()) {
             Ok(b) => b,
@@ -3741,7 +3804,12 @@ pub async fn review_submit(
 
 /// The award endpoint for a subject: the issue/MR body (`note_id` None) or one
 /// of its notes. `target` is `"issue"` or `"mr"`.
-fn award_endpoint(enc: &str, target: &str, number: u64, note_id: Option<&str>) -> AppResult<String> {
+fn award_endpoint(
+    enc: &str,
+    target: &str,
+    number: u64,
+    note_id: Option<&str>,
+) -> AppResult<String> {
     let seg = match target {
         "issue" => "issues",
         "mr" => "merge_requests",
@@ -3904,8 +3972,10 @@ async fn project_members(repo_path: &str) -> AppResult<Vec<GlabMember>> {
 /// read is capped at one page).
 async fn resolve_assignee_ids(repo_path: &str, assignees: &[String]) -> AppResult<Vec<u64>> {
     let members = project_members(repo_path).await?;
-    let by_name: HashMap<&str, u64> =
-        members.iter().map(|m| (m.username.as_str(), m.id)).collect();
+    let by_name: HashMap<&str, u64> = members
+        .iter()
+        .map(|m| (m.username.as_str(), m.id))
+        .collect();
     let mut ids = Vec::with_capacity(assignees.len());
     let mut missing: Vec<&str> = Vec::new();
     for u in assignees {
@@ -3988,7 +4058,11 @@ pub async fn set_pr_reviewers(repo_path: &str, number: u64, desired: &[String]) 
         .into_iter()
         .filter_map(|r| r.user.map(|u| u.username))
         .collect();
-    let dropped: Vec<String> = desired.iter().filter(|d| !now.contains(*d)).cloned().collect();
+    let dropped: Vec<String> = desired
+        .iter()
+        .filter(|d| !now.contains(*d))
+        .cloned()
+        .collect();
     if !dropped.is_empty() {
         return Err(AppError::Glab(format!(
             "GitLab didn't set reviewer(s) {} — this GitLab tier may allow only one \
@@ -4088,11 +4162,7 @@ pub async fn set_issue_assignees(
 
 /// Set a merge request's assignees (usernames; empty clears). GitLab-only — GitHub
 /// PRs have no assignee picker in this app.
-pub async fn set_mr_assignees(
-    repo_path: &str,
-    number: u64,
-    assignees: &[String],
-) -> AppResult<()> {
+pub async fn set_mr_assignees(repo_path: &str, number: u64, assignees: &[String]) -> AppResult<()> {
     set_target_assignees(repo_path, "merge_requests", number, assignees).await
 }
 
@@ -4179,9 +4249,7 @@ pub async fn repo_star_status(repo_path: &str) -> AppResult<bool> {
         );
         let out = run_glab(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT).await?;
         let starred: Vec<GlabStarredProject> = serde_json::from_str(&out.stdout_lossy())
-            .map_err(|e| {
-                AppError::Glab(format!("could not parse GitLab starred projects: {e}"))
-            })?;
+            .map_err(|e| AppError::Glab(format!("could not parse GitLab starred projects: {e}")))?;
         if starred.iter().any(|p| p.path_with_namespace == path) {
             return Ok(true);
         }
@@ -4278,8 +4346,7 @@ pub async fn publish_repo(
         // failure (not a repo, git missing, …) keeps its real message.
         match &e {
             AppError::Git { stderr, .. }
-                if stderr.contains("ambiguous argument")
-                    || stderr.contains("unknown revision") =>
+                if stderr.contains("ambiguous argument") || stderr.contains("unknown revision") =>
             {
                 AppError::InvalidArgument(
                     "make an initial commit before publishing (this repository has none yet)"
@@ -4715,7 +4782,9 @@ fn clean_trace(raw: &str) -> String {
             .char_indices()
             .find(|(_, ch)| !ch.is_ascii_digit())
             .map_or(after.len(), |(i, _)| i);
-        let named = after[digits_end..].strip_prefix(':').unwrap_or(&after[digits_end..]);
+        let named = after[digits_end..]
+            .strip_prefix(':')
+            .unwrap_or(&after[digits_end..]);
         let name_end = named
             .char_indices()
             .find(|(_, ch)| !(ch.is_ascii_alphanumeric() || *ch == '_' || *ch == '-' || *ch == '.'))
@@ -4883,7 +4952,10 @@ pub async fn view_run(repo_path: &str, run_id: u64) -> AppResult<RunDetail> {
     // matching how view_pr reorders commits oldest-first.
     let mut jobs: Vec<GlabJob> = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/pipelines/{run_id}/jobs?per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/pipelines/{run_id}/jobs?per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -4946,7 +5018,10 @@ pub async fn run_failed_logs(repo_path: &str, run_id: u64) -> AppResult<String> 
     let enc = encode_project(&project_path(repo_path).await?);
     let jobs: Vec<GlabJob> = run_glab(
         Some(repo_path),
-        &["api", &format!("projects/{enc}/pipelines/{run_id}/jobs?per_page=100")],
+        &[
+            "api",
+            &format!("projects/{enc}/pipelines/{run_id}/jobs?per_page=100"),
+        ],
         GLAB_NETWORK_TIMEOUT,
     )
     .await
@@ -5391,7 +5466,9 @@ pub async fn delete_release_asset(repo_path: &str, tag: &str, asset_name: &str) 
         return Err(AppError::InvalidArgument("a tag is required".into()));
     }
     if asset_name.is_empty() {
-        return Err(AppError::InvalidArgument("an asset name is required".into()));
+        return Err(AppError::InvalidArgument(
+            "an asset name is required".into(),
+        ));
     }
     let enc = encode_project(&project_path(repo_path).await?);
     let enc_tag = encode_query_value(tag);
@@ -5640,27 +5717,15 @@ pub async fn update_repo_settings(
     input: GitLabRepoSettingsInput,
 ) -> AppResult<GitLabRepoSettings> {
     for (field, value, allowed) in [
-        (
-            "issues",
-            &input.issues_access_level,
-            &ACCESS_LEVELS[..],
-        ),
+        ("issues", &input.issues_access_level, &ACCESS_LEVELS[..]),
         (
             "merge requests",
             &input.merge_requests_access_level,
             &ACCESS_LEVELS[..],
         ),
         ("wiki", &input.wiki_access_level, &ACCESS_LEVELS[..]),
-        (
-            "snippets",
-            &input.snippets_access_level,
-            &ACCESS_LEVELS[..],
-        ),
-        (
-            "forking",
-            &input.forking_access_level,
-            &ACCESS_LEVELS[..],
-        ),
+        ("snippets", &input.snippets_access_level, &ACCESS_LEVELS[..]),
+        ("forking", &input.forking_access_level, &ACCESS_LEVELS[..]),
         ("merge method", &input.merge_method, &MERGE_METHODS[..]),
         ("squash option", &input.squash_option, &SQUASH_OPTIONS[..]),
     ] {
@@ -6366,9 +6431,7 @@ pub async fn list_variables(repo_path: &str) -> AppResult<Vec<GitLabVariable>> {
 fn validate_variable_key(key: &str) -> AppResult<()> {
     let valid = !key.is_empty()
         && key.len() <= 255
-        && key
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+        && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
     if !valid {
         return Err(AppError::InvalidArgument(
             "variable keys use only letters, digits, and underscores".into(),
@@ -6529,7 +6592,9 @@ fn map_protected_branch(pb: GlabProtectedBranch) -> GitLabProtectedBranch {
 /// address it in the URL) and can't be blank.
 fn validate_branch_name(name: &str) -> AppResult<()> {
     if name.trim().is_empty() {
-        return Err(AppError::InvalidArgument("branch name can't be empty".into()));
+        return Err(AppError::InvalidArgument(
+            "branch name can't be empty".into(),
+        ));
     }
     Ok(())
 }
@@ -6551,8 +6616,8 @@ pub async fn list_protected_branches(repo_path: &str) -> AppResult<Vec<GitLabPro
     for page in 1..=10 {
         let endpoint = format!("projects/{enc}/protected_branches?per_page=100&page={page}");
         let out = run_glab(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT).await?;
-        let batch: Vec<GlabProtectedBranch> = serde_json::from_str(&out.stdout_lossy())
-            .map_err(|e| {
+        let batch: Vec<GlabProtectedBranch> =
+            serde_json::from_str(&out.stdout_lossy()).map_err(|e| {
                 AppError::Glab(format!("could not parse GitLab protected branches: {e}"))
             })?;
         let done = batch.len() < 100;
@@ -6783,7 +6848,14 @@ pub async fn issue_set_time_estimate(
     number: u64,
     duration: Option<&str>,
 ) -> AppResult<GitLabTimeStats> {
-    write_time(repo_path, TimeTarget::Issue, number, TimeWrite::Estimate, duration).await
+    write_time(
+        repo_path,
+        TimeTarget::Issue,
+        number,
+        TimeWrite::Estimate,
+        duration,
+    )
+    .await
 }
 
 /// Add to (or, when blank, reset) an issue's spent time; returns the new stats.
@@ -6792,7 +6864,14 @@ pub async fn issue_add_spent_time(
     number: u64,
     duration: Option<&str>,
 ) -> AppResult<GitLabTimeStats> {
-    write_time(repo_path, TimeTarget::Issue, number, TimeWrite::Spent, duration).await
+    write_time(
+        repo_path,
+        TimeTarget::Issue,
+        number,
+        TimeWrite::Spent,
+        duration,
+    )
+    .await
 }
 
 /// Set (or, when blank, reset) a merge request's time estimate; returns new stats.
@@ -6948,7 +7027,14 @@ mod tests {
         assert_eq!(map_job_check_status("canceled"), "CANCELLED");
         assert_eq!(map_job_check_status("cancelled"), "CANCELLED");
         // Everything else (in-flight, skipped, manual, unknown) → pending bucket.
-        for s in ["running", "pending", "manual", "skipped", "created", "weird_new_state"] {
+        for s in [
+            "running",
+            "pending",
+            "manual",
+            "skipped",
+            "created",
+            "weird_new_state",
+        ] {
             assert_eq!(map_job_check_status(s), "PENDING", "status {s}");
         }
     }
@@ -7559,7 +7645,10 @@ mod tests {
             "discussion_locked": true
         }"#;
         let issue: GlabIssueDetail = serde_json::from_str(json).unwrap();
-        assert_eq!(issue.labels, vec!["enhancement".to_string(), "ui".to_string()]);
+        assert_eq!(
+            issue.labels,
+            vec!["enhancement".to_string(), "ui".to_string()]
+        );
         assert_eq!(issue.assignees.len(), 2);
         assert_eq!(issue.assignees[0].username, "bob");
         let m = issue.milestone.as_ref().unwrap();
@@ -7571,13 +7660,31 @@ mod tests {
 
     #[test]
     fn ci_status_maps_to_neutral_two_field_model() {
-        assert_eq!(map_ci_status("success"), ("completed".into(), "success".into()));
-        assert_eq!(map_ci_status("failed"), ("completed".into(), "failure".into()));
-        assert_eq!(map_ci_status("canceled"), ("completed".into(), "cancelled".into()));
-        assert_eq!(map_ci_status("skipped"), ("completed".into(), "skipped".into()));
-        assert_eq!(map_ci_status("manual"), ("completed".into(), "action_required".into()));
+        assert_eq!(
+            map_ci_status("success"),
+            ("completed".into(), "success".into())
+        );
+        assert_eq!(
+            map_ci_status("failed"),
+            ("completed".into(), "failure".into())
+        );
+        assert_eq!(
+            map_ci_status("canceled"),
+            ("completed".into(), "cancelled".into())
+        );
+        assert_eq!(
+            map_ci_status("skipped"),
+            ("completed".into(), "skipped".into())
+        );
+        assert_eq!(
+            map_ci_status("manual"),
+            ("completed".into(), "action_required".into())
+        );
         // In-flight states map to a non-completed lifecycle (so the UI keeps polling).
-        assert_eq!(map_ci_status("running"), ("in_progress".into(), String::new()));
+        assert_eq!(
+            map_ci_status("running"),
+            ("in_progress".into(), String::new())
+        );
         assert_eq!(map_ci_status("pending"), ("pending".into(), String::new()));
         assert_eq!(map_ci_status("created"), ("queued".into(), String::new()));
     }
@@ -7633,7 +7740,10 @@ mod tests {
     fn cleans_gitlab_trace_of_ansi_and_section_markers() {
         let raw = "\u{1b}[0Ksection_start:1718000000:prepare\rPreparing\u{1b}[0;m\nsection_end:1718000000:prepare\r\u{1b}[32;1mDone\u{1b}[0m\n";
         let cleaned = clean_trace(raw);
-        assert!(!cleaned.contains('\u{1b}'), "ANSI escapes remain: {cleaned:?}");
+        assert!(
+            !cleaned.contains('\u{1b}'),
+            "ANSI escapes remain: {cleaned:?}"
+        );
         assert!(!cleaned.contains('\r'));
         assert!(!cleaned.contains("section_start"));
         assert!(!cleaned.contains("section_end"));
@@ -7695,7 +7805,10 @@ mod tests {
     fn encodes_query_significant_chars_in_a_branch_ref() {
         // The plain branch name survives; `/` and query-significant chars encode so
         // `glab api`'s verbatim query can't be corrupted/split.
-        assert_eq!(encode_query_value("feature/dark-mode"), "feature%2Fdark-mode");
+        assert_eq!(
+            encode_query_value("feature/dark-mode"),
+            "feature%2Fdark-mode"
+        );
         assert_eq!(encode_query_value("fix_bug.v2"), "fix_bug.v2");
         assert_eq!(encode_query_value("a&b=c#d"), "a%26b%3Dc%23d");
     }
@@ -7822,7 +7935,11 @@ mod tests {
             ))
             .unwrap()
         };
-        let list = vec![mk("v2.0.0-next", true), mk("v1.1.0", false), mk("v1.0.0", false)];
+        let list = vec![
+            mk("v2.0.0-next", true),
+            mk("v1.1.0", false),
+            mk("v1.0.0", false),
+        ];
         let infos = releases_to_infos(&list);
         assert!(!infos[0].is_latest, "an upcoming release is never latest");
         assert!(infos[1].is_latest, "the newest published release is latest");
@@ -7848,9 +7965,18 @@ mod tests {
         // glab CSV-splits the --variables flag value; the token must be a fully
         // quoted CSV field with embedded quotes doubled (forms validated live).
         assert_eq!(variable_token("KEY", "simple"), "\"KEY:simple\"");
-        assert_eq!(variable_token("REGIONS", "us-east-1,eu-west-1"), "\"REGIONS:us-east-1,eu-west-1\"");
-        assert_eq!(variable_token("NOTE", "say \"hi\", ok"), "\"NOTE:say \"\"hi\"\", ok\"");
-        assert_eq!(variable_token("MSG", "hello: world"), "\"MSG:hello: world\"");
+        assert_eq!(
+            variable_token("REGIONS", "us-east-1,eu-west-1"),
+            "\"REGIONS:us-east-1,eu-west-1\""
+        );
+        assert_eq!(
+            variable_token("NOTE", "say \"hi\", ok"),
+            "\"NOTE:say \"\"hi\"\", ok\""
+        );
+        assert_eq!(
+            variable_token("MSG", "hello: world"),
+            "\"MSG:hello: world\""
+        );
     }
 
     #[test]
@@ -7948,7 +8074,8 @@ mod tests {
         assert!(env.errors.is_empty());
         assert!(env.data.unwrap().request_changes.unwrap().errors.is_empty());
 
-        let refused = r#"{"data":{"mergeRequestRequestChanges":{"errors":["Reviewer not found"]}}}"#;
+        let refused =
+            r#"{"data":{"mergeRequestRequestChanges":{"errors":["Reviewer not found"]}}}"#;
         let env: GlabGqlRequestChangesEnvelope = serde_json::from_str(refused).unwrap();
         assert_eq!(
             env.data.unwrap().request_changes.unwrap().errors,
@@ -8090,7 +8217,9 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::InvalidArgument(_)));
-        let err = update_protected_branch("/repo", "", false).await.unwrap_err();
+        let err = update_protected_branch("/repo", "", false)
+            .await
+            .unwrap_err();
         assert!(matches!(err, AppError::InvalidArgument(_)));
         let err = delete_protected_branch("/repo", "  ").await.unwrap_err();
         assert!(matches!(err, AppError::InvalidArgument(_)));
@@ -8286,7 +8415,10 @@ mod tests {
     fn parse_hunk_header_ignores_untrusted_heading() {
         // Direct unit coverage of the range/heading split (input is the text AFTER the
         // leading `@@`, as `gl_diff_line_refs` passes it).
-        assert_eq!(parse_hunk_header(" -40,3 +40,4 @@ fn f() -> T"), Some((40, 40)));
+        assert_eq!(
+            parse_hunk_header(" -40,3 +40,4 @@ fn f() -> T"),
+            Some((40, 40))
+        );
         assert_eq!(parse_hunk_header(" -1,2 +1,2 @@ x +5"), Some((1, 1)));
         assert_eq!(parse_hunk_header(" -5,2 +5,3 @@ @@count"), Some((5, 5)));
         // A malformed range (no `+` start) is still None.
@@ -8389,15 +8521,13 @@ mod tests {
 
     #[test]
     fn file_diff_matches_by_side_path() {
-        let changes = vec![
-            GlabChange {
-                old_path: "old_name.rs".into(),
-                new_path: "new_name.rs".into(),
-                new_file: false,
-                deleted_file: false,
-                diff: "@@ -1 +1 @@\n-a\n+b\n".into(),
-            },
-        ];
+        let changes = vec![GlabChange {
+            old_path: "old_name.rs".into(),
+            new_path: "new_name.rs".into(),
+            new_file: false,
+            deleted_file: false,
+            diff: "@@ -1 +1 @@\n-a\n+b\n".into(),
+        }];
         // New side matches on new_path; old side on old_path.
         assert!(gl_file_diff(&changes, "new_name.rs", "new").is_some());
         assert!(gl_file_diff(&changes, "old_name.rs", "old").is_some());

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::{AppError, AppResult};
 use crate::forge::glab::{run_glab, run_glab_ex, run_glab_raw, GLAB_NETWORK_TIMEOUT, GLAB_TIMEOUT};
 use crate::forge::model::{
-    Capabilities, ForgeRepo, ForgeRepoList, ForgeStatus, ForgeUserRef, Implemented, Provider,
+    Capabilities, CompletedReviewerOut, ForgeRepo, ForgeRepoList, ForgeStatus, ForgeUserRef,
+    Implemented, Provider,
 };
 use crate::forge::Forge;
 use crate::github::actions::{RunDetail, RunJob, WorkflowRun};
@@ -866,6 +867,52 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         .author
         .map(|a| (a.username, a.avatar_url))
         .unwrap_or_default();
+
+    // Reviewer verdicts. GitLab MRs carry no reviewable review objects, so a
+    // completed reviewer is an assigned reviewer whose per-reviewer state is
+    // `approved` or `requested_changes` (from `…/reviewers`). Best-effort: a
+    // failed/omitted fetch just leaves `completed_reviewers` empty (never fails
+    // the view). NOTE: `reviewers` below stays the FULL assigned set — on GitLab
+    // an approver remains an assigned reviewer, and that list drives a
+    // full-replacement reviewer PUT, so dropping acted reviewers from it would
+    // un-assign them on the next edit. The frontend de-dups the display instead.
+    let reviewer_states: std::collections::HashMap<String, String> =
+        mr_reviewers(repo_path, &enc, number)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|r| {
+                r.user
+                    .map(|u| (u.username, r.state.to_ascii_lowercase()))
+                    .filter(|(name, _)| !name.is_empty())
+            })
+            .collect();
+
+    // The acted subset (approved / requested-changes), with each reviewer's
+    // verdict — built by borrowing `mr.reviewers` so the full list below can
+    // still consume it.
+    let completed_reviewers: Vec<CompletedReviewerOut> = mr
+        .reviewers
+        .iter()
+        .filter(|u| !u.username.is_empty())
+        .filter_map(|u| {
+            let state = match reviewer_states.get(&u.username).map(String::as_str) {
+                Some("approved") => "APPROVED",
+                Some("requested_changes") => "CHANGES_REQUESTED",
+                _ => return None,
+            };
+            Some(CompletedReviewerOut {
+                user: ForgeUserRef {
+                    id: u.username.clone(),
+                    label: u.username.clone(),
+                    avatar_url: u.avatar_url.clone(),
+                    is_bot: false,
+                },
+                state: state.to_string(),
+            })
+        })
+        .collect();
+
     Ok(PrDetails {
         // No GraphQL node id on GitLab; the GitLab mutations key on the iid (labels
         // by name, assignees by resolved numeric id), so an empty id is fine.
@@ -898,9 +945,11 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
                 is_bot: false,
             })
             .collect(),
-        // Reviewers, keyed by username (like assignees — the setter resolves
-        // username→id, candidates use username), so the picker's selected chips
-        // match its candidate ids.
+        // The FULL assigned reviewer set, keyed by username (like assignees — the
+        // setter resolves username→id, candidates use username), so the picker's
+        // selected chips match its candidate ids. Acted reviewers stay here (this
+        // list drives a full-replacement PUT); `completed_reviewers` carries their
+        // verdicts and the frontend de-dups the display.
         reviewers: mr
             .reviewers
             .into_iter()
@@ -912,6 +961,7 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
                 is_bot: false,
             })
             .collect(),
+        completed_reviewers,
     })
 }
 

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -131,7 +131,11 @@ fn glab_config_paths() -> Vec<PathBuf> {
     }
     #[cfg(target_os = "macos")]
     if let Some(h) = &home {
-        dirs.push(h.join("Library").join("Application Support").join("glab-cli"));
+        dirs.push(
+            h.join("Library")
+                .join("Application Support")
+                .join("glab-cli"),
+        );
     }
     dirs.into_iter().map(|d| d.join("config.yml")).collect()
 }
@@ -278,7 +282,10 @@ pub async fn run_glab_ex(
     })?;
     if let Some(body) = input {
         if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(body.as_bytes()).await.map_err(AppError::Io)?;
+            stdin
+                .write_all(body.as_bytes())
+                .await
+                .map_err(AppError::Io)?;
             stdin.shutdown().await.ok();
         }
     }
@@ -356,7 +363,10 @@ hosts:
             normalize_host("https://GitLab.Example.com:8443/gitlab"),
             Some("gitlab.example.com".into())
         );
-        assert_eq!(normalize_host("gitlab.example.com"), Some("gitlab.example.com".into()));
+        assert_eq!(
+            normalize_host("gitlab.example.com"),
+            Some("gitlab.example.com".into())
+        );
         assert_eq!(normalize_host("  "), None);
     }
 }

--- a/src-tauri/src/forge/http.rs
+++ b/src-tauri/src/forge/http.rs
@@ -428,7 +428,8 @@ mod tests {
     #[test]
     fn http_error_other_403_falls_through_to_envelope_message() {
         // A 403 that is NOT a missing-scope error keeps the API's own message.
-        let body = r#"{"type":"error","error":{"message":"You do not have access to this repository."}}"#;
+        let body =
+            r#"{"type":"error","error":{"message":"You do not have access to this repository."}}"#;
         match http_error(403, body) {
             AppError::Bitbucket(m) => {
                 assert!(m.contains("access to this repository"));

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -2506,6 +2506,10 @@ pub async fn forge_repo_delete(
             )));
         }
     }
+    // origin is gone (either just removed, or already absent) — drop any cached URL so a
+    // forge query within the TTL sees the repo as unpublished instead of serving the stale
+    // (now-deleted) remote URL.
+    crate::git::remote::invalidate_remote_url_cache(&repo_path, "origin");
     Ok(())
 }
 

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -624,6 +624,17 @@ pub struct ForgeUserRef {
     pub is_bot: bool,
 }
 
+/// A reviewer who has submitted a verdict (GitLab approval/requested-changes,
+/// Bitbucket participant state). GitHub derives its own completed reviewers on
+/// the frontend from `reviews`, so it leaves this empty.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletedReviewerOut {
+    pub user: ForgeUserRef,
+    /// Uppercased: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED".
+    pub state: String,
+}
+
 /// A repository as listed for cloning — neutral across providers (the clone
 /// browser's row). GitHub fields map 1:1 from `GhRepo`; GitLab fills it from a
 /// `glab` project.

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
@@ -6,21 +10,86 @@ use crate::state::AppState;
 
 fn validate_remote_arg(value: &str, what: &str) -> AppResult<()> {
     if value.is_empty() || value.starts_with('-') {
-        return Err(AppError::InvalidArgument(format!("invalid {what}: {value}")));
+        return Err(AppError::InvalidArgument(format!(
+            "invalid {what}: {value}"
+        )));
     }
     Ok(())
+}
+
+/// How long a resolved remote URL stays trusted before we re-shell to `git`. A few seconds
+/// is enough to collapse the burst of concurrent `forge_*` queries a single forge view fires
+/// (each of which otherwise spawns `git remote get-url origin` twice), while staying short
+/// enough that an external `git remote set-url` run in a terminal is picked up promptly. An
+/// in-app `git_remote_set_url` invalidates eagerly, so the TTL is only the backstop for
+/// out-of-band changes.
+const REMOTE_URL_TTL: Duration = Duration::from_secs(5);
+
+/// Cache map keyed by `(repo_path, remote_name)`; value is `(fetch time, resolved url)`.
+type RemoteUrlCache = Mutex<HashMap<(String, String), (Instant, String)>>;
+
+/// Per-`(repo_path, remote_name)` cache of the last resolved remote URL and when it was
+/// fetched. Bounded by (#repos × #remote names) — tiny, so a stale entry is simply
+/// overwritten on the next fetch rather than evicted. Only successful lookups are cached.
+static REMOTE_URL_CACHE: OnceLock<RemoteUrlCache> = OnceLock::new();
+
+fn remote_url_cache() -> &'static RemoteUrlCache {
+    REMOTE_URL_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Return the cached URL for `(repo, name)` only if an entry exists AND it was fetched less
+/// than `ttl` ago. Pure over the module-level cache; the lock is held only long enough to
+/// clone the value out.
+fn cache_get(repo: &str, name: &str, ttl: Duration) -> Option<String> {
+    let guard = remote_url_cache().lock().unwrap();
+    let (fetched_at, url) = guard.get(&(repo.to_string(), name.to_string()))?;
+    if fetched_at.elapsed() < ttl {
+        Some(url.clone())
+    } else {
+        None
+    }
+}
+
+/// Record `url` as the current value for `(repo, name)`, stamped with the fetch time.
+fn cache_put(repo: &str, name: &str, url: &str) {
+    remote_url_cache().lock().unwrap().insert(
+        (repo.to_string(), name.to_string()),
+        (Instant::now(), url.to_string()),
+    );
+}
+
+/// Drop any cached entry for `(repo, name)` so the next read re-resolves immediately.
+fn cache_invalidate(repo: &str, name: &str) {
+    remote_url_cache()
+        .lock()
+        .unwrap()
+        .remove(&(repo.to_string(), name.to_string()));
+}
+
+/// Invalidate the cached URL for `(repo, name)` from another module. Call this after any
+/// out-of-band mutation of a remote's URL that bypasses [`git_remote_set_url`] — e.g. a
+/// forge rename that rewrites `origin` or a repo delete that removes it — so a forge query
+/// firing within the TTL re-resolves the now-changed remote instead of serving the stale
+/// value. Idempotent: a no-op when nothing is cached.
+pub(crate) fn invalidate_remote_url_cache(repo: &str, name: &str) {
+    cache_invalidate(repo, name);
 }
 
 #[tauri::command]
 pub async fn git_remote_url(repo_path: String, name: String) -> AppResult<String> {
     validate_remote_arg(&name, "remote name")?;
+    if let Some(url) = cache_get(&repo_path, &name, REMOTE_URL_TTL) {
+        return Ok(url);
+    }
     let out = run_git(
         Some(&repo_path),
         &["remote", "get-url", &name],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    Ok(out.stdout_lossy().trim().to_string())
+    let url = out.stdout_lossy().trim().to_string();
+    cache_put(&repo_path, &name, &url);
+    Ok(url)
 }
 
 #[tauri::command]
@@ -39,6 +108,9 @@ pub async fn git_remote_set_url(
         DEFAULT_TIMEOUT,
     )
     .await?;
+    // The URL changed under us — drop the cached entry so the next read re-resolves
+    // immediately instead of waiting out the TTL.
+    cache_invalidate(&repo_path, &name);
     Ok(())
 }
 
@@ -115,4 +187,68 @@ pub(crate) async fn git_push_core(
     }
     run_git_mutating(state, &repo_path, &args, NETWORK_TIMEOUT).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cache_get, cache_invalidate, cache_put};
+    use std::time::Duration;
+
+    // Distinct keys per test — the cache is a process-wide static shared across all tests.
+    const BIG: Duration = Duration::from_secs(3600);
+
+    #[test]
+    fn put_then_get_within_ttl_hits() {
+        cache_put("/repo/a", "origin", "git@example.com:a.git");
+        assert_eq!(
+            cache_get("/repo/a", "origin", BIG),
+            Some("git@example.com:a.git".to_string())
+        );
+    }
+
+    #[test]
+    fn zero_ttl_is_always_expired() {
+        cache_put("/repo/b", "origin", "https://example.com/b.git");
+        // Zero TTL: any elapsed time (however small) is >= the TTL, so the entry reads as expired.
+        assert_eq!(cache_get("/repo/b", "origin", Duration::ZERO), None);
+    }
+
+    #[test]
+    fn invalidate_drops_the_entry() {
+        cache_put("/repo/c", "origin", "https://example.com/c.git");
+        assert!(cache_get("/repo/c", "origin", BIG).is_some());
+        cache_invalidate("/repo/c", "origin");
+        assert_eq!(cache_get("/repo/c", "origin", BIG), None);
+    }
+
+    #[test]
+    fn distinct_keys_do_not_collide() {
+        cache_put("/repo/d", "origin", "url-origin");
+        cache_put("/repo/d", "upstream", "url-upstream");
+        cache_put("/repo/e", "origin", "url-e-origin");
+        assert_eq!(
+            cache_get("/repo/d", "origin", BIG),
+            Some("url-origin".to_string())
+        );
+        assert_eq!(
+            cache_get("/repo/d", "upstream", BIG),
+            Some("url-upstream".to_string())
+        );
+        assert_eq!(
+            cache_get("/repo/e", "origin", BIG),
+            Some("url-e-origin".to_string())
+        );
+        // Invalidating one key leaves the others intact.
+        cache_invalidate("/repo/d", "origin");
+        assert_eq!(cache_get("/repo/d", "origin", BIG), None);
+        assert_eq!(
+            cache_get("/repo/d", "upstream", BIG),
+            Some("url-upstream".to_string())
+        );
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        assert_eq!(cache_get("/repo/never-written", "origin", BIG), None);
+    }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1687,6 +1687,11 @@ pub struct PrDetails {
     /// is true; the id is the provider's stable handle (GitHub login, GitLab username,
     /// Bitbucket the braced account uuid), the label the display name.
     pub reviewers: Vec<crate::forge::model::ForgeUserRef>,
+    /// Reviewers who have submitted a verdict, supplied by the backend for providers
+    /// that don't populate `reviews` (GitLab approvals, Bitbucket participant states).
+    /// GitHub derives its completed reviewers on the frontend from `reviews`, so it
+    /// leaves this empty.
+    pub completed_reviewers: Vec<crate::forge::model::CompletedReviewerOut>,
 }
 
 /// A merge/pull request's approval summary — who has approved and whether the
@@ -1909,6 +1914,8 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
                 }
             })
             .collect(),
+        // GitHub derives its completed reviewers on the frontend from `reviews`.
+        completed_reviewers: Vec::new(),
     })
 }
 

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -503,6 +503,25 @@ fn cap_tail(s: String, max: usize) -> String {
     format!("…[truncated]\n\n{}", &s[start..])
 }
 
+/// Max review-thread `diffHunk` lines surfaced by `list_pull_request_comments`
+/// (both this MCP tool and its TS review-loop twin — KEEP IN SYNC). A GitHub
+/// comment on a brand-new file drags the whole file into `diffHunk`, so it is
+/// bounded here rather than at the shared IPC struct.
+const HUNK_MAX_LINES: usize = 24;
+
+/// Caps a review-thread diff hunk to at most `max_lines` lines, keeping the
+/// **tail** (GitHub's `diffHunk` ends at the anchored line, so the last lines are
+/// the relevant context) and prefixing a marker when it overflows. Pure so it's
+/// unit-testable; an already-short hunk (including empty) is returned unchanged.
+fn cap_hunk_lines(hunk: String, max_lines: usize) -> String {
+    let total = hunk.lines().count();
+    if total <= max_lines {
+        return hunk;
+    }
+    let tail: Vec<&str> = hunk.lines().skip(total - max_lines).collect();
+    format!("…[hunk truncated]\n{}", tail.join("\n"))
+}
+
 /// Entry point for the `gitdesktop-mcp` binary. Parses `--repo <path>` (falling
 /// back to the current working directory), then runs the stdio MCP server until
 /// the client disconnects.
@@ -605,6 +624,37 @@ mod tests {
 
     fn parse(argv: &[&str]) -> McpArgs {
         McpArgs::parse(argv.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn cap_hunk_lines_passes_short_hunks_through() {
+        // At or under the cap → returned byte-for-byte, no marker.
+        let three = "a\nb\nc".to_string();
+        assert_eq!(cap_hunk_lines(three.clone(), 24), three);
+        let exactly = (0..24)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(cap_hunk_lines(exactly.clone(), 24), exactly);
+        // Empty stays empty.
+        assert_eq!(cap_hunk_lines(String::new(), 24), "");
+    }
+
+    #[test]
+    fn cap_hunk_lines_keeps_last_max_lines_with_marker() {
+        // 30-line hunk, cap 24 → marker + exactly the last 24 lines (6..29).
+        let hunk = (0..30)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let capped = cap_hunk_lines(hunk, 24);
+        let expected_tail = (6..30)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(capped, format!("…[hunk truncated]\n{expected_tail}"));
+        // The body is exactly 24 lines (the marker adds one more).
+        assert_eq!(capped.lines().count(), 25);
     }
 
     #[test]

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -14,8 +14,8 @@ use rmcp::model::{CallToolResult, Content};
 use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
 
 use super::{
-    app_err, cap_head, cap_tail, json_result, json_result_untrusted, GitDesktopMcp, JobIdArg,
-    NumberArg, RunIdArg, GH_TEXT_MAX_BYTES,
+    app_err, cap_head, cap_hunk_lines, cap_tail, json_result, json_result_untrusted, GitDesktopMcp,
+    JobIdArg, NumberArg, RunIdArg, GH_TEXT_MAX_BYTES, HUNK_MAX_LINES,
 };
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -47,6 +47,22 @@ struct IssueListArgs {
     /// Max issues to return. Omit for the provider default (GitHub ~30; GitLab a full page).
     #[serde(default)]
     limit: Option<u32>,
+}
+
+/// Default for `PrCommentsArgs::include_diff_hunk`: include the (capped) hunk.
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct PrCommentsArgs {
+    /// The pull request number.
+    number: u64,
+    /// Include each review thread's `diffHunk` code-context excerpt, capped to the
+    /// last few lines (default true). Set false to drop hunks entirely — useful when
+    /// you only need the threads' structure (path, line, resolution, replies).
+    #[serde(default = "default_true")]
+    include_diff_hunk: bool,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -173,22 +189,37 @@ impl GitDesktopMcp {
                        (GitHub, GitLab, or Bitbucket, per its remote): `comments` (the top-level \
                        conversation), `reviews` (review summaries), and `review_threads` (file:line \
                        -anchored threads, each with its full reply chain) — every entry carries the \
-                       author, date, and the original markdown body. Read-only; returns JSON. (For \
-                       the PR's metadata + changed files use get_pull_request; for its diff, \
-                       pull_request_diff.)"
+                       author, date, and the original markdown body. Each thread's `diffHunk` \
+                       code-context excerpt (GitHub only) is capped to its last few lines; set \
+                       `include_diff_hunk` false to drop hunks entirely (default true). Read-only; \
+                       returns JSON. (For the PR's metadata + changed files use get_pull_request; \
+                       for its diff, pull_request_diff.)"
     )]
     async fn list_pull_request_comments(
         &self,
-        Parameters(args): Parameters<NumberArg>,
+        Parameters(args): Parameters<PrCommentsArgs>,
     ) -> Result<CallToolResult, McpError> {
         let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number)
             .await
             .map_err(app_err)?;
-        let review_threads = crate::forge::forge_pr_review_threads(self.repo.clone(), args.number)
-            .await
-            .map_err(app_err)?;
+        let mut review_threads =
+            crate::forge::forge_pr_review_threads(self.repo.clone(), args.number)
+                .await
+                .map_err(app_err)?;
+        // Bound each thread's diffHunk so a comment on a new file can't drag the
+        // whole file into the payload (GitHub-only; GitLab/Bitbucket set it ""),
+        // or drop it entirely when the caller opts out. Mutating this OWNED Vec
+        // never touches the shared IPC struct's serialized shape.
+        for t in &mut review_threads {
+            t.diff_hunk = if args.include_diff_hunk {
+                cap_hunk_lines(std::mem::take(&mut t.diff_hunk), HUNK_MAX_LINES)
+            } else {
+                String::new()
+            };
+        }
         // KEEP IN SYNC: src/lib/ai/review-tools.ts (`list_pull_request_comments`)
-        // mirrors this composed shape for the HTTP review tool loop.
+        // mirrors this composed shape (and the diffHunk cap) for the HTTP review
+        // tool loop.
         json_result_untrusted(&serde_json::json!({
             "number": args.number,
             "comments": pr.comments,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -513,6 +513,10 @@ files with diffs, and CI checks. From there you can **comment** (with quote-repl
 **labels**, **assignees**, and **reviewers** (request a review from a collaborator — the
 picker excludes the PR author, whom GitHub won't let you request), mark a draft **ready**,
 **merge** (merge commit, squash, or rebase, with optional branch deletion), and **close**.
+Reviewers who've already reviewed show as read-only chips carrying their verdict — a check
+for **approved**, an X for **requested changes**, a speech bubble for **commented** (icon
+shape plus the word, never color alone) — so a finished review (including Copilot's) stays
+visible after the reviewer leaves the pending-request list.
 
 The Conversation tab is a single **date-sorted activity feed** — reviews, comments,
 pushed commits, and events all interleaved oldest-to-newest. A run of pushes collapses

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -723,7 +723,22 @@ export function RemotePrView({
   // state, so we surface each as a read-only chip carrying that state. Derived
   // like humanReviewers/botReviewers above (plain, not a hook — this is past the
   // component's early returns).
-  const completedReviewers = deriveCompletedReviewers(pr.reviews, pr.reviewers);
+  const completedReviewers = [
+    ...deriveCompletedReviewers(pr.reviews, pr.reviewers),
+    ...pr.completedReviewers.map((cr) => ({
+      login: cr.user.id,
+      label: cr.user.label,
+      isBot: cr.user.isBot,
+      avatarUrl: cr.user.avatarUrl,
+      state: cr.state.toUpperCase(),
+    })),
+  ];
+  // Logins that already render as completed chips. For GitLab/Bitbucket an acted
+  // reviewer stays in `pr.reviewers` (the full assigned set — the picker preserves
+  // them on save) AND appears in `pr.completedReviewers`, so the read-only pending
+  // list filters these out to avoid a duplicate pending+completed chip. GitHub never
+  // overlaps (its completed reviewers have already left `pr.reviewers`).
+  const completedLogins = new Set(completedReviewers.map((c) => c.login));
   const busy =
     comment.isPending ||
     mergePr.isPending ||
@@ -947,22 +962,24 @@ export function RemotePrView({
         ) : (
           (pr.reviewers.length > 0 || completedReviewers.length > 0) && (
             <div className="flex flex-wrap items-center gap-1.5">
-              {humanReviewers.map((user) => {
-                const hint = userRefHint(user, humanReviewers);
-                return (
-                  <span
-                    key={user.id}
-                    title={hint ? `${user.label} (${hint})` : undefined}
-                    className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-                  >
-                    <ForgeUserAvatar user={user} ghHost={ghHost} />
-                    {user.label}
-                    {hint && (
-                      <span className="text-muted-foreground"> · {hint}</span>
-                    )}
-                  </span>
-                );
-              })}
+              {humanReviewers
+                .filter((h) => !completedLogins.has(h.id))
+                .map((user) => {
+                  const hint = userRefHint(user, humanReviewers);
+                  return (
+                    <span
+                      key={user.id}
+                      title={hint ? `${user.label} (${hint})` : undefined}
+                      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+                    >
+                      <ForgeUserAvatar user={user} ghHost={ghHost} />
+                      {user.label}
+                      {hint && (
+                        <span className="text-muted-foreground"> · {hint}</span>
+                      )}
+                    </span>
+                  );
+                })}
               {botReviewers.map((user) => (
                 <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
               ))}
@@ -2107,6 +2124,9 @@ interface CompletedReviewer {
   login: string;
   label: string;
   isBot: boolean;
+  /** The reviewer's avatar URL when the provider supplies one (GitLab/Bitbucket).
+   *  Empty for GitHub, where `ForgeUserAvatar` derives it from the login. */
+  avatarUrl: string;
   /** Uppercased review state — APPROVED / CHANGES_REQUESTED / COMMENTED. */
   state: string;
 }
@@ -2145,6 +2165,8 @@ function deriveCompletedReviewers(
       login,
       label: isCopilot ? "Copilot" : login,
       isBot,
+      // GitHub avatars are login-derived; ForgeUserAvatar falls back when empty.
+      avatarUrl: "",
       state: review.state.toUpperCase(),
     };
   });
@@ -2204,7 +2226,7 @@ function CompletedReviewerChip({
           user={{
             id: reviewer.login,
             label: reviewer.label,
-            avatarUrl: "",
+            avatarUrl: reviewer.avatarUrl,
             isBot: false,
           }}
           ghHost={ghHost}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2,6 +2,7 @@ import {
   ArrowCounterClockwiseIcon,
   ArrowSquareOutIcon,
   CaretDownIcon,
+  ChatCircleIcon,
   CheckCircleIcon,
   ClockCountdownIcon,
   DotsThreeIcon,
@@ -111,6 +112,7 @@ import {
   type ApprovalState,
   type ForgeProvider,
   type ForgeUserRef,
+  type PrThreadOut,
   providerLabel,
   type ReviewThreadOut,
 } from "@/lib/git/types";
@@ -715,6 +717,13 @@ export function RemotePrView({
   // so botReviewers stays empty there — those PRs render exactly as before.
   const humanReviewers = pr.reviewers.filter((r) => !r.isBot);
   const botReviewers = pr.reviewers.filter((r) => r.isBot);
+  // Completed reviewers — reviewers who already submitted a verdict (they leave
+  // gh's `reviewRequests`, so they're gone from `pr.reviewers`, but their review
+  // stays in `pr.reviews`). GitHub's own sidebar keeps showing them WITH their
+  // state, so we surface each as a read-only chip carrying that state. Derived
+  // like humanReviewers/botReviewers above (plain, not a hook — this is past the
+  // component's early returns).
+  const completedReviewers = deriveCompletedReviewers(pr.reviews, pr.reviewers);
   const busy =
     comment.isPending ||
     mergePr.isPending ||
@@ -927,9 +936,16 @@ export function RemotePrView({
             {botReviewers.map((user) => (
               <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
             ))}
+            {completedReviewers.map((reviewer) => (
+              <CompletedReviewerChip
+                key={reviewer.login}
+                reviewer={reviewer}
+                ghHost={ghHost}
+              />
+            ))}
           </div>
         ) : (
-          pr.reviewers.length > 0 && (
+          (pr.reviewers.length > 0 || completedReviewers.length > 0) && (
             <div className="flex flex-wrap items-center gap-1.5">
               {humanReviewers.map((user) => {
                 const hint = userRefHint(user, humanReviewers);
@@ -949,6 +965,13 @@ export function RemotePrView({
               })}
               {botReviewers.map((user) => (
                 <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
+              ))}
+              {completedReviewers.map((reviewer) => (
+                <CompletedReviewerChip
+                  key={reviewer.login}
+                  reviewer={reviewer}
+                  ghHost={ghHost}
+                />
               ))}
             </div>
           )
@@ -2072,6 +2095,124 @@ export function RemotePrView({
         }
       />
     </div>
+  );
+}
+
+/** GitHub's Copilot review-bot login (the same value the AI-review context maps to
+ *  a "GitHub Copilot" display name). Its reviews arrive under this login. */
+const COPILOT_LOGIN = "copilot-pull-request-reviewer";
+
+/** A reviewer who has already submitted a verdict, in display shape. */
+interface CompletedReviewer {
+  login: string;
+  label: string;
+  isBot: boolean;
+  /** Uppercased review state — APPROVED / CHANGES_REQUESTED / COMMENTED. */
+  state: string;
+}
+
+/**
+ * Derives the completed-reviewer chips from a PR's reviews. Keeps only submitted
+ * verdicts (APPROVED / CHANGES_REQUESTED / COMMENTED), the latest per author, and
+ * drops anyone still in the pending request set (they render as pending instead,
+ * so there's never a duplicate). Copilot and `[bot]` logins are flagged as bots.
+ */
+function deriveCompletedReviewers(
+  reviews: PrThreadOut[],
+  pending: ForgeUserRef[],
+): CompletedReviewer[] {
+  const pendingLogins = new Set(pending.map((r) => r.id.toLowerCase()));
+  const latestByAuthor = new Map<string, PrThreadOut>();
+  for (const review of reviews) {
+    const s = review.state.toUpperCase();
+    if (s !== "APPROVED" && s !== "CHANGES_REQUESTED" && s !== "COMMENTED") {
+      continue;
+    }
+    if (!review.author || pendingLogins.has(review.author.toLowerCase())) {
+      continue;
+    }
+    const prev = latestByAuthor.get(review.author);
+    // Latest verdict wins; a tie or unparseable date keeps the first seen.
+    if (!prev || review.date > prev.date) {
+      latestByAuthor.set(review.author, review);
+    }
+  }
+  return Array.from(latestByAuthor.values()).map((review) => {
+    const login = review.author;
+    const isCopilot = login.toLowerCase() === COPILOT_LOGIN;
+    const isBot = isCopilot || /\[bot\]$/i.test(login);
+    return {
+      login,
+      label: isCopilot ? "Copilot" : login,
+      isBot,
+      state: review.state.toUpperCase(),
+    };
+  });
+}
+
+/**
+ * Icon + tone + accessible word for a completed reviewer's state, so the verdict
+ * never rides on color alone (distinct icon shapes + the word in title/aria-label).
+ * Mirrors ChecksRollup's status→{Icon,tone} map; tones are token classes, never
+ * hardcoded colors. Unknown states fall back to the neutral comment presentation.
+ */
+function reviewStatePresentation(state: string): {
+  Icon: typeof CheckCircleIcon;
+  tone: string;
+  word: string;
+} {
+  if (state === "APPROVED") {
+    return { Icon: CheckCircleIcon, tone: "text-success", word: "approved" };
+  }
+  if (state === "CHANGES_REQUESTED") {
+    return {
+      Icon: XCircleIcon,
+      tone: "text-destructive",
+      word: "requested changes",
+    };
+  }
+  return { Icon: ChatCircleIcon, tone: "text-info", word: "commented" };
+}
+
+/**
+ * A read-only chip for a reviewer who already submitted a verdict. Leads with a
+ * state icon (distinct shape + semantic token tone), then the reviewer avatar
+ * (a robot glyph for bots) and label. The state word lives in the chip's title
+ * AND aria-label, so meaning never rides on color alone. Non-interactive display:
+ * completed reviews are managed on the forge, so there's no picker affordance.
+ */
+function CompletedReviewerChip({
+  reviewer,
+  ghHost,
+}: {
+  reviewer: CompletedReviewer;
+  ghHost: string | null;
+}) {
+  const { Icon, tone, word } = reviewStatePresentation(reviewer.state);
+  const name = `${reviewer.label} — ${word}`;
+  return (
+    <span
+      title={name}
+      aria-label={name}
+      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+    >
+      <Icon aria-hidden className={cn("size-3 shrink-0", tone)} />
+      {reviewer.isBot ? (
+        <RobotIcon aria-hidden className="size-3 shrink-0" />
+      ) : (
+        <ForgeUserAvatar
+          user={{
+            id: reviewer.login,
+            label: reviewer.label,
+            avatarUrl: "",
+            isBot: false,
+          }}
+          ghHost={ghHost}
+          decorative
+        />
+      )}
+      {reviewer.label}
+    </span>
   );
 }
 

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
 import {
   useBbRepoSettings,
   useBbUpdateRepoSettings,
@@ -27,6 +26,7 @@ import type {
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { DescriptionField } from "./DescriptionField";
 import { useGenerateRepoDescription } from "./useGenerateRepoDescription";
 
 /** The Bitbucket counterpart of {@link GeneralSettingsSection}: Bitbucket's
@@ -137,59 +137,55 @@ function BitbucketGeneralForm({
 
   return (
     <div className="min-w-0 space-y-4">
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="bb-repo-description">Description</Label>
-          {aiEnabled &&
-            (!aiConfigured ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="text-muted-foreground"
-                onClick={() => openSettings("ai")}
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Set up AI
-              </Button>
-            ) : descGen.generating ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="text-muted-foreground"
-                onClick={descGen.cancel}
-              >
-                <Spinner data-icon="inline-start" />
-                Cancel
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() =>
-                  descGen.generate({
-                    repoName,
-                    onResult: ({ description }) => {
-                      if (description) set("description", description);
-                    },
-                  })
-                }
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Generate
-              </Button>
-            ))}
-        </div>
-        <Textarea
-          id="bb-repo-description"
-          value={form.description}
-          onChange={(e) => set("description", e.target.value)}
-          placeholder="Short description of this repository"
-          rows={3}
-        />
-      </div>
+      <DescriptionField
+        id="bb-repo-description"
+        value={form.description}
+        onChange={(v) => set("description", v)}
+        placeholder="Short description of this repository"
+        generate={
+          aiEnabled &&
+          (!aiConfigured ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              onClick={() => openSettings("ai")}
+            >
+              <SparkleIcon data-icon="inline-start" />
+              Set up AI
+            </Button>
+          ) : descGen.generating ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              onClick={descGen.cancel}
+            >
+              <Spinner data-icon="inline-start" />
+              Cancel
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() =>
+                descGen.generate({
+                  repoName,
+                  onResult: ({ description }) => {
+                    if (description) set("description", description);
+                  },
+                })
+              }
+            >
+              <SparkleIcon data-icon="inline-start" />
+              Generate
+            </Button>
+          ))
+        }
+      />
 
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1.5">

--- a/src/features/repo-settings/DescriptionField.tsx
+++ b/src/features/repo-settings/DescriptionField.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+/** The description field shared by the GitHub, GitLab, and Bitbucket general
+ *  sections: a multi-line {@link Textarea} (so long "About" text wraps instead
+ *  of clipping mid-word) with an optional {@link generate} slot on the right of
+ *  the label row. Each section builds its own Generate button because
+ *  `descGen.generate`'s `onResult` differs per provider (GitHub also applies
+ *  topics), so the button JSX is passed in rather than owned here. */
+export function DescriptionField({
+  id,
+  value,
+  onChange,
+  placeholder,
+  generate,
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  generate?: ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={id}>Description</Label>
+        {generate}
+      </div>
+      <Textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={3}
+      />
+    </div>
+  );
+}

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -27,6 +27,8 @@ import type { Branch, RepoSettings, RepoSettingsInput } from "@/lib/git/types";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { DescriptionField } from "./DescriptionField";
+import { GITHUB_TOPIC_RULES, TopicsField } from "./TopicsField";
 import { useGenerateRepoDescription } from "./useGenerateRepoDescription";
 
 export function GeneralSettingsSection({
@@ -186,16 +188,15 @@ function CommitMessageSelect({
   );
 }
 
-/** Space/comma-separated text → GitHub's lowercase, deduped, capped topic list. */
-function parseTopics(text: string): string[] {
-  return [
-    ...new Set(
-      text
-        .split(/[\s,]+/)
-        .map((t) => t.toLowerCase().replace(/[^a-z0-9-]/g, ""))
-        .filter(Boolean),
-    ),
-  ].slice(0, 20);
+/** Normalize a list of raw topic strings per GitHub's rules (slugified,
+ *  deduped, capped 20) — used when the AI Generate result seeds topics. */
+function normalizeTopics(raw: string[]): string[] {
+  const seen = new Set<string>();
+  for (const t of raw) {
+    const topic = GITHUB_TOPIC_RULES.normalize(t);
+    if (topic) seen.add(topic);
+  }
+  return [...seen].slice(0, GITHUB_TOPIC_RULES.maxTopics ?? 20);
 }
 
 function GeneralForm({
@@ -210,8 +211,6 @@ function GeneralForm({
   const update = useUpdateRepoSettings(repoPath);
   const base = toInput(settings);
   const [form, setForm] = useState<RepoSettingsInput>(base);
-  // Topics edit as free text (space-separated) but persist as a parsed array.
-  const [topicsText, setTopicsText] = useState(settings.topics.join(" "));
 
   const aiEnabled = useAiEnabled();
   const aiConfigured = useAiConfigured();
@@ -227,13 +226,6 @@ function GeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
-  // Keep the raw text (so trailing spaces survive typing) and the parsed array
-  // (used for the dirty check and save) in sync.
-  function applyTopics(text: string) {
-    setTopicsText(text);
-    set("topics", parseTopics(text));
-  }
-
   const mergeValid =
     form.allowSquashMerge || form.allowMergeCommit || form.allowRebaseMerge;
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
@@ -246,74 +238,70 @@ function GeneralForm({
 
   return (
     <div className="min-w-0 space-y-4">
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <Label htmlFor="repo-description">Description</Label>
-          {aiEnabled &&
-            (!aiConfigured ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="text-muted-foreground"
-                onClick={() => openSettings("ai")}
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Set up AI
-              </Button>
-            ) : descGen.generating ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="text-muted-foreground"
-                onClick={descGen.cancel}
-              >
-                <Spinner data-icon="inline-start" />
-                Cancel
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() =>
-                  descGen.generate({
-                    repoName,
-                    onResult: ({ description, topics }) => {
-                      if (description) set("description", description);
-                      if (topics.length) applyTopics(topics.join(" "));
-                    },
-                  })
-                }
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Generate
-              </Button>
-            ))}
-        </div>
-        <Input
-          id="repo-description"
-          value={form.description}
-          onChange={(e) => set("description", e.target.value)}
-          placeholder="Short description of this repository"
-        />
-      </div>
+      <DescriptionField
+        id="repo-description"
+        value={form.description}
+        onChange={(v) => set("description", v)}
+        placeholder="Short description of this repository"
+        generate={
+          aiEnabled &&
+          (!aiConfigured ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              onClick={() => openSettings("ai")}
+            >
+              <SparkleIcon data-icon="inline-start" />
+              Set up AI
+            </Button>
+          ) : descGen.generating ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              onClick={descGen.cancel}
+            >
+              <Spinner data-icon="inline-start" />
+              Cancel
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() =>
+                descGen.generate({
+                  repoName,
+                  onResult: ({ description, topics }) => {
+                    if (description) set("description", description);
+                    if (topics.length)
+                      set("topics", normalizeTopics(topics));
+                  },
+                })
+              }
+            >
+              <SparkleIcon data-icon="inline-start" />
+              Generate
+            </Button>
+          ))
+        }
+      />
 
       <div className="space-y-1.5">
-        <Label htmlFor="repo-topics">
-          Topics{" "}
-          <span className="font-normal text-muted-foreground">
-            (separate with spaces)
+        <div className="flex items-center justify-between">
+          <Label htmlFor="repo-topics">Topics</Label>
+          <span className="text-[11px] text-muted-foreground tabular-nums">
+            {form.topics.length} / 20
           </span>
-        </Label>
-        <Input
+        </div>
+        <TopicsField
           id="repo-topics"
-          value={topicsText}
-          onChange={(e) => applyTopics(e.target.value)}
-          placeholder="react typescript cli"
-          autoComplete="off"
-          spellCheck={false}
+          topics={form.topics}
+          onChange={(next) => set("topics", next)}
+          rules={GITHUB_TOPIC_RULES}
         />
       </div>
 

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -196,6 +196,8 @@ function normalizeTopics(raw: string[]): string[] {
     const topic = GITHUB_TOPIC_RULES.normalize(t);
     if (topic) seen.add(topic);
   }
+  // `maxTopics` is optional on `TopicRules`, so the `?? 20` satisfies the type;
+  // the GitHub preset always sets 20, so the fallback never fires at runtime.
   return [...seen].slice(0, GITHUB_TOPIC_RULES.maxTopics ?? 20);
 }
 

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -2,7 +2,6 @@ import { SparkleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -27,6 +26,8 @@ import type {
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { DescriptionField } from "./DescriptionField";
+import { GITLAB_TOPIC_RULES, TopicsField } from "./TopicsField";
 import { useGenerateRepoDescription } from "./useGenerateRepoDescription";
 
 /** The GitLab counterpart of {@link GeneralSettingsSection}: GitLab's settings
@@ -141,16 +142,11 @@ const SQUASH_OPTION_ITEMS: Record<string, string> = Object.fromEntries(
   SQUASH_OPTIONS.map((o) => [o.value, o.label]),
 );
 
-/** Comma-separated text → GitLab's topic list (topics may contain spaces, so
- *  only commas separate; trimmed, deduped). */
-function parseTopics(text: string): string[] {
+/** Normalize AI-suggested topics per GitLab's rules (trim only, case + spaces
+ *  preserved), deduped and with no cap — used when the Generate result seeds topics. */
+function normalizeGlTopics(raw: string[]): string[] {
   return [
-    ...new Set(
-      text
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean),
-    ),
+    ...new Set(raw.map((t) => GITLAB_TOPIC_RULES.normalize(t)).filter(Boolean)),
   ];
 }
 
@@ -166,8 +162,6 @@ function GitLabGeneralForm({
   const update = useUpdateGlRepoSettings(repoPath);
   const base = toInput(settings);
   const [form, setForm] = useState<GitLabRepoSettingsInput>(base);
-  // Topics edit as free text (comma-separated) but persist as a parsed array.
-  const [topicsText, setTopicsText] = useState(settings.topics.join(", "));
 
   const aiEnabled = useAiEnabled();
   const aiConfigured = useAiConfigured();
@@ -183,11 +177,6 @@ function GitLabGeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
-  function applyTopics(text: string) {
-    setTopicsText(text);
-    set("topics", parseTopics(text));
-  }
-
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
 
   // Keep the current default selectable even if that branch isn't local.
@@ -199,98 +188,93 @@ function GitLabGeneralForm({
 
   return (
     <div className="min-w-0 space-y-4">
+      <DescriptionField
+        id="gl-repo-description"
+        value={form.description}
+        onChange={(v) => set("description", v)}
+        placeholder="Short description of this project"
+        generate={
+          aiEnabled &&
+          (!aiConfigured ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              onClick={() => openSettings("ai")}
+            >
+              <SparkleIcon data-icon="inline-start" />
+              Set up AI
+            </Button>
+          ) : descGen.generating ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              onClick={descGen.cancel}
+            >
+              <Spinner data-icon="inline-start" />
+              Cancel
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() =>
+                descGen.generate({
+                  repoName,
+                  onResult: ({ description, topics }) => {
+                    if (description) set("description", description);
+                    if (topics.length)
+                      set("topics", normalizeGlTopics(topics));
+                  },
+                })
+              }
+            >
+              <SparkleIcon data-icon="inline-start" />
+              Generate
+            </Button>
+          ))
+        }
+      />
+
       <div className="space-y-1.5">
         <div className="flex items-center justify-between">
-          <Label htmlFor="gl-repo-description">Description</Label>
-          {aiEnabled &&
-            (!aiConfigured ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="text-muted-foreground"
-                onClick={() => openSettings("ai")}
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Set up AI
-              </Button>
-            ) : descGen.generating ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                className="text-muted-foreground"
-                onClick={descGen.cancel}
-              >
-                <Spinner data-icon="inline-start" />
-                Cancel
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() =>
-                  descGen.generate({
-                    repoName,
-                    onResult: ({ description, topics }) => {
-                      if (description) set("description", description);
-                      if (topics.length) applyTopics(topics.join(", "));
-                    },
-                  })
-                }
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Generate
-              </Button>
-            ))}
+          <Label htmlFor="gl-repo-topics">Topics</Label>
+          <span className="text-[11px] text-muted-foreground tabular-nums">
+            {form.topics.length}
+          </span>
         </div>
-        <Input
-          id="gl-repo-description"
-          value={form.description}
-          onChange={(e) => set("description", e.target.value)}
-          placeholder="Short description of this project"
+        <TopicsField
+          id="gl-repo-topics"
+          topics={form.topics}
+          onChange={(next) => set("topics", next)}
+          rules={GITLAB_TOPIC_RULES}
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-1.5">
-          <Label htmlFor="gl-repo-topics">
-            Topics{" "}
-            <span className="font-normal text-muted-foreground">
-              (separate with commas)
-            </span>
-          </Label>
-          <Input
-            id="gl-repo-topics"
-            value={topicsText}
-            onChange={(e) => applyTopics(e.target.value)}
-            placeholder="react, typescript, cli"
-            autoComplete="off"
-            spellCheck={false}
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="gl-repo-default-branch">Default branch</Label>
-          <Select
-            items={Object.fromEntries(branchOptions.map((b) => [b, b]))}
-            value={form.defaultBranch ?? ""}
-            onValueChange={(v) => {
-              if (v) set("defaultBranch", v);
-            }}
-          >
-            <SelectTrigger id="gl-repo-default-branch" className="w-full">
-              <SelectValue placeholder="No default branch yet" />
-            </SelectTrigger>
-            <SelectContent>
-              {branchOptions.map((b) => (
-                <SelectItem key={b} value={b}>
-                  {b}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="gl-repo-default-branch">Default branch</Label>
+        <Select
+          items={Object.fromEntries(branchOptions.map((b) => [b, b]))}
+          value={form.defaultBranch ?? ""}
+          onValueChange={(v) => {
+            if (v) set("defaultBranch", v);
+          }}
+        >
+          <SelectTrigger id="gl-repo-default-branch" className="w-full">
+            <SelectValue placeholder="No default branch yet" />
+          </SelectTrigger>
+          <SelectContent>
+            {branchOptions.map((b) => (
+              <SelectItem key={b} value={b}>
+                {b}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="space-y-2">

--- a/src/features/repo-settings/TopicsField.tsx
+++ b/src/features/repo-settings/TopicsField.tsx
@@ -60,13 +60,23 @@ export function TopicsField({
 
   const atCap = rules.maxTopics != null && topics.length >= rules.maxTopics;
 
-  /** Normalize the buffer and append it (deduped) — a no-op if it normalizes to
-   *  empty, is already present, or we're at the cap. Clears the buffer either way. */
+  /** Commit the buffer as one or more chips. Splits on the same delimiters that
+   *  commit while typing (comma always; whitespace where space commits) so a
+   *  pasted or space-separated list ("react typescript") becomes multiple chips
+   *  rather than one mangled token — matching the field's documented behavior.
+   *  Each part is normalized, deduped, and capped; the buffer clears either way. */
   function commit() {
-    const topic = rules.normalize(draft);
+    const raw = draft;
     setDraft("");
-    if (!topic || atCap || topics.includes(topic)) return;
-    onChange([...topics, topic]);
+    const splitter = rules.commitKeys.includes("space") ? /[\s,]+/ : /,+/;
+    let next = topics;
+    for (const part of raw.split(splitter)) {
+      const topic = rules.normalize(part);
+      if (!topic || next.includes(topic)) continue;
+      if (rules.maxTopics != null && next.length >= rules.maxTopics) break;
+      next = [...next, topic];
+    }
+    if (next.length !== topics.length) onChange(next);
   }
 
   function removeAt(index: number) {
@@ -100,12 +110,10 @@ export function TopicsField({
       onChange(topics.slice(0, -1));
       return;
     }
-    // ← from the start of an empty-ish buffer hops onto the last chip.
-    if (
-      e.key === "ArrowLeft" &&
-      topics.length > 0 &&
-      inputRef.current?.selectionStart === 0
-    ) {
+    // ← from an EMPTY buffer hops onto the last chip; with a non-empty draft, ←
+    // stays normal cursor movement so it never commits the draft (matches the
+    // Backspace branch above — focusing a chip blurs the input and would `commit()`).
+    if (e.key === "ArrowLeft" && topics.length > 0 && draft === "") {
       e.preventDefault();
       focusChip(topics.length - 1);
     }

--- a/src/features/repo-settings/TopicsField.tsx
+++ b/src/features/repo-settings/TopicsField.tsx
@@ -1,0 +1,174 @@
+import { XIcon } from "@phosphor-icons/react";
+import { type KeyboardEvent, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/** How a provider turns a raw typed token into a committed topic, which
+ *  keystrokes commit the buffer, and whether there's a hard cap. GitHub slugs
+ *  and caps; GitLab is freeform. */
+export type TopicRules = {
+  /** Raw buffer → committed topic. Returns "" to reject (e.g. empty). */
+  normalize: (raw: string) => string;
+  /** Keys that flush the add-buffer into a chip. */
+  commitKeys: Array<"enter" | "comma" | "space">;
+  /** Hard limit; omit for unbounded (GitLab). */
+  maxTopics?: number;
+};
+
+/** GitHub topics: lowercase slug — runs of non-alphanumerics collapse to a
+ *  single dash, edges trimmed, capped at 50 chars. `React Native` → `react-native`. */
+export const GITHUB_TOPIC_RULES: TopicRules = {
+  normalize: (raw) =>
+    raw
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 50)
+      .replace(/-+$/g, ""),
+  commitKeys: ["enter", "comma", "space"],
+  maxTopics: 20,
+};
+
+/** GitLab topics: freeform — trim only, case and spaces preserved. Space is a
+ *  valid topic char, so only Enter/comma commit. */
+export const GITLAB_TOPIC_RULES: TopicRules = {
+  normalize: (raw) => raw.trim(),
+  commitKeys: ["enter", "comma"],
+};
+
+/** Removable topic chips + an inline add-input, all inside one bordered
+ *  field-shell that matches the app's other inputs. `topics` (the parent's
+ *  `form.topics`) is the single source of truth; the uncommitted add-buffer is
+ *  local `draft` state and never leaks into `topics` until committed.
+ *
+ *  Keyboard: Enter/comma (and space for GitHub) commit the buffer; Backspace on
+ *  an empty buffer removes the last chip; ←/→ move focus among chips; Enter or
+ *  the ✕ removes a focused chip; the add-input keeps focus after a commit. */
+export function TopicsField({
+  id,
+  topics,
+  onChange,
+  rules,
+}: {
+  id?: string;
+  topics: string[];
+  onChange: (next: string[]) => void;
+  rules: TopicRules;
+}) {
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const chipRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const atCap = rules.maxTopics != null && topics.length >= rules.maxTopics;
+
+  /** Normalize the buffer and append it (deduped) — a no-op if it normalizes to
+   *  empty, is already present, or we're at the cap. Clears the buffer either way. */
+  function commit() {
+    const topic = rules.normalize(draft);
+    setDraft("");
+    if (!topic || atCap || topics.includes(topic)) return;
+    onChange([...topics, topic]);
+  }
+
+  function removeAt(index: number) {
+    onChange(topics.filter((_, i) => i !== index));
+    // Defer to after re-render: at the cap the input is `disabled`, so a
+    // synchronous focus() would no-op until it re-enables next render.
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  function focusChip(index: number) {
+    chipRefs.current[index]?.focus();
+  }
+
+  function onInputKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    const commitOnEnter = rules.commitKeys.includes("enter");
+    const commitOnComma = rules.commitKeys.includes("comma");
+    const commitOnSpace = rules.commitKeys.includes("space");
+
+    if (
+      (e.key === "Enter" && commitOnEnter) ||
+      (e.key === "," && commitOnComma) ||
+      (e.key === " " && commitOnSpace)
+    ) {
+      e.preventDefault();
+      commit();
+      return;
+    }
+    // Backspace on an empty buffer removes the last chip.
+    if (e.key === "Backspace" && draft === "" && topics.length > 0) {
+      e.preventDefault();
+      onChange(topics.slice(0, -1));
+      return;
+    }
+    // ← from the start of an empty-ish buffer hops onto the last chip.
+    if (
+      e.key === "ArrowLeft" &&
+      topics.length > 0 &&
+      inputRef.current?.selectionStart === 0
+    ) {
+      e.preventDefault();
+      focusChip(topics.length - 1);
+    }
+  }
+
+  function onChipKeyDown(e: KeyboardEvent<HTMLButtonElement>, index: number) {
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      if (index > 0) focusChip(index - 1);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      if (index < topics.length - 1) focusChip(index + 1);
+      else inputRef.current?.focus();
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      removeAt(index);
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-8 w-full flex-wrap items-center gap-1.5 rounded-none border border-input bg-transparent px-2 py-1.5 text-xs transition-colors dark:bg-input/30",
+        "focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/50",
+      )}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {topics.map((topic, index) => (
+        <span
+          key={topic}
+          className="inline-flex items-center gap-1 border py-0.5 pr-0.5 pl-1.5 text-[11px] text-muted-foreground"
+        >
+          <span className="max-w-[16rem] truncate">{topic}</span>
+          <button
+            type="button"
+            ref={(el) => {
+              chipRefs.current[index] = el;
+            }}
+            aria-label={`Remove topic ${topic}`}
+            className="flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-none text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring/50"
+            // Don't steal focus from the add-input on mousedown, or its
+            // onBlur→commit would flush a half-typed draft into a spurious chip.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => removeAt(index)}
+            onKeyDown={(e) => onChipKeyDown(e, index)}
+          >
+            <XIcon className="size-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        id={id}
+        value={draft}
+        disabled={atCap}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onInputKeyDown}
+        onBlur={commit}
+        placeholder={topics.length === 0 ? "Add a topic…" : undefined}
+        autoComplete="off"
+        spellCheck={false}
+        className="min-w-24 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </div>
+  );
+}

--- a/src/lib/ai/review-tools.ts
+++ b/src/lib/ai/review-tools.ts
@@ -31,6 +31,24 @@ function capHead(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max)}\n[... truncated]` : text;
 }
 
+/** Max review-thread `diffHunk` lines surfaced by `list_pull_request_comments`.
+ *  KEEP IN SYNC with `HUNK_MAX_LINES` in src-tauri/src/mcp_server/mod.rs. */
+const HUNK_MAX_LINES = 24;
+
+/** Caps a review-thread diff hunk to its last `maxLines` lines (GitHub's
+ *  `diffHunk` ends at the anchored line, so the tail is the relevant context),
+ *  prefixing a marker when it overflows. Mirrors `cap_hunk_lines` in
+ *  src-tauri/src/mcp_server/mod.rs — an already-short (or empty) hunk is
+ *  returned unchanged. */
+function capHunkLines(hunk: string, maxLines: number): string {
+  // Mirror Rust `str::lines()` (mcp_server/mod.rs): strip one trailing line
+  // terminator, then split on \r?\n so CRLF and a final newline can't shift the
+  // window vs the Rust side.
+  const lines = hunk.replace(/\r?\n$/, "").split(/\r?\n/);
+  if (lines.length <= maxLines) return hunk;
+  return `…[hunk truncated]\n${lines.slice(lines.length - maxLines).join("\n")}`;
+}
+
 /** One line prepended to every forge tool's output so the model treats the
  *  third-party content strictly as data (parity with the MCP server's framing). */
 const UNTRUSTED_PREFIX =
@@ -304,22 +322,42 @@ export function buildReviewTools(ctx: ReviewToolContext): ToolSet {
       description:
         "This pull request's conversation from the forge: top-level comments, " +
         "review summaries, and file:line-anchored review threads with their " +
-        "reply chains.",
-      inputSchema: z.object({}),
-      execute: async (_input, { abortSignal }) => {
+        "reply chains. Each thread's diffHunk code-context excerpt (GitHub only) " +
+        "is capped to its last few lines; set include_diff_hunk false to drop " +
+        "hunks entirely (default true).",
+      inputSchema: z.object({
+        include_diff_hunk: z
+          .boolean()
+          .default(true)
+          .describe(
+            "Include each review thread's capped diffHunk excerpt (default true); " +
+              "false drops hunks entirely.",
+          ),
+      }),
+      execute: async ({ include_diff_hunk }, { abortSignal }) => {
         try {
           if (abortSignal?.aborted) return "Error: cancelled";
           const [pr, reviewThreads] = await Promise.all([
             forgePrView(ctx.repoPath, prNumber),
             forgePrReviewThreads(ctx.repoPath, prNumber),
           ]);
+          // Bound (or drop) each thread's diffHunk so a comment on a new file
+          // can't drag the whole file into the payload (GitHub-only; other
+          // providers already set it "").
+          const cappedThreads = reviewThreads.map((t) => ({
+            ...t,
+            diffHunk: include_diff_hunk
+              ? capHunkLines(t.diffHunk, HUNK_MAX_LINES)
+              : "",
+          }));
           // KEEP IN SYNC: src-tauri/src/mcp_server/read_forge.rs (the
-          // list_pull_request_comments MCP tool) composes the same shape.
+          // list_pull_request_comments MCP tool) composes the same shape (and
+          // the diffHunk cap).
           const composed = {
             number: prNumber,
             comments: pr.comments,
             reviews: pr.reviews,
-            review_threads: reviewThreads,
+            review_threads: cappedThreads,
           };
           return (
             UNTRUSTED_PREFIX +

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1508,6 +1508,19 @@ export interface PrDetails {
    *  is true; the id is the provider's stable handle (GitHub login, GitLab username,
    *  Bitbucket the braced account uuid), the label the display name, never the id. */
   reviewers: ForgeUserRef[];
+  /** Reviewers who have submitted a verdict, supplied by the backend for providers
+   *  that don't populate `reviews` (GitLab approvals, Bitbucket participant states).
+   *  GitHub derives its completed reviewers on the frontend from `reviews`, so it
+   *  leaves this empty. */
+  completedReviewers: CompletedReviewerWithState[];
+}
+
+/** A reviewer who has submitted a verdict, as supplied by the backend (GitLab
+ *  approvals, Bitbucket participant states). The `state` is uppercased —
+ *  APPROVED / CHANGES_REQUESTED / COMMENTED. */
+export interface CompletedReviewerWithState {
+  user: ForgeUserRef;
+  state: string;
 }
 
 /** A provider user reference for pickers — a stable id + a human label.


### PR DESCRIPTION
This change makes repository settings more user-friendly by redesigning the Description and Topics fields, improves performance of forge queries by caching remote URL lookups in memory, and ensures that MCP review comment hunks are capped to avoid large payloads. These improvements provide a more responsive UI, especially on Windows, and make topic editing predictable and keyboard-friendly.

### Repository Settings UI
- Adds a multi-line Description input shared by GitHub, GitLab, and Bitbucket via `src/features/repo-settings/DescriptionField.tsx`.
- Redesigns Topics field as removable chips with a live add-box, and full keyboard accessibility, in `src/features/repo-settings/TopicsField.tsx`.
- Normalizes topic handling per provider:
  - GitHub: lowercases, slugifies, dedupes, and caps at 20 topics; normalizes with feedback as chips are added (`GITHUB_TOPIC_RULES` in `TopicsField.tsx` and corresponding code in `GeneralSettingsSection.tsx`).
  - GitLab: case and spaces preserved, unbounded topic count (`GITLAB_TOPIC_RULES` in `TopicsField.tsx` and use in `GitLabGeneralSection.tsx`).
- Updates related forms: 
  - `src/features/repo-settings/GeneralSettingsSection.tsx` (GitHub)
  - `src/features/repo-settings/GitLabGeneralSection.tsx`
  - `src/features/repo-settings/BitbucketGeneralSection.tsx`
- Removes previous raw text topic editors and updates AI Generate logic (in all providers) to seed normalized topics.
- Updates changelog entries in `changelog.d/changed-repo-settings-fields.md`.

### Git Remote URL Caching and Invalidation
- Implements short-lived in-memory caching for `git remote get-url` in `src-tauri/src/git/remote.rs`, reducing redundant git process spawns and latency for bursty forge queries.
- Introduces `invalidate_remote_url_cache` for eager invalidation after in-app remote URL changes or repo deletes (`src-tauri/src/forge/bitbucket.rs`, `src-tauri/src/forge/mod.rs`).
- Adds cache hit/eviction logic, unit tests, and documents cache TTL and usage.
- Updates changelog with user-facing explanation in `changelog.d/changed-forge-origin-url-cache.md`.

### MCP Review-Thread Diff Hunk Capping
- Adds `cap_hunk_lines` in `src-tauri/src/mcp_server/mod.rs` and applies a maximum of 24 lines per thread’s `diffHunk` in MCP's `list_pull_request_comments` tool, defaulting to include capped hunks and allowing clients to drop hunks entirely.
- Mirrors this capping logic for the HTTP review tool in `src/lib/ai/review-tools.ts` and makes the option explicit in the tool's input schema.
- Updates changelog detailing this output capping in `changelog.d/changed-mcp-comment-output.md`.
- Updates and adds Rust/JS unit tests for capping logic.

### Forge/CLI/Backend Cleanups
- Updates `src-tauri/src/forge/github.rs`, `src-tauri/src/forge/gitlab.rs`, and related files to follow new cache usage and ensure correct GitLab project remote resolution.
- Cleans up formatting and line breaks, rewrites certain commands for clarity/performance, and ensures cache is properly invalidated after repo rename/delete actions on all providers.