### PR TITLE
feat(repo-settings,forks,gitlab): add in-app fork detach for GitLab; polish Danger zone fork actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,10 @@ workflow against any two branches with no remote at all).
   at your fork or the **parent** repository. Opening a PR targets a repository explicitly,
   offering your fork or the upstream repo on a fork. When you're done with a fork, the
   settings **Danger zone** can **remove the upstream remote** (a local detach — reversible)
-  or, on GitHub, link out to **leave the fork network** entirely (permanent, done on
-  github.com), with a **Re-check fork status** button that refreshes the fork badge in place.
+  or **leave the fork network** entirely: on **GitLab** this happens right in the app
+  (Owner-only — open MRs to the parent close), and on **GitHub** and **Bitbucket** it links
+  out to the provider's detach page. A **Re-check fork status** button refreshes the fork
+  badge in place afterward.
 
 A Write/Preview markdown editor (formatting toolbar + live preview) is everywhere you author.
 

--- a/changelog.d/added-fork-detach.md
+++ b/changelog.d/added-fork-detach.md
@@ -1,7 +1,8 @@
 - **Detach from a fork.** The repository settings Danger zone now offers two ways
   to break a fork's ties: **Remove upstream remote** detaches your clone from the
   parent locally (the Fork/Upstream switcher and "Update from upstream" disappear;
-  reversible by re-adding the remote), and, on GitHub, **Leave fork network** links
-  out to github.com to permanently detach the repository from its fork network —
-  with a **Re-check fork status** button that refreshes the fork badge in place once
-  you've done it.
+  reversible by re-adding the remote), and **Leave fork network** detaches the
+  repository from its fork network. On GitLab this happens right in the app
+  (Owner-only — open merge requests to the parent are closed), while GitHub and
+  Bitbucket link out to the provider's detach page. A **Re-check fork status**
+  button refreshes the fork badge in place once you've done it.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -101,7 +101,7 @@ export const capabilities: Capability[] = [
   // — Repository & workspace —
   { group: "Repository & workspace", label: "Clone, add local, create (README/.gitignore/license) or fork" },
   { group: "Repository & workspace", label: "Update a fork from its upstream — fetch, then fast-forward or merge" },
-  { group: "Repository & workspace", label: "Detach from a fork — remove the upstream remote; leave the fork network on GitHub" },
+  { group: "Repository & workspace", label: "Detach from a fork — remove the upstream remote; leave the fork network on GitHub, GitLab, or Bitbucket (in-app on GitLab)" },
   { group: "Repository & workspace", label: "Publish a local repo to GitHub, GitLab or Bitbucket" },
   { group: "Repository & workspace", label: "Worktree manager — create, switch, promote & remove", highlight: true },
   { group: "Repository & workspace", label: "Submodule status & update" },

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -4449,6 +4449,23 @@ pub async fn repo_visibility(repo_path: &str) -> AppResult<crate::forge::RepoVis
     })
 }
 
