### PR TITLE
fix(github,pr,issue,discussion,history,ui): pin repo origin on forks and show "issues disabled" notice

### DIFF
--- a/changelog.d/fixed-fork-repo-identity.md
+++ b/changelog.d/fixed-fork-repo-identity.md
@@ -1,0 +1,11 @@
+- On a GitHub fork, the app now consistently targets **your fork** instead of the
+  parent repository. Previously the GitHub CLI's own auto-resolution preferred the
+  upstream repo, so PR and issue surfaces (lists, detail views, comments, reviews,
+  merges, labels, assignees, milestones, stars, reactions) and the PR-notification
+  poller could silently act on the parent's data. They now all pin to the fork's
+  own `origin`. This also covers the History tab: commit diffs and commit comments
+  resolve against your fork, and a new commit comment is posted to your fork rather
+  than the parent. Forks with issues turned off (GitHub's default for new forks) now
+  show an informative "issues are disabled" notice instead of a failing retry.
+  Repositories without an `upstream` remote are unaffected — the behavior there is
+  identical to before.

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -13,6 +13,8 @@ pub enum AppError {
     GhNotFound,
     #[error("{0}")]
     Gh(String),
+    #[error("This repository has issues disabled.")]
+    IssuesDisabled,
     #[error("GitLab CLI (glab) not found")]
     GlabNotFound,
     #[error("{0}")]
@@ -52,6 +54,9 @@ impl Serialize for AppError {
             AppError::GitNotFound => "gitNotFound",
             AppError::GhNotFound => "ghNotFound",
             AppError::Gh(_) => "gh",
+            // Stable serialized kind — the frontend branches on this exact string
+            // to render the "issues are disabled" notice (no retry).
+            AppError::IssuesDisabled => "issuesDisabled",
             AppError::GlabNotFound => "glabNotFound",
             AppError::Glab(_) => "glab",
             AppError::Bitbucket(_) => "bitbucket",

--- a/src-tauri/src/github/discussion.rs
+++ b/src-tauri/src/github/discussion.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::error::{AppError, AppResult};
 use crate::github::issue::{map_reaction_groups, IssueReactions};
 use crate::github::pr::{PrAuthor, PrRef, RepoLabel};
-use crate::github::runner::{run_gh, GhOutput, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
+use crate::github::runner::{run_gh, GhOutput, GH_NETWORK_TIMEOUT};
 
 /// Discussions are Labelable, so labels come back as a `{ nodes: [...] }`
 /// connection (name + color; id stays empty, like PR-embedded labels).
@@ -34,15 +34,16 @@ fn strip_html(s: &str) -> String {
     out.trim().to_string()
 }
 
+/// The repo's GraphQL `owner`/`name`, pinned to the ORIGIN slug (via
+/// `gh_origin_slug`), NOT a bare `gh repo view`: on a fork with an `upstream`
+/// remote a bare `gh repo view` auto-resolves to the PARENT, so every discussion
+/// read built on this pair (categories/list/view/reactions) would answer for the
+/// upstream instead of the fork. On a non-fork the slug equals gh's resolution,
+/// so behavior is unchanged. (The discussion MUTATIONS below are node-id
+/// addressed and carry no repo argument, so they're already fork-safe.)
 async fn owner_name(repo_path: &str) -> AppResult<(String, String)> {
-    let out = run_gh(
-        Some(repo_path),
-        &["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-        GH_TIMEOUT,
-    )
-    .await?;
-    let nwo = out.stdout_lossy().trim().to_string();
-    nwo.split_once('/')
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    slug.split_once('/')
         .map(|(o, n)| (o.to_string(), n.to_string()))
         .ok_or_else(|| AppError::Gh("could not determine the repository owner".into()))
 }

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -14,6 +14,25 @@ pub struct Milestone {
     pub title: String,
 }
 
+/// Whether a gh failure is the "issues are turned off on this repo" error.
+/// GitHub forks disable issues by default, so pinning to the origin slug surfaces
+/// this where a bare `gh` would have silently resolved to the parent. gh's line is
+/// `the '<owner>/<repo>' repository has disabled issues`; match the stable
+/// substring case-insensitively so a wording tweak doesn't slip past.
+fn is_issues_disabled(stderr: &str) -> bool {
+    stderr.to_ascii_lowercase().contains("has disabled issues")
+}
+
+/// Remaps a gh failure to [`AppError::IssuesDisabled`] when its message is the
+/// disabled-issues signature, leaving every other error untouched. `run_gh`
+/// carries gh's stderr as the `Gh` variant's message, so that's what we inspect.
+fn map_issues_disabled(err: AppError) -> AppError {
+    match &err {
+        AppError::Gh(msg) if is_issues_disabled(msg) => AppError::IssuesDisabled,
+        _ => err,
+    }
+}
+
 /// An org-defined issue type (Bug/Feature/Task/…). `color` is a GitHub color
 /// NAME (GRAY/BLUE/GREEN/…), mapped to a swatch on the frontend.
 #[derive(Serialize, Deserialize, Clone)]
@@ -67,16 +86,17 @@ pub fn map_reaction_groups(groups: Option<&serde_json::Value>) -> Vec<Reaction> 
 
 /// Resolves the repo's GraphQL `owner` and `name`. GraphQL (unlike REST) has no
 /// `{owner}/{repo}` substitution, so callers must pass them explicitly.
+///
+/// Pinned to the ORIGIN slug (via `gh_origin_slug`), NOT a bare `gh repo view`:
+/// on a fork with an `upstream` remote a bare `gh repo view` auto-resolves to the
+/// PARENT, so every GraphQL read built on this pair (issue types/reactions/
+/// relations/dependencies/development, PR reactions/timeline/review-threads/
+/// external-reviews) would answer for the upstream instead of the fork. This one
+/// resolver pins them all. For a single-remote repo the slug equals what gh
+/// resolved before, so behavior is unchanged there.
 pub(crate) async fn repo_owner_name(repo_path: &str) -> AppResult<(String, String)> {
-    let out = run_gh(
-        Some(repo_path),
-        &["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-        GH_TIMEOUT,
-    )
-    .await?;
-    let name_with_owner = out.stdout_lossy().trim().to_string();
-    name_with_owner
-        .split_once('/')
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    slug.split_once('/')
         .map(|(o, n)| (o.to_string(), n.to_string()))
         .ok_or_else(|| AppError::Gh("could not determine the repository owner".into()))
 }
@@ -113,9 +133,16 @@ pub async fn gh_issue_list(
     state: String,
     limit: Option<u32>,
 ) -> AppResult<Vec<IssueInfo>> {
+    // Pin the origin slug so a fork lists its OWN issues, not the parent's (a bare
+    // `gh issue list` on a fork auto-resolves to the upstream repo).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let mut args: Vec<&str> = match state.as_str() {
-        "open" => vec!["issue", "list", "--state", "open", "--json", ISSUE_LIST_FIELDS],
-        "closed" => vec!["issue", "list", "--state", "closed", "--json", ISSUE_LIST_FIELDS],
+        "open" => vec![
+            "issue", "list", "--repo", &slug, "--state", "open", "--json", ISSUE_LIST_FIELDS,
+        ],
+        "closed" => vec![
+            "issue", "list", "--repo", &slug, "--state", "closed", "--json", ISSUE_LIST_FIELDS,
+        ],
         _ => {
             return Err(AppError::InvalidArgument(format!(
                 "unknown issue state filter: {state}"
@@ -133,7 +160,12 @@ pub async fn gh_issue_list(
         args.push("--limit");
         args.push(&limit_str);
     }
-    let out = run_gh(Some(&repo_path), &args, GH_TIMEOUT).await?;
+    // A fork with issues turned off (GitHub's default) fails here with a stable
+    // signature — remap it to a typed variant the UI renders as an informative,
+    // non-retryable state instead of a generic "couldn't load" + Retry.
+    let out = run_gh(Some(&repo_path), &args, GH_TIMEOUT)
+        .await
+        .map_err(map_issues_disabled)?;
     serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh issue list: {e}")))
 }
@@ -238,11 +270,15 @@ const ISSUE_VIEW_FIELDS: &str =
 /// conversation comments (with node ids for editing/hiding).
 #[tauri::command]
 pub async fn gh_issue_view(repo_path: String, number: u64) -> AppResult<IssueDetails> {
+    // Pin the origin slug so a fork's issue number resolves against the fork, not
+    // the parent gh would auto-detect from an `upstream` remote (used by both the
+    // `issue view --repo` read and the literal `repos/<slug>` lock-state path).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     // The conversation view and the (REST-only) lock state are fetched
     // concurrently so the lock state adds no extra round-trip latency.
     let n = number.to_string();
-    let issue_path = format!("repos/{{owner}}/{{repo}}/issues/{number}");
-    let view_args = ["issue", "view", &n, "--json", ISSUE_VIEW_FIELDS];
+    let issue_path = format!("repos/{slug}/issues/{number}");
+    let view_args = ["issue", "view", &n, "--repo", &slug, "--json", ISSUE_VIEW_FIELDS];
     let lock_args = [
         "api",
         &issue_path,
@@ -253,7 +289,9 @@ pub async fn gh_issue_view(repo_path: String, number: u64) -> AppResult<IssueDet
         run_gh(Some(&repo_path), &view_args, GH_TIMEOUT),
         run_gh(Some(&repo_path), &lock_args, GH_TIMEOUT),
     );
-    let out = view_res?;
+    // On a fork with issues disabled, viewing an issue fails with the same gh
+    // signature — remap it to the typed variant (consistent with `gh_issue_list`).
+    let out = view_res.map_err(map_issues_disabled)?;
     let raw: RawIssue = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh issue view: {e}")))?;
     // Best-effort: a failed lock lookup just leaves the issue shown as unlocked.
@@ -352,20 +390,20 @@ pub async fn gh_issue_create(
     }
     let input = serde_json::to_string(&payload)
         .map_err(|e| AppError::Gh(format!("could not encode issue: {e}")))?;
+    // Pin the origin slug so a new issue is filed on the fork, not the parent gh
+    // would auto-detect from an `upstream` remote (on a non-fork this is a no-op).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/issues");
+    // Creating an issue on a fork with issues disabled fails with the same gh
+    // signature — remap it so the toast carries the readable variant message.
     let out = run_gh_input(
         Some(&repo_path),
-        &[
-            "api",
-            "--method",
-            "POST",
-            "repos/{owner}/{repo}/issues",
-            "--input",
-            "-",
-        ],
+        &["api", "--method", "POST", &endpoint, "--input", "-"],
         &input,
         GH_NETWORK_TIMEOUT,
     )
-    .await?;
+    .await
+    .map_err(map_issues_disabled)?;
     let created: CreatedIssue = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse created issue: {e}")))?;
     Ok(PrRef {
@@ -377,14 +415,12 @@ pub async fn gh_issue_create(
 /// Logins that can be assigned to issues/PRs in this repo (collaborators).
 #[tauri::command]
 pub async fn gh_assignable_users(repo_path: String) -> AppResult<Vec<String>> {
+    // Pin the origin slug so a fork lists its own assignees, not the parent's.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/assignees");
     let out = run_gh(
         Some(&repo_path),
-        &[
-            "api",
-            "repos/{owner}/{repo}/assignees",
-            "--jq",
-            "[.[].login]",
-        ],
+        &["api", &endpoint, "--jq", "[.[].login]"],
         GH_TIMEOUT,
     )
     .await?;
@@ -395,14 +431,12 @@ pub async fn gh_assignable_users(repo_path: String) -> AppResult<Vec<String>> {
 /// Open milestones for the milestone picker.
 #[tauri::command]
 pub async fn gh_milestones(repo_path: String) -> AppResult<Vec<Milestone>> {
+    // Pin the origin slug so a fork lists its own milestones, not the parent's.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/milestones?state=open&per_page=100");
     let out = run_gh(
         Some(&repo_path),
-        &[
-            "api",
-            "repos/{owner}/{repo}/milestones?state=open&per_page=100",
-            "--jq",
-            "[.[] | {number, title}]",
-        ],
+        &["api", &endpoint, "--jq", "[.[] | {number, title}]"],
         GH_TIMEOUT,
     )
     .await?;
@@ -419,16 +453,12 @@ pub async fn gh_issue_set_assignees(
 ) -> AppResult<()> {
     let input = serde_json::to_string(&serde_json::json!({ "assignees": assignees }))
         .map_err(|e| AppError::Gh(format!("could not encode assignees: {e}")))?;
+    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/issues/{number}");
     run_gh_input(
         Some(&repo_path),
-        &[
-            "api",
-            "--method",
-            "PATCH",
-            &format!("repos/{{owner}}/{{repo}}/issues/{number}"),
-            "--input",
-            "-",
-        ],
+        &["api", "--method", "PATCH", &endpoint, "--input", "-"],
         &input,
         GH_NETWORK_TIMEOUT,
     )
@@ -450,16 +480,12 @@ pub async fn gh_issue_set_milestone(
     let input =
         serde_json::to_string(&serde_json::json!({ "milestone": milestone_value }))
             .map_err(|e| AppError::Gh(format!("could not encode milestone: {e}")))?;
+    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/issues/{number}");
     run_gh_input(
         Some(&repo_path),
-        &[
-            "api",
-            "--method",
-            "PATCH",
-            &format!("repos/{{owner}}/{{repo}}/issues/{number}"),
-            "--input",
-            "-",
-        ],
+        &["api", "--method", "PATCH", &endpoint, "--input", "-"],
         &input,
         GH_NETWORK_TIMEOUT,
     )
@@ -526,9 +552,13 @@ pub async fn gh_issue_set_type(
     type_name: Option<String>,
 ) -> AppResult<()> {
     let n = number.to_string();
+    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let args: Vec<&str> = match type_name.as_deref() {
-        Some(t) if !t.trim().is_empty() => vec!["issue", "edit", &n, "--type", t],
-        _ => vec!["issue", "edit", &n, "--remove-type"],
+        Some(t) if !t.trim().is_empty() => {
+            vec!["issue", "edit", &n, "--repo", &slug, "--type", t]
+        }
+        _ => vec!["issue", "edit", &n, "--repo", &slug, "--remove-type"],
     };
     run_gh(Some(&repo_path), &args, GH_NETWORK_TIMEOUT).await?;
     Ok(())
@@ -545,9 +575,11 @@ pub async fn gh_issue_comment(
         return Err(AppError::InvalidArgument("a comment is required".into()));
     }
     let n = number.to_string();
+    // Pin the origin slug so the comment lands on the fork's issue, not the parent's.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["issue", "comment", &n, "--body", &body],
+        &["issue", "comment", &n, "--repo", &slug, "--body", &body],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -572,9 +604,11 @@ pub async fn gh_issue_close(
             )));
         }
     };
+    // Pin the origin slug so a fork's issue closes on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["issue", "close", &n, "--reason", reason],
+        &["issue", "close", &n, "--repo", &slug, "--reason", reason],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -585,9 +619,11 @@ pub async fn gh_issue_close(
 #[tauri::command]
 pub async fn gh_issue_reopen(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
+    // Pin the origin slug so a fork's issue reopens on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["issue", "reopen", &n],
+        &["issue", "reopen", &n, "--repo", &slug],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -611,13 +647,16 @@ pub async fn gh_issue_edit(
             "an issue title is required".into(),
         ));
     }
+    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/issues/{number}");
     run_gh(
         Some(&repo_path),
         &[
             "api",
             "--method",
             "PATCH",
-            &format!("repos/{{owner}}/{{repo}}/issues/{number}"),
+            &endpoint,
             "-f",
             &format!("title={title}"),
             "-f",
@@ -633,14 +672,28 @@ pub async fn gh_issue_edit(
 #[tauri::command]
 pub async fn gh_issue_pin(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
-    run_gh(Some(&repo_path), &["issue", "pin", &n], GH_NETWORK_TIMEOUT).await?;
+    // Pin the origin slug so a fork's issue is pinned on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    run_gh(
+        Some(&repo_path),
+        &["issue", "pin", &n, "--repo", &slug],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
 #[tauri::command]
 pub async fn gh_issue_unpin(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
-    run_gh(Some(&repo_path), &["issue", "unpin", &n], GH_NETWORK_TIMEOUT).await?;
+    // Pin the origin slug so a fork's issue is unpinned on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    run_gh(
+        Some(&repo_path),
+        &["issue", "unpin", &n, "--repo", &slug],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -653,7 +706,9 @@ pub async fn gh_issue_lock(
     reason: Option<String>,
 ) -> AppResult<()> {
     let n = number.to_string();
-    let mut args = vec!["issue", "lock", &n];
+    // Pin the origin slug so a fork's issue is locked on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let mut args = vec!["issue", "lock", &n, "--repo", &slug];
     if let Some(r) = reason.as_deref() {
         if !matches!(r, "off_topic" | "resolved" | "spam" | "too_heated") {
             return Err(AppError::InvalidArgument(format!(
@@ -670,7 +725,14 @@ pub async fn gh_issue_lock(
 #[tauri::command]
 pub async fn gh_issue_unlock(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
-    run_gh(Some(&repo_path), &["issue", "unlock", &n], GH_NETWORK_TIMEOUT).await?;
+    // Pin the origin slug so a fork's issue is unlocked on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    run_gh(
+        Some(&repo_path),
+        &["issue", "unlock", &n, "--repo", &slug],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -823,9 +885,12 @@ pub async fn gh_issue_transfer(
         ));
     }
     let n = number.to_string();
+    // Pin the origin slug so the SOURCE issue resolves against the fork, not the
+    // parent (the `destination` arg is explicit and unaffected).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let out = run_gh(
         Some(&repo_path),
-        &["issue", "transfer", &n, destination],
+        &["issue", "transfer", &n, destination, "--repo", &slug],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -838,9 +903,11 @@ pub async fn gh_issue_transfer(
 #[tauri::command]
 pub async fn gh_issue_delete(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
+    // Pin the origin slug so a fork's issue is deleted on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["issue", "delete", &n, "--yes"],
+        &["issue", "delete", &n, "--repo", &slug, "--yes"],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -945,10 +1012,12 @@ pub async fn gh_issue_add_sub_issue(
     sub_number: u64,
 ) -> AppResult<()> {
     // Resolve the child's node id (this also rejects PRs / missing numbers).
+    // Pin the origin slug so the child number resolves against the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let n = sub_number.to_string();
     let id_out = run_gh(
         Some(&repo_path),
-        &["issue", "view", &n, "--json", "id", "-q", ".id"],
+        &["issue", "view", &n, "--repo", &slug, "--json", "id", "-q", ".id"],
         GH_TIMEOUT,
     )
     .await?;
@@ -1076,9 +1145,11 @@ pub async fn gh_issue_set_dependency(
     };
     let n = number.to_string();
     let t = target.to_string();
+    // Pin the origin slug so the dependency is edited on the fork's issue, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["issue", "edit", &n, flag, &t],
+        &["issue", "edit", &n, "--repo", &slug, flag, &t],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -1282,4 +1353,30 @@ pub fn read_issue_templates(repo_path: String) -> AppResult<Vec<String>> {
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_issues_disabled;
+
+    #[test]
+    fn detects_the_disabled_issues_signature() {
+        // The full line gh prints on a repo with issues turned off.
+        assert!(is_issues_disabled(
+            "the 'theBGuy/biome' repository has disabled issues"
+        ));
+        // Match is case-insensitive (gh capitalization can drift).
+        assert!(is_issues_disabled("The 'a/b' repository HAS DISABLED ISSUES"));
+    }
+
+    #[test]
+    fn leaves_other_gh_failures_alone() {
+        assert!(!is_issues_disabled(""));
+        assert!(!is_issues_disabled(
+            "GraphQL: Could not resolve to a Repository with the name 'a/b'."
+        ));
+        assert!(!is_issues_disabled(
+            "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable"
+        ));
+    }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -985,11 +985,8 @@ fn name_with_owner_from_url(url: &str) -> Option<String> {
 /// PR lists/creation, issues, and "View on GitHub" follow afterwards.
 #[tauri::command]
 pub async fn gh_repo_fork(repo_path: String, contribute_to_parent: bool) -> AppResult<String> {
-    // INVARIANT — do NOT origin-pin this read. Before forking, `origin` still
-    // points at the PARENT, and this deliberately resolves the parent's slug so a
-    // later `gh repo set-default` can target it. Pinning to the origin slug would
-    // be a no-op here (origin IS the parent pre-fork) but is misleading — leave the
-    // bare cwd resolution to make the "reads the parent" intent explicit.
+    // Deliberately NOT origin-pinned: before forking, this read must resolve the
+    // PARENT repo — pinning it would break fork creation.
     let parent = run_gh(
         Some(&repo_path),
         &["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -79,16 +79,24 @@ pub async fn gh_status(repo_path: String) -> AppResult<GhStatus> {
 
     // gh auto-detects the repo's host from its remote, so this resolves
     // nameWithOwner + the canonical URL on github.com OR an Enterprise server.
+    // Pin the origin slug positionally (`gh repo view <slug>` — the `repo` family
+    // takes the target positionally, not via `-R`): on a fork with an `upstream`
+    // remote a bare `gh repo view` auto-resolves to the PARENT, so the status
+    // "repo" field would name the upstream instead of the fork. Best-effort: an
+    // unparseable origin just leaves repo/host unresolved (same as before).
     let view = if authenticated {
-        run_gh_raw(
-            Some(&repo_path),
-            &["repo", "view", "--json", "nameWithOwner,url"],
-            GH_TIMEOUT,
-        )
-        .await
-        .ok()
-        .filter(|o| o.code == 0)
-        .and_then(|o| serde_json::from_str::<RepoView>(&o.stdout_lossy()).ok())
+        match crate::github::gh_origin_slug(&repo_path).await {
+            Ok(slug) => run_gh_raw(
+                Some(&repo_path),
+                &["repo", "view", &slug, "--json", "nameWithOwner,url"],
+                GH_TIMEOUT,
+            )
+            .await
+            .ok()
+            .filter(|o| o.code == 0)
+            .and_then(|o| serde_json::from_str::<RepoView>(&o.stdout_lossy()).ok()),
+            Err(_) => None,
+        }
     } else {
         None
     };
@@ -398,9 +406,13 @@ pub async fn gh_publish_repo(
 /// Append paths like `/issues/new` for specific pages.
 #[tauri::command]
 pub async fn gh_repo_url(repo_path: String) -> AppResult<String> {
+    // Pin the origin slug positionally (`gh repo view <slug>` — the `repo` family
+    // has no `-R` flag): a bare `gh repo view` on a fork with an `upstream` remote
+    // auto-resolves to the PARENT, so "View on GitHub" would open the upstream.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let out = run_gh(
         Some(&repo_path),
-        &["repo", "view", "--json", "url", "-q", ".url"],
+        &["repo", "view", &slug, "--json", "url", "-q", ".url"],
         GH_TIMEOUT,
     )
     .await?;
@@ -416,13 +428,16 @@ pub async fn gh_repo_url(repo_path: String) -> AppResult<String> {
 /// Whether the signed-in user has starred this repo.
 /// `GET /user/starred/{owner}/{repo}` answers 204 (starred) or 404 (not),
 /// which gh surfaces as exit 0 / non-zero — hence `run_gh_raw`, so a 404 reads
-/// as "not starred" rather than erroring. gh resolves `{owner}/{repo}` from the
-/// repo at `repo_path`.
+/// as "not starred" rather than erroring. Pinned to the origin slug (a bare
+/// `gh api …/{owner}/{repo}` resolves to the PARENT on a fork) so the star
+/// reflects the fork itself.
 #[tauri::command]
 pub async fn gh_repo_star_status(repo_path: String) -> AppResult<bool> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("user/starred/{slug}");
     let out = run_gh_raw(
         Some(&repo_path),
-        &["api", "--method", "GET", "user/starred/{owner}/{repo}"],
+        &["api", "--method", "GET", &endpoint],
         GH_TIMEOUT,
     )
     .await?;
@@ -430,13 +445,16 @@ pub async fn gh_repo_star_status(repo_path: String) -> AppResult<bool> {
 }
 
 /// Stars (PUT) or unstars (DELETE) this repo for the signed-in user via
-/// `/user/starred/{owner}/{repo}`. Both are idempotent on GitHub's side.
+/// `/user/starred/{owner}/{repo}`. Both are idempotent on GitHub's side. Pinned
+/// to the origin slug so a fork stars itself, not its parent.
 #[tauri::command]
 pub async fn gh_repo_set_star(repo_path: String, starred: bool) -> AppResult<()> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("user/starred/{slug}");
     let method = if starred { "PUT" } else { "DELETE" };
     run_gh(
         Some(&repo_path),
-        &["api", "--method", method, "user/starred/{owner}/{repo}"],
+        &["api", "--method", method, &endpoint],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -510,8 +528,11 @@ pub async fn gh_pr_review(
             )));
         }
     };
+    // Pin the origin slug (`gh pr … --repo OWNER/REPO`) so a fork's PR resolves
+    // against the fork, not the parent gh auto-detects from an `upstream` remote.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let body = body.trim();
-    let mut args = vec!["pr", "review", &n, flag];
+    let mut args = vec!["pr", "review", &n, flag, "--repo", &slug];
     if !body.is_empty() {
         args.push("--body");
         args.push(body);
@@ -527,9 +548,11 @@ pub async fn gh_pr_comment(repo_path: String, number: u64, body: String) -> AppR
         return Err(AppError::InvalidArgument("a comment is required".into()));
     }
     let n = number.to_string();
+    // Pin the origin slug so the comment lands on the fork's PR, not the parent's.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["pr", "comment", &n, "--body", &body],
+        &["pr", "comment", &n, "--body", &body, "--repo", &slug],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -582,9 +605,11 @@ pub async fn gh_pr_merge(
             )));
         }
     };
+    // Pin the origin slug so the merge targets the fork's PR, not the parent's.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["pr", "merge", &n, method],
+        &["pr", "merge", &n, method, "--repo", &slug],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -632,12 +657,21 @@ struct RawRepoName {
 /// rather than a merge failure. A branch that is already gone (e.g. a repo that
 /// auto-deletes head branches on merge) counts as success.
 async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult<()> {
+    // Pin the origin slug for the READ so a fork's PR resolves against the fork
+    // (the DELETE below then targets the PR's OWN head repository — see its note).
+    let slug = crate::github::gh_origin_slug(repo_path).await.map_err(|e| {
+        AppError::Gh(format!(
+            "Merged #{number}, but couldn't clean up the remote head branch: {e}"
+        ))
+    })?;
     let out = run_gh(
         Some(repo_path),
         &[
             "pr",
             "view",
             &number.to_string(),
+            "--repo",
+            &slug,
             "--json",
             "headRefName,isCrossRepository,headRepositoryOwner,headRepository",
         ],
@@ -692,6 +726,10 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
         }
     };
 
+    // INVARIANT — do NOT origin-pin this DELETE. `owner`/`repo` come from the PR's
+    // OWN `headRepository[Owner]` (the fork side of a cross-repo PR), which is
+    // exactly where the branch to delete lives. Substituting the origin slug here
+    // would delete refs on the wrong repo for a cross-repository PR.
     let endpoint = format!("repos/{owner}/{repo}/git/refs/heads/{branch}");
     match run_gh(
         Some(repo_path),
@@ -730,7 +768,14 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
 #[tauri::command]
 pub async fn gh_pr_close(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
-    run_gh(Some(&repo_path), &["pr", "close", &n], GH_NETWORK_TIMEOUT).await?;
+    // Pin the origin slug so a fork's PR closes on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    run_gh(
+        Some(&repo_path),
+        &["pr", "close", &n, "--repo", &slug],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -738,7 +783,14 @@ pub async fn gh_pr_close(repo_path: String, number: u64) -> AppResult<()> {
 #[tauri::command]
 pub async fn gh_pr_reopen(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
-    run_gh(Some(&repo_path), &["pr", "reopen", &n], GH_NETWORK_TIMEOUT).await?;
+    // Pin the origin slug so a fork's PR reopens on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    run_gh(
+        Some(&repo_path),
+        &["pr", "reopen", &n, "--repo", &slug],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -902,9 +954,12 @@ pub async fn gh_pr_unminimize_comment(repo_path: String, comment_id: String) -> 
 #[tauri::command]
 pub async fn gh_pr_checkout(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
+    // Pin the origin slug so a fork's PR number checks out from the fork, not the
+    // parent gh would auto-resolve from an `upstream` remote.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     run_gh(
         Some(&repo_path),
-        &["pr", "checkout", &n],
+        &["pr", "checkout", &n, "--repo", &slug],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -930,7 +985,11 @@ fn name_with_owner_from_url(url: &str) -> Option<String> {
 /// PR lists/creation, issues, and "View on GitHub" follow afterwards.
 #[tauri::command]
 pub async fn gh_repo_fork(repo_path: String, contribute_to_parent: bool) -> AppResult<String> {
-    // Before forking, origin still points at the parent.
+    // INVARIANT — do NOT origin-pin this read. Before forking, `origin` still
+    // points at the PARENT, and this deliberately resolves the parent's slug so a
+    // later `gh repo set-default` can target it. Pinning to the origin slug would
+    // be a no-op here (origin IS the parent pre-fork) but is misleading — leave the
+    // bare cwd resolution to make the "reads the parent" intent explicit.
     let parent = run_gh(
         Some(&repo_path),
         &["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
@@ -980,7 +1039,14 @@ pub async fn gh_repo_fork(repo_path: String, contribute_to_parent: bool) -> AppR
 #[tauri::command]
 pub async fn gh_pr_ready(repo_path: String, number: u64) -> AppResult<()> {
     let n = number.to_string();
-    run_gh(Some(&repo_path), &["pr", "ready", &n], GH_NETWORK_TIMEOUT).await?;
+    // Pin the origin slug so a fork's PR is marked ready on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    run_gh(
+        Some(&repo_path),
+        &["pr", "ready", &n, "--repo", &slug],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -996,11 +1062,18 @@ pub async fn gh_pr_list(
     state: String,
     limit: Option<u32>,
 ) -> AppResult<Vec<PrInfo>> {
+    // Pin the origin slug so a fork lists its OWN PRs, not the parent's (a bare
+    // `gh pr list` on a fork auto-resolves to the upstream repo).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let mut args: Vec<&str> = match state.as_str() {
-        "open" => vec!["pr", "list", "--state", "open", "--json", PR_LIST_FIELDS],
+        "open" => vec![
+            "pr", "list", "--repo", &slug, "--state", "open", "--json", PR_LIST_FIELDS,
+        ],
         "closed" => vec![
             "pr",
             "list",
+            "--repo",
+            &slug,
             "--search",
             "is:closed",
             "--json",
@@ -1210,13 +1283,17 @@ pub async fn gh_pr_edit(
     if title.is_empty() {
         return Err(AppError::InvalidArgument("a PR title is required".into()));
     }
+    // Pin the origin slug so a fork's PR is edited on the fork, not the parent
+    // (`gh api` has no `-R` flag, so build a literal `repos/<slug>/…` path).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let endpoint = format!("repos/{slug}/pulls/{number}");
     run_gh(
         Some(&repo_path),
         &[
             "api",
             "--method",
             "PATCH",
-            &format!("repos/{{owner}}/{{repo}}/pulls/{number}"),
+            &endpoint,
             "-f",
             &format!("title={title}"),
             "-f",
@@ -1260,14 +1337,11 @@ fn validate_graphql_embed(value: &str, what: &str) -> AppResult<()> {
 /// picker. (`gh label list --json id` returns empty ids on older gh.)
 #[tauri::command]
 pub async fn gh_repo_labels(repo_path: String) -> AppResult<Vec<RepoLabel>> {
-    let out = run_gh(
-        Some(&repo_path),
-        &["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-        GH_TIMEOUT,
-    )
-    .await?;
-    let name_with_owner = out.stdout_lossy().trim().to_string();
-    let Some((owner, name)) = name_with_owner.split_once('/') else {
+    // Pin the origin slug: an unpinned `gh repo view` on a fork with an `upstream`
+    // remote auto-resolves to the PARENT, so the picker would show the upstream's
+    // labels. `gh_origin_slug` returns "owner/repo".
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let Some((owner, name)) = slug.split_once('/') else {
         return Err(AppError::Gh("could not determine the repository owner".into()));
     };
     validate_graphql_embed(owner, "repository owner")?;
@@ -1382,14 +1456,11 @@ pub struct PrPollInfo {
 /// (reliable on old gh, unlike `pr list --json statusCheckRollup`).
 #[tauri::command]
 pub async fn gh_pr_poll(repo_path: String) -> AppResult<Vec<PrPollInfo>> {
-    let out = run_gh(
-        Some(&repo_path),
-        &["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-        GH_TIMEOUT,
-    )
-    .await?;
-    let name_with_owner = out.stdout_lossy().trim().to_string();
-    let Some((owner, name)) = name_with_owner.split_once('/') else {
+    // Pin the origin slug: an unpinned `gh repo view` on a fork with an `upstream`
+    // remote auto-resolves to the PARENT, so PR notifications + background pr-sync
+    // would poll the upstream's PRs. Pinned, the poller reads the fork's own PRs.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let Some((owner, name)) = slug.split_once('/') else {
         return Err(AppError::Gh("could not determine the repository owner".into()));
     };
     validate_graphql_embed(owner, "repository owner")?;
@@ -1997,9 +2068,22 @@ async fn gh_repo_merge_settings(repo_path: &str, pr_url: &str) -> AppResult<Repo
 /// Full details for one PR's read view.
 #[tauri::command]
 pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> {
+    // Pin the origin slug so a fork's PR number resolves against the fork, not the
+    // parent gh would auto-detect from an `upstream` remote. The REST top-ups this
+    // fn calls (files/commits/reviews/comments) are likewise pinned to origin so
+    // they resolve to the SAME repo these PR numbers came from.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let out = run_gh(
         Some(&repo_path),
-        &["pr", "view", &number.to_string(), "--json", PR_VIEW_FIELDS],
+        &[
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            &slug,
+            "--json",
+            PR_VIEW_FIELDS,
+        ],
         GH_TIMEOUT,
     )
     .await?;
@@ -2294,9 +2378,19 @@ async fn current_requested_reviewer_logins(repo_path: &str, number: u64) -> AppR
         #[serde(default)]
         review_requests: Vec<RawReviewRequest>,
     }
+    // Pin the origin slug so a fork's PR resolves against the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
     let out = run_gh(
         Some(repo_path),
-        &["pr", "view", &number.to_string(), "--json", "reviewRequests"],
+        &[
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            &slug,
+            "--json",
+            "reviewRequests",
+        ],
         GH_TIMEOUT,
     )
     .await?;
@@ -2313,6 +2407,8 @@ async fn current_requested_reviewer_logins(repo_path: &str, number: u64) -> AppR
 /// The PR author's login (`gh pr view --json author`) — excluded from the reviewer
 /// candidates, because GitHub rejects requesting a review from the author.
 async fn pr_author_login(repo_path: &str, number: u64) -> AppResult<String> {
+    // Pin the origin slug so a fork's PR resolves against the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
     let out = run_gh(
         Some(repo_path),
         // `// empty` so a GraphQL-null author (deleted account / some bots) yields an
@@ -2322,6 +2418,8 @@ async fn pr_author_login(repo_path: &str, number: u64) -> AppResult<String> {
             "pr",
             "view",
             &number.to_string(),
+            "--repo",
+            &slug,
             "--json",
             "author",
             "-q",
@@ -2362,7 +2460,11 @@ pub async fn set_pr_reviewers(repo_path: &str, number: u64, desired: &[String]) 
     let num = number.to_string();
     let add_csv = add.join(",");
     let remove_csv = remove.join(",");
-    let mut args: Vec<&str> = vec!["pr", "edit", &num];
+    // Pin the origin slug so a fork's PR reviewers are edited on the fork, not the
+    // parent (`current_requested_reviewer_logins` above is already pinned, so the
+    // diff and the write agree on which repo's PR they target).
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let mut args: Vec<&str> = vec!["pr", "edit", &num, "--repo", &slug];
     if !add.is_empty() {
         args.push("--add-reviewer");
         args.push(&add_csv);
@@ -2644,9 +2746,12 @@ pub async fn pr_timeline(
 /// other error propagates raw.
 #[tauri::command]
 pub async fn gh_pr_diff(repo_path: String, number: u64) -> AppResult<String> {
+    // Pin the origin slug so a fork's PR diff resolves against the fork, not the
+    // parent (the files-API fallback below goes through the pinned `gh_pr_files_paginated`).
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let out = match run_gh(
         Some(&repo_path),
-        &["pr", "diff", &number.to_string()],
+        &["pr", "diff", &number.to_string(), "--repo", &slug],
         GH_TIMEOUT,
     )
     .await
@@ -2673,13 +2778,21 @@ fn validate_commit_oid(oid: &str) -> AppResult<()> {
     Ok(())
 }
 
-/// The unified diff of ONE commit in a PR (`gh api repos/{owner}/{repo}/commits/{oid}`
-/// with the `application/vnd.github.diff` media type — gh resolves the `{owner}/{repo}`
-/// placeholders from the repo cwd). Returns the raw unified diff string, capped like
-/// `gh_pr_diff`. Plain fn (called by the forge dispatch).
+/// The unified diff of ONE commit in a PR (`gh api repos/<slug>/commits/{oid}`
+/// with the `application/vnd.github.diff` media type). Pinned to the origin slug
+/// so a fork reads its own commit, not the parent's. Returns the raw unified diff
+/// string, capped like `gh_pr_diff`. Plain fn (called by the forge dispatch).
+///
+/// INVARIANT — origin-pin the whole commit cluster (this + `commit_comments`),
+/// even for an upstream-only SHA the History tab surfaces on a fork. GitHub's
+/// fork-network storage serves ANY network SHA via the fork's own commits
+/// endpoint, so the pin does not 404 (probed live on a real fork, 2026-07-16),
+/// and the comments namespace deliberately becomes the fork's own thread rather
+/// than the parent's.
 pub async fn commit_diff(repo_path: &str, oid: &str) -> AppResult<String> {
     validate_commit_oid(oid)?;
-    let endpoint = format!("repos/{{owner}}/{{repo}}/commits/{oid}");
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/commits/{oid}");
     let out = run_gh(
         Some(repo_path),
         &[
@@ -2732,8 +2845,10 @@ struct GhCommitComment {
 /// tolerantly-resolved current login.
 pub async fn commit_comments(repo_path: &str, sha: &str) -> AppResult<Vec<CommitCommentOut>> {
     validate_commit_oid(sha)?;
+    // Pin the origin slug so a fork reads its own commit's comments, not the parent's.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
     let viewer = current_login(repo_path).await;
-    let endpoint = format!("repos/{{owner}}/{{repo}}/commits/{sha}/comments");
+    let endpoint = format!("repos/{slug}/commits/{sha}/comments");
     let out = run_gh(
         Some(repo_path),
         &[
@@ -2775,9 +2890,15 @@ pub async fn commit_comments(repo_path: &str, sha: &str) -> AppResult<Vec<Commit
         .collect())
 }
 
-/// Post a comment on a commit (`POST repos/{o}/{r}/commits/{sha}/comments`). A
+/// Post a comment on a commit (`POST repos/<slug>/commits/{sha}/comments`). A
 /// whole-commit comment sends only `body`; an anchored one adds `path` + `position`
 /// (GitHub's diff-position — the frontend computes it; `line` is ignored for GitHub).
+///
+/// INVARIANT — origin-pin the whole commit-comment cluster (this + edit/delete).
+/// A comment created here MUST land on the user's own repo, not the parent: on a
+/// fork, GitHub's fork-network storage lets you comment on any network SHA via the
+/// fork's endpoint (probed live, 2026-07-16), and the resulting thread is the
+/// fork's own — so create/read/edit/delete all agree on the fork's namespace.
 pub async fn commit_comment_create(
     repo_path: &str,
     sha: &str,
@@ -2789,7 +2910,9 @@ pub async fn commit_comment_create(
         return Err(AppError::InvalidArgument("a comment is required".into()));
     }
     validate_commit_oid(sha)?;
-    let endpoint = format!("repos/{{owner}}/{{repo}}/commits/{sha}/comments");
+    // Pin the origin slug so a fork's commit comment lands on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/commits/{sha}/comments");
     let mut payload = serde_json::json!({ "body": body });
     if let (Some(p), Some(pos)) = (path, position) {
         payload["path"] = serde_json::Value::String(p.to_string());
@@ -2819,7 +2942,9 @@ pub async fn commit_comment_edit(
         .trim()
         .parse()
         .map_err(|_| AppError::InvalidArgument(format!("invalid comment id: {comment_id}")))?;
-    let endpoint = format!("repos/{{owner}}/{{repo}}/comments/{id}");
+    // Pin the origin slug so a fork's commit comment is edited on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/comments/{id}");
     let payload = serde_json::json!({ "body": body });
     run_gh_input(
         Some(repo_path),
@@ -2838,7 +2963,9 @@ pub async fn commit_comment_delete(repo_path: &str, comment_id: &str) -> AppResu
         .trim()
         .parse()
         .map_err(|_| AppError::InvalidArgument(format!("invalid comment id: {comment_id}")))?;
-    let endpoint = format!("repos/{{owner}}/{{repo}}/comments/{id}");
+    // Pin the origin slug so a fork's commit comment is deleted on the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/comments/{id}");
     run_gh(
         Some(repo_path),
         &["api", "-X", "DELETE", &endpoint],
@@ -2852,12 +2979,16 @@ pub async fn commit_comment_delete(repo_path: &str, comment_id: &str) -> AppResu
 /// anchor a new inline review comment/thread to the current head — the commits list
 /// caps at 100, so this dedicated read is the reliable source.
 async fn head_ref_oid(repo_path: &str, number: u64) -> AppResult<String> {
+    // Pin the origin slug so a fork's PR resolves against the fork, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
     let out = run_gh(
         Some(repo_path),
         &[
             "pr",
             "view",
             &number.to_string(),
+            "--repo",
+            &slug,
             "--json",
             "headRefOid",
             "-q",
@@ -2914,7 +3045,9 @@ pub async fn thread_create(
         payload["start_line"] = serde_json::Value::from(start);
         payload["start_side"] = serde_json::Value::String(gh_side.to_string());
     }
-    let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{number}/comments");
+    // Pin the origin slug so a fork's review thread lands on the fork's PR, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/pulls/{number}/comments");
     run_gh_input(
         Some(repo_path),
         &["api", "-X", "POST", &endpoint, "--input", "-"],
@@ -2971,7 +3104,9 @@ pub async fn review_submit(
     if !arr.is_empty() {
         payload["comments"] = serde_json::Value::Array(arr);
     }
-    let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{number}/reviews");
+    // Pin the origin slug so a fork's review is submitted on the fork's PR, not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/pulls/{number}/reviews");
     run_gh_input(
         Some(repo_path),
         &["api", "-X", "POST", &endpoint, "--input", "-"],
@@ -3026,12 +3161,14 @@ struct GhPrFile {
 /// connection limit; this endpoint paginates past it. Used both to reconstruct the
 /// >300-file diff and to complete the PR-view file rail.
 async fn gh_pr_files_paginated(repo_path: &str, number: u64) -> AppResult<Vec<GhPrFile>> {
-    // `gh` resolves the literal {owner}/{repo} placeholders from the repo cwd
-    // (run_gh runs with `current_dir`). `--paginate` on an array endpoint emits
-    // one JSON array PER PAGE concatenated, which a single `from_str::<Vec<_>>`
-    // can't parse — `--slurp` wraps the pages into one outer array of arrays,
-    // which we then flatten. (gh 2.44+ supports `--slurp`.)
-    let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{number}/files");
+    // Pin the origin slug: the caller (`gh_pr_view`) resolves PR numbers against the
+    // fork's own PRs, so this top-up must resolve to the SAME repo (the fork), not
+    // the parent gh would auto-detect from an `upstream` remote. `--paginate` on an
+    // array endpoint emits one JSON array PER PAGE concatenated, which a single
+    // `from_str::<Vec<_>>` can't parse — `--slurp` wraps the pages into one outer
+    // array of arrays, which we then flatten. (gh 2.44+ supports `--slurp`.)
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/pulls/{number}/files");
     let out = run_gh(
         Some(repo_path),
         &[
@@ -3224,10 +3361,10 @@ fn rest_comment_to_out(c: GhPrRestComment, viewer_login: Option<&str>) -> PrThre
 /// 100-item GraphQL cap `gh pr view --json commits` hits. Returns rows in the
 /// PR-view shape.
 async fn gh_pr_commits_paginated(repo_path: &str, number: u64) -> AppResult<Vec<PrCommitOut>> {
-    // {owner}/{repo} placeholders (not the origin slug): the PR number came from
-    // gh's own repo resolution, so this top-up must resolve to the same repo or a
-    // fork would 404.
-    let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{number}/commits");
+    // Pin the origin slug: `gh_pr_view` resolves PR numbers against the fork's own
+    // PRs, so this top-up must resolve to the SAME repo (the fork), not the parent.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/pulls/{number}/commits");
     let out = run_gh(
         Some(repo_path),
         &[
@@ -3255,9 +3392,10 @@ async fn gh_pr_commits_paginated(repo_path: &str, number: u64) -> AppResult<Vec<
 /// Completes the PR's review list via the paginated reviews REST API, past the
 /// 100-item GraphQL cap. Returns rows in the PR-view thread shape.
 async fn gh_pr_reviews_paginated(repo_path: &str, number: u64) -> AppResult<Vec<PrThreadOut>> {
-    // {owner}/{repo} placeholders (not the origin slug): must resolve to the same
-    // repo gh resolved the PR number against, or a fork would 404.
-    let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{number}/reviews");
+    // Pin the origin slug: must resolve to the same repo (the fork) `gh_pr_view`
+    // resolved the PR number against, or a fork would 404.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/pulls/{number}/reviews");
     let out = run_gh(
         Some(repo_path),
         &[
@@ -3287,9 +3425,10 @@ async fn gh_pr_reviews_paginated(repo_path: &str, number: u64) -> AppResult<Vec<
 /// GraphQL cap. Resolves the authenticated login once (best-effort) to set
 /// `viewer_did_author`. Returns rows in the PR-view thread shape.
 async fn gh_pr_comments_paginated(repo_path: &str, number: u64) -> AppResult<Vec<PrThreadOut>> {
-    // {owner}/{repo} placeholders (not the origin slug): must resolve to the same
-    // repo gh resolved the PR number against, or a fork would 404.
-    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/{number}/comments");
+    // Pin the origin slug: must resolve to the same repo (the fork) `gh_pr_view`
+    // resolved the PR number against, or a fork would 404.
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let endpoint = format!("repos/{slug}/issues/{number}/comments");
     let out = run_gh(
         Some(repo_path),
         &[
@@ -3877,11 +4016,16 @@ pub async fn gh_prs_for_branch(repo_path: String, head: String) -> AppResult<Vec
     if head.is_empty() || head.starts_with('-') {
         return Err(AppError::InvalidArgument(format!("invalid branch: {head}")));
     }
+    // Pin the origin slug so this "does a PR exist for this branch?" check reads the
+    // fork's own PRs (consistent with `gh_pr_list`), not the parent's.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
             "pr",
             "list",
+            "--repo",
+            &slug,
             "--head",
             &head,
             "--state",

--- a/src/features/issues/IssuesPanel.tsx
+++ b/src/features/issues/IssuesPanel.tsx
@@ -32,6 +32,7 @@ import {
 import { formatStoryPoints, type JiraIssueInfo } from "@/lib/jira/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
+import { isAppError } from "@/lib/tauri/invoke";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { CreateIssueDialog } from "./CreateIssueDialog";
@@ -88,6 +89,17 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   // How many remote issues to load; "Load more" bumps it. A tab switch resets it.
   const [limit, setLimit] = useState(PAGE_SIZE);
   const issueList = useIssueList(repoPath, ghReady, stateFilter, limit);
+  // A fork (issues off by default on GitHub) surfaces a typed error here. It's a
+  // permanent repo condition, not a transient fetch failure, so the section shows
+  // an informative notice with no Retry — and issue creation is offered as
+  // disabled-with-reason rather than a call that can only ever fail.
+  const issuesDisabled =
+    issueList.isError &&
+    isAppError(issueList.error) &&
+    issueList.error.kind === "issuesDisabled";
+  // Creation is possible only when the forge allows it AND the repo hasn't turned
+  // issues off — gates every path that opens the GitHub create dialog.
+  const canOpenGhCreate = canCreateGh && !issuesDisabled;
   const onStateFilter = (s: IssueStateFilter) => {
     setStateFilter(s);
     setLimit(PAGE_SIZE);
@@ -119,7 +131,7 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   >();
 
   useHotkeyAction("focus-filter", () => filterRef.current?.focus());
-  useHotkeyAction("create-issue", () => setCreateOpen(true), canCreateGh);
+  useHotkeyAction("create-issue", () => setCreateOpen(true), canOpenGhCreate);
   useHotkeyAction(
     "create-jira-issue",
     () => setCreateJiraOpen(true),
@@ -132,19 +144,19 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   // panel's — never open a create dialog that can't submit.
   useEffect(() => {
     if (pendingIssueDraft) {
-      if (canCreateGh) {
+      if (canOpenGhCreate) {
         setIssueDraft(pendingIssueDraft);
         setCreateOpen(true);
       }
       setPendingIssueDraft(null);
     }
-  }, [pendingIssueDraft, setPendingIssueDraft, canCreateGh]);
+  }, [pendingIssueDraft, setPendingIssueDraft, canOpenGhCreate]);
 
   // Opened from the command palette / New menu via requestCreate (works from any
   // tab — RepositoryView switches here first, then this fires).
   useEffect(() => {
     if (pendingCreate === "issue") {
-      if (canCreateGh) setCreateOpen(true);
+      if (canOpenGhCreate) setCreateOpen(true);
       clearPendingCreate();
     } else if (pendingCreate === "local-issue") {
       setCreateLocalOpen(true);
@@ -156,7 +168,7 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
       if (canCreateJira) setCreateJiraOpen(true);
       clearPendingCreate();
     }
-  }, [pendingCreate, clearPendingCreate, canCreateGh, canCreateJira]);
+  }, [pendingCreate, clearPendingCreate, canOpenGhCreate, canCreateJira]);
 
   const {
     filterText,
@@ -258,16 +270,22 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
           : isGitLab
             ? "Issue on GitLab…"
             : "Issue on GitHub…",
-        ghDisabled: !canCreateGh,
-        ghReason: canCreateGh
-          ? undefined
-          : isBitbucket
-            ? "Bitbucket has retired its native issue tracker — link a Jira project to track issues."
-            : isGitLab
-              ? gh.data?.installed
-                ? "Sign in to GitLab (glab auth login) to open issues here."
-                : "Install the GitLab CLI (glab) to open issues here."
-              : "Connect this repository to GitHub to open an issue.",
+        // Issues disabled on the repo (a fork's default) also blocks creation, even
+        // when the forge is otherwise ready — gate it with the reason so "New" isn't
+        // a button that can only fail.
+        ghDisabled: !canCreateGh || issuesDisabled,
+        ghReason:
+          canCreateGh && !issuesDisabled
+            ? undefined
+            : isBitbucket
+              ? "Bitbucket has retired its native issue tracker — link a Jira project to track issues."
+              : isGitLab
+                ? gh.data?.installed
+                  ? "Sign in to GitLab (glab auth login) to open issues here."
+                  : "Install the GitLab CLI (glab) to open issues here."
+                : issuesDisabled
+                  ? "Issues are disabled on this repository — enable them in the repository settings on GitHub."
+                  : "Connect this repository to GitHub to open an issue.",
         onGh: () => setCreateOpen(true),
         localLabel: "Local issue…",
         onLocal: () => setCreateLocalOpen(true),
@@ -326,17 +344,27 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
       listPending={issueList.isPending}
       remoteError={issueList.isError}
       remoteErrorSlot={
-        <div className="space-y-2 px-3 py-4 text-xs text-muted-foreground">
-          <p>Couldn't load issues.</p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="cursor-pointer"
-            onClick={() => issueList.refetch()}
-          >
-            Retry
-          </Button>
-        </div>
+        issuesDisabled ? (
+          <div className="space-y-1 px-3 py-4 text-xs text-muted-foreground">
+            <p>Issues are disabled on this repository.</p>
+            <p className="text-[11px]">
+              Forks start with issues turned off — enable them in the repository
+              settings on GitHub.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2 px-3 py-4 text-xs text-muted-foreground">
+            <p>Couldn't load issues.</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="cursor-pointer"
+              onClick={() => issueList.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        )
       }
       // More may exist server-side exactly when this page filled the requested
       // limit (compared against the raw loaded count, not the filtered view).

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -21,6 +21,7 @@ const KIND_LABELS: Record<AppError["kind"], string> = {
   gitNotFound: "Git not found",
   ghNotFound: "GitHub CLI not found",
   gh: "GitHub error",
+  issuesDisabled: "Issues disabled",
   glabNotFound: "GitLab CLI not found",
   glab: "GitLab error",
   bitbucketNotConfigured: "Bitbucket not configured",

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -7,6 +7,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
+import { isAppError } from "@/lib/tauri/invoke";
 import { COLD_START_NO_GH, COLD_START_NO_GIT } from "@/lib/test-mode";
 import * as api from "./api";
 import { primeCommitAuthorIndex } from "./commit-avatar";
@@ -1424,6 +1425,9 @@ export function useIssueList(
     queryFn: () => api.forgeIssueList(repo, state, limit),
     enabled,
     staleTime: 30_000,
+    // issuesDisabled is a permanent repo condition — retrying only delays the notice.
+    retry: (failureCount, err) =>
+      !(isAppError(err) && err.kind === "issuesDisabled") && failureCount < 1,
     // Keep current rows visible while a grown "Load more" page loads.
     placeholderData: keepPreviousDataForRepo(repo),
   });

--- a/src/lib/tauri/invoke.ts
+++ b/src/lib/tauri/invoke.ts
@@ -7,6 +7,7 @@ export interface AppError {
     | "gitNotFound"
     | "ghNotFound"
     | "gh"
+    | "issuesDisabled"
     | "glabNotFound"
     | "glab"
     | "bitbucketNotConfigured"


### PR DESCRIPTION
This change ensures that when working on a GitHub fork, all PRs, issues, and related API calls consistently target the fork (the `origin` remote) rather than the parent repository, avoiding silent redirection of actions and reads to the upstream repo. Additionally, it improves the user experience when issues are disabled on a fork (the default for new forks on GitHub), by displaying a clear, non-retryable notice in the issues panel, rather than a generic loading error.

### GitHub Repo Origin Pinning
- Pins repo slug to the `origin` remote via `gh_origin_slug` in all GitHub PR, issue, and discussion commands in `src-tauri/src/github/pr.rs`, `src-tauri/src/github/issue.rs`, and `src-tauri/src/github/discussion.rs`. This affects reads, writes, comments, reactions, stars, assignments, milestones, and notifications to always act on the fork itself, not the parent.
- Applies consistent slug pinning in the commit history/diff/commit-comment code paths of `src-tauri/src/github/pr.rs` and `src-tauri/src/github/issue.rs`.
- Ensures that fork-specific PRs, issues, and review actions are not erroneously performed or listed from the parent repository.
- Maintains invariants in special cases (such as the fork creation workflow), not pinning where the remote must refer to the parent.

### Improved Handling for Disabled Issues on Forks
- Detects the "repository has disabled issues" error from the GitHub CLI in `src-tauri/src/github/issue.rs` by matching a stable signature in error output.
- Introduces an `IssuesDisabled` error variant in `src-tauri/src/error.rs`, serializes it as `issuesDisabled`, and ensures that all issue list, view, and create commands map this error to the typed variant.
- Updates error summary strings to include "Issues disabled" in `src/lib/error-summary.ts`.
- Extends the Tauri invoke types with the new error kind in `src/lib/tauri/invoke.ts`.

### Issues Panel UI
- In `src/features/issues/IssuesPanel.tsx`, recognizes the `issuesDisabled` error and displays an informative, permanent notice explaining that issues are disabled on this repository, replacing the retry UI.
- Disables the issue creation flow and explains why, preventing attempts to create issues when the repo has them switched off.
- Adjusts all issue-creation logic, hotkeys, command palette, and "New" menu to use the updated eligibility check.

### Changelog Update
- Documents the bugfix and behavioral improvement in a new changelog entry at `changelog.d/fixed-fork-repo-identity.md`.