### PR TITLE
fix(jira,mcp,settings,pr,pages,repo-list,ai): cross-worktree repo scoping; permissions/admins; merge method gating; accessibility

### DIFF
--- a/changelog.d/changed-mcp-comment-output.md
+++ b/changelog.d/changed-mcp-comment-output.md
@@ -1,0 +1,5 @@
+- The MCP `list_pull_request_comments` tool and the AI PR review now emit
+  leaner comment payloads, omitting always-empty default fields (avatar URL,
+  state, permalink, minimized flags, and review id) from each comment and
+  review thread — the same JSON both consumers read, so agent runs and reviews
+  spend fewer tokens on empty fields.

--- a/changelog.d/fixed-jira-admin-worklog-comment-perms.md
+++ b/changelog.d/fixed-jira-admin-worklog-comment-perms.md
@@ -1,0 +1,4 @@
+- Jira project admins can now edit and delete other people's worklogs and
+  comments from the issue view — GitDesktop previously only offered those
+  actions on your own entries, even when your Jira role held the project-wide
+  edit/delete permissions.

--- a/changelog.d/fixed-mcp-repo-scope-worktrees.md
+++ b/changelog.d/fixed-mcp-repo-scope-worktrees.md
@@ -1,0 +1,5 @@
+- MCP servers scoped to "this repo" — and the per-repo On/Optional/Off overrides
+  of global servers — are now shared across the repo's worktrees, so a server you
+  scoped or tuned in one checkout is offered in its sibling worktrees too.
+  Existing entries keep working and migrate to the shared key the next time you
+  edit them.

--- a/changelog.d/fixed-merge-method-server-settings.md
+++ b/changelog.d/fixed-merge-method-server-settings.md
@@ -1,0 +1,6 @@
+- The merge-method menu on a GitHub pull request now respects the repository's
+  own merge settings: a method disabled in the repo (allow merge commit / squash /
+  rebase) is shown greyed out as "disabled in repository settings" instead of
+  failing with a raw error only after you open the confirm dialog and click Merge.
+  When no method is enabled by both the repository settings and your branch rules,
+  the Merge button is disabled with an explanation.

--- a/changelog.d/fixed-pages-https-cert-gate.md
+++ b/changelog.d/fixed-pages-https-cert-gate.md
@@ -1,0 +1,5 @@
+- The GitHub Pages **Enforce HTTPS** toggle is now disabled while a custom
+  domain's TLS certificate is still being issued, with a note explaining why —
+  so you no longer see a raw GitHub error when you flip it too early. It also
+  calls out when certificate provisioning has failed so you can fix the domain's
+  DNS.

--- a/changelog.d/fixed-repo-list-combobox-aria.md
+++ b/changelog.d/fixed-repo-list-combobox-aria.md
@@ -1,0 +1,3 @@
+- The repository filter list (welcome screen and repo switcher) now exposes its
+  keyboard highlight to screen readers as a proper combobox/listbox, announcing
+  the focused repository as you arrow through the results.

--- a/changelog.d/fixed-worktree-repo-facts.md
+++ b/changelog.d/fixed-worktree-repo-facts.md
@@ -1,0 +1,4 @@
+- The repository list's owner, provider, and visibility/fork badges are now
+  shared across a repo's worktrees: a probe from any checkout updates every
+  entry for the same underlying repository, so sibling worktrees no longer show
+  divergent grouping or badges.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -1210,6 +1210,11 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
             })
             .collect(),
         completed_reviewers,
+        // Repository-level merge-method gating is a GitHub-only concept here; the
+        // fields are honestly "unknown" for Bitbucket (the picker never gates on `None`).
+        merge_commit_allowed: None,
+        squash_merge_allowed: None,
+        rebase_merge_allowed: None,
     })
 }
 

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -1099,6 +1099,11 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
             })
             .collect(),
         completed_reviewers,
+        // Repository-level merge-method gating is a GitHub-only concept here; the
+        // fields are honestly "unknown" for GitLab (the picker never gates on `None`).
+        merge_commit_allowed: None,
+        squash_merge_allowed: None,
+        rebase_merge_allowed: None,
     })
 }
 

--- a/src-tauri/src/forge/jira.rs
+++ b/src-tauri/src/forge/jira.rs
@@ -2522,6 +2522,14 @@ pub struct JiraProjectPermissions {
     pub edit_own_worklogs: bool,
     /// `DELETE_OWN_WORKLOGS` — gates deleting your own worklog entries.
     pub delete_own_worklogs: bool,
+    /// `EDIT_ALL_WORKLOGS` — gates editing anyone's worklog entries (project admins).
+    pub edit_all_worklogs: bool,
+    /// `DELETE_ALL_WORKLOGS` — gates deleting anyone's worklog entries (project admins).
+    pub delete_all_worklogs: bool,
+    /// `EDIT_ALL_COMMENTS` — gates editing anyone's comment (project admins).
+    pub edit_all_comments: bool,
+    /// `DELETE_ALL_COMMENTS` — gates deleting anyone's comment (project admins).
+    pub delete_all_comments: bool,
 }
 
 /// Whether a single permission in a `mypermissions` response is granted. Defensive: an
@@ -2551,6 +2559,10 @@ fn parse_permissions(body: &Value) -> JiraProjectPermissions {
         work_on_issues: have_permission(body, "WORK_ON_ISSUES"),
         edit_own_worklogs: have_permission(body, "EDIT_OWN_WORKLOGS"),
         delete_own_worklogs: have_permission(body, "DELETE_OWN_WORKLOGS"),
+        edit_all_worklogs: have_permission(body, "EDIT_ALL_WORKLOGS"),
+        delete_all_worklogs: have_permission(body, "DELETE_ALL_WORKLOGS"),
+        edit_all_comments: have_permission(body, "EDIT_ALL_COMMENTS"),
+        delete_all_comments: have_permission(body, "DELETE_ALL_COMMENTS"),
     }
 }
 
@@ -2569,7 +2581,8 @@ pub async fn permissions(site: &str, project_key: &str) -> AppResult<JiraProject
     let path = format!(
         "mypermissions?projectKey={}&permissions=ADD_COMMENTS,TRANSITION_ISSUES,\
          CREATE_ISSUES,ASSIGN_ISSUES,SCHEDULE_ISSUES,EDIT_ISSUES,EDIT_OWN_COMMENTS,\
-         DELETE_OWN_COMMENTS,WORK_ON_ISSUES,EDIT_OWN_WORKLOGS,DELETE_OWN_WORKLOGS",
+         DELETE_OWN_COMMENTS,WORK_ON_ISSUES,EDIT_OWN_WORKLOGS,DELETE_OWN_WORKLOGS,\
+         EDIT_ALL_WORKLOGS,DELETE_ALL_WORKLOGS,EDIT_ALL_COMMENTS,DELETE_ALL_COMMENTS",
         crate::forge::encode_query_value(project_key),
     );
     let body: Value = get_json(&creds, &path, "permissions").await?;
@@ -3550,6 +3563,10 @@ mod tests {
                 "WORK_ON_ISSUES": { "havePermission": true },
                 "EDIT_OWN_WORKLOGS": { "havePermission": false },
                 // DELETE_OWN_WORKLOGS absent entirely.
+                "EDIT_ALL_WORKLOGS": { "havePermission": true },
+                "DELETE_ALL_WORKLOGS": { "havePermission": false },
+                "EDIT_ALL_COMMENTS": { "havePermission": true },
+                // DELETE_ALL_COMMENTS absent entirely.
             }
         });
         let p = parse_permissions(&body);
@@ -3568,6 +3585,12 @@ mod tests {
         assert!(p.work_on_issues);
         assert!(!p.edit_own_worklogs);
         assert!(!p.delete_own_worklogs);
+        // The ALL-scoped admin keys: present-true, present-false, absent-false.
+        assert!(p.edit_all_worklogs);
+        assert!(!p.delete_all_worklogs);
+        assert!(p.edit_all_comments);
+        // Absent key → false.
+        assert!(!p.delete_all_comments);
     }
 
     #[test]
@@ -3585,6 +3608,10 @@ mod tests {
         assert!(!p.work_on_issues);
         assert!(!p.edit_own_worklogs);
         assert!(!p.delete_own_worklogs);
+        assert!(!p.edit_all_worklogs);
+        assert!(!p.delete_all_worklogs);
+        assert!(!p.edit_all_comments);
+        assert!(!p.delete_all_comments);
         // A present entry with a non-bool havePermission also defaults false.
         let p2 = parse_permissions(&json!({
             "permissions": { "ADD_COMMENTS": { "havePermission": "yes" } }

--- a/src-tauri/src/github/pages.rs
+++ b/src-tauri/src/github/pages.rs
@@ -20,6 +20,11 @@ pub struct PagesInfo {
     pub source_path: String,
     pub cname: String,
     pub https_enforced: bool,
+    /// TLS certificate provisioning state for a custom domain, e.g. "new",
+    /// "authorization_created", "authorization_pending", "authorized",
+    /// "uploaded", "approved", "errored", "bad_authz". `None` when the repo has
+    /// no custom domain (the `https_certificate` object is absent entirely).
+    pub https_certificate_state: Option<String>,
 }
 
 #[tauri::command]
@@ -56,6 +61,10 @@ pub async fn gh_pages_get(repo_path: String) -> AppResult<Option<PagesInfo>> {
             .get("https_enforced")
             .and_then(Value::as_bool)
             .unwrap_or(false),
+        https_certificate_state: v
+            .pointer("/https_certificate/state")
+            .and_then(Value::as_str)
+            .map(str::to_string),
     }))
 }
 

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1900,6 +1900,15 @@ pub struct PrDetails {
     /// GitHub derives its completed reviewers on the frontend from `reviews`, so it
     /// leaves this empty.
     pub completed_reviewers: Vec<crate::forge::model::CompletedReviewerOut>,
+    /// Whether the repository the PR lives in (its base/parent repo, not origin on a
+    /// fork) allows the merge-commit method. GitHub only, best-effort — `None` means
+    /// unknown (fetch failed, or GitLab/Bitbucket). The merge-method picker pre-gates
+    /// on `false`; `None` never gates (the raw server error on merge is the fallback).
+    pub merge_commit_allowed: Option<bool>,
+    /// Whether the repository allows the squash-merge method. See `merge_commit_allowed`.
+    pub squash_merge_allowed: Option<bool>,
+    /// Whether the repository allows the rebase-merge method. See `merge_commit_allowed`.
+    pub rebase_merge_allowed: Option<bool>,
 }
 
 /// A merge/pull request's approval summary — who has approved and whether the
@@ -1930,6 +1939,60 @@ pub struct ApprovalState {
 }
 
 const PR_VIEW_FIELDS: &str = "id,number,title,body,author,state,isDraft,baseRefName,headRefName,additions,deletions,url,commits,files,reviews,comments,statusCheckRollup,labels,assignees,reviewRequests";
+
+const REPO_MERGE_SETTINGS_QUERY: &str = "query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ mergeCommitAllowed squashMergeAllowed rebaseMergeAllowed } }";
+
+/// The three repository-level merge-method toggles (allow merge / squash / rebase),
+/// each `None` when unknown.
+#[derive(Default)]
+struct RepoMergeSettings {
+    merge_commit_allowed: Option<bool>,
+    squash_merge_allowed: Option<bool>,
+    rebase_merge_allowed: Option<bool>,
+}
+
+/// Fetch the repository's server-side merge-method settings for the repo the PR
+/// LIVES IN. `pr_url` is the PR's html url — for a fork's outgoing PR this is the
+/// PARENT/base repo (a PR url is always on the base repo), so we derive owner/name
+/// from it rather than from origin (which is the fork). Best-effort by contract:
+/// the caller treats any `Err` as "unknown" (all fields `None`) and never fails the
+/// PR view over it. Owner/name are passed as GraphQL variables (validated by
+/// [`parse_pr_url_repo`]), never interpolated into the query.
+async fn gh_repo_merge_settings(repo_path: &str, pr_url: &str) -> AppResult<RepoMergeSettings> {
+    let (host, owner, name) = parse_pr_url_repo(pr_url)?;
+    let hostname_arg = (host != "github.com").then_some(host);
+
+    let query_arg = format!("query={REPO_MERGE_SETTINGS_QUERY}");
+    let owner_arg = format!("owner={owner}");
+    let name_arg = format!("name={name}");
+    let mut args: Vec<&str> = vec!["api", "graphql"];
+    if let Some(h) = &hostname_arg {
+        args.push("--hostname");
+        args.push(h);
+    }
+    args.push("-f");
+    args.push(&query_arg);
+    args.push("-f");
+    args.push(&owner_arg);
+    args.push("-f");
+    args.push(&name_arg);
+
+    let out = run_gh(Some(repo_path), &args, GH_NETWORK_TIMEOUT).await?;
+    let value: serde_json::Value = serde_json::from_str(&out.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not parse merge settings: {e}")))?;
+    let repo = value.pointer("/data/repository");
+    // A field GitHub omits/nulls stays `None` (unknown) rather than defaulting to a
+    // gating value — the picker never disables an option on unknown.
+    let flag = |key: &str| {
+        repo.and_then(|r| r.get(key))
+            .and_then(serde_json::Value::as_bool)
+    };
+    Ok(RepoMergeSettings {
+        merge_commit_allowed: flag("mergeCommitAllowed"),
+        squash_merge_allowed: flag("squashMergeAllowed"),
+        rebase_merge_allowed: flag("rebaseMergeAllowed"),
+    })
+}
 
 /// Full details for one PR's read view.
 #[tauri::command]
@@ -2114,6 +2177,16 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
             .collect()
     };
 
+    // Repository-level merge-method settings (allow merge / squash / rebase). The
+    // `gh pr view --json` surface can't return these, so it's one extra `gh api
+    // graphql` call, best-effort: on any failure the three fields stay `None` and the
+    // picker gates exactly as before (raw server error on merge as the fallback). The
+    // repo is derived from the PR's own url, so a fork's PR reports its BASE repo's
+    // settings — the repo the merge actually lands in.
+    let merge_settings = gh_repo_merge_settings(&repo_path, &raw.url)
+        .await
+        .unwrap_or_default();
+
     Ok(PrDetails {
         id: raw.id,
         number: raw.number,
@@ -2204,6 +2277,9 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
             .collect(),
         // GitHub derives its completed reviewers on the frontend from `reviews`.
         completed_reviewers: Vec::new(),
+        merge_commit_allowed: merge_settings.merge_commit_allowed,
+        squash_merge_allowed: merge_settings.squash_merge_allowed,
+        rebase_merge_allowed: merge_settings.rebase_merge_allowed,
     })
 }
 
