### PR TITLE
fix(git,github): robustly resolve git and gh binaries in CLI runners on macOS

### DIFF
--- a/changelog.d/fixed-macos-cli-detection.md
+++ b/changelog.d/fixed-macos-cli-detection.md
@@ -1,0 +1,5 @@
+- **macOS: GitHub and Git are found when launched from Finder or the Dock.** A
+  GUI launch doesn't inherit your shell's `PATH`, so a Homebrew-installed `gh` or
+  `git` used to read as "not found" everywhere except the About screen — breaking
+  clone, pull requests, issues, and other GitHub features. GitDesktop now resolves
+  these tools the same robust way About already did.

--- a/changelog.d/fixed-macos-cli-detection.md
+++ b/changelog.d/fixed-macos-cli-detection.md
@@ -1,5 +1,5 @@
 - **macOS: GitHub and Git are found when launched from Finder or the Dock.** A
   GUI launch doesn't inherit your shell's `PATH`, so a Homebrew-installed `gh` or
   `git` used to read as "not found" everywhere except the About screen — breaking
-  clone, pull requests, issues, and other GitHub features. GitDesktop now resolves
-  these tools the same robust way About already did.
+  clone, pull requests, issues, and other GitHub features. GitDesktop now finds
+  these tools the same way the About screen already did.

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -7,13 +7,13 @@ pub enum AppError {
     Git { code: i32, stderr: String },
     #[error("not a git repository: {0}")]
     NotARepo(String),
-    #[error("git executable not found on PATH")]
+    #[error("git executable not found")]
     GitNotFound,
-    #[error("GitHub CLI (gh) not found on PATH")]
+    #[error("GitHub CLI (gh) not found")]
     GhNotFound,
     #[error("{0}")]
     Gh(String),
-    #[error("GitLab CLI (glab) not found on PATH")]
+    #[error("GitLab CLI (glab) not found")]
     GlabNotFound,
     #[error("{0}")]
     Glab(String),

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
 
@@ -33,6 +34,29 @@ impl GlabOutput {
     }
 }
 
