### PR TITLE
feat(lan,companion,infra): launch phone companion preview as separate frontend, embed and serve via LAN server

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,6 +15,7 @@ on:
       - "pnpm-workspace.yaml"
       - "patches/**"
       - "src/**"
+      - "companion/**"
       - "index.html"
       - "vite.config.ts"
       - "tsconfig*.json"
@@ -47,4 +48,4 @@ jobs:
 
       # Check-only (biome ci never writes); `pnpm lint` locally is --write.
       - name: Lint and format check
-        run: pnpm exec biome ci ./src/
+        run: pnpm exec biome ci ./src/ ./companion/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Embedded LAN-companion frontend bundle (built by `pnpm build:companion` into
+# src-tauri/companion-dist/). The build output is generated, but the folder must
+# exist for rust-embed, so keep the .gitkeep and ignore everything else.
+src-tauri/companion-dist/*
+!src-tauri/companion-dist/.gitkeep
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -1,7 +1,8 @@
 - **Phone companion (experimental preview).** Share the open repository with your
   phone over your local network from **Settings → Phone companion**: pair a device by
-  scanning a QR code and typing a PIN. This early preview exposes read-only API access
-  to the open repo — the companion phone app arrives in an upcoming release. Off by
-  default, with per-device tokens you can review and revoke at any time (even while
-  sharing is off), and connected phones are disconnected the moment you stop sharing,
-  switch repos, or revoke their device.
+  scanning a QR code and typing a PIN. Scanning opens a slim companion web app right
+  in your phone's browser — pair with the PIN, then read the repo's **Status, pull
+  requests, and CI** from your phone, read-only. Off by default, with per-device tokens
+  you can review and revoke at any time (even while sharing is off), and connected
+  phones are disconnected the moment you stop sharing, switch repos, or revoke their
+  device.

--- a/companion/index.html
+++ b/companion/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark light" />
+    <title>GitDesktop Companion</title>
+    <!-- No inline script or style: the LAN server serves this under a strict
+         `script-src 'self'; style-src 'self'` CSP, so every script and style
+         must come from a built file. Vite's production output complies. -->
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -25,7 +25,11 @@ export default function App() {
   // auth signal. Only poll it while Status is the visible tab (other tabs run
   // their own polling query); elsewhere it still fetches once on mount/route
   // change for the header + 401 check.
-  const statusQuery = useStatus(route.tab === "status" && !route.isPairing);
+  const statusQuery = useStatus(
+    route.tab === "status" && !route.isPairing,
+    // No authed traffic while unpaired: an unpaired page 401s on every probe.
+    !route.isPairing,
+  );
   const statusErr = asApiError(statusQuery.error);
 
   // Global 401 → the device isn't paired (or was revoked). Bounce to #pair —

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { BottomNav, TopBar } from "./components/Chrome";
-import { ErrorState, UnreachableBanner } from "./components/states";
+import { ErrorState } from "./components/states";
 import { lastPairedAt } from "./lib/pairing-signal";
 import { asApiError, useStatus } from "./lib/queries";
 import { navigate, useRoute } from "./lib/router";
@@ -11,9 +11,12 @@ import { StatusBody } from "./screens/Status";
 
 // The app shell. It owns the cross-cutting states so every screen inherits them:
 //   • 401 anywhere → route to #pair (token revoked / never paired)
+//   • 409 no-repo → a central teaching state
 //   • the sticky TopBar (repo name + connection) + BottomNav
-//   • a top-of-flow "unreachable" banner when the server can't be reached but a
-//     screen still has stale data on show.
+// Degraded/unreachable presentation is NOT here: each body renders its own
+// StaleBanner keyed on its OWN query (see the round-4 finding in states.tsx). A
+// shell-level banner derived from the status query doubled the message on the
+// Status tab and never fired on PRs/CI — so it was removed.
 // The Status query doubles as the shell's connection probe: it drives the
 // TopBar's live/offline dot and the global 401 redirect.
 
@@ -68,7 +71,6 @@ export default function App() {
 
   const repoName = deriveRepoName(statusQuery.data?.branch.name ?? null);
   const connected = statusQuery.isSuccess;
-  const unreachable = statusErr?.isUnreachable ?? false;
   // A no-repo (409) is a whole-app state — show it centrally, not per tab.
   const noRepo = statusErr?.isNoActiveRepo ?? false;
 
@@ -79,9 +81,6 @@ export default function App() {
         subtitle={statusQuery.data?.branch.name ?? undefined}
         connected={connected}
       />
-      {unreachable && statusQuery.data ? (
-        <UnreachableBanner onRetry={() => statusQuery.refetch()} />
-      ) : null}
 
       <main className="flex-1">
         {noRepo ? (

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -1,0 +1,120 @@
+import { useEffect } from "react";
+import { BottomNav, TopBar } from "./components/Chrome";
+import { ErrorState, UnreachableBanner } from "./components/states";
+import { lastPairedAt } from "./lib/pairing-signal";
+import { asApiError, useStatus } from "./lib/queries";
+import { navigate, useRoute } from "./lib/router";
+import { CiBody, CiDetail } from "./screens/Ci";
+import { Pair } from "./screens/Pair";
+import { PrDetail, PrsBody } from "./screens/Prs";
+import { StatusBody } from "./screens/Status";
+
+// The app shell. It owns the cross-cutting states so every screen inherits them:
+//   • 401 anywhere → route to #pair (token revoked / never paired)
+//   • the sticky TopBar (repo name + connection) + BottomNav
+//   • a top-of-flow "unreachable" banner when the server can't be reached but a
+//     screen still has stale data on show.
+// The Status query doubles as the shell's connection probe: it drives the
+// TopBar's live/offline dot and the global 401 redirect.
+
+export default function App() {
+  const route = useRoute();
+
+  // Probe the shared repo's status regardless of the active tab — it's the
+  // cheapest always-available authenticated call, so it's our connection +
+  // auth signal. Only poll it while Status is the visible tab (other tabs run
+  // their own polling query); elsewhere it still fetches once on mount/route
+  // change for the header + 401 check.
+  const statusQuery = useStatus(route.tab === "status" && !route.isPairing);
+  const statusErr = asApiError(statusQuery.error);
+
+  // Global 401 → the device isn't paired (or was revoked). Bounce to #pair —
+  // but ONLY on a FRESH 401.
+  //
+  // LIVE-FOUND RACE (post-pair bounce): while the user sat on #pair, this probe
+  // cached a 401 (no cookie yet). Without the guards below, pairing → navigate
+  // to #status → this effect reads the STALE cached 401 → bounces the freshly-
+  // paired user straight back to the PIN screen (Back then lands on #status,
+  // authed). Two guards make a pre-pair 401 un-bounceable:
+  //   • `!isFetching` — never act while a refetch is in flight (the settled
+  //     result may be a 200);
+  //   • `errorUpdatedAt > lastPairedAt()` — the 401 must be NEWER than the last
+  //     successful pair. Pair.tsx stamps `markPaired()` and awaits a status
+  //     refetch before navigating, so a genuine post-pair revoke still bounces,
+  //     but the pre-pair 401 (older timestamp) never does.
+  useEffect(() => {
+    if (
+      statusErr?.isUnauthorized &&
+      !route.isPairing &&
+      !statusQuery.isFetching &&
+      statusQuery.errorUpdatedAt > lastPairedAt()
+    ) {
+      navigate("#pair");
+    }
+  }, [
+    statusErr,
+    route.isPairing,
+    statusQuery.isFetching,
+    statusQuery.errorUpdatedAt,
+  ]);
+
+  if (route.isPairing) {
+    return <Pair />;
+  }
+
+  const repoName = deriveRepoName(statusQuery.data?.branch.name ?? null);
+  const connected = statusQuery.isSuccess;
+  const unreachable = statusErr?.isUnreachable ?? false;
+  // A no-repo (409) is a whole-app state — show it centrally, not per tab.
+  const noRepo = statusErr?.isNoActiveRepo ?? false;
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-md flex-col">
+      <TopBar
+        title={repoName}
+        subtitle={statusQuery.data?.branch.name ?? undefined}
+        connected={connected}
+      />
+      {unreachable && statusQuery.data ? (
+        <UnreachableBanner onRetry={() => statusQuery.refetch()} />
+      ) : null}
+
+      <main className="flex-1">
+        {noRepo ? (
+          <ErrorState
+            error={statusQuery.error}
+            onRetry={() => statusQuery.refetch()}
+          />
+        ) : (
+          <Screen route={route} />
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}
+
+function Screen({ route }: { route: ReturnType<typeof useRoute> }) {
+  if (route.tab === "prs") {
+    return route.detailId != null ? (
+      <PrDetail number={route.detailId} />
+    ) : (
+      <PrsBody active />
+    );
+  }
+  if (route.tab === "ci") {
+    return route.detailId != null ? (
+      <CiDetail id={route.detailId} />
+    ) : (
+      <CiBody active />
+    );
+  }
+  return <StatusBody active />;
+}
+
+/** A short repo label. The status API exposes the branch, not the repo name, so
+ *  fall back to a neutral title until a richer field exists (a later slice). */
+function deriveRepoName(_branch: string | null): string {
+  return "GitDesktop";
+}

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -1,0 +1,103 @@
+import {
+  GitBranchIcon,
+  GitPullRequestIcon,
+  PlayCircleIcon,
+} from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+import { navigate, type Tab, useRoute } from "../lib/router";
+
+// Shared chrome: a sticky top bar (repo/connection) and a bottom tab nav. Both
+// are keyboard-operable; the bottom nav uses roving links with ≥44px targets.
+
+/** Sticky top bar: the shared repo name (left) and a quiet connection dot
+ *  (right). `connected` false renders a muted/offline indicator with text. */
+export function TopBar({
+  title,
+  subtitle,
+  connected,
+}: {
+  title: string;
+  subtitle?: string;
+  connected: boolean;
+}) {
+  return (
+    <header className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-border bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {title}
+        </p>
+        {subtitle ? (
+          <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+        ) : null}
+      </div>
+      <span
+        className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
+        title={connected ? "Connected" : "Not connected"}
+      >
+        <span
+          aria-hidden
+          className={`h-2 w-2 rounded-full ${connected ? "bg-success" : "bg-muted-foreground"}`}
+        />
+        {connected ? "Live" : "Offline"}
+      </span>
+    </header>
+  );
+}
+
+const TABS: { tab: Tab; label: string; icon: ReactNode; hash: string }[] = [
+  {
+    tab: "status",
+    label: "Status",
+    icon: <GitBranchIcon size={22} />,
+    hash: "#status",
+  },
+  {
+    tab: "prs",
+    label: "PRs",
+    icon: <GitPullRequestIcon size={22} />,
+    hash: "#prs",
+  },
+  { tab: "ci", label: "CI", icon: <PlayCircleIcon size={22} />, hash: "#ci" },
+];
+
+/** Bottom tab nav. Each tab is a real link (Tab-focusable); the active tab is
+ *  marked with `aria-current`. Left/Right arrows move between tabs (roving). */
+export function BottomNav() {
+  const route = useRoute();
+
+  function onKeyDown(e: React.KeyboardEvent, index: number) {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const dir = e.key === "ArrowRight" ? 1 : -1;
+    const next = (index + dir + TABS.length) % TABS.length;
+    navigate(TABS[next].hash);
+    // Canonical roving-tablist behavior: DOM focus follows the arrow selection.
+    const links = e.currentTarget.closest("nav")?.querySelectorAll("a");
+    links?.[next]?.focus();
+  }
+
+  return (
+    <nav
+      className="sticky bottom-0 z-10 grid grid-cols-3 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)]"
+      aria-label="Sections"
+    >
+      {TABS.map((t, i) => {
+        const active = route.tab === t.tab && !route.isPairing;
+        return (
+          <a
+            key={t.tab}
+            href={t.hash}
+            aria-current={active ? "page" : undefined}
+            onKeyDown={(e) => onKeyDown(e, i)}
+            className={`flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium ${
+              active ? "text-primary" : "text-muted-foreground"
+            }`}
+          >
+            {t.icon}
+            {t.label}
+          </a>
+        );
+      })}
+    </nav>
+  );
+}

--- a/companion/src/components/chips.tsx
+++ b/companion/src/components/chips.tsx
@@ -1,0 +1,156 @@
+import {
+  CheckCircleIcon,
+  CircleDashedIcon,
+  CircleIcon,
+  ClockIcon,
+  GitMergeIcon,
+  GitPullRequestIcon,
+  ProhibitIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+
+// State chips pair an ICON + TEXT so meaning never rests on color alone (WCAG
+// 1.4.1). The color is a token (--success / --destructive / --merged / …), the
+// same semantics the desktop uses.
+
+function Chip({
+  icon,
+  label,
+  className,
+}: {
+  icon: ReactNode;
+  label: string;
+  className: string;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${className}`}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+/** A PR's lifecycle chip. `state` is the provider string (open/closed/merged),
+ *  `isDraft` overrides an open PR to the muted draft look. */
+export function PrStateChip({
+  state,
+  isDraft,
+}: {
+  state: string;
+  isDraft: boolean;
+}) {
+  const s = state.toLowerCase();
+  if (s === "merged") {
+    return (
+      <Chip
+        icon={<GitMergeIcon size={14} />}
+        label="Merged"
+        className="bg-merged/15 text-merged"
+      />
+    );
+  }
+  if (s === "closed" || s === "declined") {
+    return (
+      <Chip
+        icon={<XCircleIcon size={14} />}
+        label="Closed"
+        className="bg-destructive/15 text-destructive"
+      />
+    );
+  }
+  if (isDraft) {
+    return (
+      <Chip
+        icon={<GitPullRequestIcon size={14} />}
+        label="Draft"
+        className="bg-muted text-muted-foreground"
+      />
+    );
+  }
+  return (
+    <Chip
+      icon={<GitPullRequestIcon size={14} />}
+      label="Open"
+      className="bg-success/15 text-success"
+    />
+  );
+}
+
+/**
+ * A CI run's status/conclusion chip. GitHub-convention semantics: a completed
+ * run shows its `conclusion` (success/failure/…); a still-running one shows its
+ * `status` (queued/in_progress/…). Empty conclusion + completed = neutral.
+ */
+export function CiStatusChip({
+  status,
+  conclusion,
+}: {
+  status: string;
+  conclusion: string;
+}) {
+  const done = status.toLowerCase() === "completed";
+  if (done) {
+    const c = conclusion.toLowerCase();
+    if (c === "success") {
+      return (
+        <Chip
+          icon={<CheckCircleIcon size={14} />}
+          label="Passed"
+          className="bg-success/15 text-success"
+        />
+      );
+    }
+    if (c === "failure" || c === "timed_out" || c === "startup_failure") {
+      return (
+        <Chip
+          icon={<XCircleIcon size={14} />}
+          label="Failed"
+          className="bg-destructive/15 text-destructive"
+        />
+      );
+    }
+    if (c === "cancelled") {
+      return (
+        <Chip
+          icon={<ProhibitIcon size={14} />}
+          label="Cancelled"
+          className="bg-muted text-muted-foreground"
+        />
+      );
+    }
+    if (c === "skipped") {
+      return (
+        <Chip
+          icon={<CircleDashedIcon size={14} />}
+          label="Skipped"
+          className="bg-muted text-muted-foreground"
+        />
+      );
+    }
+    return (
+      <Chip
+        icon={<CircleIcon size={14} />}
+        label={conclusion || "Done"}
+        className="bg-muted text-muted-foreground"
+      />
+    );
+  }
+  // Still running / queued.
+  const running = status.toLowerCase() === "in_progress";
+  return (
+    <Chip
+      icon={
+        running ? (
+          <CircleIcon size={14} weight="fill" />
+        ) : (
+          <ClockIcon size={14} />
+        )
+      }
+      label={running ? "Running" : "Queued"}
+      className="bg-info/15 text-info"
+    />
+  );
+}

--- a/companion/src/components/states.tsx
+++ b/companion/src/components/states.tsx
@@ -169,13 +169,27 @@ export function ErrorState({
  * query — render stale data with THIS banner above it, and only full-screen
  * `ErrorState` when there's no data to show. Do not reintroduce a shell-level
  * banner.
+ *
+ * The copy blames the LAN link ONLY for a genuinely unreachable server (status
+ * 0); any other error (e.g. a transient forge 5xx behind a reachable desktop)
+ * gets neutral "couldn't refresh" wording — round-5 finding: a hardcoded
+ * "can't reach your desktop" misattributed forge blips to the LAN.
  */
-export function StaleBanner({ onRetry }: { onRetry: () => void }) {
+export function StaleBanner({
+  error,
+  onRetry,
+}: {
+  error?: unknown;
+  onRetry: () => void;
+}) {
+  const unreachable = error instanceof ApiError && error.isUnreachable;
   return (
     <div className="flex items-center justify-between gap-3 border-b border-border bg-warning/15 px-4 py-2 text-sm">
       <span className="flex items-center gap-2 text-foreground">
         <PlugsIcon size={16} className="text-warning" />
-        Can't reach your desktop — showing the last known state.
+        {unreachable
+          ? "Can't reach your desktop — showing the last known state."
+          : "Couldn't refresh — showing the last known state."}
       </span>
       <button
         type="button"

--- a/companion/src/components/states.tsx
+++ b/companion/src/components/states.tsx
@@ -154,19 +154,33 @@ export function ErrorState({
   );
 }
 
-/** A thin banner shown ABOVE content (in layout flow, not overlaid) when the
- *  server is unreachable but stale data is still on screen. */
-export function UnreachableBanner({ onRetry }: { onRetry: () => void }) {
+/**
+ * A slim inline banner rendered ABOVE a body's content (in layout flow, never an
+ * overlay) when that body's OWN query has errored but still holds its last
+ * successful data. Calm warning treatment — the data below is real, just stale.
+ *
+ * ROUND-4 FINDING (PR #75, doubled message + lost snapshot): the earlier design
+ * full-screened `ErrorState` from each body on `isError` AND rendered a separate
+ * shell-level unreachable banner (gated on the status query's data) at the same
+ * time — so on the Status tab a mid-session drop showed the "can't reach" message
+ * TWICE and discarded the last-known snapshot the banner was meant to preserve;
+ * meanwhile PRs/CI showed no banner at all (it derived from the status query, not
+ * theirs). The fix: each body owns its degraded presentation keyed on its own
+ * query — render stale data with THIS banner above it, and only full-screen
+ * `ErrorState` when there's no data to show. Do not reintroduce a shell-level
+ * banner.
+ */
+export function StaleBanner({ onRetry }: { onRetry: () => void }) {
   return (
     <div className="flex items-center justify-between gap-3 border-b border-border bg-warning/15 px-4 py-2 text-sm">
       <span className="flex items-center gap-2 text-foreground">
         <PlugsIcon size={16} className="text-warning" />
-        Can't reach your desktop
+        Can't reach your desktop — showing the last known state.
       </span>
       <button
         type="button"
         onClick={onRetry}
-        className="inline-flex min-h-9 items-center gap-1 rounded px-2 py-1 font-medium text-primary"
+        className="inline-flex min-h-9 shrink-0 items-center gap-1 rounded px-2 py-1 font-medium text-primary"
       >
         <ArrowClockwiseIcon size={14} weight="bold" />
         Retry

--- a/companion/src/components/states.tsx
+++ b/companion/src/components/states.tsx
@@ -1,0 +1,173 @@
+import {
+  ArrowClockwiseIcon,
+  PlugsIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+import { ApiError } from "../lib/api";
+import { navigate } from "../lib/router";
+
+// The shared data-screen states. Every list/detail screen routes its hook's
+// status through these so loading/empty/error/no-repo/unreachable look identical
+// everywhere. Meaning is never carried by color alone — each state pairs an icon
+// (or text) with its message.
+
+/** A single skeleton row (a pulsing placeholder, not a spinner). */
+export function SkeletonRows({ count = 5 }: { count?: number }) {
+  return (
+    <div className="flex flex-col divide-y divide-border" aria-hidden>
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className="flex flex-col gap-2 px-4 py-4">
+          <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-1/3 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** A calm centered message block used by empty / error / no-repo states. */
+function CenteredState({
+  icon,
+  title,
+  children,
+}: {
+  icon?: ReactNode;
+  title: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 px-8 py-16 text-center"
+      role="status"
+    >
+      {icon}
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {children ? (
+        <p className="max-w-xs text-sm text-muted-foreground">{children}</p>
+      ) : null}
+    </div>
+  );
+}
+
+/** A teaching empty state — the screen is fine, there's just nothing here yet. */
+export function EmptyState({ title, hint }: { title: string; hint?: string }) {
+  return <CenteredState title={title}>{hint}</CenteredState>;
+}
+
+/** A retry button matching the primary-action styling. */
+function RetryButton({ onRetry }: { onRetry: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onRetry}
+      className="mt-2 inline-flex min-h-11 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+    >
+      <ArrowClockwiseIcon size={16} weight="bold" />
+      Retry
+    </button>
+  );
+}
+
+/**
+ * Route a query error to the right full-screen state. 401 never lands here —
+ * the app shell redirects to `#pair` before rendering — but we guard it anyway.
+ * 409 → no-repo teaching state. status 0 → unreachable banner-style state. Any
+ * other error → a generic error with retry.
+ */
+export function ErrorState({
+  error,
+  onRetry,
+}: {
+  error: unknown;
+  onRetry: () => void;
+}) {
+  const api = error instanceof ApiError ? error : null;
+
+  if (api?.isUnauthorized) {
+    // Shouldn't normally render (shell redirects first), but fail safe.
+    return (
+      <CenteredState
+        icon={<PlugsIcon size={32} className="text-muted-foreground" />}
+        title="This phone isn't paired."
+      >
+        <button
+          type="button"
+          onClick={() => navigate("#pair")}
+          className="mt-3 inline-flex min-h-11 items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          Pair this device
+        </button>
+      </CenteredState>
+    );
+  }
+
+  if (api?.isNoRemote) {
+    // A local-only repo (no `origin` remote — the desktop shows "Publish
+    // repository…"). PRs/CI live on a forge, so there's nothing to fetch yet.
+    // This is a teaching state, not an error: calm empty-state treatment, and NO
+    // retry (retrying can't conjure a remote). See `ApiError.isNoRemote` for why
+    // the detection is a display-only heuristic.
+    return (
+      <CenteredState title="No remote yet">
+        PRs and CI live on a forge like GitHub. Publish this repository from
+        GitDesktop on your desktop to browse them here.
+      </CenteredState>
+    );
+  }
+
+  if (api?.isNoActiveRepo) {
+    return (
+      <CenteredState title="No repository shared.">
+        Open a repository in GitDesktop on your desktop.
+      </CenteredState>
+    );
+  }
+
+  if (api?.isUnreachable) {
+    return (
+      <CenteredState
+        icon={<PlugsIcon size={32} className="text-warning" />}
+        title="Can't reach your desktop."
+      >
+        Make sure GitDesktop is sharing and your phone is on the same network.
+        <span className="mt-3 block">
+          <RetryButton onRetry={onRetry} />
+        </span>
+      </CenteredState>
+    );
+  }
+
+  return (
+    <CenteredState
+      icon={<WarningCircleIcon size={32} className="text-destructive" />}
+      title="Something went wrong."
+    >
+      {api?.message ?? "The request failed."}
+      <span className="mt-3 block">
+        <RetryButton onRetry={onRetry} />
+      </span>
+    </CenteredState>
+  );
+}
+
+/** A thin banner shown ABOVE content (in layout flow, not overlaid) when the
+ *  server is unreachable but stale data is still on screen. */
+export function UnreachableBanner({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border bg-warning/15 px-4 py-2 text-sm">
+      <span className="flex items-center gap-2 text-foreground">
+        <PlugsIcon size={16} className="text-warning" />
+        Can't reach your desktop
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex min-h-9 items-center gap-1 rounded px-2 py-1 font-medium text-primary"
+      >
+        <ArrowClockwiseIcon size={14} weight="bold" />
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/companion/src/components/states.tsx
+++ b/companion/src/components/states.tsx
@@ -44,7 +44,10 @@ function CenteredState({
       {icon}
       <p className="text-sm font-medium text-foreground">{title}</p>
       {children ? (
-        <p className="max-w-xs text-sm text-muted-foreground">{children}</p>
+        // A div, not a <p>: some callers pass action buttons alongside text
+        // (valid phrasing content in a <p>, but a paragraph isn't the right
+        // container for controls — and a div also tolerates future block content).
+        <div className="max-w-xs text-sm text-muted-foreground">{children}</div>
       ) : null}
     </div>
   );

--- a/companion/src/index.css
+++ b/companion/src/index.css
@@ -1,0 +1,137 @@
+@import "tailwindcss";
+@import "@fontsource-variable/jetbrains-mono";
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Design tokens DUPLICATED from src/App.css — keep in sync; extraction to a
+   shared token file is slice-3. Only the subset the companion actually uses is
+   copied (mono + dark + mint accent + semantic state colors). Values are the
+   exact OKLCH from App.css so the companion carries GitDesktop's visual identity.
+
+   Dark-first WITHOUT inline script (the LAN CSP forbids inline JS/CSS): the dark
+   palette is applied BOTH under `.dark` (for an explicit toggle, unused today)
+   AND under `@media (prefers-color-scheme: dark)` on :root, so the OS scheme
+   drives the theme with zero JavaScript.
+   ───────────────────────────────────────────────────────────────────────────── */
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --font-sans: "JetBrains Mono Variable", monospace;
+  --font-mono: "JetBrains Mono Variable", monospace;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
+  --color-merged: var(--merged);
+  --color-border: var(--border);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+}
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.48 0.1 175);
+  --primary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.516 0 0);
+  --accent: oklch(0.93 0.035 175);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.55 0.13 150);
+  --warning: oklch(0.62 0.13 65);
+  --info: oklch(0.52 0.16 250);
+  --merged: oklch(0.53 0.2 300);
+  --border: oklch(0.922 0 0);
+  --ring: oklch(0.55 0.11 175);
+  --radius: 0.625rem;
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.82 0.11 175);
+  --primary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.715 0 0);
+  --accent: oklch(0.32 0.04 175);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.8 0.17 150);
+  --warning: oklch(0.83 0.15 75);
+  --info: oklch(0.72 0.15 250);
+  --merged: oklch(0.75 0.16 305);
+  --border: oklch(1 0 0 / 10%);
+  --ring: oklch(0.82 0.11 175);
+}
+
+/* OS dark mode, no JS: mirror the `.dark` palette onto :root. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.82 0.11 175);
+    --primary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.715 0 0);
+    --accent: oklch(0.32 0.04 175);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --success: oklch(0.8 0.17 150);
+    --warning: oklch(0.83 0.15 75);
+    --info: oklch(0.72 0.15 250);
+    --merged: oklch(0.75 0.16 305);
+    --border: oklch(1 0 0 / 10%);
+    --ring: oklch(0.82 0.11 175);
+  }
+}
+
+@layer base {
+  * {
+    border-color: var(--border);
+  }
+  html {
+    font-family: var(--font-mono);
+    /* Respect the phone's safe areas (notches / home indicator). */
+    background-color: var(--background);
+  }
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+    -webkit-font-smoothing: antialiased;
+    /* No overscroll bounce revealing a mismatched background. */
+    overscroll-behavior-y: none;
+  }
+  /* Keyboard focus is always visible (WCAG 2.4.7) — never remove the outline. */
+  :focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
+}

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -56,12 +56,12 @@ export class ApiError extends Error {
    * Grounded in the server shape: `auth.rs`'s `pairing_inactive()` returns
    * `403 Forbidden` with `{ kind: "pairingInactive", … }` from both the
    * challenge and submit routes (a `None` session AND an expired one collapse to
-   * the same response). Match the distinctive `kind` primarily; the 403 status
-   * is a secondary signal (the only other 403s are `host_guard`'s bad-host /
-   * bad-origin, which carry a plain-text body, so no `kind`).
+   * the same response). Match ONLY the distinctive `kind` — the other 403s
+   * (`host_guard`'s bad-host / bad-origin, plain-text body, no `kind`) are real
+   * connectivity/security problems that must NOT read as "waiting for desktop".
    */
   get isPairingInactive(): boolean {
-    return this.kind === "pairingInactive" || this.status === 403;
+    return this.kind === "pairingInactive";
   }
   /**
    * The repo has no `origin` remote (a local-only repo the desktop shows

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -1,0 +1,201 @@
+// Thin, typed fetchers over the desktop's LAN server. These call the SAME routes
+// the desktop's `src-tauri/src/lan/routes/*` mount and return the SAME serde
+// camelCase types the desktop declares — imported TYPE-ONLY via the `@` alias
+// (never the desktop's `api.ts`/`queries.ts`, which are Tauri-command-shaped).
+//
+// Auth is implicit: after pairing, the server set an HttpOnly `gd_lan` cookie the
+// browser attaches to every same-origin request automatically. So there is NO
+// Authorization header anywhere here — `credentials: "same-origin"` is the whole
+// auth story. A 401 means the cookie is missing/revoked (→ re-pair).
+
+import type { PrDetails, PrInfo, RepoStatus } from "@/lib/git/types";
+import type { RunDetail, WorkflowRun } from "@/lib/github/actions";
+
+/** A failed API call. `status` is the HTTP status (0 = the server was
+ *  unreachable — DNS/connection refused/offline). `kind`/`message` mirror the
+ *  server's `{ kind, message }` JSON body when it sent one. */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly kind?: string;
+  /** Seconds to wait before retrying, from a `Retry-After` header (429 only);
+   *  `null` when the header was absent or unparseable. */
+  readonly retryAfter: number | null;
+  constructor(
+    status: number,
+    message: string,
+    kind?: string,
+    retryAfter: number | null = null,
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.kind = kind;
+    this.retryAfter = retryAfter;
+  }
+  /** The server has no repository shared (`409 noActiveRepo`). */
+  get isNoActiveRepo(): boolean {
+    return this.status === 409;
+  }
+  /** Not paired, or the device token was revoked (`401`). Route to `#pair`. */
+  get isUnauthorized(): boolean {
+    return this.status === 401;
+  }
+  /** The server couldn't be reached at all (offline / wrong network). */
+  get isUnreachable(): boolean {
+    return this.status === 0;
+  }
+  /** Rate-limited by the pairing/auth throttle (`429`). */
+  get isRateLimited(): boolean {
+    return this.status === 429;
+  }
+  /**
+   * There is no active pairing offer on the desktop — either it hasn't clicked
+   * "Pair a device" yet, or the offer expired. NOT an error: the Pair screen
+   * shows a calm "waiting for your desktop" state and gently re-checks.
+   *
+   * Grounded in the server shape: `auth.rs`'s `pairing_inactive()` returns
+   * `403 Forbidden` with `{ kind: "pairingInactive", … }` from both the
+   * challenge and submit routes (a `None` session AND an expired one collapse to
+   * the same response). Match the distinctive `kind` primarily; the 403 status
+   * is a secondary signal (the only other 403s are `host_guard`'s bad-host /
+   * bad-origin, which carry a plain-text body, so no `kind`).
+   */
+  get isPairingInactive(): boolean {
+    return this.kind === "pairingInactive" || this.status === 403;
+  }
+  /**
+   * The repo has no `origin` remote (a local-only repo the desktop shows
+   * "Publish repository…" for) — so PRs/CI, which live on a forge, can't be
+   * fetched. NOT a failure to report as an error; the screens render a calm
+   * teaching state instead.
+   *
+   * The server surfaces this as `AppError::Git` (`kind: "git"`) whose message is
+   * the raw git stderr — `error: No such remote 'origin'` (confirmed by running
+   * `git remote get-url origin` on a remoteless repo). `kind: "git"` is shared by
+   * every git failure, so it can't distinguish this case; a case-insensitive
+   * substring on the message is the only signal. This is a DISPLAY-ONLY
+   * heuristic: if git's wording ever changes and the match misses, the screen
+   * simply falls back to the generic error-with-retry state — no correctness or
+   * data risk, just a less-tailored message.
+   */
+  get isNoRemote(): boolean {
+    return this.kind === "git" && /no such remote/i.test(this.message);
+  }
+}
+
+interface ErrorBody {
+  kind?: unknown;
+  message?: unknown;
+}
+
+/** GET a JSON API route, mapping any non-2xx (or a network failure) to an
+ *  {@link ApiError}. */
+async function getJson<T>(path: string): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(path, {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    });
+  } catch {
+    // A thrown fetch = the server is unreachable (offline, refused, DNS). Model
+    // it as status 0 so hooks can show the "can't reach your desktop" banner.
+    throw new ApiError(0, "Could not reach your desktop.");
+  }
+  if (!res.ok) {
+    throw await toApiError(res);
+  }
+  return (await res.json()) as T;
+}
+
+/** Build an {@link ApiError} from a non-2xx response, reading the server's
+ *  `{ kind, message }` body when present. */
+async function toApiError(res: Response): Promise<ApiError> {
+  let kind: string | undefined;
+  let message: string | undefined;
+  try {
+    const body = (await res.json()) as ErrorBody;
+    if (typeof body.kind === "string") kind = body.kind;
+    if (typeof body.message === "string") message = body.message;
+  } catch {
+    // Non-JSON error body — fall back to the status text below.
+  }
+  const retryHeader = res.headers.get("Retry-After");
+  const retryAfter =
+    retryHeader && /^\d+$/.test(retryHeader) ? Number(retryHeader) : null;
+  return new ApiError(
+    res.status,
+    message ?? res.statusText ?? "Request failed",
+    kind,
+    retryAfter,
+  );
+}
+
+// ── Read routes ──────────────────────────────────────────────────────────────
+
+export const fetchStatus = () => getJson<RepoStatus>("/api/repo/status");
+
+export const fetchPrs = (state = "open", limit = 30) =>
+  getJson<PrInfo[]>(
+    `/api/forge/prs?state=${encodeURIComponent(state)}&limit=${limit}`,
+  );
+
+export const fetchPr = (number: number) =>
+  getJson<PrDetails>(`/api/forge/prs/${number}`);
+
+export const fetchCiRuns = (limit = 20) =>
+  getJson<WorkflowRun[]>(`/api/forge/ci/runs?limit=${limit}`);
+
+export const fetchCiRun = (id: number) =>
+  getJson<RunDetail>(`/api/forge/ci/runs/${id}`);
+
+// ── Pairing ──────────────────────────────────────────────────────────────────
+
+/** `POST /api/pair/challenge` → `{ challenge, salt }` (hex). Requires an active
+ *  pairing offer on the desktop; 403 `pairingInactive` when expired/absent. */
+interface Challenge {
+  challenge: string;
+  salt: string;
+}
+
+export async function pairChallenge(): Promise<Challenge> {
+  return postJson<Challenge>("/api/pair/challenge", {});
+}
+
+/** `POST /api/pair` with `{ deviceName, proof }`. On success the server sets the
+ *  `gd_lan` cookie and returns `{ deviceId, token, name, scope }`; the browser
+ *  keeps the cookie, so the companion just needs to know it succeeded. */
+export interface PairResult {
+  deviceId: string;
+  name: string;
+  scope: string;
+}
+
+export async function pairSubmit(
+  deviceName: string,
+  proof: string,
+): Promise<PairResult> {
+  return postJson<PairResult>("/api/pair", { deviceName, proof });
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(path, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new ApiError(0, "Could not reach your desktop.");
+  }
+  if (!res.ok) {
+    throw await toApiError(res);
+  }
+  return (await res.json()) as T;
+}

