### PR TITLE
feat(git,branches,ui): push or publish any branch to its own remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,9 @@ commit that hasn't been pushed yet.
   parallel folders without stashing — with one-click jumps to the main workspace right
   from the branch switcher.
 - **Push or publish a branch without switching to it** — from the branch switcher's
-  right-click menu, push a branch that's ahead of its `origin` remote or publish an
-  unpushed one, without checking it out; it works even when the branch is checked out
+  right-click menu, push a branch that's ahead of the remote it tracks (its own remote,
+  not just `origin`) or publish an unpushed one (choosing the remote when there's more
+  than one), without checking it out; it works even when the branch is checked out
   in another worktree.
 - **Start a branch from any base** — the new-branch dialog's *Base it on* picker is a
   searchable list grouped into local and remote branches, so you can branch off any of

--- a/changelog.d/changed-push-any-remote.md
+++ b/changelog.d/changed-push-any-remote.md
@@ -1,0 +1,7 @@
+- **Push a branch to any remote, not just origin.** Pushing a branch from the branch
+  switcher now targets the branch's OWN remote — a branch tracking a fork's `upstream`
+  is pushed there, not to origin. On a repo with several remotes, **Publish** offers a
+  per-remote choice (one item per remote). The MCP `push` tool gains an optional
+  `remote` parameter, and a bare `push {branch}` for a branch tracking a non-origin
+  remote now correctly targets that remote instead of pushing to origin under the
+  branch's own name.