+/// Remove the project's fork relationship (`DELETE projects/{enc}/fork`),
+/// detaching it from the fork network. Requires the administrator or project
+/// Owner role — glab surfaces a non-Owner's 403 as an error, which bubbles up
+/// as an honest toast. Side effect: any open merge requests from the fork to
+/// the source are closed (and stay closed even if the relationship is later
+/// re-established via the GitLab API).
+pub async fn remove_fork_relationship(repo_path: &str) -> AppResult<()> {
+    let enc = encode_project(&project_path(repo_path).await?);
+    run_glab(
+        Some(repo_path),
+        &["api", "--method", "DELETE", &format!("projects/{enc}/fork")],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await?;
+    Ok(())
+}
+
 /// One of the viewer's starred projects (only the path is needed).
 #[derive(Deserialize)]
 struct GlabStarredProject {

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -2601,6 +2601,12 @@ pub async fn forge_gl_mr_cancel_auto_merge(repo_path: String, number: u64) -> Ap
     gl_only!(repo_path, gitlab::cancel_auto_merge_mr(&repo_path, number))
 }
 
+/// Remove the project's fork relationship (detach from the fork network). GitLab-only.
+#[tauri::command]
+pub async fn forge_gl_remove_fork_relationship(repo_path: String) -> AppResult<()> {
+    gl_only!(repo_path, gitlab::remove_fork_relationship(&repo_path))
+}
+
 /// Play (start) a manual CI job. GitLab-only — GitHub Actions has no per-job
 /// manual play, so this is `gl_only` rather than a neutral forge dispatch.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -369,6 +369,7 @@ pub fn run() {
             forge::forge_gl_mr_merge_state,
             forge::forge_gl_mr_auto_merge,
             forge::forge_gl_mr_cancel_auto_merge,
+            forge::forge_gl_remove_fork_relationship,
             forge::forge_gl_ci_play_job,
             forge::forge_gl_issue_time_stats,
             forge::forge_gl_mr_time_stats,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -168,9 +168,11 @@ like this:
   never touched. When the repo has an **upstream remote**, **Remove upstream remote**
   detaches this clone from the parent locally (the Fork/Upstream switcher and "Update
   from upstream" disappear — reversible by re-adding the remote). On a **fork**, **Leave
-  fork network** links out to GitHub to permanently detach the repository from its fork
-  network (GitHub has no API for this; it's done on the web and can't be undone). After
-  you leave the network on GitHub, **Re-check fork status** refreshes the badge in place.
+  fork network** detaches the repository from its fork network: on **GitLab** it happens
+  right here (Owner-only — open merge requests to the parent are closed, and stay closed),
+  while on **GitHub** and **Bitbucket** it links out to the provider's page (neither has an
+  API for it; the action can't be undone). **Re-check fork status** then refreshes the badge
+  in place.
 
 > Some options GitHub exposes to no app appear as **"Manage on GitHub"** links rather
 > than dead toggles.

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -389,7 +389,7 @@ function LeaveForkNetworkAction({
 
   const isGitLab = provider === "gitlab";
   const isBitbucket = provider === "bitbucket";
-  // The provider's own label, for the re-check toasts (gh is the default).
+  // The provider's own label, for the re-check toasts.
   const label = providerLabel(provider);
 
   // Derive the host — on GitHub Enterprise the provider is still "github" but a
@@ -400,6 +400,11 @@ function LeaveForkNetworkAction({
   const ghHost = forge.data?.host || record?.host || "github.com";
   const bbHost = record?.host || "bitbucket.org";
 
+  // Post-success confirmation probe (GitLab in-app detach). A failure is
+  // swallowed deliberately: the detach itself already succeeded (and toasted),
+  // the persisted badge self-heals on the next repo open, and the row's own
+  // "Re-check fork status" button — which does surface errors — remains
+  // available meanwhile.
   const reprobe = () =>
     probeAndPersistVisibility(repoPath)
       .then(() =>
@@ -421,7 +426,7 @@ function LeaveForkNetworkAction({
         toast.success(
           probe.isFork
             ? `Still a fork on ${label}`
-            : "No longer a fork — badge cleared",
+            : `No longer a fork on ${label} — badge cleared`,
         );
       }
     } catch (e) {
@@ -724,7 +729,7 @@ function DeleteAction({
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const noun = isGitLab ? "project" : "repository";
-  const providerLabel = isGitLab
+  const providerName = isGitLab
     ? "GitLab"
     : isBitbucket
       ? "Bitbucket"
@@ -733,7 +738,7 @@ function DeleteAction({
   return (
     <Row
       title={`Delete this ${noun}`}
-      desc={`Permanently remove the ${noun} on ${providerLabel}.`}
+      desc={`Permanently remove the ${noun} on ${providerName}.`}
     >
       <DangerButton
         variant="destructive"
@@ -761,7 +766,7 @@ function DeleteAction({
           del.mutate(undefined, {
             onSuccess: () => {
               toast.success(
-                `${isGitLab ? "Project" : "Repository"} deleted on ${providerLabel}`,
+                `${isGitLab ? "Project" : "Repository"} deleted on ${providerName}`,
               );
               setOpen(false);
               // The remote is gone — re-probe the repo's hosted panels so they

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -31,6 +31,7 @@ import {
   useBbRepoSettings,
   useDeleteRepo,
   useForgeStatus,
+  useGlRemoveForkRelationship,
   useGlRepoSettings,
   useRemotes,
   useRemoveRemote,
@@ -41,6 +42,7 @@ import {
   useSetVisibility,
   useTransferRepo,
 } from "@/lib/git/queries";
+import { type ForgeProvider, providerLabel } from "@/lib/git/types";
 import { deleteRepoLens } from "@/lib/repo-lens/store";
 import { settingsKeys, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
@@ -354,32 +356,56 @@ function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
   );
 }
 
-/** GitHub-only link-out: GitHub has NO API to leave a fork network, so we send
- *  the user to the repo's settings page. A "Re-check fork status" affordance
- *  re-probes and re-persists after they detach on github.com, so the fork badge
- *  + persisted `isFork` clear without an app restart — never cleared
- *  optimistically (it reflects GitHub-side truth). Gated on the persisted fork
- *  provenance, independent of the upstream-remote gate. */
+/** Leave the fork network — provider-branched, gated on the persisted fork
+ *  provenance (independent of the upstream-remote gate):
+ *  - **GitLab** has a real API, so this is an in-app, Owner-gated detach that
+ *    removes the fork relationship (open MRs to the parent are closed).
+ *  - **GitHub** and **Bitbucket** have no detach API, so they link out to the
+ *    provider's settings page (GitHub `…/settings`, Bitbucket `…/admin`).
+ *  A shared "Re-check fork status" affordance re-probes and re-persists, so the
+ *  fork badge + persisted `isFork` clear once the network is left — never
+ *  cleared optimistically (it reflects forge-side truth). Its toasts name the
+ *  active provider. The GitLab arm also fires the re-probe itself on success. */
 function LeaveForkNetworkAction({
   repoPath,
   fullName,
+  provider,
+  isOwner,
 }: {
   repoPath: string;
   fullName: string;
+  provider: ForgeProvider;
+  isOwner: boolean;
 }) {
   const queryClient = useQueryClient();
   const settings = useSettings();
   const forge = useForgeStatus(repoPath);
+  const removeFork = useGlRemoveForkRelationship(repoPath);
   const [rechecking, setRechecking] = useState(false);
+  const [confirming, setConfirming] = useState(false);
   const record = settings.data?.recentRepos.find((r) => r.path === repoPath);
 
   if (record?.isFork !== true) return null;
 
+  const isGitLab = provider === "gitlab";
+  const isBitbucket = provider === "bitbucket";
+  // The provider's own label, for the re-check toasts (gh is the default).
+  const label = providerLabel(provider);
+
   // Derive the host — on GitHub Enterprise the provider is still "github" but a
   // hardcoded github.com would open the wrong host's settings page. While the
   // forge status is still resolving (or errored — retry: false), fall back to
-  // the persisted RecentRepo host, which is available synchronously.
+  // the persisted RecentRepo host, which is available synchronously. Bitbucket
+  // support is Cloud-only, so its fallback is always bitbucket.org.
   const ghHost = forge.data?.host || record?.host || "github.com";
+  const bbHost = record?.host || "bitbucket.org";
+
+  const reprobe = () =>
+    probeAndPersistVisibility(repoPath)
+      .then(() =>
+        queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
+      )
+      .catch(() => undefined);
 
   const recheck = async () => {
     setRechecking(true);
@@ -390,11 +416,11 @@ function LeaveForkNetworkAction({
       // gone) — the badge still clears, but don't present that as a verified
       // detach.
       if (probe === null) {
-        toast.success("Couldn't verify on GitHub — fork badge cleared");
+        toast.success(`Couldn't verify on ${label} — fork badge cleared`);
       } else {
         toast.success(
           probe.isFork
-            ? "Still a fork on GitHub"
+            ? `Still a fork on ${label}`
             : "No longer a fork — badge cleared",
         );
       }
@@ -405,23 +431,65 @@ function LeaveForkNetworkAction({
     }
   };
 
+  const desc = isGitLab
+    ? "Removes the fork relationship on GitLab. Open merge requests to the parent are closed — they stay closed even if the relationship is later re-established via the GitLab API. Your code and history are kept. Requires the Owner role."
+    : isBitbucket
+      ? "Bitbucket has no API for this — detach on bitbucket.org under Repository settings → Repository details → Manage repository → Detach fork. A one-time action that cannot be undone. Existing pull requests to the parent stay viewable; new ones can't be created."
+      : "Permanently detaches this repository from its fork network on GitHub — this cannot be undone. GitHub requires the fork be public, under 1 GB, and have no child forks. Your code and history are kept; issues, PRs, stars, and watchers are lost.";
+
   return (
     <>
       <div className="border-t" />
-      <Row
-        title="Leave fork network"
-        desc="Permanently detaches this repository from its fork network on GitHub — this cannot be undone. GitHub requires the fork be public, under 1 GB, and have no child forks. Your code and history are kept; issues, PRs, stars, and watchers are lost."
-      >
+      <Row title="Leave fork network" desc={desc}>
         {/* Stacked so the description keeps its width — two side-by-side
             buttons squeezed the copy into a tall, narrow column. */}
         <div className="flex shrink-0 flex-col gap-2">
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => openUrl(`https://${ghHost}/${fullName}/settings`)}
-          >
-            Leave on GitHub…
-          </Button>
+          {isGitLab ? (
+            confirming ? (
+              <InlineConfirm
+                actLabel="Remove"
+                pending={removeFork.isPending}
+                onCancel={() => setConfirming(false)}
+                onAct={() =>
+                  removeFork.mutate(undefined, {
+                    onSuccess: () => {
+                      toast.success("Fork relationship removed");
+                      setConfirming(false);
+                      // Re-probe to flip the persisted badge; the row unmounts
+                      // itself once `isFork` reads false.
+                      reprobe();
+                    },
+                    onError: toastError,
+                  })
+                }
+              />
+            ) : (
+              <DangerButton
+                variant="destructive"
+                disabled={!isOwner}
+                hint={isOwner ? undefined : OWNER_HINT}
+                onClick={() => setConfirming(true)}
+              >
+                Remove fork relationship
+              </DangerButton>
+            )
+          ) : isBitbucket ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => openUrl(`https://${bbHost}/${fullName}/admin`)}
+            >
+              Detach on Bitbucket…
+            </Button>
+          ) : (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => openUrl(`https://${ghHost}/${fullName}/settings`)}
+            >
+              Leave on GitHub…
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"
@@ -789,12 +857,18 @@ export function DangerZone({
       />
       {/* Local detach — any provider, whenever an `upstream` remote exists. */}
       <RemoveUpstreamAction repoPath={repoPath} />
-      {/* Leave-fork-network — GitHub only, gated on persisted fork provenance.
-          Gates are independent: a detached-on-GitHub repo may still have the
-          remote; a remote-less fork may still be in the network. */}
-      {isGitHub && (
-        <LeaveForkNetworkAction repoPath={repoPath} fullName={info.fullName} />
-      )}
+      {/* Leave-fork-network — every provider, gated on persisted fork
+          provenance. The row itself branches three ways: an in-app,
+          Owner-gated detach on GitLab (real API), and a link-out on GitHub
+          (…/settings) and Bitbucket (…/admin), neither of which has a detach
+          API. Independent of the upstream-remote gate: a detached fork may
+          still have the remote; a remote-less fork may still be in the network. */}
+      <LeaveForkNetworkAction
+        repoPath={repoPath}
+        fullName={info.fullName}
+        provider={provider}
+        isOwner={isOwner}
+      />
       {/* Bitbucket can't archive over the API — hide the row (platform limit). */}
       {!isBitbucket && (
         <>

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2191,6 +2191,11 @@ export const forgeGlMrAutoMerge = (
 export const forgeGlMrCancelAutoMerge = (repoPath: string, number: number) =>
   invoke<void>("forge_gl_mr_cancel_auto_merge", { repoPath, number });
 
+/** Remove the project's fork relationship (detach from the fork network) —
+ *  GitLab-only. Requires the Owner role; open MRs to the parent are closed. */
+export const forgeGlRemoveForkRelationship = (repoPath: string) =>
+  invoke<void>("forge_gl_remove_fork_relationship", { repoPath });
+
 export const forgePrClose = (
   repoPath: string,
   number: number,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4001,6 +4001,16 @@ export function useGlCancelAutoMerge(repo: string) {
   );
 }
 
+/** Remove a GitLab project's fork relationship (detach from the fork network) —
+ *  GitLab-only. Deliberately does NO cache patching or invalidation: `isFork` is
+ *  forge truth that only flips via a re-probe, so the Danger-zone call site owns
+ *  the post-success `probeAndPersistVisibility` + settings invalidation. */
+export function useGlRemoveForkRelationship(repo: string) {
+  return useMutation({
+    mutationFn: () => api.forgeGlRemoveForkRelationship(repo),
+  });
+}
+
 export function useClosePr(repo: string, lens: RemoteLens) {
   return useRepoMutation(repo, (number: number) =>
     api.forgePrClose(repo, number, lens),


### PR DESCRIPTION
This change introduces a true in-app mechanism to detach GitLab forks directly from the Danger zone panel in repository settings, making the fork "Leave network" action provider-aware, and refining text and UI for clarity. Owners of GitLab forks can now sever the parent relationship without leaving the app—open merge requests to the parent are closed as per GitLab rules. On GitHub and Bitbucket, the action still links out to the provider’s web interface. Documentation, help copy, and app capability listings are updated to reflect this broader cross-provider support.

### GitLab fork detach API + backend wiring
- Adds `remove_fork_relationship` in `src-tauri/src/forge/gitlab.rs` to call the GitLab API's `DELETE projects/{id}/fork` endpoint.
- Exposes this method as a Tauri command via `forge_gl_remove_fork_relationship` in `src-tauri/src/forge/mod.rs`, and registers it in `src-tauri/src/lib.rs`.

### React UI, Danger zone, and provider distinction
- Refactors `LeaveForkNetworkAction` in `src/features/repo-settings/DangerZone.tsx` to branch logic and UI by provider:
  - GitLab: Adds in-app destructive action gated to Owners, with inline confirmation and success feedback/toasts, auto-refreshing fork state.
  - Bitbucket and GitHub: Action remains a link out, but now uses provider-correct URLs and copy.
- Polishes descriptions for each provider, including edge case behaviors and requirements.
- Inline confirmation for GitLab detach, disables button for non-owners with a hint.
- Shared "Re-check fork status" affordance refactored for cross-provider use.

### API/type plumbing
- Adds `forgeGlRemoveForkRelationship` in `src/lib/git/api.ts`, wiring up the Tauri command for use in the app.
- Adds `useGlRemoveForkRelationship` mutation in `src/lib/git/queries.ts` for the UI callsite, with explainers for why probe/refresh is manual.

### Documentation, help, and marketing content
- Updates `README.md` and `site/src/data/capabilities.ts` with accurate provider behaviors and feature distinctions.
- Refines changelog copy in `changelog.d/added-fork-detach.md` to describe all supported providers and their respective detach mechanisms.
- Improves help text in `src/features/help/content.ts` to detail each forge's behavior, including in-app detachment for GitLab and link-outs for others.