--- a/companion/src/lib/format.ts
+++ b/companion/src/lib/format.ts
@@ -16,7 +16,9 @@ export function timeAgo(iso: string): string {
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
   const weeks = Math.floor(days / 7);
-  if (weeks < 52) return `${weeks}w ago`;
   const years = Math.floor(days / 365);
+  // Guard on years, not weeks: at day 364, weeks is already 52 but years still
+  // floors to 0 — a weeks-based cutoff would render "0y ago" for that window.
+  if (years < 1) return `${weeks}w ago`;
   return `${years}y ago`;
 }

--- a/companion/src/lib/format.ts
+++ b/companion/src/lib/format.ts
@@ -1,0 +1,22 @@
+// Small presentational formatters. No dependency — the desktop uses its own
+// date libs, but the companion keeps its bundle tiny.
+
+/** A compact relative time ("just now", "5m", "3h", "2d", "4w"). Empty/invalid
+ *  input → "". */
+export function timeAgo(iso: string): string {
+  if (!iso) return "";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 45) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 52) return `${weeks}w ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}

--- a/companion/src/lib/pairing-signal.ts
+++ b/companion/src/lib/pairing-signal.ts
@@ -1,0 +1,22 @@
+// A tiny module-level signal recording WHEN this browser last paired
+// successfully. It exists to defeat a live-found race (see App.tsx's 401→#pair
+// redirect): the shell's `["status"]` probe can cache a 401 while the user sits
+// on #pair (no cookie yet); on pair-success the shell must NOT bounce back to
+// #pair on that STALE 401. The redirect gates on the 401 being newer than this
+// timestamp, so a pre-pair 401 can never trigger it.
+//
+// Module state (not React state) on purpose: it must survive the #pair→#status
+// hash navigation and the remount that follows, and it's read once inside an
+// effect — no re-render needs to key off it.
+
+let pairedAt = 0;
+
+/** Stamp "just paired now" (called by the Pair screen on success). */
+export function markPaired(): void {
+  pairedAt = Date.now();
+}
+
+/** The epoch-ms of the last successful pair (0 if never). */
+export function lastPairedAt(): number {
+  return pairedAt;
+}

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -1,0 +1,77 @@
+import { QueryClient, useQuery } from "@tanstack/react-query";
+import {
+  ApiError,
+  fetchCiRun,
+  fetchCiRuns,
+  fetchPr,
+  fetchPrs,
+  fetchStatus,
+} from "./api";
+
+// A fresh QueryClient for the companion — modest freshness, one retry, and NO
+// refetch-on-focus (a phone backgrounds/foregrounds constantly; we drive
+// freshness with a polling interval on the ACTIVE screen instead).
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 10_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+// Poll the active screen every ~15s; inactive screens don't poll (their hook is
+// unmounted, or `active` is false). A number-or-false is exactly what
+// react-query's `refetchInterval` expects.
+const POLL_MS = 15_000;
+const poll = (active: boolean) => (active ? POLL_MS : (false as const));
+
+/** The shared repo's status. `active` gates polling to the visible screen. */
+export function useStatus(active: boolean) {
+  return useQuery({
+    queryKey: ["status"],
+    queryFn: fetchStatus,
+    refetchInterval: poll(active),
+  });
+}
+
+export function usePrs(active: boolean) {
+  return useQuery({
+    queryKey: ["prs", "open"],
+    queryFn: () => fetchPrs("open"),
+    refetchInterval: poll(active),
+  });
+}
+
+export function usePr(number: number | null) {
+  return useQuery({
+    queryKey: ["pr", number],
+    queryFn: () => fetchPr(number as number),
+    enabled: number != null,
+    // A detail view is a deliberate drill-in; poll it while it's open.
+    refetchInterval: number != null ? POLL_MS : (false as const),
+  });
+}
+
+export function useCiRuns(active: boolean) {
+  return useQuery({
+    queryKey: ["ci", "runs"],
+    queryFn: () => fetchCiRuns(),
+    refetchInterval: poll(active),
+  });
+}
+
+export function useCiRun(id: number | null) {
+  return useQuery({
+    queryKey: ["ci", "run", id],
+    queryFn: () => fetchCiRun(id as number),
+    enabled: id != null,
+    refetchInterval: id != null ? POLL_MS : (false as const),
+  });
+}
+
+/** Narrow an unknown query error to an {@link ApiError} for state routing. */
+export function asApiError(error: unknown): ApiError | null {
+  return error instanceof ApiError ? error : null;
+}

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -27,12 +27,17 @@ export const queryClient = new QueryClient({
 const POLL_MS = 15_000;
 const poll = (active: boolean) => (active ? POLL_MS : (false as const));
 
-/** The shared repo's status. `active` gates polling to the visible screen. */
-export function useStatus(active: boolean) {
+/** The shared repo's status. `active` gates polling to the visible screen;
+ *  `enabled` (default true) gates the query entirely — the shell passes false
+ *  while the phone sits on `#pair`, so an unpaired page never fires authed
+ *  requests (each would 401, and pre-pair traffic was how the shell once banked
+ *  rate-limit failures before the user ever typed a PIN). */
+export function useStatus(active: boolean, enabled = true) {
   return useQuery({
     queryKey: ["status"],
     queryFn: fetchStatus,
-    refetchInterval: poll(active),
+    enabled,
+    refetchInterval: enabled ? poll(active) : false,
   });
 }
 

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import { QueryClient, useQuery } from "@tanstack/react-query";
+import { QueryCache, QueryClient, useQuery } from "@tanstack/react-query";
 import {
   ApiError,
   fetchCiRun,
@@ -7,15 +7,36 @@ import {
   fetchPrs,
   fetchStatus,
 } from "./api";
+import { navigate } from "./router";
 
 // A fresh QueryClient for the companion — modest freshness, one retry, and NO
 // refetch-on-focus (a phone backgrounds/foregrounds constantly; we drive
 // freshness with a polling interval on the ACTIVE screen instead).
 export const queryClient = new QueryClient({
+  // ROUND-6 FINDING (PR #75): the "401 anywhere → #pair" invariant must hold
+  // centrally, not just via the shell's status probe — that probe doesn't poll
+  // on the PRs/CI tabs, so a phone revoked while sitting there kept its stale
+  // list (the banner read "couldn't refresh") AND re-sent its dead cookie every
+  // poll, burning the server's brute-force budget until it rate-limited itself
+  // out of RE-pairing. Any query's fresh 401 now redirects; `navigate` is a
+  // no-op when already on #pair. (The shell's status-based redirect remains as
+  // belt-and-braces with its post-pair freshness gate.)
+  queryCache: new QueryCache({
+    onError: (err) => {
+      if (err instanceof ApiError && err.isUnauthorized) navigate("#pair");
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 10_000,
-      retry: 1,
+      // One retry for transient failures — but never for a 401/409: both are
+      // definitive, and a retried 401 re-sends the dead cookie, double-billing
+      // the per-IP lockout budget on every poll cycle.
+      retry: (failureCount, err) =>
+        !(
+          err instanceof ApiError &&
+          (err.isUnauthorized || err.isNoActiveRepo)
+        ) && failureCount < 1,
       refetchOnWindowFocus: false,
     },
   },

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -1,0 +1,57 @@
+import { useMemo, useSyncExternalStore } from "react";
+
+// Hash routing ONLY — the LAN server serves a single `index.html` and does no
+// history-API rewriting, so every route lives in `location.hash`. Routes:
+//   #pair · #status · #prs · #prs/{n} · #ci · #ci/{id}
+// Default (empty / unknown hash) resolves to #status.
+
+export type Tab = "status" | "prs" | "ci";
+
+export interface Route {
+  /** The active bottom-tab. Pair is not a tab (it's a full-screen takeover). */
+  tab: Tab;
+  /** True when on the pairing screen (`#pair`). */
+  isPairing: boolean;
+  /** A selected PR number (`#prs/{n}`) or CI run id (`#ci/{id}`), else null. */
+  detailId: number | null;
+  /** The raw normalized hash (without the leading `#`). */
+  raw: string;
+}
+
+function parseHash(hash: string): Route {
+  const raw = hash.replace(/^#/, "");
+  if (raw === "pair") {
+    return { tab: "status", isPairing: true, detailId: null, raw };
+  }
+  const [head, tail] = raw.split("/", 2);
+  const detailId = tail && /^\d+$/.test(tail) ? Number(tail) : null;
+  switch (head) {
+    case "prs":
+      return { tab: "prs", isPairing: false, detailId, raw };
+    case "ci":
+      return { tab: "ci", isPairing: false, detailId, raw };
+    default:
+      return { tab: "status", isPairing: false, detailId: null, raw };
+  }
+}
+
+function subscribe(cb: () => void): () => void {
+  window.addEventListener("hashchange", cb);
+  return () => window.removeEventListener("hashchange", cb);
+}
+
+const getSnapshot = () => window.location.hash;
+
+/** The current parsed route, re-rendering on `hashchange`. The external-store
+ *  snapshot is the raw hash STRING (stable across renders); the parsed `Route`
+ *  object is derived via `useMemo` so callers get a referentially-stable value
+ *  per hash. */
+export function useRoute(): Route {
+  const hash = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useMemo(() => parseHash(hash), [hash]);
+}
+
+/** Navigate by setting the hash (adds a history entry so Back works). */
+export function navigate(hash: string): void {
+  window.location.hash = hash.startsWith("#") ? hash : `#${hash}`;
+}

--- a/companion/src/lib/sha256.ts
+++ b/companion/src/lib/sha256.ts
@@ -1,0 +1,137 @@
+// Pure-TS SHA-256 (FIPS 180-4), no npm dependency and — critically — no
+// `crypto.subtle`.
+//
+// WHY NOT `crypto.subtle`: the Web Crypto API is only exposed on SECURE contexts
+// (https:, or http://localhost). The phone companion is served over PLAIN HTTP on
+// a LAN IP (e.g. http://192.168.1.5:38473), which the browser treats as an
+// INSECURE origin — so `crypto.subtle` is `undefined` there and any call throws.
+// A dependency-free implementation is the only option that works on the real
+// transport. Do NOT "simplify" this back to `crypto.subtle.digest`.
+//
+// The algorithm below is the standard public-domain SHA-256; it is validated by
+// the companion's pairing round-trip and by the shared test vectors the Rust
+// side (`compute_proof`) already asserts.
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+function rotr(x: number, n: number): number {
+  return (x >>> n) | (x << (32 - n));
+}
+
+/** SHA-256 of a byte array → the 32-byte digest. */
+export function sha256(bytes: Uint8Array): Uint8Array {
+  const h = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+    0x1f83d9ab, 0x5be0cd19,
+  ]);
+
+  // Pre-processing: append 0x80, then zero-pad to 56 mod 64, then the 64-bit
+  // big-endian bit length.
+  const bitLen = bytes.length * 8;
+  const withPad = new Uint8Array(((bytes.length + 8) >> 6) * 64 + 64);
+  withPad.set(bytes);
+  withPad[bytes.length] = 0x80;
+  // 64-bit length, big-endian, in the final 8 bytes. JS bitwise ops are 32-bit,
+  // so split into a high and low 32-bit word (`bitLen` never exceeds 2^53 here).
+  const view = new DataView(withPad.buffer);
+  view.setUint32(withPad.length - 8, Math.floor(bitLen / 0x100000000));
+  view.setUint32(withPad.length - 4, bitLen >>> 0);
+
+  const w = new Uint32Array(64);
+  for (let off = 0; off < withPad.length; off += 64) {
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getUint32(off + i * 4);
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0;
+    }
+
+    let a = h[0];
+    let b = h[1];
+    let c = h[2];
+    let d = h[3];
+    let e = h[4];
+    let f = h[5];
+    let g = h[6];
+    let hh = h[7];
+
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const t1 = (hh + S1 + ch + K[i] + w[i]) | 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const t2 = (S0 + maj) | 0;
+      hh = g;
+      g = f;
+      f = e;
+      e = (d + t1) | 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (t1 + t2) | 0;
+    }
+
+    h[0] = (h[0] + a) | 0;
+    h[1] = (h[1] + b) | 0;
+    h[2] = (h[2] + c) | 0;
+    h[3] = (h[3] + d) | 0;
+    h[4] = (h[4] + e) | 0;
+    h[5] = (h[5] + f) | 0;
+    h[6] = (h[6] + g) | 0;
+    h[7] = (h[7] + hh) | 0;
+  }
+
+  const out = new Uint8Array(32);
+  const outView = new DataView(out.buffer);
+  for (let i = 0; i < 8; i++) {
+    outView.setUint32(i * 4, h[i]);
+  }
+  return out;
+}
+
+/** Lowercase hex of a byte array. */
+export function hex(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) {
+    s += b.toString(16).padStart(2, "0");
+  }
+  return s;
+}
+
+/** `hex(sha256(utf8(input)))` — the building block the pairing proof is made of. */
+export function sha256Hex(input: string): string {
+  return hex(sha256(new TextEncoder().encode(input)));
+}
+
+/**
+ * The pairing proof the phone must POST to `/api/pair`, computed EXACTLY as the
+ * Rust server does (`crate::lan::auth::compute_proof`):
+ *
+ *   proof = hex(sha256( hex(sha256(pin + salt)) + challenge ))
+ *
+ * Splitting the PIN behind an inner salted hash keeps the PIN off the wire, and
+ * binding the outer hash to the server's one-time `challenge` defeats replay.
+ */
+export function computeProof(
+  pin: string,
+  salt: string,
+  challenge: string,
+): string {
+  const inner = sha256Hex(pin + salt);
+  return sha256Hex(inner + challenge);
+}

