### PR TITLE
feat(branches,ui,help): clarify branch sync and divergence indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,10 @@ discarding a whole untracked file goes to the recycle bin. Commit with title + b
 co-authors suggested from history, amend, undo, reset, and revert.
 
 **Branches** — switch (bring-changes / stash prompt), create, rename, delete, and
-**archive** (hide from the switcher without deleting). Per-branch ahead/behind vs. the
-default branch and a PR badge show in the switcher.
+**archive** (hide from the switcher without deleting). Each switcher row shows a branch's
+own **push/pull state** vs. its upstream (↑ to push / ↓ to pull, plus markers for
+never-published and upstream-deleted branches) and its **+/− divergence vs. the default
+branch**, labeled with the default's name — plus a PR badge.
 
 - **Clean up branches** ⭐ — a bulk sweep that archives or deletes every stale branch
   (merged into the default branch, or with no commits in a chosen window) in one

--- a/changelog.d/changed-branch-sync-indicators.md
+++ b/changelog.d/changed-branch-sync-indicators.md
@@ -1,0 +1,6 @@
+- Branch menu rows now show a branch's own push/pull state (↑ to push, ↓ to pull, plus
+  markers for never-published and upstream-deleted branches) separately from its divergence
+  vs. the default branch, which now reads `+N −M` with the default branch named — previously
+  both rendered as identical ↑/↓ arrows, so being ahead of the default looked like unpushed
+  work. Rows now span two lines — the branch name on its own line, the details below it —
+  giving long branch names more room.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -348,8 +348,11 @@ tracked file and blames the one you choose as it is now.
 
 The branch name in the header opens the **branch switcher** ({{kbd:show-branches}}).
 
