### PR TITLE
feat(diff): off-thread Shiki highlighting for large diffs via worker ASTs

### DIFF
--- a/changelog.d/changed-diff-highlight-large-files-worker.md
+++ b/changelog.d/changed-diff-highlight-large-files-worker.md
@@ -1,0 +1,5 @@
+- Large diffs in TextMate-highlighted languages (Rust, TSX, Astro, Svelte, and
+  other Shiki-rendered or custom-grammar languages) no longer lose their
+  VSCode-fidelity highlighting past the size budget in commit, history, and
+  pull-request diffs — they now tokenize in a background thread and fill in when
+  ready, with standard highlighting shown in the interim.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@codemirror/language": "^6.12.3",
     "@codemirror/legacy-modes": "^6.5.3",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@git-diff-view/core": "^0.1.5",
     "@git-diff-view/react": "^0.1.5",
     "@openrouter/ai-sdk-provider": "^2.9.0",
     "@phosphor-icons/react": "^2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@git-diff-view/core':
+        specifier: ^0.1.5
+        version: 0.1.5(patch_hash=75ef62db50aa8a15e3b2a9171bf9b4af13c9676f39197307ddee5e5fc5e00b3c)
       '@git-diff-view/react':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -36,7 +36,7 @@ import { DiffErrorBoundary } from "./DiffErrorBoundary";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
 import { diffLang } from "./diff-lang";
