### PR TITLE
feat(transport,tauri): add IPC transport seam for backend invocation

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -121,6 +121,20 @@ pub enum ReviewEvent {
     NativeSession { id: String },
 }
 
+/// Sink for streaming agent events — one emitter, N consumers (the Tauri
+/// channel today; a LAN broadcast fan-out later).
+pub trait EventSink: Send + Sync {
+    fn send(&self, ev: ReviewEvent);
+}
+
+impl EventSink for Channel<ReviewEvent> {
+    fn send(&self, ev: ReviewEvent) {
+        // Fully qualified so this forwards to the inherent method instead of
+        // recursing into the trait impl.
+        let _ = Channel::send(self, ev);
+    }
+}
+
 // --- binary resolution -----------------------------------------------------
 //
 // A GUI app does not reliably inherit the user's shell PATH, and npm-installed
@@ -1505,7 +1519,7 @@ async fn stream_agent(
     // `-e COPILOT_GITHUB_TOKEN` with no value, so the token is inherited here and
     // never appears in argv / `docker inspect`).
     extra_env: &[(&str, String)],
-    on_event: &Channel<ReviewEvent>,
+    on_event: &dyn EventSink,
 ) -> AppResult<()> {
     let mut cmd = Command::new(binary);
     cmd.args(args)
@@ -1598,7 +1612,7 @@ async fn stream_agent(
                             }
                         };
                         if let Some(ev) = ev {
-                            let _ = on_event.send(ev);
+                            on_event.send(ev);
                         }
                     }
                     Ok(None) => break, // EOF: process closed stdout
