### PR TITLE
feat(pr,issue,repo-lens,git,ui): fork · upstream lens for GitHub forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,12 @@ workflow against any two branches with no remote at all).
 - **Record management** — right-click a local PR in the list to **Archive / Unarchive**
   or **Delete** it (Delete confirms; the branches are untouched), also from the command
   palette.
+- **Fork · Upstream lens** — on a GitHub fork (a repo with an `upstream` remote), a
+  **Fork | Upstream** switch in the list toolbar (remembered per repo, defaulting to your
+  fork; also the **Switch to fork / upstream view** palette commands) points the remote
+  PR list — and every PR you open under it: description, comments, reviews, and metadata —
+  at your fork or the **parent** repository. Opening a PR targets a repository explicitly,
+  offering your fork or the upstream repo on a fork.
 
 A Write/Preview markdown editor (formatting toolbar + live preview) is everywhere you author.
 
@@ -418,7 +424,10 @@ and edit (drafting with AI from your repo's issue templates), react with emoji,
 and manage the full metadata: labels, assignees, milestones, issue type,
 sub-issues, dependencies (blocked-by / blocking), and development links (linked
 and closing PRs and branches, plus create-a-branch). Duplicate, transfer,
-pin/unpin, lock/unlock, or delete.
+pin/unpin, lock/unlock, or delete. On a **fork**, the same **Fork | Upstream**
+lens as the PR tab browses the parent repository's issues (and creating one under
+the Upstream lens opens it **on the parent**); a fork with issues turned off
+offers a one-click switch to Upstream instead of a dead end.
 
 ![An issue open in GitDesktop with its description, labels, assignees, milestone, sub-issues, and a linked development branch and pull request; local and GitHub issues appear together in the sidebar.](site/src/assets/app-issues.png)
 

--- a/changelog.d/added-fork-upstream-lens.md
+++ b/changelog.d/added-fork-upstream-lens.md
@@ -1,0 +1,11 @@
+- **Fork · Upstream lens for GitHub forks.** On a fork (a repo with an
+  `upstream` remote), the **Pull Requests** and **Issues** tabs gain a
+  **Fork | Upstream** switcher in the list toolbar — remembered per repo,
+  defaulting to your fork. Switch to **Upstream** and the remote list, detail
+  views, comments, reactions, and metadata pickers all read and write the
+  **parent** repository (your local to-dos and Jira issues are untouched).
+  Creating an issue under the Upstream lens opens it **on the parent**, with the
+  dialog saying so plainly. Two palette commands, **Switch to fork view** and
+  **Switch to upstream view**, flip the lens without the mouse. A fork with
+  issues turned off now offers a one-click **Switch to upstream** to browse the
+  parent's issues instead of a dead end.

--- a/changelog.d/changed-pr-create-explicit-target.md
+++ b/changelog.d/changed-pr-create-explicit-target.md
@@ -1,0 +1,6 @@
+- Opening a pull request now targets a repository explicitly. On a **fork** the
+  create dialog lets you choose where the PR lands — your **fork** or the
+  **upstream** repository (defaulting to upstream), listing the chosen
+  repository's base branches; previously the target was left to `gh`'s implicit
+  resolution. Labels and assignees aren't available when you open the PR on the
+  upstream repository.

--- a/changelog.d/changed-pr-create-explicit-target.md
+++ b/changelog.d/changed-pr-create-explicit-target.md
@@ -3,4 +3,5 @@
   **upstream** repository (defaulting to upstream), listing the chosen
   repository's base branches; previously the target was left to `gh`'s implicit
   resolution. Labels and assignees aren't available when you open the PR on the
