### PR TITLE
feat(compare): replace base-branch picker with searchable combobox

### DIFF
--- a/changelog.d/changed-compare-branch-combobox.md
+++ b/changelog.d/changed-compare-branch-combobox.md
@@ -1,3 +1,4 @@
 - The **Compare** tab's base-branch picker is now a searchable combobox: type to filter,
   archived branches are hidden, and each branch shows whether it's checked out in another
-  worktree and how far it's ahead of and behind your current branch.
+  worktree and — when it has diverged — how far it's ahead of and behind your current
+  branch.

--- a/changelog.d/changed-compare-branch-combobox.md
+++ b/changelog.d/changed-compare-branch-combobox.md
@@ -1,0 +1,3 @@
+- The **Compare** tab's base-branch picker is now a searchable combobox: type to filter,
+  archived branches are hidden, and each branch shows whether it's checked out in another
+  worktree and how far it's ahead of and behind your current branch.

--- a/src/features/compare/CompareBranchCombobox.tsx
+++ b/src/features/compare/CompareBranchCombobox.tsx
@@ -30,8 +30,12 @@ const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
  * context menu — this is the daily "what am I about to PR" surface.
  *
  * The ahead/behind badges are computed vs `currentName` (the compare base shown
- * in the header "Compare {current} with"), not vs the default branch, so each
- * row previews the comparison the tab would show.
+ * in the header "Compare {current} with"), not vs the default branch. Note the
+ * frame: a row's badges describe the ROW's branch (↑ = commits it has that
+ * `currentName` lacks) — the subject-is-the-row idiom every BranchSwitcher row
+ * uses — while the tab's "N ahead / M behind" reads from `currentName`'s side,
+ * so the same two numbers swap labels between a row and the selected
+ * comparison. The badge tooltip names the direction.
  */
 export function CompareBranchCombobox({
   repoPath,
@@ -191,6 +195,9 @@ function BranchRow({
           worktree
         </span>
       )}
+      {/* ↑/↓ describe THIS row's branch vs `currentName` (the app-wide row-badge
+          frame) — deliberately not the tab's current-side frame; the tooltip
+          names the direction. Hidden when the branches are even. */}
       {div && (div.ahead > 0 || div.behind > 0) && (
         <span
           className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"

--- a/src/features/compare/CompareBranchCombobox.tsx
+++ b/src/features/compare/CompareBranchCombobox.tsx
@@ -1,0 +1,220 @@
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  TreeStructureIcon,
+} from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import { useBranchDivergence, useUserWorktrees } from "@/lib/git/queries";
+import type { Branch, BranchDivergence } from "@/lib/git/types";
+import { formatRelativeTime } from "@/lib/time";
+
+/** Lower-cased, forward-slashed path for cross-source comparison — git emits
+ *  "/", the app stores "\" on Windows (mirrors BranchSwitcher's helper). */
+const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
+
+/**
+ * The Compare tab's base-branch picker: a searchable combobox over the local
+ * branches (already filtered by the caller — no current, no `gd/session/*`, no
+ * archived). Rows mirror the BranchSwitcher vocabulary (worktree chip,
+ * ahead/behind badges, relative date, default tag) MINUS the PR badge and
+ * context menu — this is the daily "what am I about to PR" surface.
+ *
+ * The ahead/behind badges are computed vs `currentName` (the compare base shown
+ * in the header "Compare {current} with"), not vs the default branch, so each
+ * row previews the comparison the tab would show.
+ */
+export function CompareBranchCombobox({
+  repoPath,
+  branches,
+  currentName,
+  defaultName,
+  value,
+  onValueChange,
+}: {
+  repoPath: string;
+  /** Already filtered: no current, no gd/session/*, no archived. */
+  branches: Branch[];
+  /** The compare base; ahead/behind badges are computed vs this branch. */
+  currentName: string;
+  defaultName: string | null;
+  value: string | null;
+  onValueChange: (name: string) => void;
+}) {
+  // Popup state drives the N-per-branch git calls below: divergence + worktrees
+  // fetch only while open (mirrors BranchSwitcher's `open`-gated queries).
+  const [open, setOpen] = useState(false);
+
+  // Ahead/behind vs the CURRENT branch (the compare base), fetched only while
+  // open. Keyed under `currentName` so switching branches re-derives.
+  const divergence = useBranchDivergence(repoPath, currentName, open);
+  const divByName = useMemo(
+    () =>
+      new Map((divergence.data ?? []).map((d) => [d.name, d] as const)) as Map<
+        string,
+        BranchDivergence
+      >,
+    [divergence.data],
+  );
+
+  // Branches checked out in *another* worktree → that worktree's path. Git
+  // forbids the same branch in two worktrees; the active repo's own checkout is
+  // excluded (that's just the current branch). Fetched only while open.
+  const userWorktrees = useUserWorktrees(repoPath, open);
+  const activeNorm = normPath(repoPath);
+  const worktreeByBranch = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const w of userWorktrees.data ?? []) {
+      if (w.branch && normPath(w.path) !== activeNorm)
+        map.set(w.branch, w.path);
+    }
+    return map;
+  }, [userWorktrees.data, activeNorm]);
+
+  // Default branch pinned first, then most recently committed. Memoized: the
+  // compiler won't hoist the `.sort()` copy, and it would otherwise recompute on
+  // every filter keystroke (each re-render).
+  const sorted = useMemo(
+    () =>
+      [...branches].sort((a, b) => {
+        if (a.name === defaultName) return -1;
+        if (b.name === defaultName) return 1;
+        return b.lastCommitDate.localeCompare(a.lastCommitDate);
+      }),
+    [branches, defaultName],
+  );
+
+  // Item values are branch NAME STRINGS (the store holds a string); Base UI's
+  // default contains/case-insensitive filter matches those directly, so typing
+  // in the input filters the list. The `items` prop drives that filtering: the
+  // List's render-function form auto-wraps in a Collection that maps the store's
+  // `filteredItems` (a subset of `items`, in order) — static children would
+  // bypass filtering entirely, so rows MUST come from the render function.
+  const names = useMemo(() => sorted.map((b) => b.name), [sorted]);
+  const branchByName = useMemo(
+    () => new Map(sorted.map((b) => [b.name, b] as const)),
+    [sorted],
+  );
+
+  return (
+    <Combobox
+      items={names}
+      value={value}
+      // Selecting an item fires this with the branch name and closes the popup.
+      onValueChange={(name) => name && onValueChange(name)}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <ComboboxTrigger className="flex w-full items-center justify-between gap-1.5 rounded-none border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50">
+        {/* Clamp the selected branch name (the vendored SelectTrigger's
+            line-clamp idiom) so a long name truncates and the caret stays put in
+            the narrow Compare sidebar. */}
+        <span className="min-w-0 flex-1 truncate text-left">
+          <ComboboxValue />
+        </span>
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput showTrigger={false} placeholder="Filter branches…" />
+        <ComboboxEmpty>No branches match</ComboboxEmpty>
+        <ComboboxList>
+          {(name: string) => (
+            <BranchRow
+              key={name}
+              name={name}
+              branch={branchByName.get(name)}
+              defaultName={defaultName}
+              currentName={currentName}
+              div={divByName.get(name)}
+              worktreePath={worktreeByBranch.get(name)}
+            />
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+/** One combobox row, keyed by branch name (the value Base UI's Collection hands
+ *  the render function). The ItemIndicator check (rendered by the vendored
+ *  `ComboboxItem`, its `pr-8` reserving the space) marks the selected row. The
+ *  `branch` lookup is defensively optional — `name` always resolves in practice
+ *  (both derive from the same sorted list) — so the row still renders its value
+ *  even if metadata is momentarily missing. */
+function BranchRow({
+  name,
+  branch,
+  defaultName,
+  currentName,
+  div,
+  worktreePath,
+}: {
+  name: string;
+  branch: Branch | undefined;
+  defaultName: string | null;
+  currentName: string;
+  div: BranchDivergence | undefined;
+  worktreePath: string | undefined;
+}) {
+  return (
+    <ComboboxItem value={name}>
+      <span
+        className="min-w-0 flex-1 truncate"
+        // Only expose the full name as a tooltip when it's actually clipped —
+        // measured just-in-time on hover, so no per-row refs.
+        onMouseEnter={(e) => {
+          const el = e.currentTarget;
+          el.title = el.scrollWidth > el.clientWidth ? name : "";
+        }}
+      >
+        {name}
+        {name === defaultName && (
+          <span className="ml-1.5 text-[10px] text-muted-foreground">
+            default
+          </span>
+        )}
+      </span>
+      {worktreePath && (
+        <span
+          className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
+          title={`Checked out in another worktree (${worktreePath})`}
+        >
+          <TreeStructureIcon className="size-3" weight="bold" />
+          worktree
+        </span>
+      )}
+      {div && (div.ahead > 0 || div.behind > 0) && (
+        <span
+          className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
+          title={`${div.ahead} ahead, ${div.behind} behind ${currentName}`}
+        >
+          {div.ahead > 0 && (
+            <span className="flex items-center gap-0.5">
+              <ArrowUpIcon className="size-3" weight="bold" />
+              {div.ahead}
+            </span>
+          )}
+          {div.behind > 0 && (
+            <span className="flex items-center gap-0.5">
+              <ArrowDownIcon className="size-3" weight="bold" />
+              {div.behind}
+            </span>
+          )}
+        </span>
+      )}
+      {branch?.lastCommitDate && (
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {formatRelativeTime(branch.lastCommitDate)}
+        </span>
+      )}
+    </ComboboxItem>
+  );
+}

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -17,14 +17,8 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { CompareBranchCombobox } from "@/features/compare/CompareBranchCombobox";
 import { CreatePrDialog } from "@/features/pulls/CreatePrDialog";
 import {
   forgeFeatureReady,
@@ -75,22 +69,28 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
   const branchPrs = usePrsForBranch(repoPath, currentName, prProbe, "origin");
   // Agent-session branches (`gd/session/*`) are app-internal — never offer them
   // as a compare target (the PR button would even push one), like BranchSwitcher.
+  // Archived branches are hidden here too, matching BranchSwitcher (they were
+  // archived to get them out of the way); archiving a branch that was the
+  // compare target auto-falls-back via the default effect below.
   const otherBranches = (branches.data ?? []).filter(
-    (b) => !b.isCurrent && !b.name.startsWith("gd/session/"),
+    (b) => !b.isCurrent && !b.name.startsWith("gd/session/") && !b.archived,
   );
   const firstOther = otherBranches[0]?.name ?? null;
   const compareValid =
     compareBranch !== null &&
     otherBranches.some((b) => b.name === compareBranch);
   const defaultName = defaultBranch.data ?? null;
+  // Only pick the default branch when it's actually offered: an archived default
+  // must fall back to `firstOther`, else `compareValid` stays false forever and
+  // the effect keeps firing a no-op set. Stable primitive for the effect deps.
+  const defaultOffered = otherBranches.some((b) => b.name === defaultName);
 
-  // Default the comparison to the default branch, else the first other branch.
+  // Default the comparison to the default branch (when offered), else the first
+  // other branch.
   useEffect(() => {
     if (firstOther === null || compareValid) return;
-    setCompareBranch(
-      defaultName && defaultName !== currentName ? defaultName : firstOther,
-    );
-  }, [firstOther, compareValid, defaultName, currentName, setCompareBranch]);
+    setCompareBranch(defaultOffered && defaultName ? defaultName : firstOther);
+  }, [firstOther, compareValid, defaultOffered, defaultName, setCompareBranch]);
 
   const comparison = useCompareBranches(repoPath, compareBranch, currentName);
 
@@ -199,22 +199,14 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
         <p className="px-1 text-xs text-muted-foreground">
           Compare <span className="font-mono">{currentName}</span> with
         </p>
-        <Select
-          items={Object.fromEntries(otherBranches.map((b) => [b.name, b.name]))}
-          value={compareBranch || null}
-          onValueChange={(v) => v && setCompareBranch(v)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {otherBranches.map((b) => (
-              <SelectItem key={b.name} value={b.name}>
-                {b.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <CompareBranchCombobox
+          repoPath={repoPath}
+          branches={otherBranches}
+          currentName={currentName}
+          defaultName={defaultName}
+          value={compareBranch}
+          onValueChange={setCompareBranch}
+        />
         {canPr && compareBranch && existingPr && (
           <Button
             variant="outline"

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -75,7 +75,14 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
   const otherBranches = (branches.data ?? []).filter(
     (b) => !b.isCurrent && !b.name.startsWith("gd/session/") && !b.archived,
   );
-  const firstOther = otherBranches[0]?.name ?? null;
+  // Fallback when the default branch isn't offered: the most recently committed
+  // other branch — the same row the picker surfaces first, so the auto-pick
+  // matches the top of the list the user sees (not raw git ref order).
+  const firstOther = otherBranches.length
+    ? otherBranches.reduce((a, b) =>
+        b.lastCommitDate > a.lastCommitDate ? b : a,
+      ).name
+    : null;
   const compareValid =
     compareBranch !== null &&
     otherBranches.some((b) => b.name === compareBranch);

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -416,8 +416,9 @@ dismiss the notice.
 The **Compare** tab ({{kbd:tab-compare}}) lets you pick any base branch and see what the
 current branch adds: the commits ahead and behind, and the full three-dot diff a PR would
 show. The base-branch picker is searchable — type to filter — hides archived branches, and
-shows which branches live in other worktrees plus how far each is ahead of and behind your
-current branch. From here you can merge, rebase, or jump straight to opening a pull request.
+shows which branches live in other worktrees plus, when a branch has diverged, how far it
+is ahead of and behind your current branch. From here you can merge, rebase, or jump
+straight to opening a pull request.
 
 ## Branch rules
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -415,7 +415,9 @@ dismiss the notice.
 
 The **Compare** tab ({{kbd:tab-compare}}) lets you pick any base branch and see what the
 current branch adds: the commits ahead and behind, and the full three-dot diff a PR would
-show. From here you can merge, rebase, or jump straight to opening a pull request.
+show. The base-branch picker is searchable — type to filter — hides archived branches, and
+shows which branches live in other worktrees plus how far each is ahead of and behind your
+current branch. From here you can merge, rebase, or jump straight to opening a pull request.
 
 ## Branch rules
 


### PR DESCRIPTION
This change improves the Compare tab's UX by replacing the base-branch select menu with a searchable combobox that offers richer context for each available branch and better discoverability when many branches are present. The new component hides archived branches, previews worktree status, and displays ahead/behind counts versus the current branch—making it easier to pick a meaningful comparison base.

### Compare feature
- Adds `CompareBranchCombobox.tsx` implementing a combobox with type-to-filter, worktree badges, and ahead/behind badges (`src/features/compare/CompareBranchCombobox.tsx`).
- Updates the Compare panel to use the new combobox in place of the old select menu (`src/features/compare/ComparePanel.tsx`): filters out archived and session branches, and adjusts default-branch selection to skip archived branches.
- Improves the branch selection user experience by hiding archived branches and surfacing default-branch context and recent activity for each choice in the compare UI.

### Documentation
- Updates Compare tab help text to reflect the searchable base-branch picker and describe new features (filtering, worktree, ahead/behind indicators) (`src/features/help/content.ts`).

### Changelog
- Adds a changelog entry noting the new Compare branch combobox and its improved capabilities (`changelog.d/changed-compare-branch-combobox.md`).