-- Branches are sorted by most recent commit, with the default branch pinned on top and
-  each branch's ahead/behind counts vs. the default.
+- Branches are sorted by most recent commit, with the default branch pinned on top. Each
+  row shows two distinct indicators: the branch's own **push/pull state** vs. its upstream
+  (↑ commits to push, ↓ commits to pull, plus a marker for a never-published branch and one
+  for a branch whose upstream was deleted on the remote), and its **+/− divergence vs. the
+  default branch**, written \`+N −M\` and labeled with the default branch's name.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
   it, collapsing it into an "Archived" section. When creating, the **Base it on** picker is
@@ -378,8 +381,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 - **Update a branch from its own upstream** without switching to it: when a branch is
   behind the remote it tracks, its right-click menu offers **Update from _origin/…_**. This
   is the "just merged a PR — bring the default branch current before I switch back" flow;
-  the default branch's row shows how far behind its upstream it is after a fetch, and
-  *Update default branch from its remote* is available from the command palette too.
+  every branch's row shows its own push/pull state (↑/↓ vs. its upstream) after a fetch, so
+  the branches with commits to pull are visible at a glance, and *Update default branch from
+  its remote* is available from the command palette too.
 - **Push a branch without switching to it** — the outbound counterpart: a branch ahead
   of the remote it tracks offers **Push to _its remote/…_** in its right-click menu — so a
   branch tracking a fork's _upstream_ is pushed there, not to origin. An unpushed or

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -351,8 +351,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 - Branches are sorted by most recent commit, with the default branch pinned on top. Each
   row shows two distinct indicators: the branch's own **push/pull state** vs. its upstream
   (↑ commits to push, ↓ commits to pull, plus a marker for a never-published branch and one
-  for a branch whose upstream was deleted on the remote), and its **+/− divergence vs. the
-  default branch**, written \`+N −M\` and labeled with the default branch's name.
+  for a branch whose upstream was deleted on the remote — or whose tracked remote is no
+  longer configured), and its **+/− divergence vs. the default branch**, written \`+N −M\`
+  and labeled with the default branch's name.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
   it, collapsing it into an "Archived" section. When creating, the **Base it on** picker is

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -5,6 +5,8 @@ import {
   CaretDownIcon,
   CheckIcon,
   CloudArrowDownIcon,
+  CloudSlashIcon,
+  CloudXIcon,
   GitBranchIcon,
   GitPullRequestIcon,
   TreeStructureIcon,
@@ -879,111 +881,167 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             <button
               type="button"
               data-row={branch.name}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
+              className="flex w-full flex-col gap-y-0.5 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
               onClick={() => {
                 if (!branch.isCurrent) switchTo(branch.name);
               }}
             >
-              <span
-                className="min-w-0 flex-1 truncate"
-                // Only expose the full name as a tooltip when it's actually
-                // clipped — measured just-in-time on hover, so no per-row refs.
-                onMouseEnter={(e) => {
-                  const el = e.currentTarget;
-                  el.title = el.scrollWidth > el.clientWidth ? branch.name : "";
-                }}
-              >
-                {branch.name}
-                {branch.name === defaultName && (
-                  <span className="ml-1.5 text-[10px] text-muted-foreground">
-                    default
+              {/* Line 1: branch name (+ default tag) with the current-branch
+                  check pinned to the right edge. */}
+              <span className="flex w-full items-center gap-2">
+                <span
+                  className="min-w-0 flex-1 truncate"
+                  // Only expose the full name as a tooltip when it's actually
+                  // clipped — measured just-in-time on hover, so no per-row refs.
+                  onMouseEnter={(e) => {
+                    const el = e.currentTarget;
+                    el.title =
+                      el.scrollWidth > el.clientWidth ? branch.name : "";
+                  }}
+                >
+                  {branch.name}
+                  {branch.name === defaultName && (
+                    <span className="ml-1.5 text-[10px] text-muted-foreground">
+                      default
+                    </span>
+                  )}
+                </span>
+                {branch.isCurrent && (
+                  <CheckIcon className="size-3.5 shrink-0" />
+                )}
+              </span>
+              {/* Line 2: PR badge · worktree · sync · divergence, then the
+                  relative time pushed to the far right. Always renders (the
+                  time is always present). */}
+              <span className="flex w-full items-center gap-2">
+                {(() => {
+                  const pr = prByBranch.get(branch.name);
+                  if (!pr) return null;
+                  const isLocal = pr.select.kind === "local";
+                  return (
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      title={
+                        isLocal
+                          ? `${PR_STATE_LABEL[pr.state]} local pull request — open in Pull Requests`
+                          : `${PR_STATE_LABEL[pr.state]} pull request ${pr.label} — open in Pull Requests`
+                      }
+                      className={cn(
+                        "flex shrink-0 cursor-pointer items-center gap-0.5 text-[11px] tabular-nums hover:underline",
+                        PR_TONE[pr.state],
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openPr(pr.select);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          openPr(pr.select);
+                        }
+                      }}
+                    >
+                      <GitPullRequestIcon className="size-3" weight="bold" />
+                      {pr.label}
+                    </span>
+                  );
+                })()}
+                {inWorktree && (
+                  <span
+                    className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
+                    title={`Checked out in another worktree (${worktreeByBranch.get(
+                      branch.name,
+                    )}) — open it instead of switching`}
+                  >
+                    <TreeStructureIcon className="size-3" weight="bold" />
+                    worktree
+                  </span>
+                )}
+                {/* Two distinct indicators per row: (1) the sync indicator
+                    below shows the branch's OWN upstream push/pull state in the
+                    arrow vocabulary (matching the header's Push/Pull badges), so
+                    "Update from {upstream}" / "Push to {upstream}" stay
+                    discoverable on every branch; (2) the divergence indicator
+                    further down shows how far the branch has drifted from the
+                    DEFAULT branch, rendered as `+N −M {default}` text so it can't
+                    be mistaken for unpushed work. Sync is skipped entirely on a
+                    remoteless repo (there's no push story). */}
+                {remoteNames.length > 0 &&
+                  (() => {
+                    if (branch.upstream && !branch.upstreamGone) {
+                      if (
+                        branch.upstreamAhead === 0 &&
+                        branch.upstreamBehind === 0
+                      ) {
+                        // In sync with the upstream — silence means synced.
+                        return null;
+                      }
+                      const parts: string[] = [];
+                      if (branch.upstreamAhead > 0)
+                        parts.push(`${branch.upstreamAhead} to push`);
+                      if (branch.upstreamBehind > 0)
+                        parts.push(`${branch.upstreamBehind} to pull`);
+                      return (
+                        <span
+                          // No text color: inherits the row foreground (a step
+                          // stronger than the muted divergence) and follows the
+                          // hover accent-foreground automatically.
+                          className="flex shrink-0 items-center gap-1 text-[11px] tabular-nums"
+                          title={`${parts.join(", ")} — vs ${branch.upstream}`}
+                        >
+                          {branch.upstreamAhead > 0 && (
+                            <span className="flex items-center gap-0.5">
+                              <ArrowUpIcon className="size-3" weight="bold" />
+                              {branch.upstreamAhead}
+                            </span>
+                          )}
+                          {branch.upstreamBehind > 0 && (
+                            <span className="flex items-center gap-0.5">
+                              <ArrowDownIcon className="size-3" weight="bold" />
+                              {branch.upstreamBehind}
+                            </span>
+                          )}
+                        </span>
+                      );
+                    }
+                    if (branch.upstreamGone) {
+                      return (
+                        <span
+                          className="flex shrink-0 items-center text-muted-foreground"
+                          title={`Upstream ${branch.upstream} was deleted on the remote — likely merged. Right-click to publish again or delete.`}
+                        >
+                          <CloudXIcon className="size-3" />
+                        </span>
+                      );
+                    }
+                    // !branch.upstream
+                    return (
+                      <span
+                        className="flex shrink-0 items-center text-muted-foreground"
+                        title="Local only — never published. Right-click to publish."
+                      >
+                        <CloudSlashIcon className="size-3" />
+                      </span>
+                    );
+                  })()}
+                {div && (div.ahead > 0 || div.behind > 0) && (
+                  <span
+                    className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
+                    title={`${div.ahead} commits ahead of ${defaultName}, ${div.behind} behind`}
+                  >
+                    {div.ahead > 0 && <span>+{div.ahead}</span>}
+                    {div.behind > 0 && <span>{`−${div.behind}`}</span>}
+                    <span>{defaultName}</span>
+                  </span>
+                )}
+                {branch.lastCommitDate && (
+                  <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+                    {formatRelativeTime(branch.lastCommitDate)}
                   </span>
                 )}
               </span>
-              {(() => {
-                const pr = prByBranch.get(branch.name);
-                if (!pr) return null;
-                const isLocal = pr.select.kind === "local";
-                return (
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    title={
-                      isLocal
-                        ? `${PR_STATE_LABEL[pr.state]} local pull request — open in Pull Requests`
-                        : `${PR_STATE_LABEL[pr.state]} pull request ${pr.label} — open in Pull Requests`
-                    }
-                    className={cn(
-                      "flex shrink-0 cursor-pointer items-center gap-0.5 text-[11px] tabular-nums hover:underline",
-                      PR_TONE[pr.state],
-                    )}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openPr(pr.select);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        openPr(pr.select);
-                      }
-                    }}
-                  >
-                    <GitPullRequestIcon className="size-3" weight="bold" />
-                    {pr.label}
-                  </span>
-                );
-              })()}
-              {inWorktree && (
-                <span
-                  className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
-                  title={`Checked out in another worktree (${worktreeByBranch.get(
-                    branch.name,
-                  )}) — open it instead of switching`}
-                >
-                  <TreeStructureIcon className="size-3" weight="bold" />
-                  worktree
-                </span>
-              )}
-              {div && (div.ahead > 0 || div.behind > 0) && (
-                <span
-                  className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
-                  title={`${div.ahead} ahead, ${div.behind} behind ${defaultName}`}
-                >
-                  {div.ahead > 0 && (
-                    <span className="flex items-center gap-0.5">
-                      <ArrowUpIcon className="size-3" weight="bold" />
-                      {div.ahead}
-                    </span>
-                  )}
-                  {div.behind > 0 && (
-                    <span className="flex items-center gap-0.5">
-                      <ArrowDownIcon className="size-3" weight="bold" />
-                      {div.behind}
-                    </span>
-                  )}
-                </span>
-              )}
-              {/* The vs-default arrows are vacuous on the default branch's own
-                  row; surface how far it's behind its OWN upstream instead, so
-                  the "Update from {upstream}" action is discoverable after a Fetch. */}
-              {branch.name === defaultName &&
-                branch.upstream &&
-                branch.upstreamBehind > 0 && (
-                  <span
-                    className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground tabular-nums"
-                    title={`${branch.upstreamBehind} behind ${branch.upstream}`}
-                  >
-                    <ArrowDownIcon className="size-3" weight="bold" />
-                    {branch.upstreamBehind}
-                  </span>
-                )}
-              {branch.lastCommitDate && (
-                <span className="shrink-0 text-[11px] text-muted-foreground">
-                  {formatRelativeTime(branch.lastCommitDate)}
-                </span>
-              )}
-              {branch.isCurrent && <CheckIcon className="size-3.5 shrink-0" />}
             </button>
           }
         />

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -970,6 +970,33 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     remoteless repo (there's no push story). */}
                 {remoteNames.length > 0 &&
                   (() => {
+                    // A branch tracking a remote that's since been removed (while
+                    // other remotes remain) offers neither Push nor Publish in the
+                    // context menu — arrows here would imply a push/pull action the
+                    // menu can't honor, so render the muted local-only marker with a
+                    // NO-action title. `upstreamRemote` is null for a branch tracking
+                    // a LOCAL upstream (git's `%(upstream:remotename)` is empty →
+                    // None on the Rust side); the `branch.upstreamRemote &&` conjunct
+                    // keeps such a branch OUT of this case so its truthful vs-local
+                    // arrows still show below.
+                    if (
+                      branch.upstream &&
+                      !branch.upstreamGone &&
+                      branch.upstreamRemote &&
+                      !remoteNames.includes(branch.upstreamRemote)
+                    ) {
+                      const label = `Tracks ${branch.upstream}, but that remote is no longer configured.`;
+                      return (
+                        <span
+                          role="img"
+                          aria-label={label}
+                          className="flex shrink-0 items-center text-muted-foreground"
+                          title={label}
+                        >
+                          <CloudSlashIcon className="size-3" />
+                        </span>
+                      );
+                    }
                     if (branch.upstream && !branch.upstreamGone) {
                       if (
                         branch.upstreamAhead === 0 &&
@@ -983,13 +1010,16 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                         parts.push(`${branch.upstreamAhead} to push`);
                       if (branch.upstreamBehind > 0)
                         parts.push(`${branch.upstreamBehind} to pull`);
+                      const label = `${parts.join(", ")} — vs ${branch.upstream}`;
                       return (
                         <span
                           // No text color: inherits the row foreground (a step
                           // stronger than the muted divergence) and follows the
-                          // hover accent-foreground automatically.
+                          // hover accent-foreground automatically. The arrow SVGs are
+                          // aria-hidden, so the span carries the name for readers.
+                          aria-label={label}
                           className="flex shrink-0 items-center gap-1 text-[11px] tabular-nums"
-                          title={`${parts.join(", ")} — vs ${branch.upstream}`}
+                          title={label}
                         >
                           {branch.upstreamAhead > 0 && (
                             <span className="flex items-center gap-0.5">
@@ -1007,10 +1037,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       );
                     }
                     if (branch.upstreamGone) {
+                      const label = `Upstream ${branch.upstream} was deleted on the remote — likely merged. Right-click to publish again or delete.`;
                       return (
                         <span
+                          role="img"
+                          aria-label={label}
                           className="flex shrink-0 items-center text-muted-foreground"
-                          title={`Upstream ${branch.upstream} was deleted on the remote — likely merged. Right-click to publish again or delete.`}
+                          title={label}
                         >
                           <CloudXIcon className="size-3" />
                         </span>
@@ -1019,6 +1052,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     // !branch.upstream
                     return (
                       <span
+                        role="img"
+                        aria-label="Local only — never published. Right-click to publish."
                         className="flex shrink-0 items-center text-muted-foreground"
                         title="Local only — never published. Right-click to publish."
                       >
@@ -1026,16 +1061,31 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       </span>
                     );
                   })()}
-                {div && (div.ahead > 0 || div.behind > 0) && (
-                  <span
-                    className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
-                    title={`${div.ahead} commits ahead of ${defaultName}, ${div.behind} behind`}
-                  >
-                    {div.ahead > 0 && <span>+{div.ahead}</span>}
-                    {div.behind > 0 && <span>{`−${div.behind}`}</span>}
-                    <span>{defaultName}</span>
-                  </span>
-                )}
+                {div &&
+                  (div.ahead > 0 || div.behind > 0) &&
+                  (() => {
+                    const parts: string[] = [];
+                    if (div.ahead > 0)
+                      parts.push(
+                        `${div.ahead} commit${div.ahead === 1 ? "" : "s"} ahead of ${defaultName}`,
+                      );
+                    if (div.behind > 0)
+                      parts.push(
+                        `${div.behind} commit${div.behind === 1 ? "" : "s"} behind`,
+                      );
+                    const label = parts.join(", ");
+                    return (
+                      <span
+                        aria-label={label}
+                        className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
+                        title={label}
+                      >
+                        {div.ahead > 0 && <span>+{div.ahead}</span>}
+                        {div.behind > 0 && <span>{`−${div.behind}`}</span>}
+                        <span>{defaultName}</span>
+                      </span>
+                    );
+                  })()}
                 {branch.lastCommitDate && (
                   <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
                     {formatRelativeTime(branch.lastCommitDate)}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1073,8 +1073,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                         `${div.ahead} commit${div.ahead === 1 ? "" : "s"} ahead of ${defaultName}`,
                       );
                     if (div.behind > 0)
+                      // Behind-only must still name the base: role="img" hides the
+                      // visible {defaultName} child from AT, so the label is all
+                      // a reader gets. Skipped when the ahead part named it already.
                       parts.push(
-                        `${div.behind} commit${div.behind === 1 ? "" : "s"} behind`,
+                        `${div.behind} commit${div.behind === 1 ? "" : "s"} behind${div.ahead > 0 ? "" : ` ${defaultName}`}`,
                       );
                     const label = parts.join(", ");
                     return (

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1016,7 +1016,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                           // No text color: inherits the row foreground (a step
                           // stronger than the muted divergence) and follows the
                           // hover accent-foreground automatically. The arrow SVGs are
-                          // aria-hidden, so the span carries the name for readers.
+                          // aria-hidden, so the span carries the name for readers —
+                          // role="img" because aria-label is not valid (nor reliably
+                          // announced) on a generic span.
+                          role="img"
                           aria-label={label}
                           className="flex shrink-0 items-center gap-1 text-[11px] tabular-nums"
                           title={label}
@@ -1076,6 +1079,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     const label = parts.join(", ");
                     return (
                       <span
+                        role="img"
                         aria-label={label}
                         className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground tabular-nums"
                         title={label}


### PR DESCRIPTION
Separate each branch’s upstream push/pull state from its divergence against the default branch so the branch switcher no longer makes work that is merely ahead of the default appear unpushed. The updated indicators and documentation make branch synchronization and comparison status easier to interpret at a glance.

### Branch switcher

- Updates `src/features/repository/BranchSwitcher.tsx` to display each branch’s own upstream sync state, including commits to push, commits to pull, never-published branches, and branches whose upstream was deleted.
- Replaces ambiguous default-branch arrows in `src/features/repository/BranchSwitcher.tsx` with explicit `+N`/`−M` divergence counts labeled with the default branch name.
- Restructures branch rows in `src/features/repository/BranchSwitcher.tsx` into separate name and detail lines, giving long branch names more room while keeping current-branch checks and relative commit times visible.
- Preserves pull request and worktree indicators in the detail line of `src/features/repository/BranchSwitcher.tsx`.

### Documentation

- Clarifies the branch sync and default-branch divergence indicators in `README.md`.
- Expands the branch switcher guidance in `src/features/help/content.ts` to explain upstream push/pull state, remote-deleted branches, and `+/−` divergence counts.
- Updates the fetch, update, and push workflow documentation in `src/features/help/content.ts` to describe sync indicators for every branch.

### Changelog

- Records the changed branch indicators and two-line branch row layout in `changelog.d/changed-branch-sync-indicators.md`.