### PR TITLE
fix(git,auth,remotes): sever ambient credential chain for push, tag, and delete ops

### DIFF
--- a/changelog.d/fixed-credential-helper-severs-ambient-chain.md
+++ b/changelog.d/fixed-credential-helper-severs-ambient-chain.md
@@ -1,0 +1,5 @@
+- Push, pull, fetch, and clone to private repos no longer fail with "Repository not
+  found" when a stale credential in the system keychain (macOS Keychain, Windows
+  Credential Manager) shadows your `gh`/`glab` sign-in — Git is now told to use exactly
+  the signed-in CLI's identity for that host. Tag pushes, remote branch deletion, and
+  fork PR pushes now authenticate the same way.

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -735,18 +735,51 @@ pub async fn create_issue(
     .await
 }
 
-/// The `git -c credential.https://<host>.helper=…` entry that lets a private
-/// GitHub repo authenticate via gh's token with an ABSOLUTE gh path — so it works
-/// even when git's ambient `!gh` helper can't find gh on a GUI-launch minimal PATH
-/// (macOS launchd), or when gh was configured for SSH and never installed the
-/// HTTPS helper. One-shot per `git` invocation; nothing written to git config, no
-/// token in the remote URL. Mirrors gitlab::clone_credential_config.
+/// The one-shot `git -c` credential entries that authenticate a private GitHub
+/// repo via gh's token with an ABSOLUTE gh path — so it works even when git's
+/// ambient `!gh` helper can't find gh on a GUI-launch minimal PATH (macOS
+/// launchd), or when gh was configured for SSH and never installed the HTTPS
+/// helper. One-shot per `git` invocation; nothing written to git config, no token
+/// in the remote URL. Mirrors gitlab::clone_credential_config.
+///
+/// Returns the `[reset, helper]` pair (see [`github_credential_entries`]) ONLY
+/// when gh is present AND authenticated for `host`; when gh is present but not
+/// authenticated for that host, returns an empty Vec so git's ambient behavior is
+/// preserved unchanged (a user relying on git-credential-manager / the OS keychain
+/// must not be broken). Missing gh → `Err(GhNotFound)`, unchanged — callers'
+/// `.unwrap_or_default()` keeps the fail-open, strict `?` clone sites stay
+/// fail-closed on a missing CLI.
 pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> {
     let gh = crate::agent::resolve_named(&["gh"], None)
         .await
         .ok_or(AppError::GhNotFound)?;
     let host = crate::forge::remote_host(clone_url).unwrap_or_else(|| "github.com".to_string());
-    Ok(vec![github_credential_entry(&host, &gh.display().to_string())])
+    if !gh_authenticated(&host).await {
+        // gh is installed but has no token for this host — inject nothing so git's
+        // ambient credential helpers (keychain, git-credential-manager) still run.
+        return Ok(Vec::new());
+    }
+    Ok(github_credential_entries(&host, &gh.display().to_string()))
+}
+
+/// The one-shot `-c` credential entries for an authenticated GitHub host — a
+/// `[reset, helper]` pair. Pure/format-only.
+///
+/// entry[0] SEVERS git's accumulated helper chain for this URL: `-c
+/// credential.https://<host>.helper=` sets the key to the EMPTY string, which git
+/// treats as "clear the list of helpers so far" (gitcredentials(7); this is the
+/// same blank entry `gh auth setup-git` writes before its own). The trailing `=`
+/// is load-bearing — `-c name=` sets the empty string, whereas `-c name` without
+/// the `=` would set boolean `true` and break the reset. entry[1] then installs
+/// gh as the sole helper, so an ambient helper earlier in the config chain (e.g.
+/// macOS `osxkeychain` in Apple Git's system gitconfig) can't shadow gh's identity.
+/// Order matters: reset FIRST — consumers prefix `-c` pairs in Vec order.
+fn github_credential_entries(host: &str, gh_path: &str) -> Vec<String> {
+    vec![
+        // Reset: empty value clears the accumulated helper list for this URL.
+        format!("credential.https://{host}.helper="),
+        github_credential_entry(host, gh_path),
+    ]
 }
 
 /// The one-shot `-c` credential-helper config value for a GitHub host. Pure/format-only.
@@ -754,24 +787,133 @@ fn github_credential_entry(host: &str, gh_path: &str) -> String {
     format!("credential.https://{host}.helper=!\"{gh_path}\" auth git-credential")
 }
 
