### PR TITLE
fix(history,settings,mcp): commit avatar fallback via GitHub author API; MCP server allowed-host affordance; blame view a11y; worktree temp cleanup

### DIFF
--- a/changelog.d/changed-mcp-url-allow-note.md
+++ b/changelog.d/changed-mcp-url-allow-note.md
@@ -1,0 +1,7 @@
+- Remote (HTTP) MCP servers now surface the same allowed-hosts affordance as
+  custom AI provider URLs: the add/edit dialog shows an advisory note under a
+  URL whose host isn't on your AI allowlist, with a one-click **Allow host**,
+  and the MCP servers list flags such a server with a **host not allowed**
+  badge. It's advisory only — nothing is blocked or disabled, and existing
+  servers keep working — a reminder that the CLI connects to that host outside
+  GitDesktop's AI host allowlist.

--- a/changelog.d/fixed-blame-a11y.md
+++ b/changelog.d/fixed-blame-a11y.md
@@ -1,0 +1,3 @@
+- The blame view now announces as a structured list to screen readers, so each
+  line is read as an item with its position (line 12 of 340) instead of an
+  unstructured run of text.

--- a/changelog.d/fixed-history-commit-avatars.md
+++ b/changelog.d/fixed-history-commit-avatars.md
@@ -1,0 +1,3 @@
+- History commit avatars now fall back to a GitHub author's real avatar instead
+  of their initials when their commit email isn't a GitHub no-reply and has no
+  Gravatar — resolved in a batch from the recent-commits window for GitHub repos.

--- a/changelog.d/fixed-review-worktree-temp-leak.md
+++ b/changelog.d/fixed-review-worktree-temp-leak.md
@@ -1,0 +1,3 @@
+- Empty `gd-review-*` worktree folders no longer leak into the temp directory:
+  the review-worktree cleanup now retries the folder delete past a transient
+  Windows file-handle race, and any leftover empty husks are swept on startup.

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -340,6 +340,33 @@ pub async fn git_review_worktree(repo_path: String, sha: String) -> AppResult<Op
     Ok(Some(path_str))
 }
 
+/// Whether `path` is a `git_review_worktree`-shaped review temp dir: located
+/// DIRECTLY under the OS temp dir with a basename starting `gd-review-`. This is
+/// the guard for the `remove_dir_all` fallback in `git_remove_worktree` — the
+/// fallback must NEVER widen that `#[tauri::command]` into an arbitrary recursive
+/// delete of any caller-supplied path (git's own `worktree remove` refuses a
+/// non-worktree path, so the fallback is the only unbounded-delete risk). Only
+/// paths this returns `true` for get the fallback; every other path degrades to
+/// git-only baseline. Comparison is component-wise (robust to trailing
+/// separators) and case-insensitive on the file name to match Windows semantics.
+fn is_review_worktree_temp_path(path: &std::path::Path) -> bool {
+    let temp = std::env::temp_dir();
+    // The path's parent must be exactly the temp dir. Compare component sequences
+    // rather than raw strings so a trailing separator on either side can't matter.
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    if parent.components().collect::<Vec<_>>() != temp.components().collect::<Vec<_>>() {
+        return false;
+    }
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    // Windows temp paths are case-insensitive; a lowercased compare is safe here
+    // because the prefix is pure ASCII.
+    name.to_ascii_lowercase().starts_with("gd-review-")
+}
+
 /// Removes a review worktree created by `git_review_worktree` and prunes stale
 /// administrative entries. Best-effort and idempotent.
 #[tauri::command]
