### PR TITLE
feat(lan,tls,api,docs,ui): serve companion via persistent self-signed HTTPS cert, surface fingerprint for TOFU pairing

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -5,4 +5,6 @@
   requests, and CI** from your phone, read-only. Off by default, with per-device tokens
   you can review and revoke at any time (even while sharing is off), and connected
   phones are disconnected the moment you stop sharing, switch repos, or revoke their
-  device.
+  device. The connection is served over HTTPS with a self-signed certificate GitDesktop
+  generates — your phone shows a one-time certificate warning on first connect, and the
+  pairing dialog shows the certificate's SHA-256 fingerprint so you can verify it.

--- a/companion/src/lib/sha256.ts
+++ b/companion/src/lib/sha256.ts
@@ -1,12 +1,13 @@
 // Pure-TS SHA-256 (FIPS 180-4), no npm dependency and — critically — no
 // `crypto.subtle`.
 //
-// WHY NOT `crypto.subtle`: the Web Crypto API is only exposed on SECURE contexts
-// (https:, or http://localhost). The phone companion is served over PLAIN HTTP on
-// a LAN IP (e.g. http://192.168.1.5:38473), which the browser treats as an
-// INSECURE origin — so `crypto.subtle` is `undefined` there and any call throws.
-// A dependency-free implementation is the only option that works on the real
-// transport. Do NOT "simplify" this back to `crypto.subtle.digest`.
+// WHY NOT `crypto.subtle`: the Web Crypto API is only exposed on SECURE contexts.
+// The companion is served over self-signed HTTPS, and whether a browser treats an
+// origin whose certificate error the user clicked through as a secure context (and
+// exposes `crypto.subtle`) is NOT guaranteed across browsers/versions — and the
+// loopback dev/preview mode plus any future plain-HTTP fallback sit outside it
+// entirely. A dependency-free implementation works on every transport the pairing
+// page can load from. Do NOT "simplify" this back to `crypto.subtle.digest`.
 //
 // The algorithm below is the standard public-domain SHA-256; it is validated by
 // the companion's pairing round-trip and by the shared test vectors the Rust

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,6 +57,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,7 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -248,10 +295,8 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -278,6 +323,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,7 +362,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -303,6 +370,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -868,6 +944,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1734,7 @@ name = "gitdesktop"
 version = "0.3.1"
 dependencies = [
  "axum",
+ "axum-server",
  "base64 0.22.1",
  "chrono",
  "dirs",
@@ -1644,8 +1745,12 @@ dependencies = [
  "portable-pty",
  "qrcode",
  "rand 0.10.2",
+ "rcgen",
+ "reqwest 0.12.28",
  "rmcp",
  "rust-embed",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha1",
@@ -1663,7 +1768,6 @@ dependencies = [
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
  "tower",
  "trash",
  "uuid",
@@ -2527,6 +2631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,10 +2792,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2917,6 +3056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3199,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3477,6 +3635,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3752,6 +3924,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,6 +3951,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5150,18 +5332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5417,22 +5587,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "typeid"
@@ -6597,6 +6751,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6604,6 +6776,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,16 +56,37 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # RustCrypto sha1 — hashing only, no extra default features needed.
 sha1 = "0.10"
 # LAN phone-companion server (src/lan/): an embedded, default-OFF axum HTTP server
-# that lets a paired phone read the active repo over the LAN. `ws` is enabled now
-# (slice 2 needs it; cheaper to land the feature up front). `sha2`/`rand` back the
-# pairing challenge/response + bearer tokens; `qrcode` renders the pairing QR as an
-# inline SVG (svg-only — no `image` default feature); `local-ip-address` enumerates
-# the machine's LAN IPv4s for the advertised urls.
-axum = { version = "0.8.9", features = ["ws"] }
+# that lets a paired phone read the active repo over the LAN. The reviews monitor
+# is a Server-Sent-Events stream (axum's built-in `Sse`, no extra feature), NOT a
+# WebSocket — SSE is one-way (all this route needs) and, unlike `wss:`, an
+# `EventSource` rides a self-signed-cert exception on iOS Safari. `sha2`/`rand`
+# back the pairing challenge/response + bearer tokens; `qrcode` renders the pairing
+# QR as an inline SVG (svg-only — no `image` default feature); `local-ip-address`
+# enumerates the machine's LAN IPv4s for the advertised urls; `futures-util`
+# powers the hand-rolled SSE event stream (`stream::unfold`).
+axum = "0.8.9"
 sha2 = "0.11.0"
 rand = "0.10.2"
 qrcode = { version = "0.14.1", default-features = false, features = ["svg"] }
 local-ip-address = "0.6.13"
+futures-util = "0.3.32"
+# LAN companion TLS (src/lan/tls.rs): the phone browser needs a secure context
+# (`crypto.subtle`, no mixed-content), so the server speaks HTTPS with a persistent
+# self-signed cert the user excepts once (TOFU). `rcgen` mints the cert — KEEP its
+# default features (crypto+pem+ring); its `aws_lc_rs` feature is deliberately NOT
+# enabled (aws-lc-rs needs NASM/CMake on Windows MSVC, which our 3-OS CI must stay
+# free of). `axum-server` serves it over the pre-bound TcpListener with graceful
+# shutdown — the `tls-rustls-no-provider` feature (NOT plain `tls-rustls`, which
+# would pull `rustls/aws-lc-rs` into the tree) keeps us ring-only. `rustls` is a
+# direct dep so we build the `ServerConfig` with an EXPLICIT ring provider (not the
+# process-global default) — hence `default-features = false` + `ring`; `std`/`tls12`/
+# `logging` are the plain-server essentials. `rustls-pki-types` (already transitive)
+# is direct for its PEM parser (`PemObject`) that turns the stored cert/key back into
+# rustls DER types on reuse.
+rcgen = "0.14"
+axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-pki-types = { version = "1", features = ["std"] }
 # Embeds the companion frontend bundle (src-tauri/companion-dist/, written by the
 # sibling `pnpm build:companion`) into the binary so a shipped app serves the phone
 # UI with nothing extra to ship. `mime-guess` powers `EmbeddedFile::metadata().mimetype()`
@@ -99,11 +120,14 @@ windows-sys = { version = "0.61", features = [
 portable-pty = { path = "vendor/portable-pty" }
 
 # `tower::ServiceExt::oneshot` drives the LAN router in unit tests without opening
-# a socket (auth/host/allowlist assertions in src/lan/).
+# a socket (auth/host/allowlist assertions in src/lan/). `futures-util` (a direct
+# dependency above, for the SSE stream) also reads the router's SSE body
+# incrementally in the reviews-monitor test.
 [dev-dependencies]
-futures-util = "0.3.32"
-# 0.29 (not latest) on purpose: axum's ws feature already pulls tokio-tungstenite
-# 0.29, so matching it reuses that tree instead of compiling a second
-# tungstenite/sha1 stack into every test build.
-tokio-tungstenite = "0.29"
 tower = { version = "0.5.3", features = ["util"] }
+# The real-socket TLS smoke test (src/lan/mod.rs) drives the started server over an
+# actual `https://` connection to prove the rustls handshake + serve loop + auth
+# chain all work end-to-end (the oneshot router tests are transport-agnostic). 0.12
+# is already in the graph via tauri-plugin-http, so this is near-zero extra compile;
+# `rustls-tls` (no default features) keeps it off the native-TLS / aws-lc path.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -24,10 +24,13 @@
 //!
 //! ### Transport hardening
 //!
-//! Every response carries `X-Frame-Options: DENY` + `Content-Security-Policy:
-//! frame-ancestors 'none'`, and every request's `Host` (and `Origin`, when
-//! present) must match a bound address — the DNS-rebinding defense that a
-//! localhost HTTP service otherwise lacks (the qBittorrent CVE lesson).
+//! The companion serves HTTPS with a persistent self-signed certificate (see
+//! [`crate::lan::tls`]) so the phone origin is a secure context and the bearer
+//! cookie can be `Secure`. On top of TLS, every response carries `X-Frame-Options:
+//! DENY` + `Content-Security-Policy: frame-ancestors 'none'`, and every request's
+//! `Host` (and `Origin`, when present) must match a bound address — the
+//! DNS-rebinding defense that a bound localhost service otherwise lacks (the
+//! qBittorrent CVE lesson).
 //!
 //! ### Rate limiting
 //!
@@ -602,18 +605,26 @@ pub fn clear_failures(map: &RateLimitMap, ip: IpAddr) {
 /// `AppState` shares individual fields rather than `Arc<Whole>`). Cheap to clone.
 #[derive(Clone)]
 pub struct RouterState {
-    /// The currently-active repo path the read routes operate on. `None` → 409.
+    /// The currently-active repo path the alias read routes operate on. `None` →
+    /// 409. The alias resolver middleware reads this and inserts a `ScopedRepo`.
     pub active_repo: Arc<Mutex<Option<String>>>,
+    /// The repo registry (opaque-id → [`crate::lan::RegisteredRepo`]) backing the
+    /// scoped `/api/repos/{repoId}/…` routes. The SAME `Arc` [`crate::lan::LanState`]
+    /// owns, so `lan_set_active_repo` refreshes it live. The scoped resolver looks a
+    /// `{repoId}` up here (miss → 404) and the `/api/repos` list enumerates it.
+    pub repos: crate::lan::RepoRegistry,
     /// The single active pairing session, if any.
     pub pairing: Arc<Mutex<Option<PairingSession>>>,
     /// Per-IP failure windows.
     pub rate_limit: RateLimitMap,
     /// Every bound `<ip>:<port>` we accept in a `Host`/`Origin` header.
     pub bound_hosts: Arc<Vec<String>>,
-    /// Cut signal for live WebSocket monitors. A `stream` handler subscribes a
-    /// receiver from this before upgrading; the desktop fires `()` on it when
-    /// sharing is disabled, the shared repo changes, or a device is revoked, so
-    /// in-flight sockets close and the phone must reconnect and re-authorize.
+    /// Cut signal for live SSE monitors. The `stream` handler (a plain GET, no
+    /// upgrade) subscribes a receiver from this before returning its `Sse` response;
+    /// the desktop fires `()` on it when sharing is disabled, the shared repo
+    /// changes, or a device is revoked, so in-flight event streams end and the phone
+    /// must reconnect and re-authorize (its EventSource auto-reconnect then hits a
+    /// 401/404 and closes permanently).
     pub monitor_cut: tokio::sync::broadcast::Sender<()>,
     /// The live agent-stream registry — the SAME `Arc` [`crate::state::AppState`]
     /// holds, so a review/session registered there is watchable from the LAN
@@ -658,10 +669,19 @@ pub async fn host_guard(
     req: Request<Body>,
     next: Next,
 ) -> Response {
-    let host_ok = req
+    // The request authority to match against the bound-host allowlist. HTTP/1.1
+    // carries it in the `Host` header; HTTP/2 (which we negotiate via ALPN `h2`)
+    // drops `Host` and puts it in the `:authority` pseudo-header, which hyper/axum
+    // surface on `req.uri().authority()`. Check the `Host` header first, then fall
+    // back to the URI authority, so both protocol versions are guarded identically.
+    let host = req
         .headers()
         .get(axum::http::header::HOST)
         .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+        .or_else(|| req.uri().authority().map(|a| a.as_str().to_string()));
+    let host_ok = host
+        .as_deref()
         .map(|h| state.bound_hosts.iter().any(|b| b == h))
         .unwrap_or(false);
     if !host_ok {
@@ -699,9 +719,11 @@ pub const AUTH_COOKIE: &str = "gd_lan";
 /// of page JS; `SameSite=Strict` (with the existing [`host_guard`] Origin/Host
 /// validation) is the CSRF story — a cross-site request can't attach this cookie,
 /// and the only unauthenticated state-changing routes are the rate-limited pairing
-/// endpoints. No `Secure`: the companion is plain HTTP on the LAN by design (v1),
-/// so `Secure` would suppress the cookie entirely. One year `Max-Age`.
-const AUTH_COOKIE_ATTRS: &str = "HttpOnly; SameSite=Strict; Path=/; Max-Age=31536000";
+/// endpoints. `Secure` is now both SAFE and load-bearing: the companion serves
+/// HTTPS (self-signed; see [`crate::lan::tls`]), so the cookie is delivered and
+/// returned normally, and `Secure` guarantees the bearer never rides a plaintext
+/// downgrade if a request somehow hit an `http://` origin. One year `Max-Age`.
+const AUTH_COOKIE_ATTRS: &str = "HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=31536000";
 
 /// Pull the value of the cookie named `name` from a request's `Cookie` header, if
 /// present. A manual parse (split on `;`, trim, match `name=`) — no cookie crate,

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -19,7 +19,9 @@ pub mod auth;
 pub mod routes;
 pub mod server;
 pub mod static_serve;
+pub mod tls;
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, State};
@@ -28,11 +30,34 @@ use crate::error::{AppError, AppResult};
 use auth::{LanDevice, PairingSession, RateLimitMap};
 use server::ServerHandle;
 
+/// A repo registered in the LAN companion's repo registry, keyed by an opaque
+/// stable id (see [`LanState::set_active_repo`]). Carries the on-disk `path` the
+/// read handlers operate on and a display `name` (last path component) for the
+/// `/api/repos` listing. The `path` is NEVER placed on the wire — only the id +
+/// name are — so a filesystem path can't leak through the registered-repos API.
+#[derive(Debug, Clone)]
+pub struct RegisteredRepo {
+    pub path: String,
+    pub name: String,
+}
+
+/// The shared repo registry: opaque-id → [`RegisteredRepo`]. Shared (per-field
+/// `Arc`) with the router state so the scoped `/api/repos/{repoId}/…` routes can
+/// resolve an id to its path. Registry v1 mirrors the active repo exactly (the map
+/// holds at most the one active entry); a future browse-all-repos direction fills
+/// it with more.
+pub type RepoRegistry = Arc<Mutex<HashMap<String, RegisteredRepo>>>;
+
 /// The Tauri-managed state for the LAN companion.
 pub struct LanState {
     /// The active repo path the read routes operate on. Shared (per-field `Arc`)
     /// with the router state so `lan_set_active_repo` updates it live.
     active_repo: Arc<Mutex<Option<String>>>,
+    /// The repo registry (opaque-id → [`RegisteredRepo`]), shared with the router
+    /// state so the scoped `/api/repos/{repoId}/…` routes can resolve an id to its
+    /// path. Registry v1 mirrors the active repo exactly (see
+    /// [`LanState::set_active_repo`]).
+    repos: RepoRegistry,
     /// The running server handle (bound port + shutdown signal + task), or `None`
     /// when disabled. Guarded so enable/disable are serialized.
     running: Mutex<Option<RunningServer>>,
@@ -40,13 +65,14 @@ pub struct LanState {
     pairing: Arc<Mutex<Option<PairingSession>>>,
     /// Per-IP failure windows for rate-limiting, shared with the router state.
     rate_limit: RateLimitMap,
-    /// Fires a cut signal to every live WebSocket monitor (see
-    /// [`routes::reviews::forward_stream`]). Sent on `lan_disable`, on a
-    /// mode-switch rebind, when the active repo actually changes, and on a
-    /// device revoke — each closes in-flight sockets so a phone must reconnect
-    /// and re-authorize against the new state. The `Sender` is shared (cloned)
+    /// Fires a cut signal to every live SSE monitor (see
+    /// [`routes::reviews::stream`]). Sent on `lan_disable`, on a mode-switch
+    /// rebind, when the active repo actually changes, and on a device revoke —
+    /// each ends in-flight event streams so a phone must reconnect and
+    /// re-authorize against the new state (its EventSource auto-reconnect then
+    /// hits a 401/404 and closes permanently). The `Sender` is shared (cloned)
     /// into the router state; only the send half is ever needed there (each
-    /// socket subscribes its own receiver).
+    /// stream subscribes its own receiver).
     monitor_cut: tokio::sync::broadcast::Sender<()>,
     /// Serializes the WHOLE enable/disable lifecycle transition (an async-aware
     /// `Mutex`, held across the bind/shutdown `.await`s). Without it, two
@@ -59,17 +85,21 @@ pub struct LanState {
 }
 
 /// The bits we track for a running server: its handle, the mode it was started
-/// in, and the advertised urls (for `lan_status` without re-enumerating).
+/// in, the advertised urls (for `lan_status` without re-enumerating), and the
+/// self-signed cert's SHA-256 fingerprint (surfaced in status + pairing for the
+/// TOFU ceremony).
 struct RunningServer {
     handle: ServerHandle,
     bind_lan: bool,
     urls: Vec<String>,
+    fingerprint: String,
 }
 
 impl Default for LanState {
     fn default() -> Self {
         Self {
             active_repo: Arc::new(Mutex::new(None)),
+            repos: Arc::new(Mutex::new(HashMap::new())),
             running: Mutex::new(None),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -87,16 +117,52 @@ impl LanState {
     /// repo actually changed. Returns whether it changed (the cut fired). Split
     /// out from the [`lan_set_active_repo`] command so the change-detection +
     /// cut-fire behavior is unit-testable without a Tauri `State`.
-    fn set_active_repo(&self, repo_path: Option<String>) -> bool {
+    ///
+    /// Also refreshes the repo registry so the scoped `/api/repos/{repoId}/…`
+    /// routes can resolve an id. Registry v1 mirrors the active repo EXACTLY:
+    /// `Some(path)` clears the map and inserts a single entry under an opaque,
+    /// worktree-stable id; `None` clears the map. The id is the lowercase hex of
+    /// the first 8 bytes of `sha256(repo_identity(path))` — opaque and stable,
+    /// never leaking a filesystem path (only the id + display name reach the wire).
+    /// `repo_identity` is the one shared worktree-stable resolver (common git dir,
+    /// falling back to the raw path for a non-repo, which keeps tests
+    /// deterministic).
+    ///
+    /// Change-detection and the monitor cut stay keyed on the PATH exactly as
+    /// before: a same-value set is a no-op that must NOT cut (the App effect
+    /// re-pushes the same repoPath on every render).
+    ///
+    /// The registry install is guarded against a concurrent-call interleave: the
+    /// opaque id resolves via a git subprocess (an `.await`), so two rapid calls
+    /// A→B could race — A's slower resolve could otherwise install `{id_A → A}`
+    /// AFTER B's install, leaving the scoped registry pointing at A while
+    /// `active_repo == B`. So the post-await install ([`install_active_repo`]) only
+    /// clears+inserts when `active_repo` STILL equals the path this call resolved;
+    /// if a later call has already moved it on, this call skips the install (the
+    /// later call owns the registry). No `std::Mutex` is held across the await, and
+    /// the locks are never nested (each install takes `active_repo`, compares, drops
+    /// it, then takes `repos`).
+    async fn set_active_repo(&self, repo_path: Option<String>) -> bool {
         let changed = {
             let mut guard = self.active_repo.lock().unwrap_or_else(|p| p.into_inner());
             if *guard == repo_path {
                 false
             } else {
-                *guard = repo_path;
+                *guard = repo_path.clone();
                 true
             }
         };
+        // Resolve the opaque id OUTSIDE any lock (it awaits git), then guarded-install
+        // it — the install no-ops if `active_repo` has since moved past this path.
+        let entry = match repo_path {
+            Some(ref path) => {
+                let id = repo_id_for(path).await;
+                let name = repo_basename(path);
+                Some((id, RegisteredRepo { path: path.clone(), name }))
+            }
+            None => None,
+        };
+        self.install_active_repo(repo_path.as_deref(), entry);
         // Only cut live monitors when the shared repo ACTUALLY changed. The App
         // effect re-pushes on every repoPath render, so a same-value set is a
         // no-op and must not sever a healthy stream; a real switch/clear must,
@@ -106,6 +172,35 @@ impl LanState {
             let _ = self.monitor_cut.send(());
         }
         changed
+    }
+
+    /// Guarded registry install: mirror the active repo into the registry — clear
+    /// the map and insert `entry` — ONLY IF `active_repo` still equals `resolved`
+    /// (the path whose id `entry` was computed for). If a later `set_active_repo`
+    /// has already moved `active_repo` on, skip entirely: that later call owns the
+    /// registry, and clobbering it here would install a stale entry (the A-after-B
+    /// interleave). Sync + `&self` so it's unit-testable without racing real git.
+    ///
+    /// Lock discipline: read `active_repo` under its own lock and drop the guard
+    /// BEFORE taking the `repos` lock — the two are never held nested, and no
+    /// `std::Mutex` is held across an `.await` (this fn has none).
+    fn install_active_repo(
+        &self,
+        resolved: Option<&str>,
+        entry: Option<(String, RegisteredRepo)>,
+    ) {
+        let still_current = {
+            let guard = self.active_repo.lock().unwrap_or_else(|p| p.into_inner());
+            guard.as_deref() == resolved
+        };
+        if !still_current {
+            return; // a later call moved active_repo on — it owns the registry now.
+        }
+        let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+        repos.clear();
+        if let Some((id, repo)) = entry {
+            repos.insert(id, repo);
+        }
     }
 
     /// Revoke a paired device, then cut live monitors on success. Split out from
@@ -149,6 +244,7 @@ impl LanState {
                 active_repo,
                 device_count: auth::device_count(),
                 pairing_active,
+                cert_fingerprint: Some(rs.fingerprint.clone()),
             },
             None => LanStatus {
                 enabled: false,
@@ -162,6 +258,8 @@ impl LanState {
                 // `lan_status` poll off-disk for the (default) disabled case.
                 device_count: 0,
                 pairing_active,
+                // No cert while disabled — there's no running server to key it to.
+                cert_fingerprint: None,
             },
         }
     }
@@ -181,6 +279,9 @@ pub struct LanStatus {
     pub active_repo: Option<String>,
     pub device_count: u32,
     pub pairing_active: bool,
+    /// The running server's self-signed cert SHA-256 fingerprint (colon-separated
+    /// uppercase hex) for the TOFU display — `Some` exactly when enabled/running.
+    pub cert_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -190,6 +291,9 @@ pub struct LanPairing {
     pub qr_svg: String,
     pub pin: String,
     pub expires_at: String,
+    /// The self-signed cert SHA-256 fingerprint (colon-separated uppercase hex) the
+    /// user confirms against what the phone shows on first connect (TOFU).
+    pub cert_fingerprint: String,
 }
 
 // --------------------------------------------------------------------------
@@ -243,9 +347,10 @@ pub async fn lan_enable(
         }
     }
 
-    let (handle, urls, _hosts) = server::start(
+    let (handle, urls, _hosts, fingerprint) = server::start(
         bind_lan,
         state.active_repo.clone(),
+        state.repos.clone(),
         state.pairing.clone(),
         state.rate_limit.clone(),
         // The SAME stream registry `AppState` owns — so a review/session running
@@ -260,6 +365,7 @@ pub async fn lan_enable(
             handle,
             bind_lan,
             urls,
+            fingerprint,
         });
     }
     // Keep the tray truthful about whether we're sharing.
@@ -298,13 +404,16 @@ pub async fn lan_disable(app: AppHandle, state: State<'_, LanState>) -> AppResul
 
 /// Point the read routes at `repo_path` (the desktop's currently-open repo).
 /// `None` clears the active repo (the desktop closed its repo), after which the
-/// read routes 409 via `repo_or_409!` — paired devices stop seeing the last repo.
+/// alias read routes 409 — paired devices stop seeing the last repo. Also refreshes
+/// the repo registry that backs the scoped `/api/repos/{repoId}/…` routes (see
+/// [`LanState::set_active_repo`]). Async because computing the registry id resolves
+/// the repo's worktree-stable identity via git.
 #[tauri::command]
-pub fn lan_set_active_repo(
+pub async fn lan_set_active_repo(
     state: State<'_, LanState>,
     repo_path: Option<String>,
 ) -> AppResult<()> {
-    state.set_active_repo(repo_path);
+    state.set_active_repo(repo_path).await;
     Ok(())
 }
 
@@ -313,12 +422,13 @@ pub fn lan_set_active_repo(
 /// isn't enabled (there's no url to pair against yet).
 #[tauri::command]
 pub fn lan_pairing_start(state: State<'_, LanState>) -> AppResult<LanPairing> {
-    // The pair url is the FIRST advertised url + "/#pair".
-    let first_url = {
+    // The pair url is the FIRST advertised url + "/#pair", and the fingerprint is
+    // the running server's cert fingerprint — read both under the one lock.
+    let (first_url, fingerprint) = {
         let running = state.running.lock().unwrap_or_else(|p| p.into_inner());
         running
             .as_ref()
-            .and_then(|rs| rs.urls.first().cloned())
+            .and_then(|rs| rs.urls.first().cloned().map(|u| (u, rs.fingerprint.clone())))
             .ok_or_else(|| {
                 AppError::Command(
                     "enable the phone companion before starting pairing".to_string(),
@@ -335,6 +445,7 @@ pub fn lan_pairing_start(state: State<'_, LanState>) -> AppResult<LanPairing> {
         qr_svg,
         pin: session.pin.clone(),
         expires_at: session.expires_at_iso.clone(),
+        cert_fingerprint: fingerprint,
     };
     {
         let mut guard = state.pairing.lock().unwrap_or_else(|p| p.into_inner());
@@ -361,6 +472,26 @@ pub fn lan_devices_list(_state: State<'_, LanState>) -> AppResult<Vec<LanDevice>
 #[tauri::command]
 pub fn lan_device_revoke(state: State<'_, LanState>, device_id: String) -> AppResult<()> {
     state.revoke_device(&device_id)
+}
+
+/// The opaque, worktree-stable registry id for `repo_path`: the lowercase hex of
+/// the FIRST 8 BYTES of `sha256(repo_identity(path))` (16 hex chars). Opaque and
+/// stable across worktrees of the same repo (keyed on the common git dir), and
+/// never a filesystem path — so the id can go on the wire without leaking one.
+async fn repo_id_for(repo_path: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let identity = crate::git::repo::repo_identity(repo_path).await;
+    let digest = Sha256::digest(identity.as_bytes());
+    auth::hex_encode(&digest[..8])
+}
+
+/// The display name for a registered repo: the last path component of `repo_path`,
+/// falling back to the whole string when there isn't one (a bare root or empty).
+fn repo_basename(repo_path: &str) -> String {
+    std::path::Path::new(repo_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| repo_path.to_string())
 }
 
 /// Render `data` as an SVG QR code (string). Uses medium error correction and a
@@ -395,17 +526,34 @@ mod tests {
         ))
     }
 
-    /// A router wired to the given active repo + a fresh (empty) device store.
-    /// Host allowlist is `testhost` so the `Host` header is deterministic.
+    /// A router wired to the given active repo + a fresh (empty) device store and an
+    /// empty repo registry. Host allowlist is `testhost` so the `Host` header is
+    /// deterministic. Tests that exercise the scoped `/api/repos/{repoId}/…` surface
+    /// pre-register an entry via [`register_repo`].
     fn test_router(active: Option<String>) -> auth::RouterState {
         auth::RouterState {
             active_repo: Arc::new(Mutex::new(active)),
+            repos: Arc::new(Mutex::new(std::collections::HashMap::new())),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
             bound_hosts: Arc::new(vec!["testhost".to_string()]),
             streams: Arc::new(Mutex::new(std::collections::HashMap::new())),
             monitor_cut: tokio::sync::broadcast::channel(4).0,
         }
+    }
+
+    /// Pre-register a repo entry in a test router's registry (opaque-id → path), so
+    /// the scoped `/api/repos/{repoId}/…` routes resolve `repo_id` to `repo_path`.
+    /// Returns the id for convenience.
+    fn register_repo(state: &auth::RouterState, repo_id: &str, repo_path: &str) -> String {
+        state.repos.lock().unwrap().insert(
+            repo_id.to_string(),
+            RegisteredRepo {
+                path: repo_path.to_string(),
+                name: repo_basename(repo_path),
+            },
+        );
+        repo_id.to_string()
     }
 
     fn get(path: &str) -> Request<Body> {
@@ -433,30 +581,114 @@ mod tests {
         assert_eq!(state.status().active_repo, None);
     }
 
-    #[test]
-    fn set_active_repo_cuts_monitors_only_on_change() {
+    #[tokio::test]
+    async fn set_active_repo_cuts_monitors_only_on_change() {
         // The monitor-cut signal fires when the shared repo actually changes, and
         // NOT on a same-value set (the App effect re-pushes the same repoPath on
-        // every render — cutting on those would sever healthy phone streams).
+        // every render — cutting on those would sever healthy phone streams). Now
+        // async (it resolves the registry id via git), but the cut-on-real-change
+        // contract is unchanged.
         let state = LanState::default();
         let mut cut_rx = state.monitor_cut.subscribe();
 
         // (1) None → Some(repo) is a change → fires.
-        assert!(state.set_active_repo(Some("C:/repo".to_string())));
+        assert!(state.set_active_repo(Some("C:/repo".to_string())).await);
         assert!(cut_rx.try_recv().is_ok());
 
         // (2) Setting the SAME value again is a no-op → no fire.
-        assert!(!state.set_active_repo(Some("C:/repo".to_string())));
+        assert!(!state.set_active_repo(Some("C:/repo".to_string())).await);
         assert!(matches!(
             cut_rx.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Empty)
         ));
 
         // (3) A real switch (and a clear) each fire.
-        assert!(state.set_active_repo(Some("C:/other".to_string())));
+        assert!(state.set_active_repo(Some("C:/other".to_string())).await);
         assert!(cut_rx.try_recv().is_ok());
-        assert!(state.set_active_repo(None));
+        assert!(state.set_active_repo(None).await);
         assert!(cut_rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn set_active_repo_mirrors_the_registry() {
+        // Registry v1 mirrors the active repo: a set registers exactly one entry
+        // under a 16-hex opaque id whose path is the set path; a clear empties it.
+        // The id never IS the path (opacity), and a same-value set keeps the entry.
+        let state = LanState::default();
+
+        state.set_active_repo(Some("C:/repo".to_string())).await;
+        let (id, path) = {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "one registered repo after a set");
+            let (id, repo) = repos.iter().next().unwrap();
+            (id.clone(), repo.path.clone())
+        };
+        assert_eq!(path, "C:/repo");
+        assert_eq!(id.len(), 16, "opaque id is 16 hex chars: {id}");
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()), "id is hex: {id}");
+        assert_ne!(id, "C:/repo", "id must not leak the path");
+
+        // A switch replaces the entry (still exactly one).
+        state.set_active_repo(Some("C:/other".to_string())).await;
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1);
+            assert_eq!(repos.values().next().unwrap().path, "C:/other");
+        }
+
+        // A clear empties the registry.
+        state.set_active_repo(None).await;
+        assert!(state.repos.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn install_active_repo_skips_a_stale_install() {
+        // The concurrent-call guard: a slow resolve (call A) whose install lands
+        // AFTER a later call (B) already moved active_repo on must NOT clobber the
+        // registry. `install_active_repo` no-ops unless `active_repo` still equals
+        // the path the entry was resolved for. Driven synchronously (no real git
+        // race) by setting active_repo to B and calling A's install with A's path.
+        let state = LanState::default();
+
+        // B is the winning, current active repo, with B's entry already installed.
+        {
+            *state.active_repo.lock().unwrap() = Some("C:/repo-B".to_string());
+        }
+        let entry_b = ("bbbbbbbbbbbbbbbb".to_string(), RegisteredRepo {
+            path: "C:/repo-B".to_string(),
+            name: "repo-B".to_string(),
+        });
+        state.install_active_repo(Some("C:/repo-B"), Some(entry_b));
+        assert_eq!(
+            state.repos.lock().unwrap().get("bbbbbbbbbbbbbbbb").map(|r| r.path.clone()),
+            Some("C:/repo-B".to_string()),
+            "B's install lands while B is current"
+        );
+
+        // A is a STALE resolve for a path active_repo no longer equals → skipped.
+        let entry_a = ("aaaaaaaaaaaaaaaa".to_string(), RegisteredRepo {
+            path: "C:/repo-A".to_string(),
+            name: "repo-A".to_string(),
+        });
+        state.install_active_repo(Some("C:/repo-A"), Some(entry_a));
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "stale install must not add A's entry");
+            assert!(repos.contains_key("bbbbbbbbbbbbbbbb"), "B's entry survives");
+            assert!(!repos.contains_key("aaaaaaaaaaaaaaaa"), "A's stale entry rejected");
+        }
+
+        // A matching install (active_repo == resolved) still applies normally.
+        let entry_b2 = ("cccccccccccccccc".to_string(), RegisteredRepo {
+            path: "C:/repo-B".to_string(),
+            name: "repo-B".to_string(),
+        });
+        state.install_active_repo(Some("C:/repo-B"), Some(entry_b2));
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "a matching install clears+inserts");
+            assert!(repos.contains_key("cccccccccccccccc"), "B's fresh entry installed");
+        }
     }
 
     #[test]
@@ -500,10 +732,10 @@ mod tests {
     async fn review_routes_are_bearer_gated() {
         // The live-monitoring routes live under the same authed subtree as the git
         // routes, so an unauthenticated request 401s BEFORE reaching the handler —
-        // for both the enumeration route and the WebSocket-upgrade route (an
-        // upgrade is a plain GET until the handler accepts it, so `require_auth`
-        // runs first). This is the middleware-layering guarantee the WS route
-        // relies on for its no-approve/no-stdin read-only contract.
+        // for both the enumeration route and the SSE stream route. The SSE stream is
+        // an ordinary GET (no upgrade step), so `require_auth` runs ahead of the
+        // handler exactly like every other read route — the middleware-layering
+        // guarantee the stream route relies on for its one-way, read-only contract.
         let router = server::build_router(test_router(Some("C:/repo".to_string())));
         let list = router.clone().oneshot(get("/api/reviews")).await.unwrap();
         assert_eq!(list.status(), StatusCode::UNAUTHORIZED);
@@ -966,8 +1198,9 @@ mod tests {
         assert!(set_cookie.contains("SameSite=Strict"), "SameSite=Strict: {set_cookie}");
         assert!(set_cookie.contains("Path=/"), "Path=/: {set_cookie}");
         assert!(set_cookie.contains("Max-Age=31536000"), "Max-Age: {set_cookie}");
-        // No Secure — plain HTTP on the LAN by design.
-        assert!(!set_cookie.contains("Secure"), "must NOT be Secure: {set_cookie}");
+        // Secure is now present AND load-bearing: the companion serves HTTPS, so the
+        // bearer cookie must never ride a plaintext downgrade.
+        assert!(set_cookie.contains("Secure"), "must be Secure: {set_cookie}");
 
         // The JSON body is unchanged — the token is still returned for API clients.
         let bytes = axum::body::to_bytes(pair_resp.into_body(), 64 * 1024)
@@ -975,8 +1208,8 @@ mod tests {
             .unwrap();
         let minted: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let token = minted["token"].as_str().unwrap();
-        // The cookie value equals the raw bearer.
-        assert_eq!(set_cookie, format!("gd_lan={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=31536000"));
+        // The cookie value equals the raw bearer, with the exact frozen attributes.
+        assert_eq!(set_cookie, format!("gd_lan={token}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=31536000"));
 
         auth::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();
@@ -1251,144 +1484,459 @@ mod tests {
         std::fs::remove_file(&tmp).ok();
     }
 
+    /// Read the next SSE `data:` payload from a live response body within `timeout`,
+    /// or `None` if the stream ended first. SSE is one-way, so unlike a WebSocket we
+    /// can drain the body incrementally with `into_data_stream` + `StreamExt::next`
+    /// — `axum::body::to_bytes` would hang forever on a stream that never completes.
+    /// Concatenates chunks until a full `data:` line is seen, so a payload split
+    /// across chunks (or preceded by keep-alive `:ka` comments) is handled.
+    async fn next_sse_data(
+        body: &mut axum::body::BodyDataStream,
+        timeout: std::time::Duration,
+    ) -> Option<String> {
+        use futures_util::StreamExt;
+        let mut buf = String::new();
+        loop {
+            let chunk = tokio::time::timeout(timeout, body.next()).await.ok()??;
+            let bytes = chunk.ok()?;
+            buf.push_str(&String::from_utf8_lossy(&bytes));
+            // An SSE event is terminated by a blank line; a `data:` field carries the
+            // payload. Scan for a complete `data:` line.
+            for line in buf.lines() {
+                if let Some(rest) = line.strip_prefix("data:") {
+                    return Some(rest.trim().to_string());
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
-    async fn live_websocket_monitor_is_severed_by_the_cut_signal() {
-        // End-to-end: bind a REAL listener, connect a REAL WebSocket to the
-        // `/api/reviews/{id}/stream` route as a paired device, prove the pump is
-        // live (one event → one Text frame), then fire the lifecycle cut and prove
-        // the socket is closed (next frame is a Close). This exercises the exact
-        // production path the in-memory `oneshot` tests can't reach — the upgraded
-        // socket and `forward_stream`'s monitor-cut `select!` branch.
-        use futures_util::StreamExt;
-        use tokio::time::{timeout, Duration};
-        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-        use tokio_tungstenite::tungstenite::Message;
+    async fn sse_monitor_forwards_then_is_severed_by_the_cut_signal() {
+        // Router-level (no socket): request the `/api/reviews/{id}/stream` SSE stream
+        // with a valid bearer via `oneshot`, read the body INCREMENTALLY, assert a
+        // broadcast event arrives as a `data:` frame, fire the lifecycle cut, and
+        // assert the stream ENDS (next read → None within the timeout). This covers
+        // `forward_stream`'s forward path and its biased monitor-cut branch.
+        use tokio::time::Duration;
 
         let _lock = auth::store_test_lock();
         let tmp = temp_store();
         let prev = auth::set_store_path_for_test(Some(tmp.clone()));
 
-        // The shared arcs a real server needs — built directly (not via a whole
-        // `LanState`) so we can inject an event and fire the cut ourselves. The
-        // active repo and the stream's `repo_path` match, so the stream is in scope.
         let repo = "C:/repo".to_string();
-        let active_repo = Arc::new(Mutex::new(Some(repo.clone())));
-        let pairing = Arc::new(Mutex::new(None));
-        let rate_limit = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let streams: Arc<Mutex<std::collections::HashMap<String, crate::state::StreamInfo>>> =
-            Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let monitor_cut = tokio::sync::broadcast::channel::<()>(4).0;
-
+        let state = test_router(Some(repo.clone()));
+        let monitor_cut = state.monitor_cut.clone();
         // A live "review" stream on the shared repo; keep the sender to emit events.
-        let (ev_tx, _ev_rx) = tokio::sync::broadcast::channel::<crate::agent::ReviewEvent>(16);
-        streams.lock().unwrap().insert(
-            "rev-e2e".to_string(),
-            crate::state::StreamInfo {
-                tx: ev_tx.clone(),
-                kind: "review".to_string(),
-                started_at: "2026-07-17T00:00:00.000Z".to_string(),
-                repo_path: repo.clone(),
-            },
-        );
+        let ev_tx = insert_stream(&state, "rev-sse", "review", &repo);
 
-        // Seed a paired device and keep its raw bearer for the WS handshake.
-        let (device, bearer, token_hash) = auth::mint_device("E2E Phone");
+        let (device, bearer, token_hash) = auth::mint_device("SSE Phone");
         auth::persist_device(&device, &token_hash).unwrap();
 
-        // Bind a real listener in loopback mode (the port scan handles a busy
-        // default port). `server::start` spawns its serve task on the tauri
-        // async runtime, which self-initializes here.
-        let (handle, _urls, _hosts) = server::start(
-            false,
-            active_repo.clone(),
-            pairing,
-            rate_limit,
-            streams.clone(),
-            monitor_cut.clone(),
-        )
-        .await
-        .unwrap();
-        let port = handle.port;
-
-        // Connect a REAL WebSocket. Build the handshake request from the URI (which
-        // fills in the mandatory `Upgrade`/`Sec-WebSocket-*` headers and a `Host` of
-        // `127.0.0.1:{port}`, which is in the bound-hosts allowlist), then add the
-        // per-device bearer the way a paired phone would.
-        let url = format!("ws://127.0.0.1:{port}/api/reviews/rev-e2e/stream");
-        let mut req = url.into_client_request().unwrap();
-        req.headers_mut().insert(
-            "authorization",
-            format!("Bearer {bearer}").parse().unwrap(),
-        );
-        let (mut ws, _resp) = timeout(Duration::from_secs(5), tokio_tungstenite::connect_async(req))
+        let router = server::build_router(state);
+        let resp = router
+            .oneshot(authed_get("/api/reviews/rev-sse/stream", &bearer))
             .await
-            .expect("WebSocket connect timed out")
-            .expect("WebSocket handshake failed (auth/host/upgrade)");
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "text/event-stream"
+        );
+        let mut body = resp.into_body().into_data_stream();
 
-        // (1) The pump is live: one event through the registry tx arrives as one
-        // Text frame carrying the ReviewEvent's own JSON.
+        // (1) One event through the registry tx arrives as one `data:` frame.
         ev_tx
             .send(crate::agent::ReviewEvent::Delta {
                 text: "hello phone".to_string(),
             })
             .unwrap();
-        let frame = timeout(Duration::from_secs(5), ws.next())
+        let data = next_sse_data(&mut body, Duration::from_secs(5))
             .await
-            .expect("timed out waiting for the forwarded event")
-            .expect("stream ended before the event")
-            .expect("websocket error waiting for the event");
-        match frame {
-            Message::Text(t) => assert!(
-                t.contains("hello phone"),
-                "forwarded frame should carry the event JSON: {t}"
-            ),
-            other => panic!("expected a Text frame, got {other:?}"),
-        }
+            .expect("timed out / stream ended before the event");
+        assert!(
+            data.contains("hello phone"),
+            "forwarded frame should carry the event JSON: {data}"
+        );
 
-        // (2) Fire the lifecycle cut (what `lan_disable` / repo-switch / revoke do).
-        // The pump's `select!` cut branch must break and close the socket.
+        // (2) Fire the lifecycle cut (what disable / repo-switch / revoke do). The
+        // stream's biased cut branch must end it: the next read is None (end).
         monitor_cut.send(()).unwrap();
+        let next = next_sse_data(&mut body, Duration::from_secs(5)).await;
+        assert!(next.is_none(), "the stream must end on the cut, got {next:?}");
 
-        // The next frame the client sees is a Close (the pump's best-effort
-        // graceful close). Some stacks surface the close as the stream ending
-        // (`None`) right after; accept either as "severed", but never another Text.
-        let next = timeout(Duration::from_secs(5), ws.next())
-            .await
-            .expect("timed out waiting for the socket to be severed");
-        match next {
-            Some(Ok(Message::Close(_))) | None => { /* severed, as required */ }
-            Some(Ok(other)) => panic!("expected the socket to be cut, got {other:?}"),
-            Some(Err(_)) => { /* an abrupt transport close is still a severed socket */ }
-        }
-
-        // Best-effort client-side close, then tear the server down and clean up.
-        let _ = ws.close(None).await;
-        handle.shutdown().await;
         auth::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();
     }
 
-    // NOTE on the `stream` route's 409/404 branches: `WebSocketUpgrade` is an
-    // extractor, and axum runs it during extraction — a plain (non-upgrade) GET is
-    // rejected with `400 Bad Request` by the extractor BEFORE the handler body runs,
-    // so a `tower::oneshot` (which can't perform a real WS upgrade) can never reach
-    // the body's `repo_or_409!` (409) or its scoped-`subscribe_in_for` 404. The
-    // pre-existing `review_routes_are_bearer_gated` test likewise only reaches the
-    // 401 because that's middleware, ahead of extraction. The scoping logic these
-    // branches call is unit-tested directly in `state::tests`
-    // (`scoped_snapshot_and_subscribe_filter_by_repo`): matching repo → `Some`,
-    // out-of-scope id and unknown id → `None` (the 404 source), with no oracle
-    // distinguishing them. Asserting the route-level 404/409 would need a live
-    // socket, out of scope for these in-memory router tests.
-    //
-    // NOTE on `forward_stream`'s monitor-cut `select!` branch: a `tower::oneshot`
-    // can't drive it (the `WebSocketUpgrade` extractor rejects a non-upgrade GET
-    // during extraction, before the handler runs), so the cut branch only runs on a
-    // real upgraded socket. It is now covered end-to-end by
-    // `live_websocket_monitor_is_severed_by_the_cut_signal` above, which binds a
-    // real listener, connects a real WebSocket, and asserts the socket is closed
-    // when the cut fires. The fire points are separately covered by
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn sse_monitor_ends_on_a_terminal_done_event() {
+        // A terminal `Done` event is forwarded, then the stream ENDS on the next poll
+        // (the "yield then end" contract). Read the Done frame, then assert the next
+        // read is None.
+        use tokio::time::Duration;
+
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let repo = "C:/repo".to_string();
+        let state = test_router(Some(repo.clone()));
+        // Hold a `monitor_cut` Sender clone for the whole test. In production
+        // `LanState` owns this Sender for the server's lifetime; under `oneshot` the
+        // router (and its Sender) is dropped once the response is produced, and a
+        // dropped last Sender makes `cut_rx.recv()` return `Closed` — which the
+        // stream's biased cut arm treats as a sever, ending it before any event.
+        let _monitor_cut = state.monitor_cut.clone();
+        let ev_tx = insert_stream(&state, "rev-done", "review", &repo);
+
+        let (device, bearer, token_hash) = auth::mint_device("Done Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let router = server::build_router(state);
+        let resp = router
+            .oneshot(authed_get("/api/reviews/rev-done/stream", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body = resp.into_body().into_data_stream();
+
+        // A terminal Done event is forwarded as a `data:` frame...
+        ev_tx
+            .send(crate::agent::ReviewEvent::Done {
+                text: "all done".to_string(),
+                is_error: false,
+                cost_usd: None,
+            })
+            .unwrap();
+        let data = next_sse_data(&mut body, Duration::from_secs(5))
+            .await
+            .expect("timed out / stream ended before the Done event");
+        assert!(data.contains("done"), "the Done event's JSON: {data}");
+
+        // ...then the stream ends (yield-then-end).
+        let next = next_sse_data(&mut body, Duration::from_secs(5)).await;
+        assert!(next.is_none(), "stream must end after Done, got {next:?}");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn sse_monitor_unknown_id_404s_before_the_stream_starts() {
+        // An unknown (or out-of-scope) stream id 404s with `noSuchStream` BEFORE any
+        // stream is opened — the no-oracle property. Unlike the old WS route (whose
+        // extractor rejected a non-upgrade GET before the handler), the SSE handler
+        // runs on a plain GET, so this is now assertable at the router level.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = test_router(Some("C:/repo".to_string()));
+        let (device, bearer, token_hash) = auth::mint_device("Unknown Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(state);
+
+        let resp = router
+            .oneshot(authed_get("/api/reviews/does-not-exist/stream", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "noSuchStream");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn list_repos_lists_the_registered_repo_and_is_empty_when_none() {
+        // `GET /api/repos` returns the registered repos as `[{ id, name }]` with a
+        // 16-hex id + basename name, and `[]` when none is registered. No path is on
+        // the wire.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("Repos Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        // (1) One registered repo → one entry with a 16-hex id + basename.
+        let state = test_router(Some("C:/repo".to_string()));
+        register_repo(&state, "abcdef0123456789", "C:/work/my-repo");
+        let router = server::build_router(state);
+        let resp = router
+            .oneshot(authed_get("/api/repos", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], "abcdef0123456789");
+        assert_eq!(arr[0]["name"], "my-repo");
+        assert!(
+            arr[0].get("path").is_none() && arr[0].get("repoPath").is_none(),
+            "no filesystem path on the wire: {arr:?}"
+        );
+
+        // (2) No registered repo → [].
+        let empty_state = test_router(None);
+        let empty_router = server::build_router(empty_state);
+        let resp = empty_router
+            .oneshot(authed_get("/api/repos", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 0);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn scoped_route_reaches_the_same_handler_as_the_alias() {
+        // A scoped `/api/repos/{repoId}/status` request resolves the id to the repo
+        // and reaches the SAME handler as the alias `/api/repo/status`. With a fake
+        // path it fails at the git layer exactly like the alias does (past auth +
+        // resolution, NOT 401/404/409).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("Scoped Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let state = test_router(Some("C:/repo".to_string()));
+        register_repo(&state, "cafebabecafebabe", "C:/repo");
+        let router = server::build_router(state);
+
+        let resp = router
+            .oneshot(authed_get("/api/repos/cafebabecafebabe/status", &bearer))
+            .await
+            .unwrap();
+        // Reached the handler: not an auth/resolution rejection.
+        assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+        assert_ne!(resp.status(), StatusCode::CONFLICT);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn scoped_route_unknown_repo_id_404s_nosuchrepo() {
+        // An unknown/unshared `{repoId}` 404s with `noSuchRepo` (404 not 403 — an
+        // unknown id and an unshared repo are indistinguishable).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("NoRepo Scoped Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        // Registry is empty (no register_repo call).
+        let state = test_router(Some("C:/repo".to_string()));
+        let router = server::build_router(state);
+
+        let resp = router
+            .oneshot(authed_get("/api/repos/deadbeefdeadbeef/status", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "noSuchRepo");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn alias_route_with_no_active_repo_409s_noactiverepo() {
+        // The alias surface still 409s `noActiveRepo` when no repo is shared — the
+        // frozen contract the shipped companion relies on (its body moved from the
+        // old per-handler macro into the alias resolver).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("NoActive Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let state = test_router(None);
+        let router = server::build_router(state);
+
+        let resp = router
+            .oneshot(authed_get("/api/repo/status", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "noActiveRepo");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn scoped_reviews_stream_works_with_the_registered_id() {
+        // The scoped `/api/repos/{repoId}/reviews/{id}/stream` reaches the SSE
+        // handler and forwards an event, proving the two-path-param extraction
+        // (`repoId` + `id`) and the shared handler work under the scoped mount.
+        use tokio::time::Duration;
+
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let repo = "C:/repo".to_string();
+        let state = test_router(Some(repo.clone()));
+        // See `sse_monitor_ends_on_a_terminal_done_event`: hold the cut Sender so the
+        // stream isn't severed by `Closed` when `oneshot` drops the router.
+        let _monitor_cut = state.monitor_cut.clone();
+        register_repo(&state, "0011223344556677", &repo);
+        let ev_tx = insert_stream(&state, "rev-scoped", "review", &repo);
+
+        let (device, bearer, token_hash) = auth::mint_device("Scoped Stream Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let router = server::build_router(state);
+        let resp = router
+            .oneshot(authed_get(
+                "/api/repos/0011223344556677/reviews/rev-scoped/stream",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body = resp.into_body().into_data_stream();
+
+        ev_tx
+            .send(crate::agent::ReviewEvent::Delta {
+                text: "scoped hello".to_string(),
+            })
+            .unwrap();
+        let data = next_sse_data(&mut body, Duration::from_secs(5))
+            .await
+            .expect("timed out / stream ended before the event");
+        assert!(data.contains("scoped hello"), "scoped stream frame: {data}");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    // NOTE: the `stream` route's 404 (`noSuchStream`) and the alias 409
+    // (`noActiveRepo`) / scoped 404 (`noSuchRepo`) branches are now directly
+    // assertable at the router level (see the tests above) because the SSE handler
+    // runs on a plain GET — unlike the old `WebSocketUpgrade` extractor, which
+    // rejected a non-upgrade `oneshot` GET before the handler body ran. The
+    // monitor-cut branch is covered by `sse_monitor_forwards_then_is_severed_by_the_cut_signal`
+    // at the router level; its fire points are separately covered by
     // `set_active_repo_cuts_monitors_only_on_change` and
-    // `revoke_device_cuts_monitors_on_success`.
+    // `revoke_device_cuts_monitors_on_success`. The scoping logic the 404 calls
+    // (`subscribe_in_for`) is additionally unit-tested in `state::tests`.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::await_holding_lock)]
+    // Multi-thread flavor: the client request and the server's accept/serve loop
+    // (spawned on Tauri's runtime) run concurrently over a real socket.
+    async fn real_socket_tls_serves_and_shuts_down() {
+        // The one end-to-end test that goes over a REAL TLS socket (the oneshot
+        // router tests are transport-agnostic). Starting the server in loopback mode
+        // then GETting `https://127.0.0.1:{port}/api/repo/status` with a cert-
+        // ignoring client proves the whole stack is live over TLS: the rustls
+        // handshake completes, the serve loop accepts, and the host guard + auth
+        // chain run (an unauthenticated read → 401). Then a graceful shutdown must
+        // stop accepting, so a second request errors.
+        let _lock = auth::store_test_lock();
+        let store_tmp = temp_store();
+        let store_prev = auth::set_store_path_for_test(Some(store_tmp.clone()));
+        let tls_dir = std::env::temp_dir().join(format!(
+            "gd-lan-tls-smoke-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let tls_prev = tls::set_tls_dir_for_test(Some(tls_dir.clone()));
+
+        let (handle, urls, _hosts, fingerprint) = server::start(
+            false, // loopback
+            Arc::new(Mutex::new(Some("C:/repo".to_string()))),
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            tokio::sync::broadcast::channel(4).0,
+        )
+        .await
+        .expect("server should start over TLS");
+
+        // The advertised url is https and the fingerprint has the frozen shape.
+        assert!(urls[0].starts_with("https://"), "https url: {}", urls[0]);
+        assert_eq!(fingerprint.split(':').count(), 32, "fingerprint: {fingerprint}");
+        let port = handle.port;
+
+        let url = format!("https://127.0.0.1:{port}/api/repo/status");
+        {
+            // Scope the client so it's DROPPED (closing its connection) before we
+            // shut down — a lingering pooled keep-alive connection would make
+            // `graceful_shutdown` wait out its full 5s deadline for nothing.
+            // `pool_max_idle_per_host(0)` also refuses to keep the socket idle, and a
+            // short request `timeout` guarantees no reqwest call can stall the suite.
+            let client = reqwest::Client::builder()
+                .danger_accept_invalid_certs(true)
+                .pool_max_idle_per_host(0)
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap();
+            let resp = client
+                .get(&url)
+                .send()
+                .await
+                .expect("TLS GET should reach the server");
+            // Host guard passes (127.0.0.1:{port} is a bound host) → auth chain runs →
+            // 401 for the missing bearer. That single status proves the whole path.
+            assert_eq!(
+                resp.status(),
+                reqwest::StatusCode::UNAUTHORIZED,
+                "unauthenticated read over TLS must be 401"
+            );
+        }
+
+        // Graceful shutdown, then a fresh connection must fail (port released).
+        handle.shutdown().await;
+        let after = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .pool_max_idle_per_host(0)
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap()
+            .get(&url)
+            .send()
+            .await;
+        assert!(after.is_err(), "post-shutdown request must error, got {after:?}");
+
+        tls::set_tls_dir_for_test(tls_prev);
+        std::fs::remove_dir_all(&tls_dir).ok();
+        auth::set_store_path_for_test(store_prev);
+        std::fs::remove_file(&store_tmp).ok();
+    }
 }

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -130,18 +130,22 @@ impl LanState {
     ///
     /// Change-detection and the monitor cut stay keyed on the PATH exactly as
     /// before: a same-value set is a no-op that must NOT cut (the App effect
-    /// re-pushes the same repoPath on every render).
+    /// re-pushes the same repoPath on every render). That no-op is SUBPROCESS-FREE —
+    /// it returns right after the cheap `*guard == repo_path` compare, without
+    /// resolving the registry id or touching the registry (the prior *changed* call
+    /// already installed the right entry). This keeps a chatty per-render re-push
+    /// off the git subprocess `repo_id_for` spawns, even while the companion is off.
     ///
-    /// The registry install is guarded against a concurrent-call interleave: the
-    /// opaque id resolves via a git subprocess (an `.await`), so two rapid calls
-    /// A→B could race — A's slower resolve could otherwise install `{id_A → A}`
-    /// AFTER B's install, leaving the scoped registry pointing at A while
-    /// `active_repo == B`. So the post-await install ([`install_active_repo`]) only
-    /// clears+inserts when `active_repo` STILL equals the path this call resolved;
-    /// if a later call has already moved it on, this call skips the install (the
-    /// later call owns the registry). No `std::Mutex` is held across the await, and
-    /// the locks are never nested (each install takes `active_repo`, compares, drops
-    /// it, then takes `repos`).
+    /// The registry install (only reached on a real switch/clear) is guarded against
+    /// a concurrent-call interleave: the opaque id resolves via a git subprocess (an
+    /// `.await`), so two rapid *changed* calls A→B could race — A's slower resolve
+    /// could otherwise install `{id_A → A}` AFTER B's install, leaving the scoped
+    /// registry pointing at A while `active_repo == B`. So the post-await install
+    /// ([`install_active_repo`]) only clears+inserts when `active_repo` STILL equals
+    /// the path this call resolved; if a later call has already moved it on, this
+    /// call skips the install (the later call owns the registry). No `std::Mutex` is
+    /// held across the await, and the locks are never nested (each install takes
+    /// `active_repo`, compares, drops it, then takes `repos`).
     async fn set_active_repo(&self, repo_path: Option<String>) -> bool {
         let changed = {
             let mut guard = self.active_repo.lock().unwrap_or_else(|p| p.into_inner());
@@ -152,6 +156,12 @@ impl LanState {
                 true
             }
         };
+        // A same-value re-push is a no-op: the registry already holds the right entry
+        // from the prior changed call, so skip the git-subprocess resolve AND the
+        // install entirely. Only a real switch/clear resolves + guarded-installs.
+        if !changed {
+            return false;
+        }
         // Resolve the opaque id OUTSIDE any lock (it awaits git), then guarded-install
         // it — the install no-ops if `active_repo` has since moved past this path.
         let entry = match repo_path {
@@ -163,15 +173,11 @@ impl LanState {
             None => None,
         };
         self.install_active_repo(repo_path.as_deref(), entry);
-        // Only cut live monitors when the shared repo ACTUALLY changed. The App
-        // effect re-pushes on every repoPath render, so a same-value set is a
-        // no-op and must not sever a healthy stream; a real switch/clear must,
-        // since the phone's in-flight stream is now scoped to a repo we no longer
-        // share.
-        if changed {
-            let _ = self.monitor_cut.send(());
-        }
-        changed
+        // The shared repo actually changed → cut live monitors: a real switch/clear
+        // means the phone's in-flight stream is now scoped to a repo we no longer
+        // share, so it must reconnect and re-authorize against the new state.
+        let _ = self.monitor_cut.send(());
+        true
     }
 
     /// Guarded registry install: mirror the active repo into the registry — clear
@@ -627,6 +633,27 @@ mod tests {
         assert_eq!(id.len(), 16, "opaque id is 16 hex chars: {id}");
         assert!(id.chars().all(|c| c.is_ascii_hexdigit()), "id is hex: {id}");
         assert_ne!(id, "C:/repo", "id must not leak the path");
+
+        // A same-value re-push (the App effect fires one per render) is a no-op: it
+        // returns `false` and leaves BOTH active_repo and the registry entry exactly
+        // as they were — proving the resolve + install were skipped (no per-render
+        // git subprocess). Same id object, same path.
+        assert!(
+            !state.set_active_repo(Some("C:/repo".to_string())).await,
+            "a same-value set reports no change"
+        );
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "same-value set leaves the single entry");
+            let (id2, repo2) = repos.iter().next().unwrap();
+            assert_eq!(id2, &id, "same-value set does not re-resolve the id");
+            assert_eq!(repo2.path, "C:/repo", "same-value set leaves the entry path");
+        }
+        assert_eq!(
+            state.active_repo.lock().unwrap().as_deref(),
+            Some("C:/repo"),
+            "same-value set leaves active_repo untouched"
+        );
 
         // A switch replaces the entry (still exactly one).
         state.set_active_repo(Some("C:/other".to_string())).await;

--- a/src-tauri/src/lan/routes/forge.rs
+++ b/src-tauri/src/lan/routes/forge.rs
@@ -1,18 +1,31 @@
 //! Read-only forge routes — thin adapters over the existing `crate::forge::*`
 //! core fns (which fan out to GitHub/GitLab/Bitbucket by the repo's remote). Each
-//! pulls the active repo from state and calls the core fn unchanged. The `lens`
-//! param is deliberately omitted from the HTTP surface (always `None`).
+//! reads its scoped repo from the `Extension<ScopedRepo>` a resolver middleware
+//! inserts and calls the core fn unchanged. The `lens` param is deliberately
+//! omitted from the HTTP surface (always `None`).
 //!
 //! Note: the forge issue fns hard-error on Bitbucket ("Bitbucket issues aren't
 //! supported yet."); that surfaces as the mapped `InvalidArgument` → 400. It is
 //! NOT special-cased here — the error propagates like any other.
 
-use axum::extract::{Path, Query, State};
+use std::collections::HashMap;
+
+use axum::extract::{Path, Query};
 use axum::response::Response;
+use axum::Extension;
 use serde::Deserialize;
 
-use crate::lan::auth::RouterState;
-use crate::lan::routes::{repo_or_409, respond};
+use crate::lan::routes::{bad_request, path_param, respond, ScopedRepo};
+
+/// Read a `u64` path param by name (`number`/`id`), returning the app's standard
+/// 400 when it's absent or not a non-negative integer. Shared across both mounts,
+/// so the param is read by name (see [`crate::lan::routes`]). The `Err` `Response`
+/// is boxed to keep the `Result` small (the `result_large_err` lint).
+fn u64_param(params: &HashMap<String, String>, name: &str) -> Result<u64, Box<Response>> {
+    let raw = path_param(params, name)?;
+    raw.parse::<u64>()
+        .map_err(|_| Box::new(bad_request(&format!("{name} must be a non-negative integer"))))
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,29 +34,45 @@ pub struct ListQuery {
     limit: Option<u32>,
 }
 
-/// GET /api/forge/prs?state&limit
-pub async fn pr_list(State(state): State<RouterState>, Query(q): Query<ListQuery>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET PR list (alias: `/api/forge/prs?state&limit`).
+pub async fn pr_list(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Query(q): Query<ListQuery>,
+) -> Response {
     let pr_state = q.state.unwrap_or_else(|| "open".to_string());
     respond(crate::forge::forge_pr_list(repo, pr_state, q.limit, None).await)
 }
 
-/// GET /api/forge/prs/{number}
-pub async fn pr_view(State(state): State<RouterState>, Path(number): Path<u64>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET PR view (alias: `/api/forge/prs/{number}`).
+pub async fn pr_view(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
+) -> Response {
+    let number = match u64_param(&params, "number") {
+        Ok(n) => n,
+        Err(resp) => return *resp,
+    };
     respond(crate::forge::forge_pr_view(repo, number, None).await)
 }
 
-/// GET /api/forge/issues?state&limit
-pub async fn issue_list(State(state): State<RouterState>, Query(q): Query<ListQuery>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET issue list (alias: `/api/forge/issues?state&limit`).
+pub async fn issue_list(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Query(q): Query<ListQuery>,
+) -> Response {
     let issue_state = q.state.unwrap_or_else(|| "open".to_string());
     respond(crate::forge::forge_issue_list(repo, issue_state, q.limit, None).await)
 }
 
-/// GET /api/forge/issues/{number}
-pub async fn issue_view(State(state): State<RouterState>, Path(number): Path<u64>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET issue view (alias: `/api/forge/issues/{number}`).
+pub async fn issue_view(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
+) -> Response {
+    let number = match u64_param(&params, "number") {
+        Ok(n) => n,
+        Err(resp) => return *resp,
+    };
     respond(crate::forge::forge_issue_view(repo, number, None).await)
 }
 
@@ -54,18 +83,23 @@ pub struct CiListQuery {
     branch: Option<String>,
 }
 
-/// GET /api/forge/ci/runs?limit&branch
+/// GET CI run list (alias: `/api/forge/ci/runs?limit&branch`).
 pub async fn ci_run_list(
-    State(state): State<RouterState>,
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
     Query(q): Query<CiListQuery>,
 ) -> Response {
-    let repo = repo_or_409!(state);
     let limit = q.limit.unwrap_or(20);
     respond(crate::forge::forge_ci_run_list(repo, limit, q.branch).await)
 }
 
-/// GET /api/forge/ci/runs/{id}
-pub async fn ci_run_view(State(state): State<RouterState>, Path(id): Path<u64>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET CI run view (alias: `/api/forge/ci/runs/{id}`).
+pub async fn ci_run_view(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
+) -> Response {
+    let id = match u64_param(&params, "id") {
+        Ok(i) => i,
+        Err(resp) => return *resp,
+    };
     respond(crate::forge::forge_ci_run_view(repo, id).await)
 }

--- a/src-tauri/src/lan/routes/git.rs
+++ b/src-tauri/src/lan/routes/git.rs
@@ -1,23 +1,26 @@
 //! Read-only git routes — thin adapters over the existing `crate::git::*` core
-//! fns. Each pulls the active repo from state, calls the core fn with no shape
-//! translation, and returns its result as JSON. No new git logic lives here.
+//! fns. Each reads its scoped repo from the `Extension<ScopedRepo>` a resolver
+//! middleware inserts, calls the core fn with no shape translation, and returns its
+//! result as JSON. No new git logic lives here. Handlers with a path param read it
+//! by name (see [`crate::lan::routes`]) so they work under both the alias and the
+//! scoped mounts.
 
-use axum::extract::{Path, Query, State};
+use std::collections::HashMap;
+
+use axum::extract::{Path, Query};
 use axum::response::Response;
+use axum::Extension;
 use serde::Deserialize;
 
-use crate::lan::auth::RouterState;
-use crate::lan::routes::{bad_request, is_safe_relative_path, repo_or_409, respond};
+use crate::lan::routes::{bad_request, is_safe_relative_path, path_param, respond, ScopedRepo};
 
-/// GET /api/repo/status
-pub async fn status(State(state): State<RouterState>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET status — for the shared repo (alias: `/api/repo/status`).
+pub async fn status(Extension(ScopedRepo(repo)): Extension<ScopedRepo>) -> Response {
     respond(crate::git::status::status_core(&repo).await)
 }
 
-/// GET /api/repo/branches
-pub async fn branches(State(state): State<RouterState>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET branches (alias: `/api/repo/branches`).
+pub async fn branches(Extension(ScopedRepo(repo)): Extension<ScopedRepo>) -> Response {
     respond(crate::git::branches::git_branches(repo).await)
 }
 
@@ -29,20 +32,27 @@ pub struct LogQuery {
     search: Option<String>,
 }
 
-/// GET /api/repo/log?limit&skip&search
-pub async fn log(State(state): State<RouterState>, Query(q): Query<LogQuery>) -> Response {
-    let repo = repo_or_409!(state);
+/// GET log (alias: `/api/repo/log?limit&skip&search`).
+pub async fn log(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Query(q): Query<LogQuery>,
+) -> Response {
     let limit = q.limit.unwrap_or(50);
     let skip = q.skip.unwrap_or(0);
     respond(crate::git::history::git_log(repo, limit, skip, q.search).await)
 }
 
-/// GET /api/repo/commits/{hash}
+/// GET commit details (alias: `/api/repo/commits/{hash}`). The `hash` path param
+/// is read by name so the handler works under BOTH the alias (`{hash}`) and scoped
+/// (`{repoId}` + `{hash}`) mounts (see [`crate::lan::routes`]).
 pub async fn commit_details(
-    State(state): State<RouterState>,
-    Path(hash): Path<String>,
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
 ) -> Response {
-    let repo = repo_or_409!(state);
+    let hash = match path_param(&params, "hash") {
+        Ok(h) => h,
+        Err(resp) => return *resp,
+    };
     respond(crate::git::history::git_commit_details(repo, hash).await)
 }
 
@@ -52,13 +62,16 @@ pub struct MaxBytesQuery {
     max_bytes: Option<usize>,
 }
 
-/// GET /api/repo/commits/{hash}/diff?maxBytes
+/// GET commit diff (alias: `/api/repo/commits/{hash}/diff?maxBytes`).
 pub async fn commit_diff(
-    State(state): State<RouterState>,
-    Path(hash): Path<String>,
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
     Query(q): Query<MaxBytesQuery>,
 ) -> Response {
-    let repo = repo_or_409!(state);
+    let hash = match path_param(&params, "hash") {
+        Ok(h) => h,
+        Err(resp) => return *resp,
+    };
     respond(crate::git::history::git_commit_diff(repo, hash, q.max_bytes).await)
 }
 
@@ -69,12 +82,11 @@ pub struct WorkingDiffQuery {
     worktree: Option<bool>,
 }
 
-/// GET /api/repo/diff/working?maxBytes&worktree
+/// GET working diff (alias: `/api/repo/diff/working?maxBytes&worktree`).
 pub async fn diff_working(
-    State(state): State<RouterState>,
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
     Query(q): Query<WorkingDiffQuery>,
 ) -> Response {
-    let repo = repo_or_409!(state);
     // `exclude` has no HTTP surface in this slice — always None.
     respond(crate::git::diff::git_staged_diff(repo, q.max_bytes, None, q.worktree).await)
 }
@@ -89,12 +101,11 @@ pub struct FileDiffQuery {
     untracked: bool,
 }
 
-/// GET /api/repo/diff/file?path&staged&untracked
+/// GET file diff (alias: `/api/repo/diff/file?path&staged&untracked`).
 pub async fn diff_file(
-    State(state): State<RouterState>,
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
     Query(q): Query<FileDiffQuery>,
 ) -> Response {
-    let repo = repo_or_409!(state);
     // Path containment: this is a paired LAN device supplying `path`, and the
     // untracked branch of `git_diff_file` runs `git diff --no-index` (NOT
     // repo-confined). Reject anything that isn't a safe repo-relative path so a

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -1,47 +1,83 @@
 //! The read-only route handlers mounted by the LAN companion server.
 //!
-//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 13
-//! handlers below and nothing else — there is no catch-all and no static
-//! serving, so any path outside the list 404s. Each handler pulls the active
-//! repo from [`crate::lan::auth::RouterState`] (a `None` active repo → 409), calls
+//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 15
+//! handlers below and nothing else — there is no catch-all and no static serving,
+//! so any path outside the list 404s. Every handler operates on ONE resolved repo
+//! it reads from the `Extension<ScopedRepo>` a resolver middleware inserts, calls
 //! the existing core git/forge fn unchanged, and returns its result as JSON with
 //! no shape translation. Errors map via [`crate::lan::auth::app_error_response`].
+//!
+//! ## Two mounts, one handler set (alias ↔ scoped)
+//!
+//! [`crate::lan::server`] mounts each handler TWICE, sharing the same fns:
+//!
+//! * The **alias** subtree — the frozen surface the shipped companion consumes,
+//!   scoped to the desktop's *active* repo. A resolver reads `active_repo` from
+//!   state and inserts the `ScopedRepo`; a `None` active repo → 409 `noActiveRepo`.
+//! * The **scoped** subtree under `/api/repos/{repoId}/…` with FLAT paths (the
+//!   alias's `repo`/`forge` grouping segments drop out). A resolver looks
+//!   `{repoId}` up in the repo registry → hit inserts the `ScopedRepo`; miss → 404
+//!   `noSuchRepo` (404 not 403, so an unknown id and an unshared repo are
+//!   indistinguishable — no probe oracle).
+//!
+//! | alias (active-repo)                   | scoped (`/api/repos/{repoId}/…`)      |
+//! |---------------------------------------|---------------------------------------|
+//! | `/api/repo/status`                    | `status`                              |
+//! | `/api/repo/branches`                  | `branches`                            |
+//! | `/api/repo/log`                       | `log`                                 |
+//! | `/api/repo/commits/{hash}`            | `commits/{hash}`                      |
+//! | `/api/repo/commits/{hash}/diff`       | `commits/{hash}/diff`                 |
+//! | `/api/repo/diff/working`              | `diff/working`                        |
+//! | `/api/repo/diff/file`                 | `diff/file`                           |
+//! | `/api/forge/prs`                      | `prs`                                 |
+//! | `/api/forge/prs/{number}`             | `prs/{number}`                        |
+//! | `/api/forge/issues`                   | `issues`                              |
+//! | `/api/forge/issues/{number}`          | `issues/{number}`                     |
+//! | `/api/forge/ci/runs`                  | `ci/runs`                             |
+//! | `/api/forge/ci/runs/{id}`             | `ci/runs/{id}`                        |
+//! | `/api/reviews`                        | `reviews`                             |
+//! | `/api/reviews/{id}/stream`            | `reviews/{id}/stream`                 |
+//!
+//! Plus `GET /api/repos` (protected) → the registered repos as `[{ id, name }]`.
+//!
+//! ## The shared-handler extraction trap
+//!
+//! A handler mounted under BOTH subtrees sees different path-param sets: `{hash}`
+//! alone on the alias mount, `{repoId}` + `{hash}` on the scoped mount. A
+//! `Path<String>` extractor would fail on the two-param mount, so every shared
+//! handler (and the resolver middleware) that reads a path param extracts
+//! `Path<HashMap<String, String>>` and reads the param BY NAME via [`path_param`].
 
 pub mod forge;
 pub mod git;
 pub mod reviews;
 
+use std::collections::HashMap;
+
 use axum::response::Response;
 
-use crate::lan::auth::RouterState;
+/// The single repo a request is scoped to, resolved by a resolver middleware and
+/// inserted as a request extension. Both the alias subtree (from `active_repo`)
+/// and the scoped subtree (from a `{repoId}` registry lookup) produce this, so the
+/// handlers are identical under either mount. A newtype around the repo path
+/// String; the path is used only server-side (git/forge calls) and never returned.
+#[derive(Clone)]
+pub(crate) struct ScopedRepo(pub String);
 
-/// The active repo path from router state, or `None` when none is set. The 409
-/// response for the `None` case is built at the call site (via [`no_active_repo`])
-/// so this stays a cheap `Option` rather than a `Result` carrying a large
-/// `Response` in its `Err` arm.
-pub(crate) fn active_repo(state: &RouterState) -> Option<String> {
-    state
-        .active_repo
-        .lock()
-        .unwrap_or_else(|p| p.into_inner())
-        .clone()
-}
-
-/// The 409 response returned when no repo is shared yet.
-pub(crate) fn no_active_repo() -> Response {
-    use axum::http::StatusCode;
-    use axum::response::IntoResponse;
-    use axum::Json;
-    use serde_json::json;
-
-    (
-        StatusCode::CONFLICT,
-        Json(json!({
-            "kind": "noActiveRepo",
-            "message": "no active repository is shared yet"
-        })),
-    )
-        .into_response()
+/// Read a path parameter by NAME from the extracted `Path<HashMap<…>>` map. Shared
+/// handlers are mounted under two subtrees with different param sets, so params are
+/// always read by name rather than positionally. Returns the app's standard 400 on
+/// a missing key — which can't happen through the router (the route pattern names
+/// the param), but we never unwrap on request-derived data. The `Err` `Response` is
+/// boxed so the (impossible) error path doesn't bloat every handler's `Result`.
+pub(crate) fn path_param(
+    params: &HashMap<String, String>,
+    name: &str,
+) -> Result<String, Box<Response>> {
+    params
+        .get(name)
+        .cloned()
+        .ok_or_else(|| Box::new(bad_request(&format!("missing path parameter: {name}"))))
 }
 
 /// A 400 response with the app's standard `{ kind, message }` shape (mirrors
@@ -79,17 +115,112 @@ pub(crate) fn is_safe_relative_path(path: &str) -> bool {
         .all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
 }
 
-/// Convenience: fetch the active repo or short-circuit-return its 409 response.
-macro_rules! repo_or_409 {
-    ($state:expr) => {
-        match $crate::lan::routes::active_repo(&$state) {
-            Some(r) => r,
-            None => return $crate::lan::routes::no_active_repo(),
-        }
+/// Alias-subtree resolver middleware: scope the request to the desktop's ACTIVE
+/// repo. Reads `active_repo` from state and inserts a [`ScopedRepo`] extension the
+/// handlers read; a `None` active repo short-circuits with the frozen 409
+/// `noActiveRepo` (the same response the shipped companion's read routes returned
+/// before the scoped mount existed — its body moved here from the old per-handler
+/// macro).
+pub(crate) async fn resolve_active_repo(
+    axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
+    mut req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let active = state
+        .active_repo
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone();
+    let Some(repo) = active else {
+        return no_active_repo();
     };
+    req.extensions_mut().insert(ScopedRepo(repo));
+    next.run(req).await
 }
 
-pub(crate) use repo_or_409;
+/// Scoped-subtree resolver middleware: scope the request to the repo named by the
+/// `{repoId}` path param. Looks the id up in the repo registry → hit inserts a
+/// [`ScopedRepo`] extension; miss → 404 `noSuchRepo`. 404 (not 403) so an unknown
+/// id and an unshared repo are indistinguishable — no probe oracle for which repos
+/// exist. Extractors precede `req`/`next` in the `from_fn` signature, as axum
+/// requires.
+pub(crate) async fn resolve_scoped_repo(
+    axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
+    axum::extract::Path(params): axum::extract::Path<HashMap<String, String>>,
+    mut req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let repo_id = match path_param(&params, "repoId") {
+        Ok(id) => id,
+        Err(resp) => return *resp,
+    };
+    let path = state
+        .repos
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .get(&repo_id)
+        .map(|r| r.path.clone());
+    let Some(path) = path else {
+        return no_such_repo();
+    };
+    req.extensions_mut().insert(ScopedRepo(path));
+    next.run(req).await
+}
+
+/// The frozen 409 returned by the alias subtree when no repo is shared yet.
+fn no_active_repo() -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use serde_json::json;
+
+    (
+        StatusCode::CONFLICT,
+        Json(json!({
+            "kind": "noActiveRepo",
+            "message": "no active repository is shared yet"
+        })),
+    )
+        .into_response()
+}
+
+/// The 404 returned by the scoped subtree for an unknown/unshared `{repoId}`.
+fn no_such_repo() -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use serde_json::json;
+
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "kind": "noSuchRepo",
+            "message": "no shared repository with that id"
+        })),
+    )
+        .into_response()
+}
+
+/// GET /api/repos — the registered repos as `[{ id, name }]` (camelCase). Today
+/// that's the desktop's active repo (or empty when none is shared). Only the
+/// opaque id + display name reach the wire — never a filesystem path.
+pub(crate) async fn list_repos(
+    axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
+) -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use serde_json::json;
+
+    let items: Vec<_> = state
+        .repos
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .iter()
+        .map(|(id, repo)| json!({ "id": id, "name": repo.name }))
+        .collect();
+    (StatusCode::OK, Json(items)).into_response()
+}
 
 /// Wrap an `AppResult<T: Serialize>` into a JSON response or the mapped error.
 pub(crate) fn json_or_error<T: serde::Serialize>(

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -32,7 +32,7 @@
 //! auto-reconnects, and that reconnect hits a non-200 — 401 if the device was
 //! revoked, 404 if the stream is gone or the shared repo switched away. A non-200
 //! response permanently closes an `EventSource` (it does not retry a hard error),
-//! so the sever is durable with nothing extra server-side. A clean terminal
+//! so the cut is durable with nothing extra server-side. A clean terminal
 //! (`Done`/`Error`) behaves the same way: the stream ends, the reconnect 404s the
 //! now-absent stream, and the client stays closed. The slice-3 client
 //! probe-classifies that reconnect status (401 vs 404) to tell "revoked" from
@@ -178,7 +178,7 @@ fn forward_stream(
             tokio::select! {
                 // `biased` + cut-first: when a cut and an event are both ready, the
                 // cut wins — a just-revoked/disabled stream never forwards one more
-                // buffered frame before it honors the sever.
+                // buffered frame before it honors the cut.
                 biased;
                 // Lifecycle cut: sharing was disabled, the shared repo changed, or a
                 // device was revoked — end this stream unconditionally so the phone

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -1,59 +1,97 @@
 //! Read-only live-monitoring routes: enumerate the desktop's active agent
-//! streams (reviews/sessions) and watch one over a WebSocket.
+//! streams (reviews/sessions) and watch one over a Server-Sent-Events stream.
 //!
 //! These sit under the authed `/api/` subtree, so the same `require_auth` +
 //! `host_guard` middleware that gates every other read route also gates the
-//! enumeration AND the WebSocket upgrade (the upgrade is a normal GET request
-//! until the handler accepts it — the auth layer runs first and 401s an
-//! unauthenticated upgrade before this handler is ever reached).
+//! enumeration AND the SSE stream (the stream is a normal GET request — the auth
+//! layer runs first and 401s an unauthenticated request before this handler is
+//! ever reached).
 //!
 //! Monitoring is strictly one-way: the phone WATCHES the same [`ReviewEvent`]
 //! stream the desktop renders. There is no approve/deny, no stdin, and no write
-//! path — inbound client frames are drained and ignored (except a Close).
+//! path. SSE is a one-way transport BY CONSTRUCTION — an [`EventSource`] can only
+//! receive — which is exactly the property this route wants; the previous
+//! WebSocket impl drained and ignored all inbound client frames anyway, so nothing
+//! is lost by the switch.
 //!
-//! **Scoped to the shared repo.** Both routes authorize against the currently-
-//! shared repo: with no active repo they 409 like every other read route, and
-//! they only ever surface streams whose run operates on that repo. A stream on a
-//! repo the desktop has since closed or switched away from is invisible — the
-//! enumeration omits it and the watch route 404s it (indistinguishable from an
-//! unknown id, so there's no probe oracle). This upholds the clear-on-close
-//! containment: paired devices never watch a run on a repo that isn't shared.
+//! ## Why SSE and not a WebSocket
 //!
-//! **In-flight sockets are actively cut.** Scoping only gates NEW requests; a
-//! WebSocket accepted while a repo was shared is hijacked out of the serve loop
-//! and would keep forwarding after the desktop disables sharing, switches/clears
-//! the shared repo, or revokes the device (auth runs only at upgrade time). So
+//! Serving over self-signed HTTPS (see [`crate::lan::tls`]) hits a load-bearing
+//! iOS Safari gotcha:
+//! Safari does NOT extend a manually-accepted self-signed-certificate exception to
+//! `wss://` — a WebSocket over TLS goes through a SEPARATE trust path that ignores
+//! the exception the user granted the `https://` origin (an unfixed WebKit
+//! limitation). An `EventSource`, by contrast, is a plain HTTP request that rides
+//! the already-excepted `https://` origin, so it just works once the page loads.
+//! No companion client consumes this stream yet (slice 3 wires it), so swapping the
+//! transport now — before any client depends on the WS wire — is free.
+//!
+//! ## EventSource reconnect semantics (handled by construction)
+//!
+//! After a lifecycle cut the stream simply ENDS; the browser's `EventSource`
+//! auto-reconnects, and that reconnect hits a non-200 — 401 if the device was
+//! revoked, 404 if the stream is gone or the shared repo switched away. A non-200
+//! response permanently closes an `EventSource` (it does not retry a hard error),
+//! so the sever is durable with nothing extra server-side. A clean terminal
+//! (`Done`/`Error`) behaves the same way: the stream ends, the reconnect 404s the
+//! now-absent stream, and the client stays closed. The slice-3 client
+//! probe-classifies that reconnect status (401 vs 404) to tell "revoked" from
+//! "stream ended"; the server needs no event ids or named event types for this.
+//!
+//! ## Scoped to the shared repo
+//!
+//! Both routes authorize against the request's resolved repo (from the
+//! `Extension<ScopedRepo>` a resolver middleware inserts): the alias mount scopes
+//! to the desktop's active repo (a `None` active repo 409s), and either mount only
+//! ever surfaces streams whose run operates on that repo. A stream on a repo the
+//! desktop has since closed or switched away from is invisible — the enumeration
+//! omits it and the watch route 404s it (indistinguishable from an unknown id, so
+//! there's no probe oracle). This upholds the clear-on-close containment: paired
+//! devices never watch a run on a repo that isn't shared.
+//!
+//! ## In-flight streams are actively cut
+//!
+//! Scoping only gates NEW requests; an SSE stream accepted while a repo was shared
+//! would keep forwarding after the desktop disables sharing, switches/clears the
+//! shared repo, or revokes the device (auth runs only at request time). So
 //! [`forward_stream`] also selects on a broadcast cut signal
-//! ([`crate::lan::LanState::monitor_cut`]) that the desktop fires at each of
-//! those lifecycle points; on a cut the socket is closed and the phone must
-//! reconnect and re-authorize.
+//! ([`crate::lan::LanState::monitor_cut`]) that the desktop fires at each of those
+//! lifecycle points; on a cut the stream ends and the phone must reconnect and
+//! re-authorize (see the reconnect-semantics section above).
 //!
-//! **No replay.** The underlying channel is a `tokio::sync::broadcast` with no
-//! history, so a subscriber that connects mid-stream sees only events emitted
-//! *after* it subscribed; earlier deltas are not resent. Acceptable for v1 (the
-//! phone opens the stream to follow along, not to reconstruct the full transcript).
+//! ## No replay
+//!
+//! The underlying channel is a `tokio::sync::broadcast` with no history, so a
+//! subscriber that connects mid-stream sees only events emitted *after* it
+//! subscribed; earlier deltas are not resent. Acceptable for v1 (the phone opens
+//! the stream to follow along, not to reconstruct the full transcript).
 
-use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{Path, State};
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::extract::Extension;
 use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
 use tokio::sync::broadcast::error::RecvError;
 
 use crate::agent::ReviewEvent;
-use crate::lan::auth::RouterState;
-use crate::lan::routes::repo_or_409;
+use crate::lan::routes::{path_param, ScopedRepo};
 use crate::state::{snapshot_streams_for, subscribe_in_for};
 
-/// GET /api/reviews — the active agent streams the phone can watch, as
+/// GET reviews — the active agent streams the phone can watch, as
 /// `[{ id, kind, startedAt }]` (camelCase). `kind` is `"review"` | `"session"`.
-/// Scoped to the currently-shared repo: a `None` active repo 409s (like every
-/// other read route), and only streams operating on that repo are listed — a
-/// device never sees streams from a repo the desktop has closed or switched away
-/// from. Repo paths are never exposed on the wire.
-pub async fn list(State(state): State<RouterState>) -> Response {
-    let repo = repo_or_409!(state);
+/// Scoped to the request's repo (from `Extension<ScopedRepo>`): only streams
+/// operating on that repo are listed — a device never sees streams from a repo the
+/// desktop has closed or switched away from. Repo paths are never exposed on the
+/// wire. (Alias: `/api/reviews`, scoped to the active repo — a `None` active repo
+/// 409s in the resolver before this handler runs.)
+pub async fn list(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
+) -> Response {
     let items: Vec<_> = snapshot_streams_for(&state.streams, &repo)
         .into_iter()
         .map(|(id, kind, started_at)| {
@@ -67,25 +105,27 @@ pub async fn list(State(state): State<RouterState>) -> Response {
     (StatusCode::OK, Json(items)).into_response()
 }
 
-/// GET /api/reviews/{id}/stream — upgrade to a WebSocket that forwards the live
-/// stream's [`ReviewEvent`]s as they happen. Scoped to the currently-shared repo:
-/// a `None` active repo 409s, and a stream on any other repo is treated as
-/// unknown (404) — a device can't probe for or watch streams outside the shared
-/// repo. An unknown/out-of-scope id 404s BEFORE the upgrade (no socket is opened
-/// for a stream that isn't running or isn't ours to share).
+/// GET reviews stream — an SSE stream forwarding the live run's [`ReviewEvent`]s as
+/// they happen. Scoped to the request's repo: a stream on any other repo is treated
+/// as unknown (404) — a device can't probe for or watch streams outside the shared
+/// repo. An unknown/out-of-scope id 404s BEFORE the stream is opened (no stream is
+/// started for a run that isn't running or isn't ours to share). (Alias:
+/// `/api/reviews/{id}/stream`, scoped to the active repo.)
 pub async fn stream(
-    State(state): State<RouterState>,
-    Path(id): Path<String>,
-    ws: WebSocketUpgrade,
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
+    axum::extract::Path(params): axum::extract::Path<std::collections::HashMap<String, String>>,
 ) -> Response {
-    let repo = repo_or_409!(state);
+    let id = match path_param(&params, "id") {
+        Ok(id) => id,
+        Err(resp) => return *resp,
+    };
     // Subscribe up front so we can reject an unknown (or out-of-scope) id with a
-    // plain 404 instead of upgrading and immediately closing. Scoping to `repo`
-    // here means a stream on a different repo is indistinguishable from an unknown
-    // id. Subscribing now also means we don't miss events between the upgrade
-    // handshake and the receive loop starting.
-    let rx = subscribe_in_for(&state.streams, &id, &repo);
-    let Some(rx) = rx else {
+    // plain 404 instead of opening a stream and immediately ending it. Scoping to
+    // `repo` here means a stream on a different repo is indistinguishable from an
+    // unknown id. Subscribing now also means we don't miss events between this
+    // check and the pump starting.
+    let Some(rx) = subscribe_in_for(&state.streams, &id, &repo) else {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({
@@ -95,81 +135,94 @@ pub async fn stream(
         )
             .into_response();
     };
-    // Subscribe to the lifecycle cut signal BEFORE upgrading, so a cut fired
-    // between here and the pump starting isn't missed. Auth ran at upgrade time
-    // only; this receiver is how a later disable / repo-switch / revoke reaches an
-    // already-accepted socket and forces it closed.
+    // Subscribe to the lifecycle cut signal BEFORE returning the stream, so a cut
+    // fired between here and the pump starting isn't missed. Auth ran at request
+    // time only; this receiver is how a later disable / repo-switch / revoke reaches
+    // an already-open stream and ends it.
     let cut_rx = state.monitor_cut.subscribe();
-    ws.on_upgrade(move |socket| forward_stream(socket, rx, cut_rx))
+    // A 15s keep-alive comment defeats phone-side idle timeouts. The LAN has no
+    // buffering proxies, so the keep-alive exists purely to keep the connection
+    // warm through mobile-OS background timers.
+    Sse::new(forward_stream(rx, cut_rx))
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("ka"),
+        )
+        .into_response()
 }
 
-/// The per-connection pump: forward each broadcast event as one JSON text frame,
-/// translate lag/close, and drain inbound client frames (read-only monitor — no
-/// stdin path exists). Terminates on the terminal `Done`/`Error` event, on the
-/// stream ending (`Closed`), or when the client hangs up.
-async fn forward_stream(
-    mut socket: WebSocket,
-    mut rx: tokio::sync::broadcast::Receiver<ReviewEvent>,
-    mut cut_rx: tokio::sync::broadcast::Receiver<()>,
-) {
-    loop {
-        tokio::select! {
-            // `biased` + cut-first: when a cut and an event are both ready, the
-            // cut wins — a just-revoked/disabled socket never forwards one more
-            // buffered frame before it honors the sever.
-            biased;
-            // Lifecycle cut: sharing was disabled, the shared repo changed, or a
-            // device was revoked — sever this socket unconditionally so the phone
-            // must reconnect and re-authorize against the new state. ANY result
-            // ends the loop: Ok is a real cut; Lagged means we missed one but a cut
-            // still happened; Closed can't occur while `LanState` holds the Sender,
-            // but we match it defensively and treat it the same (terminate).
-            _cut = cut_rx.recv() => {
-                break;
+/// The per-connection event stream: forward each broadcast [`ReviewEvent`] as one
+/// SSE `data:` payload, translate lag/close, and end on the terminal `Done`/`Error`
+/// event, on the stream ending (`Closed`), or on a lifecycle cut. There is NO
+/// inbound arm — SSE is one-way, which is the point (see the module docs).
+///
+/// A hand-rolled [`futures_util::stream::unfold`] over `(rx, cut_rx,
+/// terminal_seen)` with a biased inner `select!`, dependency-free (`futures-util`
+/// is already a dep; `async-stream` is deliberately not in the tree). The
+/// `terminal_seen` flag makes the terminal event's "yield then END on the next
+/// poll" explicit: the poll that forwards `Done`/`Error` sets the flag, and the
+/// next poll returns `None` to end the stream.
+fn forward_stream(
+    rx: tokio::sync::broadcast::Receiver<ReviewEvent>,
+    cut_rx: tokio::sync::broadcast::Receiver<()>,
+) -> impl futures_util::Stream<Item = Result<Event, Infallible>> {
+    futures_util::stream::unfold(
+        (rx, cut_rx, false),
+        |(mut rx, mut cut_rx, terminal_seen)| async move {
+            // A terminal event was forwarded on the previous poll — end the stream
+            // now (yield then END, exactly as the WS impl did).
+            if terminal_seen {
+                return None;
             }
-            // Broadcast side: forward events to the client.
-            recv = rx.recv() => match recv {
-                Ok(ev) => {
-                    // Terminal? Forward it, then close the socket cleanly.
-                    let terminal = matches!(ev, ReviewEvent::Done { .. } | ReviewEvent::Error { .. });
-                    // The wire format is ReviewEvent's own tagged camelCase serde,
-                    // verbatim — the same JSON the desktop channel carries.
-                    let Ok(text) = serde_json::to_string(&ev) else {
-                        // A ReviewEvent that won't serialize is a bug, not a
-                        // client-recoverable state; drop the connection.
-                        break;
-                    };
-                    if socket.send(Message::Text(text.into())).await.is_err() {
-                        break; // client went away
+            tokio::select! {
+                // `biased` + cut-first: when a cut and an event are both ready, the
+                // cut wins — a just-revoked/disabled stream never forwards one more
+                // buffered frame before it honors the sever.
+                biased;
+                // Lifecycle cut: sharing was disabled, the shared repo changed, or a
+                // device was revoked — end this stream unconditionally so the phone
+                // must reconnect and re-authorize against the new state. ANY result
+                // ends it: Ok is a real cut; Lagged means we missed one but a cut
+                // still happened; Closed can't occur while `LanState` holds the
+                // Sender, but we match it defensively and treat it the same (end).
+                _cut = cut_rx.recv() => None,
+                // Broadcast side: forward events to the client.
+                recv = rx.recv() => match recv {
+                    Ok(ev) => {
+                        // Terminal? Forward it, then end on the NEXT poll.
+                        let terminal = matches!(
+                            ev,
+                            ReviewEvent::Done { .. } | ReviewEvent::Error { .. }
+                        );
+                        // The wire format is ReviewEvent's own tagged camelCase
+                        // serde, verbatim — the same JSON the desktop channel carries
+                        // — as one SSE `data:` payload.
+                        match serde_json::to_string(&ev) {
+                            Ok(text) => Some((
+                                Ok(Event::default().data(text)),
+                                (rx, cut_rx, terminal),
+                            )),
+                            // A ReviewEvent that won't serialize is a bug, not a
+                            // client-recoverable state; end the stream.
+                            Err(_) => None,
+                        }
                     }
-                    if terminal {
-                        break;
+                    Err(RecvError::Lagged(n)) => {
+                        // The subscriber fell behind the buffer. Tell it how many
+                        // events it missed (a synthetic status event) and keep going
+                        // — recv() resumes from the oldest still-buffered event.
+                        let notice = json!({
+                            "kind": "status",
+                            "text": format!("…skipped {n} events")
+                        })
+                        .to_string();
+                        Some((Ok(Event::default().data(notice)), (rx, cut_rx, false)))
                     }
-                }
-                Err(RecvError::Lagged(n)) => {
-                    // The subscriber fell behind the 256-deep buffer. Tell it how
-                    // many events it missed (a synthetic status frame) and keep
-                    // going — recv() resumes from the oldest still-buffered event.
-                    let notice = json!({
-                        "kind": "status",
-                        "text": format!("…skipped {n} events")
-                    })
-                    .to_string();
-                    if socket.send(Message::Text(notice.into())).await.is_err() {
-                        break;
-                    }
-                }
-                // The stream ended and its registry entry (and sender) dropped.
-                Err(RecvError::Closed) => break,
-            },
-            // Client side: a read-only monitor. Drain frames; act only on Close.
-            inbound = socket.recv() => match inbound {
-                Some(Ok(Message::Close(_))) | None => break,
-                Some(Ok(_)) => { /* ignore data/ping/pong — no stdin path exists */ }
-                Some(Err(_)) => break,
-            },
-        }
-    }
-    // Best-effort graceful close (ignored if the socket is already gone).
-    let _ = socket.send(Message::Close(None)).await;
+                    // The stream ended and its registry entry (and sender) dropped.
+                    Err(RecvError::Closed) => None,
+                },
+            }
+        },
+    )
 }

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -2,27 +2,33 @@
 //! shutdown for the LAN companion server.
 //!
 //! The router mounts EXACTLY the pairing routes plus the read-only routes
-//! (structural allowlist — see [`crate::lan::routes`]): the 13 git/forge routes
-//! plus the two live-monitoring routes (`/api/reviews` and the
-//! `/api/reviews/{id}/stream` WebSocket); anything else 404s. Two middleware
-//! layers wrap everything: [`crate::lan::auth::host_guard`] (runs on every
-//! request — DNS-rebind defense + hardening headers) and, on the protected
-//! subtree only, [`crate::lan::auth::require_auth`] (per-device bearer). The
-//! WebSocket upgrade lives inside that protected subtree, so it is bearer-gated
-//! and host-guarded like every other read route.
+//! (structural allowlist — see [`crate::lan::routes`]): the 15 read handlers,
+//! mounted TWICE — once as the frozen active-repo ALIAS surface (`/api/repo/…`,
+//! `/api/forge/…`, `/api/reviews…`) and once under the SCOPED
+//! `/api/repos/{repoId}/…` surface — plus `GET /api/repos`; anything else 404s.
+//! Each mount carries a resolver middleware that resolves the request's repo and
+//! inserts an `Extension<ScopedRepo>` (alias → the active repo; scoped → a
+//! `{repoId}` registry lookup) so the shared handlers are identical under either.
+//! Two outer middleware layers wrap everything: [`crate::lan::auth::host_guard`]
+//! (runs on every request — DNS-rebind defense + hardening headers) and, on the
+//! protected subtree only, [`crate::lan::auth::require_auth`] (per-device bearer).
+//! The `/api/reviews/{id}/stream` SSE stream lives inside that protected subtree,
+//! so it is bearer-gated and host-guarded like every other read route.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::routing::{get, post};
 use axum::Router;
-use tokio::net::TcpListener;
-use tokio::sync::Notify;
+use axum_server::tls_rustls::RustlsConfig;
+use axum_server::Handle;
 
 use crate::error::{AppError, AppResult};
 use crate::lan::auth::{self, RouterState};
-use crate::lan::routes::{forge, git, reviews};
+use crate::lan::routes::{self, forge, git, reviews};
 use crate::lan::static_serve;
+use crate::lan::tls;
 
 /// The default port the server tries first — a fixed value in the IANA dynamic /
 /// private range (49152–65535 is the strict private range, but the 38400s are
@@ -33,26 +39,29 @@ pub const DEFAULT_PORT: u16 = 38473;
 /// the first is already in use.
 const PORT_SCAN: u16 = 4;
 
-/// A bound, running server: the port it landed on, a shutdown signal, and the
-/// task handle. Dropping the handle does not stop the server — call
-/// [`ServerHandle::shutdown`].
+/// A bound, running server: the port it landed on, the axum-server shutdown
+/// handle, and the task handle. Dropping the handle does not stop the server —
+/// call [`ServerHandle::shutdown`].
 pub struct ServerHandle {
     pub port: u16,
-    shutdown: Arc<Notify>,
+    handle: Handle<SocketAddr>,
     task: tauri::async_runtime::JoinHandle<()>,
 }
 
 impl ServerHandle {
     /// Signal graceful shutdown and await the serve task's exit.
     pub async fn shutdown(self) {
-        // `notify_one` (NOT `notify_waiters`): the serve task registers its
-        // `notified()` waiter only on its first poll, and a rapid enable→disable
-        // can call shutdown before that. `notify_one` stores a permit so a
-        // pre-registration signal is still consumed; `notify_waiters` would be
-        // lost, leaving `task.await` pending forever with the lifecycle lock held.
-        self.shutdown.notify_one();
-        // The serve future observes the notify and returns; join to be sure the
-        // listener is released before we (possibly) rebind on a mode change.
+        // axum-server's `Handle` stores the shutdown signal internally, so the
+        // pre-registration race the old `Notify` had (the serve task registered its
+        // `notified()` waiter only on its first poll, so a rapid enable→disable could
+        // signal before that and hang) is gone: a `graceful_shutdown` before the
+        // serve loop's first accept is still honored. The 5s cap bounds the worst
+        // case — SSE monitors are LIVE connections, but `monitor_cut` fires before
+        // shutdown in every path (disable/rebind), so they close fast; the cap only
+        // guards a stream that somehow didn't get the cut.
+        self.handle.graceful_shutdown(Some(Duration::from_secs(5)));
+        // Join to be sure the listener is released before we (possibly) rebind on a
+        // mode change.
         let _ = self.task.await;
     }
 }
@@ -60,8 +69,10 @@ impl ServerHandle {
 /// Build the axum router for the given state. Separated from binding so tests can
 /// drive it via `tower::ServiceExt::oneshot` without opening a socket.
 pub fn build_router(state: RouterState) -> Router {
-    // The protected read-only subtree: bearer-auth required.
-    let api = Router::new()
+    // The frozen ALIAS surface — the shipped companion consumes these paths
+    // verbatim. Its resolver scopes every request to the desktop's ACTIVE repo (a
+    // `None` active repo → 409 `noActiveRepo`).
+    let alias = Router::new()
         .route("/api/repo/status", get(git::status))
         .route("/api/repo/branches", get(git::branches))
         .route("/api/repo/log", get(git::log))
@@ -75,12 +86,51 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/forge/issues/{number}", get(forge::issue_view))
         .route("/api/forge/ci/runs", get(forge::ci_run_list))
         .route("/api/forge/ci/runs/{id}", get(forge::ci_run_view))
-        // Live-monitoring: enumerate active agent streams + watch one over a
-        // WebSocket. Mounted INSIDE this subtree so the upgrade is bearer-gated by
-        // `require_auth` below (and host-guarded by the outer layer) exactly like
-        // every other read route.
+        // Live-monitoring: enumerate active agent streams + watch one over SSE.
         .route("/api/reviews", get(reviews::list))
         .route("/api/reviews/{id}/stream", get(reviews::stream))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            routes::resolve_active_repo,
+        ));
+
+    // The SCOPED surface under `/api/repos/{repoId}/…` with FLAT paths (the alias's
+    // `repo`/`forge` grouping segments drop out) — the same handler set. Its
+    // resolver looks `{repoId}` up in the registry (miss → 404 `noSuchRepo`).
+    let scoped = Router::new()
+        .route("/api/repos/{repoId}/status", get(git::status))
+        .route("/api/repos/{repoId}/branches", get(git::branches))
+        .route("/api/repos/{repoId}/log", get(git::log))
+        .route("/api/repos/{repoId}/commits/{hash}", get(git::commit_details))
+        .route(
+            "/api/repos/{repoId}/commits/{hash}/diff",
+            get(git::commit_diff),
+        )
+        .route("/api/repos/{repoId}/diff/working", get(git::diff_working))
+        .route("/api/repos/{repoId}/diff/file", get(git::diff_file))
+        .route("/api/repos/{repoId}/prs", get(forge::pr_list))
+        .route("/api/repos/{repoId}/prs/{number}", get(forge::pr_view))
+        .route("/api/repos/{repoId}/issues", get(forge::issue_list))
+        .route("/api/repos/{repoId}/issues/{number}", get(forge::issue_view))
+        .route("/api/repos/{repoId}/ci/runs", get(forge::ci_run_list))
+        .route("/api/repos/{repoId}/ci/runs/{id}", get(forge::ci_run_view))
+        .route("/api/repos/{repoId}/reviews", get(reviews::list))
+        .route(
+            "/api/repos/{repoId}/reviews/{id}/stream",
+            get(reviews::stream),
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            routes::resolve_scoped_repo,
+        ));
+
+    // The protected read-only subtree: bearer-auth required. `GET /api/repos`
+    // (the registered-repo listing) is authed but goes through NEITHER repo
+    // resolver — it reads the registry directly.
+    let api = Router::new()
+        .route("/api/repos", get(routes::list_repos))
+        .merge(alias)
+        .merge(scoped)
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_auth,
@@ -232,9 +282,13 @@ fn rank_ips(ifaces: Vec<(String, Ipv4Addr)>) -> Vec<Ipv4Addr> {
     out
 }
 
-/// The `http://<ip>:<port>` urls for the advertised addresses.
+/// The `https://<ip>:<port>` urls for the advertised addresses. HTTPS: the
+/// companion serves the phone browser a self-signed cert (see [`crate::lan::tls`])
+/// so the origin is a secure context.
 pub fn urls_for(ips: &[Ipv4Addr], port: u16) -> Vec<String> {
-    ips.iter().map(|ip| format!("http://{ip}:{port}")).collect()
+    ips.iter()
+        .map(|ip| format!("https://{ip}:{port}"))
+        .collect()
 }
 
 /// The `<ip>:<port>` host strings we accept in a `Host`/`Origin` header. Always
@@ -254,15 +308,27 @@ pub fn bound_hosts_for(ips: &[Ipv4Addr], port: u16) -> Vec<String> {
     hosts
 }
 
-/// Bind a `TcpListener`, scanning DEFAULT_PORT..=DEFAULT_PORT+PORT_SCAN when the
-/// preferred port is already in use. Returns the listener and the port it landed
-/// on. A non-`AddrInUse` error (e.g. permission) fails immediately.
-async fn bind_listener(bind_ip: IpAddr) -> AppResult<(TcpListener, u16)> {
+/// Bind a `std::net::TcpListener`, scanning DEFAULT_PORT..=DEFAULT_PORT+PORT_SCAN
+/// when the preferred port is already in use. Returns the listener and the port it
+/// landed on. A non-`AddrInUse` error (e.g. permission) fails immediately. A sync
+/// bind is fine here — it's fast and runs under the lifecycle lock — and
+/// `axum_server::from_tcp_rustls` takes a `std::net::TcpListener` directly.
+///
+/// The listener is set NON-BLOCKING: `axum_server` hands it to
+/// `tokio::net::TcpListener::from_std`, which requires a non-blocking socket — a
+/// blocking one leaves the async accept loop unable to see readiness, so
+/// connections TCP-connect but their TLS handshake never runs (they hang).
+fn bind_listener(bind_ip: IpAddr) -> AppResult<(std::net::TcpListener, u16)> {
     let mut last_err: Option<std::io::Error> = None;
     for port in DEFAULT_PORT..=DEFAULT_PORT.saturating_add(PORT_SCAN) {
         let addr = SocketAddr::new(bind_ip, port);
-        match TcpListener::bind(addr).await {
-            Ok(listener) => return Ok((listener, port)),
+        match std::net::TcpListener::bind(addr) {
+            Ok(listener) => {
+                listener
+                    .set_nonblocking(true)
+                    .map_err(|e| bind_error(bind_ip, &e))?;
+                return Ok((listener, port));
+            }
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                 last_err = Some(e);
                 continue;
@@ -290,25 +356,32 @@ fn bind_error(bind_ip: IpAddr, e: &std::io::Error) -> AppError {
     ))
 }
 
-/// Start the server: resolve addresses, bind, spawn the serve task with graceful
-/// shutdown wired to a `Notify`, and return the handle plus the advertised urls
-/// and the bound-host allowlist. The `RouterState` is built here so the host
-/// guard sees the exact hosts we bound.
+/// Start the server: resolve addresses, ensure the TLS material, bind, spawn the
+/// TLS serve task with graceful shutdown wired to an `axum_server::Handle`, and
+/// return the handle plus the advertised urls, the bound-host allowlist, and the
+/// certificate fingerprint (for the TOFU pairing display). The `RouterState` is
+/// built here so the host guard sees the exact hosts we bound.
 pub async fn start(
     bind_lan: bool,
     active_repo: Arc<std::sync::Mutex<Option<String>>>,
+    repos: crate::lan::RepoRegistry,
     pairing: Arc<std::sync::Mutex<Option<auth::PairingSession>>>,
     rate_limit: auth::RateLimitMap,
     streams: Arc<std::sync::Mutex<std::collections::HashMap<String, crate::state::StreamInfo>>>,
     monitor_cut: tokio::sync::broadcast::Sender<()>,
-) -> AppResult<(ServerHandle, Vec<String>, Vec<String>)> {
+) -> AppResult<(ServerHandle, Vec<String>, Vec<String>, String)> {
     let (bind_ip, ips) = resolve_ips(bind_lan);
-    let (listener, port) = bind_listener(bind_ip).await?;
+    // Ensure a self-signed cert covering the addresses we're about to advertise
+    // (reused across IP churn so the fingerprint — the TOFU anchor — stays stable).
+    let material = tls::ensure_tls(&ips)?;
+    let fingerprint = material.fingerprint.clone();
+    let (listener, port) = bind_listener(bind_ip)?;
     let urls = urls_for(&ips, port);
     let bound_hosts = bound_hosts_for(&ips, port);
 
     let state = RouterState {
         active_repo,
+        repos,
         pairing,
         rate_limit,
         bound_hosts: Arc::new(bound_hosts.clone()),
@@ -317,22 +390,27 @@ pub async fn start(
     };
     let router = build_router(state);
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = shutdown.clone();
+    let handle = Handle::new();
+    let serve_handle = handle.clone();
+    let tls_config = RustlsConfig::from_config(material.config);
     // Quit-time teardown is IMPLICIT: `app.exit(0)` from the tray kills the
     // process, which drops the listener — so there's no exit-site hook to add.
-    // A user-driven `lan_disable` calls `ServerHandle::shutdown`, which notifies
-    // this signal for a graceful drain. (Sleep auto-off is a known later-slice
-    // gap — not handled here.)
+    // A user-driven `lan_disable` calls `ServerHandle::shutdown`, which drives this
+    // handle's graceful shutdown. (Sleep auto-off is a known later-slice gap — not
+    // handled here.)
     let task = tauri::async_runtime::spawn(async move {
-        let serve = axum::serve(
-            listener,
-            router.into_make_service_with_connect_info::<SocketAddr>(),
-        )
-        .with_graceful_shutdown(async move {
-            shutdown_signal.notified().await;
-        });
-        if let Err(e) = serve.await {
+        let server = match axum_server::from_tcp_rustls(listener, tls_config) {
+            Ok(server) => server,
+            Err(e) => {
+                eprintln!("lan companion server could not start over TLS: {e}");
+                return;
+            }
+        };
+        if let Err(e) = server
+            .handle(serve_handle)
+            .serve(router.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+        {
             // The listener died unexpectedly (not a graceful shutdown). Nothing to
             // recover to here; log to stderr so a dev sees it.
             eprintln!("lan companion server exited with error: {e}");
@@ -340,13 +418,10 @@ pub async fn start(
     });
 
     Ok((
-        ServerHandle {
-            port,
-            shutdown,
-            task,
-        },
+        ServerHandle { port, handle, task },
         urls,
         bound_hosts,
+        fingerprint,
     ))
 }
 
@@ -359,7 +434,7 @@ mod tests {
         let (bind_ip, ips) = resolve_ips(false);
         assert_eq!(bind_ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
         assert_eq!(ips, vec![Ipv4Addr::LOCALHOST]);
-        assert_eq!(urls_for(&ips, 38473), vec!["http://127.0.0.1:38473"]);
+        assert_eq!(urls_for(&ips, 38473), vec!["https://127.0.0.1:38473"]);
     }
 
     #[test]

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -324,9 +324,14 @@ fn bind_listener(bind_ip: IpAddr) -> AppResult<(std::net::TcpListener, u16)> {
         let addr = SocketAddr::new(bind_ip, port);
         match std::net::TcpListener::bind(addr) {
             Ok(listener) => {
-                listener
-                    .set_nonblocking(true)
-                    .map_err(|e| bind_error(bind_ip, &e))?;
+                // The bind SUCCEEDED; a set_nonblocking failure is a distinct
+                // condition, so it gets its own message (not `bind_error`'s "could
+                // not bind", which would misattribute the failure).
+                listener.set_nonblocking(true).map_err(|e| {
+                    AppError::Command(format!(
+                        "could not configure the phone-companion listener (set_nonblocking) on {bind_ip}: {e}"
+                    ))
+                })?;
                 return Ok((listener, port));
             }
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
@@ -393,19 +398,22 @@ pub async fn start(
     let handle = Handle::new();
     let serve_handle = handle.clone();
     let tls_config = RustlsConfig::from_config(material.config);
+    // Build the TLS server BEFORE spawning: `from_tcp_rustls` is synchronous and
+    // fallible (it wraps the std listener into a tokio one), so its failure must
+    // propagate out of `start()` as an error — otherwise the caller would store a
+    // RunningServer, flip the tray to "sharing on", and advertise urls + fingerprint
+    // while nothing is actually serving. Only the async `.serve(...)` goes in the task.
+    let server = axum_server::from_tcp_rustls(listener, tls_config).map_err(|e| {
+        AppError::Command(format!(
+            "could not construct the phone-companion TLS server on {bind_ip}: {e}"
+        ))
+    })?;
     // Quit-time teardown is IMPLICIT: `app.exit(0)` from the tray kills the
     // process, which drops the listener — so there's no exit-site hook to add.
     // A user-driven `lan_disable` calls `ServerHandle::shutdown`, which drives this
     // handle's graceful shutdown. (Sleep auto-off is a known later-slice gap — not
     // handled here.)
     let task = tauri::async_runtime::spawn(async move {
-        let server = match axum_server::from_tcp_rustls(listener, tls_config) {
-            Ok(server) => server,
-            Err(e) => {
-                eprintln!("lan companion server could not start over TLS: {e}");
-                return;
-            }
-        };
         if let Err(e) = server
             .handle(serve_handle)
             .serve(router.into_make_service_with_connect_info::<SocketAddr>())

--- a/src-tauri/src/lan/static_serve.rs
+++ b/src-tauri/src/lan/static_serve.rs
@@ -26,7 +26,7 @@
 //! ## Page CSP
 //!
 //! HTML/asset responses carry a fuller [`PAGE_CSP`] (self-only scripts/styles;
-//! `connect-src 'self'` covers same-origin fetch/SSE/WebSockets; framing locked
+//! `connect-src 'self'` covers same-origin fetch/SSE; framing locked
 //! down). The outer
 //! [`crate::lan::auth::harden_headers`] is insert-if-absent for the CSP, so this
 //! page CSP survives while API responses keep their bare one.
@@ -46,9 +46,10 @@ struct Companion;
 
 /// The page Content-Security-Policy stamped on served HTML/asset responses. Locks
 /// scripts/styles to self, allows `data:` images, and denies framing / external
-/// base & form targets. `connect-src 'self'` covers same-origin fetch, SSE, AND
-/// same-origin WebSockets in modern browsers — a bare `ws:` scheme-source would
-/// permit sockets to ANY host, so it is deliberately absent.
+/// base & form targets. `connect-src 'self'` covers same-origin fetch AND the
+/// same-origin SSE stream (`EventSource`) the reviews monitor uses — no WebSocket
+/// scheme-source is needed (the monitor moved from `wss:` to SSE, partly because
+/// iOS Safari won't extend a self-signed-cert exception to `wss://`).
 pub const PAGE_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
 /// The 503 body shown when the companion bundle hasn't been built (CI, or a dev who

--- a/src-tauri/src/lan/tls.rs
+++ b/src-tauri/src/lan/tls.rs
@@ -1,0 +1,508 @@
+//! Persistent self-signed TLS material for the LAN phone-companion server.
+//!
+//! ## Why HTTPS at all, and why self-signed
+//!
+//! The companion serves a phone BROWSER over the LAN, and a browser needs a
+//! secure context (`https://`) for `crypto.subtle` and to avoid mixed-content
+//! blocking. A self-signed certificate is the right (and only workable) fit here:
+//!
+//! - Phone browsers click through a self-signed interstitial once and then treat
+//!   the origin as a normal secure context. (The "phones hard-reject self-signed"
+//!   lore was about NATIVE companion apps pinning a CA — not Safari/Chrome, which
+//!   let the user grant a per-origin exception.)
+//! - Let's-Encrypt-style publicly-trusted certs can't help: an ACME IP cert is
+//!   issued only for PUBLIC IPs, and the companion binds RFC1918 LAN addresses.
+//! - The realtime channel is Server-Sent Events, NOT a WebSocket, precisely
+//!   because iOS Safari does not extend a manually-accepted self-signed exception
+//!   to `wss://` (see [`crate::lan::routes::reviews`]). SSE rides the already-
+//!   excepted `https://` origin.
+//!
+//! ## Stability is the point (TOFU)
+//!
+//! The desktop shows the certificate's SHA-256 fingerprint; the user confirms it
+//! matches what the phone reports the first time it connects (trust-on-first-use).
+//! For that ceremony to hold, the fingerprint must stay STABLE across restarts and
+//! across the churn of the machine's LAN IP (DHCP renewals, Wi-Fi ↔ Ethernet). So
+//! the cert is persisted under the app-data dir and REUSED whenever its recorded
+//! SAN set still covers the addresses we're about to advertise; it is regenerated
+//! only when a required address is missing (with a SAN set that is the UNION of the
+//! recorded and required addresses, so an A→B→A DHCP flip-flop doesn't thrash the
+//! fingerprint) or when the stored files are missing/corrupt.
+//!
+//! Long validity is deliberate: browsers cap the lifetime of PUBLICLY-trusted
+//! certificates, but a self-signed cert the user manually excepted is exempt, and a
+//! long life keeps the TOFU fingerprint stable. rcgen's default validity is used.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair, SanType};
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::{AppError, AppResult};
+use crate::local_prs::APP_IDENTIFIER;
+
+/// The three persisted filenames under `dirs::data_dir()/<APP_IDENTIFIER>/` — the
+/// same app-data root the device store ([`crate::lan::auth`]) uses.
+const CERT_FILE: &str = "lan-cert.pem";
+const KEY_FILE: &str = "lan-key.pem";
+const META_FILE: &str = "lan-cert.json";
+
+/// The certificate common name. Cosmetic (browsers show it in the exception UI);
+/// SAN entries are what actually match.
+const CERT_CN: &str = "GitDesktop LAN companion";
+
+/// The ready-to-serve TLS material: a rustls server config (wired to serve the
+/// persisted cert) and the cert's SHA-256 fingerprint for the TOFU ceremony.
+pub struct TlsMaterial {
+    pub config: Arc<rustls::ServerConfig>,
+    /// Colon-separated UPPERCASE-hex SHA-256 of the certificate DER (95 chars,
+    /// `AB:12:…`). The frozen wire format the desktop UI renders.
+    pub fingerprint: String,
+}
+
+/// The sidecar metadata persisted alongside the cert so a later run can decide
+/// whether the stored cert still covers the addresses it's about to advertise.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CertMeta {
+    /// Every IP SAN baked into the stored cert (127.0.0.1 ∪ whatever was advertised
+    /// when it was minted, accreted as a union across regenerations).
+    san_ips: Vec<Ipv4Addr>,
+    /// When the stored cert was generated (informational; RFC3339 millis + `Z`).
+    created_at: String,
+}
+
+// --------------------------------------------------------------------------
+// TLS-dir path injection (for tests) — mirrors auth.rs's device-store override
+// --------------------------------------------------------------------------
+
+/// Test-only override for the directory the cert/key/meta live in. Production
+/// always resolves the real app-data dir via [`tls_dir`]; tests point this at a
+/// temp dir so they never touch (or require) the real app-data folder.
+static TLS_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+fn tls_dir_override() -> &'static Mutex<Option<PathBuf>> {
+    TLS_DIR_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+/// Point the TLS material dir at `path` for the current process (test-only).
+/// Returns the previous override so a test can restore it. Hold
+/// [`crate::lan::auth::store_test_lock`] across any test that sets this — the
+/// override is a single process-global slot, exactly like the device store's.
+#[cfg(test)]
+pub(crate) fn set_tls_dir_for_test(path: Option<PathBuf>) -> Option<PathBuf> {
+    let mut guard = tls_dir_override().lock().unwrap_or_else(|p| p.into_inner());
+    std::mem::replace(&mut *guard, path)
+}
+
+/// Resolve the directory the cert/key/meta files live in — the app-data dir
+/// `dirs::data_dir()/<APP_IDENTIFIER>/`, the same root the device store uses. A
+/// test override (if set) wins.
+fn tls_dir() -> AppResult<PathBuf> {
+    if let Some(over) = tls_dir_override()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone()
+    {
+        return Ok(over);
+    }
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(APP_IDENTIFIER))
+}
+
+/// Ensure a usable self-signed cert exists for `ips` and return ready-to-serve TLS
+/// material. Reuses the persisted cert when its recorded SAN set already covers the
+/// required addresses (so the TOFU fingerprint survives IP churn); regenerates —
+/// never errors out of enabling the server — when a required address is missing or
+/// the stored files are missing/corrupt/unparseable.
+pub fn ensure_tls(ips: &[Ipv4Addr]) -> AppResult<TlsMaterial> {
+    let dir = tls_dir()?;
+    let cert_path = dir.join(CERT_FILE);
+    let key_path = dir.join(KEY_FILE);
+    let meta_path = dir.join(META_FILE);
+
+    // The SANs we REQUIRE this run: loopback plus every advertised address, deduped
+    // and ordered deterministically.
+    let required = required_san_ips(ips);
+
+    // Try to reuse: all three files must load AND the recorded SANs must cover the
+    // required set. Any failure (missing/corrupt/uncovered) falls through to regen.
+    if let Some(material) = try_reuse(&cert_path, &key_path, &meta_path, &required) {
+        return Ok(material);
+    }
+
+    // Regenerate. The new SAN set is the UNION of whatever the (possibly stale) meta
+    // recorded and the required set, so a DHCP flip-flop A→B→A keeps A covered and
+    // doesn't churn the fingerprint back and forth.
+    let recorded = read_meta(&meta_path).map(|m| m.san_ips).unwrap_or_default();
+    let san_ips = union_ips(&recorded, &required);
+    generate_and_persist(&dir, &cert_path, &key_path, &meta_path, &san_ips)
+}
+
+/// The IP SANs required for `ips`: always loopback, plus every advertised IP,
+/// deduped preserving order (loopback first).
+fn required_san_ips(ips: &[Ipv4Addr]) -> Vec<Ipv4Addr> {
+    let mut out = vec![Ipv4Addr::LOCALHOST];
+    for ip in ips {
+        if !out.contains(ip) {
+            out.push(*ip);
+        }
+    }
+    out
+}
+
+/// The union of two IP lists, preserving `a`'s order then appending `b`'s new
+/// entries. Used so a regenerated cert never DROPS an address a prior cert covered.
+fn union_ips(a: &[Ipv4Addr], b: &[Ipv4Addr]) -> Vec<Ipv4Addr> {
+    let mut out: Vec<Ipv4Addr> = a.to_vec();
+    for ip in b {
+        if !out.contains(ip) {
+            out.push(*ip);
+        }
+    }
+    out
+}
+
+/// Attempt to load and reuse the persisted cert. Returns `Some` only when all three
+/// files load, the key/cert parse into a rustls config, and the recorded SANs cover
+/// every required address. Any miss returns `None` (→ regenerate).
+fn try_reuse(
+    cert_path: &Path,
+    key_path: &Path,
+    meta_path: &Path,
+    required: &[Ipv4Addr],
+) -> Option<TlsMaterial> {
+    let meta = read_meta(meta_path)?;
+    // Coverage: every required IP must already be a recorded SAN.
+    if !required.iter().all(|ip| meta.san_ips.contains(ip)) {
+        return None;
+    }
+    let cert_pem = std::fs::read(cert_path).ok()?;
+    let key_pem = std::fs::read(key_path).ok()?;
+    build_material(&cert_pem, &key_pem).ok()
+}
+
+/// Read + parse the meta sidecar. `None` on any error (missing/corrupt/unparseable),
+/// which the callers treat as "regenerate".
+fn read_meta(meta_path: &Path) -> Option<CertMeta> {
+    let bytes = std::fs::read(meta_path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Generate a fresh self-signed cert covering `san_ips`, persist the cert/key/meta,
+/// and return the serving material. On unix the key file is `chmod 600` (Windows
+/// app-data is already user-scoped by ACL).
+fn generate_and_persist(
+    dir: &Path,
+    cert_path: &Path,
+    key_path: &Path,
+    meta_path: &Path,
+    san_ips: &[Ipv4Addr],
+) -> AppResult<TlsMaterial> {
+    std::fs::create_dir_all(dir).map_err(AppError::Io)?;
+
+    let mut params = CertificateParams::default();
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, CERT_CN);
+    params.distinguished_name = dn;
+    // SANs: DNS "localhost" first, then every IP.
+    params.subject_alt_names = std::iter::once(SanType::DnsName(
+        "localhost"
+            .to_string()
+            .try_into()
+            .map_err(|e| AppError::Command(format!("build localhost SAN: {e}")))?,
+    ))
+    .chain(san_ips.iter().map(|ip| SanType::IpAddress(IpAddr::V4(*ip))))
+    .collect();
+
+    let key_pair = KeyPair::generate()
+        .map_err(|e| AppError::Command(format!("generate LAN companion key pair: {e}")))?;
+    let cert = params
+        .self_signed(&key_pair)
+        .map_err(|e| AppError::Command(format!("self-sign LAN companion cert: {e}")))?;
+
+    let cert_pem = cert.pem();
+    let key_pem = key_pair.serialize_pem();
+
+    // Persist before building the config — a serve failure shouldn't lose the cert,
+    // and a build failure below still leaves the files for the next run to reuse.
+    // The cert + meta are public, so a plain atomic write is fine; the KEY is written
+    // owner-only-from-the-first-byte (see [`write_key_file`]) so no world-readable
+    // window ever exists on a shared unix host.
+    crate::fsops::atomic_write(cert_path, cert_pem.as_bytes())?;
+    write_key_file(key_path, key_pem.as_bytes())?;
+    // Belt-and-braces: also chmod the final file (a no-op on the fresh-write path
+    // above, but it tightens an old world-readable key left by a prior version whose
+    // reuse path we're about to hit).
+    restrict_key_file_perms(key_path);
+    let meta = CertMeta {
+        san_ips: san_ips.to_vec(),
+        created_at: now_iso(),
+    };
+    let meta_json = serde_json::to_string_pretty(&meta)
+        .map_err(|e| AppError::Command(format!("serialize lan-cert meta: {e}")))?;
+    crate::fsops::atomic_write(meta_path, meta_json.as_bytes())?;
+
+    build_material(cert_pem.as_bytes(), key_pem.as_bytes())
+}
+
+/// Build the rustls `ServerConfig` (explicit ring provider, no client auth, single
+/// cert, ALPN `h2` + `http/1.1`) and the fingerprint from PEM cert + key bytes.
+fn build_material(cert_pem: &[u8], key_pem: &[u8]) -> AppResult<TlsMaterial> {
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(cert_pem)
+        .collect::<Result<_, _>>()
+        .map_err(|e| AppError::Command(format!("parse LAN companion cert PEM: {e}")))?;
+    let leaf = certs.first().ok_or_else(|| {
+        AppError::Command("LAN companion cert PEM had no certificate".to_string())
+    })?;
+    let fingerprint = fingerprint_of(leaf);
+
+    let key = PrivateKeyDer::from_pem_slice(key_pem)
+        .map_err(|e| AppError::Command(format!("parse LAN companion key PEM: {e}")))?;
+
+    // An EXPLICIT ring provider (not the process-global default) so future feature
+    // unification in the dependency graph can't silently flip us onto a different
+    // crypto backend.
+    let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| AppError::Command(format!("build LAN companion TLS config: {e}")))?
+    .with_no_client_auth()
+    .with_single_cert(certs, key)
+    .map_err(|e| AppError::Command(format!("install LAN companion cert: {e}")))?;
+    // h2 lets a phone multiplex parallel SSE + fetches over one connection.
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+    Ok(TlsMaterial {
+        config: Arc::new(config),
+        fingerprint,
+    })
+}
+
+/// The colon-separated UPPERCASE-hex SHA-256 of a certificate's DER encoding
+/// (`AB:12:…`, 95 chars) — the frozen fingerprint format.
+fn fingerprint_of(cert: &CertificateDer<'_>) -> String {
+    let digest = Sha256::digest(cert.as_ref());
+    digest
+        .iter()
+        .map(|b| format!("{b:02X}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// The current UTC timestamp in JS `Date.prototype.toISOString()` shape, matching
+/// every other app-data timestamp we write.
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Atomically write the private-key file with owner-only permissions from the very
+/// first byte. On unix the temp file is created `mode(0o600)` BEFORE any key
+/// material is written (so it never briefly inherits the umask's default, commonly
+/// 0644, in the write→rename window — the shared-host key-disclosure gap), then
+/// renamed over the target to preserve the atomic-rename property. On non-unix we
+/// fall back to the shared [`crate::fsops::atomic_write`] (Windows app-data ACLs are
+/// already user-scoped). Mirrors `atomic_write`'s temp-name scheme (pid + uuid, same
+/// dir) so the rename stays same-filesystem and collision-free.
+#[cfg(unix)]
+fn write_key_file(key_path: &Path, contents: &[u8]) -> AppResult<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let dir = key_path.parent().ok_or_else(|| {
+        AppError::Command(format!(
+            "path {} has no parent directory",
+            key_path.display()
+        ))
+    })?;
+    std::fs::create_dir_all(dir).map_err(AppError::Io)?;
+    let file_name = key_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "tmp".to_string());
+    let tmp = dir.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    // Create the temp file 0600 up front — the mode is applied at creation, so the
+    // key bytes are never on disk under a looser mode.
+    let write_res = (|| -> std::io::Result<()> {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp)?;
+        f.write_all(contents)?;
+        f.sync_all()?;
+        Ok(())
+    })();
+    if let Err(e) = write_res {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(AppError::Io(e));
+    }
+    if let Err(e) = std::fs::rename(&tmp, key_path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(AppError::Io(e));
+    }
+    Ok(())
+}
+
+/// Non-unix: no umask, and Windows app-data is user-scoped by ACL, so a plain atomic
+/// write is sufficient.
+#[cfg(not(unix))]
+fn write_key_file(key_path: &Path, contents: &[u8]) -> AppResult<()> {
+    crate::fsops::atomic_write(key_path, contents)
+}
+
+/// Restrict the private-key file to owner-only on unix (`chmod 600`). A no-op on
+/// Windows, where the app-data dir is already user-scoped by ACL.
+#[cfg(unix)]
+fn restrict_key_file_perms(key_path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn restrict_key_file_perms(_key_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh temp dir for a test's TLS material, unique per test invocation.
+    fn temp_dir() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-lan-tls-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    /// The frozen fingerprint format: 32 uppercase-hex byte pairs joined by colons.
+    fn is_fingerprint(s: &str) -> bool {
+        let parts: Vec<&str> = s.split(':').collect();
+        parts.len() == 32
+            && parts.iter().all(|p| {
+                p.len() == 2
+                    && p.chars()
+                        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase())
+            })
+    }
+
+    #[test]
+    fn fresh_gen_writes_files_and_valid_fingerprint() {
+        let _lock = crate::lan::auth::store_test_lock();
+        let dir = temp_dir();
+        let prev = set_tls_dir_for_test(Some(dir.clone()));
+
+        let material = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+
+        assert!(dir.join(CERT_FILE).exists(), "cert PEM written");
+        assert!(dir.join(KEY_FILE).exists(), "key PEM written");
+        assert!(dir.join(META_FILE).exists(), "meta json written");
+        assert!(
+            is_fingerprint(&material.fingerprint),
+            "fingerprint format: {}",
+            material.fingerprint
+        );
+
+        set_tls_dir_for_test(prev);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn covered_ips_reuse_the_same_cert() {
+        let _lock = crate::lan::auth::store_test_lock();
+        let dir = temp_dir();
+        let prev = set_tls_dir_for_test(Some(dir.clone()));
+
+        let first = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        // A second call whose required IPs are a SUBSET of the recorded set (here the
+        // same set) must reuse — same fingerprint, phones keep their exception.
+        let second = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        assert_eq!(first.fingerprint, second.fingerprint, "covered ips reuse");
+        // Loopback alone is also covered by the recorded set → still a reuse.
+        let third = ensure_tls(&[]).unwrap();
+        assert_eq!(first.fingerprint, third.fingerprint, "loopback-only reuses");
+
+        set_tls_dir_for_test(prev);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn new_ip_regenerates_and_unions_sans() {
+        let _lock = crate::lan::auth::store_test_lock();
+        let dir = temp_dir();
+        let prev = set_tls_dir_for_test(Some(dir.clone()));
+
+        let first = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        // A NEW, uncovered IP forces a regen → different fingerprint.
+        let second = ensure_tls(&[Ipv4Addr::new(10, 0, 0, 9)]).unwrap();
+        assert_ne!(first.fingerprint, second.fingerprint, "new ip regenerates");
+
+        // The regenerated meta's SANs are the UNION: loopback + both IPs.
+        let meta = read_meta(&dir.join(META_FILE)).unwrap();
+        assert!(meta.san_ips.contains(&Ipv4Addr::LOCALHOST));
+        assert!(meta.san_ips.contains(&Ipv4Addr::new(192, 168, 1, 5)));
+        assert!(meta.san_ips.contains(&Ipv4Addr::new(10, 0, 0, 9)));
+
+        // And because A is still covered, going back to A reuses the union cert
+        // (a DHCP A→B→A flip-flop must not churn the fingerprint).
+        let third = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        assert_eq!(second.fingerprint, third.fingerprint, "A→B→A stays stable");
+
+        set_tls_dir_for_test(prev);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn corrupt_cert_regenerates_instead_of_erroring() {
+        let _lock = crate::lan::auth::store_test_lock();
+        let dir = temp_dir();
+        let prev = set_tls_dir_for_test(Some(dir.clone()));
+
+        let _first = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        // Corrupt the cert PEM on disk.
+        std::fs::write(dir.join(CERT_FILE), b"not a real certificate").unwrap();
+        // ensure_tls must recover by regenerating (returning a valid cert), not error
+        // out of enabling the server.
+        let second = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        assert!(is_fingerprint(&second.fingerprint));
+        // The regen wrote fresh, parseable files — the next call reuses them.
+        let reloaded = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        assert_eq!(second.fingerprint, reloaded.fingerprint, "post-regen reuse");
+
+        set_tls_dir_for_test(prev);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_key_file_is_owner_only_0600() {
+        // The private key must land 0600 (owner rw only) — never briefly
+        // world/group-readable in the write→rename window on a shared unix host.
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = crate::lan::auth::store_test_lock();
+        let dir = temp_dir();
+        let prev = set_tls_dir_for_test(Some(dir.clone()));
+
+        ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
+        let mode = std::fs::metadata(dir.join(KEY_FILE))
+            .unwrap()
+            .permissions()
+            .mode();
+        // Compare the permission bits only (the file-type bits live above 0o777).
+        assert_eq!(mode & 0o777, 0o600, "key file mode: {:o}", mode & 0o777);
+
+        set_tls_dir_for_test(prev);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1574,6 +1574,12 @@ phone's browser. Type the PIN there; once it matches, the phone is paired and dr
 straight into the companion app — a bottom tab bar with **Status**, **PRs**, and **CI**,
 each read-only.
 
+Because the connection uses a **self-signed certificate** GitDesktop generates, your
+phone shows a **certificate warning on first connect** — that's expected; tap through to
+continue. If you'd rather verify it first, the pairing dialog shows the certificate's
+**SHA-256 fingerprint**, which you can compare against the one your phone's browser
+reports.
+
 The offer counts down and expires after a short while; if it lapses before the phone
 connects, choose **Start again** (the desktop shows a fresh QR and PIN), and the phone's
 pairing page will prompt you to enter the new code. When a device pairs, the dialog
@@ -1596,8 +1602,11 @@ Sharing is convenient but deliberately simple, so treat it accordingly:
 
 - **Anyone on the same Wi-Fi who has the pairing PIN can read this repo** while sharing
   is on.
-- The connection is **unencrypted** on your local network. Use it on **trusted networks
-  only** (your home or a private office network — not public or café Wi-Fi).
+- The connection is **encrypted** with a **self-signed certificate** GitDesktop
+  generates, so your phone shows a one-time certificate warning on first connect
+  (expected — you can verify it against the fingerprint shown while pairing). Use it on
+  **trusted networks only** (your home or a private office network — not public or café
+  Wi-Fi).
 - **Turn sharing off when you're done.** It doesn't turn itself off.
 
 ## Phone can't reach your computer?

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -117,8 +117,9 @@ export function CompanionSection() {
       {/* The honest security caveat — always visible, never a tooltip. */}
       <p className="rounded border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
         Anyone on this Wi-Fi with the pairing PIN can read this repo while
-        sharing is on. It's unencrypted on your local network — use it on
-        trusted networks only. Turn sharing off when you're done.
+        sharing is on. Traffic is encrypted with a certificate this app
+        generates, so your phone asks you to confirm it on first connect. Use it
+        on trusted networks only, and turn sharing off when you're done.
       </p>
 
       {enabled && status.data && (
@@ -138,6 +139,14 @@ export function CompanionSection() {
               Sharing on port{" "}
               <span className="font-mono">{status.data.port}</span> — no network
               address detected. Check you're connected to Wi-Fi.
+            </p>
+          )}
+          {status.data.certFingerprint !== null && (
+            <p>
+              Certificate SHA-256:{" "}
+              <span className="font-mono break-all select-all">
+                {status.data.certFingerprint}
+              </span>
             </p>
           )}
         </div>

--- a/src/features/settings/PairDeviceDialog.tsx
+++ b/src/features/settings/PairDeviceDialog.tsx
@@ -194,6 +194,16 @@ export function PairDeviceDialog({
                   : `Expires in ${remaining}s`}
               </p>
             </div>
+            <div className="space-y-1 text-center">
+              <p className="text-xs text-muted-foreground">
+                On first connect your phone shows a certificate warning — that's
+                expected for a self-signed certificate. To verify, compare the
+                certificate SHA-256 your phone reports with this one:
+              </p>
+              <p className="font-mono text-[10px] break-all select-all">
+                {pairing.certFingerprint}
+              </p>
+            </div>
           </div>
         )}
 

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1961,6 +1961,10 @@ export interface LanStatus {
   deviceCount: number;
   /** Whether a pairing window is currently open (a PIN is live). */
   pairingActive: boolean;
+  /** Colon-separated uppercase-hex SHA-256 of the self-signed certificate's DER
+   *  (e.g. "AB:12:…"), for trust-on-first-use verification on the phone.
+   *  Non-null exactly when `enabled` is true — null iff sharing is off. */
+  certFingerprint: string | null;
 }
 
 /** A live pairing offer — the phone scans the QR (or opens the URL) and types
@@ -1974,6 +1978,10 @@ export interface LanPairing {
   pin: string;
   /** ISO-8601 instant when this pairing offer expires. */
   expiresAt: string;
+  /** Colon-separated uppercase-hex SHA-256 of the self-signed certificate's DER
+   *  (e.g. "AB:12:…") — shown while pairing so the user can compare it against the
+   *  certificate the phone's browser reports on the first-connect warning. */
+  certFingerprint: string;
 }
 
 /** A phone that has paired and holds a revocable access token. */


### PR DESCRIPTION
This change migrates the LAN companion server from plain HTTP to persistent self-signed HTTPS, strengthens transport security and trust-on-first-use (TOFU) pairing, and adapts the frontend, backend, and documentation accordingly. The desktop now generates and reuses a self-signed certificate per device, surfaces its SHA-256 fingerprint for verification during pairing, and serves all traffic—including the live reviews monitor—over secure transport. The backend migrates the realtime protocol from WebSockets to Server-Sent Events (SSE) for broad client compatibility under self-signed certs (especially on iOS Safari).

### TLS and Transport Security
- Adds persistent self-signed TLS support in `src-tauri/src/lan/tls.rs`, including certificate minting via `rcgen`, file-based storage, and deterministic fingerprinting for TOFU verification.
- Updates server binding in `src-tauri/src/lan/server.rs` to use HTTPS with TLS config from the self-signed cert, switching serve loop and shutdown semantics to `axum-server` and `rustls`.
- Extends `Cargo.toml` to add and document dependencies: `rcgen`, `axum-server`, `rustls`, and related libraries, configuring them for use without introducing native build dependencies.
- Modifies `src-tauri/src/lan/mod.rs` to persist and expose the cert fingerprint via status API, and integrate certificate life cycle management into the state model.

### Backend API and SSE Monitoring
- Swaps the live reviews monitor protocol from WebSockets to SSE in `src-tauri/src/lan/routes/reviews.rs`, `src-tauri/src/lan/server.rs`, and related handler infrastructure, with comments for browser compatibility and clean shutdown on repo or device changes.
- Updates router organization (`src-tauri/src/lan/routes/mod.rs`, `src-tauri/src/lan/routes/forge.rs`, `src-tauri/src/lan/routes/git.rs`) to support both "alias" (active repo) and "scoped" routes, with repo resolver middleware so API handlers work identically whether accessed via active or registered repo context.
- Ensures secure-cookie semantics now that the backend is HTTPS-only (`src-tauri/src/lan/auth.rs`).

### Frontend and Documentation
- Surfaces the certificate SHA-256 fingerprint in the UI for TOFU—companion status and pairing dialogs now display the cert hash (`src/features/settings/CompanionSection.tsx`, `src/features/settings/PairDeviceDialog.tsx`). Updates TS types for corresponding API responses in `src/lib/git/types.ts`.
- Revises help and settings copy to explain the HTTPS connection, certificate warning, and fingerprint verification process to users (`src/features/help/content.ts`, `src/features/settings/CompanionSection.tsx`).
- Updates the changelog entry for the LAN companion preview to note HTTPS and fingerprint-based verification (`changelog.d/added-lan-companion-preview.md`).

### Security and Hardening
- Enhances HTTP headers and authority checks for defense-in-depth, including proper handling of host/authority matching for both HTTP/1.1 and HTTP/2 (`src-tauri/src/lan/auth.rs`).
- Revises CSP in `src-tauri/src/lan/static_serve.rs` to reflect SSE use and remove unnecessary WebSocket entries.

### Miscellaneous and Internal Refactoring
- Refactors types, state, and resolver infrastructure to support expanded API surface (including future multi-repo and registry features).
- Augments README-level docs in Rust source files for clarity on cert management and compatibility rationale for architectural choices.