### PR TITLE
fix(ai,agentic,review-history,ui): strip narration from agentic review body, show in "Thought process" disclosure

### DIFF
--- a/changelog.d/fixed-review-narration-trim.md
+++ b/changelog.d/fixed-review-narration-trim.md
@@ -1,0 +1,5 @@
+- AI reviews no longer prepend the agent's streamed working narration ("I'll examine
+  the code… let me check the call sites…") to the review body — the review is now the
+  agent's final answer, and the narration is preserved under a collapsible **Thought
+  process** disclosure. This applies to CLI and agentic HTTP reviews, automation-posted
+  comments, and research report synthesis.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1261,6 +1261,10 @@ fn parse_copilot_line(
                 .get("data")
                 .and_then(|d| d.get("deltaContent"))
                 .and_then(|t| t.as_str())?;
+            // Empty deltas are dropped here, while the Claude parser still emits
+            // `Delta { text: "" }` for them (its pre-separator behavior, kept
+            // byte-identical). Both deliberately leave `pending_sep` armed — the
+            // separator belongs on the first REAL text.
             if t.is_empty() {
                 return None;
             }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1237,10 +1237,18 @@ fn parse_codex_line(
 /// `assistant.message.content` as the authoritative final text, and emits `Done` at
 /// the terminal `result` (whose `exitCode` decides success). Setup / MCP / skills /
 /// reasoning / turn-marker events are ignored.
+///
+/// Successive assistant messages would otherwise concatenate with no separator
+/// ("…real context.Let me check…"), so a paragraph break is lazily PREPENDED to the
+/// first non-empty delta after a completed message (`emitted_text`/`pending_sep`).
+/// The separator lands before the delta text, so the delta buffer still ends with
+/// `Done.text` (which stays verbatim, never separator-prefixed).
 fn parse_copilot_line(
     line: &str,
     saw_terminal: &mut bool,
     last_message: &mut String,
+    emitted_text: &mut bool,
+    pending_sep: &mut bool,
 ) -> Option<ReviewEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -1248,11 +1256,23 @@ fn parse_copilot_line(
     }
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     match v.get("type")?.as_str()? {
-        "assistant.message_delta" => v
-            .get("data")
-            .and_then(|d| d.get("deltaContent"))
-            .and_then(|t| t.as_str())
-            .map(|t| ReviewEvent::Delta { text: t.to_string() }),
+        "assistant.message_delta" => {
+            let t = v
+                .get("data")
+                .and_then(|d| d.get("deltaContent"))
+                .and_then(|t| t.as_str())?;
+            if t.is_empty() {
+                return None;
+            }
+            let text = if *pending_sep {
+                *pending_sep = false;
+                format!("\n\n{t}")
+            } else {
+                t.to_string()
+            };
+            *emitted_text = true;
+            Some(ReviewEvent::Delta { text })
+        }
         "assistant.message" => {
             if let Some(text) = v
                 .get("data")
@@ -1260,6 +1280,10 @@ fn parse_copilot_line(
                 .and_then(|t| t.as_str())
             {
                 *last_message = text.to_string();
+            }
+            // A completed message: separate the next message's narration from this one.
+            if *emitted_text {
+                *pending_sep = true;
             }
             None
         }
@@ -1308,13 +1332,18 @@ fn parse_copilot_line(
 /// single terminal event — a turn is a sequence of steps; `step_finish` with
 /// `reason == "stop"` ends it (`"tool-calls"` means another step follows). It emits
 /// whole `text` parts (not token deltas), each a distinct segment, so we stream them
-/// as deltas *and* accumulate them; the final `Done` carries the full text. The
-/// generated `sessionID` (on every event) is surfaced once as `NativeSession` so a
-/// host resume targets the right session — the store de-dups, so re-emitting is fine.
+/// as deltas *and* accumulate them. The agent narrates as it works, so the final
+/// `Done` carries only the FINAL step's text (the actual answer, in `step_text`) —
+/// the earlier steps' narration stays in the `Delta` stream but is stripped off the
+/// final body. `last_message` accumulates every step for the degenerate fallback (a
+/// final step that produced no text). The generated `sessionID` (on every event) is
+/// surfaced once as `NativeSession` so a host resume targets the right session — the
+/// store de-dups, so re-emitting is fine.
 fn parse_opencode_line(
     line: &str,
     saw_terminal: &mut bool,
     last_message: &mut String,
+    step_text: &mut String,
 ) -> Option<ReviewEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -1322,24 +1351,36 @@ fn parse_opencode_line(
     }
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     match v.get("type")?.as_str()? {
-        // First event of the run carries the session id we need for resume.
-        "step_start" => v
-            .get("sessionID")
-            .and_then(|s| s.as_str())
-            .map(|id| ReviewEvent::NativeSession { id: id.to_string() }),
+        // First event of the run carries the session id we need for resume. A new
+        // step starts here — reset the per-step accumulator so `Done` reflects only
+        // the final step's text.
+        "step_start" => {
+            step_text.clear();
+            v.get("sessionID")
+                .and_then(|s| s.as_str())
+                .map(|id| ReviewEvent::NativeSession { id: id.to_string() })
+        }
         "text" => {
             let text = v.get("part")?.get("text")?.as_str()?;
             if text.is_empty() {
                 return None;
             }
             // Separate consecutive segments so multi-step narration stays readable;
-            // the delta mirrors what we append, so the buffer == last_message.
+            // the delta mirrors what we append, so the buffer == last_message and its
+            // tail == the current step's text.
             let chunk = if last_message.is_empty() {
                 text.to_string()
             } else {
                 format!("\n\n{text}")
             };
             last_message.push_str(&chunk);
+            // Mirror into the per-step accumulator (join parts within a step the same
+            // way) so `Done.text` can carry the final step verbatim as the buffer tail.
+            if step_text.is_empty() {
+                step_text.push_str(text);
+            } else {
+                step_text.push_str(&format!("\n\n{text}"));
+            }
             Some(ReviewEvent::Delta { text: chunk })
         }
         "tool_use" => {
@@ -1368,8 +1409,18 @@ fn parse_opencode_line(
                 return None;
             }
             *saw_terminal = true;
+            // The final answer is the final step's text; earlier steps were narration
+            // and stay in the delta stream only. Fall back to the full accumulation
+            // only for a degenerate final step that produced no text — never emit an
+            // empty Done when text existed.
+            let text = std::mem::take(step_text);
+            let text = if text.is_empty() {
+                std::mem::take(last_message)
+            } else {
+                text
+            };
             Some(ReviewEvent::Done {
-                text: std::mem::take(last_message),
+                text,
                 is_error: false,
                 cost_usd: None,
             })
@@ -1394,10 +1445,19 @@ fn parse_opencode_line(
 /// accumulates each in-flight tool call's streamed input JSON, keyed by block
 /// index (the input arrives as `input_json_delta` fragments after the block
 /// starts); a completed block emits one `Tool` event with the extracted target.
+///
+/// Consecutive text blocks/messages would otherwise concatenate with no separator
+/// ("…real context.Let me check…"), so a paragraph break is lazily PREPENDED to the
+/// first non-empty `text_delta` following a completed TEXT block (every text block
+/// ends with `content_block_stop`), gated on some text already having been emitted
+/// (`emitted_text`/`pending_sep`). The separator lands before the delta text, so the
+/// delta buffer still ends with `Done.text` (the raw `result`, never separator-prefixed).
 fn parse_claude_line(
     line: &str,
     saw_result: &mut bool,
     tool_inputs: &mut std::collections::HashMap<i64, (String, String)>,
+    emitted_text: &mut bool,
+    pending_sep: &mut bool,
 ) -> Option<ReviewEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -1427,9 +1487,24 @@ fn parse_claude_line(
                 "content_block_delta" => {
                     let delta = event.get("delta")?;
                     match delta.get("type")?.as_str()? {
-                        "text_delta" => Some(ReviewEvent::Delta {
-                            text: delta.get("text")?.as_str()?.to_string(),
-                        }),
+                        "text_delta" => {
+                            let t = delta.get("text")?.as_str()?;
+                            // Empty deltas keep today's behavior and must NOT consume
+                            // the pending separator (it belongs on the first REAL text).
+                            if t.is_empty() {
+                                return Some(ReviewEvent::Delta {
+                                    text: String::new(),
+                                });
+                            }
+                            let text = if *pending_sep {
+                                *pending_sep = false;
+                                format!("\n\n{t}")
+                            } else {
+                                t.to_string()
+                            };
+                            *emitted_text = true;
+                            Some(ReviewEvent::Delta { text })
+                        }
                         // A tool's input streams as JSON fragments — append to its buffer.
                         "input_json_delta" => {
                             if let (Some(idx), Some(frag)) = (
@@ -1445,10 +1520,18 @@ fn parse_claude_line(
                         _ => None,
                     }
                 }
-                // The tool call is fully described now — emit one structured step.
+                // A block finished. A tool block (idx in `tool_inputs`) emits one
+                // structured Tool step. A TEXT block (idx absent) ends a paragraph:
+                // arm the lazy separator so the next message/block's first text delta
+                // is prefixed — but only once some text has actually been emitted.
                 "content_block_stop" => {
                     let idx = event.get("index").and_then(|i| i.as_i64())?;
-                    let (name, json) = tool_inputs.remove(&idx)?;
+                    let Some((name, json)) = tool_inputs.remove(&idx) else {
+                        if *emitted_text {
+                            *pending_sep = true;
+                        }
+                        return None;
+                    };
                     let input = serde_json::from_str(&json).unwrap_or(serde_json::Value::Null);
                     Some(ReviewEvent::Tool {
                         tool: normalize_tool(&name).to_string(),
@@ -1598,6 +1681,11 @@ async fn stream_agent(
     // claude: per-tool-call streamed input JSON, keyed by content-block index.
     let mut claude_tool_inputs: std::collections::HashMap<i64, (String, String)> =
         std::collections::HashMap::new();
+    // opencode: the final step's text, so `Done` carries the answer, not narration.
+    let mut opencode_step_text = String::new();
+    // claude/copilot: lazy `\n\n` between successive text blocks/messages.
+    let mut emitted_text = false;
+    let mut pending_sep = false;
     let mut cancelled = false;
     let mut timed_out = false;
 
@@ -1620,18 +1708,29 @@ async fn stream_agent(
                 match line {
                     Ok(Some(l)) => {
                         let ev = match kind {
-                            AgentKind::Claude => {
-                                parse_claude_line(&l, &mut saw_result, &mut claude_tool_inputs)
-                            }
+                            AgentKind::Claude => parse_claude_line(
+                                &l,
+                                &mut saw_result,
+                                &mut claude_tool_inputs,
+                                &mut emitted_text,
+                                &mut pending_sep,
+                            ),
                             AgentKind::Codex => {
                                 parse_codex_line(&l, &mut saw_result, &mut last_message)
                             }
-                            AgentKind::Copilot => {
-                                parse_copilot_line(&l, &mut saw_result, &mut last_message)
-                            }
-                            AgentKind::Opencode => {
-                                parse_opencode_line(&l, &mut saw_result, &mut last_message)
-                            }
+                            AgentKind::Copilot => parse_copilot_line(
+                                &l,
+                                &mut saw_result,
+                                &mut last_message,
+                                &mut emitted_text,
+                                &mut pending_sep,
+                            ),
+                            AgentKind::Opencode => parse_opencode_line(
+                                &l,
+                                &mut saw_result,
+                                &mut last_message,
+                                &mut opencode_step_text,
+                            ),
                         };
                         if let Some(ev) = ev {
                             on_event.send(ev);
@@ -2288,8 +2387,8 @@ mod tests {
 
     #[test]
     fn opencode_step_start_yields_native_session_id() {
-        let (mut term, mut msg) = (false, String::new());
-        let ev = parse_opencode_line(STEP_START, &mut term, &mut msg).unwrap();
+        let (mut term, mut msg, mut step) = (false, String::new(), String::new());
+        let ev = parse_opencode_line(STEP_START, &mut term, &mut msg, &mut step).unwrap();
         match ev {
             ReviewEvent::NativeSession { id } => assert_eq!(id, "ses_abc"),
             other => panic!("expected NativeSession, got {other:?}"),
@@ -2299,21 +2398,21 @@ mod tests {
 
     #[test]
     fn opencode_text_parts_stream_as_separated_deltas() {
-        let (mut term, mut msg) = (false, String::new());
+        let (mut term, mut msg, mut step) = (false, String::new(), String::new());
         // First segment: emitted verbatim, no leading separator.
-        let ev = parse_opencode_line(TEXT_A, &mut term, &mut msg).unwrap();
+        let ev = parse_opencode_line(TEXT_A, &mut term, &mut msg, &mut step).unwrap();
         assert!(matches!(ev, ReviewEvent::Delta { text } if text == "First."));
         // Second segment: separated so multi-step narration stays readable, and the
         // delta mirrors exactly what we appended (buffer == last_message).
-        let ev = parse_opencode_line(TEXT_B, &mut term, &mut msg).unwrap();
+        let ev = parse_opencode_line(TEXT_B, &mut term, &mut msg, &mut step).unwrap();
         assert!(matches!(ev, ReviewEvent::Delta { text } if text == "\n\nSecond."));
         assert_eq!(msg, "First.\n\nSecond.");
     }
 
     #[test]
     fn opencode_tool_use_emits_a_tool_step() {
-        let (mut term, mut msg) = (false, String::new());
-        let ev = parse_opencode_line(TOOL, &mut term, &mut msg).unwrap();
+        let (mut term, mut msg, mut step) = (false, String::new(), String::new());
+        let ev = parse_opencode_line(TOOL, &mut term, &mut msg, &mut step).unwrap();
         match ev {
             ReviewEvent::Tool { tool, target } => {
                 assert_eq!(tool, "write");
@@ -2328,8 +2427,8 @@ mod tests {
 
     #[test]
     fn opencode_tool_use_extracts_target_from_input() {
-        let (mut term, mut msg) = (false, String::new());
-        let ev = parse_opencode_line(OC_TOOL_WITH_INPUT, &mut term, &mut msg).unwrap();
+        let (mut term, mut msg, mut step) = (false, String::new(), String::new());
+        let ev = parse_opencode_line(OC_TOOL_WITH_INPUT, &mut term, &mut msg, &mut step).unwrap();
         match ev {
             ReviewEvent::Tool { tool, target } => {
                 assert_eq!(tool, "read");
@@ -2383,14 +2482,15 @@ mod tests {
         // fragments, stop — only the stop emits a Tool, carrying the joined input.
         let mut saw = false;
         let mut acc = std::collections::HashMap::new();
+        let (mut emitted, mut pending) = (false, false);
         let start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"Read","input":{}}}}"#;
         let d1 = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"file_pa"}}}"#;
         let d2 = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"th\":\"src/x.ts\"}"}}}"#;
         let stop = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":1}}"#;
-        assert!(parse_claude_line(start, &mut saw, &mut acc).is_none());
-        assert!(parse_claude_line(d1, &mut saw, &mut acc).is_none());
-        assert!(parse_claude_line(d2, &mut saw, &mut acc).is_none());
-        let ev = parse_claude_line(stop, &mut saw, &mut acc).unwrap();
+        assert!(parse_claude_line(start, &mut saw, &mut acc, &mut emitted, &mut pending).is_none());
+        assert!(parse_claude_line(d1, &mut saw, &mut acc, &mut emitted, &mut pending).is_none());
+        assert!(parse_claude_line(d2, &mut saw, &mut acc, &mut emitted, &mut pending).is_none());
+        let ev = parse_claude_line(stop, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
         match ev {
             ReviewEvent::Tool { tool, target } => {
                 assert_eq!(tool, "read");
@@ -2399,16 +2499,117 @@ mod tests {
             other => panic!("expected Tool, got {other:?}"),
         }
         assert!(acc.is_empty(), "the completed block is removed from the buffer");
+        // A tool block's stop must NOT arm the separator (no text emitted yet).
+        assert!(!pending, "a tool block does not arm the paragraph separator");
+    }
+
+    #[test]
+    fn claude_lazy_separator_between_text_blocks_across_a_tool() {
+        // Two text blocks separated by a tool call: the second block's first delta is
+        // prefixed `\n\n`; the first block's first delta is NOT. `Done.text` is the raw
+        // `result` string, with no separator prepended — and the delta buffer, once
+        // concatenated, ENDS WITH `Done.text` (the frontend's suffix-strip invariant).
+        let mut saw = false;
+        let mut acc = std::collections::HashMap::new();
+        let (mut emitted, mut pending) = (false, false);
+        let mut buffer = String::new();
+
+        // Text block 1: "Looking at the code." then its stop.
+        let t1a = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Looking at "}}}"#;
+        let t1b = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"the code."}}}"#;
+        let stop1 = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0}}"#;
+        // A tool block (start + stop) — its stop must not add a separator.
+        let tstart = r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"Read","input":{}}}}"#;
+        let tstop = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":1}}"#;
+        // Text block 2: the final answer.
+        let t2 = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"The fix is X."}}}"#;
+        let stop2 = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":2}}"#;
+        let result = r#"{"type":"result","result":"The fix is X.","is_error":false}"#;
+
+        for (line, expect) in [
+            (t1a, Some("Looking at ")),
+            (t1b, Some("the code.")),
+        ] {
+            let ev = parse_claude_line(line, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+            match ev {
+                ReviewEvent::Delta { text } => {
+                    assert_eq!(text, expect.unwrap());
+                    buffer.push_str(&text);
+                }
+                other => panic!("expected Delta, got {other:?}"),
+            }
+        }
+        // Block-1 stop arms the separator; the tool block's stop leaves it armed.
+        parse_claude_line(stop1, &mut saw, &mut acc, &mut emitted, &mut pending);
+        assert!(pending, "a text block's stop arms the separator");
+        parse_claude_line(tstart, &mut saw, &mut acc, &mut emitted, &mut pending);
+        parse_claude_line(tstop, &mut saw, &mut acc, &mut emitted, &mut pending);
+        assert!(pending, "a tool block's stop leaves the pending separator intact");
+
+        // Block-2's first delta is prefixed `\n\n`.
+        let ev = parse_claude_line(t2, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+        match ev {
+            ReviewEvent::Delta { text } => {
+                assert_eq!(text, "\n\nThe fix is X.");
+                buffer.push_str(&text);
+            }
+            other => panic!("expected Delta, got {other:?}"),
+        }
+        parse_claude_line(stop2, &mut saw, &mut acc, &mut emitted, &mut pending);
+
+        let done = parse_claude_line(result, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+        match done {
+            ReviewEvent::Done { text, .. } => {
+                assert_eq!(text, "The fix is X.", "Done.text is the raw result, no separator");
+                assert!(saw);
+                // Load-bearing: concatenated deltas END WITH Done.text.
+                assert_eq!(buffer, "Looking at the code.\n\nThe fix is X.");
+                assert!(buffer.ends_with(&text));
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copilot_lazy_separator_between_assistant_messages() {
+        // Deltas across two assistant messages get exactly one `\n\n` between them.
+        let (mut term, mut msg) = (false, String::new());
+        let (mut emitted, mut pending) = (false, false);
+        let d1 = r#"{"type":"assistant.message_delta","data":{"deltaContent":"First."}}"#;
+        let m1 = r#"{"type":"assistant.message","data":{"content":"First."}}"#;
+        let d2 = r#"{"type":"assistant.message_delta","data":{"deltaContent":"Second."}}"#;
+
+        let ev = parse_copilot_line(d1, &mut term, &mut msg, &mut emitted, &mut pending).unwrap();
+        assert!(matches!(ev, ReviewEvent::Delta { text } if text == "First."));
+        // A completed message arms the separator; the next delta is prefixed once.
+        assert!(parse_copilot_line(m1, &mut term, &mut msg, &mut emitted, &mut pending).is_none());
+        assert!(pending);
+        let ev = parse_copilot_line(d2, &mut term, &mut msg, &mut emitted, &mut pending).unwrap();
+        assert!(matches!(ev, ReviewEvent::Delta { text } if text == "\n\nSecond."));
+        assert!(!pending, "the separator is consumed by the first following delta");
+    }
+
+    #[test]
+    fn copilot_first_delta_has_no_separator() {
+        // The very first delta of a run must not be prefixed (nothing emitted before).
+        let (mut term, mut msg) = (false, String::new());
+        let (mut emitted, mut pending) = (false, false);
+        let d = r#"{"type":"assistant.message_delta","data":{"deltaContent":"Hello."}}"#;
+        let ev = parse_copilot_line(d, &mut term, &mut msg, &mut emitted, &mut pending).unwrap();
+        assert!(matches!(ev, ReviewEvent::Delta { text } if text == "Hello."));
+        assert!(emitted);
     }
 
     #[test]
     fn opencode_tool_calls_finish_is_not_terminal_but_stop_is() {
-        let (mut term, mut msg) = (false, "hello".to_string());
+        // Degenerate: the final step produced no text (step accumulator empty), so
+        // `Done` falls back to the full accumulation rather than emitting empty.
+        let (mut term, mut msg, mut step) = (false, "hello".to_string(), String::new());
         // `reason: tool-calls` means another step follows — not the turn's end.
-        assert!(parse_opencode_line(FINISH_TOOLS, &mut term, &mut msg).is_none());
+        assert!(parse_opencode_line(FINISH_TOOLS, &mut term, &mut msg, &mut step).is_none());
         assert!(!term);
-        // `reason: stop` ends the turn and carries the accumulated text.
-        let ev = parse_opencode_line(FINISH_STOP, &mut term, &mut msg).unwrap();
+        // `reason: stop` ends the turn and carries the fallback text.
+        let ev = parse_opencode_line(FINISH_STOP, &mut term, &mut msg, &mut step).unwrap();
         match ev {
             ReviewEvent::Done { text, is_error, .. } => {
                 assert_eq!(text, "hello");
@@ -2417,6 +2618,66 @@ mod tests {
             other => panic!("expected Done, got {other:?}"),
         }
         assert!(term);
+    }
+
+    #[test]
+    fn opencode_done_carries_only_the_final_step_text() {
+        // A run of [step1 text "A", tool, step2 text "B"]: both stream as deltas ("A"
+        // then "\n\nB"), but `Done.text` is the FINAL step's text only — the step-1
+        // narration is stripped off the body.
+        let (mut term, mut msg, mut step) = (false, String::new(), String::new());
+        let s1 = r#"{"type":"step_start","sessionID":"s","part":{"type":"step-start"}}"#;
+        let a = r#"{"type":"text","sessionID":"s","part":{"type":"text","text":"A"}}"#;
+        let tool = r#"{"type":"tool_use","sessionID":"s","part":{"type":"tool","tool":"read","state":{"status":"completed"}}}"#;
+        let fin_tool = r#"{"type":"step_finish","sessionID":"s","part":{"type":"step-finish","reason":"tool-calls"}}"#;
+        let s2 = r#"{"type":"step_start","sessionID":"s","part":{"type":"step-start"}}"#;
+        let b = r#"{"type":"text","sessionID":"s","part":{"type":"text","text":"B"}}"#;
+        let fin_stop = r#"{"type":"step_finish","sessionID":"s","part":{"type":"step-finish","reason":"stop"}}"#;
+
+        let mut buffer = String::new();
+        parse_opencode_line(s1, &mut term, &mut msg, &mut step); // NativeSession
+        if let Some(ReviewEvent::Delta { text }) =
+            parse_opencode_line(a, &mut term, &mut msg, &mut step)
+        {
+            buffer.push_str(&text);
+        }
+        parse_opencode_line(tool, &mut term, &mut msg, &mut step); // Tool
+        parse_opencode_line(fin_tool, &mut term, &mut msg, &mut step); // not terminal
+        parse_opencode_line(s2, &mut term, &mut msg, &mut step); // NativeSession, clears step
+        if let Some(ReviewEvent::Delta { text }) =
+            parse_opencode_line(b, &mut term, &mut msg, &mut step)
+        {
+            buffer.push_str(&text);
+        }
+        let done = parse_opencode_line(fin_stop, &mut term, &mut msg, &mut step).unwrap();
+        match done {
+            ReviewEvent::Done { text, .. } => {
+                assert_eq!(text, "B");
+                // Load-bearing frontend invariant: the delta buffer ENDS WITH Done.text.
+                assert_eq!(buffer, "A\n\nB");
+                assert!(buffer.ends_with(&text));
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opencode_final_step_joins_multiple_text_parts() {
+        // A final step with several text parts joins them with `\n\n` — so Done.text
+        // (the buffer tail) matches exactly what streamed within the final step.
+        let (mut term, mut msg, mut step) = (false, String::new(), String::new());
+        let s = r#"{"type":"step_start","sessionID":"s","part":{"type":"step-start"}}"#;
+        let p1 = r#"{"type":"text","sessionID":"s","part":{"type":"text","text":"one"}}"#;
+        let p2 = r#"{"type":"text","sessionID":"s","part":{"type":"text","text":"two"}}"#;
+        let fin_stop = r#"{"type":"step_finish","sessionID":"s","part":{"type":"step-finish","reason":"stop"}}"#;
+        parse_opencode_line(s, &mut term, &mut msg, &mut step);
+        parse_opencode_line(p1, &mut term, &mut msg, &mut step);
+        parse_opencode_line(p2, &mut term, &mut msg, &mut step);
+        let done = parse_opencode_line(fin_stop, &mut term, &mut msg, &mut step).unwrap();
+        match done {
+            ReviewEvent::Done { text, .. } => assert_eq!(text, "one\n\ntwo"),
+            other => panic!("expected Done, got {other:?}"),
+        }
     }
 
     #[cfg(windows)]

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -774,7 +774,10 @@ call, so agentic runs are slower and pricier than a one-shot review; and small l
 (some Ollama models) may not support tool calling — the review fails with a clear message
 suggesting you turn agentic off or pick another model. (Codex reviews already explore the
 repo on their own but can't attach the GitDesktop tools, so they get the file-exploration
-framing without the PR tools.)
+framing without the PR tools.) When an agentic run finishes, the panel shows only its
+final review; the exploration narration it streamed along the way is tucked under a
+collapsible **Thought process** disclosure below the review (and saved with it in
+*Previous reviews*).
 
 Every AI-posted review is **clearly machine-authored**: a branded GitDesktop header and
 footer on the comment, and on a **local PR** a "GitDesktop" bot author with a robot avatar.

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -53,6 +53,7 @@ import {
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { ReviewHistory } from "./ReviewHistory";
+import { ThoughtsDisclosure } from "./ThoughtsDisclosure";
 
 /** Pre-run note shown when a re-run's "changes since" delta couldn't be used. */
 const DELTA_NOTE: Partial<Record<string, string>> = {
@@ -111,6 +112,7 @@ export function PrReviewPanel({
     truncatedCoverage,
     phase,
     error,
+    thoughts,
   } = useReviewRun(target);
 
   // Prior reviews for this PR, used for the per-mode context banner. Read-only —
@@ -501,7 +503,10 @@ export function PrReviewPanel({
               {text.trim() && <Markdown>{text}</Markdown>}
             </div>
           ) : text.trim() ? (
-            <Markdown>{text}</Markdown>
+            <>
+              <Markdown>{text}</Markdown>
+              {thoughts.trim() && <ThoughtsDisclosure thoughts={thoughts} />}
+            </>
           ) : generating ? (
             <p className="flex items-center gap-2 text-xs text-muted-foreground">
               <Spinner className="size-3" />

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -17,6 +17,7 @@ import {
   useUpdateReviewText,
 } from "@/lib/pulls/queries";
 import { formatRelativeTime } from "@/lib/time";
+import { ThoughtsDisclosure } from "./ThoughtsDisclosure";
 
 /**
  * The "Previous reviews" disclosure — past AI reviews for this PR (both modes),
@@ -203,6 +204,9 @@ export function ReviewHistory({
                     ) : (
                       <>
                         <Markdown>{r.text}</Markdown>
+                        {r.thoughts?.trim() && (
+                          <ThoughtsDisclosure thoughts={r.thoughts} />
+                        )}
                         <Button
                           variant="ghost"
                           size="xs"

--- a/src/features/pulls/ThoughtsDisclosure.tsx
+++ b/src/features/pulls/ThoughtsDisclosure.tsx
@@ -1,0 +1,36 @@
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { Markdown } from "@/components/ui/markdown";
+
+/**
+ * A collapsed-by-default "Thought process" disclosure for an agentic review's
+ * streamed working narration ("Let me check the call sites…"). The narration is
+ * peeled off the review body at settle and shown here so it stays available
+ * without polluting the review. Shared by the live review panel and the history
+ * rows; both render inside a `ph-no-capture` container, so no capture guard here.
+ */
+export function ThoughtsDisclosure({ thoughts }: { thoughts: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-2 text-xs">
+      <button
+        type="button"
+        className="flex items-center gap-1 text-muted-foreground hover:text-foreground"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? (
+          <CaretDownIcon className="size-3" />
+        ) : (
+          <CaretRightIcon className="size-3" />
+        )}
+        Thought process
+      </button>
+      {open && (
+        <div className="mt-1 text-muted-foreground">
+          <Markdown>{thoughts}</Markdown>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -609,10 +609,12 @@ export const useResearchStore = create<ResearchState>((set, get) => {
             if (ev.kind === "delta") {
               finalText += ev.text;
             } else if (ev.kind === "done") {
-              // Defensive fallback — Claude's `done` event may carry more text than
-              // the accumulated deltas (this branch is Claude-only: non-Claude runs
-              // return null above, so no whole-message agent ever reaches here).
-              if (ev.text.length > finalText.length) finalText = ev.text;
+              // The distill has web tools, so its streamed deltas are working
+              // narration ("Let me search…") ahead of the synthesized report. The
+              // terminal event's text is the authoritative final answer — adopt it
+              // whenever present (falling back to the deltas only for a degenerate
+              // empty terminal event) so the narration never leaks into the report.
+              if (ev.text.trim()) finalText = ev.text;
               // The distill IS the latest turn, so its cost is the run's latest cost.
               if (ev.costUsd != null) patch(id, { costUsd: ev.costUsd });
               if (ev.isError) errored = true;

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -246,6 +246,13 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
   // off into "thoughts" for a disclosure. When the conclusion is empty (all prose
   // preceded the last tool step — a heuristic miss), leave the full buffer as the
   // body and emit no thoughts, never dropping content.
+  //
+  // Known limitation (accepted): a model that interleaves real findings with
+  // verification tool calls ("X is broken … [reads file] … and Y too") gets the
+  // pre-tool findings demoted into the disclosure — content preserved, placement
+  // imperfect. This mirrors the CLI providers' native semantics (Claude's `result`
+  // is likewise only the final post-tool message), and models overwhelmingly
+  // conclude after exploring, so the last-tool split is the right default.
   if (conclusionStart > 0) {
     const conclusion = buffer.slice(conclusionStart).trim();
     if (conclusion) {

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -116,6 +116,10 @@ export interface AgenticStreamOpts {
   abortSignal: AbortSignal;
   setText: (t: string) => void;
   setStatus: (s: string) => void;
+  /** Called at most once, at successful settle, with the narration (prose before
+   *  the last tool step) that preceded the conclusion. Never called when the run
+   *  had no tool steps or no distinct narration to peel off. */
+  onThoughts?: (t: string) => void;
 }
 
 /** Max reasoning/tool steps a single agentic review may take before it must
@@ -156,6 +160,10 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
   // Terminal state, captured on `finish` so a zero-text run can explain itself.
   let finishReason = "unknown";
   let toolSteps = 0;
+  // Offset in `buffer` where the conclusion begins — advanced to the current
+  // buffer length after every tool step, so it ends up pointing just past the LAST
+  // tool activity. Prose after it is the review body; prose before it is narration.
+  let conclusionStart = 0;
   try {
     for await (const part of result.fullStream) {
       switch (part.type) {
@@ -189,11 +197,14 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
           toolSteps++;
           opts.setStatus(httpToolStatusLine(part.toolName, part.input));
           pendingBreak = true;
+          // Everything after this last tool activity is (so far) the conclusion.
+          conclusionStart = buffer.length;
           break;
         }
         case "tool-error": {
           opts.setStatus(`Tool ${part.toolName} failed — continuing…`);
           pendingBreak = true;
+          conclusionStart = buffer.length;
           break;
         }
         case "finish": {
@@ -227,6 +238,21 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
     throw new Error(
       `The review ended after ${toolSteps} tool step(s) without producing a conclusion (${finishReason}). Try again, or turn off Agentic review for a single-pass response.`,
     );
+  }
+
+  // A tool-using run streams its exploration narration ("Let me check the call
+  // sites…") ahead of the final review. The prose after the LAST tool step is the
+  // conclusion — the authoritative body; the prose before it is narration, peeled
+  // off into "thoughts" for a disclosure. When the conclusion is empty (all prose
+  // preceded the last tool step — a heuristic miss), leave the full buffer as the
+  // body and emit no thoughts, never dropping content.
+  if (conclusionStart > 0) {
+    const conclusion = buffer.slice(conclusionStart).trim();
+    if (conclusion) {
+      opts.setText(conclusion);
+      const thoughts = buffer.slice(0, conclusionStart).trim();
+      if (thoughts) opts.onThoughts?.(thoughts);
+    }
   }
 }
 

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -35,6 +35,11 @@ export interface CliStreamOpts {
    *  agentic reviewer can pull the full PR diff and read files at any ref. Default
    *  off keeps every other CLI flow (Debug with AI, generation) byte-identical. */
   mcpSelf?: boolean;
+  /** Called at most once, at successful settle, with the narration that streamed
+   *  before the final answer (a tool-using run's "Let me check…" prose). Never
+   *  called when there is none — a codex run (no deltas) or a run whose whole
+   *  buffer IS the final answer. */
+  onThoughts?: (text: string) => void;
 }
 
 /** A short, human status line for a tool step, from the normalized kind + target
@@ -75,6 +80,7 @@ export async function runCliStream({
   onCost,
   effort,
   mcpSelf,
+  onThoughts,
 }: CliStreamOpts): Promise<void> {
   const kind = providerKind(ai.provider);
   if (!kind) throw new Error(`Unsupported CLI provider: ${ai.provider}`);
@@ -125,12 +131,32 @@ export async function runCliStream({
           } else if (event.kind === "done") {
             settled = true;
             onCost?.(event.costUsd);
-            // The terminal event carries the authoritative full text; prefer it
-            // if the partial stream fell short (e.g. deltas were coalesced).
-            if (event.text.length > buffer.length) setText(event.text);
-            if (event.isError)
+            // An errored run keeps whatever streamed (partial text + the error is
+            // today's UX) — no replace/strip.
+            if (event.isError) {
               reject(new Error("The run ended with an error."));
-            else resolve();
+              return;
+            }
+            // The terminal event's text IS the agent's final answer — the
+            // authoritative review body. The accumulated delta buffer additionally
+            // holds any tool-using narration ("Let me check…") that streamed ahead
+            // of it; adopting the buffer here (the old length heuristic) leaked that
+            // narration into the review. So: the final answer wins (falling back to
+            // the buffer only for a degenerate empty terminal event), and the
+            // narration is peeled off as separate "thoughts" for a disclosure.
+            const final = event.text.trim() ? event.text : buffer;
+            setText(final);
+            if (event.text.trim() && buffer !== event.text) {
+              // The buffer ends with the final answer (deltas may prepend a
+              // separator), so strip that suffix; if it doesn't match (older CLI
+              // behavior), keep the whole buffer as the thoughts.
+              const cut = buffer.endsWith(event.text)
+                ? buffer.slice(0, buffer.length - event.text.length)
+                : buffer;
+              const thoughts = cut.trim();
+              if (thoughts) onThoughts?.(thoughts);
+            }
+            resolve();
           } else if (event.kind === "error") {
             settled = true;
             reject(new Error(event.message));
@@ -170,6 +196,10 @@ export interface StreamAiOpts {
   reviewTools?: ToolSet;
   setText: (text: string) => void;
   setStatus: (status: string) => void;
+  /** Called at most once, at successful settle, with the narration that streamed
+   *  before the final answer (agentic CLI + HTTP runs only). The plain HTTP text
+   *  path has no narration and never calls it. */
+  onThoughts?: (text: string) => void;
   /** CLI path: receives the agent review id (cancel via `cancelAgentReview`). */
   onCliId: (id: string) => void;
   /** HTTP path: receives the AbortController driving the stream (cancel via
@@ -194,6 +224,7 @@ export async function streamAi({
   reviewTools,
   setText,
   setStatus,
+  onThoughts,
   onCliId,
   onAbort,
 }: StreamAiOpts): Promise<void> {
@@ -208,6 +239,7 @@ export async function streamAi({
       setText,
       setStatus,
       registerId: onCliId,
+      onThoughts,
     });
     return;
   }
@@ -229,6 +261,7 @@ export async function streamAi({
       abortSignal: abort.signal,
       setText,
       setStatus,
+      onThoughts,
     });
     return;
   }

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -146,14 +146,19 @@ export async function runCliStream({
             // narration is peeled off as separate "thoughts" for a disclosure.
             const final = event.text.trim() ? event.text : buffer;
             setText(final);
-            if (event.text.trim() && buffer !== event.text) {
-              // The buffer ends with the final answer (deltas may prepend a
-              // separator), so strip that suffix; if it doesn't match (older CLI
-              // behavior), keep the whole buffer as the thoughts.
-              const cut = buffer.endsWith(event.text)
-                ? buffer.slice(0, buffer.length - event.text.length)
-                : buffer;
-              const thoughts = cut.trim();
+            // Peel narration ONLY on a genuine suffix match (deltas may prepend a
+            // separator before the final answer, so the buffer ends with it). A
+            // mismatched buffer is NOT narration — it's a fallen-short delta stream
+            // (coalesced deltas on a non-agentic run) or a drifted wire format; a
+            // spurious "thoughts" copy of the review body is worse than no thoughts.
+            if (
+              event.text.trim() &&
+              buffer !== event.text &&
+              buffer.endsWith(event.text)
+            ) {
+              const thoughts = buffer
+                .slice(0, buffer.length - event.text.length)
+                .trim();
               if (thoughts) onThoughts?.(thoughts);
             }
             resolve();

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -290,7 +290,7 @@ async function run(event: AutomationEvent): Promise<void> {
       ).catch(() => undefined);
     };
     try {
-      const text = await generateReviewText(
+      const result = await generateReviewText(
         settings.reviewAi,
         action,
         event,
@@ -303,11 +303,15 @@ async function run(event: AutomationEvent): Promise<void> {
         toast.info(`AI ${label} cancelled.`, { duration: 4000 });
         continue;
       }
-      if (text === null) {
+      if (result === null) {
         releaseClaim();
         toast.info(`AI ${label} skipped — no changes to review.`);
         continue;
       }
+      const { text, thoughts } = result;
+      // The delivered comment body carries the final review text ONLY — the
+      // agentic narration is persisted to history for later inspection, never
+      // posted (buildAiCommentBody + deliver both take `text`).
       const body = buildAiCommentBody({
         kind: label,
         model: settings.reviewAi.model,
@@ -325,6 +329,7 @@ async function run(event: AutomationEvent): Promise<void> {
           action,
           text,
           settings.reviewAi.model,
+          thoughts,
         ).catch(() => undefined);
       }
     } catch (e) {
@@ -348,10 +353,18 @@ async function run(event: AutomationEvent): Promise<void> {
   }
 }
 
+/** A completed automated review: the final answer `text` plus any agentic
+ *  narration `thoughts` (empty for non-agentic / codex / HTTP-text runs). */
+interface ReviewResult {
+  text: string;
+  thoughts: string;
+}
+
 /**
  * Resolves the diff, builds the prompt, and runs the model to completion.
  * `signal` aborts the HTTP stream; `onCliId` reports the CLI run's id so the
  * caller can kill the subprocess (CLI providers don't take an AbortSignal).
+ * Returns the final answer plus any agentic narration, or null for no changes.
  */
 async function generateReviewText(
   ai: AiSettings,
@@ -359,7 +372,7 @@ async function generateReviewText(
   event: AutomationEvent,
   signal: AbortSignal,
   onCliId: (id: string) => void,
-): Promise<string | null> {
+): Promise<ReviewResult | null> {
   let diff: { text: string; truncated: boolean; files: DiffStatEntry[] };
   if (event.kind === "commit") {
     diff = await gitCommitDiff(event.repoPath, event.hash, DIFF_MAX_BYTES);
@@ -466,6 +479,7 @@ async function generateReviewText(
   // route them the same way the interactive review does.
   if (isCliProvider(ai.provider)) {
     let result = "";
+    let thoughts = "";
     await runCliStream({
       ai,
       system,
@@ -474,14 +488,18 @@ async function generateReviewText(
       // Read the reviewed commit / PR-head's files in a worktree, not whatever
       // branch happens to be checked out.
       headSha: event.kind === "commit" ? event.hash : event.headSha,
-      // runCliStream accumulates; the last setText carries the full text.
+      // runCliStream replaces with the agent's final answer on done; the last
+      // setText carries that clean review body (narration is peeled into onThoughts).
       setText: (t) => {
         result = t;
       },
       setStatus: () => undefined,
       registerId: onCliId,
+      onThoughts: (t) => {
+        thoughts = t;
+      },
     });
-    return result;
+    return { text: result, thoughts };
   }
 
   const client = await createAiClient(ai);
@@ -496,7 +514,8 @@ async function generateReviewText(
   })) {
     buffer += chunk;
   }
-  return buffer;
+  // The plain HTTP text path has no tool narration.
+  return { text: buffer, thoughts: "" };
 }
 
 async function deliver(
@@ -597,14 +616,16 @@ async function deliver(
  * Persists an automated PR review into the keyed history store (same shape +
  * key the interactive path uses), so the next review of that PR + mode builds
  * on it. Keyed by `(kind, ref, mode)`; `text` is the raw findings, not the
- * comment-wrapped body. Invalidates the panel's history query so an open Review
- * tab reflects it immediately.
+ * comment-wrapped body. `thoughts` is the agentic narration (display-only, never
+ * fed forward). Invalidates the panel's history query so an open Review tab
+ * reflects it immediately.
  */
 async function persistReviewHistory(
   event: PrAutomationEvent,
   mode: ReviewMode,
   text: string,
   model: string,
+  thoughts: string,
 ): Promise<void> {
   if (!text.trim()) return;
   const kind = event.target.type;
@@ -619,6 +640,8 @@ async function persistReviewHistory(
     model,
     title: event.title,
     text,
+    // Display-only narration (omitted when empty; never fed to the next run).
+    ...(thoughts.trim() ? { thoughts } : {}),
     headSha: event.headSha ?? "",
     startedAt: now,
     finishedAt: now,

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -25,6 +25,11 @@ export interface PersistedReview {
   title: string;
   /** Raw finding markdown — the soft context fed into the next run. */
   text: string;
+  /** The agentic run's streamed working narration ("Let me check…"), shown behind
+   *  a collapsed "Thought process" disclosure. DISPLAY-ONLY metadata — never fed
+   *  into the next run's soft context (that reads `text` alone). Absent for
+   *  non-agentic / codex runs. Additive optional field; schemaVersion stays 1. */
+  thoughts?: string;
   /** PR head at the time this review ran — the delta anchor for the next run. */
   headSha: string;
   startedAt: number;

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -98,6 +98,10 @@ export interface ReviewEntry {
    *  upgrade nudge. A tool-bearing run handles its own coverage, so this stays
    *  false there. */
   truncatedCoverage?: boolean;
+  /** The agentic run's streamed working narration, set once at settle (arrives via
+   *  a single patch, so it lives on the entry, not the per-token `texts` map). The
+   *  panel shows it behind a "Thought process" disclosure; the dock ignores it. */
+  thoughts?: string;
 }
 
 /** A store entry tagged with its key — what the activity dock renders. */
@@ -338,6 +342,7 @@ export async function startReview(
     error: "",
     deltaState: undefined,
     truncatedCoverage: undefined,
+    thoughts: undefined,
   });
 
   // Wall-clock start for the persisted history record (the store itself orders
@@ -459,6 +464,7 @@ export async function startReview(
       reviewTools,
       setText: pushText,
       setStatus: (s) => patch({ status: s }),
+      onThoughts: (t) => patch({ thoughts: t }),
       onCliId: (id) => {
         control.cliReviewId = id;
       },
@@ -480,6 +486,9 @@ export async function startReview(
     // paths); a cancelled run returns above, so no mid-stream fragment is ever
     // stored. Best-effort — a persistence failure must not surface to the user.
     const finalText = useReviewStore.getState().texts[key] ?? "";
+    // The agentic run's narration, peeled off at settle — persisted as display-only
+    // metadata (omitted when empty; the next run's soft context reads `text` alone).
+    const thoughts = useReviewStore.getState().entries[key]?.thoughts;
     if (finalText.trim()) {
       void saveReview(target.repoPath, {
         schemaVersion: 1,
@@ -490,6 +499,7 @@ export async function startReview(
         model: ai.model,
         title,
         text: finalText,
+        ...(thoughts?.trim() ? { thoughts } : {}),
         // Empty when the view supplied no head (degenerate no-commits state);
         // the next run then routes to the safe "indeterminate" delta path and
         // self-heals once a later review records a real SHA.
@@ -701,5 +711,8 @@ export function useReviewRun(target: ReviewTarget) {
     phase: entry.phase,
     /** Failure message when `phase === "error"`. */
     error: entry.error,
+    /** The finished agentic run's streamed narration — shown behind a collapsed
+     *  "Thought process" disclosure. Empty on non-agentic / codex runs. */
+    thoughts: entry.thoughts ?? "",
   };
 }


### PR DESCRIPTION
AI agentic reviews no longer append their streamed working narration (prose like "I'll examine the code… let me check the call sites…") to the review body. Instead, only the final answer is retained as the review, while the narration appears under a collapsible **Thought process** disclosure. This sharpens review output and keeps exploration details accessible but separate. The behavior is consistent across agentic CLI reviews, HTTP reviews, automation-posted comments, and research report synthesis.

### AI streaming and agentic review separation
- Refactors narration streaming and segment handling in `src-tauri/src/agent.rs` to ensure Copilot, Claude, and Opencode agentic reviewers only emit the authoritative final answer as the review body, with preceding narration stripped.
- Adds and improves tests in `src-tauri/src/agent.rs` for correct narration separation and delta buffer invariants.
- Updates `src/lib/ai/client.ts` and `src/lib/ai/stream.ts` to split narration (`thoughts`) from the review (`text`) at the point of agentic tool steps or stream settle.
- Ensures narration is only surfaced via a new optional `thoughts` field, set via the streaming APIs' `onThoughts` hook.

### Review storage, automation, and research
- Extends `PersistedReview` in `src/lib/pulls/reviews-history.ts` with optional `thoughts` to persist agentic narration as display-only metadata.
- Updates review history handling and save logic in `src/lib/stores/reviews.ts`, ensuring automated and manual reviews save narration separately and do not feed it forward.
- Adjusts `src/features/research/store.ts` to stop leaking tool-streamed narration into distillates, adopting only the final answer for report synthesis.
- Refactors `src/lib/automations/runner.ts` to pass narration and save separately, never including narration in GitHub comments or review bodies.

### UI and user experience
- Adds the new `ThoughtsDisclosure` collapsible component in `src/features/pulls/ThoughtsDisclosure.tsx` to display the stripped narration under "Thought process".
- Integrates `ThoughtsDisclosure` into the live panel (`src/features/pulls/PrReviewPanel.tsx`) and review history (`src/features/pulls/ReviewHistory.tsx`), ensuring narration is available but unobtrusive.
- Updates automation- and agentic-run documentation in `src/features/help/content.ts` to clarify narration handling and where to find agentic reasoning.

### Changelog
- Adds `changelog.d/fixed-review-narration-trim.md` documenting that agentic narration is now separated from review bodies and shown under "Thought process".