### PR TITLE
feat(pulls,timeline,github): add timestamps to PR activity feeds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ don't wait to be asked:**
    one file per change keeps parallel branches conflict-free. Preview with
    `pnpm changelog:preview`; conventions live in `changelog.d/README.md`.
 
+When a change alters **existing** behavior, grep README / site / help for the old
+wording (e.g. the feature's old phrase) rather than updating spots from memory — stale
+copies of the same claim hide across all three surfaces.
+
 If a feature is too minor for the README / site / guide, it's fine to add only the
 capability line + changelog fragment — but make the call deliberately, don't skip silently.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   browser. Set **labels and assignees** right when you **open** a PR/MR (GitHub &
   GitLab); request reviewers across GitHub, GitLab & Bitbucket.
   - **Activity feed** — a PR's Conversation is a **date-sorted timeline** of reviews,
-    comments, grouped **pushed commits** (each SHA clickable), and events, with an
+    comments, grouped **pushed commits** (each SHA clickable), and events, every entry
+    **timestamped** (hover for the exact time), with an
     **approval marked stale** once later commits land — on GitHub, GitLab, Bitbucket,
     and local PRs (GitLab has no force-push/draft events, Bitbucket no labels or
     review-requests).
@@ -415,7 +416,8 @@ workflow against any two branches with no remote at all).
   Bitbucket). The same commit comments are available from the **History tab** on any
   pushed commit (an unpushed one shows a push hint).
 - **Activity feed** — the Conversation is a **date-sorted timeline** of reviews,
-  comments, grouped pushed commits (each SHA clickable), and events, marking an approval
+  comments, grouped pushed commits (each SHA clickable), and events, every entry carrying
+  a relative **timestamp** (hover for the exact local time), marking an approval
   or changes-request **stale** once later commits land. GitHub carries the full event set
   (force-push, label add/remove, review request, ready-for-review, convert-to-draft,
   close, reopen, merge, rename); **GitLab MRs** add commits, label changes,

--- a/changelog.d/added-pr-timeline-timestamps.md
+++ b/changelog.d/added-pr-timeline-timestamps.md
@@ -1,0 +1,4 @@
+- **PR timeline timestamps.** Every entry in a pull request's activity feed now
+  shows when it happened — review-thread replies and pushed-commit groups (both the
+  group header and each commit) gained relative timestamps that were previously
+  missing — and hovering any timeline time reveals the exact local date and time.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -75,7 +75,7 @@ export const capabilities: Capability[] = [
   { group: "Pull requests & review", label: "Inline review comments — reply, resolve, apply suggestions locally", highlight: true },
   { group: "Pull requests & review", label: "Compose a review from the diff — batch drafts, submit with a verdict" },
   { group: "Pull requests & review", label: "Drill into a PR's commits — per-file diffs, whole-commit & line comments" },
-  { group: "Pull requests & review", label: "PR activity feed — reviews, comments, grouped commits, stale-approval marks" },
+  { group: "Pull requests & review", label: "PR activity feed — reviews, comments, grouped commits, stale-approval marks, all timestamped" },
   { group: "Pull requests & review", label: "Comment on commits from History — whole-commit or line-anchored" },
   { group: "Pull requests & review", label: "Fork · Upstream lens — browse & work a fork's PRs and issues or the parent's" },
 

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1750,13 +1750,23 @@ fn parse_actions_run_job(url: &str) -> (Option<String>, Option<String>) {
     (Some(run_id), job_id)
 }
 
-/// Whether a CheckRun timestamp string is a real time worth keeping. `gh`
-/// serializes a null GraphQL timestamp as Go's zero value
-/// (`"0001-01-01T00:00:00Z"`), so a still-running check "has" a `completedAt`
-/// unless that sentinel is dropped along with the empty string. Dropping both is
-/// what lets the frontend tell a finished check from an in-progress one.
+/// Whether a timestamp string is a real time worth keeping. `gh` serializes a
+/// null GraphQL timestamp as Go's zero value (`"0001-01-01T00:00:00Z"`), so a
+/// still-running check "has" a `completedAt` — and a PENDING review "has" a
+/// `submittedAt` — unless that sentinel is dropped along with the empty string.
+/// Dropping both is what lets the frontend tell a finished check from an
+/// in-progress one, and skip rendering a pending review's absent submit time
+/// (its `date &&` guard treats `""` as absent) instead of a year-0001 date.
 fn real_check_time(s: &str) -> bool {
     !s.is_empty() && !s.starts_with("0001-01-01")
+}
+
+/// A timeline date from the `gh pr view` Go-serialized path, cleared to `""`
+/// when it's absent or the Go-zero sentinel (see `real_check_time`), so the
+/// frontend's `date &&` guards skip rendering it rather than showing a
+/// year-0001 date.
+fn real_time_or_empty(s: String) -> String {
+    if real_check_time(&s) { s } else { String::new() }
 }
 
 #[derive(Deserialize)]
@@ -2182,7 +2192,7 @@ pub async fn gh_pr_view(
                         oid: c.oid,
                         headline: c.message_headline,
                         message_body: c.message_body,
-                        date: c.authored_date,
+                        date: real_time_or_empty(c.authored_date),
                         author,
                     }
                 })