-import { djb2 } from "./highlight-worker";
+import { djb2 } from "./highlight-worker-shared";
 import { ImageDiff, ImagePanes, type ImageRevs, imageMime } from "./ImageDiff";
 import {
   ensureBuiltinShikiLang,

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -44,6 +44,7 @@ import {
   isBuiltinShikiLang,
   isShikiLang,
   shikiDiffHighlighter,
+  SYNTAX_LINE_CAP,
 } from "./shiki-highlighter";
 import { ensureCustomLanguages } from "./syntax";
 import { useWorkerHighlight, type WorkerAsts } from "./use-worker-highlight";
@@ -272,7 +273,7 @@ function precomputedHighlighter(asts: WorkerAsts) {
   return {
     name: "shiki",
     type: "style" as const,
-    maxLineToIgnoreSyntax: 15_000,
+    maxLineToIgnoreSyntax: SYNTAX_LINE_CAP,
     setMaxLineToIgnoreSyntax: () => undefined,
     ignoreSyntaxHighlightList: [],
     setIgnoreSyntaxHighlightList: () => undefined,
@@ -297,8 +298,8 @@ export const HIGHLIGHT_MAX_LINES = 2000;
 // reconstruction lines tokenize at ~5–20µs each (≤~200ms one-time at this cap),
 // while real-content cost is bounded separately by the char budgets above. The
 // default was 2000, which silently dropped highlighting for any edit past line
-// 2000. Keep in sync with the Shiki cap in shiki-highlighter.ts.
-highlighter.setMaxLineToIgnoreSyntax(15_000);
+// 2000. SYNTAX_LINE_CAP is shared with the Shiki + precomputed highlighters.
+highlighter.setMaxLineToIgnoreSyntax(SYNTAX_LINE_CAP);
 
 /**
  * Build a parsed `DiffFile` from unified-diff text, with syntax highlighting

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -1,3 +1,4 @@
+import type { DiffAST } from "@git-diff-view/core";
 import {
   DiffFile,
   DiffModeEnum,
@@ -8,6 +9,7 @@ import {
   type LineRange,
   type MultiSelectResult,
   type MultiSelectState,
+  processAST,
   SplitSide,
 } from "@git-diff-view/react";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -34,6 +36,7 @@ import { DiffErrorBoundary } from "./DiffErrorBoundary";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
 import { diffLang } from "./diff-lang";
+import { djb2 } from "./highlight-worker";
 import { ImageDiff, ImagePanes, type ImageRevs, imageMime } from "./ImageDiff";
 import {
   ensureBuiltinShikiLang,
@@ -43,6 +46,7 @@ import {
   shikiDiffHighlighter,
 } from "./shiki-highlighter";
 import { ensureCustomLanguages } from "./syntax";
+import { useWorkerHighlight, type WorkerAsts } from "./use-worker-highlight";
 
 /**
  * A line-anchored annotation rendered under a specific diff line (e.g. a PR
@@ -227,11 +231,57 @@ export function GitDiffView({
 // hunk path runs on first paint. Measured warm cost on unique real content:
 // highlight.js ≈0.37ms/KB (~150ms at 400KB), Shiki ≈1ms/KB for rust and
 // ≈3.2ms/KB for tsx (~150ms rust / ~480ms worst-case tsx at 150KB). Shiki is
-// ~8× the per-KB cost, so it gets the tighter budget. A worker-built DiffFile
-// (backlog) is the future unbounded fix; until then these keep the blocking
-// tokenize bounded.
+// ~8× the per-KB cost, so it gets the tighter budget. Over budget, a Shiki-routed
+// language tokenizes off-thread instead (see {@link useWorkerHighlight}); an
+// over-budget hljs language keeps the view's own hljs pass (≤15K lines) unchanged.
 const HIGHLIGHT_MAX_CHARS_HLJS = 400_000;
 const HIGHLIGHT_MAX_CHARS_SHIKI = 150_000;
+
+/**
+ * Whether a diff of `textLength` chars is over the synchronous-tokenize budget
+ * for the engine it routes to (Shiki gets the tighter budget — ~8× the per-KB
+ * cost). Over budget for a Shiki language, the sync path skips highlighting and
+ * the Web Worker tokenizes off-thread; under budget it highlights inline. Shared
+ * so the worker call site computes engagement the SAME way the skip logic inside
+ * {@link createDiffFile} does.
+ */
+export function overHighlightBudget(
+  textLength: number,
+  useShiki: boolean,
+): boolean {
+  const maxChars = useShiki
+    ? HIGHLIGHT_MAX_CHARS_SHIKI
+    : HIGHLIGHT_MAX_CHARS_HLJS;
+  return textLength > maxChars;
+}
+
+// An empty tree for a side whose AST the worker didn't supply; the renderer
+// treats it as "no highlighting" (that side plain — fail-open).
+const EMPTY_WORKER_AST: DiffAST = { type: "root", children: [] };
+
+/**
+ * A @git-diff-view highlighter backed by ASTs the worker already tokenized. Its
+ * `getAST` just looks the side up by the raw text's djb2 hash — no engine runs
+ * on the main thread. Fed to a REAL local `initSyntax` so the instance is
+ * indistinguishable from a locally-highlighted one (its `syntaxFile` populates,
+ * so the view's clone restores rather than wipes the highlighting on mount). A
+ * hash miss returns the empty AST (that side plain). Shiki emits style-based
+ * spans, so `type: "style"` — matching the worker's own highlighter.
+ */
+function precomputedHighlighter(asts: WorkerAsts) {
+  return {
+    name: "shiki",
+    type: "style" as const,
+    maxLineToIgnoreSyntax: 15_000,
+    setMaxLineToIgnoreSyntax: () => undefined,
+    ignoreSyntaxHighlightList: [],
+    setIgnoreSyntaxHighlightList: () => undefined,
+    getAST: (raw: string) =>
+      asts.sides.find((s) => s.rawHash === djb2(raw))?.ast ?? EMPTY_WORKER_AST,
+    processAST,
+    hasRegisteredCurrentLang: () => true,
+  };
+}
 // Content mode reads and highlights BOTH whole files over IPC (≈2× the hunk
 // path's cost), so it keeps the original, tighter 100KB budget.
 const CONTENT_HIGHLIGHT_MAX_CHARS = 100_000;
@@ -264,6 +314,11 @@ export function createDiffFile(
   // files (correct comment/string state) and maps tokens onto the diff lines —
   // and switches to collapsible full-file context instead of a bare hunk.
   content?: { old: string | null; new: string | null },
+  // Per-side ASTs the highlight worker already tokenized. Passed only for an
+  // over-budget Shiki-routed file (the sync path would have SKIPPED Shiki): run
+  // a REAL local initSyntax off the precomputed ASTs to paint the worker's
+  // highlighting in. Undefined = exactly today's path.
+  workerAsts?: WorkerAsts,
 ): DiffFile | null {
   if (!text.trim()) return null;
   try {
@@ -286,7 +341,7 @@ export function createDiffFile(
     // loaded. Until then a built-in Shiki language falls back to highlight.js /
     // plain; RenderedDiff rebuilds the diff when the grammar finishes loading.
     const useShiki = lang ? isShikiLang(lang) : false;
-    const file = DiffFile.createInstance({
+    const data = {
       oldFile: {
         fileName: filePath,
         fileLang: lang,
@@ -298,7 +353,21 @@ export function createDiffFile(
         content: content?.new ?? null,
       },
       hunks: [text],
-    });
+    };
+    // Worker ASTs arrive only for an over-budget Shiki-routed file the sync path
+    // skipped. Build the instance locally and run the REAL initSyntax off the
+    // precomputed ASTs — the resulting instance is a genuinely-highlighted one
+    // (syntaxFile populated), so the view's clone restores it on mount instead of
+    // wiping to plain (as a getBundle-merged Shiki instance would).
+    if (workerAsts) {
+      const file = DiffFile.createInstance(data);
+      file.initRaw();
+      file.initSyntax({
+        registerHighlighter: precomputedHighlighter(workerAsts),
+      });
+      return file;
+    }
+    const file = DiffFile.createInstance(data);
     file.initRaw();
     // The char budget bounds the one-time synchronous tokenization cost, which
     // differs ~8× by engine (see the constants) — so gate on the budget for the
@@ -307,10 +376,7 @@ export function createDiffFile(
     // 15_000 for both engines), which bounds the placeholder-reconstruction cost
     // of an edit deep in a huge file. Gating here on a line count would wrongly
     // skip large Shiki-rendered files (e.g. Rust) the renderer would happily do.
-    const maxChars = useShiki
-      ? HIGHLIGHT_MAX_CHARS_SHIKI
-      : HIGHLIGHT_MAX_CHARS_HLJS;
-    if (lang && text.length <= maxChars) {
+    if (lang && !overHighlightBudget(text.length, useShiki)) {
       if (useShiki) {
         file.initSyntax({ registerHighlighter: shikiDiffHighlighter() });
       } else {
@@ -503,7 +569,12 @@ function RenderedDiff({
       !lang ||
       !isBuiltinShikiLang(lang) ||
       isShikiLang(lang) ||
-      grammarState[lang] !== undefined
+      grammarState[lang] !== undefined ||
+      // Over the Shiki budget (a builtin-Shiki lang is Shiki-routed, so that's
+      // the budget that applies) the main thread never tokenizes this file —
+      // the worker loads its own grammar copy. Loading here too would waste the
+      // fetch AND flip grammarState, rebuilding the interim hljs paint to plain.
+      overHighlightBudget(shown.length, true)
     )
       return;
     let cancelled = false;
@@ -514,7 +585,7 @@ function RenderedDiff({
     return () => {
       cancelled = true;
     };
-  }, [lang, grammarState]);
+  }, [lang, grammarState, shown.length]);
 
   // A built-in Shiki grammar this diff needs is still loading (never seen a
   // "ready"/"failed" result for it): hold the paint. `isShikiLang(lang)` already
@@ -525,20 +596,67 @@ function RenderedDiff({
     !isShikiLang(lang) &&
     !grammarState[lang];
 
+  // Off-thread highlighting, Shiki-only. Over-budget Shiki-routed files (Rust,
+  // TSX, Astro, custom grammars &c.) otherwise get the WRONG engine — the view's
+  // own hljs pass, which those languages are routed off on purpose — so the
+  // worker delivers correct Shiki off-thread. An over-budget hljs-routed file
+  // sends NO request: the view clone already hljs-highlights it (≤15K lines),
+  // which is the intended engine there. `useShikiWorker` also routes a builtin
+  // Shiki lang whose grammar the main thread hasn't loaded yet — the worker loads
+  // it itself. `tmGrammar` is a custom Shiki language's raw grammar for the worker
+  // to register. A custom tmGrammar routes to Shiki here directly because its
+  // registration happens lazily inside createDiffFile with no rebuild trigger —
+  // `tmGrammar` is available on the first render, module state is not. The hook
+  // adds the size ceiling.
+  const tmGrammar = useMemo(
+    () =>
+      lang
+        ? (customLanguages?.find((c) => c.id === lang)?.tmGrammar ?? null)
+        : null,
+    [lang, customLanguages],
+  );
+  const useShikiWorker =
+    !!lang &&
+    (isShikiLang(lang) || isBuiltinShikiLang(lang) || tmGrammar != null);
+  const overBudget =
+    !!lang && overHighlightBudget(shown.length, useShikiWorker);
+  const workerAsts = useWorkerHighlight({
+    // Shiki-routed + over budget only. Don't request while whole-file reads are
+    // still settling — the worker input would be built on interim text and
+    // superseded. (Over budget we never hold the paint on grammarPending, so it
+    // isn't gated on here.)
+    enabled: overBudget && useShikiWorker && !contentPending,
+    filePath: deferredPath,
+    text: shown,
+    lang: lang ?? null,
+    isDark,
+    content: content ?? null,
+    tmGrammar,
+  });
+
+  // Over budget, the main thread will NEVER Shiki-tokenize this file, so holding
+  // the plain paint on a grammar only the worker needs would just delay the
+  // interim paint — the worker loads its own grammar. Under budget, keep the
+  // original hold so the lazy-grammar rebuild still lands in one paint.
+  const holdForGrammar = grammarPending && !overBudget;
+
   // grammarState is a deliberate rebuild trigger: createDiffFile reads the
   // now-loaded Shiki grammar via module state (isShikiLang), not a passed value,
   // so recording the load result is what forces the rebuild that picks the
   // grammar up (the gate below only lets the first build run once it's settled).
+  // `workerAsts` is the analogous trigger for the over-budget path: its identity
+  // change when the ASTs land is what rebuilds the diff highlighted.
   // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>
-      contentPending || grammarPending
+      contentPending || holdForGrammar
         ? null
         : createDiffFile(
             deferredPath,
             shown,
             { syntaxMap, customLanguages },
             content ?? undefined,
+            workerAsts ?? undefined,
           ),
     [
       shown,
@@ -547,8 +665,9 @@ function RenderedDiff({
       customLanguages,
       content,
       contentPending,
-      grammarPending,
+      holdForGrammar,
       grammarState,
+      workerAsts,
     ],
   );
 
@@ -871,8 +990,12 @@ function RenderedDiff({
   // rather than a hunk-only diff we'd immediately rebuild — the single-paint gate
   // that removes the flash. Must precede the empty-state placeholder so loading
   // never masquerades as "No changes to show". Matches DiffContent's own
-  // render-nothing-while-loading design (see the comment there).
-  if (contentPending || grammarPending) return null;
+  // render-nothing-while-loading design (see the comment there). Over budget we
+  // use `holdForGrammar` (never true there) so the interim paint isn't delayed
+  // for a grammar only the worker needs — the interim is the view clone's own
+  // hljs pass (≤15K lines; plain past it), and correct Shiki swaps in when the
+  // worker ASTs land.
+  if (contentPending || holdForGrammar) return null;
   if (!diffFile) return <DiffPlaceholder message="No changes to show" />;
   return (
     <>

--- a/src/features/diff/highlight-worker-shared.ts
+++ b/src/features/diff/highlight-worker-shared.ts
@@ -1,0 +1,48 @@
+// Shared between the worker entry (`highlight-worker.ts`) and the main thread
+// (`use-worker-highlight.ts`, `DiffSurface.tsx`), so the worker implementation
+// never enters a main-thread chunk: the main thread imports `djb2` and these
+// types from here, and references the worker only via `new Worker(new
+// URL("./highlight-worker.ts", ...))` (review finding, PR #57).
+import type { DiffAST } from "@git-diff-view/core";
+
+/** djb2 over a full string — O(n) at ~1ms/MB, negligible next to tokenize. The
+ *  hook keys request signatures with it; the worker tags each captured side's
+ *  raw text with it so the main-thread highlighter can look its AST up by hash.
+ *  Shared from here so the two never drift. */
+export function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = (h * 33) ^ s.charCodeAt(i);
+  return h >>> 0;
+}
+
+/** One tokenized side: the raw text's djb2 hash paired with its HAST. */
+export interface HighlightAst {
+  rawHash: number;
+  ast: DiffAST;
+}
+
+/** The worker's payload: the per-side tokenized ASTs (old + new). */
+export interface WorkerAsts {
+  sides: HighlightAst[];
+}
+
+/** Work posted from the main thread. The worker is Shiki-only, so there's no
+ *  engine flag — the call site only requests when the file routes to Shiki. */
+export interface HighlightWorkRequest {
+  id: number;
+  filePath: string;
+  /** Already resolved on the main thread via `diffLang`. */
+  lang: string;
+  isDark: boolean;
+  hunkText: string;
+  content: { old: string | null; new: string | null } | null;
+  /** A custom language's raw tmLanguage JSON, when that's what routed to Shiki. */
+  tmGrammar: object | null;
+}
+
+/** The worker's reply. `result: null` means "couldn't highlight — keep the
+ *  interim paint". */
+export interface HighlightWorkResponse {
+  id: number;
+  result: WorkerAsts | null;
+}

--- a/src/features/diff/highlight-worker.ts
+++ b/src/features/diff/highlight-worker.ts
@@ -122,9 +122,9 @@ async function handle(req: HighlightWorkRequest): Promise<WorkerAsts | null> {
 }
 
 // Only wire the message handler inside a real Worker context (no `document`).
-// The main thread imports pure helpers from this module (`djb2`, the shared
-// types); guarding the registration keeps that import side-effect-free instead
-// of installing an onmessage handler on the app window.
+// Nothing on the main thread imports this entry anymore (shared helpers live in
+// highlight-worker-shared.ts) — the guard is defence-in-depth so an accidental
+// future re-import can't install an onmessage handler on the app window.
 if (typeof document === "undefined") {
   self.onmessage = (e: MessageEvent<HighlightWorkRequest>) => {
     const req = e.data;

--- a/src/features/diff/highlight-worker.ts
+++ b/src/features/diff/highlight-worker.ts
@@ -1,0 +1,179 @@
+/**
+ * The diff syntax-highlighting Web Worker — Shiki (TextMate) only.
+ *
+ * Some languages the repo routes to Shiki for correctness (Rust, TSX, Astro,
+ * Svelte, custom-grammar languages &c.) are too big to tokenize synchronously on
+ * first paint: a 1MB tsx file would block the UI for ~3s (measured ≈3.2ms/KB).
+ * Over the per-engine char budget (see DiffSurface.tsx) the sync path skips
+ * Shiki, so those files fall back to the view's own highlight.js pass (or plain
+ * past the renderer's line cap) — the WRONG engine for languages routed off
+ * highlight.js on purpose. This worker fixes exactly that: it tokenizes the file
+ * off-thread and ships back the per-side HAST ASTs, which the main thread feeds
+ * into a REAL local `initSyntax` so the resulting instance is indistinguishable
+ * from a locally-highlighted one (its `syntaxFile` is populated, so the view's
+ * clone restores rather than wipes the highlighting on mount).
+ *
+ * Why ASTs, not a `getBundle()` transfer: a merged (`createInstance(data,
+ * bundle)`) Shiki instance has no `oldFileResult`/`newFileResult.syntaxFile`, so
+ * the view clone's no-arg `initSyntax()` re-reads empty syntax lines and wipes
+ * the highlighting to plain (verified against core index.mjs:2392-2400 +
+ * react:1631-1636). The bundle is also far heavier (a 12K-line file: ~45MB vs
+ * ~17MB of ASTs) and its weight killed the WebView2 renderer live.
+ *
+ * Everything here is FAIL-OPEN: any failure (grammar load, tokenize throw)
+ * responds `result: null`, and the main thread keeps its interim paint. The
+ * whole handler is wrapped so no error escapes unhandled.
+ *
+ * This module imports ONLY from `@git-diff-view/core` (`DiffFile`, `DiffAST`)
+ * and the worker-safe shiki helpers — never `@git-diff-view/react` (React in the
+ * worker chunk) and no longer `@git-diff-view/lowlight` (hljs isn't run here).
+ */
+import { type DiffAST, DiffFile } from "@git-diff-view/core";
+import type { CustomLanguage } from "@/lib/settings/api";
+import {
+  ensureBuiltinShikiLang,
+  ensureShikiGrammars,
+  shikiDiffHighlighter,
+} from "./shiki-highlighter";
+
+/** djb2 over a full string — O(n) at ~1ms/MB, negligible next to tokenize. The
+ *  hook keys request signatures with it; the worker tags each captured side's
+ *  raw text with it so the main-thread highlighter can look its AST up by hash.
+ *  Shared from here so the two never drift. */
+export function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = (h * 33) ^ s.charCodeAt(i);
+  return h >>> 0;
+}
+
+/** One tokenized side: the raw text's djb2 hash paired with its HAST. */
+export interface HighlightAst {
+  rawHash: number;
+  ast: DiffAST;
+}
+
+/** The worker's payload: the per-side tokenized ASTs (old + new). */
+export interface WorkerAsts {
+  sides: HighlightAst[];
+}
+
+/** Work posted from the main thread. The worker is Shiki-only, so there's no
+ *  engine flag — the call site only requests when the file routes to Shiki. */
+export interface HighlightWorkRequest {
+  id: number;
+  filePath: string;
+  /** Already resolved on the main thread via `diffLang`. */
+  lang: string;
+  isDark: boolean;
+  hunkText: string;
+  content: { old: string | null; new: string | null } | null;
+  /** A custom language's raw tmLanguage JSON, when that's what routed to Shiki. */
+  tmGrammar: object | null;
+}
+
+/** The worker's reply. `result: null` means "couldn't highlight — keep the
+ *  interim paint". */
+export interface HighlightWorkResponse {
+  id: number;
+  result: WorkerAsts | null;
+}
+
+// The renderer caps highlighting at 15_000 reconstructed lines; mirror that here
+// so a file past the cap tokenizes exactly the lines the view will show and no
+// more. Lifting this ceiling belongs to the diff-virtualization epic.
+const WORKER_MAX_LINE = 15_000;
+
+/**
+ * Load the Shiki grammar this file needs into the worker's own engine. The
+ * worker starts with no grammars loaded, so it always loads on demand. Resolves
+ * true when highlighting can proceed, false to fall back (interim paint).
+ */
+async function ensureGrammar(req: HighlightWorkRequest): Promise<boolean> {
+  if (req.tmGrammar) {
+    // Synthesize a CustomLanguage-shaped object carrying just the grammar;
+    // ensureShikiGrammars registers it under `lang` and ignores the rest.
+    const synthetic: CustomLanguage = {
+      id: req.lang,
+      name: req.lang,
+      keywords: "",
+      lineComment: "",
+      blockCommentStart: "",
+      blockCommentEnd: "",
+      stringDelimiters: "",
+      caseInsensitive: false,
+      tmGrammar: req.tmGrammar as Record<string, unknown>,
+    };
+    ensureShikiGrammars([synthetic]);
+    return true;
+  }
+  // A built-in Shiki language (astro/tsx/rust &c.): the dynamic `@shikijs/langs/*`
+  // imports work in a Vite module worker.
+  return ensureBuiltinShikiLang(req.lang);
+}
+
+async function handle(req: HighlightWorkRequest): Promise<WorkerAsts | null> {
+  const ready = await ensureGrammar(req);
+  if (!ready) return null;
+
+  const file = DiffFile.createInstance({
+    oldFile: {
+      fileName: req.filePath,
+      fileLang: req.lang,
+      content: req.content?.old ?? null,
+    },
+    newFile: {
+      fileName: req.filePath,
+      fileLang: req.lang,
+      content: req.content?.new ?? null,
+    },
+    hunks: [req.hunkText],
+  });
+  file.initTheme(req.isDark ? "dark" : "light");
+  file.initRaw();
+
+  // Wrap the real Shiki highlighter so we CAPTURE each side's AST as initSyntax
+  // drives getAST (once per side — old then new), instead of shipping the whole
+  // built DiffFile. initSyntax alone calls getAST for both sides via each
+  // File.doSyntax (core composeSyntax) — no build*/getBundle needed.
+  const inner = shikiDiffHighlighter(req.isDark);
+  inner.maxLineToIgnoreSyntax = WORKER_MAX_LINE;
+  const sides: HighlightAst[] = [];
+  const seen = new Set<number>();
+  const capturing = {
+    ...inner,
+    getAST: (raw: string, fileName?: string, lang?: string) => {
+      const ast = inner.getAST(raw, fileName, lang);
+      const rawHash = djb2(raw);
+      // Dedupe by hash: an unchanged side (identical old/new content) tokenizes
+      // to the same AST, so store it once.
+      if (!seen.has(rawHash)) {
+        seen.add(rawHash);
+        sides.push({ rawHash, ast });
+      }
+      return ast;
+    },
+  };
+  file.initSyntax({ registerHighlighter: capturing });
+
+  return { sides };
+}
+
+// Only wire the message handler inside a real Worker context (no `document`).
+// The main thread imports pure helpers from this module (`djb2`, the shared
+// types); guarding the registration keeps that import side-effect-free instead
+// of installing an onmessage handler on the app window.
+if (typeof document === "undefined") {
+  self.onmessage = (e: MessageEvent<HighlightWorkRequest>) => {
+    const req = e.data;
+    handle(req)
+      .then((result) => {
+        const res: HighlightWorkResponse = { id: req.id, result };
+        self.postMessage(res);
+      })
+      .catch(() => {
+        // Fail-open: any throw (grammar load, tokenize, clone) → keep interim paint.
+        const res: HighlightWorkResponse = { id: req.id, result: null };
+        self.postMessage(res);
+      });
+  };
+}

--- a/src/features/diff/highlight-worker.ts
+++ b/src/features/diff/highlight-worker.ts
@@ -24,64 +24,25 @@
  * responds `result: null`, and the main thread keeps its interim paint. The
  * whole handler is wrapped so no error escapes unhandled.
  *
- * This module imports ONLY from `@git-diff-view/core` (`DiffFile`, `DiffAST`)
- * and the worker-safe shiki helpers — never `@git-diff-view/react` (React in the
- * worker chunk) and no longer `@git-diff-view/lowlight` (hljs isn't run here).
+ * This module imports ONLY from `@git-diff-view/core` (`DiffFile`), the
+ * worker-safe shiki helpers, and the shared djb2/types module — never
+ * `@git-diff-view/react` (React in the worker chunk) and no longer
+ * `@git-diff-view/lowlight` (hljs isn't run here).
  */
-import { type DiffAST, DiffFile } from "@git-diff-view/core";
+import { DiffFile } from "@git-diff-view/core";
 import type { CustomLanguage } from "@/lib/settings/api";
+import type {
+  HighlightAst,
+  HighlightWorkRequest,
+  HighlightWorkResponse,
+  WorkerAsts,
+} from "./highlight-worker-shared";
+import { djb2 } from "./highlight-worker-shared";
 import {
   ensureBuiltinShikiLang,
   ensureShikiGrammars,
   shikiDiffHighlighter,
 } from "./shiki-highlighter";
-
-/** djb2 over a full string — O(n) at ~1ms/MB, negligible next to tokenize. The
- *  hook keys request signatures with it; the worker tags each captured side's
- *  raw text with it so the main-thread highlighter can look its AST up by hash.
- *  Shared from here so the two never drift. */
-export function djb2(s: string): number {
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = (h * 33) ^ s.charCodeAt(i);
-  return h >>> 0;
-}
-
-/** One tokenized side: the raw text's djb2 hash paired with its HAST. */
-export interface HighlightAst {
-  rawHash: number;
-  ast: DiffAST;
-}
-
-/** The worker's payload: the per-side tokenized ASTs (old + new). */
-export interface WorkerAsts {
-  sides: HighlightAst[];
-}
-
-/** Work posted from the main thread. The worker is Shiki-only, so there's no
- *  engine flag — the call site only requests when the file routes to Shiki. */
-export interface HighlightWorkRequest {
-  id: number;
-  filePath: string;
-  /** Already resolved on the main thread via `diffLang`. */
-  lang: string;
-  isDark: boolean;
-  hunkText: string;
-  content: { old: string | null; new: string | null } | null;
-  /** A custom language's raw tmLanguage JSON, when that's what routed to Shiki. */
-  tmGrammar: object | null;
-}
-
-/** The worker's reply. `result: null` means "couldn't highlight — keep the
- *  interim paint". */
-export interface HighlightWorkResponse {
-  id: number;
-  result: WorkerAsts | null;
-}
-
-// The renderer caps highlighting at 15_000 reconstructed lines; mirror that here
-// so a file past the cap tokenizes exactly the lines the view will show and no
-// more. Lifting this ceiling belongs to the diff-virtualization epic.
-const WORKER_MAX_LINE = 15_000;
 
 /**
  * Load the Shiki grammar this file needs into the worker's own engine. The
@@ -135,8 +96,10 @@ async function handle(req: HighlightWorkRequest): Promise<WorkerAsts | null> {
   // drives getAST (once per side — old then new), instead of shipping the whole
   // built DiffFile. initSyntax alone calls getAST for both sides via each
   // File.doSyntax (core composeSyntax) — no build*/getBundle needed.
+  // The worker inherits the highlighter's own 15_000 reconstructed-line cap
+  // (`shikiDiffHighlighter` sets it), mirroring the renderer; lifting that
+  // ceiling belongs to the diff-virtualization epic.
   const inner = shikiDiffHighlighter(req.isDark);
-  inner.maxLineToIgnoreSyntax = WORKER_MAX_LINE;
   const sides: HighlightAst[] = [];
   const seen = new Set<number>();
   const capturing = {

--- a/src/features/diff/shiki-highlighter.ts
+++ b/src/features/diff/shiki-highlighter.ts
@@ -247,6 +247,16 @@ function buildHast(
  * style-based spans (the renderer applies `properties.style` directly). AST
  * post-processing is reused from the default highlighter's exported `processAST`.
  */
+/**
+ * Line cap on the RECONSTRUCTED file, deciding whether a small edit deep in a
+ * big file gets highlighted at all (not the diff's own size). Placeholder-
+ * reconstructed lines tokenize cheaply (measured 61ms at 12K lines). The ONE
+ * shared cap for every highlighter the diff uses — the Shiki object below, the
+ * highlight.js singleton pin, and the worker-AST precomputed highlighter (both
+ * in DiffSurface.tsx) — so they can't silently diverge.
+ */
+export const SYNTAX_LINE_CAP = 15_000;
+
 export function shikiDiffHighlighter(
   // When set, forces the token theme instead of sniffing the `.dark` class —
   // required off the main thread (the highlight worker has no `document`), and
@@ -256,11 +266,7 @@ export function shikiDiffHighlighter(
   return {
     name: "shiki",
     type: "style",
-    // Line cap on the RECONSTRUCTED file, so it decides whether a small edit
-    // deep in a big file gets highlighted at all (not the diff's own size).
-    // Placeholder-reconstructed lines tokenize cheaply (measured 61ms at 12K
-    // lines); keep in sync with the highlight.js cap set in DiffSurface.tsx.
-    maxLineToIgnoreSyntax: 15_000,
+    maxLineToIgnoreSyntax: SYNTAX_LINE_CAP,
     setMaxLineToIgnoreSyntax: () => undefined,
     ignoreSyntaxHighlightList: [],
     setIgnoreSyntaxHighlightList: () => undefined,

--- a/src/features/diff/shiki-highlighter.ts
+++ b/src/features/diff/shiki-highlighter.ts
@@ -2,7 +2,7 @@ import {
   type DiffAST,
   type DiffFileHighlighter,
   processAST,
-} from "@git-diff-view/react";
+} from "@git-diff-view/core";
 import { createHighlighterCoreSync, type HighlighterCore } from "@shikijs/core";
 import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
 // `json` stays a static import: it's small, and it backs the synchronous
@@ -201,8 +201,14 @@ function styleFor(color: string | undefined, fontStyle: number | undefined) {
  * `createDiffFile` runs `initSyntax` — and the view's later dark re-sync uses
  * the *default* highlighter, not ours, so a stale light tokenization would
  * stick (light token colors on the dark diff background = unreadable).
+ *
+ * `typeof document` guards the DOM sniff so this module is importable in a Web
+ * Worker (no `document`) — the worker highlight path always threads an explicit
+ * `isDarkOverride`, so the sniff is never actually reached there.
  */
-function isDarkMode(): boolean {
+function isDarkMode(override?: boolean): boolean {
+  if (override !== undefined) return override;
+  if (typeof document === "undefined") return false;
   return document.documentElement.classList.contains("dark");
 }
 
@@ -212,10 +218,14 @@ const EMPTY_AST: DiffAST = { type: "root", children: [] };
 
 // Flat hast (the same shape highlight.js produces): token spans separated by
 // "\n" text nodes. The renderer applies each span's `properties.style` directly.
-function buildHast(raw: string, lang: string): DiffAST {
+function buildHast(
+  raw: string,
+  lang: string,
+  isDarkOverride?: boolean,
+): DiffAST {
   const lines = getCore().codeToTokensBase(raw, {
     lang,
-    theme: isDarkMode() ? "gd-diff-dark" : "gd-diff-light",
+    theme: isDarkMode(isDarkOverride) ? "gd-diff-dark" : "gd-diff-light",
   });
   const children: DiffAST["children"] = [];
   lines.forEach((line, i) => {
@@ -237,7 +247,12 @@ function buildHast(raw: string, lang: string): DiffAST {
  * style-based spans (the renderer applies `properties.style` directly). AST
  * post-processing is reused from the default highlighter's exported `processAST`.
  */
-export function shikiDiffHighlighter(): DiffFileHighlighter {
+export function shikiDiffHighlighter(
+  // When set, forces the token theme instead of sniffing the `.dark` class —
+  // required off the main thread (the highlight worker has no `document`), and
+  // used there to render against the app's current theme.
+  isDarkOverride?: boolean,
+): DiffFileHighlighter {
   return {
     name: "shiki",
     type: "style",
@@ -252,7 +267,7 @@ export function shikiDiffHighlighter(): DiffFileHighlighter {
     getAST: (raw, _fileName, lang) => {
       if (!lang || !loaded.has(lang)) return EMPTY_AST;
       try {
-        return buildHast(raw, lang);
+        return buildHast(raw, lang, isDarkOverride);
       } catch {
         return EMPTY_AST;
       }

--- a/src/features/diff/shiki-highlighter.ts
+++ b/src/features/diff/shiki-highlighter.ts
@@ -243,11 +243,6 @@ function buildHast(
 }
 
 /**
- * A @git-diff-view DiffFileHighlighter that tokenizes with Shiki and emits
- * style-based spans (the renderer applies `properties.style` directly). AST
- * post-processing is reused from the default highlighter's exported `processAST`.
- */
-/**
  * Line cap on the RECONSTRUCTED file, deciding whether a small edit deep in a
  * big file gets highlighted at all (not the diff's own size). Placeholder-
  * reconstructed lines tokenize cheaply (measured 61ms at 12K lines). The ONE
@@ -257,6 +252,11 @@ function buildHast(
  */
 export const SYNTAX_LINE_CAP = 15_000;
 
+/**
+ * A @git-diff-view DiffFileHighlighter that tokenizes with Shiki and emits
+ * style-based spans (the renderer applies `properties.style` directly). AST
+ * post-processing is reused from the default highlighter's exported `processAST`.
+ */
 export function shikiDiffHighlighter(
   // When set, forces the token theme instead of sniffing the `.dark` class —
   // required off the main thread (the highlight worker has no `document`), and

--- a/src/features/diff/use-worker-highlight.ts
+++ b/src/features/diff/use-worker-highlight.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 import {
   djb2,
   type HighlightWorkRequest,
@@ -113,26 +113,25 @@ export function useWorkerHighlight(
     asts: WorkerAsts;
   } | null>(null);
 
-  // `signature` is the canonical digest of every request-shaping input (path /
-  // lang / isDark / text + content hashes); the other `args.*` reads are exactly
-  // the fields it summarizes, so depending on them too would only re-fire this
-  // effect spuriously. `result` is read to skip re-posting a result we already
-  // hold, not to drive the effect.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: signature digests every request input; raw fields would re-fire spuriously
-  useEffect(() => {
-    if (!engaged || signature === null) return;
+  // Post the request for `sig` off the render path. An effect event reads the
+  // LATEST `args`/`result` without making them reactive — the effect below
+  // re-fires only when the signature (which digests every request-shaping
+  // input: path / lang / isDark / text + content hashes) or engagement changes,
+  // never on unrelated arg identity churn. Returns the request id for the
+  // effect's cleanup to disarm, or null when nothing was posted (result
+  // already in hand, or the worker is unavailable → interim paint).
+  const postRequest = useEffectEvent((sig: string): number | null => {
     // Already have this exact result — don't re-post.
-    if (result?.signature === signature) return;
+    if (result?.signature === sig) return null;
 
     const w = getWorker();
-    if (!w) return; // unavailable → keeps interim paint
+    if (!w) return null; // unavailable → keeps interim paint
 
     const id = nextId++;
-    let cancelled = false;
     const req: HighlightWorkRequest = {
       id,
       filePath: args.filePath,
-      // `engaged` already gated on lang being non-null.
+      // `engaged` (checked by the caller) already gated on lang being non-null.
       lang: args.lang as string,
       isDark: args.isDark,
       hunkText: args.text,
@@ -140,16 +139,23 @@ export function useWorkerHighlight(
       tmGrammar: args.tmGrammar,
     };
     handlers.set(id, (res) => {
-      if (cancelled) return;
-      // Latest-wins: only accept the response for the request we last sent.
-      if (res.result) setResult({ signature, asts: res.result });
+      // Latest-wins: a superseded request's handler was already deleted by its
+      // cleanup (onmessage and the crash-drain both go through the map), so
+      // reaching here means this response is for the request we last sent. A
+      // null result (tokenize failure) leaves the interim paint.
+      if (res.result) setResult({ signature: sig, asts: res.result });
     });
     w.postMessage(req);
+    return id;
+  });
 
+  useEffect(() => {
+    if (!engaged || signature === null) return;
+    const id = postRequest(signature);
+    if (id === null) return;
     return () => {
-      cancelled = true;
-      // Drop the pending handler so a late reply for a superseded/unmounted
-      // request is ignored (and the map doesn't leak).
+      // Disarm the pending handler so a late reply for a superseded/unmounted
+      // request is dropped by the onmessage map lookup (and the map doesn't leak).
       handlers.delete(id);
     };
   }, [engaged, signature]);

--- a/src/features/diff/use-worker-highlight.ts
+++ b/src/features/diff/use-worker-highlight.ts
@@ -4,9 +4,9 @@ import {
   type HighlightWorkRequest,
   type HighlightWorkResponse,
   type WorkerAsts,
-} from "./highlight-worker";
+} from "./highlight-worker-shared";
 
-export type { WorkerAsts } from "./highlight-worker";
+export type { WorkerAsts } from "./highlight-worker-shared";
 
 // One worker shared by every mounted diff on the main thread. Created lazily on
 // the first enabled request; if construction throws (a headless/webview quirk
@@ -36,6 +36,24 @@ function getWorker(): Worker | null {
         handler(e.data);
       }
     };
+    // A worker that dies at module-init (bad import, OOM) or on a malformed
+    // message would otherwise leave `worker` non-null and every future request
+    // posting into a corpse — interim paint forever, no signal. Mark it
+    // unavailable and drain the pending handlers fail-open (result: null keeps
+    // each requester on its interim paint, matching the behavior matrix).
+    const fail = (kind: string) => (err: unknown) => {
+      workerUnavailable = true;
+      worker = null;
+      console.warn(
+        `[diff] highlight worker ${kind}; large Shiki diffs keep their interim paint`,
+        err,
+      );
+      const pending = [...handlers.values()];
+      handlers.clear();
+      for (const handler of pending) handler({ id: -1, result: null });
+    };
+    worker.onerror = fail("crashed");
+    worker.onmessageerror = fail("message failed to deserialize");
     return worker;
   } catch (err) {
     workerUnavailable = true;

--- a/src/features/diff/use-worker-highlight.ts
+++ b/src/features/diff/use-worker-highlight.ts
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import {
+  djb2,
+  type HighlightWorkRequest,
+  type HighlightWorkResponse,
+  type WorkerAsts,
+} from "./highlight-worker";
+
+export type { WorkerAsts } from "./highlight-worker";
+
+// One worker shared by every mounted diff on the main thread. Created lazily on
+// the first enabled request; if construction throws (a headless/webview quirk
+// where module workers aren't available) it's marked permanently unavailable
+// and every future request fails open to the interim paint.
+let worker: Worker | null = null;
+let workerUnavailable = false;
+let nextId = 1;
+
+// Per-request handlers, keyed by request id, so multiple mounted hook instances
+// share the one worker without leaking listeners: the single onmessage below
+// dispatches each response to (and removes) its handler. A response with no
+// registered handler (the requester unmounted) is simply dropped.
+const handlers = new Map<number, (res: HighlightWorkResponse) => void>();
+
+function getWorker(): Worker | null {
+  if (worker) return worker;
+  if (workerUnavailable) return null;
+  try {
+    worker = new Worker(new URL("./highlight-worker.ts", import.meta.url), {
+      type: "module",
+    });
+    worker.onmessage = (e: MessageEvent<HighlightWorkResponse>) => {
+      const handler = handlers.get(e.data.id);
+      if (handler) {
+        handlers.delete(e.data.id);
+        handler(e.data);
+      }
+    };
+    return worker;
+  } catch (err) {
+    workerUnavailable = true;
+    console.warn(
+      "[diff] highlight worker unavailable; large diffs stay plain",
+      err,
+    );
+    return null;
+  }
+}
+
+interface WorkerHighlightArgs {
+  enabled: boolean;
+  filePath: string;
+  text: string;
+  lang: string | null;
+  isDark: boolean;
+  content: { old: string | null; new: string | null } | null;
+  tmGrammar: object | null;
+}
+
+// Files past this size never engage the worker. The AST payload amplifies the
+// text ~37× (measured), so 1.5MB of text ≈ 55MB of ASTs — the prudent ceiling
+// for structured-clone transfer + main-thread rebuild until diff virtualization
+// lands. The motivating ~1MB-tsx case stays covered; past it, the diff keeps its
+// interim paint.
+const WORKER_MAX_CHARS = 1_500_000;
+
+function signatureOf(args: WorkerHighlightArgs): string {
+  // Fold `content` into the signature too: the whole-file old/new text shapes
+  // the worker request (it's what gets tokenized), so a content change on the
+  // same path/length must re-request. Content is ≤100KB/side (the content-mode
+  // budget), so the extra hashing is negligible. Empty-string forms when null.
+  const old = args.content?.old ?? "";
+  const nw = args.content?.new ?? "";
+  return `${args.filePath}|${args.lang}|${args.isDark}|${args.text.length}|${djb2(args.text)}|${old.length}|${djb2(old)}|${nw.length}|${djb2(nw)}`;
+}
+
+/**
+ * Off-thread Shiki highlighting for over-budget Shiki-routed diffs. Returns the
+ * per-side tokenized ASTs to hand `createDiffFile(..., workerAsts)` once they
+ * land, or null until then (and forever if the worker is unavailable or the
+ * tokenize fails) — the caller keeps its interim paint. Latest-wins: a response
+ * for a superseded request (rapid file navigation) is discarded, so no
+ * stale/wrong-file highlighting flashes in.
+ */
+export function useWorkerHighlight(
+  args: WorkerHighlightArgs,
+): WorkerAsts | null {
+  // The size ceiling is enforced here, once, folded into engagement.
+  const engaged =
+    args.enabled && !!args.lang && args.text.length <= WORKER_MAX_CHARS;
+  const signature = engaged ? signatureOf(args) : null;
+
+  const [result, setResult] = useState<{
+    signature: string;
+    asts: WorkerAsts;
+  } | null>(null);
+
+  // `signature` is the canonical digest of every request-shaping input (path /
+  // lang / isDark / text + content hashes); the other `args.*` reads are exactly
+  // the fields it summarizes, so depending on them too would only re-fire this
+  // effect spuriously. `result` is read to skip re-posting a result we already
+  // hold, not to drive the effect.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: signature digests every request input; raw fields would re-fire spuriously
+  useEffect(() => {
+    if (!engaged || signature === null) return;
+    // Already have this exact result — don't re-post.
+    if (result?.signature === signature) return;
+
+    const w = getWorker();
+    if (!w) return; // unavailable → keeps interim paint
+
+    const id = nextId++;
+    let cancelled = false;
+    const req: HighlightWorkRequest = {
+      id,
+      filePath: args.filePath,
+      // `engaged` already gated on lang being non-null.
+      lang: args.lang as string,
+      isDark: args.isDark,
+      hunkText: args.text,
+      content: args.content,
+      tmGrammar: args.tmGrammar,
+    };
+    handlers.set(id, (res) => {
+      if (cancelled) return;
+      // Latest-wins: only accept the response for the request we last sent.
+      if (res.result) setResult({ signature, asts: res.result });
+    });
+    w.postMessage(req);
+
+    return () => {
+      cancelled = true;
+      // Drop the pending handler so a late reply for a superseded/unmounted
+      // request is ignored (and the map doesn't leak).
+      handlers.delete(id);
+    };
+  }, [engaged, signature]);
+
+  return result?.signature === signature ? result.asts : null;
+}


### PR DESCRIPTION
This change enables background-thread syntax highlighting for large diffs in Shiki-routed languages (Rust, TSX, Astro, Svelte, and custom grammars). Instead of falling back to fallback or plain highlighting when a diff exceeds the synchronous tokenization budget, the app now uses a dedicated Web Worker to tokenize via Shiki off the main thread, then overlays the correct highlighting. This resolves the fidelity loss for large files and preserves UI responsiveness.

### Highlighting pipeline & worker integration
- Adds `src/features/diff/highlight-worker.ts`, a new Shiki-only Web Worker that tokenizes oversized diffs and returns per-side ASTs for main-thread rendering. 
- Adds `src/features/diff/use-worker-highlight.ts`, a React hook and integration layer that manages requests to the highlight worker and delivers results on completion.
- Updates `src/features/diff/DiffSurface.tsx` to engage the highlight worker for over-budget, Shiki-routed files, supply ASTs to `createDiffFile`, and feed results into a real `initSyntax` call to enable seamless clone/restore behavior.
- Establishes a deterministic char budget check with shared `overHighlightBudget` logic, gating both main-thread and worker engagement on the same size bound.

### Highlighter implementation & theme handling
- Updates `src/features/diff/shiki-highlighter.ts` to:
  - Support an explicit `isDarkOverride` for off-thread theme consistency where no DOM is present.
  - Export a Shiki highlighter that serves both main-thread and worker contexts.
  - Accept grammar objects for custom grammar registration in the worker.
- Adds a "precomputed AST" highlighter that retrieves side ASTs by hash, ensuring efficient rehydration from worker output.

### Core integration and type flow
- Updates `createDiffFile` in `src/features/diff/DiffSurface.tsx` to accept optional worker ASTs and delegate highlighting accordingly.
- Ensures the hold/release logic for grammar loading is correctly bypassed when using background-thread ASTs, optimizing initial and interim paints.
- Applies a file size ceiling for worker engagement to limit structured clone volume and memory costs for extremely large input cases.

### Dependency and documentation updates
- Adds `@git-diff-view/core` to `package.json` and `pnpm-lock.yaml` for worker-safe diff utilities.
- Documents the feature in `changelog.d/changed-diff-highlight-large-files-worker.md` to explain the improvement and intended behavior.