@@ -4010,10 +4086,20 @@ mod tests {
         assert_eq!(owner, "my-org");
         assert_eq!(name, "my_repo.js");
 
+        // Trailing garbage after `/pull/N` is fine — owner/name are the two segments
+        // before `/pull/`, so the merge-settings fetch still targets the right repo.
+        let (host, owner, name) =
+            parse_pr_url_repo("https://github.com/biomejs/biome/pull/10937/files#diff-1").unwrap();
+        assert_eq!(host, "github.com");
+        assert_eq!(owner, "biomejs");
+        assert_eq!(name, "biome");
+
         // Malformed / non-PR urls → Err.
         assert!(parse_pr_url_repo("https://github.com/biomejs/biome/issues/1").is_err());
         assert!(parse_pr_url_repo("https://github.com/onlyowner/pull/1").is_err());
         assert!(parse_pr_url_repo("not a url").is_err());
+        // Empty string → Err (no host, no segments).
+        assert!(parse_pr_url_repo("").is_err());
         // A `-`-prefixed segment (flag-injection guard) → Err.
         assert!(parse_pr_url_repo("https://github.com/-evil/repo/pull/1").is_err());
         assert!(parse_pr_url_repo("https://github.com/owner/-evil/pull/1").is_err());

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -216,14 +216,42 @@ impl GitDesktopMcp {
             };
         }
         // KEEP IN SYNC: src/lib/ai/review-tools.ts (`list_pull_request_comments`)
-        // mirrors this composed shape (and the diffHunk cap) for the HTTP review
-        // tool loop.
-        json_result_untrusted(&serde_json::json!({
+        // mirrors this composed shape — the diffHunk cap AND the empty-field
+        // pruning below — for the HTTP review tool loop.
+        let mut payload = serde_json::json!({
             "number": args.number,
             "comments": pr.comments,
             "reviews": pr.reviews,
             "review_threads": review_threads,
-        }))
+        });
+        // Prune always-default empty fields from every comment/thread object so
+        // agent consumers (the AI review eats the same JSON) don't pay tokens for
+        // e.g. `authorAvatarUrl:""` or `isMinimized:false`. Mutates the OWNED
+        // Value; the shared IPC struct's serialized shape is untouched.
+        if let Some(arr) = payload.get_mut("comments").and_then(|v| v.as_array_mut()) {
+            for c in arr {
+                strip_empty_comment_defaults(c);
+            }
+        }
+        if let Some(arr) = payload.get_mut("reviews").and_then(|v| v.as_array_mut()) {
+            for c in arr {
+                strip_empty_comment_defaults(c);
+            }
+        }
+        if let Some(arr) = payload
+            .get_mut("review_threads")
+            .and_then(|v| v.as_array_mut())
+        {
+            for thread in arr {
+                strip_empty_comment_defaults(thread);
+                if let Some(nested) = thread.get_mut("comments").and_then(|v| v.as_array_mut()) {
+                    for c in nested {
+                        strip_empty_comment_defaults(c);
+                    }
+                }
+            }
+        }
+        json_result_untrusted(&payload)
     }
 
     #[tool(
@@ -465,6 +493,40 @@ impl GitDesktopMcp {
     }
 }
 