+/// Whether gh has a token for `host` — the auth gate deciding whether to inject
+/// the credential helper. Runs `gh auth token --hostname <host>`, which is
+/// local-only (no network): exit 0 iff a token exists for that host (from gh's
+/// config file, the system keyring, or `GH_TOKEN` — the very sources `gh auth
+/// git-credential` answers from). Memoized per-host with a 60s TTL: auth state
+/// changes rarely, and 60s bounds staleness after the user signs in/out mid-session.
+///
+/// SECURITY: `gh auth token`'s stdout IS the user's token — this reads only the
+/// exit code and drops the output; the token is never logged or formatted anywhere.
+async fn gh_authenticated(host: &str) -> bool {
+    if let Some(hit) = auth_cache_get(host, GH_AUTH_TTL) {
+        return hit;
+    }
+    match crate::github::runner::run_gh_raw(
+        None,
+        &["auth", "token", "--hostname", host],
+        crate::github::runner::GH_TIMEOUT,
+    )
+    .await
+    {
+        // Successful spawn: exit 0 ⇔ a token exists. Cache both outcomes.
+        Ok(out) => {
+            let authed = out.code == 0;
+            auth_cache_put(host, authed);
+            authed
+        }
+        // Missing binary / timeout is transient — don't cache; treat as unauthenticated.
+        Err(_) => false,
+    }
+}
+
+/// TTL bounding how long a per-host gh auth result stays trusted before we re-probe.
+const GH_AUTH_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Per-host cache of `(probe time, authenticated)` for [`gh_authenticated`]. Bounded
+/// by the number of distinct hosts (tiny) — a stale entry is overwritten, not evicted.
+type GhAuthCache =
+    std::sync::Mutex<std::collections::HashMap<String, (std::time::Instant, bool)>>;
+static GH_AUTH_CACHE: std::sync::OnceLock<GhAuthCache> = std::sync::OnceLock::new();
+
+fn gh_auth_cache() -> &'static GhAuthCache {
+    GH_AUTH_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// The cached auth result for `host` only if an entry exists AND it was probed less
+/// than `ttl` ago. Pure over the module-level cache; the lock is held only long
+/// enough to copy the value out.
+fn auth_cache_get(host: &str, ttl: std::time::Duration) -> Option<bool> {
+    let guard = gh_auth_cache().lock().unwrap();
+    let (probed_at, authed) = guard.get(host)?;
+    if probed_at.elapsed() < ttl {
+        Some(*authed)
+    } else {
+        None
+    }
+}
+
+/// Record `authed` as the current result for `host`, stamped with the probe time.
+fn auth_cache_put(host: &str, authed: bool) {
+    gh_auth_cache()
+        .lock()
+        .unwrap()
+        .insert(host.to_string(), (std::time::Instant::now(), authed));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn credential_entry_uses_host_and_absolute_gh_path() {
+    fn credential_entries_are_reset_then_helper_for_default_host() {
+        let entries = github_credential_entries("github.com", "/abs/gh");
+        assert_eq!(entries.len(), 2);
+        // entry[0] resets the helper chain: empty value, nothing after the `=`.
+        assert_eq!(entries[0], "credential.https://github.com.helper=");
+        // entry[1] is byte-identical to the historical single helper entry.
         assert_eq!(
-            github_credential_entry("github.com", "/abs/gh"),
+            entries[1],
             "credential.https://github.com.helper=!\"/abs/gh\" auth git-credential"
         );
     }
 
     #[test]
-    fn credential_entry_substitutes_enterprise_host() {
+    fn credential_entries_substitute_enterprise_host() {
+        let entries = github_credential_entries("github.example.com", "/abs/gh");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], "credential.https://github.example.com.helper=");
         assert_eq!(
-            github_credential_entry("github.example.com", "/abs/gh"),
+            entries[1],
             "credential.https://github.example.com.helper=!\"/abs/gh\" auth git-credential"
         );
+    }
+
+    // --- gh-auth TTL cache (mirrors remote.rs's cache tests). Distinct host keys
+    // per test — the cache is a process-wide static shared across all tests. ---
+
+    const BIG: std::time::Duration = std::time::Duration::from_secs(3600);
+
+    #[test]
+    fn auth_cache_put_then_get_within_ttl_hits() {
+        auth_cache_put("cache-a.example.com", true);
+        assert_eq!(auth_cache_get("cache-a.example.com", BIG), Some(true));
+        auth_cache_put("cache-a-false.example.com", false);
+        assert_eq!(auth_cache_get("cache-a-false.example.com", BIG), Some(false));
+    }
+
+    #[test]
+    fn auth_cache_zero_ttl_is_always_expired() {
+        auth_cache_put("cache-b.example.com", true);
+        // Zero TTL: any elapsed time is >= the TTL, so the entry reads as expired.
+        assert_eq!(
+            auth_cache_get("cache-b.example.com", std::time::Duration::ZERO),
+            None
+        );
+    }
+
+    #[test]
+    fn auth_cache_distinct_hosts_do_not_collide() {
+        auth_cache_put("cache-c-one.example.com", true);
+        auth_cache_put("cache-c-two.example.com", false);
+        assert_eq!(auth_cache_get("cache-c-one.example.com", BIG), Some(true));
+        assert_eq!(auth_cache_get("cache-c-two.example.com", BIG), Some(false));
+    }
+
+    #[test]
+    fn auth_cache_miss_returns_none() {
+        assert_eq!(auth_cache_get("cache-never-written.example.com", BIG), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -821,10 +821,15 @@ async fn gh_authenticated(host: &str) -> bool {
         }
         // A spawn/timeout hiccup, NOT absence: `resolve_named` already proved gh
         // exists, so an Err here is transient. Optimistically inject (uncached) —
-        // with run_git_mutating_with_creds's ambient fallback in place this is safe
-        // both ways: if gh is genuinely signed out its helper returns nothing and
-        // the fallback restores ambient, whereas a pessimistic `false` here would
-        // silently reopen the stale-keychain bug for that op.
+        // on the NETWORK path run_git_mutating_with_creds's ambient fallback makes
+        // this safe both ways: if gh is genuinely signed out its helper returns
+        // nothing and the fallback restores ambient, whereas a pessimistic `false`
+        // would silently reopen the stale-keychain bug for that op. The CLONE path
+        // (repo.rs extra_config) takes this optimistic inject UNPROTECTED — a
+        // signed-out gh + a transient probe error there severs ambient and the
+        // clone hard-fails; accepted: it needs the spawn to fail right after
+        // resolve_named succeeded, and it self-heals on re-clone (a clean probe
+        // then returns false → no injection → ambient runs).
         Err(_) => true,
     }
 }

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -743,10 +743,13 @@ pub async fn create_issue(
 /// in the remote URL. Mirrors gitlab::clone_credential_config.
 ///
 /// Returns the `[reset, helper]` pair (see [`github_credential_entries`]) ONLY
-/// when gh is present AND authenticated for `host`; when gh is present but not
-/// authenticated for that host, returns an empty Vec so git's ambient behavior is
+/// when gh is present AND has a STORED token for `host`; when gh is present but has
+/// no stored token for that host, returns an empty Vec so git's ambient behavior is
 /// preserved unchanged (a user relying on git-credential-manager / the OS keychain
-/// must not be broken). Missing gh → `Err(GhNotFound)`, unchanged — callers'
+/// must not be broken). The stored-token check is a local read — it proves the
+/// token EXISTS, not that it's valid; a revoked token still passes, which is why
+/// [`crate::git::remote::run_git_mutating_with_creds`] carries the ambient
+/// fallback. Missing gh → `Err(GhNotFound)`, unchanged — callers'
 /// `.unwrap_or_default()` keeps the fail-open, strict `?` clone sites stay
 /// fail-closed on a missing CLI.
 pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> {
@@ -787,12 +790,15 @@ fn github_credential_entry(host: &str, gh_path: &str) -> String {
     format!("credential.https://{host}.helper=!\"{gh_path}\" auth git-credential")
 }
 
-/// Whether gh has a token for `host` — the auth gate deciding whether to inject
-/// the credential helper. Runs `gh auth token --hostname <host>`, which is
+/// Whether gh has a STORED token for `host` — the auth gate deciding whether to
+/// inject the credential helper. Runs `gh auth token --hostname <host>`, which is
 /// local-only (no network): exit 0 iff a token exists for that host (from gh's
 /// config file, the system keyring, or `GH_TOKEN` — the very sources `gh auth
-/// git-credential` answers from). Memoized per-host with a 60s TTL: auth state
-/// changes rarely, and 60s bounds staleness after the user signs in/out mid-session.
+/// git-credential` answers from). This proves the token EXISTS, not that it's
+/// valid — a revoked token still passes; the ambient fallback in
+/// [`crate::git::remote::run_git_mutating_with_creds`] covers that case. Memoized
+/// per-host with a 60s TTL: auth state changes rarely, and 60s bounds staleness
+/// after the user signs in/out mid-session.
 ///
 /// SECURITY: `gh auth token`'s stdout IS the user's token — this reads only the
 /// exit code and drops the output; the token is never logged or formatted anywhere.
@@ -813,8 +819,13 @@ async fn gh_authenticated(host: &str) -> bool {
             auth_cache_put(host, authed);
             authed
         }
-        // Missing binary / timeout is transient — don't cache; treat as unauthenticated.
-        Err(_) => false,
+        // A spawn/timeout hiccup, NOT absence: `resolve_named` already proved gh
+        // exists, so an Err here is transient. Optimistically inject (uncached) —
+        // with run_git_mutating_with_creds's ambient fallback in place this is safe
+        // both ways: if gh is genuinely signed out its helper returns nothing and
+        // the fallback restores ambient, whereas a pessimistic `false` here would
+        // silently reopen the stale-keychain bug for that op.
+        Err(_) => true,
     }
 }
 

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -174,10 +174,14 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
 /// token lands in the remote URL. Validated live against a private gitlab.com repo.
 ///
 /// Returns the `[reset, helper]` pair (see [`gitlab_credential_entries`]) ONLY
-/// when glab is present AND signed in to `host`; when glab is present but not
-/// signed in to that host, returns an empty Vec so git's ambient behavior is
-/// preserved unchanged. Missing glab → `Err(GlabNotFound)`, unchanged — the
-/// strict `?` clone sites stay fail-closed on a missing CLI.
+/// when glab is present AND has a STORED session for `host`; when glab is present
+/// but has no stored session for that host, returns an empty Vec so git's ambient
+/// behavior is preserved unchanged. The stored-session check is a `hosts:` entry in
+/// glab's config — it persists past PAT expiry, so it proves a session EXISTS, not
+/// that it works; the ambient fallback in
+/// [`crate::git::remote::run_git_mutating_with_creds`] covers a dead session.
+/// Missing glab → `Err(GlabNotFound)`, unchanged — the strict `?` clone sites stay
+/// fail-closed on a missing CLI.
 pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> {
     let glab = crate::agent::resolve_named(&["glab"], None)
         .await

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -167,20 +167,46 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
     })
 }
 