--- a/companion/src/lib/use-roving-list.ts
+++ b/companion/src/lib/use-roving-list.ts
@@ -15,16 +15,21 @@ export function useRovingList() {
     [],
   );
 
-  const onKeyDown = useCallback((e: React.KeyboardEvent, index: number) => {
+  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
     const items = rows.current.filter(Boolean) as HTMLElement[];
     if (items.length === 0) return;
+    // Locate the row that fired the event IN the compacted array, so a null
+    // middle ref can never skew the arithmetic — registration indices and
+    // compacted positions diverge exactly then.
+    const cur = items.indexOf(e.currentTarget as HTMLElement);
+    if (cur === -1) return;
     let next: number | null = null;
     switch (e.key) {
       case "ArrowDown":
-        next = Math.min(index + 1, items.length - 1);
+        next = Math.min(cur + 1, items.length - 1);
         break;
       case "ArrowUp":
-        next = Math.max(index - 1, 0);
+        next = Math.max(cur - 1, 0);
         break;
       case "Home":
         next = 0;
@@ -36,8 +41,6 @@ export function useRovingList() {
         return;
     }
     e.preventDefault();
-    // `next` indexes the COMPACTED `items` array — focus through it, not the raw
-    // ref array, whose indices could diverge if a middle row were ever null.
     items[next]?.focus();
   }, []);
 

--- a/companion/src/lib/use-roving-list.ts
+++ b/companion/src/lib/use-roving-list.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef } from "react";
+
+// Arrow-key roving focus for a vertical list of rows (repo convention: every
+// selectable list gets keyboard nav). Each row registers its element by index;
+// ArrowUp/Down move focus, Home/End jump to the ends. Enter/Space activation is
+// left to the row itself (it's a real <button>/<a>).
+
+export function useRovingList() {
+  const rows = useRef<(HTMLElement | null)[]>([]);
+
+  const register = useCallback(
+    (index: number) => (el: HTMLElement | null) => {
+      rows.current[index] = el;
+    },
+    [],
+  );
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent, index: number) => {
+    const items = rows.current.filter(Boolean) as HTMLElement[];
+    if (items.length === 0) return;
+    let next: number | null = null;
+    switch (e.key) {
+      case "ArrowDown":
+        next = Math.min(index + 1, items.length - 1);
+        break;
+      case "ArrowUp":
+        next = Math.max(index - 1, 0);
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = items.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    // `next` indexes the COMPACTED `items` array — focus through it, not the raw
+    // ref array, whose indices could diverge if a middle row were ever null.
+    items[next]?.focus();
+  }, []);
+
+  return { register, onKeyDown };
+}

