### PR TITLE
feat(lan,companion,settings): support sharing multiple repositories

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -1,12 +1,15 @@
-- **Phone companion (experimental preview).** Share the open repository with your
+- **Phone companion (experimental preview).** Share your repositories with your
   phone over your local network from **Settings → Phone companion**: pair a device by
   scanning a QR code and typing a PIN. Scanning opens a slim companion web app right
-  in your phone's browser — pair with the PIN, then read the repo's **Status, pull
+  in your phone's browser — pair with the PIN, then read a repo's **Status, pull
   requests, and CI** from your phone, read-only. Open a pull request for its overview,
   activity timeline, and review-thread conversation, and watch live **AI PR reviews and
-  agent sessions** stream in as they happen. Off by default, with per-device tokens
+  agent sessions** stream in as they happen. Your phone always sees the repository open
+  on this desktop, and you can **share and unshare additional repositories** (from the
+  panel or the command palette) to keep them reachable while you work in another —
+  switching repos no longer cuts a phone watching a shared repository. Off by default, with per-device tokens
   you can review and revoke at any time (even while sharing is off), and connected
-  phones are disconnected the moment you stop sharing, switch repos, or revoke their
+  phones are disconnected the moment you stop sharing, unshare a repository, or revoke their
   device. While sharing is on, GitDesktop keeps your computer awake so a phone can keep
   watching unattended (the display may still sleep). The connection is served over HTTPS
   with a self-signed certificate GitDesktop generates — your phone shows a one-time

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { BottomNav, TopBar } from "./components/Chrome";
 import { ErrorState } from "./components/states";
 import type { RepoSummary } from "./lib/api";
@@ -10,6 +10,7 @@ import {
   type Route,
   replace,
   repoHash,
+  type Tab,
   useRoute,
 } from "./lib/router";
 import { AgentsBody, AgentWatch } from "./screens/Agents";
