### PR TITLE
feat(repo-settings,forks,remotes): add Danger zone fork detach actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,10 @@ workflow against any two branches with no remote at all).
   fork; also the **Switch to fork / upstream view** palette commands) points the remote
   PR list — and every PR you open under it: description, comments, reviews, and metadata —
   at your fork or the **parent** repository. Opening a PR targets a repository explicitly,
-  offering your fork or the upstream repo on a fork.
+  offering your fork or the upstream repo on a fork. When you're done with a fork, the
+  settings **Danger zone** can **remove the upstream remote** (a local detach — reversible)
+  or, on GitHub, link out to **leave the fork network** entirely (permanent, done on
+  github.com), with a **Re-check fork status** button that refreshes the fork badge in place.
 
 A Write/Preview markdown editor (formatting toolbar + live preview) is everywhere you author.
 

--- a/changelog.d/added-fork-detach.md
+++ b/changelog.d/added-fork-detach.md
@@ -1,0 +1,7 @@
+- **Detach from a fork.** The repository settings Danger zone now offers two ways
+  to break a fork's ties: **Remove upstream remote** detaches your clone from the
+  parent locally (the Fork/Upstream switcher and "Update from upstream" disappear;
+  reversible by re-adding the remote), and, on GitHub, **Leave fork network** links
+  out to github.com to permanently detach the repository from its fork network —
+  with a **Re-check fork status** button that refreshes the fork badge in place once
+  you've done it.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -101,6 +101,7 @@ export const capabilities: Capability[] = [
   // — Repository & workspace —
   { group: "Repository & workspace", label: "Clone, add local, create (README/.gitignore/license) or fork" },
   { group: "Repository & workspace", label: "Update a fork from its upstream — fetch, then fast-forward or merge" },
+  { group: "Repository & workspace", label: "Detach from a fork — remove the upstream remote; leave the fork network on GitHub" },
   { group: "Repository & workspace", label: "Publish a local repo to GitHub, GitLab or Bitbucket" },
   { group: "Repository & workspace", label: "Worktree manager — create, switch, promote & remove", highlight: true },
   { group: "Repository & workspace", label: "Submodule status & update" },

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -170,6 +170,46 @@ pub async fn git_remote_add(
     Ok(())
 }
 
