### PR TITLE
feat(branches,ui): create branch from any base (local or remote) in dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ commit that hasn't been pushed yet.
   right-click menu, push a branch that's ahead of its `origin` remote or publish an
   unpushed one, without checking it out; it works even when the branch is checked out
   in another worktree.
+- **Start a branch from any base** — the new-branch dialog's *Base it on* picker is a
+  searchable list grouped into local and remote branches, so you can branch off any of
+  them. Basing on a remote branch (e.g. `origin/epic/big-feature`) starts from the remote
+  tip and leaves the new branch untracked, so its first push publishes it under its own name.
 
 Plus tag and submodule management.
 

--- a/changelog.d/added-create-branch-from-any-base.md
+++ b/changelog.d/added-create-branch-from-any-base.md
@@ -1,0 +1,6 @@
+- **Start a new branch from any base.** The new-branch dialog's **Base it on** picker is
+  now a searchable list grouped into **Local** and **Remote** branches, so you can base a
+  branch on any of them instead of only the current or default branch. Basing on a remote
+  branch (e.g. `origin/epic/big-feature`) starts from the remote tip and leaves the new
+  branch untracked, so its first push publishes it under its own name. Agents get the same
+  option via the MCP `create_branch` tool's `noTrack` flag.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -48,6 +48,7 @@ export const capabilities: Capability[] = [
   { group: "Branches & history", label: "Branch compare — ahead/behind, three-dot diff, jump to PR", highlight: true },
   { group: "Branches & history", label: "Update a branch from its upstream — no checkout needed" },
   { group: "Branches & history", label: "Push or publish a branch — no checkout needed" },
+  { group: "Branches & history", label: "Start a branch from any base — another local branch or a remote ref" },
   { group: "Branches & history", label: "Check out or delete remote-only branches from the switcher" },
   { group: "Branches & history", label: "Archive branches — hide from the switcher without deleting" },
   { group: "Branches & history", label: "Clean up branches in bulk — archive or delete stale ones in one sweep", highlight: true },

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -450,6 +450,43 @@ pub async fn git_checkout_remote_branch(
     Ok(())
 }
 
