### PR TITLE
feat(lan,companion,ai): stream agent runs and enrich PR views

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -2,9 +2,13 @@
   phone over your local network from **Settings → Phone companion**: pair a device by
   scanning a QR code and typing a PIN. Scanning opens a slim companion web app right
   in your phone's browser — pair with the PIN, then read the repo's **Status, pull
-  requests, and CI** from your phone, read-only. Off by default, with per-device tokens
+  requests, and CI** from your phone, read-only. Open a pull request for its overview,
+  activity timeline, and review-thread conversation, and watch live **AI PR reviews and
+  agent sessions** stream in as they happen. Off by default, with per-device tokens
   you can review and revoke at any time (even while sharing is off), and connected
   phones are disconnected the moment you stop sharing, switch repos, or revoke their
-  device. The connection is served over HTTPS with a self-signed certificate GitDesktop
-  generates — your phone shows a one-time certificate warning on first connect, and the
-  pairing dialog shows the certificate's SHA-256 fingerprint so you can verify it.
+  device. While sharing is on, GitDesktop keeps your computer awake so a phone can keep
+  watching unattended (the display may still sleep). The connection is served over HTTPS
+  with a self-signed certificate GitDesktop generates — your phone shows a one-time
+  certificate warning on first connect, and the pairing dialog shows the certificate's
+  SHA-256 fingerprint so you can verify it.

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -4,6 +4,7 @@ import { ErrorState } from "./components/states";
 import { lastPairedAt } from "./lib/pairing-signal";
 import { asApiError, useStatus } from "./lib/queries";
 import { navigate, useRoute } from "./lib/router";
+import { AgentsBody, AgentWatch } from "./screens/Agents";
 import { CiBody, CiDetail } from "./screens/Ci";
 import { Pair } from "./screens/Pair";
 import { PrDetail, PrsBody } from "./screens/Prs";
@@ -111,6 +112,16 @@ function Screen({ route }: { route: ReturnType<typeof useRoute> }) {
       <CiDetail id={route.detailId} />
     ) : (
       <CiBody active />
+    );
+  }
+  if (route.tab === "agents") {
+    // The ternary UNMOUNTS the list while a watch is open, so the list's polling
+    // query stops on its own — the list is only mounted (and thus polling) in the
+    // else-arm, where it's always the active view.
+    return route.streamId != null ? (
+      <AgentWatch id={route.streamId} />
+    ) : (
+      <AgentsBody active />
     );
   }
   return <StatusBody active />;

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -2,6 +2,7 @@ import {
   GitBranchIcon,
   GitPullRequestIcon,
   PlayCircleIcon,
+  RobotIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
 import { navigate, type Tab, useRoute } from "../lib/router";
@@ -58,6 +59,12 @@ const TABS: { tab: Tab; label: string; icon: ReactNode; hash: string }[] = [
     hash: "#prs",
   },
   { tab: "ci", label: "CI", icon: <PlayCircleIcon size={22} />, hash: "#ci" },
+  {
+    tab: "agents",
+    label: "Agents",
+    icon: <RobotIcon size={22} />,
+    hash: "#agents",
+  },
 ];
 
 /** Bottom tab nav. Each tab is a real link (Tab-focusable); the active tab is
@@ -78,7 +85,7 @@ export function BottomNav() {
 
   return (
     <nav
-      className="sticky bottom-0 z-10 grid grid-cols-3 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)]"
+      className="sticky bottom-0 z-10 grid grid-cols-4 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)]"
       aria-label="Sections"
     >
       {TABS.map((t, i) => {

--- a/companion/src/components/chips.tsx
+++ b/companion/src/components/chips.tsx
@@ -5,7 +5,9 @@ import {
   ClockIcon,
   GitMergeIcon,
   GitPullRequestIcon,
+  MagnifyingGlassIcon,
   ProhibitIcon,
+  RobotIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
@@ -75,6 +77,27 @@ export function PrStateChip({
       icon={<GitPullRequestIcon size={14} />}
       label="Open"
       className="bg-success/15 text-success"
+    />
+  );
+}
+
+/** An agent stream's kind chip — an AI PR **review** or an agent **session**.
+ *  Icon + text so the distinction never rests on color alone (WCAG 1.4.1). */
+export function ReviewKindChip({ kind }: { kind: "review" | "session" }) {
+  if (kind === "review") {
+    return (
+      <Chip
+        icon={<MagnifyingGlassIcon size={14} />}
+        label="Review"
+        className="bg-info/15 text-info"
+      />
+    );
+  }
+  return (
+    <Chip
+      icon={<RobotIcon size={14} />}
+      label="Session"
+      className="bg-primary/15 text-primary"
     />
   );
 }

