### PR TITLE
feat(pulls,github,gitlab): show live check steps and skipped status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
     **approval marked stale** once later commits land — on GitHub, GitLab, Bitbucket,
     and local PRs (GitLab has no force-push/draft events, Bitbucket no labels or
     review-requests).
-  - **CI rollup** — checks fold into a **pass/fail/pending** summary that peeks a
-    failing **GitHub Actions** or **GitLab pipeline** job's log inline; **Bitbucket**
-    build statuses link out (name/state/URL, no fetchable logs).
+  - **CI rollup** — checks fold into a **pass/fail/pending/skipped** summary; a
+    running **GitHub Actions** check shows its current step live, a finished one peeks
+    its (or a **GitLab pipeline** job's) log inline; **Bitbucket** build statuses link
+    out (name/state/URL, no fetchable logs).
   - **Local PRs** — the same loop against any two branches with **no remote**,
     promotable to a real GitHub PR (comments and all) in one click. A merge
     **pre-shows conflicts** and lets you resolve them in an **in-app editor** — in an
@@ -422,10 +423,11 @@ workflow against any two branches with no remote at all).
   — but no force-push/draft events; **Bitbucket PRs** add
   commits, merge/close, and approved / changes-requested (no labels or review-requests);
   **local PRs** get created → commits → comments → merged/closed.
-- **CI rollup** — checks collapse into a **✓ passed · ✕ failed · ● pending** summary
-  (auto-expanding on failure); failing **GitHub Actions** and **GitLab pipeline** jobs
-  peek their log inline, while **Bitbucket** and other external checks link out
-  (name/state/URL, no fetchable logs).
+- **CI rollup** — checks collapse into a **✓ passed · ✕ failed · ● pending · ⊖ skipped**
+  summary (auto-expanding on failure); a running **GitHub Actions** check shows its
+  current step inline and a live step checklist when expanded, while finished **GitHub
+  Actions** and **GitLab pipeline** jobs peek their log inline and **Bitbucket** and
+  other external checks link out (name/state/URL, no fetchable logs).
 - **Record management** — right-click a local PR in the list to **Archive / Unarchive**
   or **Delete** it (Delete confirms; the branches are untouched), also from the command
   palette.

--- a/changelog.d/added-pr-checks-live-steps.md
+++ b/changelog.d/added-pr-checks-live-steps.md
@@ -1,0 +1,3 @@
+- A **GitHub Actions** check that's still running in the pull-request view now shows
+  its **current step** inline in the checks rollup, and a **live step checklist** when
+  you expand it — real progress as the run advances, instead of an empty log skeleton.

--- a/changelog.d/fixed-skipped-checks-pending.md
+++ b/changelog.d/fixed-skipped-checks-pending.md
@@ -1,0 +1,3 @@
+- Skipped CI checks (and neutral or stale ones) in a pull request's checks rollup
+  now show as their own muted **skipped** segment instead of masquerading as
+  amber **pending** — on GitHub and for GitLab's skipped pipeline jobs alike.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -96,7 +96,7 @@ export const capabilities: Capability[] = [
 
   // — CI, tags & releases —
   { group: "CI, tags & releases", label: "GitHub Actions — runs, jobs, steps, re-run, cancel & dispatch", highlight: true },