-/// The `git -c credential.https://<host>.helper=…` entry that lets `git clone` of
-/// a private GitLab repo authenticate via glab's token — glab's token isn't in
-/// git's credential store, so plain `git clone` (and even `glab repo clone`) 401s.
+/// The one-shot `git -c` credential entries that let a network op on a private
+/// GitLab repo authenticate via glab's token — glab's token isn't in git's
+/// credential store, so plain `git clone` (and even `glab repo clone`) 401s.
 /// One-shot (per `git` invocation), so nothing is written to git config and no
 /// token lands in the remote URL. Validated live against a private gitlab.com repo.
+///
+/// Returns the `[reset, helper]` pair (see [`gitlab_credential_entries`]) ONLY
+/// when glab is present AND signed in to `host`; when glab is present but not
+/// signed in to that host, returns an empty Vec so git's ambient behavior is
+/// preserved unchanged. Missing glab → `Err(GlabNotFound)`, unchanged — the
+/// strict `?` clone sites stay fail-closed on a missing CLI.
 pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> {
     let glab = crate::agent::resolve_named(&["glab"], None)
         .await
         .ok_or(AppError::GlabNotFound)?;
     let host = crate::forge::remote_host(clone_url).unwrap_or_else(|| "gitlab.com".to_string());
-    Ok(vec![format!(
-        "credential.https://{host}.helper=!\"{}\" auth git-credential",
-        glab.display()
-    )])
+    // glab's signed-in hosts are the `hosts:` keys of its config.yml — an entry
+    // exists only after `glab auth login`. No signed-in host → inject nothing so
+    // git's ambient credential helpers still run (the established repo signal; we
+    // don't invent a new `glab auth status` probe).
+    if !crate::forge::glab::known_hosts().await.contains(&host) {
+        return Ok(Vec::new());
+    }
+    Ok(gitlab_credential_entries(&host, &glab.display().to_string()))
+}
+
+/// The one-shot `-c` credential entries for a signed-in GitLab host — a
+/// `[reset, helper]` pair, mirroring the GitHub arm. entry[0] SEVERS git's
+/// accumulated helper chain for this URL (empty value = "clear the helper list",
+/// per gitcredentials(7); the trailing `=` is load-bearing — `-c name` without it
+/// sets boolean `true` and breaks the reset), and entry[1] installs glab as the
+/// sole helper so an ambient helper earlier in the config chain can't shadow
+/// glab's identity. Order matters: reset FIRST — consumers prefix `-c` pairs in
+/// Vec order. Pure/format-only.
+fn gitlab_credential_entries(host: &str, glab_path: &str) -> Vec<String> {
+    vec![
+        // Reset: empty value clears the accumulated helper list for this URL.
+        format!("credential.https://{host}.helper="),
+        format!("credential.https://{host}.helper=!\"{glab_path}\" auth git-credential"),
+    ]
 }
 
 // ── Merge requests (read) ─────────────────────────────────────────────────────
