### PR TITLE
feat(sync,ui): show ahead and behind counts on sync buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,8 @@ commit that hasn't been pushed yet.
 
 Plus tag and submodule management.
 
-**Syncing** — fetch / pull / push with ahead/behind indicators; pull is
+**Syncing** — push / pull / fetch, with the ahead/behind counts shown right on
+the Push and Pull buttons; pull is
 `--ff-only`, and divergence routes to a guarded force push with
 `--force-with-lease`. When a repo has an `upstream` remote, the Pull menu adds
 **Update from upstream** — one click fetches upstream and brings your branch up

--- a/changelog.d/changed-sync-header-buttons.md
+++ b/changelog.d/changed-sync-header-buttons.md
@@ -1,0 +1,4 @@
+- The header sync buttons are reordered to **Push / Pull / Fetch** so the most-used
+  action is first, and the ahead/behind counts now appear directly on the **Push** and
+  **Pull** buttons — making it clear which button acts on them — instead of in separate
+  arrow badges.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -486,16 +486,16 @@ Worktrees that AI agent sessions use internally are hidden here.{{/ai}}`,
   {
     id: "syncing",
     label: "Syncing & conflicts",
-    body: `# Fetch, pull, push & conflicts
+    body: `# Push, pull, fetch & conflicts
 
 The header shows **Push / Pull / Fetch**, with the number of commits to push or pull shown
 right on the **Push** and **Pull** buttons.
 
-- **Fetch** ({{kbd:fetch}}) updates your view of the remote without changing your branch.
-- **Pull** ({{kbd:pull}}) is fast-forward only by design — it won't create surprise merge
-  commits.
 - **Push** ({{kbd:push}}) sends your commits. For a branch with no upstream yet, you'll
   see **Publish branch** instead.
+- **Pull** ({{kbd:pull}}) is fast-forward only by design — it won't create surprise merge
+  commits.
+- **Fetch** ({{kbd:fetch}}) updates your view of the remote without changing your branch.
 
 ## Update a fork from upstream
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -488,7 +488,8 @@ Worktrees that AI agent sessions use internally are hidden here.{{/ai}}`,
     label: "Syncing & conflicts",
     body: `# Fetch, pull, push & conflicts
 
-The header shows **Fetch / Pull / Push** with ahead/behind indicators.
+The header shows **Push / Pull / Fetch**, with the number of commits to push or pull shown
+right on the **Push** and **Pull** buttons.
 
 - **Fetch** ({{kbd:fetch}}) updates your view of the remote without changing your branch.
 - **Pull** ({{kbd:pull}}) is fast-forward only by design — it won't create surprise merge

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -961,7 +961,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 )}
                 {/* Two distinct indicators per row: (1) the sync indicator
                     below shows the branch's OWN upstream push/pull state in the
-                    arrow vocabulary (matching the header's Push/Pull badges), so
+                    arrow vocabulary (matching the counts on the header's
+                    Push/Pull buttons), so
                     "Update from {upstream}" / "Push to {upstream}" stay
                     discoverable on every branch; (2) the divergence indicator
                     further down shows how far the branch has drifted from the

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -160,9 +160,13 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
     ? `Pull — branch has diverged (${behindCount} commit${behindCount === 1 ? "" : "s"} behind ${head?.upstream}); use Pull with rebase or merge from the menu`
     : detached
       ? "Pull — you're on a detached HEAD; check out a branch to pull"
-      : !hasUpstream
-        ? "Pull — no upstream branch to pull from yet; publish the branch first"
-        : behindLabel;
+      : head?.upstreamGone
+        ? // A gone upstream is configured-but-dead (branch deleted on the
+          // remote, e.g. after a merge) — not never-published; say so.
+          `Pull — upstream ${head?.upstream} was deleted on the remote (likely merged); use Publish branch to recreate it`
+        : !hasUpstream
+          ? "Pull — no upstream branch to pull from yet; publish the branch first"
+          : behindLabel;
 
   function doPull(mode: PullMode) {
     pull.mutate(mode, {
@@ -253,8 +257,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           ButtonGroup's border-collapse/rounding child selectors
           (`*:data-slot:rounded-r-none` + `[&>[data-slot]~[data-slot]]`) — the
           primitive then contributes only layout + `role="group"`, and THIS call
-          site owns the seams explicitly on the Buttons (rounded outer caps,
-          `rounded-none border-l-0` on the inner joins). Keep it that way: a
+          site owns the seams explicitly on the Buttons. The vendored Button is
+          square (`rounded-none` in its cva root and `sm` variant), so the only
+          load-bearing seam class is `border-l-0` on the joins. Keep it that way: a
           future reorder must set these classes, not lean on the primitive's
           adjacency magic (it has now misfired on two arrangements). The group's
           `*:focus-visible:z-10` also can't reach the Buttons through the spans,
@@ -266,7 +271,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             size="sm"
             disabled={busy || detached}
             aria-label={pushDescription}
-            className="rounded-r-none focus-visible:relative focus-visible:z-10"
+            className="focus-visible:relative focus-visible:z-10"
             onClick={() => {
               if (diverged) {
                 setForceConfirmOpen(true);
@@ -299,7 +304,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             size="sm"
             disabled={busy || !hasUpstream || diverged}
             aria-label={pullDescription}
-            className="rounded-none border-l-0 focus-visible:relative focus-visible:z-10"
+            className="border-l-0 focus-visible:relative focus-visible:z-10"
             onClick={() => doPull("ffOnly")}
           >
             {pull.isPending ? (
@@ -330,7 +335,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
                   // reconcile options (need a tracking upstream) or "Update from
                   // upstream" (needs the fork's upstream remote).
                   disabled={busy || (!hasUpstream && !canUpdateUpstream)}
-                  className="rounded-none border-l-0 px-1.5 focus-visible:relative focus-visible:z-10"
+                  className="border-l-0 px-1.5 focus-visible:relative focus-visible:z-10"
                 >
                   <CaretDownIcon />
                 </Button>
@@ -364,7 +369,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             variant="outline"
             size="sm"
             disabled={busy}
-            className="rounded-l-none border-l-0 focus-visible:relative focus-visible:z-10"
+            className="border-l-0 focus-visible:relative focus-visible:z-10"
             onClick={() => doFetch(false)}
           >
             {fetchRemote.isPending ? (

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -5,10 +5,8 @@ import {
   CaretDownIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
-import { AnimatePresence, m } from "motion/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import {
@@ -42,7 +40,6 @@ import {
   useUpdateFromUpstream,
 } from "@/lib/git/queries";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
-import { quickTransition } from "@/lib/motion";
 import { useSettings } from "@/lib/settings/queries";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
@@ -131,6 +128,42 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
       ? "Fetch from origin"
       : `Last fetched ${formatRelativeTime(new Date(lastFetchedAt).toISOString())}`;
 
+  // Ahead/behind counts now ride on the Push and Pull buttons themselves (the
+  // old standalone badges didn't say which button acted on them). Compute ONE
+  // description string per button and reuse it for BOTH the wrapper span's
+  // `title` and the Button's `aria-label`, so the pointer tooltip and the
+  // accessible name never drift. Each string starts with the button's visible
+  // label (WCAG 2.5.3, "label in name") and, when the button is disabled,
+  // carries the reason + remedy AND the count — the count needs a full-contrast
+  // home while the button itself sits at disabled opacity. The chains pick the
+  // first matching state; `undefined` means the visible label alone suffices
+  // (enabled + synced), so no tooltip and no aria-label are emitted.
+  const aheadCount = head?.ahead ?? 0;
+  const behindCount = head?.behind ?? 0;
+  const pushLabel = diverged
+    ? "Force push"
+    : hasUpstream
+      ? "Push"
+      : "Publish branch";
+  const aheadLabel =
+    aheadCount > 0
+      ? `${pushLabel} — ${aheadCount} commit${aheadCount === 1 ? "" : "s"} to push to ${head?.upstream}`
+      : undefined;
+  const behindLabel =
+    behindCount > 0
+      ? `Pull — ${behindCount} commit${behindCount === 1 ? "" : "s"} to pull from ${head?.upstream}`
+      : undefined;
+  const pushDescription = detached
+    ? `${pushLabel} — you're on a detached HEAD; check out a branch to push`
+    : aheadLabel;
+  const pullDescription = diverged
+    ? `Pull — branch has diverged (${behindCount} commit${behindCount === 1 ? "" : "s"} behind ${head?.upstream}); use Pull with rebase or merge from the menu`
+    : detached
+      ? "Pull — you're on a detached HEAD; check out a branch to pull"
+      : !hasUpstream
+        ? "Pull — no upstream branch to pull from yet; publish the branch first"
+        : behindLabel;
+
   function doPull(mode: PullMode) {
     pull.mutate(mode, {
       onSuccess: () => {
@@ -214,122 +247,26 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
 
   return (
     <div className="flex items-center gap-2">
-      <AnimatePresence>
-        {head && head.ahead > 0 && (
-          <m.div
-            key="ahead"
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.8 }}
-            transition={quickTransition}
-          >
-            <Badge variant="secondary">
-              <ArrowUpIcon className="size-3" />
-              {head.ahead}
-            </Badge>
-          </m.div>
-        )}
-        {head && head.behind > 0 && (
-          <m.div
-            key="behind"
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.8 }}
-            transition={quickTransition}
-          >
-            <Badge variant="secondary">
-              <ArrowDownIcon className="size-3" />
-              {head.behind}
-            </Badge>
-          </m.div>
-        )}
-      </AnimatePresence>
+      {/* Every segment is wrapped in a `title` <span> so a disabled button's
+          reason still shows on hover (a natively disabled button swallows its
+          own tooltip). Those spans have no `data-slot`, so they opt out of
+          ButtonGroup's border-collapse/rounding child selectors
+          (`*:data-slot:rounded-r-none` + `[&>[data-slot]~[data-slot]]`) — the
+          primitive then contributes only layout + `role="group"`, and THIS call
+          site owns the seams explicitly on the Buttons (rounded outer caps,
+          `rounded-none border-l-0` on the inner joins). Keep it that way: a
+          future reorder must set these classes, not lean on the primitive's
+          adjacency magic (it has now misfired on two arrangements). The group's
+          `*:focus-visible:z-10` also can't reach the Buttons through the spans,
+          so each Button carries `focus-visible:relative focus-visible:z-10`. */}
       <ButtonGroup>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={busy}
-          title={fetchTitle}
-          onClick={() => doFetch(false)}
-        >
-          {fetchRemote.isPending ? (
-            <Spinner data-icon="inline-start" />
-          ) : (
-            <ArrowsClockwiseIcon data-icon="inline-start" />
-          )}
-          Fetch
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={busy || !hasUpstream || diverged}
-          title={
-            diverged
-              ? "Branch has diverged — use Pull with rebase or merge from the menu"
-              : undefined
-          }
-          onClick={() => doPull("ffOnly")}
-        >
-          {pull.isPending ? (
-            <Spinner data-icon="inline-start" />
-          ) : (
-            <ArrowDownIcon data-icon="inline-start" />
-          )}
-          Pull
-        </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                variant="outline"
-                size="sm"
-                aria-label="Pull options"
-                // Reachable whenever there's a menu item to show: the pull
-                // reconcile options (need a tracking upstream) or "Update from
-                // upstream" (needs the fork's upstream remote).
-                disabled={busy || (!hasUpstream && !canUpdateUpstream)}
-                className="px-1.5"
-              >
-                <CaretDownIcon />
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="end" className="min-w-48">
-            {hasUpstream && (
-              <>
-                <DropdownMenuItem onClick={() => doPull("rebase")}>
-                  Pull with rebase
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => doPull("merge")}>
-                  Pull with merge
-                </DropdownMenuItem>
-              </>
-            )}
-            {canUpdateUpstream && (
-              <>
-                {hasUpstream && <DropdownMenuSeparator />}
-                {/* Base UI menu items fire on onClick, NOT onSelect. */}
-                <DropdownMenuItem onClick={doUpdateFromUpstream}>
-                  Update from upstream
-                </DropdownMenuItem>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        {/* Wrap so the detached-HEAD explanation still shows on hover — a
-            natively disabled button swallows its own `title` tooltip. */}
-        <span
-          className="inline-flex"
-          title={
-            detached
-              ? "You're on a detached HEAD — check out a branch to push"
-              : undefined
-          }
-        >
+        <span className="inline-flex" title={pushDescription}>
           <Button
             variant="outline"
             size="sm"
             disabled={busy || detached}
+            aria-label={pushDescription}
+            className="rounded-r-none focus-visible:relative focus-visible:z-10"
             onClick={() => {
               if (diverged) {
                 setForceConfirmOpen(true);
@@ -345,7 +282,97 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             ) : (
               <ArrowUpIcon data-icon="inline-start" />
             )}
-            {diverged ? "Force push" : hasUpstream ? "Push" : "Publish branch"}
+            {pushLabel}
+            {aheadCount > 0 && (
+              <span
+                aria-hidden="true"
+                className="text-muted-foreground tabular-nums"
+              >
+                {aheadCount}
+              </span>
+            )}
+          </Button>
+        </span>
+        <span className="inline-flex" title={pullDescription}>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy || !hasUpstream || diverged}
+            aria-label={pullDescription}
+            className="rounded-none border-l-0 focus-visible:relative focus-visible:z-10"
+            onClick={() => doPull("ffOnly")}
+          >
+            {pull.isPending ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <ArrowDownIcon data-icon="inline-start" />
+            )}
+            Pull
+            {behindCount > 0 && (
+              <span
+                aria-hidden="true"
+                className="text-muted-foreground tabular-nums"
+              >
+                {behindCount}
+              </span>
+            )}
+          </Button>
+        </span>
+        <span className="inline-flex">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  aria-label="Pull options"
+                  // Reachable whenever there's a menu item to show: the pull
+                  // reconcile options (need a tracking upstream) or "Update from
+                  // upstream" (needs the fork's upstream remote).
+                  disabled={busy || (!hasUpstream && !canUpdateUpstream)}
+                  className="rounded-none border-l-0 px-1.5 focus-visible:relative focus-visible:z-10"
+                >
+                  <CaretDownIcon />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end" className="min-w-48">
+              {hasUpstream && (
+                <>
+                  <DropdownMenuItem onClick={() => doPull("rebase")}>
+                    Pull with rebase
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => doPull("merge")}>
+                    Pull with merge
+                  </DropdownMenuItem>
+                </>
+              )}
+              {canUpdateUpstream && (
+                <>
+                  {hasUpstream && <DropdownMenuSeparator />}
+                  {/* Base UI menu items fire on onClick, NOT onSelect. */}
+                  <DropdownMenuItem onClick={doUpdateFromUpstream}>
+                    Update from upstream
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </span>
+        <span className="inline-flex" title={fetchTitle}>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            className="rounded-l-none border-l-0 focus-visible:relative focus-visible:z-10"
+            onClick={() => doFetch(false)}
+          >
+            {fetchRemote.isPending ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <ArrowsClockwiseIcon data-icon="inline-start" />
+            )}
+            Fetch
           </Button>
         </span>
       </ButtonGroup>


### PR DESCRIPTION
Surface branch synchronization counts directly on the actions that use them, so users can immediately see what will be pushed or pulled without interpreting separate badges. Reorders the controls to prioritize Push and Pull while preserving clear disabled-state guidance and accessible labels.

### Sync controls

- Updates `src/features/repository/SyncControls.tsx` to display ahead counts on the Push or Publish branch button and behind counts on the Pull button.
- Reorders the header controls in `src/features/repository/SyncControls.tsx` to Push, Pull, Pull options, and Fetch.
- Adds matching tooltips and accessible labels that describe commit counts, detached HEAD state, missing upstreams, and diverged branches.
- Removes the standalone animated ahead/behind badges and explicitly manages button-group borders and focus styling across the wrapped controls.

### Documentation and changelog

- Updates the sync feature help text in `src/features/help/content.ts` to describe the reordered controls and inline counts.
- Updates the syncing overview in `README.md` to document counts on the Push and Pull buttons.
- Adds `changelog.d/changed-sync-header-buttons.md` describing the control reorder and count placement.
- Updates the sync indicator reference in `src/features/repository/BranchSwitcher.tsx` to match the new header button terminology.