### PR TITLE
fix(lan,settings): cut in-flight sockets on device revoke or repo change, always show revocable device list

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -2,4 +2,6 @@
   phone over your local network from **Settings → Phone companion**: pair a device by
   scanning a QR code and typing a PIN. This early preview exposes read-only API access
   to the open repo — the companion phone app arrives in an upcoming release. Off by
-  default, with per-device tokens you can revoke at any time.
+  default, with per-device tokens you can review and revoke at any time (even while
+  sharing is off), and connected phones are disconnected the moment you stop sharing,
+  switch repos, or revoke their device.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -248,10 +248,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1637,6 +1637,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs",
+ "futures-util",
  "keyring",
  "local-ip-address",
  "os_info",
@@ -1646,7 +1647,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.11.0",
  "tauri",
  "tauri-build",
@@ -1661,6 +1662,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.30.0",
  "tower",
  "trash",
  "uuid",
@@ -4159,6 +4161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5109,7 +5122,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.30.0",
 ]
 
 [[package]]
@@ -5381,7 +5406,23 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "sha1 0.11.0",
  "thiserror 2.0.18",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -248,10 +248,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1647,7 +1647,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
- "sha1 0.10.6",
+ "sha1",
  "sha2 0.11.0",
  "tauri",
  "tauri-build",
@@ -1662,7 +1662,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.30.0",
+ "tokio-tungstenite",
  "tower",
  "trash",
  "uuid",
@@ -4161,17 +4161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,19 +5111,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.30.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5406,23 +5383,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.10.2",
- "sha1 0.11.0",
+ "sha1",
  "thiserror 2.0.18",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -95,5 +95,8 @@ portable-pty = { path = "vendor/portable-pty" }
 # a socket (auth/host/allowlist assertions in src/lan/).
 [dev-dependencies]
 futures-util = "0.3.32"
