### PR TITLE
feat(aiignore,repo-files,ui): add Exclude from AI actions to changes context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,9 @@ display can't strand it off-screen.
 - **AI ignore patterns** (keep files out of AI context; they still commit
   normally), gitignore-style:
   - **Global** — Settings → Excluded files (one pattern per line).
-  - **Per-repo** — `.gitdesktop/aiignore` in the repo.
+  - **Per-repo** — `.gitdesktop/aiignore` in the repo. Right-click a changed
+    file → **Exclude from AI** (file, folder, or file type — or a
+    multi-selection) creates and updates this file for you.
 - **Keys** live in the OS keychain (Windows Credential Manager, macOS Keychain,
   libsecret). **Hide AI** (Settings → General) hides every AI surface while
   keeping your config.

--- a/changelog.d/added-aiignore-context-menu.md
+++ b/changelog.d/added-aiignore-context-menu.md
@@ -1,0 +1,5 @@
+- **Exclude files from AI in flow.** Right-click a changed file to keep it out of
+  AI context — new **Exclude from AI** actions (the file, its folder, or its file
+  type, plus a bulk action for multi-selections) append to the repo's
+  `.gitdesktop/aiignore`, creating the file (and the `.gitdesktop` folder) if
+  needed.

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -34,6 +34,68 @@ pub async fn read_repo_ai_ignore(repo_path: String) -> AppResult<Vec<String>> {
     }
 }
 
+/// Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore`, creating the
+/// `.gitdesktop` directory and the file (with a header comment) if absent.
+/// Mirrors `append_to_gitignore` (trim + in-batch de-dupe + skip lines already
+/// present) with two deltas: any leading `/` is stripped — these lines are
+/// consumed as git pathspecs via `:(exclude)<pattern>`, where a leading slash
+/// makes git treat it as an absolute path outside the repo — and a fresh file
+/// is seeded with a header comment (`parse_patterns` and the pathspec builders
+/// both skip `#` lines).
+#[tauri::command]
+pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> AppResult<()> {
+    const HEADER: &str =
+        "# Files excluded from AI context — gitignore-style patterns, one per line.";
+
+    // Normalize (trim + strip leading '/') and de-dupe within the batch
+    // (preserving order).
+    let mut wanted: Vec<String> = Vec::new();
+    for p in patterns {
+        let t = p.trim().trim_start_matches('/').to_string();
+        if !t.is_empty() && !wanted.contains(&t) {
+            wanted.push(t);
+        }
+    }
+    if wanted.is_empty() {
+        return Ok(());
+    }
+
+    let dir = Path::new(&repo_path).join(".gitdesktop");
+    let path = dir.join("aiignore");
+    let (mut content, is_new) = match tokio::fs::read_to_string(&path).await {
+        Ok(text) => (text, false),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), true),
+        Err(e) => return Err(AppError::Io(e)),
+    };
+
+    // Drop anything already in the file (scoped so the borrow ends before we
+    // mutate `content`).
+    let to_add: Vec<String> = {
+        let existing: HashSet<&str> = content.lines().map(str::trim).collect();
+        wanted
+            .into_iter()
+            .filter(|p| !existing.contains(p.as_str()))
+            .collect()
+    };
+    if to_add.is_empty() {
+        return Ok(());
+    }
+
+    tokio::fs::create_dir_all(&dir).await.map_err(AppError::Io)?;
+
+    if is_new {
+        content.push_str(HEADER);
+        content.push('\n');
+    } else if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    for p in to_add {
+        content.push_str(&p);
+        content.push('\n');
+    }
+    tokio::fs::write(&path, content).await.map_err(AppError::Io)
+}
+
 /// Per-repo SHARED branch rules, read from `<repo>/.gitdesktop/branch-rules.json`.
 /// Returns the raw file contents (parsed and normalized on the frontend, which
 /// owns the schema), or None when the file is absent or empty.