+/// Drop the always-default empty fields from one comment/thread JSON object,
+/// in place. Removes a key ONLY when it holds its empty default; every other
+/// key (including load-bearing `false`s like `isResolved`/`viewerDidAuthor`,
+/// and the `id` write tools consume even when empty) is left as-is. Explicit
+/// per-key list on purpose — a generic "remove falsy" strip would eat those
+/// load-bearing `false`s. Non-object values are ignored.
+///
+/// KEEP IN SYNC: src/lib/ai/review-tools.ts (`list_pull_request_comments`)
+/// mirrors this drop-list character-for-character.
+fn strip_empty_comment_defaults(v: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = v else {
+        return;
+    };
+    // (key, empty-default) pairs — remove the key only on an exact match.
+    if map.get("authorAvatarUrl") == Some(&serde_json::Value::String(String::new())) {
+        map.remove("authorAvatarUrl");
+    }
+    if map.get("state") == Some(&serde_json::Value::String(String::new())) {
+        map.remove("state");
+    }
+    if map.get("url") == Some(&serde_json::Value::String(String::new())) {
+        map.remove("url");
+    }
+    if map.get("minimizedReason") == Some(&serde_json::Value::String(String::new())) {
+        map.remove("minimizedReason");
+    }
+    if map.get("isMinimized") == Some(&serde_json::Value::Bool(false)) {
+        map.remove("isMinimized");
+    }
+    if map.get("reviewId") == Some(&serde_json::Value::String(String::new())) {
+        map.remove("reviewId");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -486,5 +548,107 @@ mod tests {
         // A host present in glab's known-hosts is a self-managed GitLab → refused.
         let glab_hosts = vec!["gitlab.acme.com".to_string()];
         assert!(!host_is_github("gitlab.acme.com", &glab_hosts));
+    }
+
+    /// The empty-default prune: a populated comment keeps every field; an
+    /// all-defaults comment loses exactly the six empty-default keys; nested
+    /// thread comments are pruned too; and load-bearing `false`s survive.
+    #[test]
+    fn strip_empty_comment_defaults_only_drops_empty_defaults() {
+        // A populated object: every field holds a non-default value → untouched.
+        let mut populated = serde_json::json!({
+            "author": "octocat",
+            "authorAvatarUrl": "https://example/avatar.png",
+            "state": "APPROVED",
+            "body": "looks good",
+            "date": "2026-07-15T00:00:00Z",
+            "id": "PRRC_1",
+            "url": "https://example/pr/1#c",
+            "viewerDidAuthor": true,
+            "isMinimized": true,
+            "minimizedReason": "spam",
+            "reviewId": "PRR_1",
+        });
+        let before = populated.clone();
+        strip_empty_comment_defaults(&mut populated);
+        assert_eq!(populated, before, "populated object must survive untouched");
+
+        // An all-defaults object: loses exactly the six empty-default keys, and
+        // keeps the load-bearing ones (including an empty-string `id`).
+        let mut defaults = serde_json::json!({
+            "author": "octocat",
+            "authorAvatarUrl": "",
+            "state": "",
+            "body": "hi",
+            "date": "2026-07-15T00:00:00Z",
+            "id": "",
+            "url": "",
+            "viewerDidAuthor": false,
+            "isMinimized": false,
+            "minimizedReason": "",
+            "reviewId": "",
+        });
+        strip_empty_comment_defaults(&mut defaults);
+        let obj = defaults.as_object().unwrap();
+        for dropped in [
+            "authorAvatarUrl",
+            "state",
+            "url",
+            "minimizedReason",
+            "isMinimized",
+            "reviewId",
+        ] {
+            assert!(!obj.contains_key(dropped), "{dropped} should be dropped");
+        }
+        // Load-bearing keys survive, including empty-string id and false viewerDidAuthor.
+        assert_eq!(obj.get("id"), Some(&serde_json::Value::String(String::new())));
+        assert_eq!(obj.get("viewerDidAuthor"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(obj.get("author"), Some(&serde_json::json!("octocat")));
+        assert_eq!(obj.get("body"), Some(&serde_json::json!("hi")));
+        assert_eq!(obj.len(), 5, "exactly six of eleven keys removed");
+
+        // Nested thread comments are pruned when the caller walks them, and a
+        // thread's own `isResolved:false` / `viewerDidAuthor:false` survive.
+        let mut thread = serde_json::json!({
+            "id": "T1",
+            "path": "src/main.rs",
+            "line": 10,
+            "isResolved": false,
+            "isOutdated": false,
+            "diffHunk": "@@ -1 +1 @@",
+            "reviewId": "",
+            "state": "",
+            "comments": [serde_json::json!({
+                "author": "octocat",
+                "authorAvatarUrl": "",
+                "state": "",
+                "body": "nit",
+                "viewerDidAuthor": false,
+                "isMinimized": false,
+                "minimizedReason": "",
+                "url": "",
+                "reviewId": "",
+                "id": "C1",
+            })],
+        });
+        strip_empty_comment_defaults(&mut thread);
+        if let Some(nested) = thread.get_mut("comments").and_then(|v| v.as_array_mut()) {
+            for c in nested {
+                strip_empty_comment_defaults(c);
+            }
+        }
+        let t = thread.as_object().unwrap();
+        // Thread-level empty defaults dropped; load-bearing false fields survive.
+        assert!(!t.contains_key("state"));
+        assert!(!t.contains_key("reviewId"));
+        assert_eq!(t.get("isResolved"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(t.get("isOutdated"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(t.get("diffHunk"), Some(&serde_json::json!("@@ -1 +1 @@")));
+        let nested = t.get("comments").unwrap().as_array().unwrap();
+        let nc = nested[0].as_object().unwrap();
+        assert!(!nc.contains_key("authorAvatarUrl"));
+        assert!(!nc.contains_key("isMinimized"));
+        assert_eq!(nc.get("viewerDidAuthor"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(nc.get("id"), Some(&serde_json::json!("C1")));
     }
 }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -827,10 +827,11 @@ the section simply doesn't show). You'll see the **original estimate**, **remain
 grammar (\`2d 4h 30m\` — weeks, days, hours, and minutes) with an optional note, and Jira
 decrements the remaining estimate for you; you can also **set or clear the original and
 remaining estimates** directly. The most recent **worklog entries** are listed (Jira returns
-the first 20), you can **edit or delete your own** entries, and the full history is a **View
-all in Jira** link away. As with every other action here, these are gated on your Jira
-permissions — logging work, editing estimates, and worklog edits each need the matching
-permission, so a control appears only when your role allows it.
+the first 20), you can **edit or delete your own** entries — or anyone's, if you hold Jira's
+project-admin worklog permissions — and the full history is a **View all in Jira** link away.
+As with every other action here, these are gated on your Jira permissions — logging work,
+editing estimates, and worklog edits each need the matching permission, so a control appears
+only when your role allows it.
 
 You can work an issue without leaving the tab. **Create** one ({{kbd:create-jira-issue}}
 from the palette) with a summary, Markdown description, and an **issue-type** picker;
@@ -839,9 +840,10 @@ the confirmation names the real resulting status, not a generic "closed" — or 
 any workflow status from the **status menu** on the chip, which lists the transitions your
 role allows by their target status name; **assign or unassign** it by searching your
 project's users; set or clear its **due date**, change its **priority**, and edit its
-**labels**; and **edit or delete your own comments**. Each action is gated on your Jira
-permissions, so anything your token and role can't do simply doesn't appear — a control shows
-up only when your permissions allow it.
+**labels**; and **edit or delete your own comments** (or anyone's, with Jira's project-admin
+comment permissions). Each action is gated on your Jira permissions, so anything your token
+and role can't do simply doesn't appear — a control shows up only when your permissions allow
+it.
 
 **Referenced issues follow your work.** When a **branch name**, a commit's message (in the
 commit detail view), or a pull request's title or description mentions one of the linked

--- a/src/features/issues/JiraIssueSidebar.tsx
+++ b/src/features/issues/JiraIssueSidebar.tsx
@@ -37,6 +37,8 @@ export function JiraIssueSidebar({
   canLogWork,
   canEditOwnWorklogs,
   canDeleteOwnWorklogs,
+  canEditAllWorklogs,
+  canDeleteAllWorklogs,
 }: {
   repoPath: string;
   issueKey: string;
@@ -50,6 +52,8 @@ export function JiraIssueSidebar({
   canLogWork: boolean;
   canEditOwnWorklogs: boolean;
   canDeleteOwnWorklogs: boolean;
+  canEditAllWorklogs: boolean;
+  canDeleteAllWorklogs: boolean;
 }) {
   const setDueDate = useJiraSetDueDate(repoPath, link);
   const selectIssue = useUiStore((s) => s.selectIssue);
@@ -288,6 +292,8 @@ export function JiraIssueSidebar({
           canEditEstimates={canEditIssue}
           canEditOwnWorklogs={canEditOwnWorklogs}
           canDeleteOwnWorklogs={canDeleteOwnWorklogs}
+          canEditAllWorklogs={canEditAllWorklogs}
+          canDeleteAllWorklogs={canDeleteAllWorklogs}
         />
       )}
     </aside>

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -739,8 +739,10 @@ function JiraCommentItem({
   issueKey,
   comment,
   isOwn,
-  canEdit,
-  canDelete,
+  canEditOwn,
+  canDeleteOwn,
+  canEditAll,
+  canDeleteAll,
 }: {
   repoPath: string;
   /** `null` during the link-pending window (a cached detail can still render
@@ -750,8 +752,14 @@ function JiraCommentItem({
   issueKey: string;
   comment: JiraComment;
   isOwn: boolean;
-  canEdit: boolean;
-  canDelete: boolean;
+  /** Edit the viewer's OWN comment (EDIT_OWN_COMMENTS). */
+  canEditOwn: boolean;
+  /** Delete the viewer's OWN comment (DELETE_OWN_COMMENTS). */
+  canDeleteOwn: boolean;
+  /** Edit ANYONE's comment — project admins (EDIT_ALL_COMMENTS). */
+  canEditAll: boolean;
+  /** Delete ANYONE's comment — project admins (DELETE_ALL_COMMENTS). */
+  canDeleteAll: boolean;
 }) {
   const edit = useJiraCommentEdit(repoPath, link);
   const del = useJiraCommentDelete(repoPath, link);
@@ -769,9 +777,13 @@ function JiraCommentItem({
     return () => cancelAnimationFrame(raf);
   }, [editing]);
 
+  // Own-scoped perms apply to the viewer's own comment; ALL-scoped perms (project
+  // admins) apply to anyone's — so the affordance shows for others' comments too.
+  const canEdit = (isOwn && canEditOwn) || canEditAll;
+  const canDelete = (isOwn && canDeleteOwn) || canDeleteAll;
   // Edit/delete require a live link (the mutations key on its site). During the
   // link-pending window the menu is simply absent — the comment still renders.
-  const showMenu = link !== null && isOwn && (canEdit || canDelete);
+  const showMenu = link !== null && (canEdit || canDelete);
   const edited =
     comment.updatedAt != null && comment.updatedAt !== comment.createdAt;
 
@@ -909,7 +921,11 @@ function JiraCommentItem({
         open={confirmDelete}
         onCancel={() => setConfirmDelete(false)}
         title="Delete comment?"
-        body="This permanently deletes your comment on this Jira issue. This cannot be undone."
+        body={
+          isOwn
+            ? "This permanently deletes your comment on this Jira issue. This cannot be undone."
+            : "This permanently deletes this comment on this Jira issue. This cannot be undone."
+        }
         confirmLabel="Delete comment"
         confirmVariant="destructive"
         pending={del.isPending}
@@ -933,8 +949,10 @@ function JiraWorklogItem({
   issueKey,
   worklog,
   isOwn,
-  canEdit,
-  canDelete,
+  canEditOwn,
+  canDeleteOwn,
+  canEditAll,
+  canDeleteAll,
 }: {
   repoPath: string;
   /** `null` during the link-pending window — the read-only row always renders;
@@ -943,8 +961,14 @@ function JiraWorklogItem({
   issueKey: string;
   worklog: JiraWorklog;
   isOwn: boolean;
-  canEdit: boolean;
-  canDelete: boolean;
+  /** Edit the viewer's OWN worklog (EDIT_OWN_WORKLOGS). */
+  canEditOwn: boolean;
+  /** Delete the viewer's OWN worklog (DELETE_OWN_WORKLOGS). */
+  canDeleteOwn: boolean;
+  /** Edit ANYONE's worklog — project admins (EDIT_ALL_WORKLOGS). */
+  canEditAll: boolean;
+  /** Delete ANYONE's worklog — project admins (DELETE_ALL_WORKLOGS). */
+  canDeleteAll: boolean;
 }) {
   const update = useJiraUpdateWorklog(repoPath, link);
   const del = useJiraDeleteWorklog(repoPath, link);
@@ -953,9 +977,13 @@ function JiraWorklogItem({
   const [noteDraft, setNoteDraft] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
 
+  // Own-scoped perms apply to the viewer's own entry; ALL-scoped perms (project
+  // admins) apply to anyone's — so the affordance shows for others' entries too.
+  const canEdit = (isOwn && canEditOwn) || canEditAll;
+  const canDelete = (isOwn && canDeleteOwn) || canDeleteAll;
   // Edit/delete require a live link (the mutations key on its site). During the
   // link-pending window the actions are simply absent — the row still renders.
-  const showActions = link !== null && isOwn && (canEdit || canDelete);
+  const showActions = link !== null && (canEdit || canDelete);
   const hadNote = worklog.commentMd.trim().length > 0;
 
   const durationTrimmed = durationDraft.trim();
@@ -1125,7 +1153,11 @@ function JiraWorklogItem({
         open={confirmDelete}
         onCancel={() => setConfirmDelete(false)}
         title="Delete worklog?"
-        body="This permanently deletes your logged work on this Jira issue and restores the remaining estimate. This cannot be undone."
+        body={
+          isOwn
+            ? "This permanently deletes your logged work on this Jira issue and restores the remaining estimate. This cannot be undone."
+            : "This permanently deletes this logged work on this Jira issue and restores the remaining estimate. This cannot be undone."
+        }
         confirmLabel="Delete worklog"
         confirmVariant="destructive"
         pending={del.isPending}
@@ -1158,6 +1190,8 @@ export function JiraTimeTrackingSection({
   canEditEstimates,
   canEditOwnWorklogs,
   canDeleteOwnWorklogs,
+  canEditAllWorklogs,
+  canDeleteAllWorklogs,
 }: {
   repoPath: string;
   link: JiraLink | null;
@@ -1171,6 +1205,8 @@ export function JiraTimeTrackingSection({
   canEditEstimates: boolean;
   canEditOwnWorklogs: boolean;
   canDeleteOwnWorklogs: boolean;
+  canEditAllWorklogs: boolean;
+  canDeleteAllWorklogs: boolean;
 }) {
   const logWork = useJiraLogWork(repoPath, link);
   const setOriginal = useJiraSetOriginalEstimate(repoPath, link);
@@ -1364,8 +1400,10 @@ export function JiraTimeTrackingSection({
               isOwn={
                 viewerAccountId != null && w.author?.id === viewerAccountId
               }
-              canEdit={canEditOwnWorklogs}
-              canDelete={canDeleteOwnWorklogs}
+              canEditOwn={canEditOwnWorklogs}
+              canDeleteOwn={canDeleteOwnWorklogs}
+              canEditAll={canEditAllWorklogs}
+              canDeleteAll={canDeleteAllWorklogs}
             />
           ))}
           {worklogsTotal > worklogs.length && (
@@ -1500,9 +1538,13 @@ export function JiraIssueView({
   const canEditIssue = perms.data?.editIssues ?? false;
   const canEditOwnComments = perms.data?.editOwnComments ?? false;
   const canDeleteOwnComments = perms.data?.deleteOwnComments ?? false;
+  const canEditAllComments = perms.data?.editAllComments ?? false;
+  const canDeleteAllComments = perms.data?.deleteAllComments ?? false;
   const canLogWork = perms.data?.workOnIssues ?? false;
   const canEditOwnWorklogs = perms.data?.editOwnWorklogs ?? false;
   const canDeleteOwnWorklogs = perms.data?.deleteOwnWorklogs ?? false;
+  const canEditAllWorklogs = perms.data?.editAllWorklogs ?? false;
+  const canDeleteAllWorklogs = perms.data?.deleteAllWorklogs ?? false;
 
   const comment = useJiraComment(repoPath, link.data);
   const transition = useJiraTransition(repoPath, link.data);
@@ -1679,8 +1721,10 @@ export function JiraIssueView({
                     issue.viewerAccountId != null &&
                     c.author?.id === issue.viewerAccountId
                   }
-                  canEdit={canEditOwnComments}
-                  canDelete={canDeleteOwnComments}
+                  canEditOwn={canEditOwnComments}
+                  canDeleteOwn={canDeleteOwnComments}
+                  canEditAll={canEditAllComments}
+                  canDeleteAll={canDeleteAllComments}
                 />
               ))}
               {issue.comments.length === 0 && (
@@ -1753,6 +1797,8 @@ export function JiraIssueView({
           canLogWork={canLogWork}
           canEditOwnWorklogs={canEditOwnWorklogs}
           canDeleteOwnWorklogs={canDeleteOwnWorklogs}
+          canEditAllWorklogs={canEditAllWorklogs}
+          canDeleteAllWorklogs={canDeleteAllWorklogs}
         />
       </div>
     </div>

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -114,6 +114,7 @@ import {
   type ApprovalState,
   type ForgeProvider,
   type ForgeUserRef,
+  type PrDetails,
   type PrThreadOut,
   providerLabel,
   type ReviewThreadOut,
@@ -166,6 +167,24 @@ const MERGE_LABEL: Record<MergeStrategy, string> = {
   rebase: "Rebase and merge",
   fast_forward: "Fast-forward",
 };
+
+/** Whether a GitHub merge method is disabled by the repository's server-side merge
+ *  settings (allow merge commit / squash / rebase). Only an explicit `false` gates —
+ *  `null`/`undefined` is "unknown" (fetch failed, or a non-GitHub provider) and is
+ *  treated as NOT disabled, so the picker behaves exactly as before when unknown.
+ *  Fast-forward is a Bitbucket-only method with no GitHub server toggle, so it's
+ *  never server-disabled here. */
+function isServerMergeDisabled(pr: PrDetails, s: MergeStrategy): boolean {
+  const flag =
+    s === "merge"
+      ? pr.mergeCommitAllowed
+      : s === "squash"
+        ? pr.squashMergeAllowed
+        : s === "rebase"
+          ? pr.rebaseMergeAllowed
+          : null;
+  return flag === false;
+}
 
 export function RemotePrView({
   repoPath,
@@ -637,6 +656,22 @@ export function RemotePrView({
   // we can't guard — so for GitLab we disable Merge rather than merge unguarded on an
   // irreversible op; reloading refetches the head. (GitHub has no guard, so it's exempt.)
   const mergeGuardMissing = provider === "gitlab" && pr?.commits.length === 0;
+
+  // GitHub-only: when the server ∩ branch-rule intersection is empty — every one of
+  // the three GitHub merge methods is disabled either in the repo's settings or by a
+  // GitDesktop branch rule — opening a menu of all-disabled items is useless, so the
+  // Merge trigger itself is disabled with an explanation. `null`/`unknown` server
+  // flags never count as disabled, so a failed settings fetch can never trip this
+  // (behaviour stays exactly as today). GitLab/Bitbucket gate their methods elsewhere.
+  const allMergeMethodsBlocked =
+    pr != null &&
+    provider !== "gitlab" &&
+    provider !== "bitbucket" &&
+    (["merge", "squash", "rebase"] as const).every(
+      (s) =>
+        isServerMergeDisabled(pr, s) ||
+        !isMergeMethodAllowed(rulesConfig, pr.baseRefName, s),
+    );
 
   // Auto-merge derived state (GitLab-only). The arm affordance shows only while the
   // head pipeline is in flight; the footer indicator shows once armed. Both classify
@@ -1883,23 +1918,38 @@ export function RemotePrView({
           )}
           {canMerge && (
             <DropdownMenu>
+              {/* A natively-disabled Button swallows `title`, so the hint rides a
+                  wrapping span (same idiom as the "Checked out" button above and
+                  documented in DangerZone.tsx). Existing disabled causes (draft,
+                  merge-guard) keep their exact reasons; the all-methods-blocked cause
+                  adds its own only when it's the blocker. */}
               <DropdownMenuTrigger
                 render={
-                  <Button
-                    size="sm"
-                    disabled={busy || pr.isDraft || mergeGuardMissing}
+                  <span
                     title={
                       pr.isDraft
                         ? `Mark the ${prNoun} ready before merging`
                         : mergeGuardMissing
                           ? "Reload to merge — couldn't load the head commit to guard the merge"
-                          : `Merge this ${prNoun}`
+                          : allMergeMethodsBlocked
+                            ? "No merge method is enabled by both this repository's settings and its branch rules"
+                            : `Merge this ${prNoun}`
                     }
                   >
-                    <GitMergeIcon data-icon="inline-start" />
-                    Merge
-                    <CaretDownIcon data-icon="inline-end" />
-                  </Button>
+                    <Button
+                      size="sm"
+                      disabled={
+                        busy ||
+                        pr.isDraft ||
+                        mergeGuardMissing ||
+                        allMergeMethodsBlocked
+                      }
+                    >
+                      <GitMergeIcon data-icon="inline-start" />
+                      Merge
+                      <CaretDownIcon data-icon="inline-end" />
+                    </Button>
+                  </span>
                 }
               />
               <DropdownMenuContent align="end" className="w-56">
@@ -1913,14 +1963,22 @@ export function RemotePrView({
                     ? (["merge", "squash", "fast_forward"] as const)
                     : (["merge", "squash", "rebase"] as const)
                 ).map((s) => {
-                  const blocked =
+                  const isGitHub =
                     provider !== "gitlab" &&
                     provider !== "bitbucket" &&
                     // Bitbucket's "fast_forward" isn't a GitHub MergeMethod and
                     // never reaches this arm (bitbucket is excluded above) — the
-                    // narrowing also keeps `s` a valid MergeMethod for the check.
-                    s !== "fast_forward" &&
+                    // narrowing also keeps `s` a valid MergeMethod for the checks.
+                    s !== "fast_forward";
+                  // Repository-level server setting (allow merge/squash/rebase). Only
+                  // an explicit `false` disables — `null`/`undefined` is "unknown" and
+                  // never gates (behaviour then matches today's, GitLab/BB included).
+                  const serverDisabled =
+                    isGitHub && isServerMergeDisabled(pr, s);
+                  const locallyBlocked =
+                    isGitHub &&
                     !isMergeMethodAllowed(rulesConfig, pr.baseRefName, s);
+                  const blocked = serverDisabled || locallyBlocked;
                   return (
                     <DropdownMenuItem
                       key={s}
@@ -1933,7 +1991,9 @@ export function RemotePrView({
                       }}
                     >
                       {MERGE_LABEL[s]}
-                      {blocked && " — blocked by branch rule"}
+                      {serverDisabled
+                        ? " — disabled in repository settings"
+                        : locallyBlocked && " — blocked by branch rule"}
                     </DropdownMenuItem>
                   );
                 })}

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -191,6 +191,18 @@ function PagesEnabled({
   })();
   const sourceChanged =
     branch !== pages.sourceBranch || path !== (pages.sourcePath || "/");
+  // HTTPS can only be enforced once GitHub has issued the TLS certificate for a
+  // custom domain. Without a custom domain (default *.github.io) there's no
+  // certificate object at all and HTTPS is always available, so never gate on it.
+  const certReady = !pages.cname || pages.httpsCertificateState === "approved";
+  const certFailed =
+    pages.httpsCertificateState === "errored" ||
+    pages.httpsCertificateState === "bad_authz";
+  const httpsHint = certReady
+    ? undefined
+    : certFailed
+      ? "HTTPS certificate provisioning failed — check the domain's DNS configuration"
+      : "Waiting for the HTTPS certificate to be issued for this domain";
 
   return (
     <div className="min-w-0 space-y-4">
@@ -307,23 +319,29 @@ function PagesEnabled({
       <label className="flex cursor-pointer items-center justify-between gap-3 text-xs">
         <span>
           Enforce HTTPS
-          <span className="ml-1 text-[11px] text-muted-foreground">
-            (available once the certificate is ready)
-          </span>
+          {!certReady && (
+            <span className="ml-1 text-[11px] text-muted-foreground">
+              {certFailed
+                ? "(certificate provisioning failed)"
+                : "(available once the certificate is ready)"}
+            </span>
+          )}
         </span>
-        <Switch
-          checked={pages.httpsEnforced}
-          disabled={update.isPending}
-          onCheckedChange={(v) =>
-            update.mutate(
-              { httpsEnforced: v },
-              {
-                onSuccess: () => toast.success("Updated"),
-                onError: toastError,
-              },
-            )
-          }
-        />
+        <span title={certReady ? undefined : httpsHint} className="inline-flex">
+          <Switch
+            checked={pages.httpsEnforced}
+            disabled={update.isPending || !certReady}
+            onCheckedChange={(v) =>
+              update.mutate(
+                { httpsEnforced: v },
+                {
+                  onSuccess: () => toast.success("Updated"),
+                  onError: toastError,
+                },
+              )
+            }
+          />
+        </span>
       </label>
 
       <div className="flex items-center justify-end gap-2 border-t pt-3">

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -48,6 +48,13 @@ import { useOpenRepoByPath } from "./useOpenRepoByPath";
 const RECENT_COUNT = 5;
 const OTHER_GROUP = "Other";
 
+const REPO_LISTBOX_ID = "repo-list-listbox";
+/** Stable DOM id per repo row, so the filter's aria-activedescendant can point
+ *  at the keyboard-highlighted option for screen readers. `repo.path` is the
+ *  unique key (already the row's `data-repo-path`). */
+const repoOptionId = (path: string) =>
+  `repo-list-${path.replace(/[^\w-]/g, "_")}`;
+
 // Paths whose visibility probe has already been attempted this app session, so
 // a failing probe (e.g. a signed-out provider) is retried at most once per
 // session — no probe storms on every dropdown open. Module-level and read only
@@ -345,6 +352,13 @@ export function RepoList({
           onKeyDown={handleKeyDown}
           placeholder="Filter repositories"
           aria-label="Filter repositories"
+          role="combobox"
+          aria-expanded={visible.length > 0}
+          aria-controls={REPO_LISTBOX_ID}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            highlightedPath ? repoOptionId(highlightedPath) : undefined
+          }
           className="h-7"
         />
       </div>
@@ -354,7 +368,14 @@ export function RepoList({
       >
         <ContextMenu>
           <ContextMenuTrigger
-            render={<div onContextMenuCapture={handleContextMenu} />}
+            render={
+              <div
+                onContextMenuCapture={handleContextMenu}
+                role="listbox"
+                id={REPO_LISTBOX_ID}
+                aria-label="Repositories"
+              />
+            }
           >
             {filtered.length === 0 ? (
               <p className="px-3 py-6 text-center text-xs text-muted-foreground">
@@ -415,7 +436,9 @@ function RepoSection({
 }: RepoRowsProps & { title: string; repos: RecentRepo[] }) {
   if (repos.length === 0) return null;
   return (
-    <div>
+    // Presentation wrapper so this section div (and its header <p>) doesn't sit
+    // as a non-option node between the listbox and its options in the a11y tree.
+    <div role="presentation">
       <p className="px-3 pt-2 pb-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
         {title}
       </p>
@@ -472,6 +495,9 @@ function RepoRow({
     >
       <button
         type="button"
+        id={repoOptionId(repo.path)}
+        role="option"
+        aria-selected={highlighted}
         className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left"
         onClick={() => onOpen(repo.path)}
         disabled={openingPath !== null}

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -353,7 +353,9 @@ export function RepoList({
           placeholder="Filter repositories"
           aria-label="Filter repositories"
           role="combobox"
-          aria-expanded={visible.length > 0}
+          // The listbox is always rendered (the empty state lives inside it), and
+          // aria-expanded reflects popup visibility, not result count.
+          aria-expanded={true}
           aria-controls={REPO_LISTBOX_ID}
           aria-autocomplete="list"
           aria-activedescendant={

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -27,7 +27,7 @@ import {
   mcpServerUsableBy,
   mcpSupportedFor,
 } from "@/lib/settings/mcp";
-import { useSettings } from "@/lib/settings/queries";
+import { useRepoKeys, useSettings } from "@/lib/settings/queries";
 import { cn } from "@/lib/utils";
 import {
   AgentPicker,
@@ -229,6 +229,10 @@ export function SessionComposer({
   // (each CLI reads different dirs).
   const settings = useSettings();
   const customCommands = settings.data?.customCommands;
+  // Scope/override lookup keys for this repo (identity + raw path), so a
+  // repo-scoped server or per-repo override set from a sibling worktree is
+  // OFFERED here. A plain query hook (no effects) — safe under <Activity>.
+  const repoKeys = useRepoKeys(repoPath);
   // MCP registry (Settings → MCP servers) → the new-session opt-in, narrowed to
   // the servers OFFERED in THIS repo (in scope and not per-repo "off"). Default
   // selection is the per-repo "on" set; the picker lets you pare it down. Applied to
@@ -237,9 +241,9 @@ export function SessionComposer({
   const mcpRegistry = useMemo(
     () =>
       (settings.data?.mcpServers ?? []).filter((s) =>
-        isServerAvailable(s, repoPath),
+        isServerAvailable(s, repoKeys),
       ),
-    [settings.data?.mcpServers, repoPath],
+    [settings.data?.mcpServers, repoKeys],
   );
   const isContainer = settings.data?.agentIsolation === "container";
   // Servers the chosen agent can actually run (Codex = local/stdio only).
@@ -250,9 +254,9 @@ export function SessionComposer({
   const enabledMcpIds = useMemo(
     () =>
       mcpServersForAgent
-        .filter((s) => isServerDefaultOn(s, repoPath))
+        .filter((s) => isServerDefaultOn(s, repoKeys))
         .map((s) => s.id),
-    [mcpServersForAgent, repoPath],
+    [mcpServersForAgent, repoKeys],
   );
   const effectiveMcp = startMcp ?? enabledMcpIds;
   // MCP runs on host + container for Claude/Copilot/opencode, and on container Codex.

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -8,6 +8,7 @@ import {
   type TranscriptSegment,
 } from "@/lib/ai/agent";
 import { cleanupContainerSandbox, stopTestContainer } from "@/lib/ai/sandbox";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import {
   commitWorktreeAll,
   createWorktree,
@@ -277,11 +278,19 @@ async function runTurn(
   // setting it per-repo "off" stops it applying, matching what the picker would
   // now offer. The backend resolves secret env/header values from the keychain.
   const mcpIds = s0.mcpServers ?? [];
+  // Scope/override lookup keys for the session's repo (its worktree-stable
+  // identity + the raw checkout path), so a server scoped/overridden from a
+  // sibling worktree still resolves as OFFERED here.
+  const repoKeys = mcpIds.length
+    ? await repoIdentity(s0.repoPath).then((id) =>
+        id !== s0.repoPath ? [s0.repoPath, id] : [s0.repoPath],
+      )
+    : [];
   const mcpServers = mcpIds.length
     ? ((await loadSettings().catch(() => null))?.mcpServers ?? []).filter(
         (srv) =>
           mcpIds.includes(srv.id) &&
-          isServerAvailable(srv, s0.repoPath) &&
+          isServerAvailable(srv, repoKeys) &&
           mcpServerUsableBy(srv, s0.agent),
       )
     : undefined;

--- a/src/features/settings/McpServersSection.tsx
+++ b/src/features/settings/McpServersSection.tsx
@@ -75,6 +75,11 @@ export const McpServersSection = withForm({
     }
 
     async function saveServer(server: McpServer) {
+      // Close optimistically FIRST: foldServerScopeKeys' cold repoIdentity IPC
+      // call would otherwise visibly delay the dialog closing. It never rejects,
+      // and the write below composes via the functional setter, so closing before
+      // the await is safe.
+      setEditing(null);
       // Fold the dialog's scope/override keys onto the repo IDENTITY before
       // storing: the dialog's "This repo" option carries the raw checkout path,
       // and folding here (rather than editing the dialog) is what makes a
@@ -89,7 +94,6 @@ export const McpServersSection = withForm({
           ? cur.map((s) => (s.id === folded.id ? folded : s))
           : [...cur, folded];
       });
-      setEditing(null);
     }
 
     function removeServer(server: McpServer) {
@@ -308,9 +312,10 @@ export const McpServersSection = withForm({
                         {isGlobal && repoPath && repoScopeKey ? (
                           <PerRepoStateControl
                             server={server}
-                            // Read the override under the identity key (where writes
-                            // land); the write resolves identity from repoPath itself.
-                            repoPath={repoScopeKey}
+                            // Read the override across ALL the repo's keys (raw path
+                            // AND identity) so a legacy raw-path override still shows;
+                            // the write resolves identity from repoPath itself.
+                            repoKeys={repoKeys}
                             disabled={incomplete}
                             onChange={(state) =>
                               void setRepoOverride(server, repoPath, state)

--- a/src/features/settings/McpServersSection.tsx
+++ b/src/features/settings/McpServersSection.tsx
@@ -12,14 +12,18 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { withForm } from "@/lib/form";
 import { deleteMcpSecret } from "@/lib/git/api";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { McpServer } from "@/lib/settings/api";
 import {
   effectiveMcpState,
+  foldServerScopeKeys,
+  isServerInScope,
   MCP_SCOPE_GLOBAL,
   type McpRepoState,
   serverScope,
 } from "@/lib/settings/mcp";
+import { useRepoKeys } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { BrowseRegistryDialog } from "./mcp/BrowseRegistryDialog";
 import { GitDesktopAsServer } from "./mcp/GitDesktopAsServer";
@@ -39,6 +43,15 @@ export const McpServersSection = withForm({
     const listRef = useRef<HTMLDivElement>(null);
     const repoPath = useUiStore((s) => s.repoPath);
     const repoName = useUiStore((s) => s.repoName);
+    // Scope/override lookup keys for the open repo: [repoPath] while the identity
+    // resolves, [repoPath, identity] once it does. Matches a server scoped/overridden
+    // under EITHER the raw checkout path (legacy) or the worktree-stable identity,
+    // so a scope set from a sibling worktree is recognized here.
+    const repoKeys = useRepoKeys(repoPath);
+    // The single key writes land under (the resolved identity, or the raw path
+    // while it's still resolving / unresolvable). PerRepoStateControl does an
+    // exact-key override lookup, so it must read under this same key.
+    const repoScopeKey = repoKeys.length ? repoKeys[repoKeys.length - 1] : null;
     // The registry browser's open state lives in the store so the command
     // palette can deep-link to it (see openMcpBrowse).
     const browseOpen = useUiStore((s) => s.mcpBrowseOpen);
@@ -61,13 +74,21 @@ export const McpServersSection = withForm({
       form.setFieldValue("mcpServers", (prev) => [...(prev ?? []), server]);
     }
 
-    function saveServer(server: McpServer) {
-      const exists = list.some((s) => s.id === server.id);
-      setServers(
-        exists
-          ? list.map((s) => (s.id === server.id ? server : s))
-          : [...list, server],
-      );
+    async function saveServer(server: McpServer) {
+      // Fold the dialog's scope/override keys onto the repo IDENTITY before
+      // storing: the dialog's "This repo" option carries the raw checkout path,
+      // and folding here (rather than editing the dialog) is what makes a
+      // repo-scoped server cross the repo's worktrees. A no-op for global servers
+      // and for paths git can't resolve.
+      const folded = await foldServerScopeKeys(server);
+      // Re-read via the functional setter so this async write composes with any
+      // interleaving edit instead of clobbering it.
+      form.setFieldValue("mcpServers", (prev) => {
+        const cur = prev ?? [];
+        return cur.some((s) => s.id === folded.id)
+          ? cur.map((s) => (s.id === folded.id ? folded : s))
+          : [...cur, folded];
+      });
       setEditing(null);
     }
 
@@ -84,23 +105,26 @@ export const McpServersSection = withForm({
     }
 
     // Set (or clear, when null = "follow the global default") a global server's
-    // per-repo state override for the open repo.
-    function setRepoOverride(
+    // per-repo state override for the open repo. Writes under the repo's
+    // worktree-stable IDENTITY key (resolved from the checkout path `rp`), and
+    // folds the server's legacy raw-path keys onto their identities in the same
+    // write, so an override set from any checkout is honored from its siblings.
+    async function setRepoOverride(
       server: McpServer,
       rp: string,
       state: McpRepoState | null,
     ) {
-      setServers(
-        list.map((s) => {
-          if (s.id !== server.id) return s;
-          const overrides = { ...(s.repoOverrides ?? {}) };
-          if (state) overrides[rp] = state;
-          else delete overrides[rp];
-          const next: McpServer = { ...s, repoOverrides: overrides };
-          if (Object.keys(overrides).length === 0)
-            next.repoOverrides = undefined;
-          return next;
-        }),
+      const key = await repoIdentity(rp);
+      const folded = await foldServerScopeKeys(server);
+      const overrides = { ...(folded.repoOverrides ?? {}) };
+      if (state) overrides[key] = state;
+      else delete overrides[key];
+      const next: McpServer = { ...folded, repoOverrides: overrides };
+      if (Object.keys(overrides).length === 0) next.repoOverrides = undefined;
+      // Re-read `list` via the functional setter so this async write composes with
+      // any interleaving edit rather than clobbering it.
+      form.setFieldValue("mcpServers", (prev) =>
+        (prev ?? []).map((s) => (s.id === server.id ? next : s)),
       );
     }
 
@@ -123,8 +147,15 @@ export const McpServersSection = withForm({
       {
         key: "repo",
         label: `This repo — ${repoName ?? (repoPath ? repoBasename(repoPath) : "")}`,
+        // "This repo" = scoped to any of the open repo's keys (identity or a
+        // legacy raw checkout path), so a server scoped from a sibling worktree
+        // groups here too.
         servers: repoPath
-          ? list.filter((s) => serverScope(s) === repoPath)
+          ? list.filter(
+              (s) =>
+                serverScope(s) !== MCP_SCOPE_GLOBAL &&
+                isServerInScope(s, repoKeys),
+            )
           : [],
       },
       {
@@ -132,7 +163,7 @@ export const McpServersSection = withForm({
         label: "Other repositories",
         servers: list.filter((s) => {
           const sc = serverScope(s);
-          return sc !== MCP_SCOPE_GLOBAL && sc !== repoPath;
+          return sc !== MCP_SCOPE_GLOBAL && !isServerInScope(s, repoKeys);
         }),
       },
     ].filter((g) => g.servers.length > 0);
@@ -236,7 +267,7 @@ export const McpServersSection = withForm({
                       data-mcp-row={server.id}
                       aria-label={`${server.name}, ${server.transport}, ${effectiveMcpState(
                         server,
-                        repoPath,
+                        repoKeys,
                       )}. Press Enter to edit.`}
                       tabIndex={
                         i === safeActive || (safeActive === -1 && i === 0)
@@ -274,13 +305,15 @@ export const McpServersSection = withForm({
                         </span>
                       )}
                       <div className="ml-auto flex shrink-0 items-center gap-1">
-                        {isGlobal && repoPath ? (
+                        {isGlobal && repoPath && repoScopeKey ? (
                           <PerRepoStateControl
                             server={server}
-                            repoPath={repoPath}
+                            // Read the override under the identity key (where writes
+                            // land); the write resolves identity from repoPath itself.
+                            repoPath={repoScopeKey}
                             disabled={incomplete}
                             onChange={(state) =>
-                              setRepoOverride(server, repoPath, state)
+                              void setRepoOverride(server, repoPath, state)
                             }
                           />
                         ) : (

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -117,6 +117,10 @@ export function McpServerDialog({
   // The Select's value must equal an option value. A draft scoped to the current
   // repo under a legacy raw path (curScope) won't equal the canonical "This repo"
   // option value (the identity); normalize to it so the option stays selected.
+  // The `?? curScope` arm is type-level only: `scopedToThisRepo` implies repoKeys
+  // is non-empty, so `thisRepoKey` is non-null here — the fallback is unreachable
+  // at runtime, but TS can't narrow `thisRepoKey` across the `scopedToThisRepo`
+  // check, so removing it fails the null check.
   const selectedScope = scopedToThisRepo ? (thisRepoKey ?? curScope) : curScope;
 
   // Reconstruct a candidate server from the live draft + rows for validation.

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -25,9 +25,11 @@ import {
   emptyMcpServer,
   entriesFor,
   MCP_SCOPE_GLOBAL,
+  scopeRepoPath,
   serverScope,
   validateMcpServer,
 } from "@/lib/settings/mcp";
+import { useRepoKeys } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 import { EntryEditor } from "./EntryEditor";
 import { type EntryRow, repoBasename } from "./shared";
@@ -77,23 +79,45 @@ export function McpServerDialog({
       rs.map((r) => (r.rowId === rowId ? { ...r, ...patch } : r)),
     );
 
+  // Scope/override lookup keys for the open repo: [repoPath] while its identity
+  // resolves, [repoPath, identity] once it does. A server scoped under EITHER the
+  // raw checkout path (legacy) or the worktree-stable identity counts as "this
+  // repo", so a scope set from a sibling worktree is recognized here.
+  const repoKeys = useRepoKeys(repoPath);
+  // The canonical value the "This repo" option stores + selects with: the resolved
+  // identity when available (so new/changed scopes are identity-keyed, matching
+  // fold-on-write), else the raw path.
+  const thisRepoKey = repoKeys.length ? repoKeys[repoKeys.length - 1] : null;
+
+  const curScope = serverScope(draft);
+  // Is the draft repo-scoped to the OPEN repo (under any of its keys)? Legacy
+  // raw-path scopes for the current repo read as "this repo" too — repoKeys
+  // includes the raw path — so they select the "This repo" option, not "other".
+  const scopedToThisRepo =
+    curScope !== MCP_SCOPE_GLOBAL && repoKeys.includes(curScope);
+
   // Scope choices: always Global; "This repo" when one is open; plus the server's
   // own scope when it points at a DIFFERENT repo (editing it elsewhere), so that
   // assignment is preserved rather than silently dropped.
   const scopeOptions: { value: string; label: string }[] = [
     { value: MCP_SCOPE_GLOBAL, label: "Global — all repositories" },
   ];
-  if (repoPath)
+  if (repoPath && thisRepoKey)
     scopeOptions.push({
-      value: repoPath,
+      value: thisRepoKey,
       label: `This repo — ${repoName ?? repoBasename(repoPath)}`,
     });
-  const curScope = serverScope(draft);
-  if (curScope !== MCP_SCOPE_GLOBAL && curScope !== repoPath)
+  if (curScope !== MCP_SCOPE_GLOBAL && !scopedToThisRepo)
     scopeOptions.push({
       value: curScope,
-      label: `${repoBasename(curScope)} — other repo`,
+      // The stored scope is a worktree-stable identity key (`…/.git`); show the
+      // containing repo folder, never a bare ".git".
+      label: `${repoBasename(scopeRepoPath(curScope))} — other repo`,
     });
+  // The Select's value must equal an option value. A draft scoped to the current
+  // repo under a legacy raw path (curScope) won't equal the canonical "This repo"
+  // option value (the identity); normalize to it so the option stays selected.
+  const selectedScope = scopedToThisRepo ? (thisRepoKey ?? curScope) : curScope;
 
   // Reconstruct a candidate server from the live draft + rows for validation.
   function candidate(): McpServer {
@@ -209,7 +233,7 @@ export function McpServerDialog({
             <div className="space-y-2">
               <Label>Available in</Label>
               <Select
-                value={serverScope(draft)}
+                value={selectedScope}
                 onValueChange={(v) => v && set("scope", v)}
               >
                 <SelectTrigger size="sm" className="w-full">

--- a/src/features/settings/mcp/PerRepoStateControl.tsx
+++ b/src/features/settings/mcp/PerRepoStateControl.tsx
@@ -6,24 +6,37 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { McpServer } from "@/lib/settings/api";
-import type { McpRepoState } from "@/lib/settings/mcp";
+import {
+  type McpRepoState,
+  pickForRepo,
+  type RepoKeys,
+} from "@/lib/settings/mcp";
 
 /** Per-repo state picker for a GLOBAL server, shown on its row when a repo is
  *  open: On (available + default-on) / Optional (available, off by default) /
  *  Off (not offered here), or "Default" to follow the global Enabled. Muted
- *  while inheriting; solid once this repo overrides it. */
+ *  while inheriting; solid once this repo overrides it.
+ *
+ *  The override lookup spans ALL of the repo's keys (raw checkout path AND the
+ *  worktree-stable identity) via `pickForRepo`, so a pre-identity-keying override
+ *  stored under the legacy raw path still displays correctly during the migration
+ *  window — an exact-identity-only lookup would show "Default" for a legacy
+ *  override that `effectiveMcpState` still honors, inviting the user to
+ *  unknowingly overwrite it. `pickForRepo`'s last-hit-wins order means the
+ *  identity key (last in `repoKeys`) beats a legacy raw-path override — the
+ *  wanted preference. */
 export function PerRepoStateControl({
   server,
-  repoPath,
+  repoKeys,
   disabled,
   onChange,
 }: {
   server: McpServer;
-  repoPath: string;
+  repoKeys: RepoKeys;
   disabled?: boolean;
   onChange: (state: McpRepoState | null) => void;
 }) {
-  const override = server.repoOverrides?.[repoPath];
+  const override = pickForRepo(server.repoOverrides, repoKeys);
   const baseline = server.enabled ? "On" : "Optional";
   return (
     <Select

--- a/src/lib/ai/review-tools.ts
+++ b/src/lib/ai/review-tools.ts
@@ -57,7 +57,12 @@ function capHunkLines(hunk: string, maxLines: number): string {
  *  strip would eat those load-bearing `false`s.
  *
  *  KEEP IN SYNC: src-tauri/src/mcp_server/read_forge.rs
- *  (`strip_empty_comment_defaults`) mirrors this drop-list character-for-character. */
+ *  (`strip_empty_comment_defaults`) mirrors this drop-list character-for-character.
+ *
+ *  INVARIANT: the param is deliberately `object`, not `<T extends Record<string,
+ *  unknown>>`. Callers pass interface types (`PrThreadOut` etc.) that have no index
+ *  signature and so do not extend `Record<string, unknown>`; the generic form fails
+ *  tsc. */
 function stripEmptyCommentDefaults(obj: object): Record<string, unknown> {
   const out: Record<string, unknown> = { ...obj };
   // (key, empty-default) pairs — remove the key only on an exact match.

--- a/src/lib/ai/review-tools.ts
+++ b/src/lib/ai/review-tools.ts
@@ -49,6 +49,27 @@ function capHunkLines(hunk: string, maxLines: number): string {
   return `…[hunk truncated]\n${lines.slice(lines.length - maxLines).join("\n")}`;
 }
 
+/** Drop the always-default empty fields from one comment/thread object,
+ *  returning a shallow copy without them. Removes a key ONLY when it holds its
+ *  empty default; every other key (load-bearing `false`s like
+ *  `isResolved`/`viewerDidAuthor`, and the `id` write tools consume even when
+ *  empty) is kept. Explicit per-key list on purpose — a generic "remove falsy"
+ *  strip would eat those load-bearing `false`s.
+ *
+ *  KEEP IN SYNC: src-tauri/src/mcp_server/read_forge.rs
+ *  (`strip_empty_comment_defaults`) mirrors this drop-list character-for-character. */
+function stripEmptyCommentDefaults(obj: object): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...obj };
+  // (key, empty-default) pairs — remove the key only on an exact match.
+  if (out.authorAvatarUrl === "") delete out.authorAvatarUrl;
+  if (out.state === "") delete out.state;
+  if (out.url === "") delete out.url;
+  if (out.minimizedReason === "") delete out.minimizedReason;
+  if (out.isMinimized === false) delete out.isMinimized;
+  if (out.reviewId === "") delete out.reviewId;
+  return out;
+}
+
 /** One line prepended to every forge tool's output so the model treats the
  *  third-party content strictly as data (parity with the MCP server's framing). */
 const UNTRUSTED_PREFIX =
@@ -351,13 +372,22 @@ export function buildReviewTools(ctx: ReviewToolContext): ToolSet {
               : "",
           }));
           // KEEP IN SYNC: src-tauri/src/mcp_server/read_forge.rs (the
-          // list_pull_request_comments MCP tool) composes the same shape (and
-          // the diffHunk cap).
+          // list_pull_request_comments MCP tool) composes the same shape — the
+          // diffHunk cap AND the empty-field pruning below.
+          // Prune always-default empty fields from every comment/thread object
+          // so agent consumers (this same JSON feeds the AI review) don't pay
+          // tokens for e.g. `authorAvatarUrl:""` or `isMinimized:false`.
           const composed = {
             number: prNumber,
-            comments: pr.comments,
-            reviews: pr.reviews,
-            review_threads: cappedThreads,
+            comments: pr.comments.map(stripEmptyCommentDefaults),
+            reviews: pr.reviews.map(stripEmptyCommentDefaults),
+            review_threads: cappedThreads.map((t) => {
+              const pruned = stripEmptyCommentDefaults(t);
+              if (Array.isArray(t.comments)) {
+                pruned.comments = t.comments.map(stripEmptyCommentDefaults);
+              }
+              return pruned;
+            }),
           };
           return (
             UNTRUSTED_PREFIX +

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1201,6 +1201,11 @@ export interface PagesInfo {
   sourcePath: string;
   cname: string;
   httpsEnforced: boolean;
+  /** TLS certificate state for a custom domain — one of "new",
+   * "authorization_created", "authorization_pending", "authorized",
+   * "uploaded", "approved", "errored", "bad_authz". `null` when the repo has no
+   * custom domain (no certificate is provisioned). */
+  httpsCertificateState: string | null;
 }
 
 export type RulesetEnforcement = "active" | "evaluate" | "disabled";
@@ -1534,6 +1539,17 @@ export interface PrDetails {
    *  GitHub derives its completed reviewers on the frontend from `reviews`, so it
    *  leaves this empty. */
   completedReviewers: CompletedReviewerWithState[];
+  /** Whether the repository allows the merge-commit method (server-side setting of
+   *  the repo the PR lives in — its base/parent repo on a fork). GitHub only; `null`
+   *  = unknown — do not gate on `null`. The merge-method picker pre-disables an
+   *  option only when its flag is explicitly `false`. */
+  mergeCommitAllowed: boolean | null;
+  /** Whether the repository allows the squash-merge method. GitHub only; `null` =
+   *  unknown — do not gate on `null`. */
+  squashMergeAllowed: boolean | null;
+  /** Whether the repository allows the rebase-merge method. GitHub only; `null` =
+   *  unknown — do not gate on `null`. */
+  rebaseMergeAllowed: boolean | null;
 }
 
 /** A reviewer who has submitted a verdict, as supplied by the backend (GitLab

--- a/src/lib/jira/types.ts
+++ b/src/lib/jira/types.ts
@@ -178,6 +178,14 @@ export interface JiraPermissions {
   editOwnWorklogs: boolean;
   /** Delete the viewer's own worklogs (Jira's DELETE_OWN_WORKLOGS). */
   deleteOwnWorklogs: boolean;
+  /** Edit anyone's worklogs — project admins (Jira's EDIT_ALL_WORKLOGS). */
+  editAllWorklogs: boolean;
+  /** Delete anyone's worklogs — project admins (Jira's DELETE_ALL_WORKLOGS). */
+  deleteAllWorklogs: boolean;
+  /** Edit anyone's comments — project admins (Jira's EDIT_ALL_COMMENTS). */
+  editAllComments: boolean;
+  /** Delete anyone's comments — project admins (Jira's DELETE_ALL_COMMENTS). */
+  deleteAllComments: boolean;
 }
 
 /** A priority option for the priority picker (`/priority`). */

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -1,5 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import type { AiSettings } from "@/lib/ai/types";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
 
 export interface RecentRepo {
@@ -123,13 +124,19 @@ export interface McpServer {
   /** Offered to new sessions by default when true. */
   enabled: boolean;
   /** Where this server is available: "global" (or absent) = every repo; otherwise
-   *  a repo root path = only sessions in that repo. Organization only — un-scoped
-   *  servers are still never auto-inherited (strict mode gags un-registered ones). */
+   *  a repo's worktree-stable identity key (`repoIdentity` — the git common dir,
+   *  shared by a repo's main checkout and all its worktrees) = only sessions in
+   *  that repo. Values written before identity-keying are a raw checkout path and
+   *  are still honored on read (and folded onto the identity on the next write).
+   *  Organization only — un-scoped servers are still never auto-inherited (strict
+   *  mode gags un-registered ones). */
   scope?: string;
-  /** Per-repo overrides of a GLOBAL server's state, keyed by repo root path:
-   *  "on" (available + on by default), "optional" (available, off by default),
-   *  "off" (not offered in that repo). Absent for a repo = inherit `enabled`.
-   *  Only meaningful for global servers; repo-scoped ones use `enabled` directly. */
+  /** Per-repo overrides of a GLOBAL server's state, keyed by the repo's
+   *  worktree-stable identity key (see `scope`; legacy raw-path keys still honored
+   *  on read, folded on write): "on" (available + on by default), "optional"
+   *  (available, off by default), "off" (not offered in that repo). Absent for a
+   *  repo = inherit `enabled`. Only meaningful for global servers; repo-scoped
+   *  ones use `enabled` directly. */
   repoOverrides?: Record<string, "on" | "optional" | "off">;
   /** "stdio" = a local subprocess; "http" = a remote streamable-HTTP server. */
   transport: "stdio" | "http";
@@ -396,6 +403,13 @@ export function addRecentRepo(repo: {
  * the context menu names the right provider from the first frame. Touches only
  * records whose stored values actually changed; an empty remote clears them.
  * No-op when nothing changed, so it never loops with its own settings refetch.
+ *
+ * Matching is by worktree-stable identity ({@link repoIdentity}, git common
+ * dir), not raw checkout path, so a probe from one checkout of a repo updates
+ * EVERY recentRepos row for the same underlying repo (its other worktrees'
+ * rows) — the rows keep their own `.path` identity; only the probed fields fan
+ * out. `repoIdentity` falls back to the raw path on a git error, so a repo that
+ * can't be resolved matches by path exactly as before.
  */
 export function persistRepoOwners(
   owners: {
@@ -408,10 +422,20 @@ export function persistRepoOwners(
   if (owners.length === 0) return Promise.resolve();
   return serializedRecentRepoWrite(async () => {
     const settings = await loadSettings();
-    const byPath = new Map(owners.map((o) => [o.path, o]));
+    // Index the incoming probes by the repo IDENTITY of their path, and resolve
+    // each existing row's identity too, so a row matches an entry for a sibling
+    // worktree of the same repo (not just the exact checkout that was probed).
+    const byIdentity = new Map(
+      await Promise.all(
+        owners.map(async (o) => [await repoIdentity(o.path), o] as const),
+      ),
+    );
+    const rowIdentities = await Promise.all(
+      settings.recentRepos.map((r) => repoIdentity(r.path)),
+    );
     let changed = false;
-    const recentRepos = settings.recentRepos.map((r) => {
-      const resolved = byPath.get(r.path);
+    const recentRepos = settings.recentRepos.map((r, i) => {
+      const resolved = byIdentity.get(rowIdentities[i]);
       if (!resolved) return r;
       const owner = resolved.owner || undefined;
       const host = resolved.host || undefined;
@@ -448,6 +472,11 @@ export function persistRepoOwners(
  * has no resolvable remote anymore). Touches only records whose stored values
  * actually changed; no-op when nothing changed, so it never loops with its own
  * settings refetch (mirrors {@link persistRepoOwners}).
+ *
+ * Matched by worktree-stable identity ({@link repoIdentity}), like
+ * {@link persistRepoOwners}, so a probe from one checkout updates every
+ * recentRepos row for the same underlying repo (its other worktrees). Falls back
+ * to the raw path when git can't resolve it — exactly today's behavior.
  */
 export function persistRepoVisibility(
   entries: {
@@ -462,10 +491,17 @@ export function persistRepoVisibility(
   if (entries.length === 0) return Promise.resolve();
   return serializedRecentRepoWrite(async () => {
     const settings = await loadSettings();
-    const byPath = new Map(entries.map((e) => [e.path, e]));
+    const byIdentity = new Map(
+      await Promise.all(
+        entries.map(async (e) => [await repoIdentity(e.path), e] as const),
+      ),
+    );
+    const rowIdentities = await Promise.all(
+      settings.recentRepos.map((r) => repoIdentity(r.path)),
+    );
     let changed = false;
-    const recentRepos = settings.recentRepos.map((r) => {
-      const resolved = byPath.get(r.path);
+    const recentRepos = settings.recentRepos.map((r, i) => {
+      const resolved = byIdentity.get(rowIdentities[i]);
       if (!resolved) return r;
       const visibility = resolved.visibility || undefined;
       // Fork provenance shares visibility's lifecycle: a null visibility (remote
@@ -475,7 +511,9 @@ export function persistRepoVisibility(
       // re-probes; only `undefined` (never probed / cleared) triggers a refetch.
       // `forkParent` stays undefined-when-absent (a non-fork has no upstream).
       const isFork = visibility ? (resolved.isFork ?? false) : undefined;
-      const forkParent = visibility ? resolved.forkParent || undefined : undefined;
+      const forkParent = visibility
+        ? resolved.forkParent || undefined
+        : undefined;
       if (
         visibility === r.visibility &&
         isFork === r.isFork &&

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -425,6 +425,8 @@ export function persistRepoOwners(
     // Index the incoming probes by the repo IDENTITY of their path, and resolve
     // each existing row's identity too, so a row matches an entry for a sibling
     // worktree of the same repo (not just the exact checkout that was probed).
+    // repoIdentity is promise-memoized per path, so the per-row fan-out costs
+    // one IPC round per path per session, not per probe.
     const byIdentity = new Map(
       await Promise.all(
         owners.map(async (o) => [await repoIdentity(o.path), o] as const),
@@ -491,6 +493,7 @@ export function persistRepoVisibility(
   if (entries.length === 0) return Promise.resolve();
   return serializedRecentRepoWrite(async () => {
     const settings = await loadSettings();
+    // Identity lookups are promise-memoized per path (see persistRepoOwners).
     const byIdentity = new Map(
       await Promise.all(
         entries.map(async (e) => [await repoIdentity(e.path), e] as const),

--- a/src/lib/settings/mcp.ts
+++ b/src/lib/settings/mcp.ts
@@ -1,3 +1,4 @@
+import { repoIdentity } from "@/lib/git/repo-identity";
 import type { McpKeyValue, McpServer } from "./api";
 
 /** Server name = the key in the generated MCP config: letters/digits/`-`/`_`,
@@ -14,53 +15,140 @@ export function serverScope(server: McpServer): string {
   return s ? s : MCP_SCOPE_GLOBAL;
 }
 
-/** Whether a server is in SCOPE for `repoPath` (ignores per-repo on/off):
- *  global servers always are; a repo-scoped server only in its own repo. */
-export function isServerInScope(
-  server: McpServer,
-  repoPath: string | null,
-): boolean {
-  const scope = serverScope(server);
-  return scope === MCP_SCOPE_GLOBAL || scope === repoPath;
+/** The scope / override keys that identify "the current repo", most-preferred
+ *  LAST. A worktree-stable identity key ({@link repoIdentity}) and the raw
+ *  checkout path both appear so scope/override lookups match a value stored under
+ *  either — new writes land under the identity key, legacy ones under the raw
+ *  path stay honored (read-both). Callers build this via `useRepoKeys`
+ *  (queries.ts); pass `[repoPath]` while the identity is still resolving (exactly
+ *  today's raw-path behavior), and `[]` when no repo is open. */
+export type RepoKeys = readonly string[];
+
+/** The override/scope value that wins for `repoKeys`, preferring the LATER key
+ *  (the resolved identity) over an earlier one (the raw path) so a folded
+ *  identity entry beats a stale legacy one. */
+function pickForRepo<T>(
+  byKey: Record<string, T> | undefined,
+  repoKeys: RepoKeys,
+): T | undefined {
+  if (!byKey) return undefined;
+  let hit: T | undefined;
+  for (const k of repoKeys) {
+    const v = byKey[k];
+    if (v !== undefined) hit = v;
+  }
+  return hit;
 }
 
-/** A server's resolved state in `repoPath`: "on" (available + default-on),
- *  "optional" (available, off by default), or "off" (not offered). A global
- *  server can be overridden per repo (`repoOverrides`); otherwise — and always
- *  for repo-scoped servers — it follows `enabled` (on / optional). */
+/** Whether a server is in SCOPE for `repoKeys` (ignores per-repo on/off):
+ *  global servers always are; a repo-scoped server only when its scope matches
+ *  one of the repo's keys (identity or raw checkout path). */
+export function isServerInScope(
+  server: McpServer,
+  repoKeys: RepoKeys,
+): boolean {
+  const scope = serverScope(server);
+  return scope === MCP_SCOPE_GLOBAL || repoKeys.includes(scope);
+}
+
+/** A server's resolved state in the repo named by `repoKeys`: "on" (available +
+ *  default-on), "optional" (available, off by default), or "off" (not offered).
+ *  A global server can be overridden per repo (`repoOverrides`, keyed by identity
+ *  or a legacy raw path); otherwise — and always for repo-scoped servers — it
+ *  follows `enabled` (on / optional). */
 export type McpRepoState = "on" | "optional" | "off";
 export function effectiveMcpState(
   server: McpServer,
-  repoPath: string | null,
+  repoKeys: RepoKeys,
 ): McpRepoState {
-  if (repoPath && serverScope(server) === MCP_SCOPE_GLOBAL) {
-    const override = server.repoOverrides?.[repoPath];
+  if (repoKeys.length > 0 && serverScope(server) === MCP_SCOPE_GLOBAL) {
+    const override = pickForRepo(server.repoOverrides, repoKeys);
     if (override) return override;
   }
   return server.enabled ? "on" : "optional";
 }
 
-/** Whether a server is OFFERED to sessions in `repoPath` (in scope and not
- *  per-repo "off"). The composer picker + resume both use this. */
+/** Whether a server is OFFERED to sessions in the repo named by `repoKeys` (in
+ *  scope and not per-repo "off"). The composer picker + resume both use this. */
 export function isServerAvailable(
   server: McpServer,
-  repoPath: string | null,
+  repoKeys: RepoKeys,
 ): boolean {
   return (
-    isServerInScope(server, repoPath) &&
-    effectiveMcpState(server, repoPath) !== "off"
+    isServerInScope(server, repoKeys) &&
+    effectiveMcpState(server, repoKeys) !== "off"
   );
 }
 
-/** Whether a server is pre-selected by default for a new session in `repoPath`. */
+/** Whether a server is pre-selected by default for a new session in the repo
+ *  named by `repoKeys`. */
 export function isServerDefaultOn(
   server: McpServer,
-  repoPath: string | null,
+  repoKeys: RepoKeys,
 ): boolean {
   return (
-    isServerAvailable(server, repoPath) &&
-    effectiveMcpState(server, repoPath) === "on"
+    isServerAvailable(server, repoKeys) &&
+    effectiveMcpState(server, repoKeys) === "on"
   );
+}
+
+/** A repo-scope key rendered for humans: strip a trailing `.git` common-dir
+ *  segment (the identity key is `<repo>/.git`) so the label shows the containing
+ *  repo folder, not a bare `.git`. Global stays "global"; a raw legacy path (no
+ *  `.git` suffix) is returned unchanged. The STORED value is never altered — this
+ *  is display-only. */
+export function scopeRepoPath(scope: string): string {
+  return scope.replace(/[/\\]\.git\/?$/, "");
+}
+
+/** Fold a written server's LEGACY raw-path scope/override keys onto the repo's
+ *  worktree-stable identity key, so a value set from one checkout is honored from
+ *  a sibling worktree. Resolves {@link repoIdentity} for `scope` (when repo-scoped)
+ *  and for each `repoOverrides` key; rewrites each under its identity, and where a
+ *  value already exists under the identity key that value WINS (conservative
+ *  merge). A key that already IS its identity (or whose git can't be resolved, so
+ *  identity === the raw key) folds to a no-op. Call at write time (dialog save /
+ *  override toggle) on the single server being written — never a global sweep, so
+ *  legacy entries stay harmless until touched (reads already match both). */
+export async function foldServerScopeKeys(
+  server: McpServer,
+): Promise<McpServer> {
+  let next = server;
+
+  // Repo-scoped servers: migrate the scope key itself onto the identity.
+  const scope = server.scope?.trim();
+  if (scope && scope !== MCP_SCOPE_GLOBAL) {
+    const id = await repoIdentity(scope);
+    if (id !== scope) next = { ...next, scope: id };
+  }
+
+  const overrides = server.repoOverrides;
+  if (overrides && Object.keys(overrides).length > 0) {
+    // Resolve every non-global override key to its identity, then rebuild the map
+    // under identity keys. An existing identity value wins over a legacy one.
+    const keys = Object.keys(overrides);
+    const ids = await Promise.all(
+      keys.map(async (key) =>
+        key === MCP_SCOPE_GLOBAL
+          ? key
+          : await repoIdentity(key).catch(() => key),
+      ),
+    );
+    // Seed the folded map with entries already stored under their identity key
+    // (`id === key`) FIRST, so a legacy raw-path value never clobbers one that's
+    // already on the identity — the identity value wins regardless of key order.
+    const folded: Record<string, McpRepoState> = {};
+    keys.forEach((key, i) => {
+      if (ids[i] === key) folded[key] = overrides[key];
+    });
+    keys.forEach((key, i) => {
+      const id = ids[i];
+      if (folded[id] === undefined) folded[id] = overrides[key];
+    });
+    next = { ...next, repoOverrides: folded };
+  }
+
+  return next;
 }
 
 /** Whether an (agent, isolation) combination can run MCP servers at all.

--- a/src/lib/settings/mcp.ts
+++ b/src/lib/settings/mcp.ts
@@ -27,7 +27,7 @@ export type RepoKeys = readonly string[];
 /** The override/scope value that wins for `repoKeys`, preferring the LATER key
  *  (the resolved identity) over an earlier one (the raw path) so a folded
  *  identity entry beats a stale legacy one. */
-function pickForRepo<T>(
+export function pickForRepo<T>(
   byKey: Record<string, T> | undefined,
   repoKeys: RepoKeys,
 ): T | undefined {

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { PROVIDERS_REQUIRING_KEY } from "@/lib/ai/providers";
 import type { AiProviderId } from "@/lib/ai/types";
 import { getSecret } from "@/lib/git/api";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import {
   type AppSettings,
   addRecentRepo,
@@ -11,6 +13,7 @@ import {
   saveSettings,
   setRepoAlias,
 } from "./api";
+import type { RepoKeys } from "./mcp";
 
 export const settingsKeys = {
   settings: ["settings"] as const,
@@ -23,6 +26,35 @@ export function useSettings() {
     queryFn: loadSettings,
     staleTime: Number.POSITIVE_INFINITY,
   });
+}
+
+/**
+ * The scope/override lookup keys for a repo, most-preferred LAST: `[repoPath]`
+ * while the identity is still resolving (or when null — no repo open → `[]`), and
+ * `[repoPath, identity]` (deduped) once `repoIdentity` resolves. Feeds the MCP
+ * scope helpers ({@link isServerAvailable} et al.) so a repo-scoped server or
+ * per-repo override set from one checkout matches from a sibling worktree, while
+ * a value still under a raw checkout path (pre-identity-keying) keeps matching.
+ *
+ * Identity is stable for a session, so this never refetches (`staleTime`
+ * Infinity) — a plain query, safe to read inside an `<Activity>`-managed tab
+ * (no effects).
+ */
+export function useRepoKeys(repoPath: string | null): RepoKeys {
+  const { data: identity } = useQuery({
+    queryKey: ["repo-identity", repoPath],
+    queryFn: () => repoIdentity(repoPath as string),
+    enabled: !!repoPath,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+  // Stable reference across renders (same repoPath/identity) so it can sit in
+  // downstream `useMemo` dependency arrays without churning them.
+  return useMemo(() => {
+    if (!repoPath) return [];
+    return identity && identity !== repoPath
+      ? [repoPath, identity]
+      : [repoPath];
+  }, [repoPath, identity]);
 }
 
 /** Whether AI features are shown. False once the user hides them in Settings;


### PR DESCRIPTION
This update improves repo scoping logic to make MCP server settings and repository metadata (badges, ownership, permissions) consistent across worktrees, enhances admin permissions for Jira project administrators, adds pre-merge method gating and clearer feedback in the PR UI, fixes accessibility for repo filtering, and prunes empty fields from AI/agent review payloads to reduce token usage. The goal is to ensure correct, cross-worktree behavior, promote accurate permissions/admin affordances, reduce confusing PR merge failures, and enhance accessibility and efficiency for both users and agent integrations.

### MCP server repository scoping and cross-worktree state
- Shares MCP server scoping and per-repo override settings across all worktrees by keying entries on the repo's worktree-stable identity rather than the checkout path (see `src/lib/settings/mcp.ts`, `src/lib/settings/api.ts`, `src/features/settings/McpServersSection.tsx`, `src/features/sessions/store.ts`, `src/features/sessions/SessionComposer.tsx`, `src/lib/settings/queries.ts`, `src/features/settings/mcp/McpServerDialog.tsx`).
- Migrates legacy path-based entries to the identity-keyed format on edit or override.
- Ensures a server or override set from one checkout is available in sibling worktrees.
- Adjusts UI grouping, selection, and dialog logic to consistently follow worktree identity.

### Repository owner, provider, and visibility consistency
- Updates recent repo entries by worktree-stable identity, fanning out owner/provider/visibility/fork metadata changes to all worktrees (see `src/lib/settings/api.ts`).
- Ensures badges and grouping in `src/features/repository/RepoList.tsx` stay consistent across worktrees.

### Jira admin permissions and affordances
- Surfaces Jira's project-admin permissions for editing/deleting others' comments and worklogs (see `src-tauri/src/forge/jira.rs`, `src/lib/jira/types.ts`, `src/features/issues/JiraIssueView.tsx`, `src/features/issues/JiraIssueSidebar.tsx`, `src/features/help/content.ts`).
- UI now offers edit/delete actions to admins for both own and others' entries (comments, worklogs).
- Updates documentation and help to clarify new admin affordances.

### GitHub PR merge method gating/checks
- Adds fetch of repo-level GitHub merge method settings (allow merge/squash/rebase) and exposes fields in `PrDetails` (see `src-tauri/src/github/pr.rs`, `src/lib/git/types.ts`).
- PR UI disables and annotates merge actions and menu items if a method is disallowed in repo settings, replacing previous post-confirm raw errors (see `src/features/pulls/RemotePrView.tsx`).
- Disables the Merge button entirely with an explanation when all methods are blocked.

### GitHub Pages HTTPS toggle gating
- Disables the "Enforce HTTPS" toggle in repo settings UI while TLS certificate is still being provisioned for a custom domain, with a context-aware message (see `src-tauri/src/github/pages.rs`, `src/features/repo-settings/PagesSection.tsx`, `src/lib/git/types.ts`).
- Surfaces provisioning failure via annotation and disables toggle until fix.

### Accessibility in repo filter list
- Reworks the repo list filter and entries as a proper combobox/listbox (`aria-*` attributes, keyboard highlight tracking) for screen reader support (see `src/features/repository/RepoList.tsx`).

### MCP comment output/pruning for agents and AI review
- Prunes always-default/empty fields from PR comment and review thread payloads (avatar URL, state, permalink, minimized flags, review ID) in both the MCP HTTP surface (`src-tauri/src/mcp_server/read_forge.rs`) and AI review tools (`src/lib/ai/review-tools.ts`), reducing tokens consumed.
- Maintains explicit drop-lists for safe pruning; keeps meaningful falsey/load-bearing fields.

### Documentation and changelogs
- Adds and updates changelog entries for all significant changes and fixes (see `changelog.d/`).