@@ -1624,7 +1638,7 @@ async fn stream_agent(
         return Ok(());
     }
     if timed_out {
-        let _ = on_event.send(ReviewEvent::Error {
+        on_event.send(ReviewEvent::Error {
             message: format!("The {noun} timed out after {}s.", timeout.as_secs()),
         });
         return Ok(());
@@ -1633,7 +1647,7 @@ async fn stream_agent(
         // No terminal result event — surface stderr. Covers auth/quota
         // failures and the empty-stdout-without-a-TTY class of CLI bugs.
         let msg = stderr_text.trim();
-        let _ = on_event.send(ReviewEvent::Error {
+        on_event.send(ReviewEvent::Error {
             message: if msg.is_empty() {
                 format!("The {noun} process ended without producing any output.")
             } else {
@@ -2559,5 +2573,41 @@ mod tests {
         assert!(diff_only.iter().any(|a| a == "--allow-all-tools"));
         assert!(diff_only.iter().any(|a| a == "--deny-tool=write"));
         assert!(!diff_only.iter().any(|a| a == "--disable-builtin-mcps"));
+    }
+
+    // --- EventSink seam ------------------------------------------------------
+
+    /// A second `EventSink` implementation (the Tauri `Channel` is the first),
+    /// proving the seam takes a non-channel sink — the substrate the LAN
+    /// broadcast fan-out will reuse. Collects every event into a `Vec`.
+    struct CollectorSink {
+        events: std::sync::Mutex<Vec<ReviewEvent>>,
+    }
+
+    impl EventSink for CollectorSink {
+        fn send(&self, ev: ReviewEvent) {
+            self.events.lock().unwrap().push(ev);
+        }
+    }
+
+    #[test]
+    fn event_sink_collects_events_through_dyn_object() {
+        let sink = CollectorSink {
+            events: std::sync::Mutex::new(Vec::new()),
+        };
+        // Drive it through `&dyn EventSink` to exercise object safety — the same
+        // coercion `stream_agent`'s callers rely on.
+        let dyn_sink: &dyn EventSink = &sink;
+        dyn_sink.send(ReviewEvent::Delta {
+            text: "hello".to_string(),
+        });
+        dyn_sink.send(ReviewEvent::Error {
+            message: "boom".to_string(),
+        });
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], ReviewEvent::Delta { text } if text == "hello"));
+        assert!(matches!(&events[1], ReviewEvent::Error { message } if message == "boom"));
     }
 }

--- a/src/lib/tauri/invoke.ts
+++ b/src/lib/tauri/invoke.ts
@@ -39,13 +39,17 @@ export function errorMessage(e: unknown): string {
   return String(e);
 }
 
-/** Typed wrapper around Tauri invoke that normalizes thrown errors to AppError. */
+/** Typed wrapper around the installed transport's invoke that normalizes
+ *  thrown errors to AppError. */
 export async function invoke<T>(
   cmd: string,
   args?: Record<string, unknown>,
 ): Promise<T> {
+  // Outside the try: a missing installer surfaces as its own raw Error
+  // instead of being reclassified as an `io` AppError below.
+  const transport = getTransport();
   try {
-    return await getTransport().invoke<T>(cmd, args);
+    return await transport.invoke<T>(cmd, args);
   } catch (e) {
     if (isAppError(e)) throw e;
     throw {

--- a/src/lib/tauri/invoke.ts
+++ b/src/lib/tauri/invoke.ts
@@ -1,4 +1,4 @@
-import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import { getTransport } from "@/lib/transport";
 
 export interface AppError {
   kind:
@@ -45,7 +45,7 @@ export async function invoke<T>(
   args?: Record<string, unknown>,
 ): Promise<T> {
   try {
-    return await tauriInvoke<T>(cmd, args);
+    return await getTransport().invoke<T>(cmd, args);
   } catch (e) {
     if (isAppError(e)) throw e;
     throw {

--- a/src/lib/transport/desktop.ts
+++ b/src/lib/transport/desktop.ts
@@ -1,0 +1,10 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import type { Transport } from "@/lib/transport";
+
+/** The desktop transport: forwards straight to Tauri's IPC bridge. Errors pass
+ *  through raw — the invoke() wrapper normalizes them to AppError. */
+export const desktopTransport: Transport = {
+  invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+    return tauriInvoke<T>(cmd, args);
+  },
+};

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -1,0 +1,32 @@
+/**
+ * IPC transport seam. Every backend call funnels through the single invoke()
+ * wrapper (@/lib/tauri/invoke), which delegates to whichever Transport is
+ * installed here. The desktop app installs the Tauri-backed transport; a future
+ * LAN-companion bundle can bind an HTTP transport, and tests can bind a mock —
+ * all without touching any of the ~36 call sites that import invoke().
+ */
+export interface Transport {
+  /** Invoke a backend command. Implementations reject with raw errors —
+   *  normalization to AppError happens once, in the invoke() wrapper. */
+  invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T>;
+}
+
+let current: Transport | null = null;
+
+/** Install the transport all invoke() calls route through. Installers are
+ *  side-effect modules imported once at the app entry, before any invoke(). */
+export function installTransport(t: Transport): void {
+  if (import.meta.env.DEV && current)
+    console.warn("[transport] replacing installed transport");
+  current = t;
+}
+
+/** The installed transport. Throws if none is installed yet — a signal that an
+ *  installer import is missing at the app entry. */
+export function getTransport(): Transport {
+  if (!current)
+    throw new Error(
+      "No transport installed — import an installer (e.g. @/lib/transport/install-desktop) at the app entry before any invoke().",
+    );
+  return current;
+}

--- a/src/lib/transport/install-desktop.ts
+++ b/src/lib/transport/install-desktop.ts
@@ -1,0 +1,7 @@
+import { desktopTransport } from "@/lib/transport/desktop";
+import { installTransport } from "@/lib/transport";
+
+// Side-effect-only module: importing it installs the Tauri-backed transport.
+// The app entry (main.tsx) imports this FIRST so the transport is in place
+// before any other module can reach an invoke().
+installTransport(desktopTransport);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// Position is load-bearing: the transport must be installed before any other
+// module's evaluation can reach an invoke() — this import stays FIRST.
+import "@/lib/transport/install-desktop";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { domAnimation, LazyMotion, MotionConfig } from "motion/react";
 import { StrictMode } from "react";


### PR DESCRIPTION
Introduces an IPC transport abstraction layer, allowing backend command invocations to be routed through an installable "transport" seam instead of being hardcoded to the Tauri IPC bridge. This prepares the codebase for future alternative transport modes (e.g., LAN, in-memory for tests) and centralizes delegation for better separation of concerns.

### Transport Abstraction
- Adds `src/lib/transport/index.ts` defining the `Transport` interface and implementable transport install/get functions.
- Adds `src/lib/transport/desktop.ts` implementing the `desktopTransport` using Tauri's IPC bridge.
- Adds `src/lib/transport/install-desktop.ts` as a side-effect import to install the Tauri transport at app start.

### Integration and Adaptation
- Updates `src/lib/tauri/invoke.ts` to delegate all backend command invocations to `getTransport().invoke()` instead of directly calling `@tauri-apps/api/core`.
- Ensures `src/main.tsx` imports `install-desktop.ts` first, guaranteeing the transport is set up before any calls to `invoke()` can occur.

### Backend Rust Seam
- Introduces an `EventSink` trait in `src-tauri/src/agent.rs` for emitting agent events, establishing a generic abstraction over event sinks (like Tauri channels or future fan-outs).
- Refactors `stream_agent` and related event emission code to use the `EventSink` trait.
- Adds comprehensive tests for object safety and alternate sink implementations, verifying the seam's correctness.