-  { group: "CI, tags & releases", label: "CI checks rollup — pass/fail/pending, peeks a failing job's log inline" },
+  { group: "CI, tags & releases", label: "CI checks rollup — pass/fail/pending/skipped, live step progress on running Actions checks" },
   { group: "CI, tags & releases", label: "Tags, releases & cross-platform assets" },
   { group: "CI, tags & releases", label: "Insights graphs — commit activity, churn & more, computed locally" },
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -450,7 +450,8 @@ const forges = [
     <p>
       GitHub&nbsp;Actions, in the app — browse runs for the current branch, drill into
       jobs and steps, dispatch a workflow, and re-run or cancel. A PR's checks collapse
-      into a pass/fail/pending rollup that peeks a failing job's log inline.
+      into a pass/fail/pending/skipped rollup that shows a running check's current step
+      live and peeks a failing job's log inline.
     </p>
     <p class="text-muted">
       GitLab pipelines get the same inline-log treatment; Bitbucket build statuses link

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -4953,17 +4953,20 @@ fn map_ci_status(s: &str) -> (String, String) {
 }
 
 /// Map a GitLab job `status` onto the check-status vocabulary the PR-view rollup
-/// keys on (`ChecksRollup.checkPresentation`, matched uppercased): only `SUCCESS`
-/// reads as passed, `FAILURE`/`CANCELLED` (+ ERROR/TIMED_OUT) as failed, and
-/// everything else — running/pending/manual/skipped/created — as the pending bucket.
-/// Pure (unit-tested).
+/// keys on (`ChecksRollup.checkPresentation`, matched uppercased): `SUCCESS`
+/// reads as passed, `FAILURE`/`CANCELLED` (+ ERROR/TIMED_OUT) as failed,
+/// `SKIPPED` as its own muted bucket, and everything else —
+/// running/pending/manual/created — as the pending bucket. `manual` stays
+/// pending because it's blocked on a human (not skipped). Pure (unit-tested).
 fn map_job_check_status(status: &str) -> String {
     match status {
         "success" => "SUCCESS",
         "failed" => "FAILURE",
         "canceled" | "cancelled" => "CANCELLED",
-        // running / pending / manual / skipped / created / preparing / scheduled /
-        // waiting_for_resource / any new state → the frontend's pending bucket.
+        "skipped" => "SKIPPED",
+        // running / pending / manual / created / preparing / scheduled /
+        // waiting_for_resource / any new state → the frontend's pending bucket
+        // (`manual` is blocked on a human, not skipped).
         _ => "PENDING",
     }
     .to_string()
@@ -7324,15 +7327,11 @@ mod tests {
         assert_eq!(map_job_check_status("failed"), "FAILURE");
         assert_eq!(map_job_check_status("canceled"), "CANCELLED");
         assert_eq!(map_job_check_status("cancelled"), "CANCELLED");
-        // Everything else (in-flight, skipped, manual, unknown) → pending bucket.
-        for s in [
-            "running",
-            "pending",
-            "manual",
-            "skipped",
-            "created",
-            "weird_new_state",
-        ] {
+        // Skipped jobs read as their own muted bucket, not pending.
+        assert_eq!(map_job_check_status("skipped"), "SKIPPED");
+        // Everything else (in-flight, manual, unknown) → pending bucket. `manual`
+        // stays pending — it's blocked on a human, not skipped.
+        for s in ["running", "pending", "manual", "created", "weird_new_state"] {
             assert_eq!(map_job_check_status(s), "PENDING", "status {s}");
         }
     }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1750,6 +1750,15 @@ fn parse_actions_run_job(url: &str) -> (Option<String>, Option<String>) {
     (Some(run_id), job_id)
 }
 
+/// Whether a CheckRun timestamp string is a real time worth keeping. `gh`
+/// serializes a null GraphQL timestamp as Go's zero value
+/// (`"0001-01-01T00:00:00Z"`), so a still-running check "has" a `completedAt`
+/// unless that sentinel is dropped along with the empty string. Dropping both is
+/// what lets the frontend tell a finished check from an in-progress one.
+fn real_check_time(s: &str) -> bool {
+    !s.is_empty() && !s.starts_with("0001-01-01")
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RawPr {
@@ -2335,18 +2344,16 @@ pub async fn gh_pr_view(
                     .as_deref()
                     .map(parse_actions_run_job)
                     .unwrap_or((None, None));
-                // gh serializes a null GraphQL timestamp as Go's zero value
-                // ("0001-01-01T00:00:00Z"), so an in-progress check "has" a
-                // completedAt unless the sentinel is dropped along with "".
-                let real_time = |s: &String| !s.is_empty() && !s.starts_with("0001-01-01");
+                // Drop empty AND Go-zero-value sentinel timestamps (see
+                // `real_check_time`) so a still-running check reads as unfinished.
                 PrCheckOut {
                     name,
                     status,
                     details_url,
                     run_id,
                     job_id,
-                    started_at: c.started_at.filter(real_time),
-                    completed_at: c.completed_at.filter(real_time),
+                    started_at: c.started_at.filter(|s| real_check_time(s)),
+                    completed_at: c.completed_at.filter(|s| real_check_time(s)),
                 }
             })
             .collect(),
@@ -4496,7 +4503,7 @@ fn scrape_pr_ref(stdout: &str) -> (u64, String) {
 mod tests {
     use super::{
         external_items_from_thread_nodes, host_from_url, is_diff_too_large, map_timeline_node,
-        parse_actions_run_job,
+        parse_actions_run_job, real_check_time,
         parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
@@ -4884,6 +4891,17 @@ github.acme.com
             parse_actions_run_job("https://github.com/o/r/actions/runs/"),
             (None, None)
         );
+    }
+
+    #[test]
+    fn real_check_time_drops_empty_and_go_zero_value() {
+        // An absent timestamp arrives as "" and must be dropped.
+        assert!(!real_check_time(""));
+        // gh serializes a null GraphQL time as Go's zero value — dropping it is
+        // what lets a still-running check read as unfinished (no completedAt).
+        assert!(!real_check_time("0001-01-01T00:00:00Z"));
+        // A real ISO timestamp is kept.
+        assert!(real_check_time("2026-07-18T12:34:56Z"));
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2335,14 +2335,18 @@ pub async fn gh_pr_view(
                     .as_deref()
                     .map(parse_actions_run_job)
                     .unwrap_or((None, None));
+                // gh serializes a null GraphQL timestamp as Go's zero value
+                // ("0001-01-01T00:00:00Z"), so an in-progress check "has" a
+                // completedAt unless the sentinel is dropped along with "".
+                let real_time = |s: &String| !s.is_empty() && !s.starts_with("0001-01-01");
                 PrCheckOut {
                     name,
                     status,
                     details_url,
                     run_id,
                     job_id,
-                    started_at: c.started_at.filter(|s| !s.is_empty()),
-                    completed_at: c.completed_at.filter(|s| !s.is_empty()),
+                    started_at: c.started_at.filter(real_time),
+                    completed_at: c.completed_at.filter(real_time),
                 }
             })
             .collect(),

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -595,8 +595,8 @@ each one reports.
 
 CI checks appear as a **rollup summary** — **✓ N passed · ✕ M failed · ● K pending ·
 ⊖ K skipped**, each count with its own icon and word so status never rides on color
-alone. Skipped (and neutral) checks show as their own muted segment rather than
-masquerading as pending. It auto-expands whenever something has failed. Expanding lists
+alone. Skipped checks (plus neutral or stale ones) show as their own muted segment rather
+than masquerading as pending. It auto-expands whenever something has failed. Expanding lists
 the checks failures-first (arrow-navigable). A **GitHub Actions** check that's still
 **running** shows its **current step** right in the row and, when expanded, a **live step
 checklist** that updates as the run progresses; a finished Actions check **peeks its job

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -593,12 +593,15 @@ since**), so an out-of-date verdict never reads as current. The feed works for *
 MRs**, **Bitbucket PRs**, and **local PRs** too — see their sections below for the events
 each one reports.
 
-CI checks appear as a **rollup summary** — **✓ N passed · ✕ M failed · ● K pending**,
-each count with its own icon and word so status never rides on color alone. It
-auto-expands whenever something has failed. Expanding lists the checks failures-first
-(arrow-navigable). A failing **GitHub Actions** check **peeks its job log inline**,
-without leaving the PR — **copy** the log with the button in its top-right corner — with
-an **Open full run** link; an external check (Vercel and the
+CI checks appear as a **rollup summary** — **✓ N passed · ✕ M failed · ● K pending ·
+⊖ K skipped**, each count with its own icon and word so status never rides on color
+alone. Skipped (and neutral) checks show as their own muted segment rather than
+masquerading as pending. It auto-expands whenever something has failed. Expanding lists
+the checks failures-first (arrow-navigable). A **GitHub Actions** check that's still
+**running** shows its **current step** right in the row and, when expanded, a **live step
+checklist** that updates as the run progresses; a finished Actions check **peeks its job
+log inline** instead — without leaving the PR — **copy** the log with the button in its
+top-right corner — with an **Open full run** link. An external check (Vercel and the
 like) links straight out to its details. **GitLab MRs** get the same rollup from the MR's
 pipeline jobs, with the same **inline log peek**; **Bitbucket PRs** get it from the PR's
 commit build statuses, but those **link out only** (name, state, and URL — Bitbucket

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -594,7 +594,7 @@ MRs**, **Bitbucket PRs**, and **local PRs** too — see their sections below for
 each one reports.
 
 CI checks appear as a **rollup summary** — **✓ N passed · ✕ M failed · ● K pending ·
-⊖ K skipped**, each count with its own icon and word so status never rides on color
+⊖ J skipped**, each count with its own icon and word so status never rides on color
 alone. Skipped checks (plus neutral or stale ones) show as their own muted segment rather
 than masquerading as pending. It auto-expands whenever something has failed. Expanding lists
 the checks failures-first (arrow-navigable). A **GitHub Actions** check that's still

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -4,20 +4,29 @@ import {
   CaretRightIcon,
   CheckCircleIcon,
   CircleIcon,
+  MinusCircleIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
+  type Dispatch,
   type KeyboardEvent,
   type MouseEvent,
+  type SetStateAction,
   useEffect,
   useRef,
   useState,
 } from "react";
 import { LogBlock } from "@/components/LogBlock";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { PrCheckOut } from "@/lib/git/types";
-import { useJobLogs, useRunFailedLogs } from "@/lib/github/actions";
+import { StatusIcon } from "@/features/actions/status";
+import type { ForgeProvider, PrCheckOut } from "@/lib/git/types";
+import {
+  type RunJob,
+  useJobLogs,
+  useRunDetail,
+  useRunFailedLogs,
+} from "@/lib/github/actions";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { cn } from "@/lib/utils";
 
@@ -31,7 +40,7 @@ function checkPresentation(status: string): {
   Icon: typeof CheckCircleIcon;
   label: string;
   /** Coarse bucket for the rollup summary + failures-first sort. */
-  bucket: "passed" | "failed" | "pending";
+  bucket: "passed" | "failed" | "pending" | "skipped";
 } {
   const s = status.toUpperCase();
   if (s === "SUCCESS") {
@@ -42,7 +51,11 @@ function checkPresentation(status: string): {
       bucket: "passed",
     };
   }
-  if (["FAILURE", "ERROR", "CANCELLED", "TIMED_OUT"].includes(s)) {
+  if (
+    ["FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE"].includes(
+      s,
+    )
+  ) {
     return {
       tone: "text-destructive",
       Icon: XCircleIcon,
@@ -50,12 +63,55 @@ function checkPresentation(status: string): {
       bucket: "failed",
     };
   }
+  if (["SKIPPED", "NEUTRAL", "STALE"].includes(s)) {
+    return {
+      tone: "text-muted-foreground",
+      Icon: MinusCircleIcon,
+      label: "skipped",
+      bucket: "skipped",
+    };
+  }
+  // Everything still in flight — IN_PROGRESS/QUEUED/PENDING — plus
+  // ACTION_REQUIRED (deliberately here: it awaits a human, so the amber warning
+  // tone fits) falls through to the pending bucket.
   return {
     tone: "text-warning",
     Icon: CircleIcon,
     label: "pending",
     bucket: "pending",
   };
+}
+
+/** A GitHub Actions check that hasn't finished yet — it has a parsed run id, the
+ *  repo is GitHub, and no `completedAt`. Only these fetch run detail for the live
+ *  step checklist; GitLab checks also carry run/job ids (pipeline/job ids) but have
+ *  no steps, so gating on the provider avoids wasted `forge_ci_run_view` spawns. */
+function isRunningActionsCheck(
+  check: PrCheckOut,
+  provider: ForgeProvider,
+): boolean {
+  return provider === "github" && Boolean(check.runId) && !check.completedAt;
+}
+
+/** The run's job for a check: by job id first (the reliable key), falling back to
+ *  matching the job name when the check carries no job id. */
+function jobForCheck(
+  check: PrCheckOut,
+  jobs: RunJob[] | undefined,
+): RunJob | undefined {
+  if (!jobs) return undefined;
+  if (check.jobId) {
+    const id = Number(check.jobId);
+    const byId = jobs.find((j) => j.id === id);
+    if (byId) return byId;
+  }
+  return jobs.find((j) => j.name === check.name);
+}
+
+/** The step a running job is currently executing (first `in_progress` step), or
+ *  null when none has started yet (still "queued"). */
+function currentStep(job: RunJob | undefined) {
+  return job?.steps.find((s) => s.status === "in_progress") ?? null;
 }
 
 /** "1m 12s" elapsed between two ISO timestamps (mirrors RunDetailView's helper).
@@ -144,19 +200,65 @@ function CheckLogTail({
   );
 }
 
+/** The live step checklist for a running GitHub Actions check: one compact row
+ *  per step (status glyph + name + duration), shown in the expanded panel instead
+ *  of the (mid-run useless) log tail. Real rows render as data arrives — no spinner. */
+function RunSteps({ job }: { job: RunJob }) {
+  return (
+    <div className="mt-1.5 space-y-0.5">
+      {job.steps.map((step) => {
+        const elapsed = duration(step.startedAt, step.completedAt);
+        return (
+          <div
+            key={step.number}
+            className="flex items-center gap-2 text-[11px]"
+          >
+            <StatusIcon
+              status={step.status}
+              conclusion={step.conclusion}
+              className="size-3.5"
+            />
+            <span
+              className="min-w-0 flex-1 truncate"
+              onMouseEnter={clipTitle(step.name)}
+            >
+              {step.name}
+            </span>
+            {elapsed && (
+              <span className="shrink-0 text-muted-foreground tabular-nums">
+                {elapsed}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 /** One check row: state icon + name + duration + trailing affordance. GitHub
  *  Actions checks (a parsed run id) peek their log inline; external checks link
- *  out; URL-less checks show just name + status. */
+ *  out; URL-less checks show just name + status. A running Actions check surfaces
+ *  its current step inline and its live step checklist when expanded. */
 function CheckRow({
   repoPath,
   check,
   rowId,
+  runJob,
+  isRunning,
 }: {
   repoPath: string;
   check: PrCheckOut;
   /** Unique row identity (the sorted index) for `data-row` + roving focus —
    *  GitHub allows two checks with the same `name`, so name can't be the id. */
   rowId: string;
+  /** The resolved run job for a running Actions check (from the rollup's shared
+   *  run-detail queries); undefined until the run detail resolves, or for a
+   *  non-running / non-Actions check. */
+  runJob: RunJob | undefined;
+  /** Whether this is a still-running GitHub Actions check (drives the inline
+   *  current-step peek + the expanded step checklist). */
+  isRunning: boolean;
 }) {
   const { tone, Icon, label } = checkPresentation(check.status);
   const elapsed = duration(check.startedAt, check.completedAt);
@@ -164,6 +266,15 @@ function CheckRow({
   // one job's log; a run id without a job falls back to the run's failed logs.
   const isActionsCheck = Boolean(check.runId);
   const [logsOpen, setLogsOpen] = useState(false);
+
+  // Running Actions check: the current step's name, shown inline after the check
+  // name. `undefined` while run detail hasn't resolved (render nothing — no jump);
+  // "queued" once resolved but no step is in progress yet.
+  const stepPeek = isRunning
+    ? runJob
+      ? (currentStep(runJob)?.name ?? "queued")
+      : undefined
+    : undefined;
 
   // The row's shared inner content (icon + name + duration). Rendered inside a
   // focusable button for interactive rows (Actions → toggles logs; else the
@@ -187,6 +298,16 @@ function CheckRow({
       >
         {check.name}
       </span>
+      {stepPeek !== undefined && (
+        // The running check's current step, after the name — muted + truncated so
+        // a long step name can't push the row wide (name keeps its flex share).
+        <span
+          className="min-w-0 max-w-[45%] shrink truncate text-muted-foreground"
+          onMouseEnter={clipTitle(stepPeek)}
+        >
+          · {stepPeek}
+        </span>
+      )}
       {elapsed && (
         <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
           {elapsed}
@@ -245,11 +366,41 @@ function CheckRow({
       </div>
       {isActionsCheck && logsOpen && (
         <div className="px-3 pb-2 pl-10">
-          <CheckLogTail repoPath={repoPath} check={check} />
+          {/* A running Actions check shows its live step checklist (logs are
+              useless mid-run); if its job can't be resolved yet or it has no
+              steps, and for every completed check, fall back to the log tail. */}
+          {isRunning && runJob && runJob.steps.length > 0 ? (
+            <RunSteps job={runJob} />
+          ) : (
+            <CheckLogTail repoPath={repoPath} check={check} />
+          )}
         </div>
       )}
     </div>
   );
+}
+
+/** A headless per-run fetcher: mounts one `useRunDetail` query for a running
+ *  Actions run and lifts its jobs to the parent so each row can resolve its own
+ *  job (React Query dedupes by run-id key, so N rows sharing a run cost one fetch).
+ *  Mounted only while the rollup is open; `useRunDetail` refetches every 5s while
+ *  the run stays active. Renders nothing. */
+function RunDetailFetcher({
+  repoPath,
+  runId,
+  setJobs,
+}: {
+  repoPath: string;
+  runId: string;
+  /** The parent's `setJobsByRun` state updater (stable across renders). */
+  setJobs: Dispatch<SetStateAction<Record<string, RunJob[]>>>;
+}) {
+  const detail = useRunDetail(repoPath, Number(runId), true);
+  const jobs = detail.data?.jobs;
+  useEffect(() => {
+    if (jobs) setJobs((prev) => ({ ...prev, [runId]: jobs }));
+  }, [jobs, runId, setJobs]);
+  return null;
 }
 
 /**
@@ -266,9 +417,13 @@ function CheckRow({
 export function ChecksRollup({
   checks,
   repoPath,
+  provider,
 }: {
   checks: PrCheckOut[];
   repoPath: string;
+  /** The repo's forge provider — gates the running-Actions live-steps fetch to
+   *  GitHub (GitLab checks also carry run/job ids but have no steps). */
+  provider: ForgeProvider;
 }) {
   const passed = checks.filter(
     (c) => checkPresentation(c.status).bucket === "passed",
@@ -279,10 +434,17 @@ export function ChecksRollup({
   const pending = checks.filter(
     (c) => checkPresentation(c.status).bucket === "pending",
   ).length;
+  const skipped = checks.filter(
+    (c) => checkPresentation(c.status).bucket === "skipped",
+  ).length;
 
   // Auto-expand on any failure — a failing PR should show what failed without a
   // click. Otherwise collapsed by default.
   const [open, setOpen] = useState(failed > 0);
+  // The jobs of each running Actions run, keyed by run id. Populated by the
+  // headless `RunDetailFetcher`s mounted while the rollup is open (one per distinct
+  // run id); each row resolves its own job from here. Empty until run detail lands.
+  const [jobsByRun, setJobsByRun] = useState<Record<string, RunJob[]>>({});
   // …and re-open when failures FIRST appear after mount: usePrDetails refetches
   // on window focus (no remount), so a PR opened while CI is pending would
   // otherwise stay collapsed when a check later fails. Fire only on the 0→>0
@@ -293,13 +455,25 @@ export function ChecksRollup({
     prevFailed.current = failed;
   }, [failed]);
 
-  // Failures first, then pending, then passed; stable within a bucket.
-  const bucketRank = { failed: 0, pending: 1, passed: 2 } as const;
+  // Failures first, then pending, then passed, then skipped (least interesting);
+  // stable within a bucket.
+  const bucketRank = { failed: 0, pending: 1, passed: 2, skipped: 3 } as const;
   const sorted = [...checks].sort(
     (a, b) =>
       bucketRank[checkPresentation(a.status).bucket] -
       bucketRank[checkPresentation(b.status).bucket],
   );
+
+  // The distinct run ids of the still-running GitHub Actions checks — one
+  // run-detail query mounts per id below (React Query dedupes rows sharing a run),
+  // and only while the rollup is OPEN, so a collapsed rollup fires nothing.
+  const runningRunIds = [
+    ...new Set(
+      checks
+        .filter((c) => isRunningActionsCheck(c, provider))
+        .map((c) => c.runId as string),
+    ),
+  ];
 
   // Roving focus: the "active" row is whichever row element currently holds DOM
   // focus, keyed by `data-row` = the row's sorted index (a check `name` isn't
@@ -356,6 +530,13 @@ export function ChecksRollup({
       tone: "text-warning",
       word: "pending",
     },
+    {
+      key: "skipped",
+      count: skipped,
+      Icon: MinusCircleIcon,
+      tone: "text-muted-foreground",
+      word: "skipped",
+    },
   ].filter((s) => s.count > 0);
 
   return (
@@ -388,22 +569,43 @@ export function ChecksRollup({
         </span>
       </button>
       {open && (
-        <div
-          className="mt-1.5 max-h-64 overflow-y-auto border"
-          onKeyDown={onKeyDown}
-        >
-          {sorted.map((c, i) => (
-            // Key + data-row on the sorted index — `c.name` isn't unique (GitHub
-            // allows two checks with the same name), which would collide keys and
-            // make the second row unfocusable.
-            <CheckRow
-              key={rowId(i)}
-              rowId={rowId(i)}
+        <>
+          {/* One run-detail query per distinct running Actions run, mounted only
+              while the rollup is open (collapsed → no fetch). Headless — they lift
+              jobs into `jobsByRun` for the rows to read. */}
+          {runningRunIds.map((id) => (
+            <RunDetailFetcher
+              key={id}
               repoPath={repoPath}
-              check={c}
+              runId={id}
+              setJobs={setJobsByRun}
             />
           ))}
-        </div>
+          <div
+            className="mt-1.5 max-h-64 overflow-y-auto border"
+            onKeyDown={onKeyDown}
+          >
+            {sorted.map((c, i) => {
+              // Key + data-row on the sorted index — `c.name` isn't unique (GitHub
+              // allows two checks with the same name), which would collide keys and
+              // make the second row unfocusable.
+              const running = isRunningActionsCheck(c, provider);
+              const runJob = running
+                ? jobForCheck(c, c.runId ? jobsByRun[c.runId] : undefined)
+                : undefined;
+              return (
+                <CheckRow
+                  key={rowId(i)}
+                  rowId={rowId(i)}
+                  repoPath={repoPath}
+                  check={c}
+                  isRunning={running}
+                  runJob={runJob}
+                />
+              );
+            })}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { StatusIcon } from "@/features/actions/status";
 import type { ForgeProvider, PrCheckOut } from "@/lib/git/types";
 import {
+  isRunActive,
   type RunJob,
   useJobLogs,
   useRunDetail,
@@ -67,7 +68,10 @@ function checkPresentation(status: string): {
     return {
       tone: "text-muted-foreground",
       Icon: MinusCircleIcon,
-      label: "skipped",
+      // The three share a bucket/icon/tone, but the accessible label is each
+      // status's own word ("skipped" / "neutral" / "stale") so a screen reader
+      // announces the actual result. The summary segment still says "skipped".
+      label: s.toLowerCase(),
       bucket: "skipped",
     };
   }
@@ -83,14 +87,23 @@ function checkPresentation(status: string): {
 }
 
 /** A GitHub Actions check that hasn't finished yet — it has a parsed run id, the
- *  repo is GitHub, and no `completedAt`. Only these fetch run detail for the live
- *  step checklist; GitLab checks also carry run/job ids (pipeline/job ids) but have
- *  no steps, so gating on the provider avoids wasted `forge_ci_run_view` spawns. */
+ *  repo is GitHub, no `completedAt`, AND its status still reads as pending. The
+ *  bucket check guards against a StatusContext whose `targetUrl` is coincidentally
+ *  an Actions-run URL (so a runId parses) but whose state is already SUCCESS/
+ *  FAILURE and carries no timestamps — without it, such a check would read as
+ *  "running". Only these fetch run detail for the live step checklist; GitLab
+ *  checks also carry run/job ids (pipeline/job ids) but have no steps, so gating on
+ *  the provider avoids wasted `forge_ci_run_view` spawns. */
 function isRunningActionsCheck(
   check: PrCheckOut,
   provider: ForgeProvider,
 ): boolean {
-  return provider === "github" && Boolean(check.runId) && !check.completedAt;
+  return (
+    provider === "github" &&
+    Boolean(check.runId) &&
+    !check.completedAt &&
+    checkPresentation(check.status).bucket === "pending"
+  );
 }
 
 /** The run's job for a check: by job id first (the reliable key), falling back to
@@ -593,13 +606,21 @@ export function ChecksRollup({
               const runJob = running
                 ? jobForCheck(c, c.runId ? jobsByRun[c.runId] : undefined)
                 : undefined;
+              // `useRunDetail` polls at 5s but usePrDetails only refetches on
+              // focus, so when a run finishes the check's `completedAt` stays
+              // stale (→ `running` true) until a focus event. Treat the resolved
+              // job as authoritative: once it reports a non-active status, drop
+              // the live UI immediately, reverting the row to the log tail before
+              // the PR payload catches up.
+              const jobDone = runJob ? !isRunActive(runJob.status) : false;
+              const live = running && !jobDone;
               return (
                 <CheckRow
                   key={rowId(i)}
                   rowId={rowId(i)}
                   repoPath={repoPath}
                   check={c}
-                  isRunning={running}
+                  isRunning={live}
                   runJob={runJob}
                 />
               );

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1111,7 +1111,11 @@ export function RemotePrView({
             }}
           />
         )}
-        <ChecksRollup checks={pr.checks} repoPath={repoPath} />
+        <ChecksRollup
+          checks={pr.checks}
+          repoPath={repoPath}
+          provider={providerKey}
+        />
         <div className="flex gap-1 pt-1">
           {/* The AI Review tab needs only the diff (forge-neutral) and a way to
               post the result as a comment — so it follows canComment, which


### PR DESCRIPTION
Improve pull-request check visibility by showing meaningful progress while GitHub Actions runs are still active, rather than displaying an empty log state. Clarify skipped, neutral, and stale checks so they no longer appear as pending, consistently across GitHub and GitLab.

### Checks rollup

- Updates `src/features/pulls/ChecksRollup.tsx` to display passed, failed, pending, and skipped segments with distinct icons, labels, sorting, and status tones.
- Adds live GitHub Actions step tracking in `src/features/pulls/ChecksRollup.tsx`, including the current step inline and an expandable step checklist with status icons and durations.
- Uses `useRunDetail` in `src/features/pulls/ChecksRollup.tsx` to refresh active GitHub Actions runs while the rollup is open and resolve each check to its corresponding job.
- Extends `src/features/pulls/ChecksRollup.tsx` status handling for `STARTUP_FAILURE`, `SKIPPED`, `NEUTRAL`, and `STALE`.
- Passes the forge provider from `src/features/pulls/RemotePrView.tsx` so live-step fetching is limited to GitHub Actions checks.

### Provider status mapping

- Filters GitHub's zero-value GraphQL timestamps in `src-tauri/src/github/pr.rs` so in-progress checks do not appear to have completed.
- Maps GitLab `skipped` jobs to the `SKIPPED` check status in `src-tauri/src/forge/gitlab.rs`, while keeping manually blocked jobs pending.
- Updates the unit assertions in `src-tauri/src/forge/gitlab.rs` to cover skipped, pending, manual, and unknown job states.

### Documentation and changelog

- Documents live GitHub Actions steps and the skipped status segment in `src/features/help/content.ts`.
- Adds the live-step behavior to `changelog.d/added-pr-checks-live-steps.md`.
- Adds the skipped-check status fix to `changelog.d/fixed-skipped-checks-pending.md`.