@@ -351,7 +378,68 @@ pub async fn git_remove_worktree(repo_path: String, worktree_path: String) -> Ap
     )
     .await;
     let _ = run_git_raw(Some(&repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    // `git worktree remove` deletes the directory itself, but on Windows that
+    // recursive delete can lose a handle race (an antivirus/indexer still holding
+    // the temp dir) and leave an EMPTY husk behind, and `git_remove_worktree`
+    // discards every result above — so the husk leaks in %TEMP% forever. Finish
+    // the delete ourselves best-effort with a short backoff. GUARDED to exactly
+    // the `gd-review-*` temp shape the only caller passes: git's own remove can
+    // never delete a non-worktree path, so an unguarded `remove_dir_all` here
+    // would widen this command into an arbitrary recursive-delete primitive on any
+    // caller-supplied path. Off the guard, behavior degrades to the git-only
+    // baseline. Still returns Ok(()) regardless (best-effort; the caller swallows).
+    if is_review_worktree_temp_path(std::path::Path::new(&worktree_path)) {
+        for _ in 0..2 {
+            if !std::path::Path::new(&worktree_path).exists() {
+                break;
+            }
+            let _ = std::fs::remove_dir_all(&worktree_path);
+            if !std::path::Path::new(&worktree_path).exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+        }
+    }
     Ok(())
+}
+
+/// Sweep leaked empty `gd-review-*` worktree husks from the OS temp dir. A review
+/// worktree (`git_review_worktree`) lives its whole life NON-empty — populated by
+/// `worktree add`, then deleted whole by `git_remove_worktree` — so unlike the
+/// paused-state `gd-resolve-*` worktrees (which need a keep-list), a `gd-review-*`
+/// dir that is *empty* can only be a husk whose delete lost the Windows handle
+/// race; there is no in-flight review it could belong to. That makes "empty" a
+/// sufficient exclusion with no keep-list needed. Best-effort housekeeping, run
+/// once fire-and-forget on startup; every failure is skipped conservatively.
+pub fn sweep_review_worktree_husks() {
+    let _ = sweep_review_husks_in(&std::env::temp_dir());
+}
+
+/// The testable core of [`sweep_review_worktree_husks`], parameterized on the
+/// directory so a unit test can drive it against a real fixture dir. Deletes only
+/// entries whose basename starts with exactly `gd-review-` AND are empty
+/// directories: `remove_dir` HARD-FAILS on a non-empty dir, so it is the real
+/// TOCTOU-safe guard (not just the name filter) — a review that repopulates
+/// between the filter and the delete simply fails the `remove_dir` and is spared.
+/// Returns how many husks were removed (for the test); a dir it can't list is
+/// skipped, not an error.
+fn sweep_review_husks_in(dir: &std::path::Path) -> std::io::Result<usize> {
+    let mut removed = 0;
+    // "Can't list it" ⇒ skip the whole sweep conservatively.
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("gd-review-") {
+            continue;
+        }
+        // NEVER remove_dir_all here: `remove_dir` refuses a non-empty dir, which is
+        // exactly the guard that keeps a live review's populated worktree safe.
+        if std::fs::remove_dir(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    Ok(removed)
 }
 
 /// Best-effort fetch of specific commit objects from `origin`, so a remote PR's
@@ -755,5 +843,70 @@ mod tests {
         assert!(matches!(err, AppError::InvalidArgument(_)));
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// The review-husk sweep removes only EMPTY `gd-review-*` dirs: a non-empty
+    /// `gd-review-*` (a live review's populated worktree) and a non-matching name
+    /// are both spared.
+    #[test]
+    fn sweep_review_husks_removes_only_empty_gd_review_dirs() {
+        let base = std::env::temp_dir().join(format!(
+            "gd-sweep-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+
+        // An empty gd-review-* husk → removed.
+        let empty_husk = base.join("gd-review-abc123-42");
+        std::fs::create_dir(&empty_husk).unwrap();
+        // A non-empty gd-review-* (live review worktree) → kept.
+        let live = base.join("gd-review-def456-7");
+        std::fs::create_dir(&live).unwrap();
+        std::fs::write(live.join("file.txt"), b"content").unwrap();
+        // A non-matching empty dir → kept (name filter).
+        let other = base.join("gd-resolve-xyz-1");
+        std::fs::create_dir(&other).unwrap();
+
+        let removed = super::sweep_review_husks_in(&base).unwrap();
+        assert_eq!(removed, 1, "exactly the one empty gd-review-* husk is removed");
+        assert!(!empty_husk.exists(), "empty gd-review-* husk was removed");
+        assert!(live.exists(), "non-empty gd-review-* (live review) is kept");
+        assert!(other.exists(), "non-matching name is kept");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// The `remove_dir_all` fallback guard admits only `gd-review-*` dirs directly
+    /// under the OS temp dir, so the command can't become an arbitrary recursive
+    /// delete of any caller-supplied path.
+    #[test]
+    fn is_review_worktree_temp_path_admits_only_temp_gd_review() {
+        let temp = std::env::temp_dir();
+        // A real review-worktree-shaped husk path → true (need not exist on disk).
+        assert!(super::is_review_worktree_temp_path(
+            &temp.join("gd-review-abc123-42")
+        ));
+        // A temp dir but the wrong prefix (e.g. a resolve worktree, or anything
+        // else) → false.
+        assert!(!super::is_review_worktree_temp_path(
+            &temp.join("gd-resolve-abc123-42")
+        ));
+        assert!(!super::is_review_worktree_temp_path(&temp.join("random-dir")));
+        // A gd-review-* name OUTSIDE the temp dir → false (a user's Documents, say).
+        assert!(!super::is_review_worktree_temp_path(std::path::Path::new(
+            "C:\\Users\\me\\Documents\\gd-review-evil"
+        )));
+        assert!(!super::is_review_worktree_temp_path(std::path::Path::new(
+            "/home/me/gd-review-evil"
+        )));
+        // NESTED under temp (not a direct child) → false: the fallback must not
+        // reach a path a level below the temp root.
+        assert!(!super::is_review_worktree_temp_path(
+            &temp.join("sub").join("gd-review-abc123-42")
+        ));
     }
 }

--- a/src-tauri/src/github/avatar.rs
+++ b/src-tauri/src/github/avatar.rs
@@ -125,9 +125,8 @@ pub struct CommitAuthorAvatar {
 /// PR parses reuse — don't touch that type).
 #[derive(Deserialize)]
 struct GhCommitsListAuthor {
-    #[serde(default)]
-    #[allow(dead_code)]
-    login: String,
+    // Only `avatar_url` is consumed; the account's `login` is deliberately not
+    // deserialized (serde ignores unknown JSON fields).
     #[serde(default)]
     avatar_url: String,
 }
@@ -210,9 +209,13 @@ pub async fn gh_commit_author_avatars(repo_path: String) -> AppResult<Vec<Commit
     // Pin the origin slug: `gh api`'s `{owner}/{repo}` placeholders auto-resolve
     // to the PARENT on a fork with an `upstream` remote, so build the literal
     // `repos/<slug>` path to keep this on the user's own fork (precedent:
-    // `gh_rulesets_list`). `gh_origin_slug` errors on an unparseable origin
-    // rather than passing garbage, so `?` here can only fail closed.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // `gh_rulesets_list`). An unparseable/missing origin resolves to the empty
+    // list — every OTHER gh_origin_slug caller is a user-initiated command where
+    // propagating is right; this one is a decoration bound by the "never errors"
+    // contract above.
+    let Ok(slug) = crate::github::gh_origin_slug(&repo_path).await else {
+        return Ok(Vec::new());
+    };
     // One non-paginated call — intentionally NOT `--paginate`: this is a partial
     // decoration, not the exhaustive completion `gh_pr_commits_paginated` does.
     let out = match run_gh(

--- a/src-tauri/src/github/avatar.rs
+++ b/src-tauri/src/github/avatar.rs
@@ -14,8 +14,10 @@
 //! github.com only: `gh api users/…` targets github.com, so Enterprise bots stay
 //! on the initials fallback.
 
+use serde::{Deserialize, Serialize};
+
 use crate::error::AppResult;
-use crate::github::runner::{run_gh_raw, GH_TIMEOUT};
+use crate::github::runner::{run_gh, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
 
 /// The bare bot name for a bot login, or `None` if `login` isn't a valid bot
 /// handle. Accepts three shapes gh emits or callers hold — `app/<name>`,
@@ -104,9 +106,133 @@ pub async fn gh_bot_avatar(login: String) -> AppResult<String> {
     }
 }
 
+/// A `commit.author.email → avatar_url` pairing the History surfaces use to
+/// upgrade a commit author's initials to their real GitHub avatar. Only pairs
+/// whose email matches a GitHub account (so the API returns a non-null `author`)
+/// and whose avatar host we trust survive; everyone else keeps initials.
+#[derive(Serialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitAuthorAvatar {
+    pub email: String,
+    pub avatar_url: String,
+}
+
+/// The GitHub *account* attached to a commit in the commits-list response — null
+/// whenever the commit's author email matches no GitHub user (common: any
+/// non-GitHub email, a since-changed address). Mirrors the `Option<…>` account
+/// shape the PR file/commit parses use (see `pr.rs`), but with its own struct so
+/// it can also read `avatar_url` (which `RawLogin` doesn't carry, and which the
+/// PR parses reuse — don't touch that type).
+#[derive(Deserialize)]
+struct GhCommitsListAuthor {
+    #[serde(default)]
+    #[allow(dead_code)]
+    login: String,
+    #[serde(default)]
+    avatar_url: String,
+}
+
+#[derive(Deserialize, Default)]
+struct GhCommitsListCommitAuthor {
+    #[serde(default)]
+    email: String,
+}
+
+#[derive(Deserialize, Default)]
+struct GhCommitsListCommitInner {
+    #[serde(default)]
+    author: GhCommitsListCommitAuthor,
+}
+
+/// One entry of `repos/{owner}/{repo}/commits`. `commit.author.email` is the git
+/// author email (always present); the top-level `author` is the GitHub account,
+/// null when the email maps to no user.
+#[derive(Deserialize)]
+struct GhCommitsListItem {
+    #[serde(default)]
+    commit: GhCommitsListCommitInner,
+    #[serde(default)]
+    author: Option<GhCommitsListAuthor>,
+}
+
+/// Parse a commits-list JSON body into the trusted `email → avatar_url` pairs.
+/// Pure (no I/O), so it's unit-tested directly: skips entries with a null GitHub
+/// account (email matches no user), an empty email, or an empty/untrusted avatar
+/// URL; lowercases emails; and dedupes on email (first occurrence wins — the
+/// list is newest-first, so the freshest avatar for an email is kept).
+fn parse_commit_author_avatars(body: &str) -> Vec<CommitAuthorAvatar> {
+    let items: Vec<GhCommitsListItem> = match serde_json::from_str(body) {
+        Ok(items) => items,
+        // A malformed/empty body (or the object an error response returns) yields
+        // no avatars — a decoration never errors.
+        Err(_) => return Vec::new(),
+    };
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for item in items {
+        let Some(author) = item.author else { continue };
+        let email = item.commit.author.email.trim().to_ascii_lowercase();
+        if email.is_empty() {
+            continue;
+        }
+        let avatar_url = author.avatar_url.trim();
+        if avatar_url.is_empty() || !is_trusted_avatar_url(avatar_url) {
+            continue;
+        }
+        if seen.insert(email.clone()) {
+            out.push(CommitAuthorAvatar {
+                email,
+                avatar_url: avatar_url.to_string(),
+            });
+        }
+    }
+    out
+}
+
+/// Resolve `commit-author email → GitHub avatar URL` for one recent-commits page
+/// of a GitHub repo — the History surfaces' fourth avatar tier, for human
+/// authors whose email is neither a GitHub no-reply nor has a Gravatar. This is a
+/// **decoration with deliberately partial coverage**: a single non-paginated
+/// commits-API call (the most recent 100 commits), NOT the completion pagination
+/// `gh_pr_commits_paginated` needs — emails outside that window simply keep their
+/// initials, matching this module's existing silent-miss philosophy.
+///
+/// github.com only: `is_trusted_avatar_url` filters every returned URL to
+/// https + github.com/githubusercontent hosts, so a GitHub Enterprise repo's
+/// GHE-hosted avatars are dropped and GHE repos keep initials — the same
+/// github.com-only stance `gh_bot_avatar` takes, by design.
+///
+/// Never errors: any gh failure — no gh, offline, or the 409 an EMPTY repo's
+/// commits endpoint returns — resolves to an empty list, because a decoration
+/// must not raise a toast.
+#[tauri::command]
+pub async fn gh_commit_author_avatars(repo_path: String) -> AppResult<Vec<CommitAuthorAvatar>> {
+    // Pin the origin slug: `gh api`'s `{owner}/{repo}` placeholders auto-resolve
+    // to the PARENT on a fork with an `upstream` remote, so build the literal
+    // `repos/<slug>` path to keep this on the user's own fork (precedent:
+    // `gh_rulesets_list`). `gh_origin_slug` errors on an unparseable origin
+    // rather than passing garbage, so `?` here can only fail closed.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // One non-paginated call — intentionally NOT `--paginate`: this is a partial
+    // decoration, not the exhaustive completion `gh_pr_commits_paginated` does.
+    let out = match run_gh(
+        Some(&repo_path),
+        &["api", &format!("repos/{slug}/commits?per_page=100")],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await
+    {
+        Ok(out) => out,
+        // gh failed (offline / no auth / the 409 an empty repo returns) → no
+        // avatars, no error.
+        Err(_) => return Ok(Vec::new()),
+    };
+    Ok(parse_commit_author_avatars(&out.stdout_lossy()))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{is_trusted_avatar_url, normalize_bot_login};
+    use super::{is_trusted_avatar_url, normalize_bot_login, parse_commit_author_avatars};
 
     #[test]
     fn normalize_accepts_the_three_bot_login_shapes() {
@@ -155,5 +281,57 @@ mod tests {
         assert!(!is_trusted_avatar_url("https://evil.com/x"));
         // Empty.
         assert!(!is_trusted_avatar_url(""));
+    }
+
+    #[test]
+    fn parse_keeps_only_valid_first_entries_lowercased() {
+        // Newest-first, with: a valid entry; a null-account entry (no GitHub
+        // user); an empty-avatar entry (account present but blank URL); a
+        // duplicate email (later, older — must lose to the first); an
+        // untrusted-host avatar (GHE-style) that must be filtered; and an
+        // empty-email entry.
+        let body = r#"[
+            {
+                "commit": { "author": { "email": "Alice@Example.com" } },
+                "author": { "login": "alice", "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4" }
+            },
+            {
+                "commit": { "author": { "email": "nomatch@example.com" } },
+                "author": null
+            },
+            {
+                "commit": { "author": { "email": "blank@example.com" } },
+                "author": { "login": "blank", "avatar_url": "" }
+            },
+            {
+                "commit": { "author": { "email": "alice@example.com" } },
+                "author": { "login": "alice2", "avatar_url": "https://avatars.githubusercontent.com/u/999?v=4" }
+            },
+            {
+                "commit": { "author": { "email": "ghe@example.com" } },
+                "author": { "login": "ghe", "avatar_url": "https://ghe.corp.example.com/avatars/u/2" }
+            },
+            {
+                "commit": { "author": { "email": "" } },
+                "author": { "login": "noemail", "avatar_url": "https://avatars.githubusercontent.com/u/3?v=4" }
+            }
+        ]"#;
+        let got = parse_commit_author_avatars(body);
+        // Only Alice survives: lowercased, and the FIRST (newest) avatar wins over
+        // the later duplicate.
+        assert_eq!(
+            got,
+            vec![super::CommitAuthorAvatar {
+                email: "alice@example.com".to_string(),
+                avatar_url: "https://avatars.githubusercontent.com/u/1?v=4".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_tolerates_a_malformed_body() {
+        // The 409/empty-repo body (an object, not an array) or any junk → no avatars.
+        assert!(parse_commit_author_avatars("").is_empty());
+        assert!(parse_commit_author_avatars(r#"{"message":"Git Repository is empty."}"#).is_empty());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,6 +89,14 @@ pub fn run() {
                         mcp_launcher::refresh_if_present(&version);
                     });
                 }
+                // Sweep leaked empty `gd-review-*` worktree husks from %TEMP%
+                // (a Windows handle race can leave one behind; see
+                // `git::compare::sweep_review_worktree_husks`). Plain fs op —
+                // harmless everywhere, so not cfg(windows)-gated; fire-and-forget
+                // so startup never blocks on it.
+                tauri::async_runtime::spawn_blocking(|| {
+                    git::compare::sweep_review_worktree_husks();
+                });
             }
             Ok(())
         })
@@ -518,6 +526,7 @@ pub fn run() {
             github::repo_settings::gh_repo_admin,
             github::auth::gh_token_scopes,
             github::avatar::gh_bot_avatar,
+            github::avatar::gh_commit_author_avatars,
             github::collaborators::gh_collaborators_list,
             github::collaborators::gh_collaborator_add,
             github::collaborators::gh_collaborator_remove,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1135,7 +1135,11 @@ Register **Model Context Protocol** servers under **Settings → MCP servers** �
 the ones you choose from the composer's **MCP** picker. **Claude**, **Copilot**, and
 **opencode** run MCP servers on the **host** *or* in a **container**; **Codex** runs them
 in a **container** only (local/\`stdio\` servers — host Codex can't approve MCP tool calls,
-so it needs the container's sandbox). In a container the servers run *inside* the sandbox,
+so it needs the container's sandbox). A **remote (HTTP)** server whose host isn't on your
+**AI allowed hosts** list is flagged with a **host not allowed** badge (and an advisory note
+in its editor with a one-click **Allow host**) — a reminder that the CLI connects to that
+host outside GitDesktop's AI host allowlist. It's advisory only: nothing is blocked, and the
+server keeps working. In a container the servers run *inside* the sandbox,
 sharing an npm cache so an \`npx\` server is downloaded only once. A Claude run is **strict** —
 it gets *only* the servers you picked and never inherits others on your machine — while
 Copilot and opencode layer your picks onto their own config. The composer's **MCP** picker

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -101,7 +101,12 @@ export function BlameDialog({
             virtualizer's getScrollElement gets the real scrollable node — see
             docs/list-virtualization.md. Fixed-height flex child so getTotalSize
             resolves (max-h would leave it unbounded → 0). */}
-        <div ref={setScrollEl} className="min-h-0 flex-1 overflow-auto border">
+        <div
+          ref={setScrollEl}
+          role="list"
+          aria-label={`Blame for ${name}`}
+          className="min-h-0 flex-1 overflow-auto border"
+        >
           {blame.isPending ? (
             <div className="flex justify-center p-4">
               <Spinner />
@@ -162,6 +167,10 @@ function BlameLines({
 
   return (
     <div
+      // Presentation wrapper so the virtualizer's positioning div doesn't sit
+      // between the role="list" scroll container and its listitem rows in the
+      // a11y tree (same reasoning as CloneRepoDialog.tsx:474-476).
+      role="presentation"
       className="relative w-full font-mono text-[11px] leading-relaxed"
       style={{ height: `${virtualizer.getTotalSize()}px` }}
     >
@@ -191,6 +200,9 @@ function BlameLines({
             key={vi.key}
             data-index={vi.index}
             ref={virtualizer.measureElement}
+            role="listitem"
+            aria-setsize={lines.length}
+            aria-posinset={vi.index + 1}
             className="absolute top-0 left-0 flex w-full items-start hover:bg-muted/40"
             style={{ transform: `translateY(${vi.start}px)` }}
           >

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -103,7 +103,14 @@ export function BlameDialog({
             resolves (max-h would leave it unbounded → 0). */}
         <div
           ref={setScrollEl}
-          role="list"
+          // List semantics only while listitem rows are actually rendered — the
+          // pending/error/empty branches would otherwise sit as non-listitem
+          // children of a role="list" (an invalid a11y tree).
+          role={
+            !blame.isPending && !blame.isError && lines.length > 0
+              ? "list"
+              : undefined
+          }
           aria-label={`Blame for ${name}`}
           className="min-h-0 flex-1 overflow-auto border"
         >

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -28,6 +28,7 @@ import {
   forgeReady,
   useCheckoutCommit,
   useCherryPick,
+  useCommitAuthorAvatarIndex,
   useCommitComments,
   useCommitDetails,
   useCommitFileDiff,
@@ -57,6 +58,8 @@ export function CommitDetailView({
 }) {
   const details = useCommitDetails(repoPath, hash);
   const files = useCommitFiles(repoPath, hash);
+  // Batch-resolve commit-author avatars (GitHub-only; deduped by react-query).
+  useCommitAuthorAvatarIndex(repoPath);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   // Reset the manual selection when a different commit is shown — a render
   // -time state adjustment, not an effect.

--- a/src/features/history/FileHistoryDialog.tsx
+++ b/src/features/history/FileHistoryDialog.tsx
@@ -11,7 +11,11 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
-import { useCommitFileDiff, useFileLog } from "@/lib/git/queries";
+import {
+  useCommitAuthorAvatarIndex,
+  useCommitFileDiff,
+  useFileLog,
+} from "@/lib/git/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -29,6 +33,9 @@ export function FileHistoryDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const fileLog = useFileLog(repoPath, open ? path : null);
+  // Batch-resolve commit-author avatars (GitHub-only; deduped by react-query with
+  // the other History surfaces, so this shares one call per repo per 15min).
+  useCommitAuthorAvatarIndex(repoPath);
   const commits = fileLog.data?.pages.flat() ?? [];
   const [selected, setSelected] = useState<string | null>(null);
   // Default to the newest commit; reset when the dialog closes.

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -36,6 +36,7 @@ import {
   useBranches,
   useCheckoutCommit,
   useCherryPick,
+  useCommitAuthorAvatarIndex,
   useCommitSearch,
   useCreateBranch,
   useCreateTag,
@@ -70,6 +71,9 @@ import { useAmendWithConfirm } from "./useAmendCommit";
 
 export function HistoryPanel({ repoPath }: { repoPath: string }) {
   const log = useLog(repoPath);
+  // Batch-resolve commit-author avatars for the log's authors (GitHub-only,
+  // deduped by react-query across the History surfaces).
+  useCommitAuthorAvatarIndex(repoPath);
   const status = useRepoStatus(repoPath);
   const opState = useOpState(repoPath);
   const undoCommit = useUndoCommit(repoPath);

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -2,13 +2,12 @@ import {
   CheckCircleIcon,
   CopyIcon,
   PlusIcon,
-  WarningIcon,
   XCircleIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
-import { type ReactNode, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -62,6 +61,7 @@ import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
 import { AgentSandboxField } from "./AgentSandboxField";
+import { HostAllowNote } from "./HostAllowNote";
 import { settingsFormOpts } from "./settings-form";
 
 /** Typical key shapes per provider; used for a soft warning, never to block. */
@@ -270,46 +270,6 @@ const PRESET_ITEMS: Record<string, string> = {
   ...Object.fromEntries(OPENAI_COMPATIBLE_PRESETS.map((p) => [p.id, p.label])),
   custom: "Custom…",
 };
-
-/**
- * The note under a custom provider URL. When the URL points at a host that isn't
- * built-in / local / already allowed, it surfaces *why* requests will fail and a
- * one-click **Allow host** that adds it to the allowlist — turning a silent block
- * into a guided fix. Otherwise it shows the muted default note.
- */
-function HostAllowNote({
-  url,
-  allowedHosts,
-  onAllowHost,
-  defaultNote,
-}: {
-  url: string;
-  allowedHosts: string[];
-  onAllowHost: (url: string) => void;
-  defaultNote: ReactNode;
-}) {
-  const host = normalizeHost(url);
-  if (!host || isHostAllowed(url, allowedHosts)) {
-    return <p className="text-xs text-muted-foreground">{defaultNote}</p>;
-  }
-  return (
-    <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-warning">
-      <WarningIcon className="size-4 shrink-0" />
-      <span>
-        <code className="font-mono">{host}</code> isn't an allowed host yet — AI
-        requests to it are blocked.
-      </span>
-      <Button
-        type="button"
-        variant="outline"
-        size="xs"
-        onClick={() => onAllowHost(url)}
-      >
-        Allow host
-      </Button>
-    </p>
-  );
-}
 
 /** Ollama base-URL field — the URL the local/LAN Ollama server is reached at. */
 function OllamaConfig({

--- a/src/features/settings/HostAllowNote.tsx
+++ b/src/features/settings/HostAllowNote.tsx
@@ -1,0 +1,51 @@
+import { WarningIcon } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { isHostAllowed, normalizeHost } from "@/lib/ai/allowed-hosts";
+
+/**
+ * The note under a custom provider URL. When the URL points at a host that isn't
+ * built-in / local / already allowed, it surfaces *why* the host matters and a
+ * one-click **Allow host** that adds it to the allowlist — turning a silent block
+ * into a guided fix. Otherwise it shows the muted default note.
+ *
+ * `consequence` is the clause after "isn't an allowed host yet — " and states
+ * what follows in this context: on the AI provider fields the request is blocked
+ * (the default), while in the MCP dialog it's advisory (the agent CLI connects
+ * anyway, outside the AI allowlist), so the caller passes its own wording.
+ */
+export function HostAllowNote({
+  url,
+  allowedHosts,
+  onAllowHost,
+  defaultNote,
+  consequence = "AI requests to it are blocked.",
+}: {
+  url: string;
+  allowedHosts: string[];
+  onAllowHost: (url: string) => void;
+  defaultNote: ReactNode;
+  consequence?: ReactNode;
+}) {
+  const host = normalizeHost(url);
+  if (!host || isHostAllowed(url, allowedHosts)) {
+    return <p className="text-xs text-muted-foreground">{defaultNote}</p>;
+  }
+  return (
+    <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-warning">
+      <WarningIcon className="size-4 shrink-0" />
+      <span>
+        <code className="font-mono">{host}</code> isn't an allowed host yet —{" "}
+        {consequence}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        onClick={() => onAllowHost(url)}
+      >
+        Allow host
+      </Button>
+    </p>
+  );
+}

--- a/src/features/settings/McpServersSection.tsx
+++ b/src/features/settings/McpServersSection.tsx
@@ -10,6 +10,7 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { isHostAllowed, normalizeHost } from "@/lib/ai/allowed-hosts";
 import { withForm } from "@/lib/form";
 import { deleteMcpSecret } from "@/lib/git/api";
 import { repoIdentity } from "@/lib/git/repo-identity";
@@ -37,6 +38,13 @@ export const McpServersSection = withForm({
   ...settingsFormOpts,
   render: function McpServersSectionRender({ form }) {
     const servers = useSelector(form.store, (s) => s.values.mcpServers);
+    // The draft AI allow list, shared with the AI provider screen. An http MCP
+    // URL the CLI will connect to outside this allowlist gets an advisory badge
+    // (row) / note (dialog) — never a block, exactly like the AI URL fields.
+    const allowedHosts = useSelector(
+      form.store,
+      (s) => s.values.aiAllowedHosts,
+    );
     const [editing, setEditing] = useState<McpServer | "new" | null>(null);
     const [importOpen, setImportOpen] = useState(false);
     const [activeIndex, setActiveIndex] = useState(-1);
@@ -106,6 +114,17 @@ export const McpServersSection = withForm({
 
     function toggleEnabled(server: McpServer, enabled: boolean) {
       setServers(list.map((s) => (s.id === server.id ? { ...s, enabled } : s)));
+    }
+
+    /** Add a URL's host to the draft allow list — the one-click fix behind the
+     *  dialog's advisory host note. Mutates the shared settings draft, committed
+     *  by the screen's Save bar, exactly like the AI URL fields. Dedups via
+     *  `isHostAllowed` (not a bare `includes`), so a host already covered by a
+     *  built-in/local entry or a no-port entry isn't added redundantly. */
+    function allowHost(url: string) {
+      const host = normalizeHost(url);
+      if (host && !isHostAllowed(url, allowedHosts))
+        form.setFieldValue("aiAllowedHosts", [...allowedHosts, host]);
     }
 
     // Set (or clear, when null = "follow the global default") a global server's
@@ -265,6 +284,14 @@ export const McpServersSection = withForm({
                     server.transport === "stdio"
                       ? !server.command.trim()
                       : !server.url.trim();
+                  // An http server whose URL host isn't on the AI allowlist: the
+                  // CLI still connects (outside GitDesktop's AI host gate), so
+                  // flag it non-blockingly. Empty URLs are covered by `needs
+                  // setup`; stdio/allowlisted/local hosts show nothing.
+                  const hostNotAllowed =
+                    server.transport === "http" &&
+                    !!server.url.trim() &&
+                    !isHostAllowed(server.url, allowedHosts);
                   return (
                     <div
                       key={server.id}
@@ -301,6 +328,14 @@ export const McpServersSection = withForm({
                           title={`Set the ${server.transport === "stdio" ? "command" : "URL"} before enabling — edit this server.`}
                         >
                           needs setup
+                        </span>
+                      )}
+                      {hostNotAllowed && (
+                        <span
+                          className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-warning"
+                          title="The CLI connects to this host outside GitDesktop's AI host allowlist. Allow the host in AI settings to clear this."
+                        >
+                          host not allowed
                         </span>
                       )}
                       {server.description && (
@@ -366,6 +401,8 @@ export const McpServersSection = withForm({
             )}
             repoPath={repoPath}
             repoName={repoName}
+            allowedHosts={allowedHosts}
+            onAllowHost={allowHost}
             onSave={saveServer}
             onClose={() => setEditing(null)}
           />

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { isHostAllowed, normalizeHost } from "@/lib/ai/allowed-hosts";
 import { deleteMcpSecret, setMcpSecret } from "@/lib/git/api";
 import type { McpServer } from "@/lib/settings/api";
 import {
@@ -31,6 +32,7 @@ import {
 } from "@/lib/settings/mcp";
 import { useRepoKeys } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
+import { HostAllowNote } from "../HostAllowNote";
 import { EntryEditor } from "./EntryEditor";
 import { type EntryRow, repoBasename } from "./shared";
 
@@ -53,6 +55,8 @@ export function McpServerDialog({
   others,
   repoPath,
   repoName,
+  allowedHosts,
+  onAllowHost,
   onSave,
   onClose,
 }: {
@@ -62,6 +66,12 @@ export function McpServerDialog({
   /** The repo open behind Settings (for the "This repo" scope option). */
   repoPath: string | null;
   repoName: string | null;
+  /** The draft AI allow list (the settings form both screens share), so an http
+   *  URL pointing at a not-yet-allowed host can surface the advisory note. */
+  allowedHosts: string[];
+  /** Add a URL's host to the draft allow list — the one-click fix behind the
+   *  advisory note. Mutates the draft settings, not persisted settings. */
+  onAllowHost: (url: string) => void;
   onSave: (server: McpServer) => void;
   onClose: () => void;
 }) {
@@ -239,6 +249,12 @@ export function McpServerDialog({
               <Select
                 value={selectedScope}
                 onValueChange={(v) => v && set("scope", v)}
+                // Without `items`, Base UI's SelectValue renders the RAW value in
+                // the trigger — for an identity-keyed scope that's a bare
+                // "…/.git" path. The map makes the trigger show the option label.
+                items={Object.fromEntries(
+                  scopeOptions.map((o) => [o.value, o.label]),
+                )}
               >
                 <SelectTrigger size="sm" className="w-full">
                   <SelectValue />
@@ -304,6 +320,21 @@ export function McpServerDialog({
                 className="font-mono"
                 spellCheck={false}
               />
+              {/* The CLI connects to this URL outside GitDesktop's AI host
+                  allowlist. Advisory only — never feeds validationError or
+                  disables Save. Gated on a PARSEABLE host (so a half-typed
+                  "http://" shows nothing, not an empty note) that isn't already
+                  allowed; empty/allowlisted/local URLs show nothing. */}
+              {normalizeHost(draft.url) &&
+                !isHostAllowed(draft.url, allowedHosts) && (
+                  <HostAllowNote
+                    url={draft.url}
+                    allowedHosts={allowedHosts}
+                    onAllowHost={onAllowHost}
+                    defaultNote={null}
+                    consequence="the agent CLI will still connect to it — it sits outside GitDesktop's AI host allowlist."
+                  />
+                )}
             </div>
           )}
 

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -325,6 +325,10 @@ export function McpServerDialog({
                   disables Save. Gated on a PARSEABLE host (so a half-typed
                   "http://" shows nothing, not an empty note) that isn't already
                   allowed; empty/allowlisted/local URLs show nothing. */}
+              {/* The outer guard duplicates HostAllowNote's internal checks ON
+                  PURPOSE: with `defaultNote={null}` the component's all-clear
+                  branch would render an empty <p>, so it must never mount for a
+                  parseable-and-allowed (or unparseable mid-typing) URL. */}
               {normalizeHost(draft.url) &&
                 !isHostAllowed(draft.url, allowedHosts) && (
                   <HostAllowNote

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2366,6 +2366,20 @@ export const ghTokenScopes = (host?: string) =>
 export const ghBotAvatar = (login: string) =>
   invoke<string>("gh_bot_avatar", { login });
 
+/** One commit-author `email → avatar_url` pairing from the commits API. */
+export interface CommitAuthorAvatar {
+  email: string;
+  avatarUrl: string;
+}
+
+/** Batch-resolve commit-author `email → GitHub avatar URL` for one recent-commits
+ *  page (the History surfaces' fourth avatar tier, for human authors whose email
+ *  is neither a GitHub no-reply nor has a Gravatar). GitHub-only; deliberately
+ *  partial (one page) and never errors — an empty repo / offline / non-github
+ *  repo resolves to `[]`, so callers keep initials. */
+export const ghCommitAuthorAvatars = (repoPath: string) =>
+  invoke<CommitAuthorAvatar[]>("gh_commit_author_avatars", { repoPath });
+
 export const ghHooksList = (repoPath: string) =>
   invoke<Webhook[]>("gh_hooks_list", { repoPath });
 

--- a/src/lib/git/commit-avatar.ts
+++ b/src/lib/git/commit-avatar.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { CommitAuthorAvatar } from "./api";
 import { ghBotAvatar } from "./api";
 
 // Commit-author avatars for the History surfaces.
@@ -45,6 +46,41 @@ const gravatarPending = new Map<string, Promise<string>>();
 const botAvatarCache = new Map<string, string>();
 const botAvatarPending = new Map<string, Promise<string>>();
 
+// The fourth tier: commit-author `email → avatar_url` resolved in a batch from
+// the GitHub commits API (see `useCommitAuthorAvatarIndex`), for human authors
+// whose email is neither a GitHub no-reply nor has a Gravatar. Keyed by
+// lowercased email. Unlike the caches above (populated on demand, one email at a
+// time), this arrives asynchronously per repo AFTER rows have already painted, so
+// a listener set lets mounted rows re-resolve when it lands — the index wins over
+// an already-resolved Gravatar, since a real GitHub avatar beats an identicon.
+const authorIndexCache = new Map<string, string>();
+const authorIndexListeners = new Set<() => void>();
+
+function subscribeAuthorIndex(listener: () => void): () => void {
+  authorIndexListeners.add(listener);
+  return () => {
+    authorIndexListeners.delete(listener);
+  };
+}
+
+/** Merge a batch of commit-author `email → avatarUrl` pairs into the module index
+ *  and notify mounted rows so any showing initials (or a Gravatar) upgrade to the
+ *  real avatar. Idempotent; safe to call repeatedly as the query refetches. */
+export function primeCommitAuthorIndex(entries: CommitAuthorAvatar[]): void {
+  let changed = false;
+  for (const { email, avatarUrl } of entries) {
+    const key = email.trim().toLowerCase();
+    if (!key || !avatarUrl) continue;
+    if (authorIndexCache.get(key) !== avatarUrl) {
+      authorIndexCache.set(key, avatarUrl);
+      changed = true;
+    }
+  }
+  if (changed) {
+    for (const listener of authorIndexListeners) listener();
+  }
+}
+
 /**
  * The avatar URL for a commit author's email, `""` when there's nothing to show
  * (no email / no crypto), or `null` when the answer needs an async Gravatar hash
@@ -65,6 +101,11 @@ function commitAvatarUrlSync(email: string): string | null {
   if (bot) {
     return botAvatarCache.get(bot[1]) ?? null;
   }
+  // Fourth tier, ahead of Gravatar: a batch-resolved GitHub avatar for this
+  // email (a real avatar beats a Gravatar identicon). A miss falls through — the
+  // index is partial by design, so most emails still resolve via Gravatar/initials.
+  const indexed = authorIndexCache.get(normalized);
+  if (indexed) return indexed;
   return gravatarCache.get(normalized) ?? null;
 }
 
@@ -108,6 +149,19 @@ export function useCommitAvatarUrl(email: string): string {
   // Lazy init reads the sync answer (no-reply URL, cached Gravatar, or "") once
   // on mount, so a cache hit paints immediately with no flash. `null` → pending.
   const [url, setUrl] = useState(() => commitAvatarUrlSync(email) ?? "");
+
+  // The author-index tier arrives asynchronously per repo, often AFTER this row
+  // has already resolved to a Gravatar or initials. Subscribe so that when the
+  // index lands with an entry for this email, we upgrade to the real avatar (the
+  // index wins over an already-resolved Gravatar). No-op for emails never in the
+  // index — the notify just re-checks the map and finds nothing.
+  useEffect(() => {
+    const normalized = email.trim().toLowerCase();
+    return subscribeAuthorIndex(() => {
+      const indexed = authorIndexCache.get(normalized);
+      if (indexed) setUrl(indexed);
+    });
+  }, [email]);
 
   useEffect(() => {
     const sync = commitAvatarUrlSync(email);

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useRef } from "react";
 import { COLD_START_NO_GH, COLD_START_NO_GIT } from "@/lib/test-mode";
 import * as api from "./api";
+import { primeCommitAuthorIndex } from "./commit-avatar";
 import {
   checkoutConflictSide,
   conflictSides,
@@ -4054,6 +4055,34 @@ export function useBotAvatarUrl(name: string | null) {
     gcTime: 24 * 60 * 60 * 1000,
     retry: false,
   });
+}
+
+/** Batch-resolve commit-author `email → GitHub avatar` for a repo's recent-commits
+ *  window and prime the commit-avatar module, so History rows for human authors
+ *  whose email isn't a GitHub no-reply and has no Gravatar upgrade from initials.
+ *  Call once from each History surface (react-query dedupes by key). GitHub-only:
+ *  gated on the repo being open AND its detected provider being GitHub, so a
+ *  GitLab/Bitbucket repo never fires the commits-API call. Unlike
+ *  {@link useBotAvatarUrl}'s infinite staleTime (a bot's avatar URL is stable), the
+ *  recent-commits window shifts as commits land, so this goes stale after 15min
+ *  and re-primes newer authors. Best-effort decoration — `retry: false` and the
+ *  backend never errors (empty repo / offline → `[]`). */
+export function useCommitAuthorAvatarIndex(repo: string) {
+  const provider = useForgeStatus(repo).data?.provider;
+  const query = useQuery({
+    queryKey: ["commit-author-avatars", repo] as const,
+    queryFn: () => api.ghCommitAuthorAvatars(repo),
+    enabled: repo !== "" && provider === "github",
+    staleTime: 15 * 60 * 1000,
+    retry: false,
+  });
+  // Prime the commit-avatar module whenever fresh data arrives, notifying mounted
+  // rows so already-painted initials/Gravatars upgrade to the real avatar.
+  const entries = query.data;
+  useEffect(() => {
+    if (entries) primeCommitAuthorIndex(entries);
+  }, [entries]);
+  return query;
 }
 
 const webhooksKey = (repo: string) => ["repo", repo, "webhooks"] as const;


### PR DESCRIPTION
This change enhances history views with richer commit author avatars, adds an advisory host-allow affordance to HTTP MCP servers in settings, improves blame view accessibility, and resolves a Windows-specific worktree temp folder leak.

### Commit Author Avatars for History
- Adds batch-resolved commit author avatars using the GitHub API, so human commit authors whose email is neither a GitHub no-reply nor has a Gravatar get their true GitHub avatar instead of initials (`src-tauri/src/github/avatar.rs`, `src/lib/git/api.ts`, `src/lib/git/commit-avatar.ts`, `src/lib/git/queries.ts`).
- Implements a react-query-powered cache and propagation mechanism for avatar data (`src/lib/git/commit-avatar.ts`, `src/lib/git/queries.ts`).
- Calls the avatar batch-resolve hook from all history surfaces: `HistoryPanel.tsx`, `FileHistoryDialog.tsx`, and `CommitDetailView.tsx`.

### MCP Server Allowed Host Note
- Surfaces an advisory "host not allowed" note and badge when an HTTP MCP server's host is not in the AI allowed hosts list, providing a one-click "Allow host" affordance in both the server edit dialog and server list (`src/features/settings/McpServersSection.tsx`, `src/features/settings/mcp/McpServerDialog.tsx`, `src/features/settings/HostAllowNote.tsx`, `src/features/settings/AiProviderSection.tsx`, `src/features/help/content.ts`).
- Factors out and reuses the `HostAllowNote` component for both MCP and AI provider settings.

### Blame View Accessibility
- Updates the blame view to announce as a structured list to screen readers, with each line as a `role="listitem"` and explicit position labelling, improving accessibility for users with assistive technology (`src/features/history/BlameDialog.tsx`).

### Review Worktree Temp Folder Cleanup
- Fixes leaking of empty `gd-review-*` worktree temp folders caused by Windows handle races by adding a retry-based cleanup routine and a startup sweep (`src-tauri/src/git/compare.rs`, `src-tauri/src/lib.rs`).
- Guards cleanup operations to strictly-scoped temp directories to avoid accidental deletion, with full unit tests added (`src-tauri/src/git/compare.rs`).
- Documents this improvement and the new advisory affordance in the changelog (`changelog.d/fixed-review-worktree-temp-leak.md`, `changelog.d/changed-mcp-url-allow-note.md`).

### Minor
- Updates and migrates test coverage for new avatar parsing and worktree cleaning logic (`src-tauri/src/github/avatar.rs`, `src-tauri/src/git/compare.rs`).
- Maintains the no-error, advisory-only stance for new features, ensuring stable UI/UX.