### PR TITLE
feat(git,branches,ui): push or publish any branch to origin without switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ commit that hasn't been pushed yet.
   main checkout, and remove linked worktrees, so you can work on several branches in
   parallel folders without stashing — with one-click jumps to the main workspace right
   from the branch switcher.
+- **Push or publish a branch without switching to it** — from the branch switcher's
+  right-click menu, push a branch that's ahead of its `origin` remote or publish an
+  unpushed one, without checking it out; it works even when the branch is checked out
+  in another worktree.
 
 Plus tag and submodule management.
 

--- a/changelog.d/added-push-branch-without-switching.md
+++ b/changelog.d/added-push-branch-without-switching.md
@@ -1,0 +1,5 @@
+- **Push a branch without switching to it.** Push or publish any local branch to
+  origin straight from its right-click menu in the branch switcher, without checking
+  it out — a branch ahead of its remote offers **Push to _origin/…_**, an untracked
+  branch offers **Publish branch**. It works even when the branch is checked out in
+  another worktree, since a push touches refs, never a working tree.

--- a/changelog.d/added-push-branch-without-switching.md
+++ b/changelog.d/added-push-branch-without-switching.md
@@ -1,5 +1,5 @@
-- **Push a branch without switching to it.** Push or publish any local branch to
-  origin straight from its right-click menu in the branch switcher, without checking
-  it out — a branch ahead of its remote offers **Push to _origin/…_**, an untracked
-  branch offers **Publish branch**. It works even when the branch is checked out in
-  another worktree, since a push touches refs, never a working tree.
+- **Push a branch without switching to it.** From a branch's right-click menu in the
+  branch switcher, push a branch that's ahead of its origin remote (**Push to
+  _origin/…_**) or publish an unpushed one (**Publish branch**) — without checking it
+  out. Works even when the branch is checked out in another worktree, since a push
+  touches refs, never a working tree.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -47,6 +47,7 @@ export const capabilities: Capability[] = [
   // — Branches & history —
   { group: "Branches & history", label: "Branch compare — ahead/behind, three-dot diff, jump to PR", highlight: true },
   { group: "Branches & history", label: "Update a branch from its upstream — no checkout needed" },
+  { group: "Branches & history", label: "Push or publish a branch — no checkout needed" },
   { group: "Branches & history", label: "Check out or delete remote-only branches from the switcher" },
   { group: "Branches & history", label: "Archive branches — hide from the switcher without deleting" },
   { group: "Branches & history", label: "Clean up branches in bulk — archive or delete stale ones in one sweep", highlight: true },

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -13,6 +13,21 @@ pub(crate) fn validate_ref_name(name: &str) -> AppResult<()> {
             "invalid branch name: {name}"
         )));
     }
+    // Reject glob/refspec metacharacters. A ref name is interpolated into
+    // `for-each-ref refs/heads/<name>` (where `* ? [` glob) and, on the push
+    // path, into a push refspec `refs/heads/<name>:refs/heads/<name>` (where `*`
+    // is a wildcard and `:` a separator) — so an unfiltered `*` would glob-match
+    // and mirror-push every branch. These characters are never valid in a real
+    // git ref name. `~ ^ @ { }` are deliberately NOT rejected: this validator is
+    // also used for rev-expression start points (e.g. `main~3`, `HEAD@{2}`).
+    if name
+        .chars()
+        .any(|c| matches!(c, '*' | '?' | '[' | ':' | '\\' | ' ') || c.is_ascii_control())
+    {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid branch name: {name}"
+        )));
+    }
     Ok(())
 }
 
