### PR TITLE
fix(git,forge): ensure deterministic credential helper for HTTPS remotes on macOS

### DIFF
--- a/changelog.d/fixed-macos-fetch-repo-not-found.md
+++ b/changelog.d/fixed-macos-fetch-repo-not-found.md
@@ -1,0 +1,7 @@
+- **Fixed private-repo Fetch/Pull/Push failing on a Finder-launched macOS app.**
+  When the app was launched from Finder or the Dock, network operations against a
+  private HTTPS repo could fail with "Repository not found" because git's
+  credential helper couldn't find `gh`/`glab` on the minimal launchd PATH, so the
+  request went out unauthenticated. Fetch, pull, and push now inject the forge
+  credential helper with a resolved absolute CLI path, so authentication is
+  deterministic regardless of how the app was launched.

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -6,7 +6,7 @@
 //! `gh_status` → the neutral [`ForgeStatus`]; later phases add the PR/issue/CI
 //! methods, each delegating to the matching `gh_*` function.
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::forge::model::{
     Capabilities, ForgeRepo, ForgeRepoList, ForgeStatus, Implemented, Provider,
 };
@@ -651,9 +651,44 @@ pub async fn create_issue(
     .await
 }
 
+/// The `git -c credential.https://<host>.helper=…` entry that lets a private
+/// GitHub repo authenticate via gh's token with an ABSOLUTE gh path — so it works
+/// even when git's ambient `!gh` helper can't find gh on a GUI-launch minimal PATH
+/// (macOS launchd), or when gh was configured for SSH and never installed the
+/// HTTPS helper. One-shot per `git` invocation; nothing written to git config, no
+/// token in the remote URL. Mirrors gitlab::clone_credential_config.
+pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> {
+    let gh = crate::agent::resolve_named(&["gh"], None)
+        .await
+        .ok_or(AppError::GhNotFound)?;
+    let host = crate::forge::remote_host(clone_url).unwrap_or_else(|| "github.com".to_string());
+    Ok(vec![github_credential_entry(&host, &gh.display().to_string())])
+}
+
+/// The one-shot `-c` credential-helper config value for a GitHub host. Pure/format-only.
+fn github_credential_entry(host: &str, gh_path: &str) -> String {
+    format!("credential.https://{host}.helper=!\"{gh_path}\" auth git-credential")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn credential_entry_uses_host_and_absolute_gh_path() {
+        assert_eq!(
+            github_credential_entry("github.com", "/abs/gh"),
+            "credential.https://github.com.helper=!\"/abs/gh\" auth git-credential"
+        );
+    }
+
+    #[test]
+    fn credential_entry_substitutes_enterprise_host() {
+        assert_eq!(
+            github_credential_entry("github.example.com", "/abs/gh"),
+            "credential.https://github.example.com.helper=!\"/abs/gh\" auth git-credential"
+        );
+    }
 
     #[test]
     fn recognized_repo_maps_to_github_with_full_capabilities() {

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -134,14 +134,17 @@ async fn detect_non_github(repo_path: &str) -> Option<(Provider, String)> {
 }
 
 /// The one-shot `-c credential.helper` entries to authenticate a network op on
-/// `remote`, resolved to the provider CLI's ABSOLUTE path. Empty (→ git's ambient
-/// behavior, so this never breaks a local, SSH, or already-authenticated repo) for:
-/// SSH remotes (credential helpers don't apply), Bitbucket (its push flow injects
-/// auth its own way), a repo with no such remote, and when the provider CLI isn't
-/// installed (fail open — ambient helpers like git-credential-manager still work).
-/// An unknown HTTPS host follows the app's GitHub-default routing and gets the gh
-/// helper — harmless, since a one-shot `-c` helper only ADDS to git's helper list,
-/// so a non-answering gh falls through to git's ambient helpers.
+/// `remote`, resolved to the provider CLI's ABSOLUTE path. The provider comes from
+/// the REQUESTED remote's OWN host (not always `origin`), so a cross-forge
+/// origin/upstream pair — e.g. an `origin` on GitLab with a `github.com` `upstream`
+/// — each gets the right CLI's helper. Empty (→ git's ambient behavior, so this
+/// never breaks a local, SSH, or already-authenticated repo) for: SSH remotes
+/// (credential helpers don't apply), Bitbucket (its push flow injects auth its own
+/// way), a repo with no such remote, and when the provider CLI isn't installed
+/// (fail open — ambient helpers like git-credential-manager still work). An unknown
+/// HTTPS host follows the app's GitHub-default routing and gets the gh helper —
+/// harmless, since a one-shot `-c` helper only ADDS to git's helper list, so a
+/// non-answering gh falls through to git's ambient helpers.
 pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppResult<Vec<String>> {
     let url = match crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await
     {
@@ -151,21 +154,52 @@ pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppR
     if !is_https_remote(&url) {
         return Ok(Vec::new()); // SSH → keys, not helpers
     }
+    let Some(host) = remote_host(&url) else {
+        return Ok(Vec::new());
+    };
+    // Classify by the requested remote's OWN host, reproducing `detect_non_github`'s
+    // logic on `url` — identical when `remote == "origin"`, correct for other
+    // remotes. The glab-known-hosts config read is skipped for canonical hosts and
+    // github.com; only an unrecognized host reads it (as `detect_non_github` does).
+    let provider = if host == "github.com" || provider_for_host(&host).is_some() {
+        provider_for_remote_host(&host, &[])
+    } else {
+        // Any other host glab is signed in to is self-managed GitLab — mirrors detect_non_github.
+        provider_for_remote_host(&host, &glab::known_hosts().await)
+    };
     // Fail open when the CLI can't be resolved: a user with working ambient auth
     // (e.g. git-credential-manager) must not have every HTTPS fetch/pull/push hard-
     // fail just because gh/glab isn't installed.
-    match detect_non_github(repo_path).await {
-        Some((Provider::GitLab, _)) => Ok(gitlab::clone_credential_config(&url).await.unwrap_or_default()),
-        Some((Provider::Bitbucket, _)) => Ok(Vec::new()),
+    match provider {
+        Some(Provider::GitLab) => Ok(gitlab::clone_credential_config(&url).await.unwrap_or_default()),
+        Some(Provider::Bitbucket) => Ok(Vec::new()),
         _ => Ok(github::clone_credential_config(&url).await.unwrap_or_default()),
     }
 }
 
+/// The provider a remote's host maps to, mirroring [`detect_non_github`] but on an
+/// arbitrary remote's host rather than always `origin`. Canonical hosts match
+/// directly; any *other* host in `glab_hosts` (the hosts `glab` is signed in to) is
+/// self-managed GitLab; `github.com`, GHE, and unknown hosts return `None` (→ the
+/// app's gh-default routing). Pure/sync so it's unit-testable — the caller supplies
+/// `glab_hosts` (empty when the host is canonical/github.com and the config read is
+/// skipped).
+fn provider_for_remote_host(host: &str, glab_hosts: &[String]) -> Option<Provider> {
+    if let Some(p) = provider_for_host(host) {
+        return Some(p);
+    }
+    if host != "github.com" && glab_hosts.iter().any(|h| h == host) {
+        return Some(Provider::GitLab);
+    }
+    None
+}
+
 /// True when a remote URL uses HTTPS (credential helpers apply). SSH forms
-/// (`git@host:…`, `ssh://…`) and others return false.
+/// (`git@host:…`, `ssh://…`) and others return false — as does plain `http://`,
+/// since the helper entry we format keys on `credential.https://…` and would
+/// never match an http remote anyway.
 fn is_https_remote(url: &str) -> bool {
-    let u = url.trim();
-    u.starts_with("https://") || u.starts_with("http://")
+    url.trim().starts_with("https://")
 }
 
 /// The provider a host resolves to, as the lowercase tag the frontend keys
@@ -586,10 +620,13 @@ pub async fn forge_list_repos(provider: Provider) -> AppResult<ForgeRepoList> {
     }
 }
 
-/// Clone a repo, supplying provider auth that plain `git clone` lacks. GitHub
-/// (and the URL tab) clone fine via git + the gh credential helper; a private
+/// Clone a repo, supplying provider auth that plain `git clone` lacks. A private
 /// GitLab repo needs glab's token, injected as a ONE-SHOT `git -c` credential
-/// helper (no persistent config, no token in the remote URL). Returns the path.
+/// helper (no persistent config, no token in the remote URL) — glab IS GitLab's
+/// auth path here, so that arm stays strict. GitHub gets the same one-shot gh
+/// helper when gh is present, but falls open to git's ambient auth when gh is
+/// absent (public repos need none; a GCM user already has HTTPS auth), matching
+/// how GitHub clone worked before this helper existed. Returns the path.
 #[tauri::command]
 pub async fn forge_clone(
     provider: Provider,
@@ -599,7 +636,7 @@ pub async fn forge_clone(
 ) -> AppResult<String> {
     let extra = match provider {
         Provider::GitLab => gitlab::clone_credential_config(&url).await?,
-        Provider::GitHub => github::clone_credential_config(&url).await?,
+        Provider::GitHub => github::clone_credential_config(&url).await.unwrap_or_default(),
         Provider::Bitbucket => Vec::new(),
     };
     crate::git::repo::clone_repo_core(&url, &parent_dir, dir_name, &extra).await
@@ -3178,6 +3215,22 @@ mod tests {
         assert!(is_https_remote("https://github.com/o/r.git"));
         assert!(!is_https_remote("git@github.com:o/r.git"));
         assert!(!is_https_remote("ssh://git@github.com/o/r.git"));
+        // Plain http never matches the https-keyed helper entry we format.
+        assert!(!is_https_remote("http://github.example.com/o/r.git"));
+    }
+
+    #[test]
+    fn provider_for_remote_host_classifies_by_requested_host() {
+        let glab_hosts = vec!["gitlab.acme.com".to_string()];
+        // Canonical hosts route directly, no glab config needed.
+        assert_eq!(provider_for_remote_host("gitlab.com", &[]), Some(Provider::GitLab));
+        assert_eq!(provider_for_remote_host("bitbucket.org", &[]), Some(Provider::Bitbucket));
+        // github.com → None (gh-default routing), even if it somehow appears in glab_hosts.
+        assert_eq!(provider_for_remote_host("github.com", &glab_hosts), None);
+        // A glab-known custom host is self-managed GitLab.
+        assert_eq!(provider_for_remote_host("gitlab.acme.com", &glab_hosts), Some(Provider::GitLab));
+        // An unknown host (GHE or otherwise) → None.
+        assert_eq!(provider_for_remote_host("github.example.com", &glab_hosts), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -133,6 +133,41 @@ async fn detect_non_github(repo_path: &str) -> Option<(Provider, String)> {
     None
 }
 
+/// The one-shot `-c credential.helper` entries to authenticate a network op on
+/// `remote`, resolved to the provider CLI's ABSOLUTE path. Empty (→ git's ambient
+/// behavior, so this never breaks a local, SSH, or already-authenticated repo) for:
+/// SSH remotes (credential helpers don't apply), Bitbucket (its push flow injects
+/// auth its own way), a repo with no such remote, and when the provider CLI isn't
+/// installed (fail open — ambient helpers like git-credential-manager still work).
+/// An unknown HTTPS host follows the app's GitHub-default routing and gets the gh
+/// helper — harmless, since a one-shot `-c` helper only ADDS to git's helper list,
+/// so a non-answering gh falls through to git's ambient helpers.
+pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppResult<Vec<String>> {
+    let url = match crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await
+    {
+        Ok(u) => u,
+        Err(_) => return Ok(Vec::new()),
+    };
+    if !is_https_remote(&url) {
+        return Ok(Vec::new()); // SSH → keys, not helpers
+    }
+    // Fail open when the CLI can't be resolved: a user with working ambient auth
+    // (e.g. git-credential-manager) must not have every HTTPS fetch/pull/push hard-
+    // fail just because gh/glab isn't installed.
+    match detect_non_github(repo_path).await {
+        Some((Provider::GitLab, _)) => Ok(gitlab::clone_credential_config(&url).await.unwrap_or_default()),
+        Some((Provider::Bitbucket, _)) => Ok(Vec::new()),
+        _ => Ok(github::clone_credential_config(&url).await.unwrap_or_default()),
+    }
+}
+
+/// True when a remote URL uses HTTPS (credential helpers apply). SSH forms
+/// (`git@host:…`, `ssh://…`) and others return false.
+fn is_https_remote(url: &str) -> bool {
+    let u = url.trim();
+    u.starts_with("https://") || u.starts_with("http://")
+}
+
 /// The provider a host resolves to, as the lowercase tag the frontend keys
 /// labels on (`"github"` / `"gitlab"` / `"bitbucket"`), or `None` for hosts the
 /// app doesn't recognize (the UI treats those as GitHub, matching the routing
@@ -564,7 +599,8 @@ pub async fn forge_clone(
 ) -> AppResult<String> {
     let extra = match provider {
         Provider::GitLab => gitlab::clone_credential_config(&url).await?,
-        _ => Vec::new(),
+        Provider::GitHub => github::clone_credential_config(&url).await?,
+        Provider::Bitbucket => Vec::new(),
     };
     crate::git::repo::clone_repo_core(&url, &parent_dir, dir_name, &extra).await
 }
@@ -3135,6 +3171,13 @@ mod tests {
         assert_eq!(remote_host("https://GitLab.com/o/r").as_deref(), Some("gitlab.com"));
         // No host → None (local path).
         assert_eq!(remote_host("/local/path"), None);
+    }
+
+    #[test]
+    fn is_https_remote_distinguishes_https_from_ssh() {
+        assert!(is_https_remote("https://github.com/o/r.git"));
+        assert!(!is_https_remote("git@github.com:o/r.git"));
+        assert!(!is_https_remote("ssh://git@github.com/o/r.git"));
     }
 
     #[test]

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
-use crate::git::runner::{run_git, run_git_mutating, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
+use crate::git::runner::{run_git, run_git_mutating, GitOutput, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
 use crate::state::AppState;
 
 fn validate_remote_arg(value: &str, what: &str) -> AppResult<()> {
@@ -26,6 +26,24 @@ fn with_credentials(cred: &[String], sub: &[&str]) -> Vec<String> {
     }
     v.extend(sub.iter().map(|s| s.to_string()));
     v
+}
+
+/// Run a mutating git network op with one-shot credential `-c` entries prefixed.
+async fn run_git_mutating_with_creds(
+    state: &AppState,
+    repo_path: &str,
+    cred: &[String],
+    sub: &[&str],
+    timeout: Duration,
+) -> AppResult<GitOutput> {
+    let args = with_credentials(cred, sub);
+    run_git_mutating(
+        state,
+        repo_path,
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        timeout,
+    )
+    .await
 }
 
 /// How long a resolved remote URL stays trusted before we re-shell to `git`. A few seconds
@@ -144,14 +162,8 @@ pub async fn git_fetch(state: State<'_, AppState>, repo_path: String) -> AppResu
 
 pub(crate) async fn git_fetch_core(state: &AppState, repo_path: String) -> AppResult<()> {
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    let args = with_credentials(&cred, &["fetch", "--prune"]);
-    run_git_mutating(
-        state,
-        &repo_path,
-        &args.iter().map(String::as_str).collect::<Vec<_>>(),
-        NETWORK_TIMEOUT,
-    )
-    .await?;
+    run_git_mutating_with_creds(state, &repo_path, &cred, &["fetch", "--prune"], NETWORK_TIMEOUT)
+        .await?;
     Ok(())
 }
 
@@ -185,11 +197,11 @@ pub async fn git_fetch_remote(
 ) -> AppResult<()> {
     ensure_remote_exists(&repo_path, &remote).await?;
     let cred = crate::forge::credential_config_for_remote(&repo_path, &remote).await?;
-    let args = with_credentials(&cred, &["fetch", "--prune", &remote]);
-    run_git_mutating(
+    run_git_mutating_with_creds(
         &state,
         &repo_path,
-        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        &cred,
+        &["fetch", "--prune", &remote],
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -226,11 +238,11 @@ pub async fn git_remote_default_branch(
     // The local ref is unset — ask the remote for its HEAD (one network call),
     // then re-read. `set-head --auto` writes `refs/remotes/<remote>/HEAD`.
     let cred = crate::forge::credential_config_for_remote(&repo_path, &remote).await?;
-    let args = with_credentials(&cred, &["remote", "set-head", &remote, "--auto"]);
-    run_git_mutating(
+    run_git_mutating_with_creds(
         &state,
         &repo_path,
-        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        &cred,
+        &["remote", "set-head", &remote, "--auto"],
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -292,14 +304,7 @@ pub(crate) async fn git_pull_core(
         _ => "--ff-only",
     };
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    let args = with_credentials(&cred, &["pull", flag]);
-    run_git_mutating(
-        state,
-        &repo_path,
-        &args.iter().map(String::as_str).collect::<Vec<_>>(),
-        NETWORK_TIMEOUT,
-    )
-    .await?;
+    run_git_mutating_with_creds(state, &repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await?;
     Ok(())
 }
 
@@ -328,14 +333,7 @@ pub(crate) async fn git_push_core(
         args.extend(["-u", "origin", "HEAD"]);
     }
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    let args = with_credentials(&cred, &args);
-    run_git_mutating(
-        state,
-        &repo_path,
-        &args.iter().map(String::as_str).collect::<Vec<_>>(),
-        NETWORK_TIMEOUT,
-    )
-    .await?;
+    run_git_mutating_with_creds(state, &repo_path, &cred, &args, NETWORK_TIMEOUT).await?;
     Ok(())
 }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -17,6 +17,17 @@ fn validate_remote_arg(value: &str, what: &str) -> AppResult<()> {
     Ok(())
 }
 
+/// Prefix one-shot credential `-c` entries before a git subcommand's args.
+fn with_credentials(cred: &[String], sub: &[&str]) -> Vec<String> {
+    let mut v = Vec::with_capacity(cred.len() * 2 + sub.len());
+    for c in cred {
+        v.push("-c".to_string());
+        v.push(c.clone());
+    }
+    v.extend(sub.iter().map(|s| s.to_string()));
+    v
+}
+
 /// How long a resolved remote URL stays trusted before we re-shell to `git`. A few seconds
 /// is enough to collapse the burst of concurrent `forge_*` queries a single forge view fires
 /// (each of which otherwise spawns `git remote get-url origin` twice), while staying short
@@ -132,7 +143,15 @@ pub async fn git_fetch(state: State<'_, AppState>, repo_path: String) -> AppResu
 }
 
 pub(crate) async fn git_fetch_core(state: &AppState, repo_path: String) -> AppResult<()> {
-    run_git_mutating(state, &repo_path, &["fetch", "--prune"], NETWORK_TIMEOUT).await?;
+    let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    let args = with_credentials(&cred, &["fetch", "--prune"]);
+    run_git_mutating(
+        state,
+        &repo_path,
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -165,10 +184,12 @@ pub async fn git_fetch_remote(
     remote: String,
 ) -> AppResult<()> {
     ensure_remote_exists(&repo_path, &remote).await?;
+    let cred = crate::forge::credential_config_for_remote(&repo_path, &remote).await?;
+    let args = with_credentials(&cred, &["fetch", "--prune", &remote]);
     run_git_mutating(
         &state,
         &repo_path,
-        &["fetch", "--prune", &remote],
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -204,10 +225,12 @@ pub async fn git_remote_default_branch(
 
     // The local ref is unset — ask the remote for its HEAD (one network call),
     // then re-read. `set-head --auto` writes `refs/remotes/<remote>/HEAD`.
+    let cred = crate::forge::credential_config_for_remote(&repo_path, &remote).await?;
+    let args = with_credentials(&cred, &["remote", "set-head", &remote, "--auto"]);
     run_git_mutating(
         &state,
         &repo_path,
-        &["remote", "set-head", &remote, "--auto"],
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -268,7 +291,15 @@ pub(crate) async fn git_pull_core(
         "merge" => "--no-rebase",
         _ => "--ff-only",
     };
-    run_git_mutating(state, &repo_path, &["pull", flag], NETWORK_TIMEOUT).await?;
+    let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    let args = with_credentials(&cred, &["pull", flag]);
+    run_git_mutating(
+        state,
+        &repo_path,
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -296,7 +327,15 @@ pub(crate) async fn git_push_core(
     if set_upstream {
         args.extend(["-u", "origin", "HEAD"]);
     }
-    run_git_mutating(state, &repo_path, &args, NETWORK_TIMEOUT).await?;
+    let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    let args = with_credentials(&cred, &args);
+    run_git_mutating(
+        state,
+        &repo_path,
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
This change ensures that when the app is launched via Finder or the Dock on macOS, network operations against private HTTPS repositories (such as fetch, pull, and push) consistently use an absolute path to the required credential helper (`gh`/`glab`). This fixes failures where git is unable to authenticate due to a minimal PATH, resulting in "Repository not found" errors for private repos. Git commands now inject the resolved absolute helper path, so authentication works regardless of launch context.

### Git credential handling
- Adds `with_credentials` helper in `src-tauri/src/git/remote.rs` to prepend one-shot credential helper args to git commands.
- Updates `git_fetch_core`, `git_fetch_remote`, `git_remote_default_branch`, `git_pull_core`, and `git_push_core` in `src-tauri/src/git/remote.rs` to use provider-specific credential helpers determined at runtime.
- Integrates `credential_config_for_remote` to derive appropriate helper configs for each git remote in `src-tauri/src/forge/mod.rs`.

### Forge credential resolution
- Implements `clone_credential_config` and `github_credential_entry` in `src-tauri/src/forge/github.rs` to resolve and inject the absolute path to `gh` for HTTPS remote URLs.
- Mirrors this logic with centralized credential resolution in `credential_config_for_remote` in `src-tauri/src/forge/mod.rs`, handling GitHub, GitLab, and Bitbucket accordingly.
- Ensures that resolution fails open (does not break ambient helpers) if required CLIs are absent.

### Utility and tests
- Adds helper function `is_https_remote` in `src-tauri/src/forge/mod.rs` to distinguish HTTPS from SSH URLs.
- Expands tests in both `github.rs` and `mod.rs` to cover new helpers and edge cases.

### Documentation
- Adds `changelog.d/fixed-macos-fetch-repo-not-found.md` documenting the fixed issue with macOS app launches breaking private repo network operations.