--- a/changelog.d/fixed-form-label-associations.md
+++ b/changelog.d/fixed-form-label-associations.md
@@ -1,0 +1,4 @@
+- **Screen readers now announce every form field by name.** Labels across the app's
+  dialogs and settings are programmatically associated with their controls (`Base it on`,
+  select fields, the compare picker, and a dozen more), so assistive tech announces the
+  field name instead of just its value — and clicking a label focuses or opens its control.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -47,7 +47,7 @@ export const capabilities: Capability[] = [
   // — Branches & history —
   { group: "Branches & history", label: "Branch compare — ahead/behind, three-dot diff, jump to PR", highlight: true },
   { group: "Branches & history", label: "Update a branch from its upstream — no checkout needed" },
-  { group: "Branches & history", label: "Push or publish a branch — no checkout needed" },
+  { group: "Branches & history", label: "Push or publish a branch to any remote — no checkout needed" },
   { group: "Branches & history", label: "Start a branch from any base — another local branch or a remote ref" },
   { group: "Branches & history", label: "Check out or delete remote-only branches from the switcher" },
   { group: "Branches & history", label: "Archive branches — hide from the switcher without deleting" },

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -38,7 +38,7 @@ pub async fn git_branches(repo_path: String) -> AppResult<Vec<Branch>> {
         &[
             "for-each-ref",
             "refs/heads",
-            "--format=%(refname:short)%00%(upstream:short)%00%(HEAD)%00%(committerdate:iso8601-strict)%00%(upstream:track)",
+            "--format=%(refname:short)%00%(upstream:short)%00%(HEAD)%00%(committerdate:iso8601-strict)%00%(upstream:track)%00%(upstream:remotename)",
         ],
         DEFAULT_TIMEOUT,
     )
@@ -48,7 +48,8 @@ pub async fn git_branches(repo_path: String) -> AppResult<Vec<Branch>> {
     let mut branches = Vec::new();
     for line in text.lines() {
         let mut parts = line.split('\0');
-        let (Some(name), upstream, head, date, track) = (
+        let (Some(name), upstream, head, date, track, upstream_remote) = (
+            parts.next(),
             parts.next(),
             parts.next(),
             parts.next(),
@@ -71,6 +72,7 @@ pub async fn git_branches(repo_path: String) -> AppResult<Vec<Branch>> {
             upstream_ahead,
             upstream_behind,
             upstream_gone,
+            upstream_remote: upstream_remote.filter(|r| !r.is_empty()).map(str::to_string),
         });
     }
     Ok(branches)
@@ -830,7 +832,8 @@ fn unique_suffix() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_create_branch_args, git_create_branch_core, parse_upstream_track, validate_ref_name,
+        build_create_branch_args, git_branches, git_create_branch_core, parse_upstream_track,
+        validate_ref_name,
     };
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
     use crate::state::AppState;
@@ -1069,6 +1072,73 @@ mod tests {
             run(&repo_s, &["rev-parse", "z"]).await.trim(),
             run(&repo_s, &["rev-parse", "origin/x"]).await.trim(),
             "z should start at origin/x"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// `git_branches` must surface git's authoritative `%(upstream:remotename)`
+    /// on each branch: a tracked branch carries its remote, an untracked one
+    /// carries none. This is the single source of truth the UI reads instead of
+    /// re-deriving the remote from the upstream string.
+    #[tokio::test]
+    async fn git_branches_reports_upstream_remote() {
+        let base = temp_base("upstream-remote");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        init_repo(&repo_s, "r.txt").await;
+        // A remote named `origin` (URL is the repo's own path — never fetched) and
+        // a synthetic remote-tracking ref pointing at HEAD.
+        run(&repo_s, &["remote", "add", "origin", &repo_s]).await;
+        run(&repo_s, &["update-ref", "refs/remotes/origin/x", "HEAD"]).await;
+
+        let state = AppState::default();
+        // Pin tracking mode repo-locally so an ambient global
+        // `branch.autoSetupMerge = simple|false` can't leave `tracked` untracked
+        // and false-fail the assertion (same guard as the no-track control arm).
+        run(&repo_s, &["config", "branch.autoSetupMerge", "true"]).await;
+        // Tracked branch `tracked` → tracks origin/x.
+        git_create_branch_core(
+            &state,
+            repo_s.clone(),
+            "tracked".into(),
+            false,
+            Some("origin/x".into()),
+            false,
+        )
+        .await
+        .expect("create tracked succeeds");
+        // Untracked branch `solo` → based on the same ref with tracking suppressed.
+        git_create_branch_core(
+            &state,
+            repo_s.clone(),
+            "solo".into(),
+            false,
+            Some("origin/x".into()),
+            true,
+        )
+        .await
+        .expect("create solo succeeds");
+
+        let branches = git_branches(repo_s.clone()).await.expect("list branches");
+        let tracked = branches
+            .iter()
+            .find(|b| b.name == "tracked")
+            .expect("tracked branch present");
+        assert_eq!(
+            tracked.upstream_remote.as_deref(),
+            Some("origin"),
+            "a tracked branch carries its upstream's remote"
+        );
+        let solo = branches
+            .iter()
+            .find(|b| b.name == "solo")
+            .expect("solo branch present");
+        assert_eq!(
+            solo.upstream_remote, None,
+            "an untracked branch carries no upstream remote"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -495,7 +495,11 @@ pub(crate) async fn git_push_core(
             // validate_ref_name's blocklist already rejects). We never interpolate
             // the remote into a refspec — it's the bare `push <remote>` argument.
             if let Some(r) = &remote {
-                crate::git::branches::validate_ref_name(r)?;
+                // `validate_ref_name` is the checker, but its message speaks of a
+                // "branch name" — remap it so an invalid remote reads accurately.
+                crate::git::branches::validate_ref_name(r).map_err(|_| {
+                    AppError::InvalidArgument(format!("invalid remote name: {r}"))
+                })?;
                 let remotes = git_remotes(repo_path.clone()).await?;
                 if !remotes.iter().any(|n| n == r) {
                     return Err(AppError::InvalidArgument(format!("unknown remote: {r}")));

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -448,8 +448,9 @@ pub async fn git_push(
     set_upstream: bool,
     force: bool,
     branch: Option<String>,
+    remote: Option<String>,
 ) -> AppResult<()> {
-    git_push_core(&state, repo_path, set_upstream, force, branch).await
+    git_push_core(&state, repo_path, set_upstream, force, branch, remote).await
 }
 
 pub(crate) async fn git_push_core(
@@ -458,13 +459,24 @@ pub(crate) async fn git_push_core(
     set_upstream: bool,
     force: bool,
     branch: Option<String>,
+    remote: Option<String>,
 ) -> AppResult<()> {
+    // The credential config is scoped to the remote we actually push to, resolved
+    // below. Defaults to origin (the HEAD path and the origin-tracked cases).
+    let mut cred_remote = "origin".to_string();
     // Build the git args as owned Strings — a named-branch push interpolates the
     // branch/refspec, which can't borrow from a temporary. `None` reproduces the
     // original HEAD-relative args exactly (bare `push`, `--force-with-lease` on
     // force, `-u origin HEAD` on set_upstream).
     let args: Vec<String> = match &branch {
         None => {
+            // A remote can only be chosen for an explicit branch — the HEAD path
+            // pushes to HEAD's own upstream and stays byte-identical.
+            if remote.is_some() {
+                return Err(AppError::InvalidArgument(
+                    "remote requires an explicit branch".to_string(),
+                ));
+            }
             let mut a = vec!["push".to_string()];
             if force {
                 // refuses to clobber remote work that arrived after our last fetch
@@ -477,6 +489,18 @@ pub(crate) async fn git_push_core(
         }
         Some(b) => {
             crate::git::branches::validate_ref_name(b)?;
+            // A caller-chosen remote is validated for shape AND verified to exist
+            // BEFORE any mutation: the existence check is the primary guard (a URL
+            // can never appear in `git remote` output — and it requires `:`, which
+            // validate_ref_name's blocklist already rejects). We never interpolate
+            // the remote into a refspec — it's the bare `push <remote>` argument.
+            if let Some(r) = &remote {
+                crate::git::branches::validate_ref_name(r)?;
+                let remotes = git_remotes(repo_path.clone()).await?;
+                if !remotes.iter().any(|n| n == r) {
+                    return Err(AppError::InvalidArgument(format!("unknown remote: {r}")));
+                }
+            }
             // Resolve b's tracking state with one read-only call: the branch's own
             // `%(refname)`, its upstream's short name (e.g. `origin/feature`), the
             // upstream's remote name, and git's `%(upstream:track)` (which carries
@@ -504,10 +528,22 @@ pub(crate) async fn git_push_core(
             else {
                 return Err(AppError::InvalidArgument(format!("no such branch: {b}")));
             };
-            build_push_args(b, &upstream_short, &remotename, gone, set_upstream, force)
+            // The credential config must target the remote we actually push to, not
+            // always origin — a branch tracking a fork's `upstream` (or an explicit
+            // `remote`) authenticates against THAT host, not origin's.
+            cred_remote = resolve_push_target(remote.as_deref(), &remotename, gone).to_string();
+            build_push_args(
+                b,
+                &upstream_short,
+                &remotename,
+                gone,
+                set_upstream,
+                force,
+                remote.as_deref(),
+            )
         }
     };
-    let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    let cred = crate::forge::credential_config_for_remote(&repo_path, &cred_remote).await?;
     run_git_mutating_with_creds(
         state,
         &repo_path,
@@ -541,30 +577,62 @@ fn parse_upstream_tracking(stdout: &str, expected_ref: &str) -> Option<(String, 
     Some((upstream_short, remotename, track.contains("[gone]")))
 }
 
-/// Decide the `git push` args for pushing a NAMED local branch `branch` to
-/// origin, from its resolved tracking state. Pure — no git calls — so the
-/// decision table is unit-testable.
+/// Resolve the remote a named-branch push targets. Pure so the decision table
+/// stays unit-testable, and shared by `git_push_core` (for the credential
+/// config) and [`build_push_args`] (for the argv) so there's one source of truth.
+///
+/// - An explicit `requested_remote` always wins.
+/// - Otherwise a branch tracked (and not gone) targets its OWN upstream remote;
+///   an untracked / gone branch falls back to `origin` (the publish destination).
+fn resolve_push_target<'a>(
+    requested_remote: Option<&'a str>,
+    remotename: &'a str,
+    gone: bool,
+) -> &'a str {
+    match requested_remote {
+        Some(r) => r,
+        None if !remotename.is_empty() && !gone => remotename,
+        None => "origin",
+    }
+}
+
+/// Decide the `git push` args for pushing a NAMED local branch `branch`, from its
+/// resolved tracking state and an optional caller-chosen `requested_remote`. Pure
+/// — no git calls — so the decision table is unit-testable.
 ///
 /// - `upstream_short`: `%(upstream:short)` (e.g. `origin/feat`), empty when the
 ///   branch is untracked.
 /// - `remotename`: `%(upstream:remotename)` (the tracked upstream's remote).
 /// - `gone`: the tracked ref was deleted (`[gone]`).
+/// - `requested_remote`: an explicit push target (from the switcher's per-remote
+///   Publish items, or MCP's `remote`); `None` resolves the default below.
 ///
-/// Rules (origin-centric v1 — we only ever push to origin):
-/// - untracked / gone / `set_upstream` → `-u origin refs/heads/<branch>:refs/heads/<branch>`
+/// The target `T` is [`resolve_push_target`]: `requested_remote`, else the
+/// branch's own upstream remote when tracked-and-not-gone, else `origin`.
+/// Rules:
+/// - untracked / gone / `set_upstream` → `-u T refs/heads/<branch>:refs/heads/<branch>`
 ///   (publish + track). A *gone* upstream publishes under the LOCAL branch name
-///   (a fresh `origin/<branch>`), deliberately not resurrecting a differently-named
+///   (a fresh `T/<branch>`), deliberately not resurrecting a differently-named
 ///   deleted ref.
-/// - tracked on `origin`: strip `origin/` off `upstream_short` to get the remote
-///   name `up`; `push origin refs/heads/<branch>:refs/heads/<up>` (a bare
-///   `push origin <branch>` would advance the WRONG remote ref when the names differ).
-/// - tracked on a NON-origin remote (e.g. a fork's `upstream/main`): plain
-///   `push origin refs/heads/<branch>:refs/heads/<branch>` with NO `-u` —
-///   publishes/advances `origin/<branch>` and leaves the existing tracking config
-///   untouched (never retrack).
+/// - tracked and `T == remotename`: strip the `remotename/` prefix off
+///   `upstream_short` to get the remote branch name `up`;
+///   `push T refs/heads/<branch>:refs/heads/<up>` (a bare `push T <branch>` would
+///   advance the WRONG remote ref when the names differ).
+/// - tracked and `T != remotename` (a copy elsewhere, e.g. a fork's `origin`
+///   snapshot of an `upstream`-tracked branch, or an explicitly chosen remote):
+///   `push T refs/heads/<branch>:refs/heads/<branch>` with NO `-u` — publishes
+///   under the LOCAL name and leaves the branch's own upstream config untouched.
+///
+/// DELIBERATE BEHAVIOR CHANGE (from the origin-centric v1): with
+/// `requested_remote: None`, a tracked-NON-origin branch now targets its OWN
+/// remote (`T == remotename`, the first tracked arm) instead of the old fallback
+/// that pushed a `upstream`-tracked branch to `origin` under its own name. That
+/// old arm was UI-unreachable (per-row push required tracked-on-origin) and
+/// reachable only via MCP `push {branch}`; targeting the branch's own remote is
+/// the honest default.
 ///
 /// Refspecs are fully qualified so a branch named `+x`/`-x` can't be read as a
-/// force/delete indicator.
+/// force/delete indicator; the remote is only ever the bare `push <remote>` arg.
 ///
 /// `force` prepends `--force-with-lease` before the refspec in every arm.
 fn build_push_args(
@@ -574,7 +642,9 @@ fn build_push_args(
     gone: bool,
     set_upstream: bool,
     force: bool,
+    requested_remote: Option<&str>,
 ) -> Vec<String> {
+    let target = resolve_push_target(requested_remote, remotename, gone);
     let mut args = vec!["push".to_string()];
     if force {
         args.push("--force-with-lease".to_string());
@@ -583,19 +653,21 @@ fn build_push_args(
     if untracked || gone || set_upstream {
         // Publish + track: first push of a branch (or a resurrected gone one), or
         // an explicit retrack request. Publishes under the LOCAL name.
-        args.extend(["-u", "origin"].map(str::to_string));
+        args.extend(["-u", target].map(str::to_string));
         args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
-    } else if remotename == "origin" {
-        // Tracked on origin. Strip the `origin/` prefix to recover the remote
-        // branch name and target it explicitly (may differ from the local name).
+    } else if target == remotename {
+        // Tracked, pushing to the branch's own remote. Strip the `<remotename>/`
+        // prefix to recover the remote branch name and target it explicitly (may
+        // differ from the local name).
         let up = upstream_short
-            .strip_prefix("origin/")
+            .strip_prefix(&format!("{remotename}/"))
             .unwrap_or(upstream_short);
-        args.push("origin".to_string());
+        args.push(target.to_string());
         args.push(format!("refs/heads/{branch}:refs/heads/{up}"));
     } else {
-        // Tracked on a non-origin remote — plain push to origin, no retrack.
-        args.push("origin".to_string());
+        // Tracked, but pushing to a DIFFERENT remote than the upstream — a copy
+        // under the local name, no `-u`, upstream config untouched (never retrack).
+        args.push(target.to_string());
         args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
     }
     args
@@ -605,7 +677,7 @@ fn build_push_args(
 mod tests {
     use super::{
         build_push_args, cache_get, cache_invalidate, cache_put, git_remote_remove_core,
-        is_auth_class_failure, parse_upstream_tracking,
+        is_auth_class_failure, parse_upstream_tracking, resolve_push_target,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -716,7 +788,7 @@ mod tests {
     fn push_untracked_publishes_with_upstream() {
         // Empty upstream → first-time publish + track.
         assert_eq!(
-            build_push_args("feature", "", "", false, false, false),
+            build_push_args("feature", "", "", false, false, false, None),
             vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
@@ -725,7 +797,7 @@ mod tests {
     fn push_gone_upstream_publishes_with_upstream() {
         // A deleted upstream ref (still named by %(upstream:short)) republishes.
         assert_eq!(
-            build_push_args("feature", "origin/feature", "origin", true, false, false),
+            build_push_args("feature", "origin/feature", "origin", true, false, false, None),
             vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
@@ -733,7 +805,7 @@ mod tests {
     #[test]
     fn push_tracked_same_name_plain_push() {
         assert_eq!(
-            build_push_args("feature", "origin/feature", "origin", false, false, false),
+            build_push_args("feature", "origin/feature", "origin", false, false, false, None),
             vec!["push", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
@@ -743,17 +815,50 @@ mod tests {
         // Local `feature` tracks `origin/feat` → explicit refspec so we advance
         // the right remote ref, not `origin/feature`.
         assert_eq!(
-            build_push_args("feature", "origin/feat", "origin", false, false, false),
+            build_push_args("feature", "origin/feat", "origin", false, false, false, None),
             vec!["push", "origin", "refs/heads/feature:refs/heads/feat"]
         );
     }
 
     #[test]
-    fn push_tracked_non_origin_plain_push_no_upstream() {
-        // Tracks a fork's `upstream/main` → publish to origin, never retrack.
+    fn push_tracked_non_origin_default_targets_own_remote() {
+        // DELIBERATE BEHAVIOR CHANGE (v2): with no requested remote, a branch
+        // tracking a fork's `upstream/main` now pushes to its OWN remote
+        // (`upstream`) under the tracked remote-branch name — not the old v1
+        // fallback to origin. T == remotename → the refspec-to-`up` arm.
         assert_eq!(
-            build_push_args("main", "upstream/main", "upstream", false, false, false),
-            vec!["push", "origin", "refs/heads/main:refs/heads/main"]
+            build_push_args("main", "upstream/main", "upstream", false, false, false, None),
+            vec!["push", "upstream", "refs/heads/main:refs/heads/main"]
+        );
+    }
+
+    #[test]
+    fn push_requested_remote_matches_tracked_remote() {
+        // Explicitly requesting the branch's OWN tracked remote is the same arm:
+        // T == remotename → advance the tracked remote-branch name explicitly.
+        assert_eq!(
+            build_push_args("feature", "origin/feat", "origin", false, false, false, Some("origin")),
+            vec!["push", "origin", "refs/heads/feature:refs/heads/feat"]
+        );
+    }
+
+    #[test]
+    fn push_requested_remote_differs_from_tracked_remote() {
+        // A tracked-on-origin branch pushed explicitly to `upstream` → a copy under
+        // the LOCAL name, no `-u`, upstream config untouched.
+        assert_eq!(
+            build_push_args("feature", "origin/feat", "origin", false, false, false, Some("upstream")),
+            vec!["push", "upstream", "refs/heads/feature:refs/heads/feature"]
+        );
+    }
+
+    #[test]
+    fn push_requested_remote_on_untracked_publish() {
+        // Publishing an untracked branch to a chosen remote: `-u <remote>` under
+        // the local name.
+        assert_eq!(
+            build_push_args("feature", "", "", false, false, false, Some("fork")),
+            vec!["push", "-u", "fork", "refs/heads/feature:refs/heads/feature"]
         );
     }
 
@@ -761,7 +866,7 @@ mod tests {
     fn push_set_upstream_forces_upstream_form_even_when_tracked() {
         // An explicit set_upstream request retracks even a tracked branch.
         assert_eq!(
-            build_push_args("feature", "origin/feature", "origin", false, true, false),
+            build_push_args("feature", "origin/feature", "origin", false, true, false, None),
             vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
     }
@@ -770,7 +875,7 @@ mod tests {
     fn push_force_flag_precedes_refspec_args() {
         // --force-with-lease sits right after `push`, before the refspec.
         assert_eq!(
-            build_push_args("feature", "origin/feat", "origin", false, false, true),
+            build_push_args("feature", "origin/feat", "origin", false, false, true, None),
             vec![
                 "push",
                 "--force-with-lease",
@@ -779,12 +884,27 @@ mod tests {
             ]
         );
         assert_eq!(
-            build_push_args("feature", "", "", false, false, true),
+            build_push_args("feature", "", "", false, false, true, None),
             vec![
                 "push",
                 "--force-with-lease",
                 "-u",
                 "origin",
+                "refs/heads/feature:refs/heads/feature"
+            ]
+        );
+    }
+
+    #[test]
+    fn push_force_flag_precedes_refspec_on_requested_remote() {
+        // Force + a requested non-tracked remote: `--force-with-lease` still sits
+        // right after `push`, then the bare remote, then the fully-qualified refspec.
+        assert_eq!(
+            build_push_args("feature", "origin/feat", "origin", false, false, true, Some("upstream")),
+            vec![
+                "push",
+                "--force-with-lease",
+                "upstream",
                 "refs/heads/feature:refs/heads/feature"
             ]
         );
@@ -797,7 +917,7 @@ mod tests {
         // qualifying the refspec embeds the `+` inside `refs/heads/+main`, never
         // as its leading char, so git can't read it as a force-push.
         assert_eq!(
-            build_push_args("+main", "", "", false, false, false),
+            build_push_args("+main", "", "", false, false, false, None),
             vec!["push", "-u", "origin", "refs/heads/+main:refs/heads/+main"]
         );
     }
@@ -808,9 +928,19 @@ mod tests {
         // `origin/feature`), not the deleted `feat`, matching the "Publish"
         // affordance and toast.
         assert_eq!(
-            build_push_args("feature", "origin/feat", "origin", true, false, false),
+            build_push_args("feature", "origin/feat", "origin", true, false, false, None),
             vec!["push", "-u", "origin", "refs/heads/feature:refs/heads/feature"]
         );
+    }
+
+    #[test]
+    fn resolve_push_target_prefers_request_then_tracked_then_origin() {
+        // Explicit request wins; else the tracked-and-not-gone remote; else origin
+        // (untracked, or gone).
+        assert_eq!(resolve_push_target(Some("fork"), "upstream", false), "fork");
+        assert_eq!(resolve_push_target(None, "upstream", false), "upstream");
+        assert_eq!(resolve_push_target(None, "", false), "origin");
+        assert_eq!(resolve_push_target(None, "upstream", true), "origin");
     }
 
     #[test]

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -78,6 +78,10 @@ pub struct Branch {
     /// ref is gone (e.g. the remote branch was deleted after a PR merge). Read as
     /// "no upstream" for pushed-ness decisions.
     pub upstream_gone: bool,
+    /// The remote of the branch's upstream (`%(upstream:remotename)`), e.g.
+    /// `origin` — null when untracked. Authoritative source for which remote a
+    /// push targets; the UI must never re-derive it from the upstream string.
+    pub upstream_remote: Option<String>,
 }
 
 /// A branch that exists on a remote but not (yet) as a local branch — offered in

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -111,6 +111,11 @@ struct PushArgs {
     /// checkout, no working-tree changes; an untracked branch is published with
     /// `-u origin <branch>`). Defaults to the current branch.
     branch: Option<String>,
+    /// Remote to push to; defaults to the branch's own upstream remote (or origin
+    /// when publishing). Requires branch.
+    // Single word, so camelCase == snake_case — no rename attr needed.
+    #[serde(default)]
+    remote: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -403,11 +408,12 @@ impl GitDesktopMcp {
     }
 
     #[tool(
-        description = "Push the current branch (default) or a named local `branch` to origin in \
-                       the bound repository — pushing a named branch never switches to it or \
-                       touches the working tree; an untracked branch is published with `-u`. \
-                       Uses git's native credential flow. Never force-pushes — use force_push \
-                       (destructive) for that. Requires --allow-git-write.",
+        description = "Push the current branch (default) or a named local `branch` in the bound \
+                       repository — pushing a named branch never switches to it or touches the \
+                       working tree; an untracked branch is published with `-u`. A named branch \
+                       targets its own upstream remote (or origin when publishing) unless `remote` \
+                       overrides it. Uses git's native credential flow. Never force-pushes — use \
+                       force_push (destructive) for that. Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn push(
@@ -422,12 +428,16 @@ impl GitDesktopMcp {
             // could break session Resume semantics.
             ensure_not_session_branch(b)?;
         }
+        if let Some(r) = &args.remote {
+            ensure_not_flag(r, "remote")?;
+        }
         crate::git::remote::git_push_core(
             &self.state,
             self.repo.clone(),
             args.set_upstream,
             false,
             args.branch.clone(),
+            args.remote.clone(),
         )
         .await
         .map_err(app_err)?;
@@ -772,7 +782,7 @@ impl GitDesktopMcp {
     )]
     async fn force_push(&self) -> Result<CallToolResult, McpError> {
         self.ensure_destructive()?;
-        crate::git::remote::git_push_core(&self.state, self.repo.clone(), false, true, None)
+        crate::git::remote::git_push_core(&self.state, self.repo.clone(), false, true, None, None)
             .await
             .map_err(app_err)?;
         ok_text("force-pushed (with lease)")
@@ -918,7 +928,8 @@ mod tests {
         assert_gated!(
             h.push(Parameters(PushArgs {
                 set_upstream: false,
-                branch: None
+                branch: None,
+                remote: None
             })),
             "--allow-git-write"
         );
@@ -1125,6 +1136,20 @@ mod tests {
         )
         .unwrap();
         assert!(explicit.no_track);
+    }
+
+    /// `remote` is optional on the wire (#[serde(default)]): absent → None so a
+    /// bare `push {branch}` keeps resolving to the branch's own upstream remote,
+    /// and an explicit value parses through. Single word, so no rename attr.
+    #[test]
+    fn push_args_remote_defaults_none_and_parses_value() {
+        let absent: PushArgs = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(absent.remote, None);
+
+        let explicit: PushArgs =
+            serde_json::from_value(serde_json::json!({ "branch": "feature", "remote": "upstream" }))
+                .unwrap();
+        assert_eq!(explicit.remote.as_deref(), Some("upstream"));
     }
 
     /// The session-branch guard is wired into the branch-mutating tools even when the

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -186,12 +186,13 @@ export function SelectField({
   sizeToContent?: boolean;
 }) {
   const field = useFieldContext<string>();
+  const id = useId();
   // Opt-in rich rows: wrap the label so it can truncate and leave room for a
   // trailing annotation. Plain callers keep the exact prior markup.
   const rich = sizeToContent || annotations !== undefined;
   return (
     <div className="space-y-2">
-      {label && <Label>{label}</Label>}
+      {label && <Label htmlFor={id}>{label}</Label>}
       <Select
         items={items}
         value={field.state.value || null}
@@ -200,7 +201,7 @@ export function SelectField({
         }}
         disabled={disabled}
       >
-        <SelectTrigger className="w-full">
+        <SelectTrigger id={id} className="w-full">
           <SelectValue />
         </SelectTrigger>
         <SelectContent

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon, XIcon } from "@phosphor-icons/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,6 +39,8 @@ export function RunWorkflowDialog({
   onOpenChange: (open: boolean) => void;
   defaultRef: string;
 }) {
+  // Per-mount base for the field ids (label↔control association).
+  const idBase = useId();
   // GitLab and Bitbucket have no per-workflow dispatch — one pipeline config per
   // project — so the form is just ref + variables: the workflow picker hides (and
   // its GitHub-only `gh workflow list` query never fires), and "inputs" become
@@ -153,14 +155,14 @@ export function RunWorkflowDialog({
         <div className="space-y-4">
           {!isPipelineProvider && (
             <div className="space-y-2">
-              <Label htmlFor="wf-workflow">Workflow</Label>
+              <Label htmlFor={`${idBase}-workflow`}>Workflow</Label>
               <Select
                 items={workflowItems}
                 value={workflow}
                 onValueChange={(v) => v && setWorkflow(v)}
                 disabled={dispatchable.length === 0}
               >
-                <SelectTrigger id="wf-workflow" className="w-full">
+                <SelectTrigger id={`${idBase}-workflow`} className="w-full">
                   <SelectValue
                     placeholder={
                       workflows.isPending ? "Loading…" : "Select a workflow"
@@ -187,13 +189,13 @@ export function RunWorkflowDialog({
 
           {hasCustomPipelines && (
             <div className="space-y-2">
-              <Label htmlFor="wf-pipeline">Pipeline</Label>
+              <Label htmlFor={`${idBase}-pipeline`}>Pipeline</Label>
               <Select
                 items={pipelineItems}
                 value={pipeline}
                 onValueChange={(v) => setPipeline(v ?? "")}
               >
-                <SelectTrigger id="wf-pipeline" className="w-full">
+                <SelectTrigger id={`${idBase}-pipeline`} className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -209,9 +211,9 @@ export function RunWorkflowDialog({
           )}
 
           <div className="space-y-2">
-            <Label htmlFor="wf-ref">Branch or tag</Label>
+            <Label htmlFor={`${idBase}-ref`}>Branch or tag</Label>
             <Input
-              id="wf-ref"
+              id={`${idBase}-ref`}
               value={gitRef}
               onChange={(e) => setGitRef(e.target.value)}
               placeholder="main"
@@ -222,10 +224,10 @@ export function RunWorkflowDialog({
           <div
             className="space-y-2"
             role="group"
-            aria-labelledby="wf-inputs-label"
+            aria-labelledby={`${idBase}-inputs-label`}
           >
             <div className="flex items-center justify-between">
-              <Label id="wf-inputs-label">
+              <Label id={`${idBase}-inputs-label`}>
                 {isPipelineProvider ? "Variables" : "Inputs"}{" "}
                 <span className="font-normal text-muted-foreground">
                   (optional)

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -219,9 +219,13 @@ export function RunWorkflowDialog({
             />
           </div>
 
-          <div className="space-y-2">
+          <div
+            className="space-y-2"
+            role="group"
+            aria-labelledby="wf-inputs-label"
+          >
             <div className="flex items-center justify-between">
-              <Label>
+              <Label id="wf-inputs-label">
                 {isPipelineProvider ? "Variables" : "Inputs"}{" "}
                 <span className="font-normal text-muted-foreground">
                   (optional)

--- a/src/features/automations/LifecycleEditor.tsx
+++ b/src/features/automations/LifecycleEditor.tsx
@@ -4,7 +4,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -118,6 +118,10 @@ function ConditionsEditor({
   const [testBranch, setTestBranch] = useState("");
   const c = conditions ?? EMPTY_CONDITIONS;
   const summary = conditionsSummary(conditions);
+  const includeLabelId = useId();
+  const excludeLabelId = useId();
+  const matchSelectId = useId();
+  const testBranchId = useId();
 
   function patchList(key: "include" | "exclude", next: string[]) {
     onChange({ ...c, [key]: next });
@@ -203,17 +207,23 @@ function ConditionsEditor({
 
       {open && (
         <div className="mt-2 space-y-3">
-          <div className="space-y-1">
-            <Label className="text-xs">Only these branches (optional)</Label>
+          <div className="space-y-1" role="group" aria-labelledby={includeLabelId}>
+            <Label id={includeLabelId} className="text-xs">
+              Only these branches (optional)
+            </Label>
             {renderPatternRows("include", "release/**")}
           </div>
-          <div className="space-y-1">
-            <Label className="text-xs">Except these branches</Label>
+          <div className="space-y-1" role="group" aria-labelledby={excludeLabelId}>
+            <Label id={excludeLabelId} className="text-xs">
+              Except these branches
+            </Label>
             {renderPatternRows("exclude", "wip/*")}
           </div>
           {usesMatch(lifecycle) && (
             <div className="space-y-1">
-              <Label className="text-xs">Match against</Label>
+              <Label htmlFor={matchSelectId} className="text-xs">
+                Match against
+              </Label>
               <Select
                 items={MATCH_LABELS}
                 value={c.match}
@@ -221,7 +231,7 @@ function ConditionsEditor({
                   v && onChange({ ...c, match: v as BranchConditions["match"] })
                 }
               >
-                <SelectTrigger className="w-full" size="sm">
+                <SelectTrigger id={matchSelectId} className="w-full" size="sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -237,9 +247,12 @@ function ConditionsEditor({
             </div>
           )}
           <div className="space-y-1">
-            <Label className="text-xs">Try a branch</Label>
+            <Label htmlFor={testBranchId} className="text-xs">
+              Try a branch
+            </Label>
             <div className="flex items-center gap-2">
               <Input
+                id={testBranchId}
                 value={testBranch}
                 onChange={(e) => setTestBranch(e.target.value)}
                 placeholder="feature/login"

--- a/src/features/automations/LifecycleEditor.tsx
+++ b/src/features/automations/LifecycleEditor.tsx
@@ -207,13 +207,21 @@ function ConditionsEditor({
 
       {open && (
         <div className="mt-2 space-y-3">
-          <div className="space-y-1" role="group" aria-labelledby={includeLabelId}>
+          <div
+            className="space-y-1"
+            role="group"
+            aria-labelledby={includeLabelId}
+          >
             <Label id={includeLabelId} className="text-xs">
               Only these branches (optional)
             </Label>
             {renderPatternRows("include", "release/**")}
           </div>
-          <div className="space-y-1" role="group" aria-labelledby={excludeLabelId}>
+          <div
+            className="space-y-1"
+            role="group"
+            aria-labelledby={excludeLabelId}
+          >
             <Label id={excludeLabelId} className="text-xs">
               Except these branches
             </Label>

--- a/src/features/branch-rules/BranchRulesDialog.tsx
+++ b/src/features/branch-rules/BranchRulesDialog.tsx
@@ -1,5 +1,5 @@
 import { GithubLogoIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -59,6 +59,9 @@ export function BranchRulesDialog({
   const [importing, setImporting] = useState(false);
   const [draft, setDraft] = useState<BranchRulesConfig>(EMPTY_BRANCH_RULES);
   const [testName, setTestName] = useState("");
+  const patternInputId = useId();
+  const hintInputId = useId();
+  const testNameInputId = useId();
 
   const active = scope === "shared" ? shared : personal;
   const saving = scope === "shared" ? saveShared : savePersonal;
@@ -250,8 +253,11 @@ export function BranchRulesDialog({
                 {draft.naming.enabled && (
                   <div className="space-y-2 pl-6">
                     <div className="space-y-1">
-                      <Label className="text-xs">Pattern</Label>
+                      <Label htmlFor={patternInputId} className="text-xs">
+                        Pattern
+                      </Label>
                       <Input
+                        id={patternInputId}
                         value={draft.naming.pattern}
                         onChange={(e) => setNaming({ pattern: e.target.value })}
                         placeholder="{feature,fix,chore}/*"
@@ -259,19 +265,23 @@ export function BranchRulesDialog({
                       />
                     </div>
                     <div className="space-y-1">
-                      <Label className="text-xs">
+                      <Label htmlFor={hintInputId} className="text-xs">
                         Hint (shown when rejected)
                       </Label>
                       <Input
+                        id={hintInputId}
                         value={draft.naming.hint}
                         onChange={(e) => setNaming({ hint: e.target.value })}
                         placeholder="feature/login, fix/crash"
                       />
                     </div>
                     <div className="space-y-1">
-                      <Label className="text-xs">Try a name</Label>
+                      <Label htmlFor={testNameInputId} className="text-xs">
+                        Try a name
+                      </Label>
                       <div className="flex items-center gap-2">
                         <Input
+                          id={testNameInputId}
                           value={testName}
                           onChange={(e) => setTestName(e.target.value)}
                           placeholder="feature/login"

--- a/src/features/compare/CompareBranchCombobox.tsx
+++ b/src/features/compare/CompareBranchCombobox.tsx
@@ -118,7 +118,10 @@ export function CompareBranchCombobox({
       open={open}
       onOpenChange={setOpen}
     >
-      <ComboboxTrigger className="flex w-full items-center justify-between gap-1.5 rounded-none border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50">
+      <ComboboxTrigger
+        aria-label="Compare with branch"
+        className="flex w-full items-center justify-between gap-1.5 rounded-none border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50"
+      >
         {/* Clamp the selected branch name (the vendored SelectTrigger's
             line-clamp idiom) so a long name truncates and the caret stays put in
             the narrow Compare sidebar. */}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -381,10 +381,11 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   the default branch's row shows how far behind its upstream it is after a fetch, and
   *Update default branch from its remote* is available from the command palette too.
 - **Push a branch without switching to it** — the outbound counterpart: a branch ahead
-  of its origin remote offers **Push to _origin/…_** in its right-click menu, and an
-  unpushed or upstream-deleted branch offers **Publish branch**. Neither checks the branch
-  out or touches your working tree, so it works even for a branch checked out in another
-  worktree.
+  of the remote it tracks offers **Push to _its remote/…_** in its right-click menu — so a
+  branch tracking a fork's _upstream_ is pushed there, not to origin. An unpushed or
+  upstream-deleted branch offers **Publish**; on a repo with several remotes you pick the
+  destination (one **Publish to _…_** item per remote). Neither checks the branch out or
+  touches your working tree, so it works even for a branch checked out in another worktree.
 - The **Remote** section lists branches on your remotes you haven't checked out locally
   yet — click one to check it out (creating a local tracking branch), or right-click to
   **Delete on _origin_…**, a server-side delete that removes the branch from the remote for

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -1,5 +1,5 @@
 import { formOptions } from "@tanstack/react-form";
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -183,6 +183,7 @@ export function CherryPickOntoDialog({
   onDone: () => void;
 }) {
   const cherryPickOnto = useCherryPickOnto(repoPath);
+  const destId = useId();
   function run() {
     if (!hashes || !branch) return;
     const target = branch;
@@ -229,13 +230,13 @@ export function CherryPickOntoDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
-          <Label>Destination branch</Label>
+          <Label htmlFor={destId}>Destination branch</Label>
           <Select
             items={Object.fromEntries(branches.map((b) => [b.name, b.name]))}
             value={branch || null}
             onValueChange={(v) => v && onBranchChange(v)}
           >
-            <SelectTrigger className="w-full">
+            <SelectTrigger id={destId} className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -1,7 +1,7 @@
 import { SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useEffect, useEffectEvent, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -66,6 +66,7 @@ export function CreateJiraIssueDialog({
     [types.data],
   );
   const [issueTypeId, setIssueTypeId] = useState<string>("");
+  const issueTypeSelectId = useId();
   // A Jira validation error the create command surfaced (field-level messages
   // the Rust side joins readably) — shown inline under the form, not a toast.
   const [createError, setCreateError] = useState<string | null>(null);
@@ -166,7 +167,7 @@ export function CreateJiraIssueDialog({
             </form.AppField>
 
             <div className="space-y-2">
-              <Label>Issue type</Label>
+              <Label htmlFor={issueTypeSelectId}>Issue type</Label>
               {types.isError ? (
                 <div className="flex items-center gap-2 border px-3 py-2 text-xs text-muted-foreground">
                   <span className="flex-1">
@@ -195,7 +196,7 @@ export function CreateJiraIssueDialog({
                   }}
                   disabled={types.isPending}
                 >
-                  <SelectTrigger className="w-full">
+                  <SelectTrigger id={issueTypeSelectId} className="w-full">
                     <SelectValue
                       placeholder={
                         types.isPending ? "Loading types…" : "Select a type"

--- a/src/features/issues/RepoJiraDialog.tsx
+++ b/src/features/issues/RepoJiraDialog.tsx
@@ -1,7 +1,7 @@
 import { CheckCircleIcon, LinkBreakIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -101,6 +101,7 @@ export function RepoJiraDialog({
   const [projectQuery, setProjectQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [project, setProject] = useState<JiraProject | null>(null);
+  const projectInputId = useId();
   // Whether the connection is good enough to search projects: either a fresh
   // validation this session, or a stored credential for the typed site.
   const connected = account !== null || (hasStored && siteHost.length > 0);
@@ -396,7 +397,7 @@ export function RepoJiraDialog({
 
           {/* ── Project ─────────────────────────────────────────────────── */}
           <div className="space-y-2">
-            <Label>Project</Label>
+            <Label htmlFor={projectInputId}>Project</Label>
             <Combobox
               items={projectSearch.data ?? []}
               itemToStringLabel={(p: JiraProject) => `${p.key} · ${p.name}`}
@@ -407,6 +408,7 @@ export function RepoJiraDialog({
               openOnInputClick
             >
               <ComboboxInput
+                id={projectInputId}
                 className="w-full"
                 placeholder={
                   connected

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -8,7 +8,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -148,6 +148,12 @@ export function CreatePrDialog({
   const [reviewers, setReviewers] = useState<ForgeUserRef[]>([]);
   const [labels, setLabels] = useState<Set<string>>(new Set());
   const [assignees, setAssignees] = useState<ForgeUserRef[]>([]);
+  // Group-label ids: these fields wrap trigger-style widgets (segmented buttons
+  // and popover triggers) that carry their own aria-label, so the visible field
+  // label names the surrounding group via aria-labelledby rather than htmlFor.
+  const createInGroupId = useId();
+  const reviewersGroupId = useId();
+  const assigneesGroupId = useId();
   // Labels come from whichever repo the PR targets (parent's own labels when
   // creating upstream). The picker is hidden on the parent path anyway, but the
   // AI-description prompt still reads this list, so keep it lens-correct.
@@ -441,8 +447,12 @@ export function CreatePrDialog({
                 this is a GitHub fork with an upstream remote. Default = parent. */}
             {lensGate && (
               <div className="space-y-1.5">
-                <Label>Create in</Label>
-                <div className="flex items-center gap-1">
+                <Label id={createInGroupId}>Create in</Label>
+                <div
+                  className="flex items-center gap-1"
+                  role="group"
+                  aria-labelledby={createInGroupId}
+                >
                   {(
                     [
                       {
@@ -584,8 +594,12 @@ export function CreatePrDialog({
             )}
 
             {canPickReviewers && (
-              <div className="space-y-1.5">
-                <Label>Reviewers</Label>
+              <div
+                className="space-y-1.5"
+                role="group"
+                aria-labelledby={reviewersGroupId}
+              >
+                <Label id={reviewersGroupId}>Reviewers</Label>
                 <ReviewersPopover
                   repoPath={repoPath}
                   number={null}
@@ -661,8 +675,12 @@ export function CreatePrDialog({
             )}
 
             {canPickAssignees && (
-              <div className="space-y-1.5">
-                <Label>Assignees</Label>
+              <div
+                className="space-y-1.5"
+                role="group"
+                aria-labelledby={assigneesGroupId}
+              >
+                <Label id={assigneesGroupId}>Assignees</Label>
                 <AssigneesPopover
                   repoPath={repoPath}
                   enabled={open}

--- a/src/features/repo-settings/SecretsSection.tsx
+++ b/src/features/repo-settings/SecretsSection.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,6 +56,8 @@ export function SecretsSection({
   const [kind, setKind] = useState<"secrets" | "variables">("secrets");
   const [app, setApp] = useState<SecretApp>("actions");
   const [scope, setScope] = useState<string>(REPO_SCOPE);
+  const storeSelectId = useId();
+  const scopeSelectId = useId();
 
   const envs = useEnvironments(repoPath, open);
   // Environment scope exists only for Actions (secrets and variables).
@@ -85,12 +87,17 @@ export function SecretsSection({
 
         {kind === "secrets" && (
           <div className="space-y-1">
-            <Label className="text-[11px] text-muted-foreground">Store</Label>
+            <Label
+              htmlFor={storeSelectId}
+              className="text-[11px] text-muted-foreground"
+            >
+              Store
+            </Label>
             <Select
               value={app}
               onValueChange={(v) => v && setApp(v as SecretApp)}
             >
-              <SelectTrigger size="sm" className="w-36">
+              <SelectTrigger id={storeSelectId} size="sm" className="w-36">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -105,13 +112,18 @@ export function SecretsSection({
         )}
 
         <div className="space-y-1">
-          <Label className="text-[11px] text-muted-foreground">Scope</Label>
+          <Label
+            htmlFor={scopeSelectId}
+            className="text-[11px] text-muted-foreground"
+          >
+            Scope
+          </Label>
           <Select
             value={env ?? REPO_SCOPE}
             onValueChange={(v) => v && setScope(v)}
             disabled={!envAllowed}
           >
-            <SelectTrigger size="sm" className="w-40">
+            <SelectTrigger id={scopeSelectId} size="sm" className="w-40">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -73,6 +73,7 @@ export function BaseBranchCombobox({
   defaultName,
   value,
   onValueChange,
+  triggerId,
 }: {
   repoPath: string;
   /** The create-branch DIALOG's open state — gates the queries. */
@@ -83,6 +84,9 @@ export function BaseBranchCombobox({
   /** isRemote: whether the picked value is a remote-tracking ref (drives
    *  --no-track). */
   onValueChange: (value: string, isRemote: boolean) => void;
+  /** id applied to the combobox trigger so a caller's `<Label htmlFor>` can
+   *  name it (the trigger is a labelable button). */
+  triggerId?: string;
 }) {
   // useBranches is cached app-wide; the remote list + worktrees fetch only while
   // the dialog is open (same open-gating idiom as CompareBranchCombobox).
@@ -181,7 +185,10 @@ export function BaseBranchCombobox({
       value={value}
       onValueChange={(name) => name && onValueChange(name, remoteSet.has(name))}
     >
-      <ComboboxTrigger className="flex w-full items-center justify-between gap-1.5 rounded-none border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50">
+      <ComboboxTrigger
+        id={triggerId}
+        className="flex w-full items-center justify-between gap-1.5 rounded-none border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50"
+      >
         {/* Clamp a long branch value so it truncates and the caret stays put. */}
         <span className="min-w-0 flex-1 truncate text-left">
           <ComboboxValue />

--- a/src/features/repository/BranchMergePickerDialog.tsx
+++ b/src/features/repository/BranchMergePickerDialog.tsx
@@ -4,7 +4,7 @@ import {
   LightningIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -71,6 +71,8 @@ export function BranchMergePickerDialog({
   currentLabel: string;
 }) {
   const [pickerBranch, setPickerBranch] = useState("");
+  const branchSelectId = useId();
+  const conflictSelectId = useId();
   // Advanced merge options (merge mode only).
   const [mergeNoFf, setMergeNoFf] = useState(false);
   const [mergeStrategy, setMergeStrategy] =
@@ -183,7 +185,7 @@ export function BranchMergePickerDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
-          <Label>Branch</Label>
+          <Label htmlFor={branchSelectId}>Branch</Label>
           <Select
             items={Object.fromEntries(
               otherBranches.map((b) => [b.name, b.name]),
@@ -191,7 +193,7 @@ export function BranchMergePickerDialog({
             value={pickerBranch || null}
             onValueChange={(v) => v && setPickerBranch(v)}
           >
-            <SelectTrigger className="w-full">
+            <SelectTrigger id={branchSelectId} className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -214,7 +216,9 @@ export function BranchMergePickerDialog({
               Always create a merge commit
             </label>
             <div className="space-y-1.5">
-              <Label className="text-xs">On conflict</Label>
+              <Label htmlFor={conflictSelectId} className="text-xs">
+                On conflict
+              </Label>
               <Select
                 items={{
                   none: "Stop and let me resolve",
@@ -226,7 +230,7 @@ export function BranchMergePickerDialog({
                   v && setMergeStrategy(v as MergeConflictStrategy)
                 }
               >
-                <SelectTrigger className="w-full">
+                <SelectTrigger id={conflictSelectId} className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -121,23 +121,6 @@ const PR_STATE_LABEL: Record<PrState, string> = {
   closed: "Closed",
 };
 
-/** The remote a branch's upstream lives on, by LONGEST-prefix match against the
- *  repo's actual remotes — remote names may contain slashes, so `split("/")[0]`
- *  is wrong and the remotes list is the ground truth. Returns null when the
- *  upstream matches no configured remote (e.g. a stale tracking ref). */
-function upstreamRemoteOf(upstream: string, remotes: string[]): string | null {
-  let best: string | null = null;
-  for (const r of remotes) {
-    if (
-      upstream.startsWith(`${r}/`) &&
-      (best === null || r.length > best.length)
-    ) {
-      best = r;
-    }
-  }
-  return best;
-}
-
 function MenuRow({
   disabled,
   onClick,
@@ -874,8 +857,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // Publish (one item per remote on a multi-remote repo). Hidden (not disabled)
     // when in-sync, or tracked on a remote that no longer exists.
     const upstreamRemote =
-      branch.upstream && !branch.upstreamGone
-        ? upstreamRemoteOf(branch.upstream, remoteNames)
+      branch.upstream &&
+      !branch.upstreamGone &&
+      branch.upstreamRemote &&
+      remoteNames.includes(branch.upstreamRemote)
+        ? branch.upstreamRemote
         : null;
     const pushable = Boolean(upstreamRemote) && branch.upstreamAhead > 0;
     const publishable =

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -121,6 +121,23 @@ const PR_STATE_LABEL: Record<PrState, string> = {
   closed: "Closed",
 };
 
+/** The remote a branch's upstream lives on, by LONGEST-prefix match against the
+ *  repo's actual remotes — remote names may contain slashes, so `split("/")[0]`
+ *  is wrong and the remotes list is the ground truth. Returns null when the
+ *  upstream matches no configured remote (e.g. a stale tracking ref). */
+function upstreamRemoteOf(upstream: string, remotes: string[]): string | null {
+  let best: string | null = null;
+  for (const r of remotes) {
+    if (
+      upstream.startsWith(`${r}/`) &&
+      (best === null || r.length > best.length)
+    ) {
+      best = r;
+    }
+  }
+  return best;
+}
+
 function MenuRow({
   disabled,
   onClick,
@@ -441,9 +458,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // this branch, so switching would strand the in-progress amend and leave its
   // banner up. Lock the switcher until the user finishes or stops amending.
   const amending = amendingHash !== null;
-  // Origin presence gates the per-row push/publish items (mirrors SyncControls):
-  // a repo with no `origin` can't push a branch there.
-  const hasOrigin = remotes.isSuccess && remotes.data.includes("origin");
+  // The repo's configured remotes — ground truth for resolving a branch's
+  // upstream remote and for the per-remote Publish choices.
+  const remoteNames = remotes.data ?? [];
 
   const onError = (e: unknown) => toastError(e);
 
@@ -693,19 +710,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     );
   }
 
-  // Push a branch's ref to origin without checking it out — the outbound
-  // counterpart of doUpdateFromUpstream. Whether this publishes (-u) or plain
-  // pushes is decided backend-side from the branch's tracking state.
-  function doPushBranch(branch: Branch) {
+  // Push a branch's ref without checking it out — the outbound counterpart of
+  // doUpdateFromUpstream. Whether this publishes (-u) or plain pushes is decided
+  // backend-side from the branch's tracking state. The publish arms pass an
+  // explicit `remote` (the chosen destination); a tracked push passes none and
+  // the backend resolves to the branch's own upstream remote.
+  function doPushBranch(branch: Branch, remote?: string) {
     const publishing = !branch.upstream || branch.upstreamGone;
     setOpen(false);
     push.mutate(
-      { setUpstream: false, branch: branch.name },
+      { setUpstream: false, branch: branch.name, remote },
       {
         onSuccess: () =>
           toast.success(
             publishing
-              ? `Published ${branch.name} to origin`
+              ? `Published ${branch.name} to ${remote ?? "origin"}`
               : `Pushed ${branch.name} to ${branch.upstream}`,
           ),
         onError,
@@ -848,14 +867,25 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const canUpdate = Boolean(defaultName) && branch.name !== defaultName;
     const deletionBlocked = isDeletionBlocked(rulesConfig, branch.name);
     const inWorktree = worktreeByBranch.has(branch.name);
-    // Outbound sync gating. `pushable` = tracked on origin and ahead → offer a
-    // plain push (disabled with "(diverged)" when also behind). `publishable` =
-    // untracked or gone → offer Publish. Both need origin. Hidden (not disabled)
-    // when in-sync / no origin / tracked on a non-origin remote.
-    const trackedOnOrigin =
-      Boolean(branch.upstream?.startsWith("origin/")) && !branch.upstreamGone;
-    const pushable = hasOrigin && trackedOnOrigin && branch.upstreamAhead > 0;
-    const publishable = hasOrigin && (!branch.upstream || branch.upstreamGone);
+    // Outbound sync gating. `pushable` = tracked on a KNOWN remote and ahead →
+    // offer a plain push to that remote (disabled with "(diverged)" when also
+    // behind); the backend resolves to the branch's own upstream remote.
+    // `publishable` = untracked or gone AND at least one remote exists → offer
+    // Publish (one item per remote on a multi-remote repo). Hidden (not disabled)
+    // when in-sync, or tracked on a remote that no longer exists.
+    const upstreamRemote =
+      branch.upstream && !branch.upstreamGone
+        ? upstreamRemoteOf(branch.upstream, remoteNames)
+        : null;
+    const pushable = Boolean(upstreamRemote) && branch.upstreamAhead > 0;
+    const publishable =
+      (!branch.upstream || branch.upstreamGone) && remoteNames.length > 0;
+    // Publish destinations: origin first, then the rest alphabetical.
+    const publishRemotes = publishable
+      ? [...remoteNames].sort((a, b) =>
+          a === "origin" ? -1 : b === "origin" ? 1 : a.localeCompare(b),
+        )
+      : [];
     return (
       <ContextMenu key={branch.name}>
         <ContextMenuTrigger
@@ -1014,13 +1044,31 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     : `Push to ${branch.upstream}`}
                 </ContextMenuItem>
               )}
-              {publishable && (
+              {/* Publish an unpushed / upstream-deleted branch. One remote →
+                  a single item (the classic "Publish branch" when it's origin,
+                  else "Publish to {remote}"); multiple remotes → one flat item
+                  per remote (origin first, then alphabetical), each passing its
+                  explicit destination. Always-visible flat rows — keyboard nav is
+                  inherited from the menu. */}
+              {publishRemotes.length === 1 ? (
                 <ContextMenuItem
                   disabled={busy}
-                  onClick={() => doPushBranch(branch)}
+                  onClick={() => doPushBranch(branch, publishRemotes[0])}
                 >
-                  Publish branch
+                  {publishRemotes[0] === "origin"
+                    ? "Publish branch"
+                    : `Publish to ${publishRemotes[0]}`}
                 </ContextMenuItem>
+              ) : (
+                publishRemotes.map((r) => (
+                  <ContextMenuItem
+                    key={r}
+                    disabled={busy}
+                    onClick={() => doPushBranch(branch, r)}
+                  >
+                    Publish to {r}
+                  </ContextMenuItem>
+                ))
               )}
               <ContextMenuSeparator />
             </>

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -77,6 +77,7 @@ export function CreateBranchDialog({
   // the new branch starts with NO upstream and its first push publishes it
   // under its own name.
   const [baseIsRemote, setBaseIsRemote] = useState(false);
+  const baseTriggerId = useId();
 
   const createForm = useAppForm({
     defaultValues: { name: "", base: "" },
@@ -183,14 +184,13 @@ export function CreateBranchDialog({
             <createForm.AppField name="base">
               {(field) => (
                 <div className="space-y-2">
-                  {/* Programmatic label↔control association is deferred to the
-                      planned shared field-primitives a11y sweep. */}
-                  <Label>Base it on</Label>
+                  <Label htmlFor={baseTriggerId}>Base it on</Label>
                   <BaseBranchCombobox
                     repoPath={repoPath}
                     open={open}
                     currentName={currentName}
                     defaultName={defaultName}
+                    triggerId={baseTriggerId}
                     value={field.state.value || null}
                     onValueChange={(v, isRemote) => {
                       field.handleChange(v);

--- a/src/features/repository/RebaseOntoDialog.tsx
+++ b/src/features/repository/RebaseOntoDialog.tsx
@@ -1,5 +1,5 @@
 import { InfoIcon, WarningIcon } from "@phosphor-icons/react";
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -62,6 +62,8 @@ export function RebaseOntoDialog({
 }) {
   const [newBase, setNewBase] = useState("");
   const [oldBase, setOldBase] = useState("");
+  const newBaseSelectId = useId();
+  const oldBaseSelectId = useId();
 
   // On open, default the new base to the default branch (the usual "I meant to
   // branch off main" case) and the original base to any other branch.
@@ -175,7 +177,7 @@ export function RebaseOntoDialog({
 
         <div className="flex min-h-0 flex-col gap-4 overflow-y-auto">
           <div className="space-y-2">
-            <Label>New base</Label>
+            <Label htmlFor={newBaseSelectId}>New base</Label>
             <Select
               items={Object.fromEntries(
                 otherBranches.map((b) => [b.name, b.name]),
@@ -183,7 +185,7 @@ export function RebaseOntoDialog({
               value={newBase || null}
               onValueChange={(v) => v && setNewBase(v)}
             >
-              <SelectTrigger className="w-full">
+              <SelectTrigger id={newBaseSelectId} className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -197,7 +199,7 @@ export function RebaseOntoDialog({
           </div>
 
           <div className="space-y-2">
-            <Label>Original base</Label>
+            <Label htmlFor={oldBaseSelectId}>Original base</Label>
             <Select
               items={Object.fromEntries(
                 otherBranches.map((b) => [b.name, b.name]),
@@ -205,7 +207,7 @@ export function RebaseOntoDialog({
               value={oldBase || null}
               onValueChange={(v) => v && setOldBase(v)}
             >
-              <SelectTrigger className="w-full">
+              <SelectTrigger id={oldBaseSelectId} className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -245,7 +245,7 @@ export function McpServerDialog({
 
           {scopeOptions.length > 1 && (
             <div className="space-y-2">
-              <Label>Available in</Label>
+              <Label htmlFor="mcp-scope">Available in</Label>
               <Select
                 value={selectedScope}
                 onValueChange={(v) => v && set("scope", v)}
@@ -256,7 +256,7 @@ export function McpServerDialog({
                   scopeOptions.map((o) => [o.value, o.label]),
                 )}
               >
-                <SelectTrigger size="sm" className="w-full">
+                <SelectTrigger id="mcp-scope" size="sm" className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -75,6 +75,8 @@ export function McpServerDialog({
   onSave: (server: McpServer) => void;
   onClose: () => void;
 }) {
+  // Per-mount base for the field ids (label↔control association).
+  const idBase = useId();
   const editing = initial !== null;
   const [draft, setDraft] = useState<McpServer>(initial ?? emptyMcpServer());
   const [rows, setRows] = useState<EntryRow[]>(initial ? toRows(initial) : []);
@@ -202,9 +204,9 @@ export function McpServerDialog({
         <div className="max-h-[60vh] space-y-5 overflow-y-auto px-1">
           <div className="grid grid-cols-[1fr_1fr] gap-3">
             <div className="space-y-2">
-              <Label htmlFor="mcp-name">Name</Label>
+              <Label htmlFor={`${idBase}-name`}>Name</Label>
               <Input
-                id="mcp-name"
+                id={`${idBase}-name`}
                 autoFocus
                 value={draft.name}
                 onChange={(e) => set("name", e.target.value)}
@@ -234,9 +236,9 @@ export function McpServerDialog({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="mcp-desc">Description</Label>
+            <Label htmlFor={`${idBase}-desc`}>Description</Label>
             <Input
-              id="mcp-desc"
+              id={`${idBase}-desc`}
               value={draft.description}
               onChange={(e) => set("description", e.target.value)}
               placeholder="Local file operations"
@@ -245,7 +247,7 @@ export function McpServerDialog({
 
           {scopeOptions.length > 1 && (
             <div className="space-y-2">
-              <Label htmlFor="mcp-scope">Available in</Label>
+              <Label htmlFor={`${idBase}-scope`}>Available in</Label>
               <Select
                 value={selectedScope}
                 onValueChange={(v) => v && set("scope", v)}
@@ -256,7 +258,11 @@ export function McpServerDialog({
                   scopeOptions.map((o) => [o.value, o.label]),
                 )}
               >
-                <SelectTrigger id="mcp-scope" size="sm" className="w-full">
+                <SelectTrigger
+                  id={`${idBase}-scope`}
+                  size="sm"
+                  className="w-full"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -276,9 +282,9 @@ export function McpServerDialog({
           {isStdio ? (
             <>
               <div className="space-y-2">
-                <Label htmlFor="mcp-command">Command</Label>
+                <Label htmlFor={`${idBase}-command`}>Command</Label>
                 <Input
-                  id="mcp-command"
+                  id={`${idBase}-command`}
                   value={draft.command}
                   onChange={(e) => set("command", e.target.value)}
                   placeholder="npx"
@@ -287,9 +293,9 @@ export function McpServerDialog({
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="mcp-args">Arguments</Label>
+                <Label htmlFor={`${idBase}-args`}>Arguments</Label>
                 <Textarea
-                  id="mcp-args"
+                  id={`${idBase}-args`}
                   value={draft.args.join("\n")}
                   onChange={(e) =>
                     set(
@@ -311,9 +317,9 @@ export function McpServerDialog({
             </>
           ) : (
             <div className="space-y-2">
-              <Label htmlFor="mcp-url">URL</Label>
+              <Label htmlFor={`${idBase}-url`}>URL</Label>
               <Input
-                id="mcp-url"
+                id={`${idBase}-url`}
                 value={draft.url}
                 onChange={(e) => set("url", e.target.value)}
                 placeholder="https://mcp.example.com/mcp"

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -708,12 +708,14 @@ export const gitPush = (
   setUpstream: boolean,
   force = false,
   branch?: string,
+  remote?: string,
 ) =>
   invoke<void>("git_push", {
     repoPath,
     setUpstream,
     force,
     branch: branch ?? null,
+    remote: remote ?? null,
   });
 
 export const gitRemotes = (repoPath: string) =>

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3302,8 +3302,19 @@ export function useUpdateSubmodule(repo: string) {
 export function usePush(repo: string) {
   return useRepoMutation(
     repo,
-    (args: { setUpstream: boolean; force?: boolean; branch?: string }) =>
-      api.gitPush(repo, args.setUpstream, args.force ?? false, args.branch),
+    (args: {
+      setUpstream: boolean;
+      force?: boolean;
+      branch?: string;
+      remote?: string;
+    }) =>
+      api.gitPush(
+        repo,
+        args.setUpstream,
+        args.force ?? false,
+        args.branch,
+        args.remote,
+      ),
   );
 }
 

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -61,6 +61,10 @@ export interface Branch {
    *  remote branch was deleted after a PR merge). Read as "no upstream" for
    *  pushed-ness decisions. */
   upstreamGone: boolean;
+  /** The remote of the branch's upstream (git's `%(upstream:remotename)`), e.g.
+   *  `origin` — null when untracked. Authoritative source for which remote a push
+   *  targets; the UI must never re-derive it from the upstream string. */
+  upstreamRemote: string | null;
 }
 
 /** A branch that exists on a remote but not locally — offered in the switcher so


### PR DESCRIPTION
This change enables pushing or publishing any local branch to its own configured remote, not just `origin`. In the branch switcher, branches tracked on a fork's remote (like `upstream`) will be pushed to their respective remotes, and on publishing an untracked branch, users can select from all available remotes. Additionally, form field accessibility has been improved so all fields are now programmatically associated with their labels for better screen reader support.

### Branch switching and push flows
- Updates push logic in `src-tauri/src/git/remote.rs` to resolve and target the correct remote when pushing a branch, using the branch's upstream remote rather than defaulting to `origin`.
- Refactors the push argument builder and adds explicit remote selection, guarded and validated against actual remotes.
- Updates the MCP push tool (`src-tauri/src/mcp_server/write_git.rs`) to accept and handle an optional `remote` argument, with tests for wire format and argument resolution.
- Extends `src/lib/git/api.ts` and `src/lib/git/queries.ts` to pass an explicit `remote` to the push and mutation layers.

### Branch switcher UI
- Modifies `src/features/repository/BranchSwitcher.tsx` to:
  - Properly resolve the branch's upstream remote via a new `upstreamRemoteOf` helper.
  - Offer “Push to {remote}” for any remote-tracked branch and “Publish to {remote}” for every remote (if multiple), instead of just “origin”.
  - Let the backend decide the correct remote when invoking push for tracked branches and pass explicit remote choices for publishes.
- Updates documentation in `README.md` and `src/features/help/content.ts` to clarify remote-aware push and publish behaviors.

### Accessibility improvements for form fields
- Adds programmatic Label↔control associations across forms and dialogs so screen readers announce field names and all trigger/select/combobox/button widgets have clear accessible names:
  - Modifies `src/components/form/fields.tsx` to bind field labels via `htmlFor`/`id`.
  - Updates every affected dialog and field: `src/features/branch-rules/BranchRulesDialog.tsx`, `src/features/history/HistoryDialogs.tsx`, `src/features/issues/CreateJiraIssueDialog.tsx`, `src/features/issues/RepoJiraDialog.tsx`, `src/features/pulls/CreatePrDialog.tsx`, `src/features/repo-settings/SecretsSection.tsx`, `src/features/repository/BaseBranchCombobox.tsx`, `src/features/repository/BranchMergePickerDialog.tsx`, `src/features/repository/CreateBranchDialog.tsx`, `src/features/repository/RebaseOntoDialog.tsx`, `src/features/actions/RunWorkflowDialog.tsx`, `src/features/automations/LifecycleEditor.tsx`, `src/features/compare/CompareBranchCombobox.tsx`, `src/features/settings/mcp/McpServerDialog.tsx`.
- Includes new changelog files `changelog.d/changed-push-any-remote.md` and `changelog.d/fixed-form-label-associations.md` documenting both features.

### Tests and reliability
- Adds and adjusts targeted tests in `src-tauri/src/git/remote.rs` and `src-tauri/src/mcp_server/write_git.rs` to ensure correct remote resolution, explicit remote arguments, and validation of fallbacks and wire formats.