@@ -781,7 +796,32 @@ fn unique_suffix() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_upstream_track;
+    use super::{parse_upstream_track, validate_ref_name};
+
+    #[test]
+    fn validate_ref_name_rejects_glob_and_refspec_metacharacters() {
+        // The round-2 security regression guard: `*` would otherwise glob-match /
+        // mirror-push every branch via `for-each-ref refs/heads/*` and a wildcard
+        // push refspec.
+        for bad in ["*", "feat*", "a?b", "a[b", "a:b", "a\\b", "a b", "x\u{7f}"] {
+            assert!(validate_ref_name(bad).is_err(), "should reject {bad:?}");
+        }
+        // Pre-existing rejects still hold.
+        assert!(validate_ref_name("").is_err());
+        assert!(validate_ref_name("-x").is_err());
+    }
+
+    #[test]
+    fn validate_ref_name_accepts_names_and_rev_start_points() {
+        // Real branch names AND rev-expression start points (this validator guards
+        // git_create_branch's start_point too) must keep passing.
+        for ok in [
+            "feature", "feat/x", "origin/feat", "release-1.0",
+            "main~3", "HEAD", "HEAD@{2}", "abc123def",
+        ] {
+            assert!(validate_ref_name(ok).is_ok(), "should accept {ok:?}");
+        }
+    }
 
     #[test]
     fn parses_ahead_and_behind() {

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -7,7 +7,7 @@ use crate::git::runner::{
 use crate::git::types::{Branch, BranchDivergence, RemoteBranch};
 use crate::state::AppState;
 
-fn validate_ref_name(name: &str) -> AppResult<()> {
+pub(crate) fn validate_ref_name(name: &str) -> AppResult<()> {
     if name.is_empty() || name.starts_with('-') {
         return Err(AppError::InvalidArgument(format!(
             "invalid branch name: {name}"

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -491,18 +491,14 @@ pub(crate) async fn git_push_core(
                 DEFAULT_TIMEOUT,
             )
             .await?;
-            let text = out.stdout_lossy();
-            let line = text.lines().next().unwrap_or("");
-            if line.is_empty() {
+            // No first line → the branch does not exist (an *untracked* branch
+            // still emits a non-empty `\0\0` line — see parse_upstream_tracking).
+            let Some((upstream_short, remotename, gone)) =
+                parse_upstream_tracking(&out.stdout_lossy())
+            else {
                 return Err(AppError::InvalidArgument(format!("no such branch: {b}")));
-            }
-            let mut parts = line.split('\0');
-            let upstream_short = parts.next().unwrap_or("");
-            let remotename = parts.next().unwrap_or("");
-            let track = parts.next().unwrap_or("");
-            // Mirror branches.rs's gone detection: `[gone]` in %(upstream:track).
-            let gone = track.contains("[gone]");
-            build_push_args(b, upstream_short, remotename, gone, set_upstream, force)
+            };
+            build_push_args(b, &upstream_short, &remotename, gone, set_upstream, force)
         }
     };
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
@@ -517,6 +513,23 @@ pub(crate) async fn git_push_core(
     Ok(())
 }
 
+/// Parse one `for-each-ref … --format=%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)`
+/// line into `(upstream_short, remotename, gone)`. Returns `None` when stdout has
+/// no first line — i.e. the branch does not exist (an *untracked* branch still
+/// emits a non-empty `\0\0` line, so it parses to `Some(("","",false))`, NOT None).
+fn parse_upstream_tracking(stdout: &str) -> Option<(String, String, bool)> {
+    let line = stdout.lines().next()?;
+    if line.is_empty() {
+        return None;
+    }
+    let mut parts = line.split('\0');
+    let upstream_short = parts.next().unwrap_or("").to_string();
+    let remotename = parts.next().unwrap_or("").to_string();
+    let track = parts.next().unwrap_or("");
+    // Mirror branches.rs's gone detection: `[gone]` in %(upstream:track).
+    Some((upstream_short, remotename, track.contains("[gone]")))
+}
+
 /// Decide the `git push` args for pushing a NAMED local branch `branch` to
 /// origin, from its resolved tracking state. Pure — no git calls — so the
 /// decision table is unit-testable.
@@ -527,14 +540,20 @@ pub(crate) async fn git_push_core(
 /// - `gone`: the tracked ref was deleted (`[gone]`).
 ///
 /// Rules (origin-centric v1 — we only ever push to origin):
-/// - untracked / gone / `set_upstream` → `-u origin <branch>` (publish + track).
+/// - untracked / gone / `set_upstream` → `-u origin refs/heads/<branch>:refs/heads/<branch>`
+///   (publish + track). A *gone* upstream publishes under the LOCAL branch name
+///   (a fresh `origin/<branch>`), deliberately not resurrecting a differently-named
+///   deleted ref.
 /// - tracked on `origin`: strip `origin/` off `upstream_short` to get the remote
-///   name `up`; `push origin <branch>` when `up == branch`, else the explicit
-///   `push origin <branch>:<up>` refspec (plain `push origin <branch>` would
-///   advance the WRONG remote ref when the names differ).
+///   name `up`; `push origin refs/heads/<branch>:refs/heads/<up>` (a bare
+///   `push origin <branch>` would advance the WRONG remote ref when the names differ).
 /// - tracked on a NON-origin remote (e.g. a fork's `upstream/main`): plain
-///   `push origin <branch>` with NO `-u` — publishes/advances `origin/<branch>`
-///   and leaves the existing tracking config untouched (never retrack).
+///   `push origin refs/heads/<branch>:refs/heads/<branch>` with NO `-u` —
+///   publishes/advances `origin/<branch>` and leaves the existing tracking config
+///   untouched (never retrack).
+///
+/// Refspecs are fully qualified so a branch named `+x`/`-x` can't be read as a
+/// force/delete indicator.
 ///
 /// `force` prepends `--force-with-lease` before the refspec in every arm.
 fn build_push_args(
@@ -552,24 +571,21 @@ fn build_push_args(
     let untracked = upstream_short.is_empty();
     if untracked || gone || set_upstream {
         // Publish + track: first push of a branch (or a resurrected gone one), or
-        // an explicit retrack request.
-        args.extend(["-u", "origin", branch].map(str::to_string));
+        // an explicit retrack request. Publishes under the LOCAL name.
+        args.extend(["-u", "origin"].map(str::to_string));
+        args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
     } else if remotename == "origin" {
         // Tracked on origin. Strip the `origin/` prefix to recover the remote
-        // branch name; when it matches the local name a bare push suffices,
-        // otherwise an explicit refspec targets the right remote ref.
+        // branch name and target it explicitly (may differ from the local name).
         let up = upstream_short
             .strip_prefix("origin/")
             .unwrap_or(upstream_short);
-        if up == branch {
-            args.extend(["origin", branch].map(str::to_string));
-        } else {
-            args.push("origin".to_string());
-            args.push(format!("{branch}:{up}"));
-        }
+        args.push("origin".to_string());
+        args.push(format!("refs/heads/{branch}:refs/heads/{up}"));
     } else {
         // Tracked on a non-origin remote — plain push to origin, no retrack.
-        args.extend(["origin", branch].map(str::to_string));
+        args.push("origin".to_string());
+        args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
     }
     args
 }
@@ -578,7 +594,7 @@ fn build_push_args(
 mod tests {
     use super::{
         build_push_args, cache_get, cache_invalidate, cache_put, git_remote_remove_core,
-        is_auth_class_failure,
+        is_auth_class_failure, parse_upstream_tracking,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -690,7 +706,7 @@ mod tests {
         // Empty upstream → first-time publish + track.
         assert_eq!(
             build_push_args("feature", "", "", false, false, false),
-            vec!["push", "-u", "origin", "feature"]
+            vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
 
@@ -699,7 +715,7 @@ mod tests {
         // A deleted upstream ref (still named by %(upstream:short)) republishes.
         assert_eq!(
             build_push_args("feature", "origin/feature", "origin", true, false, false),
-            vec!["push", "-u", "origin", "feature"]
+            vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
 
@@ -707,7 +723,7 @@ mod tests {
     fn push_tracked_same_name_plain_push() {
         assert_eq!(
             build_push_args("feature", "origin/feature", "origin", false, false, false),
-            vec!["push", "origin", "feature"]
+            vec!["push", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
 
@@ -717,7 +733,7 @@ mod tests {
         // the right remote ref, not `origin/feature`.
         assert_eq!(
             build_push_args("feature", "origin/feat", "origin", false, false, false),
-            vec!["push", "origin", "feature:feat"]
+            vec!["push", "origin", "refs/heads/feature:refs/heads/feat"]
         );
     }
 
@@ -726,7 +742,7 @@ mod tests {
         // Tracks a fork's `upstream/main` → publish to origin, never retrack.
         assert_eq!(
             build_push_args("main", "upstream/main", "upstream", false, false, false),
-            vec!["push", "origin", "main"]
+            vec!["push", "origin", "refs/heads/main:refs/heads/main"]
         );
     }
 
@@ -735,7 +751,7 @@ mod tests {
         // An explicit set_upstream request retracks even a tracked branch.
         assert_eq!(
             build_push_args("feature", "origin/feature", "origin", false, true, false),
-            vec!["push", "-u", "origin", "feature"]
+            vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
 
@@ -744,11 +760,75 @@ mod tests {
         // --force-with-lease sits right after `push`, before the refspec.
         assert_eq!(
             build_push_args("feature", "origin/feat", "origin", false, false, true),
-            vec!["push", "--force-with-lease", "origin", "feature:feat"]
+            vec![
+                "push",
+                "--force-with-lease",
+                "origin",
+                "refs/heads/feature:refs/heads/feat"
+            ]
         );
         assert_eq!(
             build_push_args("feature", "", "", false, false, true),
-            vec!["push", "--force-with-lease", "-u", "origin", "feature"]
+            vec![
+                "push",
+                "--force-with-lease",
+                "-u",
+                "origin",
+                "refs/heads/feature:refs/heads/feature"
+            ]
+        );
+    }
+
+    #[test]
+    fn push_plus_prefixed_branch_is_not_a_force() {
+        // Security regression guard: a branch named `+main` is a VALID git ref,
+        // and as a BARE refspec source `+` is git's force indicator. Fully
+        // qualifying the refspec embeds the `+` inside `refs/heads/+main`, never
+        // as its leading char, so git can't read it as a force-push.
+        assert_eq!(
+            build_push_args("+main", "", "", false, false, false),
+            vec!["push", "-u", "origin", "refs/heads/+main:refs/heads/+main"]
+        );
+    }
+
+    #[test]
+    fn push_gone_different_name_publishes_under_local_name() {
+        // Deliberate v1: a gone upstream publishes under the LOCAL name (a fresh
+        // `origin/feature`), not the deleted `feat`, matching the "Publish"
+        // affordance and toast.
+        assert_eq!(
+            build_push_args("feature", "origin/feat", "origin", true, false, false),
+            vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
+        );
+    }
+
+    #[test]
+    fn parse_upstream_tracking_missing_branch_is_none() {
+        assert_eq!(parse_upstream_tracking(""), None);
+    }
+
+    #[test]
+    fn parse_upstream_tracking_untracked_is_some_empty() {
+        // An untracked branch emits a non-empty `\0\0` line → valid publish.
+        assert_eq!(
+            parse_upstream_tracking("\0\0\n"),
+            Some(("".into(), "".into(), false))
+        );
+    }
+
+    #[test]
+    fn parse_upstream_tracking_gone() {
+        assert_eq!(
+            parse_upstream_tracking("origin/feat\0origin\0[gone]"),
+            Some(("origin/feat".into(), "origin".into(), true))
+        );
+    }
+
+    #[test]
+    fn parse_upstream_tracking_normal() {
+        assert_eq!(
+            parse_upstream_tracking("origin/feature\0origin\0[ahead 2]"),
+            Some(("origin/feature".into(), "origin".into(), false))
         );
     }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -477,24 +477,30 @@ pub(crate) async fn git_push_core(
         }
         Some(b) => {
             crate::git::branches::validate_ref_name(b)?;
-            // Resolve b's tracking state with one read-only call: its upstream's
-            // short name (e.g. `origin/feature`), the upstream's remote name, and
-            // git's `%(upstream:track)` (which carries `[gone]` when the tracked
-            // ref was deleted). Empty stdout means no such local branch.
+            // Resolve b's tracking state with one read-only call: the branch's own
+            // `%(refname)`, its upstream's short name (e.g. `origin/feature`), the
+            // upstream's remote name, and git's `%(upstream:track)` (which carries
+            // `[gone]` when the tracked ref was deleted). `for-each-ref` matches a
+            // pattern as a prefix up to a slash (`refs/heads/feat` also matches
+            // `refs/heads/feat/sub`), so emitting `%(refname)` and requiring it to
+            // equal the expected ref (below) is what makes this behave as an
+            // exact-name lookup — otherwise a non-exact `feat` would read
+            // `feat/sub`'s tracking. No matching line means no such local branch.
             let out = run_git(
                 Some(&repo_path),
                 &[
                     "for-each-ref",
                     &format!("refs/heads/{b}"),
-                    "--format=%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)",
+                    "--format=%(refname)%00%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)",
                 ],
                 DEFAULT_TIMEOUT,
             )
             .await?;
-            // No first line → the branch does not exist (an *untracked* branch
-            // still emits a non-empty `\0\0` line — see parse_upstream_tracking).
+            // No line whose refname is exactly `refs/heads/<b>` → the branch does
+            // not exist (an *untracked* branch still emits a non-empty
+            // `refs/heads/<b>\0\0\0` line — see parse_upstream_tracking).
             let Some((upstream_short, remotename, gone)) =
-                parse_upstream_tracking(&out.stdout_lossy())
+                parse_upstream_tracking(&out.stdout_lossy(), &format!("refs/heads/{b}"))
             else {
                 return Err(AppError::InvalidArgument(format!("no such branch: {b}")));
             };
@@ -513,16 +519,21 @@ pub(crate) async fn git_push_core(
     Ok(())
 }
 
-/// Parse one `for-each-ref … --format=%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)`
-/// line into `(upstream_short, remotename, gone)`. Returns `None` when stdout has
-/// no first line — i.e. the branch does not exist (an *untracked* branch still
-/// emits a non-empty `\0\0` line, so it parses to `Some(("","",false))`, NOT None).
-fn parse_upstream_tracking(stdout: &str) -> Option<(String, String, bool)> {
+/// Parse one `for-each-ref … --format=%(refname)%00%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)`
+/// line into `(upstream_short, remotename, gone)`, but ONLY when its `%(refname)`
+/// equals `expected_ref`. `for-each-ref` matches a pattern as a prefix up to a
+/// slash (`refs/heads/feat` also matches `refs/heads/feat/sub`), so the exact
+/// refname check is what enforces "no such branch" for a non-exact name.
+/// Returns `None` when there is no line, or the first line's refname isn't
+/// `expected_ref`. An *untracked* branch still emits `refs/heads/<b>\0\0\0`,
+/// which (refname matches) parses to `Some(("","",false))`.
+fn parse_upstream_tracking(stdout: &str, expected_ref: &str) -> Option<(String, String, bool)> {
     let line = stdout.lines().next()?;
-    if line.is_empty() {
+    let mut parts = line.split('\0');
+    let refname = parts.next().unwrap_or("");
+    if refname != expected_ref {
         return None;
     }
-    let mut parts = line.split('\0');
     let upstream_short = parts.next().unwrap_or("").to_string();
     let remotename = parts.next().unwrap_or("").to_string();
     let track = parts.next().unwrap_or("");
@@ -804,14 +815,14 @@ mod tests {
 
     #[test]
     fn parse_upstream_tracking_missing_branch_is_none() {
-        assert_eq!(parse_upstream_tracking(""), None);
+        assert_eq!(parse_upstream_tracking("", "refs/heads/feature"), None);
     }
 
     #[test]
     fn parse_upstream_tracking_untracked_is_some_empty() {
-        // An untracked branch emits a non-empty `\0\0` line → valid publish.
+        // An untracked branch: refname present, empty upstream fields → valid publish.
         assert_eq!(
-            parse_upstream_tracking("\0\0\n"),
+            parse_upstream_tracking("refs/heads/feature\0\0\0\n", "refs/heads/feature"),
             Some(("".into(), "".into(), false))
         );
     }
@@ -819,7 +830,7 @@ mod tests {
     #[test]
     fn parse_upstream_tracking_gone() {
         assert_eq!(
-            parse_upstream_tracking("origin/feat\0origin\0[gone]"),
+            parse_upstream_tracking("refs/heads/feature\0origin/feat\0origin\0[gone]", "refs/heads/feature"),
             Some(("origin/feat".into(), "origin".into(), true))
         );
     }
@@ -827,8 +838,19 @@ mod tests {
     #[test]
     fn parse_upstream_tracking_normal() {
         assert_eq!(
-            parse_upstream_tracking("origin/feature\0origin\0[ahead 2]"),
+            parse_upstream_tracking("refs/heads/feature\0origin/feature\0origin\0[ahead 2]", "refs/heads/feature"),
             Some(("origin/feature".into(), "origin".into(), false))
+        );
+    }
+
+    #[test]
+    fn parse_upstream_tracking_prefix_match_is_rejected() {
+        // Round-3 regression guard: `for-each-ref refs/heads/feat` also matches
+        // `refs/heads/feat/sub`; the exact-refname check must reject it so the caller
+        // returns "no such branch" instead of reading feat/sub's tracking.
+        assert_eq!(
+            parse_upstream_tracking("refs/heads/feat/sub\0\0\0\n", "refs/heads/feat"),
+            None
         );
     }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -993,4 +993,81 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&base);
     }
+
+    /// The real `for-each-ref` output shape feeding `parse_upstream_tracking` — the
+    /// format assumption is otherwise only checked against hand-written strings.
+    #[tokio::test]
+    async fn parse_upstream_tracking_matches_real_for_each_ref_output() {
+        let base = temp_base("track");
+        let origin = base.join("origin");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&origin).unwrap();
+        std::fs::create_dir_all(&repo).unwrap();
+        let origin_s = origin.to_string_lossy().into_owned();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        init_repo(&origin_s, "o.txt").await;
+        // The default branch name (main/master) is whatever git is configured for.
+        let def = run(&origin_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        init_repo(&repo_s, "r.txt").await;
+        run(&repo_s, &["remote", "add", "origin", &origin_s]).await;
+        run(&repo_s, &["fetch", "-q", "origin"]).await;
+        run(
+            &repo_s,
+            &["branch", &format!("--set-upstream-to=origin/{def}"), &def],
+        )
+        .await;
+        run(&repo_s, &["branch", "feature"]).await; // untracked
+        run(&repo_s, &["branch", "feat/sub"]).await; // prefix sibling; no exact `feat`
+
+        let fmt = "--format=%(refname)%00%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)";
+        // Run the real `for-each-ref` and parse it exactly as the caller does.
+        let track = |b: &str| {
+            let repo_s = repo_s.clone();
+            let refspec = format!("refs/heads/{b}");
+            async move {
+                let out = run(&repo_s, &["for-each-ref", &refspec, fmt]).await;
+                parse_upstream_tracking(&out, &refspec)
+            }
+        };
+
+        // Untracked branch → non-empty refname line with empty upstream fields.
+        assert_eq!(
+            track("feature").await,
+            Some((String::new(), String::new(), false))
+        );
+        // Tracked branch → upstream short + remote name; gone=false (ahead/behind are
+        // ignored by the parser, so divergent histories are fine).
+        assert_eq!(
+            track(&def).await,
+            Some((format!("origin/{def}"), "origin".into(), false))
+        );
+        // Prefix: `for-each-ref refs/heads/feat` matches `feat/sub`, whose refname
+        // isn't `refs/heads/feat` → None (the round-3 exact-match guard, end to end).
+        assert_eq!(track("feat").await, None);
+
+        // Gone upstream: track origin/<def>, then delete the remote-tracking ref so
+        // `%(upstream:track)` becomes `[gone]`. Do this LAST — it also makes <def> gone.
+        run(
+            &repo_s,
+            &["branch", "--track", "goner", &format!("origin/{def}")],
+        )
+        .await;
+        run(
+            &repo_s,
+            &["update-ref", "-d", &format!("refs/remotes/origin/{def}")],
+        )
+        .await;
+        let g = track("goner").await;
+        assert!(
+            matches!(g, Some((_, _, true))),
+            "goner upstream should read gone: {g:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -447,8 +447,9 @@ pub async fn git_push(
     repo_path: String,
     set_upstream: bool,
     force: bool,
+    branch: Option<String>,
 ) -> AppResult<()> {
-    git_push_core(&state, repo_path, set_upstream, force).await
+    git_push_core(&state, repo_path, set_upstream, force, branch).await
 }
 
 pub(crate) async fn git_push_core(
@@ -456,24 +457,128 @@ pub(crate) async fn git_push_core(
     repo_path: String,
     set_upstream: bool,
     force: bool,
+    branch: Option<String>,
 ) -> AppResult<()> {
-    let mut args = vec!["push"];
-    if force {
-        // refuses to clobber remote work that arrived after our last fetch
-        args.push("--force-with-lease");
-    }
-    if set_upstream {
-        args.extend(["-u", "origin", "HEAD"]);
-    }
+    // Build the git args as owned Strings — a named-branch push interpolates the
+    // branch/refspec, which can't borrow from a temporary. `None` reproduces the
+    // original HEAD-relative args exactly (bare `push`, `--force-with-lease` on
+    // force, `-u origin HEAD` on set_upstream).
+    let args: Vec<String> = match &branch {
+        None => {
+            let mut a = vec!["push".to_string()];
+            if force {
+                // refuses to clobber remote work that arrived after our last fetch
+                a.push("--force-with-lease".to_string());
+            }
+            if set_upstream {
+                a.extend(["-u", "origin", "HEAD"].map(str::to_string));
+            }
+            a
+        }
+        Some(b) => {
+            crate::git::branches::validate_ref_name(b)?;
+            // Resolve b's tracking state with one read-only call: its upstream's
+            // short name (e.g. `origin/feature`), the upstream's remote name, and
+            // git's `%(upstream:track)` (which carries `[gone]` when the tracked
+            // ref was deleted). Empty stdout means no such local branch.
+            let out = run_git(
+                Some(&repo_path),
+                &[
+                    "for-each-ref",
+                    &format!("refs/heads/{b}"),
+                    "--format=%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)",
+                ],
+                DEFAULT_TIMEOUT,
+            )
+            .await?;
+            let text = out.stdout_lossy();
+            let line = text.lines().next().unwrap_or("");
+            if line.is_empty() {
+                return Err(AppError::InvalidArgument(format!("no such branch: {b}")));
+            }
+            let mut parts = line.split('\0');
+            let upstream_short = parts.next().unwrap_or("");
+            let remotename = parts.next().unwrap_or("");
+            let track = parts.next().unwrap_or("");
+            // Mirror branches.rs's gone detection: `[gone]` in %(upstream:track).
+            let gone = track.contains("[gone]");
+            build_push_args(b, upstream_short, remotename, gone, set_upstream, force)
+        }
+    };
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    run_git_mutating_with_creds(state, &repo_path, &cred, &args, NETWORK_TIMEOUT).await?;
+    run_git_mutating_with_creds(
+        state,
+        &repo_path,
+        &cred,
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
+}
+
+/// Decide the `git push` args for pushing a NAMED local branch `branch` to
+/// origin, from its resolved tracking state. Pure — no git calls — so the
+/// decision table is unit-testable.
+///
+/// - `upstream_short`: `%(upstream:short)` (e.g. `origin/feat`), empty when the
+///   branch is untracked.
+/// - `remotename`: `%(upstream:remotename)` (the tracked upstream's remote).
+/// - `gone`: the tracked ref was deleted (`[gone]`).
+///
+/// Rules (origin-centric v1 — we only ever push to origin):
+/// - untracked / gone / `set_upstream` → `-u origin <branch>` (publish + track).
+/// - tracked on `origin`: strip `origin/` off `upstream_short` to get the remote
+///   name `up`; `push origin <branch>` when `up == branch`, else the explicit
+///   `push origin <branch>:<up>` refspec (plain `push origin <branch>` would
+///   advance the WRONG remote ref when the names differ).
+/// - tracked on a NON-origin remote (e.g. a fork's `upstream/main`): plain
+///   `push origin <branch>` with NO `-u` — publishes/advances `origin/<branch>`
+///   and leaves the existing tracking config untouched (never retrack).
+///
+/// `force` prepends `--force-with-lease` before the refspec in every arm.
+fn build_push_args(
+    branch: &str,
+    upstream_short: &str,
+    remotename: &str,
+    gone: bool,
+    set_upstream: bool,
+    force: bool,
+) -> Vec<String> {
+    let mut args = vec!["push".to_string()];
+    if force {
+        args.push("--force-with-lease".to_string());
+    }
+    let untracked = upstream_short.is_empty();
+    if untracked || gone || set_upstream {
+        // Publish + track: first push of a branch (or a resurrected gone one), or
+        // an explicit retrack request.
+        args.extend(["-u", "origin", branch].map(str::to_string));
+    } else if remotename == "origin" {
+        // Tracked on origin. Strip the `origin/` prefix to recover the remote
+        // branch name; when it matches the local name a bare push suffices,
+        // otherwise an explicit refspec targets the right remote ref.
+        let up = upstream_short
+            .strip_prefix("origin/")
+            .unwrap_or(upstream_short);
+        if up == branch {
+            args.extend(["origin", branch].map(str::to_string));
+        } else {
+            args.push("origin".to_string());
+            args.push(format!("{branch}:{up}"));
+        }
+    } else {
+        // Tracked on a non-origin remote — plain push to origin, no retrack.
+        args.extend(["origin", branch].map(str::to_string));
+    }
+    args
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_get, cache_invalidate, cache_put, git_remote_remove_core, is_auth_class_failure,
+        build_push_args, cache_get, cache_invalidate, cache_put, git_remote_remove_core,
+        is_auth_class_failure,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -576,6 +681,75 @@ mod tests {
         assert!(!is_auth_class_failure(
             "ssh: Could not resolve hostname github.com"
         ));
+    }
+
+    // --- Pure arg-building for a named-branch push. ---
+
+    #[test]
+    fn push_untracked_publishes_with_upstream() {
+        // Empty upstream → first-time publish + track.
+        assert_eq!(
+            build_push_args("feature", "", "", false, false, false),
+            vec!["push", "-u", "origin", "feature"]
+        );
+    }
+
+    #[test]
+    fn push_gone_upstream_publishes_with_upstream() {
+        // A deleted upstream ref (still named by %(upstream:short)) republishes.
+        assert_eq!(
+            build_push_args("feature", "origin/feature", "origin", true, false, false),
+            vec!["push", "-u", "origin", "feature"]
+        );
+    }
+
+    #[test]
+    fn push_tracked_same_name_plain_push() {
+        assert_eq!(
+            build_push_args("feature", "origin/feature", "origin", false, false, false),
+            vec!["push", "origin", "feature"]
+        );
+    }
+
+    #[test]
+    fn push_tracked_different_name_uses_refspec() {
+        // Local `feature` tracks `origin/feat` → explicit refspec so we advance
+        // the right remote ref, not `origin/feature`.
+        assert_eq!(
+            build_push_args("feature", "origin/feat", "origin", false, false, false),
+            vec!["push", "origin", "feature:feat"]
+        );
+    }
+
+    #[test]
+    fn push_tracked_non_origin_plain_push_no_upstream() {
+        // Tracks a fork's `upstream/main` → publish to origin, never retrack.
+        assert_eq!(
+            build_push_args("main", "upstream/main", "upstream", false, false, false),
+            vec!["push", "origin", "main"]
+        );
+    }
+
+    #[test]
+    fn push_set_upstream_forces_upstream_form_even_when_tracked() {
+        // An explicit set_upstream request retracks even a tracked branch.
+        assert_eq!(
+            build_push_args("feature", "origin/feature", "origin", false, true, false),
+            vec!["push", "-u", "origin", "feature"]
+        );
+    }
+
+    #[test]
+    fn push_force_flag_precedes_refspec_args() {
+        // --force-with-lease sits right after `push`, before the refspec.
+        assert_eq!(
+            build_push_args("feature", "origin/feat", "origin", false, false, true),
+            vec!["push", "--force-with-lease", "origin", "feature:feat"]
+        );
+        assert_eq!(
+            build_push_args("feature", "", "", false, false, true),
+            vec!["push", "--force-with-lease", "-u", "origin", "feature"]
+        );
     }
 
     // --- Real-repo tests for git_remote_remove (temp_dir, git on PATH). ---

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -98,6 +98,10 @@ struct PushArgs {
     /// first time. Defaults to false.
     #[serde(default)]
     set_upstream: bool,
+    /// Local branch to push instead of the current one (pushed by name — no
+    /// checkout, no working-tree changes; an untracked branch is published with
+    /// `-u origin <branch>`). Defaults to the current branch.
+    branch: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -385,10 +389,11 @@ impl GitDesktopMcp {
     }
 
     #[tool(
-        description = "Push the current branch to its remote in the bound repository (uses git's \
-                       native credential flow). With `set_upstream`, sets upstream to \
-                       origin/HEAD. Never force-pushes — use force_push (destructive) for that. \
-                       Requires --allow-git-write.",
+        description = "Push the current branch (default) or a named local `branch` to origin in \
+                       the bound repository — pushing a named branch never switches to it or \
+                       touches the working tree; an untracked branch is published with `-u`. \
+                       Uses git's native credential flow. Never force-pushes — use force_push \
+                       (destructive) for that. Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn push(
@@ -396,9 +401,22 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<PushArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_git_write()?;
-        crate::git::remote::git_push_core(&self.state, self.repo.clone(), args.set_upstream, false)
-            .await
-            .map_err(app_err)?;
+        if let Some(b) = &args.branch {
+            ensure_not_flag(b, "branch name")?;
+            // Protect agent-session branches: they're filtered from every UI
+            // surface, so pushing one would publish an invisible branch and
+            // could break session Resume semantics.
+            ensure_not_session_branch(b)?;
+        }
+        crate::git::remote::git_push_core(
+            &self.state,
+            self.repo.clone(),
+            args.set_upstream,
+            false,
+            args.branch.clone(),
+        )
+        .await
+        .map_err(app_err)?;
         ok_text("pushed")
     }
 
@@ -740,7 +758,7 @@ impl GitDesktopMcp {
     )]
     async fn force_push(&self) -> Result<CallToolResult, McpError> {
         self.ensure_destructive()?;
-        crate::git::remote::git_push_core(&self.state, self.repo.clone(), false, true)
+        crate::git::remote::git_push_core(&self.state, self.repo.clone(), false, true, None)
             .await
             .map_err(app_err)?;
         ok_text("force-pushed (with lease)")
@@ -884,7 +902,8 @@ mod tests {
         );
         assert_gated!(
             h.push(Parameters(PushArgs {
-                set_upstream: false
+                set_upstream: false,
+                branch: None
             })),
             "--allow-git-write"
         );

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -31,8 +31,8 @@ fn ensure_not_session_branch(name: &str) -> Result<(), McpError> {
     if name.starts_with(SESSION_BRANCH_PREFIX) {
         return Err(McpError::invalid_params(
             format!(
-                "\"{name}\" is a GitDesktop agent-session branch; deleting it breaks session \
-                 Resume. Refusing."
+                "\"{name}\" is a GitDesktop agent-session branch; refusing to operate on it \
+                 (breaks session Resume)."
             ),
             None,
         ));

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -375,6 +375,10 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   is the "just merged a PR — bring the default branch current before I switch back" flow;
   the default branch's row shows how far behind its upstream it is after a fetch, and
   *Update default branch from its remote* is available from the command palette too.
+- **Push a branch without switching to it** — the outbound counterpart: a branch ahead
+  of its remote offers **Push to _origin/…_** in its right-click menu, and an untracked
+  branch offers **Publish branch**. Neither checks the branch out or touches your working
+  tree, so it works even for a branch checked out in another worktree.
 - The **Remote** section lists branches on your remotes you haven't checked out locally
   yet — click one to check it out (creating a local tracking branch), or right-click to
   **Delete on _origin_…**, a server-side delete that removes the branch from the remote for

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -376,9 +376,10 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   the default branch's row shows how far behind its upstream it is after a fetch, and
   *Update default branch from its remote* is available from the command palette too.
 - **Push a branch without switching to it** — the outbound counterpart: a branch ahead
-  of its remote offers **Push to _origin/…_** in its right-click menu, and an untracked
-  branch offers **Publish branch**. Neither checks the branch out or touches your working
-  tree, so it works even for a branch checked out in another worktree.
+  of its origin remote offers **Push to _origin/…_** in its right-click menu, and an
+  unpushed or upstream-deleted branch offers **Publish branch**. Neither checks the branch
+  out or touches your working tree, so it works even for a branch checked out in another
+  worktree.
 - The **Remote** section lists branches on your remotes you haven't checked out locally
   yet — click one to check it out (creating a local tracking branch), or right-click to
   **Delete on _origin_…**, a server-side delete that removes the branch from the remote for

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -42,9 +42,11 @@ import {
   useForgeStatus,
   useMergeBranch,
   usePrList,
+  usePush,
   useRebaseBranch,
   useRebaseOnto,
   useRemoteBranches,
+  useRemotes,
   useRepoStatus,
   useSetBranchArchived,
   useStashAll,
@@ -156,6 +158,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   const rebaseBranch = useRebaseBranch(repoPath);
   const rebaseOnto = useRebaseOnto(repoPath);
   const updateBranchFrom = useUpdateBranchFrom(repoPath);
+  const push = usePush(repoPath);
+  const remotes = useRemotes(repoPath);
   const setBranchArchived = useSetBranchArchived(repoPath);
   const openWorktree = useOpenWorktree();
   const rulesConfig = useEffectiveBranchRules(repoPath);
@@ -448,6 +452,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     [currentName, defaultName],
   );
 
+  // Origin presence gates the per-row push/publish items (mirrors SyncControls):
+  // a repo with no `origin` can't push a branch there.
+  const hasOrigin = remotes.isSuccess && remotes.data.includes("origin");
+
   const onError = (e: unknown) => toastError(e);
 
   function setArchived(name: string, archived: boolean) {
@@ -696,12 +704,33 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     );
   }
 
+  // Push a branch's ref to origin without checking it out — the outbound
+  // counterpart of doUpdateFromUpstream. Whether this publishes (-u) or plain
+  // pushes is decided backend-side from the branch's tracking state.
+  function doPushBranch(branch: Branch) {
+    const publishing = !branch.upstream || branch.upstreamGone;
+    setOpen(false);
+    push.mutate(
+      { setUpstream: false, branch: branch.name },
+      {
+        onSuccess: () =>
+          toast.success(
+            publishing
+              ? `Published ${branch.name} to origin`
+              : `Pushed ${branch.name} to ${branch.upstream}`,
+          ),
+        onError,
+      },
+    );
+  }
+
   const busy =
     checkout.isPending ||
     checkoutRemote.isPending ||
     mergeBranch.isPending ||
     rebaseBranch.isPending ||
     rebaseOnto.isPending ||
+    push.isPending ||
     updateBranchFrom.isPending;
 
   // Hotkey handlers reuse the menu's own flows, so every gate (clean tree,
@@ -830,6 +859,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const canUpdate = Boolean(defaultName) && branch.name !== defaultName;
     const deletionBlocked = isDeletionBlocked(rulesConfig, branch.name);
     const inWorktree = worktreeByBranch.has(branch.name);
+    // Outbound sync gating. `pushable` = tracked on origin and ahead → offer a
+    // plain push (disabled with "(diverged)" when also behind). `publishable` =
+    // untracked or gone → offer Publish. Both need origin. Hidden (not disabled)
+    // when in-sync / no origin / tracked on a non-origin remote.
+    const trackedOnOrigin =
+      Boolean(branch.upstream?.startsWith("origin/")) && !branch.upstreamGone;
+    const pushable = hasOrigin && trackedOnOrigin && branch.upstreamAhead > 0;
+    const publishable = hasOrigin && (!branch.upstream || branch.upstreamGone);
     return (
       <ContextMenu key={branch.name}>
         <ContextMenuTrigger
@@ -946,7 +983,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           }
         />
         <ContextMenuContent className="min-w-48">
-          {(canUpdate || (branch.upstream && branch.upstreamBehind > 0)) && (
+          {(canUpdate ||
+            (branch.upstream && branch.upstreamBehind > 0) ||
+            pushable ||
+            publishable) && (
             <>
               {canUpdate && (
                 <ContextMenuItem
@@ -967,6 +1007,30 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   }
                 >
                   Update from {branch.upstream}
+                </ContextMenuItem>
+              )}
+              {/* Sync-out below sync-in. Push a branch's ref to origin without
+                  checking it out — works even when the branch is checked out in
+                  another worktree, since a push touches refs, never a working
+                  tree (hence deliberately NO inWorktree gate). Diverged branches
+                  push disabled with the reason in the label; the "Update from"
+                  item above is their remedy. */}
+              {pushable && (
+                <ContextMenuItem
+                  disabled={busy || branch.upstreamBehind > 0}
+                  onClick={() => doPushBranch(branch)}
+                >
+                  {branch.upstreamBehind > 0
+                    ? `Push to ${branch.upstream} (diverged)`
+                    : `Push to ${branch.upstream}`}
+                </ContextMenuItem>
+              )}
+              {publishable && (
+                <ContextMenuItem
+                  disabled={busy}
+                  onClick={() => doPushBranch(branch)}
+                >
+                  Publish branch
                 </ContextMenuItem>
               )}
               <ContextMenuSeparator />

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -705,7 +705,14 @@ export const gitPush = (
   repoPath: string,
   setUpstream: boolean,
   force = false,
-) => invoke<void>("git_push", { repoPath, setUpstream, force });
+  branch?: string,
+) =>
+  invoke<void>("git_push", {
+    repoPath,
+    setUpstream,
+    force,
+    branch: branch ?? null,
+  });
 
 export const gitRemotes = (repoPath: string) =>
   invoke<string[]>("git_remotes", { repoPath });

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3291,8 +3291,8 @@ export function useUpdateSubmodule(repo: string) {
 export function usePush(repo: string) {
   return useRepoMutation(
     repo,
-    (args: { setUpstream: boolean; force?: boolean }) =>
-      api.gitPush(repo, args.setUpstream, args.force ?? false),
+    (args: { setUpstream: boolean; force?: boolean; branch?: string }) =>
+      api.gitPush(repo, args.setUpstream, args.force ?? false, args.branch),
   );
 }
 


### PR DESCRIPTION
This change lets you push or publish a local branch to `origin` directly from the branch switcher's right-click menu, without checking out the branch. It streamlines managing multiple branches — including ones checked out in other worktrees — by decoupling push/publish from the working tree (a push touches refs, never a working tree).

**Scope (origin-centric v1):** the menu surfaces **Push to _origin/…_** for a branch that's ahead of its `origin` remote, and **Publish branch** for an unpushed (or upstream-deleted) branch. A branch tracked on a non-origin remote is intentionally left out of v1 (multi-remote push is a follow-up).

### Branch switcher UI
- Adds **Push to _origin/..._** and **Publish branch** actions to the right-click menu for local branches in `src/features/repository/BranchSwitcher.tsx`
- Sync-out options only appear if `origin` exists (`useRemotes`)
- Push is gated/enabled based on branch status (ahead / diverged → disabled with reason, untracked → Publish, in-sync / non-origin → hidden)
- Handles push logic and toast notifications for "Push" vs. "Publish"

### Git backend and API changes
- Updates `src-tauri/src/git/remote.rs` to accept an explicit branch name for push operations (optionally, instead of always pushing the current branch); `branch: None` reproduces the pre-change HEAD push byte-for-byte
- Implements push argument logic in the pure, unit-tested `build_push_args`, supporting tracked/untracked/gone upstreams. **Refspecs are fully qualified** (`refs/heads/<src>:refs/heads/<dst>`) so a branch named `+x`/`-x` can never be read as a force/delete indicator (round-1 security hardening)
- Changes `src-tauri/src/mcp_server/write_git.rs` to accept a target branch for push, with `ensure_not_flag` + `ensure_not_session_branch` safeguards; `force_push` stays HEAD-only
- Modifies `src/lib/git/api.ts` and `src/lib/git/queries.ts` to pass an optional branch name to the push call

### Documentation and help content
- Adds `changelog.d/added-push-branch-without-switching.md`
- Updates `src/features/help/content.ts`, `README.md`, and the marketing-site `site/src/data/capabilities.ts` (non-AI capability, shown in both views)