+/// The resolved `glab` binary, memoized for the process lifetime.
+///
+/// A packaged GUI app on macOS doesn't inherit the user's shell PATH, so we
+/// resolve `glab` via `crate::agent::resolve_named` (PATH + known install dirs +
+/// a macOS login-shell fallback / the live Windows registry PATH) rather than a
+/// bare `Command::new("glab")`, which reads "not found" when launched from
+/// Finder/Dock. Cached exactly like the `git`/`gh` runners
+/// (`git::runner::git_bin`): the login-shell fallback isn't free, and only a
+/// *successful* resolution is cached, so a glab installed after launch is still
+/// picked up on the next call without a restart.
+static GLAB_BIN: OnceCell<PathBuf> = OnceCell::const_new();
+
+async fn glab_bin() -> AppResult<PathBuf> {
+    GLAB_BIN
+        .get_or_try_init(|| async {
+            crate::agent::resolve_named(&["glab"], None)
+                .await
+                .ok_or(AppError::GlabNotFound)
+        })
+        .await
+        .cloned()
+}
+
 /// Runs `glab` and returns raw output regardless of exit code. Only a missing
 /// `glab` binary or a timeout is an error here (mirrors `run_gh_raw`).
 pub async fn run_glab_raw(
@@ -40,14 +64,7 @@ pub async fn run_glab_raw(
     args: &[&str],
     timeout: Duration,
 ) -> AppResult<GlabOutput> {
-    // Resolve glab the way the agent CLIs + the About screen do (`resolve_named`:
-    // PATH + known install dirs + the live registry PATH on Windows). A bare
-    // `Command::new("glab")` only searches the app process's inherited PATH —
-    // which often lacks glab's installer dir even when it's on the user's registry
-    // PATH — so it reported "not found" while About showed glab installed.
-    let Some(glab) = crate::agent::resolve_named(&["glab"], None).await else {
-        return Err(AppError::GlabNotFound);
-    };
+    let glab = glab_bin().await?;
     let mut cmd = Command::new(&glab);
     cmd.args(args);
     if let Some(repo) = repo_path {
@@ -247,9 +264,7 @@ pub async fn run_glab_ex(
     envs: &[(&str, &str)],
     timeout: Duration,
 ) -> AppResult<GlabOutput> {
-    let Some(glab) = crate::agent::resolve_named(&["glab"], None).await else {
-        return Err(AppError::GlabNotFound);
-    };
+    let glab = glab_bin().await?;
     let mut cmd = Command::new(&glab);
     cmd.args(args);
     if let Some(repo) = repo_path {

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -39,7 +39,16 @@ pub async fn run_git_raw_input(
     input: Option<&str>,
     timeout: Duration,
 ) -> AppResult<GitOutput> {
-    let mut cmd = Command::new("git");
+    // Resolve `git` the way the About screen does (`resolve_named`: PATH + known
+    // install dirs + a macOS login-shell fallback / the live Windows registry
+    // PATH). A packaged GUI app launched from Finder/Dock doesn't inherit the
+    // user's shell PATH, so a bare `Command::new("git")` misses a Homebrew-only
+    // git (no Xcode command-line tools at `/usr/bin/git`) — mirroring the gh and
+    // glab runners.
+    let Some(git) = crate::agent::resolve_named(&["git"], None).await else {
+        return Err(AppError::GitNotFound);
+    };
+    let mut cmd = Command::new(&git);
     cmd.args(["-c", "core.quotePath=false", "-c", "color.ui=false"]);
     cmd.args(args);
     if let Some(repo) = repo_path {

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -1,7 +1,9 @@
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
 use tokio::process::Command;
+use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
@@ -19,6 +21,35 @@ impl GitOutput {
     pub fn stdout_lossy(&self) -> String {
         String::from_utf8_lossy(&self.stdout).into_owned()
     }
+}
+
+/// The resolved `git` binary, memoized for the process lifetime.
+///
+/// `run_git_raw_input` is the base of the whole git call stack (status, diffs,
+/// history, staging — all firing continuously as the user works), and a packaged
+/// GUI app on macOS doesn't inherit the user's shell PATH. So we resolve `git`
+/// the way the About screen does (`crate::agent::resolve_named`: PATH + known
+/// install dirs + a macOS login-shell fallback / the live Windows registry PATH)
+/// rather than a bare `Command::new("git")`, which finds nothing when the app is
+/// launched from Finder/Dock.
+///
+/// The result is cached because resolving isn't free: the login-shell fallback
+/// (for a git install outside `candidate_dirs()`, e.g. MacPorts `/opt/local/bin`)
+/// spawns `$SHELL -lic` with a 20s timeout, and re-running it on every git call
+/// would serialize the whole app behind it. Only a *successful* resolution is
+/// cached — `get_or_try_init` leaves the cell empty on error — so a git installed
+/// after launch is still picked up on the next call without a restart.
+static GIT_BIN: OnceCell<PathBuf> = OnceCell::const_new();
+
+async fn git_bin() -> AppResult<PathBuf> {
+    GIT_BIN
+        .get_or_try_init(|| async {
+            crate::agent::resolve_named(&["git"], None)
+                .await
+                .ok_or(AppError::GitNotFound)
+        })
+        .await
+        .cloned()
 }
 
 /// Runs git and returns the raw output regardless of exit code.
@@ -39,15 +70,7 @@ pub async fn run_git_raw_input(
     input: Option<&str>,
     timeout: Duration,
 ) -> AppResult<GitOutput> {
-    // Resolve `git` the way the About screen does (`resolve_named`: PATH + known
-    // install dirs + a macOS login-shell fallback / the live Windows registry
-    // PATH). A packaged GUI app launched from Finder/Dock doesn't inherit the
-    // user's shell PATH, so a bare `Command::new("git")` misses a Homebrew-only
-    // git (no Xcode command-line tools at `/usr/bin/git`) — mirroring the gh and
-    // glab runners.
-    let Some(git) = crate::agent::resolve_named(&["git"], None).await else {
-        return Err(AppError::GitNotFound);
-    };
+    let git = git_bin().await?;
     let mut cmd = Command::new(&git);
     cmd.args(["-c", "core.quotePath=false", "-c", "color.ui=false"]);
     cmd.args(args);
@@ -68,6 +91,9 @@ pub async fn run_git_raw_input(
     cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
     cmd.kill_on_drop(true);
 
+    // `git_bin()` already confirmed the binary exists, so a spawn-time NotFound
+    // means the memoized path went stale mid-session (git moved/removed) — still
+    // "git not found" to the user; anything else is a genuine I/O error.
     let spawn_err = |e: std::io::Error| {
         if e.kind() == std::io::ErrorKind::NotFound {
             AppError::GitNotFound

--- a/src-tauri/src/github/runner.rs
+++ b/src-tauri/src/github/runner.rs
@@ -1,7 +1,9 @@
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
 use tokio::process::Command;
+use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
 
@@ -20,6 +22,30 @@ impl GhOutput {
     }
 }
 
+/// The resolved `gh` binary, memoized for the process lifetime.
+///
+/// A packaged GUI app on macOS doesn't inherit the user's shell PATH, so we
+/// resolve `gh` the way the About screen does (`crate::agent::resolve_named`:
+/// PATH + known install dirs + a macOS login-shell fallback / the live Windows
+/// registry PATH) rather than a bare `Command::new("gh")`, which reads "not
+/// found" when launched from Finder/Dock — the reason every gh-backed surface
+/// failed while About showed gh installed. Cached like `git` (see
+/// `git::runner::git_bin`): the login-shell fallback isn't free, and only a
+/// *successful* resolution is cached, so a gh installed after launch is still
+/// picked up on the next call.
+static GH_BIN: OnceCell<PathBuf> = OnceCell::const_new();
+
+async fn gh_bin() -> AppResult<PathBuf> {
+    GH_BIN
+        .get_or_try_init(|| async {
+            crate::agent::resolve_named(&["gh"], None)
+                .await
+                .ok_or(AppError::GhNotFound)
+        })
+        .await
+        .cloned()
+}
+
 /// Runs the GitHub CLI and returns raw output regardless of exit code. Only a
 /// missing `gh` binary or a timeout is an error here.
 pub async fn run_gh_raw(
@@ -27,16 +53,7 @@ pub async fn run_gh_raw(
     args: &[&str],
     timeout: Duration,
 ) -> AppResult<GhOutput> {
-    // Resolve `gh` the way the About screen and the glab runner do
-    // (`resolve_named`: PATH + known install dirs + a macOS login-shell fallback /
-    // the live Windows registry PATH). A packaged GUI app launched from Finder,
-    // the Dock, or a desktop launcher does NOT inherit the user's shell PATH, so a
-    // bare `Command::new("gh")` misses a Homebrew-installed gh (`/opt/homebrew/bin`)
-    // — which is why every gh-backed surface read "not found" while About, which
-    // uses resolve_named, showed gh installed.
-    let Some(gh) = crate::agent::resolve_named(&["gh"], None).await else {
-        return Err(AppError::GhNotFound);
-    };
+    let gh = gh_bin().await?;
     let mut cmd = Command::new(&gh);
     cmd.args(args);
     if let Some(repo) = repo_path {
@@ -102,11 +119,7 @@ pub async fn run_gh_input(
 ) -> AppResult<GhOutput> {
     use tokio::io::AsyncWriteExt;
 
-    // Resolve `gh` via `resolve_named` (see `run_gh_raw` for why a bare
-    // `Command::new("gh")` fails in a packaged GUI app on macOS).
-    let Some(gh) = crate::agent::resolve_named(&["gh"], None).await else {
-        return Err(AppError::GhNotFound);
-    };
+    let gh = gh_bin().await?;
     let mut cmd = Command::new(&gh);
     cmd.args(args);
     if let Some(repo) = repo_path {

--- a/src-tauri/src/github/runner.rs
+++ b/src-tauri/src/github/runner.rs
@@ -27,7 +27,17 @@ pub async fn run_gh_raw(
     args: &[&str],
     timeout: Duration,
 ) -> AppResult<GhOutput> {
-    let mut cmd = Command::new("gh");
+    // Resolve `gh` the way the About screen and the glab runner do
+    // (`resolve_named`: PATH + known install dirs + a macOS login-shell fallback /
+    // the live Windows registry PATH). A packaged GUI app launched from Finder,
+    // the Dock, or a desktop launcher does NOT inherit the user's shell PATH, so a
+    // bare `Command::new("gh")` misses a Homebrew-installed gh (`/opt/homebrew/bin`)
+    // — which is why every gh-backed surface read "not found" while About, which
+    // uses resolve_named, showed gh installed.
+    let Some(gh) = crate::agent::resolve_named(&["gh"], None).await else {
+        return Err(AppError::GhNotFound);
+    };
+    let mut cmd = Command::new(&gh);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);
@@ -92,7 +102,12 @@ pub async fn run_gh_input(
 ) -> AppResult<GhOutput> {
     use tokio::io::AsyncWriteExt;
 
-    let mut cmd = Command::new("gh");
+    // Resolve `gh` via `resolve_named` (see `run_gh_raw` for why a bare
+    // `Command::new("gh")` fails in a packaged GUI app on macOS).
+    let Some(gh) = crate::agent::resolve_named(&["gh"], None).await else {
+        return Err(AppError::GhNotFound);
+    };
+    let mut cmd = Command::new(&gh);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);


### PR DESCRIPTION
This change ensures that the app reliably finds Homebrew-installed `git` and `gh` CLI tools when launched as a packaged GUI from Finder or the Dock on macOS. Previously, a bare command invocation failed to locate these tools unless the user installed Xcode CLIs or launched from a terminal—with critical Git/GitHub features reading as "not found" for many users. This unifies tool discovery with the robust fallback logic already used in the About screen, improving the experience for non-terminal launches.

### Git CLI resolution
- Updates `src-tauri/src/git/runner.rs` to resolve the `git` binary using `crate::agent::resolve_named`, matching the logic in the About screen for path handling and system fallbacks.

### GitHub CLI (`gh`) resolution
- Updates both runner functions in `src-tauri/src/github/runner.rs` to resolve `gh` via `crate::agent::resolve_named`, instead of bare `Command::new("gh")`.
- Adds explanatory comments outlining why these changes are crucial for correct CLI discovery in macOS GUI launches, aligning with the approach used for GitLab and About.

### Documentation
- Adds `changelog.d/fixed-macos-cli-detection.md` summarizing the user-facing impact of robust `git` and `gh` detection via GUI launches on macOS.