@@ -7261,6 +7287,30 @@ pub async fn unlink_issue(repo_path: &str, number: u64, link_id: &str) -> AppRes
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn credential_entries_are_reset_then_helper() {
+        let entries = gitlab_credential_entries("gitlab.com", "/abs/glab");
+        assert_eq!(entries.len(), 2);
+        // entry[0] resets the helper chain: empty value, nothing after the `=`.
+        assert_eq!(entries[0], "credential.https://gitlab.com.helper=");
+        // entry[1] is byte-identical to the historical single helper entry.
+        assert_eq!(
+            entries[1],
+            "credential.https://gitlab.com.helper=!\"/abs/glab\" auth git-credential"
+        );
+    }
+
+    #[test]
+    fn credential_entries_substitute_self_managed_host() {
+        let entries = gitlab_credential_entries("gitlab.example.com", "/abs/glab");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], "credential.https://gitlab.example.com.helper=");
+        assert_eq!(
+            entries[1],
+            "credential.https://gitlab.example.com.helper=!\"/abs/glab\" auth git-credential"
+        );
+    }
 
     #[test]
     fn job_status_maps_to_check_buckets() {

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -134,16 +134,16 @@ pub(crate) async fn detect_non_github(repo_path: &str) -> Option<(Provider, Stri
     None
 }
 
-/// The one-shot `-c credential.helper` entries to authenticate a network op on
-/// `remote`, resolved to the provider CLI's ABSOLUTE path. The provider comes from
-/// the REQUESTED remote's OWN host (not always `origin`), so a cross-forge
-/// origin/upstream pair — e.g. an `origin` on GitLab with a `github.com` `upstream`
-/// — each gets the right CLI's helper.
+/// The one-shot URL-scoped `-c credential.https://<host>.helper` entries to
+/// authenticate a network op on `remote`, resolved to the provider CLI's ABSOLUTE
+/// path. The provider comes from the REQUESTED remote's OWN host (not always
+/// `origin`), so a cross-forge origin/upstream pair — e.g. an `origin` on GitLab
+/// with a `github.com` `upstream` — each gets the right CLI's helper.
 ///
-/// Entries are injected ONLY when the provider CLI is present AND authenticated
-/// for the remote's own host, and the injection is a `[reset, helper]` PAIR: a
-/// blank reset entry (`credential.https://<host>.helper=`, empty value) that
-/// SEVERS git's accumulated helper chain for that URL, followed by the
+/// Entries are injected ONLY when the provider CLI is present AND has a stored
+/// token/session for the remote's own host, and the injection is a `[reset,
+/// helper]` PAIR: a blank reset entry (`credential.https://<host>.helper=`, empty
+/// value) that SEVERS git's accumulated helper chain for that URL, followed by the
 /// absolute-path CLI helper — the same pair `gh auth setup-git` writes. This makes
 /// the network op deterministically use the same identity as the app's forge
 /// surfaces, rather than falling through to whichever ambient helper answers first
@@ -151,13 +151,23 @@ pub(crate) async fn detect_non_github(repo_path: &str) -> Option<(Provider, Stri
 /// `osxkeychain`/git-credential-manager entry holding a stale-but-valid credential
 /// would otherwise shadow the CLI and 404 the wrong identity; that was the bug).
 ///
+/// The gates prove a credential merely EXISTS, not that it WORKS, so a stale CLI
+/// token could sever a working ambient chain (the inverse failure) —
+/// [`crate::git::remote::run_git_mutating_with_creds`] covers that with a one-shot
+/// ambient-fallback retry on an auth-class failure. Deliberate residual: the CLONE
+/// path (the `extra_config` in `repo.rs`) keeps strict injection with NO fallback —
+/// clone is user-initiated, clearly messaged, and re-runnable, and GitLab private
+/// clone was always strict-injection.
+///
 /// Empty (→ git's ambient behavior, unchanged, so this never breaks a local, SSH,
 /// or already-authenticated repo) for: SSH remotes (credential helpers don't
 /// apply), Bitbucket (its push flow injects auth its own way), a repo with no such
-/// remote, an unknown HTTPS host (the GitHub-default routing's gh gate then finds
-/// no token for it and injects nothing), and — fail open — when the provider CLI
-/// isn't installed OR is installed but not signed in to this host (ambient helpers
-/// like git-credential-manager keep working for both).
+/// remote, an unknown HTTPS host (the GitHub-default routing's gh gate injects the
+/// pair ONLY when gh holds a token for that host — e.g. a signed-in GitHub
+/// Enterprise host, which is what makes GHE work — and nothing otherwise), and —
+/// fail open — when the provider CLI isn't installed OR is installed but has no
+/// stored token/session for this host (ambient helpers like git-credential-manager
+/// keep working for both).
 pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppResult<Vec<String>> {
     let url = match crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await
     {

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -138,14 +138,26 @@ pub(crate) async fn detect_non_github(repo_path: &str) -> Option<(Provider, Stri
 /// `remote`, resolved to the provider CLI's ABSOLUTE path. The provider comes from
 /// the REQUESTED remote's OWN host (not always `origin`), so a cross-forge
 /// origin/upstream pair — e.g. an `origin` on GitLab with a `github.com` `upstream`
-/// — each gets the right CLI's helper. Empty (→ git's ambient behavior, so this
-/// never breaks a local, SSH, or already-authenticated repo) for: SSH remotes
-/// (credential helpers don't apply), Bitbucket (its push flow injects auth its own
-/// way), a repo with no such remote, and when the provider CLI isn't installed
-/// (fail open — ambient helpers like git-credential-manager still work). An unknown
-/// HTTPS host follows the app's GitHub-default routing and gets the gh helper —
-/// harmless, since a one-shot `-c` helper only ADDS to git's helper list, so a
-/// non-answering gh falls through to git's ambient helpers.
+/// — each gets the right CLI's helper.
+///
+/// Entries are injected ONLY when the provider CLI is present AND authenticated
+/// for the remote's own host, and the injection is a `[reset, helper]` PAIR: a
+/// blank reset entry (`credential.https://<host>.helper=`, empty value) that
+/// SEVERS git's accumulated helper chain for that URL, followed by the
+/// absolute-path CLI helper — the same pair `gh auth setup-git` writes. This makes
+/// the network op deterministically use the same identity as the app's forge
+/// surfaces, rather than falling through to whichever ambient helper answers first
+/// (git stops at the first helper returning a complete credential — an earlier
+/// `osxkeychain`/git-credential-manager entry holding a stale-but-valid credential
+/// would otherwise shadow the CLI and 404 the wrong identity; that was the bug).
+///
+/// Empty (→ git's ambient behavior, unchanged, so this never breaks a local, SSH,
+/// or already-authenticated repo) for: SSH remotes (credential helpers don't
+/// apply), Bitbucket (its push flow injects auth its own way), a repo with no such
+/// remote, an unknown HTTPS host (the GitHub-default routing's gh gate then finds
+/// no token for it and injects nothing), and — fail open — when the provider CLI
+/// isn't installed OR is installed but not signed in to this host (ambient helpers
+/// like git-credential-manager keep working for both).
 pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppResult<Vec<String>> {
     let url = match crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await
     {

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -283,9 +283,10 @@ pub(crate) async fn git_delete_branch_core(
     Ok(())
 }
 
-/// Deletes a branch on a remote via `git push <remote> --delete`, using git's
-/// native credential flow (exactly like `git_push` — no per-provider paths).
-/// git prunes the local remote-tracking ref on success.
+/// Deletes a branch on a remote via `git push <remote> --delete`, authenticating
+/// with the same one-shot provider-CLI credential entries `git_push` uses (so a
+/// stale ambient credential can't shadow the signed-in CLI's identity). git prunes
+/// the local remote-tracking ref on success.
 #[tauri::command]
 pub async fn git_delete_remote_branch(
     state: State<'_, AppState>,
@@ -321,9 +322,11 @@ pub(crate) async fn git_delete_remote_branch_core(
         )));
     }
 
-    let out = run_git_mutating(
+    let cred = crate::forge::credential_config_for_remote(&repo_path, &remote).await?;
+    let out = crate::git::remote::run_git_mutating_with_creds(
         state,
         &repo_path,
+        &cred,
         &["push", &remote, "--delete", "--", &name],
         NETWORK_TIMEOUT,
     )

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2769,9 +2769,11 @@ pub(crate) async fn git_push_tag_core(
 ) -> AppResult<()> {
     validate_tag_name(&name)?;
     let spec = format!("refs/tags/{name}");
-    run_git_mutating(
+    let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    crate::git::remote::run_git_mutating_with_creds(
         state,
         &repo_path,
+        &cred,
         &["push", "origin", &spec],
         crate::git::runner::NETWORK_TIMEOUT,
     )
@@ -2806,9 +2808,11 @@ pub(crate) async fn git_delete_tag_core(
     .await?;
     if on_remote {
         let spec = format!(":refs/tags/{name}");
-        run_git_mutating(
+        let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+        crate::git::remote::run_git_mutating_with_creds(
             state,
             &repo_path,
+            &cred,
             &["push", "origin", &spec],
             crate::git::runner::NETWORK_TIMEOUT,
         )

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -52,6 +52,10 @@ fn is_auth_class_failure(stderr: &str) -> bool {
     let s = stderr.to_lowercase();
     s.contains("authentication failed")
         || s.contains("could not read username")
+        // 404 tradeoff: on a transient not-found for the CORRECT CLI identity, the
+        // ambient retry can complete the op under a DIFFERENT identity than the
+        // severed CLI one — accepted (push identity ≠ commit authorship); don't
+        // widen this classifier further.
         || s.contains("repository not found")
 }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -28,7 +28,57 @@ fn with_credentials(cred: &[String], sub: &[&str]) -> Vec<String> {
     v
 }
 
+/// Whether a git network failure's `stderr` looks like an auth-class failure — the
+/// gate for the ambient-credential fallback in [`run_git_mutating_with_creds`].
+/// Case-insensitive substring match on three signatures:
+///
+/// 1. `"authentication failed"` — git exhausted a 401 retry with the
+///    helper-provided credentials (the injected CLI helper's token was rejected).
+/// 2. `"could not read username"` — every helper returned nothing and
+///    `GIT_TERMINAL_PROMPT=0` blocks the interactive prompt (covers the ≤60s
+///    stale-cache window after `gh auth logout`, where the cached auth gate still
+///    injects a helper that no longer answers).
+/// 3. `"repository not found"` — GitHub answers 404 (the sideband line
+///    `remote: Repository not found.`) for a VALID identity that lacks access to a
+///    private repo: it hides existence rather than 403ing, so a wrong-identity CLI
+///    token surfaces as not-found, not as an auth error. This is the exact
+///    motivating symptom, now inverted — a stale CLI token that shadows a working
+///    ambient credential.
+///
+/// Deliberately narrow: network/DNS failures (e.g. `"could not resolve hostname"`)
+/// and merge conflicts do NOT match — retrying those can't help and would double
+/// the network timeout.
+fn is_auth_class_failure(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("authentication failed")
+        || s.contains("could not read username")
+        || s.contains("repository not found")
+}
+
 /// Run a mutating git network op with one-shot credential `-c` entries prefixed.
+///
+/// When `cred` is non-empty and the injected run fails with an auth-class git
+/// error ([`is_auth_class_failure`]), this retries EXACTLY ONCE with NO injected
+/// config (plain [`run_git_mutating`] on the same sub-args) and returns that
+/// retry's result — on a double failure the RETRY's error is surfaced, because the
+/// ambient attempt's error names the true end state. When `cred` is empty there is
+/// nothing to fall back from, so behavior is unchanged.
+///
+/// The auth gates that produce `cred` prove a credential EXISTS locally
+/// (`gh auth token` is a local read; glab's `hosts:` entry persists past PAT
+/// expiry) — not that it WORKS. Severing the ambient chain for a user whose CLI
+/// token is revoked/expired but whose ambient credential (git-credential-manager,
+/// OS keychain) is valid would hard-fail an op that worked before this change (the
+/// additive helper let the ambient one answer first) — the exact inverse of the
+/// motivating bug. This one-shot fallback restores pre-change behavior for those
+/// users; an authenticated CLI never reaches it (its helper answers and the run
+/// succeeds).
+///
+/// The retry is safe because HTTPS auth happens at ref negotiation BEFORE any
+/// server-side ref update: a failed-auth push has mutated nothing on the remote, so
+/// re-running with different credentials can't double-apply. Only Git-kind errors
+/// are classified; every other error kind (timeout, IO, …) returns as-is with no
+/// retry.
 pub(crate) async fn run_git_mutating_with_creds(
     state: &AppState,
     repo_path: &str,
@@ -37,13 +87,25 @@ pub(crate) async fn run_git_mutating_with_creds(
     timeout: Duration,
 ) -> AppResult<GitOutput> {
     let args = with_credentials(cred, sub);
-    run_git_mutating(
+    let result = run_git_mutating(
         state,
         repo_path,
         &args.iter().map(String::as_str).collect::<Vec<_>>(),
         timeout,
     )
-    .await
+    .await;
+
+    // Fall back to git's ambient credential helpers exactly once when injected
+    // credentials are present but rejected — the CLI token may be stale while an
+    // ambient credential still works.
+    if !cred.is_empty() {
+        if let Err(AppError::Git { stderr, .. }) = &result {
+            if is_auth_class_failure(stderr) {
+                return run_git_mutating(state, repo_path, sub, timeout).await;
+            }
+        }
+    }
+    result
 }
 
 /// How long a resolved remote URL stays trusted before we re-shell to `git`. A few seconds
@@ -406,7 +468,9 @@ pub(crate) async fn git_push_core(
 
 #[cfg(test)]
 mod tests {
-    use super::{cache_get, cache_invalidate, cache_put, git_remote_remove_core};
+    use super::{
+        cache_get, cache_invalidate, cache_put, git_remote_remove_core, is_auth_class_failure,
+    };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
     use crate::state::AppState;
@@ -468,6 +532,46 @@ mod tests {
     #[test]
     fn miss_returns_none() {
         assert_eq!(cache_get("/repo/never-written", "origin", BIG), None);
+    }
+
+    // --- Auth-class classifier for the ambient-credential fallback. ---
+
+    #[test]
+    fn auth_class_matches_rejected_credentials() {
+        assert!(is_auth_class_failure(
+            "fatal: Authentication failed for 'https://github.com/x/y.git/'"
+        ));
+    }
+
+    #[test]
+    fn auth_class_matches_prompt_disabled_no_username() {
+        assert!(is_auth_class_failure(
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+        ));
+    }
+
+    #[test]
+    fn auth_class_matches_repository_not_found_sideband() {
+        // The 404 sideband line is what identifies a wrong-identity token.
+        assert!(is_auth_class_failure(
+            "remote: Repository not found.\nfatal: repository 'https://github.com/x/y.git/' not found"
+        ));
+    }
+
+    #[test]
+    fn auth_class_ignores_merge_conflict() {
+        assert!(!is_auth_class_failure(
+            "CONFLICT (content): Merge conflict in file.txt\nAutomatic merge failed; fix conflicts"
+        ));
+    }
+
+    #[test]
+    fn auth_class_ignores_network_dns_error() {
+        // A DNS/network failure must NOT trigger the fallback — retrying can't help
+        // and would double the timeout.
+        assert!(!is_auth_class_failure(
+            "ssh: Could not resolve hostname github.com"
+        ));
     }
 
     // --- Real-repo tests for git_remote_remove (temp_dir, git on PATH). ---

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -29,7 +29,7 @@ fn with_credentials(cred: &[String], sub: &[&str]) -> Vec<String> {
 }
 
 /// Run a mutating git network op with one-shot credential `-c` entries prefixed.
-async fn run_git_mutating_with_creds(
+pub(crate) async fn run_git_mutating_with_creds(
     state: &AppState,
     repo_path: &str,
     cred: &[String],

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
-use crate::git::runner::{run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
+use crate::git::runner::{run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
 use crate::github::issue::{map_reaction_groups, repo_owner_name, IssueReactions};
 use crate::github::runner::{run_gh, run_gh_input, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
 use crate::state::AppState;
@@ -4337,9 +4337,11 @@ pub(crate) async fn gh_pr_create_core(
         let fork_owner = crate::github::fork_owner_of(&origin_slug).to_string();
 
         // Push `head` to origin — origin IS the fork; the PR's head lives there.
-        run_git_mutating(
+        let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+        crate::git::remote::run_git_mutating_with_creds(
             state,
             &repo_path,
+            &cred,
             &["push", "-u", "origin", &head],
             NETWORK_TIMEOUT,
         )
@@ -4373,9 +4375,11 @@ pub(crate) async fn gh_pr_create_core(
     let origin_slug = crate::github::gh_lens_slug(&repo_path, None).await?;
 
     // gh can only open a PR for a branch that exists on the remote.
-    run_git_mutating(
+    let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    crate::git::remote::run_git_mutating_with_creds(
         state,
         &repo_path,
+        &cred,
         &["push", "-u", "origin", &head],
         NETWORK_TIMEOUT,
     )


### PR DESCRIPTION
This change ensures that all network mutating Git operations (push, tag, remote branch/tag deletion, and fork PR pushes) reliably use the signed-in GitHub or GitLab CLI identity, never falling back to an outdated system credential that could cause "Repository not found" errors. This is accomplished by explicitly severing git's ambient credential helper chain and injecting the authenticated CLI helper for these operations, eliminating identity confusion caused by stale keychain entries on macOS/Windows.

### Credential Isolation for Git Operations
- Adds credential chain severing and CLI injection logic for mutating network ops in:
  - `src-tauri/src/git/branches.rs` (remote branch delete uses provider-CLI credentials)
  - `src-tauri/src/git/ops.rs` (tag push/delete uses provider-CLI credentials)
  - `src-tauri/src/github/pr.rs` (PR fork pushes use provider-CLI credentials)
  - All now use `run_git_mutating_with_creds` instead of `run_git_mutating` and pull config from the new logic

### Provider Credential Configuration
- Refactors helper construction so each remote operation gets a `[reset, helper]` credential pair, severing git’s accumulated helpers before installing the CLI (never letting ambient helpers shadow the intended identity)
  - `src-tauri/src/forge/github.rs` defines `github_credential_entries`, adds memoized per-host `gh_authenticated` check and a TTL cache for host authentication status
  - `src-tauri/src/forge/gitlab.rs` mirrors the entry structure with `gitlab_credential_entries`; its auth gate reads glab's config `hosts:` keys via `known_hosts()` — a per-call file read with no subprocess, so it needs no TTL cache
- Both provider modules only inject helper entries when the respective CLI is both installed and holds a stored token/session for the repo’s host; otherwise, ambient credential helpers are left unchanged
- Clarifies credential config logic in `src-tauri/src/forge/mod.rs` to reflect new credential sequestering strategy and accurate fail-open/closed behaviors

### Git Command Execution
- Exposes `run_git_mutating_with_creds` in `src-tauri/src/git/remote.rs`, enabling all network-modifying commands to use injected provider-specific credentials
- Updates all call sites to use this function with the computed per-remote credential config

### Testing and Documentation
- Strengthens helper entry format tests in both provider modules and adds tests for the GitHub TTL authentication cache in `src-tauri/src/forge/github.rs` (GitLab's gate is an uncached config read, so it has no cache to test)
- Adds detailed doc comments in all affected areas to record helper chain-resetting semantics and source of registered helpers
- Updates changelog (`changelog.d/fixed-credential-helper-severs-ambient-chain.md`) with a clear note about the behavioral fix for network ops when stale credentials are present