--- a/companion/src/components/markdown.tsx
+++ b/companion/src/components/markdown.tsx
@@ -1,0 +1,53 @@
+import DOMPurify from "dompurify";
+import { Marked } from "marked";
+import { useMemo } from "react";
+
+// Renders GitHub-flavored Markdown (PR descriptions, comments, review bodies, and
+// the agent watch's final answer). Modeled on the desktop's
+// `src/components/ui/markdown.tsx` — marked (GFM) → DOMPurify.sanitize →
+// dangerouslySetInnerHTML — but deliberately leaner for the phone bundle:
+//   • NO highlight.js — fenced code renders as marked's default escaped
+//     `<pre><code>`, styled by `.markdown-body pre` as a mono block that scrolls
+//     inside its OWN container (the page never scrolls sideways).
+//   • NO @tauri-apps/plugin-opener — this is a browser, so links just open in a new
+//     tab (`target="_blank"` + `rel="noopener noreferrer"`, set by the hook below so
+//     a tap never navigates the companion page away).
+// DOMPurify keeps its strict defaults: GitHub comments embed real HTML
+// (details/summary, tables, <img> badges) which are allowed, while scripts and
+// inline event handlers are stripped. (The page CSP `img-src 'self' data:` blocks
+// cross-origin badge images — expected; nothing here weakens it.)
+
+const md = new Marked({ gfm: true });
+
+// Force external links to open in a new tab without leaking the opener. Registered
+// once at module load (DOMPurify hooks are global to the singleton). Runs after
+// sanitize, so it only ever sees anchors DOMPurify already deemed safe.
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.tagName === "A") {
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
+
+/** Render a Markdown string as sanitized, formatted HTML. Styling lives in the
+ *  `.markdown-body` block in `index.css` (scoped, token-based). */
+export function Markdown({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  const html = useMemo(() => {
+    const raw = md.parse(children, { async: false }) as string;
+    return DOMPurify.sanitize(raw);
+  }, [children]);
+
+  return (
+    <div
+      className={className ? `markdown-body ${className}` : "markdown-body"}
+      // Sanitized above — DOMPurify strips scripts and event handlers.
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/companion/src/components/states.tsx
+++ b/companion/src/components/states.tsx
@@ -109,8 +109,8 @@ export function ErrorState({
     // A local-only repo (no `origin` remote — the desktop shows "Publish
     // repository…"). PRs/CI live on a forge, so there's nothing to fetch yet.
     // This is a teaching state, not an error: calm empty-state treatment, and NO
-    // retry (retrying can't conjure a remote). See `ApiError.isNoRemote` for why
-    // the detection is a display-only heuristic.
+    // retry (retrying can't conjure a remote). Detection is the server-minted
+    // `noRemote` error kind (see `ApiError.isNoRemote`).
     return (
       <CenteredState title="No remote yet">
         PRs and CI live on a forge like GitHub. Publish this repository from

--- a/companion/src/index.css
+++ b/companion/src/index.css
@@ -135,3 +135,156 @@
     }
   }
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Rendered GitHub-flavored Markdown (PR/comment/review bodies + the agent watch's
+   final answer). Scoped to `.markdown-body`, styled with the existing design
+   tokens so it matches the rest of the companion. Phone-sized type; the screen
+   already constrains line length. Wide content (code fences, tables) scrolls
+   inside its OWN container — the page body never scrolls sideways.
+   ───────────────────────────────────────────────────────────────────────────── */
+.markdown-body {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.markdown-body > *:first-child {
+  margin-top: 0;
+}
+.markdown-body > *:last-child {
+  margin-bottom: 0;
+}
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin: 1.25em 0 0.6em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.markdown-body h1 {
+  font-size: 1.35em;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.3em;
+}
+.markdown-body h2 {
+  font-size: 1.2em;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.3em;
+}
+.markdown-body h3 {
+  font-size: 1.1em;
+}
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  font-size: 1em;
+}
+.markdown-body h6 {
+  color: var(--muted-foreground);
+}
+.markdown-body p,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body blockquote,
+.markdown-body table,
+.markdown-body pre {
+  margin: 0.6em 0;
+}
+.markdown-body ul {
+  list-style: disc;
+  padding-left: 1.4em;
+}
+.markdown-body ol {
+  list-style: decimal;
+  padding-left: 1.4em;
+}
+.markdown-body li {
+  margin: 0.25em 0;
+}
+.markdown-body li ul,
+.markdown-body li ol {
+  margin: 0.25em 0;
+}
+.markdown-body a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.markdown-body strong {
+  font-weight: 600;
+}
+.markdown-body em {
+  font-style: italic;
+}
+.markdown-body code {
+  background-color: var(--muted);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+}
+.markdown-body pre {
+  background-color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+  /* Wide code scrolls inside the block, not the page. */
+  overflow-x: auto;
+}
+.markdown-body pre code {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.85em;
+}
+.markdown-body blockquote {
+  border-left: 2px solid var(--border);
+  padding-left: 0.75rem;
+  color: var(--muted-foreground);
+}
+.markdown-body hr {
+  margin: 1.25em 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+.markdown-body table {
+  /* Block + own scroll so a wide table never widens the page. */
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.6rem;
+  text-align: left;
+}
+.markdown-body th {
+  font-weight: 600;
+}
+.markdown-body img {
+  max-width: 100%;
+  height: auto;
+}
+.markdown-body input[type="checkbox"] {
+  margin-right: 0.4em;
+  vertical-align: middle;
+}
+.markdown-body li:has(input[type="checkbox"]) {
+  list-style: none;
+  margin-left: -1.4em;
+}
+.markdown-body details {
+  margin: 0.6em 0;
+}
+.markdown-body summary {
+  cursor: pointer;
+  font-weight: 500;
+  padding: 0.25em 0;
+}

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -76,9 +76,12 @@ export class ApiError extends Error {
    * teaching state instead.
    *
    * The server now mints a dedicated `400 { kind: "noRemote", … }` for this case,
-   * so detection is an exact `kind` match — no message-substring heuristic. (It
-   * previously sniffed the raw git stderr of a shared `kind: "git"` error, which
-   * would silently miss if git's wording changed.)
+   * so detection here is an exact `kind` match — no message-substring heuristic
+   * on this side. (This getter previously sniffed the raw git stderr of a shared
+   * `kind: "git"` error.) The wording-fragility didn't vanish, it moved: the LAN
+   * boundary (`lan/auth.rs`) still substring-matches git's "no such remote" to
+   * mint the kind — but now in exactly one server-side place, and a missed match
+   * degrades to the generic error-with-retry state, not a crash.
    */
   get isNoRemote(): boolean {
     return this.kind === "noRemote";

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -8,7 +8,13 @@
 // Authorization header anywhere here — `credentials: "same-origin"` is the whole
 // auth story. A 401 means the cookie is missing/revoked (→ re-pair).
 
-import type { PrDetails, PrInfo, RepoStatus } from "@/lib/git/types";
+import type {
+  PrDetails,
+  PrInfo,
+  PrTimelineEvent,
+  RepoStatus,
+  ReviewThreadOut,
+} from "@/lib/git/types";
 import type { RunDetail, WorkflowRun } from "@/lib/github/actions";
 
 /** A failed API call. `status` is the HTTP status (0 = the server was
@@ -69,17 +75,13 @@ export class ApiError extends Error {
    * fetched. NOT a failure to report as an error; the screens render a calm
    * teaching state instead.
    *
-   * The server surfaces this as `AppError::Git` (`kind: "git"`) whose message is
-   * the raw git stderr — `error: No such remote 'origin'` (confirmed by running
-   * `git remote get-url origin` on a remoteless repo). `kind: "git"` is shared by
-   * every git failure, so it can't distinguish this case; a case-insensitive
-   * substring on the message is the only signal. This is a DISPLAY-ONLY
-   * heuristic: if git's wording ever changes and the match misses, the screen
-   * simply falls back to the generic error-with-retry state — no correctness or
-   * data risk, just a less-tailored message.
+   * The server now mints a dedicated `400 { kind: "noRemote", … }` for this case,
+   * so detection is an exact `kind` match — no message-substring heuristic. (It
+   * previously sniffed the raw git stderr of a shared `kind: "git"` error, which
+   * would silently miss if git's wording changed.)
    */
   get isNoRemote(): boolean {
-    return this.kind === "git" && /no such remote/i.test(this.message);
+    return this.kind === "noRemote";
   }
 }
 
@@ -149,6 +151,29 @@ export const fetchCiRuns = (limit = 20) =>
 
 export const fetchCiRun = (id: number) =>
   getJson<RunDetail>(`/api/forge/ci/runs/${id}`);
+
+/** A PR's activity timeline (force-pushes, label changes, review requests, state
+ *  changes, approvals). Same neutral shape the desktop's `forgePrTimeline` returns. */
+export const fetchPrTimeline = (number: number) =>
+  getJson<PrTimelineEvent[]>(`/api/forge/prs/${number}/timeline`);
+
+/** A PR's file:line-anchored review threads with their comment chains. Same
+ *  neutral shape the desktop's `forgePrReviewThreads` returns. */
+export const fetchPrThreads = (number: number) =>
+  getJson<ReviewThreadOut[]>(`/api/forge/prs/${number}/threads`);
+
+// ── Agent streams (live AI review / agent sessions) ───────────────────────────
+
+/** One shareable agent stream — an AI PR review (`review`) or an agent session
+ *  (`session`). `id` is a UUID-like STRING (never a number). `startedAt` is
+ *  ISO-8601. The live event stream is at `/api/reviews/{id}/stream` (SSE). */
+export interface ReviewInfo {
+  id: string;
+  kind: "review" | "session";
+  startedAt: string;
+}
+
+export const fetchReviews = () => getJson<ReviewInfo[]>("/api/reviews");
 
 // ── Pairing ──────────────────────────────────────────────────────────────────
 

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -5,6 +5,9 @@ import {
   fetchCiRuns,
   fetchPr,
   fetchPrs,
+  fetchPrThreads,
+  fetchPrTimeline,
+  fetchReviews,
   fetchStatus,
 } from "./api";
 import { navigate } from "./router";
@@ -94,6 +97,38 @@ export function useCiRun(id: number | null) {
     queryFn: () => fetchCiRun(id as number),
     enabled: id != null,
     refetchInterval: id != null ? POLL_MS : (false as const),
+  });
+}
+
+/** The live agent streams (AI reviews + agent sessions) to watch. `active` gates
+ *  polling — pass false while a watch screen is open so the list doesn't poll
+ *  behind it. The watch screen also refetches THIS query to classify a stream that
+ *  closed without a terminal event (present → still live, gone → ended/unshared),
+ *  which is why it lives here (a react-query refetch routes a 401 through the
+ *  central QueryCache → `#pair`, unlike a raw fetch). */
+export function useReviews(active: boolean) {
+  return useQuery({
+    queryKey: ["reviews"],
+    queryFn: fetchReviews,
+    refetchInterval: poll(active),
+  });
+}
+
+export function usePrTimeline(number: number | null) {
+  return useQuery({
+    queryKey: ["pr", number, "timeline"],
+    queryFn: () => fetchPrTimeline(number as number),
+    enabled: number != null,
+    refetchInterval: number != null ? POLL_MS : (false as const),
+  });
+}
+
+export function usePrThreads(number: number | null) {
+  return useQuery({
+    queryKey: ["pr", number, "threads"],
+    queryFn: () => fetchPrThreads(number as number),
+    enabled: number != null,
+    refetchInterval: number != null ? POLL_MS : (false as const),
   });
 }
 

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -2,10 +2,15 @@ import { useMemo, useSyncExternalStore } from "react";
 
 // Hash routing ONLY — the LAN server serves a single `index.html` and does no
 // history-API rewriting, so every route lives in `location.hash`. Routes:
-//   #pair · #status · #prs · #prs/{n} · #ci · #ci/{id}
+//   #pair · #status · #prs · #prs/{n} · #ci · #ci/{id} · #agents · #agents/{id}
 // Default (empty / unknown hash) resolves to #status.
 
-export type Tab = "status" | "prs" | "ci";
+export type Tab = "status" | "prs" | "ci" | "agents";
+
+// Agent-stream ids are opaque UUID-like STRINGS (not numbers like PR/CI ids), so
+// they parse into their own `streamId` field. A conservative charset guard keeps
+// a malformed tail from ever reaching an EventSource URL.
+const STREAM_ID_RE = /^[0-9a-zA-Z-]{1,64}$/;
 
 export interface Route {
   /** The active bottom-tab. Pair is not a tab (it's a full-screen takeover). */
@@ -14,6 +19,9 @@ export interface Route {
   isPairing: boolean;
   /** A selected PR number (`#prs/{n}`) or CI run id (`#ci/{id}`), else null. */
   detailId: number | null;
+  /** A selected agent-stream id (`#agents/{id}`), else null. String because
+   *  stream ids are UUID-like, not numeric. Only parsed on the agents tab. */
+  streamId: string | null;
   /** The raw normalized hash (without the leading `#`). */
   raw: string;
 }
@@ -21,17 +29,35 @@ export interface Route {
 function parseHash(hash: string): Route {
   const raw = hash.replace(/^#/, "");
   if (raw === "pair") {
-    return { tab: "status", isPairing: true, detailId: null, raw };
+    return {
+      tab: "status",
+      isPairing: true,
+      detailId: null,
+      streamId: null,
+      raw,
+    };
   }
   const [head, tail] = raw.split("/", 2);
   const detailId = tail && /^\d+$/.test(tail) ? Number(tail) : null;
   switch (head) {
     case "prs":
-      return { tab: "prs", isPairing: false, detailId, raw };
+      return { tab: "prs", isPairing: false, detailId, streamId: null, raw };
     case "ci":
-      return { tab: "ci", isPairing: false, detailId, raw };
+      return { tab: "ci", isPairing: false, detailId, streamId: null, raw };
+    case "agents": {
+      // Stream ids are strings, so `detailId` never applies here; a tail that
+      // fails the charset guard falls back to the list (streamId null).
+      const streamId = tail && STREAM_ID_RE.test(tail) ? tail : null;
+      return { tab: "agents", isPairing: false, detailId: null, streamId, raw };
+    }
     default:
-      return { tab: "status", isPairing: false, detailId: null, raw };
+      return {
+        tab: "status",
+        isPairing: false,
+        detailId: null,
+        streamId: null,
+        raw,
+      };
   }
 }
 

--- a/companion/src/lib/use-review-stream.ts
+++ b/companion/src/lib/use-review-stream.ts
@@ -78,6 +78,7 @@ export interface StreamState {
 }
 
 type Action =
+  | { type: "opened" }
   | { type: "event"; event: ReviewEvent }
   | { type: "closed" }
   | { type: "gone" };
@@ -91,6 +92,12 @@ const initialState: StreamState = {
 
 function reducer(state: StreamState, action: Action): StreamState {
   switch (action.type) {
+    case "opened":
+      // The SSE connection is open. Move connecting → live so the UI leaves the
+      // skeleton even before the first event (keep-alive comments never surface
+      // through EventSource). ONLY from connecting — never resurrect a terminal
+      // (`ended`/`gone`) state if `onopen` somehow fires after a close.
+      return state.phase === "connecting" ? { ...state, phase: "live" } : state;
     case "closed":
       // A terminal event already settled the outcome → keep `ended`; otherwise the
       // probe (dispatched by the effect) will refine `ended`↔`gone`.
@@ -219,8 +226,20 @@ export function useReviewStream(id: string): StreamState {
 
   useEffect(() => {
     let terminalSeen = false;
+    // `closed` guards `onerror` against double-handling the permanent close.
+    // `cancelled` is a separate teardown flag flipped ONLY by the cleanup below —
+    // `closed` can't serve for the async probe guard because `onerror` sets it true
+    // before firing the probe, so a `closed` check there would always short-circuit.
     let closed = false;
+    let cancelled = false;
     const es = new EventSource(`/api/reviews/${encodeURIComponent(id)}/stream`);
+
+    es.onopen = () => {
+      // Connection established. Leave the connecting skeleton even before the first
+      // event (keep-alive comments don't surface through EventSource). The reducer
+      // only advances connecting → live, so this never resurrects a closed state.
+      if (!cancelled) dispatch({ type: "opened" });
+    };
 
     es.onmessage = (e) => {
       const event = parseEvent(e.data);
@@ -259,11 +278,13 @@ export function useReviewStream(id: string): StreamState {
           staleTime: 0,
         })
         .then((reviews) => {
+          if (cancelled) return; // unmounted / superseded — don't dispatch
           if (!reviews.some((r) => r.id === id)) {
             dispatch({ type: "gone" });
           }
         })
         .catch(() => {
+          if (cancelled) return;
           // A 401 already redirected via the QueryCache; any other probe failure
           // leaves the calmer `ended` state in place (we can't prove it's gone).
         });
@@ -271,6 +292,7 @@ export function useReviewStream(id: string): StreamState {
 
     return () => {
       closed = true;
+      cancelled = true;
       es.close();
     };
   }, [id]);

--- a/companion/src/lib/use-review-stream.ts
+++ b/companion/src/lib/use-review-stream.ts
@@ -1,0 +1,293 @@
+import { useEffect, useReducer } from "react";
+import { fetchReviews } from "./api";
+import { queryClient } from "./queries";
+
+// Live agent-stream watch over Server-Sent Events. The desktop broadcasts an AI
+// PR review or an agent session as a stream of `ReviewEvent`s; this hook opens the
+// SSE connection, folds the events into an ordered transcript, and classifies the
+// terminal / disconnected states per the epic's END-semantics contract.
+//
+// Wire contract (frozen; the server package guarantees it in the same PR):
+//   GET /api/reviews/{id}/stream → SSE, one ReviewEvent JSON per `data:` line.
+//   camelCase (`isError` / `costUsd`) — no snake_case fallback. Keep-alive comment
+//   lines arrive every 15s (EventSource ignores comments natively). NO replay:
+//   joining mid-run yields only events from then on.
+
+/** One event off the wire. `nativeSession` is bookkeeping only (never displayed). */
+export type ReviewEvent =
+  | { kind: "delta"; text: string }
+  | { kind: "status"; text: string }
+  | { kind: "tool"; tool: ToolKind; target: string | null }
+  | { kind: "done"; text: string; isError: boolean; costUsd: number | null }
+  | { kind: "error"; message: string }
+  | { kind: "nativeSession"; id: string };
+
+export type ToolKind =
+  | "read"
+  | "search"
+  | "list"
+  | "edit"
+  | "write"
+  | "run"
+  | "web-fetch"
+  | "web-search"
+  | "task"
+  | "other";
+
+const TOOL_KINDS = new Set<ToolKind>([
+  "read",
+  "search",
+  "list",
+  "edit",
+  "write",
+  "run",
+  "web-fetch",
+  "web-search",
+  "task",
+  "other",
+]);
+
+/** A rendered transcript row: a coalesced run of prose, or a single tool step.
+ *  Consecutive `delta`s fold into one trailing `text` segment; each `tool` closes
+ *  that run and appends a `step` (mirroring the desktop's transcript semantics). */
+export type Segment =
+  | { kind: "text"; text: string }
+  | { kind: "step"; tool: ToolKind; target: string | null };
+
+/** Terminal outcome once the run finishes. */
+export type Terminal =
+  | { kind: "done"; text: string; isError: boolean; costUsd: number | null }
+  | { kind: "error"; message: string };
+
+/** Connection lifecycle:
+ *  - `connecting` — the EventSource is opening, nothing received yet.
+ *  - `live` — receiving events; the run is in progress.
+ *  - `ended` — the stream finished (a terminal event arrived, OR it closed and the
+ *    run is still shared but no longer streaming).
+ *  - `gone` — the stream closed with no terminal and the id is no longer shared
+ *    (run ended / sharing off / repo switched / device revoked). */
+export type Phase = "connecting" | "live" | "ended" | "gone";
+
+export interface StreamState {
+  segments: Segment[];
+  /** The current transient progress note (replaced by each `status`, cleared by a
+   *  `delta`/`tool`). Never persisted into `segments`. */
+  statusText: string | null;
+  terminal: Terminal | null;
+  phase: Phase;
+}
+
+type Action =
+  | { type: "event"; event: ReviewEvent }
+  | { type: "closed" }
+  | { type: "gone" };
+
+const initialState: StreamState = {
+  segments: [],
+  statusText: null,
+  terminal: null,
+  phase: "connecting",
+};
+
+function reducer(state: StreamState, action: Action): StreamState {
+  switch (action.type) {
+    case "closed":
+      // A terminal event already settled the outcome → keep `ended`; otherwise the
+      // probe (dispatched by the effect) will refine `ended`↔`gone`.
+      return state.terminal ? state : { ...state, phase: "ended" };
+    case "gone":
+      return { ...state, phase: "gone" };
+    case "event": {
+      const ev = action.event;
+      switch (ev.kind) {
+        case "delta": {
+          // Coalesce into the trailing text run, or open a new one.
+          const segs = state.segments;
+          const last = segs[segs.length - 1];
+          const nextSegs: Segment[] =
+            last && last.kind === "text"
+              ? [
+                  ...segs.slice(0, -1),
+                  { kind: "text", text: last.text + ev.text },
+                ]
+              : [...segs, { kind: "text", text: ev.text }];
+          return {
+            ...state,
+            segments: nextSegs,
+            statusText: null,
+            phase: "live",
+          };
+        }
+        case "tool":
+          // A tool step closes the current text run and appends a step row.
+          return {
+            ...state,
+            segments: [
+              ...state.segments,
+              { kind: "step", tool: ev.tool, target: ev.target },
+            ],
+            statusText: null,
+            phase: "live",
+          };
+        case "status":
+          return { ...state, statusText: ev.text, phase: "live" };
+        case "done":
+          return {
+            ...state,
+            terminal: {
+              kind: "done",
+              text: ev.text,
+              isError: ev.isError,
+              costUsd: ev.costUsd,
+            },
+            statusText: null,
+            phase: "ended",
+          };
+        case "error":
+          return {
+            ...state,
+            terminal: { kind: "error", message: ev.message },
+            statusText: null,
+            phase: "ended",
+          };
+        default:
+          // `nativeSession` (and any future kind) — ignore for display.
+          return state;
+      }
+    }
+    default:
+      return state;
+  }
+}
+
+/** Parse one SSE `data:` payload into a {@link ReviewEvent}, with per-field
+ *  `typeof` guards (repo convention for untrusted JSON derivers). Returns null for
+ *  anything malformed — the caller drops it silently. */
+function parseEvent(raw: string): ReviewEvent | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof data !== "object" || data === null) return null;
+  const o = data as Record<string, unknown>;
+  switch (o.kind) {
+    case "delta":
+      return typeof o.text === "string"
+        ? { kind: "delta", text: o.text }
+        : null;
+    case "status":
+      return typeof o.text === "string"
+        ? { kind: "status", text: o.text }
+        : null;
+    case "tool": {
+      if (typeof o.tool !== "string" || !TOOL_KINDS.has(o.tool as ToolKind)) {
+        return null;
+      }
+      const target = typeof o.target === "string" ? o.target : null;
+      return { kind: "tool", tool: o.tool as ToolKind, target };
+    }
+    case "done":
+      return typeof o.text === "string" && typeof o.isError === "boolean"
+        ? {
+            kind: "done",
+            text: o.text,
+            isError: o.isError,
+            costUsd: typeof o.costUsd === "number" ? o.costUsd : null,
+          }
+        : null;
+    case "error":
+      return typeof o.message === "string"
+        ? { kind: "error", message: o.message }
+        : null;
+    case "nativeSession":
+      return typeof o.id === "string"
+        ? { kind: "nativeSession", id: o.id }
+        : null;
+    default:
+      return null;
+  }
+}
+
+/** Watch a live agent stream by id. Opens an EventSource (relative same-origin URL
+ *  — the `gd_lan` cookie rides automatically; the page CSP `connect-src 'self'`
+ *  covers it) and folds events into transcript state. Idempotent under StrictMode's
+ *  double-mount: the effect closes its own EventSource on cleanup. */
+export function useReviewStream(id: string): StreamState {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    let terminalSeen = false;
+    let closed = false;
+    const es = new EventSource(`/api/reviews/${encodeURIComponent(id)}/stream`);
+
+    es.onmessage = (e) => {
+      const event = parseEvent(e.data);
+      if (!event) return; // drop unparseable frames silently
+      if (event.kind === "done" || event.kind === "error") {
+        terminalSeen = true;
+      }
+      dispatch({ type: "event", event });
+    };
+
+    es.onerror = () => {
+      // EventSource fires `onerror` on every transient reconnect too; only a
+      // permanently-CLOSED source is a real end. The server closes the stream
+      // after a terminal event / lifecycle cut / channel close; the browser then
+      // reconnects, hits a non-200 (404 gone / 401 revoked), and goes CLOSED.
+      if (es.readyState !== EventSource.CLOSED || closed) return;
+      closed = true;
+      es.close();
+      dispatch({ type: "closed" });
+
+      // 1. Terminal already received → the finished state stands; no probe.
+      if (terminalSeen) return;
+
+      // 2. Closed without a terminal → classify via react-query (NOT a raw fetch,
+      //    so a 401 routes through the central QueryCache → `#pair`). `staleTime: 0`
+      //    forces a network round-trip: without it, `fetchQuery` serves the still-
+      //    fresh list cache (default staleTime 10_000) and no-ops — so a revoke or a
+      //    run ending within ~10s of the list rendering would never be observed (no
+      //    401 reaches the handler, the stale list still holds the id, `gone` never
+      //    fires, and the screen froze on "ended"). The probe deliberately bypasses
+      //    freshness so a revoke/end is always seen.
+      queryClient
+        .fetchQuery({
+          queryKey: ["reviews"],
+          queryFn: fetchReviews,
+          staleTime: 0,
+        })
+        .then((reviews) => {
+          if (!reviews.some((r) => r.id === id)) {
+            dispatch({ type: "gone" });
+          }
+        })
+        .catch(() => {
+          // A 401 already redirected via the QueryCache; any other probe failure
+          // leaves the calmer `ended` state in place (we can't prove it's gone).
+        });
+    };
+
+    return () => {
+      closed = true;
+      es.close();
+    };
+  }, [id]);
+
+  return state;
+}
+
+/** The desktop's tool-verb labels, mirrored for the transcript step rows. */
+export const TOOL_VERB: Record<ToolKind, string> = {
+  read: "Read",
+  search: "Searched",
+  list: "Listed",
+  edit: "Edited",
+  write: "Wrote",
+  run: "Ran",
+  "web-fetch": "Fetched",
+  "web-search": "Searched the web",
+  task: "Delegated",
+  other: "Used",
+};

--- a/companion/src/screens/Agents.tsx
+++ b/companion/src/screens/Agents.tsx
@@ -127,6 +127,16 @@ function WatchBody({ stream }: { stream: StreamState }) {
   // `showJump` is the small piece of derived state the button needs.
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const following = useRef(true);
+  // Last observed scrollTop, to read scroll DIRECTION. This is the fix for the
+  // auto-follow self-cancel: a smooth `scrollToBottom` emits intermediate `scroll`
+  // events whose positions momentarily read not-at-bottom. A position-only test would
+  // flip `following` false mid-animation and spuriously show "Jump to latest" though
+  // the user never scrolled. Direction sidesteps it entirely — a programmatic scroll
+  // only ever moves DOWN toward the bottom, so it never trips the "scrolled up" branch,
+  // and it re-arms following when it lands at the bottom. No guard flag / timeout, and
+  // no window where a genuine user scroll is ignored. (Reduced-motion "auto" jumps
+  // straight to bottom → an atBottom event → following stays true, unchanged.)
+  const lastScrollTop = useRef(0);
   const [showJump, setShowJump] = useState(false);
 
   const scrollToBottom = useCallback((smooth: boolean) => {
@@ -143,8 +153,13 @@ function WatchBody({ stream }: { stream: StreamState }) {
     if (!el) return;
     // A small tolerance so sub-pixel rounding never reads as "scrolled up".
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
-    following.current = atBottom;
-    setShowJump(!atBottom);
+    const scrolledUp = el.scrollTop < lastScrollTop.current - 1;
+    lastScrollTop.current = el.scrollTop;
+    // Stop following only on a deliberate UP scroll; re-arm at the bottom. A
+    // programmatic down-scroll never trips the up-branch, so it can't self-cancel.
+    if (atBottom) following.current = true;
+    else if (scrolledUp) following.current = false;
+    setShowJump(!following.current);
   }, []);
 
   // A primitive that changes on every new content frame — the last segment's text
@@ -176,7 +191,9 @@ function WatchBody({ stream }: { stream: StreamState }) {
         ) : (
           <>
             {phase === "live" ? <LiveNote /> : null}
-            {empty && phase !== "live" ? <EmptyTranscript /> : null}
+            {/* Live but nothing has streamed yet (or a Codex-style run whose only
+                output is its terminal). ended/gone own their own states below. */}
+            {empty && phase === "live" ? <EmptyTranscript /> : null}
             {segments.map((seg, i) => (
               <SegmentRow key={i} seg={seg} />
             ))}

--- a/companion/src/screens/Agents.tsx
+++ b/companion/src/screens/Agents.tsx
@@ -1,0 +1,412 @@
+import {
+  ArrowDownIcon,
+  ArrowLeftIcon,
+  CaretRightIcon,
+  CheckCircleIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ReviewKindChip } from "../components/chips";
+import { Markdown } from "../components/markdown";
+import {
+  EmptyState,
+  ErrorState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import { timeAgo } from "../lib/format";
+import { useReviews } from "../lib/queries";
+import { navigate } from "../lib/router";
+import {
+  type Segment,
+  type StreamState,
+  TOOL_VERB,
+  useReviewStream,
+} from "../lib/use-review-stream";
+import { useRovingList } from "../lib/use-roving-list";
+
+// The Agents tab: a list of live agent streams (AI PR reviews + agent sessions the
+// desktop is broadcasting), and a live watch screen over SSE — the epic's phone
+// killer feature. Read-only by design: no approve/deny/write affordances here.
+
+/** The agent-stream list. `active` gates polling (false while a watch is open). */
+export function AgentsBody({ active }: { active: boolean }) {
+  const { data, isError, error, refetch } = useReviews(active);
+  const { register, onKeyDown } = useRovingList();
+
+  // Prefer stale data: keep the last-known list on screen even on error, with a
+  // StaleBanner above it. Full-screen ErrorState only when there's nothing to
+  // show; skeleton only while the first fetch is pending. (401/409 route through
+  // ErrorState/the shell exactly like the other lists.)
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
+      {data.length === 0 ? (
+        <EmptyState
+          title="Nothing running"
+          hint="Start an AI review or agent session on your desktop to watch it here."
+        />
+      ) : (
+        <ul className="flex flex-col divide-y divide-border">
+          {data.map((r, i) => (
+            <li key={r.id}>
+              <button
+                type="button"
+                ref={register(i)}
+                onKeyDown={onKeyDown}
+                onClick={() => navigate(`#agents/${r.id}`)}
+                className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <ReviewKindChip kind={r.kind} />
+                    <span className="text-xs text-muted-foreground">
+                      {timeAgo(r.startedAt)}
+                    </span>
+                  </div>
+                  <p className="mt-1 truncate text-sm font-medium text-foreground">
+                    {r.kind === "review"
+                      ? "AI review in progress"
+                      : "Agent session in progress"}
+                  </p>
+                </div>
+                <CaretRightIcon
+                  size={16}
+                  className="shrink-0 text-muted-foreground"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Whether the OS/browser is set to reduced motion — read once (a watch session is
+ *  short; we don't need to react to a mid-session toggle). */
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
+  );
+}
+
+/** The live watch screen for one agent stream. */
+export function AgentWatch({ id }: { id: string }) {
+  const stream = useReviewStream(id);
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => navigate("#agents")}
+          className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+        >
+          <ArrowLeftIcon size={16} />
+          Agents
+        </button>
+      </div>
+      <WatchBody stream={stream} />
+    </div>
+  );
+}
+
+function WatchBody({ stream }: { stream: StreamState }) {
+  const { segments, statusText, terminal, phase } = stream;
+
+  // Auto-follow: keep pinned to newest content while the user is at the bottom; if
+  // they scroll up, stop following and reveal "Jump to latest". `following` is a
+  // ref (transient, read in effects/handlers only) so scroll churn never re-renders;
+  // `showJump` is the small piece of derived state the button needs.
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const following = useRef(true);
+  const [showJump, setShowJump] = useState(false);
+
+  const scrollToBottom = useCallback((smooth: boolean) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollTo({
+      top: el.scrollHeight,
+      behavior: smooth && !prefersReducedMotion() ? "smooth" : "auto",
+    });
+  }, []);
+
+  const onScroll = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    // A small tolerance so sub-pixel rounding never reads as "scrolled up".
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+    following.current = atBottom;
+    setShowJump(!atBottom);
+  }, []);
+
+  // A primitive that changes on every new content frame — the last segment's text
+  // length grows as deltas coalesce, a new tool step bumps the count, status/terminal
+  // change too. Depending on it (rather than the object refs) re-runs the pin effect
+  // once per frame.
+  const lastSeg = segments[segments.length - 1];
+  const contentKey = `${segments.length}:${lastSeg?.kind === "text" ? lastSeg.text.length : 0}:${statusText ?? ""}:${terminal ? terminal.kind : ""}`;
+
+  // Stay pinned to newest while the user is following. `following` is a ref, so a
+  // manual scroll-up (which flips it false) doesn't itself re-run this. `contentKey`
+  // is read here so this is a genuine dependency (the effect must re-run each frame).
+  useEffect(() => {
+    void contentKey;
+    if (following.current) scrollToBottom(true);
+  }, [contentKey, scrollToBottom]);
+
+  const empty = segments.length === 0 && !terminal && !statusText;
+
+  return (
+    <div className="relative flex flex-col">
+      <div
+        ref={scrollerRef}
+        onScroll={onScroll}
+        className="flex max-h-[calc(100dvh-8rem)] flex-col gap-3 overflow-y-auto px-4 py-4"
+      >
+        {phase === "connecting" ? (
+          <ConnectingState />
+        ) : (
+          <>
+            {phase === "live" ? <LiveNote /> : null}
+            {empty && phase !== "live" ? <EmptyTranscript /> : null}
+            {segments.map((seg, i) => (
+              <SegmentRow key={i} seg={seg} />
+            ))}
+            {statusText ? <StatusRow text={statusText} /> : null}
+            {terminal ? (
+              <TerminalCard terminal={terminal} segments={segments} />
+            ) : null}
+            {/* Closed without a terminal event but still shared (`ended`, no
+                terminal): otherwise the transcript would silently freeze with no
+                cue to tell "stopped" from "paused". `gone` has its own state. */}
+            {phase === "ended" && !terminal ? <EndedNote /> : null}
+            {phase === "gone" ? <GoneState /> : null}
+          </>
+        )}
+      </div>
+
+      {showJump ? (
+        <button
+          type="button"
+          onClick={() => {
+            following.current = true;
+            setShowJump(false);
+            scrollToBottom(true);
+          }}
+          className="absolute bottom-4 left-1/2 inline-flex min-h-9 -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground shadow-md"
+        >
+          <ArrowDownIcon size={14} weight="bold" />
+          Jump to latest
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** A live-connection note: there is no replay, so we say what "live" means. */
+function LiveNote() {
+  return (
+    <p
+      className="flex items-center gap-2 text-xs text-muted-foreground"
+      role="status"
+    >
+      <span
+        aria-hidden
+        className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-success"
+      />
+      Watching live — activity from when you joined
+    </p>
+  );
+}
+
+/** The opening state: connecting to the stream, nothing received yet. */
+function ConnectingState() {
+  return (
+    <div className="flex flex-col gap-3">
+      <p
+        className="flex items-center gap-2 text-xs text-muted-foreground"
+        role="status"
+      >
+        <span
+          aria-hidden
+          className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-muted-foreground"
+        />
+        Connecting to the live stream…
+      </p>
+      <SkeletonRows count={2} />
+    </div>
+  );
+}
+
+/** Connected & live, but nothing has streamed yet (or a Codex-style run that emits
+ *  no deltas before its terminal). A calm placeholder, never a blank region. */
+function EmptyTranscript() {
+  return (
+    <p className="text-sm text-muted-foreground">
+      Waiting for the agent's next step…
+    </p>
+  );
+}
+
+/** The stream closed and the run is no longer shared (ended / sharing off / repo
+ *  switched / device revoked). */
+function GoneState() {
+  return (
+    <div className="flex flex-col items-start gap-3 rounded-md border border-border bg-muted/40 px-4 py-4">
+      <p className="text-sm font-medium text-foreground">
+        This run ended or is no longer shared.
+      </p>
+      <button
+        type="button"
+        onClick={() => navigate("#agents")}
+        className="inline-flex min-h-9 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+      >
+        <ArrowLeftIcon size={14} />
+        Back to agents
+      </button>
+    </div>
+  );
+}
+
+/** One transcript row — a prose run or a tool step. */
+function SegmentRow({ seg }: { seg: Segment }) {
+  if (seg.kind === "text") {
+    // Formatted markdown, matching the desktop's live watch — the accumulating
+    // buffer re-parses as deltas arrive (partial-markdown artifacts are momentary
+    // and marked tolerates incomplete input). Only the TRAILING run's `children`
+    // changes per frame; earlier runs are stable and `Markdown` memoizes its parse
+    // on `children`, so per-frame cost is a single parse. `.markdown-body` collapses
+    // its first/last-child margins, so a run sits in the transcript's `gap-3` rhythm.
+    return <Markdown className="text-foreground/90">{seg.text}</Markdown>;
+  }
+  return (
+    <p className="flex min-w-0 items-baseline gap-2 text-xs text-muted-foreground">
+      <span className="shrink-0 font-medium text-foreground/70">
+        {TOOL_VERB[seg.tool]}
+      </span>
+      {seg.target ? (
+        // CSS truncation (single-line ellipsis), never JS slicing — the server
+        // already clips the target to ~2000 chars.
+        <span className="truncate font-mono">{seg.target}</span>
+      ) : null}
+    </p>
+  );
+}
+
+/** The current transient progress note (replaced by each new status). */
+function StatusRow({ text }: { text: string }) {
+  return (
+    <p
+      className="flex items-center gap-2 text-xs italic text-muted-foreground"
+      role="status"
+    >
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-muted-foreground"
+      />
+      {text}
+    </p>
+  );
+}
+
+/** The stream closed WITHOUT a terminal event, but the run is still shared (`ended`
+ *  with no `done`/`error`). A small designed cue so a stopped stream reads as
+ *  stopped, not paused. (`gone` — no longer shared — has its own richer state.) */
+function EndedNote() {
+  return (
+    <p
+      className="flex items-center gap-2 text-xs text-muted-foreground"
+      role="status"
+    >
+      <span
+        aria-hidden
+        className="h-2 w-2 shrink-0 rounded-full bg-muted-foreground"
+      />
+      Stream ended.
+    </p>
+  );
+}
+
+/** Whether the terminal `done.text` is already the tail of the streamed transcript
+ *  — true for a Claude run (its delta buffer ends verbatim with `Done.text`, per
+ *  `agent.rs`), so the completion card is metadata-only and doesn't repeat the whole
+ *  answer. False for Codex (emits no deltas) or a divergent final answer — those
+ *  render `terminal.text` as the card body so it's never lost. */
+function terminalDuplicatesTranscript(
+  text: string,
+  segments: Segment[],
+): boolean {
+  const answer = text.trim();
+  if (!answer) return true; // nothing to add
+  const lastText = [...segments].reverse().find((s) => s.kind === "text");
+  return lastText?.kind === "text" && lastText.text.trim().endsWith(answer);
+}
+
+/** The terminal card — a completed run (its final answer + optional cost) or a
+ *  failure. The final answer is shown as the card body ONLY when it isn't already
+ *  the tail of the streamed transcript (see {@link terminalDuplicatesTranscript}). */
+function TerminalCard({
+  terminal,
+  segments,
+}: {
+  terminal: NonNullable<StreamState["terminal"]>;
+  segments: Segment[];
+}) {
+  if (terminal.kind === "error") {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3">
+        <p className="flex items-center gap-2 text-sm font-medium text-destructive">
+          <WarningCircleIcon size={16} weight="fill" />
+          The run failed.
+        </p>
+        <p className="whitespace-pre-wrap break-words text-sm text-foreground/90">
+          {terminal.message}
+        </p>
+      </div>
+    );
+  }
+
+  const cost =
+    terminal.costUsd != null ? `$${terminal.costUsd.toFixed(2)}` : null;
+  const showBody =
+    terminal.text.trim().length > 0 &&
+    !terminalDuplicatesTranscript(terminal.text, segments);
+
+  if (terminal.isError) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3">
+        <p className="flex items-center gap-2 text-sm font-medium text-destructive">
+          <WarningCircleIcon size={16} weight="fill" />
+          Finished with an error
+          {cost ? <span className="font-normal">· {cost}</span> : null}
+        </p>
+        {showBody ? (
+          <Markdown className="text-foreground/90">{terminal.text}</Markdown>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-success/40 bg-success/10 px-4 py-3">
+      <p className="flex items-center gap-2 text-sm font-medium text-success">
+        <CheckCircleIcon size={16} weight="fill" />
+        Done
+        {cost ? (
+          <span className="font-normal text-muted-foreground">· {cost}</span>
+        ) : null}
+      </p>
+      {showBody ? (
+        <Markdown className="text-foreground/90">{terminal.text}</Markdown>
+      ) : null}
+    </div>
+  );
+}

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -192,9 +192,20 @@ type ConversationEntry = { comment: PrThreadOut; isReview: boolean };
  *  the EXISTING `usePr` detail (no new query), so there's no separate loading/error
  *  state — the surrounding PrDetail already owns those. */
 function ConversationSection({ detail }: { detail: PrDetails }) {
+  // Drop GitHub's thread-reply wrapper reviews: replying to a review thread outside
+  // a batched review makes GitHub auto-wrap the reply in a new empty-body COMMENTED
+  // review (state delivered uppercase verbatim). Rendered here it's a contentless
+  // "Reviewed · No comment" card duplicating the reply already shown under Review
+  // threads. Matches the desktop's filter (RemotePrView.tsx) at its "body blank AND
+  // COMMENTED" core; the accepted tradeoff is that a genuinely empty COMMENTED review
+  // is also hidden (GitHub's reply-wrapping is by far the dominant producer). A
+  // bodyless APPROVED / CHANGES_REQUESTED still renders — its verdict carries meaning.
+  const visibleReviews = detail.reviews.filter(
+    (r) => r.body.trim().length > 0 || r.state.toUpperCase() !== "COMMENTED",
+  );
   const entries: ConversationEntry[] = [
     ...detail.comments.map((c) => ({ comment: c, isReview: false })),
-    ...detail.reviews.map((c) => ({ comment: c, isReview: true })),
+    ...visibleReviews.map((c) => ({ comment: c, isReview: true })),
   ].sort((a, b) => dateOrder(a.comment.date) - dateOrder(b.comment.date));
 
   return (

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -1,6 +1,21 @@
-import { ArrowLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
-import type { PrInfo } from "@/lib/git/types";
+import {
+  ArrowClockwiseIcon,
+  ArrowLeftIcon,
+  CaretRightIcon,
+  ChatCircleIcon,
+  CheckCircleIcon,
+  EyeSlashIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import type {
+  PrDetails,
+  PrInfo,
+  PrThreadOut,
+  PrTimelineEvent,
+  ReviewThreadOut,
+} from "@/lib/git/types";
 import { PrStateChip } from "../components/chips";
+import { Markdown } from "../components/markdown";
 import {
   EmptyState,
   ErrorState,
@@ -8,7 +23,7 @@ import {
   StaleBanner,
 } from "../components/states";
 import { timeAgo } from "../lib/format";
-import { usePr, usePrs } from "../lib/queries";
+import { usePr, usePrs, usePrThreads, usePrTimeline } from "../lib/queries";
 import { navigate } from "../lib/router";
 import { useRovingList } from "../lib/use-roving-list";
 
@@ -122,16 +137,308 @@ export function PrDetail({ number }: { number: number }) {
           </header>
 
           {data.body ? (
-            <p className="whitespace-pre-wrap break-words text-sm text-foreground/90">
-              {data.body}
-            </p>
+            <Markdown className="text-foreground/90">{data.body}</Markdown>
           ) : (
             <p className="text-sm italic text-muted-foreground">
               No description.
             </p>
           )}
+
+          <ConversationSection detail={data} />
+          <ActivitySection number={number} />
+          <ThreadsSection number={number} />
         </article>
       )}
     </div>
+  );
+}
+
+/** A section heading, matching the PrDetail overview typography. */
+function SectionHeading({ children }: { children: string }) {
+  return (
+    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+      {children}
+    </p>
+  );
+}
+
+/** A compact inline error with retry, scoped to ONE conversation section — a
+ *  failure here must never blank the whole PrDetail (the overview stays up). */
+function SectionError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
+      <span className="flex items-center gap-2 text-muted-foreground">
+        <WarningCircleIcon size={16} className="shrink-0 text-destructive" />
+        Couldn't load this section.
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex min-h-9 shrink-0 items-center gap-1 rounded px-2 py-1 font-medium text-primary"
+      >
+        <ArrowClockwiseIcon size={14} weight="bold" />
+        Retry
+      </button>
+    </div>
+  );
+}
+
+// One conversation entry — a plain comment or a review verdict — merged into a
+// single chronological stream. `state` is empty for comments and a review verdict
+// (APPROVED / CHANGES_REQUESTED / COMMENTED / …) for reviews.
+type ConversationEntry = { comment: PrThreadOut; isReview: boolean };
+
+/** The PR's conversation: plain comments and review verdicts, in date order. Reads
+ *  the EXISTING `usePr` detail (no new query), so there's no separate loading/error
+ *  state — the surrounding PrDetail already owns those. */
+function ConversationSection({ detail }: { detail: PrDetails }) {
+  const entries: ConversationEntry[] = [
+    ...detail.comments.map((c) => ({ comment: c, isReview: false })),
+    ...detail.reviews.map((c) => ({ comment: c, isReview: true })),
+  ].sort((a, b) => dateOrder(a.comment.date) - dateOrder(b.comment.date));
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeading>Conversation</SectionHeading>
+      {entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No comments yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {entries.map((e) => (
+            <CommentCard
+              key={`${e.isReview ? "r" : "c"}:${e.comment.id}`}
+              comment={e.comment}
+              isReview={e.isReview}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/** Sort key for a conversation entry — parsed epoch ms, or 0 for an empty/invalid
+ *  date (keeps such rows first without reordering each other, Array.sort here is
+ *  stable). */
+function dateOrder(iso: string): number {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/** One conversation row. A review verdict leads with its state chip; a plain
+ *  comment is just author + time + body. A minimized comment collapses to a hidden
+ *  line instead of its body. Body renders as GitHub-flavored Markdown (same as the
+ *  PR body). */
+function CommentCard({
+  comment,
+  isReview,
+}: {
+  comment: PrThreadOut;
+  isReview: boolean;
+}) {
+  return (
+    <li className="flex flex-col gap-1 rounded-md border border-border px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-foreground/80">
+          {comment.author || "unknown"}
+        </span>
+        {isReview && comment.state ? (
+          <ReviewStateBadge state={comment.state} />
+        ) : null}
+        {comment.date ? (
+          <span className="text-xs text-muted-foreground">
+            {timeAgo(comment.date)}
+          </span>
+        ) : null}
+      </div>
+      {comment.isMinimized ? (
+        <p className="flex items-center gap-1.5 text-xs italic text-muted-foreground">
+          <EyeSlashIcon size={14} className="shrink-0" />
+          Comment hidden
+          {comment.minimizedReason ? ` (${comment.minimizedReason})` : ""}
+        </p>
+      ) : comment.body ? (
+        <Markdown className="text-foreground/90">{comment.body}</Markdown>
+      ) : isReview ? (
+        // A bodyless review (e.g. a bare approval) — the verdict chip above says it all.
+        <p className="text-sm italic text-muted-foreground">No comment.</p>
+      ) : null}
+    </li>
+  );
+}
+
+/** A review verdict badge — icon + text so the verdict never rests on color alone
+ *  (WCAG 1.4.1). Recognizes the GitHub-convention states; any other string renders
+ *  verbatim with a neutral look. */
+function ReviewStateBadge({ state }: { state: string }) {
+  const s = state.toLowerCase();
+  if (s === "approved") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+        <CheckCircleIcon size={12} weight="fill" />
+        Approved
+      </span>
+    );
+  }
+  if (s === "changes_requested") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-destructive/15 px-2 py-0.5 text-xs font-medium text-destructive">
+        <WarningCircleIcon size={12} weight="fill" />
+        Changes requested
+      </span>
+    );
+  }
+  if (s === "commented") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+        <ChatCircleIcon size={12} />
+        Reviewed
+      </span>
+    );
+  }
+  // Dismissed, pending, or any other provider string — show it verbatim, neutral.
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      <ChatCircleIcon size={12} />
+      {state}
+    </span>
+  );
+}
+
+/** The PR's activity timeline (force-pushes, labels, review requests, state
+ *  changes). Polls while the detail is open; a failure shows an inline retry. */
+function ActivitySection({ number }: { number: number }) {
+  const { data, isPending, isError, refetch } = usePrTimeline(number);
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeading>Activity</SectionHeading>
+      {isError && !data ? (
+        <SectionError onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={2} />
+      ) : data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No activity yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {data.map((ev, i) => {
+            const row = timelineRow(ev);
+            if (!row) return null; // unknown kind → skip silently (forward-compat)
+            return (
+              <li
+                key={i}
+                className="flex items-baseline justify-between gap-2 text-xs"
+              >
+                <span className="min-w-0 text-foreground/90">{row}</span>
+                <span className="shrink-0 text-muted-foreground">
+                  {timeAgo(ev.date)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/** Render one timeline event as a compact verb + actor phrase. Returns null for an
+ *  unknown kind so the caller can skip it (forward-compatible with new events). */
+function timelineRow(ev: PrTimelineEvent): string | null {
+  const by = (actor: string) => (actor ? ` by ${actor}` : "");
+  switch (ev.kind) {
+    case "forcePushed":
+      return `Force-pushed ${short(ev.before)} → ${short(ev.after)}${by(ev.actor)}`;
+    case "labeled":
+      return `${ev.added ? "Added" : "Removed"} label “${ev.label}”${by(ev.actor)}`;
+    case "reviewRequested":
+      return `Requested review from ${ev.reviewer || "someone"}${by(ev.actor)}`;
+    case "readyForReview":
+      return `Marked ready for review${by(ev.actor)}`;
+    case "convertToDraft":
+      return `Converted to draft${by(ev.actor)}`;
+    case "approved":
+      return `Approved${by(ev.actor)}`;
+    case "changesRequested":
+      return `Requested changes${by(ev.actor)}`;
+    case "unapproved":
+      return `Dismissed approval${by(ev.actor)}`;
+    case "closed":
+      return `Closed${by(ev.actor)}`;
+    case "reopened":
+      return `Reopened${by(ev.actor)}`;
+    case "merged":
+      return `Merged${by(ev.actor)}`;
+    case "renamed":
+      return `Renamed “${ev.previous}” → “${ev.current}”${by(ev.actor)}`;
+    default:
+      return null;
+  }
+}
+
+/** Shorten a commit oid to its short form; "" stays "". */
+function short(oid: string): string {
+  return oid ? oid.slice(0, 7) : "";
+}
+
+/** The PR's file:line-anchored review threads with their comments. Polls while the
+ *  detail is open; a failure shows an inline retry. The diff hunk is deliberately
+ *  omitted (too wide for the phone). */
+function ThreadsSection({ number }: { number: number }) {
+  const { data, isPending, isError, refetch } = usePrThreads(number);
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeading>Review threads</SectionHeading>
+      {isError && !data ? (
+        <SectionError onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={2} />
+      ) : data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No review threads.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {data.map((thread) => (
+            <ThreadCard key={thread.id} thread={thread} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ThreadCard({ thread }: { thread: ReviewThreadOut }) {
+  return (
+    <li className="flex flex-col gap-2 rounded-md border border-border px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="min-w-0 truncate font-mono text-xs text-foreground/80">
+          {thread.path}
+          {thread.line > 0 ? `:${thread.line}` : ""}
+        </span>
+        {thread.isResolved ? (
+          <span className="rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+            Resolved
+          </span>
+        ) : null}
+        {thread.isOutdated ? (
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            Outdated
+          </span>
+        ) : null}
+      </div>
+      <ul className="flex flex-col gap-2">
+        {thread.comments.map((c) => (
+          <li key={c.id} className="flex flex-col gap-1">
+            <p className="flex items-baseline gap-2 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground/80">
+                {c.author || "unknown"}
+              </span>
+              {c.date ? <span>{timeAgo(c.date)}</span> : null}
+            </p>
+            <Markdown className="text-foreground/90">{c.body}</Markdown>
+          </li>
+        ))}
+      </ul>
+    </li>
   );
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "chrono",
  "dirs",
  "futures-util",
+ "keepawake",
  "keyring",
  "local-ip-address",
  "os_info",
@@ -1766,6 +1767,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -2425,6 +2427,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keepawake"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5521b450ec179362595d5cbda7c3abd5da3af3dff58456434ad3ca33c95226b7"
+dependencies = [
+ "cfg-if",
+ "derive_builder",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "zbus",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,7 +2915,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -2970,6 +2989,20 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "dispatch2",
  "libc",
  "objc2",
  "objc2-core-foundation",
@@ -6106,11 +6139,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6120,6 +6165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6168,7 +6222,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -6235,6 +6300,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6393,6 +6468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,6 +94,14 @@ rustls-pki-types = { version = "1", features = ["std"] }
 # from disk at request time (no rebuild needed to pick up a fresh frontend build) — that
 # IS the dev loop; RELEASE builds bake the files in.
 rust-embed = { version = "8.12.0", features = ["mime-guess"] }
+# Keep the desktop awake while the LAN companion is sharing (src/lan/keep_awake.rs):
+# the phone's value is unattended monitoring, so the machine must not sleep mid-watch.
+# `keepawake` requests a system-stays-awake hold (display may still sleep) via the OS
+# power API — `SetThreadExecutionState` on Windows (drags a pure-Rust `windows` crate,
+# Win32_System_Power only), IOKit on macOS, org.freedesktop inhibit (zbus) on Linux —
+# all pure-Rust, no aws-lc/NASM, 3-OS CI-safe. RAII guard released on Drop; held on a
+# dedicated thread because the Windows API is thread-affine (see keep_awake.rs).
+keepawake = "0.6"
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
@@ -131,3 +139,7 @@ tower = { version = "0.5.3", features = ["util"] }
 # is already in the graph via tauri-plugin-http, so this is near-zero extra compile;
 # `rustls-tls` (no default features) keeps it off the native-TLS / aws-lc path.
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+# RAII temp dirs for the TLS-material tests (src/lan/tls.rs): a killed or panicking
+# test run must not leak private-key material into the system temp dir — `TempDir`
+# removes the directory on Drop. Already in the graph transitively, so near-zero cost.
+tempfile = "3"

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -89,7 +89,7 @@ pub struct AgentInfo {
 
 /// Streaming events sent to the frontend over the review channel.
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum ReviewEvent {
     /// A chunk of assistant text to append to the rendered review.
     Delta { text: String },
@@ -1842,6 +1842,12 @@ pub async fn agent_review(
     system_prompt: String,
     user_prompt: String,
     repo_path: String,
+    // A repo-aware PR-head review runs in a throwaway DETACHED worktree pinned at the
+    // PR head, so `repo_path` is that worktree. The LAN monitor scopes streams by the
+    // ORIGIN repo (the shared one), so pass it here to keep such a review visible to a
+    // paired phone; `None` (the default / a non-worktree review) falls back to
+    // `repo_path`. Mirror of `agent_session`'s `origin_repo_path`.
+    origin_repo_path: Option<String>,
     repo_aware: bool,
     // Attach GitDesktop ITSELF as a read-only MCP server (`gitdesktop mcp --repo
     // <repo_path>`) so the review agent can pull the full PR diff / read files at
@@ -1956,7 +1962,11 @@ pub async fn agent_review(
     // it, fanning events out to the LAN broadcast alongside the desktop channel.
     // The guard clears the entry on every exit path (registered lifetime ==
     // streaming lifetime); the desktop leg stays byte-for-byte unchanged.
-    let tx = state.register_stream(&review_id, "review", &repo_path);
+    let tx = state.register_stream(
+        &review_id,
+        "review",
+        origin_repo_path.as_deref().unwrap_or(&repo_path),
+    );
     let _stream_guard = StreamGuard {
         state: &state,
         id: review_id.clone(),
@@ -2458,6 +2468,25 @@ pub async fn agent_session(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn done_event_serializes_multi_word_fields_as_camel_case() {
+        // The struct-variant FIELDS must hit the wire camelCase (`isError`/`costUsd`),
+        // which every desktop consumer + the phone monitor read. `rename_all` on the
+        // enum renames variants only; `rename_all_fields` is what renames the fields.
+        let json = serde_json::to_value(ReviewEvent::Done {
+            text: "all done".to_string(),
+            is_error: true,
+            cost_usd: Some(0.42),
+        })
+        .unwrap();
+        assert_eq!(json["kind"], "done");
+        assert_eq!(json["isError"], true);
+        assert_eq!(json["costUsd"], 0.42);
+        // The snake_case field names must NOT appear on the wire.
+        assert!(json.get("is_error").is_none());
+        assert!(json.get("cost_usd").is_none());
+    }
 
     // Real opencode `run --format json` lines (captured 2026-06-23, v1.17.9).
     const STEP_START: &str = r#"{"type":"step_start","sessionID":"ses_abc","part":{"type":"step-start"}}"#;

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -991,10 +991,23 @@ fn bad_request(msg: &str) -> Response {
 }
 
 /// Map an [`AppError`] to an HTTP response for the route handlers: `NotARepo` and
-/// `InvalidArgument` → 400; everything else → 502. The body reuses the app's own
-/// `{ kind, message }` serialization so a phone client sees the same shape the
-/// desktop frontend does.
+/// `InvalidArgument` → 400; a "no such remote" git failure → a dedicated 400
+/// `noRemote` (see [`no_remote_response`]); everything else → 502. The body reuses
+/// the app's own `{ kind, message }` serialization so a phone client sees the same
+/// shape the desktop frontend does.
 pub fn app_error_response(err: &AppError) -> Response {
+    // A remoteless repo surfaces as a `Git` failure whose stderr is `error: No such
+    // remote 'origin'` (chain: gh_lens_slug → git_remote_url). Its raw serialization
+    // leaks a `git`-kind 502 with `code`/`stderr`, which the companion can't classify.
+    // Re-map it to a clean 400 `noRemote` so the phone shows an actionable notice. The
+    // `AppError` enum stays untouched — this mapping lives only at the LAN boundary.
+    if let AppError::Git { stderr, .. } = err {
+        if stderr.to_ascii_lowercase().contains("no such remote")
+            || err.to_string().to_ascii_lowercase().contains("no such remote")
+        {
+            return no_remote_response();
+        }
+    }
     let status = match err {
         AppError::NotARepo(_) | AppError::InvalidArgument(_) => StatusCode::BAD_REQUEST,
         _ => StatusCode::BAD_GATEWAY,
@@ -1005,9 +1018,58 @@ pub fn app_error_response(err: &AppError) -> Response {
     (status, Json(body)).into_response()
 }
 
+/// The 400 returned when a forge route hits a repo with no `origin` remote. NOT 409
+/// (the companion reads any 409 as `noActiveRepo` by status alone) and NOT 401/429
+/// (auth / rate-limit semantics); 400 is the frozen choice. The body omits the
+/// `code`/`stderr` the raw `Git` serialization would carry.
+fn no_remote_response() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "kind": "noRemote",
+            "message": "This repository has no 'origin' remote."
+        })),
+    )
+        .into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn no_such_remote_git_error_maps_to_400_no_remote() {
+        // A remoteless repo surfaces as a `Git` error whose stderr is
+        // `error: No such remote 'origin'`. `app_error_response` must re-map it to a
+        // clean 400 `noRemote` (NOT the raw `git`-kind 502), with no code/stderr.
+        let err = AppError::Git {
+            code: 128,
+            stderr: "error: No such remote 'origin'".to_string(),
+        };
+        let resp = app_error_response(&err);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "noRemote");
+        assert_eq!(body["message"], "This repository has no 'origin' remote.");
+        assert!(body.get("code").is_none());
+        assert!(body.get("stderr").is_none());
+
+        // A control: an unrelated git error still passes through as a 502 `git`.
+        let other = AppError::Git {
+            code: 1,
+            stderr: "fatal: some other failure".to_string(),
+        };
+        let resp = app_error_response(&other);
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "git");
+    }
 
     #[test]
     fn proof_round_trips_both_directions() {

--- a/src-tauri/src/lan/keep_awake.rs
+++ b/src-tauri/src/lan/keep_awake.rs
@@ -1,0 +1,160 @@
+//! Keep the desktop awake while the LAN companion is sharing.
+//!
+//! The phone companion's whole value is *unattended* monitoring — a phone
+//! watching an agent run or CI is useless if the desktop falls asleep mid-watch.
+//! So while sharing is on we hold a system-stays-awake request (the display may
+//! still sleep — only the machine is kept from suspending). The hold is tied
+//! exactly to the LAN server lifecycle: acquired in `lan_enable`, released when
+//! the [`RunningServer`](super::RunningServer) is dropped (disable, mode-switch
+//! restart — the only paths that drop a live server; the enable-path store only
+//! ever assigns onto `None`). No quit hook is needed — the OS clears the request
+//! on process death.
+//!
+//! ## Why a dedicated holder thread
+//!
+//! On Windows the underlying request is `SetThreadExecutionState`, which is
+//! **thread-affine**: it sets state on the *calling* thread and the RAII guard's
+//! `Drop` restores it on the *dropping* thread. `lan_enable`/`lan_disable` are
+//! async Tauri commands running on tokio worker threads, so a guard created on
+//! worker T1 and dropped on worker T2 would leak the hold until process exit.
+//!
+//! [`KeepAwakeHold`] sidesteps this by owning a dedicated OS thread: that thread
+//! builds the guard and then blocks, so both the acquire and the release
+//! (`Drop`) happen on the *same* thread. Dropping the hold disconnects the
+//! channel, the holder thread unblocks, the guard drops on that thread, and the
+//! thread exits. The dropping thread never blocks or joins.
+//!
+//! Keep-awake is **best-effort**: a build failure (a headless CI box, a denied
+//! power request) logs a warning to stderr and yields `None` — it never fails or
+//! delays `lan_enable`.
+
+use std::sync::mpsc;
+use std::thread;
+
+/// A system-stays-awake hold, owned for its `Drop`. Held on a dedicated OS thread
+/// so acquire and release happen on the same thread (`SetThreadExecutionState` is
+/// thread-affine — see the module docs). Dropping this disconnects `stop`, which
+/// unblocks the holder thread so the keep-awake guard drops there.
+pub struct KeepAwakeHold {
+    /// Send half of the stop channel. Held only so its `Drop` disconnects the
+    /// channel; the value is never sent or read — dropping the field (when this
+    /// hold drops) is exactly the release signal to the holder thread. Hence
+    /// `dead_code`: it's load-bearing for its `Drop`, not for any read.
+    #[allow(dead_code)]
+    stop: mpsc::Sender<()>,
+}
+
+impl KeepAwakeHold {
+    /// Acquire a keep-awake hold on a dedicated thread. Returns `Some(hold)` once
+    /// the holder thread has successfully built the OS request; returns `None`
+    /// (after a stderr warning) if the request could not be built — keep-awake is
+    /// best-effort and must never fail `lan_enable`.
+    ///
+    /// The `ready` handshake makes acquisition synchronous only up to "did the
+    /// guard build": we block on it just long enough to learn success/failure,
+    /// then return. The guard then lives on the holder thread until this hold is
+    /// dropped.
+    pub fn acquire() -> Option<KeepAwakeHold> {
+        Self::acquire_inner().map(|(hold, _exited)| hold)
+    }
+
+    /// The acquire body, also returning an `exited` receiver whose channel
+    /// DISCONNECTS when the holder thread ends (its sender lives on that thread and
+    /// is dropped when the thread returns) — the seam the unit test uses to assert
+    /// release without depending on the OS actually granting the power request.
+    fn acquire_inner() -> Option<(KeepAwakeHold, mpsc::Receiver<()>)> {
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let (ready_tx, ready_rx) = mpsc::channel::<bool>();
+        let (exited_tx, exited_rx) = mpsc::channel::<()>();
+
+        thread::Builder::new()
+            .name("lan-keep-awake".to_string())
+            .spawn(move || {
+                // `exited_tx` fires on Drop (i.e. when this thread unwinds/returns),
+                // regardless of which branch we take — the test's release signal.
+                let _exited = exited_tx;
+                let guard = keepawake::Builder::default()
+                    .idle(true) // system stays awake…
+                    .display(false) // …display may sleep
+                    // Intentionally NOT .sleep(true): away-mode is a relic
+                    // unsupported under Modern Standby.
+                    .reason("Phone companion sharing")
+                    .app_name("GitDesktop")
+                    .app_reverse_domain("com.thebguy.gitdesktop")
+                    .create();
+                match guard {
+                    Ok(guard) => {
+                        // Signal success, then park until the hold is dropped. `recv`
+                        // returns `Err` once every `stop` sender is gone → we fall
+                        // through, `guard` drops HERE (same thread it was built on),
+                        // and the thread exits.
+                        let _ = ready_tx.send(true);
+                        let _ = stop_rx.recv();
+                        drop(guard);
+                    }
+                    Err(e) => {
+                        // Match the module's neighbor (server.rs): log to stderr so a
+                        // dev sees it; `log`/`tracing` aren't wired in this crate.
+                        eprintln!("lan companion keep-awake unavailable: {e}");
+                        let _ = ready_tx.send(false);
+                        // Thread exits immediately; `_exited` fires.
+                    }
+                }
+            })
+            .ok()?;
+
+        // Block until the holder thread reports whether the guard built. A dropped
+        // sender (thread panicked before signalling) reads as failure.
+        match ready_rx.recv() {
+            Ok(true) => Some((KeepAwakeHold { stop: stop_tx }, exited_rx)),
+            _ => None,
+        }
+    }
+}
+
+// `stop`'s `Drop` disconnects the channel on its own; no explicit `Drop` impl is
+// needed. Documented here so the release mechanism is discoverable at the type.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn acquire_then_drop_exits_the_holder_thread() {
+        use std::sync::mpsc::{RecvTimeoutError, TryRecvError};
+
+        // Assert the THREAD LIFECYCLE, not OS power state: on CI the actual power
+        // request may be denied, in which case `acquire` returns `None` and there
+        // is nothing to release — a valid outcome we tolerate. When it DID acquire,
+        // dropping the hold must disconnect the channel, unblock the holder thread,
+        // drop the guard on that thread, and let it exit. The `exited` channel's
+        // sender lives on the holder thread and is never sent on — the thread's exit
+        // is observed as the channel DISCONNECTING (the sender drops with the thread).
+        let Some((hold, exited)) = KeepAwakeHold::acquire_inner() else {
+            // Power request denied in this environment (e.g. headless CI): the
+            // best-effort contract says that's fine — nothing to release.
+            return;
+        };
+
+        // Still held: the holder thread is parked on `stop_rx`, so its `exited`
+        // sender is still alive — the channel is Empty, not yet Disconnected.
+        assert_eq!(
+            exited.try_recv(),
+            Err(TryRecvError::Empty),
+            "holder thread must stay alive while the hold is held"
+        );
+
+        drop(hold);
+
+        // Dropping the hold disconnects `stop` → the holder thread unblocks, drops
+        // the guard on that thread, and returns. Its exit drops the `exited` sender,
+        // so a bounded recv resolves to `Disconnected` — that IS the exit signal.
+        // (A `Timeout` would mean the thread is still parked → the release leaked.)
+        assert_eq!(
+            exited.recv_timeout(Duration::from_secs(5)),
+            Err(RecvTimeoutError::Disconnected),
+            "holder thread must exit promptly after the hold is dropped"
+        );
+    }
+}

--- a/src-tauri/src/lan/keep_awake.rs
+++ b/src-tauri/src/lan/keep_awake.rs
@@ -30,6 +30,15 @@
 
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
+
+/// How long [`KeepAwakeHold::acquire`] waits for the holder thread to report that
+/// the OS keep-awake request built, before returning anyway. Bounds the worst-case
+/// stall a blocking `keepawake::Builder::create()` (a synchronous D-Bus round trip
+/// on Linux) can impose on the async `lan_enable` — a hung session bus can't hang
+/// enable. 2s is generously above a healthy build (sub-millisecond on Windows/macOS,
+/// a fast IPC on Linux) yet short enough to feel instant if the bus is wedged.
+const ACQUIRE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// A system-stays-awake hold, owned for its `Drop`. Held on a dedicated OS thread
 /// so acquire and release happen on the same thread (`SetThreadExecutionState` is
@@ -50,10 +59,15 @@ impl KeepAwakeHold {
     /// (after a stderr warning) if the request could not be built — keep-awake is
     /// best-effort and must never fail `lan_enable`.
     ///
-    /// The `ready` handshake makes acquisition synchronous only up to "did the
-    /// guard build": we block on it just long enough to learn success/failure,
-    /// then return. The guard then lives on the holder thread until this hold is
-    /// dropped.
+    /// The `ready` handshake makes acquisition bounded to ~2s worst case: we block
+    /// on it only long enough to learn success/failure, then return. Building the
+    /// OS request can BLOCK — on Linux `keepawake` makes a synchronous zbus/D-Bus
+    /// round trip to the session bus, and a slow or hung bus would otherwise stall
+    /// the tokio worker `lan_enable` runs on indefinitely (the D-Bus client's own
+    /// timeout isn't ours to rely on). So we cap the wait at
+    /// [`ACQUIRE_HANDSHAKE_TIMEOUT`]; see the timeout arm below for why that's still
+    /// leak-free and honors the best-effort contract. The guard then lives on the
+    /// holder thread until this hold is dropped.
     pub fn acquire() -> Option<KeepAwakeHold> {
         Self::acquire_inner().map(|(hold, _exited)| hold)
     }
@@ -103,11 +117,32 @@ impl KeepAwakeHold {
             })
             .ok()?;
 
-        // Block until the holder thread reports whether the guard built. A dropped
-        // sender (thread panicked before signalling) reads as failure.
-        match ready_rx.recv() {
+        // Wait — but only up to the timeout — for the holder thread to report
+        // whether the guard built. Three outcomes:
+        //   Ok(true)      → guard built: hold it.
+        //   Ok(false)     → guard build FAILED (the thread already exited after its
+        //                   stderr warning): nothing to hold → None.
+        //   Disconnected  → the sender dropped without signalling (the thread
+        //                   panicked before either send): treat as failure → None.
+        //   Timeout       → the build is still in flight (e.g. a wedged D-Bus). We
+        //                   return `Some(hold)` ANYWAY rather than stall enable: the
+        //                   hold owns `stop_tx`, so the holder thread stays governed
+        //                   by the channel exactly as in the fast path. If the build
+        //                   eventually succeeds, the guard releases on this hold's
+        //                   Drop; if it eventually FAILS, that thread just exits — so
+        //                   this cannot leak a hold, and keep-awake stays best-effort.
+        match ready_rx.recv_timeout(ACQUIRE_HANDSHAKE_TIMEOUT) {
             Ok(true) => Some((KeepAwakeHold { stop: stop_tx }, exited_rx)),
-            _ => None,
+            Ok(false) => None,
+            Err(mpsc::RecvTimeoutError::Disconnected) => None,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                eprintln!(
+                    "lan companion keep-awake is still initializing after {}s; \
+                     proceeding without waiting (it will apply once ready, or exit)",
+                    ACQUIRE_HANDSHAKE_TIMEOUT.as_secs()
+                );
+                Some((KeepAwakeHold { stop: stop_tx }, exited_rx))
+            }
         }
     }
 }
@@ -118,7 +153,6 @@ impl KeepAwakeHold {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[test]
     fn acquire_then_drop_exits_the_holder_thread() {

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -16,6 +16,7 @@
 //! per-field `Arc`s, mirroring how `AppState` shares individual fields.
 
 pub mod auth;
+pub mod keep_awake;
 pub mod routes;
 pub mod server;
 pub mod static_serve;
@@ -28,6 +29,7 @@ use tauri::{AppHandle, State};
 
 use crate::error::{AppError, AppResult};
 use auth::{LanDevice, PairingSession, RateLimitMap};
+use keep_awake::KeepAwakeHold;
 use server::ServerHandle;
 
 /// A repo registered in the LAN companion's repo registry, keyed by an opaque
@@ -93,6 +95,13 @@ struct RunningServer {
     bind_lan: bool,
     urls: Vec<String>,
     fingerprint: String,
+    /// A keep-awake hold, kept alive for the server's lifetime so the desktop
+    /// doesn't sleep mid-watch (the display may still sleep). Held ONLY for its
+    /// `Drop`: every teardown path (disable, mode-switch restart) drops this
+    /// `RunningServer`, which releases the hold on the holder thread — no explicit
+    /// release needed. `None` when the OS request couldn't be acquired (best-effort;
+    /// see [`keep_awake`]). Underscore-named: never read, only dropped.
+    _keep_awake: Option<KeepAwakeHold>,
 }
 
 impl Default for LanState {
@@ -365,6 +374,10 @@ pub async fn lan_enable(
         state.monitor_cut.clone(),
     )
     .await?;
+    // Keep the machine awake while sharing (best-effort — a failure to acquire
+    // logs a warning inside `acquire` and yields `None`, never failing enable).
+    // Held on the RunningServer, so every teardown path releases it via Drop.
+    let keep_awake = KeepAwakeHold::acquire();
     {
         let mut running = state.running.lock().unwrap_or_else(|p| p.into_inner());
         *running = Some(RunningServer {
@@ -372,6 +385,7 @@ pub async fn lan_enable(
             bind_lan,
             urls,
             fingerprint,
+            _keep_awake: keep_awake,
         });
     }
     // Keep the tray truthful about whether we're sharing.
@@ -1818,6 +1832,74 @@ mod tests {
             .unwrap();
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(body["kind"], "noActiveRepo");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn alias_pr_timeline_and_threads_409_with_no_active_repo() {
+        // The alias PR-conversation routes 409 `noActiveRepo` when no repo is shared —
+        // the resolver rejects before the handler, so no git/gh subprocess runs.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("NoActive Convo Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let state = test_router(None);
+        let router = server::build_router(state);
+
+        for path in ["/api/forge/prs/1/timeline", "/api/forge/prs/1/threads"] {
+            let resp = router
+                .clone()
+                .oneshot(authed_get(path, &bearer))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::CONFLICT, "path: {path}");
+            let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["kind"], "noActiveRepo", "path: {path}");
+        }
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn scoped_pr_timeline_and_threads_404_for_unknown_repo_id() {
+        // An unknown `{repoId}` 404s `noSuchRepo` (resolver rejects before the
+        // handler, so no git/gh subprocess runs).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("NoRepo Convo Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        // Registry is empty (no register_repo call).
+        let state = test_router(Some("C:/repo".to_string()));
+        let router = server::build_router(state);
+
+        for path in [
+            "/api/repos/deadbeefdeadbeef/prs/1/timeline",
+            "/api/repos/deadbeefdeadbeef/prs/1/threads",
+        ] {
+            let resp = router
+                .clone()
+                .oneshot(authed_get(path, &bearer))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND, "path: {path}");
+            let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["kind"], "noSuchRepo", "path: {path}");
+        }
 
         auth::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();

--- a/src-tauri/src/lan/routes/forge.rs
+++ b/src-tauri/src/lan/routes/forge.rs
@@ -55,6 +55,30 @@ pub async fn pr_view(
     respond(crate::forge::forge_pr_view(repo, number, None).await)
 }
 
+/// GET PR activity timeline (alias: `/api/forge/prs/{number}/timeline`).
+pub async fn pr_timeline(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
+) -> Response {
+    let number = match u64_param(&params, "number") {
+        Ok(n) => n,
+        Err(resp) => return *resp,
+    };
+    respond(crate::forge::forge_pr_timeline(repo, number, None).await)
+}
+
+/// GET PR review threads (alias: `/api/forge/prs/{number}/threads`).
+pub async fn pr_threads(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
+) -> Response {
+    let number = match u64_param(&params, "number") {
+        Ok(n) => n,
+        Err(resp) => return *resp,
+    };
+    respond(crate::forge::forge_pr_review_threads(repo, number, None).await)
+}
+
 /// GET issue list (alias: `/api/forge/issues?state&limit`).
 pub async fn issue_list(
     Extension(ScopedRepo(repo)): Extension<ScopedRepo>,

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -1,6 +1,6 @@
 //! The read-only route handlers mounted by the LAN companion server.
 //!
-//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 15
+//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 17
 //! handlers below and nothing else — there is no catch-all and no static serving,
 //! so any path outside the list 404s. Every handler operates on ONE resolved repo
 //! it reads from the `Extension<ScopedRepo>` a resolver middleware inserts, calls
@@ -31,6 +31,8 @@
 //! | `/api/repo/diff/file`                 | `diff/file`                           |
 //! | `/api/forge/prs`                      | `prs`                                 |
 //! | `/api/forge/prs/{number}`             | `prs/{number}`                        |
+//! | `/api/forge/prs/{number}/timeline`    | `prs/{number}/timeline`               |
+//! | `/api/forge/prs/{number}/threads`     | `prs/{number}/threads`                |
 //! | `/api/forge/issues`                   | `issues`                              |
 //! | `/api/forge/issues/{number}`          | `issues/{number}`                     |
 //! | `/api/forge/ci/runs`                  | `ci/runs`                             |

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -82,6 +82,8 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/repo/diff/file", get(git::diff_file))
         .route("/api/forge/prs", get(forge::pr_list))
         .route("/api/forge/prs/{number}", get(forge::pr_view))
+        .route("/api/forge/prs/{number}/timeline", get(forge::pr_timeline))
+        .route("/api/forge/prs/{number}/threads", get(forge::pr_threads))
         .route("/api/forge/issues", get(forge::issue_list))
         .route("/api/forge/issues/{number}", get(forge::issue_view))
         .route("/api/forge/ci/runs", get(forge::ci_run_list))
@@ -110,6 +112,14 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/repos/{repoId}/diff/file", get(git::diff_file))
         .route("/api/repos/{repoId}/prs", get(forge::pr_list))
         .route("/api/repos/{repoId}/prs/{number}", get(forge::pr_view))
+        .route(
+            "/api/repos/{repoId}/prs/{number}/timeline",
+            get(forge::pr_timeline),
+        )
+        .route(
+            "/api/repos/{repoId}/prs/{number}/threads",
+            get(forge::pr_threads),
+        )
         .route("/api/repos/{repoId}/issues", get(forge::issue_list))
         .route("/api/repos/{repoId}/issues/{number}", get(forge::issue_view))
         .route("/api/repos/{repoId}/ci/runs", get(forge::ci_run_list))

--- a/src-tauri/src/lan/tls.rs
+++ b/src-tauri/src/lan/tls.rs
@@ -377,13 +377,15 @@ fn restrict_key_file_perms(_key_path: &Path) {}
 mod tests {
     use super::*;
 
-    /// A fresh temp dir for a test's TLS material, unique per test invocation.
-    fn temp_dir() -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "gd-lan-tls-test-{}-{}",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ))
+    /// A fresh temp dir for a test's TLS material, removed on `Drop` (RAII) so a
+    /// killed or panicking run can't leak private-key material into the system temp
+    /// dir. Callers keep the returned `TempDir` alive for the test and pass
+    /// `dir.path()` to the TLS-dir override.
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("gd-lan-tls-test-")
+            .tempdir()
+            .expect("create temp dir for TLS test")
     }
 
     /// The frozen fingerprint format: 32 uppercase-hex byte pairs joined by colons.
@@ -401,13 +403,13 @@ mod tests {
     fn fresh_gen_writes_files_and_valid_fingerprint() {
         let _lock = crate::lan::auth::store_test_lock();
         let dir = temp_dir();
-        let prev = set_tls_dir_for_test(Some(dir.clone()));
+        let prev = set_tls_dir_for_test(Some(dir.path().to_path_buf()));
 
         let material = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
 
-        assert!(dir.join(CERT_FILE).exists(), "cert PEM written");
-        assert!(dir.join(KEY_FILE).exists(), "key PEM written");
-        assert!(dir.join(META_FILE).exists(), "meta json written");
+        assert!(dir.path().join(CERT_FILE).exists(), "cert PEM written");
+        assert!(dir.path().join(KEY_FILE).exists(), "key PEM written");
+        assert!(dir.path().join(META_FILE).exists(), "meta json written");
         assert!(
             is_fingerprint(&material.fingerprint),
             "fingerprint format: {}",
@@ -415,14 +417,13 @@ mod tests {
         );
 
         set_tls_dir_for_test(prev);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn covered_ips_reuse_the_same_cert() {
         let _lock = crate::lan::auth::store_test_lock();
         let dir = temp_dir();
-        let prev = set_tls_dir_for_test(Some(dir.clone()));
+        let prev = set_tls_dir_for_test(Some(dir.path().to_path_buf()));
 
         let first = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
         // A second call whose required IPs are a SUBSET of the recorded set (here the
@@ -434,14 +435,13 @@ mod tests {
         assert_eq!(first.fingerprint, third.fingerprint, "loopback-only reuses");
 
         set_tls_dir_for_test(prev);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn new_ip_regenerates_and_unions_sans() {
         let _lock = crate::lan::auth::store_test_lock();
         let dir = temp_dir();
-        let prev = set_tls_dir_for_test(Some(dir.clone()));
+        let prev = set_tls_dir_for_test(Some(dir.path().to_path_buf()));
 
         let first = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
         // A NEW, uncovered IP forces a regen → different fingerprint.
@@ -449,7 +449,7 @@ mod tests {
         assert_ne!(first.fingerprint, second.fingerprint, "new ip regenerates");
 
         // The regenerated meta's SANs are the UNION: loopback + both IPs.
-        let meta = read_meta(&dir.join(META_FILE)).unwrap();
+        let meta = read_meta(&dir.path().join(META_FILE)).unwrap();
         assert!(meta.san_ips.contains(&Ipv4Addr::LOCALHOST));
         assert!(meta.san_ips.contains(&Ipv4Addr::new(192, 168, 1, 5)));
         assert!(meta.san_ips.contains(&Ipv4Addr::new(10, 0, 0, 9)));
@@ -460,18 +460,17 @@ mod tests {
         assert_eq!(second.fingerprint, third.fingerprint, "A→B→A stays stable");
 
         set_tls_dir_for_test(prev);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn corrupt_cert_regenerates_instead_of_erroring() {
         let _lock = crate::lan::auth::store_test_lock();
         let dir = temp_dir();
-        let prev = set_tls_dir_for_test(Some(dir.clone()));
+        let prev = set_tls_dir_for_test(Some(dir.path().to_path_buf()));
 
         let _first = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
         // Corrupt the cert PEM on disk.
-        std::fs::write(dir.join(CERT_FILE), b"not a real certificate").unwrap();
+        std::fs::write(dir.path().join(CERT_FILE), b"not a real certificate").unwrap();
         // ensure_tls must recover by regenerating (returning a valid cert), not error
         // out of enabling the server.
         let second = ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
@@ -481,7 +480,6 @@ mod tests {
         assert_eq!(second.fingerprint, reloaded.fingerprint, "post-regen reuse");
 
         set_tls_dir_for_test(prev);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[cfg(unix)]
@@ -492,10 +490,10 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let _lock = crate::lan::auth::store_test_lock();
         let dir = temp_dir();
-        let prev = set_tls_dir_for_test(Some(dir.clone()));
+        let prev = set_tls_dir_for_test(Some(dir.path().to_path_buf()));
 
         ensure_tls(&[Ipv4Addr::new(192, 168, 1, 5)]).unwrap();
-        let mode = std::fs::metadata(dir.join(KEY_FILE))
+        let mode = std::fs::metadata(dir.path().join(KEY_FILE))
             .unwrap()
             .permissions()
             .mode();
@@ -503,6 +501,5 @@ mod tests {
         assert_eq!(mode & 0o777, 0o600, "key file mode: {:o}", mode & 0o777);
 
         set_tls_dir_for_test(prev);
-        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1558,8 +1558,8 @@ The **Phone companion** lets you share the repository that's currently open with
 phone over your **local network**. Open it in **Settings → Phone companion**.
 
 This is an **early preview**. Once paired, your phone opens a slim companion web app in
-its browser that shows the open repo's **Status**, **pull requests**, and **CI** — all
-**read-only**. It's **off by default**.
+its browser that shows the open repo's **Status**, **pull requests**, **CI**{{ai}}, and
+live **agent** runs{{/ai}} — all **read-only**. It's **off by default**.
 
 ## Turning it on
 
@@ -1568,6 +1568,10 @@ to your machine's LAN address and shows the address(es) and port it's reachable 
 While sharing is on, a **Sharing on** banner runs across the top of the window
 (click it to jump back here). If the port can't be opened, the reason appears
 right in the panel.
+
+While sharing is on, GitDesktop keeps your computer awake so a phone can keep watching
+unattended — the display may still sleep, and normal sleep resumes as soon as you stop
+sharing.
 
 ## Pairing a phone
 
@@ -1579,8 +1583,26 @@ Choose **Pair a device** (available once sharing is on). A dialog shows:
 
 Scanning the code (or opening the URL) loads the companion's **pairing page** in your
 phone's browser. Type the PIN there; once it matches, the phone is paired and drops
-straight into the companion app — a bottom tab bar with **Status**, **PRs**, and **CI**,
-each read-only.
+straight into the companion app — a bottom tab bar with **Status**, **PRs**, **CI**{{ai}},
+and **Agents**{{/ai}}, each read-only.
+
+## What you can see on your phone
+
+- **Status** — the shared repo's current branch and connection.
+- **PRs** — the open pull-request list; open one for its **overview** (title,
+  description, branches, diff totals), its **activity** timeline (force-pushes, label
+  changes, review requests, and open/close/merge events), and its **review threads**
+  (each file:line comment chain, with resolved/outdated markers). It's read-only — a
+  place to catch up on a PR's conversation from your phone, not to reply.
+- **CI** — recent workflow runs and their jobs.
+{{ai}}- **Agents** — everything your desktop is currently broadcasting: **AI PR reviews**
+  and **agent sessions**. Open one to **watch it live** — the assistant's prose streams in
+  as it's written, and each tool step (files read or edited, commands run, searches) shows
+  as it happens. When the run finishes you get its final answer (and its cost, when
+  reported). Watching is **live only**: you see activity from the moment you open it — there's
+  no replay — and the screen keeps itself pinned to the newest output unless you scroll up,
+  with a **Jump to latest** button to return. Stopping sharing, switching repos, or revoking
+  the device ends the watch and tells you the run is no longer shared.{{/ai}}
 
 Because the connection uses a **self-signed certificate** GitDesktop generates, your
 phone shows a **certificate warning on first connect** — that's expected; tap through to

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -122,6 +122,13 @@ export function CompanionSection() {
         on trusted networks only, and turn sharing off when you're done.
       </p>
 
+      {/* Keep-awake is always-on while sharing (no toggle) — disclose it so the
+          behavior isn't a surprise. */}
+      <p className="text-xs text-muted-foreground">
+        While sharing is on, your computer won't go to sleep (the display still
+        can).
+      </p>
+
       {enabled && status.data && (
         <div className="space-y-1 text-xs text-muted-foreground">
           {status.data.urls.length > 0 ? (

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -163,6 +163,11 @@ export interface AgentReviewArgs {
   /** The diff-bearing prompt, fed to the CLI on stdin. */
   userPrompt: string;
   repoPath: string;
+  /** The ORIGIN repo a repo-aware PR-head review was spawned from. `repoPath` may be
+   *  a throwaway detached worktree pinned at the PR head; the LAN monitor scopes
+   *  streams by origin repo, so pass it to keep the review visible to a paired phone.
+   *  Omit for a non-worktree review (the backend falls back to `repoPath`). */
+  originRepoPath?: string;
   /** Tier 2: allow the agent read-only access to the repo for context. */
   repoAware: boolean;
   /** Attach GitDesktop's own read-only MCP server (`gitdesktop` tools) to the run
@@ -189,6 +194,7 @@ export async function runAgentReview(args: AgentReviewArgs): Promise<void> {
     systemPrompt: args.systemPrompt,
     userPrompt: args.userPrompt,
     repoPath: args.repoPath,
+    originRepoPath: args.originRepoPath ?? null,
     repoAware: args.repoAware,
     mcpSelf: Boolean(args.mcpSelf),
     reviewId: args.reviewId,

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -115,6 +115,9 @@ export async function runCliStream({
         systemPrompt: system,
         userPrompt: prompt,
         repoPath: cwd,
+        // `cwd` may be a throwaway review worktree; the origin repo is `repoPath`, so
+        // scope the LAN stream by that to keep the review visible to a paired phone.
+        originRepoPath: repoPath,
         repoAware: Boolean(ai.cliRepoAware),
         mcpSelf: Boolean(mcpSelf),
         reviewId,


### PR DESCRIPTION
Extend the LAN companion from passive repository monitoring into a live read-only companion for AI work and PR discussions. Phones can now watch agent activity as it happens, inspect richer pull-request conversations, and remain connected while the desktop stays awake during sharing.

### Agent streaming

- Adds the **Agents** tab and live watch route in `companion/src/App.tsx`, `companion/src/components/Chrome.tsx`, and `companion/src/lib/router.ts`.
- Implements SSE event parsing, transcript folding, terminal-state handling, and stream lifecycle classification in `companion/src/lib/use-review-stream.ts`.
- Adds agent list and live watch screens with auto-follow, reduced-motion handling, tool-step display, final answers, and stream-status states in `companion/src/screens/Agents.tsx`.
- Adds agent-stream API and polling queries in `companion/src/lib/api.ts` and `companion/src/lib/queries.ts`.
- Ensures repo-aware reviews started from detached worktrees remain visible under the origin repository in `src/lib/ai/agent.ts`, `src/lib/ai/stream.ts`, and `src-tauri/src/agent.rs`.
- Serializes multi-word review event fields as camelCase in `src-tauri/src/agent.rs`, including `isError` and `costUsd`.

### Pull-request details

- Adds PR activity timeline and review-thread endpoints in `src-tauri/src/lan/routes/forge.rs` and `src-tauri/src/lan/server.rs`, including scoped repository routes.
- Adds companion queries for timelines and review threads in `companion/src/lib/api.ts` and `companion/src/lib/queries.ts`.
- Expands PR details with Markdown-rendered descriptions, chronological conversation entries, review verdicts, activity events, and file-and-line review threads in `companion/src/screens/Prs.tsx`.
- Adds sanitized GitHub-flavored Markdown rendering for PR bodies, comments, review content, and agent answers in `companion/src/components/markdown.tsx` and `companion/src/index.css`.
- Adds `noRemote` error mapping for LAN forge requests in `src-tauri/src/lan/auth.rs`, allowing the companion to distinguish repositories without an `origin` remote from other Git failures.

### LAN sharing lifecycle

- Keeps the computer awake while LAN sharing is active, while still allowing the display to sleep, through `src-tauri/src/lan/keep_awake.rs`, `src-tauri/src/lan/mod.rs`, and the `keepawake` dependency in `src-tauri/Cargo.toml`.
- Documents the keep-awake behavior in `src/features/settings/CompanionSection.tsx`, `src/features/help/content.ts`, and `changelog.d/added-lan-companion-preview.md`.
- Updates LAN route documentation and coverage for PR timeline and thread aliases in `src-tauri/src/lan/routes/mod.rs` and `src-tauri/src/lan/mod.rs`.
- Uses RAII temporary directories for TLS test material in `src-tauri/src/lan/tls.rs` and adds the `tempfile` dependency in `src-tauri/Cargo.toml`.