--- a/companion/src/main.tsx
+++ b/companion/src/main.tsx
@@ -1,0 +1,19 @@
+// Position is load-bearing (mirrors the desktop's main.tsx): the transport must
+// be installed before any other module's evaluation can reach an invoke(). This
+// installs the companion's REJECTING transport — the phone talks to the desktop
+// over HTTP, never the Tauri IPC bridge — so this import stays FIRST.
+import "./transport";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+import { queryClient } from "./lib/queries";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/companion/src/screens/Ci.tsx
+++ b/companion/src/screens/Ci.tsx
@@ -31,7 +31,7 @@ export function CiBody({ active }: { active: boolean }) {
 
   return (
     <div className="flex flex-col">
-      {isError ? <StaleBanner onRetry={() => refetch()} /> : null}
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
       {data.length === 0 ? (
         <EmptyState
           title="No CI runs."

--- a/companion/src/screens/Ci.tsx
+++ b/companion/src/screens/Ci.tsx
@@ -1,0 +1,136 @@
+import {
+  ArrowLeftIcon,
+  CaretRightIcon,
+  GitBranchIcon,
+} from "@phosphor-icons/react";
+import type { WorkflowRun } from "@/lib/github/actions";
+import { CiStatusChip } from "../components/chips";
+import { EmptyState, ErrorState, SkeletonRows } from "../components/states";
+import { timeAgo } from "../lib/format";
+import { useCiRun, useCiRuns } from "../lib/queries";
+import { navigate } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+/** The CI run list. `active` gates polling. */
+export function CiBody({ active }: { active: boolean }) {
+  const { data, isPending, isError, error, refetch } = useCiRuns(active);
+  const { register, onKeyDown } = useRovingList();
+
+  if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+  if (isPending || !data) return <SkeletonRows />;
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        title="No CI runs."
+        hint="Workflow runs for this repository will show up here."
+      />
+    );
+  }
+
+  return (
+    <ul className="flex flex-col divide-y divide-border">
+      {data.map((run, i) => (
+        <li key={run.id}>
+          <button
+            type="button"
+            ref={register(i)}
+            onKeyDown={(e) => onKeyDown(e, i)}
+            onClick={() => navigate(`#ci/${run.id}`)}
+            className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+          >
+            <CiRow run={run} />
+            <CaretRightIcon
+              size={16}
+              className="shrink-0 text-muted-foreground"
+            />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CiRow({ run }: { run: WorkflowRun }) {
+  const when = run.updatedAt || run.createdAt;
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <CiStatusChip status={run.status} conclusion={run.conclusion} />
+      </div>
+      <p className="mt-1 truncate text-sm font-medium text-foreground">
+        {run.workflowName || run.displayTitle || "Workflow run"}
+      </p>
+      <p className="flex items-center gap-1 truncate text-xs text-muted-foreground">
+        <GitBranchIcon size={12} className="shrink-0" />
+        <span className="truncate">{run.headBranch}</span>
+        {when ? <span>· {timeAgo(when)}</span> : null}
+      </p>
+    </div>
+  );
+}
+
+/** A read-only CI run detail with its jobs. */
+export function CiDetail({ id }: { id: number }) {
+  const { data, isPending, isError, error, refetch } = useCiRun(id);
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => navigate("#ci")}
+          className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+        >
+          <ArrowLeftIcon size={16} />
+          CI
+        </button>
+      </div>
+
+      {isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={3} />
+      ) : (
+        <article className="flex flex-col gap-4 px-4 py-5">
+          <header className="flex flex-col gap-2">
+            <CiStatusChip status={data.status} conclusion={data.conclusion} />
+            <h1 className="text-base font-semibold text-foreground">
+              {data.workflowName || data.displayTitle || "Workflow run"}
+            </h1>
+            <p className="flex items-center gap-1 text-xs text-muted-foreground">
+              <GitBranchIcon size={12} />
+              {data.headBranch}
+              {data.event ? ` · ${data.event}` : ""}
+            </p>
+          </header>
+
+          <section className="flex flex-col gap-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Jobs
+            </p>
+            {data.jobs.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No jobs reported.</p>
+            ) : (
+              <ul className="flex flex-col divide-y divide-border rounded-md border border-border">
+                {data.jobs.map((job) => (
+                  <li
+                    key={job.id}
+                    className="flex items-center justify-between gap-3 px-3 py-2.5"
+                  >
+                    <span className="min-w-0 truncate text-sm text-foreground">
+                      {job.name}
+                    </span>
+                    <CiStatusChip
+                      status={job.status}
+                      conclusion={job.conclusion}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </article>
+      )}
+    </div>
+  );
+}

--- a/companion/src/screens/Ci.tsx
+++ b/companion/src/screens/Ci.tsx
@@ -34,7 +34,7 @@ export function CiBody({ active }: { active: boolean }) {
           <button
             type="button"
             ref={register(i)}
-            onKeyDown={(e) => onKeyDown(e, i)}
+            onKeyDown={onKeyDown}
             onClick={() => navigate(`#ci/${run.id}`)}
             className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
           >

--- a/companion/src/screens/Ci.tsx
+++ b/companion/src/screens/Ci.tsx
@@ -5,7 +5,12 @@ import {
 } from "@phosphor-icons/react";
 import type { WorkflowRun } from "@/lib/github/actions";
 import { CiStatusChip } from "../components/chips";
-import { EmptyState, ErrorState, SkeletonRows } from "../components/states";
+import {
+  EmptyState,
+  ErrorState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
 import { timeAgo } from "../lib/format";
 import { useCiRun, useCiRuns } from "../lib/queries";
 import { navigate } from "../lib/router";
@@ -13,40 +18,47 @@ import { useRovingList } from "../lib/use-roving-list";
 
 /** The CI run list. `active` gates polling. */
 export function CiBody({ active }: { active: boolean }) {
-  const { data, isPending, isError, error, refetch } = useCiRuns(active);
+  const { data, isError, error, refetch } = useCiRuns(active);
   const { register, onKeyDown } = useRovingList();
 
-  if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
-  if (isPending || !data) return <SkeletonRows />;
-  if (data.length === 0) {
-    return (
-      <EmptyState
-        title="No CI runs."
-        hint="Workflow runs for this repository will show up here."
-      />
-    );
+  // Prefer stale data: keep the last-known runs on screen even on error, with a
+  // StaleBanner above. Full-screen ErrorState only when there's nothing to show;
+  // skeleton only while the first fetch is pending. (401/409 unchanged.)
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
   }
 
   return (
-    <ul className="flex flex-col divide-y divide-border">
-      {data.map((run, i) => (
-        <li key={run.id}>
-          <button
-            type="button"
-            ref={register(i)}
-            onKeyDown={onKeyDown}
-            onClick={() => navigate(`#ci/${run.id}`)}
-            className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
-          >
-            <CiRow run={run} />
-            <CaretRightIcon
-              size={16}
-              className="shrink-0 text-muted-foreground"
-            />
-          </button>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col">
+      {isError ? <StaleBanner onRetry={() => refetch()} /> : null}
+      {data.length === 0 ? (
+        <EmptyState
+          title="No CI runs."
+          hint="Workflow runs for this repository will show up here."
+        />
+      ) : (
+        <ul className="flex flex-col divide-y divide-border">
+          {data.map((run, i) => (
+            <li key={run.id}>
+              <button
+                type="button"
+                ref={register(i)}
+                onKeyDown={onKeyDown}
+                onClick={() => navigate(`#ci/${run.id}`)}
+                className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+              >
+                <CiRow run={run} />
+                <CaretRightIcon
+                  size={16}
+                  className="shrink-0 text-muted-foreground"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 

--- a/companion/src/screens/Pair.tsx
+++ b/companion/src/screens/Pair.tsx
@@ -1,0 +1,323 @@
+import { CheckCircleIcon, WarningCircleIcon } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ApiError, pairChallenge, pairSubmit } from "../lib/api";
+import { markPaired } from "../lib/pairing-signal";
+import { navigate } from "../lib/router";
+import { computeProof } from "../lib/sha256";
+
+// The pairing screen. The desktop shows a QR + a 6-digit PIN; the phone lands
+// here (via the QR's `#pair` url), the user types the PIN, and we run the
+// challenge/response so the PIN never travels the wire.
+
+type PairState =
+  | { kind: "entry" }
+  | { kind: "submitting" }
+  | { kind: "wrongPin" }
+  | { kind: "locked"; retryAfter: number | null }
+  | { kind: "waiting" }
+  | { kind: "error"; message: string }
+  | { kind: "success" };
+
+const PIN_LENGTH = 6;
+
+/** A stable device name from the browser UA — best-effort, user-editable later
+ *  is out of scope for this slice. */
+function defaultDeviceName(): string {
+  const ua = navigator.userAgent;
+  if (/iphone/i.test(ua)) return "iPhone";
+  if (/ipad/i.test(ua)) return "iPad";
+  if (/android/i.test(ua)) return "Android phone";
+  return "Phone";
+}
+
+export function Pair() {
+  const [pin, setPin] = useState("");
+  const [state, setState] = useState<PairState>({ kind: "entry" });
+  const queryClient = useQueryClient();
+
+  async function submit(pinValue: string) {
+    setState({ kind: "submitting" });
+    try {
+      const { challenge, salt } = await pairChallenge();
+      const proof = computeProof(pinValue, salt, challenge);
+      await pairSubmit(defaultDeviceName(), proof);
+      // The server set the `gd_lan` cookie; the browser now authenticates
+      // automatically.
+      //
+      // LIVE-FOUND RACE (post-pair bounce): while the user sat on #pair, the
+      // shell's `["status"]` probe cached a 401 (no cookie yet). If we navigate
+      // to #status now, the shell's 401→#pair redirect reads that STALE 401 and
+      // bounces straight back to the PIN screen. Defeat it on BOTH sides:
+      //   1) here — stamp `markPaired()` (so the redirect can tell a pre-pair
+      //      401 from a fresh one), then RESET the status query and AWAIT its
+      //      refetch so the cache holds an authenticated 200 before we navigate;
+      //   2) in App.tsx — the redirect ignores any 401 older than `markPaired()`.
+      markPaired();
+      setState({ kind: "success" });
+      await queryClient.resetQueries({ queryKey: ["status"] });
+      // Keep the brief success confirmation, then head to Status with fresh auth
+      // state already in the cache.
+      window.setTimeout(() => navigate("#status"), 900);
+    } catch (e) {
+      handleError(e);
+    }
+  }
+
+  function handleError(e: unknown) {
+    if (e instanceof ApiError) {
+      if (e.isRateLimited) {
+        setState({ kind: "locked", retryAfter: e.retryAfter });
+        return;
+      }
+      // A wrong PIN comes back 401 (from submit). A missing/expired offer comes
+      // back 403 `pairingInactive` (from EITHER challenge or submit) — that's not
+      // an error, it means the desktop has no live offer, so show the calm
+      // waiting state that auto-re-checks.
+      if (e.isPairingInactive) {
+        setState({ kind: "waiting" });
+        return;
+      }
+      if (e.status === 401) {
+        setPin("");
+        setState({ kind: "wrongPin" });
+        return;
+      }
+      setState({ kind: "error", message: e.message });
+      return;
+    }
+    setState({ kind: "error", message: "Pairing failed. Please try again." });
+  }
+
+  function onPinChange(value: string) {
+    // Don't accept edits mid-submit (or after success) — the input is disabled
+    // while submitting, but guard anyway so a stray change can't double-fire.
+    if (state.kind === "submitting" || state.kind === "success") return;
+    const digits = value.replace(/\D/g, "").slice(0, PIN_LENGTH);
+    setPin(digits);
+    if (state.kind === "wrongPin" || state.kind === "error") {
+      setState({ kind: "entry" });
+    }
+    if (digits.length === PIN_LENGTH) {
+      void submit(digits);
+    }
+  }
+
+  if (state.kind === "success") {
+    return (
+      <CenteredPair
+        icon={<CheckCircleIcon size={40} className="text-success" />}
+        title="Paired!"
+        body="Taking you to your repository…"
+      />
+    );
+  }
+
+  if (state.kind === "waiting") {
+    return <WaitingForDesktop onOfferLive={() => resetTo(setPin, setState)} />;
+  }
+
+  if (state.kind === "locked") {
+    return (
+      <LockedOut
+        retryAfter={state.retryAfter}
+        onTryAgain={() => resetTo(setPin, setState)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-6 px-8 py-12 text-center">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-lg font-semibold text-foreground">
+          Pair with GitDesktop
+        </h1>
+        <p className="max-w-xs text-sm text-muted-foreground">
+          Enter the 6-digit code shown on your desktop.
+        </p>
+      </div>
+
+      <label className="flex w-full max-w-xs flex-col items-center gap-2">
+        <span className="sr-only">Pairing PIN</span>
+        <input
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          pattern="[0-9]*"
+          aria-label="Pairing PIN"
+          aria-invalid={state.kind === "wrongPin"}
+          disabled={state.kind === "submitting"}
+          value={pin}
+          onChange={(e) => onPinChange(e.target.value)}
+          // A single-purpose pairing screen — the PIN field is the only
+          // interactive element, so autofocus is right (raises the phone keyboard
+          // immediately). This repo's biome config doesn't flag noAutofocus, so
+          // no suppression is needed.
+          autoFocus
+          className="w-full rounded-md border border-border bg-card px-4 py-3 text-center text-2xl font-semibold tracking-[0.4em] tabular-nums text-foreground outline-none focus-visible:border-primary"
+          placeholder="000000"
+        />
+      </label>
+
+      {state.kind === "wrongPin" ? (
+        <p
+          className="flex items-center gap-1.5 text-sm text-destructive"
+          role="alert"
+        >
+          <WarningCircleIcon size={16} />
+          That code didn't match. Check the desktop and try again.
+        </p>
+      ) : null}
+      {state.kind === "error" ? (
+        <p
+          className="flex items-center gap-1.5 text-sm text-destructive"
+          role="alert"
+        >
+          <WarningCircleIcon size={16} />
+          {state.message}
+        </p>
+      ) : null}
+      {state.kind === "submitting" ? (
+        <p className="text-sm text-muted-foreground">Pairing…</p>
+      ) : null}
+    </div>
+  );
+}
+
+function resetTo(
+  setPin: (v: string) => void,
+  setState: (s: PairState) => void,
+) {
+  setPin("");
+  setState({ kind: "entry" });
+}
+
+function CenteredPair({
+  icon,
+  title,
+  body,
+  action,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  action?: { label: string; onClick: () => void };
+}) {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-4 px-8 py-12 text-center">
+      {icon}
+      <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+      <p className="max-w-xs text-sm text-muted-foreground">{body}</p>
+      {action ? (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="mt-2 inline-flex min-h-11 items-center rounded-md bg-primary px-5 py-2 text-sm font-medium text-primary-foreground"
+        >
+          {action.label}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** How often the waiting state re-checks whether the desktop has a live pairing
+ *  offer. Deliberately gentle — the desktop user is walking over to click "Pair
+ *  a device", not racing a clock. */
+const WAITING_RECHECK_MS = 4000;
+
+/** The calm "no active offer yet" state. Polls the challenge endpoint on a gentle
+ *  interval; the first success means the desktop now has a live offer, so it hands
+ *  control back to the PIN entry via `onOfferLive`. */
+function WaitingForDesktop({ onOfferLive }: { onOfferLive: () => void }) {
+  useEffect(() => {
+    let cancelled = false;
+    let inFlight = false;
+
+    async function recheck() {
+      // Skip if a prior probe is still outstanding (slow network) — never stack
+      // requests. The server no longer counts a challenge with no active session
+      // as a rate-limit failure, but the client stays polite regardless: one
+      // probe at a time, on a slow interval.
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        await pairChallenge();
+        // Succeeded → an offer is live now. Return to entry so the user can type
+        // the new PIN.
+        if (!cancelled) onOfferLive();
+      } catch {
+        // Still inactive (or a transient error) — keep waiting; the next tick
+        // re-checks. No state change, so the calm screen stays put.
+      } finally {
+        inFlight = false;
+      }
+    }
+
+    const id = window.setInterval(recheck, WAITING_RECHECK_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [onOfferLive]);
+
+  return (
+    <CenteredPair
+      icon={<WarningCircleIcon size={40} className="text-muted-foreground" />}
+      title="Waiting for your desktop"
+      body="In GitDesktop, choose Settings → Phone companion → Pair a device, then scan the new code or enter the new PIN."
+    />
+  );
+}
+
+/** The rate-limited state with a LIVE countdown. Ticks the remaining seconds down
+ *  each second from the server's `Retry-After`; the "Try again" button is disabled
+ *  and muted while the count is running, and lights up at zero. (A missing
+ *  `Retry-After` → no countdown, button immediately enabled.) */
+function LockedOut({
+  retryAfter,
+  onTryAgain,
+}: {
+  retryAfter: number | null;
+  onTryAgain: () => void;
+}) {
+  const [remaining, setRemaining] = useState(
+    retryAfter && retryAfter > 0 ? retryAfter : 0,
+  );
+
+  useEffect(() => {
+    if (remaining <= 0) return;
+    const id = window.setInterval(() => {
+      setRemaining((s) => (s <= 1 ? 0 : s - 1));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [remaining]);
+
+  const counting = remaining > 0;
+  const body = counting
+    ? `For safety, the desktop paused pairing from this device for a short while. Try again in ${remaining} second${remaining === 1 ? "" : "s"}.`
+    : "For safety, the desktop paused pairing from this device for a short while. You can try again now.";
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-4 px-8 py-12 text-center">
+      <WarningCircleIcon size={40} className="text-destructive" />
+      <h1 className="text-lg font-semibold text-foreground">
+        Too many attempts.
+      </h1>
+      <p className="max-w-xs text-sm text-muted-foreground">{body}</p>
+      <button
+        type="button"
+        onClick={onTryAgain}
+        disabled={counting}
+        aria-disabled={counting}
+        className={`mt-2 inline-flex min-h-11 items-center rounded-md px-5 py-2 text-sm font-medium ${
+          counting
+            ? "bg-muted text-muted-foreground"
+            : "bg-primary text-primary-foreground"
+        }`}
+      >
+        {counting ? `Try again in ${remaining}s` : "Try again"}
+      </button>
+    </div>
+  );
+}

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -1,7 +1,12 @@
 import { ArrowLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { PrInfo } from "@/lib/git/types";
 import { PrStateChip } from "../components/chips";
-import { EmptyState, ErrorState, SkeletonRows } from "../components/states";
+import {
+  EmptyState,
+  ErrorState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
 import { timeAgo } from "../lib/format";
 import { usePr, usePrs } from "../lib/queries";
 import { navigate } from "../lib/router";
@@ -9,40 +14,48 @@ import { useRovingList } from "../lib/use-roving-list";
 
 /** The PR list. `active` gates polling. */
 export function PrsBody({ active }: { active: boolean }) {
-  const { data, isPending, isError, error, refetch } = usePrs(active);
+  const { data, isError, error, refetch } = usePrs(active);
   const { register, onKeyDown } = useRovingList();
 
-  if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
-  if (isPending || !data) return <SkeletonRows />;
-  if (data.length === 0) {
-    return (
-      <EmptyState
-        title="No open pull requests."
-        hint="Open PRs on this repository will show up here."
-      />
-    );
+  // Prefer stale data: keep the last-known list on screen even on error, with a
+  // StaleBanner above it. Full-screen ErrorState only when there's nothing to
+  // show; skeleton only while the first fetch is pending. (401/409 route through
+  // ErrorState/the shell exactly as before.)
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
   }
 
   return (
-    <ul className="flex flex-col divide-y divide-border">
-      {data.map((pr, i) => (
-        <li key={pr.number}>
-          <button
-            type="button"
-            ref={register(i)}
-            onKeyDown={onKeyDown}
-            onClick={() => navigate(`#prs/${pr.number}`)}
-            className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
-          >
-            <PrRow pr={pr} />
-            <CaretRightIcon
-              size={16}
-              className="shrink-0 text-muted-foreground"
-            />
-          </button>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col">
+      {isError ? <StaleBanner onRetry={() => refetch()} /> : null}
+      {data.length === 0 ? (
+        <EmptyState
+          title="No open pull requests."
+          hint="Open PRs on this repository will show up here."
+        />
+      ) : (
+        <ul className="flex flex-col divide-y divide-border">
+          {data.map((pr, i) => (
+            <li key={pr.number}>
+              <button
+                type="button"
+                ref={register(i)}
+                onKeyDown={onKeyDown}
+                onClick={() => navigate(`#prs/${pr.number}`)}
+                className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+              >
+                <PrRow pr={pr} />
+                <CaretRightIcon
+                  size={16}
+                  className="shrink-0 text-muted-foreground"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -1,0 +1,124 @@
+import { ArrowLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
+import type { PrInfo } from "@/lib/git/types";
+import { PrStateChip } from "../components/chips";
+import { EmptyState, ErrorState, SkeletonRows } from "../components/states";
+import { timeAgo } from "../lib/format";
+import { usePr, usePrs } from "../lib/queries";
+import { navigate } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+/** The PR list. `active` gates polling. */
+export function PrsBody({ active }: { active: boolean }) {
+  const { data, isPending, isError, error, refetch } = usePrs(active);
+  const { register, onKeyDown } = useRovingList();
+
+  if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+  if (isPending || !data) return <SkeletonRows />;
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        title="No open pull requests."
+        hint="Open PRs on this repository will show up here."
+      />
+    );
+  }
+
+  return (
+    <ul className="flex flex-col divide-y divide-border">
+      {data.map((pr, i) => (
+        <li key={pr.number}>
+          <button
+            type="button"
+            ref={register(i)}
+            onKeyDown={(e) => onKeyDown(e, i)}
+            onClick={() => navigate(`#prs/${pr.number}`)}
+            className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+          >
+            <PrRow pr={pr} />
+            <CaretRightIcon
+              size={16}
+              className="shrink-0 text-muted-foreground"
+            />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function PrRow({ pr }: { pr: PrInfo }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <PrStateChip state={pr.state} isDraft={pr.isDraft} />
+        <span className="text-xs text-muted-foreground">#{pr.number}</span>
+      </div>
+      <p className="mt-1 truncate text-sm font-medium text-foreground">
+        {pr.title}
+      </p>
+      <p className="truncate text-xs text-muted-foreground">
+        {pr.author?.login ? `${pr.author.login} · ` : ""}
+        {timeAgo(pr.createdAt)}
+      </p>
+    </div>
+  );
+}
+
+/** A read-only PR detail. */
+export function PrDetail({ number }: { number: number }) {
+  const { data, isPending, isError, error, refetch } = usePr(number);
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => navigate("#prs")}
+          className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+        >
+          <ArrowLeftIcon size={16} />
+          PRs
+        </button>
+      </div>
+
+      {isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={3} />
+      ) : (
+        <article className="flex flex-col gap-4 px-4 py-5">
+          <header className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <PrStateChip state={data.state} isDraft={data.isDraft} />
+              <span className="text-xs text-muted-foreground">
+                #{data.number}
+              </span>
+            </div>
+            <h1 className="text-base font-semibold text-foreground">
+              {data.title}
+            </h1>
+            <p className="text-xs text-muted-foreground">
+              {data.author ? `${data.author} · ` : ""}
+              {data.headRefName} → {data.baseRefName}
+            </p>
+            <p className="text-xs text-muted-foreground tabular-nums">
+              +{data.additions} −{data.deletions} · {data.commits.length} commit
+              {data.commits.length === 1 ? "" : "s"} · {data.files.length} file
+              {data.files.length === 1 ? "" : "s"}
+            </p>
+          </header>
+
+          {data.body ? (
+            <p className="whitespace-pre-wrap break-words text-sm text-foreground/90">
+              {data.body}
+            </p>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">
+              No description.
+            </p>
+          )}
+        </article>
+      )}
+    </div>
+  );
+}

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -30,7 +30,7 @@ export function PrsBody({ active }: { active: boolean }) {
           <button
             type="button"
             ref={register(i)}
-            onKeyDown={(e) => onKeyDown(e, i)}
+            onKeyDown={onKeyDown}
             onClick={() => navigate(`#prs/${pr.number}`)}
             className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
           >

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -28,7 +28,7 @@ export function PrsBody({ active }: { active: boolean }) {
 
   return (
     <div className="flex flex-col">
-      {isError ? <StaleBanner onRetry={() => refetch()} /> : null}
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
       {data.length === 0 ? (
         <EmptyState
           title="No open pull requests."

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -42,7 +42,7 @@ export function StatusBody({ active }: { active: boolean }) {
 
   return (
     <div className="flex flex-col">
-      {isError ? <StaleBanner onRetry={() => refetch()} /> : null}
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
       <div className="flex flex-col gap-6 px-4 py-6">
         <section className="flex flex-col gap-1">
           <p className="text-xs uppercase tracking-wide text-muted-foreground">

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -1,0 +1,109 @@
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  GitBranchIcon,
+} from "@phosphor-icons/react";
+import type { FileEntry } from "@/lib/git/types";
+import { SkeletonRows } from "../components/states";
+import { useStatus } from "../lib/queries";
+
+// Status is a calm glanceable column (not a dashboard): current branch, its
+// ahead/behind vs. upstream, and a small tally of working-tree changes.
+
+function changeCounts(entries: FileEntry[]) {
+  let staged = 0;
+  let unstaged = 0;
+  let untracked = 0;
+  for (const e of entries) {
+    if (e.staged) staged++;
+    if (e.unstaged === "untracked") untracked++;
+    else if (e.unstaged) unstaged++;
+  }
+  return { staged, unstaged, untracked, total: entries.length };
+}
+
+/** The Status body. Loading/error/no-repo are handled by the shell; this only
+ *  renders once data (or a skeleton) is available. */
+export function StatusBody({ active }: { active: boolean }) {
+  const { data, isPending } = useStatus(active);
+
+  if (isPending || !data) return <SkeletonRows count={4} />;
+
+  const branch = data.branch;
+  const counts = changeCounts(data.entries);
+  const clean = counts.total === 0;
+
+  return (
+    <div className="flex flex-col gap-6 px-4 py-6">
+      <section className="flex flex-col gap-1">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Current branch
+        </p>
+        <p className="flex items-center gap-2 text-lg font-semibold text-foreground">
+          <GitBranchIcon size={20} className="shrink-0 text-primary" />
+          <span className="truncate">
+            {branch.detached ? "Detached HEAD" : (branch.name ?? "—")}
+          </span>
+        </p>
+        {branch.upstream ? (
+          <p className="text-xs text-muted-foreground">
+            Tracking {branch.upstream}
+            {branch.upstreamGone ? " (gone)" : ""}
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">No upstream</p>
+        )}
+      </section>
+
+      {branch.upstream && !branch.upstreamGone ? (
+        <section className="flex gap-6">
+          <Stat
+            icon={<ArrowUpIcon size={16} className="text-info" />}
+            label="Ahead"
+            value={branch.ahead}
+          />
+          <Stat
+            icon={<ArrowDownIcon size={16} className="text-warning" />}
+            label="Behind"
+            value={branch.behind}
+          />
+        </section>
+      ) : null}
+
+      <section className="flex flex-col gap-2">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Working tree
+        </p>
+        {clean ? (
+          <p className="text-sm text-muted-foreground">Clean — no changes.</p>
+        ) : (
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <Stat label="Staged" value={counts.staged} />
+            <Stat label="Changed" value={counts.unstaged} />
+            <Stat label="Untracked" value={counts.untracked} />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Stat({
+  icon,
+  label,
+  value,
+}: {
+  icon?: React.ReactNode;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="flex items-center gap-1.5 text-2xl font-semibold tabular-nums text-foreground">
+        {icon}
+        {value}
+      </span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -4,7 +4,7 @@ import {
   GitBranchIcon,
 } from "@phosphor-icons/react";
 import type { FileEntry } from "@/lib/git/types";
-import { SkeletonRows } from "../components/states";
+import { ErrorState, SkeletonRows } from "../components/states";
 import { useStatus } from "../lib/queries";
 
 // Status is a calm glanceable column (not a dashboard): current branch, its
@@ -22,11 +22,14 @@ function changeCounts(entries: FileEntry[]) {
   return { staged, unstaged, untracked, total: entries.length };
 }
 
-/** The Status body. Loading/error/no-repo are handled by the shell; this only
- *  renders once data (or a skeleton) is available. */
+/** The Status body. The shell handles 401 (→ #pair) and 409 (no repo shared)
+ *  centrally; every OTHER error must be handled here like the sibling bodies do —
+ *  without this branch, an errored query with no cached data (`isPending` false,
+ *  `data` undefined) would render a skeleton forever. */
 export function StatusBody({ active }: { active: boolean }) {
-  const { data, isPending } = useStatus(active);
+  const { data, isPending, isError, error, refetch } = useStatus(active);
 
+  if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
   if (isPending || !data) return <SkeletonRows count={4} />;
 
   const branch = data.branch;

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -4,7 +4,7 @@ import {
   GitBranchIcon,
 } from "@phosphor-icons/react";
 import type { FileEntry } from "@/lib/git/types";
-import { ErrorState, SkeletonRows } from "../components/states";
+import { ErrorState, SkeletonRows, StaleBanner } from "../components/states";
 import { useStatus } from "../lib/queries";
 
 // Status is a calm glanceable column (not a dashboard): current branch, its
@@ -23,70 +23,77 @@ function changeCounts(entries: FileEntry[]) {
 }
 
 /** The Status body. The shell handles 401 (→ #pair) and 409 (no repo shared)
- *  centrally; every OTHER error must be handled here like the sibling bodies do —
- *  without this branch, an errored query with no cached data (`isPending` false,
- *  `data` undefined) would render a skeleton forever. */
+ *  centrally; every OTHER error is handled here keyed on THIS query, preferring
+ *  stale data: when a snapshot exists we keep showing it (with a StaleBanner on
+ *  error) rather than blanking to a full-screen error — the phone-on-flaky-wifi
+ *  case is the normal case. Full-screen `ErrorState` only when there's no data at
+ *  all; skeleton only while pending. */
 export function StatusBody({ active }: { active: boolean }) {
-  const { data, isPending, isError, error, refetch } = useStatus(active);
+  const { data, isError, error, refetch } = useStatus(active);
 
-  if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
-  if (isPending || !data) return <SkeletonRows count={4} />;
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows count={4} />;
+  }
 
   const branch = data.branch;
   const counts = changeCounts(data.entries);
   const clean = counts.total === 0;
 
   return (
-    <div className="flex flex-col gap-6 px-4 py-6">
-      <section className="flex flex-col gap-1">
-        <p className="text-xs uppercase tracking-wide text-muted-foreground">
-          Current branch
-        </p>
-        <p className="flex items-center gap-2 text-lg font-semibold text-foreground">
-          <GitBranchIcon size={20} className="shrink-0 text-primary" />
-          <span className="truncate">
-            {branch.detached ? "Detached HEAD" : (branch.name ?? "—")}
-          </span>
-        </p>
-        {branch.upstream ? (
-          <p className="text-xs text-muted-foreground">
-            Tracking {branch.upstream}
-            {branch.upstreamGone ? " (gone)" : ""}
+    <div className="flex flex-col">
+      {isError ? <StaleBanner onRetry={() => refetch()} /> : null}
+      <div className="flex flex-col gap-6 px-4 py-6">
+        <section className="flex flex-col gap-1">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Current branch
           </p>
-        ) : (
-          <p className="text-xs text-muted-foreground">No upstream</p>
-        )}
-      </section>
-
-      {branch.upstream && !branch.upstreamGone ? (
-        <section className="flex gap-6">
-          <Stat
-            icon={<ArrowUpIcon size={16} className="text-info" />}
-            label="Ahead"
-            value={branch.ahead}
-          />
-          <Stat
-            icon={<ArrowDownIcon size={16} className="text-warning" />}
-            label="Behind"
-            value={branch.behind}
-          />
+          <p className="flex items-center gap-2 text-lg font-semibold text-foreground">
+            <GitBranchIcon size={20} className="shrink-0 text-primary" />
+            <span className="truncate">
+              {branch.detached ? "Detached HEAD" : (branch.name ?? "—")}
+            </span>
+          </p>
+          {branch.upstream ? (
+            <p className="text-xs text-muted-foreground">
+              Tracking {branch.upstream}
+              {branch.upstreamGone ? " (gone)" : ""}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">No upstream</p>
+          )}
         </section>
-      ) : null}
 
-      <section className="flex flex-col gap-2">
-        <p className="text-xs uppercase tracking-wide text-muted-foreground">
-          Working tree
-        </p>
-        {clean ? (
-          <p className="text-sm text-muted-foreground">Clean — no changes.</p>
-        ) : (
-          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
-            <Stat label="Staged" value={counts.staged} />
-            <Stat label="Changed" value={counts.unstaged} />
-            <Stat label="Untracked" value={counts.untracked} />
-          </div>
-        )}
-      </section>
+        {branch.upstream && !branch.upstreamGone ? (
+          <section className="flex gap-6">
+            <Stat
+              icon={<ArrowUpIcon size={16} className="text-info" />}
+              label="Ahead"
+              value={branch.ahead}
+            />
+            <Stat
+              icon={<ArrowDownIcon size={16} className="text-warning" />}
+              label="Behind"
+              value={branch.behind}
+            />
+          </section>
+        ) : null}
+
+        <section className="flex flex-col gap-2">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Working tree
+          </p>
+          {clean ? (
+            <p className="text-sm text-muted-foreground">Clean — no changes.</p>
+          ) : (
+            <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+              <Stat label="Staged" value={counts.staged} />
+              <Stat label="Changed" value={counts.unstaged} />
+              <Stat label="Untracked" value={counts.untracked} />
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/companion/src/transport.ts
+++ b/companion/src/transport.ts
@@ -1,0 +1,26 @@
+import { installTransport, type Transport } from "@/lib/transport";
+
+// The companion runs in a phone browser, NOT inside Tauri — there is no IPC
+// bridge here. It reaches the desktop purely over HTTP (see `lib/api.ts`), so no
+// data call routes through the transport seam in this slice.
+//
+// We still install a transport, though: any desktop module pulled in transitively
+// (e.g. via a shared type file that also has runtime exports) may call
+// `getTransport().invoke(...)` at import/eval time. Installing one that REJECTS
+// LOUDLY means such a call fails with a clear message instead of throwing the
+// opaque "No transport installed" error — or, worse, silently reaching for a
+// Tauri global that doesn't exist. The rejection is shaped like the app's
+// AppError so callers that inspect `.kind`/`.message` behave consistently.
+
+const notAvailable = (cmd: string): Promise<never> =>
+  Promise.reject({
+    kind: "command",
+    message: `Backend command "${cmd}" is not available on the phone companion — it talks to the desktop over HTTP, not the Tauri IPC bridge.`,
+  });
+
+const companionTransport: Transport = {
+  invoke: (cmd) => notAvailable(cmd),
+  invokeStreaming: (cmd) => notAvailable(cmd),
+};
+
+installTransport(companionTransport);

--- a/companion/tsconfig.json
+++ b/companion/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  // Standalone — deliberately NOT referenced from the root tsconfig.json project
+  // graph (mirrors how `site/` stays separate). Its strictness mirrors the
+  // desktop's tsconfig.app.json, with `strict` additionally on since this is all
+  // fresh, isolated code. The `@` alias resolves into the desktop `../src` for
+  // TYPE-ONLY imports (types.ts / actions.ts shapes the LAN server returns).
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.companion.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "paths": {
+      "@/*": ["../src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/companion/vite.config.ts
+++ b/companion/vite.config.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// The phone companion is a SEPARATE Vite app from the desktop frontend: its own
+// root (this dir), its own entry (`src/main.tsx`), and its own bundle served by
+// the desktop's LAN server. It shares the desktop's TYPES via the `@` alias
+// (type-only imports — see `src/lib/api.ts`) but none of its runtime code.
+//
+// Deliberately minimal vs. the root config: no React Compiler / babel pass (this
+// is a small hand-tuned app, not the desktop's hot path), and NO css-inlining
+// plugins — the LAN server serves this under a strict `script-src 'self';
+// style-src 'self'` CSP, so every script/style must load from a built file.
+// Vite's default production output (external hashed .js/.css) complies.
+// `tailwindcss()` IS required (Tailwind v4 rides its own Vite plugin, not
+// postcss) — without it the `@theme`/`@custom-variant`/utilities in index.css
+// pass through un-compiled and every utility class is a no-op.
+export default defineConfig({
+  root: __dirname,
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "../src"),
+    },
+  },
+  build: {
+    // The desktop LAN server serves the bundle from here (assets under
+    // `/assets/`). The sibling package creates this dir with a `.gitkeep`.
+    outDir: path.resolve(__dirname, "../src-tauri/companion-dist"),
+    // Clears the dir before each build (drops the tracked `.gitkeep` from the
+    // WORKING TREE, which is harmless — git still tracks it, so `git checkout`
+    // restores it; a stale bundle would otherwise linger between builds).
+    emptyOutDir: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "biome check --write ./src/",
+    "build": "tsc -b && vite build && pnpm run build:companion",
+    "build:companion": "tsc -p companion/tsconfig.json --noEmit && vite build --config companion/vite.config.ts && node -e \"require('fs').writeFileSync('src-tauri/companion-dist/.gitkeep','')\"",
+    "lint": "biome check --write ./src/ ./companion/",
     "preview": "vite preview",
     "changelog": "node scripts/changelog-draft.mjs",
     "changelog:preview": "node scripts/changelog-draft.mjs --preview",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "qrcode",
  "rand 0.10.2",
  "rmcp",
+ "rust-embed",
  "serde",
  "serde_json",
  "sha1",
@@ -2514,6 +2515,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minisign-verify"
@@ -3687,6 +3698,42 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "mime_guess",
+ "sha2 0.11.0",
+ "walkdir",
 ]
 
 [[package]]
@@ -5450,6 +5497,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,13 @@ sha2 = "0.11.0"
 rand = "0.10.2"
 qrcode = { version = "0.14.1", default-features = false, features = ["svg"] }
 local-ip-address = "0.6.13"
+# Embeds the companion frontend bundle (src-tauri/companion-dist/, written by the
+# sibling `pnpm build:companion`) into the binary so a shipped app serves the phone
+# UI with nothing extra to ship. `mime-guess` powers `EmbeddedFile::metadata().mimetype()`
+# for the Content-Type of served assets. In DEBUG builds rust-embed reads the folder
+# from disk at request time (no rebuild needed to pick up a fresh frontend build) — that
+# IS the dev loop; RELEASE builds bake the files in.
+rust-embed = { version = "8.12.0", features = ["mime-guess"] }
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -746,7 +746,12 @@ pub async fn require_auth(
         .filter(|s| !s.is_empty());
 
     let Some(bearer) = bearer else {
-        record_failure(&state.rate_limit, ip);
+        // NO rate-limit penalty for a request with NO credential at all. The lockout
+        // budget is the secret-guess budget, and a missing bearer/cookie carries zero
+        // guessing information — the companion shell's status probe fires while the
+        // phone sits on #pair with no cookie yet, so penalizing it banked failures
+        // into the same per-IP budget as wrong PINs and re-leaked the self-lockout
+        // this PR fixed on the pairing routes. Just 401.
         return unauthorized();
     };
     match authenticate_bearer(&bearer) {
@@ -755,6 +760,9 @@ pub async fn require_auth(
             next.run(req).await
         }
         None => {
+            // KEEP: a PRESENT-but-invalid bearer/cookie IS a guessing event — a token
+            // brute-force attempt — so it counts toward the lockout budget exactly
+            // like a wrong pairing proof does.
             record_failure(&state.rate_limit, ip);
             unauthorized()
         }

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -75,6 +75,12 @@ pub const PAIRING_TTL: Duration = Duration::from_secs(120);
 const RATE_LIMIT_MAX_FAILURES: u32 = 5;
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 
+/// Test-only accessor for the lockout threshold, so the router-level pairing
+/// rate-limit tests in `super` can drive exactly N failures without hardcoding 5
+/// (which would silently rot if the threshold changed).
+#[cfg(test)]
+pub(crate) const RATE_LIMIT_MAX_FAILURES_FOR_TEST: u32 = RATE_LIMIT_MAX_FAILURES;
+
 /// Only rewrite a device's `lastSeenAt` when the stored value is more than this
 /// stale, so a burst of authenticated requests doesn't thrash the store file.
 const LAST_SEEN_THROTTLE_SECS: i64 = 60;
@@ -99,6 +105,11 @@ pub(crate) fn set_store_path_for_test(path: Option<PathBuf>) -> Option<PathBuf> 
     let mut guard = store_path_override()
         .lock()
         .unwrap_or_else(|p| p.into_inner());
+    // Swapping the store path must drop the in-memory cache: it holds devices from
+    // the PREVIOUS path's file, and tests point this at their own temp files — a
+    // stale cache would leak one test's devices into the next. Load-bearing for the
+    // whole test-path-swap regime.
+    invalidate_device_cache();
     std::mem::replace(&mut *guard, path)
 }
 
@@ -135,6 +146,25 @@ fn store_path() -> AppResult<PathBuf> {
 fn store_lock() -> &'static Mutex<()> {
     static STORE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     STORE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// In-memory cache of the on-disk device set, so a burst of authenticated requests
+/// doesn't re-read `lan-devices.json` on every call. `None` means "not loaded";
+/// [`authenticate_bearer`] populates it on a miss (under the store lock) and every
+/// store WRITE invalidates it back to `None`. Guarded by its own mutex — always
+/// taken WHILE the caller already holds [`store_lock`], so the two never interleave
+/// into a stale read across a concurrent write.
+static DEVICE_CACHE: OnceLock<Mutex<Option<Vec<StoredDevice>>>> = OnceLock::new();
+
+fn device_cache() -> &'static Mutex<Option<Vec<StoredDevice>>> {
+    DEVICE_CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// Drop the in-memory device cache. Called on every store write (persist/revoke)
+/// and on a test store-path swap, so the next [`authenticate_bearer`] reloads from
+/// disk. Cheap (`None` assignment); safe to call under the store lock.
+fn invalidate_device_cache() {
+    *device_cache().lock().unwrap_or_else(|p| p.into_inner()) = None;
 }
 
 // --------------------------------------------------------------------------
@@ -242,7 +272,14 @@ fn write_devices(
     store.insert("devices".to_string(), Value::Array(arr));
     let body = serde_json::to_string_pretty(&Value::Object(store))
         .map_err(|e| AppError::Command(format!("serialize lan-devices store: {e}")))?;
-    crate::fsops::atomic_write(path, body.as_bytes())
+    let res = crate::fsops::atomic_write(path, body.as_bytes());
+    // Every store write invalidates the in-memory device cache. Doing it at this
+    // single write choke point (rather than in each caller — `persist_device`,
+    // `revoke_device`, and the last-seen bump all route through here) guarantees no
+    // write path can leave a stale cache. Invalidate even on a failed write: the
+    // on-disk state is then indeterminate, so a reload-from-disk is the safe default.
+    invalidate_device_cache();
+    res
 }
 
 /// The safe-to-display list of paired devices (no token hashes). Read-only.
@@ -435,21 +472,45 @@ pub fn persist_device(device: &LanDevice, token_hash: &str) -> AppResult<()> {
 
 /// Look up the device whose stored token hash matches `sha256(bearer)`; on a hit,
 /// bump its `lastSeenAt` (throttled) and return its id. `None` on no match.
+///
+/// Backed by the in-memory [`DEVICE_CACHE`] so a burst of authenticated requests
+/// doesn't re-read `lan-devices.json` every call: on a cache miss the store is read
+/// under the store lock and the cache populated; every store write invalidates it.
+/// The last-seen bump path performs a real store write (via [`write_devices`],
+/// which invalidates the cache) — so after a bump the next request repopulates from
+/// the freshly-written file, keeping the cache consistent with disk.
 fn authenticate_bearer(bearer: &str) -> Option<String> {
     let token_hash = sha256_hex(bearer.as_bytes());
     let path = store_path().ok()?;
     let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
-    let store = read_store(&path).ok()?;
-    let mut devices = devices_from(&store);
+
+    // Consult the cache; on a miss, load from disk under the store lock and cache.
+    let mut cache = device_cache().lock().unwrap_or_else(|p| p.into_inner());
+    if cache.is_none() {
+        let store = read_store(&path).ok()?;
+        *cache = Some(devices_from(&store));
+    }
+    let devices = cache.as_ref().expect("cache populated above");
     let idx = devices
         .iter()
         .position(|d| constant_time_eq(&d.token_hash, &token_hash))?;
     let id = devices[idx].id.clone();
+    let stale = last_seen_is_stale(&devices[idx].last_seen_at);
+    // Release the cache lock before the write path (which invalidates the cache).
+    drop(cache);
+
     // Throttled last-seen bump: only rewrite when the stored value is stale, so a
-    // chatty client doesn't hammer the store file.
-    if last_seen_is_stale(&devices[idx].last_seen_at) {
-        devices[idx].last_seen_at = now_iso();
-        let _ = write_devices(&path, store, &devices);
+    // chatty client doesn't hammer the store file. Re-read the store map fresh so
+    // the write preserves any unknown top-level keys, then persist (which
+    // invalidates the cache; the next request repopulates from the new file).
+    if stale {
+        if let Ok(store) = read_store(&path) {
+            let mut devices = devices_from(&store);
+            if let Some(d) = devices.iter_mut().find(|d| d.id == id) {
+                d.last_seen_at = now_iso();
+                let _ = write_devices(&path, store, &devices);
+            }
+        }
     }
     Some(id)
 }
@@ -570,14 +631,23 @@ fn peer_ip(req: &Request<Body>) -> IpAddr {
         .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST))
 }
 
-/// Apply the transport-hardening headers to every response.
+/// The default API Content-Security-Policy: bare `frame-ancestors 'none'` (an API
+/// response has no page to protect, only the clickjacking defense). The static
+/// page handler sets its OWN, fuller CSP before this middleware runs; see
+/// [`harden_headers`] for why this one defers to an already-set header.
+pub const API_CSP: &str = "frame-ancestors 'none'";
+
+/// Apply the transport-hardening headers to every response. `X-Frame-Options` is
+/// stamped unconditionally, but the CSP is insert-IF-ABSENT: the static-serving
+/// handler ([`crate::lan::static_serve`]) sets a fuller page CSP on its HTML/asset
+/// responses, and this must not clobber it. API responses (which never set a CSP
+/// themselves) still get [`API_CSP`] here, exactly as before.
 fn harden_headers(resp: &mut Response) {
     let headers = resp.headers_mut();
     headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
-    headers.insert(
-        "Content-Security-Policy",
-        HeaderValue::from_static("frame-ancestors 'none'"),
-    );
+    if !headers.contains_key("Content-Security-Policy") {
+        headers.insert("Content-Security-Policy", HeaderValue::from_static(API_CSP));
+    }
 }
 
 /// Middleware run on EVERY request (pairing routes included): validates the
@@ -620,9 +690,40 @@ pub async fn host_guard(
     resp
 }
 
+/// The cookie name a phone BROWSER authenticates with when it can't set an
+/// `Authorization` header (a WebSocket upgrade or a top-level navigation). Its
+/// value is the raw bearer token, set by [`pair_submit`] on a successful pair.
+pub const AUTH_COOKIE: &str = "gd_lan";
+
+/// The `Set-Cookie` attributes for [`AUTH_COOKIE`]. `HttpOnly` keeps the token out
+/// of page JS; `SameSite=Strict` (with the existing [`host_guard`] Origin/Host
+/// validation) is the CSRF story — a cross-site request can't attach this cookie,
+/// and the only unauthenticated state-changing routes are the rate-limited pairing
+/// endpoints. No `Secure`: the companion is plain HTTP on the LAN by design (v1),
+/// so `Secure` would suppress the cookie entirely. One year `Max-Age`.
+const AUTH_COOKIE_ATTRS: &str = "HttpOnly; SameSite=Strict; Path=/; Max-Age=31536000";
+
+/// Pull the value of the cookie named `name` from a request's `Cookie` header, if
+/// present. A manual parse (split on `;`, trim, match `name=`) — no cookie crate,
+/// and no quoted-value handling needed since we mint the value ourselves (a raw
+/// bearer, all hex).
+fn cookie_value(headers: &axum::http::HeaderMap, name: &str) -> Option<String> {
+    let raw = headers.get(axum::http::header::COOKIE)?.to_str().ok()?;
+    for pair in raw.split(';') {
+        let pair = pair.trim();
+        if let Some(val) = pair.strip_prefix(name).and_then(|r| r.strip_prefix('=')) {
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
 /// Bearer-auth middleware for the protected `/api/` routes (everything except the
 /// two pairing routes). Enforces the per-IP rate limit, then requires a valid
-/// `Authorization: Bearer <token>` whose sha256 matches a stored device.
+/// bearer whose sha256 matches a stored device — taken from `Authorization: Bearer
+/// <token>` (checked FIRST), else the [`AUTH_COOKIE`] cookie (so a phone browser
+/// that can't set an `Authorization` header on a WS upgrade / navigation still
+/// authenticates). Same 401 on either miss.
 pub async fn require_auth(
     State(state): State<RouterState>,
     req: Request<Body>,
@@ -639,13 +740,16 @@ pub async fn require_auth(
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .map(str::trim)
+        .map(str::to_string)
+        // Fall back to the auth cookie when there's no bearer header (browser path).
+        .or_else(|| cookie_value(req.headers(), AUTH_COOKIE))
         .filter(|s| !s.is_empty());
 
     let Some(bearer) = bearer else {
         record_failure(&state.rate_limit, ip);
         return unauthorized();
     };
-    match authenticate_bearer(bearer) {
+    match authenticate_bearer(&bearer) {
         Some(_id) => {
             clear_failures(&state.rate_limit, ip);
             next.run(req).await
@@ -690,12 +794,18 @@ pub async fn pair_challenge(State(state): State<RouterState>, req: Request<Body>
     }
     let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
     let Some(session) = guard.as_mut() else {
-        record_failure(&state.rate_limit, ip);
+        // NO rate-limit penalty for "no active session". The lockout budget is the
+        // PIN-guess budget, and there's no secret to guess here — the phone can sit
+        // on the pairing page polling `/challenge` while no offer is live (e.g.
+        // between a revoke and the desktop starting a fresh offer). Penalizing this
+        // locked a waiting phone out before the user ever typed a PIN (live-confirmed).
+        // Responding `pairingInactive` without a penalty leaks nothing.
         return pairing_inactive();
     };
     if session.is_expired() {
+        // Same reasoning as the no-session case: an expired session carries no
+        // secret to attack, so no penalty — just clear it and report inactive.
         *guard = None;
-        record_failure(&state.rate_limit, ip);
         return pairing_inactive();
     }
     let (challenge, salt) = new_challenge();
@@ -716,8 +826,14 @@ struct PairBody {
 }
 
 /// `POST /api/pair` → mint a device on a correct proof. On success clears the
-/// pairing session and the peer's failure window; on a bad proof records a
-/// failure (rate-limited) and 401s.
+/// pairing session and the peer's failure window.
+///
+/// Rate-limit policy (lockout budget = PIN-guess budget): a failure is recorded
+/// ONLY for events that carry secret-guessing or abuse information — a WRONG PROOF
+/// (the actual PIN guess) and a MALFORMED/oversized body. It is NOT recorded for a
+/// missing or expired pairing session, nor for a well-formed body sent out of
+/// protocol order (no challenge fetched yet): those carry no secret to attack, so
+/// penalizing them would only let a waiting/fumbling phone lock itself out.
 pub async fn pair_submit(
     State(state): State<RouterState>,
     req: Request<Body>,
@@ -731,17 +847,24 @@ pub async fn pair_submit(
     let bytes = match axum::body::to_bytes(body, 64 * 1024).await {
         Ok(b) => b,
         Err(_) => {
+            // KEEP: a body that fails to read (oversized past the 64 KiB cap, or a
+            // truncated/abusive stream) is malformed-body abuse — it counts.
             record_failure(&state.rate_limit, ip);
             return bad_request("could not read request body");
         }
     };
     let parsed: Result<PairBody, _> = serde_json::from_slice(&bytes);
     let Ok(body) = parsed else {
+        // KEEP: a body that isn't the expected `{ deviceName, proof }` JSON is a
+        // malformed body — it counts toward the lockout budget.
         record_failure(&state.rate_limit, ip);
         return bad_request("expected { deviceName, proof }");
     };
     let device_name = body.device_name.trim();
     if device_name.is_empty() {
+        // KEEP: a submission missing its required deviceName is a malformed body
+        // (well-formed JSON, but not a valid pair request); it counts. A legitimate
+        // polling phone never produces this — only an actual bad POST /pair does.
         record_failure(&state.rate_limit, ip);
         return bad_request("deviceName must not be empty");
     }
@@ -752,27 +875,34 @@ pub async fn pair_submit(
     // one critical section closes a double-mint race: two concurrent submissions
     // with the correct proof would otherwise both see a live session and both mint
     // a token from one PIN entry. A racing second submission now finds the session
-    // already taken and hits `pairing_inactive`. (Rate-limit record/clear stays
-    // exactly as before on every path.)
+    // already taken and hits `pairing_inactive`. (The wrong-proof path still records
+    // a failure and clears on success; the no-session / expired / no-challenge paths
+    // deliberately do NOT — see the rate-limit policy on this fn.)
     {
         let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
         let Some(session) = guard.as_mut() else {
-            record_failure(&state.rate_limit, ip);
+            // NO penalty: a missing session (or one a racing submission already
+            // consumed) carries no secret to guess. Penalizing it let a waiting
+            // phone lock itself out (live-confirmed on the challenge path).
             return pairing_inactive();
         };
         if session.is_expired() {
+            // NO penalty: an expired session is nothing to attack — clear + report.
             *guard = None;
-            record_failure(&state.rate_limit, ip);
             return pairing_inactive();
         }
         let (Some(challenge), Some(salt)) = (session.challenge.clone(), session.salt.clone())
         else {
-            // Phone must fetch a challenge first.
-            record_failure(&state.rate_limit, ip);
+            // NO penalty: a well-formed body sent before fetching a challenge is a
+            // protocol-order mistake, not a PIN guess and not a malformed body — the
+            // proof can't even be evaluated, so there's nothing to guess here.
             return bad_request("fetch a challenge first");
         };
         let expected = compute_proof(&session.pin, &salt, &challenge);
         if !constant_time_eq(&expected, body.proof.trim()) {
+            // KEEP: THIS is the actual PIN guess. The lockout budget IS the
+            // PIN-guess budget — a wrong proof is exactly the event that budget
+            // exists to cap (5 wrong guesses in 60s → locked out).
             record_failure(&state.rate_limit, ip);
             return unauthorized();
         }
@@ -791,7 +921,7 @@ pub async fn pair_submit(
         return app_error_response(&e);
     }
     clear_failures(&state.rate_limit, ip);
-    (
+    let mut resp = (
         StatusCode::OK,
         Json(json!({
             "deviceId": device.id,
@@ -800,7 +930,18 @@ pub async fn pair_submit(
             "scope": device.scope,
         })),
     )
-        .into_response()
+        .into_response();
+    // Also set the auth cookie so a phone BROWSER (which can't attach an
+    // `Authorization` header to a WS upgrade or a navigation) authenticates on
+    // subsequent requests. The JSON body is unchanged, so curl/API clients that
+    // read `token` keep working exactly as before. Value = the raw bearer.
+    if let Ok(cookie) = HeaderValue::from_str(&format!(
+        "{AUTH_COOKIE}={bearer}; {AUTH_COOKIE_ATTRS}"
+    )) {
+        resp.headers_mut()
+            .insert(axum::http::header::SET_COOKIE, cookie);
+    }
+    resp
 }
 
 fn pairing_inactive() -> Response {
@@ -985,5 +1126,57 @@ mod tests {
         assert!(!last_seen_is_stale(&now_iso()));
         assert!(last_seen_is_stale("2020-01-01T00:00:00.000Z"));
         assert!(last_seen_is_stale("not-a-timestamp"));
+    }
+
+    #[test]
+    fn cookie_value_parses_the_named_cookie() {
+        use axum::http::HeaderMap;
+        let mut headers = HeaderMap::new();
+        headers.insert("cookie", "gd_lan=abc123; other=zzz".parse().unwrap());
+        assert_eq!(cookie_value(&headers, "gd_lan").as_deref(), Some("abc123"));
+        assert_eq!(cookie_value(&headers, "other").as_deref(), Some("zzz"));
+        assert_eq!(cookie_value(&headers, "missing"), None);
+        // A cookie whose NAME is a suffix of another must not false-match: `lan`
+        // must not match `gd_lan` (the split+prefix guards this).
+        assert_eq!(cookie_value(&headers, "lan"), None);
+        // No Cookie header at all → None.
+        assert_eq!(cookie_value(&HeaderMap::new(), "gd_lan"), None);
+    }
+
+    #[test]
+    fn device_cache_invalidated_on_store_writes_and_path_swap() {
+        // The in-memory device cache must never outlive a store change:
+        //   • authenticate populates it,
+        //   • persist (a second device) refreshes it → both authenticate,
+        //   • revoke invalidates it → the revoked token stops authenticating.
+        // The whole suite runs under the test-path-swap regime, which itself
+        // invalidates the cache — this test proves the write-path invalidations.
+        let _lock = store_test_lock();
+        let tmp = std::env::temp_dir().join(format!(
+            "gd-lan-cache-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let prev = set_store_path_for_test(Some(tmp.clone()));
+
+        let (d1, bearer1, hash1) = mint_device("Device One");
+        persist_device(&d1, &hash1).unwrap();
+        // Populate the cache.
+        assert_eq!(authenticate_bearer(&bearer1).as_deref(), Some(d1.id.as_str()));
+
+        // Persist a second device → cache invalidated on write → both authenticate.
+        let (d2, bearer2, hash2) = mint_device("Device Two");
+        persist_device(&d2, &hash2).unwrap();
+        assert_eq!(authenticate_bearer(&bearer1).as_deref(), Some(d1.id.as_str()));
+        assert_eq!(authenticate_bearer(&bearer2).as_deref(), Some(d2.id.as_str()));
+
+        // Revoke device one → cache invalidated → its token stops authenticating,
+        // device two still does.
+        revoke_device(&d1.id).unwrap();
+        assert!(authenticate_bearer(&bearer1).is_none());
+        assert_eq!(authenticate_bearer(&bearer2).as_deref(), Some(d2.id.as_str()));
+
+        set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
     }
 }

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -814,6 +814,105 @@ mod tests {
 
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
+    async fn no_credential_probes_never_lock_out_and_leave_pairing_working() {
+        // The companion shell's status probe hits a protected route with NO
+        // credential while the phone sits on #pair (no cookie yet). A request with no
+        // credential at all carries zero guessing info, so it must NOT bank a failure
+        // — otherwise these probes reintroduce the self-lockout. Fire well past the
+        // threshold: every probe 401s, never 429, and a correct pairing flow AFTER
+        // them still succeeds (the budget was never spent).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let session = auth::new_pairing_session("http://testhost/#pair".to_string());
+        let pin = session.pin.clone();
+        let state = test_router(Some("C:/repo".to_string()));
+        *state.pairing.lock().unwrap() = Some(session);
+        let router = server::build_router(state);
+
+        // Many no-credential probes → always 401, never 429.
+        for _ in 0..(auth::RATE_LIMIT_MAX_FAILURES_FOR_TEST + 5) {
+            let resp = router
+                .clone()
+                .oneshot(get("/api/repo/status"))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "a no-credential probe must 401, never lock out"
+            );
+        }
+
+        // A correct pairing flow after the probes still works (budget untouched).
+        let chal = router
+            .clone()
+            .oneshot(post("/api/pair/challenge", None))
+            .await
+            .unwrap();
+        assert_eq!(chal.status(), StatusCode::OK);
+        let chal_bytes = axum::body::to_bytes(chal.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let chal: serde_json::Value = serde_json::from_slice(&chal_bytes).unwrap();
+        let challenge = chal["challenge"].as_str().unwrap().to_string();
+        let salt = chal["salt"].as_str().unwrap().to_string();
+        let proof = auth::compute_proof(&pin, &salt, &challenge);
+        let pair = serde_json::json!({ "deviceName": "Late Pair", "proof": proof }).to_string();
+        let pair_resp = router
+            .oneshot(post("/api/pair", Some(&pair)))
+            .await
+            .unwrap();
+        assert_eq!(
+            pair_resp.status(),
+            StatusCode::OK,
+            "pairing must still succeed after no-credential probes"
+        );
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn invalid_bearer_probes_still_lock_out_after_the_threshold() {
+        // A PRESENT-but-invalid bearer IS a guessing event (token brute force), so it
+        // must still count toward the lockout budget: N invalid-bearer requests trip
+        // the 429 at the threshold. The brute-force defense stays intact.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        // An empty store (no devices) — every bearer here is invalid.
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+
+        // Invalid bearers up to the threshold → each 401.
+        for _ in 0..auth::RATE_LIMIT_MAX_FAILURES_FOR_TEST {
+            let resp = router
+                .clone()
+                .oneshot(authed_get("/api/repo/status", "deadbeefdeadbeef"))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "an invalid bearer is a 401");
+        }
+        // Threshold reached → the next attempt is rate-limited.
+        let locked = router
+            .oneshot(authed_get("/api/repo/status", "deadbeefdeadbeef"))
+            .await
+            .unwrap();
+        assert_eq!(
+            locked.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "invalid-bearer brute force must still lock out at the threshold"
+        );
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn pair_submit_sets_the_auth_cookie() {
         // A successful pair returns the auth cookie with the exact frozen attributes
         // (in ADDITION to the unchanged JSON body), so a phone browser is

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -18,6 +18,7 @@
 pub mod auth;
 pub mod routes;
 pub mod server;
+pub mod static_serve;
 
 use std::sync::{Arc, Mutex};
 
@@ -658,6 +659,95 @@ mod tests {
         std::fs::remove_file(&tmp).ok();
     }
 
+    /// Build a POST request to `path` with an optional JSON body (host = testhost).
+    fn post(path: &str, json_body: Option<&str>) -> Request<Body> {
+        let mut b = Request::builder()
+            .uri(path)
+            .method("POST")
+            .header("host", "testhost");
+        let body = match json_body {
+            Some(j) => {
+                b = b.header("content-type", "application/json");
+                Body::from(j.to_string())
+            }
+            None => Body::empty(),
+        };
+        b.body(body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn challenge_polling_without_a_session_never_locks_out() {
+        // The live self-lockout bug: a phone sitting on the pairing page polls
+        // `/challenge` while NO session is active (e.g. between a revoke and the next
+        // offer). Each poll gets `pairingInactive` — but must NOT count toward the
+        // lockout budget, or the phone locks ITSELF out before the user types a PIN.
+        // Poll well past the threshold; every response stays 403 pairingInactive,
+        // never 429.
+        let router = server::build_router(test_router(None));
+        for _ in 0..(auth::RATE_LIMIT_MAX_FAILURES_FOR_TEST + 3) {
+            let resp = router
+                .clone()
+                .oneshot(post("/api/pair/challenge", None))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "polling with no session must stay pairingInactive, never lock out"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn wrong_proofs_still_lock_out_after_the_threshold() {
+        // The lockout budget IS the PIN-guess budget: repeated WRONG proofs must
+        // still trip the lockout at the threshold (the calibration fix removed the
+        // no-session/expired penalties but must NOT weaken the real guess defense).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        // An active session with a fetched challenge, so a submitted proof is
+        // actually evaluated (and a wrong one records a failure).
+        let session = auth::new_pairing_session("http://testhost/#pair".to_string());
+        let state = test_router(Some("C:/repo".to_string()));
+        *state.pairing.lock().unwrap() = Some(session);
+        let router = server::build_router(state);
+
+        // Fetch a challenge so proofs reach the compare (not the no-challenge branch).
+        let chal = router
+            .clone()
+            .oneshot(post("/api/pair/challenge", None))
+            .await
+            .unwrap();
+        assert_eq!(chal.status(), StatusCode::OK);
+
+        // Submit wrong proofs up to (but not hitting) the threshold → each 401s.
+        let wrong = serde_json::json!({ "deviceName": "Guesser", "proof": "00" }).to_string();
+        for _ in 0..auth::RATE_LIMIT_MAX_FAILURES_FOR_TEST {
+            let resp = router
+                .clone()
+                .oneshot(post("/api/pair", Some(&wrong)))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "a wrong proof is a 401");
+        }
+        // The threshold is now reached → the next attempt is rate-limited (429).
+        let locked = router
+            .oneshot(post("/api/pair", Some(&wrong)))
+            .await
+            .unwrap();
+        assert_eq!(
+            locked.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "wrong proofs must still lock out at the threshold"
+        );
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
     /// Build an authed GET request by seeding a device in the store and using its
     /// raw bearer. Caller must hold `store_test_lock` + a store-path override.
     fn authed_get(path: &str, bearer: &str) -> Request<Body> {
@@ -667,6 +757,199 @@ mod tests {
             .header("authorization", format!("Bearer {bearer}"))
             .body(Body::empty())
             .unwrap()
+    }
+
+    /// Build a GET request authed via the `gd_lan` cookie (the phone-browser path).
+    fn cookie_get(path: &str, cookie_value: &str) -> Request<Body> {
+        Request::builder()
+            .uri(path)
+            .header("host", "testhost")
+            .header("cookie", format!("gd_lan={cookie_value}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn cookie_auth_reaches_protected_routes() {
+        // A phone browser can't set an Authorization header on a WS upgrade or
+        // navigation, so it authenticates via the `gd_lan` cookie. A valid cookie
+        // reaches a protected route (not 401), a bad cookie 401s, and an explicit
+        // Authorization header still works.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let (device, bearer, token_hash) = auth::mint_device("Cookie Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+
+        // (1) A valid cookie reaches the protected route (past auth — may fail at the
+        //     git layer since C:/repo isn't real, but NOT 401).
+        let ok = router
+            .clone()
+            .oneshot(cookie_get("/api/repo/status", &bearer))
+            .await
+            .unwrap();
+        assert_ne!(ok.status(), StatusCode::UNAUTHORIZED);
+
+        // (2) A bad cookie 401s.
+        let bad = router
+            .clone()
+            .oneshot(cookie_get("/api/repo/status", "not-a-real-token"))
+            .await
+            .unwrap();
+        assert_eq!(bad.status(), StatusCode::UNAUTHORIZED);
+
+        // (3) The Authorization header path still works (checked FIRST).
+        let hdr = router
+            .oneshot(authed_get("/api/repo/status", &bearer))
+            .await
+            .unwrap();
+        assert_ne!(hdr.status(), StatusCode::UNAUTHORIZED);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn pair_submit_sets_the_auth_cookie() {
+        // A successful pair returns the auth cookie with the exact frozen attributes
+        // (in ADDITION to the unchanged JSON body), so a phone browser is
+        // authenticated for subsequent navigations/upgrades.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let session = auth::new_pairing_session("http://testhost/#pair".to_string());
+        let pin = session.pin.clone();
+        let state = test_router(Some("C:/repo".to_string()));
+        *state.pairing.lock().unwrap() = Some(session);
+        let router = server::build_router(state);
+
+        // Challenge → proof → pair.
+        let chal_req = Request::builder()
+            .uri("/api/pair/challenge")
+            .method("POST")
+            .header("host", "testhost")
+            .body(Body::empty())
+            .unwrap();
+        let chal_resp = router.clone().oneshot(chal_req).await.unwrap();
+        let chal_bytes = axum::body::to_bytes(chal_resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let chal: serde_json::Value = serde_json::from_slice(&chal_bytes).unwrap();
+        let challenge = chal["challenge"].as_str().unwrap().to_string();
+        let salt = chal["salt"].as_str().unwrap().to_string();
+        let proof = auth::compute_proof(&pin, &salt, &challenge);
+        let pair_body = serde_json::json!({ "deviceName": "Cookie Pair Phone", "proof": proof });
+        let pair_req = Request::builder()
+            .uri("/api/pair")
+            .method("POST")
+            .header("host", "testhost")
+            .header("content-type", "application/json")
+            .body(Body::from(pair_body.to_string()))
+            .unwrap();
+        let pair_resp = router.oneshot(pair_req).await.unwrap();
+        assert_eq!(pair_resp.status(), StatusCode::OK);
+
+        // The Set-Cookie carries the exact frozen name + attributes.
+        let set_cookie = pair_resp
+            .headers()
+            .get("set-cookie")
+            .expect("pair success must set the auth cookie")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(set_cookie.starts_with("gd_lan="), "cookie name: {set_cookie}");
+        assert!(set_cookie.contains("HttpOnly"), "HttpOnly: {set_cookie}");
+        assert!(set_cookie.contains("SameSite=Strict"), "SameSite=Strict: {set_cookie}");
+        assert!(set_cookie.contains("Path=/"), "Path=/: {set_cookie}");
+        assert!(set_cookie.contains("Max-Age=31536000"), "Max-Age: {set_cookie}");
+        // No Secure — plain HTTP on the LAN by design.
+        assert!(!set_cookie.contains("Secure"), "must NOT be Secure: {set_cookie}");
+
+        // The JSON body is unchanged — the token is still returned for API clients.
+        let bytes = axum::body::to_bytes(pair_resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let minted: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let token = minted["token"].as_str().unwrap();
+        // The cookie value equals the raw bearer.
+        assert_eq!(set_cookie, format!("gd_lan={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=31536000"));
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    async fn static_index_serves_bundle_or_reports_not_built_with_page_csp() {
+        // Through the full router (host guard + insert-if-absent hardening), `/`
+        // carries the fuller PAGE CSP — NOT the bare API CSP — in BOTH embed states.
+        // DEBUG rust-embed reads `companion-dist/` from disk, so this must be green
+        // whether or not `pnpm build:companion` has run: bundle present → 200 + the
+        // real index.html; absent (CI) → 503 + the marker.
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let resp = router.oneshot(get("/")).await.unwrap();
+        assert_eq!(
+            resp.headers().get("Content-Security-Policy").unwrap(),
+            static_serve::PAGE_CSP
+        );
+        if static_serve::bundle_present() {
+            assert_eq!(resp.status(), StatusCode::OK);
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .unwrap()
+                .to_str()
+                .unwrap();
+            assert!(ct.starts_with("text/html"), "index Content-Type: {ct}");
+            // The entry document must revalidate every load (no-cache).
+            assert_eq!(
+                resp.headers().get("cache-control").unwrap(),
+                "no-cache"
+            );
+        } else {
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            assert!(String::from_utf8_lossy(&bytes).contains("companion bundle not built"));
+        }
+    }
+
+    #[tokio::test]
+    async fn api_response_keeps_the_bare_csp() {
+        // An API response (here the 404 for an unknown route) keeps EXACTLY the
+        // current bare API CSP — the insert-if-absent change must not leak the page
+        // CSP onto API responses.
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let resp = router.oneshot(get("/api/nope")).await.unwrap();
+        assert_eq!(
+            resp.headers().get("Content-Security-Policy").unwrap(),
+            auth::API_CSP
+        );
+    }
+
+    #[tokio::test]
+    async fn static_unknown_asset_is_404() {
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let resp = router.oneshot(get("/assets/nope.js")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn static_index_is_host_guarded() {
+        // The `/` route is wrapped by the outer host guard like every other route.
+        let router = server::build_router(test_router(Some("C:/repo".to_string())));
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "evil.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -148,18 +148,36 @@ fn resolve_ips(bind_lan: bool) -> (IpAddr, Vec<Ipv4Addr>) {
 /// Interface-name substrings that mark a virtual / tunnel / VPN adapter whose IPv4
 /// we'd rather NOT lead the advertised-url list with (a phone can't reach a WSL,
 /// Docker, or Hyper-V virtual switch address). Case-insensitive substring match.
+/// `tap` is NOT here — it's too short to substring-match safely (it would flag
+/// "laptop"); it's handled token-aware by [`name_has_tap_token`].
 const VIRTUAL_IFACE_MARKERS: &[&str] = &[
     "vethernet",
     "wsl",
     "docker",
     "tailscale",
     "zerotier",
-    "tap",
     "npcap",
     "hyper-v",
     "virtual",
     "loopback",
 ];
+
+/// Whether `lower` (an already-lowercased interface name) contains a "tap" adapter
+/// TOKEN — the VPN/TAP virtual-adapter marker — without over-matching words that
+/// merely embed the letters (e.g. "laptop"). Split on non-alphanumeric boundaries
+/// and match a token that is exactly "tap" or "tap" followed by digits (e.g.
+/// "tap0"). So "TAP-Windows Adapter V9" and "OpenVPN TAP" match; "Laptop Dock
+/// Ethernet" does not.
+fn name_has_tap_token(lower: &str) -> bool {
+    lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|tok| {
+            let Some(rest) = tok.strip_prefix("tap") else {
+                return false;
+            };
+            rest.is_empty() || rest.chars().all(|c| c.is_ascii_digit())
+        })
+}
 
 /// Rank enumerated `(interface_name, IPv4)` pairs so the most likely
 /// phone-reachable address leads — the QR/URL list uses `first()`, and a VPN 10.x
@@ -167,10 +185,11 @@ const VIRTUAL_IFACE_MARKERS: &[&str] = &[
 ///
 /// Score (lower = better): a private-class base by prefix — 192.168.0.0/16 → 0,
 /// 10.0.0.0/8 → 1, 172.16.0.0/12 → 2, anything else → 3, link-local 169.254.0.0/16
-/// → 9 (last) — plus a +10 penalty when the interface NAME contains any
-/// [`VIRTUAL_IFACE_MARKERS`] substring (case-insensitive), which demotes a virtual
-/// adapter below every physical one in its own class. A STABLE sort preserves
-/// enumeration order within a score, and we dedup keeping the first occurrence.
+/// → 9 (last) — plus a +10 penalty when the interface NAME looks virtual: it
+/// contains any [`VIRTUAL_IFACE_MARKERS`] substring (case-insensitive) or a "tap"
+/// adapter token (see [`name_has_tap_token`]). That demotes a virtual adapter below
+/// every physical one in its own class. A STABLE sort preserves enumeration order
+/// within a score, and we dedup keeping the first occurrence.
 fn rank_ips(ifaces: Vec<(String, Ipv4Addr)>) -> Vec<Ipv4Addr> {
     fn class_score(ip: &Ipv4Addr) -> u32 {
         let o = ip.octets();
@@ -188,7 +207,11 @@ fn rank_ips(ifaces: Vec<(String, Ipv4Addr)>) -> Vec<Ipv4Addr> {
     }
     fn name_penalty(name: &str) -> u32 {
         let lower = name.to_ascii_lowercase();
-        if VIRTUAL_IFACE_MARKERS.iter().any(|m| lower.contains(m)) {
+        // Plain substrings for the long markers; token-aware for the short "tap" so
+        // it doesn't flag "laptop".
+        let is_virtual =
+            VIRTUAL_IFACE_MARKERS.iter().any(|m| lower.contains(m)) || name_has_tap_token(&lower);
+        if is_virtual {
             10
         } else {
             0
@@ -408,5 +431,28 @@ mod tests {
     #[test]
     fn rank_ips_empty_input() {
         assert!(rank_ips(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn tap_token_matches_adapters_not_laptop() {
+        // The three named cases: TAP virtual adapters match; "laptop" (which merely
+        // embeds the letters) does NOT.
+        assert!(name_has_tap_token("tap-windows adapter v9"));
+        assert!(name_has_tap_token("openvpn tap"));
+        assert!(!name_has_tap_token("laptop dock ethernet"));
+        // A numbered tap adapter (tap0) still matches; a bare physical name doesn't.
+        assert!(name_has_tap_token("tap0"));
+        assert!(!name_has_tap_token("wi-fi"));
+    }
+
+    #[test]
+    fn rank_ips_does_not_demote_a_laptop_named_adapter() {
+        // A physical adapter whose name contains "laptop" must NOT be demoted by the
+        // tap marker — it should lead a genuinely virtual TAP adapter in the same class.
+        let ranked = rank_ips(vec![
+            ("TAP-Windows Adapter V9".to_string(), Ipv4Addr::new(192, 168, 1, 8)),
+            ("Laptop Dock Ethernet".to_string(), Ipv4Addr::new(192, 168, 1, 4)),
+        ]);
+        assert_eq!(ranked.first(), Some(&Ipv4Addr::new(192, 168, 1, 4)));
     }
 }

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -22,6 +22,7 @@ use tokio::sync::Notify;
 use crate::error::{AppError, AppResult};
 use crate::lan::auth::{self, RouterState};
 use crate::lan::routes::{forge, git, reviews};
+use crate::lan::static_serve;
 
 /// The default port the server tries first — a fixed value in the IANA dynamic /
 /// private range (49152–65535 is the strict private range, but the 38400s are
@@ -90,11 +91,21 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/pair/challenge", post(auth::pair_challenge))
         .route("/api/pair", post(auth::pair_submit));
 
+    // The static companion frontend — served UNauthenticated (the pairing page must
+    // load before a device is paired) but still inside the outer host guard. `/` is
+    // the SPA entry (embedded index.html; 503 with a "not built" marker in CI) and
+    // `/assets/{*path}` serves its hashed assets. The app is hash-routed, so there's
+    // no history-API fallback: an unknown asset 404s.
+    let static_assets = Router::new()
+        .route("/", get(static_serve::index))
+        .route("/assets/{*path}", get(static_serve::asset));
+
     // Merge, then wrap EVERYTHING in the host guard (which also stamps the
     // hardening headers on every response, including 404s for unknown paths).
     Router::new()
         .merge(api)
         .merge(pairing)
+        .merge(static_assets)
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::host_guard,
@@ -114,25 +125,88 @@ fn resolve_ips(bind_lan: bool) -> (IpAddr, Vec<Ipv4Addr>) {
             vec![Ipv4Addr::LOCALHOST],
         );
     }
-    let mut ips: Vec<Ipv4Addr> = local_ip_address::list_afinet_netifas()
+    let ifaces: Vec<(String, Ipv4Addr)> = local_ip_address::list_afinet_netifas()
         .map(|ifaces| {
             ifaces
                 .into_iter()
-                .filter_map(|(_name, ip)| match ip {
-                    IpAddr::V4(v4) if !v4.is_loopback() && !v4.is_unspecified() => Some(v4),
+                .filter_map(|(name, ip)| match ip {
+                    IpAddr::V4(v4) if !v4.is_loopback() && !v4.is_unspecified() => Some((name, v4)),
                     _ => None,
                 })
                 .collect()
         })
         .unwrap_or_default();
-    ips.sort();
-    ips.dedup();
+    let mut ips = rank_ips(ifaces);
     if ips.is_empty() {
         // No LAN interface found — still bind 0.0.0.0 but advertise loopback so
         // the UI has at least one working url.
         ips.push(Ipv4Addr::LOCALHOST);
     }
     (IpAddr::V4(Ipv4Addr::UNSPECIFIED), ips)
+}
+
+/// Interface-name substrings that mark a virtual / tunnel / VPN adapter whose IPv4
+/// we'd rather NOT lead the advertised-url list with (a phone can't reach a WSL,
+/// Docker, or Hyper-V virtual switch address). Case-insensitive substring match.
+const VIRTUAL_IFACE_MARKERS: &[&str] = &[
+    "vethernet",
+    "wsl",
+    "docker",
+    "tailscale",
+    "zerotier",
+    "tap",
+    "npcap",
+    "hyper-v",
+    "virtual",
+    "loopback",
+];
+
+/// Rank enumerated `(interface_name, IPv4)` pairs so the most likely
+/// phone-reachable address leads — the QR/URL list uses `first()`, and a VPN 10.x
+/// or Docker 172.17.x must not beat the real 192.168.x Wi-Fi address.
+///
+/// Score (lower = better): a private-class base by prefix — 192.168.0.0/16 → 0,
+/// 10.0.0.0/8 → 1, 172.16.0.0/12 → 2, anything else → 3, link-local 169.254.0.0/16
+/// → 9 (last) — plus a +10 penalty when the interface NAME contains any
+/// [`VIRTUAL_IFACE_MARKERS`] substring (case-insensitive), which demotes a virtual
+/// adapter below every physical one in its own class. A STABLE sort preserves
+/// enumeration order within a score, and we dedup keeping the first occurrence.
+fn rank_ips(ifaces: Vec<(String, Ipv4Addr)>) -> Vec<Ipv4Addr> {
+    fn class_score(ip: &Ipv4Addr) -> u32 {
+        let o = ip.octets();
+        if o[0] == 169 && o[1] == 254 {
+            9 // link-local (169.254.0.0/16) — always last
+        } else if o[0] == 192 && o[1] == 168 {
+            0 // 192.168.0.0/16
+        } else if o[0] == 10 {
+            1 // 10.0.0.0/8
+        } else if o[0] == 172 && (16..=31).contains(&o[1]) {
+            2 // 172.16.0.0/12
+        } else {
+            3 // anything else
+        }
+    }
+    fn name_penalty(name: &str) -> u32 {
+        let lower = name.to_ascii_lowercase();
+        if VIRTUAL_IFACE_MARKERS.iter().any(|m| lower.contains(m)) {
+            10
+        } else {
+            0
+        }
+    }
+    let mut scored: Vec<(u32, Ipv4Addr)> = ifaces
+        .into_iter()
+        .map(|(name, ip)| (class_score(&ip) + name_penalty(&name), ip))
+        .collect();
+    // Stable sort by score keeps enumeration order within a score.
+    scored.sort_by_key(|(score, _)| *score);
+    let mut out: Vec<Ipv4Addr> = Vec::with_capacity(scored.len());
+    for (_, ip) in scored {
+        if !out.contains(&ip) {
+            out.push(ip); // dedup, keeping the first (best-ranked) occurrence
+        }
+    }
+    out
 }
 
 /// The `http://<ip>:<port>` urls for the advertised addresses.
@@ -280,5 +354,59 @@ mod tests {
         let (bind_ip, ips) = resolve_ips(true);
         assert_eq!(bind_ip, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         assert!(!ips.is_empty());
+    }
+
+    #[test]
+    fn rank_ips_leads_with_the_reachable_lan_address() {
+        // The user's real case: a VPN 10.x enumerates before the physical 192.168.x,
+        // but the phone-reachable 192.168.x must lead (the QR uses `first()`).
+        let ranked = rank_ips(vec![
+            ("VPN".to_string(), Ipv4Addr::new(10, 8, 0, 3)),
+            ("Wi-Fi".to_string(), Ipv4Addr::new(192, 168, 1, 20)),
+        ]);
+        assert_eq!(ranked.first(), Some(&Ipv4Addr::new(192, 168, 1, 20)));
+        assert_eq!(ranked, vec![Ipv4Addr::new(192, 168, 1, 20), Ipv4Addr::new(10, 8, 0, 3)]);
+    }
+
+    #[test]
+    fn rank_ips_demotes_docker_by_name_and_by_class() {
+        // A Docker 172.17.x is demoted BOTH by its interface name (+10) and its
+        // class (172.16/12 → 2), landing below a real 192.168.x. Even a Docker
+        // address that happened to be a 192.168.x is demoted below the physical one
+        // by the name penalty alone.
+        let ranked = rank_ips(vec![
+            ("vEthernet (Default Switch)".to_string(), Ipv4Addr::new(172, 17, 0, 1)),
+            ("docker0".to_string(), Ipv4Addr::new(192, 168, 99, 1)),
+            ("Ethernet".to_string(), Ipv4Addr::new(192, 168, 1, 10)),
+        ]);
+        assert_eq!(ranked.first(), Some(&Ipv4Addr::new(192, 168, 1, 10)));
+        // The two virtual adapters both rank after the physical one.
+        assert_eq!(ranked[0], Ipv4Addr::new(192, 168, 1, 10));
+        assert!(ranked.contains(&Ipv4Addr::new(172, 17, 0, 1)));
+        assert!(ranked.contains(&Ipv4Addr::new(192, 168, 99, 1)));
+    }
+
+    #[test]
+    fn rank_ips_puts_link_local_last() {
+        let ranked = rank_ips(vec![
+            ("APIPA".to_string(), Ipv4Addr::new(169, 254, 1, 1)),
+            ("Ethernet".to_string(), Ipv4Addr::new(10, 0, 0, 5)),
+        ]);
+        assert_eq!(ranked, vec![Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(169, 254, 1, 1)]);
+    }
+
+    #[test]
+    fn rank_ips_dedups_keeping_first() {
+        // The same address on two interfaces appears once, at its best rank.
+        let ranked = rank_ips(vec![
+            ("Wi-Fi".to_string(), Ipv4Addr::new(192, 168, 1, 5)),
+            ("Ethernet".to_string(), Ipv4Addr::new(192, 168, 1, 5)),
+        ]);
+        assert_eq!(ranked, vec![Ipv4Addr::new(192, 168, 1, 5)]);
+    }
+
+    #[test]
+    fn rank_ips_empty_input() {
+        assert!(rank_ips(Vec::new()).is_empty());
     }
 }

--- a/src-tauri/src/lan/static_serve.rs
+++ b/src-tauri/src/lan/static_serve.rs
@@ -1,0 +1,217 @@
+//! Static serving of the embedded companion frontend bundle for the LAN server.
+//!
+//! The phone UI is a hash-routed SPA built by the sibling `pnpm build:companion`
+//! into `src-tauri/companion-dist/`, which [`rust_embed`] bakes into the binary.
+//! Two routes serve it — `GET /` → `index.html`, `GET /assets/{*path}` → an asset
+//! — and BOTH sit OUTSIDE the bearer-auth subtree (the pairing page must load
+//! unauthenticated) but INSIDE the outer [`crate::lan::auth::host_guard`], so the
+//! DNS-rebind defense and the hardening headers still apply.
+//!
+//! Because the app is hash-routed (`/#pair`, `/#…`), there is NO history-API
+//! fallback: unknown asset paths 404 rather than re-serving `index.html`.
+//!
+//! ## Dev loop
+//!
+//! In DEBUG builds `rust-embed` reads `companion-dist/` from disk at request time,
+//! so a fresh `pnpm build:companion` is picked up WITHOUT recompiling the Rust
+//! side. RELEASE builds bake the files into the binary at compile time.
+//!
+//! ## CI / not-yet-built state
+//!
+//! CI never runs the frontend build, so the embed folder holds only `.gitkeep` and
+//! there is no `index.html`. In that case `/` returns a 503 whose body carries the
+//! literal marker `companion bundle not built` plus a hint — tests key on that
+//! marker, and a developer who forgot the build sees an actionable message.
+//!
+//! ## Page CSP
+//!
+//! HTML/asset responses carry a fuller [`PAGE_CSP`] (self-only scripts/styles, a
+//! `ws:` connect-src for the slice-3 monitor, framing locked down). The outer
+//! [`crate::lan::auth::harden_headers`] is insert-if-absent for the CSP, so this
+//! page CSP survives while API responses keep their bare one.
+
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use rust_embed::RustEmbed;
+
+/// The embedded companion bundle. `#[folder]` is resolved relative to
+/// `CARGO_MANIFEST_DIR` (`src-tauri/`), so `companion-dist/` is the build output the
+/// sibling frontend package's vite build writes. Debug builds read it from disk at
+/// runtime (the dev loop); release builds bake it in.
+#[derive(RustEmbed)]
+#[folder = "companion-dist/"]
+struct Companion;
+
+/// The page Content-Security-Policy stamped on served HTML/asset responses. Locks
+/// scripts/styles to self, allows `data:` images and a `ws:` connect-src (the
+/// slice-3 live monitor uses a WebSocket), and denies framing / external base &
+/// form targets. Included now so the slice-3 socket works without a later CSP edit.
+pub const PAGE_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
+
+/// The 503 body shown when the companion bundle hasn't been built (CI, or a dev who
+/// skipped `pnpm build:companion`). Carries the literal `companion bundle not built`
+/// marker tests assert on, plus an actionable hint.
+const NOT_BUILT_HTML: &str = "<!doctype html><html><head><meta charset=\"utf-8\"><title>Companion not built</title></head><body><h1>companion bundle not built</h1><p>Run <code>pnpm build:companion</code> to build the phone-companion frontend, then reload.</p></body></html>";
+
+/// `Cache-Control` for `index.html`: `no-cache` = the browser may store it but MUST
+/// revalidate every load. The entry document is NOT content-hashed, so a
+/// heuristically-cached stale `index.html` would keep referencing hashed asset
+/// filenames the NEXT build deletes → a white page. Revalidating every load avoids that.
+const INDEX_CACHE_CONTROL: &str = "no-cache";
+
+/// `Cache-Control` for `/assets/*`: `public, max-age=31536000, immutable` — safe to
+/// cache for a year and never revalidate, because vite emits content-HASHED asset
+/// filenames (a changed file gets a new name, so the URL itself busts the cache).
+const ASSET_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+
+/// `GET /` → the embedded `index.html`. When the bundle hasn't been built the embed
+/// has no `index.html`, so we return a 503 carrying the `companion bundle not built`
+/// marker instead of a bare 404.
+pub async fn index() -> Response {
+    match Companion::get("index.html") {
+        Some(file) => embedded_response(file, INDEX_CACHE_CONTROL),
+        None => not_built_response(),
+    }
+}
+
+/// `GET /assets/{*path}` → the embedded asset under `assets/<path>`. An unknown
+/// asset path 404s (no SPA fallback — the app is hash-routed).
+pub async fn asset(axum::extract::Path(path): axum::extract::Path<String>) -> Response {
+    let full = format!("assets/{path}");
+    match Companion::get(&full) {
+        Some(file) => embedded_response(file, ASSET_CACHE_CONTROL),
+        None => not_found_response(),
+    }
+}
+
+/// Build a 200 response for an embedded file: its bytes, the mime-guessed
+/// Content-Type, the given `Cache-Control`, and the page CSP (which survives the
+/// insert-if-absent hardening middleware).
+fn embedded_response(file: rust_embed::EmbeddedFile, cache_control: &'static str) -> Response {
+    let mime = file.metadata.mimetype();
+    let mut resp = (StatusCode::OK, file.data.into_owned()).into_response();
+    let headers = resp.headers_mut();
+    if let Ok(ct) = HeaderValue::from_str(mime) {
+        headers.insert(header::CONTENT_TYPE, ct);
+    }
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(cache_control),
+    );
+    stamp_page_csp(headers);
+    resp
+}
+
+/// The 503 "not built" page (with the marker), carrying the page CSP.
+fn not_built_response() -> Response {
+    let mut resp = (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        NOT_BUILT_HTML,
+    )
+        .into_response();
+    stamp_page_csp(resp.headers_mut());
+    resp
+}
+
+/// A plain 404 for an unknown asset path (matches the router's unknown-route 404).
+fn not_found_response() -> Response {
+    StatusCode::NOT_FOUND.into_response()
+}
+
+/// Whether the companion bundle is embedded (has an `index.html`). In DEBUG builds
+/// this reflects the on-disk `companion-dist/` folder at call time, so it's `false`
+/// in CI (empty dir) and `true` after `pnpm build:companion`. Test-only: tests
+/// branch on the actual embed state rather than assuming one — the served response
+/// differs between the two, and both must be asserted correctly. (Gated to
+/// `cfg(test)` so it isn't dead code in the non-test lib build.)
+#[cfg(test)]
+pub(crate) fn bundle_present() -> bool {
+    Companion::get("index.html").is_some()
+}
+
+/// Set the page CSP on a header map. This runs BEFORE the outer hardening
+/// middleware, which is insert-if-absent for the CSP — so this value is what
+/// survives on the response (the middleware won't overwrite it with the bare one).
+fn stamp_page_csp(headers: &mut axum::http::HeaderMap) {
+    headers.insert(
+        "Content-Security-Policy",
+        HeaderValue::from_static(PAGE_CSP),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn index_serves_bundle_or_reports_not_built() {
+        // DEBUG rust-embed reads `companion-dist/` from disk at call time, so this
+        // must be green in BOTH states: CI's empty dir (503 + marker) and a dev
+        // machine after `pnpm build:companion` (200 + the real index.html). Branch
+        // on the actual embed state. The page CSP applies to BOTH responses.
+        let resp = index().await;
+        assert_eq!(
+            resp.headers().get("Content-Security-Policy").unwrap(),
+            PAGE_CSP
+        );
+        if bundle_present() {
+            // Bundle built → the real index.html, served as HTML with `no-cache`
+            // (the entry document must revalidate every load — see INDEX_CACHE_CONTROL).
+            assert_eq!(resp.status(), StatusCode::OK);
+            let ct = resp
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap();
+            assert!(ct.starts_with("text/html"), "index Content-Type: {ct}");
+            assert_eq!(
+                resp.headers().get(header::CACHE_CONTROL).unwrap(),
+                INDEX_CACHE_CONTROL
+            );
+        } else {
+            // Bundle absent (CI) → 503 with the marker.
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            let body = String::from_utf8_lossy(&bytes);
+            assert!(
+                body.contains("companion bundle not built"),
+                "503 body must carry the marker: {body}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn served_asset_carries_immutable_cache_control() {
+        // Asset filenames are content-hashed, so we can't hardcode one — discover a
+        // real embedded asset (present only after `pnpm build:companion`; skip in CI's
+        // empty-dir state). A served asset must carry the year-long immutable
+        // Cache-Control (the hashed name self-busts).
+        let Some(rel) = first_asset_rel_path() else {
+            return; // no bundle built (CI) — nothing to serve; the index test covers absent state
+        };
+        let resp = asset(axum::extract::Path(rel)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            ASSET_CACHE_CONTROL
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_asset_is_404() {
+        let resp = asset(axum::extract::Path("nope.js".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// The `assets/`-relative path of the first embedded asset, or `None` when the
+    /// bundle isn't built (CI). Used to exercise the asset handler with a real,
+    /// content-hashed filename we can't hardcode.
+    fn first_asset_rel_path() -> Option<String> {
+        Companion::iter().find_map(|p| p.strip_prefix("assets/").map(str::to_string))
+    }
+}

--- a/src-tauri/src/lan/static_serve.rs
+++ b/src-tauri/src/lan/static_serve.rs
@@ -44,10 +44,11 @@ use rust_embed::RustEmbed;
 struct Companion;
 
 /// The page Content-Security-Policy stamped on served HTML/asset responses. Locks
-/// scripts/styles to self, allows `data:` images and a `ws:` connect-src (the
-/// slice-3 live monitor uses a WebSocket), and denies framing / external base &
-/// form targets. Included now so the slice-3 socket works without a later CSP edit.
-pub const PAGE_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
+/// scripts/styles to self, allows `data:` images, and denies framing / external
+/// base & form targets. `connect-src 'self'` covers same-origin fetch, SSE, AND
+/// same-origin WebSockets in modern browsers — a bare `ws:` scheme-source would
+/// permit sockets to ANY host, so it is deliberately absent.
+pub const PAGE_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
 /// The 503 body shown when the companion bundle hasn't been built (CI, or a dev who
 /// skipped `pnpm build:companion`). Carries the literal `companion bundle not built`

--- a/src-tauri/src/lan/static_serve.rs
+++ b/src-tauri/src/lan/static_serve.rs
@@ -25,8 +25,9 @@
 //!
 //! ## Page CSP
 //!
-//! HTML/asset responses carry a fuller [`PAGE_CSP`] (self-only scripts/styles, a
-//! `ws:` connect-src for the slice-3 monitor, framing locked down). The outer
+//! HTML/asset responses carry a fuller [`PAGE_CSP`] (self-only scripts/styles;
+//! `connect-src 'self'` covers same-origin fetch/SSE/WebSockets; framing locked
+//! down). The outer
 //! [`crate::lan::auth::harden_headers`] is insert-if-absent for the CSP, so this
 //! page CSP survives while API responses keep their bare one.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1533,9 +1533,9 @@ there's an equivalent.`,
 The **Phone companion** lets you share the repository that's currently open with your
 phone over your **local network**. Open it in **Settings → Phone companion**.
 
-This is an **early preview**. Right now it exposes a **read-only** API for the open
-repo over the LAN — there's no companion phone app yet (it's coming in a later release),
-so pairing today is mainly for trying the connection out. It's **off by default**.
+This is an **early preview**. Once paired, your phone opens a slim companion web app in
+its browser that shows the open repo's **Status**, **pull requests**, and **CI** — all
+**read-only**. It's **off by default**.
 
 ## Turning it on
 
@@ -1553,8 +1553,15 @@ Choose **Pair a device** (available once sharing is on). A dialog shows:
 - the same **URL** as selectable text, in case you'd rather open it manually, and
 - a short **PIN** that you type on the phone to confirm it's really you.
 
+Scanning the code (or opening the URL) loads the companion's **pairing page** in your
+phone's browser. Type the PIN there; once it matches, the phone is paired and drops
+straight into the companion app — a bottom tab bar with **Status**, **PRs**, and **CI**,
+each read-only.
+
 The offer counts down and expires after a short while; if it lapses before the phone
-connects, choose **Start again**. When a device pairs, the dialog confirms it by name.
+connects, choose **Start again** (the desktop shows a fresh QR and PIN), and the phone's
+pairing page will prompt you to enter the new code. When a device pairs, the dialog
+confirms it by name.
 
 ## Managing paired devices
 

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -81,9 +81,9 @@ export function CompanionSection() {
         </h2>
         <p className="text-xs text-muted-foreground">
           Share the open repository with your phone over your local network.
-          This is an early preview: it exposes a{" "}
-          <strong className="font-medium">read-only</strong> API for the open
-          repo, and the companion phone app arrives in an upcoming release.
+          Scanning the pairing code opens the companion app in your phone's
+          browser — <strong className="font-medium">read-only</strong> Status,
+          pull requests, and CI. Early preview.
         </p>
       </div>
 

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -1,5 +1,4 @@
-import { Channel } from "@tauri-apps/api/core";
-import { invoke } from "@/lib/tauri/invoke";
+import { invoke, invokeStreaming } from "@/lib/tauri/invoke";
 import {
   COLD_START,
   coldStartDeleteSecret,
@@ -1113,17 +1112,18 @@ export const forgeReconnect = (args: {
   host: string;
   mode: "login" | "refresh";
   onEvent: (event: ReconnectEvent) => void;
-}): Promise<void> => {
-  const channel = new Channel<ReconnectEvent>();
-  channel.onmessage = args.onEvent;
-  return invoke<void>("forge_reconnect", {
-    sessionId: args.sessionId,
-    provider: args.provider,
-    host: args.host,
-    mode: args.mode,
-    onEvent: channel,
-  });
-};
+}): Promise<void> =>
+  invokeStreaming<void, ReconnectEvent>(
+    "forge_reconnect",
+    {
+      sessionId: args.sessionId,
+      provider: args.provider,
+      host: args.host,
+      mode: args.mode,
+    },
+    "onEvent",
+    args.onEvent,
+  );
 
 /** Cancel an in-flight reconnect flow (kills the CLI subprocess). */
 export const forgeReconnectCancel = (sessionId: string) =>

--- a/src/lib/tauri/invoke.ts
+++ b/src/lib/tauri/invoke.ts
@@ -58,3 +58,26 @@ export async function invoke<T>(
     } satisfies AppError;
   }
 }
+
+/** Typed wrapper around the installed transport's invokeStreaming: a backend
+ *  command that streams `E` events (via `onEvent`) before resolving to `T`. The
+ *  transport owns the channel primitive and injects it into `args` under
+ *  `eventArg`, keeping the Tauri `Channel` off this call site. Errors normalize
+ *  to AppError exactly as {@link invoke} does. */
+export async function invokeStreaming<T, E>(
+  cmd: string,
+  args: Record<string, unknown>,
+  eventArg: string,
+  onEvent: (event: E) => void,
+): Promise<T> {
+  const transport = getTransport();
+  try {
+    return await transport.invokeStreaming<T, E>(cmd, args, eventArg, onEvent);
+  } catch (e) {
+    if (isAppError(e)) throw e;
+    throw {
+      kind: "io",
+      message: typeof e === "string" ? e : errorMessage(e),
+    } satisfies AppError;
+  }
+}

--- a/src/lib/transport/desktop.ts
+++ b/src/lib/transport/desktop.ts
@@ -1,4 +1,4 @@
-import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import { Channel, invoke as tauriInvoke } from "@tauri-apps/api/core";
 import type { Transport } from "@/lib/transport";
 
 /** The desktop transport: forwards straight to Tauri's IPC bridge. Errors pass
@@ -6,5 +6,15 @@ import type { Transport } from "@/lib/transport";
 export const desktopTransport: Transport = {
   invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
     return tauriInvoke<T>(cmd, args);
+  },
+  invokeStreaming<T, E>(
+    cmd: string,
+    args: Record<string, unknown>,
+    eventArg: string,
+    onEvent: (event: E) => void,
+  ): Promise<T> {
+    const channel = new Channel<E>();
+    channel.onmessage = onEvent;
+    return tauriInvoke<T>(cmd, { ...args, [eventArg]: channel });
   },
 };

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -9,6 +9,18 @@ export interface Transport {
   /** Invoke a backend command. Implementations reject with raw errors —
    *  normalization to AppError happens once, in the invoke() wrapper. */
   invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T>;
+  /** Invoke a backend command that streams events back before it resolves. The
+   *  implementation constructs whatever channel primitive it uses, wires
+   *  `onEvent` to each streamed event, injects the channel into `args` under
+   *  `eventArg`, and forwards to the same backend bridge as {@link invoke}. Keeps
+   *  the Tauri `Channel` off the call sites so an HTTP/mock transport can model
+   *  streaming its own way. */
+  invokeStreaming<T, E>(
+    cmd: string,
+    args: Record<string, unknown>,
+    eventArg: string,
+    onEvent: (event: E) => void,
+  ): Promise<T>;
 }
 
 let current: Transport | null = null;


### PR DESCRIPTION
This change introduces an experimental phone companion to GitDesktop, enabling users to access a read-only view of their open repository's status, PRs, and CI from their phone's browser over the local network. The phone companion is a separate React frontend, built and embedded into the app, and served securely via the desktop's LAN server. The motivation is to allow seamless, secure repository sharing to mobile devices with no external dependencies and a safe, privacy-respecting pairing flow.

### Companion frontend (new `companion/` app)
- Adds a new standalone React app in `companion/` with its own `vite.config.ts` and `tsconfig.json`.
- Main entry at `companion/index.html`, imports in `companion/src/main.tsx`.
- Implements all UI components, routes, and screens for pairing (`Pair.tsx`), status (`Status.tsx`), pull requests (`Prs.tsx`), and CI (`Ci.tsx`) in `companion/src/screens/`.
- Introduces core components and chrome in `companion/src/components/`, including navigation, state chips, error states, and skeletons.
- Strict CSP compliance: only built scripts/styles are served, with styling from `index.css` (embeds design tokens from desktop).
- Data fetching uses HTTP (`lib/api.ts`), importing types from the desktop via the `@` alias, with authentication via secure cookies.
- Handles all routing internally in hash (#) format, defined in `companion/src/lib/router.ts`.
- Keyboard and accessibility support for navigation, lists, and actions.

### Build and dev workflow
- Updates `package.json` scripts to include `build:companion` that compiles and exports the phone frontend to `src-tauri/companion-dist/`, with a `.gitkeep` and `.gitignore` management.
- Lints, formatting, and workflow checks now included for the companion code in `.github/workflows/frontend.yml` and `lint` script.

### Rust backend: embedding and serving the companion app
- Adds `rust-embed` to dependencies in `src-tauri/Cargo.toml` to bake `companion-dist/` assets into the binary for release builds (disk read for debug).
- Implements static serving of the companion bundle in `src-tauri/src/lan/static_serve.rs`.
- Updates LAN server implementation in `src-tauri/src/lan/server.rs`, `src-tauri/src/lan/mod.rs`, and related modules to serve the companion app under a strict Content Security Policy for safe browser usage.
- Ensures that hot reload in debug mode reads from the filesystem, supporting fast iteration in development.

### LAN authentication and pairing hardening
- Refactors device authentication and storage management in `src-tauri/src/lan/auth.rs`, introducing an in-memory device cache to minimize disk IO and avoid cross-test contamination.
- Provides reliable per-test setup and teardown of device storage path for deterministic tests.
- Documents and clarifies how device cache is invalidated on store path swap and on every write, preserving test and production correctness.

### Docs, help, and changelog
- Refines the help/documentation for the phone companion in `src/features/help/content.ts` and updates the changelog entry for this experimental feature.