### PR TITLE
fix(automations): ensure pr-sync automations fire for background repositories

### DIFF
--- a/changelog.d/fixed-background-pr-sync.md
+++ b/changelog.d/fixed-background-pr-sync.md
@@ -1,0 +1,4 @@
+- Auto re-review (pr-sync) automations now fire even when the repository isn't
+  the one currently open — GitDesktop keeps watching recent repositories that
+  have a re-review rule, so pushing and switching repos no longer delays the
+  review until you switch back.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { GitMissingScreen } from "@/features/welcome/GitMissingScreen";
 import { useRepoDrop } from "@/features/welcome/useRepoDrop";
 import { WelcomeScreen } from "@/features/welcome/WelcomeScreen";
 import { syncAnalytics, track } from "@/lib/analytics";
+import { useBackgroundPrSync } from "@/lib/automations/useBackgroundPrSync";
 import { useGitInstalled } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { reloadLocalPrs } from "@/lib/pulls/local";
@@ -107,6 +108,12 @@ function App() {
 
   // Drop a repo folder anywhere on the window to open it.
   useRepoDrop();
+
+  // Keep pr-sync (auto re-review) automations firing for recent repos that
+  // AREN'T the one currently open — the active repo's own poller covers it, but
+  // this catches pushes to repos you've switched away from. Always mounted (any
+  // view, welcome included); no-op unless a recent repo carries a pr-sync rule.
+  useBackgroundPrSync();
 
   // The app-wide hotkey dispatcher plus the always-available actions.
   useHotkeysListener();

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -4,6 +4,7 @@ import { maybeFireSync } from "@/lib/automations/sync";
 import { effectiveActions } from "@/lib/automations/types";
 import { forgePrPoll, forgeStatus } from "@/lib/git/api";
 import { forgeFeatureReady } from "@/lib/git/queries";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import { loadSettings } from "@/lib/settings/api";
 import { useUiStore } from "@/lib/stores/ui";
 
@@ -23,7 +24,10 @@ import { useUiStore } from "@/lib/stores/ui";
  *
  * Cost bound: one forge poll per rule-bearing recent repo per minute — the loop
  * only polls repos that carry an explicit pr-sync rule (an opt-in), so a user
- * with no automations makes no background calls here.
+ * with no automations makes no background calls here. React Query runs the first
+ * tick immediately on mount (app startup), so the initial settings/automations
+ * read happens once at launch; it stays cheap because every forge call is gated
+ * behind an explicit rule and an empty-recents early-exit.
  *
  * Active-repo exclusion: the repo open in the app is SKIPPED, because
  * RepositoryView's `usePrNotifications` poller already covers it (with the OS
@@ -45,10 +49,16 @@ export function useBackgroundPrSync(): void {
     retry: false,
     queryFn: async () => {
       const settings = await loadSettings();
+      // No recents → nothing to watch; skip the config read and the loop.
+      if (settings.recentRepos.length === 0) return { polled: 0 };
       const config = await loadAutomations();
       // Read the active repo imperatively at poll time (not reactively) so the
-      // exclusion reflects wherever the user is right now.
+      // exclusion reflects wherever the user is right now. Resolve its
+      // worktree-stable identity once (memoized) so a WORKTREE of the active repo
+      // — a different checkout path but the SAME identity — is excluded too: a raw
+      // path compare would miss it and double-fire against usePrNotifications.
       const activeRepo = useUiStore.getState().repoPath;
+      const activeIdentity = activeRepo ? await repoIdentity(activeRepo) : null;
 
       let polled = 0;
       for (const repo of settings.recentRepos) {
@@ -60,6 +70,12 @@ export function useBackgroundPrSync(): void {
           // the pr-sync gate: only rule-bearing repos are worth a forge poll.
           const entry = await repoAutomationsFor(config, path);
           if (effectiveActions(config, entry, "pr-sync").length === 0) continue;
+          // Skip a worktree/alias of the active repo: same identity, different
+          // path (usePrNotifications already polls that identity). After the rule
+          // gate so only rule-bearing repos pay it — and repoAutomationsFor above
+          // already warmed this path's memoized identity, so it's a cache hit.
+          if (activeIdentity && (await repoIdentity(path)) === activeIdentity)
+            continue;
 
           // Forge-ready gate: skip repos whose hosted integration isn't wired up
           // for PRs (unauth'd, non-hosted, or a provider we haven't built yet).

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -1,0 +1,96 @@
+import { useQuery } from "@tanstack/react-query";
+import { loadAutomations, repoAutomationsFor } from "@/lib/automations/store";
+import { maybeFireSync } from "@/lib/automations/sync";
+import { effectiveActions } from "@/lib/automations/types";
+import { forgePrPoll, forgeStatus } from "@/lib/git/api";
+import { forgeFeatureReady } from "@/lib/git/queries";
+import { loadSettings } from "@/lib/settings/api";
+import { useUiStore } from "@/lib/stores/ui";
+
+/**
+ * Always-mounted background poller that keeps pr-sync automations (auto
+ * re-review on push) firing for recent repositories that AREN'T the one
+ * currently open.
+ *
+ * Why it exists: the head-OID poll that detects a remote PR's new commits used
+ * to live only in `usePrNotifications`, mounted in RepositoryView for the active
+ * repo — so switching repos stopped polling the repo you left, and a push there
+ * went undetected until you switched back (a re-review could land 20 minutes
+ * late). Everything downstream is already repo-agnostic: the runner resolves
+ * rules / diffs / comments / claims per `event.repoPath`, and `maybeFireSync`'s
+ * module-level dedup map deliberately survives unmounts. Only the TRIGGER was
+ * active-repo-gated, so this hook covers the gap.
+ *
+ * Cost bound: one forge poll per rule-bearing recent repo per minute — the loop
+ * only polls repos that carry an explicit pr-sync rule (an opt-in), so a user
+ * with no automations makes no background calls here.
+ *
+ * Active-repo exclusion: the repo open in the app is SKIPPED, because
+ * RepositoryView's `usePrNotifications` poller already covers it (with the OS
+ * notifications this hook deliberately omits).
+ *
+ * Double-fire safety: even on an overlap tick (a repo switch mid-poll, where a
+ * repo is briefly seen by both pollers), `maybeFireSync`'s shared module-level
+ * map dedupes by head, and the runner's cross-instance claim dedupes beyond
+ * that — so a PR is never re-reviewed twice for the same head.
+ */
+export function useBackgroundPrSync(): void {
+  useQuery({
+    queryKey: ["background-pr-sync"] as const,
+    // Polling while the window is unfocused is the point — a push to a repo you
+    // aren't looking at is exactly what this catches.
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: true,
+    staleTime: 55_000,
+    retry: false,
+    queryFn: async () => {
+      const settings = await loadSettings();
+      const config = await loadAutomations();
+      // Read the active repo imperatively at poll time (not reactively) so the
+      // exclusion reflects wherever the user is right now.
+      const activeRepo = useUiStore.getState().repoPath;
+
+      let polled = 0;
+      for (const repo of settings.recentRepos) {
+        const path = repo.path;
+        // The active repo is covered by usePrNotifications (with notifications).
+        if (path === activeRepo) continue;
+        try {
+          // Identity-resolved override lookup (with legacy-path fallback), then
+          // the pr-sync gate: only rule-bearing repos are worth a forge poll.
+          const entry = await repoAutomationsFor(config, path);
+          if (effectiveActions(config, entry, "pr-sync").length === 0) continue;
+
+          // Forge-ready gate: skip repos whose hosted integration isn't wired up
+          // for PRs (unauth'd, non-hosted, or a provider we haven't built yet).
+          const status = await forgeStatus(path);
+          if (!forgeFeatureReady(status, "pullRequests")) continue;
+
+          const prs = await forgePrPoll(path);
+          polled++;
+          for (const pr of prs) {
+            if (pr.state === "OPEN" && pr.headSha) {
+              maybeFireSync({
+                repoPath: path,
+                kind: "remote",
+                ref: String(pr.number),
+                currentHeadSha: pr.headSha,
+                base: pr.baseRefName,
+                head: pr.headRefName,
+                title: pr.title,
+                body: "",
+                commitSubjects: [],
+              });
+            }
+          }
+        } catch {
+          // One bad repo (deleted/moved path, transient forge error) must not
+          // sink the batch — skip it and keep polling the rest.
+        }
+      }
+
+      // A queryFn must not return undefined; a small summary is enough.
+      return { polled };
+    },
+  });
+}


### PR DESCRIPTION
This change ensures that auto re-review (pr-sync) automations trigger for recently used repositories, even when they are not the currently open repo. The motivation is to avoid delays in review automations caused by switching away from a repository after a push, by keeping background polling for PR updates on all recent repositories with pr-sync rules.

### Automations
- Adds `useBackgroundPrSync` in `src/lib/automations/useBackgroundPrSync.ts` to run a background poller that triggers re-review automations for all recent repositories (excluding the currently open one) that have a pr-sync rule.
- Handles polling of PRs in background repos, safely skipping those not integrated with a forge, and guards against redundant executions with module-level deduplication.

### App Integration
- Calls `useBackgroundPrSync` from `src/App.tsx` so background PR sync runs in all app views, not just repository views.

### Documentation
- Adds a changelog entry in `changelog.d/fixed-background-pr-sync.md` explaining that pr-sync automations now fire even when a repo isn't currently open.