### PR TITLE
feat(lan,settings,git): add phone companion preview for LAN repo sharing

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -1,0 +1,5 @@
+- **Phone companion (experimental preview).** Share the open repository with your
+  phone over your local network from **Settings → Phone companion**: pair a device by
+  scanning a QR code and typing a PIN. This early preview exposes read-only API access
+  to the open repo — the companion phone app arrives in an upcoming release. Off by
+  default, with per-device tokens you can revoke at any time.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -223,6 +223,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -475,6 +539,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +579,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
@@ -594,6 +675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +715,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -668,12 +767,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -691,14 +814,31 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-url"
@@ -749,6 +889,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,8 +946,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -926,6 +1108,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1393,8 +1581,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1433,16 +1633,21 @@ dependencies = [
 name = "gitdesktop"
 version = "0.3.1"
 dependencies = [
+ "axum",
  "base64 0.22.1",
  "chrono",
  "dirs",
  "keyring",
+ "local-ip-address",
  "os_info",
  "portable-pty",
+ "qrcode",
+ "rand 0.10.2",
  "rmcp",
  "serde",
  "serde_json",
  "sha1",
+ "sha2 0.11.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -1456,6 +1661,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "trash",
  "uuid",
  "windows-sys 0.61.2",
@@ -1692,6 +1898,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +1926,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2210,6 +2432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
+dependencies = [
+ "libc",
+ "neli",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2485,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2344,6 +2583,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "neli"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "derive_builder",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3044,6 +3312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,7 +3364,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3144,7 +3418,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3154,7 +3439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3165,6 +3450,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-window-handle"
@@ -3389,7 +3680,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -3731,6 +4022,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3797,7 +4099,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3852,8 +4154,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3863,8 +4165,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4282,7 +4595,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -4396,7 +4709,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4788,6 +5101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,6 +5258,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4971,6 +5297,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5041,6 +5368,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typeid"
@@ -6163,7 +6506,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = { version = "3", features = ["windows-native", "apple-native", "sync-secret-service"] }
 trash = "5"
-tokio = { version = "1", features = ["process", "time", "macros", "sync", "rt-multi-thread", "io-std"] }
+tokio = { version = "1", features = ["process", "time", "macros", "sync", "rt-multi-thread", "io-std", "net"] }
 thiserror = "2"
 base64 = "0.22.1"
 tauri-plugin-notification = "2.3.3"
@@ -55,6 +55,17 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # `sha1_hex(file_path)_<old_pos>_<new_pos>` (see forge/gitlab.rs `gl_line_code`).
 # RustCrypto sha1 — hashing only, no extra default features needed.
 sha1 = "0.10"
+# LAN phone-companion server (src/lan/): an embedded, default-OFF axum HTTP server
+# that lets a paired phone read the active repo over the LAN. `ws` is enabled now
+# (slice 2 needs it; cheaper to land the feature up front). `sha2`/`rand` back the
+# pairing challenge/response + bearer tokens; `qrcode` renders the pairing QR as an
+# inline SVG (svg-only — no `image` default feature); `local-ip-address` enumerates
+# the machine's LAN IPv4s for the advertised urls.
+axum = { version = "0.8.9", features = ["ws"] }
+sha2 = "0.11.0"
+rand = "0.10.2"
+qrcode = { version = "0.14.1", default-features = false, features = ["svg"] }
+local-ip-address = "0.6.13"
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
@@ -79,3 +90,8 @@ windows-sys = { version = "0.61", features = [
 # vendor/portable-pty/src/win/psuedocon.rs. Drop this when fixed upstream (wezterm).
 [patch.crates-io]
 portable-pty = { path = "vendor/portable-pty" }
+
+# `tower::ServiceExt::oneshot` drives the LAN router in unit tests without opening
+# a socket (auth/host/allowlist assertions in src/lan/).
+[dev-dependencies]
+tower = { version = "0.5.3", features = ["util"] }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1956,7 +1956,7 @@ pub async fn agent_review(
     // it, fanning events out to the LAN broadcast alongside the desktop channel.
     // The guard clears the entry on every exit path (registered lifetime ==
     // streaming lifetime); the desktop leg stays byte-for-byte unchanged.
-    let tx = state.register_stream(&review_id, "review");
+    let tx = state.register_stream(&review_id, "review", &repo_path);
     let _stream_guard = StreamGuard {
         state: &state,
         id: review_id.clone(),
@@ -2016,6 +2016,12 @@ pub async fn agent_session(
     system_prompt: String,
     user_prompt: String,
     worktree_path: String,
+    // The open repo this session was spawned from. `worktree_path` for a write
+    // session is a `gd/session/*` worktree of it, while read-only Plan/Research
+    // sessions pass the live repo for both. The LAN monitor authorizes streams
+    // against the SHARED repo, which is this value — so a session spawned from the
+    // shared repo stays visible to a paired phone even though it runs in a worktree.
+    origin_repo_path: String,
     session_id: String,
     resume: bool,
     // Claude-only: forks a resumed conversation to a throwaway session id
@@ -2248,7 +2254,7 @@ pub async fn agent_session(
     // channel. The guard clears the entry on EVERY exit path — the host tail, the
     // container branch's early `return`, and any `?` below (registered lifetime ==
     // streaming lifetime). The desktop leg stays byte-for-byte unchanged.
-    let tx = state.register_stream(&session_id, "session");
+    let tx = state.register_stream(&session_id, "session", &origin_repo_path);
     let _stream_guard = StreamGuard {
         state: &state,
         id: session_id.clone(),

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -2997,6 +2997,9 @@ mod tests {
     }
 
     #[test]
+    // Covers the live-subscriber path; the zero-subscriber branch of the
+    // `receiver_count()` guard is pinned by
+    // `fanout_sink_with_no_subscribers_still_delivers_to_desktop` below.
     fn fanout_sink_delivers_to_both_legs() {
         use std::sync::{Arc, Mutex};
         // Desktop leg: a real `Channel` whose message handler captures the raw JSON

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -135,6 +135,41 @@ impl EventSink for Channel<ReviewEvent> {
     }
 }
 
+/// Fans one agent stream out to BOTH the desktop Tauri channel and the LAN
+/// broadcast, so a paired phone can watch a review/session live alongside the
+/// desktop. The desktop leg is unchanged (byte-for-byte the same `Channel::send`
+/// the old direct path did); the broadcast leg is best-effort — a `send` with no
+/// live subscribers returns `Err`, which is normal and ignored.
+struct FanoutSink {
+    channel: Channel<ReviewEvent>,
+    tx: tokio::sync::broadcast::Sender<ReviewEvent>,
+}
+
+impl EventSink for FanoutSink {
+    fn send(&self, ev: ReviewEvent) {
+        // LAN leg first (a clone) — no subscribers is fine. Then the desktop leg,
+        // fully qualified so it hits the inherent `Channel::send`, not this trait.
+        let _ = self.tx.send(ev.clone());
+        let _ = Channel::send(&self.channel, ev);
+    }
+}
+
+/// Clears a stream's registry entry when dropped, so the entry's lifetime matches
+/// the streaming run's on EVERY exit path — the normal return, an early `?`
+/// error, and the container branch's early `return` all run this via the guard's
+/// `Drop`, with no per-path bookkeeping to forget. Borrows `AppState` immutably
+/// (as does the `FanoutSink`/`stream_agent` on the same `&state` — shared reads).
+struct StreamGuard<'a> {
+    state: &'a AppState,
+    id: String,
+}
+
+impl Drop for StreamGuard<'_> {
+    fn drop(&mut self) {
+        self.state.clear_stream(&self.id);
+    }
+}
+
 // --- binary resolution -----------------------------------------------------
 //
 // A GUI app does not reliably inherit the user's shell PATH, and npm-installed
@@ -1908,9 +1943,22 @@ pub async fn agent_review(
     } else {
         REVIEW_TIMEOUT
     };
+    // Register this run in the live-stream registry so a paired phone can watch
+    // it, fanning events out to the LAN broadcast alongside the desktop channel.
+    // The guard clears the entry on every exit path (registered lifetime ==
+    // streaming lifetime); the desktop leg stays byte-for-byte unchanged.
+    let tx = state.register_stream(&review_id, "review");
+    let _stream_guard = StreamGuard {
+        state: &state,
+        id: review_id.clone(),
+    };
+    let sink = FanoutSink {
+        channel: on_event,
+        tx,
+    };
     let result = stream_agent(
         &state, kind, &binary, args, stdin_text, &repo_path, timeout, &review_id, "review", None,
-        &extra_env, &on_event,
+        &extra_env, &sink,
     )
     .await;
     // Remove the generated config on EVERY path (success, error), mirroring the
@@ -2186,6 +2234,21 @@ pub async fn agent_session(
         }
     };
 
+    // Register this session in the live-stream registry so a paired phone can
+    // watch it, fanning events out to the LAN broadcast alongside the desktop
+    // channel. The guard clears the entry on EVERY exit path — the host tail, the
+    // container branch's early `return`, and any `?` below (registered lifetime ==
+    // streaming lifetime). The desktop leg stays byte-for-byte unchanged.
+    let tx = state.register_stream(&session_id, "session");
+    let _stream_guard = StreamGuard {
+        state: &state,
+        id: session_id.clone(),
+    };
+    let sink = FanoutSink {
+        channel: on_event,
+        tx,
+    };
+
     // Container isolation: wrap the same invocation in an ephemeral,
     // worktree-confined container. The agent CLI lives in the image, so we don't
     // resolve a host binary; the runtime drives it.
@@ -2334,7 +2397,7 @@ pub async fn agent_session(
             "session",
             Some((runtime.clone(), name)),
             &extra_env,
-            &on_event,
+            &sink,
         )
         .await;
     }
@@ -2372,7 +2435,7 @@ pub async fn agent_session(
         "session",
         None,
         &host_extra_env,
-        &on_event,
+        &sink,
     )
     .await
 }
@@ -2922,5 +2985,68 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert!(matches!(&events[0], ReviewEvent::Delta { text } if text == "hello"));
         assert!(matches!(&events[1], ReviewEvent::Error { message } if message == "boom"));
+    }
+
+    #[test]
+    fn fanout_sink_delivers_to_both_legs() {
+        use std::sync::{Arc, Mutex};
+        // Desktop leg: a real `Channel` whose message handler captures the raw JSON
+        // body each `send` produces (a `Channel` IS unit-constructible in a test —
+        // `Channel::new` just takes a handler closure).
+        let desktop: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_desktop = desktop.clone();
+        let channel: Channel<ReviewEvent> = Channel::new(move |body| {
+            // ReviewEvent serializes to a JSON string body; record it.
+            if let tauri::ipc::InvokeResponseBody::Json(s) = body {
+                sink_desktop.lock().unwrap().push(s);
+            }
+            Ok(())
+        });
+
+        // LAN leg: a broadcast channel with a live subscriber.
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<ReviewEvent>(16);
+        let fanout = FanoutSink { channel, tx };
+
+        fanout.send(ReviewEvent::Delta {
+            text: "hi".to_string(),
+        });
+
+        // LAN leg received the event verbatim.
+        match rx.try_recv() {
+            Ok(ReviewEvent::Delta { text }) => assert_eq!(text, "hi"),
+            other => panic!("broadcast leg missed the event: {other:?}"),
+        }
+        // Desktop leg received exactly one message carrying the same event.
+        let desktop_msgs = desktop.lock().unwrap();
+        assert_eq!(desktop_msgs.len(), 1);
+        assert!(desktop_msgs[0].contains("\"kind\":\"delta\""));
+        assert!(desktop_msgs[0].contains("\"text\":\"hi\""));
+    }
+
+    #[test]
+    fn fanout_sink_with_no_subscribers_still_delivers_to_desktop() {
+        use std::sync::{Arc, Mutex};
+        // A broadcast `send` with no receivers returns `Err` — which FanoutSink
+        // ignores; the desktop leg must still receive normally.
+        let desktop: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_desktop = desktop.clone();
+        let channel: Channel<ReviewEvent> = Channel::new(move |body| {
+            if let tauri::ipc::InvokeResponseBody::Json(s) = body {
+                sink_desktop.lock().unwrap().push(s);
+            }
+            Ok(())
+        });
+        // Drop the receiver so the broadcast has zero subscribers.
+        let (tx, rx) = tokio::sync::broadcast::channel::<ReviewEvent>(16);
+        drop(rx);
+        let fanout = FanoutSink { channel, tx };
+
+        fanout.send(ReviewEvent::Status {
+            text: "note".to_string(),
+        });
+
+        let desktop_msgs = desktop.lock().unwrap();
+        assert_eq!(desktop_msgs.len(), 1);
+        assert!(desktop_msgs[0].contains("\"kind\":\"status\""));
     }
 }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -147,9 +147,18 @@ struct FanoutSink {
 
 impl EventSink for FanoutSink {
     fn send(&self, ev: ReviewEvent) {
-        // LAN leg first (a clone) — no subscribers is fine. Then the desktop leg,
-        // fully qualified so it hits the inherent `Channel::send`, not this trait.
-        let _ = self.tx.send(ev.clone());
+        // LAN leg first (a clone). Skip the clone entirely when nobody's
+        // listening — the common default-off case where the LAN server is
+        // disabled and the broadcast has zero subscribers, so we don't pay a
+        // per-event clone (including chatty token `Delta`s) on the hot desktop
+        // path. Benign race: a subscriber attaching between this check and the
+        // send just misses that one event — the same as connecting a moment
+        // later, which the WS route already handles for mid-stream joins. Then
+        // the desktop leg, fully qualified so it hits the inherent
+        // `Channel::send`, not this trait.
+        if self.tx.receiver_count() > 0 {
+            let _ = self.tx.send(ev.clone());
+        }
         let _ = Channel::send(&self.channel, ev);
     }
 }

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -288,6 +288,10 @@ pub async fn git_diff_file(
         // Full-file "added" diff for files git doesn't track yet.
         // git maps /dev/null to the platform null device; exit code 1 just
         // means "differences found" for --no-index.
+        // INVARIANT: `--no-index` is NOT repo-confined — it can read any file the
+        // process can open. Callers passing an untrusted `file_path` (the LAN
+        // companion route) MUST validate repo containment before calling this
+        // (see `crate::lan::routes::git::diff_file`).
         let out = run_git_raw(
             Some(&repo_path),
             &["diff", "--no-index", "--", "/dev/null", &file_path],

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -211,8 +211,9 @@ fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
 }
 
 /// The list of stored devices under the `"devices"` array key. Unknown top-level
-/// keys and unknown per-record fields are preserved by round-tripping through
-/// `Value` at the call sites that write.
+/// keys ARE preserved: every writer passes the previously-read store map to
+/// [`write_devices`], which replaces only the `"devices"` key. Unknown PER-RECORD
+/// fields are NOT preserved — records round-trip through the typed [`StoredDevice`].
 fn devices_from(store: &Map<String, Value>) -> Vec<StoredDevice> {
     store
         .get("devices")
@@ -225,9 +226,15 @@ fn devices_from(store: &Map<String, Value>) -> Vec<StoredDevice> {
         .unwrap_or_default()
 }
 
-/// Persist the given device set as the `"devices"` array, atomically.
-fn write_devices(path: &Path, devices: &[StoredDevice]) -> AppResult<()> {
-    let mut store = Map::new();
+/// Persist the given device set as the `"devices"` array, atomically. `store` is
+/// the previously-read store map (from [`read_store`] under the store lock); we
+/// replace only its `"devices"` key so any unknown top-level keys a future
+/// version wrote survive the round-trip.
+fn write_devices(
+    path: &Path,
+    mut store: Map<String, Value>,
+    devices: &[StoredDevice],
+) -> AppResult<()> {
     let arr = devices
         .iter()
         .map(|d| serde_json::to_value(d).unwrap_or(Value::Null))
@@ -263,7 +270,7 @@ pub fn revoke_device(id: &str) -> AppResult<()> {
     if devices.len() == before {
         return Err(AppError::InvalidArgument(format!("no paired device with id {id}")));
     }
-    write_devices(&path, &devices)
+    write_devices(&path, store, &devices)
 }
 
 // --------------------------------------------------------------------------
@@ -423,7 +430,7 @@ pub fn persist_device(device: &LanDevice, token_hash: &str) -> AppResult<()> {
         created_at: device.created_at.clone(),
         last_seen_at: device.last_seen_at.clone(),
     });
-    write_devices(&path, &devices)
+    write_devices(&path, store, &devices)
 }
 
 /// Look up the device whose stored token hash matches `sha256(bearer)`; on a hit,
@@ -442,7 +449,7 @@ fn authenticate_bearer(bearer: &str) -> Option<String> {
     // chatty client doesn't hammer the store file.
     if last_seen_is_stale(&devices[idx].last_seen_at) {
         devices[idx].last_seen_at = now_iso();
-        let _ = write_devices(&path, &devices);
+        let _ = write_devices(&path, store, &devices);
     }
     Some(id)
 }
@@ -922,6 +929,37 @@ mod tests {
         assert!(authenticate_bearer(&bearer).is_none());
         // Revoking an unknown id errors.
         assert!(revoke_device("nope").is_err());
+
+        set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn unknown_top_level_keys_survive_a_write() {
+        let _lock = store_test_lock();
+        let tmp = std::env::temp_dir().join(format!(
+            "gd-lan-devices-preserve-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let prev = set_store_path_for_test(Some(tmp.clone()));
+
+        // Seed a store file with a device AND an extra top-level key a future
+        // version might write.
+        let (device, _bearer, token_hash) = mint_device("Preserve Phone");
+        persist_device(&device, &token_hash).unwrap();
+        let mut raw: Value = serde_json::from_slice(&std::fs::read(&tmp).unwrap()).unwrap();
+        raw.as_object_mut()
+            .unwrap()
+            .insert("future".to_string(), json!({ "x": 1 }));
+        std::fs::write(&tmp, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+
+        // Perform a write (revoke) through the public API.
+        revoke_device(&device.id).unwrap();
+
+        // The extra top-level key must survive.
+        let after: Value = serde_json::from_slice(&std::fs::read(&tmp).unwrap()).unwrap();
+        assert_eq!(after["future"]["x"], json!(1));
 
         set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -1,0 +1,937 @@
+//! Pairing, per-device bearer auth, the on-disk device store, IP rate-limiting,
+//! and the axum middleware that enforces all of it for the LAN companion server.
+//!
+//! ## Security model — the LAN is a convenience boundary, NOT a trust boundary
+//!
+//! Anything that can reach the bound port could be a hostile device on the same
+//! network (a coffee-shop LAN, a roommate's laptop). So every `/api/` request
+//! except the two pairing routes carries a per-device bearer token, and pairing
+//! itself is a challenge/response that never puts the shared secret on the wire.
+//!
+//! ### Pairing exchange (the OBS-websocket SHA256 pattern)
+//!
+//! 1. The desktop shows a QR + a 6-digit PIN. The QR/URL encode ONLY the pair
+//!    URL — never the PIN or the pairing secret — so a shoulder-surfed photo of
+//!    the screen (which captures the QR) still can't pair without the PIN, which
+//!    the user reads off and types on the phone.
+//! 2. Phone → `POST /api/pair/challenge` → `{ challenge, salt }` (server-random,
+//!    one live challenge per session).
+//! 3. Phone computes `proof = hex(sha256(hex(sha256(pin + salt)) + challenge))`
+//!    and `POST /api/pair { deviceName, proof }`.
+//! 4. Server recomputes the same proof from the PIN it holds and compares. On a
+//!    match it mints a device id + a raw 128-bit bearer, stores only
+//!    `hex(sha256(bearer))`, and returns the raw token exactly once.
+//!
+//! ### Transport hardening
+//!
+//! Every response carries `X-Frame-Options: DENY` + `Content-Security-Policy:
+//! frame-ancestors 'none'`, and every request's `Host` (and `Origin`, when
+//! present) must match a bound address — the DNS-rebinding defense that a
+//! localhost HTTP service otherwise lacks (the qBittorrent CVE lesson).
+//!
+//! ### Rate limiting
+//!
+//! Pairing attempts and auth failures are counted per peer IP: 5 failures in a
+//! 60s window locks that IP out (429 + `Retry-After`) for the remainder of the
+//! window. The lockout map is IN-MEMORY only — it resets whenever the server is
+//! disabled or restarted, which is acceptable for v1 (a restart is a deliberate
+//! user action, not an attacker-triggerable reset).
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::extract::{ConnectInfo, State};
+use axum::http::{HeaderValue, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use rand::RngExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::net::{Ipv4Addr, SocketAddr};
+
+use crate::error::{AppError, AppResult};
+use crate::local_prs::APP_IDENTIFIER;
+
+/// The device-store filename under the app-data dir. Rust-owned and app-global
+/// (NOT per-repo): pairing a phone is an app-level trust decision, and the same
+/// paired device reads whatever repo is currently active.
+const STORE_FILE: &str = "lan-devices.json";
+
+/// The only scope a paired device gets in this slice: read-only.
+pub const SCOPE_READ: &str = "read";
+
+/// Pairing session time-to-live: ~2 minutes. Long enough to scan + type the PIN,
+/// short enough that an abandoned session closes the window quickly.
+pub const PAIRING_TTL: Duration = Duration::from_secs(120);
+
+/// Rate-limit window and threshold: 5 failed attempts (pairing or auth) from one
+/// peer IP within 60s trips a lockout for the remainder of the window.
+const RATE_LIMIT_MAX_FAILURES: u32 = 5;
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+/// Only rewrite a device's `lastSeenAt` when the stored value is more than this
+/// stale, so a burst of authenticated requests doesn't thrash the store file.
+const LAST_SEEN_THROTTLE_SECS: i64 = 60;
+
+// --------------------------------------------------------------------------
+// Device-store path injection (for tests)
+// --------------------------------------------------------------------------
+
+/// Test-only override for the device-store path. Production always resolves the
+/// real app-data file via [`store_path`]; tests set this to a temp file so they
+/// never touch (or require) the real `%APPDATA%\com.thebguy.gitdesktop` dir.
+static STORE_PATH_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+fn store_path_override() -> &'static Mutex<Option<PathBuf>> {
+    STORE_PATH_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+/// Point the device store at `path` for the current process (test-only). Returns
+/// the previous override so a test can restore it.
+#[cfg(test)]
+pub(crate) fn set_store_path_for_test(path: Option<PathBuf>) -> Option<PathBuf> {
+    let mut guard = store_path_override()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    std::mem::replace(&mut *guard, path)
+}
+
+/// A process-global lock any test that touches the device store must hold, so the
+/// single [`STORE_PATH_OVERRIDE`] isn't raced by tests running on parallel threads
+/// (each points it at its own temp file). Returns the guard; hold it for the test.
+#[cfg(test)]
+pub(crate) fn store_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}
+
+/// Resolve the absolute path of `lan-devices.json` under the app-data dir —
+/// `dirs::data_dir()/<APP_IDENTIFIER>/`, the same root [`crate::local_prs`] and
+/// [`crate::jira_field_maps`] use. A test override (if set) wins.
+fn store_path() -> AppResult<PathBuf> {
+    if let Some(over) = store_path_override()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone()
+    {
+        return Ok(over);
+    }
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
+}
+
+/// Serializes the whole read-modify-write of the device store across the sync
+/// I/O only (the `oplog.rs` discipline). Never held across an `.await`.
+fn store_lock() -> &'static Mutex<()> {
+    static STORE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    STORE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+// --------------------------------------------------------------------------
+// Device records
+// --------------------------------------------------------------------------
+
+/// A paired device as returned to the frontend. The raw bearer token is NEVER
+/// carried here — only its hash lives on disk; this is the safe-to-display shape.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanDevice {
+    pub id: String,
+    pub name: String,
+    pub scope: String,
+    pub created_at: String,
+    pub last_seen_at: String,
+}
+
+/// The persisted device record (adds the token hash the wire shape omits).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredDevice {
+    id: String,
+    name: String,
+    scope: String,
+    /// `hex(sha256(bearer))`. The raw bearer is returned to the phone once at
+    /// pairing time and never stored — a leaked store file can't be replayed.
+    token_hash: String,
+    created_at: String,
+    last_seen_at: String,
+}
+
+impl StoredDevice {
+    fn to_device(&self) -> LanDevice {
+        LanDevice {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            scope: self.scope.clone(),
+            created_at: self.created_at.clone(),
+            last_seen_at: self.last_seen_at.clone(),
+        }
+    }
+}
+
+/// The current UTC timestamp in JS `Date.prototype.toISOString()` shape
+/// (RFC3339, millis + `Z`) — matching every other app-data timestamp we write.
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Read the whole device-store file as a JSON object. A missing file is an empty
+/// object; a present-but-malformed file is a hard error (never clobber it — it
+/// holds pairing trust we must not silently drop).
+fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Command(format!(
+                    "lan-devices store at {} is not valid JSON: {e}",
+                    path.display()
+                ))
+            })?;
+            match value {
+                Value::Object(map) => Ok(map),
+                _ => Err(AppError::Command(format!(
+                    "lan-devices store at {} is not a JSON object",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(AppError::Io(e)),
+    }
+}
+
+/// The list of stored devices under the `"devices"` array key. Unknown top-level
+/// keys and unknown per-record fields are preserved by round-tripping through
+/// `Value` at the call sites that write.
+fn devices_from(store: &Map<String, Value>) -> Vec<StoredDevice> {
+    store
+        .get("devices")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value::<StoredDevice>(v.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Persist the given device set as the `"devices"` array, atomically.
+fn write_devices(path: &Path, devices: &[StoredDevice]) -> AppResult<()> {
+    let mut store = Map::new();
+    let arr = devices
+        .iter()
+        .map(|d| serde_json::to_value(d).unwrap_or(Value::Null))
+        .collect::<Vec<_>>();
+    store.insert("devices".to_string(), Value::Array(arr));
+    let body = serde_json::to_string_pretty(&Value::Object(store))
+        .map_err(|e| AppError::Command(format!("serialize lan-devices store: {e}")))?;
+    crate::fsops::atomic_write(path, body.as_bytes())
+}
+
+/// The safe-to-display list of paired devices (no token hashes). Read-only.
+pub fn list_devices() -> AppResult<Vec<LanDevice>> {
+    let path = store_path()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let store = read_store(&path)?;
+    Ok(devices_from(&store).iter().map(|d| d.to_device()).collect())
+}
+
+/// The number of paired devices. Convenience for `lan_status`.
+pub fn device_count() -> u32 {
+    list_devices().map(|d| d.len() as u32).unwrap_or(0)
+}
+
+/// Revoke (delete) the device with `id`. Idempotent-ish: an unknown id errors so
+/// the UI can surface "already gone", matching the local-PR store's id handling.
+pub fn revoke_device(id: &str) -> AppResult<()> {
+    let path = store_path()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let store = read_store(&path)?;
+    let mut devices = devices_from(&store);
+    let before = devices.len();
+    devices.retain(|d| d.id != id);
+    if devices.len() == before {
+        return Err(AppError::InvalidArgument(format!("no paired device with id {id}")));
+    }
+    write_devices(&path, &devices)
+}
+
+// --------------------------------------------------------------------------
+// Hashing / proof
+// --------------------------------------------------------------------------
+
+/// `hex(sha256(bytes))`.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    hex_encode(&digest)
+}
+
+/// Lowercase hex of a byte slice. Small and dependency-free (avoids pulling a
+/// hex crate for two call sites).
+pub fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        s.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+    }
+    s
+}
+
+/// Compute the pairing proof the phone must send:
+/// `proof = hex(sha256( hex(sha256(pin + salt)) + challenge ))`.
+///
+/// Splitting the PIN behind an inner hash (with a per-session salt) means the
+/// wire never carries the PIN, and a captured `{challenge, salt, proof}` triple
+/// can't be replayed against a fresh challenge.
+pub fn compute_proof(pin: &str, salt: &str, challenge: &str) -> String {
+    let inner = sha256_hex(format!("{pin}{salt}").as_bytes());
+    sha256_hex(format!("{inner}{challenge}").as_bytes())
+}
+
+/// Constant-time equality over two hex strings. Both operands here are always
+/// fixed-length SHA-256 hex (or bearer hashes), so a length mismatch alone is
+/// not a secret — but we still fold the whole comparison to avoid an
+/// early-return timing side channel on the shared prefix. (A dedicated `subtle`
+/// dependency is deliberately avoided; comparing already-hashed values with this
+/// fold is sufficient — noted per the spec.)
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+// --------------------------------------------------------------------------
+// Pairing session
+// --------------------------------------------------------------------------
+
+/// An in-progress pairing session. Single active session per server: starting a
+/// new one replaces any prior. Lives only in memory (never persisted).
+#[derive(Debug, Clone)]
+pub struct PairingSession {
+    /// The 6-digit PIN shown on the desktop and typed on the phone.
+    pub pin: String,
+    /// 32 random bytes (hex) — a session id reserved for future session-binding.
+    /// Deliberately NOT part of the pairing proof (which is PIN + salt + challenge)
+    /// and never placed on the wire or in the QR. Read only by tests today (which
+    /// assert the QR/url can't leak it), so it's dead in the non-test build.
+    #[allow(dead_code)]
+    pub secret: String,
+    /// The pair URL shown as a QR (first LAN url + `/#pair`). No PIN/secret in it.
+    pub url: String,
+    /// When this session expires.
+    pub expires_at: Instant,
+    /// ISO-8601 rendering of `expires_at`, for the frontend.
+    pub expires_at_iso: String,
+    /// The current outstanding challenge (hex), if the phone has fetched one.
+    /// One live challenge at a time — a fresh `/challenge` call overwrites it.
+    pub challenge: Option<String>,
+    /// The per-challenge salt (hex) returned alongside the challenge.
+    pub salt: Option<String>,
+}
+
+impl PairingSession {
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}
+
+/// Generate a fresh pairing session for the given pair `url`. PIN is 6 digits
+/// from the OS CSPRNG; the secret is 32 random bytes. TTL is [`PAIRING_TTL`].
+pub fn new_pairing_session(url: String) -> PairingSession {
+    let mut rng = rand::rng();
+    // 6-digit PIN, zero-padded (000000..=999999) — uniform over the full range.
+    let pin_num: u32 = rng.random_range(0..1_000_000);
+    let pin = format!("{pin_num:06}");
+    let mut secret_bytes = [0u8; 32];
+    rng.fill(&mut secret_bytes[..]);
+    let expires_at = Instant::now() + PAIRING_TTL;
+    PairingSession {
+        pin,
+        secret: hex_encode(&secret_bytes),
+        url,
+        expires_at,
+        expires_at_iso: iso_after(PAIRING_TTL),
+        challenge: None,
+        salt: None,
+    }
+}
+
+/// A fresh `(challenge, salt)` pair: 32-byte challenge, 16-byte salt, both hex.
+pub fn new_challenge() -> (String, String) {
+    let mut rng = rand::rng();
+    let mut challenge = [0u8; 32];
+    let mut salt = [0u8; 16];
+    rng.fill(&mut challenge[..]);
+    rng.fill(&mut salt[..]);
+    (hex_encode(&challenge), hex_encode(&salt))
+}
+
+/// An ISO-8601 timestamp `d` from now (for a pairing expiry the frontend renders).
+fn iso_after(d: Duration) -> String {
+    let when = chrono::Utc::now() + chrono::Duration::from_std(d).unwrap_or_default();
+    when.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Mint a device from a successful pairing: returns `(StoredDevice-as-persisted,
+/// raw_bearer)`. The raw bearer is the caller's to return once and then forget.
+pub fn mint_device(name: &str) -> (LanDevice, String, String) {
+    let id = uuid::Uuid::new_v4().to_string();
+    // 128-bit bearer as uuid v4 hex (no dashes) — plenty of entropy, and it's the
+    // same primitive the rest of the app already mints ids with.
+    let bearer = uuid::Uuid::new_v4().simple().to_string();
+    let token_hash = sha256_hex(bearer.as_bytes());
+    let now = now_iso();
+    let device = LanDevice {
+        id,
+        name: name.to_string(),
+        scope: SCOPE_READ.to_string(),
+        created_at: now.clone(),
+        last_seen_at: now,
+    };
+    (device, bearer, token_hash)
+}
+
+/// Persist a freshly-minted device (with its token hash). Separate from
+/// [`mint_device`] so the pure minting stays testable without disk I/O.
+pub fn persist_device(device: &LanDevice, token_hash: &str) -> AppResult<()> {
+    let path = store_path()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let store = read_store(&path)?;
+    let mut devices = devices_from(&store);
+    devices.push(StoredDevice {
+        id: device.id.clone(),
+        name: device.name.clone(),
+        scope: device.scope.clone(),
+        token_hash: token_hash.to_string(),
+        created_at: device.created_at.clone(),
+        last_seen_at: device.last_seen_at.clone(),
+    });
+    write_devices(&path, &devices)
+}
+
+/// Look up the device whose stored token hash matches `sha256(bearer)`; on a hit,
+/// bump its `lastSeenAt` (throttled) and return its id. `None` on no match.
+fn authenticate_bearer(bearer: &str) -> Option<String> {
+    let token_hash = sha256_hex(bearer.as_bytes());
+    let path = store_path().ok()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let store = read_store(&path).ok()?;
+    let mut devices = devices_from(&store);
+    let idx = devices
+        .iter()
+        .position(|d| constant_time_eq(&d.token_hash, &token_hash))?;
+    let id = devices[idx].id.clone();
+    // Throttled last-seen bump: only rewrite when the stored value is stale, so a
+    // chatty client doesn't hammer the store file.
+    if last_seen_is_stale(&devices[idx].last_seen_at) {
+        devices[idx].last_seen_at = now_iso();
+        let _ = write_devices(&path, &devices);
+    }
+    Some(id)
+}
+
+/// Whether a stored `lastSeenAt` ISO timestamp is older than the throttle window
+/// (or unparseable — then treat as stale so we refresh it to a valid value).
+fn last_seen_is_stale(iso: &str) -> bool {
+    match chrono::DateTime::parse_from_rfc3339(iso) {
+        Ok(then) => {
+            let age = chrono::Utc::now().signed_duration_since(then.with_timezone(&chrono::Utc));
+            age.num_seconds() >= LAST_SEEN_THROTTLE_SECS
+        }
+        Err(_) => true,
+    }
+}
+
+// --------------------------------------------------------------------------
+// Rate limiting
+// --------------------------------------------------------------------------
+
+/// A rolling failure window for one peer IP. In-memory only.
+#[derive(Debug, Clone)]
+pub struct FailureWindow {
+    /// When the current window started.
+    window_start: Instant,
+    /// Failures recorded within the current window.
+    count: u32,
+}
+
+/// The shared rate-limit map, cloned into the router via `Arc`.
+pub type RateLimitMap = Arc<Mutex<HashMap<IpAddr, FailureWindow>>>;
+
+/// Result of a rate-limit check: either allowed, or locked out with the number of
+/// seconds remaining (for a `Retry-After` header).
+pub enum RateCheck {
+    Allowed,
+    LockedOut { retry_after_secs: u64 },
+}
+
+/// Check whether `ip` is currently locked out, expiring a stale window first.
+pub fn rate_check(map: &RateLimitMap, ip: IpAddr) -> RateCheck {
+    let mut guard = map.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(win) = guard.get(&ip) {
+        let elapsed = win.window_start.elapsed();
+        if elapsed >= RATE_LIMIT_WINDOW {
+            // Window expired — drop it; the next failure starts fresh.
+            guard.remove(&ip);
+            return RateCheck::Allowed;
+        }
+        if win.count >= RATE_LIMIT_MAX_FAILURES {
+            let remaining = RATE_LIMIT_WINDOW.saturating_sub(elapsed);
+            return RateCheck::LockedOut {
+                retry_after_secs: remaining.as_secs().max(1),
+            };
+        }
+    }
+    RateCheck::Allowed
+}
+
+/// Record a failed attempt (pairing or auth) from `ip`, starting or extending its
+/// window.
+pub fn record_failure(map: &RateLimitMap, ip: IpAddr) {
+    let mut guard = map.lock().unwrap_or_else(|p| p.into_inner());
+    let now = Instant::now();
+    let entry = guard.entry(ip).or_insert(FailureWindow {
+        window_start: now,
+        count: 0,
+    });
+    if entry.window_start.elapsed() >= RATE_LIMIT_WINDOW {
+        // Stale window — reset it.
+        entry.window_start = now;
+        entry.count = 0;
+    }
+    entry.count += 1;
+}
+
+/// Clear an IP's failure window (called on a successful pairing/auth so a device
+/// that eventually succeeds isn't punished for earlier typos).
+pub fn clear_failures(map: &RateLimitMap, ip: IpAddr) {
+    let mut guard = map.lock().unwrap_or_else(|p| p.into_inner());
+    guard.remove(&ip);
+}
+
+// --------------------------------------------------------------------------
+// Router state + middleware
+// --------------------------------------------------------------------------
+
+/// The per-field Arc-cloned state the axum router needs (mirrors how the main
+/// `AppState` shares individual fields rather than `Arc<Whole>`). Cheap to clone.
+#[derive(Clone)]
+pub struct RouterState {
+    /// The currently-active repo path the read routes operate on. `None` → 409.
+    pub active_repo: Arc<Mutex<Option<String>>>,
+    /// The single active pairing session, if any.
+    pub pairing: Arc<Mutex<Option<PairingSession>>>,
+    /// Per-IP failure windows.
+    pub rate_limit: RateLimitMap,
+    /// Every bound `<ip>:<port>` we accept in a `Host`/`Origin` header.
+    pub bound_hosts: Arc<Vec<String>>,
+    /// The live agent-stream registry — the SAME `Arc` [`crate::state::AppState`]
+    /// holds, so a review/session registered there is watchable from the LAN
+    /// review routes without any further plumbing.
+    pub streams: Arc<Mutex<HashMap<String, crate::state::StreamInfo>>>,
+}
+
+/// Extract the peer IP from `ConnectInfo`, falling back to loopback when it's
+/// absent (the `tower::oneshot` test path has no ConnectInfo). Rate-limiting a
+/// test's synthetic requests as loopback is harmless.
+fn peer_ip(req: &Request<Body>) -> IpAddr {
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST))
+}
+
+/// Apply the transport-hardening headers to every response.
+fn harden_headers(resp: &mut Response) {
+    let headers = resp.headers_mut();
+    headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
+    headers.insert(
+        "Content-Security-Policy",
+        HeaderValue::from_static("frame-ancestors 'none'"),
+    );
+}
+
+/// Middleware run on EVERY request (pairing routes included): validates the
+/// `Host` header (and `Origin`, when present) against our bound addresses — the
+/// DNS-rebinding defense — and stamps the hardening headers on the way out.
+pub async fn host_guard(
+    State(state): State<RouterState>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let host_ok = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(|h| state.bound_hosts.iter().any(|b| b == h))
+        .unwrap_or(false);
+    if !host_ok {
+        let mut resp = (StatusCode::FORBIDDEN, "bad host").into_response();
+        harden_headers(&mut resp);
+        return resp;
+    }
+    // If an Origin header is present, its host portion must also be one of ours.
+    if let Some(origin) = req
+        .headers()
+        .get(axum::http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    {
+        let origin_host = origin
+            .strip_prefix("http://")
+            .or_else(|| origin.strip_prefix("https://"))
+            .unwrap_or(origin);
+        if !state.bound_hosts.iter().any(|b| b == origin_host) {
+            let mut resp = (StatusCode::FORBIDDEN, "bad origin").into_response();
+            harden_headers(&mut resp);
+            return resp;
+        }
+    }
+    let mut resp = next.run(req).await;
+    harden_headers(&mut resp);
+    resp
+}
+
+/// Bearer-auth middleware for the protected `/api/` routes (everything except the
+/// two pairing routes). Enforces the per-IP rate limit, then requires a valid
+/// `Authorization: Bearer <token>` whose sha256 matches a stored device.
+pub async fn require_auth(
+    State(state): State<RouterState>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let ip = peer_ip(&req);
+    // Rate-limit auth failures the same as pairing.
+    if let RateCheck::LockedOut { retry_after_secs } = rate_check(&state.rate_limit, ip) {
+        return too_many_requests(retry_after_secs);
+    }
+    let bearer = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let Some(bearer) = bearer else {
+        record_failure(&state.rate_limit, ip);
+        return unauthorized();
+    };
+    match authenticate_bearer(bearer) {
+        Some(_id) => {
+            clear_failures(&state.rate_limit, ip);
+            next.run(req).await
+        }
+        None => {
+            record_failure(&state.rate_limit, ip);
+            unauthorized()
+        }
+    }
+}
+
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({ "kind": "unauthorized", "message": "invalid or missing bearer token" })),
+    )
+        .into_response()
+}
+
+fn too_many_requests(retry_after_secs: u64) -> Response {
+    let mut resp = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(json!({ "kind": "rateLimited", "message": "too many attempts; try again later" })),
+    )
+        .into_response();
+    if let Ok(val) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+        resp.headers_mut().insert("Retry-After", val);
+    }
+    resp
+}
+
+// --------------------------------------------------------------------------
+// Pairing HTTP handlers (unauthenticated, rate-limited)
+// --------------------------------------------------------------------------
+
+/// `POST /api/pair/challenge` → `{ challenge, salt }`. Requires an active,
+/// unexpired pairing session; stores the challenge/salt on it (one at a time).
+pub async fn pair_challenge(State(state): State<RouterState>, req: Request<Body>) -> Response {
+    let ip = peer_ip(&req);
+    if let RateCheck::LockedOut { retry_after_secs } = rate_check(&state.rate_limit, ip) {
+        return too_many_requests(retry_after_secs);
+    }
+    let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
+    let Some(session) = guard.as_mut() else {
+        record_failure(&state.rate_limit, ip);
+        return pairing_inactive();
+    };
+    if session.is_expired() {
+        *guard = None;
+        record_failure(&state.rate_limit, ip);
+        return pairing_inactive();
+    }
+    let (challenge, salt) = new_challenge();
+    session.challenge = Some(challenge.clone());
+    session.salt = Some(salt.clone());
+    (
+        StatusCode::OK,
+        Json(json!({ "challenge": challenge, "salt": salt })),
+    )
+        .into_response()
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PairBody {
+    device_name: String,
+    proof: String,
+}
+
+/// `POST /api/pair` → mint a device on a correct proof. On success clears the
+/// pairing session and the peer's failure window; on a bad proof records a
+/// failure (rate-limited) and 401s.
+pub async fn pair_submit(
+    State(state): State<RouterState>,
+    req: Request<Body>,
+) -> Response {
+    let ip = peer_ip(&req);
+    if let RateCheck::LockedOut { retry_after_secs } = rate_check(&state.rate_limit, ip) {
+        return too_many_requests(retry_after_secs);
+    }
+    // Manually read the JSON body so we keep the request for peer_ip above.
+    let (_parts, body) = req.into_parts();
+    let bytes = match axum::body::to_bytes(body, 64 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            record_failure(&state.rate_limit, ip);
+            return bad_request("could not read request body");
+        }
+    };
+    let parsed: Result<PairBody, _> = serde_json::from_slice(&bytes);
+    let Ok(body) = parsed else {
+        record_failure(&state.rate_limit, ip);
+        return bad_request("expected { deviceName, proof }");
+    };
+    let device_name = body.device_name.trim();
+    if device_name.is_empty() {
+        record_failure(&state.rate_limit, ip);
+        return bad_request("deviceName must not be empty");
+    }
+
+    // Compute the expected proof from the stored PIN + this session's challenge.
+    let expected = {
+        let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(session) = guard.as_mut() else {
+            record_failure(&state.rate_limit, ip);
+            return pairing_inactive();
+        };
+        if session.is_expired() {
+            *guard = None;
+            record_failure(&state.rate_limit, ip);
+            return pairing_inactive();
+        }
+        let (Some(challenge), Some(salt)) = (session.challenge.clone(), session.salt.clone())
+        else {
+            // Phone must fetch a challenge first.
+            record_failure(&state.rate_limit, ip);
+            return bad_request("fetch a challenge first");
+        };
+        compute_proof(&session.pin, &salt, &challenge)
+    };
+
+    if !constant_time_eq(&expected, body.proof.trim()) {
+        record_failure(&state.rate_limit, ip);
+        return unauthorized();
+    }
+
+    // Correct proof → mint + persist, then clear the pairing session.
+    let (device, bearer, token_hash) = mint_device(device_name);
+    if let Err(e) = persist_device(&device, &token_hash) {
+        return app_error_response(&e);
+    }
+    {
+        let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = None;
+    }
+    clear_failures(&state.rate_limit, ip);
+    (
+        StatusCode::OK,
+        Json(json!({
+            "deviceId": device.id,
+            "token": bearer,
+            "name": device.name,
+            "scope": device.scope,
+        })),
+    )
+        .into_response()
+}
+
+fn pairing_inactive() -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({ "kind": "pairingInactive", "message": "no active pairing session" })),
+    )
+        .into_response()
+}
+
+fn bad_request(msg: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "kind": "invalidArgument", "message": msg })),
+    )
+        .into_response()
+}
+
+/// Map an [`AppError`] to an HTTP response for the route handlers: `NotARepo` and
+/// `InvalidArgument` → 400; everything else → 502. The body reuses the app's own
+/// `{ kind, message }` serialization so a phone client sees the same shape the
+/// desktop frontend does.
+pub fn app_error_response(err: &AppError) -> Response {
+    let status = match err {
+        AppError::NotARepo(_) | AppError::InvalidArgument(_) => StatusCode::BAD_REQUEST,
+        _ => StatusCode::BAD_GATEWAY,
+    };
+    let body = serde_json::to_value(err).unwrap_or_else(|_| {
+        json!({ "kind": "command", "message": err.to_string() })
+    });
+    (status, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_round_trips_both_directions() {
+        // The phone and the server compute the SAME proof from the shared inputs.
+        let pin = "483920";
+        let salt = "0011223344556677";
+        let challenge = "aabbccddeeff00112233445566778899";
+        let phone = compute_proof(pin, salt, challenge);
+        let server = compute_proof(pin, salt, challenge);
+        assert_eq!(phone, server);
+        // A wrong PIN yields a different proof.
+        assert_ne!(compute_proof("000000", salt, challenge), server);
+        // A different challenge (replay defense) yields a different proof.
+        assert_ne!(compute_proof(pin, salt, "ffffffffffffffffffffffffffffffff"), server);
+        // Proof is a 64-char (32-byte) sha256 hex.
+        assert_eq!(server.len(), 64);
+        assert!(server.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn token_hash_verifies() {
+        let (_device, bearer, token_hash) = mint_device("Pixel 9");
+        // The stored hash is sha256(bearer), and re-hashing verifies.
+        assert_eq!(sha256_hex(bearer.as_bytes()), token_hash);
+        // A wrong bearer does not verify.
+        assert!(!constant_time_eq(&sha256_hex(b"not-the-bearer"), &token_hash));
+        // Bearer is 32 hex chars (128-bit uuid, no dashes).
+        assert_eq!(bearer.len(), 32);
+        assert!(bearer.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn constant_time_eq_matches_and_rejects() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd")); // length mismatch
+    }
+
+    #[test]
+    fn rate_limit_window_locks_out_after_threshold() {
+        let map: RateLimitMap = Arc::new(Mutex::new(HashMap::new()));
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
+        // Under threshold → allowed.
+        for _ in 0..RATE_LIMIT_MAX_FAILURES - 1 {
+            record_failure(&map, ip);
+            assert!(matches!(rate_check(&map, ip), RateCheck::Allowed));
+        }
+        // Hitting the threshold → locked out with a positive retry-after.
+        record_failure(&map, ip);
+        match rate_check(&map, ip) {
+            RateCheck::LockedOut { retry_after_secs } => assert!(retry_after_secs >= 1),
+            RateCheck::Allowed => panic!("expected lockout at threshold"),
+        }
+        // Clearing releases the lock.
+        clear_failures(&map, ip);
+        assert!(matches!(rate_check(&map, ip), RateCheck::Allowed));
+    }
+
+    #[test]
+    fn pairing_session_ttl_expiry() {
+        let mut session = new_pairing_session("http://192.168.1.2:38473/#pair".to_string());
+        assert!(!session.is_expired());
+        // Force expiry by rewinding the deadline.
+        session.expires_at = Instant::now() - Duration::from_secs(1);
+        assert!(session.is_expired());
+        // PIN shape: 6 digits.
+        assert_eq!(session.pin.len(), 6);
+        assert!(session.pin.chars().all(|c| c.is_ascii_digit()));
+        // The QR/pair url must NOT leak the PIN or the secret.
+        assert!(!session.url.contains(&session.pin));
+        assert!(!session.url.contains(&session.secret));
+    }
+
+    #[test]
+    fn device_store_round_trips_via_temp_file() {
+        let _lock = store_test_lock();
+        let tmp = std::env::temp_dir().join(format!(
+            "gd-lan-devices-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let prev = set_store_path_for_test(Some(tmp.clone()));
+
+        // Empty to start.
+        assert_eq!(list_devices().unwrap().len(), 0);
+        assert_eq!(device_count(), 0);
+
+        let (device, bearer, token_hash) = mint_device("iPhone");
+        persist_device(&device, &token_hash).unwrap();
+
+        // Listed without the token hash.
+        let listed = list_devices().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "iPhone");
+        assert_eq!(listed[0].scope, SCOPE_READ);
+
+        // The bearer authenticates; a wrong one does not.
+        assert_eq!(authenticate_bearer(&bearer).as_deref(), Some(device.id.as_str()));
+        assert!(authenticate_bearer("deadbeef").is_none());
+
+        // Revoke → gone → its token no longer authenticates.
+        revoke_device(&device.id).unwrap();
+        assert_eq!(list_devices().unwrap().len(), 0);
+        assert!(authenticate_bearer(&bearer).is_none());
+        // Revoking an unknown id errors.
+        assert!(revoke_device("nope").is_err());
+
+        set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn last_seen_staleness() {
+        // A just-now timestamp is fresh; an old one is stale; garbage is stale.
+        assert!(!last_seen_is_stale(&now_iso()));
+        assert!(last_seen_is_stale("2020-01-01T00:00:00.000Z"));
+        assert!(last_seen_is_stale("not-a-timestamp"));
+    }
+}

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -233,10 +233,15 @@ pub async fn lan_disable(app: AppHandle, state: State<'_, LanState>) -> AppResul
 }
 
 /// Point the read routes at `repo_path` (the desktop's currently-open repo).
+/// `None` clears the active repo (the desktop closed its repo), after which the
+/// read routes 409 via `repo_or_409!` — paired devices stop seeing the last repo.
 #[tauri::command]
-pub fn lan_set_active_repo(state: State<'_, LanState>, repo_path: String) -> AppResult<()> {
+pub fn lan_set_active_repo(
+    state: State<'_, LanState>,
+    repo_path: Option<String>,
+) -> AppResult<()> {
     let mut guard = state.active_repo.lock().unwrap_or_else(|p| p.into_inner());
-    *guard = Some(repo_path);
+    *guard = repo_path;
     Ok(())
 }
 
@@ -345,6 +350,23 @@ mod tests {
             .header("host", "testhost")
             .body(Body::empty())
             .unwrap()
+    }
+
+    #[test]
+    fn set_active_repo_none_clears() {
+        // Setting a repo then clearing with None must leave the status snapshot
+        // with no active repo (Close repo stops sharing the last repo).
+        let state = LanState::default();
+        {
+            let mut guard = state.active_repo.lock().unwrap();
+            *guard = Some("C:/repo".to_string());
+        }
+        assert_eq!(state.status().active_repo.as_deref(), Some("C:/repo"));
+        {
+            let mut guard = state.active_repo.lock().unwrap();
+            *guard = None;
+        }
+        assert_eq!(state.status().active_repo, None);
     }
 
     #[tokio::test]
@@ -493,5 +515,104 @@ mod tests {
 
         auth::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();
+    }
+
+    /// Build an authed GET request by seeding a device in the store and using its
+    /// raw bearer. Caller must hold `store_test_lock` + a store-path override.
+    fn authed_get(path: &str, bearer: &str) -> Request<Body> {
+        Request::builder()
+            .uri(path)
+            .header("host", "testhost")
+            .header("authorization", format!("Bearer {bearer}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn diff_file_rejects_paths_escaping_the_repo() {
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        // A real temp repo so a legitimate untracked path can be served (200) and
+        // the guard — not a downstream git error — is what rejects bad paths.
+        let repo_dir = std::env::temp_dir().join(format!(
+            "gd-lan-diff-guard-repo-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        assert!(std::process::Command::new("git")
+            .arg("init")
+            .current_dir(&repo_dir)
+            .output()
+            .unwrap()
+            .status
+            .success());
+        std::fs::write(repo_dir.join("hello.txt"), "hello lan\n").unwrap();
+        let repo = repo_dir.to_string_lossy().to_string();
+
+        // Seed a paired device and grab its raw bearer.
+        let (device, bearer, token_hash) = auth::mint_device("Guard Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let router = server::build_router(test_router(Some(repo.clone())));
+
+        // ../x → 400 (ParentDir).
+        let resp = router
+            .clone()
+            .oneshot(authed_get(
+                "/api/repo/diff/file?path=../x&untracked=true",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // /etc/passwd → 400 (RootDir; a leading `/` parses as RootDir on Windows too).
+        let resp = router
+            .clone()
+            .oneshot(authed_get(
+                "/api/repo/diff/file?path=/etc/passwd&untracked=true",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // A Windows drive prefix → 400 (Prefix). On unix `C:/x` is a Normal
+        // component, so only assert this where it's actually an escape.
+        #[cfg(windows)]
+        {
+            let resp = router
+                .clone()
+                .oneshot(authed_get(
+                    "/api/repo/diff/file?path=C:/x&untracked=true",
+                    &bearer,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        }
+
+        // A legitimate untracked file inside the repo is served, not rejected.
+        let resp = router
+            .oneshot(authed_get(
+                "/api/repo/diff/file?path=hello.txt&untracked=true",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(body.contains("hello lan"), "diff body should include the file content: {body}");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+        std::fs::remove_dir_all(&repo_dir).ok();
     }
 }

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -106,7 +106,11 @@ impl LanState {
                 port: None,
                 urls: Vec::new(),
                 active_repo,
-                device_count: auth::device_count(),
+                // The device count is only meaningful/consumed while sharing is
+                // on, so report 0 here and skip `auth::device_count()`'s disk
+                // read of `lan-devices.json`. This keeps the app-wide 5s
+                // `lan_status` poll off-disk for the (default) disabled case.
+                device_count: 0,
                 pairing_active,
             },
         }
@@ -595,6 +599,32 @@ mod tests {
                 .unwrap();
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         }
+
+        // `.git/config` is a Normal component INSIDE the repo root (containment
+        // passes), so without the `.git`-component guard this would 200 and leak
+        // `.git/` internals (`git init` creates `.git/config`). Must 400.
+        let resp = router
+            .clone()
+            .oneshot(authed_get(
+                "/api/repo/diff/file?path=.git/config&untracked=true",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // `.GIT/config` → 400 on every filesystem: case-insensitive ones
+        // canonicalize it to `.git` and the new guard rejects; case-sensitive
+        // ones have no such path, so canonicalize fails → 400 from containment.
+        let resp = router
+            .clone()
+            .oneshot(authed_get(
+                "/api/repo/diff/file?path=.GIT/config&untracked=true",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         // A legitimate untracked file inside the repo is served, not rejected.
         let resp = router

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -645,4 +645,103 @@ mod tests {
         std::fs::remove_file(&tmp).ok();
         std::fs::remove_dir_all(&repo_dir).ok();
     }
+
+    /// Insert a live stream into a router state's registry, tagged with the repo it
+    /// operates on. Mirrors what `AppState::register_stream` stores, but built
+    /// directly so the test doesn't need a whole `AppState`. Returns the sender so
+    /// the caller can keep it alive (dropping it would close the stream).
+    fn insert_stream(
+        state: &auth::RouterState,
+        id: &str,
+        kind: &str,
+        repo_path: &str,
+    ) -> tokio::sync::broadcast::Sender<crate::agent::ReviewEvent> {
+        let (tx, _rx) = tokio::sync::broadcast::channel(16);
+        state.streams.lock().unwrap().insert(
+            id.to_string(),
+            crate::state::StreamInfo {
+                tx: tx.clone(),
+                kind: kind.to_string(),
+                started_at: "2026-07-17T00:00:00.000Z".to_string(),
+                repo_path: repo_path.to_string(),
+            },
+        );
+        tx
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn reviews_list_is_scoped_to_the_shared_repo() {
+        // A stream registered on the shared repo is listed; one on a different repo
+        // is omitted — a paired device only ever sees streams on the shared repo.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("List Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        // Sharing C:/repo, with one stream on it and one on C:/other.
+        let state = test_router(Some("C:/repo".to_string()));
+        let _tx_here = insert_stream(&state, "rev-here", "review", "C:/repo");
+        let _tx_other = insert_stream(&state, "rev-other", "session", "C:/other");
+        let router = server::build_router(state);
+
+        let resp = router
+            .oneshot(authed_get("/api/reviews", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let items: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = items.as_array().unwrap();
+        // Exactly the shared repo's stream; the other repo's is filtered out. Repo
+        // paths are never on the wire (only id/kind/startedAt).
+        assert_eq!(arr.len(), 1, "only the shared repo's stream: {items}");
+        assert_eq!(arr[0]["id"], "rev-here");
+        assert_eq!(arr[0]["kind"], "review");
+        assert!(arr[0].get("repoPath").is_none() && arr[0].get("repo_path").is_none());
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn reviews_list_409s_when_no_repo_shared() {
+        // With no active repo, the enumeration route 409s (like every other read
+        // route) even when a stream is registered — nothing is shared to list.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("NoRepo Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let state = test_router(None);
+        let _tx = insert_stream(&state, "rev-1", "review", "C:/repo");
+        let router = server::build_router(state);
+
+        let list = router
+            .oneshot(authed_get("/api/reviews", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(list.status(), StatusCode::CONFLICT);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    // NOTE on the `stream` route's 409/404 branches: `WebSocketUpgrade` is an
+    // extractor, and axum runs it during extraction — a plain (non-upgrade) GET is
+    // rejected with `400 Bad Request` by the extractor BEFORE the handler body runs,
+    // so a `tower::oneshot` (which can't perform a real WS upgrade) can never reach
+    // the body's `repo_or_409!` (409) or its scoped-`subscribe_in_for` 404. The
+    // pre-existing `review_routes_are_bearer_gated` test likewise only reaches the
+    // 401 because that's middleware, ahead of extraction. The scoping logic these
+    // branches call is unit-tested directly in `state::tests`
+    // (`scoped_snapshot_and_subscribe_filter_by_repo`): matching repo → `Some`,
+    // out-of-scope id and unknown id → `None` (the 404 source), with no oracle
+    // distinguishing them. Asserting the route-level 404/409 would need a live
+    // socket, out of scope for these in-memory router tests.
 }

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -1,0 +1,497 @@
+//! The LAN phone-companion server: an embedded, default-OFF axum HTTP server
+//! inside the Tauri process that lets a paired phone read the desktop's active
+//! repo over the LAN. API-only in this slice (the phone UI arrives in slice 2).
+//!
+//! Security is the gate — see [`auth`] for the full model. In short: the server
+//! is off until [`lan_enable`]; every `/api/` request except pairing carries a
+//! per-device bearer; pairing is a PIN-gated challenge/response; and the route
+//! surface is a structural read-only allowlist.
+//!
+//! ## State ownership
+//!
+//! [`LanState`] is Tauri-managed. Like [`crate::state::AppState`] it hand-rolls
+//! `Default` (its fields — a `Notify`-backed server handle, `Mutex`es — don't
+//! derive). The axum router does NOT get `Arc<LanState>`; instead the individual
+//! pieces it needs (active repo, pairing session, rate-limit map) are shared as
+//! per-field `Arc`s, mirroring how `AppState` shares individual fields.
+
+pub mod auth;
+pub mod routes;
+pub mod server;
+
+use std::sync::{Arc, Mutex};
+
+use tauri::{AppHandle, State};
+
+use crate::error::{AppError, AppResult};
+use auth::{LanDevice, PairingSession, RateLimitMap};
+use server::ServerHandle;
+
+/// The Tauri-managed state for the LAN companion.
+pub struct LanState {
+    /// The active repo path the read routes operate on. Shared (per-field `Arc`)
+    /// with the router state so `lan_set_active_repo` updates it live.
+    active_repo: Arc<Mutex<Option<String>>>,
+    /// The running server handle (bound port + shutdown signal + task), or `None`
+    /// when disabled. Guarded so enable/disable are serialized.
+    running: Mutex<Option<RunningServer>>,
+    /// The single active pairing session, shared with the router state.
+    pairing: Arc<Mutex<Option<PairingSession>>>,
+    /// Per-IP failure windows for rate-limiting, shared with the router state.
+    rate_limit: RateLimitMap,
+    /// Serializes the WHOLE enable/disable lifecycle transition (an async-aware
+    /// `Mutex`, held across the bind/shutdown `.await`s). Without it, two
+    /// concurrent `lan_enable`s could both observe "not running", both bind a
+    /// listener, and race to store — leaking one bound socket. Holding this for
+    /// the transition guarantees exactly one listener results. (The `running`
+    /// `std::Mutex` above is only ever taken for short, non-async reads/writes;
+    /// this is the coarse gate that makes the transition atomic.)
+    lifecycle: tokio::sync::Mutex<()>,
+}
+
+/// The bits we track for a running server: its handle, the mode it was started
+/// in, and the advertised urls (for `lan_status` without re-enumerating).
+struct RunningServer {
+    handle: ServerHandle,
+    bind_lan: bool,
+    urls: Vec<String>,
+}
+
+impl Default for LanState {
+    fn default() -> Self {
+        Self {
+            active_repo: Arc::new(Mutex::new(None)),
+            running: Mutex::new(None),
+            pairing: Arc::new(Mutex::new(None)),
+            rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            lifecycle: tokio::sync::Mutex::new(()),
+        }
+    }
+}
+
+impl LanState {
+    /// Build the current [`LanStatus`] snapshot.
+    fn status(&self) -> LanStatus {
+        let running = self.running.lock().unwrap_or_else(|p| p.into_inner());
+        let pairing_active = {
+            let mut guard = self.pairing.lock().unwrap_or_else(|p| p.into_inner());
+            // Treat an expired session as inactive (and clear it lazily).
+            match guard.as_ref() {
+                Some(s) if s.is_expired() => {
+                    *guard = None;
+                    false
+                }
+                Some(_) => true,
+                None => false,
+            }
+        };
+        let active_repo = self
+            .active_repo
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
+        match running.as_ref() {
+            Some(rs) => LanStatus {
+                enabled: true,
+                bind_lan: rs.bind_lan,
+                port: Some(rs.handle.port),
+                urls: rs.urls.clone(),
+                active_repo,
+                device_count: auth::device_count(),
+                pairing_active,
+            },
+            None => LanStatus {
+                enabled: false,
+                bind_lan: false,
+                port: None,
+                urls: Vec::new(),
+                active_repo,
+                device_count: auth::device_count(),
+                pairing_active,
+            },
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// FROZEN command-contract response shapes
+// --------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanStatus {
+    pub enabled: bool,
+    pub bind_lan: bool,
+    pub port: Option<u16>,
+    pub urls: Vec<String>,
+    pub active_repo: Option<String>,
+    pub device_count: u32,
+    pub pairing_active: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanPairing {
+    pub url: String,
+    pub qr_svg: String,
+    pub pin: String,
+    pub expires_at: String,
+}
+
+// --------------------------------------------------------------------------
+// Commands (thin wrappers over LanState methods)
+// --------------------------------------------------------------------------
+
+/// Current server + pairing + device status.
+#[tauri::command]
+pub fn lan_status(state: State<'_, LanState>) -> AppResult<LanStatus> {
+    Ok(state.status())
+}
+
+/// Enable the server. `bind_lan` false → 127.0.0.1 (dev/preview); true →
+/// 0.0.0.0 (LAN). Already-enabled with the SAME mode is a no-op returning current
+/// status; a DIFFERENT mode restarts the listener. Reflects the new state on the
+/// tray.
+#[tauri::command]
+pub async fn lan_enable(
+    app: AppHandle,
+    state: State<'_, LanState>,
+    app_state: State<'_, crate::state::AppState>,
+    bind_lan: bool,
+) -> AppResult<LanStatus> {
+    // Hold the lifecycle lock across the WHOLE transition so two concurrent
+    // enables can't both bind (the TOCTOU that would leak a listener). Released
+    // when `_lifecycle` drops at the end of the fn.
+    let _lifecycle = state.lifecycle.lock().await;
+
+    // Same-mode no-op / different-mode restart decision. Take what we need under
+    // the (short, non-async) `running` lock, then drop it before awaiting the
+    // (async) shutdown/start.
+    let existing_mode = {
+        let running = state.running.lock().unwrap_or_else(|p| p.into_inner());
+        running.as_ref().map(|rs| rs.bind_lan)
+    };
+    if let Some(mode) = existing_mode {
+        if mode == bind_lan {
+            return Ok(state.status()); // already running in this mode
+        }
+        // Different mode → stop the old listener first.
+        let old = {
+            let mut running = state.running.lock().unwrap_or_else(|p| p.into_inner());
+            running.take()
+        };
+        if let Some(rs) = old {
+            rs.handle.shutdown().await;
+        }
+    }
+
+    let (handle, urls, _hosts) = server::start(
+        bind_lan,
+        state.active_repo.clone(),
+        state.pairing.clone(),
+        state.rate_limit.clone(),
+        // The SAME stream registry `AppState` owns — so a review/session running
+        // there is enumerable + watchable over the LAN.
+        app_state.streams_arc(),
+    )
+    .await?;
+    {
+        let mut running = state.running.lock().unwrap_or_else(|p| p.into_inner());
+        *running = Some(RunningServer {
+            handle,
+            bind_lan,
+            urls,
+        });
+    }
+    // Keep the tray truthful about whether we're sharing.
+    crate::tray::update_companion_indicator(&app, true);
+    Ok(state.status())
+}
+
+/// Disable the server (graceful). Idempotent: disabling when already off is a
+/// no-op. Reflects the new state on the tray.
+#[tauri::command]
+pub async fn lan_disable(app: AppHandle, state: State<'_, LanState>) -> AppResult<LanStatus> {
+    // Serialize against enable/disable via the same lifecycle lock (so a disable
+    // racing an enable can't tear down a listener the enable is mid-way through
+    // storing). Released when `_lifecycle` drops.
+    let _lifecycle = state.lifecycle.lock().await;
+    let old = {
+        let mut running = state.running.lock().unwrap_or_else(|p| p.into_inner());
+        running.take()
+    };
+    if let Some(rs) = old {
+        rs.handle.shutdown().await;
+    }
+    // Any in-flight pairing is meaningless once the server is down.
+    {
+        let mut pairing = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
+        *pairing = None;
+    }
+    crate::tray::update_companion_indicator(&app, false);
+    Ok(state.status())
+}
+
+/// Point the read routes at `repo_path` (the desktop's currently-open repo).
+#[tauri::command]
+pub fn lan_set_active_repo(state: State<'_, LanState>, repo_path: String) -> AppResult<()> {
+    let mut guard = state.active_repo.lock().unwrap_or_else(|p| p.into_inner());
+    *guard = Some(repo_path);
+    Ok(())
+}
+
+/// Start (or restart) a pairing session: a fresh 6-digit PIN + QR. The QR/url
+/// encode ONLY the pair url — never the PIN or the secret. Errors if the server
+/// isn't enabled (there's no url to pair against yet).
+#[tauri::command]
+pub fn lan_pairing_start(state: State<'_, LanState>) -> AppResult<LanPairing> {
+    // The pair url is the FIRST advertised url + "/#pair".
+    let first_url = {
+        let running = state.running.lock().unwrap_or_else(|p| p.into_inner());
+        running
+            .as_ref()
+            .and_then(|rs| rs.urls.first().cloned())
+            .ok_or_else(|| {
+                AppError::Command(
+                    "enable the phone companion before starting pairing".to_string(),
+                )
+            })?
+    };
+    let pair_url = format!("{first_url}/#pair");
+    let session = auth::new_pairing_session(pair_url.clone());
+    // QR of the pair url (deliberately WITHOUT the PIN/secret — a shoulder-surfed
+    // QR photo alone can't pair; the PIN is typed on the phone).
+    let qr_svg = render_qr_svg(&pair_url)?;
+    let pairing = LanPairing {
+        url: session.url.clone(),
+        qr_svg,
+        pin: session.pin.clone(),
+        expires_at: session.expires_at_iso.clone(),
+    };
+    {
+        let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = Some(session); // single active session — replaces any prior
+    }
+    Ok(pairing)
+}
+
+/// Cancel any active pairing session. Idempotent.
+#[tauri::command]
+pub fn lan_pairing_cancel(state: State<'_, LanState>) -> AppResult<()> {
+    let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
+    *guard = None;
+    Ok(())
+}
+
+/// List paired devices (no token hashes).
+#[tauri::command]
+pub fn lan_devices_list(_state: State<'_, LanState>) -> AppResult<Vec<LanDevice>> {
+    auth::list_devices()
+}
+
+/// Revoke a paired device by id. Its bearer token stops authenticating.
+#[tauri::command]
+pub fn lan_device_revoke(_state: State<'_, LanState>, device_id: String) -> AppResult<()> {
+    auth::revoke_device(&device_id)
+}
+
+/// Render `data` as an SVG QR code (string). Uses medium error correction and a
+/// quiet zone so a phone camera reads it reliably.
+fn render_qr_svg(data: &str) -> AppResult<String> {
+    use qrcode::render::svg;
+    use qrcode::{EcLevel, QrCode};
+    let code = QrCode::with_error_correction_level(data, EcLevel::M)
+        .map_err(|e| AppError::Command(format!("could not build the pairing QR code: {e}")))?;
+    let svg = code
+        .render::<svg::Color>()
+        .min_dimensions(200, 200)
+        .quiet_zone(true)
+        .dark_color(svg::Color("#000000"))
+        .light_color(svg::Color("#ffffff"))
+        .build();
+    Ok(svg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt; // for `oneshot`
+
+    fn temp_store() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-lan-router-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    /// A router wired to the given active repo + a fresh (empty) device store.
+    /// Host allowlist is `testhost` so the `Host` header is deterministic.
+    fn test_router(active: Option<String>) -> auth::RouterState {
+        auth::RouterState {
+            active_repo: Arc::new(Mutex::new(active)),
+            pairing: Arc::new(Mutex::new(None)),
+            rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            bound_hosts: Arc::new(vec!["testhost".to_string()]),
+            streams: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        }
+    }
+
+    fn get(path: &str) -> Request<Body> {
+        Request::builder()
+            .uri(path)
+            .header("host", "testhost")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_api_is_401() {
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let resp = router.oneshot(get("/api/repo/status")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn review_routes_are_bearer_gated() {
+        // The live-monitoring routes live under the same authed subtree as the git
+        // routes, so an unauthenticated request 401s BEFORE reaching the handler —
+        // for both the enumeration route and the WebSocket-upgrade route (an
+        // upgrade is a plain GET until the handler accepts it, so `require_auth`
+        // runs first). This is the middleware-layering guarantee the WS route
+        // relies on for its no-approve/no-stdin read-only contract.
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let list = router.clone().oneshot(get("/api/reviews")).await.unwrap();
+        assert_eq!(list.status(), StatusCode::UNAUTHORIZED);
+        let stream = router
+            .oneshot(get("/api/reviews/whatever/stream"))
+            .await
+            .unwrap();
+        assert_eq!(stream.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn review_routes_are_host_guarded() {
+        // The outer host guard wraps the review routes too (DNS-rebind defense).
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let req = Request::builder()
+            .uri("/api/reviews")
+            .header("host", "evil.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn bad_host_is_403() {
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let req = Request::builder()
+            .uri("/api/repo/status")
+            .header("host", "evil.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn unknown_route_is_404() {
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let resp = router.oneshot(get("/api/nope")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn hardening_headers_on_every_response() {
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let resp = router.oneshot(get("/api/nope")).await.unwrap();
+        assert_eq!(resp.headers().get("X-Frame-Options").unwrap(), "DENY");
+        assert_eq!(
+            resp.headers().get("Content-Security-Policy").unwrap(),
+            "frame-ancestors 'none'"
+        );
+    }
+
+    #[tokio::test]
+    // The store-path override is a process global; this serialization guard keeps
+    // parallel store-touching tests off each other's temp file. Held across the
+    // in-memory `oneshot` awaits below — safe here (current-thread test runtime,
+    // no contention that could deadlock), so the lint doesn't apply.
+    #[allow(clippy::await_holding_lock)]
+    async fn pairing_happy_path_mints_a_token_that_authenticates() {
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        // Seed an active pairing session so /challenge + /pair work.
+        let session = auth::new_pairing_session("http://testhost/#pair".to_string());
+        let pin = session.pin.clone();
+        let state = test_router(Some("C:/repo".to_string()));
+        *state.pairing.lock().unwrap() = Some(session);
+        let router = server::build_router(state);
+
+        // 1) Fetch a challenge.
+        let chal_req = Request::builder()
+            .uri("/api/pair/challenge")
+            .method("POST")
+            .header("host", "testhost")
+            .body(Body::empty())
+            .unwrap();
+        let chal_resp = router.clone().oneshot(chal_req).await.unwrap();
+        assert_eq!(chal_resp.status(), StatusCode::OK);
+        let chal_bytes = axum::body::to_bytes(chal_resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let chal: serde_json::Value = serde_json::from_slice(&chal_bytes).unwrap();
+        let challenge = chal["challenge"].as_str().unwrap().to_string();
+        let salt = chal["salt"].as_str().unwrap().to_string();
+
+        // 2) Submit the correct proof.
+        let proof = auth::compute_proof(&pin, &salt, &challenge);
+        let pair_body = serde_json::json!({ "deviceName": "Test Phone", "proof": proof });
+        let pair_req = Request::builder()
+            .uri("/api/pair")
+            .method("POST")
+            .header("host", "testhost")
+            .header("content-type", "application/json")
+            .body(Body::from(pair_body.to_string()))
+            .unwrap();
+        let pair_resp = router.clone().oneshot(pair_req).await.unwrap();
+        assert_eq!(pair_resp.status(), StatusCode::OK);
+        let pair_bytes = axum::body::to_bytes(pair_resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let minted: serde_json::Value = serde_json::from_slice(&pair_bytes).unwrap();
+        let token = minted["token"].as_str().unwrap().to_string();
+        let device_id = minted["deviceId"].as_str().unwrap().to_string();
+        assert_eq!(minted["scope"], "read");
+
+        // 3) The minted token authenticates a protected route (past auth — it may
+        //    then fail at the git layer since C:/repo isn't real, but NOT 401).
+        let auth_req = Request::builder()
+            .uri("/api/repo/status")
+            .header("host", "testhost")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let auth_resp = router.clone().oneshot(auth_req).await.unwrap();
+        assert_ne!(auth_resp.status(), StatusCode::UNAUTHORIZED);
+
+        // 4) Revoke the device → the same token now 401s.
+        auth::revoke_device(&device_id).unwrap();
+        let revoked_req = Request::builder()
+            .uri("/api/repo/status")
+            .header("host", "testhost")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let revoked_resp = router.oneshot(revoked_req).await.unwrap();
+        assert_eq!(revoked_resp.status(), StatusCode::UNAUTHORIZED);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+}

--- a/src-tauri/src/lan/routes/forge.rs
+++ b/src-tauri/src/lan/routes/forge.rs
@@ -1,0 +1,71 @@
+//! Read-only forge routes — thin adapters over the existing `crate::forge::*`
+//! core fns (which fan out to GitHub/GitLab/Bitbucket by the repo's remote). Each
+//! pulls the active repo from state and calls the core fn unchanged. The `lens`
+//! param is deliberately omitted from the HTTP surface (always `None`).
+//!
+//! Note: the forge issue fns hard-error on Bitbucket ("Bitbucket issues aren't
+//! supported yet."); that surfaces as the mapped `InvalidArgument` → 400. It is
+//! NOT special-cased here — the error propagates like any other.
+
+use axum::extract::{Path, Query, State};
+use axum::response::Response;
+use serde::Deserialize;
+
+use crate::lan::auth::RouterState;
+use crate::lan::routes::{repo_or_409, respond};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListQuery {
+    state: Option<String>,
+    limit: Option<u32>,
+}
+
+/// GET /api/forge/prs?state&limit
+pub async fn pr_list(State(state): State<RouterState>, Query(q): Query<ListQuery>) -> Response {
+    let repo = repo_or_409!(state);
+    let pr_state = q.state.unwrap_or_else(|| "open".to_string());
+    respond(crate::forge::forge_pr_list(repo, pr_state, q.limit, None).await)
+}
+
+/// GET /api/forge/prs/{number}
+pub async fn pr_view(State(state): State<RouterState>, Path(number): Path<u64>) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::forge::forge_pr_view(repo, number, None).await)
+}
+
+/// GET /api/forge/issues?state&limit
+pub async fn issue_list(State(state): State<RouterState>, Query(q): Query<ListQuery>) -> Response {
+    let repo = repo_or_409!(state);
+    let issue_state = q.state.unwrap_or_else(|| "open".to_string());
+    respond(crate::forge::forge_issue_list(repo, issue_state, q.limit, None).await)
+}
+
+/// GET /api/forge/issues/{number}
+pub async fn issue_view(State(state): State<RouterState>, Path(number): Path<u64>) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::forge::forge_issue_view(repo, number, None).await)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CiListQuery {
+    limit: Option<u32>,
+    branch: Option<String>,
+}
+
+/// GET /api/forge/ci/runs?limit&branch
+pub async fn ci_run_list(
+    State(state): State<RouterState>,
+    Query(q): Query<CiListQuery>,
+) -> Response {
+    let repo = repo_or_409!(state);
+    let limit = q.limit.unwrap_or(20);
+    respond(crate::forge::forge_ci_run_list(repo, limit, q.branch).await)
+}
+
+/// GET /api/forge/ci/runs/{id}
+pub async fn ci_run_view(State(state): State<RouterState>, Path(id): Path<u64>) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::forge::forge_ci_run_view(repo, id).await)
+}

--- a/src-tauri/src/lan/routes/git.rs
+++ b/src-tauri/src/lan/routes/git.rs
@@ -7,7 +7,7 @@ use axum::response::Response;
 use serde::Deserialize;
 
 use crate::lan::auth::RouterState;
-use crate::lan::routes::{repo_or_409, respond};
+use crate::lan::routes::{bad_request, is_safe_relative_path, repo_or_409, respond};
 
 /// GET /api/repo/status
 pub async fn status(State(state): State<RouterState>) -> Response {
@@ -95,5 +95,28 @@ pub async fn diff_file(
     Query(q): Query<FileDiffQuery>,
 ) -> Response {
     let repo = repo_or_409!(state);
+    // Path containment: this is a paired LAN device supplying `path`, and the
+    // untracked branch of `git_diff_file` runs `git diff --no-index` (NOT
+    // repo-confined). Reject anything that isn't a safe repo-relative path so a
+    // device can't read arbitrary files (e.g. `?path=/etc/passwd&untracked=true`).
+    if !is_safe_relative_path(&q.path) {
+        return bad_request("path must be a repo-relative path");
+    }
+    // For the untracked (`--no-index`, on-disk) branch, also require that the
+    // resolved file actually lives inside the repo — closes the symlink-that-
+    // points-outside case that a purely lexical check can't. (Untracked files
+    // exist on disk, so canonicalize succeeds for legitimate requests. The
+    // tracked branch is skipped: git confines its own pathspecs, and a
+    // deleted-but-tracked file isn't on disk to canonicalize.)
+    if q.untracked {
+        let repo_root = match std::fs::canonicalize(&repo) {
+            Ok(p) => p,
+            Err(_) => return bad_request("path is outside the shared repository"),
+        };
+        match std::fs::canonicalize(std::path::Path::new(&repo).join(&q.path)) {
+            Ok(target) if target.starts_with(&repo_root) => {}
+            _ => return bad_request("path is outside the shared repository"),
+        }
+    }
     respond(crate::git::diff::git_diff_file(repo, q.path, q.staged, q.untracked).await)
 }

--- a/src-tauri/src/lan/routes/git.rs
+++ b/src-tauri/src/lan/routes/git.rs
@@ -108,14 +108,36 @@ pub async fn diff_file(
     // exist on disk, so canonicalize succeeds for legitimate requests. The
     // tracked branch is skipped: git confines its own pathspecs, and a
     // deleted-but-tracked file isn't on disk to canonicalize.)
+    //
+    // Both the containment AND the `.git`-guard below run on the CANONICALIZED
+    // path, not the raw input: `std::fs::canonicalize` returns the real
+    // long-name path, so Windows 8.3 short names (`GIT~1`) and case tricks on
+    // case-insensitive filesystems (`.GIT`) resolve to their true form before
+    // we inspect the components.
     if q.untracked {
         let repo_root = match std::fs::canonicalize(&repo) {
             Ok(p) => p,
             Err(_) => return bad_request("path is outside the shared repository"),
         };
-        match std::fs::canonicalize(std::path::Path::new(&repo).join(&q.path)) {
-            Ok(target) if target.starts_with(&repo_root) => {}
+        let target = match std::fs::canonicalize(std::path::Path::new(&repo).join(&q.path)) {
+            Ok(target) if target.starts_with(&repo_root) => target,
             _ => return bad_request("path is outside the shared repository"),
+        };
+        // Reject anything inside the repo's git directory: `.git` is a `Normal`
+        // component, so containment alone lets `?path=.git/config` reach
+        // `git diff --no-index` and leak `.git/` internals (a `[remote "origin"]`
+        // url can embed credentials). Match ANY component (not just the first),
+        // mirroring git's own refusal to track paths containing a `.git`
+        // component (submodule gitdirs etc.).
+        let rel = match target.strip_prefix(&repo_root) {
+            Ok(rel) => rel,
+            Err(_) => return bad_request("path is outside the shared repository"),
+        };
+        if rel
+            .components()
+            .any(|c| c.as_os_str().eq_ignore_ascii_case(".git"))
+        {
+            return bad_request("path is inside the repository's git directory");
         }
     }
     respond(crate::git::diff::git_diff_file(repo, q.path, q.staged, q.untracked).await)

--- a/src-tauri/src/lan/routes/git.rs
+++ b/src-tauri/src/lan/routes/git.rs
@@ -1,0 +1,99 @@
+//! Read-only git routes — thin adapters over the existing `crate::git::*` core
+//! fns. Each pulls the active repo from state, calls the core fn with no shape
+//! translation, and returns its result as JSON. No new git logic lives here.
+
+use axum::extract::{Path, Query, State};
+use axum::response::Response;
+use serde::Deserialize;
+
+use crate::lan::auth::RouterState;
+use crate::lan::routes::{repo_or_409, respond};
+
+/// GET /api/repo/status
+pub async fn status(State(state): State<RouterState>) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::git::status::status_core(&repo).await)
+}
+
+/// GET /api/repo/branches
+pub async fn branches(State(state): State<RouterState>) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::git::branches::git_branches(repo).await)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogQuery {
+    limit: Option<u32>,
+    skip: Option<u32>,
+    search: Option<String>,
+}
+
+/// GET /api/repo/log?limit&skip&search
+pub async fn log(State(state): State<RouterState>, Query(q): Query<LogQuery>) -> Response {
+    let repo = repo_or_409!(state);
+    let limit = q.limit.unwrap_or(50);
+    let skip = q.skip.unwrap_or(0);
+    respond(crate::git::history::git_log(repo, limit, skip, q.search).await)
+}
+
+/// GET /api/repo/commits/{hash}
+pub async fn commit_details(
+    State(state): State<RouterState>,
+    Path(hash): Path<String>,
+) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::git::history::git_commit_details(repo, hash).await)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaxBytesQuery {
+    max_bytes: Option<usize>,
+}
+
+/// GET /api/repo/commits/{hash}/diff?maxBytes
+pub async fn commit_diff(
+    State(state): State<RouterState>,
+    Path(hash): Path<String>,
+    Query(q): Query<MaxBytesQuery>,
+) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::git::history::git_commit_diff(repo, hash, q.max_bytes).await)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkingDiffQuery {
+    max_bytes: Option<usize>,
+    worktree: Option<bool>,
+}
+
+/// GET /api/repo/diff/working?maxBytes&worktree
+pub async fn diff_working(
+    State(state): State<RouterState>,
+    Query(q): Query<WorkingDiffQuery>,
+) -> Response {
+    let repo = repo_or_409!(state);
+    // `exclude` has no HTTP surface in this slice — always None.
+    respond(crate::git::diff::git_staged_diff(repo, q.max_bytes, None, q.worktree).await)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileDiffQuery {
+    path: String,
+    #[serde(default)]
+    staged: bool,
+    #[serde(default)]
+    untracked: bool,
+}
+
+/// GET /api/repo/diff/file?path&staged&untracked
+pub async fn diff_file(
+    State(state): State<RouterState>,
+    Query(q): Query<FileDiffQuery>,
+) -> Response {
+    let repo = repo_or_409!(state);
+    respond(crate::git::diff::git_diff_file(repo, q.path, q.staged, q.untracked).await)
+}

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -44,6 +44,41 @@ pub(crate) fn no_active_repo() -> Response {
         .into_response()
 }
 
+/// A 400 response with the app's standard `{ kind, message }` shape (mirrors
+/// [`crate::lan::auth::bad_request`], reused by routes that validate client input
+/// before touching the git core).
+pub(crate) fn bad_request(message: &str) -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use serde_json::json;
+
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "kind": "invalidArgument",
+            "message": message
+        })),
+    )
+        .into_response()
+}
+
+/// Whether `path` is a safe repo-relative path: non-empty and built only from
+/// `Normal`/`CurDir` components. Any `RootDir` (a leading `/`), `Prefix` (a
+/// Windows drive like `C:`), or `ParentDir` (`..`) component rejects it — those
+/// are the ways a client could escape the repo. This is a purely lexical check;
+/// callers that also need on-disk containment (the untracked `--no-index` path)
+/// must additionally canonicalize + `starts_with` the repo root.
+pub(crate) fn is_safe_relative_path(path: &str) -> bool {
+    use std::path::{Component, Path};
+    if path.is_empty() {
+        return false;
+    }
+    Path::new(path)
+        .components()
+        .all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
+}
+
 /// Convenience: fetch the active repo or short-circuit-return its 409 response.
 macro_rules! repo_or_409 {
     ($state:expr) => {
@@ -69,3 +104,25 @@ pub(crate) fn json_or_error<T: serde::Serialize>(
 }
 
 pub(crate) use json_or_error as respond;
+
+#[cfg(test)]
+mod tests {
+    use super::is_safe_relative_path;
+
+    #[test]
+    fn safe_relative_paths_accepted() {
+        assert!(is_safe_relative_path("src/main.rs"));
+        assert!(is_safe_relative_path("./src/main.rs"));
+        assert!(is_safe_relative_path("file.txt"));
+    }
+
+    #[test]
+    fn escaping_paths_rejected() {
+        assert!(!is_safe_relative_path("")); // empty
+        assert!(!is_safe_relative_path("../x")); // ParentDir
+        assert!(!is_safe_relative_path("a/../b")); // ParentDir mid-path
+        assert!(!is_safe_relative_path("/etc/passwd")); // RootDir (leading /)
+        #[cfg(windows)]
+        assert!(!is_safe_relative_path("C:/x")); // Prefix (drive), Windows only
+    }
+}

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -1,0 +1,71 @@
+//! The read-only route handlers mounted by the LAN companion server.
+//!
+//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 13
+//! handlers below and nothing else — there is no catch-all and no static
+//! serving, so any path outside the list 404s. Each handler pulls the active
+//! repo from [`crate::lan::auth::RouterState`] (a `None` active repo → 409), calls
+//! the existing core git/forge fn unchanged, and returns its result as JSON with
+//! no shape translation. Errors map via [`crate::lan::auth::app_error_response`].
+
+pub mod forge;
+pub mod git;
+pub mod reviews;
+
+use axum::response::Response;
+
+use crate::lan::auth::RouterState;
+
+/// The active repo path from router state, or `None` when none is set. The 409
+/// response for the `None` case is built at the call site (via [`no_active_repo`])
+/// so this stays a cheap `Option` rather than a `Result` carrying a large
+/// `Response` in its `Err` arm.
+pub(crate) fn active_repo(state: &RouterState) -> Option<String> {
+    state
+        .active_repo
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone()
+}
+
+/// The 409 response returned when no repo is shared yet.
+pub(crate) fn no_active_repo() -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use serde_json::json;
+
+    (
+        StatusCode::CONFLICT,
+        Json(json!({
+            "kind": "noActiveRepo",
+            "message": "no active repository is shared yet"
+        })),
+    )
+        .into_response()
+}
+
+/// Convenience: fetch the active repo or short-circuit-return its 409 response.
+macro_rules! repo_or_409 {
+    ($state:expr) => {
+        match $crate::lan::routes::active_repo(&$state) {
+            Some(r) => r,
+            None => return $crate::lan::routes::no_active_repo(),
+        }
+    };
+}
+
+pub(crate) use repo_or_409;
+
+/// Wrap an `AppResult<T: Serialize>` into a JSON response or the mapped error.
+pub(crate) fn json_or_error<T: serde::Serialize>(
+    result: crate::error::AppResult<T>,
+) -> Response {
+    use axum::response::IntoResponse;
+    use axum::Json;
+    match result {
+        Ok(value) => Json(value).into_response(),
+        Err(err) => crate::lan::auth::app_error_response(&err),
+    }
+}
+
+pub(crate) use json_or_error as respond;

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -1,0 +1,124 @@
+//! Read-only live-monitoring routes: enumerate the desktop's active agent
+//! streams (reviews/sessions) and watch one over a WebSocket.
+//!
+//! These sit under the authed `/api/` subtree, so the same `require_auth` +
+//! `host_guard` middleware that gates every other read route also gates the
+//! enumeration AND the WebSocket upgrade (the upgrade is a normal GET request
+//! until the handler accepts it — the auth layer runs first and 401s an
+//! unauthenticated upgrade before this handler is ever reached).
+//!
+//! Monitoring is strictly one-way: the phone WATCHES the same [`ReviewEvent`]
+//! stream the desktop renders. There is no approve/deny, no stdin, and no write
+//! path — inbound client frames are drained and ignored (except a Close).
+//!
+//! **No replay.** The underlying channel is a `tokio::sync::broadcast` with no
+//! history, so a subscriber that connects mid-stream sees only events emitted
+//! *after* it subscribed; earlier deltas are not resent. Acceptable for v1 (the
+//! phone opens the stream to follow along, not to reconstruct the full transcript).
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::agent::ReviewEvent;
+use crate::lan::auth::RouterState;
+use crate::state::{snapshot_streams, subscribe_in};
+
+/// GET /api/reviews — the active agent streams the phone can watch, as
+/// `[{ id, kind, startedAt }]` (camelCase). `kind` is `"review"` | `"session"`.
+pub async fn list(State(state): State<RouterState>) -> Response {
+    let items: Vec<_> = snapshot_streams(&state.streams)
+        .into_iter()
+        .map(|(id, kind, started_at)| {
+            json!({
+                "id": id,
+                "kind": kind,
+                "startedAt": started_at,
+            })
+        })
+        .collect();
+    (StatusCode::OK, Json(items)).into_response()
+}
+
+/// GET /api/reviews/{id}/stream — upgrade to a WebSocket that forwards the live
+/// stream's [`ReviewEvent`]s as they happen. An unknown id 404s BEFORE the
+/// upgrade (no socket is opened for a stream that isn't running).
+pub async fn stream(
+    State(state): State<RouterState>,
+    Path(id): Path<String>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    // Subscribe up front so we can reject an unknown id with a plain 404 instead
+    // of upgrading and immediately closing. Subscribing here also means we don't
+    // miss events between the upgrade handshake and the receive loop starting.
+    let rx = subscribe_in(&state.streams, &id);
+    let Some(rx) = rx else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "kind": "noSuchStream",
+                "message": "no active stream with that id"
+            })),
+        )
+            .into_response();
+    };
+    ws.on_upgrade(move |socket| forward_stream(socket, rx))
+}
+
+/// The per-connection pump: forward each broadcast event as one JSON text frame,
+/// translate lag/close, and drain inbound client frames (read-only monitor — no
+/// stdin path exists). Terminates on the terminal `Done`/`Error` event, on the
+/// stream ending (`Closed`), or when the client hangs up.
+async fn forward_stream(mut socket: WebSocket, mut rx: tokio::sync::broadcast::Receiver<ReviewEvent>) {
+    loop {
+        tokio::select! {
+            // Broadcast side: forward events to the client.
+            recv = rx.recv() => match recv {
+                Ok(ev) => {
+                    // Terminal? Forward it, then close the socket cleanly.
+                    let terminal = matches!(ev, ReviewEvent::Done { .. } | ReviewEvent::Error { .. });
+                    // The wire format is ReviewEvent's own tagged camelCase serde,
+                    // verbatim — the same JSON the desktop channel carries.
+                    let Ok(text) = serde_json::to_string(&ev) else {
+                        // A ReviewEvent that won't serialize is a bug, not a
+                        // client-recoverable state; drop the connection.
+                        break;
+                    };
+                    if socket.send(Message::Text(text.into())).await.is_err() {
+                        break; // client went away
+                    }
+                    if terminal {
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(n)) => {
+                    // The subscriber fell behind the 256-deep buffer. Tell it how
+                    // many events it missed (a synthetic status frame) and keep
+                    // going — recv() resumes from the oldest still-buffered event.
+                    let notice = json!({
+                        "kind": "status",
+                        "text": format!("…skipped {n} events")
+                    })
+                    .to_string();
+                    if socket.send(Message::Text(notice.into())).await.is_err() {
+                        break;
+                    }
+                }
+                // The stream ended and its registry entry (and sender) dropped.
+                Err(RecvError::Closed) => break,
+            },
+            // Client side: a read-only monitor. Drain frames; act only on Close.
+            inbound = socket.recv() => match inbound {
+                Some(Ok(Message::Close(_))) | None => break,
+                Some(Ok(_)) => { /* ignore data/ping/pong — no stdin path exists */ }
+                Some(Err(_)) => break,
+            },
+        }
+    }
+    // Best-effort graceful close (ignored if the socket is already gone).
+    let _ = socket.send(Message::Close(None)).await;
+}

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -11,6 +11,14 @@
 //! stream the desktop renders. There is no approve/deny, no stdin, and no write
 //! path — inbound client frames are drained and ignored (except a Close).
 //!
+//! **Scoped to the shared repo.** Both routes authorize against the currently-
+//! shared repo: with no active repo they 409 like every other read route, and
+//! they only ever surface streams whose run operates on that repo. A stream on a
+//! repo the desktop has since closed or switched away from is invisible — the
+//! enumeration omits it and the watch route 404s it (indistinguishable from an
+//! unknown id, so there's no probe oracle). This upholds the clear-on-close
+//! containment: paired devices never watch a run on a repo that isn't shared.
+//!
 //! **No replay.** The underlying channel is a `tokio::sync::broadcast` with no
 //! history, so a subscriber that connects mid-stream sees only events emitted
 //! *after* it subscribed; earlier deltas are not resent. Acceptable for v1 (the
@@ -26,12 +34,18 @@ use tokio::sync::broadcast::error::RecvError;
 
 use crate::agent::ReviewEvent;
 use crate::lan::auth::RouterState;
-use crate::state::{snapshot_streams, subscribe_in};
+use crate::lan::routes::repo_or_409;
+use crate::state::{snapshot_streams_for, subscribe_in_for};
 
 /// GET /api/reviews — the active agent streams the phone can watch, as
 /// `[{ id, kind, startedAt }]` (camelCase). `kind` is `"review"` | `"session"`.
+/// Scoped to the currently-shared repo: a `None` active repo 409s (like every
+/// other read route), and only streams operating on that repo are listed — a
+/// device never sees streams from a repo the desktop has closed or switched away
+/// from. Repo paths are never exposed on the wire.
 pub async fn list(State(state): State<RouterState>) -> Response {
-    let items: Vec<_> = snapshot_streams(&state.streams)
+    let repo = repo_or_409!(state);
+    let items: Vec<_> = snapshot_streams_for(&state.streams, &repo)
         .into_iter()
         .map(|(id, kind, started_at)| {
             json!({
@@ -45,17 +59,23 @@ pub async fn list(State(state): State<RouterState>) -> Response {
 }
 
 /// GET /api/reviews/{id}/stream — upgrade to a WebSocket that forwards the live
-/// stream's [`ReviewEvent`]s as they happen. An unknown id 404s BEFORE the
-/// upgrade (no socket is opened for a stream that isn't running).
+/// stream's [`ReviewEvent`]s as they happen. Scoped to the currently-shared repo:
+/// a `None` active repo 409s, and a stream on any other repo is treated as
+/// unknown (404) — a device can't probe for or watch streams outside the shared
+/// repo. An unknown/out-of-scope id 404s BEFORE the upgrade (no socket is opened
+/// for a stream that isn't running or isn't ours to share).
 pub async fn stream(
     State(state): State<RouterState>,
     Path(id): Path<String>,
     ws: WebSocketUpgrade,
 ) -> Response {
-    // Subscribe up front so we can reject an unknown id with a plain 404 instead
-    // of upgrading and immediately closing. Subscribing here also means we don't
-    // miss events between the upgrade handshake and the receive loop starting.
-    let rx = subscribe_in(&state.streams, &id);
+    let repo = repo_or_409!(state);
+    // Subscribe up front so we can reject an unknown (or out-of-scope) id with a
+    // plain 404 instead of upgrading and immediately closing. Scoping to `repo`
+    // here means a stream on a different repo is indistinguishable from an unknown
+    // id. Subscribing now also means we don't miss events between the upgrade
+    // handshake and the receive loop starting.
+    let rx = subscribe_in_for(&state.streams, &id, &repo);
     let Some(rx) = rx else {
         return (
             StatusCode::NOT_FOUND,

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -44,7 +44,12 @@ pub struct ServerHandle {
 impl ServerHandle {
     /// Signal graceful shutdown and await the serve task's exit.
     pub async fn shutdown(self) {
-        self.shutdown.notify_waiters();
+        // `notify_one` (NOT `notify_waiters`): the serve task registers its
+        // `notified()` waiter only on its first poll, and a rapid enable→disable
+        // can call shutdown before that. `notify_one` stores a permit so a
+        // pre-registration signal is still consumed; `notify_waiters` would be
+        // lost, leaving `task.await` pending forever with the lifecycle lock held.
+        self.shutdown.notify_one();
         // The serve future observes the notify and returns; join to be sure the
         // listener is released before we (possibly) rebind on a mode change.
         let _ = self.task.await;

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -1,0 +1,277 @@
+//! The axum router assembly, listener bind (with port scanning), and graceful
+//! shutdown for the LAN companion server.
+//!
+//! The router mounts EXACTLY the pairing routes plus the read-only routes
+//! (structural allowlist — see [`crate::lan::routes`]): the 13 git/forge routes
+//! plus the two live-monitoring routes (`/api/reviews` and the
+//! `/api/reviews/{id}/stream` WebSocket); anything else 404s. Two middleware
+//! layers wrap everything: [`crate::lan::auth::host_guard`] (runs on every
+//! request — DNS-rebind defense + hardening headers) and, on the protected
+//! subtree only, [`crate::lan::auth::require_auth`] (per-device bearer). The
+//! WebSocket upgrade lives inside that protected subtree, so it is bearer-gated
+//! and host-guarded like every other read route.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use axum::routing::{get, post};
+use axum::Router;
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+use crate::error::{AppError, AppResult};
+use crate::lan::auth::{self, RouterState};
+use crate::lan::routes::{forge, git, reviews};
+
+/// The default port the server tries first — a fixed value in the IANA dynamic /
+/// private range (49152–65535 is the strict private range, but the 38400s are
+/// conventionally free and memorable). If it's taken we scan the next few.
+pub const DEFAULT_PORT: u16 = 38473;
+
+/// How many consecutive ports to try (DEFAULT_PORT ..= DEFAULT_PORT + SCAN) when
+/// the first is already in use.
+const PORT_SCAN: u16 = 4;
+
+/// A bound, running server: the port it landed on, a shutdown signal, and the
+/// task handle. Dropping the handle does not stop the server — call
+/// [`ServerHandle::shutdown`].
+pub struct ServerHandle {
+    pub port: u16,
+    shutdown: Arc<Notify>,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
+
+impl ServerHandle {
+    /// Signal graceful shutdown and await the serve task's exit.
+    pub async fn shutdown(self) {
+        self.shutdown.notify_waiters();
+        // The serve future observes the notify and returns; join to be sure the
+        // listener is released before we (possibly) rebind on a mode change.
+        let _ = self.task.await;
+    }
+}
+
+/// Build the axum router for the given state. Separated from binding so tests can
+/// drive it via `tower::ServiceExt::oneshot` without opening a socket.
+pub fn build_router(state: RouterState) -> Router {
+    // The protected read-only subtree: bearer-auth required.
+    let api = Router::new()
+        .route("/api/repo/status", get(git::status))
+        .route("/api/repo/branches", get(git::branches))
+        .route("/api/repo/log", get(git::log))
+        .route("/api/repo/commits/{hash}", get(git::commit_details))
+        .route("/api/repo/commits/{hash}/diff", get(git::commit_diff))
+        .route("/api/repo/diff/working", get(git::diff_working))
+        .route("/api/repo/diff/file", get(git::diff_file))
+        .route("/api/forge/prs", get(forge::pr_list))
+        .route("/api/forge/prs/{number}", get(forge::pr_view))
+        .route("/api/forge/issues", get(forge::issue_list))
+        .route("/api/forge/issues/{number}", get(forge::issue_view))
+        .route("/api/forge/ci/runs", get(forge::ci_run_list))
+        .route("/api/forge/ci/runs/{id}", get(forge::ci_run_view))
+        // Live-monitoring: enumerate active agent streams + watch one over a
+        // WebSocket. Mounted INSIDE this subtree so the upgrade is bearer-gated by
+        // `require_auth` below (and host-guarded by the outer layer) exactly like
+        // every other read route.
+        .route("/api/reviews", get(reviews::list))
+        .route("/api/reviews/{id}/stream", get(reviews::stream))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_auth,
+        ));
+
+    // The unauthenticated (but rate-limited + host-guarded) pairing routes.
+    let pairing = Router::new()
+        .route("/api/pair/challenge", post(auth::pair_challenge))
+        .route("/api/pair", post(auth::pair_submit));
+
+    // Merge, then wrap EVERYTHING in the host guard (which also stamps the
+    // hardening headers on every response, including 404s for unknown paths).
+    Router::new()
+        .merge(api)
+        .merge(pairing)
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::host_guard,
+        ))
+        .with_state(state)
+}
+
+/// Enumerate the addresses we bind and advertise. `bind_lan` false → loopback
+/// only (dev/preview); true → all interfaces. Returns `(bind_ip, advertised_ips)`
+/// where `advertised_ips` are the concrete IPv4s the URLs use (loopback for
+/// loopback mode; every non-loopback IPv4 for LAN mode, falling back to loopback
+/// if none can be enumerated).
+fn resolve_ips(bind_lan: bool) -> (IpAddr, Vec<Ipv4Addr>) {
+    if !bind_lan {
+        return (
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            vec![Ipv4Addr::LOCALHOST],
+        );
+    }
+    let mut ips: Vec<Ipv4Addr> = local_ip_address::list_afinet_netifas()
+        .map(|ifaces| {
+            ifaces
+                .into_iter()
+                .filter_map(|(_name, ip)| match ip {
+                    IpAddr::V4(v4) if !v4.is_loopback() && !v4.is_unspecified() => Some(v4),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    ips.sort();
+    ips.dedup();
+    if ips.is_empty() {
+        // No LAN interface found — still bind 0.0.0.0 but advertise loopback so
+        // the UI has at least one working url.
+        ips.push(Ipv4Addr::LOCALHOST);
+    }
+    (IpAddr::V4(Ipv4Addr::UNSPECIFIED), ips)
+}
+
+/// The `http://<ip>:<port>` urls for the advertised addresses.
+pub fn urls_for(ips: &[Ipv4Addr], port: u16) -> Vec<String> {
+    ips.iter().map(|ip| format!("http://{ip}:{port}")).collect()
+}
+
+/// The `<ip>:<port>` host strings we accept in a `Host`/`Origin` header. Always
+/// includes `localhost:<port>` and `127.0.0.1:<port>` (a phone browser may resolve
+/// either) plus every advertised IP.
+pub fn bound_hosts_for(ips: &[Ipv4Addr], port: u16) -> Vec<String> {
+    let mut hosts = vec![
+        format!("localhost:{port}"),
+        format!("127.0.0.1:{port}"),
+    ];
+    for ip in ips {
+        let h = format!("{ip}:{port}");
+        if !hosts.contains(&h) {
+            hosts.push(h);
+        }
+    }
+    hosts
+}
+
+/// Bind a `TcpListener`, scanning DEFAULT_PORT..=DEFAULT_PORT+PORT_SCAN when the
+/// preferred port is already in use. Returns the listener and the port it landed
+/// on. A non-`AddrInUse` error (e.g. permission) fails immediately.
+async fn bind_listener(bind_ip: IpAddr) -> AppResult<(TcpListener, u16)> {
+    let mut last_err: Option<std::io::Error> = None;
+    for port in DEFAULT_PORT..=DEFAULT_PORT.saturating_add(PORT_SCAN) {
+        let addr = SocketAddr::new(bind_ip, port);
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Ok((listener, port)),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                last_err = Some(e);
+                continue;
+            }
+            Err(e) => return Err(bind_error(bind_ip, &e)),
+        }
+    }
+    Err(AppError::Command(format!(
+        "could not bind the phone-companion server: ports {}–{} on {} are all in use{}",
+        DEFAULT_PORT,
+        DEFAULT_PORT.saturating_add(PORT_SCAN),
+        bind_ip,
+        last_err
+            .map(|e| format!(" ({e})"))
+            .unwrap_or_default(),
+    )))
+}
+
+fn bind_error(bind_ip: IpAddr, e: &std::io::Error) -> AppError {
+    AppError::Command(format!(
+        "could not bind the phone-companion server on {} (ports {}–{}): {e}",
+        bind_ip,
+        DEFAULT_PORT,
+        DEFAULT_PORT.saturating_add(PORT_SCAN),
+    ))
+}
+
+/// Start the server: resolve addresses, bind, spawn the serve task with graceful
+/// shutdown wired to a `Notify`, and return the handle plus the advertised urls
+/// and the bound-host allowlist. The `RouterState` is built here so the host
+/// guard sees the exact hosts we bound.
+pub async fn start(
+    bind_lan: bool,
+    active_repo: Arc<std::sync::Mutex<Option<String>>>,
+    pairing: Arc<std::sync::Mutex<Option<auth::PairingSession>>>,
+    rate_limit: auth::RateLimitMap,
+    streams: Arc<std::sync::Mutex<std::collections::HashMap<String, crate::state::StreamInfo>>>,
+) -> AppResult<(ServerHandle, Vec<String>, Vec<String>)> {
+    let (bind_ip, ips) = resolve_ips(bind_lan);
+    let (listener, port) = bind_listener(bind_ip).await?;
+    let urls = urls_for(&ips, port);
+    let bound_hosts = bound_hosts_for(&ips, port);
+
+    let state = RouterState {
+        active_repo,
+        pairing,
+        rate_limit,
+        bound_hosts: Arc::new(bound_hosts.clone()),
+        streams,
+    };
+    let router = build_router(state);
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = shutdown.clone();
+    // Quit-time teardown is IMPLICIT: `app.exit(0)` from the tray kills the
+    // process, which drops the listener — so there's no exit-site hook to add.
+    // A user-driven `lan_disable` calls `ServerHandle::shutdown`, which notifies
+    // this signal for a graceful drain. (Sleep auto-off is a known later-slice
+    // gap — not handled here.)
+    let task = tauri::async_runtime::spawn(async move {
+        let serve = axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
+            shutdown_signal.notified().await;
+        });
+        if let Err(e) = serve.await {
+            // The listener died unexpectedly (not a graceful shutdown). Nothing to
+            // recover to here; log to stderr so a dev sees it.
+            eprintln!("lan companion server exited with error: {e}");
+        }
+    });
+
+    Ok((
+        ServerHandle {
+            port,
+            shutdown,
+            task,
+        },
+        urls,
+        bound_hosts,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_mode_advertises_localhost_only() {
+        let (bind_ip, ips) = resolve_ips(false);
+        assert_eq!(bind_ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(ips, vec![Ipv4Addr::LOCALHOST]);
+        assert_eq!(urls_for(&ips, 38473), vec!["http://127.0.0.1:38473"]);
+    }
+
+    #[test]
+    fn bound_hosts_always_include_localhost_and_loopback() {
+        let hosts = bound_hosts_for(&[Ipv4Addr::new(192, 168, 1, 5)], 38473);
+        assert!(hosts.contains(&"localhost:38473".to_string()));
+        assert!(hosts.contains(&"127.0.0.1:38473".to_string()));
+        assert!(hosts.contains(&"192.168.1.5:38473".to_string()));
+    }
+
+    #[test]
+    fn lan_mode_binds_unspecified() {
+        // We can't assert on the machine's real interfaces, but the bind IP must
+        // be 0.0.0.0 and at least one advertised url must exist.
+        let (bind_ip, ips) = resolve_ips(true);
+        assert_eq!(bind_ip, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert!(!ips.is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod hooks;
 mod instructions;
 mod jira_field_maps;
 mod jira_links;
+mod lan;
 mod local_issues;
 mod local_prs;
 mod mcp;
@@ -103,6 +104,7 @@ pub fn run() {
         .on_window_event(tray::handle_window_event)
         .manage(AppState::default())
         .manage(pty::PtyState::default())
+        .manage(lan::LanState::default())
         .invoke_handler(tauri::generate_handler![
             git::repo::check_git_installed,
             git::repo::validate_repo,
@@ -663,6 +665,15 @@ pub fn run() {
             agent::agent_review_cancel,
             agent::agent_session,
             tray::set_close_to_tray,
+            // LAN companion
+            lan::lan_status,
+            lan::lan_enable,
+            lan::lan_disable,
+            lan::lan_set_active_repo,
+            lan::lan_pairing_start,
+            lan::lan_pairing_cancel,
+            lan::lan_devices_list,
+            lan::lan_device_revoke,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -24,6 +24,11 @@ pub struct StreamInfo {
     pub kind: String,
     /// ISO-8601 (millis + `Z`), matching every other timestamp the app writes.
     pub started_at: String,
+    /// The repo the streaming run operates on; the LAN routes authorize against
+    /// it so a paired device only ever watches streams belonging to the
+    /// currently-shared repo (never one on a repo the desktop has since closed or
+    /// switched away from). Not exposed on the wire — used only for scoping.
+    pub repo_path: String,
 }
 
 /// The shared live-stream registry handle. `AppState` owns one and hands a clone
@@ -50,6 +55,52 @@ pub fn subscribe_in(registry: &StreamRegistry, id: &str) -> Option<broadcast::Re
         .lock()
         .unwrap_or_else(|p| p.into_inner())
         .get(id)
+        .map(|info| info.tx.subscribe())
+}
+
+/// Whether two repo paths refer to the same repo for LAN stream authorization.
+/// Equal if the raw strings match (the common case — both originate from the same
+/// frontend `repoPath`), OR if both canonicalize successfully to the same path
+/// (hardens against `/` vs `\` and drive-letter case on Windows). Canonicalization
+/// touches the filesystem, so it's the fallback, not the primary check.
+fn repo_paths_match(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// Like [`snapshot_streams`], but returns only streams whose `repo_path` matches
+/// `repo` (per [`repo_paths_match`]) — the LAN enumeration route uses this so a
+/// paired device sees only streams on the currently-shared repo. The tuple shape
+/// is unchanged (`(id, kind, started_at)`); the repo path is never exposed.
+pub fn snapshot_streams_for(registry: &StreamRegistry, repo: &str) -> Vec<(String, String, String)> {
+    registry
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .iter()
+        .filter(|(_, info)| repo_paths_match(&info.repo_path, repo))
+        .map(|(id, info)| (id.clone(), info.kind.clone(), info.started_at.clone()))
+        .collect()
+}
+
+/// Like [`subscribe_in`], but returns `None` unless the stream's `repo_path`
+/// matches `repo` (per [`repo_paths_match`]). A stream belonging to a different
+/// repo is indistinguishable from an unknown id — deliberately no oracle, so a
+/// paired device can't probe for streams on repos the desktop isn't sharing.
+pub fn subscribe_in_for(
+    registry: &StreamRegistry,
+    id: &str,
+    repo: &str,
+) -> Option<broadcast::Receiver<ReviewEvent>> {
+    registry
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(id)
+        .filter(|info| repo_paths_match(&info.repo_path, repo))
         .map(|info| info.tx.subscribe())
 }
 
@@ -115,17 +166,19 @@ impl AppState {
         }
     }
 
-    /// Register a live stream `id` (`kind` = `"review"` | `"session"`), returning
-    /// the broadcast sender the run fans its [`ReviewEvent`]s out through. The
-    /// caller must [`clear_stream`](Self::clear_stream) on every exit path so the
-    /// entry's lifetime matches the streaming run's (no leaked entries). A prior
-    /// entry under the same id is replaced.
-    pub fn register_stream(&self, id: &str, kind: &str) -> broadcast::Sender<ReviewEvent> {
+    /// Register a live stream `id` (`kind` = `"review"` | `"session"`) operating on
+    /// `repo_path` (recorded so the LAN routes can scope watching to the shared
+    /// repo), returning the broadcast sender the run fans its [`ReviewEvent`]s out
+    /// through. The caller must [`clear_stream`](Self::clear_stream) on every exit
+    /// path so the entry's lifetime matches the streaming run's (no leaked
+    /// entries). A prior entry under the same id is replaced.
+    pub fn register_stream(&self, id: &str, kind: &str, repo_path: &str) -> broadcast::Sender<ReviewEvent> {
         let (tx, _rx) = broadcast::channel(STREAM_BROADCAST_CAPACITY);
         let info = StreamInfo {
             tx: tx.clone(),
             kind: kind.to_string(),
             started_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            repo_path: repo_path.to_string(),
         };
         self.active_streams
             .lock()
@@ -194,7 +247,7 @@ mod tests {
         // A fresh state has no active streams.
         assert!(state.stream_snapshot().is_empty());
 
-        let tx = state.register_stream("rev-1", "review");
+        let tx = state.register_stream("rev-1", "review", "C:/repo");
         // The snapshot reflects the registration (id, kind, and a non-empty ISO ts).
         let snap = state.stream_snapshot();
         assert_eq!(snap.len(), 1);
@@ -217,7 +270,7 @@ mod tests {
     #[test]
     fn clear_removes_entry_and_closes_subscribers() {
         let state = AppState::default();
-        let _tx = state.register_stream("sess-1", "session");
+        let _tx = state.register_stream("sess-1", "session", "C:/repo");
         let mut rx = state.subscribe_stream("sess-1").expect("stream is active");
 
         // Clearing drops the stored sender...
@@ -237,7 +290,7 @@ mod tests {
     #[test]
     fn subscribe_after_clear_is_none() {
         let state = AppState::default();
-        state.register_stream("x", "review");
+        state.register_stream("x", "review", "C:/repo");
         state.clear_stream("x");
         assert!(state.subscribe_stream("x").is_none());
     }
@@ -248,12 +301,45 @@ mod tests {
         // a stream registered on the state is visible through the shared handle.
         let state = AppState::default();
         let shared = state.streams_arc();
-        state.register_stream("rev-1", "review");
+        state.register_stream("rev-1", "review", "C:/repo");
         assert!(shared
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .contains_key("rev-1"));
         state.clear_stream("rev-1");
         assert!(shared.lock().unwrap_or_else(|p| p.into_inner()).is_empty());
+    }
+
+    #[test]
+    fn scoped_snapshot_and_subscribe_filter_by_repo() {
+        // Two streams on different repos; scoping to one repo sees only its stream,
+        // and the other repo's id is indistinguishable from an unknown id (None).
+        let state = AppState::default();
+        let registry = state.streams_arc();
+        state.register_stream("rev-a", "review", "C:/repo");
+        state.register_stream("rev-b", "review", "C:/other");
+        // A write SESSION spawned from the shared repo registers under its ORIGIN
+        // repo (`C:/repo`), even though it runs in a `gd/session/*` worktree — so it
+        // must stay visible when scoping to `C:/repo`. (This is the product behavior
+        // the origin_repo_path plumbing exists for: sessions keep phone visibility.)
+        state.register_stream("sess-c", "session", "C:/repo");
+
+        // The unscoped snapshot sees all three (the desktop's own surface).
+        assert_eq!(snapshot_streams(&registry).len(), 3);
+
+        // Scoped to C:/repo: rev-a AND the origin-registered session, but not rev-b
+        // (raw string equality — no filesystem touch).
+        let mut scoped: Vec<String> = snapshot_streams_for(&registry, "C:/repo")
+            .into_iter()
+            .map(|(id, _, _)| id)
+            .collect();
+        scoped.sort();
+        assert_eq!(scoped, vec!["rev-a".to_string(), "sess-c".to_string()]);
+
+        // Subscribing under the matching repo works; under the wrong repo it's None
+        // even though the id exists (no oracle for out-of-scope streams).
+        assert!(subscribe_in_for(&registry, "rev-a", "C:/repo").is_some());
+        assert!(subscribe_in_for(&registry, "rev-b", "C:/repo").is_none());
+        assert!(subscribe_in_for(&registry, "does-not-exist", "C:/repo").is_none());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,10 +1,57 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use tokio::sync::{Mutex, Notify, OnceCell};
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::{broadcast, Mutex, Notify, OnceCell};
 
+use crate::agent::ReviewEvent;
 use crate::git::types::GitInfo;
+
+/// Buffer depth for a live stream's broadcast channel. A LAN subscriber that
+/// falls this far behind gets a `Lagged` notification (surfaced as a synthetic
+/// "skipped N events" status frame) rather than blocking the producer — the
+/// desktop `Channel` leg is never affected.
+const STREAM_BROADCAST_CAPACITY: usize = 256;
+
+/// A live agent stream (review or session) that LAN subscribers can watch. The
+/// broadcast sender fans each [`ReviewEvent`] out to any number of receivers; a
+/// stream with no receivers still sends fine (the producer's `send` just returns
+/// `Err`, which is ignored). The entry lives exactly as long as the streaming
+/// run — it is registered before the run and cleared on every exit path.
+pub struct StreamInfo {
+    pub tx: broadcast::Sender<ReviewEvent>,
+    /// `"review"` or `"session"`.
+    pub kind: String,
+    /// ISO-8601 (millis + `Z`), matching every other timestamp the app writes.
+    pub started_at: String,
+}
+
+/// The shared live-stream registry handle. `AppState` owns one and hands a clone
+/// to the LAN router (via [`AppState::streams_arc`]), so both see the same map.
+pub type StreamRegistry = Arc<StdMutex<HashMap<String, StreamInfo>>>;
+
+/// A `(id, kind, started_at)` snapshot of a stream registry — the shape the LAN
+/// enumeration route serializes. A free fn so both [`AppState::stream_snapshot`]
+/// and the LAN router (which holds only the shared [`StreamRegistry`], not the
+/// whole `AppState`) share one implementation.
+pub fn snapshot_streams(registry: &StreamRegistry) -> Vec<(String, String, String)> {
+    registry
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .iter()
+        .map(|(id, info)| (id.clone(), info.kind.clone(), info.started_at.clone()))
+        .collect()
+}
+
+/// Subscribe to a registry stream by id, or `None` when none is active. Shared by
+/// [`AppState::subscribe_stream`] and the LAN watch route (see [`snapshot_streams`]).
+pub fn subscribe_in(registry: &StreamRegistry, id: &str) -> Option<broadcast::Receiver<ReviewEvent>> {
+    registry
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(id)
+        .map(|info| info.tx.subscribe())
+}
 
 pub struct AppState {
     repo_locks: Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>,
@@ -12,6 +59,12 @@ pub struct AppState {
     /// In-flight agent-CLI reviews keyed by a frontend-supplied id, so a
     /// separate cancel command can signal the streaming run to stop.
     agent_cancels: Mutex<HashMap<String, Arc<Notify>>>,
+    /// Live agent streams (reviews/sessions) keyed by their frontend-supplied id,
+    /// so the LAN companion can enumerate active streams and fan their events out
+    /// to WebSocket subscribers alongside the desktop channel. A `std::Mutex` —
+    /// every access is a short, synchronous critical section (never held across an
+    /// `.await`). Shared with the LAN router via [`AppState::streams_arc`].
+    active_streams: StreamRegistry,
     /// Whether closing the window hides the app to the tray (keeping it running)
     /// instead of quitting. Mirrors the user's setting, pushed from the frontend;
     /// defaults to true so the first close behaves correctly before that sync.
@@ -24,6 +77,7 @@ impl Default for AppState {
             repo_locks: Mutex::new(HashMap::new()),
             git_info: OnceCell::new(),
             agent_cancels: Mutex::new(HashMap::new()),
+            active_streams: Arc::new(StdMutex::new(HashMap::new())),
             close_to_tray: AtomicBool::new(true),
         }
     }
@@ -61,11 +115,145 @@ impl AppState {
         }
     }
 
+    /// Register a live stream `id` (`kind` = `"review"` | `"session"`), returning
+    /// the broadcast sender the run fans its [`ReviewEvent`]s out through. The
+    /// caller must [`clear_stream`](Self::clear_stream) on every exit path so the
+    /// entry's lifetime matches the streaming run's (no leaked entries). A prior
+    /// entry under the same id is replaced.
+    pub fn register_stream(&self, id: &str, kind: &str) -> broadcast::Sender<ReviewEvent> {
+        let (tx, _rx) = broadcast::channel(STREAM_BROADCAST_CAPACITY);
+        let info = StreamInfo {
+            tx: tx.clone(),
+            kind: kind.to_string(),
+            started_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        };
+        self.active_streams
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(id.to_string(), info);
+        tx
+    }
+
+    /// Remove a stream's registry entry. Dropping the stored sender makes any
+    /// LAN subscriber's `recv()` observe `Closed`, ending its socket cleanly.
+    pub fn clear_stream(&self, id: &str) {
+        self.active_streams
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(id);
+    }
+
+    /// A snapshot of the active streams as `(id, kind, started_at)` tuples, for
+    /// the LAN enumeration route. Cheap clone; the lock is released immediately.
+    ///
+    /// Convenience over [`snapshot_streams`] for callers holding an `AppState`.
+    /// Production's LAN route holds only the shared [`StreamRegistry`] and calls
+    /// the free fn directly, so this wrapper is used only by the unit tests —
+    /// hence the `dead_code` allow (it's a deliberate, tested part of the API).
+    #[allow(dead_code)]
+    pub fn stream_snapshot(&self) -> Vec<(String, String, String)> {
+        snapshot_streams(&self.active_streams)
+    }
+
+    /// Subscribe to a live stream's events, or `None` if no stream with that id is
+    /// currently active. The returned receiver observes `Closed` once the stream
+    /// ends and [`clear_stream`](Self::clear_stream) drops the sender.
+    ///
+    /// Convenience over [`subscribe_in`] for `AppState` holders; production's LAN
+    /// watch route uses the free fn against the shared [`StreamRegistry`], so this
+    /// wrapper is exercised only by the unit tests (see `stream_snapshot`).
+    #[allow(dead_code)]
+    pub fn subscribe_stream(&self, id: &str) -> Option<broadcast::Receiver<ReviewEvent>> {
+        subscribe_in(&self.active_streams, id)
+    }
+
+    /// A clone of the shared stream-registry handle, for the LAN router state. The
+    /// router holds the SAME `Arc` this `AppState` does, so a stream registered
+    /// here is visible to the LAN routes without any further plumbing.
+    pub fn streams_arc(&self) -> StreamRegistry {
+        self.active_streams.clone()
+    }
+
     pub fn close_to_tray(&self) -> bool {
         self.close_to_tray.load(Ordering::Relaxed)
     }
 
     pub fn set_close_to_tray(&self, enabled: bool) {
         self.close_to_tray.store(enabled, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::broadcast::error::TryRecvError;
+
+    #[test]
+    fn register_subscribe_deliver_snapshot() {
+        let state = AppState::default();
+        // A fresh state has no active streams.
+        assert!(state.stream_snapshot().is_empty());
+
+        let tx = state.register_stream("rev-1", "review");
+        // The snapshot reflects the registration (id, kind, and a non-empty ISO ts).
+        let snap = state.stream_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].0, "rev-1");
+        assert_eq!(snap[0].1, "review");
+        assert!(snap[0].2.ends_with('Z'));
+
+        // A subscriber taken from the registry receives what the sender broadcasts.
+        let mut rx = state.subscribe_stream("rev-1").expect("stream is active");
+        tx.send(ReviewEvent::Delta {
+            text: "hello".to_string(),
+        })
+        .expect("a live subscriber exists");
+        match rx.try_recv() {
+            Ok(ReviewEvent::Delta { text }) => assert_eq!(text, "hello"),
+            other => panic!("expected the delta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clear_removes_entry_and_closes_subscribers() {
+        let state = AppState::default();
+        let _tx = state.register_stream("sess-1", "session");
+        let mut rx = state.subscribe_stream("sess-1").expect("stream is active");
+
+        // Clearing drops the stored sender...
+        state.clear_stream("sess-1");
+        // ...so the registry is empty again (no leak) and a fresh subscribe misses.
+        assert!(state.stream_snapshot().is_empty());
+        assert!(state.subscribe_stream("sess-1").is_none());
+
+        // An already-open receiver observes Closed once the sender is gone. (The
+        // local `_tx` we still hold is the ONLY remaining sender; drop it so the
+        // channel actually closes — this mirrors production, where `clear_stream`
+        // removing the registry entry drops the last sender.)
+        drop(_tx);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Closed)));
+    }
+
+    #[test]
+    fn subscribe_after_clear_is_none() {
+        let state = AppState::default();
+        state.register_stream("x", "review");
+        state.clear_stream("x");
+        assert!(state.subscribe_stream("x").is_none());
+    }
+
+    #[test]
+    fn streams_arc_shares_the_same_registry() {
+        // The Arc handed to the LAN router is the SAME map the AppState mutates, so
+        // a stream registered on the state is visible through the shared handle.
+        let state = AppState::default();
+        let shared = state.streams_arc();
+        state.register_stream("rev-1", "review");
+        assert!(shared
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .contains_key("rev-1"));
+        state.clear_stream("rev-1");
+        assert!(shared.lock().unwrap_or_else(|p| p.into_inner()).is_empty());
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -24,22 +24,45 @@ pub fn app_display_name() -> &'static str {
     }
 }
 
-/// Builds the system-tray icon + menu. Left-click restores the window; the
-/// menu (right-click on Windows) offers Open and a real Quit.
-pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
+/// Build the tray menu reflecting whether the LAN phone companion is currently
+/// sharing. Shared by [`setup_tray`] (initial menu, `sharing = false`) and
+/// [`update_companion_indicator`] (rebuilt on each toggle) so the companion row
+/// exists from the first render and its wording stays in one place.
+fn companion_menu(app: &AppHandle, sharing: bool) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
     let name = app_display_name();
-    let menu = MenuBuilder::new(app)
+    let companion_text = if sharing {
+        "Phone companion — sharing ON"
+    } else {
+        "Phone companion"
+    };
+    MenuBuilder::new(app)
         .text("open", format!("Open {name}"))
+        .text("companion", companion_text)
         .separator()
         .text("quit", "Quit")
-        .build()?;
+        .build()
+}
 
-    let mut builder = TrayIconBuilder::new()
+/// Builds the system-tray icon + menu. Left-click restores the window; the
+/// menu (right-click on Windows) offers Open, the Phone-companion row, and a
+/// real Quit.
+pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
+    let name = app_display_name();
+    // Initial menu already carries the companion row (sharing off), so it's
+    // present before the first `lan_enable`/`lan_disable` toggle runs.
+    let menu = companion_menu(app, false)?;
+
+    // Explicit id so `update_companion_indicator` can re-fetch this tray icon by
+    // id (`tray_by_id("main")`) to swap its menu when LAN sharing toggles.
+    let mut builder = TrayIconBuilder::with_id("main")
         .tooltip(name)
         .menu(&menu)
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
             "open" => show_main_window(app),
+            // The companion row brings the window up so the user can manage
+            // sharing / paired devices.
+            "companion" => show_main_window(app),
             "quit" => {
                 // Capture geometry before exiting (the window may still be visible
                 // and moved since the last close).
@@ -63,6 +86,24 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
     }
     builder.build(app)?;
     Ok(())
+}
+
+/// Rebuild the tray menu to reflect whether the LAN phone companion is currently
+/// sharing, and swap it onto the existing "main" tray icon (Tauri 2.11 supports
+/// replacing a tray's menu in place via `set_menu` — we do NOT rebuild the whole
+/// `TrayIcon`, which would drop its click/event wiring). Adds one "companion" row
+/// before the separator whose text reflects `sharing`; clicking it brings the
+/// window up (see the `on_menu_event` arm). Called from `lan_enable` / `lan_disable`
+/// so the tray always mirrors reality. Best-effort: a build/set failure is
+/// swallowed (the tray simply keeps its prior menu).
+pub fn update_companion_indicator(app: &AppHandle, sharing: bool) {
+    let menu = match companion_menu(app, sharing) {
+        Ok(menu) => menu,
+        Err(_) => return,
+    };
+    if let Some(tray) = app.tray_by_id("main") {
+        let _ = tray.set_menu(Some(menu));
+    }
 }
 
 pub(crate) fn show_main_window(app: &AppHandle) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { DeviceMobileIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -19,7 +20,7 @@ import { useRepoDrop } from "@/features/welcome/useRepoDrop";
 import { WelcomeScreen } from "@/features/welcome/WelcomeScreen";
 import { syncAnalytics, track } from "@/lib/analytics";
 import { useBackgroundPrSync } from "@/lib/automations/useBackgroundPrSync";
-import { useGitInstalled } from "@/lib/git/queries";
+import { useGitInstalled, useLanStatus } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { reloadLocalPrs } from "@/lib/pulls/local";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
@@ -33,7 +34,11 @@ function App() {
   const openMcpBrowse = useUiStore((s) => s.openMcpBrowse);
   const openHelp = useUiStore((s) => s.openHelp);
   const toggleActivity = useUiStore((s) => s.toggleActivity);
+  const repoPath = useUiStore((s) => s.repoPath);
   const gitInstalled = useGitInstalled();
+  // Kept mounted app-wide so the LAN "Sharing ON" banner and the companion
+  // settings panel share one 5s poller.
+  const lanStatus = useLanStatus();
   const queryClient = useQueryClient();
   const settings = useSettings();
   const saveSettings = useSaveSettings();
@@ -107,6 +112,13 @@ function App() {
     );
   }, [closeToTray]);
 
+  // The LAN companion server serves whichever repo is open, so push the active
+  // repo to the backend whenever it changes (no-op when no repo is open).
+  useEffect(() => {
+    if (!repoPath) return;
+    invoke("lan_set_active_repo", { repoPath }).catch(() => undefined);
+  }, [repoPath]);
+
   // Drop a repo folder anywhere on the window to open it.
   useRepoDrop();
 
@@ -126,6 +138,7 @@ function App() {
     !settings.data?.hideAi,
   );
   useHotkeyAction("browse-mcp-registry", openMcpBrowse, !settings.data?.hideAi);
+  useHotkeyAction("open-companion-settings", () => openSettings("companion"));
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("toggle-notifications", toggleActivity);
   useHotkeyAction("show-shortcuts", () => setShortcutsOpen(true));
@@ -170,6 +183,23 @@ function App() {
   return (
     <>
       <div className="flex h-screen flex-col">
+        {/* A calm, layout-integrated banner while the LAN companion is sharing:
+            a slim full-width strip in normal flow (shrink-0), above every screen,
+            so it pushes content down and can't collide with header chrome. The
+            screen container below is flex-1/min-h-0, so the app still fits the
+            viewport without a page scrollbar. Text-labeled (never color alone);
+            click to manage. */}
+        {lanStatus.data?.enabled && (
+          <button
+            type="button"
+            onClick={() => openSettings("companion")}
+            title="Phone companion is sharing this repo on your local network — click to manage"
+            className="flex h-6 shrink-0 items-center justify-center gap-1.5 border-b border-info/40 bg-info/10 text-[11px] font-medium text-info transition-colors hover:bg-info/20"
+          >
+            <DeviceMobileIcon className="size-3.5" />
+            Sharing on
+          </button>
+        )}
         {view === "welcome" && <WelcomeScreen />}
         {view === "repo" && <RepositoryView />}
         {view === "settings" && <SettingsScreen />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,10 +113,12 @@ function App() {
   }, [closeToTray]);
 
   // The LAN companion server serves whichever repo is open, so push the active
-  // repo to the backend whenever it changes (no-op when no repo is open).
+  // repo to the backend whenever it changes. Closing the repo pushes null, which
+  // clears it so paired devices stop seeing the last repo (routes 409).
   useEffect(() => {
-    if (!repoPath) return;
-    invoke("lan_set_active_repo", { repoPath }).catch(() => undefined);
+    invoke("lan_set_active_repo", { repoPath: repoPath ?? null }).catch(
+      () => undefined,
+    );
   }, [repoPath]);
 
   // Drop a repo folder anywhere on the window to open it.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1526,6 +1526,65 @@ commands{{/ai}}) are palette-only until you bind a key. Defaults match GitHub De
 there's an equivalent.`,
   },
   {
+    id: "phone-companion",
+    label: "Phone companion",
+    body: `# Phone companion (experimental)
+
+The **Phone companion** lets you share the repository that's currently open with your
+phone over your **local network**. Open it in **Settings → Phone companion**.
+
+This is an **early preview**. Right now it exposes a **read-only** API for the open
+repo over the LAN — there's no companion phone app yet (it's coming in a later release),
+so pairing today is mainly for trying the connection out. It's **off by default**.
+
+## Turning it on
+
+Flip **Share with your phone on this network**. GitDesktop starts a small server bound
+to your machine's LAN address and shows the address(es) and port it's reachable at.
+While sharing is on, a small **Sharing on** badge stays visible in the top corner of the
+window (click it to jump back here). If the port can't be opened, the reason appears
+right in the panel.
+
+## Pairing a phone
+
+Choose **Pair a device** (available once sharing is on). A dialog shows:
+
+- a **QR code** to scan with your phone,
+- the same **URL** as selectable text, in case you'd rather open it manually, and
+- a short **PIN** that you type on the phone to confirm it's really you.
+
+The offer counts down and expires after a short while; if it lapses before the phone
+connects, choose **Start again**. When a device pairs, the dialog confirms it by name.
+
+## Managing paired devices
+
+Each paired device is listed with its name, its **read-only** scope, and when it paired
+and was last seen. Every device holds its **own token**, and you can **Revoke** any of
+them at any time — a revoked device immediately loses access and has to pair again to
+reconnect. Arrow keys move between devices in the list.
+
+## Security — please read
+
+Sharing is convenient but deliberately simple, so treat it accordingly:
+
+- **Anyone on the same Wi-Fi who has the pairing PIN can read this repo** while sharing
+  is on.
+- The connection is **unencrypted** on your local network. Use it on **trusted networks
+  only** (your home or a private office network — not public or café Wi-Fi).
+- **Turn sharing off when you're done.** It doesn't turn itself off.
+
+## Phone can't reach your computer?
+
+If the phone scans the code but can't connect, the most common cause is **network
+isolation**: many guest networks and some routers enable **AP/client isolation**, which
+blocks devices on the same Wi-Fi from talking to each other. Put both devices on a
+network without client isolation (or your normal home Wi-Fi), and make sure the phone is
+on the **same** network — not a guest SSID or cellular data.
+
+You can jump straight here anytime from the command palette
+({{kbd:command-palette}} → *Phone companion settings*).`,
+  },
+  {
     id: "settings",
     label: "Settings & updates",
     body: `# Settings & updates
@@ -1548,6 +1607,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump to it,
   arrow-key through the list, and clear items or mark all read.
+- **Phone companion** — *experimental.* Share the open repo (read-only) with your phone
+  over your local network. Off by default; see **Phone companion** above.
 - **Keyboard** — rebind any shortcut, with live key-capture.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1541,8 +1541,8 @@ so pairing today is mainly for trying the connection out. It's **off by default*
 
 Flip **Share with your phone on this network**. GitDesktop starts a small server bound
 to your machine's LAN address and shows the address(es) and port it's reachable at.
-While sharing is on, a small **Sharing on** badge stays visible in the top corner of the
-window (click it to jump back here). If the port can't be opened, the reason appears
+While sharing is on, a **Sharing on** banner runs across the top of the window
+(click it to jump back here). If the port can't be opened, the reason appears
 right in the panel.
 
 ## Pairing a phone

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -241,6 +241,8 @@ export const usePlanStore = create<PlanState>((set, get) => {
         userPrompt,
         // Read-only: runs in the live repo, never a worktree, and can't write.
         worktreePath: run0.repoPath,
+        // Same live repo it was spawned from (read-only sessions never worktree).
+        originRepoPath: run0.repoPath,
         sessionId: run0.sessionId,
         resume,
         readOnly: true,

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -331,6 +331,8 @@ export const useResearchStore = create<ResearchState>((set, get) => {
         userPrompt,
         // Read-only: runs in the live repo, never a worktree, and can't write.
         worktreePath: run0.repoPath,
+        // Same live repo it was spawned from (read-only sessions never worktree).
+        originRepoPath: run0.repoPath,
         sessionId: run0.sessionId,
         resume,
         readOnly: true,
@@ -593,6 +595,8 @@ export const useResearchStore = create<ResearchState>((set, get) => {
           systemPrompt: "",
           userPrompt: buildResearchDistillPrompt(),
           worktreePath: run0.repoPath,
+          // Same live repo it was spawned from (read-only sessions never worktree).
+          originRepoPath: run0.repoPath,
           sessionId: run0.sessionId,
           resume: true,
           // Fork the resumed conversation to a throwaway session: the distill reads

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -265,6 +265,7 @@ async function runTurn(
   const {
     claudeSessionId,
     worktreePath,
+    repoPath,
     model,
     effort,
     isolation,
@@ -358,6 +359,11 @@ async function runTurn(
       systemPrompt: SYSTEM_PROMPT,
       userPrompt: prompt,
       worktreePath,
+      // The repo this session was spawned from (the worktree's parent). The LAN
+      // monitor scopes stream visibility to the SHARED repo, so registering under
+      // the origin keeps a session watchable on a paired phone even though it runs
+      // in a `gd/session/*` worktree.
+      originRepoPath: repoPath,
       sessionId: claudeSessionId,
       resume,
       readOnly: false,

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -133,8 +133,8 @@ export function CompanionSection() {
           ) : (
             <p>
               Sharing on port{" "}
-              <span className="font-mono">{status.data.port}</span> — no
-              network address detected. Check you're connected to Wi-Fi.
+              <span className="font-mono">{status.data.port}</span> — no network
+              address detected. Check you're connected to Wi-Fi.
             </p>
           )}
         </div>

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -1,0 +1,247 @@
+import { DeviceMobileIcon } from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+  useLanDeviceRevoke,
+  useLanDevices,
+  useLanDisable,
+  useLanEnable,
+  useLanStatus,
+} from "@/lib/git/queries";
+import type { LanDevice } from "@/lib/git/types";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { errorMessage } from "@/lib/tauri/invoke";
+import { formatRelativeTime } from "@/lib/time";
+import { PairDeviceDialog } from "./PairDeviceDialog";
+
+export function CompanionSection() {
+  const status = useLanStatus();
+  const enable = useLanEnable();
+  const disable = useLanDisable();
+  const revoke = useLanDeviceRevoke();
+
+  const enabled = status.data?.enabled ?? false;
+  // Read the device list only while sharing is on (nothing to show otherwise).
+  const devices = useLanDevices({ enabled });
+  const deviceList = devices.data ?? [];
+
+  const [pairOpen, setPairOpen] = useState(false);
+  const [confirmRevoke, setConfirmRevoke] = useState<LanDevice | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  function toggle(next: boolean) {
+    setError(null);
+    if (next) {
+      // The panel always binds to the LAN — loopback-only is a dev/test mode.
+      enable.mutate(true, { onError: (e) => setError(errorMessage(e)) });
+    } else {
+      disable.mutate(undefined, { onError: (e) => setError(errorMessage(e)) });
+    }
+  }
+
+  // Clamp a stale active index when rows are removed (revoke).
+  const safeActive =
+    activeIndex >= deviceList.length ? deviceList.length - 1 : activeIndex;
+  const onKeyDown = listKeyboardNav<LanDevice>({
+    items: deviceList,
+    activeIndex: safeActive,
+    onActivate: (_d, to) => setActiveIndex(to),
+    rowKey: (d) => d.id,
+    rowAttr: "data-device-row",
+  });
+
+  const toggleBusy = enable.isPending || disable.isPending;
+  const pairDisabledReason = enabled
+    ? null
+    : "Turn on sharing first, then pair a device.";
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-sm font-medium">
+          Phone companion{" "}
+          <span className="ml-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground uppercase">
+            Experimental
+          </span>
+        </h2>
+        <p className="text-xs text-muted-foreground">
+          Share the open repository with your phone over your local network.
+          This is an early preview: it exposes a{" "}
+          <strong className="font-medium">read-only</strong> API for the open
+          repo, and the companion phone app arrives in an upcoming release.
+        </p>
+      </div>
+
+      {/* The enable toggle — runtime state from the backend, not a settings
+          draft, so it applies immediately (no Save bar). */}
+      <div className="flex items-center justify-between gap-3 rounded border px-3 py-2.5">
+        <label
+          htmlFor="companion-enabled"
+          className="cursor-pointer text-xs font-medium"
+        >
+          Share with your phone on this network
+        </label>
+        <div className="flex items-center gap-2">
+          {toggleBusy && <Spinner className="size-3.5" />}
+          <Switch
+            id="companion-enabled"
+            checked={enabled}
+            disabled={toggleBusy || status.isPending}
+            onCheckedChange={toggle}
+            aria-label="Share with your phone on this network"
+          />
+        </div>
+      </div>
+
+      {error !== null && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* The honest security caveat — always visible, never a tooltip. */}
+      <p className="rounded border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+        Anyone on this Wi-Fi with the pairing PIN can read this repo while
+        sharing is on. It's unencrypted on your local network — use it on
+        trusted networks only. Turn sharing off when you're done.
+      </p>
+
+      {enabled && status.data && (
+        <div className="space-y-1 text-xs text-muted-foreground">
+          {status.data.urls.length > 0 ? (
+            <p>
+              Reachable at{" "}
+              {status.data.urls.map((url, i) => (
+                <span key={url}>
+                  {i > 0 && ", "}
+                  <span className="font-mono select-all">{url}</span>
+                </span>
+              ))}
+            </p>
+          ) : (
+            <p>
+              Sharing on port{" "}
+              <span className="font-mono">{status.data.port}</span> — no
+              network address detected. Check you're connected to Wi-Fi.
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-xs font-medium">Paired devices</h3>
+          <p className="text-[11px] text-muted-foreground">
+            Each device holds its own token you can revoke at any time.
+          </p>
+        </div>
+        {/* Disabled buttons don't show a native `title`, so wrap it. */}
+        <span title={pairDisabledReason ?? undefined} className="inline-flex">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!enabled}
+            onClick={() => setPairOpen(true)}
+          >
+            <DeviceMobileIcon data-icon="inline-start" /> Pair a device
+          </Button>
+        </span>
+      </div>
+
+      {deviceList.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {enabled
+            ? "No devices paired yet. Choose “Pair a device” to add your phone."
+            : "Turn on sharing to pair a device."}
+        </p>
+      ) : (
+        // A roving-focus list (arrow keys move between rows).
+        <div ref={listRef} onKeyDown={onKeyDown} className="space-y-2">
+          {deviceList.map((device, i) => (
+            <div
+              key={device.id}
+              data-device-row={device.id}
+              aria-label={`${device.name}, ${device.scope}, last seen ${formatRelativeTime(
+                device.lastSeenAt,
+              )}`}
+              tabIndex={
+                i === safeActive || (safeActive === -1 && i === 0) ? 0 : -1
+              }
+              onFocus={() => setActiveIndex(i)}
+              className="flex items-center gap-2 rounded border px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <span className="shrink-0 text-xs font-medium">
+                {device.name}
+              </span>
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase">
+                {device.scope}
+              </span>
+              <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+                paired {formatRelativeTime(device.createdAt)} · seen{" "}
+                {formatRelativeTime(device.lastSeenAt)}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="shrink-0"
+                onClick={() => setConfirmRevoke(device)}
+                aria-label={`Revoke ${device.name}`}
+              >
+                Revoke
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <PairDeviceDialog open={pairOpen} onOpenChange={setPairOpen} />
+
+      <Dialog
+        open={confirmRevoke !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmRevoke(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke access?</DialogTitle>
+            <DialogDescription>
+              {confirmRevoke?.name} will immediately lose access to this repo.
+              It'll need to pair again to reconnect.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmRevoke(null)}>
+              Keep
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={revoke.isPending}
+              onClick={() => {
+                if (!confirmRevoke) return;
+                revoke.mutate(confirmRevoke.id, {
+                  onSettled: () => setConfirmRevoke(null),
+                });
+              }}
+            >
+              {revoke.isPending && <Spinner data-icon="inline-start" />}
+              Revoke
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/src/features/settings/PairDeviceDialog.tsx
+++ b/src/features/settings/PairDeviceDialog.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { errorMessage } from "@/lib/tauri/invoke";
+import {
+  useLanDevices,
+  useLanPairingCancel,
+  useLanPairingStart,
+} from "@/lib/git/queries";
+import type { LanPairing } from "@/lib/git/types";
+
+/** Remaining whole seconds until `expiresAt`, clamped at 0. */
+function secondsLeft(expiresAt: string): number {
+  return Math.max(
+    0,
+    Math.round((new Date(expiresAt).getTime() - Date.now()) / 1000),
+  );
+}
+
+interface PairDeviceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * The pairing flow: open a pairing window on the backend, show its QR + URL +
+ * PIN, and poll the device list until a new device appears. Closing/canceling
+ * the dialog cancels the pairing window (best-effort). On expiry the user can
+ * start again.
+ */
+export function PairDeviceDialog({
+  open,
+  onOpenChange,
+}: PairDeviceDialogProps) {
+  const start = useLanPairingStart();
+  const cancel = useLanPairingCancel();
+  const [pairing, setPairing] = useState<LanPairing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [remaining, setRemaining] = useState(0);
+  const [pairedName, setPairedName] = useState<string | null>(null);
+
+  // Wall-clock time (ms) the current pairing session started. A device counts as
+  // freshly paired only if its `createdAt` is at/after this, so a PRE-EXISTING
+  // device can't be misdetected as new when the parent's device query hadn't
+  // resolved at open time (an id snapshot would have been empty). Server and UI
+  // share this machine's clock; the 5s slack below absorbs any tiny skew/latency.
+  const startTimeRef = useRef(0);
+
+  // Poll devices only while the dialog is open and we're still waiting for one.
+  const devices = useLanDevices({
+    enabled: open && pairedName === null,
+    refetchInterval: open && pairedName === null ? 1500 : false,
+  });
+
+  // Begin (or restart) a pairing window. Not an effect-event: it's also called
+  // from the "Start again" button.
+  function begin() {
+    setError(null);
+    setPairedName(null);
+    // Mark this session's start BEFORE requesting the offer, so any device that
+    // pairs against it is timestamped at/after this.
+    startTimeRef.current = Date.now();
+    start.mutate(undefined, {
+      onSuccess: (p) => {
+        setPairing(p);
+        setRemaining(secondsLeft(p.expiresAt));
+      },
+      onError: (e) => setError(errorMessage(e)),
+    });
+  }
+
+  // Open/close side effects, as effect-events so the open-transition effect can
+  // depend on `open` alone (no re-runs when the mutations' identities change).
+  const onOpen = useEffectEvent(() => {
+    begin();
+  });
+  const onClose = useEffectEvent(() => {
+    setPairing(null);
+    setError(null);
+    setPairedName(null);
+    cancel.mutate(); // best-effort — drop the live pairing offer server-side
+  });
+
+  // Fire exactly on the open→close and close→open edges (the ref guards against
+  // re-running the same transition).
+  const openedRef = useRef(false);
+  useEffect(() => {
+    if (open && !openedRef.current) {
+      openedRef.current = true;
+      onOpen();
+    } else if (!open && openedRef.current) {
+      openedRef.current = false;
+      onClose();
+    }
+  }, [open]);
+
+  // Countdown tick while a pairing offer is live and unclaimed.
+  useEffect(() => {
+    if (!open || !pairing || pairedName !== null) return;
+    const id = setInterval(
+      () => setRemaining(secondsLeft(pairing.expiresAt)),
+      1000,
+    );
+    return () => clearInterval(id);
+  }, [open, pairing, pairedName]);
+
+  // Detect a newly-paired device: one created at/after this pairing session
+  // started (with 5s slack for clock skew), NOT a pre-existing device.
+  useEffect(() => {
+    if (!open || pairedName !== null || !devices.data) return;
+    const threshold = startTimeRef.current - 5000;
+    const fresh = devices.data.find(
+      (d) => new Date(d.createdAt).getTime() >= threshold,
+    );
+    if (fresh) setPairedName(fresh.name);
+  }, [open, devices.data, pairedName]);
+
+  const expired = pairing !== null && remaining <= 0 && pairedName === null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Pair a device</DialogTitle>
+          <DialogDescription>
+            On your phone, scan this code (or open the URL) and enter the PIN to
+            pair. Keep this window open until it connects.
+          </DialogDescription>
+        </DialogHeader>
+
+        {pairedName !== null ? (
+          <div className="space-y-2 py-2 text-center">
+            <p className="text-sm font-medium text-success">
+              {pairedName} paired
+            </p>
+            <p className="text-xs text-muted-foreground">
+              It can now read this repo while sharing is on. Manage or revoke it
+              from the device list.
+            </p>
+          </div>
+        ) : error !== null ? (
+          <div className="space-y-3 py-2">
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        ) : start.isPending || pairing === null ? (
+          <div className="flex justify-center py-8">
+            <Spinner className="size-5" />
+          </div>
+        ) : (
+          <div className="space-y-4 py-2">
+            {/* Server-generated SVG (a QR image), NOT user content — safe to
+                inline. Fixed-size box so layout is stable while it loads. */}
+            <div
+              aria-label="Pairing QR code"
+              className="mx-auto flex size-48 items-center justify-center rounded border bg-white p-2 [&_svg]:size-full"
+              dangerouslySetInnerHTML={{ __html: pairing.qrSvg }}
+            />
+            <div className="space-y-1 text-center">
+              <p className="text-xs text-muted-foreground">
+                Or open this URL on your phone:
+              </p>
+              <p className="font-mono text-xs break-all select-all">
+                {pairing.url}
+              </p>
+            </div>
+            <div className="space-y-1 text-center">
+              <p className="text-xs text-muted-foreground">PIN</p>
+              <p className="font-mono text-2xl font-semibold tracking-[0.3em] select-all">
+                {pairing.pin}
+              </p>
+              <p className="text-xs text-muted-foreground" role="status">
+                {expired
+                  ? "This code has expired."
+                  : `Expires in ${remaining}s`}
+              </p>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          {pairedName !== null ? (
+            <Button onClick={() => onOpenChange(false)}>Done</Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              {(expired || error !== null) && (
+                <Button onClick={begin} disabled={start.isPending}>
+                  {start.isPending && <Spinner data-icon="inline-start" />}
+                  Start again
+                </Button>
+              )}
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/settings/PairDeviceDialog.tsx
+++ b/src/features/settings/PairDeviceDialog.tsx
@@ -9,13 +9,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { errorMessage } from "@/lib/tauri/invoke";
 import {
   useLanDevices,
   useLanPairingCancel,
   useLanPairingStart,
 } from "@/lib/git/queries";
 import type { LanPairing } from "@/lib/git/types";
+import { errorMessage } from "@/lib/tauri/invoke";
 
 /** Remaining whole seconds until `expiresAt`, clamped at 0. */
 function secondsLeft(expiresAt: string): number {

--- a/src/features/settings/PairDeviceDialog.tsx
+++ b/src/features/settings/PairDeviceDialog.tsx
@@ -50,8 +50,11 @@ export function PairDeviceDialog({
   // Wall-clock time (ms) the current pairing session started. A device counts as
   // freshly paired only if its `createdAt` is at/after this, so a PRE-EXISTING
   // device can't be misdetected as new when the parent's device query hadn't
-  // resolved at open time (an id snapshot would have been empty). Server and UI
-  // share this machine's clock; the 5s slack below absorbs any tiny skew/latency.
+  // resolved at open time (an id snapshot would have been empty). No slack is
+  // needed: `createdAt` is minted by our own Rust with millisecond precision on
+  // the SAME machine clock as `Date.now()`, and this ref is set BEFORE the
+  // pairing offer is requested — so any device minted in this session satisfies
+  // `createdAt >= startTimeRef` strictly.
   const startTimeRef = useRef(0);
 
   // Poll devices only while the dialog is open and we're still waiting for one.
@@ -113,13 +116,22 @@ export function PairDeviceDialog({
   }, [open, pairing, pairedName]);
 
   // Detect a newly-paired device: one created at/after this pairing session
-  // started (with 5s slack for clock skew), NOT a pre-existing device.
+  // started (no slack — same clock, ms precision, ref marked before the offer),
+  // NOT a pre-existing device. Pick the NEWEST match so back-to-back pairings
+  // report the device that just paired, not an earlier one.
   useEffect(() => {
     if (!open || pairedName !== null || !devices.data) return;
-    const threshold = startTimeRef.current - 5000;
-    const fresh = devices.data.find(
-      (d) => new Date(d.createdAt).getTime() >= threshold,
-    );
+    const threshold = startTimeRef.current;
+    const fresh = devices.data
+      .filter((d) => new Date(d.createdAt).getTime() >= threshold)
+      .reduce<(typeof devices.data)[number] | null>(
+        (newest, d) =>
+          newest === null ||
+          new Date(d.createdAt).getTime() > new Date(newest.createdAt).getTime()
+            ? d
+            : newest,
+        null,
+      );
     if (fresh) setPairedName(fresh.name);
   }, [open, devices.data, pairedName]);
 

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -24,6 +24,7 @@ import { AboutSection } from "./AboutSection";
 import { AccountsSection } from "./AccountsSection";
 import { AiProviderSection } from "./AiProviderSection";
 import { CommandsSection } from "./CommandsSection";
+import { CompanionSection } from "./CompanionSection";
 import { EditorSection } from "./EditorSection";
 import { GeneralSection } from "./GeneralSection";
 import {
@@ -59,6 +60,7 @@ const PANELS = [
   { id: "mcp-servers", label: "MCP servers" },
   { id: "automations", label: "Automations" },
   { id: "notifications", label: "Notifications" },
+  { id: "companion", label: "Phone companion" },
   { id: "keyboard", label: "Keyboard" },
   { id: "accounts", label: "Accounts" },
   { id: "git", label: "Git" },
@@ -276,6 +278,7 @@ export function SettingsScreen() {
               {activePanel === "notifications" && (
                 <NotificationsSection form={form} />
               )}
+              {activePanel === "companion" && <CompanionSection />}
               {activePanel === "keyboard" && <KeyboardSection form={form} />}
               {activePanel === "accounts" && <AccountsSection />}
               {activePanel === "git" && (

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -215,6 +215,12 @@ export interface AgentSessionArgs {
   /** The directory the agent runs in — a throwaway worktree for a write session,
    *  or the live repo for a read-only Plan conversation. */
   worktreePath: string;
+  /** The open repo this session was spawned from. For a write session this is the
+   *  parent repo of the `gd/session/*` `worktreePath`; for a read-only Plan/Research
+   *  session it's the live repo (same value as `worktreePath`). The LAN monitor
+   *  scopes stream visibility to the SHARED repo, which is this value — so a session
+   *  spawned from the shared repo stays watchable on a paired phone. */
+  originRepoPath: string;
   /** The session's stable uuid (sets `--session-id` on turn 1, `--resume` after);
    *  also the cancel key for `cancelAgentSession`. */
   sessionId: string;
@@ -271,6 +277,7 @@ export async function runAgentSession(args: AgentSessionArgs): Promise<void> {
     systemPrompt: args.systemPrompt,
     userPrompt: args.userPrompt,
     worktreePath: args.worktreePath,
+    originRepoPath: args.originRepoPath,
     sessionId: args.sessionId,
     resume: args.resume,
     // Default false so every non-distill caller (Plan/Delegate/Research turns +

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -3095,7 +3095,7 @@ export const lanEnable = (bindLan: boolean) =>
 
 export const lanDisable = () => invoke<LanStatus>("lan_disable");
 
-export const lanSetActiveRepo = (repoPath: string) =>
+export const lanSetActiveRepo = (repoPath: string | null) =>
   invoke<void>("lan_set_active_repo", { repoPath });
 
 export const lanPairingStart = () =>

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -79,6 +79,9 @@ import type {
   IssueRelation,
   IssueRelations,
   IssueType,
+  LanDevice,
+  LanPairing,
+  LanStatus,
   MergePreview,
   Milestone,
   OpLogEntry,
@@ -3081,3 +3084,26 @@ export const mcpSecretExists = (serverId: string, key: string) =>
   COLD_START
     ? Promise.resolve(coldStartGetSecret(mcpRef(serverId, key)) !== null)
     : invoke<boolean>("mcp_secret_exists", { serverId, key });
+
+// LAN phone companion (experimental) — controls the local-network server that
+// exposes read-only API access to the open repo to paired phones. All state is
+// runtime (not persisted settings); see queries.ts for the hooks + polling.
+export const lanStatus = () => invoke<LanStatus>("lan_status");
+
+export const lanEnable = (bindLan: boolean) =>
+  invoke<LanStatus>("lan_enable", { bindLan });
+
+export const lanDisable = () => invoke<LanStatus>("lan_disable");
+
+export const lanSetActiveRepo = (repoPath: string) =>
+  invoke<void>("lan_set_active_repo", { repoPath });
+
+export const lanPairingStart = () =>
+  invoke<LanPairing>("lan_pairing_start");
+
+export const lanPairingCancel = () => invoke<void>("lan_pairing_cancel");
+
+export const lanDevicesList = () => invoke<LanDevice[]>("lan_devices_list");
+
+export const lanDeviceRevoke = (deviceId: string) =>
+  invoke<void>("lan_device_revoke", { deviceId });

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -3098,8 +3098,7 @@ export const lanDisable = () => invoke<LanStatus>("lan_disable");
 export const lanSetActiveRepo = (repoPath: string | null) =>
   invoke<void>("lan_set_active_repo", { repoPath });
 
-export const lanPairingStart = () =>
-  invoke<LanPairing>("lan_pairing_start");
+export const lanPairingStart = () => invoke<LanPairing>("lan_pairing_start");
 
 export const lanPairingCancel = () => invoke<void>("lan_pairing_cancel");
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -39,6 +39,7 @@ import type {
   IssueReactions,
   IssueRelation,
   IssueType,
+  LanStatus,
   PrDetails,
   PrInfo,
   PrThreadOut,
@@ -5515,4 +5516,101 @@ export function useCreatePr(repo: string) {
         args.lens ?? "origin",
       ),
   );
+}
+
+// ---------------------------------------------------------------------------
+// LAN phone companion (experimental). All state is runtime (not persisted
+// settings) and there's no push channel, so status is polled. The mutations
+// return the fresh status, which we write straight into the cache (no poll
+// lag) and also invalidate the status + device keys so any parallel reader
+// re-syncs.
+// ---------------------------------------------------------------------------
+
+const LAN_STATUS_KEY = ["lan", "status"] as const;
+const LAN_DEVICES_KEY = ["lan", "devices"] as const;
+
+/** The companion server's runtime status, polled every 5s. Kept mounted at the
+ *  App level (the "Sharing ON" banner subscribes to it), so the panel and the
+ *  banner share one poller. */
+export function useLanStatus() {
+  return useQuery({
+    queryKey: LAN_STATUS_KEY,
+    queryFn: api.lanStatus,
+    refetchInterval: 5000,
+    refetchIntervalInBackground: false,
+  });
+}
+
+/** Paired devices. Enabled on demand (the panel + pairing dialog); the pairing
+ *  dialog bumps `refetchInterval` to ~1.5s while it watches for a new device. */
+export function useLanDevices(options?: {
+  enabled?: boolean;
+  refetchInterval?: number | false;
+}) {
+  return useQuery({
+    queryKey: LAN_DEVICES_KEY,
+    queryFn: api.lanDevicesList,
+    enabled: options?.enabled ?? true,
+    refetchInterval: options?.refetchInterval ?? false,
+    refetchIntervalInBackground: false,
+  });
+}
+
+/** Shared invalidation for the mutations below: prime the status cache with the
+ *  freshly returned value, then invalidate both keys so any other reader syncs. */
+function useSyncLanStatus() {
+  const queryClient = useQueryClient();
+  return (status?: LanStatus) => {
+    if (status) queryClient.setQueryData(LAN_STATUS_KEY, status);
+    void queryClient.invalidateQueries({ queryKey: LAN_STATUS_KEY });
+    void queryClient.invalidateQueries({ queryKey: LAN_DEVICES_KEY });
+  };
+}
+
+/** Start sharing. The panel always passes `bindLan: true` (loopback-only is a
+ *  dev/test mode with no UI). */
+export function useLanEnable() {
+  const sync = useSyncLanStatus();
+  return useMutation({
+    mutationFn: (bindLan: boolean) => api.lanEnable(bindLan),
+    onSuccess: (status) => sync(status),
+  });
+}
+
+/** Stop sharing (also drops any live pairing offer, server-side). */
+export function useLanDisable() {
+  const sync = useSyncLanStatus();
+  return useMutation({
+    mutationFn: () => api.lanDisable(),
+    onSuccess: (status) => sync(status),
+  });
+}
+
+/** Open a pairing window (returns the QR/URL/PIN + expiry). */
+export function useLanPairingStart() {
+  const sync = useSyncLanStatus();
+  return useMutation({
+    mutationFn: () => api.lanPairingStart(),
+    // A pairing offer flips `pairingActive` in the status — re-sync so the panel
+    // reflects it. The offer itself is returned to the caller, not cached.
+    onSettled: () => sync(),
+  });
+}
+
+/** Cancel the current pairing window (best-effort — called on dialog close). */
+export function useLanPairingCancel() {
+  const sync = useSyncLanStatus();
+  return useMutation({
+    mutationFn: () => api.lanPairingCancel(),
+    onSettled: () => sync(),
+  });
+}
+
+/** Revoke a paired device's token — it immediately loses access. */
+export function useLanDeviceRevoke() {
+  const sync = useSyncLanStatus();
+  return useMutation({
+    mutationFn: (deviceId: string) => api.lanDeviceRevoke(deviceId),
+    onSettled: () => sync(),
+  });
 }

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1932,3 +1932,56 @@ export interface UnignoreRule {
   source: string;
   pattern: string;
 }
+
+// ---------------------------------------------------------------------------
+// LAN phone companion (experimental) — mirrors the Rust structs the backend
+// serializes (camelCase). Sharing exposes read-only API access to the open
+// repo over the local network to paired phones; see CompanionSection.
+// ---------------------------------------------------------------------------
+
+/** The companion server's runtime state (polled — there's no push channel). */
+export interface LanStatus {
+  /** Whether the companion server is currently sharing. */
+  enabled: boolean;
+  /** True when bound to the LAN (reachable from phones), false when loopback-only
+   *  (a dev/test mode with no UI toggle). */
+  bindLan: boolean;
+  /** The TCP port the server listens on, or null while sharing is off
+   *  (Rust `Option<u16>` serializes to null — never read this unguarded). */
+  port: number | null;
+  /** Reachable base URLs for this machine (one per bound address). */
+  urls: string[];
+  /** Absolute path of the repo currently shared, or null when none is set. */
+  activeRepo: string | null;
+  /** Count of paired devices with live tokens. */
+  deviceCount: number;
+  /** Whether a pairing window is currently open (a PIN is live). */
+  pairingActive: boolean;
+}
+
+/** A live pairing offer — the phone scans the QR (or opens the URL) and types
+ *  the PIN to complete pairing before it expires. */
+export interface LanPairing {
+  /** The pairing URL the QR encodes (also shown as selectable text). */
+  url: string;
+  /** Server-generated SVG markup for the QR code (safe to inline; not user input). */
+  qrSvg: string;
+  /** The short PIN the user types on the phone. */
+  pin: string;
+  /** ISO-8601 instant when this pairing offer expires. */
+  expiresAt: string;
+}
+
+/** A phone that has paired and holds a revocable access token. */
+export interface LanDevice {
+  /** Stable device id (used to revoke). */
+  id: string;
+  /** Human-facing device name (self-reported at pairing). */
+  name: string;
+  /** Access scope granted to the device (read-only for now). */
+  scope: string;
+  /** ISO-8601 instant the device paired. */
+  createdAt: string;
+  /** ISO-8601 instant the device last made a request. */
+  lastSeenAt: string;
+}

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -69,6 +69,12 @@ export const ACTIONS = [
     category: "Application",
     defaultBinding: null,
   },
+  {
+    id: "open-companion-settings",
+    label: "Phone companion settings",
+    category: "Application",
+    defaultBinding: null,
+  },
 
   // Navigation
   {

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -43,6 +43,7 @@ export type SettingsTarget =
   | "mcp-servers"
   | "automations"
   | "notifications"
+  | "companion"
   | "keyboard"
   | "accounts"
   | "git"


### PR DESCRIPTION
This change implements an experimental preview of the Phone companion: a backend-embedded HTTP server that allows users to share the currently open repository with their phone over the local network, with device pairing, per-device token auth, and a full settings UI. The feature is opt-in and exposes a read-only API surface intended for upcoming mobile access, supporting careful pairing/management and local network safety.

### Backend (Rust: LAN server, pairing, and API)
- Adds a full-featured embedded axum HTTP server in `src-tauri/src/lan/`, including:
  - Device pairing flows, bearer auth, locking, and pairing state in `auth.rs`
  - Server/router assembly, safe binding, port scanning, and API allowlist in `server.rs`, `mod.rs`, and route modules under `routes/`
  - Live agent stream fan-out to LAN consumers in `agent.rs`, with broadcast registry in `state.rs`
- Implements pairing via QR+PIN with per-device tokens; stores device entries on disk (`lan-devices.json`)
- Adds read-only HTTP API routes for Git/forge/review/session data (`lan/routes/`)
- Adds DNS-rebind and rate-limiting defenses
- Integrates the LAN state into Tauri state (`lib.rs`)
- Offers backend commands for enable/disable, pairing, device management in `lan/mod.rs`

### Frontend (React: Settings UI, pair flow, banner)
- Adds `CompanionSection.tsx` (settings panel) and `PairDeviceDialog.tsx` (pairing flow), with real-time state and device management UI
- Adds a slim app-wide "Sharing on" banner when active (`App.tsx`)
- Registers new companion panel in `SettingsScreen.tsx`
- Extends help content with usage and security documentation (`help/content.ts`)
- Adds command palette and hotkey action for "Phone companion settings" (`hotkeys/registry.ts`)

### API & Data Layer (TypeScript/React)
- Adds LAN server API calls in `lib/git/api.ts` and React query hooks in `lib/git/queries.ts`
- Declares shared types in `lib/git/types.ts`
- Implements data polling and mutation handling, ensuring state across UI and backend stays synced

### Backend plumbing and integration
- Updates main Tauri state to initialize and manage the LAN server (`lib.rs`)
- Adds new dependencies for HTTP server, pairing, QR generation in `Cargo.toml`
- Records changelog entry summarizing the new feature (`changelog.d/added-lan-companion-preview.md`)
- Ensures tray menu reflects companion sharing status (`tray.rs`)