@@ -410,5 +472,105 @@ mod tests {
         assert_eq!(meta.name, "writing-guidelines");
         assert_eq!(meta.description, "Review docs");
         assert_eq!(meta.argument_hint, "<file>");
+    }
+
+    fn ai_ignore_test_repo() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "gd-aiignore-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn append_ai_ignore_creates_file_with_header() {
+        let dir = ai_ignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+
+        append_repo_ai_ignore(repo.clone(), vec!["src/foo.rs".to_string(), "*.log".to_string()])
+            .await
+            .unwrap();
+
+        let path = dir.join(".gitdesktop").join("aiignore");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let first_line = text.lines().next().unwrap();
+        assert_eq!(
+            first_line,
+            "# Files excluded from AI context — gitignore-style patterns, one per line."
+        );
+        assert!(text.contains("\nsrc/foo.rs\n"));
+        assert!(text.contains("\n*.log\n"));
+
+        // read_repo_ai_ignore / parse_patterns round-trips the patterns, header filtered.
+        let parsed = read_repo_ai_ignore(repo).await.unwrap();
+        assert_eq!(parsed, vec!["src/foo.rs".to_string(), "*.log".to_string()]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn append_ai_ignore_appends_without_duplicating() {
+        let dir = ai_ignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+
+        append_repo_ai_ignore(repo.clone(), vec!["a.txt".to_string()])
+            .await
+            .unwrap();
+        let path = dir.join(".gitdesktop").join("aiignore");
+        let after_first = std::fs::read_to_string(&path).unwrap();
+
+        // Re-add the same line plus a new one: the existing line is not duplicated,
+        // the new line is appended, existing content is preserved, no second header.
+        append_repo_ai_ignore(repo.clone(), vec!["a.txt".to_string(), "b.txt".to_string()])
+            .await
+            .unwrap();
+        let after_second = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(after_second.matches("\na.txt\n").count(), 1);
+        assert!(after_second.contains("\nb.txt\n"));
+        assert!(after_second.starts_with(&after_first));
+        assert_eq!(
+            after_second
+                .lines()
+                .filter(|l| l.starts_with('#'))
+                .count(),
+            1
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn append_ai_ignore_normalizes_patterns() {
+        let dir = ai_ignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+
+        // Leading slash stripped, whitespace-only skipped, in-batch dupes collapsed.
+        append_repo_ai_ignore(
+            repo.clone(),
+            vec![
+                "/foo".to_string(),
+                "   ".to_string(),
+                "bar".to_string(),
+                "bar".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+        let parsed = read_repo_ai_ignore(repo.clone()).await.unwrap();
+        assert_eq!(parsed, vec!["foo".to_string(), "bar".to_string()]);
+
+        // An all-duplicates batch leaves the file byte-identical.
+        let path = dir.join(".gitdesktop").join("aiignore");
+        let before = std::fs::read_to_string(&path).unwrap();
+        append_repo_ai_ignore(repo, vec!["/foo".to_string(), "bar".to_string()])
+            .await
+            .unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -647,6 +647,7 @@ pub fn run() {
             mcp::mcp_global_remove,
             instructions::read_repo_instructions,
             instructions::read_repo_ai_ignore,
+            instructions::append_repo_ai_ignore,
             instructions::read_repo_branch_rules,
             instructions::write_repo_branch_rules,
             instructions::read_repo_syntax,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1441,7 +1441,9 @@ notes**, and **repository descriptions**.
   takes precedence.
 - **AI-ignore patterns** keep sensitive or noisy files (lockfiles, vendored folders) out
   of the AI's context while still committing them normally — global in Settings, or
-  per-repo via \`.gitdesktop/aiignore\`.
+  per-repo via \`.gitdesktop/aiignore\`. Build the per-repo file in flow: right-click a
+  changed file → *Exclude from AI* (the file, its folder, or its file type — or a
+  multi-selection) creates and updates \`.gitdesktop/aiignore\` for you.
 - **Hide AI** (Settings → General) removes every AI surface from the app while keeping
   your configuration.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1441,9 +1441,9 @@ notes**, and **repository descriptions**.
   takes precedence.
 - **AI-ignore patterns** keep sensitive or noisy files (lockfiles, vendored folders) out
   of the AI's context while still committing them normally — global in Settings, or
-  per-repo via \`.gitdesktop/aiignore\`. Build the per-repo file in flow: right-click a
-  changed file → *Exclude from AI* (the file, its folder, or its file type — or a
-  multi-selection) creates and updates \`.gitdesktop/aiignore\` for you.
+  per-repo via \`.gitdesktop/aiignore\`. No need to hand-edit it: right-click a changed
+  file → *Exclude from AI* (the file, its folder, or its file type — or a
+  multi-selection) appends to \`.gitdesktop/aiignore\`, creating it if needed.
 - **Hide AI** (Settings → General) removes every AI surface from the app while keeping
   your configuration.
 

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -45,6 +45,8 @@ export interface ChangesMenuActions {
   blame: (path: string) => void;
   ignore: (pattern: string) => void;
   untrack: (pathspec: string, ignorePattern: string, label: string) => void;
+  aiExclude: (pattern: string) => void;
+  aiExcludeSelected: () => void;
 }
 
 /** "src/lib/x.ts" -> ["src/lib", "src"] (closest folder first). */
@@ -130,6 +132,11 @@ export function ChangesContextMenuItems({
         {selectedTrackedCount > 0 && (
           <ContextMenuItem onClick={actions.untrackSelected}>
             Untrack {selectedTrackedCount} files (keep on disk)
+          </ContextMenuItem>
+        )}
+        {aiEnabled && (
+          <ContextMenuItem onClick={actions.aiExcludeSelected}>
+            Exclude {selectionCount} files from AI (add to aiignore)
           </ContextMenuItem>
         )}
       </>
@@ -244,6 +251,38 @@ export function ChangesContextMenuItems({
               }
             >
               Untrack all .{extension} files (keep on disk)
+            </ContextMenuItem>
+          )}
+        </>
+      )}
+      {aiEnabled && (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => actions.aiExclude(entry.path)}>
+            Exclude from AI (add to aiignore)
+          </ContextMenuItem>
+          {folders.length > 0 && (
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                Exclude folder from AI (add to aiignore)
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                {folders.map((folder) => (
+                  <ContextMenuItem
+                    key={folder}
+                    onClick={() => actions.aiExclude(`${folder}/`)}
+                  >
+                    <span className="font-mono">{folder}/</span>
+                  </ContextMenuItem>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          )}
+          {extension && (
+            <ContextMenuItem
+              onClick={() => actions.aiExclude(`*.${extension}`)}
+            >
+              Exclude all .{extension} files from AI (add to aiignore)
             </ContextMenuItem>
           )}
         </>

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -136,7 +136,7 @@ export function ChangesContextMenuItems({
         )}
         {aiEnabled && (
           <ContextMenuItem onClick={actions.aiExcludeSelected}>
-            Exclude {selectionCount} files from AI (add to aiignore)
+            Exclude {selectionCount} files from AI (add to .gitdesktop/aiignore)
           </ContextMenuItem>
         )}
       </>
@@ -259,12 +259,12 @@ export function ChangesContextMenuItems({
         <>
           <ContextMenuSeparator />
           <ContextMenuItem onClick={() => actions.aiExclude(entry.path)}>
-            Exclude from AI (add to aiignore)
+            Exclude from AI (add to .gitdesktop/aiignore)
           </ContextMenuItem>
           {folders.length > 0 && (
             <ContextMenuSub>
               <ContextMenuSubTrigger>
-                Exclude folder from AI (add to aiignore)
+                Exclude folder from AI (add to .gitdesktop/aiignore)
               </ContextMenuSubTrigger>
               <ContextMenuSubContent>
                 {folders.map((folder) => (
@@ -282,7 +282,8 @@ export function ChangesContextMenuItems({
             <ContextMenuItem
               onClick={() => actions.aiExclude(`*.${extension}`)}
             >
-              Exclude all .{extension} files from AI (add to aiignore)
+              Exclude all .{extension} files from AI (add to
+              .gitdesktop/aiignore)
             </ContextMenuItem>
           )}
         </>

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { BlameDialog } from "@/features/history/BlameDialog";
 import { FileHistoryDialog } from "@/features/history/FileHistoryDialog";
 import {
+  useAppendRepoAiIgnore,
   useAppendToGitignore,
   useCompareBranches,
   useDefaultBranch,
@@ -110,6 +111,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   const stashPaths = useStashPaths(repoPath);
   const stashAll = useStashAll(repoPath);
   const appendIgnore = useAppendToGitignore(repoPath);
+  const appendAiIgnore = useAppendRepoAiIgnore(repoPath);
   const untrack = useUntrack(repoPath);
   const selectedFile = useUiStore((s) => s.selectedFile);
   const selectFile = useUiStore((s) => s.selectFile);
@@ -398,6 +400,13 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
       onError,
     });
   }
+  function aiExcludeOne(pattern: string) {
+    appendAiIgnore.mutate([pattern], {
+      onSuccess: () =>
+        toast.success(`Added "${pattern}" to .gitdesktop/aiignore`),
+      onError,
+    });
+  }
   function untrackOne(pathspec: string, ignorePattern: string, label: string) {
     untrack.mutate(
       { pathspecs: [pathspec], ignorePatterns: [ignorePattern] },
@@ -476,6 +485,22 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     appendIgnore.mutate(patterns, {
       onSuccess: () => {
         toast.success(`Added ${patterns.length} entries to .gitignore`);
+        setSelectedKeys(new Set());
+      },
+      onError,
+    });
+  }
+
+  // Bulk AI-exclude: add a root-relative pathspec per selected file. The Rust
+  // side strips leading slashes, de-dupes, and skips lines already present.
+  function aiExcludeSelected() {
+    if (selectionCount === 0) return;
+    const patterns = selectedEntries.map((e) => e.path);
+    appendAiIgnore.mutate(patterns, {
+      onSuccess: () => {
+        toast.success(
+          `Added ${patterns.length} entries to .gitdesktop/aiignore`,
+        );
         setSelectedKeys(new Set());
       },
       onError,
@@ -907,6 +932,8 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
                   blame: setBlamePath,
                   ignore: ignoreOne,
                   untrack: untrackOne,
+                  aiExclude: aiExcludeOne,
+                  aiExcludeSelected,
                 }}
               />
             </ContextMenuContent>

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2917,6 +2917,10 @@ export const readRepoInstructions = (repoPath: string) =>
 export const readRepoAiIgnore = (repoPath: string) =>
   invoke<string[]>("read_repo_ai_ignore", { repoPath });
 
+/** Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore` (created if absent). */
+export const appendRepoAiIgnore = (repoPath: string, patterns: string[]) =>
+  invoke<void>("append_repo_ai_ignore", { repoPath, patterns });
+
 /** Raw contents of `<repo>/.gitdesktop/branch-rules.json`, or null if absent. */
 export const readRepoBranchRules = (repoPath: string) =>
   invoke<string | null>("read_repo_branch_rules", { repoPath });

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2949,8 +2949,12 @@ export function useAppendToGitignore(repo: string) {
 }
 
 export function useAppendRepoAiIgnore(repo: string) {
-  return useRepoMutation(repo, (patterns: string[]) =>
-    api.appendRepoAiIgnore(repo, patterns),
+  return useRepoMutation(
+    repo,
+    (patterns: string[]) => api.appendRepoAiIgnore(repo, patterns),
+    // Staging-class edit — only the working tree changes (the aiignore file
+    // appears/updates), so narrow like useStage/useApplySuggestion.
+    { invalidate: workingTreeKeys(repo) },
   );
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2948,6 +2948,12 @@ export function useAppendToGitignore(repo: string) {
   );
 }
 
+export function useAppendRepoAiIgnore(repo: string) {
+  return useRepoMutation(repo, (patterns: string[]) =>
+    api.appendRepoAiIgnore(repo, patterns),
+  );
+}
+
 export function useUntrack(repo: string) {
   return useRepoMutation(
     repo,


### PR DESCRIPTION
Adds a new "Exclude from AI" action to the changes context menu, enabling users to easily keep specific files, folders, or file types out of AI context by appending patterns to `.gitdesktop/aiignore`. This streamlines AI context curation directly from the changes panel for both individual and multiple file selections.

### UI: Changes context menu and panel
- Adds "Exclude from AI" actions for files, folders, file types, and multi-selections in `src/features/repository/ChangesContextMenu.tsx`.
- Wires menu interactions to new handlers in `src/features/repository/ChangesPanel.tsx` to call the backend and update `.gitdesktop/aiignore`, with success/failure toasts and selection reset.
- Integrates `useAppendRepoAiIgnore` custom hook for mutation handling in `src/features/repository/ChangesPanel.tsx`.

### Backend: AI ignore mutation
- Implements `append_repo_ai_ignore` Tauri command in `src-tauri/src/instructions.rs` to append gitignore-style patterns to `.gitdesktop/aiignore`, creating the file and parent directory if needed, and ensuring no duplicates or blank entries.
- Exposes the new command for use by wiring it into the Tauri invocation handler in `src-tauri/src/lib.rs`.
- Provides full backend tests in `src-tauri/src/instructions.rs` covering creation, appending, normalization, and duplicate avoidance.

### API and Data Layer
- Adds `appendRepoAiIgnore` function to invoke the new command in `src/lib/git/api.ts`.
- Creates React hook `useAppendRepoAiIgnore` using `useRepoMutation` in `src/lib/git/queries.ts` for integration with UI.

### Documentation and Help
- Updates `README.md` to explain the new per-repo AI exclusion workflow, including right-click menu usage and file creation.
- Adds documentation for the new flow to `src/features/help/content.ts`.
- Notes the feature and usage in `changelog.d/added-aiignore-context-menu.md` for release documentation.