@@ -2202,7 +2212,7 @@ pub async fn gh_pr_view(
                     oid: c.oid,
                     headline: c.message_headline,
                     message_body: c.message_body,
-                    date: c.authored_date,
+                    date: real_time_or_empty(c.authored_date),
                     author,
                 }
             })
@@ -2220,7 +2230,7 @@ pub async fn gh_pr_view(
                     author_avatar_url: String::new(),
                     state: r.state,
                     body: r.body,
-                    date: r.submitted_at,
+                    date: real_time_or_empty(r.submitted_at),
                     id: r.id,
                     url: String::new(),
                     viewer_did_author: false,
@@ -2240,7 +2250,7 @@ pub async fn gh_pr_view(
                 author_avatar_url: String::new(),
                 state: r.state,
                 body: r.body,
-                date: r.submitted_at,
+                date: real_time_or_empty(r.submitted_at),
                 id: r.id,
                 url: String::new(),
                 viewer_did_author: false,
@@ -2264,7 +2274,7 @@ pub async fn gh_pr_view(
                     author_avatar_url: String::new(),
                     state: String::new(),
                     body: c.body,
-                    date: c.created_at,
+                    date: real_time_or_empty(c.created_at),
                     id: c.id,
                     url: c.url,
                     viewer_did_author: c.viewer_did_author,
@@ -2283,7 +2293,7 @@ pub async fn gh_pr_view(
                 author_avatar_url: String::new(),
                 state: String::new(),
                 body: c.body,
-                date: c.created_at,
+                date: real_time_or_empty(c.created_at),
                 id: c.id,
                 url: c.url,
                 viewer_did_author: c.viewer_did_author,
@@ -3317,8 +3327,11 @@ struct GhPrRestReview {
     state: String,
     #[serde(default)]
     body: String,
+    /// A PENDING review has no submit time, and GitHub REST spells that as literal
+    /// JSON `null` — `#[serde(default)]` only fills an ABSENT key, so an explicit
+    /// `null` needs `Option` to avoid failing the whole paginated deserialization.
     #[serde(default)]
-    submitted_at: String,
+    submitted_at: Option<String>,
 }
 
 /// One entry from `repos/{owner}/{repo}/issues/<n>/comments` — the PR's
@@ -3389,7 +3402,7 @@ fn rest_review_to_out(r: GhPrRestReview) -> PrThreadOut {
         author_avatar_url: String::new(),
         state: r.state,
         body: r.body,
-        date: r.submitted_at,
+        date: r.submitted_at.unwrap_or_default(),
         id: r.node_id,
         url: String::new(),
         viewer_did_author: false,
@@ -4503,7 +4516,7 @@ fn scrape_pr_ref(stdout: &str) -> (u64, String) {
 mod tests {
     use super::{
         external_items_from_thread_nodes, host_from_url, is_diff_too_large, map_timeline_node,
-        parse_actions_run_job, real_check_time,
+        parse_actions_run_job, real_check_time, real_time_or_empty,
         parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
@@ -4655,7 +4668,7 @@ mod tests {
             }),
             state: "CHANGES_REQUESTED".to_string(),
             body: "Please fix".to_string(),
-            submitted_at: "2026-02-03T00:00:00Z".to_string(),
+            submitted_at: Some("2026-02-03T00:00:00Z".to_string()),
         });
         assert_eq!(out.author, "reviewer");
         assert_eq!(out.state, "CHANGES_REQUESTED");
@@ -4672,7 +4685,7 @@ mod tests {
             user: None,
             state: "COMMENTED".to_string(),
             body: String::new(),
-            submitted_at: String::new(),
+            submitted_at: None,
         });
         assert_eq!(anon.author, "");
         assert_eq!(anon.id, "PRR_x");
@@ -4902,6 +4915,48 @@ github.acme.com
         assert!(!real_check_time("0001-01-01T00:00:00Z"));
         // A real ISO timestamp is kept.
         assert!(real_check_time("2026-07-18T12:34:56Z"));
+    }
+
+    #[test]
+    fn real_time_or_empty_clears_go_zero_and_passes_real() {
+        // A Go-zero sentinel (a pending review's null submittedAt through gh) and
+        // an empty string both clear to "" so the frontend's `date &&` guard skips
+        // rendering rather than showing a year-0001 date.
+        assert_eq!(real_time_or_empty("0001-01-01T00:00:00Z".into()), "");
+        assert_eq!(real_time_or_empty(String::new()), "");
+        // A real ISO timestamp passes through untouched.
+        assert_eq!(
+            real_time_or_empty("2026-07-18T12:34:56Z".into()),
+            "2026-07-18T12:34:56Z"
+        );
+    }
+
+    #[test]
+    fn rest_review_null_submitted_at_deserializes_to_empty_date() {
+        // GitHub REST spells a PENDING review's submit time as literal JSON null;
+        // `submitted_at: Option<String>` must accept it (a plain String field would
+        // fail the whole paginated deserialization) and map to an empty date.
+        let r: GhPrRestReview = serde_json::from_value(serde_json::json!({
+            "node_id": "PRR_1",
+            "user": {"login": "alice"},
+            "state": "PENDING",
+            "body": "",
+            "submitted_at": null,
+        }))
+        .expect("null submitted_at must deserialize");
+        assert_eq!(r.submitted_at, None);
+        assert_eq!(rest_review_to_out(r).date, "");
+
+        // A submitted review's real timestamp still passes straight through.
+        let r2: GhPrRestReview = serde_json::from_value(serde_json::json!({
+            "node_id": "PRR_2",
+            "user": {"login": "bob"},
+            "state": "APPROVED",
+            "body": "lgtm",
+            "submitted_at": "2026-07-18T12:34:56Z",
+        }))
+        .expect("real submitted_at must deserialize");
+        assert_eq!(rest_review_to_out(r2).date, "2026-07-18T12:34:56Z");
     }
 
     #[test]

--- a/src/components/relative-time.tsx
+++ b/src/components/relative-time.tsx
@@ -41,11 +41,12 @@ const getNow = () => now;
 export function RelativeTime({ date }: { date: string }) {
   const nowMs = useSyncExternalStore(subscribe, getNow);
   const parsed = new Date(date);
-  const absolute = Number.isNaN(parsed.getTime())
-    ? undefined
-    : parsed.toLocaleString();
+  // An unparseable date renders nothing rather than "in NaN years"
+  // (formatRelativeTime's unit walk emits the year unit for NaN) — this is a
+  // shared primitive, so don't lean on callers' `date &&` guards alone.
+  if (Number.isNaN(parsed.getTime())) return null;
   return (
-    <time dateTime={date} title={absolute}>
+    <time dateTime={date} title={parsed.toLocaleString()}>
       {formatRelativeTime(date, nowMs)}
     </time>
   );

--- a/src/components/relative-time.tsx
+++ b/src/components/relative-time.tsx
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from "react";
+import { formatRelativeTime } from "@/lib/time";
+
+// All mounted timestamps compute from ONE shared snapshot, refreshed every 30s.
+// Mutual consistency is the point — two rows mounted at different moments must
+// never disagree about the same date (the React Compiler memoizes each row's
+// output, and a bare `Date.now()` read is invisible to it, so without a shared,
+// explicitly-threaded snapshot every timestamp freezes at its own mount time).
+// Ticking every 30s is the bonus.
+const TICK_MS = 30_000;
+let now = Date.now();
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function refresh() {
+  now = Date.now();
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (timer === null) {
+    // Going 0→1 subscribers: the snapshot may be stale from an idle spell —
+    // refresh once so the first mounted timestamp starts from real now.
+    timer = setInterval(refresh, TICK_MS);
+    refresh();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+const getNow = () => now;
+
+/** Relative timestamp with the absolute local date-time on hover.
+ *  Callers keep their own `date &&` guards — pass a non-empty ISO string. */
+export function RelativeTime({ date }: { date: string }) {
+  const nowMs = useSyncExternalStore(subscribe, getNow);
+  const parsed = new Date(date);
+  const absolute = Number.isNaN(parsed.getTime())
+    ? undefined
+    : parsed.toLocaleString();
+  return (
+    <time dateTime={date} title={absolute}>
+      {formatRelativeTime(date, nowMs)}
+    </time>
+  );
+}

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -3,6 +3,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { MarkdownEditor } from "@/components/markdown-editor";
+import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,7 +21,6 @@ import type { MinimizeReason } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
 import { useActiveForgeGhHost, useActiveGhHost } from "@/lib/git/host";
 import type { PrThreadOut, Reaction, RepoLabel } from "@/lib/git/types";
-import { formatRelativeTime } from "@/lib/time";
 import { ReactionBar } from "./ReactionBar";
 
 /**
@@ -140,7 +140,7 @@ export function Thread({
           <Badge variant="secondary">{thread.state.toLowerCase()}</Badge>
         )}
         <span className="text-muted-foreground">
-          {thread.date && formatRelativeTime(thread.date)}
+          {thread.date && <RelativeTime date={thread.date} />}
         </span>
         {minimized && (
           <span className="text-[11px] text-muted-foreground italic">

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -583,7 +583,9 @@ shape plus the word, never color alone) — so a finished review (including Copi
 visible after the reviewer leaves the pending-request list.
 
 The Conversation tab is a single **date-sorted activity feed** — reviews, comments,
-pushed commits, and events all interleaved oldest-to-newest. A run of pushes collapses
+pushed commits, and events all interleaved oldest-to-newest. Every entry carries a
+**relative timestamp** (e.g. *2 days ago*), and hovering it reveals the exact local
+date and time. A run of pushes collapses
 into one **pushed N commits** row that expands to the commits (arrow-navigable), and each
 commit's short SHA is clickable — it jumps to that commit's detail. On GitHub, events show
 up as calm one-line entries: force-pushes, label added/removed, review requested, marked

--- a/src/features/pulls/LocalPrTimeline.tsx
+++ b/src/features/pulls/LocalPrTimeline.tsx
@@ -5,7 +5,7 @@ import {
   GitMergeIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
-import { formatRelativeTime } from "@/lib/time";
+import { RelativeTime } from "@/components/relative-time";
 import { cn } from "@/lib/utils";
 
 /** The lifecycle events a local PR emits — no CI/remote activity, just the
@@ -74,7 +74,7 @@ export function LocalPrLifecycleRow({
         <span className="min-w-0">{label}</span>
         {date && (
           <span className="shrink-0 text-muted-foreground/80">
-            · {formatRelativeTime(date)}
+            · <RelativeTime date={date} />
           </span>
         )}
       </div>

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -14,10 +14,10 @@ import {
   XCircleIcon,
 } from "@phosphor-icons/react";
 import { type KeyboardEvent, type MouseEvent, useState } from "react";
+import { RelativeTime } from "@/components/relative-time";
 import type { CommitRow } from "@/features/conversations/CommitsList";
 import type { PrTimelineEvent } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
-import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
 /** A merged timeline entry: the keys the feed sorts by, plus EITHER a ready
@@ -186,7 +186,7 @@ export function TimelineEventRow({ event }: { event: PrTimelineEvent }) {
         </span>
         {event.date && (
           <span className="shrink-0 text-muted-foreground/80">
-            · {formatRelativeTime(event.date)}
+            · <RelativeTime date={event.date} />
           </span>
         )}
       </div>
@@ -209,6 +209,9 @@ export function PushedCommitsRow({
 }) {
   const [open, setOpen] = useState(false);
   const n = commits.length;
+  // The feed is sorted oldest→newest and the run preserves that order, so the
+  // newest commit (the run's timestamp) is the last one.
+  const headerDate = commits[n - 1]?.date;
 
   // Arrow keys walk the sublist; Enter/Space activate the focused row — both
   // route through `onSelectCommit`. Wired only when the list is interactive.
@@ -240,19 +243,26 @@ export function PushedCommitsRow({
         label={`pushed ${n} commit${n === 1 ? "" : "s"}`}
       />
       <div className="min-w-0 flex-1 py-0.5">
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-expanded={open}
-          className="flex cursor-pointer items-center gap-1 text-muted-foreground hover:text-foreground"
-        >
-          {open ? (
-            <CaretDownIcon className="size-3 shrink-0" />
-          ) : (
-            <CaretRightIcon className="size-3 shrink-0" />
+        <div className="flex items-center gap-x-1.5">
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            className="flex cursor-pointer items-center gap-1 text-muted-foreground hover:text-foreground"
+          >
+            {open ? (
+              <CaretDownIcon className="size-3 shrink-0" />
+            ) : (
+              <CaretRightIcon className="size-3 shrink-0" />
+            )}
+            pushed {n} commit{n === 1 ? "" : "s"}
+          </button>
+          {headerDate && (
+            <span className="shrink-0 text-muted-foreground/80">
+              · <RelativeTime date={headerDate} />
+            </span>
           )}
-          pushed {n} commit{n === 1 ? "" : "s"}
-        </button>
+        </div>
         {open && (
           <ul className="mt-1 space-y-0.5 border-l pl-2" onKeyDown={onKeyDown}>
             {commits.map((c) =>
@@ -277,6 +287,11 @@ export function PushedCommitsRow({
                     <span className="shrink-0 font-mono text-[11px] text-primary underline-offset-2 group-hover:underline">
                       {c.shortSha}
                     </span>
+                    {c.date && (
+                      <span className="shrink-0 text-[11px] text-muted-foreground/80">
+                        · <RelativeTime date={c.date} />
+                      </span>
+                    )}
                   </button>
                 </li>
               ) : (
@@ -291,6 +306,11 @@ export function PushedCommitsRow({
                     <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
                       {c.shortSha}
                     </span>
+                    {c.date && (
+                      <span className="shrink-0 text-[11px] text-muted-foreground/80">
+                        · <RelativeTime date={c.date} />
+                      </span>
+                    )}
                   </div>
                 </li>
               ),

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -210,7 +210,9 @@ export function PushedCommitsRow({
   const [open, setOpen] = useState(false);
   const n = commits.length;
   // The feed is sorted oldest→newest and the run preserves that order, so the
-  // newest commit (the run's timestamp) is the last one.
+  // newest commit (the run's timestamp) is the last one. This is the AUTHORED
+  // date — no push time exists in the PR payload — so a rebased/cherry-picked
+  // batch can read older than its position in the feed.
   const headerDate = commits[n - 1]?.date;
 
   // Arrow keys walk the sublist; Enter/Space activate the focused row — both

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -24,6 +24,7 @@ import {
   MarkdownEditor,
   type MarkdownEditorHandle,
 } from "@/components/markdown-editor";
+import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -1347,6 +1348,11 @@ export function RemotePrView({
                               >
                                 View thread
                               </button>
+                            )}
+                            {r.date && (
+                              <span className="shrink-0 text-muted-foreground/80">
+                                · <RelativeTime date={r.date} />
+                              </span>
                             )}
                           </div>
                         </div>

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -24,9 +24,16 @@ const UNITS: {
 
 const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
 
-/** "8 months ago", "2 hours ago", "just now". */
-export function formatRelativeTime(isoDate: string): string {
-  const seconds = (Date.now() - new Date(isoDate).getTime()) / 1000;
+/** "8 months ago", "2 hours ago", "just now". `now` defaults to the current
+ *  time; callers that render many timestamps together (RelativeTime) pass one
+ *  shared snapshot so simultaneously-mounted rows never disagree about the same
+ *  date — and passing it explicitly keeps the React Compiler's memo key aware of
+ *  the clock (a bare `Date.now()` read is invisible to it, freezing the output). */
+export function formatRelativeTime(
+  isoDate: string,
+  now: number = Date.now(),
+): string {
+  const seconds = (now - new Date(isoDate).getTime()) / 1000;
   // Largest-first: pick the first unit the elapsed time reaches.
   for (let i = 0; i < UNITS.length; i++) {
     const { unit, seconds: unitSeconds, rollupAt } = UNITS[i];


### PR DESCRIPTION
Make pull request activity easier to understand by showing when each event occurred, while preserving relative-time readability and providing the exact local date and time on hover.

### Timeline UI

- Adds the shared `RelativeTime` component in `src/components/relative-time.tsx`, including localized absolute timestamps on hover and a shared 30-second clock snapshot.
- Updates `src/features/pulls/PrTimeline.tsx` to show timestamps for timeline events, pushed-commit groups, and individual commits.
- Updates `src/features/pulls/LocalPrTimeline.tsx`, `src/features/conversations/Thread.tsx`, and `src/features/pulls/RemotePrView.tsx` to render activity timestamps through `RelativeTime`.
- Updates `src/lib/time.ts` so `formatRelativeTime` accepts an optional shared current-time value and keeps simultaneously rendered timestamps consistent.

### GitHub timestamp handling

- Updates `src-tauri/src/github/pr.rs` to retain authored commit dates, review submission dates, comment dates, and other timeline timestamps for PR activity feeds.
- Adds `real_time_or_empty` in `src-tauri/src/github/pr.rs` to discard missing values and Go’s year-0001 sentinel instead of rendering invalid dates.
- Changes `GhPrRestReview.submitted_at` in `src-tauri/src/github/pr.rs` to `Option<String>` so pending reviews with a JSON `null` submission time deserialize correctly.

### Documentation and release notes

- Documents relative timestamps and hover behavior in `src/features/help/content.ts`.
- Adds the user-facing change to `changelog.d/added-pr-timeline-timestamps.md`.
- Updates `CLAUDE.md` with guidance to search existing documentation surfaces when behavior changes.

### Tests

- Adds coverage in `src-tauri/src/github/pr.rs` for clearing Go-zero timestamps and preserving valid timestamps.
- Adds deserialization coverage for pending and submitted review timestamps in `src-tauri/src/github/pr.rs`.