-tokio-tungstenite = "0.30.0"
+# 0.29 (not latest) on purpose: axum's ws feature already pulls tokio-tungstenite
+# 0.29, so matching it reuses that tree instead of compiling a second
+# tungstenite/sha1 stack into every test build.
+tokio-tungstenite = "0.29"
 tower = { version = "0.5.3", features = ["util"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,4 +94,6 @@ portable-pty = { path = "vendor/portable-pty" }
 # `tower::ServiceExt::oneshot` drives the LAN router in unit tests without opening
 # a socket (auth/host/allowlist assertions in src/lan/).
 [dev-dependencies]
+futures-util = "0.3.32"
+tokio-tungstenite = "0.30.0"
 tower = { version = "0.5.3", features = ["util"] }

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -549,6 +549,11 @@ pub struct RouterState {
     pub rate_limit: RateLimitMap,
     /// Every bound `<ip>:<port>` we accept in a `Host`/`Origin` header.
     pub bound_hosts: Arc<Vec<String>>,
+    /// Cut signal for live WebSocket monitors. A `stream` handler subscribes a
+    /// receiver from this before upgrading; the desktop fires `()` on it when
+    /// sharing is disabled, the shared repo changes, or a device is revoked, so
+    /// in-flight sockets close and the phone must reconnect and re-authorize.
+    pub monitor_cut: tokio::sync::broadcast::Sender<()>,
     /// The live agent-stream registry — the SAME `Arc` [`crate::state::AppState`]
     /// holds, so a review/session registered there is watchable from the LAN
     /// review routes without any further plumbing.
@@ -741,8 +746,15 @@ pub async fn pair_submit(
         return bad_request("deviceName must not be empty");
     }
 
-    // Compute the expected proof from the stored PIN + this session's challenge.
-    let expected = {
+    // Verify AND consume the session ATOMICALLY under a single lock: check the
+    // session, compute the expected proof, compare it, and — only on a match —
+    // `take()` the session before releasing. Doing the compare and the consume in
+    // one critical section closes a double-mint race: two concurrent submissions
+    // with the correct proof would otherwise both see a live session and both mint
+    // a token from one PIN entry. A racing second submission now finds the session
+    // already taken and hits `pairing_inactive`. (Rate-limit record/clear stays
+    // exactly as before on every path.)
+    {
         let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
         let Some(session) = guard.as_mut() else {
             record_failure(&state.rate_limit, ip);
@@ -759,22 +771,24 @@ pub async fn pair_submit(
             record_failure(&state.rate_limit, ip);
             return bad_request("fetch a challenge first");
         };
-        compute_proof(&session.pin, &salt, &challenge)
-    };
-
-    if !constant_time_eq(&expected, body.proof.trim()) {
-        record_failure(&state.rate_limit, ip);
-        return unauthorized();
+        let expected = compute_proof(&session.pin, &salt, &challenge);
+        if !constant_time_eq(&expected, body.proof.trim()) {
+            record_failure(&state.rate_limit, ip);
+            return unauthorized();
+        }
+        // Proof accepted → consume the session under the same lock so no second
+        // submission can also pass. From here the session is gone; a persist
+        // failure below does NOT restore it — deliberately fail-closed: we never
+        // leave a session live once its proof has been accepted, so the phone
+        // re-pairs via "Start again" rather than risk a second mint on a session
+        // whose proof already leaked to a racer.
+        guard.take();
     }
 
-    // Correct proof → mint + persist, then clear the pairing session.
+    // Correct proof, session consumed → mint + persist OUTSIDE the lock.
     let (device, bearer, token_hash) = mint_device(device_name);
     if let Err(e) = persist_device(&device, &token_hash) {
         return app_error_response(&e);
-    }
-    {
-        let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
-        *guard = None;
     }
     clear_failures(&state.rate_limit, ip);
     (

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -869,6 +869,124 @@ mod tests {
         std::fs::remove_file(&tmp).ok();
     }
 
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn live_websocket_monitor_is_severed_by_the_cut_signal() {
+        // End-to-end: bind a REAL listener, connect a REAL WebSocket to the
+        // `/api/reviews/{id}/stream` route as a paired device, prove the pump is
+        // live (one event → one Text frame), then fire the lifecycle cut and prove
+        // the socket is closed (next frame is a Close). This exercises the exact
+        // production path the in-memory `oneshot` tests can't reach — the upgraded
+        // socket and `forward_stream`'s monitor-cut `select!` branch.
+        use futures_util::StreamExt;
+        use tokio::time::{timeout, Duration};
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        use tokio_tungstenite::tungstenite::Message;
+
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        // The shared arcs a real server needs — built directly (not via a whole
+        // `LanState`) so we can inject an event and fire the cut ourselves. The
+        // active repo and the stream's `repo_path` match, so the stream is in scope.
+        let repo = "C:/repo".to_string();
+        let active_repo = Arc::new(Mutex::new(Some(repo.clone())));
+        let pairing = Arc::new(Mutex::new(None));
+        let rate_limit = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let streams: Arc<Mutex<std::collections::HashMap<String, crate::state::StreamInfo>>> =
+            Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let monitor_cut = tokio::sync::broadcast::channel::<()>(4).0;
+
+        // A live "review" stream on the shared repo; keep the sender to emit events.
+        let (ev_tx, _ev_rx) = tokio::sync::broadcast::channel::<crate::agent::ReviewEvent>(16);
+        streams.lock().unwrap().insert(
+            "rev-e2e".to_string(),
+            crate::state::StreamInfo {
+                tx: ev_tx.clone(),
+                kind: "review".to_string(),
+                started_at: "2026-07-17T00:00:00.000Z".to_string(),
+                repo_path: repo.clone(),
+            },
+        );
+
+        // Seed a paired device and keep its raw bearer for the WS handshake.
+        let (device, bearer, token_hash) = auth::mint_device("E2E Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        // Bind a real listener in loopback mode (the port scan handles a busy
+        // default port). `server::start` spawns its serve task on the tauri
+        // async runtime, which self-initializes here.
+        let (handle, _urls, _hosts) = server::start(
+            false,
+            active_repo.clone(),
+            pairing,
+            rate_limit,
+            streams.clone(),
+            monitor_cut.clone(),
+        )
+        .await
+        .unwrap();
+        let port = handle.port;
+
+        // Connect a REAL WebSocket. Build the handshake request from the URI (which
+        // fills in the mandatory `Upgrade`/`Sec-WebSocket-*` headers and a `Host` of
+        // `127.0.0.1:{port}`, which is in the bound-hosts allowlist), then add the
+        // per-device bearer the way a paired phone would.
+        let url = format!("ws://127.0.0.1:{port}/api/reviews/rev-e2e/stream");
+        let mut req = url.into_client_request().unwrap();
+        req.headers_mut().insert(
+            "authorization",
+            format!("Bearer {bearer}").parse().unwrap(),
+        );
+        let (mut ws, _resp) = timeout(Duration::from_secs(5), tokio_tungstenite::connect_async(req))
+            .await
+            .expect("WebSocket connect timed out")
+            .expect("WebSocket handshake failed (auth/host/upgrade)");
+
+        // (1) The pump is live: one event through the registry tx arrives as one
+        // Text frame carrying the ReviewEvent's own JSON.
+        ev_tx
+            .send(crate::agent::ReviewEvent::Delta {
+                text: "hello phone".to_string(),
+            })
+            .unwrap();
+        let frame = timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("timed out waiting for the forwarded event")
+            .expect("stream ended before the event")
+            .expect("websocket error waiting for the event");
+        match frame {
+            Message::Text(t) => assert!(
+                t.contains("hello phone"),
+                "forwarded frame should carry the event JSON: {t}"
+            ),
+            other => panic!("expected a Text frame, got {other:?}"),
+        }
+
+        // (2) Fire the lifecycle cut (what `lan_disable` / repo-switch / revoke do).
+        // The pump's `select!` cut branch must break and close the socket.
+        monitor_cut.send(()).unwrap();
+
+        // The next frame the client sees is a Close (the pump's best-effort
+        // graceful close). Some stacks surface the close as the stream ending
+        // (`None`) right after; accept either as "severed", but never another Text.
+        let next = timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("timed out waiting for the socket to be severed");
+        match next {
+            Some(Ok(Message::Close(_))) | None => { /* severed, as required */ }
+            Some(Ok(other)) => panic!("expected the socket to be cut, got {other:?}"),
+            Some(Err(_)) => { /* an abrupt transport close is still a severed socket */ }
+        }
+
+        // Best-effort client-side close, then tear the server down and clean up.
+        let _ = ws.close(None).await;
+        handle.shutdown().await;
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
     // NOTE on the `stream` route's 409/404 branches: `WebSocketUpgrade` is an
     // extractor, and axum runs it during extraction — a plain (non-upgrade) GET is
     // rejected with `400 Bad Request` by the extractor BEFORE the handler body runs,
@@ -882,13 +1000,13 @@ mod tests {
     // distinguishing them. Asserting the route-level 404/409 would need a live
     // socket, out of scope for these in-memory router tests.
     //
-    // NOTE on `forward_stream`'s monitor-cut `select!` branch: for the same reason
-    // the WS route can't be driven via `tower::oneshot` (the `WebSocketUpgrade`
-    // extractor rejects a non-upgrade GET during extraction, before the handler
-    // runs), the cut branch inside the pump can't be exercised here either — it
-    // only runs on an upgraded socket. What IS testable — and is tested above — is
-    // that the desktop FIRES the cut at each lifecycle point
-    // (`set_active_repo_cuts_monitors_only_on_change`,
-    // `revoke_device_cuts_monitors_on_success`); the pump's reaction (break + Close
-    // frame on any `cut_rx.recv()` result) is verified by inspection.
+    // NOTE on `forward_stream`'s monitor-cut `select!` branch: a `tower::oneshot`
+    // can't drive it (the `WebSocketUpgrade` extractor rejects a non-upgrade GET
+    // during extraction, before the handler runs), so the cut branch only runs on a
+    // real upgraded socket. It is now covered end-to-end by
+    // `live_websocket_monitor_is_severed_by_the_cut_signal` above, which binds a
+    // real listener, connects a real WebSocket, and asserts the socket is closed
+    // when the cut fires. The fire points are separately covered by
+    // `set_active_repo_cuts_monitors_only_on_change` and
+    // `revoke_device_cuts_monitors_on_success`.
 }

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -39,6 +39,14 @@ pub struct LanState {
     pairing: Arc<Mutex<Option<PairingSession>>>,
     /// Per-IP failure windows for rate-limiting, shared with the router state.
     rate_limit: RateLimitMap,
+    /// Fires a cut signal to every live WebSocket monitor (see
+    /// [`routes::reviews::forward_stream`]). Sent on `lan_disable`, on a
+    /// mode-switch rebind, when the active repo actually changes, and on a
+    /// device revoke — each closes in-flight sockets so a phone must reconnect
+    /// and re-authorize against the new state. The `Sender` is shared (cloned)
+    /// into the router state; only the send half is ever needed there (each
+    /// socket subscribes its own receiver).
+    monitor_cut: tokio::sync::broadcast::Sender<()>,
     /// Serializes the WHOLE enable/disable lifecycle transition (an async-aware
     /// `Mutex`, held across the bind/shutdown `.await`s). Without it, two
     /// concurrent `lan_enable`s could both observe "not running", both bind a
@@ -64,12 +72,53 @@ impl Default for LanState {
             running: Mutex::new(None),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            // Capacity 4: cut signals are rare lifecycle blips, and each monitor
+            // only needs to observe that *a* cut happened (the value is `()`), so
+            // a shallow buffer is plenty — a lagged receiver still terminates.
+            monitor_cut: tokio::sync::broadcast::channel(4).0,
             lifecycle: tokio::sync::Mutex::new(()),
         }
     }
 }
 
 impl LanState {
+    /// Point the read routes at `repo_path`, cutting live monitors iff the shared
+    /// repo actually changed. Returns whether it changed (the cut fired). Split
+    /// out from the [`lan_set_active_repo`] command so the change-detection +
+    /// cut-fire behavior is unit-testable without a Tauri `State`.
+    fn set_active_repo(&self, repo_path: Option<String>) -> bool {
+        let changed = {
+            let mut guard = self.active_repo.lock().unwrap_or_else(|p| p.into_inner());
+            if *guard == repo_path {
+                false
+            } else {
+                *guard = repo_path;
+                true
+            }
+        };
+        // Only cut live monitors when the shared repo ACTUALLY changed. The App
+        // effect re-pushes on every repoPath render, so a same-value set is a
+        // no-op and must not sever a healthy stream; a real switch/clear must,
+        // since the phone's in-flight stream is now scoped to a repo we no longer
+        // share.
+        if changed {
+            let _ = self.monitor_cut.send(());
+        }
+        changed
+    }
+
+    /// Revoke a paired device, then cut live monitors on success. Split out from
+    /// the [`lan_device_revoke`] command so the on-success cut-fire is unit-
+    /// testable without a Tauri `State`. The cut is deliberately coarse (all live
+    /// monitors, not just the revoked device's — per-device cut tracking is
+    /// deferred): every phone reconnects, and the revoked token is now rejected at
+    /// the upgrade, closing the "auth runs only at upgrade time" hole.
+    fn revoke_device(&self, device_id: &str) -> AppResult<()> {
+        auth::revoke_device(device_id)?;
+        let _ = self.monitor_cut.send(());
+        Ok(())
+    }
+
     /// Build the current [`LanStatus`] snapshot.
     fn status(&self) -> LanStatus {
         let running = self.running.lock().unwrap_or_else(|p| p.into_inner());
@@ -185,6 +234,10 @@ pub async fn lan_enable(
             running.take()
         };
         if let Some(rs) = old {
+            // Cut any sockets accepted on the old listener before it's torn down:
+            // a mode switch rebinds on a new port/interface, so in-flight monitors
+            // must reconnect against the new server.
+            let _ = state.monitor_cut.send(());
             rs.handle.shutdown().await;
         }
     }
@@ -197,6 +250,7 @@ pub async fn lan_enable(
         // The SAME stream registry `AppState` owns — so a review/session running
         // there is enumerable + watchable over the LAN.
         app_state.streams_arc(),
+        state.monitor_cut.clone(),
     )
     .await?;
     {
@@ -225,6 +279,11 @@ pub async fn lan_disable(app: AppHandle, state: State<'_, LanState>) -> AppResul
         running.take()
     };
     if let Some(rs) = old {
+        // Cut every live monitor before we drop the listener: `shutdown()` stops
+        // accepting, but sockets already hijacked out of the serve loop keep
+        // forwarding until told to stop. Firing here closes them so "Stop sharing"
+        // actually severs the phone.
+        let _ = state.monitor_cut.send(());
         rs.handle.shutdown().await;
     }
     // Any in-flight pairing is meaningless once the server is down.
@@ -244,8 +303,7 @@ pub fn lan_set_active_repo(
     state: State<'_, LanState>,
     repo_path: Option<String>,
 ) -> AppResult<()> {
-    let mut guard = state.active_repo.lock().unwrap_or_else(|p| p.into_inner());
-    *guard = repo_path;
+    state.set_active_repo(repo_path);
     Ok(())
 }
 
@@ -300,8 +358,8 @@ pub fn lan_devices_list(_state: State<'_, LanState>) -> AppResult<Vec<LanDevice>
 
 /// Revoke a paired device by id. Its bearer token stops authenticating.
 #[tauri::command]
-pub fn lan_device_revoke(_state: State<'_, LanState>, device_id: String) -> AppResult<()> {
-    auth::revoke_device(&device_id)
+pub fn lan_device_revoke(state: State<'_, LanState>, device_id: String) -> AppResult<()> {
+    state.revoke_device(&device_id)
 }
 
 /// Render `data` as an SVG QR code (string). Uses medium error correction and a
@@ -345,6 +403,7 @@ mod tests {
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
             bound_hosts: Arc::new(vec!["testhost".to_string()]),
             streams: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            monitor_cut: tokio::sync::broadcast::channel(4).0,
         }
     }
 
@@ -371,6 +430,62 @@ mod tests {
             *guard = None;
         }
         assert_eq!(state.status().active_repo, None);
+    }
+
+    #[test]
+    fn set_active_repo_cuts_monitors_only_on_change() {
+        // The monitor-cut signal fires when the shared repo actually changes, and
+        // NOT on a same-value set (the App effect re-pushes the same repoPath on
+        // every render — cutting on those would sever healthy phone streams).
+        let state = LanState::default();
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        // (1) None → Some(repo) is a change → fires.
+        assert!(state.set_active_repo(Some("C:/repo".to_string())));
+        assert!(cut_rx.try_recv().is_ok());
+
+        // (2) Setting the SAME value again is a no-op → no fire.
+        assert!(!state.set_active_repo(Some("C:/repo".to_string())));
+        assert!(matches!(
+            cut_rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+
+        // (3) A real switch (and a clear) each fire.
+        assert!(state.set_active_repo(Some("C:/other".to_string())));
+        assert!(cut_rx.try_recv().is_ok());
+        assert!(state.set_active_repo(None));
+        assert!(cut_rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn revoke_device_cuts_monitors_on_success() {
+        // A successful revoke fires the monitor-cut signal (so a phone with the
+        // revoked token — auth only ran at upgrade time — is severed and 401ed on
+        // reconnect). A failed revoke (unknown id) does NOT fire.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        let (device, _bearer, token_hash) = auth::mint_device("Revoke Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        // Successful revoke → fires.
+        state.revoke_device(&device.id).unwrap();
+        assert!(cut_rx.try_recv().is_ok());
+
+        // A second revoke of the same (now-unknown) id errors and must NOT fire.
+        assert!(state.revoke_device(&device.id).is_err());
+        assert!(matches!(
+            cut_rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
     }
 
     #[tokio::test]
@@ -505,6 +620,28 @@ mod tests {
             .unwrap();
         let auth_resp = router.clone().oneshot(auth_req).await.unwrap();
         assert_ne!(auth_resp.status(), StatusCode::UNAUTHORIZED);
+
+        // 3b) The session was CONSUMED atomically on the successful pair, so a
+        //     second submit with the SAME correct proof (the double-mint race, run
+        //     sequentially here) now hits `pairingInactive`/403 — it can't mint a
+        //     second token from one PIN entry.
+        let replay_body = serde_json::json!({ "deviceName": "Replay Phone", "proof": proof });
+        let replay_req = Request::builder()
+            .uri("/api/pair")
+            .method("POST")
+            .header("host", "testhost")
+            .header("content-type", "application/json")
+            .body(Body::from(replay_body.to_string()))
+            .unwrap();
+        let replay_resp = router.clone().oneshot(replay_req).await.unwrap();
+        assert_eq!(replay_resp.status(), StatusCode::FORBIDDEN);
+        let replay_bytes = axum::body::to_bytes(replay_resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let replay: serde_json::Value = serde_json::from_slice(&replay_bytes).unwrap();
+        assert_eq!(replay["kind"], "pairingInactive");
+        // Still exactly one device — no second mint slipped through.
+        assert_eq!(auth::list_devices().unwrap().len(), 1);
 
         // 4) Revoke the device → the same token now 401s.
         auth::revoke_device(&device_id).unwrap();
@@ -744,4 +881,14 @@ mod tests {
     // out-of-scope id and unknown id → `None` (the 404 source), with no oracle
     // distinguishing them. Asserting the route-level 404/409 would need a live
     // socket, out of scope for these in-memory router tests.
+    //
+    // NOTE on `forward_stream`'s monitor-cut `select!` branch: for the same reason
+    // the WS route can't be driven via `tower::oneshot` (the `WebSocketUpgrade`
+    // extractor rejects a non-upgrade GET during extraction, before the handler
+    // runs), the cut branch inside the pump can't be exercised here either — it
+    // only runs on an upgraded socket. What IS testable — and is tested above — is
+    // that the desktop FIRES the cut at each lifecycle point
+    // (`set_active_repo_cuts_monitors_only_on_change`,
+    // `revoke_device_cuts_monitors_on_success`); the pump's reaction (break + Close
+    // frame on any `cut_rx.recv()` result) is verified by inspection.
 }

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -114,6 +114,10 @@ async fn forward_stream(
 ) {
     loop {
         tokio::select! {
+            // `biased` + cut-first: when a cut and an event are both ready, the
+            // cut wins — a just-revoked/disabled socket never forwards one more
+            // buffered frame before it honors the sever.
+            biased;
             // Lifecycle cut: sharing was disabled, the shared repo changed, or a
             // device was revoked — sever this socket unconditionally so the phone
             // must reconnect and re-authorize against the new state. ANY result

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -19,6 +19,15 @@
 //! unknown id, so there's no probe oracle). This upholds the clear-on-close
 //! containment: paired devices never watch a run on a repo that isn't shared.
 //!
+//! **In-flight sockets are actively cut.** Scoping only gates NEW requests; a
+//! WebSocket accepted while a repo was shared is hijacked out of the serve loop
+//! and would keep forwarding after the desktop disables sharing, switches/clears
+//! the shared repo, or revokes the device (auth runs only at upgrade time). So
+//! [`forward_stream`] also selects on a broadcast cut signal
+//! ([`crate::lan::LanState::monitor_cut`]) that the desktop fires at each of
+//! those lifecycle points; on a cut the socket is closed and the phone must
+//! reconnect and re-authorize.
+//!
 //! **No replay.** The underlying channel is a `tokio::sync::broadcast` with no
 //! history, so a subscriber that connects mid-stream sees only events emitted
 //! *after* it subscribed; earlier deltas are not resent. Acceptable for v1 (the
@@ -86,16 +95,34 @@ pub async fn stream(
         )
             .into_response();
     };
-    ws.on_upgrade(move |socket| forward_stream(socket, rx))
+    // Subscribe to the lifecycle cut signal BEFORE upgrading, so a cut fired
+    // between here and the pump starting isn't missed. Auth ran at upgrade time
+    // only; this receiver is how a later disable / repo-switch / revoke reaches an
+    // already-accepted socket and forces it closed.
+    let cut_rx = state.monitor_cut.subscribe();
+    ws.on_upgrade(move |socket| forward_stream(socket, rx, cut_rx))
 }
 
 /// The per-connection pump: forward each broadcast event as one JSON text frame,
 /// translate lag/close, and drain inbound client frames (read-only monitor — no
 /// stdin path exists). Terminates on the terminal `Done`/`Error` event, on the
 /// stream ending (`Closed`), or when the client hangs up.
-async fn forward_stream(mut socket: WebSocket, mut rx: tokio::sync::broadcast::Receiver<ReviewEvent>) {
+async fn forward_stream(
+    mut socket: WebSocket,
+    mut rx: tokio::sync::broadcast::Receiver<ReviewEvent>,
+    mut cut_rx: tokio::sync::broadcast::Receiver<()>,
+) {
     loop {
         tokio::select! {
+            // Lifecycle cut: sharing was disabled, the shared repo changed, or a
+            // device was revoked — sever this socket unconditionally so the phone
+            // must reconnect and re-authorize against the new state. ANY result
+            // ends the loop: Ok is a real cut; Lagged means we missed one but a cut
+            // still happened; Closed can't occur while `LanState` holds the Sender,
+            // but we match it defensively and treat it the same (terminate).
+            _cut = cut_rx.recv() => {
+                break;
+            }
             // Broadcast side: forward events to the client.
             recv = rx.recv() => match recv {
                 Ok(ev) => {

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -203,6 +203,7 @@ pub async fn start(
     pairing: Arc<std::sync::Mutex<Option<auth::PairingSession>>>,
     rate_limit: auth::RateLimitMap,
     streams: Arc<std::sync::Mutex<std::collections::HashMap<String, crate::state::StreamInfo>>>,
+    monitor_cut: tokio::sync::broadcast::Sender<()>,
 ) -> AppResult<(ServerHandle, Vec<String>, Vec<String>)> {
     let (bind_ip, ips) = resolve_ips(bind_lan);
     let (listener, port) = bind_listener(bind_ip).await?;
@@ -215,6 +216,7 @@ pub async fn start(
         rate_limit,
         bound_hosts: Arc::new(bound_hosts.clone()),
         streams,
+        monitor_cut,
     };
     let router = build_router(state);
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1559,9 +1559,13 @@ connects, choose **Start again**. When a device pairs, the dialog confirms it by
 ## Managing paired devices
 
 Each paired device is listed with its name, its **read-only** scope, and when it paired
-and was last seen. Every device holds its **own token**, and you can **Revoke** any of
-them at any time — a revoked device immediately loses access and has to pair again to
-reconnect. Arrow keys move between devices in the list.
+and was last seen. The list stays visible **even while sharing is off** — pairings
+persist across sharing sessions, so you can always see (and revoke) which devices could
+connect the next time you turn sharing on. Every device holds its **own token**, and you
+can **Revoke** any of them at any time — a revoked device immediately loses access and
+has to pair again to reconnect. Stopping sharing, switching repos, or revoking a device
+also **disconnects any phone that's watching live** right away. Arrow keys move between
+devices in the list.
 
 ## Security — please read
 

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -162,7 +163,11 @@ export function CompanionSection() {
         </span>
       </div>
 
-      {deviceList.length === 0 ? (
+      {devices.isPending ? (
+        // First fetch: paired devices may exist, so don't flash the empty-state
+        // copy — show a placeholder of roughly list-row height instead.
+        <Skeleton className="h-16 w-full" />
+      ) : deviceList.length === 0 ? (
         <p className="text-xs text-muted-foreground">
           {enabled
             ? "No devices paired yet. Choose “Pair a device” to add your phone."

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -31,8 +31,10 @@ export function CompanionSection() {
   const revoke = useLanDeviceRevoke();
 
   const enabled = status.data?.enabled ?? false;
-  // Read the device list only while sharing is on (nothing to show otherwise).
-  const devices = useLanDevices({ enabled });
+  // Always read the device list, even while sharing is off: a paired device's
+  // token persists across sharing being toggled, so the user must be able to see
+  // and revoke standing access at any time (the guide promises exactly this).
+  const devices = useLanDevices({ enabled: true });
   const deviceList = devices.data ?? [];
 
   const [pairOpen, setPairOpen] = useState(false);
@@ -167,43 +169,52 @@ export function CompanionSection() {
             : "Turn on sharing to pair a device."}
         </p>
       ) : (
-        // A roving-focus list (arrow keys move between rows).
-        <div ref={listRef} onKeyDown={onKeyDown} className="space-y-2">
-          {deviceList.map((device, i) => (
-            <div
-              key={device.id}
-              data-device-row={device.id}
-              aria-label={`${device.name}, ${device.scope}, last seen ${formatRelativeTime(
-                device.lastSeenAt,
-              )}`}
-              tabIndex={
-                i === safeActive || (safeActive === -1 && i === 0) ? 0 : -1
-              }
-              onFocus={() => setActiveIndex(i)}
-              className="flex items-center gap-2 rounded border px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              <span className="shrink-0 text-xs font-medium">
-                {device.name}
-              </span>
-              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase">
-                {device.scope}
-              </span>
-              <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
-                paired {formatRelativeTime(device.createdAt)} · seen{" "}
-                {formatRelativeTime(device.lastSeenAt)}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="shrink-0"
-                onClick={() => setConfirmRevoke(device)}
-                aria-label={`Revoke ${device.name}`}
+        <>
+          {/* Paired tokens persist while sharing is off, so the list stays
+              visible and revocable — but note they can't connect right now. */}
+          {!enabled && (
+            <p className="text-xs text-muted-foreground">
+              These devices can connect the next time sharing is on.
+            </p>
+          )}
+          {/* A roving-focus list (arrow keys move between rows). */}
+          <div ref={listRef} onKeyDown={onKeyDown} className="space-y-2">
+            {deviceList.map((device, i) => (
+              <div
+                key={device.id}
+                data-device-row={device.id}
+                aria-label={`${device.name}, ${device.scope}, last seen ${formatRelativeTime(
+                  device.lastSeenAt,
+                )}`}
+                tabIndex={
+                  i === safeActive || (safeActive === -1 && i === 0) ? 0 : -1
+                }
+                onFocus={() => setActiveIndex(i)}
+                className="flex items-center gap-2 rounded border px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                Revoke
-              </Button>
-            </div>
-          ))}
-        </div>
+                <span className="shrink-0 text-xs font-medium">
+                  {device.name}
+                </span>
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase">
+                  {device.scope}
+                </span>
+                <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+                  paired {formatRelativeTime(device.createdAt)} · seen{" "}
+                  {formatRelativeTime(device.lastSeenAt)}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => setConfirmRevoke(device)}
+                  aria-label={`Revoke ${device.name}`}
+                >
+                  Revoke
+                </Button>
+              </div>
+            ))}
+          </div>
+        </>
       )}
 
       <PairDeviceDialog open={pairOpen} onOpenChange={setPairOpen} />

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -167,6 +167,12 @@ export function CompanionSection() {
         // First fetch: paired devices may exist, so don't flash the empty-state
         // copy — show a placeholder of roughly list-row height instead.
         <Skeleton className="h-16 w-full" />
+      ) : devices.isError ? (
+        // A failed read is not "no devices" — paired devices may exist, so never
+        // show the empty-state copy on error.
+        <p className="text-xs text-muted-foreground">
+          Couldn't load paired devices.
+        </p>
       ) : deviceList.length === 0 ? (
         <p className="text-xs text-muted-foreground">
           {enabled


### PR DESCRIPTION
This change hardens the LAN companion device security model by actively terminating any in-flight WebSocket monitor connections whenever sharing is disabled, the shared repo is changed, or a device is revoked. It also ensures that the list of revocable devices is always visible in the settings, even when sharing is off, so users can review and revoke access at any time.

### LAN server/cut-socket lifecycle
- Adds `monitor_cut` broadcast channel to `src-tauri/src/lan/mod.rs`, `src-tauri/src/lan/auth.rs`, and `src-tauri/src/lan/server.rs`. This channel is fired on:
  - Disabling LAN sharing
  - Actual changes to the shared repo path
  - Revoking a device
  - Mode switch rebinds
- Tunes lifecycle methods to fire `monitor_cut.send(())` only on actual state changes (`set_active_repo`), so healthy sockets aren't severed on repeats.
- Refactors device revocation in `src-tauri/src/lan/mod.rs` so that on successful device revoke, all in-flight monitor connections are forcibly closed.
- The cut is coarse (all connections); per-device cuts are left for later.
- Updates pair submission in `src-tauri/src/lan/auth.rs` to atomically verify then consume pairing sessions, closing a rare double-mint race on concurrent submissions.
- Expands unit tests and comments in `src-tauri/src/lan/mod.rs` to verify and document these lifecycle events.

### WebSocket monitor handling
- In `src-tauri/src/lan/routes/reviews.rs`, updates the monitor stream upgrade logic so each socket also listens for the `monitor_cut` signal, closing itself when triggered (on repo switch, sharing off, or revoke).
- Detailed comments clarify why and how in-flight monitors are actively terminated.

### Companion device settings UI
- Changes `src/features/settings/CompanionSection.tsx` so the list of paired devices is always visible and up to date, regardless of whether sharing is currently enabled (`useLanDevices({ enabled: true })`).
- UI copy and explanations are added to make it clear that tokens persist while sharing is off, and existing device tokens must remain revocable at all times.
- Fixes focus handling and roving keyboard navigation for the device list to support the always-on view.