-  upstream repository.
+  upstream repository. Targeting the upstream repository requires an `upstream`
+  remote; on a fork cloned without one, the create dialog now offers to add it.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -75,6 +75,7 @@ export const capabilities: Capability[] = [
   { group: "Pull requests & review", label: "Drill into a PR's commits — per-file diffs, whole-commit & line comments" },
   { group: "Pull requests & review", label: "PR activity feed — reviews, comments, grouped commits, stale-approval marks" },
   { group: "Pull requests & review", label: "Comment on commits from History — whole-commit or line-anchored" },
+  { group: "Pull requests & review", label: "Fork · Upstream lens — browse & work a fork's PRs and issues or the parent's" },
 
   // — Forges & trackers —
   { group: "Forges & trackers", label: "GitHub, GitLab & Bitbucket — first-class, each on its own identity", highlight: true },

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -85,8 +85,9 @@ pub async fn list_prs(
     repo_path: &str,
     state: &str,
     limit: Option<u32>,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::PrInfo>> {
-    crate::github::pr::gh_pr_list(repo_path.to_string(), state.to_string(), limit).await
+    crate::github::pr::gh_pr_list(repo_path.to_string(), state.to_string(), limit, lens).await
 }
 
 pub async fn list_ci(
@@ -99,19 +100,24 @@ pub async fn list_ci(
     crate::github::pr::gh_pr_list_ci(repo_path, numbers, sample_url).await
 }
 
-pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<crate::github::pr::PrDetails> {
-    crate::github::pr::gh_pr_view(repo_path.to_string(), number).await
+pub async fn view_pr(
+    repo_path: &str,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<crate::github::pr::PrDetails> {
+    crate::github::pr::gh_pr_view(repo_path.to_string(), number, lens).await
 }
 
 pub async fn pr_timeline(
     repo_path: &str,
     number: u64,
+    lens: Option<&str>,
 ) -> AppResult<Vec<crate::github::pr::PrTimelineEventOut>> {
-    crate::github::pr::pr_timeline(repo_path, number).await
+    crate::github::pr::pr_timeline(repo_path, number, lens).await
 }
 
-pub async fn diff_pr(repo_path: &str, number: u64) -> AppResult<String> {
-    crate::github::pr::gh_pr_diff(repo_path.to_string(), number).await
+pub async fn diff_pr(repo_path: &str, number: u64, lens: Option<String>) -> AppResult<String> {
+    crate::github::pr::gh_pr_diff(repo_path.to_string(), number, lens).await
 }
 
 pub async fn commit_diff(repo_path: &str, oid: &str) -> AppResult<String> {
@@ -121,8 +127,9 @@ pub async fn commit_diff(repo_path: &str, oid: &str) -> AppResult<String> {
 pub async fn commit_comments(
     repo_path: &str,
     sha: &str,
+    lens: Option<&str>,
 ) -> AppResult<Vec<crate::github::pr::CommitCommentOut>> {
-    crate::github::pr::commit_comments(repo_path, sha).await
+    crate::github::pr::commit_comments(repo_path, sha, lens).await
 }
 
 /// Create a commit comment. GitHub anchored comments use `path` + `position`; `line`
@@ -133,8 +140,9 @@ pub async fn commit_comment_create(
     body: &str,
     path: Option<&str>,
     position: Option<u64>,
+    lens: Option<&str>,
 ) -> AppResult<()> {
-    crate::github::pr::commit_comment_create(repo_path, sha, body, path, position).await
+    crate::github::pr::commit_comment_create(repo_path, sha, body, path, position, lens).await
 }
 
 pub async fn commit_comment_edit(repo_path: &str, comment_id: &str, body: &str) -> AppResult<()> {
@@ -154,8 +162,10 @@ pub async fn thread_create(
     side: &str,
     start_line: Option<u64>,
     body: &str,
+    lens: Option<&str>,
 ) -> AppResult<()> {
-    crate::github::pr::thread_create(repo_path, number, path, line, side, start_line, body).await
+    crate::github::pr::thread_create(repo_path, number, path, line, side, start_line, body, lens)
+        .await
 }
 
 pub async fn review_submit(
@@ -164,22 +174,25 @@ pub async fn review_submit(
     verdict: &str,
     summary: Option<&str>,
     comments: &[crate::github::pr::DraftCommentIn],
+    lens: Option<&str>,
 ) -> AppResult<crate::github::pr::ReviewSubmitOut> {
-    crate::github::pr::review_submit(repo_path, number, verdict, summary, comments).await
+    crate::github::pr::review_submit(repo_path, number, verdict, summary, comments, lens).await
 }
 
 pub async fn external_reviews(
     repo_path: &str,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::ExternalReviewItem>> {
-    crate::github::pr::gh_pr_external_reviews(repo_path.to_string(), number).await
+    crate::github::pr::gh_pr_external_reviews(repo_path.to_string(), number, lens).await
 }
 
 pub async fn review_threads(
     repo_path: &str,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::ReviewThreadOut>> {
-    crate::github::pr::gh_pr_review_threads(repo_path.to_string(), number).await
+    crate::github::pr::gh_pr_review_threads(repo_path.to_string(), number, lens).await
 }
 
 pub async fn reply_thread(repo_path: &str, thread_id: &str, body: &str) -> AppResult<()> {
@@ -211,12 +224,19 @@ pub async fn poll_prs(repo_path: &str) -> AppResult<Vec<crate::github::pr::PrPol
 // `gh_pr_merge` inside `forge_pr_merge` (no delegate here); full reviews stay
 // GitHub-only and aren't fronted.
 
-pub async fn edit_pr(repo_path: &str, number: u64, title: &str, body: &str) -> AppResult<()> {
+pub async fn edit_pr(
+    repo_path: &str,
+    number: u64,
+    title: &str,
+    body: &str,
+    lens: Option<String>,
+) -> AppResult<()> {
     crate::github::pr::gh_pr_edit(
         repo_path.to_string(),
         number,
         title.to_string(),
         body.to_string(),
+        lens,
     )
     .await
 }
@@ -224,12 +244,18 @@ pub async fn edit_pr(repo_path: &str, number: u64, title: &str, body: &str) -> A
 pub async fn prs_for_branch(
     repo_path: &str,
     head: &str,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::PrInfo>> {
-    crate::github::pr::gh_prs_for_branch(repo_path.to_string(), head.to_string()).await
+    crate::github::pr::gh_prs_for_branch(repo_path.to_string(), head.to_string(), lens).await
 }
 
-pub async fn comment_pr(repo_path: &str, number: u64, body: &str) -> AppResult<()> {
-    crate::github::pr::gh_pr_comment(repo_path.to_string(), number, body.to_string()).await
+pub async fn comment_pr(
+    repo_path: &str,
+    number: u64,
+    body: &str,
+    lens: Option<String>,
+) -> AppResult<()> {
+    crate::github::pr::gh_pr_comment(repo_path.to_string(), number, body.to_string(), lens).await
 }
 
 /// Edit a conversation comment's body. GitHub's `updateIssueComment` mutation
@@ -256,12 +282,12 @@ pub async fn delete_review_comment(repo_path: &str, comment_id: &str) -> AppResu
     crate::github::pr::delete_review_comment(repo_path, comment_id).await
 }
 
-pub async fn close_pr(repo_path: &str, number: u64) -> AppResult<()> {
-    crate::github::pr::gh_pr_close(repo_path.to_string(), number).await
+pub async fn close_pr(repo_path: &str, number: u64, lens: Option<String>) -> AppResult<()> {
+    crate::github::pr::gh_pr_close(repo_path.to_string(), number, lens).await
 }
 
-pub async fn reopen_pr(repo_path: &str, number: u64) -> AppResult<()> {
-    crate::github::pr::gh_pr_reopen(repo_path.to_string(), number).await
+pub async fn reopen_pr(repo_path: &str, number: u64, lens: Option<String>) -> AppResult<()> {
+    crate::github::pr::gh_pr_reopen(repo_path.to_string(), number, lens).await
 }
 
 // ── Issues (read) ────────────────────────────────────────────────────────────
@@ -272,15 +298,17 @@ pub async fn list_issues(
     repo_path: &str,
     state: &str,
     limit: Option<u32>,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::issue::IssueInfo>> {
-    crate::github::issue::gh_issue_list(repo_path.to_string(), state.to_string(), limit).await
+    crate::github::issue::gh_issue_list(repo_path.to_string(), state.to_string(), limit, lens).await
 }
 
 pub async fn view_issue(
     repo_path: &str,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueDetails> {
-    crate::github::issue::gh_issue_view(repo_path.to_string(), number).await
+    crate::github::issue::gh_issue_view(repo_path.to_string(), number, lens).await
 }
 
 // ── CI / Actions ─────────────────────────────────────────────────────────────
@@ -425,43 +453,77 @@ pub async fn delete_release_asset(repo_path: &str, tag: &str, asset_name: &str) 
 // remainder of the issue write surface (pin, sub-issues, close reason, …) stays
 // GitHub-only.
 
-pub async fn comment_issue(repo_path: &str, number: u64, body: &str) -> AppResult<()> {
-    crate::github::issue::gh_issue_comment(repo_path.to_string(), number, body.to_string()).await
+pub async fn comment_issue(
+    repo_path: &str,
+    number: u64,
+    body: &str,
+    lens: Option<String>,
+) -> AppResult<()> {
+    crate::github::issue::gh_issue_comment(repo_path.to_string(), number, body.to_string(), lens)
+        .await
 }
 
-pub async fn close_issue(repo_path: &str, number: u64, reason: &str) -> AppResult<()> {
-    crate::github::issue::gh_issue_close(repo_path.to_string(), number, reason.to_string()).await
+pub async fn close_issue(
+    repo_path: &str,
+    number: u64,
+    reason: &str,
+    lens: Option<String>,
+) -> AppResult<()> {
+    crate::github::issue::gh_issue_close(repo_path.to_string(), number, reason.to_string(), lens)
+        .await
 }
 
-pub async fn reopen_issue(repo_path: &str, number: u64) -> AppResult<()> {
-    crate::github::issue::gh_issue_reopen(repo_path.to_string(), number).await
+pub async fn reopen_issue(repo_path: &str, number: u64, lens: Option<String>) -> AppResult<()> {
+    crate::github::issue::gh_issue_reopen(repo_path.to_string(), number, lens).await
 }
 
-pub async fn edit_issue(repo_path: &str, number: u64, title: &str, body: &str) -> AppResult<()> {
+pub async fn edit_issue(
+    repo_path: &str,
+    number: u64,
+    title: &str,
+    body: &str,
+    lens: Option<String>,
+) -> AppResult<()> {
     crate::github::issue::gh_issue_edit(
         repo_path.to_string(),
         number,
         title.to_string(),
         body.to_string(),
+        lens,
     )
     .await
 }
 
-pub async fn lock_issue(repo_path: &str, number: u64, reason: Option<String>) -> AppResult<()> {
-    crate::github::issue::gh_issue_lock(repo_path.to_string(), number, reason).await
+pub async fn lock_issue(
+    repo_path: &str,
+    number: u64,
+    reason: Option<String>,
+    lens: Option<String>,
+) -> AppResult<()> {
+    crate::github::issue::gh_issue_lock(repo_path.to_string(), number, reason, lens).await
 }
 
-pub async fn unlock_issue(repo_path: &str, number: u64) -> AppResult<()> {
-    crate::github::issue::gh_issue_unlock(repo_path.to_string(), number).await
+pub async fn unlock_issue(repo_path: &str, number: u64, lens: Option<String>) -> AppResult<()> {
+    crate::github::issue::gh_issue_unlock(repo_path.to_string(), number, lens).await
 }
 
-pub async fn transfer_issue(repo_path: &str, number: u64, destination: &str) -> AppResult<String> {
-    crate::github::issue::gh_issue_transfer(repo_path.to_string(), number, destination.to_string())
-        .await
+pub async fn transfer_issue(
+    repo_path: &str,
+    number: u64,
+    destination: &str,
+    lens: Option<String>,
+) -> AppResult<String> {
+    crate::github::issue::gh_issue_transfer(
+        repo_path.to_string(),
+        number,
+        destination.to_string(),
+        lens,
+    )
+    .await
 }
 
-pub async fn delete_issue(repo_path: &str, number: u64) -> AppResult<()> {
-    crate::github::issue::gh_issue_delete(repo_path.to_string(), number).await
+pub async fn delete_issue(repo_path: &str, number: u64, lens: Option<String>) -> AppResult<()> {
+    crate::github::issue::gh_issue_delete(repo_path.to_string(), number, lens).await
 }
 
 // ── Milestones (read + write) ──────────────────────────────────────────────────
@@ -470,8 +532,11 @@ pub async fn delete_issue(repo_path: &str, number: u64) -> AppResult<()> {
 // write. GitHub keys on the milestone number; the GitLab impl keys on its global
 // milestone id — both travel as the neutral `Milestone.number`.
 
-pub async fn milestones(repo_path: &str) -> AppResult<Vec<crate::github::issue::Milestone>> {
-    crate::github::issue::gh_milestones(repo_path.to_string()).await
+pub async fn milestones(
+    repo_path: &str,
+    lens: Option<String>,
+) -> AppResult<Vec<crate::github::issue::Milestone>> {
+    crate::github::issue::gh_milestones(repo_path.to_string(), lens).await
 }
 
 // ── Repository actions & publish ───────────────────────────────────────────────
@@ -525,15 +590,17 @@ pub async fn publish_repo(
 pub async fn issue_reactions(
     repo_path: &str,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueReactions> {
-    crate::github::issue::gh_issue_reactions(repo_path.to_string(), number).await
+    crate::github::issue::gh_issue_reactions(repo_path.to_string(), number, lens).await
 }
 
 pub async fn pr_reactions(
     repo_path: &str,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueReactions> {
-    crate::github::pr::gh_pr_reactions(repo_path.to_string(), number).await
+    crate::github::pr::gh_pr_reactions(repo_path.to_string(), number, lens).await
 }
 
 pub async fn add_reaction(repo_path: &str, subject_id: &str, content: &str) -> AppResult<()> {
@@ -558,8 +625,10 @@ pub async fn set_issue_milestone(
     repo_path: &str,
     number: u64,
     milestone: Option<u64>,
+    lens: Option<String>,
 ) -> AppResult<()> {
-    crate::github::issue::gh_issue_set_milestone(repo_path.to_string(), number, milestone).await
+    crate::github::issue::gh_issue_set_milestone(repo_path.to_string(), number, milestone, lens)
+        .await
 }
 
 // ── Labels & assignees (read + write) ─────────────────────────────────────────
@@ -569,17 +638,21 @@ pub async fn set_issue_milestone(
 // assignees are a shared issue control. GitHub is byte-identical to calling the
 // `gh_*` commands directly — the abstraction only adds the dispatch seam.
 
-pub async fn repo_labels(repo_path: &str) -> AppResult<Vec<crate::github::pr::RepoLabel>> {
-    crate::github::pr::gh_repo_labels(repo_path.to_string()).await
+pub async fn repo_labels(
+    repo_path: &str,
+    lens: Option<String>,
+) -> AppResult<Vec<crate::github::pr::RepoLabel>> {
+    crate::github::pr::gh_repo_labels(repo_path.to_string(), lens).await
 }
 
 pub async fn assignable_users(
     repo_path: &str,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::forge::model::ForgeUserRef>> {
     // GitHub carries no avatar in the assignees endpoint; the picker derives it
     // from the login (id), so leave `avatar_url` empty and let the frontend fill it.
     Ok(
-        crate::github::issue::gh_assignable_users(repo_path.to_string())
+        crate::github::issue::gh_assignable_users(repo_path.to_string(), lens)
             .await?
             .into_iter()
             .map(|l| crate::forge::model::ForgeUserRef {
@@ -592,15 +665,21 @@ pub async fn assignable_users(
     )
 }
 
-pub async fn set_pr_reviewers(repo_path: &str, number: u64, reviewers: &[String]) -> AppResult<()> {
-    crate::github::pr::set_pr_reviewers(repo_path, number, reviewers).await
+pub async fn set_pr_reviewers(
+    repo_path: &str,
+    number: u64,
+    reviewers: &[String],
+    lens: Option<&str>,
+) -> AppResult<()> {
+    crate::github::pr::set_pr_reviewers(repo_path, number, reviewers, lens).await
 }
 
 pub async fn reviewer_candidates(
     repo_path: &str,
     number: Option<u64>,
+    lens: Option<&str>,
 ) -> AppResult<Vec<crate::forge::model::ForgeUserRef>> {
-    crate::github::pr::reviewer_candidates(repo_path, number).await
+    crate::github::pr::reviewer_candidates(repo_path, number, lens).await
 }
 
 pub async fn edit_labels(
@@ -622,14 +701,17 @@ pub async fn set_issue_assignees(
     repo_path: &str,
     number: u64,
     assignees: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
-    crate::github::issue::gh_issue_set_assignees(repo_path.to_string(), number, assignees).await
+    crate::github::issue::gh_issue_set_assignees(repo_path.to_string(), number, assignees, lens)
+        .await
 }
 
 /// Create an issue — delegates to the gh-backed REST create with the full GitHub
 /// field set (labels/assignees/milestone/org issue type). (PR create has no delegate
 /// here: `forge_pr_create`'s GitHub arm calls `gh_pr_create_core` directly, since the
 /// push needs an `AppState`, like `forge_pr_merge`.)
+#[allow(clippy::too_many_arguments)]
 pub async fn create_issue(
     repo_path: &str,
     title: &str,
@@ -638,6 +720,7 @@ pub async fn create_issue(
     assignees: Vec<String>,
     milestone: Option<u64>,
     issue_type: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::PrRef> {
     crate::github::issue::gh_issue_create(
         repo_path.to_string(),
@@ -647,6 +730,7 @@ pub async fn create_issue(
         assignees,
         milestone,
         issue_type,
+        lens,
     )
     .await
 }

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -646,16 +646,25 @@ pub async fn forge_clone(
 /// delegates to the existing `gh pr list`; GitLab maps `glab` merge requests onto
 /// the same neutral [`PrInfo`] shape. `state` is `"open"` or `"closed"` (closed
 /// includes merged, matching the GitHub panel's Closed tab).
+///
+/// `lens` (the fork-identity Part B primitive — `None`/`Some("origin")`/
+/// `Some("upstream")`) is threaded to the GitHub arm ONLY: it selects whether a
+/// fork addresses its own PRs (origin) or the parent's (upstream). The GitLab and
+/// Bitbucket arms deliberately do NOT receive the lens — their behavior is
+/// byte-identical to today, and the frontend gates the lens UI to GitHub, so a
+/// stray upstream lens on GitLab/Bitbucket simply reads as origin (acceptable v1).
+/// This note stands for every `forge_*` PR/issue dispatcher below.
 #[tauri::command]
 pub async fn forge_pr_list(
     repo_path: String,
     state: String,
     limit: Option<u32>,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::PrInfo>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::list_prs(&repo_path, &state, limit).await,
         Some((Provider::Bitbucket, _)) => bitbucket::list_prs(&repo_path, &state, limit).await,
-        _ => github::list_prs(&repo_path, &state, limit).await,
+        _ => github::list_prs(&repo_path, &state, limit, lens).await,
     }
 }
 
@@ -703,17 +712,37 @@ pub async fn forge_pr_poll(repo_path: String) -> AppResult<Vec<crate::github::pr
     }
 }
 
+/// The upstream lens is a GitHub-only fork affordance (Part B). Reject it before a
+/// GitLab/Bitbucket dispatch so a stray upstream value can't be silently treated as
+/// origin on those providers (the frontend gates the lens UI to GitHub anyway).
+fn reject_upstream_on_non_github(lens: Option<&str>) -> AppResult<()> {
+    if lens == Some("upstream") {
+        return Err(AppError::InvalidArgument(
+            "Creating a pull request on the upstream repository is currently supported for GitHub only.".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Open merge/pull requests whose head is `head`, behind the abstraction — the
 /// ComparePanel duplicate probe ("View" instead of "Create" once one exists).
+/// `lens` is GitHub-only (see `forge_pr_list`).
 #[tauri::command]
 pub async fn forge_prs_for_branch(
     repo_path: String,
     head: String,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::PrInfo>> {
     match detect_non_github(&repo_path).await {
-        Some((Provider::GitLab, _)) => gitlab::prs_for_branch(&repo_path, &head).await,
-        Some((Provider::Bitbucket, _)) => bitbucket::prs_for_branch(&repo_path, &head).await,
-        _ => github::prs_for_branch(&repo_path, &head).await,
+        Some((Provider::GitLab, _)) => {
+            reject_upstream_on_non_github(lens.as_deref())?;
+            gitlab::prs_for_branch(&repo_path, &head).await
+        }
+        Some((Provider::Bitbucket, _)) => {
+            reject_upstream_on_non_github(lens.as_deref())?;
+            bitbucket::prs_for_branch(&repo_path, &head).await
+        }
+        _ => github::prs_for_branch(&repo_path, &head, lens).await,
     }
 }
 
@@ -722,11 +751,12 @@ pub async fn forge_prs_for_branch(
 pub async fn forge_pr_view(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::PrDetails> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::view_pr(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::view_pr(&repo_path, number).await,
-        _ => github::view_pr(&repo_path, number).await,
+        _ => github::view_pr(&repo_path, number, lens).await,
     }
 }
 
@@ -739,21 +769,26 @@ pub async fn forge_pr_view(
 pub async fn forge_pr_timeline(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::PrTimelineEventOut>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::mr_timeline(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::pr_activity(&repo_path, number).await,
-        _ => github::pr_timeline(&repo_path, number).await,
+        _ => github::pr_timeline(&repo_path, number, lens.as_deref()).await,
     }
 }
 
 /// The unified diff for one merge/pull request, behind the abstraction.
 #[tauri::command]
-pub async fn forge_pr_diff(repo_path: String, number: u64) -> AppResult<String> {
+pub async fn forge_pr_diff(
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<String> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::diff_pr(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::diff_pr(&repo_path, number).await,
-        _ => github::diff_pr(&repo_path, number).await,
+        _ => github::diff_pr(&repo_path, number, lens).await,
     }
 }
 
@@ -769,6 +804,9 @@ pub async fn forge_pr_commit_diff(
     // `number` is part of the neutral contract (the diff is scoped to a PR in the
     // UI), but every provider addresses the commit by sha alone.
     let _ = number;
+    // No lens param here (Part B): the commit is sha-addressed, and GitHub's
+    // fork-network storage serves any network SHA via the fork's own endpoint, so an
+    // origin/upstream distinction would make no difference to what's returned.
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::commit_diff(&repo_path, &oid).await,
         Some((Provider::Bitbucket, _)) => bitbucket::commit_diff(&repo_path, &oid).await,
@@ -783,11 +821,12 @@ pub async fn forge_pr_commit_diff(
 pub async fn forge_commit_comments(
     repo_path: String,
     sha: String,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::CommitCommentOut>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::commit_comments(&repo_path, &sha).await,
         Some((Provider::Bitbucket, _)) => bitbucket::commit_comments(&repo_path, &sha).await,
-        _ => github::commit_comments(&repo_path, &sha).await,
+        _ => github::commit_comments(&repo_path, &sha, lens.as_deref()).await,
     }
 }
 
@@ -807,6 +846,7 @@ pub async fn forge_commit_comment_create(
     line: Option<u64>,
     start_line: Option<u64>,
     position: Option<u64>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -824,7 +864,15 @@ pub async fn forge_commit_comment_create(
             bitbucket::commit_comment_create(&repo_path, &sha, &body, path.as_deref(), line).await
         }
         _ => {
-            github::commit_comment_create(&repo_path, &sha, &body, path.as_deref(), position).await
+            github::commit_comment_create(
+                &repo_path,
+                &sha,
+                &body,
+                path.as_deref(),
+                position,
+                lens.as_deref(),
+            )
+            .await
         }
     }
 }
@@ -880,13 +928,14 @@ pub async fn forge_commit_comment_delete(
 pub async fn forge_pr_external_reviews(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::ExternalReviewItem>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::external_reviews(&repo_path, number).await,
         // By design: no bot-review ecosystem posts on Bitbucket PRs. Cheap,
         // permanent no-network empty — nothing to map.
         Some((Provider::Bitbucket, _)) => Ok(Vec::new()),
-        _ => github::external_reviews(&repo_path, number).await,
+        _ => github::external_reviews(&repo_path, number, lens).await,
     }
 }
 
@@ -898,11 +947,12 @@ pub async fn forge_pr_external_reviews(
 pub async fn forge_pr_review_threads(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::ReviewThreadOut>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::review_threads(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::review_threads(&repo_path, number).await,
-        _ => github::review_threads(&repo_path, number).await,
+        _ => github::review_threads(&repo_path, number, lens).await,
     }
 }
 
@@ -941,6 +991,7 @@ pub async fn forge_pr_thread_create(
     side: String,
     start_line: Option<u64>,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -949,7 +1000,19 @@ pub async fn forge_pr_thread_create(
         Some((Provider::Bitbucket, _)) => {
             bitbucket::thread_create(&repo_path, number, &path, line, &side, start_line, &body).await
         }
-        _ => github::thread_create(&repo_path, number, &path, line, &side, start_line, &body).await,
+        _ => {
+            github::thread_create(
+                &repo_path,
+                number,
+                &path,
+                line,
+                &side,
+                start_line,
+                &body,
+                lens.as_deref(),
+            )
+            .await
+        }
     }
 }
 
@@ -965,6 +1028,7 @@ pub async fn forge_pr_review_submit(
     verdict: String,
     summary: Option<String>,
     comments: Vec<crate::github::pr::DraftCommentIn>,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::ReviewSubmitOut> {
     // Pre-mutation guards: verdict validity, and request_changes needs a summary.
     if !matches!(verdict.as_str(), "comment" | "approve" | "request_changes") {
@@ -985,7 +1049,10 @@ pub async fn forge_pr_review_submit(
         Some((Provider::Bitbucket, _)) => {
             bitbucket::review_submit(&repo_path, number, &verdict, summary, &comments).await
         }
-        _ => github::review_submit(&repo_path, number, &verdict, summary, &comments).await,
+        _ => {
+            github::review_submit(&repo_path, number, &verdict, summary, &comments, lens.as_deref())
+                .await
+        }
     }
 }
 
@@ -1022,13 +1089,14 @@ pub async fn forge_pr_comment(
     number: u64,
     body: String,
     as_bot: Option<bool>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
             gitlab::comment_mr(&repo_path, number, &body, as_bot.unwrap_or(false)).await
         }
         Some((Provider::Bitbucket, _)) => bitbucket::comment_pr(&repo_path, number, &body).await,
-        _ => github::comment_pr(&repo_path, number, &body).await,
+        _ => github::comment_pr(&repo_path, number, &body, lens).await,
     }
 }
 
@@ -1143,17 +1211,17 @@ pub async fn forge_pr_delete_review_comment(
 
 /// Close a merge/pull request (not merge), behind the abstraction.
 #[tauri::command]
-pub async fn forge_pr_close(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn forge_pr_close(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::close_mr(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::decline_pr(&repo_path, number).await,
-        _ => github::close_pr(&repo_path, number).await,
+        _ => github::close_pr(&repo_path, number, lens).await,
     }
 }
 
 /// Reopen a closed (not merged) merge/pull request, behind the abstraction.
 #[tauri::command]
-pub async fn forge_pr_reopen(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn forge_pr_reopen(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::reopen_mr(&repo_path, number).await,
         // A declined Bitbucket PR can't be reopened via API or web (BCLOUD-4954). The
@@ -1161,7 +1229,7 @@ pub async fn forge_pr_reopen(repo_path: String, number: u64) -> AppResult<()> {
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket declined pull requests can't be reopened.".into(),
         )),
-        _ => github::reopen_pr(&repo_path, number).await,
+        _ => github::reopen_pr(&repo_path, number, lens).await,
     }
 }
 
@@ -1176,6 +1244,7 @@ pub async fn forge_pr_request_changes(
     repo_path: String,
     number: u64,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -1184,8 +1253,14 @@ pub async fn forge_pr_request_changes(
         Some((Provider::Bitbucket, _)) => {
             bitbucket::request_changes_pr(&repo_path, number, &body).await
         }
-        _ => crate::github::pr::gh_pr_review(repo_path, number, "request_changes".to_string(), body)
-            .await,
+        _ => crate::github::pr::gh_pr_review(
+            repo_path,
+            number,
+            "request_changes".to_string(),
+            body,
+            lens,
+        )
+        .await,
     }
 }
 
@@ -1233,6 +1308,7 @@ pub async fn forge_pr_set_reviewers(
     repo_path: String,
     number: u64,
     reviewers: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::Bitbucket, _)) => {
@@ -1241,7 +1317,7 @@ pub async fn forge_pr_set_reviewers(
         Some((Provider::GitLab, _)) => {
             gitlab::set_pr_reviewers(&repo_path, number, &reviewers).await
         }
-        _ => github::set_pr_reviewers(&repo_path, number, &reviewers).await,
+        _ => github::set_pr_reviewers(&repo_path, number, &reviewers, lens.as_deref()).await,
     }
 }
 
@@ -1254,13 +1330,14 @@ pub async fn forge_pr_set_reviewers(
 pub async fn forge_pr_reviewer_candidates(
     repo_path: String,
     number: Option<u64>,
+    lens: Option<String>,
 ) -> AppResult<Vec<model::ForgeUserRef>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::Bitbucket, _)) => {
             bitbucket::reviewer_candidates(&repo_path, number).await
         }
         Some((Provider::GitLab, _)) => gitlab::reviewer_candidates(&repo_path, number).await,
-        _ => github::reviewer_candidates(&repo_path, number).await,
+        _ => github::reviewer_candidates(&repo_path, number, lens.as_deref()).await,
     }
 }
 
@@ -1272,13 +1349,14 @@ pub async fn forge_pr_edit(
     number: u64,
     title: String,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::edit_mr(&repo_path, number, &title, &body).await,
         Some((Provider::Bitbucket, _)) => {
             bitbucket::edit_pr(&repo_path, number, &title, &body).await
         }
-        _ => github::edit_pr(&repo_path, number, &title, &body).await,
+        _ => github::edit_pr(&repo_path, number, &title, &body, lens).await,
     }
 }
 
@@ -1307,12 +1385,18 @@ pub async fn forge_pr_approvals(
 /// (false for GitHub, which uses its native review flow there); this arm serves
 /// the MCP `approve_pull_request` tool.
 #[tauri::command]
-pub async fn forge_pr_approve(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn forge_pr_approve(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::approve_pr(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::approve_pr(&repo_path, number).await,
-        _ => crate::github::pr::gh_pr_review(repo_path, number, "approve".to_string(), String::new())
-            .await,
+        _ => crate::github::pr::gh_pr_review(
+            repo_path,
+            number,
+            "approve".to_string(),
+            String::new(),
+            lens,
+        )
+        .await,
     }
 }
 
@@ -1348,6 +1432,7 @@ pub async fn forge_pr_merge(
     strategy: String,
     delete_branch: bool,
     sha: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::PrMergeOutcome> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::merge_mr(
@@ -1363,7 +1448,7 @@ pub async fn forge_pr_merge(
         Some((Provider::Bitbucket, _)) => bitbucket::merge_pr(&repo_path, number, &strategy, delete_branch)
             .await
             .map(|()| crate::github::pr::PrMergeOutcome::default()),
-        _ => crate::github::pr::gh_pr_merge(repo_path, number, strategy, delete_branch).await,
+        _ => crate::github::pr::gh_pr_merge(repo_path, number, strategy, delete_branch, lens).await,
     }
 }
 
@@ -1376,13 +1461,14 @@ pub async fn forge_issue_list(
     repo_path: String,
     state: String,
     limit: Option<u32>,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::issue::IssueInfo>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::list_issues(&repo_path, &state, limit).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::list_issues(&repo_path, &state, limit).await,
+        _ => github::list_issues(&repo_path, &state, limit, lens).await,
     }
 }
 
@@ -1391,13 +1477,14 @@ pub async fn forge_issue_list(
 pub async fn forge_issue_view(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueDetails> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::view_issue(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::view_issue(&repo_path, number).await,
+        _ => github::view_issue(&repo_path, number, lens).await,
     }
 }
 
@@ -1644,13 +1731,18 @@ pub async fn forge_release_delete_asset(
 /// Post a comment on an issue, behind the provider abstraction — the first GitLab
 /// WRITE. GitHub delegates to `gh issue comment`; GitLab posts a note via `glab`.
 #[tauri::command]
-pub async fn forge_issue_comment(repo_path: String, number: u64, body: String) -> AppResult<()> {
+pub async fn forge_issue_comment(
+    repo_path: String,
+    number: u64,
+    body: String,
+    lens: Option<String>,
+) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::comment_issue(&repo_path, number, &body).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::comment_issue(&repo_path, number, &body).await,
+        _ => github::comment_issue(&repo_path, number, &body, lens).await,
     }
 }
 
@@ -1698,25 +1790,30 @@ pub async fn forge_issue_delete_comment(
 /// Close an issue, behind the abstraction. `reason` is GitHub's close reason
 /// (`completed`/`not_planned`); GitLab has no close reason and ignores it.
 #[tauri::command]
-pub async fn forge_issue_close(repo_path: String, number: u64, reason: String) -> AppResult<()> {
+pub async fn forge_issue_close(
+    repo_path: String,
+    number: u64,
+    reason: String,
+    lens: Option<String>,
+) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::close_issue(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::close_issue(&repo_path, number, &reason).await,
+        _ => github::close_issue(&repo_path, number, &reason, lens).await,
     }
 }
 
 /// Reopen a closed issue, behind the abstraction.
 #[tauri::command]
-pub async fn forge_issue_reopen(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn forge_issue_reopen(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::reopen_issue(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::reopen_issue(&repo_path, number).await,
+        _ => github::reopen_issue(&repo_path, number, lens).await,
     }
 }
 
@@ -1728,13 +1825,14 @@ pub async fn forge_issue_edit(
     number: u64,
     title: String,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::edit_issue(&repo_path, number, &title, &body).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::edit_issue(&repo_path, number, &title, &body).await,
+        _ => github::edit_issue(&repo_path, number, &title, &body, lens).await,
     }
 }
 
@@ -1747,25 +1845,26 @@ pub async fn forge_issue_lock(
     repo_path: String,
     number: u64,
     reason: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::lock_issue(&repo_path, number, true).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::lock_issue(&repo_path, number, reason).await,
+        _ => github::lock_issue(&repo_path, number, reason, lens).await,
     }
 }
 
 /// Unlock an issue's conversation, behind the abstraction.
 #[tauri::command]
-pub async fn forge_issue_unlock(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn forge_issue_unlock(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::lock_issue(&repo_path, number, false).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::unlock_issue(&repo_path, number).await,
+        _ => github::unlock_issue(&repo_path, number, lens).await,
     }
 }
 
@@ -1777,13 +1876,14 @@ pub async fn forge_issue_transfer(
     repo_path: String,
     number: u64,
     destination: String,
+    lens: Option<String>,
 ) -> AppResult<String> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::move_issue(&repo_path, number, &destination).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::transfer_issue(&repo_path, number, &destination).await,
+        _ => github::transfer_issue(&repo_path, number, &destination, lens).await,
     }
 }
 
@@ -1791,13 +1891,13 @@ pub async fn forge_issue_transfer(
 /// this server-side (GitHub: admin/triage; GitLab: owner) — their errors
 /// surface as-is.
 #[tauri::command]
-pub async fn forge_issue_delete(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn forge_issue_delete(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::delete_issue(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::delete_issue(&repo_path, number).await,
+        _ => github::delete_issue(&repo_path, number, lens).await,
     }
 }
 
@@ -1807,13 +1907,14 @@ pub async fn forge_issue_delete(repo_path: String, number: u64) -> AppResult<()>
 #[tauri::command]
 pub async fn forge_milestones(
     repo_path: String,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::issue::Milestone>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::list_milestones(&repo_path).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket milestones aren't supported yet.".into(),
         )),
-        _ => github::milestones(&repo_path).await,
+        _ => github::milestones(&repo_path, lens).await,
     }
 }
 
@@ -1824,13 +1925,14 @@ pub async fn forge_milestones(
 pub async fn forge_issue_reactions(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueReactions> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::issue_reactions(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::issue_reactions(&repo_path, number).await,
+        _ => github::issue_reactions(&repo_path, number, lens).await,
     }
 }
 
@@ -1839,13 +1941,14 @@ pub async fn forge_issue_reactions(
 pub async fn forge_pr_reactions(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueReactions> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::mr_reactions(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket merge requests aren't supported yet.".into(),
         )),
-        _ => github::pr_reactions(&repo_path, number).await,
+        _ => github::pr_reactions(&repo_path, number, lens).await,
     }
 }
 
@@ -1905,6 +2008,7 @@ pub async fn forge_issue_set_milestone(
     repo_path: String,
     number: u64,
     milestone: Option<u64>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -1913,7 +2017,7 @@ pub async fn forge_issue_set_milestone(
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket issues aren't supported yet.".into(),
         )),
-        _ => github::set_issue_milestone(&repo_path, number, milestone).await,
+        _ => github::set_issue_milestone(&repo_path, number, milestone, lens).await,
     }
 }
 
@@ -1923,13 +2027,14 @@ pub async fn forge_issue_set_milestone(
 #[tauri::command]
 pub async fn forge_repo_labels(
     repo_path: String,
+    lens: Option<String>,
 ) -> AppResult<Vec<crate::github::pr::RepoLabel>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::repo_labels(&repo_path).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket labels aren't supported yet.".into(),
         )),
-        _ => github::repo_labels(&repo_path).await,
+        _ => github::repo_labels(&repo_path, lens).await,
     }
 }
 
@@ -1939,13 +2044,14 @@ pub async fn forge_repo_labels(
 #[tauri::command]
 pub async fn forge_assignable_users(
     repo_path: String,
+    lens: Option<String>,
 ) -> AppResult<Vec<model::ForgeUserRef>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::assignable_users(&repo_path).await,
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket assignees aren't supported yet.".into(),
         )),
-        _ => github::assignable_users(&repo_path).await,
+        _ => github::assignable_users(&repo_path, lens).await,
     }
 }
 
@@ -1985,6 +2091,7 @@ pub async fn forge_issue_set_assignees(
     repo_path: String,
     number: u64,
     assignees: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -1993,7 +2100,7 @@ pub async fn forge_issue_set_assignees(
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket assignees aren't supported yet.".into(),
         )),
-        _ => github::set_issue_assignees(&repo_path, number, assignees).await,
+        _ => github::set_issue_assignees(&repo_path, number, assignees, lens).await,
     }
 }
 
@@ -2007,6 +2114,7 @@ pub async fn forge_mr_set_assignees(
     repo_path: String,
     number: u64,
     assignees: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -2016,7 +2124,7 @@ pub async fn forge_mr_set_assignees(
             "Bitbucket assignees aren't supported yet.".into(),
         )),
         // A PR number addresses the same issues endpoint (PRs are issues on GitHub).
-        _ => github::set_issue_assignees(&repo_path, number, assignees).await,
+        _ => github::set_issue_assignees(&repo_path, number, assignees, lens).await,
     }
 }
 
@@ -2026,6 +2134,7 @@ pub async fn forge_mr_set_assignees(
 /// drops it like `forge_issue_close` drops the GitHub-only close reason).
 /// `milestone` is whatever `forge_milestones` returned as `number`.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn forge_issue_create(
     repo_path: String,
     title: String,
@@ -2034,6 +2143,7 @@ pub async fn forge_issue_create(
     assignees: Vec<String>,
     milestone: Option<u64>,
     issue_type: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::PrRef> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -2044,7 +2154,7 @@ pub async fn forge_issue_create(
         )),
         _ => {
             github::create_issue(
-                &repo_path, &title, &body, labels, assignees, milestone, issue_type,
+                &repo_path, &title, &body, labels, assignees, milestone, issue_type, lens,
             )
             .await
         }
@@ -3113,12 +3223,13 @@ pub async fn forge_pr_create(
     reviewers: Option<Vec<String>>,
     labels: Option<Vec<String>>,
     assignees: Option<Vec<String>>,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::PrRef> {
     // The `#[tauri::command]` shell just derefs the managed `State` to a plain
     // `&AppState` and delegates to the core, so non-Tauri callers (the MCP server)
     // can create a PR with an `AppState` they own — GUI behavior is unchanged.
     forge_pr_create_core(
-        &state, repo_path, base, head, title, body, draft, reviewers, labels, assignees,
+        &state, repo_path, base, head, title, body, draft, reviewers, labels, assignees, lens,
     )
     .await
 }
@@ -3139,8 +3250,17 @@ pub(crate) async fn forge_pr_create_core(
     reviewers: Option<Vec<String>>,
     labels: Option<Vec<String>>,
     assignees: Option<Vec<String>>,
+    lens: Option<String>,
 ) -> AppResult<crate::github::pr::PrRef> {
     let detected = detect_non_github(&repo_path).await;
+    // The upstream lens (a fork contribution to the PARENT) is GitHub-only. Reject it
+    // for GitLab/Bitbucket BEFORE any dispatch or remote work (`None`/`Some("origin")`
+    // proceed as today; an unknown lens is caught in `gh_pr_create_core`).
+    if lens.as_deref() == Some("upstream") && detected.is_some() {
+        return Err(AppError::InvalidArgument(
+            "Creating a pull request on the upstream repository is currently supported for GitHub only.".into(),
+        ));
+    }
     // Create-time reviewers are Bitbucket-only. GitHub/GitLab reject a non-empty list
     // BEFORE dispatching (existing callers omit the key → `None` → untouched behavior).
     if reviewers.as_deref().is_some_and(|r| !r.is_empty())
@@ -3184,7 +3304,7 @@ pub(crate) async fn forge_pr_create_core(
         }
         _ => {
             crate::github::pr::gh_pr_create_core(
-                state, repo_path, base, head, title, body, draft, labels, assignees,
+                state, repo_path, base, head, title, body, draft, labels, assignees, lens,
             )
             .await
         }

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -143,6 +143,33 @@ pub async fn git_remote_set_url(
     Ok(())
 }
 
+/// Add a new remote (`git remote add <name> <url>`) — used to give a fork the
+/// `upstream` remote it was cloned without, so the fork/upstream lens and
+/// create-on-parent path light up. Mirrors [`git_remote_set_url`]'s validation
+/// and cache handling; git itself errors (surfaced readably) if the remote name
+/// already exists.
+#[tauri::command]
+pub async fn git_remote_add(
+    state: State<'_, AppState>,
+    repo_path: String,
+    name: String,
+    url: String,
+) -> AppResult<()> {
+    validate_remote_arg(&name, "remote name")?;
+    validate_remote_arg(url.trim(), "remote URL")?;
+    run_git_mutating(
+        &state,
+        &repo_path,
+        &["remote", "add", &name, url.trim()],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    // A stale negative entry (a prior get-url miss for this name) would otherwise
+    // linger until the TTL — drop it so the next read resolves the new remote.
+    cache_invalidate(&repo_path, &name);
+    Ok(())
+}
+
 /// Names of the configured remotes (e.g. `["origin"]`), empty for a local repo.
 #[tauri::command]
 pub async fn git_remotes(repo_path: String) -> AppResult<Vec<String>> {

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -87,15 +87,18 @@ pub fn map_reaction_groups(groups: Option<&serde_json::Value>) -> Vec<Reaction> 
 /// Resolves the repo's GraphQL `owner` and `name`. GraphQL (unlike REST) has no
 /// `{owner}/{repo}` substitution, so callers must pass them explicitly.
 ///
-/// Pinned to the ORIGIN slug (via `gh_origin_slug`), NOT a bare `gh repo view`:
+/// Resolved through the lens (via `gh_lens_slug`), NOT a bare `gh repo view`:
 /// on a fork with an `upstream` remote a bare `gh repo view` auto-resolves to the
 /// PARENT, so every GraphQL read built on this pair (issue types/reactions/
 /// relations/dependencies/development, PR reactions/timeline/review-threads/
-/// external-reviews) would answer for the upstream instead of the fork. This one
-/// resolver pins them all. For a single-remote repo the slug equals what gh
-/// resolved before, so behavior is unchanged there.
-pub(crate) async fn repo_owner_name(repo_path: &str) -> AppResult<(String, String)> {
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+/// external-reviews) would answer for the upstream instead of the fork. `lens`
+/// (`None`/`Some("origin")`/`Some("upstream")`) selects which remote to resolve;
+/// `None` = origin, so a single-remote repo's behavior is unchanged.
+pub(crate) async fn repo_owner_name(
+    repo_path: &str,
+    lens: Option<&str>,
+) -> AppResult<(String, String)> {
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     slug.split_once('/')
         .map(|(o, n)| (o.to_string(), n.to_string()))
         .ok_or_else(|| AppError::Gh("could not determine the repository owner".into()))
@@ -132,10 +135,11 @@ pub async fn gh_issue_list(
     repo_path: String,
     state: String,
     limit: Option<u32>,
+    lens: Option<String>,
 ) -> AppResult<Vec<IssueInfo>> {
-    // Pin the origin slug so a fork lists its OWN issues, not the parent's (a bare
+    // Resolve the lens slug so a fork lists the chosen repo's issues (a bare
     // `gh issue list` on a fork auto-resolves to the upstream repo).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let mut args: Vec<&str> = match state.as_str() {
         "open" => vec![
             "issue", "list", "--repo", &slug, "--state", "open", "--json", ISSUE_LIST_FIELDS,
@@ -269,11 +273,15 @@ const ISSUE_VIEW_FIELDS: &str =
 /// Full details for one issue's read view: body, assignees, labels and the
 /// conversation comments (with node ids for editing/hiding).
 #[tauri::command]
-pub async fn gh_issue_view(repo_path: String, number: u64) -> AppResult<IssueDetails> {
-    // Pin the origin slug so a fork's issue number resolves against the fork, not
+pub async fn gh_issue_view(
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<IssueDetails> {
+    // Resolve the lens slug so the issue number resolves against the chosen repo, not
     // the parent gh would auto-detect from an `upstream` remote (used by both the
     // `issue view --repo` read and the literal `repos/<slug>` lock-state path).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     // The conversation view and the (REST-only) lock state are fetched
     // concurrently so the lock state adds no extra round-trip latency.
     let n = number.to_string();
@@ -360,6 +368,7 @@ struct CreatedIssue {
 /// (by number) go in one call and the response carries the new number + URL
 /// directly. `labels` and `assignees` are applied by name/login (must exist).
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn gh_issue_create(
     repo_path: String,
     title: String,
@@ -368,6 +377,7 @@ pub async fn gh_issue_create(
     assignees: Vec<String>,
     milestone: Option<u64>,
     issue_type: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<PrRef> {
     let title = title.trim();
     if title.is_empty() {
@@ -390,9 +400,10 @@ pub async fn gh_issue_create(
     }
     let input = serde_json::to_string(&payload)
         .map_err(|e| AppError::Gh(format!("could not encode issue: {e}")))?;
-    // Pin the origin slug so a new issue is filed on the fork, not the parent gh
-    // would auto-detect from an `upstream` remote (on a non-fork this is a no-op).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so a new issue is filed on the chosen repo, not the
+    // parent gh would auto-detect from an `upstream` remote (on a non-fork this is a
+    // no-op).
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/issues");
     // Creating an issue on a fork with issues disabled fails with the same gh
     // signature — remap it so the toast carries the readable variant message.
@@ -414,9 +425,12 @@ pub async fn gh_issue_create(
 
 /// Logins that can be assigned to issues/PRs in this repo (collaborators).
 #[tauri::command]
-pub async fn gh_assignable_users(repo_path: String) -> AppResult<Vec<String>> {
-    // Pin the origin slug so a fork lists its own assignees, not the parent's.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+pub async fn gh_assignable_users(
+    repo_path: String,
+    lens: Option<String>,
+) -> AppResult<Vec<String>> {
+    // Resolve the lens slug so a fork lists the chosen repo's assignees.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/assignees");
     let out = run_gh(
         Some(&repo_path),
@@ -430,9 +444,9 @@ pub async fn gh_assignable_users(repo_path: String) -> AppResult<Vec<String>> {
 
 /// Open milestones for the milestone picker.
 #[tauri::command]
-pub async fn gh_milestones(repo_path: String) -> AppResult<Vec<Milestone>> {
-    // Pin the origin slug so a fork lists its own milestones, not the parent's.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+pub async fn gh_milestones(repo_path: String, lens: Option<String>) -> AppResult<Vec<Milestone>> {
+    // Resolve the lens slug so a fork lists the chosen repo's milestones.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/milestones?state=open&per_page=100");
     let out = run_gh(
         Some(&repo_path),
@@ -450,11 +464,12 @@ pub async fn gh_issue_set_assignees(
     repo_path: String,
     number: u64,
     assignees: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let input = serde_json::to_string(&serde_json::json!({ "assignees": assignees }))
         .map_err(|e| AppError::Gh(format!("could not encode assignees: {e}")))?;
-    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is edited on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/issues/{number}");
     run_gh_input(
         Some(&repo_path),
@@ -472,6 +487,7 @@ pub async fn gh_issue_set_milestone(
     repo_path: String,
     number: u64,
     milestone: Option<u64>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let milestone_value = match milestone {
         Some(m) => serde_json::json!(m),
@@ -480,8 +496,8 @@ pub async fn gh_issue_set_milestone(
     let input =
         serde_json::to_string(&serde_json::json!({ "milestone": milestone_value }))
             .map_err(|e| AppError::Gh(format!("could not encode milestone: {e}")))?;
-    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is edited on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/issues/{number}");
     run_gh_input(
         Some(&repo_path),
@@ -496,8 +512,8 @@ pub async fn gh_issue_set_milestone(
 /// The repo's enabled issue types (org-defined). Empty when the owner defines
 /// none (e.g. a personal repo), which hides the picker on the frontend.
 #[tauri::command]
-pub async fn gh_issue_types(repo_path: String) -> AppResult<Vec<IssueType>> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+pub async fn gh_issue_types(repo_path: String, lens: Option<String>) -> AppResult<Vec<IssueType>> {
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     let query = "query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ issueTypes(first:25){ nodes{ id name color isEnabled } } } }";
     let out = run_gh(
         Some(&repo_path),
@@ -550,10 +566,11 @@ pub async fn gh_issue_set_type(
     repo_path: String,
     number: u64,
     type_name: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is edited on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let args: Vec<&str> = match type_name.as_deref() {
         Some(t) if !t.trim().is_empty() => {
             vec!["issue", "edit", &n, "--repo", &slug, "--type", t]
@@ -570,13 +587,14 @@ pub async fn gh_issue_comment(
     repo_path: String,
     number: u64,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     if body.trim().is_empty() {
         return Err(AppError::InvalidArgument("a comment is required".into()));
     }
     let n = number.to_string();
-    // Pin the origin slug so the comment lands on the fork's issue, not the parent's.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the comment lands on the chosen repo's issue.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "comment", &n, "--repo", &slug, "--body", &body],
@@ -593,6 +611,7 @@ pub async fn gh_issue_close(
     repo_path: String,
     number: u64,
     reason: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let n = number.to_string();
     let reason = match reason.as_str() {
@@ -604,8 +623,8 @@ pub async fn gh_issue_close(
             )));
         }
     };
-    // Pin the origin slug so a fork's issue closes on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue closes on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "close", &n, "--repo", &slug, "--reason", reason],
@@ -617,10 +636,10 @@ pub async fn gh_issue_close(
 
 /// Reopens a closed issue.
 #[tauri::command]
-pub async fn gh_issue_reopen(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_issue_reopen(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue reopens on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue reopens on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "reopen", &n, "--repo", &slug],
@@ -640,6 +659,7 @@ pub async fn gh_issue_edit(
     number: u64,
     title: String,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let title = title.trim();
     if title.is_empty() {
@@ -647,8 +667,8 @@ pub async fn gh_issue_edit(
             "an issue title is required".into(),
         ));
     }
-    // Pin the origin slug so a fork's issue is edited on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is edited on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/issues/{number}");
     run_gh(
         Some(&repo_path),
@@ -670,10 +690,10 @@ pub async fn gh_issue_edit(
 
 /// Pins an issue (GitHub allows at most 3 pinned issues; gh surfaces the error).
 #[tauri::command]
-pub async fn gh_issue_pin(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_issue_pin(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue is pinned on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is pinned on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "pin", &n, "--repo", &slug],
@@ -684,10 +704,10 @@ pub async fn gh_issue_pin(repo_path: String, number: u64) -> AppResult<()> {
 }
 
 #[tauri::command]
-pub async fn gh_issue_unpin(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_issue_unpin(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue is unpinned on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is unpinned on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "unpin", &n, "--repo", &slug],
@@ -704,10 +724,11 @@ pub async fn gh_issue_lock(
     repo_path: String,
     number: u64,
     reason: Option<String>,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue is locked on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is locked on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let mut args = vec!["issue", "lock", &n, "--repo", &slug];
     if let Some(r) = reason.as_deref() {
         if !matches!(r, "off_topic" | "resolved" | "spam" | "too_heated") {
@@ -723,10 +744,10 @@ pub async fn gh_issue_lock(
 }
 
 #[tauri::command]
-pub async fn gh_issue_unlock(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_issue_unlock(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue is unlocked on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is unlocked on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "unlock", &n, "--repo", &slug],
@@ -754,8 +775,9 @@ const REACTIONS_QUERY: &str = "query($owner:String!,$name:String!,$number:Int!){
 pub async fn gh_issue_reactions(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<IssueReactions> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
 
     // owner/name/number go in as typed variables (no string interpolation).
     let out = run_gh(
@@ -877,6 +899,7 @@ pub async fn gh_issue_transfer(
     repo_path: String,
     number: u64,
     destination: String,
+    lens: Option<String>,
 ) -> AppResult<String> {
     let destination = destination.trim();
     if destination.is_empty() || destination.starts_with('-') {
@@ -885,9 +908,9 @@ pub async fn gh_issue_transfer(
         ));
     }
     let n = number.to_string();
-    // Pin the origin slug so the SOURCE issue resolves against the fork, not the
-    // parent (the `destination` arg is explicit and unaffected).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the SOURCE issue resolves against the chosen repo (the
+    // `destination` arg is explicit and unaffected).
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &["issue", "transfer", &n, destination, "--repo", &slug],
@@ -901,10 +924,10 @@ pub async fn gh_issue_transfer(
 /// Permanently deletes an issue (requires admin/triage; gh confirms the error
 /// when the user lacks permission). `--yes` skips gh's interactive prompt.
 #[tauri::command]
-pub async fn gh_issue_delete(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_issue_delete(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's issue is deleted on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the issue is deleted on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "delete", &n, "--repo", &slug, "--yes"],
@@ -946,8 +969,9 @@ const RELATIONS_QUERY: &str = "query($owner:String!,$name:String!,$number:Int!){
 pub async fn gh_issue_relations(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<IssueRelations> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
@@ -1010,10 +1034,11 @@ pub async fn gh_issue_add_sub_issue(
     repo_path: String,
     parent_id: String,
     sub_number: u64,
+    lens: Option<String>,
 ) -> AppResult<()> {
     // Resolve the child's node id (this also rejects PRs / missing numbers).
-    // Pin the origin slug so the child number resolves against the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the child number resolves against the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let n = sub_number.to_string();
     let id_out = run_gh(
         Some(&repo_path),
@@ -1085,8 +1110,9 @@ const DEPENDENCIES_QUERY: &str = "query($owner:String!,$name:String!,$number:Int
 pub async fn gh_issue_dependencies(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<IssueDependencies> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
@@ -1131,6 +1157,7 @@ pub async fn gh_issue_set_dependency(
     relation: String,
     target: u64,
     add: bool,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let flag = match (relation.as_str(), add) {
         ("blocked_by", true) => "--add-blocked-by",
@@ -1145,8 +1172,8 @@ pub async fn gh_issue_set_dependency(
     };
     let n = number.to_string();
     let t = target.to_string();
-    // Pin the origin slug so the dependency is edited on the fork's issue, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the dependency is edited on the chosen repo's issue.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["issue", "edit", &n, "--repo", &slug, flag, &t],
@@ -1183,8 +1210,9 @@ const DEVELOPMENT_QUERY: &str = "query($owner:String!,$name:String!,$number:Int!
 pub async fn gh_issue_development(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<IssueDevelopment> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
@@ -1236,6 +1264,7 @@ pub async fn gh_issue_create_linked_branch(
     repo_path: String,
     issue_id: String,
     name: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let name = name.trim();
     if name.is_empty() {
@@ -1243,7 +1272,7 @@ pub async fn gh_issue_create_linked_branch(
             "a branch name is required".into(),
         ));
     }
-    let (owner, repo_name) = repo_owner_name(&repo_path).await?;
+    let (owner, repo_name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
 
     // The new branch points at the default branch's current HEAD.
     let oid_query = "query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ defaultBranchRef{ target{ oid } } } }";

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -34,10 +34,85 @@ use crate::error::{AppError, AppResult};
 /// `https://…` and scp-style `git@github.com:owner/repo` URLs. A GitHub origin
 /// path is exactly `owner/repo`; the callers can't work without a GitHub origin,
 /// so no origin / an unparseable one is a clear error (`AppError::Gh`).
+///
+/// This is the origin-pinned entry point (100+ call sites across
+/// actions/releases/settings/discussions rely on it), kept as a thin delegate to
+/// [`gh_lens_slug`] with no lens so those surfaces stay on the fork.
 pub(crate) async fn gh_origin_slug(repo_path: &str) -> AppResult<String> {
+    gh_lens_slug(repo_path, None).await
+}
+
+/// Resolve a GitHub `owner/repo` slug through a validated **remote lens** — the
+/// fork-identity Part B primitive. `lens` is `None` (defaults to `origin`),
+/// `Some("origin")`, or `Some("upstream")`; anything else is rejected before any
+/// git spawn. The `upstream` lens lets a fork user address the PARENT repo's
+/// PRs/issues without disturbing the origin-pinning that Part A (#56) established
+/// for every other surface.
+///
+/// Resolves `git_remote_url(repo_path, remote)` for `remote = lens.unwrap_or("origin")`,
+/// then the shared origin-path parser (strips `.git`, handles `https://…` and
+/// scp-style URLs). The error NAMES the remote it failed on so a missing
+/// `upstream` on a non-fork clone reads clearly. `git_remote_url`'s TTL cache is
+/// keyed by (repo, name), so each lens caches independently — no extra work here.
+pub(crate) async fn gh_lens_slug(repo_path: &str, lens: Option<&str>) -> AppResult<String> {
+    let remote = lens_remote(lens)?;
     let url =
-        crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await?;
+        crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await?;
     crate::forge::remote_path(&url).ok_or_else(|| {
-        AppError::Gh("could not determine the GitHub repository from the origin remote".into())
+        AppError::Gh(format!(
+            "could not determine the GitHub repository from the {remote} remote"
+        ))
     })
+}
+
+/// Validate a lens value and map it to the git remote name it resolves. Pure —
+/// the network-free half of [`gh_lens_slug`], split out so it can be unit-tested.
+/// `None`/`Some("origin")` → `"origin"`, `Some("upstream")` → `"upstream"`;
+/// anything else is an `InvalidArgument` before any git spawn.
+fn lens_remote(lens: Option<&str>) -> AppResult<&'static str> {
+    match lens {
+        None | Some("origin") => Ok("origin"),
+        Some("upstream") => Ok("upstream"),
+        Some(other) => Err(AppError::InvalidArgument(format!(
+            "unknown remote lens: {other}"
+        ))),
+    }
+}
+
+/// The fork owner (the part before `/`) of an `owner/repo` slug — the `<user>` in
+/// `gh pr create --head <user>:<branch>` for the upstream-lens fork flow. Pure.
+pub(crate) fn fork_owner_of(slug: &str) -> &str {
+    slug.split('/').next().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fork_owner_of, lens_remote};
+
+    #[test]
+    fn lens_remote_accepts_none_origin_upstream() {
+        assert_eq!(lens_remote(None).unwrap(), "origin");
+        assert_eq!(lens_remote(Some("origin")).unwrap(), "origin");
+        assert_eq!(lens_remote(Some("upstream")).unwrap(), "upstream");
+    }
+
+    #[test]
+    fn lens_remote_rejects_junk() {
+        for junk in ["fork", "", "ORIGIN", "upstream ", "origin/x"] {
+            let err = lens_remote(Some(junk)).unwrap_err();
+            assert!(
+                matches!(err, crate::error::AppError::InvalidArgument(_)),
+                "expected InvalidArgument for {junk:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fork_owner_extracts_owner_before_slash() {
+        assert_eq!(fork_owner_of("PhoenixMputu/biome"), "PhoenixMputu");
+        assert_eq!(fork_owner_of("octocat/hello-world"), "octocat");
+        // A malformed slug with no slash yields the whole string (gh then errors).
+        assert_eq!(fork_owner_of("nowhere"), "nowhere");
+        assert_eq!(fork_owner_of(""), "");
+    }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -4113,6 +4113,22 @@ fn rest_pull_to_pr_info(p: GhPrRestPull) -> PrInfo {
     }
 }
 
+/// Build the REST endpoint for the upstream-lens duplicate probe:
+/// `repos/<parent_slug>/pulls?head=<fork_owner>:<head>&state=open`. `fork_owner`
+/// and `head` are the only untrusted query VALUES, so each is percent-encoded via
+/// the shared [`encode_query_value`](crate::forge::encode_query_value) (escapes
+/// `&`, `%`, `#`, `+`, `?`, `=`, space, `/`, `:`, … — everything outside the
+/// RFC-3986 unreserved set) so a legal-but-hostile refname like `feat&state=all`
+/// can't inject query parameters. The `:` separator is added LITERALLY between the
+/// two encoded parts because GitHub's `?head=owner:branch` filter needs a real
+/// colon there; `parent_slug` is a validated `owner/repo` remote path whose `/` is
+/// a real path segment, so it stays unencoded. Pure — unit-tested.
+fn upstream_pulls_endpoint(parent_slug: &str, fork_owner: &str, head: &str) -> String {
+    let owner = crate::forge::encode_query_value(fork_owner);
+    let head = crate::forge::encode_query_value(head);
+    format!("repos/{parent_slug}/pulls?head={owner}:{head}&state=open")
+}
+
 /// Open PRs whose head is `head` (there's at most one per base). Lets the UI
 /// offer "View pull request" instead of "Create" once one already exists.
 ///
@@ -4139,10 +4155,7 @@ pub async fn gh_prs_for_branch(
         let parent_slug = crate::github::gh_lens_slug(&repo_path, Some("upstream")).await?;
         let origin_slug = crate::github::gh_lens_slug(&repo_path, None).await?;
         let fork_owner = crate::github::fork_owner_of(&origin_slug);
-        // `head`/`owner`/`ref` are all `[A-Za-z0-9_./-]` (branch validated above),
-        // so they're query-safe interpolated literally into the endpoint.
-        let endpoint =
-            format!("repos/{parent_slug}/pulls?head={fork_owner}:{head}&state=open");
+        let endpoint = upstream_pulls_endpoint(&parent_slug, fork_owner, &head);
         let out = run_gh(
             Some(&repo_path),
             &["api", "--method", "GET", &endpoint],
@@ -4412,8 +4425,9 @@ mod tests {
         parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
-        split_commit_message, GhPrFile, GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor,
-        GhPrRestCommitInner, GhPrRestPull, GhPrRestReview, PrTimelineEventOut, RawLogin,
+        split_commit_message, upstream_pulls_endpoint, GhPrFile, GhPrRestComment, GhPrRestCommit,
+        GhPrRestCommitGitAuthor, GhPrRestCommitInner, GhPrRestPull, GhPrRestReview,
+        PrTimelineEventOut, RawLogin,
     };
     use crate::error::AppError;
 
@@ -4952,6 +4966,33 @@ github.acme.com
                 "expected InvalidArgument, got {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn upstream_pulls_endpoint_encodes_hostile_refnames() {
+        // Plain refname: nothing to escape but the reserved `:` separator stays literal.
+        assert_eq!(
+            upstream_pulls_endpoint("biomejs/biome", "PhoenixMputu", "feat/x"),
+            "repos/biomejs/biome/pulls?head=PhoenixMputu:feat%2Fx&state=open",
+        );
+        // A legal refname carrying `&` can't inject a second query parameter — the
+        // `&` is encoded, so `state=all` lands inside the head VALUE, not as a param.
+        let ep = upstream_pulls_endpoint("o/r", "me", "feat&state=all");
+        assert_eq!(ep, "repos/o/r/pulls?head=me:feat%26state%3Dall&state=open");
+        // Exactly one `&` (the real separator) and one `state=` (the real filter).
+        assert_eq!(ep.matches('&').count(), 1);
+        assert_eq!(ep.matches("state=").count(), 1);
+        // `%` and space are escaped too (no half-open percent-escape, no raw space).
+        assert_eq!(
+            upstream_pulls_endpoint("o/r", "me", "a b%c"),
+            "repos/o/r/pulls?head=me:a%20b%25c&state=open",
+        );
+        // A hostile FORK OWNER is encoded the same way (defense in depth, though a
+        // real login is alphanumeric).
+        assert_eq!(
+            upstream_pulls_endpoint("o/r", "ev&il", "b"),
+            "repos/o/r/pulls?head=ev%26il:b&state=open",
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -516,6 +516,7 @@ pub async fn gh_pr_review(
     number: u64,
     action: String,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let n = number.to_string();
     let flag = match action.as_str() {
@@ -528,9 +529,9 @@ pub async fn gh_pr_review(
             )));
         }
     };
-    // Pin the origin slug (`gh pr … --repo OWNER/REPO`) so a fork's PR resolves
-    // against the fork, not the parent gh auto-detects from an `upstream` remote.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug (`gh pr … --repo OWNER/REPO`) so a fork's PR resolves
+    // against the chosen remote, not the parent gh auto-detects from `upstream`.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let body = body.trim();
     let mut args = vec!["pr", "review", &n, flag, "--repo", &slug];
     if !body.is_empty() {
@@ -543,13 +544,18 @@ pub async fn gh_pr_review(
 
 /// Adds a standalone comment to the PR conversation.
 #[tauri::command]
-pub async fn gh_pr_comment(repo_path: String, number: u64, body: String) -> AppResult<()> {
+pub async fn gh_pr_comment(
+    repo_path: String,
+    number: u64,
+    body: String,
+    lens: Option<String>,
+) -> AppResult<()> {
     if body.trim().is_empty() {
         return Err(AppError::InvalidArgument("a comment is required".into()));
     }
     let n = number.to_string();
-    // Pin the origin slug so the comment lands on the fork's PR, not the parent's.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the comment lands on the chosen repo's PR.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["pr", "comment", &n, "--body", &body, "--repo", &slug],
@@ -593,6 +599,7 @@ pub async fn gh_pr_merge(
     number: u64,
     strategy: String,
     delete_branch: bool,
+    lens: Option<String>,
 ) -> AppResult<PrMergeOutcome> {
     let n = number.to_string();
     let method = match strategy.as_str() {
@@ -605,8 +612,8 @@ pub async fn gh_pr_merge(
             )));
         }
     };
-    // Pin the origin slug so the merge targets the fork's PR, not the parent's.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the merge targets the chosen repo's PR.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["pr", "merge", &n, method, "--repo", &slug],
@@ -617,7 +624,7 @@ pub async fn gh_pr_merge(
     // warning on a successful outcome — never an error — so the UI can't show a
     // red "merge failed" toast for a PR that already merged.
     let cleanup_warning = if delete_branch {
-        gh_delete_remote_head_branch(&repo_path, number)
+        gh_delete_remote_head_branch(&repo_path, number, lens.as_deref())
             .await
             .err()
             .map(|e| e.to_string())
@@ -656,10 +663,14 @@ struct RawRepoName {
 /// message that `gh_pr_merge` folds into a successful outcome's `cleanup_warning`
 /// rather than a merge failure. A branch that is already gone (e.g. a repo that
 /// auto-deletes head branches on merge) counts as success.
-async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult<()> {
-    // Pin the origin slug for the READ so a fork's PR resolves against the fork
+async fn gh_delete_remote_head_branch(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<()> {
+    // Resolve the lens slug for the READ so the PR resolves against the chosen repo
     // (the DELETE below then targets the PR's OWN head repository — see its note).
-    let slug = crate::github::gh_origin_slug(repo_path).await.map_err(|e| {
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await.map_err(|e| {
         AppError::Gh(format!(
             "Merged #{number}, but couldn't clean up the remote head branch: {e}"
         ))
@@ -766,10 +777,10 @@ async fn gh_delete_remote_head_branch(repo_path: &str, number: u64) -> AppResult
 }
 
 #[tauri::command]
-pub async fn gh_pr_close(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_pr_close(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's PR closes on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the PR closes on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["pr", "close", &n, "--repo", &slug],
@@ -781,10 +792,10 @@ pub async fn gh_pr_close(repo_path: String, number: u64) -> AppResult<()> {
 
 /// Reopens a closed (not merged) pull request.
 #[tauri::command]
-pub async fn gh_pr_reopen(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_pr_reopen(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's PR reopens on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the PR reopens on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["pr", "reopen", &n, "--repo", &slug],
@@ -952,11 +963,11 @@ pub async fn gh_pr_unminimize_comment(repo_path: String, comment_id: String) -> 
 
 /// Checks out a PR's branch locally (handles fork-sourced PRs too).
 #[tauri::command]
-pub async fn gh_pr_checkout(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_pr_checkout(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's PR number checks out from the fork, not the
+    // Resolve the lens slug so the PR number checks out from the chosen repo, not the
     // parent gh would auto-resolve from an `upstream` remote.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["pr", "checkout", &n, "--repo", &slug],
@@ -1034,10 +1045,10 @@ pub async fn gh_repo_fork(repo_path: String, contribute_to_parent: bool) -> AppR
 
 /// Marks a draft PR as ready for review.
 #[tauri::command]
-pub async fn gh_pr_ready(repo_path: String, number: u64) -> AppResult<()> {
+pub async fn gh_pr_ready(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
     let n = number.to_string();
-    // Pin the origin slug so a fork's PR is marked ready on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Resolve the lens slug so the PR is marked ready on the chosen repo.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(
         Some(&repo_path),
         &["pr", "ready", &n, "--repo", &slug],
@@ -1058,10 +1069,11 @@ pub async fn gh_pr_list(
     repo_path: String,
     state: String,
     limit: Option<u32>,
+    lens: Option<String>,
 ) -> AppResult<Vec<PrInfo>> {
-    // Pin the origin slug so a fork lists its OWN PRs, not the parent's (a bare
+    // Resolve the lens slug so a fork lists the chosen repo's PRs (a bare
     // `gh pr list` on a fork auto-resolves to the upstream repo).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let mut args: Vec<&str> = match state.as_str() {
         "open" => vec![
             "pr", "list", "--repo", &slug, "--state", "open", "--json", PR_LIST_FIELDS,
@@ -1275,14 +1287,15 @@ pub async fn gh_pr_edit(
     number: u64,
     title: String,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     let title = title.trim();
     if title.is_empty() {
         return Err(AppError::InvalidArgument("a PR title is required".into()));
     }
-    // Pin the origin slug so a fork's PR is edited on the fork, not the parent
+    // Resolve the lens slug so the PR is edited on the chosen repo
     // (`gh api` has no `-R` flag, so build a literal `repos/<slug>/…` path).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let endpoint = format!("repos/{slug}/pulls/{number}");
     run_gh(
         Some(&repo_path),
@@ -1333,11 +1346,11 @@ fn validate_graphql_embed(value: &str, what: &str) -> AppResult<()> {
 /// The repository's labels with their GraphQL node ids, for the PR label
 /// picker. (`gh label list --json id` returns empty ids on older gh.)
 #[tauri::command]
-pub async fn gh_repo_labels(repo_path: String) -> AppResult<Vec<RepoLabel>> {
-    // Pin the origin slug: an unpinned `gh repo view` on a fork with an `upstream`
-    // remote auto-resolves to the PARENT, so the picker would show the upstream's
-    // labels. `gh_origin_slug` returns "owner/repo".
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+pub async fn gh_repo_labels(repo_path: String, lens: Option<String>) -> AppResult<Vec<RepoLabel>> {
+    // Resolve the lens slug: an unpinned `gh repo view` on a fork with an `upstream`
+    // remote auto-resolves to the PARENT, so the origin picker would show the
+    // upstream's labels. `gh_lens_slug` returns "owner/repo".
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let Some((owner, name)) = slug.split_once('/') else {
         return Err(AppError::Gh("could not determine the repository owner".into()));
     };
@@ -2064,12 +2077,16 @@ async fn gh_repo_merge_settings(repo_path: &str, pr_url: &str) -> AppResult<Repo
 
 /// Full details for one PR's read view.
 #[tauri::command]
-pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> {
-    // Pin the origin slug so a fork's PR number resolves against the fork, not the
-    // parent gh would auto-detect from an `upstream` remote. The REST top-ups this
-    // fn calls (files/commits/reviews/comments) are likewise pinned to origin so
-    // they resolve to the SAME repo these PR numbers came from.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+pub async fn gh_pr_view(
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<PrDetails> {
+    // Resolve the lens slug so the PR number resolves against the chosen repo, not
+    // the parent gh would auto-detect from an `upstream` remote. The REST top-ups
+    // this fn calls (files/commits/reviews/comments) inherit the SAME lens so they
+    // resolve to the SAME repo these PR numbers came from.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
@@ -2095,7 +2112,7 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
     // exactly 100 files just makes one redundant call). Best-effort: if the REST
     // completion fails, keep the 100 GraphQL entries rather than failing the view.
     let files: Vec<PrFileOut> = if raw.files.len() >= 100 {
-        match gh_pr_files_paginated(&repo_path, number).await {
+        match gh_pr_files_paginated(&repo_path, number, lens.as_deref()).await {
             Ok(complete) => complete
                 .into_iter()
                 .map(|f| PrFileOut {
@@ -2129,7 +2146,7 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
     // from its paginated REST endpoint when we hit 100, best-effort (a REST
     // failure keeps the 100 GraphQL entries rather than failing the view).
     let commits: Vec<PrCommitOut> = if raw.commits.len() >= 100 {
-        match gh_pr_commits_paginated(&repo_path, number).await {
+        match gh_pr_commits_paginated(&repo_path, number, lens.as_deref()).await {
             Ok(complete) => complete,
             Err(_) => raw
                 .commits
@@ -2173,7 +2190,7 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
     };
 
     let reviews: Vec<PrThreadOut> = if raw.reviews.len() >= 100 {
-        match gh_pr_reviews_paginated(&repo_path, number).await {
+        match gh_pr_reviews_paginated(&repo_path, number, lens.as_deref()).await {
             Ok(complete) => complete,
             Err(_) => raw
                 .reviews
@@ -2217,7 +2234,7 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
     };
 
     let comments: Vec<PrThreadOut> = if raw.comments.len() >= 100 {
-        match gh_pr_comments_paginated(&repo_path, number).await {
+        match gh_pr_comments_paginated(&repo_path, number, lens.as_deref()).await {
             Ok(complete) => complete,
             Err(_) => raw
                 .comments
@@ -2368,15 +2385,19 @@ pub async fn gh_pr_view(repo_path: String, number: u64) -> AppResult<PrDetails> 
 /// and bots (e.g. Copilot) are intentionally excluded — exactly like teams — so
 /// [`set_pr_reviewers`] can preserve them untouched and never `--remove-reviewer`
 /// a bot.
-async fn current_requested_reviewer_logins(repo_path: &str, number: u64) -> AppResult<Vec<String>> {
+async fn current_requested_reviewer_logins(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<Vec<String>> {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct Wrap {
         #[serde(default)]
         review_requests: Vec<RawReviewRequest>,
     }
-    // Pin the origin slug so a fork's PR resolves against the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // Inherit the lens so the PR resolves against the same repo as the write below.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let out = run_gh(
         Some(repo_path),
         &[
@@ -2403,9 +2424,9 @@ async fn current_requested_reviewer_logins(repo_path: &str, number: u64) -> AppR
 
 /// The PR author's login (`gh pr view --json author`) — excluded from the reviewer
 /// candidates, because GitHub rejects requesting a review from the author.
-async fn pr_author_login(repo_path: &str, number: u64) -> AppResult<String> {
-    // Pin the origin slug so a fork's PR resolves against the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+async fn pr_author_login(repo_path: &str, number: u64, lens: Option<&str>) -> AppResult<String> {
+    // Inherit the lens so the PR resolves against the same repo as its candidates.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let out = run_gh(
         Some(repo_path),
         // `// empty` so a GraphQL-null author (deleted account / some bots) yields an
@@ -2436,9 +2457,14 @@ async fn pr_author_login(repo_path: &str, number: u64) -> AppResult<String> {
 /// rejects requesting a review from the PR author, and a reviewer who already
 /// submitted needs a *re-request* — those failures surface as the gh error rather
 /// than being swallowed (`run_gh` carries the stderr).
-pub async fn set_pr_reviewers(repo_path: &str, number: u64, desired: &[String]) -> AppResult<()> {
+pub async fn set_pr_reviewers(
+    repo_path: &str,
+    number: u64,
+    desired: &[String],
+    lens: Option<&str>,
+) -> AppResult<()> {
     use std::collections::HashSet;
-    let current = current_requested_reviewer_logins(repo_path, number).await?;
+    let current = current_requested_reviewer_logins(repo_path, number, lens).await?;
     let desired_set: HashSet<&str> = desired.iter().map(String::as_str).collect();
     let current_set: HashSet<&str> = current.iter().map(String::as_str).collect();
     let add: Vec<&str> = desired
@@ -2457,10 +2483,10 @@ pub async fn set_pr_reviewers(repo_path: &str, number: u64, desired: &[String]) 
     let num = number.to_string();
     let add_csv = add.join(",");
     let remove_csv = remove.join(",");
-    // Pin the origin slug so a fork's PR reviewers are edited on the fork, not the
-    // parent (`current_requested_reviewer_logins` above is already pinned, so the
+    // Resolve the lens slug so the PR reviewers are edited on the chosen repo
+    // (`current_requested_reviewer_logins` above inherits the same lens, so the
     // diff and the write agree on which repo's PR they target).
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let mut args: Vec<&str> = vec!["pr", "edit", &num, "--repo", &slug];
     if !add.is_empty() {
         args.push("--add-reviewer");
@@ -2482,10 +2508,13 @@ pub async fn set_pr_reviewers(repo_path: &str, number: u64, desired: &[String]) 
 pub async fn reviewer_candidates(
     repo_path: &str,
     number: Option<u64>,
+    lens: Option<&str>,
 ) -> AppResult<Vec<crate::forge::model::ForgeUserRef>> {
-    let logins = crate::github::issue::gh_assignable_users(repo_path.to_string()).await?;
+    let logins =
+        crate::github::issue::gh_assignable_users(repo_path.to_string(), lens.map(str::to_string))
+            .await?;
     let exclude = match number {
-        Some(n) => pr_author_login(repo_path, n).await.unwrap_or_default(),
+        Some(n) => pr_author_login(repo_path, n, lens).await.unwrap_or_default(),
         None => current_login(repo_path).await.unwrap_or_default(),
     };
     let mut out: Vec<crate::forge::model::ForgeUserRef> = logins
@@ -2510,8 +2539,12 @@ const PR_REACTIONS_QUERY: &str = "query($owner:String!,$name:String!,$number:Int
 /// GraphQL-only, so this loads in parallel with the PR view and leaves
 /// `gh_pr_view` untouched. Reuses the issue reaction types + mapper.
 #[tauri::command]
-pub async fn gh_pr_reactions(repo_path: String, number: u64) -> AppResult<IssueReactions> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+pub async fn gh_pr_reactions(
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<IssueReactions> {
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
@@ -2704,8 +2737,9 @@ fn map_timeline_node(node: &serde_json::Value) -> Option<PrTimelineEventOut> {
 pub async fn pr_timeline(
     repo_path: &str,
     number: u64,
+    lens: Option<&str>,
 ) -> AppResult<Vec<PrTimelineEventOut>> {
-    let (owner, name) = repo_owner_name(repo_path).await?;
+    let (owner, name) = repo_owner_name(repo_path, lens).await?;
     let out = run_gh(
         Some(repo_path),
         &[
@@ -2742,10 +2776,10 @@ pub async fn pr_timeline(
 /// files API (`gh_pr_diff_from_files`) instead of failing the whole view. Any
 /// other error propagates raw.
 #[tauri::command]
-pub async fn gh_pr_diff(repo_path: String, number: u64) -> AppResult<String> {
-    // Pin the origin slug so a fork's PR diff resolves against the fork, not the
-    // parent (the files-API fallback below goes through the pinned `gh_pr_files_paginated`).
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+pub async fn gh_pr_diff(repo_path: String, number: u64, lens: Option<String>) -> AppResult<String> {
+    // Resolve the lens slug so the PR diff resolves against the chosen repo (the
+    // files-API fallback below inherits the lens via `gh_pr_diff_from_files`).
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let out = match run_gh(
         Some(&repo_path),
         &["pr", "diff", &number.to_string(), "--repo", &slug],
@@ -2756,7 +2790,7 @@ pub async fn gh_pr_diff(repo_path: String, number: u64) -> AppResult<String> {
         Ok(out) => out,
         Err(e) if is_diff_too_large(&e.to_string()) => {
             // Reconstruct from the files API; if THAT fails, surface its error raw.
-            return gh_pr_diff_from_files(&repo_path, number).await;
+            return gh_pr_diff_from_files(&repo_path, number, lens.as_deref()).await;
         }
         Err(e) => return Err(e),
     };
@@ -2840,10 +2874,15 @@ struct GhCommitComment {
 /// List a commit's comments (`GET repos/{o}/{r}/commits/{sha}/comments`, paginated
 /// via the `--slurp` idiom). `viewer_did_author` compares each author against the
 /// tolerantly-resolved current login.
-pub async fn commit_comments(repo_path: &str, sha: &str) -> AppResult<Vec<CommitCommentOut>> {
+pub async fn commit_comments(
+    repo_path: &str,
+    sha: &str,
+    lens: Option<&str>,
+) -> AppResult<Vec<CommitCommentOut>> {
     validate_commit_oid(sha)?;
-    // Pin the origin slug so a fork reads its own commit's comments, not the parent's.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // Resolve the lens slug so the commit's comments read from the chosen repo's
+    // namespace (default origin — a fork reads its own, not the parent's).
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let viewer = current_login(repo_path).await;
     let endpoint = format!("repos/{slug}/commits/{sha}/comments");
     let out = run_gh(
@@ -2902,13 +2941,15 @@ pub async fn commit_comment_create(
     body: &str,
     path: Option<&str>,
     position: Option<u64>,
+    lens: Option<&str>,
 ) -> AppResult<()> {
     if body.trim().is_empty() {
         return Err(AppError::InvalidArgument("a comment is required".into()));
     }
     validate_commit_oid(sha)?;
-    // Pin the origin slug so a fork's commit comment lands on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // Resolve the lens slug so the commit comment lands in the chosen repo's
+    // namespace (default origin — a fork's comment lands on the fork, not the parent).
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/commits/{sha}/comments");
     let mut payload = serde_json::json!({ "body": body });
     if let (Some(p), Some(pos)) = (path, position) {
@@ -2975,9 +3016,9 @@ pub async fn commit_comment_delete(repo_path: &str, comment_id: &str) -> AppResu
 /// Resolve a PR's head commit oid (`gh pr view {n} --json headRefOid`). Used to
 /// anchor a new inline review comment/thread to the current head — the commits list
 /// caps at 100, so this dedicated read is the reliable source.
-async fn head_ref_oid(repo_path: &str, number: u64) -> AppResult<String> {
-    // Pin the origin slug so a fork's PR resolves against the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+async fn head_ref_oid(repo_path: &str, number: u64, lens: Option<&str>) -> AppResult<String> {
+    // Inherit the lens so the PR resolves against the same repo as the write below.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let out = run_gh(
         Some(repo_path),
         &[
@@ -3014,6 +3055,7 @@ fn gh_side(side: &str) -> AppResult<&'static str> {
 /// repos/{o}/{r}/pulls/{n}/comments` via `--input -`). `side` is `"new"`/`"old"`;
 /// `start_line` (GitHub-only multi-line range) adds `start_line` + `start_side`.
 /// The head oid is resolved internally. Plain fn (called by the forge dispatch).
+#[allow(clippy::too_many_arguments)]
 pub async fn thread_create(
     repo_path: &str,
     number: u64,
@@ -3022,6 +3064,7 @@ pub async fn thread_create(
     side: &str,
     start_line: Option<u64>,
     body: &str,
+    lens: Option<&str>,
 ) -> AppResult<()> {
     if body.trim().is_empty() {
         return Err(AppError::InvalidArgument("a comment is required".into()));
@@ -3030,7 +3073,7 @@ pub async fn thread_create(
         return Err(AppError::InvalidArgument("a file path is required".into()));
     }
     let gh_side = gh_side(side)?;
-    let commit_id = head_ref_oid(repo_path, number).await?;
+    let commit_id = head_ref_oid(repo_path, number, lens).await?;
     let mut payload = serde_json::json!({
         "body": body,
         "commit_id": commit_id,
@@ -3042,8 +3085,8 @@ pub async fn thread_create(
         payload["start_line"] = serde_json::Value::from(start);
         payload["start_side"] = serde_json::Value::String(gh_side.to_string());
     }
-    // Pin the origin slug so a fork's review thread lands on the fork's PR, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // Resolve the lens slug so the review thread lands on the chosen repo's PR.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/pulls/{number}/comments");
     run_gh_input(
         Some(repo_path),
@@ -3069,6 +3112,7 @@ pub async fn review_submit(
     verdict: &str,
     summary: Option<&str>,
     comments: &[DraftCommentIn],
+    lens: Option<&str>,
 ) -> AppResult<ReviewSubmitOut> {
     let event = match verdict {
         "comment" => "COMMENT",
@@ -3078,7 +3122,7 @@ pub async fn review_submit(
     };
     // Anchor the review's inline comments against the head the reviewer's lines were
     // computed on (not whatever head exists at submit time), like `thread_create`.
-    let commit_id = head_ref_oid(repo_path, number).await?;
+    let commit_id = head_ref_oid(repo_path, number, lens).await?;
     let mut payload = serde_json::json!({ "event": event, "commit_id": commit_id });
     if let Some(s) = summary.filter(|s| !s.trim().is_empty()) {
         payload["body"] = serde_json::Value::String(s.to_string());
@@ -3101,8 +3145,8 @@ pub async fn review_submit(
     if !arr.is_empty() {
         payload["comments"] = serde_json::Value::Array(arr);
     }
-    // Pin the origin slug so a fork's review is submitted on the fork's PR, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // Resolve the lens slug so the review is submitted on the chosen repo's PR.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/pulls/{number}/reviews");
     run_gh_input(
         Some(repo_path),
@@ -3157,14 +3201,18 @@ struct GhPrFile {
 /// `gh pr view --json files` and `gh pr diff` both cap at GitHub's GraphQL 100-file
 /// connection limit; this endpoint paginates past it. Used both to reconstruct the
 /// >300-file diff and to complete the PR-view file rail.
-async fn gh_pr_files_paginated(repo_path: &str, number: u64) -> AppResult<Vec<GhPrFile>> {
-    // Pin the origin slug: the caller (`gh_pr_view`) resolves PR numbers against the
-    // fork's own PRs, so this top-up must resolve to the SAME repo (the fork), not
-    // the parent gh would auto-detect from an `upstream` remote. `--paginate` on an
-    // array endpoint emits one JSON array PER PAGE concatenated, which a single
-    // `from_str::<Vec<_>>` can't parse — `--slurp` wraps the pages into one outer
-    // array of arrays, which we then flatten. (gh 2.44+ supports `--slurp`.)
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+async fn gh_pr_files_paginated(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<Vec<GhPrFile>> {
+    // Inherit the caller's lens: `gh_pr_view` resolves PR numbers against one repo,
+    // so this top-up must resolve to the SAME repo, not the parent gh would
+    // auto-detect from an `upstream` remote. `--paginate` on an array endpoint emits
+    // one JSON array PER PAGE concatenated, which a single `from_str::<Vec<_>>` can't
+    // parse — `--slurp` wraps the pages into one outer array of arrays, which we then
+    // flatten. (gh 2.44+ supports `--slurp`.)
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/pulls/{number}/files");
     let out = run_gh(
         Some(repo_path),
@@ -3357,10 +3405,14 @@ fn rest_comment_to_out(c: GhPrRestComment, viewer_login: Option<&str>) -> PrThre
 /// Completes the PR's commit list via the paginated commits REST API, past the
 /// 100-item GraphQL cap `gh pr view --json commits` hits. Returns rows in the
 /// PR-view shape.
-async fn gh_pr_commits_paginated(repo_path: &str, number: u64) -> AppResult<Vec<PrCommitOut>> {
-    // Pin the origin slug: `gh_pr_view` resolves PR numbers against the fork's own
-    // PRs, so this top-up must resolve to the SAME repo (the fork), not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+async fn gh_pr_commits_paginated(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<Vec<PrCommitOut>> {
+    // Inherit the caller's lens: `gh_pr_view` resolves PR numbers against one repo,
+    // so this top-up must resolve to the SAME repo, not the parent.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/pulls/{number}/commits");
     let out = run_gh(
         Some(repo_path),
@@ -3388,10 +3440,14 @@ async fn gh_pr_commits_paginated(repo_path: &str, number: u64) -> AppResult<Vec<
 
 /// Completes the PR's review list via the paginated reviews REST API, past the
 /// 100-item GraphQL cap. Returns rows in the PR-view thread shape.
-async fn gh_pr_reviews_paginated(repo_path: &str, number: u64) -> AppResult<Vec<PrThreadOut>> {
-    // Pin the origin slug: must resolve to the same repo (the fork) `gh_pr_view`
-    // resolved the PR number against, or a fork would 404.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+async fn gh_pr_reviews_paginated(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<Vec<PrThreadOut>> {
+    // Inherit the caller's lens: must resolve to the same repo `gh_pr_view`
+    // resolved the PR number against, or it would 404.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/pulls/{number}/reviews");
     let out = run_gh(
         Some(repo_path),
@@ -3421,10 +3477,14 @@ async fn gh_pr_reviews_paginated(repo_path: &str, number: u64) -> AppResult<Vec<
 /// REST API (a PR's conversation comments are issue comments), past the 100-item
 /// GraphQL cap. Resolves the authenticated login once (best-effort) to set
 /// `viewer_did_author`. Returns rows in the PR-view thread shape.
-async fn gh_pr_comments_paginated(repo_path: &str, number: u64) -> AppResult<Vec<PrThreadOut>> {
-    // Pin the origin slug: must resolve to the same repo (the fork) `gh_pr_view`
-    // resolved the PR number against, or a fork would 404.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+async fn gh_pr_comments_paginated(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<Vec<PrThreadOut>> {
+    // Inherit the caller's lens: must resolve to the same repo `gh_pr_view`
+    // resolved the PR number against, or it would 404.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/issues/{number}/comments");
     let out = run_gh(
         Some(repo_path),
@@ -3466,8 +3526,12 @@ async fn gh_pr_comments_paginated(repo_path: &str, number: u64) -> AppResult<Vec
 /// unified diff from them, in the same `git`-style format `gh pr diff` produces
 /// so the frontend diff viewer parses it identically. This is the >300-file
 /// fallback for `gh_pr_diff`.
-async fn gh_pr_diff_from_files(repo_path: &str, number: u64) -> AppResult<String> {
-    let files = gh_pr_files_paginated(repo_path, number).await?;
+async fn gh_pr_diff_from_files(
+    repo_path: &str,
+    number: u64,
+    lens: Option<&str>,
+) -> AppResult<String> {
+    let files = gh_pr_files_paginated(repo_path, number, lens).await?;
     let diff = reconstruct_pr_diff(&files);
     let (text, _) = crate::git::diff::truncate_at_char_boundary(diff, 2_000_000);
     Ok(text)
@@ -3585,8 +3649,9 @@ pub struct ExternalReviewItem {
 pub async fn gh_pr_external_reviews(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<ExternalReviewItem>> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     validate_graphql_embed(&owner, "repository owner")?;
     validate_graphql_embed(&name, "repository name")?;
 
@@ -3798,8 +3863,9 @@ async fn gh_thread_comment_replies_topup(
 pub async fn gh_pr_review_threads(
     repo_path: String,
     number: u64,
+    lens: Option<String>,
 ) -> AppResult<Vec<ReviewThreadOut>> {
-    let (owner, name) = repo_owner_name(&repo_path).await?;
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
     validate_graphql_embed(&owner, "repository owner")?;
     validate_graphql_embed(&name, "repository name")?;
 
@@ -4006,16 +4072,90 @@ pub async fn gh_pr_resolve_review_thread(
     Ok(())
 }
 
+/// A subset of the GitHub REST `GET /repos/{slug}/pulls` item, enough to build a
+/// [`PrInfo`] for the upstream-lens duplicate probe (see [`gh_prs_for_branch`]).
+/// Tolerant serde over the untrusted REST payload.
+#[derive(Deserialize)]
+struct GhPrRestPull {
+    number: u64,
+    html_url: String,
+    #[serde(default)]
+    title: String,
+    base: GhPrRestPullRef,
+    head: GhPrRestPullRef,
+    #[serde(default)]
+    draft: bool,
+}
+
+#[derive(Deserialize)]
+struct GhPrRestPullRef {
+    #[serde(rename = "ref", default)]
+    ref_name: String,
+}
+
+/// Map a REST `pulls` item onto the [`PrInfo`] the frontend already consumes. The
+/// caller queries `state=open`, so every item here is open by construction — hence
+/// the `"OPEN"` casing (matching what `gh pr list --json state` emits for the
+/// origin path). Only the fields the compare-panel probe needs are populated.
+fn rest_pull_to_pr_info(p: GhPrRestPull) -> PrInfo {
+    PrInfo {
+        number: p.number,
+        url: p.html_url,
+        title: p.title,
+        base_ref_name: p.base.ref_name,
+        head_ref_name: p.head.ref_name,
+        is_draft: p.draft,
+        state: "OPEN".to_string(),
+        author: None,
+        labels: Vec::new(),
+        created_at: String::new(),
+        head_sha: String::new(),
+    }
+}
+
 /// Open PRs whose head is `head` (there's at most one per base). Lets the UI
 /// offer "View pull request" instead of "Create" once one already exists.
+///
+/// `lens`: `None`/`Some("origin")` probes the fork's own PRs (consistent with
+/// `gh_pr_list`); `Some("upstream")` probes the PARENT repo — the fork
+/// contribution flow's "did I already open this upstream?" check.
+///
+/// The upstream arm does NOT use `gh pr list --head`: verified live 2026-07-16,
+/// `gh pr list --head "owner:branch"` silently returns `[]` even when the PR
+/// exists (it doesn't support the owner-prefixed head form). We hit REST instead
+/// — `GET repos/<parent>/pulls?head=<fork_owner>:<head>&state=open` — which
+/// matches cross-fork heads correctly. The caller passes a BARE branch name; we
+/// compose the `owner:` prefix here from the fork's origin owner.
 #[tauri::command]
-pub async fn gh_prs_for_branch(repo_path: String, head: String) -> AppResult<Vec<PrInfo>> {
+pub async fn gh_prs_for_branch(
+    repo_path: String,
+    head: String,
+    lens: Option<String>,
+) -> AppResult<Vec<PrInfo>> {
     if head.is_empty() || head.starts_with('-') {
         return Err(AppError::InvalidArgument(format!("invalid branch: {head}")));
     }
-    // Pin the origin slug so this "does a PR exist for this branch?" check reads the
+    if lens.as_deref() == Some("upstream") {
+        let parent_slug = crate::github::gh_lens_slug(&repo_path, Some("upstream")).await?;
+        let origin_slug = crate::github::gh_lens_slug(&repo_path, None).await?;
+        let fork_owner = crate::github::fork_owner_of(&origin_slug);
+        // `head`/`owner`/`ref` are all `[A-Za-z0-9_./-]` (branch validated above),
+        // so they're query-safe interpolated literally into the endpoint.
+        let endpoint =
+            format!("repos/{parent_slug}/pulls?head={fork_owner}:{head}&state=open");
+        let out = run_gh(
+            Some(&repo_path),
+            &["api", "--method", "GET", &endpoint],
+            GH_TIMEOUT,
+        )
+        .await?;
+        let pulls: Vec<GhPrRestPull> = serde_json::from_str(&out.stdout_lossy())
+            .map_err(|e| AppError::Gh(format!("could not parse gh api pulls: {e}")))?;
+        return Ok(pulls.into_iter().map(rest_pull_to_pr_info).collect());
+    }
+    // Pin the resolved slug so this "does a PR exist for this branch?" check reads the
     // fork's own PRs (consistent with `gh_pr_list`), not the parent's.
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
         &[
@@ -4051,15 +4191,34 @@ pub async fn gh_pr_create(
     draft: bool,
     labels: Vec<String>,
     assignees: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<PrRef> {
     // The command shell derefs the managed `State` to a plain `&AppState` and
     // delegates to the core, so off-Tauri callers (the MCP server, via
     // `forge_pr_create_core`) can create a PR with an `AppState` they own.
-    gh_pr_create_core(&state, repo_path, base, head, title, body, draft, labels, assignees).await
+    gh_pr_create_core(
+        &state, repo_path, base, head, title, body, draft, labels, assignees, lens,
+    )
+    .await
 }
 
 /// The body of [`gh_pr_create`], taking a plain `&AppState` so it is callable off
 /// the Tauri runtime (the MCP server routes here through `forge_pr_create_core`).
+///
+/// `lens` selects the target repo:
+/// - `None`/`Some("origin")`: a same-repo PR **on the fork itself**, created with
+///   an explicit `-R <origin-slug>`. This is a deliberate behavior change from
+///   Part A (#56): the create call used to be UNPINNED, so on a fork `gh` would
+///   auto-resolve to the PARENT — meaning `gh_prs_for_branch`/`gh_pr_list` checked
+///   the fork while create silently targeted upstream. Pinning origin here closes
+///   that disclosed asymmetry: origin lens = honest, explicit same-repo PR.
+/// - `Some("upstream")`: the real fork contribution flow — push `head` to origin
+///   (origin IS the fork), then `gh pr create -R <parent> --head <fork_owner>:<head>`.
+///   Labels/assignees/reviewers are rejected up front (v1 keeps the cross-repo
+///   create minimal; the post-create edit is skipped on this path). Per gh's own
+///   docs (`gh pr create --help`, verified 2026-07-16) the `<user>:<branch>` head
+///   form does NOT support an organization as `<user>` (cli/cli#10093); gh's error
+///   is the disclosure surface if the fork owner is an org.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn gh_pr_create_core(
     state: &AppState,
@@ -4071,12 +4230,68 @@ pub(crate) async fn gh_pr_create_core(
     draft: bool,
     labels: Vec<String>,
     assignees: Vec<String>,
+    lens: Option<String>,
 ) -> AppResult<PrRef> {
+    // Pre-mutation guards: every local precondition is checked BEFORE the push, so
+    // no remote mutation happens on an input we'd have rejected.
     validate_branch(&base)?;
     validate_branch(&head)?;
     if title.trim().is_empty() {
         return Err(AppError::InvalidArgument("a PR title is required".into()));
     }
+
+    let upstream = lens.as_deref() == Some("upstream");
+    if lens.is_some() && !matches!(lens.as_deref(), Some("origin") | Some("upstream")) {
+        // Validate the lens before any remote work, mirroring `gh_lens_slug`.
+        return Err(AppError::InvalidArgument(format!(
+            "unknown remote lens: {}",
+            lens.as_deref().unwrap_or_default()
+        )));
+    }
+
+    if upstream {
+        // v1: the cross-repo create is minimal — no post-create edit — so reject
+        // metadata up front rather than silently dropping it (pre-mutation guard).
+        reject_upstream_create_metadata(&labels, &assignees)?;
+        let parent_slug = crate::github::gh_lens_slug(&repo_path, Some("upstream")).await?;
+        let origin_slug = crate::github::gh_lens_slug(&repo_path, None).await?;
+        let fork_owner = crate::github::fork_owner_of(&origin_slug).to_string();
+
+        // Push `head` to origin — origin IS the fork; the PR's head lives there.
+        run_git_mutating(
+            state,
+            &repo_path,
+            &["push", "-u", "origin", &head],
+            NETWORK_TIMEOUT,
+        )
+        .await?;
+
+        let cross_head = format!("{fork_owner}:{head}");
+        let mut args = vec![
+            "pr",
+            "create",
+            "--repo",
+            &parent_slug,
+            "--base",
+            &base,
+            "--head",
+            &cross_head,
+            "--title",
+            &title,
+            "--body",
+            &body,
+        ];
+        if draft {
+            args.push("--draft");
+        }
+        let out = run_gh(Some(&repo_path), &args, GH_NETWORK_TIMEOUT).await?;
+        let (number, url) = scrape_pr_ref(&out.stdout_lossy());
+        return Ok(PrRef { number, url });
+    }
+
+    // Origin lens (default). Pin the origin slug so this is a same-repo PR on the
+    // fork, explicit and honest (see the doc comment above).
+    let origin_slug = crate::github::gh_lens_slug(&repo_path, None).await?;
 
     // gh can only open a PR for a branch that exists on the remote.
     run_git_mutating(
@@ -4088,7 +4303,18 @@ pub(crate) async fn gh_pr_create_core(
     .await?;
 
     let mut args = vec![
-        "pr", "create", "--base", &base, "--head", &head, "--title", &title, "--body", &body,
+        "pr",
+        "create",
+        "--repo",
+        &origin_slug,
+        "--base",
+        &base,
+        "--head",
+        &head,
+        "--title",
+        &title,
+        "--body",
+        &body,
     ];
     if draft {
         args.push("--draft");
@@ -4101,20 +4327,7 @@ pub(crate) async fn gh_pr_create_core(
     // each exactly once. (Reproduced empirically 2026-07-10.)
     let out = run_gh(Some(&repo_path), &args, GH_NETWORK_TIMEOUT).await?;
 
-    // gh prints the new PR's URL as its last stdout line.
-    let url = out
-        .stdout_lossy()
-        .lines()
-        .rev()
-        .map(str::trim)
-        .find(|l| l.starts_with("http"))
-        .unwrap_or_default()
-        .to_string();
-    let number = url
-        .rsplit('/')
-        .next()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(0);
+    let (number, url) = scrape_pr_ref(&out.stdout_lossy());
 
     // Apply labels + assignees once, post-create. Address the PR by NUMBER when the
     // URL scrape yielded one (unambiguous, and the only form `gh pr edit` accepts for
@@ -4122,14 +4335,15 @@ pub(crate) async fn gh_pr_create_core(
     // still never depends on the scrape succeeding (the old `gh pr create --label`
     // argv applied labels unconditionally; keep that guarantee). Values come from the
     // repo's own pickers, so they resolve; an unknown one would fail this edit AFTER
-    // the PR exists (surfaced, not silent).
+    // the PR exists (surfaced, not silent). Pinned to the origin slug to match the
+    // create call above.
     if !labels.is_empty() || !assignees.is_empty() {
         let pr_id = if number != 0 {
             number.to_string()
         } else {
             head.clone()
         };
-        let mut edit_args = vec!["pr", "edit", pr_id.as_str()];
+        let mut edit_args = vec!["pr", "edit", pr_id.as_str(), "--repo", &origin_slug];
         for label in &labels {
             edit_args.push("--add-label");
             edit_args.push(label);
@@ -4158,15 +4372,50 @@ pub(crate) async fn gh_pr_create_core(
     Ok(PrRef { number, url })
 }
 
+/// Pre-mutation guard for the upstream-lens PR create: the v1 cross-repo flow is
+/// minimal (no post-create `gh pr edit`), so any labels or assignees are rejected
+/// up front rather than silently dropped. Pure, so it's unit-testable and runs
+/// before the branch push. (Reviewers aren't a param here — the `forge_pr_create`
+/// dispatch rejects create-time reviewers for GitHub before reaching this core —
+/// but the message names them so the surface reads consistently.)
+fn reject_upstream_create_metadata(labels: &[String], assignees: &[String]) -> AppResult<()> {
+    if !labels.is_empty() || !assignees.is_empty() {
+        return Err(AppError::InvalidArgument(
+            "Labels, assignees, and reviewers aren't supported when creating a pull request on the upstream repository.".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Scrape the new PR's number + URL from `gh pr create` stdout (gh prints the URL
+/// as its last line). Shared by the origin and upstream create paths.
+fn scrape_pr_ref(stdout: &str) -> (u64, String) {
+    let url = stdout
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|l| l.starts_with("http"))
+        .unwrap_or_default()
+        .to_string();
+    let number = url
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    (number, url)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         host_from_url, is_diff_too_large, map_timeline_node, parse_actions_run_job,
-        parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff, rest_comment_to_out,
-        rest_commit_to_out, rest_review_to_out, rollup_state_to_ci, split_commit_message, GhPrFile,
-        GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner,
-        GhPrRestReview, PrTimelineEventOut, RawLogin,
+        parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
+        reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
+        rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
+        split_commit_message, GhPrFile, GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor,
+        GhPrRestCommitInner, GhPrRestPull, GhPrRestReview, PrTimelineEventOut, RawLogin,
     };
+    use crate::error::AppError;
 
     fn file(status: &str, filename: &str, patch: Option<&str>) -> GhPrFile {
         GhPrFile {
@@ -4640,5 +4889,79 @@ github.acme.com
         // An unrecognized/missing __typename is skipped (None), not a panic.
         assert!(node(serde_json::json!({ "__typename": "SomeOtherEvent" })).is_none());
         assert!(node(serde_json::json!({ "actor": {"login": "a"} })).is_none());
+    }
+
+    #[test]
+    fn rest_pull_maps_onto_pr_info_as_open() {
+        // A REST `GET /repos/{parent}/pulls?head=…&state=open` item, matching the
+        // shape verified live against biomejs/biome#10965. Only the compare-panel
+        // probe's fields need to survive the mapping; state is "OPEN" by construction.
+        let raw: GhPrRestPull = serde_json::from_value(serde_json::json!({
+            "number": 10965,
+            "html_url": "https://github.com/biomejs/biome/pull/10965",
+            "title": "feat: resolve globals from d.ts",
+            "base": { "ref": "main" },
+            "head": { "ref": "feat/resolve-globals-from-dts" },
+            "draft": false,
+        }))
+        .expect("REST pull fixture deserializes");
+        let info = rest_pull_to_pr_info(raw);
+        assert_eq!(info.number, 10965);
+        assert_eq!(info.url, "https://github.com/biomejs/biome/pull/10965");
+        assert_eq!(info.title, "feat: resolve globals from d.ts");
+        assert_eq!(info.base_ref_name, "main");
+        assert_eq!(info.head_ref_name, "feat/resolve-globals-from-dts");
+        assert!(!info.is_draft);
+        // Open by construction → the same casing gh's `--json state` emits, so the
+        // frontend's `pr.state === "OPEN"` checks fire identically on this path.
+        assert_eq!(info.state, "OPEN");
+    }
+
+    #[test]
+    fn rest_pull_tolerates_missing_optional_fields_and_draft() {
+        // A draft PR with an absent title (tolerant serde: defaults to "").
+        let raw: GhPrRestPull = serde_json::from_value(serde_json::json!({
+            "number": 7,
+            "html_url": "https://github.com/o/r/pull/7",
+            "base": { "ref": "trunk" },
+            "head": { "ref": "wip" },
+            "draft": true,
+        }))
+        .expect("draft REST pull fixture deserializes");
+        let info = rest_pull_to_pr_info(raw);
+        assert_eq!(info.title, "");
+        assert!(info.is_draft);
+        assert_eq!(info.state, "OPEN");
+    }
+
+    #[test]
+    fn upstream_create_rejects_labels_or_assignees() {
+        let label = vec!["bug".to_string()];
+        let assignee = vec!["octocat".to_string()];
+        // Empty metadata is allowed on the upstream path.
+        assert!(reject_upstream_create_metadata(&[], &[]).is_ok());
+        // A non-empty label OR assignee list is rejected (pre-mutation, no push).
+        for (labels, assignees) in [
+            (label.as_slice(), [].as_slice()),
+            ([].as_slice(), assignee.as_slice()),
+            (label.as_slice(), assignee.as_slice()),
+        ] {
+            let err = reject_upstream_create_metadata(labels, assignees).unwrap_err();
+            assert!(
+                matches!(err, AppError::InvalidArgument(_)),
+                "expected InvalidArgument, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn scrape_pr_ref_reads_the_last_url_line() {
+        // gh prints the new PR's URL as the last stdout line.
+        let (number, url) =
+            scrape_pr_ref("Warning: something\nhttps://github.com/o/r/pull/42\n");
+        assert_eq!(number, 42);
+        assert_eq!(url, "https://github.com/o/r/pull/42");
+        // No URL line → number 0, empty url (create still returns Ok elsewhere).
+        assert_eq!(scrape_pr_ref("no url here"), (0, String::new()));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -624,6 +624,7 @@ pub fn run() {
             git::remote::git_remotes,
             git::remote::git_remote_url,
             git::remote::git_remote_set_url,
+            git::remote::git_remote_add,
             git::submodule::git_submodules,
             git::submodule::git_submodule_update,
             secrets::set_secret,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -862,7 +862,7 @@ impl GitDesktopMcp {
 
         // Labels are best-effort: a forge error omits the section entirely rather
         // than failing the tool (mirrors the spec's best-effort contract).
-        let available_labels = crate::forge::forge_repo_labels(self.repo.clone())
+        let available_labels = crate::forge::forge_repo_labels(self.repo.clone(), None)
             .await
             .map(|labels| labels.into_iter().map(|l| l.name).collect::<Vec<_>>())
             .unwrap_or_default();

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -146,6 +146,10 @@ impl GitDesktopMcp {
             self.repo.clone(),
             args.state.unwrap_or_else(|| "open".to_string()),
             args.limit,
+            // MCP stays origin-pinned in v1 (no lens surface): a fork's MCP server
+            // always answers for the fork itself. Documented gap, tracked for a later
+            // pass. Same for every `None` lens below.
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -162,7 +166,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
-        let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number)
+        let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result_untrusted(&pr)
@@ -176,7 +180,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
-        let diff = crate::forge::forge_pr_diff(self.repo.clone(), args.number)
+        let diff = crate::forge::forge_pr_diff(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         text_result_untrusted(cap_head(diff, GH_TEXT_MAX_BYTES))
@@ -197,11 +201,11 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<PrCommentsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number)
+        let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         let mut review_threads =
-            crate::forge::forge_pr_review_threads(self.repo.clone(), args.number)
+            crate::forge::forge_pr_review_threads(self.repo.clone(), args.number, None)
                 .await
                 .map_err(app_err)?;
         // Bound each thread's diffHunk so a comment on a new file can't drag the
@@ -272,6 +276,7 @@ impl GitDesktopMcp {
             self.repo.clone(),
             args.state.unwrap_or_else(|| "open".to_string()),
             args.limit,
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -289,7 +294,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
-        let issue = crate::forge::forge_issue_view(self.repo.clone(), args.number)
+        let issue = crate::forge::forge_issue_view(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result_untrusted(&issue)
@@ -368,7 +373,7 @@ impl GitDesktopMcp {
                        these names when applying labels via edit_labels. Returns JSON."
     )]
     async fn list_labels(&self) -> Result<CallToolResult, McpError> {
-        let labels = crate::forge::forge_repo_labels(self.repo.clone())
+        let labels = crate::forge::forge_repo_labels(self.repo.clone(), None)
             .await
             .map_err(app_err)?;
         json_result(&labels)
@@ -379,7 +384,7 @@ impl GitDesktopMcp {
                        remote; Bitbucket milestones aren't supported). Returns JSON."
     )]
     async fn list_milestones(&self) -> Result<CallToolResult, McpError> {
-        let milestones = crate::forge::forge_milestones(self.repo.clone())
+        let milestones = crate::forge::forge_milestones(self.repo.clone(), None)
             .await
             .map_err(app_err)?;
         json_result_untrusted(&milestones)
@@ -419,7 +424,7 @@ impl GitDesktopMcp {
                        set_pull_request_assignees. Returns JSON."
     )]
     async fn list_assignable_users(&self) -> Result<CallToolResult, McpError> {
-        let users = crate::forge::forge_assignable_users(self.repo.clone())
+        let users = crate::forge::forge_assignable_users(self.repo.clone(), None)
             .await
             .map_err(app_err)?;
         json_result(&users)
@@ -434,7 +439,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
-        let timeline = crate::forge::forge_pr_timeline(self.repo.clone(), args.number)
+        let timeline = crate::forge::forge_pr_timeline(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result_untrusted(&timeline)

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -415,6 +415,8 @@ impl GitDesktopMcp {
             args.assignees,
             None,
             None,
+            // Lens: MCP stays origin-pinned in v1 (documented gap). Same below.
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -436,7 +438,7 @@ impl GitDesktopMcp {
         self.ensure_remote_write()?;
         // Append the attribution footer so the comment is identifiable as ours.
         let body = format!("{}{GD_COMMENT_FOOTER}", args.body);
-        crate::forge::forge_issue_comment(self.repo.clone(), args.number, body)
+        crate::forge::forge_issue_comment(self.repo.clone(), args.number, body, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "issue": args.number, "action": "commented" }))
@@ -462,7 +464,7 @@ impl GitDesktopMcp {
         } else {
             args.reason.as_str()
         };
-        crate::forge::forge_issue_close(self.repo.clone(), args.number, args.reason.clone())
+        crate::forge::forge_issue_close(self.repo.clone(), args.number, args.reason.clone(), None)
             .await
             .map_err(app_err)?;
         json_result(
@@ -482,7 +484,7 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<ReopenIssueArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_issue_reopen(self.repo.clone(), args.number)
+        crate::forge::forge_issue_reopen(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "issue": args.number, "status": "open" }))
@@ -503,7 +505,7 @@ impl GitDesktopMcp {
         self.ensure_remote_write()?;
         // Append the attribution footer so the comment is identifiable as ours.
         let body = format!("{}{GD_COMMENT_FOOTER}", args.body);
-        crate::forge::forge_pr_comment(self.repo.clone(), args.number, body, None)
+        crate::forge::forge_pr_comment(self.repo.clone(), args.number, body, None, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "pull_request": args.number, "action": "commented" }))
@@ -542,6 +544,8 @@ impl GitDesktopMcp {
             args.reviewers,
             args.labels,
             args.assignees,
+            // Lens: MCP always creates on origin in v1 (no upstream-PR affordance yet).
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -567,6 +571,7 @@ impl GitDesktopMcp {
             args.number,
             strategy.clone(),
             args.delete_branch,
+            None,
             None,
         )
         .await
@@ -601,14 +606,14 @@ impl GitDesktopMcp {
         // forge_pr_edit replaces BOTH title and body, so fetch the current PR to fill
         // whichever the caller omitted — otherwise an omitted field would be wiped.
         let (title, body) = if args.title.is_none() || args.body.is_none() {
-            let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number)
+            let pr = crate::forge::forge_pr_view(self.repo.clone(), args.number, None)
                 .await
                 .map_err(app_err)?;
             (args.title.unwrap_or(pr.title), args.body.unwrap_or(pr.body))
         } else {
             (args.title.unwrap(), args.body.unwrap())
         };
-        crate::forge::forge_pr_edit(self.repo.clone(), args.number, title, body)
+        crate::forge::forge_pr_edit(self.repo.clone(), args.number, title, body, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "pull_request": args.number, "action": "updated" }))
@@ -644,7 +649,7 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_pr_close(self.repo.clone(), args.number)
+        crate::forge::forge_pr_close(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "pull_request": args.number, "status": "closed" }))
@@ -662,7 +667,7 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_pr_reopen(self.repo.clone(), args.number)
+        crate::forge::forge_pr_reopen(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "pull_request": args.number, "status": "open" }))
@@ -685,6 +690,7 @@ impl GitDesktopMcp {
             self.repo.clone(),
             args.number,
             args.reviewers.clone(),
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -724,19 +730,19 @@ impl GitDesktopMcp {
         // maps come back empty there — harmless, since GitLab uses the name side.)
         let labelable_id = match target {
             "mr" => {
-                crate::forge::forge_pr_view(self.repo.clone(), args.number)
+                crate::forge::forge_pr_view(self.repo.clone(), args.number, None)
                     .await
                     .map_err(app_err)?
                     .id
             }
             _ => {
-                crate::forge::forge_issue_view(self.repo.clone(), args.number)
+                crate::forge::forge_issue_view(self.repo.clone(), args.number, None)
                     .await
                     .map_err(app_err)?
                     .id
             }
         };
-        let repo_labels = crate::forge::forge_repo_labels(self.repo.clone())
+        let repo_labels = crate::forge::forge_repo_labels(self.repo.clone(), None)
             .await
             .map_err(app_err)?;
         let id_for = |name: &str| -> Option<String> {
@@ -813,6 +819,7 @@ impl GitDesktopMcp {
             self.repo.clone(),
             args.number,
             args.assignees.clone(),
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -836,6 +843,7 @@ impl GitDesktopMcp {
             self.repo.clone(),
             args.number,
             args.assignees.clone(),
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -855,7 +863,7 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<NumberArg>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_pr_approve(self.repo.clone(), args.number)
+        crate::forge::forge_pr_approve(self.repo.clone(), args.number, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "pull_request": args.number, "action": "approved" }))
@@ -1120,6 +1128,7 @@ impl GitDesktopMcp {
             side,
             args.start_line,
             body,
+            None,
         )
         .await
         .map_err(app_err)?;
@@ -1139,7 +1148,7 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<RequestChangesArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_pr_request_changes(self.repo.clone(), args.number, args.body)
+        crate::forge::forge_pr_request_changes(self.repo.clone(), args.number, args.body, None)
             .await
             .map_err(app_err)?;
         json_result(
@@ -1184,7 +1193,7 @@ impl GitDesktopMcp {
         // fill whichever the caller omitted — otherwise an omitted field would be wiped
         // (same fetch-and-preserve as update_pull_request).
         let (title, body) = if args.title.is_none() || args.body.is_none() {
-            let issue = crate::forge::forge_issue_view(self.repo.clone(), args.number)
+            let issue = crate::forge::forge_issue_view(self.repo.clone(), args.number, None)
                 .await
                 .map_err(app_err)?;
             (
@@ -1194,7 +1203,7 @@ impl GitDesktopMcp {
         } else {
             (args.title.unwrap(), args.body.unwrap())
         };
-        crate::forge::forge_issue_edit(self.repo.clone(), args.number, title, body)
+        crate::forge::forge_issue_edit(self.repo.clone(), args.number, title, body, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "issue": args.number, "action": "updated" }))
@@ -1212,7 +1221,7 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<SetIssueMilestoneArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_issue_set_milestone(self.repo.clone(), args.number, args.milestone)
+        crate::forge::forge_issue_set_milestone(self.repo.clone(), args.number, args.milestone, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "issue": args.number, "milestone": args.milestone }))

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -69,7 +69,10 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
   const prProbe = forgeFeatureReady(gh.data, "pullRequests");
   const isGitLab = gh.data?.provider === "gitlab";
   const prNoun = isGitLab ? "merge request" : "pull request";
-  const branchPrs = usePrsForBranch(repoPath, currentName, prProbe);
+  // Origin lens: this duplicate probe is about the FORK's own branch (the repo's
+  // origin), not any upstream contribution. The lens switcher is a PR/Issues-tab
+  // affordance; the Compare tab always reads origin.
+  const branchPrs = usePrsForBranch(repoPath, currentName, prProbe, "origin");
   // Agent-session branches (`gd/session/*`) are app-internal — never offer them
   // as a compare target (the PR button would even push one), like BranchSwitcher.
   const otherBranches = (branches.data ?? []).filter(

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -93,6 +93,10 @@ export function ConversationListPanel<L, R, J = never>(props: {
   onStateFilter: (s: "open" | "closed") => void;
   newMenu: NewMenuConfig;
   filterSlot: ReactNode;
+  /** Optional Fork | Upstream lens switch, rendered in the toolbar after the
+   *  state filter (before the New menu). Omit (the default) and nothing renders,
+   *  so panels without a lens are unaffected. */
+  lensControl?: ReactNode;
   // search
   filterRef: Ref<HTMLInputElement>;
   filterText: string;
@@ -190,6 +194,7 @@ export function ConversationListPanel<L, R, J = never>(props: {
     onStateFilter,
     newMenu,
     filterSlot,
+    lensControl,
     filterRef,
     filterText,
     onFilterText,
@@ -249,6 +254,7 @@ export function ConversationListPanel<L, R, J = never>(props: {
             {s === "open" ? "Open" : "Closed"}
           </Button>
         ))}
+        {lensControl}
         <DropdownMenu>
           <DropdownMenuTrigger
             render={

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
 import { useEditPrLabels, useRepoLabels } from "@/lib/git/queries";
-import type { RepoLabel } from "@/lib/git/types";
+import type { RemoteLens, RepoLabel } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
 import { LabelChip } from "./Thread";
 
@@ -22,6 +22,7 @@ export function LabelsPopover({
   target,
   labelableId,
   labels,
+  lens,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -31,9 +32,11 @@ export function LabelsPopover({
   target: "issue" | "mr";
   labelableId: string;
   labels: RepoLabel[];
+  /** The origin|upstream lens the parent PR/issue surface resolved. */
+  lens: RemoteLens;
 }) {
-  const repoLabels = useRepoLabels(repoPath, enabled);
-  const editLabels = useEditPrLabels(repoPath);
+  const repoLabels = useRepoLabels(repoPath, enabled, lens);
+  const editLabels = useEditPrLabels(repoPath, lens);
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<Set<string>>(new Set());
 

--- a/src/features/conversations/RepoLensSwitcher.tsx
+++ b/src/features/conversations/RepoLensSwitcher.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@/components/ui/button";
+import type { RemoteLens } from "@/lib/git/types";
+import {
+  useLensGate,
+  useRemoteSlug,
+  useRepoLens,
+  useSetRepoLens,
+} from "@/lib/repo-lens/queries";
+
+/**
+ * The per-repo Fork | Upstream lens switch, shared by the Pull Requests and
+ * Issues panels. A segmented pair of `aria-pressed` buttons mirroring the
+ * Open/Closed state filter in ConversationListPanel. Rendered only on a GitHub
+ * fork (useLensGate) — hidden entirely on GitLab/Bitbucket or a repo with no
+ * upstream remote. Each button's `title` names the repo it targets (the
+ * resolved slug), so the meaning is never conveyed by position alone.
+ */
+export function RepoLensSwitcher({ repoPath }: { repoPath: string }) {
+  const gate = useLensGate(repoPath);
+  const lens = useRepoLens(repoPath);
+  const setLens = useSetRepoLens(repoPath);
+  // Resolve both slugs only while the switcher is shown.
+  const forkSlug = useRemoteSlug(repoPath, "origin", gate);
+  const upstreamSlug = useRemoteSlug(repoPath, "upstream", gate);
+
+  if (!gate) return null;
+
+  const buttons: { value: RemoteLens; label: string; slug: string | null }[] = [
+    { value: "origin", label: "Fork", slug: forkSlug },
+    { value: "upstream", label: "Upstream", slug: upstreamSlug },
+  ];
+
+  return (
+    <div className="flex items-center gap-1">
+      {buttons.map((b) => (
+        <Button
+          key={b.value}
+          variant={lens === b.value ? "secondary" : "ghost"}
+          size="xs"
+          aria-pressed={lens === b.value}
+          title={b.slug ?? undefined}
+          onClick={() => setLens(b.value)}
+        >
+          {b.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -179,8 +179,10 @@ export function DiscussionView({
     ["repo", repoPath, "discussion", number, "reactions"] as const,
     details.data?.id ?? "",
   );
-  const editLabels = useEditPrLabels(repoPath);
-  const repoLabels = useRepoLabels(repoPath, true);
+  // Discussions are a GitHub-only surface with no fork/upstream lens (repo labels
+  // are identical either way); the "origin" lens just satisfies the shared hooks.
+  const editLabels = useEditPrLabels(repoPath, "origin");
+  const repoLabels = useRepoLabels(repoPath, true, "origin");
   const lockDiscussion = useLockDiscussion(repoPath);
   const unlockDiscussion = useUnlockDiscussion(repoPath);
   const closeDiscussion = useCloseDiscussion(repoPath);

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -526,6 +526,20 @@ The **Pull Requests** tab ({{kbd:tab-pulls}}) manages GitHub PRs, GitLab merge r
 and local PRs. (Hosted PRs/MRs need the matching CLI — \`gh\` or \`glab\` — installed and
 authenticated.)
 
+## Fork · Upstream lens
+
+When the repo is a **GitHub fork** — an \`origin\` you pushed to plus an \`upstream\`
+remote pointing at the parent — a **Fork | Upstream** switch appears in the list toolbar.
+It's **remembered per repository** and defaults to **Fork** (your \`origin\`). Flip it to
+**Upstream** and the remote pull-request list, and every PR you open from it — description,
+commits, comments, reviews, reactions, labels, assignees, and reviewers — read and write
+the **parent** repository instead of your fork; the section header names the repository
+you're looking at. Switch back to **Fork** for your own. The switch shows only on a GitHub
+fork (never on GitLab or Bitbucket, or a repo with no upstream remote). Two palette
+commands do the same thing without the mouse: **Switch to fork view** ({{kbd:repo-lens-origin}})
+and **Switch to upstream view** ({{kbd:repo-lens-upstream}}). The same lens scopes the
+**Issues** tab (see *Issues*).
+
 ## GitHub PRs
 
 Browse open/closed PRs and open one in a full in-app view: description, commits, changed
@@ -777,6 +791,22 @@ add labels, **close / reopen**, **lock**, and **transfer** an issue to another r
 - **Dependencies** — link issues as blocked-by / blocking.
 - **Development** — see linked PRs and branches, and **create a branch** wired to the
   issue.
+
+## Fork · Upstream lens
+
+When the repo is a **GitHub fork** (an \`upstream\` remote alongside your \`origin\`), the
+same **Fork | Upstream** switch as the Pull Requests tab appears in the toolbar —
+**remembered per repository**, defaulting to **Fork**, and also reachable as the
+**Switch to fork view** ({{kbd:repo-lens-origin}}) and **Switch to upstream view**
+({{kbd:repo-lens-upstream}}) palette commands. It scopes **only the GitHub (remote)
+section** — your local to-dos and any linked Jira issues are unaffected. Under **Upstream**
+the list, and every issue you open, read and write the **parent** repository. Because a
+fresh GitHub fork starts with **issues turned off**, browsing your fork may show an
+*issues are disabled* notice — from there a one-click **Switch to upstream** jumps you to
+the parent's issues rather than a dead end. **Creating** an issue while the **Upstream**
+lens is active opens it **on the parent repository, not your fork** — the create dialog
+retitles to *New issue in \<parent\>*, says so in its description, and its submit button
+reads **Create in \<parent\>**.
 
 ## GitLab issues
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -538,7 +538,9 @@ you're looking at. Switch back to **Fork** for your own. The switch shows only o
 fork (never on GitLab or Bitbucket, or a repo with no upstream remote). Two palette
 commands do the same thing without the mouse: **Switch to fork view** ({{kbd:repo-lens-origin}})
 and **Switch to upstream view** ({{kbd:repo-lens-upstream}}). The same lens scopes the
-**Issues** tab (see *Issues*).
+**Issues** tab (see *Issues*). Opening a PR against the parent — and this whole switch —
+needs an \`upstream\` remote; if you cloned your fork without one, the **Create pull
+request** dialog offers an **Add upstream remote** button that wires it up for you.
 
 ## GitHub PRs
 

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -96,7 +96,13 @@ export function CommitDetailView({
   const gate = ready && canCommentCommits;
   const onRemote = useCommitOnRemote(repoPath, gate ? hash : null);
   const commentsEnabled = gate && onRemote.data === true;
-  const comments = useCommitComments(repoPath, commentsEnabled ? hash : null);
+  // Origin lens: the History surface reads a repo's OWN commits (the fork's
+  // origin); the fork/upstream lens is a PR/Issues-tab affordance.
+  const comments = useCommitComments(
+    repoPath,
+    commentsEnabled ? hash : null,
+    "origin",
+  );
   // GitHub commit-comment `position` mapping must walk GitHub's OWN patch (local
   // git's diff can differ — rename detection, context), so we fetch the forge's
   // diff only for GitHub. GitLab/Bitbucket anchor by plain line and need none.
@@ -145,6 +151,7 @@ export function CommitDetailView({
               : undefined
           }
           onClose={onClose}
+          lens="origin"
         />
       ),
     };
@@ -383,6 +390,7 @@ export function CommitDetailView({
             diffSections={providerKey === "github" ? remoteSections : undefined}
             selectedPath={deferredPath}
             onSelectFile={selectFileFromComments}
+            lens="origin"
           />
         </div>
       ) : gate && onRemote.data === false ? (

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -22,7 +22,8 @@ import {
   useForgeStatus,
   useRepoLabels,
 } from "@/lib/git/queries";
-import type { ForgeUserRef, IssueType } from "@/lib/git/types";
+import type { ForgeUserRef, IssueType, RemoteLens } from "@/lib/git/types";
+import { useRemoteSlug } from "@/lib/repo-lens/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
@@ -36,12 +37,16 @@ import { useGenerateIssueDraft } from "./useGenerateIssueDraft";
 
 export function CreateIssueDialog({
   repoPath,
+  lens,
   open,
   onOpenChange,
   initialDraft,
   subIssueParentId,
 }: {
   repoPath: string;
+  /** The issues surface's origin|upstream lens. Under "upstream" the issue is
+   *  created ON THE PARENT — the dialog reframes to say so. */
+  lens: RemoteLens;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Seeds title/body (and labels, when duplicating) when opened — e.g.
@@ -51,14 +56,23 @@ export function CreateIssueDialog({
    *  (parent), and the view stays on the parent instead of navigating away. */
   subIssueParentId?: string;
 }) {
-  const createIssue = useCreateIssue(repoPath);
-  const addSubIssue = useAddSubIssue(repoPath);
-  const repoLabels = useRepoLabels(repoPath, open);
+  const createIssue = useCreateIssue(repoPath, lens);
+  const addSubIssue = useAddSubIssue(repoPath, lens);
+  const repoLabels = useRepoLabels(repoPath, open, lens);
+  // Under the upstream lens the issue is created ON THE PARENT; name that repo
+  // (the parent slug) so the create framing is unambiguous.
+  const isUpstream = lens === "upstream";
+  const parentSlug = useRemoteSlug(repoPath, "upstream", open && isUpstream);
   // The org issue type is a GitHub-only picker; the shared fields
   // (title/body/labels/assignees/milestone) work on both providers.
   const forge = useForgeStatus(repoPath);
   const isGitLab = forge.data?.provider === "gitlab";
   const remoteLabel = isGitLab ? "GitLab" : "GitHub";
+  // The create target's display name: the parent slug under the upstream lens
+  // (falling back to "the upstream repository" while it loads), else the forge.
+  const targetLabel = isUpstream
+    ? (parentSlug ?? "the upstream repository")
+    : remoteLabel;
   const selectIssue = useUiStore((s) => s.selectIssue);
   const repoName = useUiStore((s) => s.repoName) ?? "";
   const aiEnabled = useAiEnabled();
@@ -170,18 +184,29 @@ export function CreateIssueDialog({
         >
           <DialogHeader>
             <DialogTitle>
-              {subIssueParentId ? "Create sub-issue" : "Create issue"}
+              {subIssueParentId
+                ? "Create sub-issue"
+                : isUpstream
+                  ? `New issue in ${targetLabel}`
+                  : "Create issue"}
             </DialogTitle>
             <DialogDescription>
               {subIssueParentId
                 ? "Opens a new issue on GitHub and links it as a sub-issue."
-                : `Opens a new issue on ${remoteLabel} for this repository.`}
+                : isUpstream
+                  ? `Opens a new issue on ${targetLabel} (the upstream repository), not your fork.`
+                  : `Opens a new issue on ${remoteLabel} for this repository.`}
             </DialogDescription>
           </DialogHeader>
 
           {/* Fields scroll; the header and submit footer stay pinned so a long
               body or many metadata pickers can't push the dialog off-screen. */}
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+            {isUpstream && !subIssueParentId && (
+              <p className="text-xs text-muted-foreground">
+                This opens an issue on the upstream repository, not your fork.
+              </p>
+            )}
             <form.AppField
               name="title"
               validators={{ onChange: ({ value }) => required(value) }}
@@ -298,12 +323,14 @@ export function CreateIssueDialog({
               repoPath={repoPath}
               enabled={open}
               value={assignees}
+              lens={lens}
               onChange={setAssignees}
             />
             <MilestoneMenu
               repoPath={repoPath}
               enabled={open}
               value={milestone}
+              lens={lens}
               onChange={setMilestone}
             />
             {!isGitLab && (
@@ -311,6 +338,7 @@ export function CreateIssueDialog({
                 repoPath={repoPath}
                 enabled={open}
                 value={issueType}
+                lens={lens}
                 onChange={setIssueType}
               />
             )}
@@ -326,7 +354,11 @@ export function CreateIssueDialog({
             </Button>
             <form.AppForm>
               <form.SubmitButton disabled={generating}>
-                {subIssueParentId ? "Create sub-issue" : "Create issue"}
+                {subIssueParentId
+                  ? "Create sub-issue"
+                  : isUpstream
+                    ? `Create in ${targetLabel}`
+                    : "Create issue"}
               </form.SubmitButton>
             </form.AppForm>
           </DialogFooter>

--- a/src/features/issues/IssueDevelopment.tsx
+++ b/src/features/issues/IssueDevelopment.tsx
@@ -26,6 +26,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { useCreateLinkedBranch, useIssueDevelopment } from "@/lib/git/queries";
+import type { RemoteLens } from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
@@ -76,15 +77,18 @@ export function IssueDevelopment({
   issueId,
   issueTitle,
   issueUrl,
+  lens,
 }: {
   repoPath: string;
   number: number;
   issueId: string;
   issueTitle: string;
   issueUrl: string;
+  /** The origin|upstream lens the parent issue view resolved. */
+  lens: RemoteLens;
 }) {
-  const dev = useIssueDevelopment(repoPath, number);
-  const createBranch = useCreateLinkedBranch(repoPath);
+  const dev = useIssueDevelopment(repoPath, number, lens);
+  const createBranch = useCreateLinkedBranch(repoPath, lens);
   const selectPr = useUiStore((s) => s.selectPr);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
   const [branchOpen, setBranchOpen] = useState(false);

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -21,7 +21,7 @@ import {
   useIssueTypes,
   useMilestones,
 } from "@/lib/git/queries";
-import type { ForgeUserRef, IssueType } from "@/lib/git/types";
+import type { ForgeUserRef, IssueType, RemoteLens } from "@/lib/git/types";
 import { cn } from "@/lib/utils";
 
 /** GitHub issue-type color NAMES → a swatch hex (matches GitHub's palette). */
@@ -68,14 +68,17 @@ export function AssigneesPopover({
   value,
   onChange,
   commitOnClose = false,
+  lens,
 }: {
   repoPath: string;
   enabled: boolean;
   value: ForgeUserRef[];
   onChange: (next: ForgeUserRef[]) => void;
   commitOnClose?: boolean;
+  /** The origin|upstream lens the parent surface resolved. */
+  lens: RemoteLens;
 }) {
-  const users = useAssignableUsers(repoPath, enabled);
+  const users = useAssignableUsers(repoPath, enabled, lens);
   const ghHost = useForgeGhHost(repoPath);
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<Map<string, ForgeUserRef>>(new Map());
@@ -187,14 +190,17 @@ export function MilestoneMenu({
   value,
   valueLabel,
   onChange,
+  lens,
 }: {
   repoPath: string;
   enabled: boolean;
   value: number | null;
   valueLabel?: string;
   onChange: (milestone: number | null, title: string | null) => void;
+  /** The origin|upstream lens the parent surface resolved. */
+  lens: RemoteLens;
 }) {
-  const milestones = useMilestones(repoPath, enabled);
+  const milestones = useMilestones(repoPath, enabled, lens);
   const list = milestones.data ?? [];
   const current = list.find((m) => m.number === value);
   const display =
@@ -253,13 +259,16 @@ export function IssueTypeMenu({
   enabled,
   value,
   onChange,
+  lens,
 }: {
   repoPath: string;
   enabled: boolean;
   value: IssueType | null;
   onChange: (type: IssueType | null) => void;
+  /** The origin|upstream lens the parent surface resolved. */
+  lens: RemoteLens;
 }) {
-  const types = useIssueTypes(repoPath, enabled);
+  const types = useIssueTypes(repoPath, enabled, lens);
   const list = types.data ?? [];
   // No types defined for this owner → hide the control entirely.
   if (list.length === 0) return null;

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -31,7 +31,12 @@ import {
   useRemoveSubIssue,
   useSetIssueDependency,
 } from "@/lib/git/queries";
-import type { IssueInfo, IssueRelation, RelatedIssue } from "@/lib/git/types";
+import type {
+  IssueInfo,
+  IssueRelation,
+  RelatedIssue,
+  RemoteLens,
+} from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { CreateIssueDialog } from "./CreateIssueDialog";
@@ -125,14 +130,17 @@ export function IssuePicker({
   exclude,
   pending,
   onPick,
+  lens,
 }: {
   repoPath: string;
   exclude: Set<number>;
   pending: boolean;
   onPick: (n: number) => void;
+  /** The origin|upstream lens the parent issue surface resolved. */
+  lens: RemoteLens;
 }) {
-  const open = useIssueList(repoPath, true, "open");
-  const closed = useIssueList(repoPath, true, "closed");
+  const open = useIssueList(repoPath, true, "open", undefined, lens);
+  const closed = useIssueList(repoPath, true, "closed", undefined, lens);
   const candidates = [...(open.data ?? []), ...(closed.data ?? [])].filter(
     (i) => !exclude.has(i.number),
   );
@@ -175,13 +183,16 @@ export function IssueSubIssues({
   repoPath,
   issueId,
   number,
+  lens,
 }: {
   repoPath: string;
   issueId: string;
   number: number;
+  /** The origin|upstream lens the parent issue view resolved. */
+  lens: RemoteLens;
 }) {
-  const relations = useIssueRelations(repoPath, number);
-  const addSub = useAddSubIssue(repoPath);
+  const relations = useIssueRelations(repoPath, number, lens);
+  const addSub = useAddSubIssue(repoPath, lens);
   const removeSub = useRemoveSubIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const [mode, setMode] = useState<null | "existing">(null);
@@ -301,6 +312,7 @@ export function IssueSubIssues({
                 exclude={exclude}
                 pending={addSub.isPending}
                 onPick={pickExisting}
+                lens={lens}
               />
             </div>
             <Button variant="ghost" size="xs" onClick={() => setMode(null)}>
@@ -312,6 +324,7 @@ export function IssueSubIssues({
 
       <CreateIssueDialog
         repoPath={repoPath}
+        lens={lens}
         open={createOpen}
         onOpenChange={setCreateOpen}
         subIssueParentId={issueId}
@@ -327,12 +340,15 @@ export function IssueSubIssues({
 export function IssueRelationships({
   repoPath,
   number,
+  lens,
 }: {
   repoPath: string;
   number: number;
+  /** The origin|upstream lens the parent issue view resolved. */
+  lens: RemoteLens;
 }) {
-  const dependencies = useIssueDependencies(repoPath, number);
-  const setDep = useSetIssueDependency(repoPath);
+  const dependencies = useIssueDependencies(repoPath, number, lens);
+  const setDep = useSetIssueDependency(repoPath, lens);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const [addRelation, setAddRelation] = useState<IssueRelation | null>(null);
 
@@ -455,6 +471,7 @@ export function IssueRelationships({
                     { onSuccess: () => setAddRelation(null), onError },
                   )
                 }
+                lens={lens}
               />
             </div>
             <Button

--- a/src/features/issues/IssuesPanel.tsx
+++ b/src/features/issues/IssuesPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { ConversationFilterPopover } from "@/features/conversations/ConversationFilterPopover";
 import { ConversationListPanel } from "@/features/conversations/ConversationListPanel";
 import { PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
+import { RepoLensSwitcher } from "@/features/conversations/RepoLensSwitcher";
 import { useCollapsedSections } from "@/features/conversations/useCollapsedSections";
 import { useLocalRemoteFilter } from "@/features/conversations/useLocalRemoteFilter";
 import type { IssueStateFilter } from "@/lib/git/api";
@@ -31,6 +32,12 @@ import {
 } from "@/lib/jira/queries";
 import { formatStoryPoints, type JiraIssueInfo } from "@/lib/jira/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import {
+  useLensGate,
+  useRemoteSlug,
+  useRepoLens,
+  useSetRepoLens,
+} from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
 import { formatRelativeTime } from "@/lib/time";
@@ -78,7 +85,17 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   const provider = gh.data?.provider;
   const isGitLab = provider === "gitlab";
   const isBitbucket = provider === "bitbucket";
-  const remoteLabel = providerLabel(provider);
+  // The origin|upstream lens (GitHub forks only) scopes ONLY the remote section
+  // below — local + Jira issues are lens-independent. It decides which repo feeds
+  // `remotes`, not how rows are partitioned.
+  const lens = useRepoLens(repoPath);
+  const lensGate = useLensGate(repoPath);
+  const setLens = useSetRepoLens(repoPath);
+  const upstreamSlug = useRemoteSlug(repoPath, "upstream", lens === "upstream");
+  const providerName = providerLabel(provider);
+  // When browsing the parent, the remote section header names the parent slug.
+  const remoteLabel =
+    lens === "upstream" ? (upstreamSlug ?? "Upstream") : providerName;
   // Issue *reads* are provider-neutral (the panel-level `issues` flag); issue
   // *creation* follows its own per-action write flag — ready GitHub AND GitLab
   // repos both offer the create dialog (which hides GitHub-only fields per
@@ -88,7 +105,7 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   const [stateFilter, setStateFilter] = useState<IssueStateFilter>("open");
   // How many remote issues to load; "Load more" bumps it. A tab switch resets it.
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const issueList = useIssueList(repoPath, ghReady, stateFilter, limit);
+  const issueList = useIssueList(repoPath, ghReady, stateFilter, limit, lens);
   // A fork (issues off by default on GitHub) surfaces a typed error here. It's a
   // permanent repo condition, not a transient fetch failure, so the section shows
   // an informative notice with no Retry — and issue creation is offered as
@@ -106,7 +123,7 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   };
   const selectedIssue = useUiStore((s) => s.selectedIssue);
   const selectIssue = useUiStore((s) => s.selectIssue);
-  const prefetchIssue = usePrefetchIssue(repoPath);
+  const prefetchIssue = usePrefetchIssue(repoPath, lens);
   const hoverPrefetch = useHoverPrefetch();
   const filterRef = useRef<HTMLInputElement>(null);
   const [createOpen, setCreateOpen] = useState(false);
@@ -264,6 +281,7 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
       remoteLabel={remoteLabel}
       stateFilter={stateFilter}
       onStateFilter={onStateFilter}
+      lensControl={<RepoLensSwitcher repoPath={repoPath} />}
       newMenu={{
         ghLabel: isBitbucket
           ? "Issue on Bitbucket…"
@@ -351,6 +369,25 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
               Forks start with issues turned off — enable them in the repository
               settings on GitHub.
             </p>
+            {/* This disabled state only ever renders for the origin (fork) lens by
+                construction; when the repo is a GitHub fork, offer browsing the
+                parent's issues instead of a dead end. */}
+            {lensGate && lens === "origin" && (
+              <div className="space-y-1.5 pt-1.5">
+                <p className="text-[11px]">
+                  Your fork has issues disabled — switch to Upstream to browse
+                  the parent repository's issues.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={() => setLens("upstream")}
+                >
+                  Switch to upstream
+                </Button>
+              </div>
+            )}
           </div>
         ) : (
           <div className="space-y-2 px-3 py-4 text-xs text-muted-foreground">
@@ -491,6 +528,7 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
     >
       <CreateIssueDialog
         repoPath={repoPath}
+        lens={lens}
         open={createOpen}
         onOpenChange={(o) => {
           setCreateOpen(o);

--- a/src/features/issues/PromoteLocalIssueDialog.tsx
+++ b/src/features/issues/PromoteLocalIssueDialog.tsx
@@ -27,6 +27,7 @@ import {
   useJiraLink,
   useJiraPermissions,
 } from "@/lib/jira/queries";
+import { useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
@@ -54,9 +55,11 @@ export function PromoteLocalIssueDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const createIssue = useCreateIssue(repoPath);
+  // Promotion always targets the fork's own remote (origin) — never the parent.
+  const createIssue = useCreateIssue(repoPath, "origin");
   const update = useUpdateLocalIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
+  const setLens = useSetRepoLens(repoPath);
 
   const forge = useForgeStatus(repoPath);
   const remoteLabel = forge.data?.provider === "gitlab" ? "GitLab" : "GitHub";
@@ -145,7 +148,7 @@ export function PromoteLocalIssueDialog({
       created = { number, url };
       failedStep = "carrying over comments";
       for (const c of carried) {
-        await forgeIssueComment(repoPath, number, c.body);
+        await forgeIssueComment(repoPath, number, c.body, "origin");
       }
       failedStep = "closing the local issue";
       await closeLocalWithBackLink(
@@ -156,6 +159,10 @@ export function PromoteLocalIssueDialog({
         action: { label: "View", onClick: () => openUrl(url) },
       });
       onOpenChange(false);
+      // The promoted issue lives on the fork (origin) — force the origin lens so
+      // the Issues tab shows it (and any stale remote selection is cleared) before
+      // navigating to it.
+      setLens("origin");
       selectIssue({ kind: "remote", id: String(number) });
     } catch (e) {
       if (created === null) {

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -67,6 +67,7 @@ import {
 } from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
+import { useRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
@@ -116,6 +117,9 @@ export function RemoteIssueView({
   const provider = forge.data?.provider;
   const canWrite = provider !== "gitlab" && provider !== "bitbucket";
   const remoteLabel = providerLabel(provider);
+  // The single lens-resolution point for this surface (package B2): every issue
+  // read/write below targets the fork (origin) or its parent (upstream).
+  const lens = useRepoLens(repoPath);
   // GitLab WRITES land per-action. Each shared control is
   // `canWrite || forgeFeatureReady(...)` so GitHub keeps its controls while a
   // forge-status query is pending/failed (canWrite default-true) AND a ready GitLab
@@ -150,20 +154,20 @@ export function RemoteIssueView({
   // Time tracking + related issues are GitLab-unique too — flag alone gates.
   const canTrackTime = forgeFeatureReady(forge.data, "timeTracking");
   const canLinkIssues = forgeFeatureReady(forge.data, "issueLinks");
-  const details = useIssueDetails(repoPath, number);
-  const comment = useCommentIssue(repoPath);
-  const closeIssue = useCloseIssue(repoPath);
-  const reopenIssue = useReopenIssue(repoPath);
-  const editIssue = useEditIssue(repoPath);
-  const editComment = useEditIssueComment(repoPath);
-  const deleteComment = useDeleteIssueComment(repoPath);
+  const details = useIssueDetails(repoPath, number, lens);
+  const comment = useCommentIssue(repoPath, lens);
+  const closeIssue = useCloseIssue(repoPath, lens);
+  const reopenIssue = useReopenIssue(repoPath, lens);
+  const editIssue = useEditIssue(repoPath, lens);
+  const editComment = useEditIssueComment(repoPath, lens);
+  const deleteComment = useDeleteIssueComment(repoPath, lens);
   const minimizeComment = useMinimizeComment(repoPath);
   const unminimizeComment = useUnminimizeComment(repoPath);
-  const pinIssue = usePinIssue(repoPath);
-  const lockIssue = useLockIssue(repoPath);
-  const unlockIssue = useUnlockIssue(repoPath);
-  const transferIssue = useTransferIssue(repoPath);
-  const deleteIssue = useDeleteIssue(repoPath);
+  const pinIssue = usePinIssue(repoPath, lens);
+  const lockIssue = useLockIssue(repoPath, lens);
+  const unlockIssue = useUnlockIssue(repoPath, lens);
+  const transferIssue = useTransferIssue(repoPath, lens);
+  const deleteIssue = useDeleteIssue(repoPath, lens);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const setPendingIssueDraft = useUiStore((s) => s.setPendingIssueDraft);
   // Reactions are a shared control (GitLab awards emoji); the fetch is gated so
@@ -175,10 +179,10 @@ export function RemoteIssueView({
   // wired, so `issueCommentEdit` is false there.
   const canEditOwnComments =
     canWrite || forgeFeatureReady(forge.data, "issueCommentEdit");
-  const reactions = useIssueReactions(repoPath, canReact ? number : null);
+  const reactions = useIssueReactions(repoPath, canReact ? number : null, lens);
   const toggleReactionMutation = useToggleReaction(
     repoPath,
-    ["repo", repoPath, "issue", number, "reactions"] as const,
+    ["repo", repoPath, "issue", lens, number, "reactions"] as const,
     details.data?.id ?? "",
     { target: "issue", number },
   );
@@ -632,6 +636,7 @@ export function RemoteIssueView({
                   repoPath={repoPath}
                   issueId={issue.id}
                   number={number}
+                  lens={lens}
                 />
               )}
               {comments.map((c) => (
@@ -805,6 +810,7 @@ export function RemoteIssueView({
           canTrackTime={canTrackTime}
           canLinkIssues={canLinkIssues}
           remoteLabel={remoteLabel}
+          lens={lens}
         />
       </div>
 

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -37,6 +37,7 @@ import type {
   GitLabLinkedIssue,
   GitLabTimeStats,
   IssueDetails,
+  RemoteLens,
 } from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
@@ -69,6 +70,7 @@ export function IssueSidebar({
   canTrackTime,
   canLinkIssues,
   remoteLabel,
+  lens,
 }: {
   repoPath: string;
   number: number;
@@ -84,10 +86,12 @@ export function IssueSidebar({
   canTrackTime: boolean;
   canLinkIssues: boolean;
   remoteLabel: string;
+  /** The origin|upstream lens the parent issue view resolved. */
+  lens: RemoteLens;
 }) {
-  const setAssignees = useSetIssueAssignees(repoPath);
-  const setMilestone = useSetIssueMilestone(repoPath);
-  const setType = useSetIssueType(repoPath);
+  const setAssignees = useSetIssueAssignees(repoPath, lens);
+  const setMilestone = useSetIssueMilestone(repoPath, lens);
+  const setType = useSetIssueType(repoPath, lens);
   const setConfidential = useSetIssueConfidential(repoPath);
   const setDueDate = useSetIssueDueDate(repoPath);
   const onError = (e: unknown) => toastError(e);
@@ -122,6 +126,7 @@ export function IssueSidebar({
             target="issue"
             labelableId={issue.id}
             labels={issue.labels}
+            lens={lens}
           />
         )}
         {canEditAssignees && (
@@ -130,6 +135,7 @@ export function IssueSidebar({
             enabled
             value={issue.assignees}
             commitOnClose
+            lens={lens}
             onChange={(next) =>
               setAssignees.mutate({ number, assignees: next }, { onError })
             }
@@ -141,6 +147,7 @@ export function IssueSidebar({
             enabled
             value={issue.milestone?.number ?? null}
             valueLabel={issue.milestone?.title}
+            lens={lens}
             onChange={(m, title) =>
               setMilestone.mutate({ number, milestone: m, title }, { onError })
             }
@@ -186,6 +193,7 @@ export function IssueSidebar({
             repoPath={repoPath}
             number={number}
             editable={issue.state === "OPEN"}
+            lens={lens}
           />
         )}
         <div className="space-y-1.5">
@@ -209,6 +217,7 @@ export function IssueSidebar({
         repoPath={repoPath}
         enabled
         value={issue.issueType}
+        lens={lens}
         onChange={(type) =>
           setType.mutate(
             { number, typeName: type?.name ?? null, type },
@@ -221,6 +230,7 @@ export function IssueSidebar({
         enabled
         value={issue.assignees}
         commitOnClose
+        lens={lens}
         onChange={(next) =>
           setAssignees.mutate({ number, assignees: next }, { onError })
         }
@@ -232,12 +242,14 @@ export function IssueSidebar({
         target="issue"
         labelableId={issue.id}
         labels={issue.labels}
+        lens={lens}
       />
       <MilestoneMenu
         repoPath={repoPath}
         enabled
         value={issue.milestone?.number ?? null}
         valueLabel={issue.milestone?.title}
+        lens={lens}
         onChange={(m, title) =>
           setMilestone.mutate({ number, milestone: m, title }, { onError })
         }
@@ -253,13 +265,14 @@ export function IssueSidebar({
           Manage on GitHub
         </button>
       </div>
-      <IssueRelationships repoPath={repoPath} number={number} />
+      <IssueRelationships repoPath={repoPath} number={number} lens={lens} />
       <IssueDevelopment
         repoPath={repoPath}
         number={number}
         issueId={issue.id}
         issueTitle={issue.title}
         issueUrl={issue.url}
+        lens={lens}
       />
       <div className="space-y-1.5">
         <p className="text-xs font-medium text-muted-foreground">
@@ -587,10 +600,13 @@ function IssueLinksSection({
   repoPath,
   number,
   editable,
+  lens,
 }: {
   repoPath: string;
   number: number;
   editable: boolean;
+  /** The parent issue's lens (GitLab-only section, so always "origin"). */
+  lens: RemoteLens;
 }) {
   const links = useGlIssueLinks(repoPath, number);
   const linkIssue = useLinkIssue(repoPath);
@@ -656,6 +672,7 @@ function IssueLinksSection({
               repoPath={repoPath}
               exclude={exclude}
               pending={linkIssue.isPending}
+              lens={lens}
               onPick={(target) =>
                 linkIssue.mutate(
                   { number, targetNumber: target },

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -13,7 +13,11 @@ import {
   useDeleteCommitComment,
   useEditCommitComment,
 } from "@/lib/git/queries";
-import type { CommitCommentOut, PrThreadOut } from "@/lib/git/types";
+import type {
+  CommitCommentOut,
+  PrThreadOut,
+  RemoteLens,
+} from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
 import { SUBMIT_HINT } from "./ReviewThreads";
 
@@ -230,6 +234,7 @@ export function CommitComments({
   diffSections,
   selectedPath,
   onSelectFile,
+  lens,
 }: {
   repoPath: string;
   sha: string;
@@ -243,11 +248,14 @@ export function CommitComments({
   /** Selects a file in the sidebar; makes each group's path label a button that
    *  jumps to that file's diff. Absent = the label is plain text. */
   onSelectFile?: (path: string) => void;
+  /** Which repo the commit's comments live on: "origin" (the History surface, or
+   *  a non-fork) or the parent under the upstream lens (PR-commit context). */
+  lens: RemoteLens;
 }) {
-  const comments = useCommitComments(repoPath, sha);
-  const createComment = useCreateCommitComment(repoPath);
-  const editComment = useEditCommitComment(repoPath);
-  const deleteComment = useDeleteCommitComment(repoPath);
+  const comments = useCommitComments(repoPath, sha, lens);
+  const createComment = useCreateCommitComment(repoPath, lens);
+  const editComment = useEditCommitComment(repoPath, lens);
+  const deleteComment = useDeleteCommitComment(repoPath, lens);
 
   const [body, setBody] = useState("");
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -462,6 +470,7 @@ export function CommitLineComposer({
   provider,
   fileSection,
   onClose,
+  lens,
 }: {
   repoPath: string;
   sha: string;
@@ -475,8 +484,10 @@ export function CommitLineComposer({
   /** This file's unified-diff section, for recovering the GitHub `position`. */
   fileSection: string | undefined;
   onClose: () => void;
+  /** Which repo the commit lives on (origin vs upstream lens). */
+  lens: RemoteLens;
 }) {
-  const createComment = useCreateCommitComment(repoPath);
+  const createComment = useCreateCommitComment(repoPath, lens);
   const [body, setBody] = useState("");
 
   // The multi-line range, normalized: [from, line] with from <= line.

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -1,5 +1,11 @@
 import { Popover } from "@base-ui/react/popover";
-import { SparkleIcon, TagIcon, XIcon } from "@phosphor-icons/react";
+import {
+  ArrowSquareOutIcon,
+  SparkleIcon,
+  TagIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
@@ -20,16 +26,27 @@ import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
 import { track } from "@/lib/analytics";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { required, useAppForm } from "@/lib/form";
+import * as api from "@/lib/git/api";
 import {
   forgeFeatureReady,
   useCompareBranches,
   useCreatePr,
   useDefaultBranch,
   useForgeStatus,
+  usePrsForBranch,
   useRepoLabels,
   useRepoStatus,
 } from "@/lib/git/queries";
-import { type ForgeUserRef, providerLabel } from "@/lib/git/types";
+import {
+  type ForgeUserRef,
+  providerLabel,
+  type RemoteLens,
+} from "@/lib/git/types";
+import {
+  useLensGate,
+  useRemoteSlug,
+  useSetRepoLens,
+} from "@/lib/repo-lens/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 import { ReviewersPopover } from "./ReviewersPopover";
@@ -54,22 +71,49 @@ export function CreatePrDialog({
   const status = useRepoStatus(repoPath);
   const defaultBranch = useDefaultBranch(repoPath);
   const createPr = useCreatePr(repoPath);
+  const setRepoLens = useSetRepoLens(repoPath);
   const forge = useForgeStatus(repoPath);
+
+  // Fork PR-create: on a GitHub fork (upstream remote present) the dialog offers
+  // an explicit "Create in" target — the parent (lens "upstream") or the fork
+  // (lens "origin"). The gate is hidden entirely otherwise, so behavior collapses
+  // to today's origin-only path. Default = parent: that reproduces what gh's
+  // implicit auto-resolution did before this feature, keeping the common
+  // contribution flow's outcome (now explicit).
+  const lensGate = useLensGate(repoPath);
+  const [target, setTarget] = useState<RemoteLens>("upstream");
+  // Resolved slugs label the two target buttons and the success toast; only
+  // fetched while the picker is shown.
+  const forkSlug = useRemoteSlug(repoPath, "origin", lensGate && open);
+  const upstreamSlug = useRemoteSlug(repoPath, "upstream", lensGate && open);
+  const targetIsParent = lensGate && target === "upstream";
+  // The effective lens for this create — always "origin" when the gate is off.
+  const createLens: RemoteLens = targetIsParent ? "upstream" : "origin";
+  const targetSlug = targetIsParent ? upstreamSlug : forkSlug;
+
   // Create-TIME reviewers stay Bitbucket-only: `forge_pr_create` rejects a reviewer
   // list for GitHub/GitLab (their create arms don't accept one yet). The
   // `mrReviewers` capability now covers all three, but only for editing reviewers on
   // an existing PR (the RemotePrView picker), so scope the create dialog explicitly.
+  // Targeting the parent rejects reviewers/labels/assignees backend-side, so the
+  // pickers are hidden on that path entirely (never offered as dead controls).
   const canPickReviewers =
+    !targetIsParent &&
     forge.data?.provider === "bitbucket" &&
     forgeFeatureReady(forge.data, "mrReviewers");
   // Labels + assignees are GitHub/GitLab; a repo is exactly one provider, so
   // these and the Bitbucket create-time reviewers picker are mutually exclusive.
-  const canPickLabels = forgeFeatureReady(forge.data, "mrLabels");
-  const canPickAssignees = forgeFeatureReady(forge.data, "mrAssignees");
+  const canPickLabels =
+    !targetIsParent && forgeFeatureReady(forge.data, "mrLabels");
+  const canPickAssignees =
+    !targetIsParent && forgeFeatureReady(forge.data, "mrAssignees");
   const [reviewers, setReviewers] = useState<ForgeUserRef[]>([]);
   const [labels, setLabels] = useState<Set<string>>(new Set());
   const [assignees, setAssignees] = useState<ForgeUserRef[]>([]);
-  const repoLabels = useRepoLabels(repoPath, open);
+  // Labels come from whichever repo the PR targets (parent's own labels when
+  // creating upstream). The picker is hidden on the parent path anyway, but the
+  // AI-description prompt still reads this list, so keep it lens-correct.
+  const repoLabels = useRepoLabels(repoPath, open, createLens);
   const isGitLab = forge.data?.provider === "gitlab";
   const remoteLabel = providerLabel(forge.data?.provider);
   const prNoun = isGitLab ? "merge request" : "pull request";
@@ -89,21 +133,76 @@ export function CreatePrDialog({
     defaultBranch.data,
   ]);
 
+  // Base options for the parent target: fetch `upstream` (like
+  // useUpdateFromUpstream), then read the local upstream refs and the parent's
+  // default branch. A failed fetch still yields whatever upstream refs are
+  // already local, so the picker stays usable — the error surfaces inline.
+  const parentBranches = useQuery({
+    queryKey: ["repo", repoPath, "create-pr-parent-branches"] as const,
+    queryFn: async () => {
+      let fetchError: string | null = null;
+      try {
+        await api.gitFetchRemote(repoPath, "upstream");
+      } catch (e) {
+        // Keep going with the refs already on disk; report the fetch failure.
+        fetchError = e instanceof Error ? e.message : String(e);
+      }
+      const remoteBranches = await api.gitRemoteBranches(repoPath);
+      const upstreamNames = remoteBranches
+        .filter((b) => b.remote === "upstream")
+        .map((b) => b.name);
+      let defaultBase = "";
+      try {
+        defaultBase = await api.gitRemoteDefaultBranch(repoPath, "upstream");
+      } catch {
+        // Fall back to the first upstream ref below; the picker stays usable.
+      }
+      return { names: upstreamNames, defaultBase, fetchError };
+    },
+    enabled: open && targetIsParent,
+    staleTime: 30_000,
+  });
+  const parentNames = parentBranches.data?.names ?? [];
+  const parentItems = Object.fromEntries(parentNames.map((n) => [n, n]));
+  const parentFetchError = parentBranches.data?.fetchError ?? null;
+  const parentBase = parentBranches.data?.defaultBase || parentNames[0] || "";
+
+  // Which base picker the current target drives. Parent → the upstream refs;
+  // fork → the local branches (unchanged behavior).
+  const baseItems = targetIsParent ? parentItems : items;
+  const baseAnnotations = targetIsParent ? undefined : annotations;
+  const baseLoading = targetIsParent && parentBranches.isPending;
+
   const form = useAppForm({
     defaultValues: { head: "", base: "", title: "", body: "", draft: false },
     validators: {
-      // Same branch on both sides proposes nothing — gate the submit.
+      // Same branch on both sides proposes nothing — gate the submit. On the
+      // parent target the base is an `upstream/<name>` ref, so a local head that
+      // merely shares the parent branch's *name* is still a distinct ref and is
+      // allowed; the real ref-identity check lives in `sameBranch` below.
       onChange: ({ value }) =>
-        value.head === value.base ? "Pick two different branches." : undefined,
+        !targetIsParent && value.head === value.base
+          ? "Pick two different branches."
+          : undefined,
     },
     onSubmit: async ({ value }) => {
       try {
         const { number, url } = await createPr.mutateAsync({
           base: value.base,
+          // Head stays a bare LOCAL branch name either way: the backend pushes it
+          // to origin and composes the `owner:branch` head ref itself on the
+          // upstream path. Org-owned forks aren't supported by `gh pr create`
+          // ("Using an organization as the <user> is currently not supported",
+          // cli/cli#10093) — we don't pre-gate; gh's own error surfaces via
+          // toastError below.
           head: value.head,
           title: value.title.trim(),
           body: value.body,
           draft: value.draft,
+          // Targets the fork ("origin") or its parent ("upstream"); the parent
+          // path rejects reviewers/labels/assignees backend-side (their pickers
+          // are hidden above), so those keys are already omitted there.
+          lens: createLens,
           // Bitbucket-only; omit the key otherwise (GitHub/GitLab byte-identical).
           // An empty selection also omits it, preserving server-side default reviewers.
           ...(canPickReviewers && reviewers.length > 0
@@ -123,7 +222,14 @@ export function CreatePrDialog({
             has_ai_description: aiDescriptionRef.current,
           },
         });
-        toast.success(`Opened ${prNoun} #${number}`, {
+        // Creating on the parent means the new PR lives under the upstream lens —
+        // flip the persisted lens so the PRs tab shows it (setter is a no-op when
+        // already "upstream").
+        if (createLens === "upstream") setRepoLens("upstream");
+        // Name the target repo in the toast so "Opened PR #N in owner/repo" is
+        // unambiguous for a fork contribution.
+        const where = targetSlug ? ` in ${targetSlug}` : "";
+        toast.success(`Opened ${prNoun} #${number}${where}`, {
           description: url,
           action: { label: "View", onClick: () => openUrl(url) },
         });
@@ -159,6 +265,9 @@ export function CreatePrDialog({
     setReviewers([]);
     setLabels(new Set());
     setAssignees([]);
+    // Reset the target to the default (parent) every open, so a prior fork/parent
+    // choice doesn't leak into the next PR.
+    setTarget("upstream");
     const h = defaultHead ?? currentName ?? names[0] ?? "";
     const fallbackBase =
       defaultBranch.data && defaultBranch.data !== h
@@ -167,6 +276,10 @@ export function CreatePrDialog({
     form.reset(
       {
         head: h,
+        // Seed the LOCAL (fork) base first; the base-reconcile effect below
+        // swaps in the parent's default branch when the parent target is active
+        // (and its branches have loaded). A ComparePanel-seeded `defaultBase` is
+        // a local branch, so it only applies to the fork target.
         base: defaultBase ?? fallbackBase,
         title: "",
         body: "",
@@ -182,10 +295,67 @@ export function CreatePrDialog({
   // Live head/base drive the "N commits" hint, AI generation, and submit gate.
   const head = useSelector(form.store, (s) => s.values.head);
   const base = useSelector(form.store, (s) => s.values.base);
-  const comparison = useCompareBranches(repoPath, base || null, head || null);
+
+  // Compute the fork-side fallback base (used both here and when reconciling back
+  // from the parent target). Mirrors the seed logic: default branch, else the
+  // first non-head branch.
+  const forkFallbackBase = useEffectEvent(() => {
+    const h = form.state.values.head;
+    return defaultBranch.data && defaultBranch.data !== h
+      ? defaultBranch.data
+      : (names.find((n) => n !== h) ?? "");
+  });
+  // Reconcile the base when the target changes (or the parent's branches arrive):
+  // re-seed ONLY when the current base isn't a valid option for the active
+  // target, so a user-picked base survives a target toggle where it still fits.
+  // The guard makes `base` safe to read directly — a valid pick is left alone, so
+  // this never fights the user's own edit.
+  useEffect(() => {
+    if (!open) return;
+    if (targetIsParent) {
+      // Wait for the parent refs before touching the base — otherwise we'd clear
+      // it to "" mid-fetch and lose the seed.
+      if (parentBranches.isPending) return;
+      if (!base || !parentNames.includes(base)) {
+        form.setFieldValue("base", parentBase);
+      }
+    } else if (base && !names.includes(base)) {
+      // Back on the fork target: re-seed only when the current value (e.g. a
+      // parent branch that isn't a local one) no longer fits.
+      form.setFieldValue("base", defaultBase ?? forkFallbackBase());
+    }
+  }, [
+    open,
+    targetIsParent,
+    parentBranches.isPending,
+    parentBase,
+    base,
+    parentNames,
+    names,
+    defaultBase,
+    form,
+  ]);
+  // The base ref to compare against: for the parent target the picked base is a
+  // bare upstream branch name, so qualify it as `upstream/<base>` (the ref that
+  // exists locally after the fetch) — otherwise `git log main..head` would
+  // resolve against a *local* `main`, a stale proxy for the parent's branch.
+  const compareBaseRef = base
+    ? targetIsParent
+      ? `upstream/${base}`
+      : base
+    : null;
+  const comparison = useCompareBranches(repoPath, compareBaseRef, head || null);
   const ahead = comparison.data?.ahead ?? [];
-  const sameBranch = base === head;
+  // A head equal to the parent's base name is still a distinct ref (local branch
+  // vs. `upstream/<name>`), so only treat identical refs as "same branch".
+  const sameBranch = compareBaseRef !== null && compareBaseRef === head;
   const nothingToMerge = sameBranch || ahead.length === 0;
+
+  // Duplicate probe: an open PR from this head against the chosen target already
+  // exists. Probe with the target's lens ("upstream" composes owner:branch
+  // Rust-side; pass the BARE head), matching ComparePanel's baseRefName match.
+  const branchPrs = usePrsForBranch(repoPath, head || null, open, createLens);
+  const existingPr = (branchPrs.data ?? []).find((p) => p.baseRefName === base);
 
   function toggleLabel(name: string, on: boolean) {
     setLabels((prev) => {
@@ -215,13 +385,50 @@ export function CreatePrDialog({
             <DialogDescription>
               Pushes <span className="font-mono">{head || "…"}</span> and opens
               a {prNoun} into <span className="font-mono">{base || "…"}</span>{" "}
-              on {remoteLabel}.
+              on {targetSlug ?? remoteLabel}.
             </DialogDescription>
           </DialogHeader>
 
           {/* Fields scroll; the header and submit footer stay pinned so a long
               body can't push the dialog off-screen. */}
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+            {/* Fork PR-create: choose the repo the PR opens against. Hidden unless
+                this is a GitHub fork with an upstream remote. Default = parent. */}
+            {lensGate && (
+              <div className="space-y-1.5">
+                <Label>Create in</Label>
+                <div className="flex items-center gap-1">
+                  {(
+                    [
+                      {
+                        value: "upstream",
+                        label: "Parent",
+                        slug: upstreamSlug,
+                      },
+                      { value: "origin", label: "Fork", slug: forkSlug },
+                    ] as const
+                  ).map((b) => (
+                    <Button
+                      key={b.value}
+                      type="button"
+                      variant={target === b.value ? "secondary" : "ghost"}
+                      size="xs"
+                      aria-pressed={target === b.value}
+                      title={b.slug ?? undefined}
+                      onClick={() => setTarget(b.value)}
+                    >
+                      {b.label}
+                      {b.slug ? (
+                        <span className="ml-1.5 font-mono text-[11px] text-muted-foreground">
+                          {b.slug}
+                        </span>
+                      ) : null}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+
             <div className="flex items-end gap-2">
               <div className="min-w-0 flex-initial">
                 <form.AppField name="head">
@@ -243,8 +450,9 @@ export function CreatePrDialog({
                   {(field) => (
                     <field.SelectField
                       label="Base"
-                      items={items}
-                      annotations={annotations}
+                      items={baseLoading ? {} : baseItems}
+                      annotations={baseAnnotations}
+                      disabled={baseLoading}
                       sizeToContent
                     />
                   )}
@@ -254,9 +462,19 @@ export function CreatePrDialog({
             <div className="space-y-0.5">
               <p className="font-mono text-xs wrap-break-word text-foreground/80">
                 {head || "…"} <span className="text-muted-foreground">→</span>{" "}
-                {base || "…"}
+                {targetIsParent && base ? `upstream/${base}` : base || "…"}
               </p>
-              {sameBranch ? (
+              {baseLoading ? (
+                <p className="text-xs text-muted-foreground">
+                  Fetching upstream branches…
+                </p>
+              ) : parentFetchError ? (
+                // Fetch failed but local upstream refs (if any) still populate the
+                // picker — surface the error inline, keep the control usable.
+                <p className="text-xs text-warning">
+                  Couldn't fetch upstream: {parentFetchError}
+                </p>
+              ) : sameBranch ? (
                 <p className="text-xs text-warning">
                   Pick two different branches.
                 </p>
@@ -265,7 +483,30 @@ export function CreatePrDialog({
                   {ahead.length} commit{ahead.length === 1 ? "" : "s"} to merge.
                 </p>
               )}
+              {targetIsParent && (
+                <p className="text-xs text-muted-foreground">
+                  Labels and assignees can be added on {remoteLabel} after
+                  opening.
+                </p>
+              )}
             </div>
+
+            {existingPr && (
+              // An open PR from this head against the chosen target already
+              // exists — offer to view it instead of allowing a duplicate.
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full cursor-pointer"
+                onClick={() => openUrl(existingPr.url)}
+                title={existingPr.title}
+              >
+                <ArrowSquareOutIcon data-icon="inline-start" />
+                View {prNoun} #{existingPr.number}
+                {existingPr.isDraft ? " (draft)" : ""}
+              </Button>
+            )}
 
             {canPickReviewers && (
               <div className="space-y-1.5">
@@ -275,6 +516,7 @@ export function CreatePrDialog({
                   number={null}
                   enabled={open && canPickReviewers}
                   value={reviewers}
+                  lens="origin"
                   onChange={setReviewers}
                 />
               </div>
@@ -350,6 +592,7 @@ export function CreatePrDialog({
                   repoPath={repoPath}
                   enabled={open}
                   value={assignees}
+                  lens="origin"
                   onChange={setAssignees}
                 />
               </div>
@@ -444,7 +687,14 @@ export function CreatePrDialog({
             <form.AppForm>
               <form.Subscribe selector={(s) => s.values.draft}>
                 {(draft) => (
-                  <form.SubmitButton disabled={generating || nothingToMerge}>
+                  <form.SubmitButton
+                    disabled={
+                      generating ||
+                      nothingToMerge ||
+                      baseLoading ||
+                      Boolean(existingPr)
+                    }
+                  >
                     {draft ? "Create draft" : `Create ${prNoun}`}
                   </form.SubmitButton>
                 )}

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -339,11 +339,18 @@ export function CreatePrDialog({
   // bare upstream branch name, so qualify it as `upstream/<base>` (the ref that
   // exists locally after the fetch) — otherwise `git log main..head` would
   // resolve against a *local* `main`, a stale proxy for the parent's branch.
-  const compareBaseRef = base
-    ? targetIsParent
-      ? `upstream/${base}`
+  // While the parent fetch is in flight, `base` is still the fork-seeded local
+  // name and `upstream/<name>` may not exist yet — yield null so the compare
+  // query stays idle (baseLoading already gates the hint + submit) rather than
+  // erroring on a not-yet-fetched ref.
+  const compareBaseRef =
+    targetIsParent && parentBranches.isPending
+      ? null
       : base
-    : null;
+        ? targetIsParent
+          ? `upstream/${base}`
+          : base
+        : null;
   const comparison = useCompareBranches(repoPath, compareBaseRef, head || null);
   const ahead = comparison.data?.ahead ?? [];
   // A head equal to the parent's base name is still a distinct ref (local branch
@@ -485,8 +492,8 @@ export function CreatePrDialog({
               )}
               {targetIsParent && (
                 <p className="text-xs text-muted-foreground">
-                  Labels and assignees can be added on {remoteLabel} after
-                  opening.
+                  Labels and assignees can be added on{" "}
+                  {upstreamSlug ?? remoteLabel} after opening.
                 </p>
               )}
             </div>

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -29,6 +29,7 @@ import { required, useAppForm } from "@/lib/form";
 import * as api from "@/lib/git/api";
 import {
   forgeFeatureReady,
+  useAddRemote,
   useCompareBranches,
   useCreatePr,
   useDefaultBranch,
@@ -47,7 +48,7 @@ import {
   useRemoteSlug,
   useSetRepoLens,
 } from "@/lib/repo-lens/queries";
-import { useAiEnabled } from "@/lib/settings/queries";
+import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 import { ReviewersPopover } from "./ReviewersPopover";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
@@ -90,6 +91,40 @@ export function CreatePrDialog({
   // The effective lens for this create — always "origin" when the gate is off.
   const createLens: RemoteLens = targetIsParent ? "upstream" : "origin";
   const targetSlug = targetIsParent ? upstreamSlug : forkSlug;
+
+  // Fork-without-upstream affordance: a fork cloned by plain `git clone` has no
+  // `upstream` remote, so the lens gate is off and the pinned origin path opens
+  // the PR on the fork — a silent regression from gh's old parent auto-resolution.
+  // When the persisted fork provenance says this GitHub repo IS a fork with a
+  // known parent, offer to add the remote so the parent-target path returns.
+  const settings = useSettings();
+  const isGithub = forge.data?.provider === "github";
+  const forkRecord = settings.data?.recentRepos.find(
+    (r) => r.path === repoPath,
+  );
+  const forkParent = forkRecord?.forkParent ?? null;
+  // Only when: GitHub, the lens gate is OFF (no upstream remote), settings have
+  // loaded (no flash), the repo is a fork, AND the parent slug is known. A fork
+  // whose parent is unreadable renders nothing rather than a broken hint.
+  const canOfferUpstream =
+    isGithub &&
+    !lensGate &&
+    settings.isSuccess &&
+    forkRecord?.isFork === true &&
+    forkParent !== null;
+  const addRemote = useAddRemote(repoPath);
+  function addUpstreamRemote() {
+    if (!forkParent) return;
+    addRemote.mutate(
+      { name: "upstream", url: `https://github.com/${forkParent}.git` },
+      {
+        // On success the broad invalidation refreshes the remotes query →
+        // `useLensGate` flips true → the "Create in" picker appears (default
+        // Parent). No local state to reset; the effect chain handles it.
+        onError: (e) => toastError(e),
+      },
+    );
+  }
 
   // Create-TIME reviewers stay Bitbucket-only: `forge_pr_create` rejects a reviewer
   // list for GitHub/GitLab (their create arms don't accept one yet). The
@@ -433,6 +468,36 @@ export function CreatePrDialog({
                     </Button>
                   ))}
                 </div>
+              </div>
+            )}
+
+            {/* Fork without an `upstream` remote: the picker can't render (no
+                remote to read), so offer to add it. Mutually exclusive with the
+                picker above — `canOfferUpstream` requires the gate to be OFF. */}
+            {canOfferUpstream && (
+              <div className="space-y-1.5 rounded-none bg-muted/40 p-2.5 ring-1 ring-foreground/10">
+                <p className="text-xs text-muted-foreground">
+                  This repository is a fork of{" "}
+                  <span className="font-mono text-foreground/80">
+                    {forkParent}
+                  </span>
+                  . Add an upstream remote to open pull requests against{" "}
+                  <span className="font-mono text-foreground/80">
+                    {forkParent}
+                  </span>
+                  .
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  disabled={addRemote.isPending}
+                  onClick={addUpstreamRemote}
+                >
+                  {addRemote.isPending
+                    ? "Adding upstream remote…"
+                    : "Add upstream remote"}
+                </Button>
               </div>
             )}
 

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -115,8 +115,11 @@ export function CreatePrDialog({
   const addRemote = useAddRemote(repoPath);
   function addUpstreamRemote() {
     if (!forkParent) return;
+    // Derive the host — on GitHub Enterprise `isGithub` still holds, and a
+    // hardcoded github.com would add a wrong-host remote that fails later.
+    const ghHost = forge.data?.host || "github.com";
     addRemote.mutate(
-      { name: "upstream", url: `https://github.com/${forkParent}.git` },
+      { name: "upstream", url: `https://${ghHost}/${forkParent}.git` },
       {
         // On success the broad invalidation refreshes the remotes query →
         // `useLensGate` flips true → the "Create in" picker appears (default

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -9,7 +9,7 @@ import { FileRowActions } from "@/features/history/FileRowActions";
 import { copyText } from "@/lib/clipboard";
 import { splitUnifiedDiff } from "@/lib/git/diff-split";
 import { useCommitComments, usePrCommitDiff } from "@/lib/git/queries";
-import type { PrCommitOut } from "@/lib/git/types";
+import type { PrCommitOut, RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -31,6 +31,8 @@ interface PrCommitDetailProps {
   /** The forge provider, for the line-comment composer's anchoring (GitHub needs
    *  a diff `position`; GitLab/Bitbucket anchor by line). Defaults to "github". */
   provider?: "github" | "gitlab" | "bitbucket";
+  /** The origin|upstream lens the parent PR view resolved. */
+  lens: RemoteLens;
 }
 
 /** Adds/deletions in one file's unified-diff section (its `+`/`-` body lines,
@@ -63,9 +65,10 @@ export function PrCommitDetail({
   canCommentCommits,
   remoteLabel,
   provider = "github",
+  lens,
 }: PrCommitDetailProps) {
-  const diff = usePrCommitDiff(repoPath, number, commit.oid);
-  const comments = useCommitComments(repoPath, commit.oid);
+  const diff = usePrCommitDiff(repoPath, number, commit.oid, lens);
+  const comments = useCommitComments(repoPath, commit.oid, lens);
 
   const sections = useMemo(
     () => splitUnifiedDiff(diff.data ?? ""),
@@ -136,6 +139,7 @@ export function PrCommitDetail({
           provider={provider}
           fileSection={sections.get(effectivePath)}
           onClose={onClose}
+          lens={lens}
         />
       ),
     };
@@ -146,6 +150,7 @@ export function PrCommitDetail({
     commit.oid,
     provider,
     sections,
+    lens,
   ]);
 
   return (
@@ -265,6 +270,7 @@ export function PrCommitDetail({
                 diffSections={sections}
                 selectedPath={effectivePath}
                 onSelectFile={setSelectedPath}
+                lens={lens}
               />
             </div>
           </main>

--- a/src/features/pulls/PromoteLocalPrDialog.tsx
+++ b/src/features/pulls/PromoteLocalPrDialog.tsx
@@ -16,6 +16,7 @@ import { forgePrComment } from "@/lib/git/api";
 import { useCreatePr, useForgeStatus } from "@/lib/git/queries";
 import type { LocalPr } from "@/lib/pulls/local";
 import { useUpdateLocalPr } from "@/lib/pulls/queries";
+import { useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
@@ -41,6 +42,7 @@ export function PromoteLocalPrDialog({
   const createPr = useCreatePr(repoPath);
   const update = useUpdateLocalPr(repoPath);
   const selectPr = useUiStore((s) => s.selectPr);
+  const setLens = useSetRepoLens(repoPath);
   const forge = useForgeStatus(repoPath);
   const isGitLab = forge.data?.provider === "gitlab";
   const remoteLabel = isGitLab ? "GitLab" : "GitHub";
@@ -72,7 +74,7 @@ export function PromoteLocalPrDialog({
       setPosting(true);
       try {
         for (const c of carried) {
-          await forgePrComment(repoPath, number, c.body);
+          await forgePrComment(repoPath, number, c.body, undefined, "origin");
         }
       } finally {
         setPosting(false);
@@ -98,6 +100,9 @@ export function PromoteLocalPrDialog({
         action: { label: "View", onClick: () => openUrl(url) },
       });
       onOpenChange(false);
+      // The promoted PR lives on the fork (origin) — force the origin lens so the
+      // Pulls tab shows it (clearing any stale remote selection) before selecting.
+      setLens("origin");
       selectPr({ kind: "remote", id: String(number) });
     } catch (e) {
       if (created === null) {

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { ConversationFilterPopover } from "@/features/conversations/ConversationFilterPopover";
 import { ConversationListPanel } from "@/features/conversations/ConversationListPanel";
 import { PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
+import { RepoLensSwitcher } from "@/features/conversations/RepoLensSwitcher";
 import { useCollapsedSections } from "@/features/conversations/useCollapsedSections";
 import { useLocalRemoteFilter } from "@/features/conversations/useLocalRemoteFilter";
 import type { PrStateFilter } from "@/lib/git/api";
@@ -31,6 +32,7 @@ import {
   useLocalPrs,
   useUpdateLocalPr,
 } from "@/lib/pulls/queries";
+import { useRemoteSlug, useRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
@@ -44,7 +46,15 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   // Merge request reads work for GitHub and GitLab; the noun + section header
   // follow the provider so a GitLab repo reads "merge requests" / "GitLab".
   const isGitLab = provider === "gitlab";
-  const remoteLabel = providerLabel(provider);
+  // The origin|upstream lens (GitHub forks only; "origin" everywhere else). It
+  // decides which repo the remote PR list + every PR read/write below target.
+  const lens = useRepoLens(repoPath);
+  // When browsing the parent, the section header names the parent slug (whose
+  // data this is) — falling back to "Upstream" while the slug loads.
+  const upstreamSlug = useRemoteSlug(repoPath, "upstream", lens === "upstream");
+  const providerName = providerLabel(provider);
+  const remoteLabel =
+    lens === "upstream" ? (upstreamSlug ?? "Upstream") : providerName;
   const remoteNoun = isGitLab ? "merge requests" : "pull requests";
   const ghReady = forgeFeatureReady(gh.data, "pullRequests");
   // "closed" matches the Closed tab: closed and merged alike.
@@ -52,7 +62,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   // How many remote PRs to load; "Load more" bumps it. A tab switch (open/closed)
   // resets to the first page.
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const prList = usePrList(repoPath, ghReady, stateFilter, limit);
+  const prList = usePrList(repoPath, ghReady, stateFilter, limit, lens);
   // Row CI icons hydrate separately from the list (so the list paints immediately)
   // and are provider-neutral now — the backend routes GitHub/GitLab/Bitbucket — so
   // `ghReady` alone is the correct gate. Fires whenever the remote list is ready and
@@ -63,6 +73,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
     stateFilter,
     limit,
     prList.data,
+    lens,
   );
   const ciMap = prListCi.data;
   const onStateFilter = (s: PrStateFilter) => {
@@ -74,7 +85,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   useReconcileLocalPrs(repoPath);
   const selectedPr = useUiStore((s) => s.selectedPr);
   const selectPr = useUiStore((s) => s.selectPr);
-  const prefetchPr = usePrefetchPr(repoPath);
+  const prefetchPr = usePrefetchPr(repoPath, lens);
   const hoverPrefetch = useHoverPrefetch();
   const [ghCreateOpen, setGhCreateOpen] = useState(false);
   const filterRef = useRef<HTMLInputElement>(null);
@@ -207,10 +218,11 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
       remoteLabel={remoteLabel}
       stateFilter={stateFilter}
       onStateFilter={onStateFilter}
+      lensControl={<RepoLensSwitcher repoPath={repoPath} />}
       newMenu={{
         ghLabel: isGitLab
           ? "Merge request on GitLab…"
-          : `Pull request on ${remoteLabel}…`,
+          : `Pull request on ${providerName}…`,
         ghDisabled: !canCreateGhPr,
         ghReason: ghCreateReason ?? undefined,
         onGh: () => setGhCreateOpen(true),

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -124,6 +124,7 @@ import {
   useClearReviewDrafts,
   useReviewDrafts,
 } from "@/lib/pulls/review-drafts";
+import { useRepoLens } from "@/lib/repo-lens/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
@@ -204,6 +205,10 @@ export function RemotePrView({
   const provider = forge.data?.provider;
   const remoteLabel = providerLabel(provider);
   const prNoun = provider === "gitlab" ? "merge request" : "pull request";
+  // The single lens-resolution point for this surface (see package B2): every PR
+  // read/write below reads/writes against the fork (origin) or its parent
+  // (upstream). "origin" everywhere but a GitHub fork whose lens is set upstream.
+  const lens = useRepoLens(repoPath);
   // Per-action write-capability flags, derived purely from forge status + provider
   // (see usePrCapabilities for the full gating convention). Destructured so every
   // downstream reference keeps compiling unchanged.
@@ -232,20 +237,20 @@ export function RemotePrView({
     canCreateThread,
     canSubmitReview,
   } = usePrCapabilities(forge.data, provider);
-  const details = usePrDetails(repoPath, number);
-  const prDiff = usePrDiff(repoPath, number);
-  const setAssignees = useSetPrAssignees(repoPath);
-  const setReviewers = useSetPrReviewers(repoPath);
+  const details = usePrDetails(repoPath, number, lens);
+  const prDiff = usePrDiff(repoPath, number, lens);
+  const setAssignees = useSetPrAssignees(repoPath, lens);
+  const setReviewers = useSetPrReviewers(repoPath, lens);
   // For the read-only assignee/reviewer chips (closed/merged PRs): GitHub avatars
   // are login-derived, GitLab/Bitbucket carry a real avatarUrl on the ref.
   const ghHost = useForgeGhHost(repoPath);
-  const comment = useCommentPr(repoPath);
-  const checkout = useCheckoutPr(repoPath);
+  const comment = useCommentPr(repoPath, lens);
+  const checkout = useCheckoutPr(repoPath, lens);
   const repoStatus = useRepoStatus(repoPath);
   const applySuggestion = useApplySuggestion(repoPath);
-  const mergePr = useMergePr(repoPath);
-  const closePr = useClosePr(repoPath);
-  const reopenPr = useReopenPr(repoPath);
+  const mergePr = useMergePr(repoPath, lens);
+  const closePr = useClosePr(repoPath, lens);
+  const reopenPr = useReopenPr(repoPath, lens);
   // Approval + reviewer state drives the GitLab-only approve toggle and
   // Request-changes control; only fetched for a ready GitLab repo with an open MR
   // (null disables the read for GitHub / closed MRs).
@@ -255,9 +260,9 @@ export function RemotePrView({
       ? number
       : null,
   );
-  const approvePr = useApprovePr(repoPath);
+  const approvePr = useApprovePr(repoPath, lens);
   const unapprovePr = useUnapprovePr(repoPath);
-  const requestChangesPr = useRequestChangesPr(repoPath);
+  const requestChangesPr = useRequestChangesPr(repoPath, lens);
   const unrequestChangesPr = useUnrequestChangesPr(repoPath);
   // Auto-merge state (GitLab-only): read only for a ready GitLab repo with an open
   // MR (null disables the read for GitHub / closed MRs). It polls server-side so the
@@ -274,29 +279,29 @@ export function RemotePrView({
   );
   const armAutoMerge = useGlArmAutoMerge(repoPath);
   const cancelAutoMerge = useGlCancelAutoMerge(repoPath);
-  const editComment = useEditPrComment(repoPath);
-  const deleteComment = useDeletePrComment(repoPath);
-  const editReviewComment = useEditReviewComment(repoPath);
-  const deleteReviewComment = useDeleteReviewComment(repoPath);
+  const editComment = useEditPrComment(repoPath, lens);
+  const deleteComment = useDeletePrComment(repoPath, lens);
+  const editReviewComment = useEditReviewComment(repoPath, lens);
+  const deleteReviewComment = useDeleteReviewComment(repoPath, lens);
   const minimizeComment = useMinimizeComment(repoPath);
   const unminimizeComment = useUnminimizeComment(repoPath);
-  const readyPr = useReadyPr(repoPath);
+  const readyPr = useReadyPr(repoPath, lens);
   const setDraft = useSetPrDraft(repoPath);
-  const editPr = useEditPr(repoPath);
+  const editPr = useEditPr(repoPath, lens);
   // File:line-anchored review threads (Copilot/CodeRabbit/human line comments).
   // The read serves both the Conversation block below and (later) the Files
   // diff anchors, so it lives here at the top level. The read gates on the PR
   // number alone (a flaky status probe mustn't hide threads); the WRITE controls
   // below stay gated on the per-provider Implemented flags.
-  const reviewThreads = usePrReviewThreads(repoPath, number);
-  const threadReply = useThreadReply(repoPath, number);
-  const threadResolve = useThreadResolve(repoPath, number);
+  const reviewThreads = usePrReviewThreads(repoPath, number, lens);
+  const threadReply = useThreadReply(repoPath, number, lens);
+  const threadResolve = useThreadResolve(repoPath, number, lens);
   // The reactions fetch is gated on `canReact` (see usePrCapabilities) so it never
   // fires for a provider whose reactions aren't wired (Bitbucket).
-  const reactions = usePrReactions(repoPath, canReact ? number : null);
+  const reactions = usePrReactions(repoPath, canReact ? number : null, lens);
   const toggleReactionMutation = useToggleReaction(
     repoPath,
-    ["repo", repoPath, "pr", number, "reactions"] as const,
+    ["repo", repoPath, "pr", lens, number, "reactions"] as const,
     details.data?.id ?? "",
     { target: "mr", number },
   );
@@ -317,6 +322,7 @@ export function RemotePrView({
     repoPath,
     number,
     section === "conversation" && !!provider,
+    lens,
   );
   const pendingPrSection = useUiStore((s) => s.pendingPrSection);
   const setPendingPrSection = useUiStore((s) => s.setPendingPrSection);
@@ -407,7 +413,9 @@ export function RemotePrView({
   async function toggleApproval() {
     const approved = approvals.data?.viewerHasApproved ?? false;
     const action = approved ? unapprovePr : approvePr;
-    const key = ["repo", repoPath, "pr", number, "approvals"] as const;
+    // Must mirror usePrApprovals' key exactly — GitLab-only, so the lens segment
+    // is the literal "origin" there; a mismatch makes this optimistic flip a no-op.
+    const key = ["repo", repoPath, "pr", "origin", number, "approvals"] as const;
     // Cancel any in-flight approvals refetch first — otherwise it can resolve
     // AFTER this optimistic flip and silently revert the click (the approval
     // state lives in a separate query, so nothing else guards it).
@@ -451,7 +459,8 @@ export function RemotePrView({
     // (its title says how to clear); a re-click must not fire the Premium-only
     // undo path. Bitbucket falls through to the revoke below.
     if (requested && !canUnrequestChanges) return;
-    const key = ["repo", repoPath, "pr", number, "approvals"] as const;
+    // Same as toggleApproval: mirror usePrApprovals' literal "origin" lens segment.
+    const key = ["repo", repoPath, "pr", "origin", number, "approvals"] as const;
     // Same guard as toggleApproval: cancel an in-flight approvals refetch so it
     // can't land after the optimistic flip and revert it.
     await queryClient.cancelQueries({ queryKey: key });
@@ -762,6 +771,7 @@ export function RemotePrView({
               fileSection={fileSections.get(effectivePath) ?? ""}
               draftCount={draftCount}
               canCreateThread={canCreateThread}
+              lens={lens}
               onClose={onClose}
             />
           ),
@@ -954,6 +964,7 @@ export function RemotePrView({
             target="mr"
             labelableId={pr.id}
             labels={pr.labels}
+            lens={lens}
           />
         ) : (
           pr.labels.length > 0 && (
@@ -973,6 +984,7 @@ export function RemotePrView({
             enabled
             value={pr.assignees}
             commitOnClose
+            lens={lens}
             onChange={(next) =>
               setAssignees.mutate(
                 { number, assignees: next },
@@ -1008,6 +1020,7 @@ export function RemotePrView({
               number={number}
               enabled
               value={humanReviewers}
+              lens={lens}
               onChange={(next) =>
                 setReviewers.mutate(
                   { number, reviewers: next },
@@ -1131,7 +1144,7 @@ export function RemotePrView({
             // re-fetching it — PR diffs are among the slowest loads in the app.
             loadDiff: () =>
               queryClient
-                .ensureQueryData(prDiffOptions(repoPath, number))
+                .ensureQueryData(prDiffOptions(repoPath, number, lens))
                 .then((text) => ({
                   text,
                   truncated: false,
@@ -1745,6 +1758,7 @@ export function RemotePrView({
                 canCommentCommits={canCommentCommits}
                 remoteLabel={remoteLabel}
                 provider={providerKey}
+                lens={lens}
               />
             );
           }
@@ -2101,7 +2115,7 @@ export function RemotePrView({
                   // so this works for fork PRs / unfetched head branches.
                   () =>
                     queryClient
-                      .ensureQueryData(prDiffOptions(repoPath, number))
+                      .ensureQueryData(prDiffOptions(repoPath, number, lens))
                       .then((text) => ({
                         text,
                         truncated: false,
@@ -2189,6 +2203,7 @@ export function RemotePrView({
           canRequestChanges: canWrite || canRequestChanges,
         }}
         remoteLabel={remoteLabel}
+        lens={lens}
       />
 
       {/* Palette-triggered "Discard pending review" confirmation (the bar has its

--- a/src/features/pulls/ReviewComposer.tsx
+++ b/src/features/pulls/ReviewComposer.tsx
@@ -2,6 +2,7 @@ import { type KeyboardEvent, useState } from "react";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { useCreateReviewThread } from "@/lib/git/queries";
+import type { RemoteLens } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useAddReviewDraft } from "@/lib/pulls/review-drafts";
 import { toastError } from "@/lib/toast";
@@ -26,6 +27,8 @@ export interface ReviewComposerProps {
   /** Current pending-review size — drives the Add-to-review button label. */
   draftCount: number;
   canCreateThread: boolean;
+  /** The origin|upstream lens the parent PR view resolved (scopes the thread). */
+  lens: RemoteLens;
   onClose: () => void;
 }
 
@@ -48,11 +51,12 @@ export function ReviewComposer({
   fileSection,
   draftCount,
   canCreateThread,
+  lens,
   onClose,
 }: ReviewComposerProps) {
   const [body, setBody] = useState("");
   const [pending, setPending] = useState(false);
-  const createThread = useCreateReviewThread(repoPath);
+  const createThread = useCreateReviewThread(repoPath, lens);
   const addDraft = useAddReviewDraft(repoPath, number);
 
   // The multi-line range, normalized: [from, line] with from <= line.

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useForgeGhHost } from "@/lib/git/host";
 import { useReviewerCandidates } from "@/lib/git/queries";
-import type { ForgeUserRef } from "@/lib/git/types";
+import type { ForgeUserRef, RemoteLens } from "@/lib/git/types";
 
 /**
  * A short, stable disambiguator for a reviewer whose label collides with a
@@ -45,14 +45,17 @@ export function ReviewersPopover({
   enabled,
   value,
   onChange,
+  lens,
 }: {
   repoPath: string;
   number: number | null;
   enabled: boolean;
   value: ForgeUserRef[];
   onChange: (next: ForgeUserRef[]) => void;
+  /** The origin|upstream lens the parent surface resolved (create dialog: "origin"). */
+  lens: RemoteLens;
 }) {
-  const candidates = useReviewerCandidates(repoPath, number, enabled);
+  const candidates = useReviewerCandidates(repoPath, number, enabled, lens);
   // GitHub reviewer ids are logins (avatars served at `<host>/<login>.png`), so the
   // avatar is login-derived there; off GitHub it's the initial fallback unless the
   // ref carries a real avatarUrl (GitLab/Bitbucket do).

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Radio, RadioGroup } from "@/components/ui/radio-group";
 import type { ReviewVerdict } from "@/lib/git/api";
 import { useSubmitReview } from "@/lib/git/queries";
-import type { DraftCommentIn } from "@/lib/git/types";
+import type { DraftCommentIn, RemoteLens } from "@/lib/git/types";
 import {
   useClearReviewDrafts,
   useReviewDrafts,
@@ -35,6 +35,7 @@ export function SubmitReviewDialog({
   onOpenChange,
   caps,
   remoteLabel,
+  lens,
 }: {
   repoPath: string;
   number: number;
@@ -42,9 +43,11 @@ export function SubmitReviewDialog({
   onOpenChange: (o: boolean) => void;
   caps: { canApprove: boolean; canRequestChanges: boolean };
   remoteLabel: string;
+  /** The origin|upstream lens the parent PR view resolved. */
+  lens: RemoteLens;
 }) {
   const drafts = useReviewDrafts(repoPath, number);
-  const submitReview = useSubmitReview(repoPath);
+  const submitReview = useSubmitReview(repoPath, lens);
   const clearDrafts = useClearReviewDrafts(repoPath, number);
   const [verdict, setVerdict] = useState<ReviewVerdict>("comment");
   const [summary, setSummary] = useState("");

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -58,6 +58,7 @@ import { listUserWorktrees, type UserWorktree } from "@/lib/git/worktree";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useLocalPrs } from "@/lib/pulls/queries";
+import { useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { type SelectedPr, useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
@@ -256,10 +257,25 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // Per-branch PR/MR popovers — the list reads work for GitHub and GitLab alike.
   const gh = useForgeStatus(repoPath);
   const canGh = forgeFeatureReady(gh.data, "pullRequests");
-  const openPrs = usePrList(repoPath, canGh && open, "open");
-  const closedPrs = usePrList(repoPath, canGh && open, "closed");
+  // Origin lens: the branch popover lists the FORK's own branch PRs; the
+  // fork/upstream lens is a Pulls/Issues-tab affordance.
+  const openPrs = usePrList(
+    repoPath,
+    canGh && open,
+    "open",
+    undefined,
+    "origin",
+  );
+  const closedPrs = usePrList(
+    repoPath,
+    canGh && open,
+    "closed",
+    undefined,
+    "origin",
+  );
   const localPrs = useLocalPrs(repoPath);
   const selectPr = useUiStore((s) => s.selectPr);
+  const setLens = useSetRepoLens(repoPath);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
 
   const prByBranch = useMemo(() => {
@@ -303,6 +319,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   }, [openPrs.data, closedPrs.data, localPrs.data]);
 
   const openPr = (select: SelectedPr) => {
+    // A remote PR here is a fork (origin) PR — force the origin lens (which also
+    // clears any stale upstream remote selection) before navigating to it.
+    if (select.kind === "remote") setLens("origin");
     selectPr(select);
     setRepoTab("pulls");
     setOpen(false);

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -60,6 +60,7 @@ import {
 } from "@/lib/git/queries";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink, useJiraPermissions } from "@/lib/jira/queries";
+import { useLensGate, useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useAiEnabled, useRepoAlias } from "@/lib/settings/queries";
 import { type RepoTab, useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
@@ -253,6 +254,18 @@ export function RepositoryView() {
   useHotkeyAction("create-tag", () => requestCreate("tag"));
   // Palette-only "Blame file…": open the fuzzy tracked-file picker from any tab.
   useHotkeyAction("blame-file", () => setBlamePickerOpen(true));
+
+  // Fork/upstream lens (PR + Issues surfaces). Wired ONCE here — not in the
+  // panels, which can be mounted together under <Activity> (double-register).
+  // Absolute set-actions (idempotent), gated on the lens applying (GitHub fork).
+  const lensGate = useLensGate(repoPath ?? "");
+  const setRepoLens = useSetRepoLens(repoPath ?? "");
+  useHotkeyAction("repo-lens-origin", () => setRepoLens("origin"), lensGate);
+  useHotkeyAction(
+    "repo-lens-upstream",
+    () => setRepoLens("upstream"),
+    lensGate,
+  );
 
   // "repo • branch" in the OS title bar (and Alt-Tab) while a repo is open. No
   // cleanup here: a branch switch updates the title in one pass instead of

--- a/src/lib/ai/external-context.ts
+++ b/src/lib/ai/external-context.ts
@@ -97,7 +97,9 @@ export async function fetchExternalFindings(
 ): Promise<ExternalReviewItem[]> {
   if (provider === "bitbucket") return [];
   try {
-    const items = await forgePrExternalReviews(repoPath, prNumber);
+    // Origin-pinned (package B2 recorded gap): AI review context reads the fork's
+    // own PR; upstream-lens AI review is a follow-up.
+    const items = await forgePrExternalReviews(repoPath, prNumber, "origin");
     return items.filter((item) => isReviewerFinding(item, provider));
   } catch {
     return [];

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -117,7 +117,9 @@ export async function resolveOwnCommentsContext(
 
   let items: ExternalReviewItem[];
   try {
-    items = await forgePrExternalReviews(repoPath, prNumber);
+    // Origin-pinned (package B2 recorded gap): AI review context reads the fork's
+    // own PR; upstream-lens AI review is a follow-up.
+    items = await forgePrExternalReviews(repoPath, prNumber, "origin");
   } catch {
     return {};
   }

--- a/src/lib/ai/review-tools.ts
+++ b/src/lib/ai/review-tools.ts
@@ -295,7 +295,7 @@ export function buildReviewTools(ctx: ReviewToolContext): ToolSet {
       execute: async (_input, { abortSignal }) => {
         try {
           if (abortSignal?.aborted) return "Error: cancelled";
-          const diff = await forgePrDiff(ctx.repoPath, prNumber);
+          const diff = await forgePrDiff(ctx.repoPath, prNumber, "origin");
           return UNTRUSTED_PREFIX + capHead(diff, FORGE_DIFF_CAP);
         } catch (e) {
           return `Error: ${errorMessage(e)}`;
@@ -311,7 +311,7 @@ export function buildReviewTools(ctx: ReviewToolContext): ToolSet {
       execute: async (_input, { abortSignal }) => {
         try {
           if (abortSignal?.aborted) return "Error: cancelled";
-          const pr = await forgePrView(ctx.repoPath, prNumber);
+          const pr = await forgePrView(ctx.repoPath, prNumber, "origin");
           // Trimmed shape — the metadata a reviewer needs, NOT the full
           // comments/checks payload (that's list_pull_request_comments).
           const trimmed = {
@@ -363,9 +363,11 @@ export function buildReviewTools(ctx: ReviewToolContext): ToolSet {
       execute: async ({ include_diff_hunk }, { abortSignal }) => {
         try {
           if (abortSignal?.aborted) return "Error: cancelled";
+          // Origin-pinned (package B2 recorded gap): the AI PR-review tools read
+          // the fork's own PR; upstream-lens AI review is a follow-up.
           const [pr, reviewThreads] = await Promise.all([
-            forgePrView(ctx.repoPath, prNumber),
-            forgePrReviewThreads(ctx.repoPath, prNumber),
+            forgePrView(ctx.repoPath, prNumber, "origin"),
+            forgePrReviewThreads(ctx.repoPath, prNumber, "origin"),
           ]);
           // Bound (or drop) each thread's diffHunk so a comment on a new file
           // can't drag the whole file into the payload (GitHub-only; other

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -369,7 +369,13 @@ async function generateReviewText(
     // pushed elsewhere). Use the provider's authoritative PR diff; it has no
     // numstat, so derive the file summary from the diff text. (pr-open and local
     // pr-sync keep the local branch diff below, which already includes file counts.)
-    const text = await forgePrDiff(event.repoPath, event.target.number);
+    // Origin-pinned (package B2 recorded gap): pr-sync automation tracks the
+    // fork's own PRs (the poller is origin-scoped); upstream-lens is a follow-up.
+    const text = await forgePrDiff(
+      event.repoPath,
+      event.target.number,
+      "origin",
+    );
     diff = { text, truncated: false, files: filesFromDiff(text) };
   } else {
     diff = await gitBranchDiff(
@@ -531,13 +537,22 @@ async function deliver(
   }
 
   if (event.target.type === "remote") {
-    await forgePrComment(event.repoPath, event.target.number, body, true);
+    // Origin-pinned (package B2 recorded gap): automation posts to the fork's own
+    // PRs (the poller is origin-scoped); upstream-lens is a follow-up.
+    await forgePrComment(
+      event.repoPath,
+      event.target.number,
+      body,
+      true,
+      "origin",
+    );
     // Narrow to the PR's own key family (prefix-matches its detail/reactions/
     // timeline/review-threads) rather than the whole-repo subtree — a posted
     // conversation comment only touches this PR. Mirrors the local-target path
-    // below, which invalidates just its own store.
+    // below, which invalidates just its own store. Scoped to the origin lens (the
+    // PR the comment landed on).
     await queryClient.invalidateQueries({
-      queryKey: ["repo", event.repoPath, "pr", event.target.number],
+      queryKey: ["repo", event.repoPath, "pr", "origin", event.target.number],
     });
     toast.success(`AI ${label} posted on #${event.target.number}`);
     if (notify) {

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -94,6 +94,7 @@ import type {
   ReleaseDetails,
   ReleaseInfo,
   RemoteBranch,
+  RemoteLens,
   RepoDependencies,
   RepoInfo,
   RepoLabel,
@@ -1101,9 +1102,10 @@ export const forgePrCreate = (
   title: string,
   body: string,
   draft: boolean,
-  reviewers?: string[],
-  labels?: string[],
-  assignees?: string[],
+  reviewers: string[] | undefined,
+  labels: string[] | undefined,
+  assignees: string[] | undefined,
+  lens: RemoteLens,
 ) =>
   invoke<PrRef>("forge_pr_create", {
     repoPath,
@@ -1119,6 +1121,7 @@ export const forgePrCreate = (
     // (null) for Bitbucket so the backend leaves behavior untouched.
     labels: labels ?? null,
     assignees: assignees ?? null,
+    lens,
   });
 
 /** Which providers this machine can publish to (CLI installed + signed in) —
@@ -1154,8 +1157,11 @@ export const forgePublishRepo = (
   });
 
 /** Open PRs/MRs whose head is `head` — the ComparePanel duplicate probe. */
-export const forgePrsForBranch = (repoPath: string, head: string) =>
-  invoke<PrInfo[]>("forge_prs_for_branch", { repoPath, head });
+export const forgePrsForBranch = (
+  repoPath: string,
+  head: string,
+  lens: RemoteLens,
+) => invoke<PrInfo[]>("forge_prs_for_branch", { repoPath, head, lens });
 
 export type PrStateFilter = "open" | "closed";
 
@@ -1181,8 +1187,11 @@ export const ghPrView = (repoPath: string, number: number) =>
 /** A PR's activity timeline (force-pushes, label changes, review requests, state
  *  changes, approvals) for the Conversation tab. Provider-neutral — the backend
  *  dispatches per provider (GitHub `gh`, GitLab `glab`, Bitbucket HTTP). */
-export const forgePrTimeline = (repoPath: string, number: number) =>
-  invoke<PrTimelineEvent[]>("forge_pr_timeline", { repoPath, number });
+export const forgePrTimeline = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<PrTimelineEvent[]>("forge_pr_timeline", { repoPath, number, lens });
 
 // Provider-neutral merge/pull request reads — the backend resolves the repo's
 // provider and dispatches (GitHub `gh`, GitLab `glab`), returning the same neutral
@@ -1193,14 +1202,21 @@ export const forgePrTimeline = (repoPath: string, number: number) =>
 export const forgePrList = (
   repoPath: string,
   state: PrStateFilter,
-  limit?: number,
-) => invoke<PrInfo[]>("forge_pr_list", { repoPath, state, limit });
+  limit: number | undefined,
+  lens: RemoteLens,
+) => invoke<PrInfo[]>("forge_pr_list", { repoPath, state, limit, lens });
 
-export const forgePrView = (repoPath: string, number: number) =>
-  invoke<PrDetails>("forge_pr_view", { repoPath, number });
+export const forgePrView = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<PrDetails>("forge_pr_view", { repoPath, number, lens });
 
-export const forgePrDiff = (repoPath: string, number: number) =>
-  invoke<string>("forge_pr_diff", { repoPath, number });
+export const forgePrDiff = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<string>("forge_pr_diff", { repoPath, number, lens });
 
 /** The unified diff for a single commit of a PR/MR (per-commit review view). */
 export const forgePrCommitDiff = (
@@ -1224,8 +1240,12 @@ export const commitOnRemote = (repoPath: string, sha: string) =>
 // Commit comments (GitHub commit comments / GitLab commit notes) — plain or
 // diff-anchored, provider-neutral. `sha` is the commit; `commentId` addresses a
 // single comment for edit/delete.
-export const forgeCommitComments = (repoPath: string, sha: string) =>
-  invoke<CommitCommentOut[]>("forge_commit_comments", { repoPath, sha });
+export const forgeCommitComments = (
+  repoPath: string,
+  sha: string,
+  lens: RemoteLens,
+) =>
+  invoke<CommitCommentOut[]>("forge_commit_comments", { repoPath, sha, lens });
 
 export const forgeCommitCommentCreate = (
   repoPath: string,
@@ -1237,6 +1257,7 @@ export const forgeCommitCommentCreate = (
     startLine?: number;
     position?: number;
   },
+  lens: RemoteLens,
 ) =>
   invoke<void>("forge_commit_comment_create", {
     repoPath,
@@ -1246,6 +1267,7 @@ export const forgeCommitCommentCreate = (
     line: args.line ?? null,
     startLine: args.startLine ?? null,
     position: args.position ?? null,
+    lens,
   });
 
 export const forgeCommitCommentEdit = (
@@ -1287,11 +1309,15 @@ export type IssueStateFilter = "open" | "closed";
 export const forgeIssueList = (
   repoPath: string,
   state: IssueStateFilter,
-  limit?: number,
-) => invoke<IssueInfo[]>("forge_issue_list", { repoPath, state, limit });
+  limit: number | undefined,
+  lens: RemoteLens,
+) => invoke<IssueInfo[]>("forge_issue_list", { repoPath, state, limit, lens });
 
-export const forgeIssueView = (repoPath: string, number: number) =>
-  invoke<IssueDetails>("forge_issue_view", { repoPath, number });
+export const forgeIssueView = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<IssueDetails>("forge_issue_view", { repoPath, number, lens });
 
 /** Create an issue. Provider-neutral: `milestone` is the provider's milestone key
  *  (whatever `forgeMilestones` returned as `number`); only `issueType` is
@@ -1304,6 +1330,7 @@ export const forgeIssueCreate = (
   assignees: string[],
   milestone: number | null,
   issueType: string | null,
+  lens: RemoteLens,
 ) =>
   invoke<PrRef>("forge_issue_create", {
     repoPath,
@@ -1313,34 +1340,51 @@ export const forgeIssueCreate = (
     assignees,
     milestone,
     issueType,
+    lens,
   });
 
-export const forgeAssignableUsers = (repoPath: string) =>
-  invoke<ForgeUserRef[]>("forge_assignable_users", { repoPath });
+export const forgeAssignableUsers = (repoPath: string, lens: RemoteLens) =>
+  invoke<ForgeUserRef[]>("forge_assignable_users", { repoPath, lens });
 
 /** Open/active milestones for the milestone picker. `number` is whatever key the
  *  provider's milestone write takes (GitHub milestone number, GitLab global id). */
-export const forgeMilestones = (repoPath: string) =>
-  invoke<Milestone[]>("forge_milestones", { repoPath });
+export const forgeMilestones = (repoPath: string, lens: RemoteLens) =>
+  invoke<Milestone[]>("forge_milestones", { repoPath, lens });
 
 export const forgeIssueSetAssignees = (
   repoPath: string,
   number: number,
   assignees: string[],
-) => invoke<void>("forge_issue_set_assignees", { repoPath, number, assignees });
+  lens: RemoteLens,
+) =>
+  invoke<void>("forge_issue_set_assignees", {
+    repoPath,
+    number,
+    assignees,
+    lens,
+  });
 
 /** Set an MR's assignees — GitLab-only (GitHub PRs have no assignee picker). */
 export const forgeMrSetAssignees = (
   repoPath: string,
   number: number,
   assignees: string[],
-) => invoke<void>("forge_mr_set_assignees", { repoPath, number, assignees });
+  lens: RemoteLens,
+) =>
+  invoke<void>("forge_mr_set_assignees", { repoPath, number, assignees, lens });
 
 export const forgeIssueSetMilestone = (
   repoPath: string,
   number: number,
   milestone: number | null,
-) => invoke<void>("forge_issue_set_milestone", { repoPath, number, milestone });
+  lens: RemoteLens,
+) =>
+  invoke<void>("forge_issue_set_milestone", {
+    repoPath,
+    number,
+    milestone,
+    lens,
+  });
 
 /** Mark an issue confidential (members-only) or public — GitLab-only. */
 export const forgeGlIssueSetConfidential = (
@@ -1437,20 +1481,27 @@ export const forgeGlIssueUnlink = (
 ) => invoke<void>("forge_gl_issue_unlink", { repoPath, number, linkId });
 
 /** The repo's enabled issue types (empty when the owner defines none). */
-export const ghIssueTypes = (repoPath: string) =>
-  invoke<IssueType[]>("gh_issue_types", { repoPath });
+export const ghIssueTypes = (repoPath: string, lens: RemoteLens) =>
+  invoke<IssueType[]>("gh_issue_types", { repoPath, lens });
 
 export const ghIssueSetType = (
   repoPath: string,
   number: number,
   typeName: string | null,
-) => invoke<void>("gh_issue_set_type", { repoPath, number, typeName });
+  lens: RemoteLens,
+) => invoke<void>("gh_issue_set_type", { repoPath, number, typeName, lens });
 
-export const ghIssuePin = (repoPath: string, number: number) =>
-  invoke<void>("gh_issue_pin", { repoPath, number });
+export const ghIssuePin = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("gh_issue_pin", { repoPath, number, lens });
 
-export const ghIssueUnpin = (repoPath: string, number: number) =>
-  invoke<void>("gh_issue_unpin", { repoPath, number });
+export const ghIssueUnpin = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("gh_issue_unpin", { repoPath, number, lens });
 
 export type LockReason = "off_topic" | "resolved" | "spam" | "too_heated";
 
@@ -1460,13 +1511,21 @@ export const forgeIssueLock = (
   repoPath: string,
   number: number,
   reason: LockReason | null,
-) => invoke<void>("forge_issue_lock", { repoPath, number, reason });
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_lock", { repoPath, number, reason, lens });
 
-export const forgeIssueUnlock = (repoPath: string, number: number) =>
-  invoke<void>("forge_issue_unlock", { repoPath, number });
+export const forgeIssueUnlock = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_unlock", { repoPath, number, lens });
 
-export const forgeIssueReactions = (repoPath: string, number: number) =>
-  invoke<IssueReactions>("forge_issue_reactions", { repoPath, number });
+export const forgeIssueReactions = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) =>
+  invoke<IssueReactions>("forge_issue_reactions", { repoPath, number, lens });
 
 /** The reaction subject travels in BOTH provider vocabularies: GitHub keys on
  *  `subjectId` (a GraphQL node id) and ignores `target`/`number`; GitLab keys on
@@ -1613,23 +1672,29 @@ export const forgeIssueComment = (
   repoPath: string,
   number: number,
   body: string,
-) => invoke<void>("forge_issue_comment", { repoPath, number, body });
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_comment", { repoPath, number, body, lens });
 
 export const forgeIssueClose = (
   repoPath: string,
   number: number,
   reason: string,
-) => invoke<void>("forge_issue_close", { repoPath, number, reason });
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_close", { repoPath, number, reason, lens });
 
-export const forgeIssueReopen = (repoPath: string, number: number) =>
-  invoke<void>("forge_issue_reopen", { repoPath, number });
+export const forgeIssueReopen = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_reopen", { repoPath, number, lens });
 
 export const forgeIssueEdit = (
   repoPath: string,
   number: number,
   title: string,
   body: string,
-) => invoke<void>("forge_issue_edit", { repoPath, number, title, body });
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_edit", { repoPath, number, title, body, lens });
 
 /** Transfers (GitHub) / moves (GitLab) an issue to `destination` — "owner/repo"
  *  on GitHub, a full "group/name" project path on GitLab; returns the new URL. */
@@ -1637,26 +1702,58 @@ export const forgeIssueTransfer = (
   repoPath: string,
   number: number,
   destination: string,
-) => invoke<string>("forge_issue_transfer", { repoPath, number, destination });
+  lens: RemoteLens,
+) =>
+  invoke<string>("forge_issue_transfer", {
+    repoPath,
+    number,
+    destination,
+    lens,
+  });
 
-export const forgeIssueDelete = (repoPath: string, number: number) =>
-  invoke<void>("forge_issue_delete", { repoPath, number });
+export const forgeIssueDelete = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("forge_issue_delete", { repoPath, number, lens });
 
-export const ghIssueRelations = (repoPath: string, number: number) =>
-  invoke<IssueRelations>("gh_issue_relations", { repoPath, number });
+export const ghIssueRelations = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<IssueRelations>("gh_issue_relations", { repoPath, number, lens });
 
-export const ghIssueDependencies = (repoPath: string, number: number) =>
-  invoke<IssueDependencies>("gh_issue_dependencies", { repoPath, number });
+export const ghIssueDependencies = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) =>
+  invoke<IssueDependencies>("gh_issue_dependencies", {
+    repoPath,
+    number,
+    lens,
+  });
 
-export const ghIssueDevelopment = (repoPath: string, number: number) =>
-  invoke<IssueDevelopment>("gh_issue_development", { repoPath, number });
+export const ghIssueDevelopment = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) =>
+  invoke<IssueDevelopment>("gh_issue_development", { repoPath, number, lens });
 
 /** Creates a new branch off the default branch, linked to the issue. */
 export const ghIssueCreateLinkedBranch = (
   repoPath: string,
   issueId: string,
   name: string,
-) => invoke<void>("gh_issue_create_linked_branch", { repoPath, issueId, name });
+  lens: RemoteLens,
+) =>
+  invoke<void>("gh_issue_create_linked_branch", {
+    repoPath,
+    issueId,
+    name,
+    lens,
+  });
 
 /** Adds/removes a blocked-by or blocking dependency by target issue number. */
 export const ghIssueSetDependency = (
@@ -1665,6 +1762,7 @@ export const ghIssueSetDependency = (
   relation: IssueRelation,
   target: number,
   add: boolean,
+  lens: RemoteLens,
 ) =>
   invoke<void>("gh_issue_set_dependency", {
     repoPath,
@@ -1672,6 +1770,7 @@ export const ghIssueSetDependency = (
     relation,
     target,
     add,
+    lens,
   });
 
 /** Adds issue `subNumber` (this repo) as a sub-issue of `parentId` (node id). */
@@ -1679,7 +1778,14 @@ export const ghIssueAddSubIssue = (
   repoPath: string,
   parentId: string,
   subNumber: number,
-) => invoke<void>("gh_issue_add_sub_issue", { repoPath, parentId, subNumber });
+  lens: RemoteLens,
+) =>
+  invoke<void>("gh_issue_add_sub_issue", {
+    repoPath,
+    parentId,
+    subNumber,
+    lens,
+  });
 
 export const ghIssueRemoveSubIssue = (
   repoPath: string,
@@ -1693,16 +1799,29 @@ export const ghPrDiff = (repoPath: string, number: number) =>
 /** Third-party AI-reviewer findings on a PR/MR (Copilot/CodeRabbit/…), behind the
  *  forge abstraction: GitHub delegates unchanged, GitLab maps MR discussions,
  *  Bitbucket returns empty by design. Shape is provider-agnostic. */
-export const forgePrExternalReviews = (repoPath: string, number: number) =>
+export const forgePrExternalReviews = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) =>
   invoke<ExternalReviewItem[]>("forge_pr_external_reviews", {
     repoPath,
     number,
+    lens,
   });
 
 /** File:line-anchored review threads on a PR/MR, provider-neutral (GitHub
  *  reviewThreads / GitLab diff-note discussions / Bitbucket inline comments). */
-export const forgePrReviewThreads = (repoPath: string, number: number) =>
-  invoke<ReviewThreadOut[]>("forge_pr_review_threads", { repoPath, number });
+export const forgePrReviewThreads = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) =>
+  invoke<ReviewThreadOut[]>("forge_pr_review_threads", {
+    repoPath,
+    number,
+    lens,
+  });
 
 /** Post a reply into an existing review thread. */
 export const forgePrThreadReply = (
@@ -1740,6 +1859,7 @@ export const forgePrThreadCreate = (
     startLine?: number;
     body: string;
   },
+  lens: RemoteLens,
 ) =>
   invoke<void>("forge_pr_thread_create", {
     repoPath,
@@ -1749,6 +1869,7 @@ export const forgePrThreadCreate = (
     side: args.side,
     startLine: args.startLine ?? null,
     body: args.body,
+    lens,
   });
 
 export type ReviewVerdict = "comment" | "approve" | "request_changes";
@@ -1764,6 +1885,7 @@ export const forgePrReviewSubmit = (
     summary?: string;
     comments: DraftCommentIn[];
   },
+  lens: RemoteLens,
 ) =>
   invoke<ReviewSubmitOut>("forge_pr_review_submit", {
     repoPath,
@@ -1771,6 +1893,7 @@ export const forgePrReviewSubmit = (
     verdict: args.verdict,
     summary: args.summary ?? null,
     comments: args.comments,
+    lens,
   });
 
 // The GitLab review-bot token — a second GitLab token so batch reviews / bot
@@ -1807,13 +1930,15 @@ export const forgePrComment = (
   repoPath: string,
   number: number,
   body: string,
-  asBot?: boolean,
+  asBot: boolean | undefined,
+  lens: RemoteLens,
 ) =>
   invoke<void>("forge_pr_comment", {
     repoPath,
     number,
     body,
     asBot: asBot ?? null,
+    lens,
   });
 
 // MR approve/unapprove and request-changes are GitLab-only controls (GitHub does
@@ -1821,8 +1946,11 @@ export const forgePrComment = (
 export const forgePrApprovals = (repoPath: string, number: number) =>
   invoke<ApprovalState>("forge_pr_approvals", { repoPath, number });
 
-export const forgePrApprove = (repoPath: string, number: number) =>
-  invoke<void>("forge_pr_approve", { repoPath, number });
+export const forgePrApprove = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("forge_pr_approve", { repoPath, number, lens });
 
 export const forgePrUnapprove = (repoPath: string, number: number) =>
   invoke<void>("forge_pr_unapprove", { repoPath, number });
@@ -1833,7 +1961,8 @@ export const forgePrRequestChanges = (
   repoPath: string,
   number: number,
   body: string,
-) => invoke<void>("forge_pr_request_changes", { repoPath, number, body });
+  lens: RemoteLens,
+) => invoke<void>("forge_pr_request_changes", { repoPath, number, body, lens });
 
 /** Revoke the viewer's requested-changes state — Bitbucket-only (its revoke works
  *  on every plan, making the control a true toggle; GitLab's undo is Premium). */
@@ -1855,7 +1984,9 @@ export const forgePrSetReviewers = (
   repoPath: string,
   number: number,
   reviewers: string[],
-) => invoke<void>("forge_pr_set_reviewers", { repoPath, number, reviewers });
+  lens: RemoteLens,
+) =>
+  invoke<void>("forge_pr_set_reviewers", { repoPath, number, reviewers, lens });
 
 /** Reviewer-picker candidates for a PR — Bitbucket: workspace members minus the
  *  user the server would reject. For an existing PR pass its number (the PR author
@@ -1863,8 +1994,13 @@ export const forgePrSetReviewers = (
 export const forgePrReviewerCandidates = (
   repoPath: string,
   number: number | null,
+  lens: RemoteLens,
 ) =>
-  invoke<ForgeUserRef[]>("forge_pr_reviewer_candidates", { repoPath, number });
+  invoke<ForgeUserRef[]>("forge_pr_reviewer_candidates", {
+    repoPath,
+    number,
+    lens,
+  });
 
 // Comment edit/delete are provider-neutral (GitHub via `gh`, GitLab via `glab`,
 // Bitbucket via its API). `number` is the PR/MR (or issue) the comment lives on —
@@ -1966,7 +2102,8 @@ export const forgePrMerge = (
   number: number,
   strategy: MergeStrategy,
   deleteBranch: boolean,
-  sha?: string,
+  sha: string | undefined,
+  lens: RemoteLens,
 ) =>
   invoke<PrMergeOutcome>("forge_pr_merge", {
     repoPath,
@@ -1974,6 +2111,7 @@ export const forgePrMerge = (
     strategy,
     deleteBranch,
     sha: sha ?? null,
+    lens,
   });
 
 // GitLab auto-merge (merge-when-pipeline-succeeds) — GitLab-only, gated on
@@ -2003,11 +2141,17 @@ export const forgeGlMrAutoMerge = (
 export const forgeGlMrCancelAutoMerge = (repoPath: string, number: number) =>
   invoke<void>("forge_gl_mr_cancel_auto_merge", { repoPath, number });
 
-export const forgePrClose = (repoPath: string, number: number) =>
-  invoke<void>("forge_pr_close", { repoPath, number });
+export const forgePrClose = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("forge_pr_close", { repoPath, number, lens });
 
-export const forgePrReopen = (repoPath: string, number: number) =>
-  invoke<void>("forge_pr_reopen", { repoPath, number });
+export const forgePrReopen = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("forge_pr_reopen", { repoPath, number, lens });
 
 export const ghAccounts = () => invoke<GhAccounts>("gh_accounts");
 
@@ -2017,13 +2161,19 @@ export const ghListRepos = () => invoke<GhRepoList>("gh_list_repos");
 export const ghSwitchAccount = (host: string, login: string) =>
   invoke<void>("gh_switch_account", { host, login });
 
-export const ghPrCheckout = (repoPath: string, number: number) =>
-  invoke<void>("gh_pr_checkout", { repoPath, number });
+export const ghPrCheckout = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<void>("gh_pr_checkout", { repoPath, number, lens });
 
 /** Reactions for a PR/MR body + each comment (keyed by the comment's id — a
  *  GraphQL node id on GitHub, a note id on GitLab). */
-export const forgePrReactions = (repoPath: string, number: number) =>
-  invoke<IssueReactions>("forge_pr_reactions", { repoPath, number });
+export const forgePrReactions = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) => invoke<IssueReactions>("forge_pr_reactions", { repoPath, number, lens });
 
 /** Returns the fork's URL ("" when the fork already existed). */
 export const ghRepoFork = (repoPath: string, contributeToParent: boolean) =>
@@ -2611,18 +2761,19 @@ export const fundingSet = (repoPath: string, content: string) =>
 export const fundingDelete = (repoPath: string) =>
   invoke<void>("funding_delete", { repoPath });
 
-export const ghPrReady = (repoPath: string, number: number) =>
-  invoke<void>("gh_pr_ready", { repoPath, number });
+export const ghPrReady = (repoPath: string, number: number, lens: RemoteLens) =>
+  invoke<void>("gh_pr_ready", { repoPath, number, lens });
 
 export const forgePrEdit = (
   repoPath: string,
   number: number,
   title: string,
   body: string,
-) => invoke<void>("forge_pr_edit", { repoPath, number, title, body });
+  lens: RemoteLens,
+) => invoke<void>("forge_pr_edit", { repoPath, number, title, body, lens });
 
-export const forgeRepoLabels = (repoPath: string) =>
-  invoke<RepoLabel[]>("forge_repo_labels", { repoPath });
+export const forgeRepoLabels = (repoPath: string, lens: RemoteLens) =>
+  invoke<RepoLabel[]>("forge_repo_labels", { repoPath, lens });
 
 /** GitHub's (classic) branch protection rules — read-only, for importing. */
 export const ghBranchProtections = (repoPath: string) =>

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -713,6 +713,9 @@ export const gitRemoteUrl = (repoPath: string, name: string) =>
 export const gitRemoteSetUrl = (repoPath: string, name: string, url: string) =>
   invoke<void>("git_remote_set_url", { repoPath, name, url });
 
+export const gitRemoteAdd = (repoPath: string, name: string, url: string) =>
+  invoke<void>("git_remote_add", { repoPath, name, url });
+
 export const gitSubmodules = (repoPath: string) =>
   invoke<Submodule[]>("git_submodules", { repoPath });
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2711,6 +2711,12 @@ export function useRemoteUrl(repo: string, name: string, enabled: boolean) {
     queryKey: ["repo", repo, "remote-url", name] as const,
     queryFn: () => api.gitRemoteUrl(repo, name),
     enabled,
+    // Consumed by the always-visible RepoLensSwitcher + CreatePrDialog via
+    // useRemoteSlug, so leave the house default (not Infinity): the Rust cache's
+    // short 5s TTL exists so an external `git remote set-url` is picked up
+    // promptly, and in-app edits invalidate this key eagerly (useSetRemoteUrl).
+    // Without this, every window focus re-spawned `git remote get-url` twice.
+    staleTime: 30_000,
   });
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -43,6 +43,7 @@ import type {
   PrInfo,
   PrThreadOut,
   Reaction,
+  RemoteLens,
   RepoOp,
   RepoRole,
   RepoSettingsInput,
@@ -852,10 +853,11 @@ export function usePrsForBranch(
   repo: string,
   head: string | null,
   enabled: boolean,
+  lens: RemoteLens,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "prs", head ?? ""] as const,
-    queryFn: () => api.forgePrsForBranch(repo, head ?? ""),
+    queryKey: ["repo", repo, "prs", lens, head ?? ""] as const,
+    queryFn: () => api.forgePrsForBranch(repo, head ?? "", lens),
     enabled: enabled && head !== null,
     staleTime: 30_000,
   });
@@ -865,11 +867,12 @@ export function usePrList(
   repo: string,
   enabled: boolean,
   state: api.PrStateFilter,
-  limit?: number,
+  limit: number | undefined,
+  lens: RemoteLens,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "pr-list", state, limit ?? null] as const,
-    queryFn: () => api.forgePrList(repo, state, limit),
+    queryKey: ["repo", repo, "pr-list", lens, state, limit ?? null] as const,
+    queryFn: () => api.forgePrList(repo, state, limit, lens),
     enabled,
     staleTime: 30_000,
     // Growing the limit ("Load more") keeps the current rows visible instead of
@@ -893,12 +896,14 @@ export function usePrListCi(
   state: api.PrStateFilter,
   limit: number | undefined,
   prs: PrInfo[] | undefined,
+  lens: RemoteLens,
 ) {
   return useQuery({
     queryKey: [
       "repo",
       repo,
       "pr-ci",
+      lens,
       state,
       limit ?? null,
       prs?.map((p) => p.number).join(",") ?? "",
@@ -906,6 +911,10 @@ export function usePrListCi(
     queryFn: async () => {
       // `enabled` guarantees a non-empty list here; `prs![0]` is safe.
       const list = prs as PrInfo[];
+      // No lens arg on the api call: `sampleUrl` (list[0].url) already pins which
+      // repo these numbers belong to, so the CI rollup is fork/parent-correct by
+      // construction. The lens rides the key only, so the fork's and parent's
+      // rollups never collide in the cache.
       const rows = await api.forgePrListCi(
         repo,
         list.map((p) => ({ number: p.number, headSha: p.headSha })),
@@ -920,10 +929,14 @@ export function usePrListCi(
   });
 }
 
-export function useRepoLabels(repo: string, enabled: boolean) {
+export function useRepoLabels(
+  repo: string,
+  enabled: boolean,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "labels"] as const,
-    queryFn: () => api.forgeRepoLabels(repo),
+    queryKey: ["repo", repo, "labels", lens] as const,
+    queryFn: () => api.forgeRepoLabels(repo, lens),
     enabled,
     staleTime: 5 * 60_000,
   });
@@ -932,31 +945,39 @@ export function useRepoLabels(repo: string, enabled: boolean) {
 // Shared definitions so the hook and the prefetch path stay in sync. A short
 // stale window makes a hover-prefetched PR open with no extra round-trip; the
 // window-focus refetch still keeps an open PR current.
-const prDetailsOptions = (repo: string, number: number) =>
+const prDetailsOptions = (repo: string, number: number, lens: RemoteLens) =>
   queryOptions({
-    queryKey: ["repo", repo, "pr", number] as const,
-    queryFn: () => api.forgePrView(repo, number),
+    queryKey: ["repo", repo, "pr", lens, number] as const,
+    queryFn: () => api.forgePrView(repo, number, lens),
     staleTime: 30_000,
   });
 
-export const prDiffOptions = (repo: string, number: number) =>
+export const prDiffOptions = (repo: string, number: number, lens: RemoteLens) =>
   queryOptions({
-    queryKey: ["repo", repo, "pr", number, "diff"] as const,
-    queryFn: () => api.forgePrDiff(repo, number),
+    queryKey: ["repo", repo, "pr", lens, number, "diff"] as const,
+    queryFn: () => api.forgePrDiff(repo, number, lens),
     staleTime: 30_000,
   });
 
-export function usePrDetails(repo: string, number: number | null) {
+export function usePrDetails(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    ...prDetailsOptions(repo, number ?? 0),
+    ...prDetailsOptions(repo, number ?? 0, lens),
     enabled: number !== null,
     placeholderData: keepPreviousDataForRepo(repo),
   });
 }
 
-export function usePrDiff(repo: string, number: number | null) {
+export function usePrDiff(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    ...prDiffOptions(repo, number ?? 0),
+    ...prDiffOptions(repo, number ?? 0, lens),
     enabled: number !== null,
     placeholderData: keepPreviousDataForRepo(repo),
   });
@@ -965,13 +986,20 @@ export function usePrDiff(repo: string, number: number | null) {
 // File:line-anchored review threads (Copilot/CodeRabbit/human line comments); the
 // data serves both the Conversation grouping and the Files diff anchors, so it
 // lives at the PR top level.
-export const prReviewThreadsKey = (repo: string, number: number) =>
-  ["repo", repo, "pr", number, "review-threads"] as const;
+export const prReviewThreadsKey = (
+  repo: string,
+  number: number,
+  lens: RemoteLens,
+) => ["repo", repo, "pr", lens, number, "review-threads"] as const;
 
-export function usePrReviewThreads(repo: string, number: number | null) {
+export function usePrReviewThreads(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: prReviewThreadsKey(repo, number ?? 0),
-    queryFn: () => api.forgePrReviewThreads(repo, number ?? 0),
+    queryKey: prReviewThreadsKey(repo, number ?? 0, lens),
+    queryFn: () => api.forgePrReviewThreads(repo, number ?? 0, lens),
     staleTime: 30_000,
     // Gate on `number !== null` alone, exactly like usePrDetails/usePrReactions.
     // A transient gh status-probe failure (useForgeStatus has retry:false) leaves
@@ -1022,9 +1050,12 @@ export function usePrCommitDiff(
   repo: string,
   number: number,
   oid: string | null,
+  lens: RemoteLens,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "pr", number, "commit-diff", oid] as const,
+    // The diff itself is sha-addressed (forgePrCommitDiff takes no lens), but the
+    // PARENT PR this attaches to is lens-scoped, so the lens rides the key.
+    queryKey: ["repo", repo, "pr", lens, number, "commit-diff", oid] as const,
     queryFn: () => api.forgePrCommitDiff(repo, number, oid ?? ""),
     enabled: oid !== null,
     staleTime: 30_000,
@@ -1032,11 +1063,17 @@ export function usePrCommitDiff(
 }
 
 /** Comments on a commit (GitHub commit comments / GitLab commit notes). Pass
- *  `sha: null` when no commit is selected so the read doesn't fire. */
-export function useCommitComments(repo: string, sha: string | null) {
+ *  `sha: null` when no commit is selected so the read doesn't fire. The `lens`
+ *  scopes which repo the commit's comments come from — "origin" from the History
+ *  surface, the live lens inside the PR-commit review context. */
+export function useCommitComments(
+  repo: string,
+  sha: string | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "commit", sha, "comments"] as const,
-    queryFn: () => api.forgeCommitComments(repo, sha ?? ""),
+    queryKey: commitCommentsKey(repo, sha ?? "", lens),
+    queryFn: () => api.forgeCommitComments(repo, sha ?? "", lens),
     enabled: sha !== null,
     staleTime: 30_000,
   });
@@ -1068,8 +1105,8 @@ export function useRemoteCommitDiff(repo: string, sha: string | null) {
   });
 }
 
-const commitCommentsKey = (repo: string, sha: string) =>
-  ["repo", repo, "commit", sha, "comments"] as const;
+const commitCommentsKey = (repo: string, sha: string, lens: RemoteLens) =>
+  ["repo", repo, "commit", sha, "comments", lens] as const;
 
 /**
  * The shared skeleton behind every optimistic-cache mutation in this file:
@@ -1142,7 +1179,7 @@ function useOptimisticCacheMutation<TArgs, TData, TCache>(
  * key's cache; onSettled keeps the repo-wide invalidation as server-truth
  * reconciliation.
  */
-export function useCreateCommitComment(repo: string) {
+export function useCreateCommitComment(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: {
@@ -1152,7 +1189,7 @@ export function useCreateCommitComment(repo: string) {
       line?: number;
       startLine?: number;
       position?: number;
-    }) => api.forgeCommitCommentCreate(repo, args),
+    }) => api.forgeCommitCommentCreate(repo, args, lens),
     onMutate: async (args: {
       sha: string;
       body: string;
@@ -1161,7 +1198,7 @@ export function useCreateCommitComment(repo: string) {
       startLine?: number;
       position?: number;
     }) => {
-      const key = commitCommentsKey(repo, args.sha);
+      const key = commitCommentsKey(repo, args.sha, lens);
       await queryClient.cancelQueries({ queryKey: key });
       const prev = queryClient.getQueryData<CommitCommentOut[]>(key);
       // The viewer's login is read from the already-cached forge status (no fetch);
@@ -1204,6 +1241,7 @@ export function useCreateCommitComment(repo: string) {
  */
 function useOptimisticCommitCommentMutation<TData>(
   repo: string,
+  lens: RemoteLens,
   mutationFn: (args: {
     sha: string;
     commentId: string;
@@ -1220,7 +1258,7 @@ function useOptimisticCommitCommentMutation<TData>(
     CommitCommentOut[]
   >(
     mutationFn,
-    (args) => commitCommentsKey(repo, args.sha),
+    (args) => commitCommentsKey(repo, args.sha, lens),
     (list, args) =>
       list?.flatMap((c) => {
         if (c.id !== args.commentId) return [c];
@@ -1232,9 +1270,10 @@ function useOptimisticCommitCommentMutation<TData>(
   );
 }
 
-export function useEditCommitComment(repo: string) {
+export function useEditCommitComment(repo: string, lens: RemoteLens) {
   return useOptimisticCommitCommentMutation(
     repo,
+    lens,
     (args: { sha: string; commentId: string; body?: string }) =>
       api.forgeCommitCommentEdit(repo, {
         sha: args.sha,
@@ -1245,9 +1284,10 @@ export function useEditCommitComment(repo: string) {
   );
 }
 
-export function useDeleteCommitComment(repo: string) {
+export function useDeleteCommitComment(repo: string, lens: RemoteLens) {
   return useOptimisticCommitCommentMutation(
     repo,
+    lens,
     (args: { sha: string; commentId: string }) =>
       api.forgeCommitCommentDelete(repo, {
         sha: args.sha,
@@ -1266,7 +1306,7 @@ export function useDeleteCommitComment(repo: string) {
  * the reconciliation refetch replaces it); onSettled keeps the repo-wide
  * invalidation as server-truth reconciliation.
  */
-export function useCreateReviewThread(repo: string) {
+export function useCreateReviewThread(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: {
@@ -1276,7 +1316,7 @@ export function useCreateReviewThread(repo: string) {
       side: "new" | "old";
       startLine?: number;
       body: string;
-    }) => api.forgePrThreadCreate(repo, args),
+    }) => api.forgePrThreadCreate(repo, args, lens),
     onMutate: async (args: {
       number: number;
       path: string;
@@ -1285,7 +1325,7 @@ export function useCreateReviewThread(repo: string) {
       startLine?: number;
       body: string;
     }) => {
-      const key = prReviewThreadsKey(repo, args.number);
+      const key = prReviewThreadsKey(repo, args.number, lens);
       await queryClient.cancelQueries({ queryKey: key });
       const prev = queryClient.getQueryData<ReviewThreadOut[]>(key);
       const login = queryClient.getQueryData<ForgeStatus>([
@@ -1339,7 +1379,7 @@ export function useCreateReviewThread(repo: string) {
  *  optimistic — on some providers it fans out to several calls, so it just
  *  invalidates the repo subtree on success and returns the {@link ReviewSubmitOut}
  *  so the caller can toast the posted/total counts. */
-export function useSubmitReview(repo: string) {
+export function useSubmitReview(repo: string, lens: RemoteLens) {
   return useRepoMutation(
     repo,
     (args: {
@@ -1347,25 +1387,29 @@ export function useSubmitReview(repo: string) {
       verdict: api.ReviewVerdict;
       summary?: string;
       comments: DraftCommentIn[];
-    }) => api.forgePrReviewSubmit(repo, args),
+    }) => api.forgePrReviewSubmit(repo, args, lens),
   );
 }
 
-export function useThreadReply(repo: string, number: number) {
+export function useThreadReply(repo: string, number: number, lens: RemoteLens) {
   return useRepoMutation(
     repo,
     (args: { threadId: string; body: string }) =>
       api.forgePrThreadReply(repo, number, args.threadId, args.body),
-    { invalidate: [prReviewThreadsKey(repo, number)] },
+    { invalidate: [prReviewThreadsKey(repo, number, lens)] },
   );
 }
 
-export function useThreadResolve(repo: string, number: number) {
+export function useThreadResolve(
+  repo: string,
+  number: number,
+  lens: RemoteLens,
+) {
   return useRepoMutation(
     repo,
     (args: { threadId: string; resolved: boolean }) =>
       api.forgePrThreadResolve(repo, number, args.threadId, args.resolved),
-    { invalidate: [prReviewThreadsKey(repo, number)] },
+    { invalidate: [prReviewThreadsKey(repo, number, lens)] },
   );
 }
 
@@ -1374,23 +1418,27 @@ export function useThreadResolve(repo: string, number: number) {
  * comes over the network (the slowest loads in the app), so prefetching on row
  * hover and for the adjacent rows pays off most here.
  */
-export function usePrefetchPr(repo: string) {
+export function usePrefetchPr(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useCallback(
     (number: number) => {
-      queryClient.prefetchQuery(prDetailsOptions(repo, number));
-      queryClient.prefetchQuery(prDiffOptions(repo, number));
+      queryClient.prefetchQuery(prDetailsOptions(repo, number, lens));
+      queryClient.prefetchQuery(prDiffOptions(repo, number, lens));
     },
-    [queryClient, repo],
+    [queryClient, repo, lens],
   );
 }
 
 /** Reactions for a PR's body + comments — decoupled from the PR view so it
  *  loads in parallel and leaves the (untouched) PR query alone. */
-export function usePrReactions(repo: string, number: number | null) {
+export function usePrReactions(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "pr", number ?? 0, "reactions"] as const,
-    queryFn: () => api.forgePrReactions(repo, number ?? 0),
+    queryKey: ["repo", repo, "pr", lens, number ?? 0, "reactions"] as const,
+    queryFn: () => api.forgePrReactions(repo, number ?? 0, lens),
     enabled: number !== null,
     staleTime: 30_000,
   });
@@ -1405,10 +1453,11 @@ export function usePrTimeline(
   repoPath: string,
   number: number,
   enabled: boolean,
+  lens: RemoteLens,
 ) {
   return useQuery({
-    queryKey: ["repo", repoPath, "pr", number, "timeline"] as const,
-    queryFn: () => api.forgePrTimeline(repoPath, number),
+    queryKey: ["repo", repoPath, "pr", lens, number, "timeline"] as const,
+    queryFn: () => api.forgePrTimeline(repoPath, number, lens),
     enabled,
     staleTime: 30_000,
   });
@@ -1418,11 +1467,12 @@ export function useIssueList(
   repo: string,
   enabled: boolean,
   state: api.IssueStateFilter,
-  limit?: number,
+  limit: number | undefined,
+  lens: RemoteLens,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "issue-list", state, limit ?? null] as const,
-    queryFn: () => api.forgeIssueList(repo, state, limit),
+    queryKey: ["repo", repo, "issue-list", lens, state, limit ?? null] as const,
+    queryFn: () => api.forgeIssueList(repo, state, limit, lens),
     enabled,
     staleTime: 30_000,
     // issuesDisabled is a permanent repo condition — retrying only delays the notice.
@@ -1433,16 +1483,20 @@ export function useIssueList(
   });
 }
 
-const issueDetailsOptions = (repo: string, number: number) =>
+const issueDetailsOptions = (repo: string, number: number, lens: RemoteLens) =>
   queryOptions({
-    queryKey: ["repo", repo, "issue", number] as const,
-    queryFn: () => api.forgeIssueView(repo, number),
+    queryKey: ["repo", repo, "issue", lens, number] as const,
+    queryFn: () => api.forgeIssueView(repo, number, lens),
     staleTime: 30_000,
   });
 
-export function useIssueDetails(repo: string, number: number | null) {
+export function useIssueDetails(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    ...issueDetailsOptions(repo, number ?? 0),
+    ...issueDetailsOptions(repo, number ?? 0, lens),
     enabled: number !== null,
     placeholderData: keepPreviousDataForRepo(repo),
   });
@@ -1450,17 +1504,17 @@ export function useIssueDetails(repo: string, number: number | null) {
 
 /** Warms an issue's view so opening it from the list is instant (hover/adjacent
  *  rows), mirroring {@link usePrefetchPr}. */
-export function usePrefetchIssue(repo: string) {
+export function usePrefetchIssue(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useCallback(
     (number: number) => {
-      queryClient.prefetchQuery(issueDetailsOptions(repo, number));
+      queryClient.prefetchQuery(issueDetailsOptions(repo, number, lens));
     },
-    [queryClient, repo],
+    [queryClient, repo, lens],
   );
 }
 
-export function useCreateIssue(repo: string) {
+export function useCreateIssue(repo: string, lens: RemoteLens) {
   return useRepoMutation(
     repo,
     (args: {
@@ -1479,23 +1533,32 @@ export function useCreateIssue(repo: string) {
         args.assignees,
         args.milestone,
         args.type,
+        lens,
       ),
   );
 }
 
-export function useAssignableUsers(repo: string, enabled: boolean) {
+export function useAssignableUsers(
+  repo: string,
+  enabled: boolean,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "assignable-users"] as const,
-    queryFn: () => api.forgeAssignableUsers(repo),
+    queryKey: ["repo", repo, "assignable-users", lens] as const,
+    queryFn: () => api.forgeAssignableUsers(repo, lens),
     enabled,
     staleTime: 5 * 60_000,
   });
 }
 
-export function useMilestones(repo: string, enabled: boolean) {
+export function useMilestones(
+  repo: string,
+  enabled: boolean,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "milestones"] as const,
-    queryFn: () => api.forgeMilestones(repo),
+    queryKey: ["repo", repo, "milestones", lens] as const,
+    queryFn: () => api.forgeMilestones(repo, lens),
     enabled,
     staleTime: 5 * 60_000,
   });
@@ -1522,6 +1585,7 @@ function changedKeys<T extends object>(prev: T, next: T): (keyof T)[] {
 
 function useOptimisticIssueMutation<TArgs extends { number: number }, TData>(
   repo: string,
+  lens: RemoteLens,
   mutationFn: (args: TArgs) => Promise<TData>,
   patch: (issue: IssueDetails, args: TArgs) => IssueDetails,
 ) {
@@ -1529,7 +1593,7 @@ function useOptimisticIssueMutation<TArgs extends { number: number }, TData>(
   return useMutation({
     mutationFn,
     onMutate: async (args: TArgs) => {
-      const key = ["repo", repo, "issue", args.number] as const;
+      const key = ["repo", repo, "issue", lens, args.number] as const;
       await queryClient.cancelQueries({ queryKey: key });
       const prev = queryClient.getQueryData<IssueDetails>(key);
       if (!prev) return { key, restore: undefined };
@@ -1551,36 +1615,40 @@ function useOptimisticIssueMutation<TArgs extends { number: number }, TData>(
         cur ? { ...cur, ...ctx.restore } : cur,
       );
     },
-    // Narrow reconciliation: only the one issue's detail subtree (not repo-wide).
+    // Narrow reconciliation: only the one issue's detail subtree (not repo-wide),
+    // scoped to the lens the mutation ran under.
     onSettled: (_d, _e, args) =>
       void queryClient.invalidateQueries({
-        queryKey: ["repo", repo, "issue", args.number],
+        queryKey: ["repo", repo, "issue", lens, args.number],
       }),
   });
 }
 
-export function useSetIssueAssignees(repo: string) {
+export function useSetIssueAssignees(repo: string, lens: RemoteLens) {
   return useOptimisticIssueMutation(
     repo,
+    lens,
     (args: { number: number; assignees: ForgeUserRef[] }) =>
       api.forgeIssueSetAssignees(
         repo,
         args.number,
         args.assignees.map((a) => a.id),
+        lens,
       ),
     (issue, args) => ({ ...issue, assignees: args.assignees }),
   );
 }
 
-export function useSetIssueMilestone(repo: string) {
+export function useSetIssueMilestone(repo: string, lens: RemoteLens) {
   return useOptimisticIssueMutation(
     repo,
+    lens,
     (args: {
       number: number;
       milestone: number | null;
       /** Title for the optimistic chip (backend takes only the number). */
       title?: string | null;
-    }) => api.forgeIssueSetMilestone(repo, args.number, args.milestone),
+    }) => api.forgeIssueSetMilestone(repo, args.number, args.milestone, lens),
     (issue, args) => ({
       ...issue,
       milestone:
@@ -1592,20 +1660,24 @@ export function useSetIssueMilestone(repo: string) {
 }
 
 /** Toggle an issue's GitLab-only confidential flag, with the optimistic
- *  cache patch every other issue-field mutation uses. */
+ *  cache patch every other issue-field mutation uses. GitLab-only, so it only
+ *  ever runs under the origin lens (the switcher is GitHub-only). */
 export function useSetIssueConfidential(repo: string) {
   return useOptimisticIssueMutation(
     repo,
+    "origin",
     (args: { number: number; confidential: boolean }) =>
       api.forgeGlIssueSetConfidential(repo, args.number, args.confidential),
     (issue, args) => ({ ...issue, confidential: args.confidential }),
   );
 }
 
-/** Set ("YYYY-MM-DD") or clear (null) an issue's GitLab-only due date. */
+/** Set ("YYYY-MM-DD") or clear (null) an issue's GitLab-only due date. GitLab-only,
+ *  so it only ever runs under the origin lens. */
 export function useSetIssueDueDate(repo: string) {
   return useOptimisticIssueMutation(
     repo,
+    "origin",
     (args: { number: number; dueDate: string | null }) =>
       api.forgeGlIssueSetDueDate(repo, args.number, args.dueDate),
     (issue, args) => ({ ...issue, dueDate: args.dueDate }),
@@ -1614,10 +1686,14 @@ export function useSetIssueDueDate(repo: string) {
 
 // ── GitLab time tracking + related issues ────────────────────────────────────
 
+// GitLab-only time-tracking / links keys. These surfaces are GitLab-only and the
+// lens switcher is GitHub-only, so they always live under the "origin" lens
+// segment — baked in so they stay nested under the (lens-scoped) issue/MR detail
+// subtree that repoKeys.all + the details refetch reconcile.
 const issueTimeStatsKey = (repo: string, number: number) =>
-  ["repo", repo, "issue", number, "time-stats"] as const;
+  ["repo", repo, "issue", "origin", number, "time-stats"] as const;
 const mrTimeStatsKey = (repo: string, number: number) =>
-  ["repo", repo, "pr", number, "time-stats"] as const;
+  ["repo", repo, "pr", "origin", number, "time-stats"] as const;
 
 /** An issue's GitLab time-tracking stats (estimate + spent). Pass `null` when
  *  the section isn't shown so the read doesn't fire. */
@@ -1676,10 +1752,11 @@ function useTimeTrackingMutation(
   });
 }
 
+// GitLab-only time-tracking view keys — see issueTimeStatsKey: pinned to "origin".
 const issueViewKey = (repo: string, number: number) =>
-  ["repo", repo, "issue", number] as const;
+  ["repo", repo, "issue", "origin", number] as const;
 const mrViewKey = (repo: string, number: number) =>
-  ["repo", repo, "pr", number] as const;
+  ["repo", repo, "pr", "origin", number] as const;
 
 export function useSetIssueTimeEstimate(repo: string) {
   return useTimeTrackingMutation(
@@ -1711,8 +1788,9 @@ export function useAddMrSpentTime(repo: string) {
   );
 }
 
+// GitLab-only related-issue links key — pinned to "origin" (see issueTimeStatsKey).
 const issueLinksKey = (repo: string, number: number) =>
-  ["repo", repo, "issue", number, "links"] as const;
+  ["repo", repo, "issue", "origin", number, "links"] as const;
 
 /** An issue's GitLab related-issue links. Pass `null` when the section isn't
  *  shown so the read doesn't fire. */
@@ -1758,25 +1836,30 @@ export function useUnlinkIssue(repo: string) {
   });
 }
 
-export function useIssueTypes(repo: string, enabled: boolean) {
+export function useIssueTypes(
+  repo: string,
+  enabled: boolean,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "issue-types"] as const,
-    queryFn: () => api.ghIssueTypes(repo),
+    queryKey: ["repo", repo, "issue-types", lens] as const,
+    queryFn: () => api.ghIssueTypes(repo, lens),
     enabled,
     staleTime: 5 * 60_000,
     retry: false,
   });
 }
 
-export function useSetIssueType(repo: string) {
+export function useSetIssueType(repo: string, lens: RemoteLens) {
   return useOptimisticIssueMutation(
     repo,
+    lens,
     (args: {
       number: number;
       typeName: string | null;
       /** The full type for the optimistic patch (backend takes only the name). */
       type?: IssueType | null;
-    }) => api.ghIssueSetType(repo, args.number, args.typeName),
+    }) => api.ghIssueSetType(repo, args.number, args.typeName, lens),
     (issue, args) => ({ ...issue, issueType: args.type ?? null }),
   );
 }
@@ -1795,6 +1878,7 @@ export function useSetIssueType(repo: string) {
  */
 function useIssueLifecycleMutation<TArgs, TData>(
   repo: string,
+  lens: RemoteLens,
   mutationFn: (args: TArgs) => Promise<TData>,
   numberOf: (args: TArgs) => number,
 ) {
@@ -1804,47 +1888,54 @@ function useIssueLifecycleMutation<TArgs, TData>(
     onSettled: (_d, _e, args) =>
       void Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["repo", repo, "issue-list"],
+          queryKey: ["repo", repo, "issue-list", lens],
         }),
         queryClient.invalidateQueries({
-          queryKey: ["repo", repo, "issue", numberOf(args)],
+          queryKey: ["repo", repo, "issue", lens, numberOf(args)],
         }),
       ]),
   });
 }
 
-export function usePinIssue(repo: string) {
+export function usePinIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
+    lens,
     (args: { number: number; pinned: boolean }) =>
       args.pinned
-        ? api.ghIssuePin(repo, args.number)
-        : api.ghIssueUnpin(repo, args.number),
+        ? api.ghIssuePin(repo, args.number, lens)
+        : api.ghIssueUnpin(repo, args.number, lens),
     (args) => args.number,
   );
 }
 
-export function useLockIssue(repo: string) {
+export function useLockIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
+    lens,
     (args: { number: number; reason: api.LockReason | null }) =>
-      api.forgeIssueLock(repo, args.number, args.reason),
+      api.forgeIssueLock(repo, args.number, args.reason, lens),
     (args) => args.number,
   );
 }
 
-export function useUnlockIssue(repo: string) {
+export function useUnlockIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
-    (number: number) => api.forgeIssueUnlock(repo, number),
+    lens,
+    (number: number) => api.forgeIssueUnlock(repo, number, lens),
     (number) => number,
   );
 }
 
-export function useIssueReactions(repo: string, number: number | null) {
+export function useIssueReactions(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "issue", number ?? 0, "reactions"] as const,
-    queryFn: () => api.forgeIssueReactions(repo, number ?? 0),
+    queryKey: ["repo", repo, "issue", lens, number ?? 0, "reactions"] as const,
+    queryFn: () => api.forgeIssueReactions(repo, number ?? 0, lens),
     enabled: number !== null,
     staleTime: 30_000,
   });
@@ -2152,100 +2243,131 @@ export function useDiscussionReactions(repo: string, number: number | null) {
   });
 }
 
-export function useCommentIssue(repo: string) {
-  return useOptimisticCreateCommentMutation(repo, "issue", (args) =>
-    api.forgeIssueComment(repo, args.number, args.body),
+export function useCommentIssue(repo: string, lens: RemoteLens) {
+  return useOptimisticCreateCommentMutation(repo, "issue", lens, (args) =>
+    api.forgeIssueComment(repo, args.number, args.body, lens),
   );
 }
 
-export function useCloseIssue(repo: string) {
+export function useCloseIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
+    lens,
     (args: { number: number; reason: string }) =>
-      api.forgeIssueClose(repo, args.number, args.reason),
+      api.forgeIssueClose(repo, args.number, args.reason, lens),
     (args) => args.number,
   );
 }
 
-export function useReopenIssue(repo: string) {
+export function useReopenIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
-    (number: number) => api.forgeIssueReopen(repo, number),
+    lens,
+    (number: number) => api.forgeIssueReopen(repo, number, lens),
     (number) => number,
   );
 }
 
-export function useEditIssue(repo: string) {
+export function useEditIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
+    lens,
     (args: { number: number; title: string; body: string }) =>
-      api.forgeIssueEdit(repo, args.number, args.title, args.body),
+      api.forgeIssueEdit(repo, args.number, args.title, args.body, lens),
     (args) => args.number,
   );
 }
 
-export function useTransferIssue(repo: string) {
+export function useTransferIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
+    lens,
     (args: { number: number; destination: string }) =>
-      api.forgeIssueTransfer(repo, args.number, args.destination),
+      api.forgeIssueTransfer(repo, args.number, args.destination, lens),
     (args) => args.number,
   );
 }
 
-export function useDeleteIssue(repo: string) {
+export function useDeleteIssue(repo: string, lens: RemoteLens) {
   return useIssueLifecycleMutation(
     repo,
-    (number: number) => api.forgeIssueDelete(repo, number),
+    lens,
+    (number: number) => api.forgeIssueDelete(repo, number, lens),
     (number) => number,
   );
 }
 
 /** An issue's parent + sub-issues, loaded alongside the conversation. */
-export function useIssueRelations(repo: string, number: number | null) {
+export function useIssueRelations(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "issue", number ?? 0, "relations"] as const,
-    queryFn: () => api.ghIssueRelations(repo, number ?? 0),
+    queryKey: ["repo", repo, "issue", lens, number ?? 0, "relations"] as const,
+    queryFn: () => api.ghIssueRelations(repo, number ?? 0, lens),
     enabled: number !== null,
     staleTime: 30_000,
   });
 }
 
-export function useAddSubIssue(repo: string) {
+export function useAddSubIssue(repo: string, lens: RemoteLens) {
   return useRepoMutation(
     repo,
     (args: { parentId: string; subNumber: number }) =>
-      api.ghIssueAddSubIssue(repo, args.parentId, args.subNumber),
+      api.ghIssueAddSubIssue(repo, args.parentId, args.subNumber, lens),
   );
 }
 
 /** An issue's blocked-by / blocking dependencies. */
-export function useIssueDependencies(repo: string, number: number | null) {
+export function useIssueDependencies(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "issue", number ?? 0, "dependencies"] as const,
-    queryFn: () => api.ghIssueDependencies(repo, number ?? 0),
+    queryKey: [
+      "repo",
+      repo,
+      "issue",
+      lens,
+      number ?? 0,
+      "dependencies",
+    ] as const,
+    queryFn: () => api.ghIssueDependencies(repo, number ?? 0, lens),
     enabled: number !== null,
     staleTime: 30_000,
   });
 }
 
 /** An issue's "Development" links: closing PRs + linked branches. */
-export function useIssueDevelopment(repo: string, number: number | null) {
+export function useIssueDevelopment(
+  repo: string,
+  number: number | null,
+  lens: RemoteLens,
+) {
   return useQuery({
-    queryKey: ["repo", repo, "issue", number ?? 0, "development"] as const,
-    queryFn: () => api.ghIssueDevelopment(repo, number ?? 0),
+    queryKey: [
+      "repo",
+      repo,
+      "issue",
+      lens,
+      number ?? 0,
+      "development",
+    ] as const,
+    queryFn: () => api.ghIssueDevelopment(repo, number ?? 0, lens),
     enabled: number !== null,
     staleTime: 30_000,
   });
 }
 
-export function useCreateLinkedBranch(repo: string) {
+export function useCreateLinkedBranch(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (args: { issueId: string; name: string }) =>
-    api.ghIssueCreateLinkedBranch(repo, args.issueId, args.name),
+    api.ghIssueCreateLinkedBranch(repo, args.issueId, args.name, lens),
   );
 }
 
-export function useSetIssueDependency(repo: string) {
+export function useSetIssueDependency(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: {
@@ -2260,6 +2382,7 @@ export function useSetIssueDependency(repo: string) {
         args.relation,
         args.target,
         args.add,
+        lens,
       ),
     // Cross-issue: a dependency touches BOTH the source's and the target's detail
     // subtrees (their `dependencies` sub-query is keyed by number) — no list-
@@ -2268,7 +2391,7 @@ export function useSetIssueDependency(repo: string) {
       void Promise.all(
         [args.number, args.target].map((n) =>
           queryClient.invalidateQueries({
-            queryKey: ["repo", repo, "issue", n],
+            queryKey: ["repo", repo, "issue", lens, n],
           }),
         ),
       ),
@@ -3456,18 +3579,18 @@ export function useReviewPr(repo: string) {
   );
 }
 
-export function useCommentPr(repo: string) {
-  return useOptimisticCreateCommentMutation(repo, "pr", (args) =>
-    api.forgePrComment(repo, args.number, args.body, args.asBot),
+export function useCommentPr(repo: string, lens: RemoteLens) {
+  return useOptimisticCreateCommentMutation(repo, "pr", lens, (args) =>
+    api.forgePrComment(repo, args.number, args.body, args.asBot, lens),
   );
 }
 
 /** A merge request's approval state — the GitLab-only approve/unapprove toggle's
  *  driver. Pass `null` when the toggle isn't shown (GitHub, or a closed MR) so the
- *  read doesn't fire. */
+ *  read doesn't fire. GitLab-only, so it lives under the "origin" lens segment. */
 export function usePrApprovals(repo: string, number: number | null) {
   return useQuery({
-    queryKey: ["repo", repo, "pr", number ?? 0, "approvals"] as const,
+    queryKey: ["repo", repo, "pr", "origin", number ?? 0, "approvals"] as const,
     queryFn: () => api.forgePrApprovals(repo, number ?? 0),
     enabled: number !== null,
     staleTime: 30_000,
@@ -3475,9 +3598,9 @@ export function usePrApprovals(repo: string, number: number | null) {
   });
 }
 
-export function useApprovePr(repo: string) {
+export function useApprovePr(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (number: number) =>
-    api.forgePrApprove(repo, number),
+    api.forgePrApprove(repo, number, lens),
   );
 }
 
@@ -3486,7 +3609,7 @@ export function useApprovePr(repo: string) {
  *  `usePrApprovals`). */
 export function usePrTasks(repo: string, number: number | null) {
   return useQuery({
-    queryKey: ["repo", repo, "pr", number, "tasks"] as const,
+    queryKey: prTasksKey(repo, number ?? 0),
     queryFn: () => api.forgeBbPrTasks(repo, number ?? 0),
     enabled: number !== null,
     staleTime: 30_000,
@@ -3497,8 +3620,10 @@ export function usePrTasks(repo: string, number: number | null) {
 // PR-task mutations invalidate the exact tasks key onSettled (keyed on the PR number
 // carried in the mutation args); the component patches its own local state
 // optimistically (like toggleApproval), so no optimistic logic lives in the hook.
+// Bitbucket-only surface, so it lives under the "origin" lens segment (the lens
+// switcher is GitHub-only).
 export const prTasksKey = (repo: string, number: number) =>
-  ["repo", repo, "pr", number, "tasks"] as const;
+  ["repo", repo, "pr", "origin", number, "tasks"] as const;
 
 export function useCreatePrTask(repo: string) {
   const queryClient = useQueryClient();
@@ -3557,9 +3682,9 @@ export function useUnapprovePr(repo: string) {
 /** Request changes on an MR with an optional comment (GitLab + Bitbucket, gated
  *  on `implemented.mrRequestChanges`). The caller patches the approvals cache
  *  optimistically, like the approve toggle. */
-export function useRequestChangesPr(repo: string) {
+export function useRequestChangesPr(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (args: { number: number; body: string }) =>
-    api.forgePrRequestChanges(repo, args.number, args.body),
+    api.forgePrRequestChanges(repo, args.number, args.body, lens),
   );
 }
 
@@ -3589,16 +3714,18 @@ export function useReviewerCandidates(
   repo: string,
   number: number | null,
   enabled: boolean,
+  lens: RemoteLens,
 ) {
   return useQuery({
     queryKey: [
       "repo",
       repo,
       "pr",
+      lens,
       number ?? "create",
       "reviewer-candidates",
     ] as const,
-    queryFn: () => api.forgePrReviewerCandidates(repo, number),
+    queryFn: () => api.forgePrReviewerCandidates(repo, number, lens),
     enabled,
     staleTime: 5 * 60_000,
     retry: false,
@@ -3612,7 +3739,7 @@ export function useReviewerCandidates(
  * instead of waiting on the PUT + refetch. The list is the picker's HUMAN set;
  * bot/team requests never travel through it (preserved provider-side).
  */
-export function useSetPrReviewers(repo: string) {
+export function useSetPrReviewers(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: { number: number; reviewers: ForgeUserRef[] }) =>
@@ -3620,9 +3747,10 @@ export function useSetPrReviewers(repo: string) {
         repo,
         args.number,
         args.reviewers.map((r) => r.id),
+        lens,
       ),
     onMutate: async (args) => {
-      const key = ["repo", repo, "pr", args.number] as const;
+      const key = ["repo", repo, "pr", lens, args.number] as const;
       await queryClient.cancelQueries({ queryKey: key });
       const prev = queryClient.getQueryData<PrDetails>(key);
       queryClient.setQueryData<PrDetails>(key, (d) =>
@@ -3643,7 +3771,7 @@ export function useSetPrReviewers(repo: string) {
     },
     onSettled: (_d, _e, args) =>
       queryClient.invalidateQueries({
-        queryKey: ["repo", repo, "pr", args.number],
+        queryKey: ["repo", repo, "pr", lens, args.number],
       }),
   });
 }
@@ -3654,7 +3782,7 @@ export function useSetPrReviewers(repo: string) {
  * `useSetIssueAssignees` — the picker's chips update instantly instead of
  * waiting on the PATCH/PUT + refetch (the CLI spawns a process per call).
  */
-export function useSetPrAssignees(repo: string) {
+export function useSetPrAssignees(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: { number: number; assignees: ForgeUserRef[] }) =>
@@ -3662,9 +3790,10 @@ export function useSetPrAssignees(repo: string) {
         repo,
         args.number,
         args.assignees.map((a) => a.id),
+        lens,
       ),
     onMutate: async (args) => {
-      const key = ["repo", repo, "pr", args.number] as const;
+      const key = ["repo", repo, "pr", lens, args.number] as const;
       await queryClient.cancelQueries({ queryKey: key });
       const prev = queryClient.getQueryData<PrDetails>(key);
       queryClient.setQueryData<PrDetails>(key, (d) =>
@@ -3685,12 +3814,12 @@ export function useSetPrAssignees(repo: string) {
     },
     onSettled: (_d, _e, args) =>
       queryClient.invalidateQueries({
-        queryKey: ["repo", repo, "pr", args.number],
+        queryKey: ["repo", repo, "pr", lens, args.number],
       }),
   });
 }
 
-export function useMergePr(repo: string) {
+export function useMergePr(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useRepoMutation(
     repo,
@@ -3707,6 +3836,7 @@ export function useMergePr(repo: string) {
         args.strategy,
         args.deleteBranch,
         args.sha,
+        lens,
       );
       // The remote just advanced (and, on a deleteBranch merge, dropped the
       // head branch), but the local repo is now stale — ahead/behind, history,
@@ -3800,15 +3930,15 @@ export function useGlCancelAutoMerge(repo: string) {
   );
 }
 
-export function useClosePr(repo: string) {
+export function useClosePr(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (number: number) =>
-    api.forgePrClose(repo, number),
+    api.forgePrClose(repo, number, lens),
   );
 }
 
-export function useReopenPr(repo: string) {
+export function useReopenPr(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (number: number) =>
-    api.forgePrReopen(repo, number),
+    api.forgePrReopen(repo, number, lens),
   );
 }
 
@@ -3833,6 +3963,7 @@ let optimisticCommentSeq = 0;
 function useOptimisticCreateCommentMutation<TData>(
   repo: string,
   kind: "pr" | "issue",
+  lens: RemoteLens,
   // `asBot` is threaded through for the PR path (posts as the review-bot identity
   // on GitLab; ignored elsewhere). Optional + additive — the issue path and the
   // existing PR callers never pass it, so their behavior is unchanged.
@@ -3848,7 +3979,7 @@ function useOptimisticCreateCommentMutation<TData>(
     PrDetails | IssueDetails
   >(
     (args) => mutationFn(args),
-    (args) => ["repo", repo, kind, args.number] as const,
+    (args) => ["repo", repo, kind, lens, args.number] as const,
     (d, args) => {
       const synthetic: PrThreadOut = {
         author: args.author,
@@ -3889,12 +4020,13 @@ function useOptimisticCommentMutation<
 >(
   repo: string,
   kind: "pr" | "issue",
+  lens: RemoteLens,
   mutationFn: (args: TArgs) => Promise<TData>,
   patchComment: (comment: PrThreadOut, args: TArgs) => PrThreadOut | null,
 ) {
   return useOptimisticCacheMutation<TArgs, TData, PrDetails | IssueDetails>(
     mutationFn,
-    (args) => ["repo", repo, kind, args.number] as const,
+    (args) => ["repo", repo, kind, lens, args.number] as const,
     (d, args) =>
       d
         ? {
@@ -3911,40 +4043,44 @@ function useOptimisticCommentMutation<
   );
 }
 
-export function useEditPrComment(repo: string) {
+export function useEditPrComment(repo: string, lens: RemoteLens) {
   return useOptimisticCommentMutation(
     repo,
     "pr",
+    lens,
     (args: { number: number; commentId: string; body: string }) =>
       api.forgePrEditComment(repo, args.number, args.commentId, args.body),
     (comment, args) => ({ ...comment, body: args.body }),
   );
 }
 
-export function useDeletePrComment(repo: string) {
+export function useDeletePrComment(repo: string, lens: RemoteLens) {
   return useOptimisticCommentMutation(
     repo,
     "pr",
+    lens,
     (args: { number: number; commentId: string }) =>
       api.forgePrDeleteComment(repo, args.number, args.commentId),
     () => null,
   );
 }
 
-export function useEditIssueComment(repo: string) {
+export function useEditIssueComment(repo: string, lens: RemoteLens) {
   return useOptimisticCommentMutation(
     repo,
     "issue",
+    lens,
     (args: { number: number; commentId: string; body: string }) =>
       api.forgeIssueEditComment(repo, args.number, args.commentId, args.body),
     (comment, args) => ({ ...comment, body: args.body }),
   );
 }
 
-export function useDeleteIssueComment(repo: string) {
+export function useDeleteIssueComment(repo: string, lens: RemoteLens) {
   return useOptimisticCommentMutation(
     repo,
     "issue",
+    lens,
     (args: { number: number; commentId: string }) =>
       api.forgeIssueDeleteComment(repo, args.number, args.commentId),
     () => null,
@@ -3966,12 +4102,13 @@ function useOptimisticReviewCommentMutation<
   TData,
 >(
   repo: string,
+  lens: RemoteLens,
   mutationFn: (args: TArgs) => Promise<TData>,
   patchComment: (comment: PrThreadOut, args: TArgs) => PrThreadOut | null,
 ) {
   return useOptimisticCacheMutation<TArgs, TData, ReviewThreadOut[]>(
     mutationFn,
-    (args) => prReviewThreadsKey(repo, args.number),
+    (args) => prReviewThreadsKey(repo, args.number, lens),
     (threads, args) =>
       threads?.flatMap((t) => {
         if (!t.comments.some((c) => c.id === args.commentId)) return [t];
@@ -3988,9 +4125,10 @@ function useOptimisticReviewCommentMutation<
   );
 }
 
-export function useEditReviewComment(repo: string) {
+export function useEditReviewComment(repo: string, lens: RemoteLens) {
   return useOptimisticReviewCommentMutation(
     repo,
+    lens,
     (args: { number: number; commentId: string; body: string }) =>
       api.forgePrEditReviewComment(
         repo,
@@ -4002,9 +4140,10 @@ export function useEditReviewComment(repo: string) {
   );
 }
 
-export function useDeleteReviewComment(repo: string) {
+export function useDeleteReviewComment(repo: string, lens: RemoteLens) {
   return useOptimisticReviewCommentMutation(
     repo,
+    lens,
     (args: { number: number; commentId: string }) =>
       api.forgePrDeleteReviewComment(repo, args.number, args.commentId),
     () => null,
@@ -4025,9 +4164,9 @@ export function useUnminimizeComment(repo: string) {
   );
 }
 
-export function useCheckoutPr(repo: string) {
+export function useCheckoutPr(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (number: number) =>
-    api.ghPrCheckout(repo, number),
+    api.ghPrCheckout(repo, number, lens),
   );
 }
 
@@ -5198,15 +5337,17 @@ export function useSetRulesetEnforcement(repo: string) {
   });
 }
 
-export function useReadyPr(repo: string) {
-  return useRepoMutation(repo, (number: number) => api.ghPrReady(repo, number));
+export function useReadyPr(repo: string, lens: RemoteLens) {
+  return useRepoMutation(repo, (number: number) =>
+    api.ghPrReady(repo, number, lens),
+  );
 }
 
-export function useEditPr(repo: string) {
+export function useEditPr(repo: string, lens: RemoteLens) {
   return useRepoMutation(
     repo,
     (args: { number: number; title: string; body: string }) =>
-      api.forgePrEdit(repo, args.number, args.title, args.body),
+      api.forgePrEdit(repo, args.number, args.title, args.body, lens),
   );
 }
 
@@ -5219,7 +5360,7 @@ export function useEditPr(repo: string) {
  *  wire `target` derives from `kind`: issue→"issue", mr→"mr", discussion→"issue"
  *  (the old default). Reconciles per-kind on settle instead of the whole-repo
  *  default, since the args now carry a reliable discriminator. */
-export function useEditPrLabels(repo: string) {
+export function useEditPrLabels(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: {
@@ -5244,16 +5385,18 @@ export function useEditPrLabels(repo: string) {
         args.removeNames ?? [],
       ),
     onSettled: (_d, _e, args) => {
+      // Issue/MR narrow keys carry the lens they were read under; discussions are
+      // not lens-scoped (GitHub Discussions have no fork lens) — keyed as before.
       const keys =
         args.kind === "issue"
           ? [
-              ["repo", repo, "issue-list"],
-              ["repo", repo, "issue", args.number],
+              ["repo", repo, "issue-list", lens],
+              ["repo", repo, "issue", lens, args.number],
             ]
           : args.kind === "mr"
             ? [
-                ["repo", repo, "pr", args.number],
-                ["repo", repo, "pr-list"],
+                ["repo", repo, "pr", lens, args.number],
+                ["repo", repo, "pr-list", lens],
               ]
             : args.kind === "discussion"
               ? [
@@ -5283,6 +5426,10 @@ export function useCreatePr(repo: string) {
       labels?: string[];
       /** Create-time assignee login/username strings (GitHub/GitLab; omit for Bitbucket). */
       assignees?: string[];
+      /** Which repo the PR opens against: the fork itself ("origin", default) or
+       *  its parent ("upstream" — GitHub fork only; the backend composes
+       *  `owner:head` and rejects reviewers/labels/assignees on that path). */
+      lens?: RemoteLens;
     }) =>
       api.forgePrCreate(
         repo,
@@ -5294,6 +5441,7 @@ export function useCreatePr(repo: string) {
         args.reviewers,
         args.labels,
         args.assignees,
+        args.lens ?? "origin",
       ),
   );
 }

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2726,6 +2726,16 @@ export function useSetRemoteUrl(repo: string) {
   );
 }
 
+/** Adds a remote (e.g. `upstream` on a fork cloned without one). The default
+ *  broad invalidation (`["repo", repo]`) prefix-covers the `remotes` and
+ *  `remote-url` queries, so `useLensGate` re-reads and the fork/upstream UI
+ *  lights up live once the remote exists. */
+export function useAddRemote(repo: string) {
+  return useRepoMutation(repo, (args: { name: string; url: string }) =>
+    api.gitRemoteAdd(repo, args.name, args.url),
+  );
+}
+
 export function useOpState(repo: string) {
   return useQuery({
     queryKey: ["repo", repo, "op-state"] as const,

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1316,6 +1316,11 @@ export interface PrRef {
   url: string;
 }
 
+/** Which repository a fork's PR/issue surfaces read & write against: the fork
+ *  itself ("origin") or its parent ("upstream"). GitHub-only — GitLab/Bitbucket
+ *  arms ignore it, so the frontend gates the lens UI to GitHub forks. */
+export type RemoteLens = "origin" | "upstream";
+
 export interface PrInfo {
   number: number;
   url: string;

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -187,6 +187,18 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "repo-lens-origin",
+    label: "Switch to fork view (pull requests & issues)",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
+    id: "repo-lens-upstream",
+    label: "Switch to upstream view (pull requests & issues)",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
     id: "open-in-terminal",
     label: "Open in terminal",
     category: "Repository",

--- a/src/lib/pulls/audit.ts
+++ b/src/lib/pulls/audit.ts
@@ -62,8 +62,10 @@ export function usePrAuditByBranch(
   const localPrs = useLocalPrs(repo);
   const forge = useForgeStatus(repo);
   const remote = enabled && forgeFeatureReady(forge.data, "pullRequests");
-  const openPrs = usePrList(repo, remote, "open");
-  const closedPrs = usePrList(repo, remote, "closed");
+  // Origin lens: the branch audit maps the FORK's own branches to their PRs; the
+  // fork/upstream lens is a PR/Issues-tab affordance.
+  const openPrs = usePrList(repo, remote, "open", undefined, "origin");
+  const closedPrs = usePrList(repo, remote, "closed", undefined, "origin");
 
   return useMemo(() => {
     const map = new Map<string, PrAudit>();

--- a/src/lib/repo-lens/queries.ts
+++ b/src/lib/repo-lens/queries.ts
@@ -1,0 +1,95 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { useForgeStatus, useRemotes, useRemoteUrl } from "@/lib/git/queries";
+import type { RemoteLens } from "@/lib/git/types";
+import { useUiStore } from "@/lib/stores/ui";
+import { loadRepoLens, saveRepoLens } from "./store";
+
+const lensKey = (repo: string) => ["repo", repo, "lens"] as const;
+
+/** The raw persisted lens for a repo, unfiltered by the gate. Prefer
+ *  {@link useRepoLens} in surfaces — this exists so the setter and the switcher
+ *  can read/write the stored preference directly. */
+export function useRepoLensRaw(repo: string) {
+  return useQuery({
+    queryKey: lensKey(repo),
+    queryFn: () => loadRepoLens(repo),
+    // The store is the source of truth; there's no server to go stale against.
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}
+
+/** Whether the origin|upstream lens applies at all: a GitHub fork (an `upstream`
+ *  remote present) is the only shape where the parent differs from origin. On
+ *  GitLab/Bitbucket, or a repo with no upstream remote, the lens is a no-op and
+ *  its UI stays hidden. Mirrors SyncControls' `hasUpstreamRemote` idiom. */
+export function useLensGate(repo: string): boolean {
+  const provider = useForgeStatus(repo).data?.provider;
+  const remotes = useRemotes(repo);
+  return provider === "github" && Boolean(remotes.data?.includes("upstream"));
+}
+
+/** THE lens every PR/Issues surface consumes. Returns "origin" unless the gate
+ *  passes AND the persisted value is "upstream" — so removing the upstream remote
+ *  silently falls back to origin without touching the store. */
+export function useRepoLens(repo: string): RemoteLens {
+  const gate = useLensGate(repo);
+  const raw = useRepoLensRaw(repo).data;
+  return gate && raw === "upstream" ? "upstream" : "origin";
+}
+
+/** A setter for the persisted lens. It writes the query cache synchronously (so
+ *  the UI flips instantly), persists to disk (fire-and-forget with an error
+ *  toast), and clears any REMOTE PR/issue selection so a selected number can't
+ *  silently point at a different repo's item. No-op when the lens is unchanged. */
+export function useSetRepoLens(repo: string) {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (lens: RemoteLens) => {
+      const current =
+        queryClient.getQueryData<RemoteLens>(lensKey(repo)) ?? "origin";
+      if (current === lens) return;
+      queryClient.setQueryData(lensKey(repo), lens);
+      void saveRepoLens(repo, lens).catch(() => {
+        toast.error("Couldn't save the fork/upstream view preference.");
+      });
+      // A remote number selected under the old lens would resolve against the
+      // wrong repo — drop it. Local + Jira selections are lens-independent.
+      const ui = useUiStore.getState();
+      if (ui.selectedPr?.kind === "remote") ui.selectPr(null);
+      if (ui.selectedIssue?.kind === "remote") ui.selectIssue(null);
+    },
+    [queryClient, repo],
+  );
+}
+
+/** Parse "owner/repo" from a remote's URL (both `https://host/owner/repo(.git)`
+ *  and `git@host:owner/repo(.git)` forms). Returns null when the remote is
+ *  absent or the URL doesn't parse. Drives the switcher tooltips, the remote
+ *  section label, and the issue-create-on-parent confirm framing. */
+export function useRemoteSlug(
+  repo: string,
+  remote: RemoteLens,
+  enabled: boolean,
+): string | null {
+  const url = useRemoteUrl(repo, remote, enabled).data;
+  return url ? slugFromRemoteUrl(url) : null;
+}
+
+/** "owner/repo" from a git remote URL, or null. Handles the SSH (`git@host:o/r`)
+ *  and HTTP(S) (`https://host/o/r`) forms, with or without a trailing `.git`. */
+export function slugFromRemoteUrl(url: string): string | null {
+  const trimmed = url
+    .trim()
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "");
+  // SSH: git@host:owner/repo
+  const ssh = trimmed.match(/^[^@]+@[^:]+:(.+)$/);
+  const path = ssh ? ssh[1] : trimmed.replace(/^[a-z]+:\/\/[^/]+\//i, "");
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+  // owner/repo are the last two path segments (GitLab subgroups collapse to the
+  // final owner segment, which is fine for a display label).
+  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+}

--- a/src/lib/repo-lens/store.ts
+++ b/src/lib/repo-lens/store.ts
@@ -1,0 +1,40 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import { repoIdentity } from "@/lib/git/repo-identity";
+import type { RemoteLens } from "@/lib/git/types";
+import { storeName } from "@/lib/test-mode";
+
+// The per-repo origin|upstream lens for the Pull Requests + Issues surfaces,
+// persisted in app data (never committed). Keyed by the repo's worktree-stable
+// identity (git-common-dir), like the other per-repo personal stores, so the
+// choice is shared across a repo's main checkout and every worktree.
+//
+// This is a NEW store file, so there are no legacy checkout-path-keyed entries
+// to fold — a plain identity-key read/write suffices (no identityKeyFor).
+
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("repo-lens.json"), {
+    autoSave: true,
+    defaults: {},
+  });
+  return storePromise;
+}
+
+/** Read the persisted lens for a repo. Any value that isn't exactly "upstream"
+ *  (missing, hand-edited junk, an older shape) reads as "origin" — the safe
+ *  default that targets the fork itself. */
+export async function loadRepoLens(repo: string): Promise<RemoteLens> {
+  const store = await getStore();
+  const id = await repoIdentity(repo);
+  const saved = await store.get(id);
+  return saved === "upstream" ? "upstream" : "origin";
+}
+
+export async function saveRepoLens(
+  repo: string,
+  lens: RemoteLens,
+): Promise<void> {
+  const store = await getStore();
+  const id = await repoIdentity(repo);
+  await store.set(id, lens);
+}


### PR DESCRIPTION
This change introduces a "Fork · Upstream lens" for GitHub forks, enabling users to explicitly browse and work with either their own fork (origin) or the parent (upstream) repository’s pull requests and issues. The lens switch is surfaced as a segmented control in the Pull Requests and Issues panels, remembered per repository. It motivates clearer control over where PRs and issues are listed, viewed, and created, closing the gap where GitHub CLI heuristics resolved targets implicitly or made interaction with the parent repo awkward. Related UI, commands, and merged-back abstractions are also refactored to propagate the lens throughout the app.

### Core repo lens logic
- Adds `gh_lens_slug` and related helpers in `src-tauri/src/github/mod.rs` for lens-based remote slug resolution (origin or upstream).
- Exposes a pure lens-resolver and test suite for correct mapping and lens-gate validation.
- Refactors GitHub actions and queries in `src-tauri/src/forge/github.rs`, `src-tauri/src/github/pr.rs`, and `src-tauri/src/github/issue.rs` to accept and propagate the lens, ensuring consistent `origin`/`upstream` targeting.
- Updates all relevant dispatchers in `src-tauri/src/forge/mod.rs` to pass lens and reject upstream on unsupported providers.

### UI: Lens switcher and propagation
- Introduces `RepoLensSwitcher` in `src/features/conversations/RepoLensSwitcher.tsx`, surfacing a Fork|Upstream control in Pull Requests and Issues panels (visible only on GitHub forks).
- Wires lens state through UI stores and surfaces in affected panels (`src/features/issues/IssuesPanel.tsx`, `src/features/pulls/CreatePrDialog.tsx`, `src/features/conversations/ConversationListPanel.tsx`).
- For forks with issues disabled, displays a "Switch to upstream" offer instead of a dead-end notice.
- Updates palette commands and hotkeys for lens switching.

### PR & Issue creation/metadata changes
- Pull request creation (`src/features/pulls/CreatePrDialog.tsx`) now prompts the user to select the repository (Fork/Upstream) to target; available base branches and metadata options adapt accordingly.
- All issue/PR metadata controls (labels, milestones, assignees, types, relationships) propagate and honor the current lens, via refactored calls and `RemoteLens` threading.
- Issue creation dialog (`src/features/issues/CreateIssueDialog.tsx`) retitles, reframes, and relabels submit actions contextually when creating on the parent repo via the upstream lens.
- Keeps local to-dos and Jira issues lens-independent.

### Git, data, and queries refactor
- Refactors almost all relevant hooks in `src/lib/git/queries.ts`, `src/lib/git/api.ts`, and types in `src/lib/git/types.ts` to thread the `RemoteLens` parameter, enforcing correct data scope everywhere the lens is engaged.
- Backend `forge_*` commands, MCP/AI infrastructure (`src-tauri/src/mcp_server/*`, `src/lib/ai/*`, `src/lib/automations/runner.ts`) receive lens-threading, defaulting to origin where lens is not surfaced.

### Documentation and help
- Updates `README.md` and help documentation (`src/features/help/content.ts`, `site/src/data/capabilities.ts`) to describe the lens feature, its UX, and palette affordances.
- Adds changelog entries under `changelog.d/added-fork-upstream-lens.md` and `changelog.d/changed-pr-create-explicit-target.md`.

### Auxiliary and UI updates
- Surfaces fork/upstream distinction in section headers and tooltips.
- Refactors PR/issue components (CommitComments, MetaPickers, Relations, etc.) to be lens-aware.
- Ensures History, PromoteLocalIssueDialog, and DiscussionView remain origin-pinned for appropriate surfaces.