@@ -38,9 +39,24 @@ export default function App() {
 
   // The shared repos list — device-level (no repo scope), so it's our always-
   // available authenticated probe AND the source of truth for the picker/title.
-  const reposQuery = useRepos();
+  // Gated OFF while pairing: a revoked-but-still-cookied device would otherwise
+  // bank rate-limit failures on every foreground during the pairing dance (the
+  // PR-75 lockout budget). See `useRepos`.
+  const reposQuery = useRepos(!route.isPairing);
   const reposErr = asApiError(reposQuery.error);
   const repos = reposQuery.data;
+
+  // Remember the last SCOPED route context (which repo + tab the user was on) so
+  // the picker — reached via `#repos`, whose hash carries NO repo segment — can
+  // still highlight the current repo and preserve the tab on a switch. In-memory
+  // only: a reload landing directly on `#repos` degrades to no-highlight/status,
+  // which is acceptable. Updated in an effect so the render stays pure.
+  const lastScoped = useRef<{ repoId: string; tab: Tab } | null>(null);
+  useEffect(() => {
+    if (route.repoId != null) {
+      lastScoped.current = { repoId: route.repoId, tab: route.tab };
+    }
+  }, [route.repoId, route.tab]);
 
   // Global 401 → the device isn't paired (or was revoked). Bounce to #pair — but
   // ONLY on a FRESH 401 (newer than the last successful pair), and never while a
@@ -104,6 +120,18 @@ export default function App() {
     : (selectedRepo?.name ?? "GitDesktop");
   const connected = reposQuery.isSuccess;
 
+  // The repo context the chrome should reflect. On a scoped route it's the route
+  // itself; on the picker (`#repos`, no repo in the hash) it's the remembered
+  // last-scoped context so the picker highlights the current repo, preserves the
+  // tab on a switch, and the bottom tabs still point somewhere coherent. Null on a
+  // cold entry directly on `#repos` (nothing remembered) — then the picker shows no
+  // highlight and the bottom nav is hidden (no repo to point its tabs at).
+  const chromeContext = route.isRepos
+    ? lastScoped.current
+    : route.repoId != null
+      ? { repoId: route.repoId, tab: route.tab }
+      : null;
+
   return (
     <div className="mx-auto flex min-h-dvh max-w-md flex-col">
       <TopBar
@@ -120,12 +148,19 @@ export default function App() {
           route={route}
           repos={repos}
           selectedRepo={selectedRepo}
+          pickerContext={chromeContext}
           reposError={reposQuery.error}
           onReposRetry={() => reposQuery.refetch()}
         />
       </main>
 
-      <BottomNav repoId={route.repoId} />
+      {/* Hide the bottom nav on the picker when there's no remembered repo — its
+          tabs would point at legacy hashes that just bounce back to #repos. With a
+          remembered repo they navigate to that repo's tabs (a real leave-the-picker
+          affordance). Off the picker it always shows, scoped to the live repo. */}
+      {route.isRepos && !chromeContext ? null : (
+        <BottomNav repoId={chromeContext?.repoId ?? null} />
+      )}
     </div>
   );
 }
@@ -166,17 +201,26 @@ function Shell({
   route,
   repos,
   selectedRepo,
+  pickerContext,
   reposError,
   onReposRetry,
 }: {
   route: Route;
   repos: RepoSummary[] | undefined;
   selectedRepo: RepoSummary | null;
+  pickerContext: { repoId: string; tab: Tab } | null;
   reposError: unknown;
   onReposRetry: () => void;
 }) {
   if (route.isRepos) {
-    return <ReposBody currentRepoId={route.repoId} currentTab={null} />;
+    // `#repos` carries no repo in the hash, so use the remembered scoped context
+    // (if any) to highlight the current repo and preserve its tab on a switch.
+    return (
+      <ReposBody
+        currentRepoId={pickerContext?.repoId ?? null}
+        currentTab={pickerContext?.tab ?? null}
+      />
+    );
   }
 
   // Repo-less route (bare entry, a legacy bookmark, or the post-pair

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -1,134 +1,243 @@
 import { useEffect } from "react";
 import { BottomNav, TopBar } from "./components/Chrome";
 import { ErrorState } from "./components/states";
+import type { RepoSummary } from "./lib/api";
 import { lastPairedAt } from "./lib/pairing-signal";
-import { asApiError, useStatus } from "./lib/queries";
-import { navigate, useRoute } from "./lib/router";
+import { asApiError, useRepos } from "./lib/queries";
+import {
+  isRepoId,
+  navigate,
+  type Route,
+  replace,
+  repoHash,
+  useRoute,
+} from "./lib/router";
 import { AgentsBody, AgentWatch } from "./screens/Agents";
 import { CiBody, CiDetail } from "./screens/Ci";
 import { Pair } from "./screens/Pair";
 import { PrDetail, PrsBody } from "./screens/Prs";
+import { ReposBody } from "./screens/Repos";
 import { StatusBody } from "./screens/Status";
 
 // The app shell. It owns the cross-cutting states so every screen inherits them:
 //   • 401 anywhere → route to #pair (token revoked / never paired)
-//   • 409 no-repo → a central teaching state
+//   • the selected repository (from the URL) + the shared-repos list
 //   • the sticky TopBar (repo name + connection) + BottomNav
 // Degraded/unreachable presentation is NOT here: each body renders its own
-// StaleBanner keyed on its OWN query (see the round-4 finding in states.tsx). A
-// shell-level banner derived from the status query doubled the message on the
-// Status tab and never fired on PRs/CI — so it was removed.
-// The Status query doubles as the shell's connection probe: it drives the
-// TopBar's live/offline dot and the global 401 redirect.
+// StaleBanner keyed on its OWN query (see the round-4 finding in states.tsx).
+//
+// The selected repo is a first-class, URL-persisted concept (slice 4). The
+// canonical routes are scoped (`#r/{repoId}/…`); the shell resolves a repo-less
+// route (a legacy bookmark, or the bare app entry) into a scoped one — or the
+// picker — once it knows the shared set. The `["repos"]` query doubles as the
+// device-level connection + auth signal (a 401 on it routes through the central
+// QueryCache → #pair, same as any other query).
 
 export default function App() {
   const route = useRoute();
 
-  // Probe the shared repo's status regardless of the active tab — it's the
-  // cheapest always-available authenticated call, so it's our connection +
-  // auth signal. Only poll it while Status is the visible tab (other tabs run
-  // their own polling query); elsewhere it still fetches once on mount/route
-  // change for the header + 401 check.
-  const statusQuery = useStatus(
-    route.tab === "status" && !route.isPairing,
-    // No authed traffic while unpaired: an unpaired page 401s on every probe.
-    !route.isPairing,
-  );
-  const statusErr = asApiError(statusQuery.error);
+  // The shared repos list — device-level (no repo scope), so it's our always-
+  // available authenticated probe AND the source of truth for the picker/title.
+  const reposQuery = useRepos();
+  const reposErr = asApiError(reposQuery.error);
+  const repos = reposQuery.data;
 
-  // Global 401 → the device isn't paired (or was revoked). Bounce to #pair —
-  // but ONLY on a FRESH 401.
+  // Global 401 → the device isn't paired (or was revoked). Bounce to #pair — but
+  // ONLY on a FRESH 401 (newer than the last successful pair), and never while a
+  // refetch is in flight (the settled result may be a 200). This mirrors the
+  // original status-probe guard, now driven by the device-level repos query so it
+  // holds on every route (including #repos, which has no repo to probe).
   //
   // LIVE-FOUND RACE (post-pair bounce): while the user sat on #pair, this probe
-  // cached a 401 (no cookie yet). Without the guards below, pairing → navigate
-  // to #status → this effect reads the STALE cached 401 → bounces the freshly-
-  // paired user straight back to the PIN screen (Back then lands on #status,
-  // authed). Two guards make a pre-pair 401 un-bounceable:
-  //   • `!isFetching` — never act while a refetch is in flight (the settled
-  //     result may be a 200);
-  //   • `errorUpdatedAt > lastPairedAt()` — the 401 must be NEWER than the last
-  //     successful pair. Pair.tsx stamps `markPaired()` and awaits a status
-  //     refetch before navigating, so a genuine post-pair revoke still bounces,
-  //     but the pre-pair 401 (older timestamp) never does.
+  // could cache a 401 (no cookie yet); without these guards, pairing → navigate
+  // would read the STALE 401 and bounce the freshly-paired user back to the PIN
+  // screen. `errorUpdatedAt > lastPairedAt()` + `!isFetching` make a pre-pair 401
+  // un-bounceable; a genuine post-pair revoke (newer timestamp) still bounces.
+  // (The central QueryCache onError also redirects on 401; this guarded effect is
+  // the belt-and-braces that survives the post-pair race.)
   useEffect(() => {
     if (
-      statusErr?.isUnauthorized &&
+      reposErr?.isUnauthorized &&
       !route.isPairing &&
-      !statusQuery.isFetching &&
-      statusQuery.errorUpdatedAt > lastPairedAt()
+      !reposQuery.isFetching &&
+      reposQuery.errorUpdatedAt > lastPairedAt()
     ) {
       navigate("#pair");
     }
   }, [
-    statusErr,
+    reposErr,
     route.isPairing,
-    statusQuery.isFetching,
-    statusQuery.errorUpdatedAt,
+    reposQuery.isFetching,
+    reposQuery.errorUpdatedAt,
   ]);
+
+  // Bootstrap/redirect: a repo-less route that isn't #pair/#repos needs resolving
+  // once the shared set is known. Exactly one repo, or an active repo → REPLACE to
+  // its scoped equivalent (preserving the tab tail). Anything else — multiple repos
+  // with none active, OR zero shared repos — sends to the picker, which owns both
+  // the choose-one and the nothing-shared teaching states. REPLACE (not push) so
+  // Back doesn't bounce onto the bare legacy hash that would just redirect again.
+  useEffect(() => {
+    if (route.isPairing || route.isRepos || route.repoId != null) return;
+    if (!repos) return; // wait for the list
+    const target = resolveRepo(repos);
+    if (target) {
+      replace(repoHash(target, tabTail(route)));
+    } else {
+      replace("#repos");
+    }
+  }, [route, repos]);
 
   if (route.isPairing) {
     return <Pair />;
   }
 
-  const repoName = deriveRepoName(statusQuery.data?.branch.name ?? null);
-  const connected = statusQuery.isSuccess;
-  // A no-repo (409) is a whole-app state — show it centrally, not per tab.
-  const noRepo = statusErr?.isNoActiveRepo ?? false;
+  const selectedRepo =
+    route.repoId != null
+      ? (repos?.find((r) => r.id === route.repoId) ?? null)
+      : null;
+  // The title: the selected repo's name, a neutral label on the picker, or a
+  // fallback while the list loads / mid-redirect. `connected` is the device-level
+  // reachability of the repos probe.
+  const title = route.isRepos
+    ? "Choose repository"
+    : (selectedRepo?.name ?? "GitDesktop");
+  const connected = reposQuery.isSuccess;
 
   return (
     <div className="mx-auto flex min-h-dvh max-w-md flex-col">
       <TopBar
-        title={repoName}
-        subtitle={statusQuery.data?.branch.name ?? undefined}
+        title={title}
+        // The title is a tappable "switch repository" trigger EXCEPT on the picker
+        // itself (nowhere to switch to) — the shell passes the handler only when a
+        // repo context exists.
+        onSwitchRepo={route.isRepos ? undefined : () => navigate("#repos")}
         connected={connected}
       />
 
       <main className="flex-1">
-        {noRepo ? (
-          <ErrorState
-            error={statusQuery.error}
-            onRetry={() => statusQuery.refetch()}
-          />
-        ) : (
-          <Screen route={route} />
-        )}
+        <Shell
+          route={route}
+          repos={repos}
+          selectedRepo={selectedRepo}
+          reposError={reposQuery.error}
+          onReposRetry={() => reposQuery.refetch()}
+        />
       </main>
 
-      <BottomNav />
+      <BottomNav repoId={route.repoId} />
     </div>
   );
 }
 
-function Screen({ route }: { route: ReturnType<typeof useRoute> }) {
+/** Pick the repo to auto-select for a repo-less route: the single shared repo, or
+ *  the active one (open on the desktop). Returns its id, or null when the choice
+ *  is ambiguous (multiple repos, none active) or empty.
+ *
+ *  Defense-in-depth: ignore any repo whose id fails the router's grammar. A
+ *  redirect to `#r/{bad}/…` would parse back to `repoId: null`, re-fire the
+ *  bootstrap effect, and loop; degrading a malformed id to the picker (or the
+ *  next valid candidate) is the safe failure. */
+function resolveRepo(repos: RepoSummary[]): string | null {
+  const valid = repos.filter((r) => isRepoId(r.id));
+  if (valid.length === 1) return valid[0].id;
+  const active = valid.find((r) => r.active);
+  return active ? active.id : null;
+}
+
+/** The `{tab}[/{detail}]` tail of the current route, for preserving context across
+ *  a redirect. A legacy `#prs/4` becomes `prs/4`; a bare `#status` becomes
+ *  `status`. */
+function tabTail(route: Route): string {
+  if (route.tab === "prs" && route.detailId != null)
+    return `prs/${route.detailId}`;
+  if (route.tab === "ci" && route.detailId != null)
+    return `ci/${route.detailId}`;
+  if (route.tab === "agents" && route.streamId != null)
+    return `agents/${route.streamId}`;
+  return route.tab;
+}
+
+/** Route to the right body. The picker (`#repos`) is handled here; a repo-less
+ *  route normally renders nothing (a redirect is pending — see the bootstrap
+ *  effect) but shows the repos error state when the list can't load; a scoped
+ *  route whose repo isn't in the shared set falls back to the picker. */
+function Shell({
+  route,
+  repos,
+  selectedRepo,
+  reposError,
+  onReposRetry,
+}: {
+  route: Route;
+  repos: RepoSummary[] | undefined;
+  selectedRepo: RepoSummary | null;
+  reposError: unknown;
+  onReposRetry: () => void;
+}) {
+  if (route.isRepos) {
+    return <ReposBody currentRepoId={route.repoId} currentTab={null} />;
+  }
+
+  // Repo-less route (bare entry, a legacy bookmark, or the post-pair
+  // `navigate("#status")`): the bootstrap effect redirects to a scoped route or
+  // the picker ONCE the list loads. But if the list itself can't load (desktop
+  // unreachable / 5xx — a 401 already bounced to #pair), there's no repo to
+  // redirect to and no tab to fall back on, so render the repos error state with a
+  // Retry rather than a permanent blank main area. (`ErrorState` owns the
+  // unreachable/generic branches; `noSuchRepo` can't occur on the un-scoped repos
+  // route.)
+  if (route.repoId == null) {
+    if (!repos && reposError != null) {
+      return <ErrorState error={reposError} onRetry={onReposRetry} />;
+    }
+    // Still loading, or a redirect is pending — render nothing to avoid a flash.
+    return null;
+  }
+
+  // A scoped route whose repoId isn't in the loaded shared set — it just stopped
+  // being shared, or the URL was hand-crafted. Route through the picker (with the
+  // current tab preserved) rather than firing scoped queries that would 404. While
+  // the list is still loading (`repos` undefined) we let the screen mount — its own
+  // query surfaces a `noSuchRepo` teaching state if the id is genuinely gone.
+  if (repos && !selectedRepo) {
+    return <ReposBody currentRepoId={route.repoId} currentTab={route.tab} />;
+  }
+
+  return <Screen route={route} repoId={route.repoId} />;
+}
+
+function Screen({ route, repoId }: { route: Route; repoId: string }) {
   if (route.tab === "prs") {
     return route.detailId != null ? (
-      <PrDetail number={route.detailId} />
+      <PrDetail repoId={repoId} number={route.detailId} />
     ) : (
-      <PrsBody active />
+      <PrsBody repoId={repoId} active />
     );
   }
   if (route.tab === "ci") {
     return route.detailId != null ? (
-      <CiDetail id={route.detailId} />
+      <CiDetail repoId={repoId} id={route.detailId} />
     ) : (
-      <CiBody active />
+      <CiBody repoId={repoId} active />
     );
   }
   if (route.tab === "agents") {
     // The ternary UNMOUNTS the list while a watch is open, so the list's polling
     // query stops on its own — the list is only mounted (and thus polling) in the
-    // else-arm, where it's always the active view.
+    // else-arm, where it's always the active view. Key the watch by `repoId:id` so
+    // a change of either forces a fresh mount (resetting the SSE reducer state) —
+    // no current path swaps them under a mounted watch, but keying makes that a
+    // non-footgun rather than relying on it never happening.
     return route.streamId != null ? (
-      <AgentWatch id={route.streamId} />
+      <AgentWatch
+        key={`${repoId}:${route.streamId}`}
+        repoId={repoId}
+        id={route.streamId}
+      />
     ) : (
-      <AgentsBody active />
+      <AgentsBody repoId={repoId} active />
     );
   }
-  return <StatusBody active />;
-}
-
-/** A short repo label. The status API exposes the branch, not the repo name, so
- *  fall back to a neutral title until a richer field exists (a later slice). */
-function deriveRepoName(_branch: string | null): string {
-  return "GitDesktop";
+  return <StatusBody repoId={repoId} active />;
 }

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -1,36 +1,53 @@
 import {
+  CaretUpDownIcon,
   GitBranchIcon,
   GitPullRequestIcon,
   PlayCircleIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
-import { navigate, type Tab, useRoute } from "../lib/router";
+import { navigate, repoHash, type Tab, useRoute } from "../lib/router";
 
 // Shared chrome: a sticky top bar (repo/connection) and a bottom tab nav. Both
 // are keyboard-operable; the bottom nav uses roving links with ≥44px targets.
 
-/** Sticky top bar: the shared repo name (left) and a quiet connection dot
- *  (right). `connected` false renders a muted/offline indicator with text. */
+/** Sticky top bar: the selected repo name (left, a tap-to-switch trigger) and a
+ *  quiet connection dot (right). `connected` false renders a muted/offline
+ *  indicator with text. When `onSwitchRepo` is provided the title is a real
+ *  button (chevron affordance, ≥44px target, "Switch repository" label);
+ *  otherwise it's plain text (e.g. on the picker itself). */
 export function TopBar({
   title,
-  subtitle,
+  onSwitchRepo,
   connected,
 }: {
   title: string;
-  subtitle?: string;
+  onSwitchRepo?: () => void;
   connected: boolean;
 }) {
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-border bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-      <div className="min-w-0">
-        <p className="truncate text-sm font-semibold text-foreground">
+    <header className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-border bg-background/95 px-4 py-1.5 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      {onSwitchRepo ? (
+        <button
+          type="button"
+          onClick={onSwitchRepo}
+          aria-label="Switch repository"
+          className="-mx-2 flex min-h-11 min-w-0 items-center gap-1.5 rounded px-2 text-left"
+        >
+          <span className="truncate text-sm font-semibold text-foreground">
+            {title}
+          </span>
+          <CaretUpDownIcon
+            size={16}
+            className="shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+        </button>
+      ) : (
+        <p className="min-w-0 truncate py-2.5 text-sm font-semibold text-foreground">
           {title}
         </p>
-        {subtitle ? (
-          <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
-        ) : null}
-      </div>
+      )}
       <span
         className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
         title={connected ? "Connected" : "Not connected"}
@@ -45,39 +62,36 @@ export function TopBar({
   );
 }
 
-const TABS: { tab: Tab; label: string; icon: ReactNode; hash: string }[] = [
-  {
-    tab: "status",
-    label: "Status",
-    icon: <GitBranchIcon size={22} />,
-    hash: "#status",
-  },
-  {
-    tab: "prs",
-    label: "PRs",
-    icon: <GitPullRequestIcon size={22} />,
-    hash: "#prs",
-  },
-  { tab: "ci", label: "CI", icon: <PlayCircleIcon size={22} />, hash: "#ci" },
-  {
-    tab: "agents",
-    label: "Agents",
-    icon: <RobotIcon size={22} />,
-    hash: "#agents",
-  },
+const TABS: { tab: Tab; label: string; icon: ReactNode }[] = [
+  { tab: "status", label: "Status", icon: <GitBranchIcon size={22} /> },
+  { tab: "prs", label: "PRs", icon: <GitPullRequestIcon size={22} /> },
+  { tab: "ci", label: "CI", icon: <PlayCircleIcon size={22} /> },
+  { tab: "agents", label: "Agents", icon: <RobotIcon size={22} /> },
 ];
 
-/** Bottom tab nav. Each tab is a real link (Tab-focusable); the active tab is
- *  marked with `aria-current`. Left/Right arrows move between tabs (roving). */
-export function BottomNav() {
+/** Build a tab's hash for the current repo scope. With a repoId the tabs are
+ *  scoped (`#r/{repoId}/{tab}`); without one (picker / mid-redirect) they fall
+ *  back to the legacy hash, which the shell resolves to a scoped route. */
+function tabHash(tab: Tab, repoId: string | null): string {
+  return repoId ? repoHash(repoId, tab) : `#${tab}`;
+}
+
+/** Bottom tab nav. Each tab is a real link (Tab-focusable) scoped to the selected
+ *  repo; the active tab is marked with `aria-current`. Left/Right arrows move
+ *  between tabs (roving). No tab is active on the picker (`#repos`) — it isn't a
+ *  tab. */
+export function BottomNav({ repoId }: { repoId: string | null }) {
   const route = useRoute();
+  // Only highlight a tab when a repo tab is actually showing — not on the picker
+  // or the pairing takeover (both set `route.tab` to its default `status`).
+  const tabActive = !route.isPairing && !route.isRepos;
 
   function onKeyDown(e: React.KeyboardEvent, index: number) {
     if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
     e.preventDefault();
     const dir = e.key === "ArrowRight" ? 1 : -1;
     const next = (index + dir + TABS.length) % TABS.length;
-    navigate(TABS[next].hash);
+    navigate(tabHash(TABS[next].tab, repoId));
     // Canonical roving-tablist behavior: DOM focus follows the arrow selection.
     const links = e.currentTarget.closest("nav")?.querySelectorAll("a");
     links?.[next]?.focus();
@@ -89,11 +103,11 @@ export function BottomNav() {
       aria-label="Sections"
     >
       {TABS.map((t, i) => {
-        const active = route.tab === t.tab && !route.isPairing;
+        const active = tabActive && route.tab === t.tab;
         return (
           <a
             key={t.tab}
-            href={t.hash}
+            href={tabHash(t.tab, repoId)}
             aria-current={active ? "page" : undefined}
             onKeyDown={(e) => onKeyDown(e, i)}
             className={`flex min-h-14 flex-col items-center justify-center gap-1 text-xs font-medium ${

--- a/companion/src/components/states.tsx
+++ b/companion/src/components/states.tsx
@@ -1,11 +1,23 @@
 import {
   ArrowClockwiseIcon,
+  FolderOpenIcon,
   PlugsIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
-import type { ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useEffect } from "react";
 import { ApiError } from "../lib/api";
 import { navigate } from "../lib/router";
+
+/** Whether a query error is the DEFINITIVE "this repo is no longer shared" 404
+ *  (`noSuchRepo`). Screens check this to let the repo-gone state WIN over the
+ *  stale-data-preference branch: a transient error keeps showing cached data with
+ *  a StaleBanner, but a definitive gone must kick the user to the teaching state
+ *  even when a cached list is still on hand. Uses the `ApiError` getter — no
+ *  string matching. */
+export function isRepoGoneError(error: unknown): boolean {
+  return error instanceof ApiError && error.isNoSuchRepo;
+}
 
 // The shared data-screen states. Every list/detail screen routes its hook's
 // status through these so loading/empty/error/no-repo/unreachable look identical
@@ -58,6 +70,52 @@ export function EmptyState({ title, hint }: { title: string; hint?: string }) {
   return <CenteredState title={title}>{hint}</CenteredState>;
 }
 
+/** A primary-action button that navigates to the repo picker. Used by the
+ *  repo-gone teaching state — the device is still paired, so the way forward is to
+ *  pick another shared repo, never to re-pair. */
+function ChooseRepoButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => navigate("#repos")}
+      className="mt-2 inline-flex min-h-11 items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+    >
+      <FolderOpenIcon size={16} weight="bold" />
+      Choose repository
+    </button>
+  );
+}
+
+/**
+ * The repository this screen was scoped to is no longer shared from the desktop
+ * (the server 404'd `noSuchRepo`). A calm teaching state, modeled on the
+ * noRemote/GoneState patterns — NOT an error, and NEVER a bounce to `#pair`: the
+ * phone is still paired, it just needs a different repo. Reusable so any screen
+ * (and the agent watch) renders the same thing.
+ */
+export function RepoGoneState() {
+  // Invalidate the shared-repos list on mount so the picker the user is about to
+  // land on is fresh. Without this, `useRepos`'s 30s staleTime can still list the
+  // just-unshared repo, and tapping it loops straight back to this gone state.
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ["repos"] });
+  }, [queryClient]);
+
+  return (
+    <CenteredState
+      icon={<FolderOpenIcon size={32} className="text-muted-foreground" />}
+      title="This repository is no longer shared from the desktop."
+    >
+      Choose another shared repository, or share this one again in GitDesktop on
+      your desktop.
+      <span className="mt-3 block">
+        <ChooseRepoButton />
+      </span>
+    </CenteredState>
+  );
+}
+
 /** A retry button matching the primary-action styling. */
 function RetryButton({ onRetry }: { onRetry: () => void }) {
   return (
@@ -103,6 +161,13 @@ export function ErrorState({
         </button>
       </CenteredState>
     );
+  }
+
+  if (api?.isNoSuchRepo) {
+    // The scoped repo stopped being shared (or never was). A teaching state with a
+    // "Choose repository" path — the device stays paired, so we never bounce to
+    // `#pair`. See {@link RepoGoneState}.
+    return <RepoGoneState />;
   }
 
   if (api?.isNoRemote) {

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -86,6 +86,18 @@ export class ApiError extends Error {
   get isNoRemote(): boolean {
     return this.kind === "noRemote";
   }
+  /**
+   * The `{repoId}` in a scoped route is not (or no longer) a shared repository —
+   * the server mints `404 { kind: "noSuchRepo", … }` for an unknown OR unshared
+   * id (deliberately indistinguishable). On a screen this means "the repo you had
+   * selected stopped being shared from the desktop"; the device is still paired,
+   * so the calm teaching state offers "Choose repository" (NEVER a bounce to
+   * `#pair`). Both the status AND the 404-kind must match so an unrelated 404
+   * (e.g. a PR number that doesn't exist) never reads as a gone repo.
+   */
+  get isNoSuchRepo(): boolean {
+    return this.status === 404 && this.kind === "noSuchRepo";
+  }
 }
 
 interface ErrorBody {
@@ -137,46 +149,71 @@ async function toApiError(res: Response): Promise<ApiError> {
   );
 }
 
-// ── Read routes ──────────────────────────────────────────────────────────────
+// ── Repo picker ───────────────────────────────────────────────────────────────
 
-export const fetchStatus = () => getJson<RepoStatus>("/api/repo/status");
+/** One shared repository the desktop is exposing over the LAN. `id` is 16
+ *  lowercase hex chars; `active` marks the one currently open on the desktop. */
+export interface RepoSummary {
+  id: string;
+  name: string;
+  active: boolean;
+}
 
-export const fetchPrs = (state = "open", limit = 30) =>
+/** The repositories shared from the desktop. Bearer-authed, NOT repo-scoped (no
+ *  resolver) — may return 0, 1, or N. Order is unspecified; callers sort. */
+export const fetchRepos = () => getJson<RepoSummary[]>("/api/repos");
+
+// ── Read routes (repo-scoped) ─────────────────────────────────────────────────
+// Every data fetcher is scoped to a `repoId` (slice 4): the path is
+// `/api/repos/{repoId}/…` and an unknown/unshared id 404s with `noSuchRepo`. The
+// legacy alias routes (`/api/repo/…`, `/api/forge/…`) still exist server-side but
+// the companion no longer uses them for data.
+
+/** Base for a repo's scoped routes. The id is already grammar-validated by the
+ *  router before it reaches here, but encode it anyway (defense in depth). */
+const scope = (repoId: string) => `/api/repos/${encodeURIComponent(repoId)}`;
+
+export const fetchStatus = (repoId: string) =>
+  getJson<RepoStatus>(`${scope(repoId)}/status`);
+
+export const fetchPrs = (repoId: string, state = "open", limit = 30) =>
   getJson<PrInfo[]>(
-    `/api/forge/prs?state=${encodeURIComponent(state)}&limit=${limit}`,
+    `${scope(repoId)}/prs?state=${encodeURIComponent(state)}&limit=${limit}`,
   );
 
-export const fetchPr = (number: number) =>
-  getJson<PrDetails>(`/api/forge/prs/${number}`);
+export const fetchPr = (repoId: string, number: number) =>
+  getJson<PrDetails>(`${scope(repoId)}/prs/${number}`);
 
-export const fetchCiRuns = (limit = 20) =>
-  getJson<WorkflowRun[]>(`/api/forge/ci/runs?limit=${limit}`);
+export const fetchCiRuns = (repoId: string, limit = 20) =>
+  getJson<WorkflowRun[]>(`${scope(repoId)}/ci/runs?limit=${limit}`);
 
-export const fetchCiRun = (id: number) =>
-  getJson<RunDetail>(`/api/forge/ci/runs/${id}`);
+export const fetchCiRun = (repoId: string, id: number) =>
+  getJson<RunDetail>(`${scope(repoId)}/ci/runs/${id}`);
 
 /** A PR's activity timeline (force-pushes, label changes, review requests, state
  *  changes, approvals). Same neutral shape the desktop's `forgePrTimeline` returns. */
-export const fetchPrTimeline = (number: number) =>
-  getJson<PrTimelineEvent[]>(`/api/forge/prs/${number}/timeline`);
+export const fetchPrTimeline = (repoId: string, number: number) =>
+  getJson<PrTimelineEvent[]>(`${scope(repoId)}/prs/${number}/timeline`);
 
 /** A PR's file:line-anchored review threads with their comment chains. Same
  *  neutral shape the desktop's `forgePrReviewThreads` returns. */
-export const fetchPrThreads = (number: number) =>
-  getJson<ReviewThreadOut[]>(`/api/forge/prs/${number}/threads`);
+export const fetchPrThreads = (repoId: string, number: number) =>
+  getJson<ReviewThreadOut[]>(`${scope(repoId)}/prs/${number}/threads`);
 
 // ── Agent streams (live AI review / agent sessions) ───────────────────────────
 
 /** One shareable agent stream — an AI PR review (`review`) or an agent session
  *  (`session`). `id` is a UUID-like STRING (never a number). `startedAt` is
- *  ISO-8601. The live event stream is at `/api/reviews/{id}/stream` (SSE). */
+ *  ISO-8601. The live event stream is at `/api/repos/{repoId}/reviews/{id}/stream`
+ *  (SSE). */
 export interface ReviewInfo {
   id: string;
   kind: "review" | "session";
   startedAt: string;
 }
 
-export const fetchReviews = () => getJson<ReviewInfo[]>("/api/reviews");
+export const fetchReviews = (repoId: string) =>
+  getJson<ReviewInfo[]>(`${scope(repoId)}/reviews`);
 
 // ── Pairing ──────────────────────────────────────────────────────────────────
 

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -7,6 +7,7 @@ import {
   fetchPrs,
   fetchPrThreads,
   fetchPrTimeline,
+  fetchRepos,
   fetchReviews,
   fetchStatus,
 } from "./api";
@@ -32,13 +33,15 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 10_000,
-      // One retry for transient failures — but never for a 401/409: both are
-      // definitive, and a retried 401 re-sends the dead cookie, double-billing
-      // the per-IP lockout budget on every poll cycle.
+      // One retry for transient failures — but never for a definitive error: a
+      // 401 (re-sending the dead cookie double-bills the per-IP lockout budget on
+      // every poll cycle), a 409 noActiveRepo, or a 404 noSuchRepo (the scoped
+      // repo is gone — a retry can't conjure it back and only delays the
+      // repo-gone state).
       retry: (failureCount, err) =>
         !(
           err instanceof ApiError &&
-          (err.isUnauthorized || err.isNoActiveRepo)
+          (err.isUnauthorized || err.isNoActiveRepo || err.isNoSuchRepo)
         ) && failureCount < 1,
       refetchOnWindowFocus: false,
     },
@@ -51,84 +54,114 @@ export const queryClient = new QueryClient({
 const POLL_MS = 15_000;
 const poll = (active: boolean) => (active ? POLL_MS : (false as const));
 
-/** The shared repo's status. `active` gates polling to the visible screen;
- *  `enabled` (default true) gates the query entirely — the shell passes false
- *  while the phone sits on `#pair`, so an unpaired page never fires authed
- *  requests (each would 401, and pre-pair traffic was how the shell once banked
- *  rate-limit failures before the user ever typed a PIN). */
-export function useStatus(active: boolean, enabled = true) {
+/** The repositories shared from the desktop, for the picker + TopBar title.
+ *  A modest freshness window plus refetch-on-focus (the ONE exception to the
+ *  companion's no-focus-refetch default): the shared set changes on the DESKTOP,
+ *  so when the user brings the phone back to foreground we want a current list —
+ *  a repo that stopped being shared should drop out promptly. Device-level (not
+ *  repo-scoped): safe to fetch on any authed screen, and a 401 still routes
+ *  through the central QueryCache → `#pair`. */
+export function useRepos() {
   return useQuery({
-    queryKey: ["status"],
-    queryFn: fetchStatus,
-    enabled,
-    refetchInterval: enabled ? poll(active) : false,
+    queryKey: ["repos"],
+    queryFn: fetchRepos,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
   });
 }
 
-export function usePrs(active: boolean) {
+/** The selected repo's status. `repoId` scopes the query + cache key; `active`
+ *  gates polling to the visible screen; `enabled` (default true) gates the query
+ *  entirely — the shell passes false while the phone sits on `#pair`, so an
+ *  unpaired page never fires authed requests (each would 401, and pre-pair
+ *  traffic was how the shell once banked rate-limit failures before the user ever
+ *  typed a PIN). A null `repoId` also disables it (no repo selected yet). */
+export function useStatus(
+  repoId: string | null,
+  active: boolean,
+  enabled = true,
+) {
+  const on = enabled && repoId != null;
   return useQuery({
-    queryKey: ["prs", "open"],
-    queryFn: () => fetchPrs("open"),
-    refetchInterval: poll(active),
+    queryKey: ["status", repoId],
+    queryFn: () => fetchStatus(repoId as string),
+    enabled: on,
+    refetchInterval: on ? poll(active) : false,
   });
 }
 
-export function usePr(number: number | null) {
+export function usePrs(repoId: string | null, active: boolean) {
   return useQuery({
-    queryKey: ["pr", number],
-    queryFn: () => fetchPr(number as number),
-    enabled: number != null,
+    queryKey: ["prs", repoId, "open"],
+    queryFn: () => fetchPrs(repoId as string, "open"),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
+  });
+}
+
+export function usePr(repoId: string | null, number: number | null) {
+  const on = repoId != null && number != null;
+  return useQuery({
+    queryKey: ["pr", repoId, number],
+    queryFn: () => fetchPr(repoId as string, number as number),
+    enabled: on,
     // A detail view is a deliberate drill-in; poll it while it's open.
-    refetchInterval: number != null ? POLL_MS : (false as const),
+    refetchInterval: on ? POLL_MS : (false as const),
   });
 }
 
-export function useCiRuns(active: boolean) {
+export function useCiRuns(repoId: string | null, active: boolean) {
   return useQuery({
-    queryKey: ["ci", "runs"],
-    queryFn: () => fetchCiRuns(),
-    refetchInterval: poll(active),
+    queryKey: ["ci", "runs", repoId],
+    queryFn: () => fetchCiRuns(repoId as string),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
   });
 }
 
-export function useCiRun(id: number | null) {
+export function useCiRun(repoId: string | null, id: number | null) {
+  const on = repoId != null && id != null;
   return useQuery({
-    queryKey: ["ci", "run", id],
-    queryFn: () => fetchCiRun(id as number),
-    enabled: id != null,
-    refetchInterval: id != null ? POLL_MS : (false as const),
+    queryKey: ["ci", "run", repoId, id],
+    queryFn: () => fetchCiRun(repoId as string, id as number),
+    enabled: on,
+    refetchInterval: on ? POLL_MS : (false as const),
   });
 }
 
-/** The live agent streams (AI reviews + agent sessions) to watch. `active` gates
- *  polling — pass false while a watch screen is open so the list doesn't poll
- *  behind it. The watch screen also refetches THIS query to classify a stream that
- *  closed without a terminal event (present → still live, gone → ended/unshared),
- *  which is why it lives here (a react-query refetch routes a 401 through the
- *  central QueryCache → `#pair`, unlike a raw fetch). */
-export function useReviews(active: boolean) {
+/** The live agent streams (AI reviews + agent sessions) to watch. `repoId` scopes
+ *  the query + cache key; `active` gates polling — pass false while a watch screen
+ *  is open so the list doesn't poll behind it. The watch screen also refetches
+ *  THIS query to classify a stream that closed without a terminal event (present →
+ *  still live, gone → ended/unshared), which is why it lives here (a react-query
+ *  refetch routes a 401 through the central QueryCache → `#pair`, unlike a raw
+ *  fetch). */
+export function useReviews(repoId: string | null, active: boolean) {
   return useQuery({
-    queryKey: ["reviews"],
-    queryFn: fetchReviews,
-    refetchInterval: poll(active),
+    queryKey: ["reviews", repoId],
+    queryFn: () => fetchReviews(repoId as string),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
   });
 }
 
-export function usePrTimeline(number: number | null) {
+export function usePrTimeline(repoId: string | null, number: number | null) {
+  const on = repoId != null && number != null;
   return useQuery({
-    queryKey: ["pr", number, "timeline"],
-    queryFn: () => fetchPrTimeline(number as number),
-    enabled: number != null,
-    refetchInterval: number != null ? POLL_MS : (false as const),
+    queryKey: ["pr", repoId, number, "timeline"],
+    queryFn: () => fetchPrTimeline(repoId as string, number as number),
+    enabled: on,
+    refetchInterval: on ? POLL_MS : (false as const),
   });
 }
 
-export function usePrThreads(number: number | null) {
+export function usePrThreads(repoId: string | null, number: number | null) {
+  const on = repoId != null && number != null;
   return useQuery({
-    queryKey: ["pr", number, "threads"],
-    queryFn: () => fetchPrThreads(number as number),
-    enabled: number != null,
-    refetchInterval: number != null ? POLL_MS : (false as const),
+    queryKey: ["pr", repoId, number, "threads"],
+    queryFn: () => fetchPrThreads(repoId as string, number as number),
+    enabled: on,
+    refetchInterval: on ? POLL_MS : (false as const),
   });
 }
 

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -60,11 +60,23 @@ const poll = (active: boolean) => (active ? POLL_MS : (false as const));
  *  so when the user brings the phone back to foreground we want a current list —
  *  a repo that stopped being shared should drop out promptly. Device-level (not
  *  repo-scoped): safe to fetch on any authed screen, and a 401 still routes
- *  through the central QueryCache → `#pair`. */
-export function useRepos() {
+ *  through the central QueryCache → `#pair`.
+ *
+ *  `enabled` (default true) gates the query entirely — the shell passes false
+ *  while the phone sits on `#pair` so an unpaired (or revoked-but-still-cookied)
+ *  page fires ZERO authed traffic. This is load-bearing, not hygiene: a device
+ *  that paired then got revoked still holds the `gd_lan` cookie, and the server
+ *  deliberately penalizes a PRESENT-but-invalid credential (the PR-75 lockout
+ *  budget). The phone backgrounds/foregrounds repeatedly during the pairing
+ *  dance; with the query enabled, each foreground's focus-refetch would bank a
+ *  rate-limit failure until the device locks itself out of RE-pairing. A disabled
+ *  query neither mount-fetches nor focus-refetches, so `refetchOnWindowFocus` is
+ *  safe to leave on for the enabled state. */
+export function useRepos(enabled = true) {
   return useQuery({
     queryKey: ["repos"],
     queryFn: fetchRepos,
+    enabled,
     staleTime: 30_000,
     refetchOnWindowFocus: true,
   });

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -1,9 +1,19 @@
 import { useMemo, useSyncExternalStore } from "react";
 
 // Hash routing ONLY — the LAN server serves a single `index.html` and does no
-// history-API rewriting, so every route lives in `location.hash`. Routes:
-//   #pair · #status · #prs · #prs/{n} · #ci · #ci/{id} · #agents · #agents/{id}
-// Default (empty / unknown hash) resolves to #status.
+// history-API rewriting, so every route lives in `location.hash`.
+//
+// The selected repository is a first-class, URL-persisted concept (slice 4). The
+// canonical scoped forms carry it:
+//   #r/{repoId}/status · #r/{repoId}/prs · #r/{repoId}/prs/{n} · #r/{repoId}/ci ·
+//   #r/{repoId}/ci/{id} · #r/{repoId}/agents · #r/{repoId}/agents/{streamId}
+// Plus two global (repo-less) routes:
+//   #pair   — the pairing takeover (unchanged)
+//   #repos  — the repo picker
+// Legacy single-repo hashes (`#status`, `#prs/{n}`, `#ci/{id}`, `#agents/{id}`)
+// still parse — with `repoId: null` — so old bookmarks keep working; the shell
+// redirects them to the scoped equivalent once it knows which repo to use.
+// Default (empty / unknown hash) resolves to #status with a null repoId.
 
 export type Tab = "status" | "prs" | "ci" | "agents";
 
@@ -12,18 +22,62 @@ export type Tab = "status" | "prs" | "ci" | "agents";
 // a malformed tail from ever reaching an EventSource URL.
 const STREAM_ID_RE = /^[0-9a-zA-Z-]{1,64}$/;
 
+// A repo id is exactly 16 lowercase hex chars (the server's contract). A segment
+// that fails this guard is treated as absent (`repoId: null`) — never trusted
+// into a scoped URL — so a malformed `#r/…` tail degrades to the legacy meaning
+// rather than crashing or hitting a route that can't exist.
+const REPO_ID_RE = /^[0-9a-f]{16}$/;
+
+/** Whether a string is a well-formed repo id (16 lowercase hex chars). Callers
+ *  that build a scoped hash from a server-supplied id use this to avoid emitting
+ *  a `#r/{bad}/…` that would just parse back to `repoId: null` and re-trigger a
+ *  redirect loop. Shares the router's single grammar (never duplicate the RE). */
+export function isRepoId(id: string): boolean {
+  return REPO_ID_RE.test(id);
+}
+
 export interface Route {
-  /** The active bottom-tab. Pair is not a tab (it's a full-screen takeover). */
+  /** The active bottom-tab. Pair/repos are not tabs (full-screen takeovers). */
   tab: Tab;
   /** True when on the pairing screen (`#pair`). */
   isPairing: boolean;
-  /** A selected PR number (`#prs/{n}`) or CI run id (`#ci/{id}`), else null. */
+  /** True when on the repo picker (`#repos`). */
+  isRepos: boolean;
+  /** The selected repository id (`#r/{repoId}/…`), else null. Null on the legacy
+   *  single-repo hashes and the global `#pair`/`#repos` routes. Always either a
+   *  valid 16-hex-char id or null — a malformed segment parses as null. */
+  repoId: string | null;
+  /** A selected PR number (`#…/prs/{n}`) or CI run id (`#…/ci/{id}`), else null. */
   detailId: number | null;
-  /** A selected agent-stream id (`#agents/{id}`), else null. String because
+  /** A selected agent-stream id (`#…/agents/{id}`), else null. String because
    *  stream ids are UUID-like, not numeric. Only parsed on the agents tab. */
   streamId: string | null;
   /** The raw normalized hash (without the leading `#`). */
   raw: string;
+}
+
+/** Parse the `{tab}[/detail]` portion shared by both the legacy and scoped forms
+ *  into `{ tab, detailId, streamId }`. `head` is the tab segment, `tail` the
+ *  optional detail segment. */
+function parseTab(
+  head: string | undefined,
+  tail: string | undefined,
+): { tab: Tab; detailId: number | null; streamId: string | null } {
+  const detailId = tail && /^\d+$/.test(tail) ? Number(tail) : null;
+  switch (head) {
+    case "prs":
+      return { tab: "prs", detailId, streamId: null };
+    case "ci":
+      return { tab: "ci", detailId, streamId: null };
+    case "agents": {
+      // Stream ids are strings, so `detailId` never applies here; a tail that
+      // fails the charset guard falls back to the list (streamId null).
+      const streamId = tail && STREAM_ID_RE.test(tail) ? tail : null;
+      return { tab: "agents", detailId: null, streamId };
+    }
+    default:
+      return { tab: "status", detailId: null, streamId: null };
+  }
 }
 
 function parseHash(hash: string): Route {
@@ -32,33 +86,51 @@ function parseHash(hash: string): Route {
     return {
       tab: "status",
       isPairing: true,
+      isRepos: false,
+      repoId: null,
       detailId: null,
       streamId: null,
       raw,
     };
   }
-  const [head, tail] = raw.split("/", 2);
-  const detailId = tail && /^\d+$/.test(tail) ? Number(tail) : null;
-  switch (head) {
-    case "prs":
-      return { tab: "prs", isPairing: false, detailId, streamId: null, raw };
-    case "ci":
-      return { tab: "ci", isPairing: false, detailId, streamId: null, raw };
-    case "agents": {
-      // Stream ids are strings, so `detailId` never applies here; a tail that
-      // fails the charset guard falls back to the list (streamId null).
-      const streamId = tail && STREAM_ID_RE.test(tail) ? tail : null;
-      return { tab: "agents", isPairing: false, detailId: null, streamId, raw };
-    }
-    default:
-      return {
-        tab: "status",
-        isPairing: false,
-        detailId: null,
-        streamId: null,
-        raw,
-      };
+  if (raw === "repos") {
+    return {
+      tab: "status",
+      isPairing: false,
+      isRepos: true,
+      repoId: null,
+      detailId: null,
+      streamId: null,
+      raw,
+    };
   }
+  const parts = raw.split("/");
+  // Scoped form: `r/{repoId}/{tab}[/{detail}]`. A malformed repoId segment falls
+  // through to the legacy parse below (repoId stays null), so it degrades to the
+  // legacy meaning rather than routing to a repo that can't exist.
+  if (parts[0] === "r" && parts[1] && REPO_ID_RE.test(parts[1])) {
+    const { tab, detailId, streamId } = parseTab(parts[2], parts[3]);
+    return {
+      tab,
+      isPairing: false,
+      isRepos: false,
+      repoId: parts[1],
+      detailId,
+      streamId,
+      raw,
+    };
+  }
+  // Legacy single-repo form: `{tab}[/{detail}]` with no repo scope.
+  const { tab, detailId, streamId } = parseTab(parts[0], parts[1]);
+  return {
+    tab,
+    isPairing: false,
+    isRepos: false,
+    repoId: null,
+    detailId,
+    streamId,
+    raw,
+  };
 }
 
 function subscribe(cb: () => void): () => void {
@@ -77,7 +149,23 @@ export function useRoute(): Route {
   return useMemo(() => parseHash(hash), [hash]);
 }
 
+/** Build the scoped hash for a repo + tab tail (with a leading `#`). Tail is the
+ *  `{tab}[/{detail}]` portion, e.g. `"prs/4"`; defaults to `status`. */
+export function repoHash(repoId: string, tail = "status"): string {
+  return `#r/${repoId}/${tail}`;
+}
+
 /** Navigate by setting the hash (adds a history entry so Back works). */
 export function navigate(hash: string): void {
   window.location.hash = hash.startsWith("#") ? hash : `#${hash}`;
+}
+
+/** Navigate WITHOUT adding a history entry (replaces the current one). Used for
+ *  the legacy→scoped bootstrap redirect so Back doesn't bounce onto the bare
+ *  legacy hash that would just redirect straight back again. */
+export function replace(hash: string): void {
+  const h = hash.startsWith("#") ? hash : `#${hash}`;
+  window.location.replace(
+    `${window.location.pathname}${window.location.search}${h}`,
+  );
 }

--- a/companion/src/lib/use-review-stream.ts
+++ b/companion/src/lib/use-review-stream.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from "react";
-import { fetchReviews } from "./api";
+import { ApiError, fetchReviews } from "./api";
 import { queryClient } from "./queries";
 
 // Live agent-stream watch over Server-Sent Events. The desktop broadcasts an AI
@@ -64,9 +64,13 @@ export type Terminal =
  *  - `live` — receiving events; the run is in progress.
  *  - `ended` — the stream finished (a terminal event arrived, OR it closed and the
  *    run is still shared but no longer streaming).
- *  - `gone` — the stream closed with no terminal and the id is no longer shared
- *    (run ended / sharing off / repo switched / device revoked). */
-export type Phase = "connecting" | "live" | "ended" | "gone";
+ *  - `gone` — the stream closed with no terminal and the STREAM id is no longer
+ *    shared (run ended / sharing off / device revoked), but the REPO still is.
+ *  - `repoGone` — the stream closed with no terminal AND the scoped reviews probe
+ *    itself 404'd `noSuchRepo`: the whole repository stopped being shared from the
+ *    desktop. Distinct from `gone` because the teaching state differs — the watch
+ *    offers "Choose repository" (→ `#repos`), not just "Back to agents". */
+export type Phase = "connecting" | "live" | "ended" | "gone" | "repoGone";
 
 export interface StreamState {
   segments: Segment[];
@@ -81,7 +85,8 @@ type Action =
   | { type: "opened" }
   | { type: "event"; event: ReviewEvent }
   | { type: "closed" }
-  | { type: "gone" };
+  | { type: "gone" }
+  | { type: "repoGone" };
 
 const initialState: StreamState = {
   segments: [],
@@ -104,6 +109,8 @@ function reducer(state: StreamState, action: Action): StreamState {
       return state.terminal ? state : { ...state, phase: "ended" };
     case "gone":
       return { ...state, phase: "gone" };
+    case "repoGone":
+      return { ...state, phase: "repoGone" };
     case "event": {
       const ev = action.event;
       switch (ev.kind) {
@@ -217,11 +224,12 @@ function parseEvent(raw: string): ReviewEvent | null {
   }
 }
 
-/** Watch a live agent stream by id. Opens an EventSource (relative same-origin URL
- *  — the `gd_lan` cookie rides automatically; the page CSP `connect-src 'self'`
- *  covers it) and folds events into transcript state. Idempotent under StrictMode's
- *  double-mount: the effect closes its own EventSource on cleanup. */
-export function useReviewStream(id: string): StreamState {
+/** Watch a live agent stream by id, scoped to `repoId`. Opens an EventSource
+ *  (relative same-origin URL — the `gd_lan` cookie rides automatically; the page
+ *  CSP `connect-src 'self'` covers it) and folds events into transcript state.
+ *  Idempotent under StrictMode's double-mount: the effect closes its own
+ *  EventSource on cleanup, and re-subscribes if `repoId`/`id` change. */
+export function useReviewStream(repoId: string, id: string): StreamState {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
@@ -232,7 +240,9 @@ export function useReviewStream(id: string): StreamState {
     // before firing the probe, so a `closed` check there would always short-circuit.
     let closed = false;
     let cancelled = false;
-    const es = new EventSource(`/api/reviews/${encodeURIComponent(id)}/stream`);
+    const es = new EventSource(
+      `/api/repos/${encodeURIComponent(repoId)}/reviews/${encodeURIComponent(id)}/stream`,
+    );
 
     es.onopen = () => {
       // Connection established. Leave the connecting skeleton even before the first
@@ -270,11 +280,13 @@ export function useReviewStream(id: string): StreamState {
       //    run ending within ~10s of the list rendering would never be observed (no
       //    401 reaches the handler, the stale list still holds the id, `gone` never
       //    fires, and the screen froze on "ended"). The probe deliberately bypasses
-      //    freshness so a revoke/end is always seen.
+      //    freshness so a revoke/end is always seen. The key is repo-scoped
+      //    (`["reviews", repoId]`) so it round-trips the SAME scoped route the list
+      //    uses — a shared cache across repos would misclassify.
       queryClient
         .fetchQuery({
-          queryKey: ["reviews"],
-          queryFn: fetchReviews,
+          queryKey: ["reviews", repoId],
+          queryFn: () => fetchReviews(repoId),
           staleTime: 0,
         })
         .then((reviews) => {
@@ -283,10 +295,16 @@ export function useReviewStream(id: string): StreamState {
             dispatch({ type: "gone" });
           }
         })
-        .catch(() => {
+        .catch((err) => {
           if (cancelled) return;
-          // A 401 already redirected via the QueryCache; any other probe failure
+          // The probe itself 404'd `noSuchRepo` → the whole repo stopped being
+          // shared. Classify as `repoGone` (distinct from a stream-only `gone`) so
+          // the watch offers "Choose repository" rather than "Back to agents". A
+          // 401 already redirected via the QueryCache; any OTHER probe failure
           // leaves the calmer `ended` state in place (we can't prove it's gone).
+          if (err instanceof ApiError && err.isNoSuchRepo) {
+            dispatch({ type: "repoGone" });
+          }
         });
     };
 
@@ -295,7 +313,7 @@ export function useReviewStream(id: string): StreamState {
       cancelled = true;
       es.close();
     };
-  }, [id]);
+  }, [repoId, id]);
 
   return state;
 }

--- a/companion/src/screens/Agents.tsx
+++ b/companion/src/screens/Agents.tsx
@@ -11,12 +11,14 @@ import { Markdown } from "../components/markdown";
 import {
   EmptyState,
   ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
   SkeletonRows,
   StaleBanner,
 } from "../components/states";
 import { timeAgo } from "../lib/format";
 import { useReviews } from "../lib/queries";
-import { navigate } from "../lib/router";
+import { navigate, repoHash } from "../lib/router";
 import {
   type Segment,
   type StreamState,
@@ -29,10 +31,22 @@ import { useRovingList } from "../lib/use-roving-list";
 // desktop is broadcasting), and a live watch screen over SSE — the epic's phone
 // killer feature. Read-only by design: no approve/deny/write affordances here.
 
-/** The agent-stream list. `active` gates polling (false while a watch is open). */
-export function AgentsBody({ active }: { active: boolean }) {
-  const { data, isError, error, refetch } = useReviews(active);
+/** The agent-stream list. `repoId` scopes the query; `active` gates polling (false
+ *  while a watch is open). */
+export function AgentsBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useReviews(repoId, active);
   const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when a cached list is on hand (see isRepoGoneError). The watch
+  // screen has its own repoGone path (the SSE probe), so this covers the list only.
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   // Prefer stale data: keep the last-known list on screen even on error, with a
   // StaleBanner above it. Full-screen ErrorState only when there's nothing to
@@ -59,7 +73,7 @@ export function AgentsBody({ active }: { active: boolean }) {
                 type="button"
                 ref={register(i)}
                 onKeyDown={onKeyDown}
-                onClick={() => navigate(`#agents/${r.id}`)}
+                onClick={() => navigate(repoHash(repoId, `agents/${r.id}`))}
                 className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
               >
                 <div className="min-w-0 flex-1">
@@ -97,28 +111,34 @@ function prefersReducedMotion(): boolean {
   );
 }
 
-/** The live watch screen for one agent stream. */
-export function AgentWatch({ id }: { id: string }) {
-  const stream = useReviewStream(id);
+/** The live watch screen for one agent stream, scoped to `repoId`. */
+export function AgentWatch({ repoId, id }: { repoId: string; id: string }) {
+  const stream = useReviewStream(repoId, id);
 
   return (
     <div className="flex flex-col">
       <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
         <button
           type="button"
-          onClick={() => navigate("#agents")}
+          onClick={() => navigate(repoHash(repoId, "agents"))}
           className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
         >
           <ArrowLeftIcon size={16} />
           Agents
         </button>
       </div>
-      <WatchBody stream={stream} />
+      <WatchBody stream={stream} repoId={repoId} />
     </div>
   );
 }
 
-function WatchBody({ stream }: { stream: StreamState }) {
+function WatchBody({
+  stream,
+  repoId,
+}: {
+  stream: StreamState;
+  repoId: string;
+}) {
   const { segments, statusText, terminal, phase } = stream;
 
   // Auto-follow: keep pinned to newest content while the user is at the bottom; if
@@ -203,9 +223,13 @@ function WatchBody({ stream }: { stream: StreamState }) {
             ) : null}
             {/* Closed without a terminal event but still shared (`ended`, no
                 terminal): otherwise the transcript would silently freeze with no
-                cue to tell "stopped" from "paused". `gone` has its own state. */}
+                cue to tell "stopped" from "paused". `gone`/`repoGone` own their
+                own states. */}
             {phase === "ended" && !terminal ? <EndedNote /> : null}
-            {phase === "gone" ? <GoneState /> : null}
+            {phase === "gone" ? <GoneState repoId={repoId} /> : null}
+            {/* The whole repo stopped being shared — a distinct teaching state
+                that routes to the picker, not back to this repo's agents list. */}
+            {phase === "repoGone" ? <RepoGoneState /> : null}
           </>
         )}
       </div>
@@ -273,9 +297,10 @@ function EmptyTranscript() {
   );
 }
 
-/** The stream closed and the run is no longer shared (ended / sharing off / repo
- *  switched / device revoked). */
-function GoneState() {
+/** The stream closed and the RUN is no longer shared (ended / sharing off /
+ *  device revoked) — but the repo is still shared, so "Back to agents" returns to
+ *  this repo's list. (The whole-repo case is `RepoGoneState`, routed separately.) */
+function GoneState({ repoId }: { repoId: string }) {
   return (
     <div className="flex flex-col items-start gap-3 rounded-md border border-border bg-muted/40 px-4 py-4">
       <p className="text-sm font-medium text-foreground">
@@ -283,7 +308,7 @@ function GoneState() {
       </p>
       <button
         type="button"
-        onClick={() => navigate("#agents")}
+        onClick={() => navigate(repoHash(repoId, "agents"))}
         className="inline-flex min-h-9 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
       >
         <ArrowLeftIcon size={14} />

--- a/companion/src/screens/Ci.tsx
+++ b/companion/src/screens/Ci.tsx
@@ -8,18 +8,30 @@ import { CiStatusChip } from "../components/chips";
 import {
   EmptyState,
   ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
   SkeletonRows,
   StaleBanner,
 } from "../components/states";
 import { timeAgo } from "../lib/format";
 import { useCiRun, useCiRuns } from "../lib/queries";
-import { navigate } from "../lib/router";
+import { navigate, repoHash } from "../lib/router";
 import { useRovingList } from "../lib/use-roving-list";
 
-/** The CI run list. `active` gates polling. */
-export function CiBody({ active }: { active: boolean }) {
-  const { data, isError, error, refetch } = useCiRuns(active);
+/** The CI run list. `repoId` scopes the query; `active` gates polling. */
+export function CiBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useCiRuns(repoId, active);
   const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when cached runs are on hand (see isRepoGoneError).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   // Prefer stale data: keep the last-known runs on screen even on error, with a
   // StaleBanner above. Full-screen ErrorState only when there's nothing to show;
@@ -45,7 +57,7 @@ export function CiBody({ active }: { active: boolean }) {
                 type="button"
                 ref={register(i)}
                 onKeyDown={onKeyDown}
-                onClick={() => navigate(`#ci/${run.id}`)}
+                onClick={() => navigate(repoHash(repoId, `ci/${run.id}`))}
                 className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
               >
                 <CiRow run={run} />
@@ -82,15 +94,20 @@ function CiRow({ run }: { run: WorkflowRun }) {
 }
 
 /** A read-only CI run detail with its jobs. */
-export function CiDetail({ id }: { id: number }) {
-  const { data, isPending, isError, error, refetch } = useCiRun(id);
+export function CiDetail({ repoId, id }: { repoId: string; id: number }) {
+  const { data, isPending, isError, error, refetch } = useCiRun(repoId, id);
+
+  // Definitive gone WINS: replace the whole detail with the teaching state (see
+  // PrDetail). ErrorState also routes noSuchRepo, but the explicit check keeps it
+  // robust against reordering.
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   return (
     <div className="flex flex-col">
       <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
         <button
           type="button"
-          onClick={() => navigate("#ci")}
+          onClick={() => navigate(repoHash(repoId, "ci"))}
           className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
         >
           <ArrowLeftIcon size={16} />

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -19,18 +19,30 @@ import { Markdown } from "../components/markdown";
 import {
   EmptyState,
   ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
   SkeletonRows,
   StaleBanner,
 } from "../components/states";
 import { timeAgo } from "../lib/format";
 import { usePr, usePrs, usePrThreads, usePrTimeline } from "../lib/queries";
-import { navigate } from "../lib/router";
+import { navigate, repoHash } from "../lib/router";
 import { useRovingList } from "../lib/use-roving-list";
 
-/** The PR list. `active` gates polling. */
-export function PrsBody({ active }: { active: boolean }) {
-  const { data, isError, error, refetch } = usePrs(active);
+/** The PR list. `repoId` scopes the query; `active` gates polling. */
+export function PrsBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = usePrs(repoId, active);
   const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when a cached list is on hand (see isRepoGoneError).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   // Prefer stale data: keep the last-known list on screen even on error, with a
   // StaleBanner above it. Full-screen ErrorState only when there's nothing to
@@ -57,7 +69,7 @@ export function PrsBody({ active }: { active: boolean }) {
                 type="button"
                 ref={register(i)}
                 onKeyDown={onKeyDown}
-                onClick={() => navigate(`#prs/${pr.number}`)}
+                onClick={() => navigate(repoHash(repoId, `prs/${pr.number}`))}
                 className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
               >
                 <PrRow pr={pr} />
@@ -93,15 +105,27 @@ function PrRow({ pr }: { pr: PrInfo }) {
 }
 
 /** A read-only PR detail. */
-export function PrDetail({ number }: { number: number }) {
-  const { data, isPending, isError, error, refetch } = usePr(number);
+export function PrDetail({
+  repoId,
+  number,
+}: {
+  repoId: string;
+  number: number;
+}) {
+  const { data, isPending, isError, error, refetch } = usePr(repoId, number);
+
+  // Definitive gone WINS: the whole detail (back-bar included) is replaced by the
+  // teaching state — "Choose repository" is the only sensible action once the repo
+  // is unshared. (ErrorState also routes noSuchRepo here, but making it explicit
+  // keeps it robust if the error handling below is ever reordered.)
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   return (
     <div className="flex flex-col">
       <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
         <button
           type="button"
-          onClick={() => navigate("#prs")}
+          onClick={() => navigate(repoHash(repoId, "prs"))}
           className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
         >
           <ArrowLeftIcon size={16} />
@@ -145,8 +169,8 @@ export function PrDetail({ number }: { number: number }) {
           )}
 
           <ConversationSection detail={data} />
-          <ActivitySection number={number} />
-          <ThreadsSection number={number} />
+          <ActivitySection repoId={repoId} number={number} />
+          <ThreadsSection repoId={repoId} number={number} />
         </article>
       )}
     </div>
@@ -318,8 +342,22 @@ function ReviewStateBadge({ state }: { state: string }) {
 
 /** The PR's activity timeline (force-pushes, labels, review requests, state
  *  changes). Polls while the detail is open; a failure shows an inline retry. */
-function ActivitySection({ number }: { number: number }) {
-  const { data, isPending, isError, refetch } = usePrTimeline(number);
+function ActivitySection({
+  repoId,
+  number,
+}: {
+  repoId: string;
+  number: number;
+}) {
+  const { data, isPending, isError, error, refetch } = usePrTimeline(
+    repoId,
+    number,
+  );
+
+  // Definitive gone WINS: if this sub-section's poll is the first to see the 404
+  // (before the parent detail's own poll), take over the whole screen with the
+  // teaching state rather than showing a small inline section error.
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   return (
     <section className="flex flex-col gap-2">
@@ -395,8 +433,21 @@ function short(oid: string): string {
 /** The PR's file:line-anchored review threads with their comments. Polls while the
  *  detail is open; a failure shows an inline retry. The diff hunk is deliberately
  *  omitted (too wide for the phone). */
-function ThreadsSection({ number }: { number: number }) {
-  const { data, isPending, isError, refetch } = usePrThreads(number);
+function ThreadsSection({
+  repoId,
+  number,
+}: {
+  repoId: string;
+  number: number;
+}) {
+  const { data, isPending, isError, error, refetch } = usePrThreads(
+    repoId,
+    number,
+  );
+
+  // Definitive gone WINS (see ActivitySection): a first-seen 404 here takes over
+  // the whole screen with the teaching state.
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   return (
     <section className="flex flex-col gap-2">

--- a/companion/src/screens/Prs.tsx
+++ b/companion/src/screens/Prs.tsx
@@ -355,8 +355,11 @@ function ActivitySection({
   );
 
   // Definitive gone WINS: if this sub-section's poll is the first to see the 404
-  // (before the parent detail's own poll), take over the whole screen with the
-  // teaching state rather than showing a small inline section error.
+  // (before the parent detail's own poll), render the teaching state IN PLACE of
+  // this section (not full-screen — the parent still renders around it). The
+  // parent's own poll 404s within one cycle and takes the whole detail over; the
+  // brief in-place card (or two, if both sub-sections race) is the transitional
+  // state, not the destination.
   if (isRepoGoneError(error)) return <RepoGoneState />;
 
   return (
@@ -445,8 +448,8 @@ function ThreadsSection({
     number,
   );
 
-  // Definitive gone WINS (see ActivitySection): a first-seen 404 here takes over
-  // the whole screen with the teaching state.
+  // Definitive gone WINS (see ActivitySection): a first-seen 404 renders the
+  // teaching state in place of this section; the parent's next poll finishes it.
   if (isRepoGoneError(error)) return <RepoGoneState />;
 
   return (

--- a/companion/src/screens/Repos.tsx
+++ b/companion/src/screens/Repos.tsx
@@ -1,0 +1,122 @@
+import { CaretRightIcon, CheckCircleIcon } from "@phosphor-icons/react";
+import { useMemo } from "react";
+import { ErrorState, SkeletonRows } from "../components/states";
+import type { RepoSummary } from "../lib/api";
+import { useRepos } from "../lib/queries";
+import { isRepoId, navigate, repoHash, type Tab } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+// The repo picker (`#repos`). Lists the repositories the desktop is sharing so the
+// phone can choose which one to browse — a first-class screen now that the
+// companion is multi-repo. Read-only; tapping a repo scopes every tab to it.
+//
+// Reached two ways: the shell's bootstrap (multiple repos shared, none picked yet)
+// and the TopBar title trigger (switching repos mid-session). When switching, the
+// caller passes the current tab so the pick lands on the SAME tab rather than
+// bouncing everyone back to Status.
+
+/** Filter to safely-navigable repos, then sort: the active repo (open on the
+ *  desktop) first, then alphabetical by name. `localeCompare` so names sort the
+ *  way a human reads them. The server's order is unspecified, so we always sort
+ *  client-side. A repo whose id fails the router grammar is dropped — tapping it
+ *  would build a `#r/{bad}/…` hash that parses back to null and loops. */
+function sortRepos(repos: RepoSummary[]): RepoSummary[] {
+  return repos
+    .filter((r) => isRepoId(r.id))
+    .sort((a, b) => {
+      if (a.active !== b.active) return a.active ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+/** A small "open on desktop" badge — icon + text so the state never rests on color
+ *  alone (WCAG 1.4.1), using the same success token the rest of the app uses. */
+function ActiveBadge() {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+      <CheckCircleIcon size={12} weight="fill" />
+      Active
+    </span>
+  );
+}
+
+/** The repo picker body. `currentRepoId` marks the currently-selected repo (a
+ *  check + `aria-current`); `currentTab` is preserved when navigating so switching
+ *  repos keeps you on the same tab. Both are null when the picker is the bootstrap
+ *  entry (no repo chosen yet) — then picks default to the Status tab. */
+export function ReposBody({
+  currentRepoId,
+  currentTab,
+}: {
+  currentRepoId: string | null;
+  currentTab: Tab | null;
+}) {
+  const { data, isError, error, refetch } = useRepos();
+  const { register, onKeyDown } = useRovingList();
+
+  const repos = useMemo(() => (data ? sortRepos(data) : []), [data]);
+
+  // Preserve the tab the user came from (if any) so a switch keeps context; the
+  // bootstrap entry (no current tab) lands on Status.
+  const tail = currentTab ?? "status";
+
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  if (repos.length === 0) {
+    // Nothing shared yet — a calm teaching state (not an error). The desktop is the
+    // only place to change what's shared, so we point there.
+    return (
+      <div
+        className="flex flex-col items-center gap-3 px-8 py-16 text-center"
+        role="status"
+      >
+        <p className="text-sm font-medium text-foreground">
+          Nothing is shared yet.
+        </p>
+        <p className="max-w-xs text-sm text-muted-foreground">
+          Share a repository from GitDesktop on your desktop to browse it here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col divide-y divide-border">
+      {repos.map((repo, i) => {
+        const selected = repo.id === currentRepoId;
+        return (
+          <li key={repo.id}>
+            <button
+              type="button"
+              ref={register(i)}
+              onKeyDown={onKeyDown}
+              aria-current={selected ? "true" : undefined}
+              onClick={() => navigate(repoHash(repo.id, tail))}
+              className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+            >
+              {/* A selection check reserves its slot whether or not it shows, so
+                  rows stay aligned and the label doesn't jump. */}
+              <CheckCircleIcon
+                size={18}
+                weight="fill"
+                className={`shrink-0 ${selected ? "text-primary" : "text-transparent"}`}
+                aria-hidden
+              />
+              <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                {repo.name}
+              </span>
+              {repo.active ? <ActiveBadge /> : null}
+              <CaretRightIcon
+                size={16}
+                className="shrink-0 text-muted-foreground"
+              />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/companion/src/screens/Repos.tsx
+++ b/companion/src/screens/Repos.tsx
@@ -51,7 +51,9 @@ export function ReposBody({
   currentRepoId: string | null;
   currentTab: Tab | null;
 }) {
-  const { data, isError, error, refetch } = useRepos();
+  // Always enabled: the picker can never mount on `#pair` (Pair early-returns in
+  // App before Shell), so its repos fetch is always safe.
+  const { data, isError, error, refetch } = useRepos(true);
   const { register, onKeyDown } = useRovingList();
 
   const repos = useMemo(() => (data ? sortRepos(data) : []), [data]);

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -4,7 +4,13 @@ import {
   GitBranchIcon,
 } from "@phosphor-icons/react";
 import type { FileEntry } from "@/lib/git/types";
-import { ErrorState, SkeletonRows, StaleBanner } from "../components/states";
+import {
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
 import { useStatus } from "../lib/queries";
 
 // Status is a calm glanceable column (not a dashboard): current branch, its
@@ -28,8 +34,19 @@ function changeCounts(entries: FileEntry[]) {
  *  error) rather than blanking to a full-screen error — the phone-on-flaky-wifi
  *  case is the normal case. Full-screen `ErrorState` only when there's no data at
  *  all; skeleton only while pending. */
-export function StatusBody({ active }: { active: boolean }) {
-  const { data, isError, error, refetch } = useStatus(active);
+export function StatusBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useStatus(repoId, active);
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 means the repo is no
+  // longer shared, so the teaching state must render even when a cached snapshot
+  // exists (otherwise the poll's 404 would sit silently behind stale content).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
 
   if (!data) {
     if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -621,11 +621,12 @@ pub struct RouterState {
     pub bound_hosts: Arc<Vec<String>>,
     /// Cut signal for live SSE monitors. The `stream` handler (a plain GET, no
     /// upgrade) subscribes a receiver from this before returning its `Sse` response;
-    /// the desktop fires `()` on it when sharing is disabled, the shared repo
-    /// changes, or a device is revoked, so in-flight event streams end and the phone
-    /// must reconnect and re-authorize (its EventSource auto-reconnect then hits a
-    /// 401/404 and closes permanently).
-    pub monitor_cut: tokio::sync::broadcast::Sender<()>,
+    /// the desktop fires a [`crate::lan::MonitorCut`] on it when sharing is disabled
+    /// or a device is revoked ([`crate::lan::MonitorCut::All`]) or when a single repo
+    /// leaves the registry ([`crate::lan::MonitorCut::Repo`]), so the affected
+    /// in-flight event streams end and those phones reconnect and re-authorize (their
+    /// EventSource auto-reconnect then hits a 401/404 and closes permanently).
+    pub monitor_cut: tokio::sync::broadcast::Sender<crate::lan::MonitorCut>,
     /// The live agent-stream registry — the SAME `Arc` [`crate::state::AppState`]
     /// holds, so a review/session registered there is watchable from the LAN
     /// review routes without any further plumbing.

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -608,6 +608,13 @@ pub struct RouterState {
     /// The currently-active repo path the alias read routes operate on. `None` →
     /// 409. The alias resolver middleware reads this and inserts a `ScopedRepo`.
     pub active_repo: Arc<Mutex<Option<String>>>,
+    /// The opaque id of the currently-active registry entry, or `None`. The SAME
+    /// `Arc` [`crate::lan::LanState`] owns (kept in sync as the desktop switches
+    /// repos), so `/api/repos` can flag the active entry BY ID — the id-based identity
+    /// the whole feature dedups on, correct even when a repo is shared under one
+    /// worktree path while the desktop is open on another (both map to one id, a path
+    /// compare would miss). Read only by [`crate::lan::routes::list_repos`].
+    pub active_repo_id: Arc<Mutex<Option<String>>>,
     /// The repo registry (opaque-id → [`crate::lan::RegisteredRepo`]) backing the
     /// scoped `/api/repos/{repoId}/…` routes. The SAME `Arc` [`crate::lan::LanState`]
     /// owns, so `lan_set_active_repo` refreshes it live. The scoped resolver looks a

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -19,6 +19,7 @@ pub mod auth;
 pub mod keep_awake;
 pub mod routes;
 pub mod server;
+pub mod shared_repos;
 pub mod static_serve;
 pub mod tls;
 
@@ -31,6 +32,26 @@ use crate::error::{AppError, AppResult};
 use auth::{LanDevice, PairingSession, RateLimitMap};
 use keep_awake::KeepAwakeHold;
 use server::ServerHandle;
+
+/// A cut signal broadcast to live SSE monitors (see [`routes::reviews::stream`]).
+/// Either a coarse "cut EVERYTHING" or a scoped "cut only streams on THIS repo".
+///
+/// The coarse [`MonitorCut::All`] fires on the whole-server lifecycle transitions
+/// (disable, a mode-switch rebind, a device revoke) where every in-flight stream
+/// must reconnect and re-authorize against the new state. The scoped
+/// [`MonitorCut::Repo`] fires when a SINGLE repo leaves the registry (an unshare of
+/// a non-active repo, or an active switch away from a repo that isn't also in the
+/// shared set) — only streams on that exact repo end; streams on still-registered
+/// repos keep forwarding. The `String` is the LEAVING repo's registered path;
+/// [`routes::reviews::forward_stream`] compares it to each stream's own repo path
+/// via [`crate::state::repo_paths_match`].
+#[derive(Clone, Debug)]
+pub enum MonitorCut {
+    /// End every live monitor unconditionally.
+    All,
+    /// End only monitors on the repo at this registered path.
+    Repo(String),
+}
 
 /// A repo registered in the LAN companion's repo registry, keyed by an opaque
 /// stable id (see [`LanState::set_active_repo`]). Carries the on-disk `path` the
@@ -45,9 +66,13 @@ pub struct RegisteredRepo {
 
 /// The shared repo registry: opaque-id → [`RegisteredRepo`]. Shared (per-field
 /// `Arc`) with the router state so the scoped `/api/repos/{repoId}/…` routes can
-/// resolve an id to its path. Registry v1 mirrors the active repo exactly (the map
-/// holds at most the one active entry); a future browse-all-repos direction fills
-/// it with more.
+/// resolve an id to its path. The map holds the desktop's ACTIVE repo ∪ the
+/// user's persisted SHARED set (see [`shared_repos`]): the active repo is
+/// installed/removed as the desktop switches ([`LanState::install_active_repo`]),
+/// and the shared entries are seeded at [`lan_enable`] and mutated by
+/// [`lan_share_repo`] / [`lan_unshare_repo`]. Deduped by opaque id, so a repo that
+/// is both active AND shared occupies exactly one entry — its removal from one role
+/// leaves the entry while the other role still holds it.
 pub type RepoRegistry = Arc<Mutex<HashMap<String, RegisteredRepo>>>;
 
 /// The Tauri-managed state for the LAN companion.
@@ -55,11 +80,25 @@ pub struct LanState {
     /// The active repo path the read routes operate on. Shared (per-field `Arc`)
     /// with the router state so `lan_set_active_repo` updates it live.
     active_repo: Arc<Mutex<Option<String>>>,
-    /// The repo registry (opaque-id → [`RegisteredRepo`]), shared with the router
-    /// state so the scoped `/api/repos/{repoId}/…` routes can resolve an id to its
-    /// path. Registry v1 mirrors the active repo exactly (see
-    /// [`LanState::set_active_repo`]).
+    /// The repo registry (opaque-id → [`RegisteredRepo`]) — the desktop's ACTIVE
+    /// repo ∪ the persisted SHARED set — shared with the router state so the scoped
+    /// `/api/repos/{repoId}/…` routes can resolve an id to its path (see
+    /// [`RepoRegistry`], [`LanState::install_active_repo`], and [`LanState::seed_shared`]).
     repos: RepoRegistry,
+    /// The resolved shared set: opaque-id → the stored path each shared repo was
+    /// shared under (the verbatim path in `lan-shared-repos.json`). The registry
+    /// bookkeeping consults this to know whether a repo LEAVING the active role is
+    /// still held by the shared role (so it stays in `repos`) or should be removed.
+    /// An `async` mutex because share/unshare/seed resolve ids via git (`.await`)
+    /// and must serialize the resolve→re-verify→install sequence; rare + user-driven,
+    /// so the coarse serialization is cheap. Never held across a NESTED `.await` that
+    /// could deadlock (only the id resolve, which touches no other LanState lock).
+    shared_index: tokio::sync::Mutex<HashMap<String, String>>,
+    /// The opaque id of the currently-installed ACTIVE registry entry, if any. Lets
+    /// an active switch remove the PREVIOUS active entry iff its id isn't also in the
+    /// shared set (a repo that's both active and shared keeps its single entry when
+    /// it leaves only the active role). A `std::Mutex` — short, sync accesses only.
+    active_repo_id: Mutex<Option<String>>,
     /// The running server handle (bound port + shutdown signal + task), or `None`
     /// when disabled. Guarded so enable/disable are serialized.
     running: Mutex<Option<RunningServer>>,
@@ -67,15 +106,16 @@ pub struct LanState {
     pairing: Arc<Mutex<Option<PairingSession>>>,
     /// Per-IP failure windows for rate-limiting, shared with the router state.
     rate_limit: RateLimitMap,
-    /// Fires a cut signal to every live SSE monitor (see
-    /// [`routes::reviews::stream`]). Sent on `lan_disable`, on a mode-switch
-    /// rebind, when the active repo actually changes, and on a device revoke —
-    /// each ends in-flight event streams so a phone must reconnect and
-    /// re-authorize against the new state (its EventSource auto-reconnect then
-    /// hits a 401/404 and closes permanently). The `Sender` is shared (cloned)
-    /// into the router state; only the send half is ever needed there (each
-    /// stream subscribes its own receiver).
-    monitor_cut: tokio::sync::broadcast::Sender<()>,
+    /// Fires a cut signal to live SSE monitors (see [`routes::reviews::stream`]).
+    /// A [`MonitorCut::All`] ends EVERY stream (sent on `lan_disable`, a mode-switch
+    /// rebind, and a device revoke); a [`MonitorCut::Repo`] ends only streams on the
+    /// repo that just left the registry (an unshare of a non-active repo, or an
+    /// active switch/clear away from a repo not in the shared set). A cut ends the
+    /// affected in-flight streams so those phones reconnect and re-authorize (their
+    /// EventSource auto-reconnect then hits a 401/404 and closes permanently). The
+    /// `Sender` is shared (cloned) into the router state; only the send half is ever
+    /// needed there (each stream subscribes its own receiver).
+    monitor_cut: tokio::sync::broadcast::Sender<MonitorCut>,
     /// Serializes the WHOLE enable/disable lifecycle transition (an async-aware
     /// `Mutex`, held across the bind/shutdown `.await`s). Without it, two
     /// concurrent `lan_enable`s could both observe "not running", both bind a
@@ -109,12 +149,15 @@ impl Default for LanState {
         Self {
             active_repo: Arc::new(Mutex::new(None)),
             repos: Arc::new(Mutex::new(HashMap::new())),
+            shared_index: tokio::sync::Mutex::new(HashMap::new()),
+            active_repo_id: Mutex::new(None),
             running: Mutex::new(None),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
             // Capacity 4: cut signals are rare lifecycle blips, and each monitor
-            // only needs to observe that *a* cut happened (the value is `()`), so
-            // a shallow buffer is plenty — a lagged receiver still terminates.
+            // only needs to observe that a cut happened (and which repo it scoped
+            // to), so a shallow buffer is plenty — a lagged receiver still
+            // terminates (its `forward_stream` treats Lagged as an All cut).
             monitor_cut: tokio::sync::broadcast::channel(4).0,
             lifecycle: tokio::sync::Mutex::new(()),
         }
@@ -127,34 +170,42 @@ impl LanState {
     /// out from the [`lan_set_active_repo`] command so the change-detection +
     /// cut-fire behavior is unit-testable without a Tauri `State`.
     ///
-    /// Also refreshes the repo registry so the scoped `/api/repos/{repoId}/…`
-    /// routes can resolve an id. Registry v1 mirrors the active repo EXACTLY:
-    /// `Some(path)` clears the map and inserts a single entry under an opaque,
-    /// worktree-stable id; `None` clears the map. The id is the lowercase hex of
-    /// the first 8 bytes of `sha256(repo_identity(path))` — opaque and stable,
-    /// never leaking a filesystem path (only the id + display name reach the wire).
-    /// `repo_identity` is the one shared worktree-stable resolver (common git dir,
-    /// falling back to the raw path for a non-repo, which keeps tests
+    /// Also refreshes the ACTIVE portion of the repo registry so the scoped
+    /// `/api/repos/{repoId}/…` routes can resolve an id. The registry holds the
+    /// active repo ∪ the persisted SHARED set: a `Some(path)` installs the active
+    /// entry under an opaque, worktree-stable id (removing the PREVIOUS active entry
+    /// unless it's still held by the shared set); `None` removes the active entry
+    /// (again, unless shared). The shared entries are untouched here — only
+    /// [`share_repo`]/[`unshare_repo`]/[`seed_shared`] mutate them. The id is the
+    /// lowercase hex of the first 8 bytes of `sha256(repo_identity(path))` — opaque
+    /// and stable, never leaking a filesystem path (only the id + display name reach
+    /// the wire). `repo_identity` is the one shared worktree-stable resolver (common
+    /// git dir, falling back to the raw path for a non-repo, which keeps tests
     /// deterministic).
     ///
-    /// Change-detection and the monitor cut stay keyed on the PATH exactly as
-    /// before: a same-value set is a no-op that must NOT cut (the App effect
-    /// re-pushes the same repoPath on every render). That no-op is SUBPROCESS-FREE —
-    /// it returns right after the cheap `*guard == repo_path` compare, without
-    /// resolving the registry id or touching the registry (the prior *changed* call
-    /// already installed the right entry). This keeps a chatty per-render re-push
-    /// off the git subprocess `repo_id_for` spawns, even while the companion is off.
+    /// Change-detection stays keyed on the PATH exactly as before: a same-value set
+    /// is a no-op (the App effect re-pushes the same repoPath on every render). That
+    /// no-op is SUBPROCESS-FREE — it returns right after the cheap `*guard ==
+    /// repo_path` compare, without resolving the registry id or touching the registry
+    /// (the prior *changed* call already installed the right entry). This keeps a
+    /// chatty per-render re-push off the git subprocess `repo_id_for` spawns, even
+    /// while the companion is off.
+    ///
+    /// Cut scoping: on a real switch/clear the monitor cut is SCOPED to the repo that
+    /// LEFT the registry — a [`MonitorCut::Repo`] on the old active path when the old
+    /// active repo isn't the new one and isn't in the shared set, and NO cut when the
+    /// old active repo REMAINS registered (it's shared, or it's the same repo). A
+    /// switch never cuts the NEW repo's streams — they were never scoped away.
     ///
     /// The registry install (only reached on a real switch/clear) is guarded against
     /// a concurrent-call interleave: the opaque id resolves via a git subprocess (an
     /// `.await`), so two rapid *changed* calls A→B could race — A's slower resolve
     /// could otherwise install `{id_A → A}` AFTER B's install, leaving the scoped
     /// registry pointing at A while `active_repo == B`. So the post-await install
-    /// ([`install_active_repo`]) only clears+inserts when `active_repo` STILL equals
-    /// the path this call resolved; if a later call has already moved it on, this
-    /// call skips the install (the later call owns the registry). No `std::Mutex` is
-    /// held across the await, and the locks are never nested (each install takes
-    /// `active_repo`, compares, drops it, then takes `repos`).
+    /// ([`install_active_repo`]) only applies when `active_repo` STILL equals the path
+    /// this call resolved; if a later call has already moved it on, this call skips
+    /// the install (the later call owns the registry). No `std::Mutex` is held across
+    /// the await.
     async fn set_active_repo(&self, repo_path: Option<String>) -> bool {
         let changed = {
             let mut guard = self.active_repo.lock().unwrap_or_else(|p| p.into_inner());
@@ -181,41 +232,72 @@ impl LanState {
             }
             None => None,
         };
-        self.install_active_repo(repo_path.as_deref(), entry);
-        // The shared repo actually changed → cut live monitors: a real switch/clear
-        // means the phone's in-flight stream is now scoped to a repo we no longer
-        // share, so it must reconnect and re-authorize against the new state.
-        let _ = self.monitor_cut.send(());
+        // Install computes the scoped cut (a repo LEAVING the registry) under the
+        // shared-index lock; fire it here so a still-registered shared repo's streams
+        // survive an active switch.
+        if let Some(cut) = self.install_active_repo(repo_path.as_deref(), entry).await {
+            let _ = self.monitor_cut.send(cut);
+        }
         true
     }
 
-    /// Guarded registry install: mirror the active repo into the registry — clear
-    /// the map and insert `entry` — ONLY IF `active_repo` still equals `resolved`
-    /// (the path whose id `entry` was computed for). If a later `set_active_repo`
-    /// has already moved `active_repo` on, skip entirely: that later call owns the
-    /// registry, and clobbering it here would install a stale entry (the A-after-B
-    /// interleave). Sync + `&self` so it's unit-testable without racing real git.
+    /// Guarded registry install for the ACTIVE role: update the active portion of the
+    /// registry to `entry` (or remove it when `entry` is `None`) — ONLY IF
+    /// `active_repo` still equals `resolved` (the path whose id `entry` was computed
+    /// for). If a later `set_active_repo` has already moved `active_repo` on, skip
+    /// entirely: that later call owns the registry, and clobbering it here would
+    /// install a stale entry (the A-after-B interleave).
     ///
-    /// Lock discipline: read `active_repo` under its own lock and drop the guard
-    /// BEFORE taking the `repos` lock — the two are never held nested, and no
-    /// `std::Mutex` is held across an `.await` (this fn has none).
-    fn install_active_repo(
+    /// Returns the [`MonitorCut`] to fire, if any: a [`MonitorCut::Repo`] on the
+    /// PREVIOUS active repo's path when that repo leaves the registry (its id isn't
+    /// the new entry's id and isn't in the shared set), else `None` (the old repo is
+    /// still registered — shared or unchanged — so its streams keep forwarding).
+    ///
+    /// Holds the `shared_index` async mutex across the whole read-membership +
+    /// mutate-registry + update-active-id sequence so a concurrent share/unshare/seed
+    /// can't interleave a half-applied view. The `repos` and `active_repo`/
+    /// `active_repo_id` `std::Mutex`es are taken briefly INSIDE and never across an
+    /// `.await`.
+    async fn install_active_repo(
         &self,
         resolved: Option<&str>,
         entry: Option<(String, RegisteredRepo)>,
-    ) {
-        let still_current = {
+    ) -> Option<MonitorCut> {
+        let shared = self.shared_index.lock().await;
+        // Re-verify currency AFTER acquiring the lock: if a later call moved
+        // active_repo past `resolved`, that call owns the registry — skip.
+        {
             let guard = self.active_repo.lock().unwrap_or_else(|p| p.into_inner());
-            guard.as_deref() == resolved
+            if guard.as_deref() != resolved {
+                return None;
+            }
+        }
+        let new_id = entry.as_ref().map(|(id, _)| id.clone());
+        // The previous active entry: remove it unless the SHARED set still holds its
+        // id, or it's the same id we're re-installing (an idempotent re-install).
+        let prev = {
+            let mut prev_guard = self.active_repo_id.lock().unwrap_or_else(|p| p.into_inner());
+            std::mem::replace(&mut *prev_guard, new_id.clone())
         };
-        if !still_current {
-            return; // a later call moved active_repo on — it owns the registry now.
+        let mut cut = None;
+        {
+            let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(prev_id) = prev.as_deref() {
+                let still_new = new_id.as_deref() == Some(prev_id);
+                let still_shared = shared.contains_key(prev_id);
+                if !still_new && !still_shared {
+                    // The old active repo leaves the registry entirely → scope the cut
+                    // to it so only ITS streams end (fetch its path before removal).
+                    if let Some(old) = repos.remove(prev_id) {
+                        cut = Some(MonitorCut::Repo(old.path));
+                    }
+                }
+            }
+            if let Some((id, repo)) = entry {
+                repos.insert(id, repo);
+            }
         }
-        let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
-        repos.clear();
-        if let Some((id, repo)) = entry {
-            repos.insert(id, repo);
-        }
+        cut
     }
 
     /// Revoke a paired device, then cut live monitors on success. Split out from
@@ -226,8 +308,151 @@ impl LanState {
     /// the upgrade, closing the "auth runs only at upgrade time" hole.
     fn revoke_device(&self, device_id: &str) -> AppResult<()> {
         auth::revoke_device(device_id)?;
-        let _ = self.monitor_cut.send(());
+        let _ = self.monitor_cut.send(MonitorCut::All);
         Ok(())
+    }
+
+    /// The persisted shared repos as the wire/command shape [`LanSharedRepo`]
+    /// (`{ path, name }`), in stored order. Reads the store off-thread of any lock
+    /// and computes each `name` via [`repo_basename`]. The desktop reads this like it
+    /// reads the device list — the `lan_status` shape is unchanged.
+    fn shared_repos_list(&self) -> AppResult<Vec<LanSharedRepo>> {
+        Ok(shared_repos::list_paths()?
+            .into_iter()
+            .map(|path| LanSharedRepo {
+                name: repo_basename(&path),
+                path,
+            })
+            .collect())
+    }
+
+    /// Seed the SHARED portion of the registry from the persisted store — called by
+    /// [`lan_enable`] inside the lifecycle lock before the server starts. Installs
+    /// every stored repo whose path still exists on disk (a missing path is skipped
+    /// silently — the desktop list still shows it from the store). Idempotent: the
+    /// registry Arcs persist across enable/disable within a process, so re-seeding
+    /// just re-affirms the same entries. Serialized through the `shared_index` async
+    /// mutex against concurrent share/unshare.
+    async fn seed_shared(&self) -> AppResult<()> {
+        let stored = shared_repos::list_paths()?;
+        // Resolve ids for the on-disk survivors OUTSIDE the shared-index lock (each
+        // resolve awaits git); the raw store path is the map value.
+        let mut resolved: Vec<(String, String)> = Vec::new();
+        for path in stored {
+            if std::path::Path::new(&path).exists() {
+                let id = repo_id_for(&path).await;
+                resolved.push((id, path));
+            }
+        }
+        let mut shared = self.shared_index.lock().await;
+        let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+        for (id, path) in resolved {
+            let name = repo_basename(&path);
+            repos.insert(
+                id.clone(),
+                RegisteredRepo {
+                    path: path.clone(),
+                    name,
+                },
+            );
+            shared.insert(id, path);
+        }
+        Ok(())
+    }
+
+    /// Add `repo_path` to the persisted shared set and install it in the registry.
+    /// Idempotent by RESOLVED ID: sharing a repo already in the shared set (even
+    /// under a different worktree path — they collide on id by design) is a no-op
+    /// returning the current list. Returns the updated shared list.
+    ///
+    /// Race guard (mirrors [`install_active_repo`]'s stale-install guard): the id
+    /// resolves via git (an `.await`) BEFORE the `shared_index` lock is taken, so a
+    /// concurrent unshare could remove this repo in between. After the resolve we
+    /// take the lock and re-verify the id isn't already present before installing;
+    /// the store add is verbatim-path-deduped in [`shared_repos::add_path`].
+    async fn share_repo(&self, repo_path: &str) -> AppResult<Vec<LanSharedRepo>> {
+        let id = repo_id_for(repo_path).await;
+        let name = repo_basename(repo_path);
+        let shared = self.shared_index.lock().await;
+        // Already shared by id → no-op (persist nothing, registry already holds it).
+        if shared.contains_key(&id) {
+            drop(shared);
+            return self.shared_repos_list();
+        }
+        // Persist first (verbatim-dedup); on a store error we install nothing.
+        let list = shared_repos::add_path(repo_path)?;
+        {
+            let mut shared = shared;
+            let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+            repos.insert(
+                id.clone(),
+                RegisteredRepo {
+                    path: repo_path.to_string(),
+                    name,
+                },
+            );
+            shared.insert(id, repo_path.to_string());
+        }
+        Ok(list
+            .into_iter()
+            .map(|path| LanSharedRepo {
+                name: repo_basename(&path),
+                path,
+            })
+            .collect())
+    }
+
+    /// Remove `repo_path` (the stored path verbatim, as returned by the list) from
+    /// the persisted shared set and, unless the repo is ALSO the active repo, from
+    /// the registry. An unknown path is a no-op returning the current list. Fires a
+    /// [`MonitorCut::Repo`] on the removed repo when it actually leaves the registry
+    /// (it wasn't the active repo); no cut when it stays (still active). Returns the
+    /// updated shared list.
+    ///
+    /// The registry key is the resolved id (looked up in `shared_index` by matching
+    /// the stored path), so an entry shared under one worktree path unshared by that
+    /// same stored path removes the right id.
+    async fn unshare_repo(&self, repo_path: &str) -> AppResult<Vec<LanSharedRepo>> {
+        let list = shared_repos::remove_path(repo_path)?;
+        let cut = {
+            let mut shared = self.shared_index.lock().await;
+            // Find the id this stored path was shared under.
+            let id = shared
+                .iter()
+                .find(|(_, p)| p.as_str() == repo_path)
+                .map(|(id, _)| id.clone());
+            match id {
+                Some(id) => {
+                    shared.remove(&id);
+                    // Remove from the registry unless it's still the active entry.
+                    let is_active = self
+                        .active_repo_id
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .as_deref()
+                        == Some(id.as_str());
+                    if is_active {
+                        None
+                    } else {
+                        let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+                        repos
+                            .remove(&id)
+                            .map(|removed| MonitorCut::Repo(removed.path))
+                    }
+                }
+                None => None,
+            }
+        };
+        if let Some(cut) = cut {
+            let _ = self.monitor_cut.send(cut);
+        }
+        Ok(list
+            .into_iter()
+            .map(|path| LanSharedRepo {
+                name: repo_basename(&path),
+                path,
+            })
+            .collect())
     }
 
     /// Build the current [`LanStatus`] snapshot.
@@ -311,6 +536,19 @@ pub struct LanPairing {
     pub cert_fingerprint: String,
 }
 
+/// A repo in the desktop's persisted SHARED set, as returned by the shared-repos
+/// commands. `path` is the on-disk path (stored verbatim; used to unshare by the
+/// exact stored value) and `name` is its display basename. Both are desktop-only —
+/// the `path` never reaches the phone wire (the scoped routes carry the opaque id +
+/// name). `rename_all = "camelCase"` is carried on the single-word fields today so a
+/// future multi-word field can't repeat the slice-3 serde casing bug.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanSharedRepo {
+    pub path: String,
+    pub name: String,
+}
+
 // --------------------------------------------------------------------------
 // Commands (thin wrappers over LanState methods)
 // --------------------------------------------------------------------------
@@ -357,9 +595,18 @@ pub async fn lan_enable(
             // Cut any sockets accepted on the old listener before it's torn down:
             // a mode switch rebinds on a new port/interface, so in-flight monitors
             // must reconnect against the new server.
-            let _ = state.monitor_cut.send(());
+            let _ = state.monitor_cut.send(MonitorCut::All);
             rs.handle.shutdown().await;
         }
+    }
+
+    // Seed the registry's SHARED portion from the persisted store (inside the
+    // lifecycle lock, before the server binds) so `/api/repos` and the scoped routes
+    // see the user's shared set the moment the server accepts. A store read error is
+    // non-fatal — the shared set is a convenience, and failing enable over it would
+    // be worse than serving just the active repo; log and continue.
+    if let Err(e) = state.seed_shared().await {
+        eprintln!("lan companion: could not seed shared repos: {e}");
     }
 
     let (handle, urls, _hosts, fingerprint) = server::start(
@@ -410,7 +657,7 @@ pub async fn lan_disable(app: AppHandle, state: State<'_, LanState>) -> AppResul
         // accepting, but sockets already hijacked out of the serve loop keep
         // forwarding until told to stop. Firing here closes them so "Stop sharing"
         // actually severs the phone.
-        let _ = state.monitor_cut.send(());
+        let _ = state.monitor_cut.send(MonitorCut::All);
         rs.handle.shutdown().await;
     }
     // Any in-flight pairing is meaningless once the server is down.
@@ -492,6 +739,37 @@ pub fn lan_devices_list(_state: State<'_, LanState>) -> AppResult<Vec<LanDevice>
 #[tauri::command]
 pub fn lan_device_revoke(state: State<'_, LanState>, device_id: String) -> AppResult<()> {
     state.revoke_device(&device_id)
+}
+
+/// The desktop's persisted shared-repo set (`{ path, name }[]`), in stored order.
+/// Read like the device list; the `lan_status` shape is unchanged. Reflects the
+/// store on disk even while sharing is off (the desktop lists it to manage shares).
+#[tauri::command]
+pub fn lan_shared_repos_list(state: State<'_, LanState>) -> AppResult<Vec<LanSharedRepo>> {
+    state.shared_repos_list()
+}
+
+/// Add `repo_path` to the persisted shared set (and to the live registry when the
+/// server is running). Idempotent by RESOLVED id — sharing an already-shared repo
+/// is a no-op. Returns the updated shared list.
+#[tauri::command]
+pub async fn lan_share_repo(
+    state: State<'_, LanState>,
+    repo_path: String,
+) -> AppResult<Vec<LanSharedRepo>> {
+    state.share_repo(&repo_path).await
+}
+
+/// Remove `repo_path` (the stored path verbatim, as returned by
+/// [`lan_shared_repos_list`]) from the persisted shared set and the live registry.
+/// An unknown path is a no-op. Cuts live monitors on the removed repo when it leaves
+/// the registry. Returns the updated shared list.
+#[tauri::command]
+pub async fn lan_unshare_repo(
+    state: State<'_, LanState>,
+    repo_path: String,
+) -> AppResult<Vec<LanSharedRepo>> {
+    state.unshare_repo(&repo_path).await
 }
 
 /// The opaque, worktree-stable registry id for `repo_path`: the lowercase hex of
@@ -603,37 +881,46 @@ mod tests {
 
     #[tokio::test]
     async fn set_active_repo_cuts_monitors_only_on_change() {
-        // The monitor-cut signal fires when the shared repo actually changes, and
-        // NOT on a same-value set (the App effect re-pushes the same repoPath on
-        // every render — cutting on those would sever healthy phone streams). Now
-        // async (it resolves the registry id via git), but the cut-on-real-change
-        // contract is unchanged.
+        // Slice-4 cut scoping: a cut fires ONLY for a repo that LEAVES the registry,
+        // and it's scoped to that repo (a `MonitorCut::Repo(path)`). A same-value set
+        // never cuts; adding the FIRST active repo (nothing left) never cuts; a switch
+        // away from a non-shared repo cuts THAT repo; a clear of a non-shared repo cuts
+        // it. (Coexistence with the shared set — where an active switch fires NO cut —
+        // is covered by `active_switch_preserves_a_shared_repo_and_fires_no_cut`.)
+        use tokio::sync::broadcast::error::TryRecvError;
         let state = LanState::default();
         let mut cut_rx = state.monitor_cut.subscribe();
 
-        // (1) None → Some(repo) is a change → fires.
+        // (1) None → Some(A): A is ADDED, nothing left the registry → NO cut.
         assert!(state.set_active_repo(Some("C:/repo".to_string())).await);
-        assert!(cut_rx.try_recv().is_ok());
+        assert!(matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)));
 
         // (2) Setting the SAME value again is a no-op → no fire.
         assert!(!state.set_active_repo(Some("C:/repo".to_string())).await);
-        assert!(matches!(
-            cut_rx.try_recv(),
-            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
-        ));
+        assert!(matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)));
 
-        // (3) A real switch (and a clear) each fire.
+        // (3) A real switch away from the non-shared A cuts exactly A (scoped).
         assert!(state.set_active_repo(Some("C:/other".to_string())).await);
-        assert!(cut_rx.try_recv().is_ok());
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, "C:/repo", "switch cuts the OLD repo"),
+            other => panic!("expected Repo(C:/repo) cut, got {other:?}"),
+        }
+
+        // (4) A clear of the non-shared C:/other cuts exactly it (scoped).
         assert!(state.set_active_repo(None).await);
-        assert!(cut_rx.try_recv().is_ok());
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, "C:/other", "clear cuts the OLD repo"),
+            other => panic!("expected Repo(C:/other) cut, got {other:?}"),
+        }
     }
 
     #[tokio::test]
     async fn set_active_repo_mirrors_the_registry() {
-        // Registry v1 mirrors the active repo: a set registers exactly one entry
-        // under a 16-hex opaque id whose path is the set path; a clear empties it.
-        // The id never IS the path (opacity), and a same-value set keeps the entry.
+        // With NO shared set, the registry tracks the active repo exactly: a set
+        // registers one entry under a 16-hex opaque id whose path is the set path; a
+        // switch replaces it (the old, non-shared active entry is removed); a clear
+        // empties it. The id never IS the path (opacity), and a same-value set keeps
+        // the entry. (Active ∪ shared coexistence is covered by its own test.)
         let state = LanState::default();
 
         state.set_active_repo(Some("C:/repo".to_string())).await;
@@ -682,13 +969,14 @@ mod tests {
         assert!(state.repos.lock().unwrap().is_empty());
     }
 
-    #[test]
-    fn install_active_repo_skips_a_stale_install() {
+    #[tokio::test]
+    async fn install_active_repo_skips_a_stale_install() {
         // The concurrent-call guard: a slow resolve (call A) whose install lands
         // AFTER a later call (B) already moved active_repo on must NOT clobber the
         // registry. `install_active_repo` no-ops unless `active_repo` still equals
         // the path the entry was resolved for. Driven synchronously (no real git
         // race) by setting active_repo to B and calling A's install with A's path.
+        // (Now async — it holds the shared-index lock — and returns the scoped cut.)
         let state = LanState::default();
 
         // B is the winning, current active repo, with B's entry already installed.
@@ -699,19 +987,27 @@ mod tests {
             path: "C:/repo-B".to_string(),
             name: "repo-B".to_string(),
         });
-        state.install_active_repo(Some("C:/repo-B"), Some(entry_b));
+        // First install of B: nothing left before it → no cut.
+        assert!(state
+            .install_active_repo(Some("C:/repo-B"), Some(entry_b))
+            .await
+            .is_none());
         assert_eq!(
             state.repos.lock().unwrap().get("bbbbbbbbbbbbbbbb").map(|r| r.path.clone()),
             Some("C:/repo-B".to_string()),
             "B's install lands while B is current"
         );
 
-        // A is a STALE resolve for a path active_repo no longer equals → skipped.
+        // A is a STALE resolve for a path active_repo no longer equals → skipped
+        // (returns None, and B's active-id tracking is left untouched).
         let entry_a = ("aaaaaaaaaaaaaaaa".to_string(), RegisteredRepo {
             path: "C:/repo-A".to_string(),
             name: "repo-A".to_string(),
         });
-        state.install_active_repo(Some("C:/repo-A"), Some(entry_a));
+        assert!(state
+            .install_active_repo(Some("C:/repo-A"), Some(entry_a))
+            .await
+            .is_none());
         {
             let repos = state.repos.lock().unwrap();
             assert_eq!(repos.len(), 1, "stale install must not add A's entry");
@@ -719,17 +1015,254 @@ mod tests {
             assert!(!repos.contains_key("aaaaaaaaaaaaaaaa"), "A's stale entry rejected");
         }
 
-        // A matching install (active_repo == resolved) still applies normally.
+        // A matching install to a DIFFERENT id (active_repo still C:/repo-B) replaces
+        // the previous active entry: B(bbbb) leaves the registry (not shared, not the
+        // new id) → a scoped Repo cut on B's path, and cccc is installed.
         let entry_b2 = ("cccccccccccccccc".to_string(), RegisteredRepo {
             path: "C:/repo-B".to_string(),
             name: "repo-B".to_string(),
         });
-        state.install_active_repo(Some("C:/repo-B"), Some(entry_b2));
+        let cut = state
+            .install_active_repo(Some("C:/repo-B"), Some(entry_b2))
+            .await;
+        assert!(
+            matches!(cut, Some(MonitorCut::Repo(ref p)) if p == "C:/repo-B"),
+            "replacing the active entry cuts the old one: {cut:?}"
+        );
         {
             let repos = state.repos.lock().unwrap();
             assert_eq!(repos.len(), 1, "a matching install clears+inserts");
             assert!(repos.contains_key("cccccccccccccccc"), "B's fresh entry installed");
         }
+    }
+
+    /// A temp shared-repos store path (distinct from the device store's temp file).
+    fn temp_shared_store() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-lan-shared-repos-mod-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn shared_and_active_coexist_and_share_dedups_by_id() {
+        // The registry holds the active repo ∪ the shared set concurrently. Sharing a
+        // repo adds it; sharing the SAME repo again (by resolved id) is a no-op; the
+        // active repo coexists as its own entry.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        // Active repo A.
+        state.set_active_repo(Some("C:/repo-A".to_string())).await;
+        // Share B and C.
+        let list = state.share_repo("C:/repo-B").await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].path, "C:/repo-B");
+        assert_eq!(list[0].name, "repo-B");
+        state.share_repo("C:/repo-C").await.unwrap();
+
+        // Registry now holds A ∪ {B, C} — three distinct entries.
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 3, "active ∪ shared = 3 entries");
+            let paths: Vec<_> = repos.values().map(|r| r.path.clone()).collect();
+            assert!(paths.contains(&"C:/repo-A".to_string()));
+            assert!(paths.contains(&"C:/repo-B".to_string()));
+            assert!(paths.contains(&"C:/repo-C".to_string()));
+        }
+
+        // Sharing B again dedups by id → still 3 entries, list length stays 2.
+        let again = state.share_repo("C:/repo-B").await.unwrap();
+        assert_eq!(again.len(), 2, "share of an already-shared repo is a no-op list");
+        assert_eq!(state.repos.lock().unwrap().len(), 3, "no duplicate entry");
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn active_switch_preserves_a_shared_repo_and_fires_no_cut() {
+        // A live stream on shared repo B survives an active switch A→C: because B is in
+        // the shared set it stays registered, and the switch away from the non-shared A
+        // cuts only A (a scoped Repo(A)), never B or C.
+        use tokio::sync::broadcast::error::TryRecvError;
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        state.set_active_repo(Some("C:/repo-A".to_string())).await;
+        state.share_repo("C:/repo-B").await.unwrap();
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        // Switch A→C. A is not shared → it leaves → a scoped Repo(A) cut. B stays.
+        state.set_active_repo(Some("C:/repo-C".to_string())).await;
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, "C:/repo-A"),
+            other => panic!("expected Repo(C:/repo-A), got {other:?}"),
+        }
+        // No further cut (B was never touched).
+        assert!(matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)));
+        // Registry now holds C (active) ∪ B (shared).
+        {
+            let repos = state.repos.lock().unwrap();
+            let paths: Vec<_> = repos.values().map(|r| r.path.clone()).collect();
+            assert!(paths.contains(&"C:/repo-B".to_string()), "shared B survives the switch");
+            assert!(paths.contains(&"C:/repo-C".to_string()), "new active C is registered");
+            assert!(!paths.contains(&"C:/repo-A".to_string()), "old non-shared A removed");
+        }
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn switch_to_a_shared_repo_fires_no_cut_and_keeps_the_old_shared() {
+        // Switching the active repo to a repo that is ALSO shared, from an old active
+        // that is ALSO shared, fires NO cut at all — both remain registered.
+        use tokio::sync::broadcast::error::TryRecvError;
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        state.share_repo("C:/repo-A").await.unwrap();
+        state.share_repo("C:/repo-B").await.unwrap();
+        // Make A active (A is shared → still registered).
+        state.set_active_repo(Some("C:/repo-A".to_string())).await;
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        // Switch A→B: A remains registered (shared), B was already registered (shared)
+        // → NO cut.
+        state.set_active_repo(Some("C:/repo-B".to_string())).await;
+        assert!(
+            matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)),
+            "an active switch between two shared repos fires no cut"
+        );
+        assert_eq!(state.repos.lock().unwrap().len(), 2, "both shared entries remain");
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn unshare_non_active_fires_a_scoped_repo_cut() {
+        // Unsharing a NON-active repo removes exactly its entry and fires a scoped
+        // Repo cut on it (asserted via a subscribed receiver).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        state.set_active_repo(Some("C:/repo-A".to_string())).await;
+        state.share_repo("C:/repo-B").await.unwrap();
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        // Unshare B (not the active repo) → B leaves → Repo(B) cut.
+        let list = state.unshare_repo("C:/repo-B").await.unwrap();
+        assert!(list.is_empty(), "B removed from the shared list");
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, "C:/repo-B"),
+            other => panic!("expected Repo(C:/repo-B), got {other:?}"),
+        }
+        // Only A (active) remains registered.
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1);
+            assert_eq!(repos.values().next().unwrap().path, "C:/repo-A");
+        }
+        // Unsharing an unknown path is a no-op returning the current list (empty), no cut.
+        let noop = state.unshare_repo("C:/nope").await.unwrap();
+        assert!(noop.is_empty());
+        assert!(matches!(
+            cut_rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn unshare_active_repo_keeps_the_registry_entry_and_fires_no_cut() {
+        // Unsharing a repo that is ALSO the active repo removes it from the shared set
+        // but KEEPS its registry entry (the active role still holds it) and fires NO
+        // cut — the phone's stream on the still-active repo must not be severed.
+        use tokio::sync::broadcast::error::TryRecvError;
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        // Share A, then make A active (both roles hold the single entry).
+        state.share_repo("C:/repo-A").await.unwrap();
+        state.set_active_repo(Some("C:/repo-A".to_string())).await;
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        let list = state.unshare_repo("C:/repo-A").await.unwrap();
+        assert!(list.is_empty(), "A removed from the shared list");
+        assert!(
+            matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)),
+            "unsharing the active repo fires no cut"
+        );
+        // The registry entry survives (still active).
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "the active entry survives the unshare");
+            assert_eq!(repos.values().next().unwrap().path, "C:/repo-A");
+        }
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn seed_shared_installs_only_on_disk_survivors() {
+        // Seeding from the store installs every entry whose path EXISTS on disk and
+        // silently skips missing ones (the desktop list still shows them). Uses a real
+        // temp dir for the survivor so `Path::exists` is true.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        // A real on-disk dir (survivor) + a bogus missing path.
+        let live_dir = std::env::temp_dir().join(format!(
+            "gd-lan-seed-live-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&live_dir).unwrap();
+        let live = live_dir.to_string_lossy().to_string();
+        shared_repos::add_path(&live).unwrap();
+        shared_repos::add_path("C:/definitely/missing/repo").unwrap();
+
+        let state = LanState::default();
+        state.seed_shared().await.unwrap();
+
+        // Only the survivor is in the registry; the store list still holds both.
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "only the on-disk survivor is installed");
+            assert_eq!(repos.values().next().unwrap().path, live);
+        }
+        assert_eq!(state.shared_repos_list().unwrap().len(), 2, "store keeps both");
+
+        // Re-seeding is idempotent (registry Arcs persist across enable/disable).
+        state.seed_shared().await.unwrap();
+        assert_eq!(state.repos.lock().unwrap().len(), 1, "re-seed adds no duplicate");
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+        std::fs::remove_dir_all(&live_dir).ok();
     }
 
     #[test]
@@ -1600,11 +2133,72 @@ mod tests {
             "forwarded frame should carry the event JSON: {data}"
         );
 
-        // (2) Fire the lifecycle cut (what disable / repo-switch / revoke do). The
-        // stream's biased cut branch must end it: the next read is None (end).
-        monitor_cut.send(()).unwrap();
+        // (2) Fire the coarse lifecycle cut (what disable / a mode-switch / a revoke
+        // do). The stream's biased cut branch must end it: the next read is None (end).
+        monitor_cut.send(MonitorCut::All).unwrap();
         let next = next_sse_data(&mut body, Duration::from_secs(5)).await;
         assert!(next.is_none(), "the stream must end on the cut, got {next:?}");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn sse_monitor_survives_a_scoped_cut_on_another_repo() {
+        // A stream on repo B survives a `Repo(A)` cut (a different repo) — it keeps
+        // forwarding — and is only ended by a `Repo(B)` cut (its own repo). This is the
+        // slice-4 scoped-cut contract that lets one repo leave the registry without
+        // severing a phone watching a still-registered repo.
+        use tokio::time::Duration;
+
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+
+        let repo_b = "C:/repo-B".to_string();
+        let state = test_router(Some(repo_b.clone()));
+        let monitor_cut = state.monitor_cut.clone();
+        let ev_tx = insert_stream(&state, "rev-b", "review", &repo_b);
+
+        let (device, bearer, token_hash) = auth::mint_device("Scoped Cut Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let router = server::build_router(state);
+        let resp = router
+            .oneshot(authed_get("/api/reviews/rev-b/stream", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut body = resp.into_body().into_data_stream();
+
+        // A first event arrives (stream is live).
+        ev_tx
+            .send(crate::agent::ReviewEvent::Delta { text: "before".to_string() })
+            .unwrap();
+        assert!(next_sse_data(&mut body, Duration::from_secs(5))
+            .await
+            .expect("first event")
+            .contains("before"));
+
+        // Fire a scoped cut on a DIFFERENT repo (A). The B stream must NOT end — it
+        // keeps forwarding, so a subsequent event still arrives.
+        monitor_cut.send(MonitorCut::Repo("C:/repo-A".to_string())).unwrap();
+        ev_tx
+            .send(crate::agent::ReviewEvent::Delta { text: "after".to_string() })
+            .unwrap();
+        assert!(
+            next_sse_data(&mut body, Duration::from_secs(5))
+                .await
+                .expect("stream survived the other-repo cut")
+                .contains("after"),
+            "a Repo(A) cut must not end a repo-B stream"
+        );
+
+        // Fire a scoped cut on B's OWN repo → the stream ends.
+        monitor_cut.send(MonitorCut::Repo(repo_b.clone())).unwrap();
+        let next = next_sse_data(&mut body, Duration::from_secs(5)).await;
+        assert!(next.is_none(), "a Repo(B) cut must end the repo-B stream, got {next:?}");
 
         auth::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();
@@ -1698,18 +2292,22 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn list_repos_lists_the_registered_repo_and_is_empty_when_none() {
-        // `GET /api/repos` returns the registered repos as `[{ id, name }]` with a
-        // 16-hex id + basename name, and `[]` when none is registered. No path is on
-        // the wire.
+        // `GET /api/repos` returns the registered repos as `[{ id, name, active }]`
+        // with a 16-hex id + basename name + a bool `active` flag (camelCase), and `[]`
+        // when none is registered. No path is on the wire. Wire-shape pin for the
+        // frozen contract the companion + desktop build against.
         let _lock = auth::store_test_lock();
         let tmp = temp_store();
         let prev = auth::set_store_path_for_test(Some(tmp.clone()));
         let (device, bearer, token_hash) = auth::mint_device("Repos Phone");
         auth::persist_device(&device, &token_hash).unwrap();
 
-        // (1) One registered repo → one entry with a 16-hex id + basename.
-        let state = test_router(Some("C:/repo".to_string()));
+        // (1) Two registered repos, ONE of them the active repo: the active flag is
+        // exactly true for the entry whose path matches the active repo, false for the
+        // other. Pin every wire key (id/name/active present + camelCase; no path).
+        let state = test_router(Some("C:/work/my-repo".to_string()));
         register_repo(&state, "abcdef0123456789", "C:/work/my-repo");
+        register_repo(&state, "0123456789abcdef", "C:/work/other-repo");
         let router = server::build_router(state);
         let resp = router
             .oneshot(authed_get("/api/repos", &bearer))
@@ -1721,13 +2319,25 @@ mod tests {
             .unwrap();
         let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let arr = arr.as_array().unwrap();
-        assert_eq!(arr.len(), 1);
-        assert_eq!(arr[0]["id"], "abcdef0123456789");
-        assert_eq!(arr[0]["name"], "my-repo");
-        assert!(
-            arr[0].get("path").is_none() && arr[0].get("repoPath").is_none(),
-            "no filesystem path on the wire: {arr:?}"
-        );
+        assert_eq!(arr.len(), 2);
+        for entry in arr {
+            // Each entry pins the exact camelCase wire keys and NO path leak.
+            assert!(entry["id"].is_string(), "id present: {entry}");
+            assert!(entry["name"].is_string(), "name present: {entry}");
+            assert!(
+                entry.get("active").and_then(|v| v.as_bool()).is_some(),
+                "active present + camelCase bool: {entry}"
+            );
+            assert!(
+                entry.get("path").is_none() && entry.get("repoPath").is_none(),
+                "no filesystem path on the wire: {entry}"
+            );
+        }
+        let active_entry = arr.iter().find(|e| e["id"] == "abcdef0123456789").unwrap();
+        assert_eq!(active_entry["name"], "my-repo");
+        assert_eq!(active_entry["active"], true, "the active repo's flag is true");
+        let other_entry = arr.iter().find(|e| e["id"] == "0123456789abcdef").unwrap();
+        assert_eq!(other_entry["active"], false, "a non-active repo's flag is false");
 
         // (2) No registered repo → [].
         let empty_state = test_router(None);
@@ -1959,8 +2569,11 @@ mod tests {
     // runs on a plain GET — unlike the old `WebSocketUpgrade` extractor, which
     // rejected a non-upgrade `oneshot` GET before the handler body ran. The
     // monitor-cut branch is covered by `sse_monitor_forwards_then_is_severed_by_the_cut_signal`
-    // at the router level; its fire points are separately covered by
-    // `set_active_repo_cuts_monitors_only_on_change` and
+    // (a coarse `All` cut) and `sse_monitor_survives_a_scoped_cut_on_another_repo` (a
+    // scoped `Repo` cut that spares another repo's stream) at the router level; its
+    // fire points are separately covered by `set_active_repo_cuts_monitors_only_on_change`,
+    // `active_switch_preserves_a_shared_repo_and_fires_no_cut`,
+    // `unshare_non_active_fires_a_scoped_repo_cut`, and
     // `revoke_device_cuts_monitors_on_success`. The scoping logic the 404 calls
     // (`subscribe_in_for`) is additionally unit-tested in `state::tests`.
 

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -334,6 +334,21 @@ impl LanState {
                 // needed to record `active_repo_id` (done above). Insert only when the
                 // active repo isn't (also) shared.
                 if !shared.contains_key(&id) {
+                    // If a non-shared entry for this id already exists under a DIFFERENT
+                    // path (a same-repo, different-worktree active switch A→B: same id,
+                    // no removal cut above), the entry's SERVED path is about to change.
+                    // A live stream captured the OLD path at connect and scoped cuts
+                    // match by that path, so overwriting silently would strand it: fire
+                    // Repo(<old path>) so streams on A are severed and the phone
+                    // re-resolves against the now-served path B. (A run registered under
+                    // A then won't appear in lists scoped to B — that's the same
+                    // containment behavior the pre-cut-scoping unconditional cut had, not
+                    // new.) `cut` is None here (the `still_new` branch skipped removal).
+                    if let Some(existing) = repos.get(&id) {
+                        if existing.path != repo.path {
+                            cut = Some(MonitorCut::Repo(existing.path.clone()));
+                        }
+                    }
                     repos.insert(id, repo);
                 }
             }
@@ -420,6 +435,8 @@ impl LanState {
     /// open on worktree B) installs the SHARED path (A) into the entry, overwriting the
     /// active-mirror path — "you shared A, the phone sees A" even while the desktop is
     /// active in B. From then on [`install_active_repo`] leaves that shared path alone.
+    /// When that overwrite CHANGES the served path (active in B, sharing A), a
+    /// [`MonitorCut::Repo`] on the OLD path fires so a stream that captured B is severed.
     ///
     /// Race guard (mirrors [`install_active_repo`]'s stale-install guard): the id
     /// resolves via git (an `.await`) BEFORE the `shared_index` lock is taken, so a
@@ -438,11 +455,19 @@ impl LanState {
         }
         // Persist first (verbatim-dedup); on a store error we install nothing.
         let list = shared_repos::add_path(repo_path)?;
-        {
+        let cut = {
             let mut shared = shared;
             let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
             // Insert (or overwrite an active-mirror entry with) the SHARED path — from
-            // here the shared path is authoritative for this id.
+            // here the shared path is authoritative for this id. If an active-mirror
+            // entry already held a DIFFERENT worktree path (active in B, now sharing A),
+            // the served path CHANGES while the entry stays registered — so fire
+            // Repo(<old active path>) to sever a stream that captured B. (Same
+            // containment behavior the pre-scoping unconditional cut had.) No prior
+            // entry, or an identical path → no cut.
+            let path_cut = repos.get(&id).and_then(|e| {
+                (e.path != repo_path).then(|| MonitorCut::Repo(e.path.clone()))
+            });
             repos.insert(
                 id.clone(),
                 RegisteredRepo {
@@ -451,6 +476,10 @@ impl LanState {
                 },
             );
             shared.insert(id, repo_path.to_string());
+            path_cut
+        };
+        if let Some(cut) = cut {
+            let _ = self.monitor_cut.send(cut);
         }
         Ok(list
             .into_iter()
@@ -476,7 +505,9 @@ impl LanState {
     /// RE-POINTED to the current active path: while shared, the entry held the shared
     /// worktree's path (shared-path-authoritative); once it's purely active, the scoped
     /// surface must serve the active worktree, so we refresh `path`/`name` to
-    /// `active_repo`. No cut fires (the repo is still shared over the active surface).
+    /// `active_repo`. If that path actually CHANGES (shared worktree ≠ active worktree)
+    /// a [`MonitorCut::Repo`] on the OLD path fires so a stream that captured it is
+    /// severed; when the paths are identical, no cut fires.
     async fn unshare_repo(&self, repo_path: &str) -> AppResult<Vec<LanSharedRepo>> {
         let list = shared_repos::remove_path(repo_path)?;
         let cut = {
@@ -505,15 +536,26 @@ impl LanState {
                             .lock()
                             .unwrap_or_else(|p| p.into_inner())
                             .clone();
+                        let mut path_cut = None;
                         if let Some(path) = active_path {
                             let name = repo_basename(&path);
                             let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
                             if let Some(e) = repos.get_mut(&id) {
+                                // The served path CHANGES (shared → active worktree) while
+                                // the entry stays registered. A live stream captured the
+                                // OLD (shared) path and scoped cuts match by path, so fire
+                                // Repo(<old shared path>) to sever it — else it would watch
+                                // a run on a path the entry no longer serves. (Same
+                                // containment behavior the pre-scoping unconditional cut
+                                // had.) No change, no cut (identical worktree path).
+                                if e.path != path {
+                                    path_cut = Some(MonitorCut::Repo(e.path.clone()));
+                                }
                                 e.path = path;
                                 e.name = name;
                             }
                         }
-                        None
+                        path_cut
                     } else {
                         let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
                         repos
@@ -1326,7 +1368,14 @@ mod tests {
         );
 
         // Now share worktree A of the same repo → path becomes A (shared authoritative).
+        // The served path CHANGES (B→A), so a scoped Repo(B) cut fires to sever a stream
+        // that captured B.
+        let mut cut_rx = state.monitor_cut.subscribe();
         state.share_repo(&main_wt).await.unwrap();
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, linked_wt, "cut carries the OLD active path B"),
+            other => panic!("expected Repo(<old active path B>), got {other:?}"),
+        }
         assert_eq!(
             state.repos.lock().unwrap().get(&id).unwrap().path,
             main_wt,
@@ -1354,8 +1403,8 @@ mod tests {
         // Unsharing a repo that is ALSO the active repo (under a different worktree)
         // keeps the entry but re-points its path from the shared worktree A to the
         // active worktree B — the scoped surface must serve the active worktree once
-        // the repo is only active. No cut fires.
-        use tokio::sync::broadcast::error::TryRecvError;
+        // the repo is only active. Because the served path CHANGES (A→B), a scoped
+        // Repo(A) cut fires so a stream that captured A is severed.
         let _lock = auth::store_test_lock();
         let tmp = temp_shared_store();
         let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
@@ -1374,8 +1423,11 @@ mod tests {
         let mut cut_rx = state.monitor_cut.subscribe();
         let list = state.unshare_repo(&main_wt).await.unwrap();
         assert!(list.is_empty(), "A removed from the shared list");
-        // No cut (still active over the alias surface).
-        assert!(matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)));
+        // The served path changed A→B → a scoped Repo(A) cut severs a stream on A.
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, main_wt, "cut carries the OLD shared path A"),
+            other => panic!("expected Repo(<old shared path A>), got {other:?}"),
+        }
         // The entry survives, now re-pointed to the ACTIVE worktree B.
         {
             let repos = state.repos.lock().unwrap();
@@ -1391,6 +1443,93 @@ mod tests {
             .output()
             .ok();
         std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn same_id_active_worktree_switch_cuts_the_old_worktree_path() {
+        // The round-3 finding's exact repro at the state level: active on NON-shared
+        // worktree A, then switch to a linked worktree B of the SAME repo (same id).
+        // The entry's served path changes A→B while it stays registered; a stream
+        // captured A and scoped cuts match by path, so a Repo(A) cut MUST fire — else
+        // the stream on A is never severed (it wouldn't match a later Repo(B) removal).
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+        let (base, main_wt, linked_wt) = temp_repo_with_worktree();
+
+        let state = LanState::default();
+        // Active on worktree A (not shared).
+        state.set_active_repo(Some(main_wt.clone())).await;
+        let id = state.repos.lock().unwrap().keys().next().unwrap().clone();
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        // Switch to linked worktree B (same id, still not shared) → path A→B changes.
+        state.set_active_repo(Some(linked_wt.clone())).await;
+        match cut_rx.try_recv() {
+            Ok(MonitorCut::Repo(p)) => assert_eq!(p, main_wt, "cut carries the OLD worktree path A"),
+            other => panic!("expected Repo(<old worktree A>), got {other:?}"),
+        }
+        // Still one entry, now serving B, active id unchanged (same repo identity).
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1);
+            assert_eq!(repos.get(&id).unwrap().path, linked_wt, "entry now serves B");
+        }
+        assert_eq!(state.active_repo_id.lock().unwrap().as_deref(), Some(id.as_str()));
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+        std::process::Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(base.join("main"))
+            .output()
+            .ok();
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn same_id_reactivation_with_identical_path_fires_no_cut() {
+        // The no-regression guard: re-activating the SAME repo under the SAME path is a
+        // no-op set (the change-detection returns early) — no cut, no path change. And a
+        // re-share of an already-shared repo is a by-id no-op — also no cut. This proves
+        // the round-3 path-change cut fires ONLY on a real path change, not on adds or
+        // identical re-installs.
+        use tokio::sync::broadcast::error::TryRecvError;
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+
+        let state = LanState::default();
+        // First activation is an ADD (no prior entry) → no cut.
+        state.set_active_repo(Some("C:/repo-A".to_string())).await;
+        let mut cut_rx = state.monitor_cut.subscribe();
+
+        // Same-value re-activation → change-detection returns early, no cut.
+        assert!(!state.set_active_repo(Some("C:/repo-A".to_string())).await);
+        assert!(
+            matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)),
+            "identical re-activation fires no cut"
+        );
+
+        // Share A, then re-share A (by-id no-op) → no cut.
+        state.share_repo("C:/repo-A").await.unwrap();
+        // Draining any cut the share might have produced (path B→A change): here the
+        // active entry already held A (same path), so sharing A does NOT change the path
+        // → no cut. Assert that.
+        assert!(
+            matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)),
+            "sharing a repo already served under the same path fires no cut"
+        );
+        state.share_repo("C:/repo-A").await.unwrap(); // by-id no-op
+        assert!(
+            matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)),
+            "re-sharing an already-shared repo fires no cut"
+        );
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
     }
 
     #[tokio::test]

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -94,11 +94,18 @@ pub struct LanState {
     /// so the coarse serialization is cheap. Never held across a NESTED `.await` that
     /// could deadlock (only the id resolve, which touches no other LanState lock).
     shared_index: tokio::sync::Mutex<HashMap<String, String>>,
-    /// The opaque id of the currently-installed ACTIVE registry entry, if any. Lets
-    /// an active switch remove the PREVIOUS active entry iff its id isn't also in the
-    /// shared set (a repo that's both active and shared keeps its single entry when
-    /// it leaves only the active role). A `std::Mutex` — short, sync accesses only.
-    active_repo_id: Mutex<Option<String>>,
+    /// The opaque id of the currently-installed ACTIVE registry entry, if any. Two
+    /// jobs: (1) an active switch removes the PREVIOUS active entry iff its id isn't
+    /// also in the shared set (a repo that's both active and shared keeps its single
+    /// entry when it leaves only the active role); (2) it is the SOURCE OF TRUTH for
+    /// the `/api/repos` `active` flag — shared (per-field `Arc`) with the router state
+    /// so `list_repos` can flag the active entry BY ID, matching the id-based identity
+    /// the whole feature dedups on. Flagging by id (not by path) is load-bearing for
+    /// the two-worktree case: a repo shared under worktree path A while the desktop is
+    /// open on worktree path B occupies ONE registry entry (same id) whose stored path
+    /// may be A; a path compare against active path B would wrongly report `active:
+    /// false`, but the id matches. A `std::Mutex` — short, sync accesses only.
+    active_repo_id: Arc<Mutex<Option<String>>>,
     /// The running server handle (bound port + shutdown signal + task), or `None`
     /// when disabled. Guarded so enable/disable are serialized.
     running: Mutex<Option<RunningServer>>,
@@ -150,7 +157,7 @@ impl Default for LanState {
             active_repo: Arc::new(Mutex::new(None)),
             repos: Arc::new(Mutex::new(HashMap::new())),
             shared_index: tokio::sync::Mutex::new(HashMap::new()),
-            active_repo_id: Mutex::new(None),
+            active_repo_id: Arc::new(Mutex::new(None)),
             running: Mutex::new(None),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -612,6 +619,7 @@ pub async fn lan_enable(
     let (handle, urls, _hosts, fingerprint) = server::start(
         bind_lan,
         state.active_repo.clone(),
+        state.active_repo_id.clone(),
         state.repos.clone(),
         state.pairing.clone(),
         state.rate_limit.clone(),
@@ -831,6 +839,7 @@ mod tests {
     fn test_router(active: Option<String>) -> auth::RouterState {
         auth::RouterState {
             active_repo: Arc::new(Mutex::new(active)),
+            active_repo_id: Arc::new(Mutex::new(None)),
             repos: Arc::new(Mutex::new(std::collections::HashMap::new())),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -838,6 +847,13 @@ mod tests {
             streams: Arc::new(Mutex::new(std::collections::HashMap::new())),
             monitor_cut: tokio::sync::broadcast::channel(4).0,
         }
+    }
+
+    /// Set a test router's active-repo id (the source of truth for the `/api/repos`
+    /// `active` flag). Pairs with [`register_repo`] so a wire-shape test can register
+    /// an entry and mark it active BY ID — the same identity `list_repos` flags on.
+    fn set_active_id(state: &auth::RouterState, repo_id: &str) {
+        *state.active_repo_id.lock().unwrap() = Some(repo_id.to_string());
     }
 
     /// Pre-register a repo entry in a test router's registry (opaque-id → path), so
@@ -2303,11 +2319,13 @@ mod tests {
         auth::persist_device(&device, &token_hash).unwrap();
 
         // (1) Two registered repos, ONE of them the active repo: the active flag is
-        // exactly true for the entry whose path matches the active repo, false for the
+        // exactly true for the entry whose ID equals the active id, false for the
         // other. Pin every wire key (id/name/active present + camelCase; no path).
+        // The flag is BY ID — set the active id, not just the active path.
         let state = test_router(Some("C:/work/my-repo".to_string()));
         register_repo(&state, "abcdef0123456789", "C:/work/my-repo");
         register_repo(&state, "0123456789abcdef", "C:/work/other-repo");
+        set_active_id(&state, "abcdef0123456789");
         let router = server::build_router(state);
         let resp = router
             .oneshot(authed_get("/api/repos", &bearer))
@@ -2338,6 +2356,33 @@ mod tests {
         assert_eq!(active_entry["active"], true, "the active repo's flag is true");
         let other_entry = arr.iter().find(|e| e["id"] == "0123456789abcdef").unwrap();
         assert_eq!(other_entry["active"], false, "a non-active repo's flag is false");
+
+        // (1b) The two-worktree case the ID mechanism exists for: a repo shared under
+        // one worktree path while the desktop is open on a DIFFERENT worktree path.
+        // The single registry entry's stored path is the SHARED path A ("C:/work/repo"),
+        // the active PATH is B ("…/worktrees/feature") — they never path-match — but the
+        // active ID equals the entry's id → `active: true`. A path compare would have
+        // wrongly reported false here.
+        let wt_state = test_router(Some("C:/work/repo/worktrees/feature".to_string()));
+        register_repo(&wt_state, "feedfacecafebeef", "C:/work/repo"); // shared under path A
+        set_active_id(&wt_state, "feedfacecafebeef"); // active on path B, SAME id
+        let wt_router = server::build_router(wt_state);
+        let resp = wt_router
+            .oneshot(authed_get("/api/repos", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], "feedfacecafebeef");
+        assert_eq!(
+            arr[0]["active"], true,
+            "shared-under-path-A + active-on-path-B still flags active by id"
+        );
 
         // (2) No registered repo → [].
         let empty_state = test_router(None);
@@ -2602,6 +2647,7 @@ mod tests {
         let (handle, urls, _hosts, fingerprint) = server::start(
             false, // loopback
             Arc::new(Mutex::new(Some("C:/repo".to_string()))),
+            Arc::new(Mutex::new(None)), // active_repo_id
             Arc::new(Mutex::new(std::collections::HashMap::new())),
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(std::collections::HashMap::new())),

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -73,6 +73,15 @@ pub struct RegisteredRepo {
 /// [`lan_share_repo`] / [`lan_unshare_repo`]. Deduped by opaque id, so a repo that
 /// is both active AND shared occupies exactly one entry — its removal from one role
 /// leaves the entry while the other role still holds it.
+///
+/// Single-entry path ownership is SHARED-PATH-AUTHORITATIVE: when an id is in the
+/// shared set, the entry's `path` is the explicitly shared worktree's path and the
+/// active mirror must not overwrite it (see [`LanState::install_active_repo`]). This
+/// matters because linked worktrees of one repo share an id: the phone browsing a
+/// shared repo must keep seeing the worktree the user shared, not whichever worktree
+/// the desktop later opens. Consequence: while a shared repo is also active under a
+/// DIFFERENT worktree, the scoped `/api/repos/{id}/…` surface serves the shared
+/// worktree while the alias `/api/repo/…` surface serves the active one (`active_repo`).
 pub type RepoRegistry = Arc<Mutex<HashMap<String, RegisteredRepo>>>;
 
 /// The Tauri-managed state for the LAN companion.
@@ -88,7 +97,9 @@ pub struct LanState {
     /// The resolved shared set: opaque-id → the stored path each shared repo was
     /// shared under (the verbatim path in `lan-shared-repos.json`). The registry
     /// bookkeeping consults this to know whether a repo LEAVING the active role is
-    /// still held by the shared role (so it stays in `repos`) or should be removed.
+    /// still held by the shared role (so it stays in `repos`) or should be removed,
+    /// AND whether an id is shared (so the active mirror must not overwrite the shared
+    /// entry's path — shared-path-authoritative; see [`LanState::install_active_repo`]).
     /// An `async` mutex because share/unshare/seed resolve ids via git (`.await`)
     /// and must serialize the resolve→re-verify→install sequence; rare + user-driven,
     /// so the coarse serialization is cheap. Never held across a NESTED `.await` that
@@ -255,6 +266,22 @@ impl LanState {
     /// entirely: that later call owns the registry, and clobbering it here would
     /// install a stale entry (the A-after-B interleave).
     ///
+    /// **Shared-path-authoritative install.** When the new active id is ALREADY in the
+    /// shared set, the entry's `path`/`name` are NOT overwritten — the explicitly
+    /// shared worktree owns the registry entry. This is load-bearing for the
+    /// linked-worktree case: a repo shared under worktree path A then opened as a
+    /// DIFFERENT linked worktree B resolves to the SAME id (git identity is the common
+    /// dir), so an unconditional insert would overwrite `repos[id].path` with B and the
+    /// scoped surface — which serves `repos[id].path` verbatim — would serve B's
+    /// branch/status to a phone that asked for the repo it was told is shared (A),
+    /// indefinitely (the switch-away `still_shared` branch would keep the clobbered B
+    /// path). So we still record `active_repo_id` (the `/api/repos` `active` flag is
+    /// id-based and unaffected) but leave the shared entry's path alone. A non-shared
+    /// active id installs its entry normally. (Divergence by design: while a shared
+    /// repo is also active under a different worktree, the SCOPED surface serves the
+    /// shared worktree; the ALIAS surface still serves the active path via
+    /// `active_repo`.)
+    ///
     /// Returns the [`MonitorCut`] to fire, if any: a [`MonitorCut::Repo`] on the
     /// PREVIOUS active repo's path when that repo leaves the registry (its id isn't
     /// the new entry's id and isn't in the shared set), else `None` (the old repo is
@@ -301,7 +328,14 @@ impl LanState {
                 }
             }
             if let Some((id, repo)) = entry {
-                repos.insert(id, repo);
+                // Shared-path-authoritative: don't clobber a shared entry's path/name
+                // with an active worktree's path. If the id is shared, the shared entry
+                // already exists (share/seed installed it) and owns its path; we only
+                // needed to record `active_repo_id` (done above). Insert only when the
+                // active repo isn't (also) shared.
+                if !shared.contains_key(&id) {
+                    repos.insert(id, repo);
+                }
             }
         }
         cut
@@ -340,6 +374,13 @@ impl LanState {
     /// registry Arcs persist across enable/disable within a process, so re-seeding
     /// just re-affirms the same entries. Serialized through the `shared_index` async
     /// mutex against concurrent share/unshare.
+    ///
+    /// Shared-path-authoritative: if a repo was made active (its entry pre-installed by
+    /// [`install_active_repo`]) under worktree B before enable, seeding it as shared
+    /// under stored path A overwrites the entry with A — the shared path wins, exactly
+    /// as [`share_repo`] does. From then on `install_active_repo` won't re-point it. So
+    /// the seed's unconditional insert is the intended order (shared last, shared wins);
+    /// `active_repo_id` is untouched here, so the `active` flag stays correct by id.
     async fn seed_shared(&self) -> AppResult<()> {
         let stored = shared_repos::list_paths()?;
         // Resolve ids for the on-disk survivors OUTSIDE the shared-index lock (each
@@ -355,6 +396,8 @@ impl LanState {
         let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
         for (id, path) in resolved {
             let name = repo_basename(&path);
+            // Shared path is authoritative — install it even over a pre-existing
+            // active-mirror entry for the same id.
             repos.insert(
                 id.clone(),
                 RegisteredRepo {
@@ -372,6 +415,12 @@ impl LanState {
     /// under a different worktree path — they collide on id by design) is a no-op
     /// returning the current list. Returns the updated shared list.
     ///
+    /// Shared-path-authoritative: sharing a repo whose registry entry currently exists
+    /// only from the active mirror (id not yet in `shared_index`, e.g. the desktop is
+    /// open on worktree B) installs the SHARED path (A) into the entry, overwriting the
+    /// active-mirror path — "you shared A, the phone sees A" even while the desktop is
+    /// active in B. From then on [`install_active_repo`] leaves that shared path alone.
+    ///
     /// Race guard (mirrors [`install_active_repo`]'s stale-install guard): the id
     /// resolves via git (an `.await`) BEFORE the `shared_index` lock is taken, so a
     /// concurrent unshare could remove this repo in between. After the resolve we
@@ -381,7 +430,8 @@ impl LanState {
         let id = repo_id_for(repo_path).await;
         let name = repo_basename(repo_path);
         let shared = self.shared_index.lock().await;
-        // Already shared by id → no-op (persist nothing, registry already holds it).
+        // Already shared by id → no-op (persist nothing, registry already holds the
+        // shared entry, which owns its path — do not re-point it).
         if shared.contains_key(&id) {
             drop(shared);
             return self.shared_repos_list();
@@ -391,6 +441,8 @@ impl LanState {
         {
             let mut shared = shared;
             let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+            // Insert (or overwrite an active-mirror entry with) the SHARED path — from
+            // here the shared path is authoritative for this id.
             repos.insert(
                 id.clone(),
                 RegisteredRepo {
@@ -419,6 +471,12 @@ impl LanState {
     /// The registry key is the resolved id (looked up in `shared_index` by matching
     /// the stored path), so an entry shared under one worktree path unshared by that
     /// same stored path removes the right id.
+    ///
+    /// When the unshared repo is ALSO the active repo, its entry stays but is
+    /// RE-POINTED to the current active path: while shared, the entry held the shared
+    /// worktree's path (shared-path-authoritative); once it's purely active, the scoped
+    /// surface must serve the active worktree, so we refresh `path`/`name` to
+    /// `active_repo`. No cut fires (the repo is still shared over the active surface).
     async fn unshare_repo(&self, repo_path: &str) -> AppResult<Vec<LanSharedRepo>> {
         let list = shared_repos::remove_path(repo_path)?;
         let cut = {
@@ -431,14 +489,30 @@ impl LanState {
             match id {
                 Some(id) => {
                     shared.remove(&id);
-                    // Remove from the registry unless it's still the active entry.
-                    let is_active = self
+                    // Is this id the active entry? Snapshot both id + active path under
+                    // their own short locks (never nested with `repos`).
+                    let active_id = self
                         .active_repo_id
                         .lock()
                         .unwrap_or_else(|p| p.into_inner())
-                        .as_deref()
-                        == Some(id.as_str());
+                        .clone();
+                    let is_active = active_id.as_deref() == Some(id.as_str());
                     if is_active {
+                        // Keep the entry but re-point it to the ACTIVE worktree's path,
+                        // since the (possibly different) shared path no longer owns it.
+                        let active_path = self
+                            .active_repo
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner())
+                            .clone();
+                        if let Some(path) = active_path {
+                            let name = repo_basename(&path);
+                            let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
+                            if let Some(e) = repos.get_mut(&id) {
+                                e.path = path;
+                                e.name = name;
+                            }
+                        }
                         None
                     } else {
                         let mut repos = self.repos.lock().unwrap_or_else(|p| p.into_inner());
@@ -1135,6 +1209,188 @@ mod tests {
 
         shared_repos::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();
+    }
+
+    /// Create a temp git repo `main/` + a linked worktree `linked/` of it, returning
+    /// `(base_dir, main_path, linked_path)`. Both paths resolve to the SAME
+    /// `repo_identity` (the common `.git` dir) → the SAME registry id, which is the
+    /// collision the shared-path-authoritative rule guards. Caller removes `base_dir`.
+    fn temp_repo_with_worktree() -> (std::path::PathBuf, String, String) {
+        let base = std::env::temp_dir().join(format!(
+            "gd-lan-wt-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let main = base.join("main");
+        let linked = base.join("linked");
+        std::fs::create_dir_all(&main).unwrap();
+        let run = |args: &[&str], cwd: &std::path::Path| {
+            assert!(
+                std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(cwd)
+                    .output()
+                    .unwrap()
+                    .status
+                    .success(),
+                "git {args:?} failed"
+            );
+        };
+        run(&["init", "-q"], &main);
+        run(&["config", "user.email", "t@t.t"], &main);
+        run(&["config", "user.name", "t"], &main);
+        run(&["commit", "-q", "--allow-empty", "-m", "init"], &main);
+        run(
+            &["worktree", "add", "-q", linked.to_str().unwrap(), "-b", "feature"],
+            &main,
+        );
+        (
+            base.clone(),
+            main.to_string_lossy().to_string(),
+            linked.to_string_lossy().to_string(),
+        )
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn shared_worktree_path_survives_active_open_of_a_linked_worktree() {
+        // The reviewer's exact repro (real git worktrees, one identity). Share the repo
+        // under worktree path A (`main`), then open a DIFFERENT linked worktree B
+        // (`linked`) of the same repo as the active repo — same id. The shared entry's
+        // path must stay A while active AND after switching away; the scoped surface
+        // serves `repos[id].path`, so a clobber to B would serve the wrong worktree.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+        let (base, main_wt, linked_wt) = temp_repo_with_worktree();
+
+        let state = LanState::default();
+        // Share under worktree A (main).
+        state.share_repo(&main_wt).await.unwrap();
+        let shared_id = state.repos.lock().unwrap().keys().next().unwrap().clone();
+
+        // Open linked worktree B as the active repo — SAME id (linked worktree).
+        state.set_active_repo(Some(linked_wt.clone())).await;
+
+        // One entry (deduped by id), still holding the SHARED path A — NOT clobbered to B.
+        {
+            let repos = state.repos.lock().unwrap();
+            assert_eq!(repos.len(), 1, "one entry (shared A == active B by id)");
+            let entry = repos.get(&shared_id).expect("shared id present");
+            assert_eq!(entry.path, main_wt, "shared worktree path A owns the entry, not B");
+        }
+        // The active flag is id-based → true (the active id equals the shared id).
+        assert_eq!(
+            state.active_repo_id.lock().unwrap().as_deref(),
+            Some(shared_id.as_str()),
+            "active id equals the shared id"
+        );
+
+        // Switch the desktop away to a different repo → the shared entry stays, STILL A.
+        state.set_active_repo(Some("C:/some/other/repo".to_string())).await;
+        {
+            let repos = state.repos.lock().unwrap();
+            let entry = repos.get(&shared_id).expect("shared entry survives switch-away");
+            assert_eq!(entry.path, main_wt, "shared path A survives the switch-away, not B");
+        }
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+        std::process::Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(base.join("main"))
+            .output()
+            .ok();
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn active_first_then_share_makes_the_shared_path_authoritative() {
+        // Test-case (2): the desktop is active on linked worktree B FIRST (its entry
+        // holds B), then the user shares worktree A of the same repo → the entry's path
+        // becomes A (shared wins), even while the desktop stays active in B.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+        let (base, main_wt, linked_wt) = temp_repo_with_worktree();
+
+        let state = LanState::default();
+        // Active on B first (main mirror installs B).
+        state.set_active_repo(Some(linked_wt.clone())).await;
+        let id = state.repos.lock().unwrap().keys().next().unwrap().clone();
+        assert_eq!(
+            state.repos.lock().unwrap().get(&id).unwrap().path,
+            linked_wt,
+            "active-mirror entry initially holds B"
+        );
+
+        // Now share worktree A of the same repo → path becomes A (shared authoritative).
+        state.share_repo(&main_wt).await.unwrap();
+        assert_eq!(
+            state.repos.lock().unwrap().get(&id).unwrap().path,
+            main_wt,
+            "sharing A re-points the entry to A even while active in B"
+        );
+        // Active flag still true (id unchanged; the desktop is still active on this id).
+        assert_eq!(
+            state.active_repo_id.lock().unwrap().as_deref(),
+            Some(id.as_str())
+        );
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+        std::process::Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(base.join("main"))
+            .output()
+            .ok();
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn unshare_active_repo_repoints_the_entry_to_the_active_worktree() {
+        // Unsharing a repo that is ALSO the active repo (under a different worktree)
+        // keeps the entry but re-points its path from the shared worktree A to the
+        // active worktree B — the scoped surface must serve the active worktree once
+        // the repo is only active. No cut fires.
+        use tokio::sync::broadcast::error::TryRecvError;
+        let _lock = auth::store_test_lock();
+        let tmp = temp_shared_store();
+        let prev = shared_repos::set_store_path_for_test(Some(tmp.clone()));
+        let (base, main_wt, linked_wt) = temp_repo_with_worktree();
+
+        let state = LanState::default();
+        state.share_repo(&main_wt).await.unwrap(); // shared under A
+        state.set_active_repo(Some(linked_wt.clone())).await; // active under B, same id
+        let id = state.repos.lock().unwrap().keys().next().unwrap().clone();
+        assert_eq!(
+            state.repos.lock().unwrap().get(&id).unwrap().path,
+            main_wt,
+            "while shared, the entry holds the shared worktree A"
+        );
+
+        let mut cut_rx = state.monitor_cut.subscribe();
+        let list = state.unshare_repo(&main_wt).await.unwrap();
+        assert!(list.is_empty(), "A removed from the shared list");
+        // No cut (still active over the alias surface).
+        assert!(matches!(cut_rx.try_recv(), Err(TryRecvError::Empty)));
+        // The entry survives, now re-pointed to the ACTIVE worktree B.
+        {
+            let repos = state.repos.lock().unwrap();
+            let entry = repos.get(&id).expect("entry survives (still active)");
+            assert_eq!(entry.path, linked_wt, "unshare re-points to the active worktree B");
+        }
+
+        shared_repos::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+        std::process::Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(base.join("main"))
+            .output()
+            .ok();
+        std::fs::remove_dir_all(&base).ok();
     }
 
     #[tokio::test]

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -40,7 +40,8 @@
 //! | `/api/reviews`                        | `reviews`                             |
 //! | `/api/reviews/{id}/stream`            | `reviews/{id}/stream`                 |
 //!
-//! Plus `GET /api/repos` (protected) → the registered repos as `[{ id, name }]`.
+//! Plus `GET /api/repos` (protected) → the registered repos (active ∪ shared) as
+//! `[{ id, name, active }]`.
 //!
 //! ## The shared-handler extraction trap
 //!
@@ -203,9 +204,12 @@ fn no_such_repo() -> Response {
         .into_response()
 }
 
-/// GET /api/repos — the registered repos as `[{ id, name }]` (camelCase). Today
-/// that's the desktop's active repo (or empty when none is shared). Only the
-/// opaque id + display name reach the wire — never a filesystem path.
+/// GET /api/repos — the registered repos as `[{ id, name, active }]` (camelCase):
+/// the desktop's ACTIVE repo ∪ the persisted SHARED set. `active` is `true` for the
+/// entry whose path matches the desktop's current active repo (per
+/// [`crate::state::repo_paths_match`]) — at most one, and none when no repo is
+/// active. Only the opaque id + display name + `active` flag reach the wire — never
+/// a filesystem path.
 pub(crate) async fn list_repos(
     axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
 ) -> Response {
@@ -214,12 +218,24 @@ pub(crate) async fn list_repos(
     use axum::Json;
     use serde_json::json;
 
+    // Snapshot the active path once (drop its lock before locking `repos`, never
+    // nested) so every entry's `active` flag is computed against one consistent value.
+    let active = state
+        .active_repo
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone();
     let items: Vec<_> = state
         .repos
         .lock()
         .unwrap_or_else(|p| p.into_inner())
         .iter()
-        .map(|(id, repo)| json!({ "id": id, "name": repo.name }))
+        .map(|(id, repo)| {
+            let is_active = active
+                .as_deref()
+                .is_some_and(|a| crate::state::repo_paths_match(&repo.path, a));
+            json!({ "id": id, "name": repo.name, "active": is_active })
+        })
         .collect();
     (StatusCode::OK, Json(items)).into_response()
 }

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -206,10 +206,19 @@ fn no_such_repo() -> Response {
 
 /// GET /api/repos — the registered repos as `[{ id, name, active }]` (camelCase):
 /// the desktop's ACTIVE repo ∪ the persisted SHARED set. `active` is `true` for the
-/// entry whose path matches the desktop's current active repo (per
-/// [`crate::state::repo_paths_match`]) — at most one, and none when no repo is
-/// active. Only the opaque id + display name + `active` flag reach the wire — never
-/// a filesystem path.
+/// entry whose opaque id equals the desktop's current active id — at most one, and
+/// none when no repo is active. Flagging BY ID (not by path) matches the id-based
+/// identity the registry dedups on: a repo shared under one worktree path while the
+/// desktop is open on another occupies one entry (same id) whose stored path may
+/// differ from the active path, so a path compare would wrongly report `active:
+/// false`. Only the opaque id + display name + `active` flag reach the wire — never a
+/// filesystem path. (An id compare also avoids a filesystem `canonicalize` under the
+/// `repos` lock.)
+///
+/// The active id and the entries are read under separate short locks (never nested).
+/// Any transient skew between `active_repo_id` and the registry during a slow install
+/// is the same eventual-consistency of a UI bool that exists across the feature — a
+/// switch settles it within one install; nothing keys correctness on the flag.
 pub(crate) async fn list_repos(
     axum::extract::State(state): axum::extract::State<crate::lan::auth::RouterState>,
 ) -> Response {
@@ -218,10 +227,10 @@ pub(crate) async fn list_repos(
     use axum::Json;
     use serde_json::json;
 
-    // Snapshot the active path once (drop its lock before locking `repos`, never
-    // nested) so every entry's `active` flag is computed against one consistent value.
-    let active = state
-        .active_repo
+    // Snapshot the active id once under its own lock (dropped before locking `repos`,
+    // never nested) so every entry's `active` flag is computed against one value.
+    let active_id = state
+        .active_repo_id
         .lock()
         .unwrap_or_else(|p| p.into_inner())
         .clone();
@@ -231,9 +240,7 @@ pub(crate) async fn list_repos(
         .unwrap_or_else(|p| p.into_inner())
         .iter()
         .map(|(id, repo)| {
-            let is_active = active
-                .as_deref()
-                .is_some_and(|a| crate::state::repo_paths_match(&repo.path, a));
+            let is_active = active_id.as_deref() == Some(id.as_str());
             json!({ "id": id, "name": repo.name, "active": is_active })
         })
         .collect();

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -142,8 +142,9 @@ pub async fn stream(
     let cut_rx = state.monitor_cut.subscribe();
     // A 15s keep-alive comment defeats phone-side idle timeouts. The LAN has no
     // buffering proxies, so the keep-alive exists purely to keep the connection
-    // warm through mobile-OS background timers.
-    Sse::new(forward_stream(rx, cut_rx))
+    // warm through mobile-OS background timers. `repo` scopes a `MonitorCut::Repo`:
+    // only a cut naming THIS stream's repo (or a coarse `All`) ends it.
+    Sse::new(forward_stream(rx, cut_rx, repo))
         .keep_alive(
             KeepAlive::new()
                 .interval(Duration::from_secs(15))
@@ -154,22 +155,32 @@ pub async fn stream(
 
 /// The per-connection event stream: forward each broadcast [`ReviewEvent`] as one
 /// SSE `data:` payload, translate lag/close, and end on the terminal `Done`/`Error`
-/// event, on the stream ending (`Closed`), or on a lifecycle cut. There is NO
-/// inbound arm — SSE is one-way, which is the point (see the module docs).
+/// event, on the stream ending (`Closed`), or on a lifecycle cut that applies to
+/// this stream's `repo`. There is NO inbound arm — SSE is one-way, which is the
+/// point (see the module docs).
 ///
-/// A hand-rolled [`futures_util::stream::unfold`] over `(rx, cut_rx,
+/// A hand-rolled [`futures_util::stream::unfold`] over `(rx, cut_rx, repo,
 /// terminal_seen)` with a biased inner `select!`, dependency-free (`futures-util`
 /// is already a dep; `async-stream` is deliberately not in the tree). The
 /// `terminal_seen` flag makes the terminal event's "yield then END on the next
 /// poll" explicit: the poll that forwards `Done`/`Error` sets the flag, and the
 /// next poll returns `None` to end the stream.
+///
+/// Cut scoping: a [`crate::lan::MonitorCut::All`] ends the stream unconditionally; a
+/// [`crate::lan::MonitorCut::Repo`] ends it ONLY when the named repo matches this
+/// stream's `repo` (per [`crate::state::repo_paths_match`]) — otherwise the select is
+/// re-armed and forwarding continues, so a repo B stream survives a `Repo(A)` cut.
+/// `Lagged` is treated as `All` (fail-safe: we can't know which cut we missed);
+/// `Closed` ends it (defensive — can't occur while `LanState` holds the Sender).
 fn forward_stream(
     rx: tokio::sync::broadcast::Receiver<ReviewEvent>,
-    cut_rx: tokio::sync::broadcast::Receiver<()>,
+    cut_rx: tokio::sync::broadcast::Receiver<crate::lan::MonitorCut>,
+    repo: String,
 ) -> impl futures_util::Stream<Item = Result<Event, Infallible>> {
+    use crate::lan::MonitorCut;
     futures_util::stream::unfold(
-        (rx, cut_rx, false),
-        |(mut rx, mut cut_rx, terminal_seen)| async move {
+        (rx, cut_rx, repo, false),
+        |(mut rx, mut cut_rx, repo, terminal_seen)| async move {
             // A terminal event was forwarded on the previous poll — end the stream
             // now (yield then END, exactly as the WS impl did).
             if terminal_seen {
@@ -180,13 +191,24 @@ fn forward_stream(
                 // cut wins — a just-revoked/disabled stream never forwards one more
                 // buffered frame before it honors the cut.
                 biased;
-                // Lifecycle cut: sharing was disabled, the shared repo changed, or a
-                // device was revoked — end this stream unconditionally so the phone
-                // must reconnect and re-authorize against the new state. ANY result
-                // ends it: Ok is a real cut; Lagged means we missed one but a cut
-                // still happened; Closed can't occur while `LanState` holds the
-                // Sender, but we match it defensively and treat it the same (end).
-                _cut = cut_rx.recv() => None,
+                // Lifecycle cut: sharing was disabled, a device was revoked (All), or
+                // a single repo left the registry (Repo). An `All` cut always ends
+                // this stream; a `Repo(p)` cut ends it only when `p` names THIS
+                // stream's repo — otherwise re-arm the select and keep forwarding, so
+                // a still-registered repo's stream survives another repo's removal.
+                // `Lagged` = an All cut (fail-safe); `Closed` (defensive) ends it.
+                cut = cut_rx.recv() => match cut {
+                    Ok(MonitorCut::All) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => None,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => None,
+                    Ok(MonitorCut::Repo(p)) => {
+                        if crate::state::repo_paths_match(&p, &repo) {
+                            None
+                        } else {
+                            // Not our repo — keep forwarding (re-arm the unfold).
+                            Some((Ok(Event::default().comment("")), (rx, cut_rx, repo, false)))
+                        }
+                    }
+                },
                 // Broadcast side: forward events to the client.
                 recv = rx.recv() => match recv {
                     Ok(ev) => {
@@ -201,7 +223,7 @@ fn forward_stream(
                         match serde_json::to_string(&ev) {
                             Ok(text) => Some((
                                 Ok(Event::default().data(text)),
-                                (rx, cut_rx, terminal),
+                                (rx, cut_rx, repo, terminal),
                             )),
                             // A ReviewEvent that won't serialize is a bug, not a
                             // client-recoverable state; end the stream.
@@ -217,7 +239,7 @@ fn forward_stream(
                             "text": format!("…skipped {n} events")
                         })
                         .to_string();
-                        Some((Ok(Event::default().data(notice)), (rx, cut_rx, false)))
+                        Some((Ok(Event::default().data(notice)), (rx, cut_rx, repo, false)))
                     }
                     // The stream ended and its registry entry (and sender) dropped.
                     Err(RecvError::Closed) => None,

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -376,9 +376,16 @@ fn bind_error(bind_ip: IpAddr, e: &std::io::Error) -> AppError {
 /// return the handle plus the advertised urls, the bound-host allowlist, and the
 /// certificate fingerprint (for the TOFU pairing display). The `RouterState` is
 /// built here so the host guard sees the exact hosts we bound.
+// The params are the individual per-field `Arc`s the router state needs (mirroring
+// how `AppState` shares individual fields rather than one `Arc<Whole>`); passing them
+// explicitly keeps the caller (`lan_enable`) the single owner of the `LanState`
+// fields. Bundling them into a struct just to satisfy the arg-count lint would add a
+// parallel type with no behavioral gain, so the lint is allowed here by design.
+#[allow(clippy::too_many_arguments)]
 pub async fn start(
     bind_lan: bool,
     active_repo: Arc<std::sync::Mutex<Option<String>>>,
+    active_repo_id: Arc<std::sync::Mutex<Option<String>>>,
     repos: crate::lan::RepoRegistry,
     pairing: Arc<std::sync::Mutex<Option<auth::PairingSession>>>,
     rate_limit: auth::RateLimitMap,
@@ -396,6 +403,7 @@ pub async fn start(
 
     let state = RouterState {
         active_repo,
+        active_repo_id,
         repos,
         pairing,
         rate_limit,

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -2,7 +2,7 @@
 //! shutdown for the LAN companion server.
 //!
 //! The router mounts EXACTLY the pairing routes plus the read-only routes
-//! (structural allowlist — see [`crate::lan::routes`]): the 15 read handlers,
+//! (structural allowlist — see [`crate::lan::routes`]): the 17 read handlers,
 //! mounted TWICE — once as the frozen active-repo ALIAS surface (`/api/repo/…`,
 //! `/api/forge/…`, `/api/reviews…`) and once under the SCOPED
 //! `/api/repos/{repoId}/…` surface — plus `GET /api/repos`; anything else 404s.
@@ -383,7 +383,7 @@ pub async fn start(
     pairing: Arc<std::sync::Mutex<Option<auth::PairingSession>>>,
     rate_limit: auth::RateLimitMap,
     streams: Arc<std::sync::Mutex<std::collections::HashMap<String, crate::state::StreamInfo>>>,
-    monitor_cut: tokio::sync::broadcast::Sender<()>,
+    monitor_cut: tokio::sync::broadcast::Sender<crate::lan::MonitorCut>,
 ) -> AppResult<(ServerHandle, Vec<String>, Vec<String>, String)> {
     let (bind_ip, ips) = resolve_ips(bind_lan);
     // Ensure a self-signed cert covering the addresses we're about to advertise

--- a/src-tauri/src/lan/shared_repos.rs
+++ b/src-tauri/src/lan/shared_repos.rs
@@ -1,0 +1,283 @@
+//! The persisted shared-repos store for the LAN companion's multi-repo registry.
+//!
+//! Registry v1 mirrored the desktop's active repo exactly; this store is the
+//! browse-all-repos direction the registry doc comment promised: a user-curated
+//! set of repos the companion serves ALONGSIDE the active repo (active ∪ shared).
+//! Only the on-disk `path` is persisted — the display `name` (basename) and the
+//! opaque wire id (`repo_id_for`) are computed at load/share time, never stored, so
+//! the store file never carries a wire id it could drift from.
+//!
+//! ## Persistence idiom (mirrors [`crate::lan::auth`]'s device store exactly)
+//!
+//! File `lan-shared-repos.json` under the same app-data dir as `lan-devices.json`,
+//! a top-level object `{"repos":[{"path":"…"}]}` whose unknown top-level keys are
+//! preserved across writes, all sync I/O serialized behind [`store_lock`] (never
+//! held across an `.await`), written via [`crate::fsops::atomic_write`], and cached
+//! in a process-global [`OnceLock`] invalidated on every write and on a test
+//! store-path swap. App-global (NOT per-repo): sharing is an app-level decision.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::error::{AppError, AppResult};
+use crate::local_prs::APP_IDENTIFIER;
+
+/// The shared-repos store filename under the app-data dir. Rust-owned and
+/// app-global (NOT per-repo), like [`crate::lan::auth`]'s `lan-devices.json`.
+const STORE_FILE: &str = "lan-shared-repos.json";
+
+// --------------------------------------------------------------------------
+// Store-path injection (for tests) — mirrors auth.rs
+// --------------------------------------------------------------------------
+
+/// Test-only override for the store path. Production resolves the real app-data
+/// file via [`store_path`]; tests point this at a temp file so they never touch
+/// the real `%APPDATA%\com.thebguy.gitdesktop` dir.
+static STORE_PATH_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+fn store_path_override() -> &'static Mutex<Option<PathBuf>> {
+    STORE_PATH_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+/// Point the shared-repos store at `path` for the current process (test-only).
+/// Returns the previous override so a test can restore it. Invalidates the cache
+/// (it holds entries from the previous path's file).
+#[cfg(test)]
+pub(crate) fn set_store_path_for_test(path: Option<PathBuf>) -> Option<PathBuf> {
+    let mut guard = store_path_override()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    invalidate_cache();
+    std::mem::replace(&mut *guard, path)
+}
+
+/// Resolve the absolute path of `lan-shared-repos.json` under the app-data dir —
+/// the same root [`crate::lan::auth`]'s device store uses. A test override wins.
+fn store_path() -> AppResult<PathBuf> {
+    if let Some(over) = store_path_override()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone()
+    {
+        return Ok(over);
+    }
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
+}
+
+/// Serializes the whole read-modify-write of the store across the sync I/O only.
+/// Never held across an `.await`.
+fn store_lock() -> &'static Mutex<()> {
+    static STORE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    STORE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// In-memory cache of the on-disk shared-repo paths, so repeated reads don't
+/// re-parse the file. `None` = not loaded; every write invalidates it back to
+/// `None`. Guarded by its own mutex, always taken WHILE holding [`store_lock`].
+static CACHE: OnceLock<Mutex<Option<Vec<String>>>> = OnceLock::new();
+
+fn cache() -> &'static Mutex<Option<Vec<String>>> {
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// Drop the in-memory cache. Called on every store write and on a test store-path
+/// swap, so the next read reloads from disk.
+fn invalidate_cache() {
+    *cache().lock().unwrap_or_else(|p| p.into_inner()) = None;
+}
+
+// --------------------------------------------------------------------------
+// Records
+// --------------------------------------------------------------------------
+
+/// A persisted shared-repo record. Only the on-disk `path` is stored; the display
+/// name and wire id are computed from it at load/share time (never persisted).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredRepo {
+    path: String,
+}
+
+/// Read the whole store file as a JSON object. A missing file is an empty object;
+/// a present-but-malformed file is a hard error (never clobber it — it holds the
+/// user's curated share list we must not silently drop).
+fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Command(format!(
+                    "lan-shared-repos store at {} is not valid JSON: {e}",
+                    path.display()
+                ))
+            })?;
+            match value {
+                Value::Object(map) => Ok(map),
+                _ => Err(AppError::Command(format!(
+                    "lan-shared-repos store at {} is not a JSON object",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(AppError::Io(e)),
+    }
+}
+
+/// The stored repo paths under the `"repos"` array key. Unknown top-level keys are
+/// preserved by [`write_repos`], which replaces only the `"repos"` key.
+fn repos_from(store: &Map<String, Value>) -> Vec<String> {
+    store
+        .get("repos")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| serde_json::from_value::<StoredRepo>(v.clone()).ok())
+                .map(|r| r.path)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Persist `paths` as the `"repos"` array, atomically. `store` is the
+/// previously-read store map (from [`read_store`] under the store lock); we
+/// replace only its `"repos"` key so unknown top-level keys survive.
+fn write_repos(path: &Path, mut store: Map<String, Value>, paths: &[String]) -> AppResult<()> {
+    let arr = paths
+        .iter()
+        .map(|p| serde_json::to_value(StoredRepo { path: p.clone() }).unwrap_or(Value::Null))
+        .collect::<Vec<_>>();
+    store.insert("repos".to_string(), Value::Array(arr));
+    let body = serde_json::to_string_pretty(&Value::Object(store))
+        .map_err(|e| AppError::Command(format!("serialize lan-shared-repos store: {e}")))?;
+    let res = crate::fsops::atomic_write(path, body.as_bytes());
+    // Invalidate at this single write choke point so no write path leaves a stale
+    // cache — even on a failed write (on-disk state is then indeterminate).
+    invalidate_cache();
+    res
+}
+
+// --------------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------------
+
+/// The persisted shared-repo paths, in stored order. Backed by the in-memory
+/// cache: on a miss the store is read under the store lock and the cache
+/// populated; every write invalidates it.
+pub fn list_paths() -> AppResult<Vec<String>> {
+    let path = store_path()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let mut c = cache().lock().unwrap_or_else(|p| p.into_inner());
+    if c.is_none() {
+        let store = read_store(&path)?;
+        *c = Some(repos_from(&store));
+    }
+    Ok(c.as_ref().expect("cache populated above").clone())
+}
+
+/// Add `repo_path` to the shared set if not already present (verbatim string
+/// match). Returns the updated list. The caller resolves id-level dedup BEFORE
+/// calling this (two worktree paths of one repo collide on id, not on string); a
+/// verbatim duplicate here is a no-op.
+pub fn add_path(repo_path: &str) -> AppResult<Vec<String>> {
+    let path = store_path()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let store = read_store(&path)?;
+    let mut paths = repos_from(&store);
+    if !paths.iter().any(|p| p == repo_path) {
+        paths.push(repo_path.to_string());
+        write_repos(&path, store, &paths)?;
+    }
+    Ok(paths)
+}
+
+/// Remove `repo_path` from the shared set (verbatim string match). Returns the
+/// updated list. An unknown path is a no-op returning the current list.
+pub fn remove_path(repo_path: &str) -> AppResult<Vec<String>> {
+    let path = store_path()?;
+    let _guard = store_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let store = read_store(&path)?;
+    let mut paths = repos_from(&store);
+    let before = paths.len();
+    paths.retain(|p| p != repo_path);
+    if paths.len() != before {
+        write_repos(&path, store, &paths)?;
+    }
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_store() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "gd-lan-shared-repos-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    #[test]
+    fn store_round_trips_and_dedups_verbatim() {
+        let _lock = crate::lan::auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = set_store_path_for_test(Some(tmp.clone()));
+
+        // Empty to start.
+        assert!(list_paths().unwrap().is_empty());
+
+        // Add two, verbatim-dedup the first.
+        add_path("C:/repo-a").unwrap();
+        let after = add_path("C:/repo-b").unwrap();
+        assert_eq!(after, vec!["C:/repo-a", "C:/repo-b"]);
+        let dup = add_path("C:/repo-a").unwrap();
+        assert_eq!(
+            dup,
+            vec!["C:/repo-a", "C:/repo-b"],
+            "verbatim add is a no-op"
+        );
+        assert_eq!(list_paths().unwrap(), vec!["C:/repo-a", "C:/repo-b"]);
+
+        // Remove one; an unknown remove is a no-op.
+        let removed = remove_path("C:/repo-a").unwrap();
+        assert_eq!(removed, vec!["C:/repo-b"]);
+        let noop = remove_path("C:/does-not-exist").unwrap();
+        assert_eq!(noop, vec!["C:/repo-b"]);
+
+        // Survives a fresh read (reads disk with the cache cleared).
+        invalidate_cache();
+        assert_eq!(list_paths().unwrap(), vec!["C:/repo-b"]);
+
+        set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn unknown_top_level_keys_survive_a_write() {
+        let _lock = crate::lan::auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = set_store_path_for_test(Some(tmp.clone()));
+
+        // Seed a store with a repo AND an extra top-level key a future version wrote.
+        add_path("C:/repo-a").unwrap();
+        let mut raw: Value = serde_json::from_slice(&std::fs::read(&tmp).unwrap()).unwrap();
+        raw.as_object_mut()
+            .unwrap()
+            .insert("future".to_string(), json!({ "x": 1 }));
+        std::fs::write(&tmp, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+        invalidate_cache();
+
+        // A write (add another) through the public API must preserve the extra key.
+        add_path("C:/repo-b").unwrap();
+        let after: Value = serde_json::from_slice(&std::fs::read(&tmp).unwrap()).unwrap();
+        assert_eq!(after["future"]["x"], json!(1));
+
+        set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -676,6 +676,9 @@ pub fn run() {
             lan::lan_pairing_cancel,
             lan::lan_devices_list,
             lan::lan_device_revoke,
+            lan::lan_shared_repos_list,
+            lan::lan_share_repo,
+            lan::lan_unshare_repo,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -63,7 +63,11 @@ pub fn subscribe_in(registry: &StreamRegistry, id: &str) -> Option<broadcast::Re
 /// frontend `repoPath`), OR if both canonicalize successfully to the same path
 /// (hardens against `/` vs `\` and drive-letter case on Windows). Canonicalization
 /// touches the filesystem, so it's the fallback, not the primary check.
-fn repo_paths_match(a: &str, b: &str) -> bool {
+///
+/// `pub(crate)` so the LAN scoped-cut path ([`crate::lan::routes::reviews`]) and the
+/// `/api/repos` `active`-flag computation share this exact equality — a repo's
+/// active-vs-shared identity, its stream-scoping, and its cut-scoping must all agree.
+pub(crate) fn repo_paths_match(a: &str, b: &str) -> bool {
     if a == b {
         return true;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ActivityStrip } from "@/features/activity/ActivityDock";
 import { AutomationResultDialog } from "@/features/automations/AutomationResultDialog";
 import { HelpScreen } from "@/features/help/HelpScreen";
 import { RepositoryView } from "@/features/repository/RepositoryView";
+import { repoBasename } from "@/features/settings/mcp/shared";
 import { SettingsScreen } from "@/features/settings/SettingsScreen";
 import { CommandPalette } from "@/features/shortcuts/CommandPalette";
 import { ShortcutsDialog } from "@/features/shortcuts/ShortcutsDialog";
@@ -20,11 +21,18 @@ import { useRepoDrop } from "@/features/welcome/useRepoDrop";
 import { WelcomeScreen } from "@/features/welcome/WelcomeScreen";
 import { syncAnalytics, track } from "@/lib/analytics";
 import { useBackgroundPrSync } from "@/lib/automations/useBackgroundPrSync";
-import { useGitInstalled, useLanStatus } from "@/lib/git/queries";
+import {
+  useGitInstalled,
+  useLanSharedRepos,
+  useLanShareRepo,
+  useLanStatus,
+  useLanUnshareRepo,
+} from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { reloadLocalPrs } from "@/lib/pulls/local";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
+import { errorMessage } from "@/lib/tauri/invoke";
 import { COLD_START } from "@/lib/test-mode";
 import { useLatestRef } from "@/lib/use-latest-ref";
 
@@ -35,10 +43,16 @@ function App() {
   const openHelp = useUiStore((s) => s.openHelp);
   const toggleActivity = useUiStore((s) => s.toggleActivity);
   const repoPath = useUiStore((s) => s.repoPath);
+  const repoName = useUiStore((s) => s.repoName);
   const gitInstalled = useGitInstalled();
   // Kept mounted app-wide so the LAN "Sharing ON" banner and the companion
   // settings panel share one 5s poller.
   const lanStatus = useLanStatus();
+  const shareRepo = useLanShareRepo();
+  const unshareRepo = useLanUnshareRepo();
+  // Read even while sharing is off (same as the panel) so the share/unshare
+  // palette twins gate correctly — exactly one is offered for the open repo.
+  const sharedRepos = useLanSharedRepos({ enabled: true });
   const queryClient = useQueryClient();
   const settings = useSettings();
   const saveSettings = useSaveSettings();
@@ -141,6 +155,49 @@ function App() {
   );
   useHotkeyAction("browse-mcp-registry", openMcpBrowse, !settings.data?.hideAi);
   useHotkeyAction("open-companion-settings", () => openSettings("companion"));
+  // Share/unshare the open repo with paired phones. These are complementary
+  // palette twins: the palette only lists actions with an enabled handler, so
+  // gating them on `alreadyShared` shows exactly one at a time (Share when the
+  // open repo isn't shared, Unshare when it is). The compare is verbatim path
+  // equality, matching CompanionSection (the stored-path-verbatim contract).
+  const sharedMatch =
+    repoPath !== null
+      ? (sharedRepos.data?.find((r) => r.path === repoPath) ?? null)
+      : null;
+  const alreadyShared = sharedMatch !== null;
+  // Share adds the open repo so it stays reachable even after you switch away.
+  // A short success/error toast is the right feedback here (a terminal result,
+  // not long-running state).
+  useHotkeyAction(
+    "lan-share-current-repo",
+    () => {
+      if (!repoPath) return;
+      const name = repoName ?? repoBasename(repoPath);
+      shareRepo.mutate(repoPath, {
+        onSuccess: () => toast.success(`Shared ${name} with paired phones`),
+        onError: (e) => toast.error(errorMessage(e)),
+      });
+    },
+    Boolean(repoPath) && !alreadyShared,
+  );
+  // Unshare the twin: pass the matched entry's stored path verbatim (the frozen
+  // contract). The unshared repo is by definition the OPEN one, so it stays
+  // reachable until the user switches away — say so honestly.
+  useHotkeyAction(
+    "lan-unshare-current-repo",
+    () => {
+      if (!sharedMatch) return;
+      const name = repoName ?? repoBasename(sharedMatch.path);
+      unshareRepo.mutate(sharedMatch.path, {
+        onSuccess: () =>
+          toast.success(
+            `Unshared ${name} — phones lose it when you switch repos.`,
+          ),
+        onError: (e) => toast.error(errorMessage(e)),
+      });
+    },
+    Boolean(repoPath) && alreadyShared,
+  );
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("toggle-notifications", toggleActivity);
   useHotkeyAction("show-shortcuts", () => setShortcutsOpen(true));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,6 +160,10 @@ function App() {
   // gating them on `alreadyShared` shows exactly one at a time (Share when the
   // open repo isn't shared, Unshare when it is). The compare is verbatim path
   // equality, matching CompanionSection (the stored-path-verbatim contract).
+  // Both twins wait for the shared list to LOAD (`sharedLoaded`) — before that,
+  // `alreadyShared` would read false for an actually-shared repo and offer the
+  // wrong twin for a moment.
+  const sharedLoaded = sharedRepos.data !== undefined;
   const sharedMatch =
     repoPath !== null
       ? (sharedRepos.data?.find((r) => r.path === repoPath) ?? null)
@@ -178,7 +182,7 @@ function App() {
         onError: (e) => toast.error(errorMessage(e)),
       });
     },
-    Boolean(repoPath) && !alreadyShared,
+    sharedLoaded && Boolean(repoPath) && !alreadyShared,
   );
   // Unshare the twin: pass the matched entry's stored path verbatim (the frozen
   // contract). The unshared repo is by definition the OPEN one, so it stays
@@ -196,7 +200,7 @@ function App() {
         onError: (e) => toast.error(errorMessage(e)),
       });
     },
-    Boolean(repoPath) && alreadyShared,
+    sharedLoaded && Boolean(repoPath) && alreadyShared,
   );
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("toggle-notifications", toggleActivity);

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1559,11 +1559,13 @@ there's an equivalent.`,
     label: "Phone companion",
     body: `# Phone companion (experimental)
 
-The **Phone companion** lets you share the repository that's currently open with your
-phone over your **local network**. Open it in **Settings → Phone companion**.
+The **Phone companion** lets you browse your repositories from your phone over your
+**local network**. Your phone can always see the repository that's **currently open** on
+this desktop, plus any repositories you've explicitly **shared** so they stay reachable
+while you work elsewhere. Open it in **Settings → Phone companion**.
 
 This is an **early preview**. Once paired, your phone opens a slim companion web app in
-its browser that shows the open repo's **Status**, **pull requests**, **CI**{{ai}}, and
+its browser that shows a repository's **Status**, **pull requests**, **CI**{{ai}}, and
 live **agent** runs{{/ai}} — all **read-only**. It's **off by default**.
 
 ## Turning it on
@@ -1593,7 +1595,7 @@ and **Agents**{{/ai}}, each read-only.
 
 ## What you can see on your phone
 
-- **Status** — the shared repo's current branch and connection.
+- **Status** — the current branch and connection for the repository you're viewing.
 - **PRs** — the open pull-request list; open one for its **overview** (title,
   description, branches, diff totals), its **activity** timeline (force-pushes, label
   changes, review requests, and open/close/merge events), and its **review threads**
@@ -1606,8 +1608,10 @@ and **Agents**{{/ai}}, each read-only.
   as it happens. When the run finishes you get its final answer (and its cost, when
   reported). Watching is **live only**: you see activity from the moment you open it — there's
   no replay — and the screen keeps itself pinned to the newest output unless you scroll up,
-  with a **Jump to latest** button to return. Stopping sharing, switching repos, or revoking
-  the device ends the watch and tells you the run is no longer shared.{{/ai}}
+  with a **Jump to latest** button to return. Stopping sharing or revoking the device ends
+  the watch and tells you the run is no longer shared; switching the desktop to a different
+  repository only ends it when the run's repository **isn't shared** (a shared repo keeps
+  its watches alive after you move on).{{/ai}}
 
 Because the connection uses a **self-signed certificate** GitDesktop generates, your
 phone shows a **certificate warning on first connect** — that's expected; tap through to
@@ -1627,9 +1631,29 @@ and was last seen. The list stays visible **even while sharing is off** — pair
 persist across sharing sessions, so you can always see (and revoke) which devices could
 connect the next time you turn sharing on. Every device holds its **own token**, and you
 can **Revoke** any of them at any time — a revoked device immediately loses access and
-has to pair again to reconnect. Stopping sharing, switching repos, or revoking a device
-also **disconnects any phone that's watching live** right away. Arrow keys move between
-devices in the list.
+has to pair again to reconnect. Stopping sharing or revoking a device also **disconnects
+any phone that's watching live** right away; switching the desktop to a different
+repository only cuts a phone that's watching a repository you **haven't shared**. Arrow
+keys move between devices in the list.
+
+## Sharing more than the open repository
+
+By default your phone can only reach the repository that's **open on this desktop**, so
+switching repositories moves what the phone sees with you. To keep other repositories
+reachable while you work elsewhere, **share** them:
+
+- In **Settings → Phone companion**, the **Shared repositories** list shows everything
+  you've shared. Choose **Share current repository** to add the repo that's currently
+  open, or run **Share current repository with phone** from the command palette
+  ({{kbd:command-palette}}). Once it's shared, the palette offers its twin —
+  **Unshare current repository from phone** — instead.
+- Shared repositories stay reachable from your phone even after you open a different repo
+  here — the phone always sees the open repo **plus** everything in this list.
+- Choose **Unshare** on any row to stop sharing it; that cuts only **that** repository's
+  live phone connections, and leaves the rest untouched. Arrow keys move between rows.
+- The list **persists across restarts** and stays visible **even while sharing is off**,
+  just like paired devices — turning sharing back on makes the whole shared set reachable
+  again.
 
 ## Security — please read
 
@@ -1678,8 +1702,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump to it,
   arrow-key through the list, and clear items or mark all read.
-- **Phone companion** — *experimental.* Share the open repo (read-only) with your phone
-  over your local network. Off by default; see **Phone companion** above.
+- **Phone companion** — *experimental.* Share repositories (read-only) with your phone
+  over your local network — the open repo, plus any you explicitly share. Off by default;
+  see **Phone companion** above.
 - **Keyboard** — rebind any shortcut, with live key-capture.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -17,10 +17,14 @@ import {
   useLanDevices,
   useLanDisable,
   useLanEnable,
+  useLanSharedRepos,
+  useLanShareRepo,
   useLanStatus,
+  useLanUnshareRepo,
 } from "@/lib/git/queries";
-import type { LanDevice } from "@/lib/git/types";
+import type { LanDevice, LanSharedRepo } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { formatRelativeTime } from "@/lib/time";
 import { PairDeviceDialog } from "./PairDeviceDialog";
@@ -31,6 +35,10 @@ export function CompanionSection() {
   const disable = useLanDisable();
   const revoke = useLanDeviceRevoke();
 
+  // The repo currently open on the desktop — the one "Share current repository"
+  // adds, and the one that's always reachable without being in the shared list.
+  const repoPath = useUiStore((s) => s.repoPath);
+
   const enabled = status.data?.enabled ?? false;
   // Always read the device list, even while sharing is off: a paired device's
   // token persists across sharing being toggled, so the user must be able to see
@@ -38,11 +46,20 @@ export function CompanionSection() {
   const devices = useLanDevices({ enabled: true });
   const deviceList = devices.data ?? [];
 
+  // Shared repos are read the same way as devices — always, even while sharing
+  // is off, since the shared set persists across toggling sharing.
+  const sharedRepos = useLanSharedRepos({ enabled: true });
+  const sharedList = sharedRepos.data ?? [];
+  const share = useLanShareRepo();
+  const unshare = useLanUnshareRepo();
+
   const [pairOpen, setPairOpen] = useState(false);
   const [confirmRevoke, setConfirmRevoke] = useState<LanDevice | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeIndex, setActiveIndex] = useState(-1);
   const listRef = useRef<HTMLDivElement>(null);
+  const [sharedActiveIndex, setSharedActiveIndex] = useState(-1);
+  const sharedListRef = useRef<HTMLDivElement>(null);
 
   function toggle(next: boolean) {
     setError(null);
@@ -65,6 +82,35 @@ export function CompanionSection() {
     rowAttr: "data-device-row",
   });
 
+  // Same roving-focus pattern for the shared-repos list, keyed by path.
+  const safeSharedActive =
+    sharedActiveIndex >= sharedList.length
+      ? sharedList.length - 1
+      : sharedActiveIndex;
+  const onSharedKeyDown = listKeyboardNav<LanSharedRepo>({
+    items: sharedList,
+    activeIndex: safeSharedActive,
+    onActivate: (_r, to) => setSharedActiveIndex(to),
+    rowKey: (r) => r.path,
+    rowAttr: "data-shared-repo-row",
+  });
+
+  // "Share current repository" is available only when a repo is open and it
+  // isn't already shared — surface each reason so the disabled button explains
+  // itself (house rule: no silent disabled controls).
+  const alreadyShared =
+    repoPath !== null && sharedList.some((r) => r.path === repoPath);
+  const shareDisabledReason = !repoPath
+    ? "Open a repository first, then share it with your phone."
+    : alreadyShared
+      ? "This repository is already shared."
+      : null;
+
+  function shareCurrentRepo() {
+    if (!repoPath) return;
+    share.mutate(repoPath, { onError: (e) => setError(errorMessage(e)) });
+  }
+
   const toggleBusy = enable.isPending || disable.isPending;
   const pairDisabledReason = enabled
     ? null
@@ -80,10 +126,11 @@ export function CompanionSection() {
           </span>
         </h2>
         <p className="text-xs text-muted-foreground">
-          Share the open repository with your phone over your local network.
-          Scanning the pairing code opens the companion app in your phone's
-          browser — <strong className="font-medium">read-only</strong> Status,
-          pull requests, and CI. Early preview.
+          Share the open repository — and any repositories you add below — with
+          your phone over your local network. Scanning the pairing code opens
+          the companion app in your phone's browser —{" "}
+          <strong className="font-medium">read-only</strong> Status, pull
+          requests, and CI. Early preview.
         </p>
       </div>
 
@@ -156,6 +203,97 @@ export function CompanionSection() {
               </span>
             </p>
           )}
+        </div>
+      )}
+
+      {/* Shared repositories — repos that stay reachable even when a different
+          repo is open on the desktop. The open repo is always reachable on its
+          own; sharing keeps others live while you work elsewhere. */}
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-xs font-medium">Shared repositories</h3>
+          <p className="text-[11px] text-muted-foreground">
+            Keep repositories reachable from your phone even when they're not
+            the one open here.
+          </p>
+        </div>
+        {/* Disabled buttons don't show a native `title`, so wrap it. */}
+        <span title={shareDisabledReason ?? undefined} className="inline-flex">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={shareDisabledReason !== null || share.isPending}
+            onClick={shareCurrentRepo}
+          >
+            {share.isPending && <Spinner data-icon="inline-start" />}
+            Share current repository
+          </Button>
+        </span>
+      </div>
+
+      {sharedRepos.isPending ? (
+        // First fetch: shared repos may exist, so show a placeholder rather than
+        // flashing the empty-state copy.
+        <Skeleton className="h-16 w-full" />
+      ) : sharedRepos.isError ? (
+        <p className="text-xs text-muted-foreground">
+          Couldn't load shared repositories.
+        </p>
+      ) : sharedList.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Only the repository open on this desktop is visible to phones. Share
+          repositories to keep them reachable while you work elsewhere.
+        </p>
+      ) : (
+        // A roving-focus list (arrow keys move between rows).
+        <div
+          ref={sharedListRef}
+          onKeyDown={onSharedKeyDown}
+          className="space-y-2"
+        >
+          {sharedList.map((repo, i) => (
+            <div
+              key={repo.path}
+              data-shared-repo-row={repo.path}
+              aria-label={`Shared repository ${repo.name}, ${repo.path}`}
+              tabIndex={
+                i === safeSharedActive || (safeSharedActive === -1 && i === 0)
+                  ? 0
+                  : -1
+              }
+              onFocus={() => setSharedActiveIndex(i)}
+              className="flex items-center gap-2 rounded border px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-xs font-medium">{repo.name}</p>
+                {/* Truncate from the START so the meaningful tail of the path
+                    stays visible: an RTL block places the ellipsis at the left,
+                    and a bdi/ltr child keeps the path's own characters in
+                    left-to-right order. */}
+                <p
+                  dir="rtl"
+                  className="truncate font-mono text-[11px] text-muted-foreground"
+                  title={repo.path}
+                >
+                  <bdi dir="ltr">{repo.path}</bdi>
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="ml-auto shrink-0"
+                disabled={unshare.isPending}
+                onClick={() =>
+                  unshare.mutate(repo.path, {
+                    onError: (e) => setError(errorMessage(e)),
+                  })
+                }
+                aria-label={`Unshare ${repo.name}`}
+              >
+                Unshare
+              </Button>
+            </div>
+          ))}
         </div>
       )}
 

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -80,6 +80,7 @@ import type {
   IssueType,
   LanDevice,
   LanPairing,
+  LanSharedRepo,
   LanStatus,
   MergePreview,
   Milestone,
@@ -3126,3 +3127,16 @@ export const lanDevicesList = () => invoke<LanDevice[]>("lan_devices_list");
 
 export const lanDeviceRevoke = (deviceId: string) =>
   invoke<void>("lan_device_revoke", { deviceId });
+
+// The set of repos the user has explicitly shared with phones (persisted). The
+// registry phones can browse is this set plus the currently open repo, so these
+// stay reachable while you work in a different repo. Share/unshare return the
+// updated list so callers can refresh without waiting for the status poll.
+export const lanSharedReposList = () =>
+  invoke<LanSharedRepo[]>("lan_shared_repos_list");
+
+export const lanShareRepo = (repoPath: string) =>
+  invoke<LanSharedRepo[]>("lan_share_repo", { repoPath });
+
+export const lanUnshareRepo = (repoPath: string) =>
+  invoke<LanSharedRepo[]>("lan_unshare_repo", { repoPath });

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -39,6 +39,7 @@ import type {
   IssueReactions,
   IssueRelation,
   IssueType,
+  LanSharedRepo,
   LanStatus,
   PrDetails,
   PrInfo,
@@ -5570,6 +5571,7 @@ export function useCreatePr(repo: string) {
 
 const LAN_STATUS_KEY = ["lan", "status"] as const;
 const LAN_DEVICES_KEY = ["lan", "devices"] as const;
+const LAN_SHARED_REPOS_KEY = ["lan", "sharedRepos"] as const;
 
 /** The companion server's runtime status, polled every 5s. Kept mounted at the
  *  App level (the "Sharing ON" banner subscribes to it), so the panel and the
@@ -5654,5 +5656,47 @@ export function useLanDeviceRevoke() {
   return useMutation({
     mutationFn: (deviceId: string) => api.lanDeviceRevoke(deviceId),
     onSettled: () => sync(),
+  });
+}
+
+/** The repos the user has explicitly shared with phones. Read even while sharing
+ *  is off (same rationale as devices — the shared set persists across sharing
+ *  being toggled, so the manager must always show it). Not polled: it only
+ *  changes through the share/unshare mutations below, which prime the cache. */
+export function useLanSharedRepos(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: LAN_SHARED_REPOS_KEY,
+    queryFn: api.lanSharedReposList,
+    enabled: options?.enabled ?? true,
+  });
+}
+
+/** Prime the shared-repos cache with the list a mutation returned, then
+ *  invalidate so any other reader re-syncs (no wait for the status poll). */
+function useSyncLanSharedRepos() {
+  const queryClient = useQueryClient();
+  return (repos: LanSharedRepo[]) => {
+    queryClient.setQueryData(LAN_SHARED_REPOS_KEY, repos);
+    void queryClient.invalidateQueries({ queryKey: LAN_SHARED_REPOS_KEY });
+  };
+}
+
+/** Share a repo (by absolute path) so phones can reach it alongside the open
+ *  repo. Idempotent server-side; returns the updated list. */
+export function useLanShareRepo() {
+  const sync = useSyncLanSharedRepos();
+  return useMutation({
+    mutationFn: (repoPath: string) => api.lanShareRepo(repoPath),
+    onSuccess: (repos) => sync(repos),
+  });
+}
+
+/** Stop sharing a repo (pass the stored path verbatim). Cuts only that repo's
+ *  live phone watches; returns the updated list. */
+export function useLanUnshareRepo() {
+  const sync = useSyncLanSharedRepos();
+  return useMutation({
+    mutationFn: (repoPath: string) => api.lanUnshareRepo(repoPath),
+    onSuccess: (repos) => sync(repos),
   });
 }

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -2001,3 +2001,15 @@ export interface LanDevice {
   /** ISO-8601 instant the device last made a request. */
   lastSeenAt: string;
 }
+
+/** A repository the user has explicitly shared with paired phones, so it stays
+ *  reachable even while a different repo is open on the desktop. The registry
+ *  phones can browse is this shared set plus whichever repo is currently open;
+ *  the list persists across app restarts and while sharing is off. */
+export interface LanSharedRepo {
+  /** Absolute path of the shared repo root (the stored path — pass it verbatim
+   *  to unshare). */
+  path: string;
+  /** Last path segment of the repo root, for display. */
+  name: string;
+}

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -174,6 +174,18 @@ export const ACTIONS = [
 
   // Repository
   {
+    id: "lan-share-current-repo",
+    label: "Share current repository with phone",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
+    id: "lan-unshare-current-repo",
+    label: "Unshare current repository from phone",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
     id: "push",
     label: "Push",
     category: "Repository",


### PR DESCRIPTION
Extend the LAN Companion from a single shared repository to a selectable set of repositories, so phones can keep browsing a shared repository while the desktop switches to another. The desktop now manages persisted share state, while the companion scopes routes and data requests to the repository selected by the user.

### Desktop sharing and LAN API

- Adds persisted shared-repository management in `src-tauri/src/lan/shared_repos.rs`.
- Expands `src-tauri/src/lan/mod.rs` with an active-plus-shared repository registry, repository install/unshare lifecycle handling, and scoped SSE monitor cuts.
- Adds repository-scoped API routing and active-state reporting in `src-tauri/src/lan/routes/mod.rs`, `src-tauri/src/lan/routes/reviews.rs`, and `src-tauri/src/lan/server.rs`.
- Updates LAN state and lifecycle integration in `src-tauri/src/lib.rs` and `src-tauri/src/state.rs`.
- Adds repository identity and lookup support in `src/lib/git/api.ts`, `src/lib/git/queries.ts`, and `src/lib/git/types.ts`.

### Settings and desktop controls

- Updates `src/features/settings/CompanionSection.tsx` to share and unshare additional repositories while retaining the active repository automatically.
- Updates `src/App.tsx` and `src/lib/hotkeys/registry.ts` to expose repository sharing through desktop commands and navigation.
- Revises companion guidance in `src/features/help/content.ts`.

### Companion repository selection

- Adds the repository picker in `companion/src/screens/Repos.tsx`, including active-repository indication, sorting, selection state, and empty-state guidance.
- Adds repository-aware routing and legacy-route resolution in `companion/src/lib/router.ts`.
- Updates `companion/src/App.tsx` and `companion/src/components/Chrome.tsx` to bootstrap repository selection, preserve the selected tab when switching, and make the top-bar repository name a switcher.
- Adds repository summaries and scoped API paths in `companion/src/lib/api.ts` and repository-scoped query caching and polling in `companion/src/lib/queries.ts`.

### Scoped companion data and stream handling

- Updates `companion/src/screens/Status.tsx`, `companion/src/screens/Prs.tsx`, `companion/src/screens/Ci.tsx`, and `companion/src/screens/Agents.tsx` to fetch and navigate within the selected repository.
- Adds repository-gone detection and a choose-another-repository state in `companion/src/components/states.tsx`.
- Scopes live agent streams and distinguishes an unshared repository from an ended stream in `companion/src/lib/use-review-stream.ts`.
- Preserves repository context across PR, CI, and agent detail navigation.

### Documentation

- Updates `changelog.d/added-lan-companion-preview.md` to document multiple shared repositories, switching behavior, and repository-level unsharing.