+/// Remove a remote (`git remote remove <name>`) — the "Detach from fork"
+/// action, dropping the `upstream` remote a fork was given so the fork/upstream
+/// lens stops treating the repo as a fork. Generic over the remote name.
+///
+/// What git does on remove (git-remote(1) / `builtin/remote.c`): it deletes the
+/// entire `remote.<name>` config section, unsets `branch.<b>.remote` /
+/// `branch.<b>.merge` for every branch that was tracking this remote (leaving
+/// those branches with **no** upstream — they are not re-pointed at another
+/// remote), and deletes the remote-tracking refs under
+/// `refs/remotes/<name>/`. The remote must exist first — [`ensure_remote_exists`]
+/// turns an unknown name into an honest `InvalidArgument` (and rejects the
+/// `-flag` injection shape) rather than a confusing raw-git error.
+#[tauri::command]
+pub async fn git_remote_remove(
+    state: State<'_, AppState>,
+    repo_path: String,
+    name: String,
+) -> AppResult<()> {
+    git_remote_remove_core(&state, repo_path, name).await
+}
+
+pub(crate) async fn git_remote_remove_core(
+    state: &AppState,
+    repo_path: String,
+    name: String,
+) -> AppResult<()> {
+    ensure_remote_exists(&repo_path, &name).await?;
+    run_git_mutating(
+        state,
+        &repo_path,
+        &["remote", "remove", &name],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    // The remote (and its URL) no longer exists — drop any cached URL so a forge
+    // query firing within the TTL doesn't serve the removed remote's stale value.
+    cache_invalidate(&repo_path, &name);
+    Ok(())
+}
+
 /// Names of the configured remotes (e.g. `["origin"]`), empty for a local repo.
 #[tauri::command]
 pub async fn git_remotes(repo_path: String) -> AppResult<Vec<String>> {
@@ -366,7 +406,10 @@ pub(crate) async fn git_push_core(
 
 #[cfg(test)]
 mod tests {
-    use super::{cache_get, cache_invalidate, cache_put};
+    use super::{cache_get, cache_invalidate, cache_put, git_remote_remove_core};
+    use crate::error::AppError;
+    use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
+    use crate::state::AppState;
     use std::time::Duration;
 
     // Distinct keys per test — the cache is a process-wide static shared across all tests.
@@ -425,5 +468,145 @@ mod tests {
     #[test]
     fn miss_returns_none() {
         assert_eq!(cache_get("/repo/never-written", "origin", BIG), None);
+    }
+
+    // --- Real-repo tests for git_remote_remove (temp_dir, git on PATH). ---
+
+    async fn run(repo: &str, args: &[&str]) -> String {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+    }
+
+    /// A unique temp base dir for a test, cleaned up by the caller.
+    fn temp_base(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-remote-{}-{}-{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    async fn init_repo(repo_s: &str, seed_file: &str) {
+        run(repo_s, &["init", "-q"]).await;
+        run(repo_s, &["config", "user.email", "t@t.local"]).await;
+        run(repo_s, &["config", "user.name", "T"]).await;
+        std::fs::write(std::path::Path::new(repo_s).join(seed_file), "hello\n").unwrap();
+        run(repo_s, &["add", "-A"]).await;
+        run(repo_s, &["commit", "-qm", "seed"]).await;
+    }
+
+    /// Add an `upstream` remote (a second local repo), fetch it, point a branch's
+    /// upstream at it, then remove it via `git_remote_remove_core` and assert git
+    /// tore down everything: the remote is gone from `git remote`, the branch's
+    /// `branch.<b>.remote` config is unset, and `refs/remotes/upstream/` is empty.
+    #[tokio::test]
+    async fn remove_drops_remote_tracking_and_branch_upstream() {
+        let base = temp_base("remove");
+        let repo = base.join("repo");
+        let up = base.join("upstream");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&up).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        let up_s = up.to_string_lossy().into_owned();
+
+        // The upstream repo, with a commit so it has a branch to fetch.
+        init_repo(&up_s, "u.txt").await;
+        let up_branch = run(&up_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        // The consuming repo, with its own branch.
+        init_repo(&repo_s, "a.txt").await;
+        let branch = run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        // Add + fetch upstream by file path, then track upstream/<branch>.
+        run(&repo_s, &["remote", "add", "upstream", &up_s]).await;
+        run(&repo_s, &["fetch", "-q", "upstream"]).await;
+        run(
+            &repo_s,
+            &[
+                "branch",
+                &format!("--set-upstream-to=upstream/{up_branch}"),
+                &branch,
+            ],
+        )
+        .await;
+
+        // Preconditions: the remote is listed, the branch tracks it, refs exist.
+        assert!(run(&repo_s, &["remote"]).await.contains("upstream"));
+        assert_eq!(
+            run(&repo_s, &["config", &format!("branch.{branch}.remote")])
+                .await
+                .trim(),
+            "upstream"
+        );
+        assert!(!run(&repo_s, &["for-each-ref", "refs/remotes/upstream/"])
+            .await
+            .trim()
+            .is_empty());
+
+        // Remove via the command core.
+        let state = AppState::default();
+        git_remote_remove_core(&state, repo_s.clone(), "upstream".into())
+            .await
+            .expect("remove succeeds");
+
+        // The remote is gone.
+        assert!(!run(&repo_s, &["remote"]).await.contains("upstream"));
+        // The branch's upstream config is unset — `git config` exits non-zero.
+        assert!(
+            run_git(
+                Some(&repo_s),
+                &["config", &format!("branch.{branch}.remote")],
+                DEFAULT_TIMEOUT,
+            )
+            .await
+            .is_err(),
+            "branch.<b>.remote is unset after removal"
+        );
+        // The remote-tracking refs are gone.
+        assert!(
+            run(&repo_s, &["for-each-ref", "refs/remotes/upstream/"])
+                .await
+                .trim()
+                .is_empty(),
+            "refs/remotes/upstream/ is empty after removal"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Removing a remote that doesn't exist is an honest `InvalidArgument`, not a
+    /// raw git error — the `ensure_remote_exists` gate.
+    #[tokio::test]
+    async fn remove_nonexistent_remote_errors_invalid_argument() {
+        let base = temp_base("missing");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "a.txt").await;
+
+        let state = AppState::default();
+        let err = git_remote_remove_core(&state, repo_s.clone(), "upstream".into())
+            .await
+            .expect_err("removing a missing remote errors");
+        match err {
+            AppError::InvalidArgument(msg) => {
+                assert_eq!(msg, "remote does not exist: upstream");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -629,6 +629,7 @@ pub fn run() {
             git::remote::git_remote_url,
             git::remote::git_remote_set_url,
             git::remote::git_remote_add,
+            git::remote::git_remote_remove,
             git::submodule::git_submodules,
             git::submodule::git_submodule_update,
             secrets::set_secret,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -165,7 +165,12 @@ like this:
 - **Danger zone** — **rename**, **archive / unarchive**, **change visibility**,
   **transfer ownership**, and **delete** the repository. The three irreversible actions
   are each behind a type-the-\`owner/repo\`-name confirmation, and your local clone is
-  never touched.
+  never touched. When the repo has an **upstream remote**, **Remove upstream remote**
+  detaches this clone from the parent locally (the Fork/Upstream switcher and "Update
+  from upstream" disappear — reversible by re-adding the remote). On a **fork**, **Leave
+  fork network** links out to GitHub to permanently detach the repository from its fork
+  network (GitHub has no API for this; it's done on the web and can't be undone). After
+  you leave the network on GitHub, **Re-check fork status** refreshes the badge in place.
 
 > Some options GitHub exposes to no app appear as **"Manage on GitHub"** links rather
 > than dead toggles.

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -376,19 +376,28 @@ function LeaveForkNetworkAction({
   if (record?.isFork !== true) return null;
 
   // Derive the host — on GitHub Enterprise the provider is still "github" but a
-  // hardcoded github.com would open the wrong host's settings page.
-  const ghHost = forge.data?.host || "github.com";
+  // hardcoded github.com would open the wrong host's settings page. While the
+  // forge status is still resolving (or errored — retry: false), fall back to
+  // the persisted RecentRepo host, which is available synchronously.
+  const ghHost = forge.data?.host || record?.host || "github.com";
 
   const recheck = async () => {
     setRechecking(true);
     try {
       const probe = await probeAndPersistVisibility(repoPath);
       queryClient.invalidateQueries({ queryKey: settingsKeys.settings });
-      toast.success(
-        probe?.isFork
-          ? "Still a fork on GitHub"
-          : "No longer a fork — badge cleared",
-      );
+      // A null probe means no provider was detected (e.g. the origin remote is
+      // gone) — the badge still clears, but don't present that as a verified
+      // detach.
+      if (probe === null) {
+        toast.success("Couldn't verify on GitHub — fork badge cleared");
+      } else {
+        toast.success(
+          probe.isFork
+            ? "Still a fork on GitHub"
+            : "No longer a fork — badge cleared",
+        );
+      }
     } catch (e) {
       toastError(e);
     } finally {

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -26,10 +26,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { probeAndPersistVisibility } from "@/features/repository/useRepoVisibilityProbe";
 import {
   useBbRepoSettings,
   useDeleteRepo,
+  useForgeStatus,
   useGlRepoSettings,
+  useRemotes,
+  useRemoveRemote,
   useRenameRepo,
   useRepoAdmin,
   useRepoSettings,
@@ -37,6 +41,8 @@ import {
   useSetVisibility,
   useTransferRepo,
 } from "@/lib/git/queries";
+import { deleteRepoLens } from "@/lib/repo-lens/store";
+import { settingsKeys, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { InlineConfirm } from "./parts";
@@ -286,6 +292,139 @@ function ArchiveAction({
         </DangerButton>
       )}
     </Row>
+  );
+}
+
+/** Local detach: drop the `upstream` remote, collapsing every fork-identity
+ *  surface (the origin/upstream switcher, "Update from upstream", "Create on
+ *  parent") via the broad `["repo", repo]` invalidation. Reversible — the user
+ *  can re-add the remote (CreatePrDialog's Add-upstream affordance returns for a
+ *  known fork). Shown for ANY provider whenever an `upstream` remote exists;
+ *  never fakes the persisted `isFork` provenance (that reflects GitHub-side
+ *  truth and only changes via re-probe). */
+function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
+  const remotes = useRemotes(repoPath);
+  const removeRemote = useRemoveRemote(repoPath);
+  const [confirming, setConfirming] = useState(false);
+
+  if (!remotes.data?.includes("upstream")) return null;
+
+  return (
+    <>
+      <div className="border-t" />
+      <Row
+        title="Remove upstream remote"
+        desc="Detaches this clone from the fork's parent locally: the Fork/Upstream switcher and “Update from upstream” disappear, and branches that tracked upstream lose their tracking. Reversible — re-add the remote to restore it."
+      >
+        {confirming ? (
+          <div className="flex shrink-0 items-center gap-2">
+            <InlineConfirm
+              actLabel="Remove"
+              pending={removeRemote.isPending}
+              onCancel={() => setConfirming(false)}
+              onAct={() =>
+                removeRemote.mutate(
+                  { name: "upstream" },
+                  {
+                    onSuccess: () => {
+                      // Hygiene: the persisted "upstream" lens no longer applies.
+                      // Fire-and-forget — the lens read safe-defaults to origin,
+                      // so a failure here is harmless.
+                      deleteRepoLens(repoPath).catch(() => undefined);
+                      toast.success("Upstream remote removed");
+                      setConfirming(false);
+                    },
+                    onError: toastError,
+                  },
+                )
+              }
+            />
+          </div>
+        ) : (
+          <DangerButton
+            variant="outline"
+            className="shrink-0"
+            onClick={() => setConfirming(true)}
+          >
+            Remove upstream
+          </DangerButton>
+        )}
+      </Row>
+    </>
+  );
+}
+
+/** GitHub-only link-out: GitHub has NO API to leave a fork network, so we send
+ *  the user to the repo's settings page. A "Re-check fork status" affordance
+ *  re-probes and re-persists after they detach on github.com, so the fork badge
+ *  + persisted `isFork` clear without an app restart — never cleared
+ *  optimistically (it reflects GitHub-side truth). Gated on the persisted fork
+ *  provenance, independent of the upstream-remote gate. */
+function LeaveForkNetworkAction({
+  repoPath,
+  fullName,
+}: {
+  repoPath: string;
+  fullName: string;
+}) {
+  const queryClient = useQueryClient();
+  const settings = useSettings();
+  const forge = useForgeStatus(repoPath);
+  const [rechecking, setRechecking] = useState(false);
+  const record = settings.data?.recentRepos.find((r) => r.path === repoPath);
+
+  if (record?.isFork !== true) return null;
+
+  // Derive the host — on GitHub Enterprise the provider is still "github" but a
+  // hardcoded github.com would open the wrong host's settings page.
+  const ghHost = forge.data?.host || "github.com";
+
+  const recheck = async () => {
+    setRechecking(true);
+    try {
+      const probe = await probeAndPersistVisibility(repoPath);
+      queryClient.invalidateQueries({ queryKey: settingsKeys.settings });
+      toast.success(
+        probe?.isFork
+          ? "Still a fork on GitHub"
+          : "No longer a fork — badge cleared",
+      );
+    } catch (e) {
+      toastError(e);
+    } finally {
+      setRechecking(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="border-t" />
+      <Row
+        title="Leave fork network"
+        desc="Permanently detaches this repository from its fork network on GitHub — this cannot be undone. GitHub requires the fork be public, under 1 GB, and have no child forks. Your code and history are kept; issues, PRs, stars, and watchers are lost."
+      >
+        {/* Stacked so the description keeps its width — two side-by-side
+            buttons squeezed the copy into a tall, narrow column. */}
+        <div className="flex shrink-0 flex-col gap-2">
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => openUrl(`https://${ghHost}/${fullName}/settings`)}
+          >
+            Leave on GitHub…
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={rechecking}
+            onClick={recheck}
+          >
+            {rechecking && <Spinner data-icon="inline-start" />}
+            Re-check fork status
+          </Button>
+        </div>
+      </Row>
+    </>
   );
 }
 
@@ -639,6 +778,14 @@ export function DangerZone({
         isGitLab={isGitLab}
         isBitbucket={isBitbucket}
       />
+      {/* Local detach — any provider, whenever an `upstream` remote exists. */}
+      <RemoveUpstreamAction repoPath={repoPath} />
+      {/* Leave-fork-network — GitHub only, gated on persisted fork provenance.
+          Gates are independent: a detached-on-GitHub repo may still have the
+          remote; a remote-less fork may still be in the network. */}
+      {isGitHub && (
+        <LeaveForkNetworkAction repoPath={repoPath} fullName={info.fullName} />
+      )}
       {/* Bitbucket can't archive over the API — hide the row (platform limit). */}
       {!isBitbucket && (
         <>

--- a/src/features/repository/useRepoVisibilityProbe.ts
+++ b/src/features/repository/useRepoVisibilityProbe.ts
@@ -1,8 +1,45 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { forgeRepoVisibility, gitRepoOwners } from "@/lib/git/api";
+import {
+  forgeRepoVisibility,
+  gitRepoOwners,
+  type RepoVisibility,
+} from "@/lib/git/api";
 import { persistRepoVisibility } from "@/lib/settings/api";
 import { settingsKeys } from "@/lib/settings/queries";
+
+/**
+ * Probe a repo's hosted visibility + fork provenance and persist the result,
+ * returning the fresh probe (or `null` when the repo has no known provider — a
+ * removed/absent remote, which persists `{ visibility: null }` so a stale badge
+ * clears). Shared by the ambient open-time probe below and the Danger zone's
+ * "Re-check fork status" affordance, so the fork badge + persisted `isFork`
+ * converge without an app restart after the user leaves the fork network on
+ * GitHub. Persistence is serialized against the other recentRepos writers.
+ *
+ * A rejection propagates to the caller (the ambient probe swallows it; the
+ * Danger-zone re-check surfaces it as a toast). Does NOT invalidate the settings
+ * query — the caller decides whether to (the ambient probe does).
+ */
+export async function probeAndPersistVisibility(
+  repoPath: string,
+): Promise<RepoVisibility | null> {
+  const [owner] = await gitRepoOwners([repoPath]);
+  if (!owner?.provider) {
+    await persistRepoVisibility([{ path: repoPath, visibility: null }]);
+    return null;
+  }
+  const probe = await forgeRepoVisibility(repoPath);
+  await persistRepoVisibility([
+    {
+      path: repoPath,
+      visibility: probe.visibility,
+      isFork: probe.isFork,
+      forkParent: probe.parent ?? undefined,
+    },
+  ]);
+  return probe;
+}
 
 /**
  * On every successful repo open (this fires for every `repoPath` — including
@@ -22,45 +59,23 @@ import { settingsKeys } from "@/lib/settings/queries";
  * Persistence goes through the raw helper + a captured queryClient (both stable
  * across unmount), NOT a component-bound mutation: the repo view unmounts when
  * the repo closes, and a probe in flight at that moment must still land its
- * result. `cancelled` only skips STARTING the second (network) probe — a value
- * already resolved is always persisted (it's keyed by its own repo's path, so
- * writing it after a repo switch is still correct, never a stale cross-repo
- * write). `persistRepoVisibility` is serialized against the other recentRepos
- * writers, so it can't lose an update.
+ * result. A value already resolved is always persisted (it's keyed by its own
+ * repo's path, so writing it after a repo switch is still correct, never a stale
+ * cross-repo write). `persistRepoVisibility` is serialized against the other
+ * recentRepos writers, so it can't lose an update.
  */
 export function useRepoVisibilityProbe(repoPath: string | null) {
   const queryClient = useQueryClient();
   // biome-ignore lint/correctness/useExhaustiveDependencies: queryClient is stable; re-run only when the open path changes
   useEffect(() => {
     if (!repoPath) return;
-    let cancelled = false;
-    const persist = async (
-      visibility: string | null,
-      isFork?: boolean,
-      forkParent?: string,
-    ) => {
-      await persistRepoVisibility([
-        { path: repoPath, visibility, isFork, forkParent },
-      ]);
-      queryClient.invalidateQueries({ queryKey: settingsKeys.settings });
-    };
     (async () => {
       try {
-        const [owner] = await gitRepoOwners([repoPath]);
-        if (!owner?.provider) {
-          await persist(null);
-          return;
-        }
-        if (cancelled) return;
-        const { visibility, isFork, parent } =
-          await forgeRepoVisibility(repoPath);
-        await persist(visibility, isFork, parent ?? undefined);
+        await probeAndPersistVisibility(repoPath);
+        queryClient.invalidateQueries({ queryKey: settingsKeys.settings });
       } catch {
         // Ambient metadata — a failed probe leaves the persisted value alone.
       }
     })();
-    return () => {
-      cancelled = true;
-    };
   }, [repoPath]);
 }

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -719,6 +719,9 @@ export const gitRemoteSetUrl = (repoPath: string, name: string, url: string) =>
 export const gitRemoteAdd = (repoPath: string, name: string, url: string) =>
   invoke<void>("git_remote_add", { repoPath, name, url });
 
+export const gitRemoteRemove = (repoPath: string, name: string) =>
+  invoke<void>("git_remote_remove", { repoPath, name });
+
 export const gitSubmodules = (repoPath: string) =>
   invoke<Submodule[]>("git_submodules", { repoPath });
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2780,6 +2780,17 @@ export function useAddRemote(repo: string) {
   );
 }
 
+/** Removes a remote (e.g. dropping `upstream` to detach a clone from the fork's
+ *  parent). The default broad invalidation (`["repo", repo]`) prefix-covers the
+ *  `remotes` and `remote-url` queries, so `useLensGate` re-reads and every
+ *  fork-identity surface — the origin/upstream switcher, "Update from upstream",
+ *  and "Create on parent" — collapses live once the remote is gone. */
+export function useRemoveRemote(repo: string) {
+  return useRepoMutation(repo, (args: { name: string }) =>
+    api.gitRemoteRemove(repo, args.name),
+  );
+}
+
 export function useOpState(repo: string) {
   return useQuery({
     queryKey: ["repo", repo, "op-state"] as const,

--- a/src/lib/repo-lens/store.ts
+++ b/src/lib/repo-lens/store.ts
@@ -38,3 +38,12 @@ export async function saveRepoLens(
   const id = await repoIdentity(repo);
   await store.set(id, lens);
 }
+
+/** Drop the persisted lens for a repo (hygiene after detaching from a fork —
+ *  the upstream remote is gone, so a stale "upstream" entry no longer applies).
+ *  Any subsequent read safe-defaults to "origin". */
+export async function deleteRepoLens(repo: string): Promise<void> {
+  const store = await getStore();
+  const id = await repoIdentity(repo);
+  await store.delete(id);
+}

--- a/src/lib/transport/install-desktop.ts
+++ b/src/lib/transport/install-desktop.ts
@@ -1,5 +1,5 @@
-import { desktopTransport } from "@/lib/transport/desktop";
 import { installTransport } from "@/lib/transport";
+import { desktopTransport } from "@/lib/transport/desktop";
 
 // Side-effect-only module: importing it installs the Tauri-backed transport.
 // The app entry (main.tsx) imports this FIRST so the transport is in place


### PR DESCRIPTION
This change expands the repository settings Danger zone to support detaching a fork from its upstream, both locally and (for GitHub) at the network level, addressing common workflows for un-forking or disconnecting a repository. By allowing local removal of the upstream remote, and linking out to GitHub's irreversible "Leave fork network", users gain explicit controls to break fork ties, with live feedback and UI updates reflecting the changed repository state.

### Danger zone: fork detach actions
- Adds `Remove upstream remote` action in `src/features/repo-settings/DangerZone.tsx` that allows users to drop the `upstream` remote locally, updating UI state and clearing any persisted lens for the repo via `deleteRepoLens` in `src/lib/repo-lens/store.ts`.
- Adds `Leave fork network` GitHub-only action, which links out to the repository's settings page on github.com and provides a `Re-check fork status` button that probes and persists new fork state, updating the badge live.

### Git backend and API
- Implements `git_remote_remove` Tauri command and core logic in `src-tauri/src/git/remote.rs`, including robust error checking and new integration tests validating remote removal behavior.
- Exposes `gitRemoteRemove` in `src/lib/git/api.ts` and integrates with React Query mutation (`useRemoveRemote` in `src/lib/git/queries.ts`) for use by the front-end.

### Repo fork metadata and badge refresh
- Refactors and shares fork badge re-probe logic as `probeAndPersistVisibility` in `src/features/repository/useRepoVisibilityProbe.ts`, enabling both background repo-open refresh and on-demand recheck from Danger zone.
- Ensures settings refresh and badge clearing behaviors are consistent and live after detachment operations.

### UX and documentation
- Updates `README.md` to document the detach options and their scope—both reversible local removal and irreversible network leave.
- Clarifies Danger zone fork detach options and UI flow in `src/features/help/content.ts`.
- Adds a new changelog entry in `changelog.d/added-fork-detach.md` explaining the new fork detach capabilities.