+/// Build the argv for creating a branch. Pure so the decision table
+/// (checkout × start_point × no_track) is unit-testable without a repo.
+///
+/// `no_track` suppresses git's automatic upstream setup so that basing a new
+/// branch on a remote-tracking ref (e.g. `origin/epic/x`) yields a branch with
+/// NO upstream — its first push then publishes it under its own name. Placement
+/// matters: `--no-track` goes right after `switch` in the checkout arm, and
+/// BEFORE the `--` in the `branch` arm.
+fn build_create_branch_args(
+    name: &str,
+    checkout: bool,
+    start_point: Option<&str>,
+    no_track: bool,
+) -> Vec<String> {
+    let mut args: Vec<String> = if checkout {
+        let mut a = vec!["switch".to_string()];
+        if no_track {
+            a.push("--no-track".to_string());
+        }
+        a.push("-c".to_string());
+        a.push(name.to_string());
+        a
+    } else {
+        let mut a = vec!["branch".to_string()];
+        if no_track {
+            a.push("--no-track".to_string());
+        }
+        a.push("--".to_string());
+        a.push(name.to_string());
+        a
+    };
+    if let Some(start) = start_point {
+        args.push(start.to_string());
+    }
+    args
+}
+
 #[tauri::command]
 pub async fn git_create_branch(
     state: State<'_, AppState>,
@@ -457,8 +494,9 @@ pub async fn git_create_branch(
     name: String,
     checkout: bool,
     start_point: Option<String>,
+    no_track: bool,
 ) -> AppResult<()> {
-    git_create_branch_core(&state, repo_path, name, checkout, start_point).await
+    git_create_branch_core(&state, repo_path, name, checkout, start_point, no_track).await
 }
 
 pub(crate) async fn git_create_branch_core(
@@ -467,6 +505,7 @@ pub(crate) async fn git_create_branch_core(
     name: String,
     checkout: bool,
     start_point: Option<String>,
+    no_track: bool,
 ) -> AppResult<()> {
     validate_ref_name(&name)?;
     if let Some(start) = &start_point {
@@ -474,15 +513,9 @@ pub(crate) async fn git_create_branch_core(
         // (non-empty, no leading '-') rather than strictly a hash.
         validate_ref_name(start)?;
     }
-    let mut args: Vec<&str> = if checkout {
-        vec!["switch", "-c", &name]
-    } else {
-        vec!["branch", "--", &name]
-    };
-    if let Some(start) = &start_point {
-        args.push(start);
-    }
-    run_git_mutating(state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
+    let args = build_create_branch_args(&name, checkout, start_point.as_deref(), no_track);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_git_mutating(state, &repo_path, &arg_refs, DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -796,7 +829,76 @@ fn unique_suffix() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_upstream_track, validate_ref_name};
+    use super::{build_create_branch_args, parse_upstream_track, validate_ref_name};
+
+    // Full decision table for the create-branch argv: checkout × start_point ×
+    // no_track (8 cases). The no_track=false rows must stay byte-identical to the
+    // pre-`--no-track` behavior for every combination.
+    #[test]
+    fn build_create_branch_args_checkout_no_start_no_track() {
+        assert_eq!(
+            build_create_branch_args("feat", true, None, false),
+            vec!["switch", "-c", "feat"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_checkout_start_no_track() {
+        assert_eq!(
+            build_create_branch_args("feat", true, Some("main"), false),
+            vec!["switch", "-c", "feat", "main"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_checkout_no_start_track_off() {
+        assert_eq!(
+            build_create_branch_args("feat", true, None, true),
+            vec!["switch", "--no-track", "-c", "feat"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_checkout_remote_start_track_off() {
+        // The motivating case: `git switch --no-track -c feat origin/epic/x`.
+        assert_eq!(
+            build_create_branch_args("feat", true, Some("origin/epic/x"), true),
+            vec!["switch", "--no-track", "-c", "feat", "origin/epic/x"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_no_checkout_no_start_no_track() {
+        assert_eq!(
+            build_create_branch_args("feat", false, None, false),
+            vec!["branch", "--", "feat"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_no_checkout_start_no_track() {
+        assert_eq!(
+            build_create_branch_args("feat", false, Some("main"), false),
+            vec!["branch", "--", "feat", "main"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_no_checkout_no_start_track_off() {
+        // `--no-track` must come BEFORE the `--`.
+        assert_eq!(
+            build_create_branch_args("feat", false, None, true),
+            vec!["branch", "--no-track", "--", "feat"]
+        );
+    }
+
+    #[test]
+    fn build_create_branch_args_no_checkout_remote_start_track_off() {
+        assert_eq!(
+            build_create_branch_args("feat", false, Some("origin/epic/x"), true),
+            vec!["branch", "--no-track", "--", "feat", "origin/epic/x"]
+        );
+    }
 
     #[test]
     fn validate_ref_name_rejects_glob_and_refspec_metacharacters() {

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -829,7 +829,11 @@ fn unique_suffix() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_create_branch_args, parse_upstream_track, validate_ref_name};
+    use super::{
+        build_create_branch_args, git_create_branch_core, parse_upstream_track, validate_ref_name,
+    };
+    use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
+    use crate::state::AppState;
 
     // Full decision table for the create-branch argv: checkout × start_point ×
     // no_track (8 cases). The no_track=false rows must stay byte-identical to the
@@ -951,5 +955,116 @@ mod tests {
         assert_eq!(parse_upstream_track(""), (0, 0, false));
         assert_eq!(parse_upstream_track("   "), (0, 0, false));
         assert_eq!(parse_upstream_track("garbage"), (0, 0, false));
+    }
+
+    // --- Real-repo test for the `--no-track` seam (temp_dir, git on PATH). ---
+
+    async fn run(repo: &str, args: &[&str]) -> String {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+    }
+
+    /// A unique temp base dir for a test, cleaned up by the caller.
+    fn temp_base(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-branches-{}-{}-{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    async fn init_repo(repo_s: &str, seed_file: &str) {
+        run(repo_s, &["init", "-q"]).await;
+        run(repo_s, &["config", "user.email", "t@t.local"]).await;
+        run(repo_s, &["config", "user.name", "T"]).await;
+        std::fs::write(std::path::Path::new(repo_s).join(seed_file), "hello\n").unwrap();
+        run(repo_s, &["add", "-A"]).await;
+        run(repo_s, &["commit", "-qm", "seed"]).await;
+    }
+
+    /// The argv table pins `--no-track` placement; this closes the argv→outcome
+    /// gap by driving `git_create_branch_core` against a real repo and asserting
+    /// git actually honors it. Synthesizes a remote-tracking ref
+    /// (`refs/remotes/origin/x` via `update-ref`, so nothing is ever fetched) and
+    /// bases two branches on it: the `no_track=true` arm must have NO upstream,
+    /// the `no_track=false` control arm must track `origin/x`. Both arms create
+    /// without checkout (`checkout=false`) to keep the assertions simple; the
+    /// checkout arm shares the same `--no-track` placement per the argv table.
+    #[tokio::test]
+    async fn create_branch_honors_no_track_against_real_repo() {
+        let base = temp_base("no-track");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        init_repo(&repo_s, "r.txt").await;
+        // A remote named `origin` (URL is the repo's own path — never fetched) and
+        // a synthetic remote-tracking ref pointing at HEAD.
+        run(&repo_s, &["remote", "add", "origin", &repo_s]).await;
+        run(&repo_s, &["update-ref", "refs/remotes/origin/x", "HEAD"]).await;
+
+        let state = AppState::default();
+
+        // no-track arm: branch `y` from `origin/x` with tracking suppressed.
+        git_create_branch_core(
+            &state,
+            repo_s.clone(),
+            "y".into(),
+            false,
+            Some("origin/x".into()),
+            true,
+        )
+        .await
+        .expect("create y succeeds");
+        // No upstream → `y@{upstream}` fails to resolve.
+        assert!(
+            run_git(
+                Some(&repo_s),
+                &["rev-parse", "--abbrev-ref", "y@{upstream}"],
+                DEFAULT_TIMEOUT,
+            )
+            .await
+            .is_err(),
+            "no-track branch y must have no upstream"
+        );
+        // But it still starts at origin/x's tip.
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "y"]).await.trim(),
+            run(&repo_s, &["rev-parse", "origin/x"]).await.trim(),
+            "y should start at origin/x"
+        );
+
+        // control arm: branch `z` from `origin/x` with tracking left on.
+        git_create_branch_core(
+            &state,
+            repo_s.clone(),
+            "z".into(),
+            false,
+            Some("origin/x".into()),
+            false,
+        )
+        .await
+        .expect("create z succeeds");
+        // Upstream resolves and IS origin/x.
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "--abbrev-ref", "z@{upstream}"])
+                .await
+                .trim(),
+            "origin/x",
+            "z should track origin/x"
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "z"]).await.trim(),
+            run(&repo_s, &["rev-parse", "origin/x"]).await.trim(),
+            "z should start at origin/x"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1040,6 +1040,12 @@ mod tests {
             "y should start at origin/x"
         );
 
+        // Pin the tracking mode repo-locally: a contributor's ambient global
+        // `branch.autoSetupMerge = simple|false` would leave `z` untracked and
+        // false-fail this control arm (probed live both ways). The `--no-track`
+        // arm above is immune — the flag overrides config.
+        run(&repo_s, &["config", "branch.autoSetupMerge", "true"]).await;
+
         // control arm: branch `z` from `origin/x` with tracking left on.
         git_create_branch_core(
             &state,

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -76,6 +76,15 @@ struct CreateBranchArgs {
     /// Defaults to the current HEAD.
     #[serde(default)]
     from: Option<String>,
+    /// Create the branch with no upstream (git --no-track). Recommended when
+    /// `from` is a remote-tracking ref (e.g. origin/epic/x) and this branch is a
+    /// NEW line of work: without it the branch tracks that ref, and a later push
+    /// would fast-forward the tracked branch instead of publishing under this
+    /// branch's own name. Defaults to false (git's normal tracking behavior).
+    // The struct has no `rename_all`, so the wire name is spelled explicitly to
+    // match the documented `noTrack` flag (and the Tauri UI's camelCase key).
+    #[serde(default, rename = "noTrack")]
+    no_track: bool,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -308,9 +317,10 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Create a branch in the bound repository, optionally checking it out and/or \
-                       starting from a given branch/tag/commit (defaults to HEAD). Refuses to \
-                       create a GitDesktop agent-session branch (gd/session/*). \
-                       Requires --allow-git-write.",
+                       starting from a given branch/tag/commit (defaults to HEAD), optionally with \
+                       no upstream (noTrack — recommended when starting a new branch from a \
+                       remote-tracking ref). Refuses to create a GitDesktop agent-session branch \
+                       (gd/session/*). Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn create_branch(
@@ -331,6 +341,10 @@ impl GitDesktopMcp {
             args.name.clone(),
             args.checkout,
             args.from,
+            // Opt-in --no-track: agents basing on a remote-tracking ref should set
+            // this so the branch publishes under its own name instead of
+            // fast-forwarding the tracked ref on a later push.
+            args.no_track,
         )
         .await
         .map_err(app_err)?;
@@ -885,7 +899,8 @@ mod tests {
             h.create_branch(Parameters(CreateBranchArgs {
                 name: "b".into(),
                 checkout: false,
-                from: None
+                from: None,
+                no_track: false
             })),
             "--allow-git-write"
         );
@@ -1074,6 +1089,7 @@ mod tests {
                 name: "gd/session/fake".into(),
                 checkout: false,
                 from: None,
+                no_track: false,
             }))
             .await
             .expect_err("create_branch into gd/session/* must be refused");
@@ -1093,6 +1109,22 @@ mod tests {
             err.to_string().contains("agent-session branch"),
             "expected the session-branch refusal, got: {err}"
         );
+    }
+
+    /// `noTrack` is optional on the wire (#[serde(default)]): absent → false so
+    /// existing agents keep git's normal tracking, and an explicit true opts into
+    /// --no-track. Guards the default that keeps MCP behavior byte-identical.
+    #[test]
+    fn create_branch_args_no_track_defaults_false_and_parses_true() {
+        let absent: CreateBranchArgs =
+            serde_json::from_value(serde_json::json!({ "name": "b" })).unwrap();
+        assert!(!absent.no_track);
+
+        let explicit: CreateBranchArgs = serde_json::from_value(
+            serde_json::json!({ "name": "b", "from": "origin/epic/x", "noTrack": true }),
+        )
+        .unwrap();
+        assert!(explicit.no_track);
     }
 
     /// The session-branch guard is wired into the branch-mutating tools even when the

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -352,7 +352,12 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   each branch's ahead/behind counts vs. the default.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
-  it, collapsing it into an "Archived" section.
+  it, collapsing it into an "Archived" section. When creating, the **Base it on** picker is
+  a searchable list grouped into **Local** and **Remote** branches, so you can start from
+  *any* branch — not just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`)
+  starts from the remote tip and leaves the new branch with **no upstream**, so its first
+  push publishes it under its own name — pairs with pushing a branch without switching to it
+  (below).
 - **Clean up branches** — from the switcher's menu or the command palette — opens a bulk
   sweep of stale branches: those **merged** into the default branch, or with no commits in a
   chosen window (30/60/90 days). Review the pre-checked list, then **archive** them

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -18,11 +18,32 @@ import {
   useRemoteBranches,
   useUserWorktrees,
 } from "@/lib/git/queries";
+import type { Branch } from "@/lib/git/types";
 import { formatRelativeTime } from "@/lib/time";
 
 /** Lower-cased, forward-slashed path for cross-source comparison — git emits
  *  "/", the app stores "\" on Windows (mirrors BranchSwitcher's helper). */
 const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
+
+/** Whether a local branch may be offered as a base: drop the agent-session
+ *  namespace (a hard repo invariant — every branch surface filters
+ *  `gd/session/*`) and archived branches, EXCEPT always keep the current branch
+ *  even if archived (it's the seeded value and must render). Single-sourced so
+ *  the picker's Local group and the `useHasBaseOptions` gate can't drift. */
+function isOfferableLocal(b: Branch, currentName: string | null): boolean {
+  return (
+    !b.name.startsWith("gd/session/") && (!b.archived || b.name === currentName)
+  );
+}
+
+/** Whether a remote branch's short name may be offered as a base — drops the
+ *  agent-session namespace. (The full `remote/name` value's collision drop with
+ *  a same-named local lives inside the component; it can't affect emptiness —
+ *  if the only remote collides with a local, that local exists and the Local
+ *  group is non-empty.) */
+function isOfferableRemoteName(name: string): boolean {
+  return !name.startsWith("gd/session/");
+}
 
 /** Metadata a combobox row renders, keyed off the option's value string. */
 interface RowMeta {
@@ -82,15 +103,11 @@ export function BaseBranchCombobox({
     return map;
   }, [userWorktrees.data, activeNorm]);
 
-  // Local group: drop the agent-session namespace (a hard repo invariant — every
-  // branch surface filters `gd/session/*`) and archived branches, EXCEPT always
-  // keep the current branch even if archived (it's the seeded value and must
-  // render). Order: current first, then default, then most-recently-committed.
+  // Local group: keep only offerable branches (see `isOfferableLocal`). Order:
+  // current first, then default, then most-recently-committed.
   const localBranches = useMemo(() => {
-    const list = (branches.data ?? []).filter(
-      (b) =>
-        !b.name.startsWith("gd/session/") &&
-        (!b.archived || b.name === currentName),
+    const list = (branches.data ?? []).filter((b) =>
+      isOfferableLocal(b, currentName),
     );
     return list.sort((a, b) => {
       if (a.name === currentName) return -1;
@@ -115,7 +132,7 @@ export function BaseBranchCombobox({
   // alongside a stale local `epic/x` IS the motivating case. Order by recency.
   const remoteBranchList = useMemo(() => {
     return (remoteBranches.data ?? [])
-      .filter((b) => !b.name.startsWith("gd/session/"))
+      .filter((b) => isOfferableRemoteName(b.name))
       .map((b) => ({ value: `${b.remote}/${b.name}`, meta: b }))
       .filter((r) => !localSet.has(r.value))
       .sort((a, b) =>
@@ -194,6 +211,32 @@ export function BaseBranchCombobox({
       </ComboboxContent>
     </Combobox>
   );
+}
+
+/**
+ * Whether the picker would render ANY offerable base — the single source of
+ * truth for the dialog's "hide the whole field" gate. It subscribes to the SAME
+ * two queries the combobox does (`useBranches`, `useRemoteBranches`; react-query
+ * dedupes) and applies the SAME offerable predicates, so the field can never
+ * show with an empty dropdown (e.g. detached HEAD + only-archived locals + no
+ * remotes) the way a raw-count gate could.
+ */
+export function useHasBaseOptions(
+  repoPath: string,
+  open: boolean,
+  currentName: string | null,
+): boolean {
+  const branches = useBranches(repoPath);
+  const remoteBranches = useRemoteBranches(repoPath, open);
+  return useMemo(() => {
+    const hasLocal = (branches.data ?? []).some((b) =>
+      isOfferableLocal(b, currentName),
+    );
+    const hasRemote = (remoteBranches.data ?? []).some((b) =>
+      isOfferableRemoteName(b.name),
+    );
+    return hasLocal || hasRemote;
+  }, [branches.data, remoteBranches.data, currentName]);
 }
 
 /** One combobox row, keyed by the option value Base UI's Collection hands the

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -1,0 +1,251 @@
+import { TreeStructureIcon } from "@phosphor-icons/react";
+import { useMemo } from "react";
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import {
+  useBranches,
+  useRemoteBranches,
+  useUserWorktrees,
+} from "@/lib/git/queries";
+import { formatRelativeTime } from "@/lib/time";
+
+/** Lower-cased, forward-slashed path for cross-source comparison — git emits
+ *  "/", the app stores "\" on Windows (mirrors BranchSwitcher's helper). */
+const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
+
+/** Metadata a combobox row renders, keyed off the option's value string. */
+interface RowMeta {
+  /** ISO-8601 committer date of the branch tip (recency chip). */
+  lastCommitDate: string;
+  /** Set when this branch is checked out in ANOTHER worktree. */
+  worktreePath?: string;
+}
+
+/**
+ * The create-branch dialog's base picker: a searchable combobox grouped into
+ * Local and Remote branches, modeled on CompareBranchCombobox. Unlike the
+ * compare picker it OWNS its data — the dialog opens from the command palette
+ * without the branch-switcher popover, so it can't reuse the switcher's
+ * popover-gated queries. It has NO divergence query (that's compare-specific).
+ *
+ * A remote base (`origin/epic/x`) is a valid start point even when a same-named
+ * local branch exists — the local may be stale or checked out in another
+ * worktree — so remote rows are NOT deduped against locals (unlike the
+ * switcher's checkout list). `onValueChange` reports whether the picked value
+ * is a remote-tracking ref, which drives the create's `--no-track` seam.
+ */
+export function BaseBranchCombobox({
+  repoPath,
+  open,
+  currentName,
+  defaultName,
+  value,
+  onValueChange,
+}: {
+  repoPath: string;
+  /** The create-branch DIALOG's open state — gates the queries. */
+  open: boolean;
+  currentName: string | null;
+  defaultName: string | null;
+  value: string | null;
+  /** isRemote: whether the picked value is a remote-tracking ref (drives
+   *  --no-track). */
+  onValueChange: (value: string, isRemote: boolean) => void;
+}) {
+  // useBranches is cached app-wide; the remote list + worktrees fetch only while
+  // the dialog is open (same open-gating idiom as CompareBranchCombobox).
+  const branches = useBranches(repoPath);
+  const remoteBranches = useRemoteBranches(repoPath, open);
+  const userWorktrees = useUserWorktrees(repoPath, open);
+
+  // Branches checked out in *another* worktree → that worktree's path. Git
+  // forbids the same branch in two worktrees; the active repo's own checkout is
+  // excluded (that's just the current branch).
+  const activeNorm = normPath(repoPath);
+  const worktreeByBranch = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const w of userWorktrees.data ?? []) {
+      if (w.branch && normPath(w.path) !== activeNorm)
+        map.set(w.branch, w.path);
+    }
+    return map;
+  }, [userWorktrees.data, activeNorm]);
+
+  // Local group: drop the agent-session namespace (a hard repo invariant — every
+  // branch surface filters `gd/session/*`) and archived branches, EXCEPT always
+  // keep the current branch even if archived (it's the seeded value and must
+  // render). Order: current first, then default, then most-recently-committed.
+  const localBranches = useMemo(() => {
+    const list = (branches.data ?? []).filter(
+      (b) =>
+        !b.name.startsWith("gd/session/") &&
+        (!b.archived || b.name === currentName),
+    );
+    return list.sort((a, b) => {
+      if (a.name === currentName) return -1;
+      if (b.name === currentName) return 1;
+      if (a.name === defaultName) return -1;
+      if (b.name === defaultName) return 1;
+      return b.lastCommitDate.localeCompare(a.lastCommitDate);
+    });
+  }, [branches.data, currentName, defaultName]);
+
+  const localNames = useMemo(
+    () => localBranches.map((b) => b.name),
+    [localBranches],
+  );
+  const localSet = useMemo(() => new Set(localNames), [localNames]);
+
+  // Remote group: `${remote}/${name}` values across ALL remotes (a fork's
+  // `upstream/x` is a valid base). Drop the session namespace and any remote
+  // value that literally collides with an existing local branch name (a local
+  // named `origin/x` would create a duplicate combobox value). Do NOT dedupe a
+  // remote merely because a same-named LOCAL exists — offering `origin/epic/x`
+  // alongside a stale local `epic/x` IS the motivating case. Order by recency.
+  const remoteBranchList = useMemo(() => {
+    return (remoteBranches.data ?? [])
+      .filter((b) => !b.name.startsWith("gd/session/"))
+      .map((b) => ({ value: `${b.remote}/${b.name}`, meta: b }))
+      .filter((r) => !localSet.has(r.value))
+      .sort((a, b) =>
+        b.meta.lastCommitDate.localeCompare(a.meta.lastCommitDate),
+      );
+  }, [remoteBranches.data, localSet]);
+
+  const remoteNames = useMemo(
+    () => remoteBranchList.map((r) => r.value),
+    [remoteBranchList],
+  );
+  const remoteSet = useMemo(() => new Set(remoteNames), [remoteNames]);
+
+  // Row metadata by option value, spanning both groups. Local rows key off the
+  // Branch; remote rows carry only a date (no worktree — a remote-tracking ref
+  // is never a checked-out worktree branch).
+  const metaByValue = useMemo(() => {
+    const map = new Map<string, RowMeta>();
+    for (const b of localBranches) {
+      map.set(b.name, {
+        lastCommitDate: b.lastCommitDate,
+        worktreePath: worktreeByBranch.get(b.name),
+      });
+    }
+    for (const r of remoteBranchList) {
+      map.set(r.value, { lastCommitDate: r.meta.lastCommitDate });
+    }
+    return map;
+  }, [localBranches, remoteBranchList, worktreeByBranch]);
+
+  // Only non-empty groups are passed to `items` — Base UI flattens groups for
+  // keyboard nav, filters per-group, and drops a group that filters empty. The
+  // `items` prop MUST carry the group shape (with `items` arrays) so the List's
+  // render-function form maps `filteredItems`; static children bypass filtering.
+  const groups = useMemo(
+    () => [
+      ...(localNames.length ? [{ value: "Local", items: localNames }] : []),
+      ...(remoteNames.length ? [{ value: "Remote", items: remoteNames }] : []),
+    ],
+    [localNames, remoteNames],
+  );
+
+  return (
+    <Combobox
+      items={groups}
+      value={value}
+      onValueChange={(name) => name && onValueChange(name, remoteSet.has(name))}
+    >
+      <ComboboxTrigger className="flex w-full items-center justify-between gap-1.5 rounded-none border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50">
+        {/* Clamp a long branch value so it truncates and the caret stays put. */}
+        <span className="min-w-0 flex-1 truncate text-left">
+          <ComboboxValue />
+        </span>
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput showTrigger={false} placeholder="Filter branches…" />
+        <ComboboxEmpty>No branches match</ComboboxEmpty>
+        <ComboboxList>
+          {(group: { value: string; items: string[] }) => (
+            <ComboboxGroup key={group.value} items={group.items}>
+              <ComboboxLabel>{group.value}</ComboboxLabel>
+              <ComboboxCollection>
+                {(name: string) => (
+                  <BaseBranchRow
+                    key={name}
+                    name={name}
+                    meta={metaByValue.get(name)}
+                    currentName={currentName}
+                    defaultName={defaultName}
+                  />
+                )}
+              </ComboboxCollection>
+            </ComboboxGroup>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+/** One combobox row, keyed by the option value Base UI's Collection hands the
+ *  render function (a local branch name or a `remote/name` string). */
+function BaseBranchRow({
+  name,
+  meta,
+  currentName,
+  defaultName,
+}: {
+  name: string;
+  meta: RowMeta | undefined;
+  currentName: string | null;
+  defaultName: string | null;
+}) {
+  return (
+    <ComboboxItem value={name}>
+      <span
+        className="min-w-0 flex-1 truncate"
+        // Only expose the full name as a tooltip when it's actually clipped —
+        // measured just-in-time on hover, so no per-row refs.
+        onMouseEnter={(e) => {
+          const el = e.currentTarget;
+          el.title = el.scrollWidth > el.clientWidth ? name : "";
+        }}
+      >
+        {name}
+        {name === currentName && (
+          <span className="ml-1.5 text-[10px] text-muted-foreground">
+            (current)
+          </span>
+        )}
+        {name === defaultName && (
+          <span className="ml-1.5 text-[10px] text-muted-foreground">
+            default
+          </span>
+        )}
+      </span>
+      {meta?.worktreePath && (
+        <span
+          className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
+          title={`Checked out in another worktree (${meta.worktreePath})`}
+        >
+          <TreeStructureIcon className="size-3" weight="bold" />
+          worktree
+        </span>
+      )}
+      {meta?.lastCommitDate && (
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {formatRelativeTime(meta.lastCommitDate)}
+        </span>
+      )}
+    </ComboboxItem>
+  );
+}

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -239,6 +239,34 @@ export function useHasBaseOptions(
   }, [branches.data, remoteBranches.data, currentName]);
 }
 
+/** First offerable seed among [current, default] — "" when neither is offerable
+ *  (⇒ create from HEAD). Single-sourced with the picker's predicates so the
+ *  seeded value can never be one the list won't show. */
+export function useSeedBase(
+  repoPath: string,
+  currentName: string | null,
+  defaultName: string | null,
+): string {
+  const branches = useBranches(repoPath);
+  return useMemo(() => {
+    const byName = new Map<string, Branch>();
+    for (const b of branches.data ?? []) byName.set(b.name, b);
+    for (const candidate of [currentName, defaultName]) {
+      if (!candidate) continue;
+      const b = byName.get(candidate);
+      // When the branch is loaded, only seed it if the picker would offer it.
+      // When it isn't loaded yet (data momentarily absent), fall back to the
+      // session-namespace check alone — preserving today's seed behavior until
+      // the offerability check can run against real data.
+      const offerable = b
+        ? isOfferableLocal(b, currentName)
+        : !candidate.startsWith("gd/session/");
+      if (offerable) return candidate;
+    }
+    return "";
+  }, [branches.data, currentName, defaultName]);
+}
+
 /** One combobox row, keyed by the option value Base UI's Collection hands the
  *  render function (a local branch name or a `remote/name` string). */
 function BaseBranchRow({

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -441,17 +441,6 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // this branch, so switching would strand the in-progress amend and leave its
   // banner up. Lock the switcher until the user finishes or stops amending.
   const amending = amendingHash !== null;
-  // Bases offered when creating a branch: the current branch and/or the
-  // default branch (deduped — they're the same when you're on the default).
-  const baseOptions = useMemo(
-    () => [
-      ...new Set(
-        [currentName, defaultName].filter((b): b is string => Boolean(b)),
-      ),
-    ],
-    [currentName, defaultName],
-  );
-
   // Origin presence gates the per-row push/publish items (mirrors SyncControls):
   // a repo with no `origin` can't push a branch there.
   const hasOrigin = remotes.isSuccess && remotes.data.includes("origin");
@@ -1497,7 +1486,6 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         headExists={headExists}
         entries={status.data?.entries ?? []}
         allBranchNames={allBranches.map((b) => b.name)}
-        baseOptions={baseOptions}
         currentName={currentName}
         defaultName={defaultName}
         onOpenSettings={openSettings}

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useEffectEvent } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,13 +9,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { branchNameError, branchNameHint } from "@/lib/branch-rules/match";
 import type { BranchRulesConfig } from "@/lib/branch-rules/types";
 import { required, useAppForm } from "@/lib/form";
-import { useCreateBranch } from "@/lib/git/queries";
+import {
+  useBranches,
+  useCreateBranch,
+  useRemoteBranches,
+} from "@/lib/git/queries";
 import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
+import { BaseBranchCombobox } from "./BaseBranchCombobox";
 import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
 
 /**
@@ -36,7 +42,6 @@ export function CreateBranchDialog({
   headExists,
   entries,
   allBranchNames,
-  baseOptions,
   currentName,
   defaultName,
   onOpenSettings,
@@ -51,12 +56,24 @@ export function CreateBranchDialog({
   headExists: boolean;
   entries: FileEntry[];
   allBranchNames: string[];
-  baseOptions: string[];
   currentName: string | null;
   defaultName: string | null;
   onOpenSettings: (section: "ai") => void;
 }) {
   const createBranch = useCreateBranch(repoPath);
+
+  // The base picker owns its own data, but the dialog checks the same two
+  // queries' lengths to hide the whole field when there's nothing to base on
+  // (unborn HEAD / fresh repo → submit with no start point creates from HEAD).
+  const branches = useBranches(repoPath);
+  const remoteBranches = useRemoteBranches(repoPath, open);
+  const hasBases =
+    (branches.data?.length ?? 0) > 0 || (remoteBranches.data?.length ?? 0) > 0;
+
+  // Whether the picked base is a remote-tracking ref → drives `--no-track` so
+  // the new branch starts with NO upstream and its first push publishes it
+  // under its own name.
+  const [baseIsRemote, setBaseIsRemote] = useState(false);
 
   const createForm = useAppForm({
     defaultValues: { name: "", base: "" },
@@ -69,6 +86,9 @@ export function CreateBranchDialog({
           name: sanitizeRefName(value.name),
           checkout: true,
           startPoint,
+          // A remote base starts untracked so its first push publishes under
+          // its own name (no upstream copied from `origin/…`).
+          noTrack: baseIsRemote && Boolean(startPoint),
         });
         onOpenChange(false);
       } catch (e) {
@@ -88,6 +108,8 @@ export function CreateBranchDialog({
       { name: "", base: currentName ?? defaultName ?? "" },
       { keepDefaultValues: true },
     );
+    // Seeded base is a local branch (current/default) → tracking stays on.
+    setBaseIsRemote(false);
   });
   useEffect(() => {
     if (open) seedOnOpen();
@@ -153,20 +175,23 @@ export function CreateBranchDialog({
               onOpenSettings("ai");
             }}
           />
-          {baseOptions.length > 0 && (
+          {hasBases && (
             <createForm.AppField name="base">
               {(field) => (
-                <field.SelectField
-                  label="Base it on"
-                  items={Object.fromEntries(
-                    baseOptions.map((b) => [
-                      b,
-                      `${b}${b === currentName ? " (current)" : ""}${
-                        b === defaultName ? " (default)" : ""
-                      }`,
-                    ]),
-                  )}
-                />
+                <div className="space-y-2">
+                  <Label>Base it on</Label>
+                  <BaseBranchCombobox
+                    repoPath={repoPath}
+                    open={open}
+                    currentName={currentName}
+                    defaultName={defaultName}
+                    value={field.state.value || null}
+                    onValueChange={(v, isRemote) => {
+                      field.handleChange(v);
+                      setBaseIsRemote(isRemote);
+                    }}
+                  />
+                </div>
               )}
             </createForm.AppField>
           )}

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -17,7 +17,11 @@ import { useCreateBranch } from "@/lib/git/queries";
 import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { BaseBranchCombobox, useHasBaseOptions } from "./BaseBranchCombobox";
+import {
+  BaseBranchCombobox,
+  useHasBaseOptions,
+  useSeedBase,
+} from "./BaseBranchCombobox";
 import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
 
 /**
@@ -65,6 +69,10 @@ export function CreateBranchDialog({
   // query counts, so the field can't render with an empty dropdown.
   const hasBases = useHasBaseOptions(repoPath, open, currentName);
 
+  // The value to seed the base picker with on open — the first of
+  // current/default the picker would actually offer, "" otherwise (⇒ HEAD).
+  const seedBase = useSeedBase(repoPath, currentName, defaultName);
+
   // Whether the picked base is a remote-tracking ref → drives `--no-track` so
   // the new branch starts with NO upstream and its first push publishes it
   // under its own name.
@@ -99,14 +107,12 @@ export function CreateBranchDialog({
   // sync sees "different defaults + untouched form" and clobbers the seeded
   // values right back on the next render.
   const seedOnOpen = useEffectEvent(() => {
-    // Never seed a `gd/session/*` branch: the picker filters that namespace (a
-    // hard repo invariant — no surface may offer session branches), so a seeded
-    // session base would render in the trigger but be absent from the list.
-    const seedBase = currentName?.startsWith("gd/session/")
-      ? (defaultName ?? "")
-      : (currentName ?? defaultName ?? "");
+    // Seed only a value the picker would actually offer (see `useSeedBase`) — a
+    // seeded base absent from the list would render in the trigger yet be
+    // unselectable. `seedBase` already encodes that invariant.
     createForm.reset({ name: "", base: seedBase }, { keepDefaultValues: true });
-    // Seeded base is a local branch (current/default) → tracking stays on.
+    // Seeded base is an offerable local branch (current/default) → never a
+    // remote value, so tracking stays on.
     setBaseIsRemote(false);
   });
   useEffect(() => {

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -13,15 +13,11 @@ import { Label } from "@/components/ui/label";
 import { branchNameError, branchNameHint } from "@/lib/branch-rules/match";
 import type { BranchRulesConfig } from "@/lib/branch-rules/types";
 import { required, useAppForm } from "@/lib/form";
-import {
-  useBranches,
-  useCreateBranch,
-  useRemoteBranches,
-} from "@/lib/git/queries";
+import { useCreateBranch } from "@/lib/git/queries";
 import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { BaseBranchCombobox } from "./BaseBranchCombobox";
+import { BaseBranchCombobox, useHasBaseOptions } from "./BaseBranchCombobox";
 import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
 
 /**
@@ -62,13 +58,12 @@ export function CreateBranchDialog({
 }) {
   const createBranch = useCreateBranch(repoPath);
 
-  // The base picker owns its own data, but the dialog checks the same two
-  // queries' lengths to hide the whole field when there's nothing to base on
-  // (unborn HEAD / fresh repo → submit with no start point creates from HEAD).
-  const branches = useBranches(repoPath);
-  const remoteBranches = useRemoteBranches(repoPath, open);
-  const hasBases =
-    (branches.data?.length ?? 0) > 0 || (remoteBranches.data?.length ?? 0) > 0;
+  // The base picker owns its own data; the dialog hides the whole field when
+  // there's no offerable base to pick (unborn HEAD / fresh repo → submit with no
+  // start point creates from HEAD). Gate on the SAME offerable predicates the
+  // picker derives its groups from (via `useHasBaseOptions`) rather than raw
+  // query counts, so the field can't render with an empty dropdown.
+  const hasBases = useHasBaseOptions(repoPath, open, currentName);
 
   // Whether the picked base is a remote-tracking ref → drives `--no-track` so
   // the new branch starts with NO upstream and its first push publishes it
@@ -104,10 +99,13 @@ export function CreateBranchDialog({
   // sync sees "different defaults + untouched form" and clobbers the seeded
   // values right back on the next render.
   const seedOnOpen = useEffectEvent(() => {
-    createForm.reset(
-      { name: "", base: currentName ?? defaultName ?? "" },
-      { keepDefaultValues: true },
-    );
+    // Never seed a `gd/session/*` branch: the picker filters that namespace (a
+    // hard repo invariant — no surface may offer session branches), so a seeded
+    // session base would render in the trigger but be absent from the list.
+    const seedBase = currentName?.startsWith("gd/session/")
+      ? (defaultName ?? "")
+      : (currentName ?? defaultName ?? "");
+    createForm.reset({ name: "", base: seedBase }, { keepDefaultValues: true });
     // Seeded base is a local branch (current/default) → tracking stays on.
     setBaseIsRemote(false);
   });
@@ -179,6 +177,8 @@ export function CreateBranchDialog({
             <createForm.AppField name="base">
               {(field) => (
                 <div className="space-y-2">
+                  {/* Programmatic label↔control association is deferred to the
+                      planned shared field-primitives a11y sweep. */}
                   <Label>Base it on</Label>
                   <BaseBranchCombobox
                     repoPath={repoPath}

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -183,12 +183,14 @@ export const gitCreateBranch = (
   name: string,
   checkout: boolean,
   startPoint?: string,
+  noTrack?: boolean,
 ) =>
   invoke<void>("git_create_branch", {
     repoPath,
     name,
     checkout,
     startPoint: startPoint ?? null,
+    noTrack: noTrack ?? false,
   });
 
 export const gitDiffFile = (

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2928,8 +2928,19 @@ export function useCheckoutRemoteBranch(repo: string) {
 export function useCreateBranch(repo: string) {
   return useRepoMutation(
     repo,
-    (args: { name: string; checkout: boolean; startPoint?: string }) =>
-      api.gitCreateBranch(repo, args.name, args.checkout, args.startPoint),
+    (args: {
+      name: string;
+      checkout: boolean;
+      startPoint?: string;
+      noTrack?: boolean;
+    }) =>
+      api.gitCreateBranch(
+        repo,
+        args.name,
+        args.checkout,
+        args.startPoint,
+        args.noTrack,
+      ),
   );
 }
 


### PR DESCRIPTION
This change allows users to create a new branch from any base—local or remote—directly in the branch creation dialog. Previously, the dialog only supported creating a branch from the current or default branch. This enhancement makes it possible to start work from arbitrary local or remote branch tips, better supporting workflows such as branching off remote feature branches. When a branch is based on a remote-tracking ref, it is created with no upstream, so its first push publishes under its own name.

### UI/UX
- Adds the new `BaseBranchCombobox` component in `src/features/repository/BaseBranchCombobox.tsx` for a grouped, searchable base branch picker.
- Integrates `BaseBranchCombobox` into the dialog in `src/features/repository/CreateBranchDialog.tsx`, replacing the previous dropdown.
- Updates dialog logic in `CreateBranchDialog.tsx` to pass the `noTrack` flag when a remote branch is selected.
- Removes obsolete create-branch baseOptions logic from `src/features/repository/BranchSwitcher.tsx`.
- Updates help content in `src/features/help/content.ts` to document the new base picker behavior.

### Backend/Git CLI
- Refactors git branch creation in `src-tauri/src/git/branches.rs`:
  - Adds `no_track` argument throughout the API and uses new helper `build_create_branch_args`.
  - Updates `git_create_branch_core` to correctly pass CLI flags for `--no-track`.
  - Adds comprehensive unit tests for CLI arg permutations in `branches.rs`.
- Extends the MCP create_branch tool in `src-tauri/src/mcp_server/write_git.rs` to accept and document the `noTrack` option (wire format and docs), passing this through to the core implementation.
- Adds serialization and deserialization logic to accept `noTrack` for agent requests and tests defaulting/explicit flag handling.

### API & Queries
- Updates `gitCreateBranch` in `src/lib/git/api.ts` to accept and forward the `noTrack` flag.
- Updates the mutation in `src/lib/git/queries.ts` to handle the additional argument from callers.

### Documentation & Changelog
- Expands documentation in `README.md` to describe starting branches from any base.
- Adds an entry in `changelog.d/added-create-branch-from-any-base.md`.
- Updates product capability table in `site/src/data/capabilities.ts` with this enhancement.