### PR TITLE
feat(hotkeys,sync,pulls): add PR and origin push shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ commit that hasn't been pushed yet.
 
 Plus tag and submodule management.
 
-**Syncing** — push / pull / fetch, with the ahead/behind counts shown right on
+**Syncing** — fetch / pull / push, with the ahead/behind counts shown right on
 the Push and Pull buttons; pull is
 `--ff-only`, and divergence routes to a guarded force push with
 `--force-with-lease`. When a repo has an `upstream` remote, the Pull menu adds

--- a/changelog.d/added-create-pr-submit-shortcut.md
+++ b/changelog.d/added-create-pr-submit-shortcut.md
@@ -1,0 +1,2 @@
+- Press **Ctrl/Cmd+Enter** from any field in the **Create pull request** or **Create local
+  PR** dialog to submit it, matching the shortcut already used to send comments.

--- a/changelog.d/added-create-pr-submit-shortcut.md
+++ b/changelog.d/added-create-pr-submit-shortcut.md
@@ -1,2 +1,4 @@
 - Press **Ctrl/Cmd+Enter** from any field in the **Create pull request** or **Create local
-  PR** dialog to submit it, matching the shortcut already used to send comments.
+  PR** dialog to submit it, matching the shortcut already used to send comments. When AI
+  features are on, the **generate commit message** shortcut (Ctrl/Cmd+G by default) runs the
+  dialog's own **Generate** for its title and description while it's open.

--- a/changelog.d/added-push-to-origin-hotkey.md
+++ b/changelog.d/added-push-to-origin-hotkey.md
@@ -1,0 +1,4 @@
+- New rebindable **Push to origin** shortcut (default **Ctrl+Alt+P** / **Cmd+Option+P**)
+  pushes or publishes a branch to **origin** — the current branch, or, with the branches
+  list open, the highlighted one. When there's nothing to push (diverged, up to date, or
+  tracking a different remote), it says so instead.

--- a/changelog.d/changed-sync-header-buttons.md
+++ b/changelog.d/changed-sync-header-buttons.md
@@ -1,4 +1,4 @@
-- The header sync buttons are reordered to **Push / Pull / Fetch** so the most-used
-  action is first, and the ahead/behind counts now appear directly on the **Push** and
-  **Pull** buttons — making it clear which button acts on them — instead of in separate
+- The header sync buttons are ordered **Fetch / Pull / Push** — mirroring the natural
+  fetch → pull → push flow — and the ahead/behind counts appear directly on the **Push**
+  and **Pull** buttons — making it clear which button acts on them — instead of in separate
   arrow badges.

--- a/changelog.d/fixed-hotkey-webview-fallthrough.md
+++ b/changelog.d/fixed-hotkey-webview-fallthrough.md
@@ -1,0 +1,5 @@
+- Keyboard shortcuts owned by a visible surface no longer fall through to the underlying
+  webview when that action is momentarily disabled — so Ctrl+P won't open a print dialog
+  (nor F5 reload the app) when there's nothing to push or fetch. Shortcuts for surfaces
+  that aren't on screen keep their native behavior. The Fetch, Pull, and Push buttons'
+  tooltips now show their shortcuts, and expose them to screen readers.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -391,6 +391,11 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   upstream-deleted branch offers **Publish**; on a repo with several remotes you pick the
   destination (one **Publish to _…_** item per remote). Neither checks the branch out or
   touches your working tree, so it works even for a branch checked out in another worktree.
+  {{kbd:push-to-origin}} is the keyboard shortcut for pushing to **origin** specifically:
+  with the **branches** list open it targets the **highlighted** branch, otherwise the
+  **current** one, and pushes or publishes it to origin. A branch that tracks a different
+  remote, has diverged, or has nothing to push says so in a short message — for those, use
+  the branch's right-click menu.
 - The **Remote** section lists branches on your remotes you haven't checked out locally
   yet — click one to check it out (creating a local tracking branch), or right-click to
   **Delete on _origin_…**, a server-side delete that removes the branch from the remote for
@@ -486,16 +491,16 @@ Worktrees that AI agent sessions use internally are hidden here.{{/ai}}`,
   {
     id: "syncing",
     label: "Syncing & conflicts",
-    body: `# Push, pull, fetch & conflicts
+    body: `# Fetch, pull, push & conflicts
 
-The header shows **Push / Pull / Fetch**, with the number of commits to push or pull shown
+The header shows **Fetch / Pull / Push**, with the number of commits to push or pull shown
 right on the **Push** and **Pull** buttons.
 
-- **Push** ({{kbd:push}}) sends your commits. For a branch with no upstream yet, you'll
-  see **Publish branch** instead.
+- **Fetch** ({{kbd:fetch}}) updates your view of the remote without changing your branch.
 - **Pull** ({{kbd:pull}}) is fast-forward only by design — it won't create surprise merge
   commits.
-- **Fetch** ({{kbd:fetch}}) updates your view of the remote without changing your branch.
+- **Push** ({{kbd:push}}) sends your commits. For a branch with no upstream yet, you'll
+  see **Publish branch** instead.
 
 ## Update a fork from upstream
 
@@ -703,7 +708,7 @@ from the branch diff and commit subjects — which additionally **proposes label
 only from the repository's existing labels and added to whatever you've already picked
 (never invented). The same **Generate** button is on the **Edit** dialog too, so you can
 write or regenerate an existing PR's title and description at any time — including for pull
-requests from forks{{/ai}}.
+requests from forks{{/ai}}. Press {{key:mod+enter}} from any field to submit the dialog.
 
 ## GitLab merge requests
 
@@ -1547,7 +1552,8 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
 
 ## Doing things
 
-- **Repository:** {{kbd:push}} push · {{kbd:pull}} pull · {{kbd:fetch}} fetch ·
+- **Repository:** {{kbd:fetch}} fetch · {{kbd:pull}} pull · {{kbd:push}} push ·
+  {{kbd:push-to-origin}} push to origin ·
   {{kbd:open-in-terminal}} terminal · {{kbd:show-in-explorer}} file manager ·
   {{kbd:open-in-editor}} editor · {{kbd:view-on-github}} GitHub · {{kbd:new-repository}}
   new repo · {{kbd:add-local-repository}} add local · {{kbd:clone-repository}} clone.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -708,7 +708,8 @@ from the branch diff and commit subjects — which additionally **proposes label
 only from the repository's existing labels and added to whatever you've already picked
 (never invented). The same **Generate** button is on the **Edit** dialog too, so you can
 write or regenerate an existing PR's title and description at any time — including for pull
-requests from forks{{/ai}}. Press {{key:mod+enter}} from any field to submit the dialog.
+requests from forks{{/ai}}. Press {{key:mod+enter}} from any field to submit the dialog.{{ai}}
+While the dialog is open, {{kbd:generate-commit-message}} runs its **Generate** for you.{{/ai}}
 
 ## GitLab merge requests
 

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -18,12 +18,17 @@ import {
   useDefaultBranch,
   useRepoStatus,
 } from "@/lib/git/queries";
+import { formatBinding } from "@/lib/hotkeys/binding";
 import { useCreateLocalPr } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
+
+/** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
+ *  literal modifier (house platform-mod-key rule). */
+const SUBMIT_HINT = formatBinding("mod+enter");
 
 // Rendered exactly ONCE, hoisted in RepositoryView — never render it inside a tab
 // panel. Its success handler's `setRepoTab("pulls")` would hide a panel host's
@@ -129,7 +134,25 @@ export function CreateLocalPrDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        // mod+enter submits from anywhere in the dialog. It's captured on
+        // DialogContent (the Popup), not the <form>: this dialog is hoisted in
+        // RepositoryView and can sit open over the Changes tab, where the global
+        // `commit` action (also mod+enter) has a live handler, and the X close
+        // button renders as a SIBLING of the form inside the Popup — a chord
+        // pressed with focus on the X would otherwise bypass a form-level
+        // handler and commit behind the dialog. Capturing on the Popup covers
+        // the X and every field, so the UNCONDITIONAL preventDefault here is
+        // what actually contains the chord. Submit only when the SubmitButton
+        // would be enabled (handleSubmit still enforces the field validators).
+        onKeyDown={(e) => {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            e.preventDefault();
+            if (!generating) form.handleSubmit();
+          }
+        }}
+      >
         <form
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
@@ -260,7 +283,7 @@ export function CreateLocalPrDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton disabled={generating}>
+              <form.SubmitButton disabled={generating} title={SUBMIT_HINT}>
                 Create local PR
               </form.SubmitButton>
             </form.AppForm>

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -18,7 +18,8 @@ import {
   useDefaultBranch,
   useRepoStatus,
 } from "@/lib/git/queries";
-import { formatBinding } from "@/lib/hotkeys/binding";
+import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import { useCreateLocalPr } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -132,6 +133,28 @@ export function CreateLocalPrDialog({
   const ahead = comparison.data?.ahead ?? [];
   const sameBranch = base === head;
 
+  // AI title+description generation — shared by the Generate button's onClick and
+  // the dialog-local generate chord below. Verbatim the button's prior body.
+  function runGenerate() {
+    generate(
+      base,
+      head,
+      ahead.map((c) => c.subject),
+      (d) => {
+        form.setFieldValue("title", d.title);
+        form.setFieldValue("body", d.body);
+      },
+    );
+  }
+  // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
+  // default) while this dialog is open — never a hardcoded chord, so a
+  // Settings → Keyboard rebinding drives it. null = explicitly unbound.
+  const generateBinding =
+    useEffectiveBindings().get("generate-commit-message") ?? null;
+  const generateHint = generateBinding
+    ? ` (${formatBinding(generateBinding)})`
+    : "";
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -150,6 +173,25 @@ export function CreateLocalPrDialog({
           if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
             e.preventDefault();
             if (!generating) form.handleSubmit();
+            return;
+          }
+          // The generate-commit-message chord (mod+g by default) runs this
+          // dialog's own Generate while it's open. Only when AI is on (no
+          // Generate surface otherwise) and the chord is bound. ALWAYS swallow
+          // it: this dialog is hoisted over the Changes tab, where the global
+          // generate-commit-message action has a live handler — without this the
+          // chord would generate a COMMIT MESSAGE behind the dialog. Run Generate
+          // only when its button would be enabled; while generating we swallow
+          // but DON'T cancel (an accidental repeat must not abort a running one).
+          if (
+            aiEnabled &&
+            generateBinding !== null &&
+            eventToBinding(e) === generateBinding
+          ) {
+            e.preventDefault();
+            if (!generating && !(sameBranch || ahead.length === 0)) {
+              runGenerate();
+            }
           }
         }}
       >
@@ -251,18 +293,8 @@ export function CreateLocalPrDialog({
                         variant="outline"
                         size="xs"
                         disabled={sameBranch || ahead.length === 0}
-                        onClick={() =>
-                          generate(
-                            base,
-                            head,
-                            ahead.map((c) => c.subject),
-                            (d) => {
-                              form.setFieldValue("title", d.title);
-                              form.setFieldValue("body", d.body);
-                            },
-                          )
-                        }
-                        title="Generate the title and description with AI"
+                        onClick={runGenerate}
+                        title={`Generate the title and description with AI${generateHint}`}
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Generate

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -43,7 +43,8 @@ import {
   providerLabel,
   type RemoteLens,
 } from "@/lib/git/types";
-import { formatBinding } from "@/lib/hotkeys/binding";
+import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import {
   useLensGate,
   useRemoteSlug,
@@ -426,6 +427,41 @@ export function CreatePrDialog({
     labels.has(l.name),
   );
 
+  // AI title+description generation — shared by the Generate button's onClick and
+  // the dialog-local generate chord below. Verbatim the button's prior body.
+  function runGenerate() {
+    aiDescriptionRef.current = true;
+    generate(
+      base,
+      head,
+      ahead.map((c) => c.subject),
+      (d) => {
+        form.setFieldValue("title", d.title);
+        form.setFieldValue("body", d.body);
+        // Additive: union the model's (already repo-validated) labels with the
+        // user's manual picks, never replace.
+        setLabels((prev) => new Set([...prev, ...d.labels]));
+      },
+      // Provider-aware prompt copy (MR/merge-request noun, markdown flavor);
+      // null host → base GitHub wording.
+      forge.data?.provider ?? undefined,
+      // Existing repo labels (name + stated purpose) the model may propose from;
+      // empty ⇒ no labels proposed.
+      repoLabels.data?.map((l) => ({
+        name: l.name,
+        description: l.description,
+      })) ?? [],
+    );
+  }
+  // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
+  // default) while this dialog is open — never a hardcoded chord, so a
+  // Settings → Keyboard rebinding drives it. null = explicitly unbound.
+  const generateBinding =
+    useEffectiveBindings().get("generate-commit-message") ?? null;
+  const generateHint = generateBinding
+    ? ` (${formatBinding(generateBinding)})`
+    : "";
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -451,6 +487,22 @@ export function CreatePrDialog({
             ) {
               form.handleSubmit();
             }
+            return;
+          }
+          // The generate-commit-message chord (mod+g by default) runs this
+          // dialog's own Generate while it's open. Only when AI is on (no
+          // Generate surface otherwise) and the chord is bound. ALWAYS swallow
+          // it so it can't reach the global listener and generate a commit
+          // message behind the dialog; run Generate only when its button would
+          // be enabled. While generating we swallow but DON'T cancel — an
+          // accidental repeat must never abort an in-flight generation.
+          if (
+            aiEnabled &&
+            generateBinding !== null &&
+            eventToBinding(e) === generateBinding
+          ) {
+            e.preventDefault();
+            if (!generating && !nothingToMerge) runGenerate();
           }
         }}
       >
@@ -756,33 +808,8 @@ export function CreatePrDialog({
                         variant="outline"
                         size="xs"
                         disabled={nothingToMerge}
-                        onClick={() => {
-                          aiDescriptionRef.current = true;
-                          generate(
-                            base,
-                            head,
-                            ahead.map((c) => c.subject),
-                            (d) => {
-                              form.setFieldValue("title", d.title);
-                              form.setFieldValue("body", d.body);
-                              // Additive: union the model's (already repo-validated)
-                              // labels with the user's manual picks, never replace.
-                              setLabels(
-                                (prev) => new Set([...prev, ...d.labels]),
-                              );
-                            },
-                            // Provider-aware prompt copy (MR/merge-request noun,
-                            // markdown flavor); null host → base GitHub wording.
-                            forge.data?.provider ?? undefined,
-                            // Existing repo labels (name + stated purpose) the
-                            // model may propose from; empty ⇒ no labels proposed.
-                            repoLabels.data?.map((l) => ({
-                              name: l.name,
-                              description: l.description,
-                            })) ?? [],
-                          );
-                        }}
-                        title="Generate the title and description with AI"
+                        onClick={runGenerate}
+                        title={`Generate the title and description with AI${generateHint}`}
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Generate

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -43,6 +43,7 @@ import {
   providerLabel,
   type RemoteLens,
 } from "@/lib/git/types";
+import { formatBinding } from "@/lib/hotkeys/binding";
 import {
   useLensGate,
   useRemoteSlug,
@@ -53,6 +54,10 @@ import { toastError } from "@/lib/toast";
 import { ReviewersPopover } from "./ReviewersPopover";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
+
+/** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
+ *  literal modifier (house platform-mod-key rule). */
+const SUBMIT_HINT = formatBinding("mod+enter");
 
 export function CreatePrDialog({
   repoPath,
@@ -423,7 +428,32 @@ export function CreatePrDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        // mod+enter submits from anywhere in the dialog. It's captured on
+        // DialogContent (the Popup), not the <form>, because the X close button
+        // renders as a SIBLING of the form inside the Popup — a chord pressed
+        // with focus on the X would otherwise bypass a form-level handler and
+        // reach the global mod+enter action. ALWAYS swallow the chord here; only
+        // submit when the same gates as the SubmitButton allow (handleSubmit
+        // then enforces the field validators — title, same-branch — so an
+        // invalid form stays inert).
+        onKeyDown={(e) => {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            e.preventDefault();
+            if (
+              !(
+                generating ||
+                nothingToMerge ||
+                baseLoading ||
+                Boolean(existingPr)
+              )
+            ) {
+              form.handleSubmit();
+            }
+          }
+        }}
+      >
         <form
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
@@ -790,6 +820,7 @@ export function CreatePrDialog({
                       baseLoading ||
                       Boolean(existingPr)
                     }
+                    title={SUBMIT_HINT}
                   >
                     {draft ? "Create draft" : `Create ${prNoun}`}
                   </form.SubmitButton>

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -729,6 +729,74 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // Hotkey handlers reuse the menu's own flows, so every gate (clean tree,
   // stash count, picker availability) and confirm dialog applies equally.
   useHotkeyAction("show-branches", () => setOpen(true), !amending);
+  // Push-to-origin: one open-aware handler drives both shapes so the chord
+  // behaves identically regardless of where focus sits (the popup is non-modal,
+  // so a two-handler split let a focus-outside-popup press act on the wrong
+  // branch). The action is ORIGIN-scoped everywhere — its palette label, help
+  // text, and name all say "origin", so it must never push somewhere the user
+  // can't predict. Enabled whenever the repo has an origin (plus a resolvable
+  // target); a non-actionable invocation gives an honest info toast rather than
+  // silence, which is what makes the help text true. The window listener's
+  // `e.repeat` guard covers key-repeat for free.
+  const currentBranch = branches.data?.find((b) => b.isCurrent);
+  useHotkeyAction(
+    "push-to-origin",
+    () => {
+      // Target: the highlighted row when the list is open, else the current
+      // branch. An open list with a highlight that resolves to no local branch
+      // (remote-only row / worktree path) is a real miss, not a fallback.
+      let branch: Branch | undefined;
+      if (open && activeBranch) {
+        branch = branches.data?.find((b) => b.name === activeBranch);
+        if (!branch) {
+          toast.info("Only local branches can be pushed from here");
+          return;
+        }
+      } else {
+        branch = currentBranch;
+      }
+      if (!branch) {
+        toast.info("No branch to push");
+        return;
+      }
+      const tracksOrigin =
+        branch.upstreamRemote === "origin" && !branch.upstreamGone;
+      const tracksOtherKnownRemote =
+        !!branch.upstream &&
+        !branch.upstreamGone &&
+        !!branch.upstreamRemote &&
+        branch.upstreamRemote !== "origin" &&
+        remoteNames.includes(branch.upstreamRemote);
+      if (
+        tracksOrigin &&
+        branch.upstreamAhead > 0 &&
+        branch.upstreamBehind === 0
+      ) {
+        doPushBranch(branch);
+      } else if (!branch.upstream || branch.upstreamGone) {
+        // `enabled` guarantees origin exists, so this publish destination is safe.
+        doPushBranch(branch, "origin");
+      } else if (tracksOrigin && branch.upstreamBehind > 0) {
+        toast.info(
+          `${branch.name} has diverged — update it from its upstream first`,
+        );
+      } else if (tracksOrigin && branch.upstreamAhead === 0) {
+        toast.info(`${branch.name} has nothing to push`);
+      } else if (tracksOtherKnownRemote) {
+        toast.info(
+          `${branch.name} tracks ${branch.upstreamRemote} — push it from its context menu`,
+        );
+      } else {
+        // Tracked, but the upstream's remote is no longer configured (only
+        // reachable when that is actually true).
+        toast.info(
+          `${branch.name} tracks a remote that's no longer configured`,
+        );
+      }
+    },
+    !busy && remoteNames.includes("origin") && (open || !!currentBranch),
+  );
+
   useHotkeyAction("new-branch", openCreate);
   useHotkeyAction(
     "rename-branch",

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -776,12 +776,29 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       } else if (!branch.upstream || branch.upstreamGone) {
         // `enabled` guarantees origin exists, so this publish destination is safe.
         doPushBranch(branch, "origin");
-      } else if (tracksOrigin && branch.upstreamBehind > 0) {
+      } else if (
+        tracksOrigin &&
+        branch.upstreamAhead > 0 &&
+        branch.upstreamBehind > 0
+      ) {
+        // Genuinely diverged: commits on BOTH sides. Behind-only is not
+        // divergence — it gets its own arm below (review-caught mislabel).
         toast.info(
           `${branch.name} has diverged — update it from its upstream first`,
         );
-      } else if (tracksOrigin && branch.upstreamAhead === 0) {
+      } else if (tracksOrigin && branch.upstreamBehind > 0) {
+        // Behind only: nothing local to push; the remedy is a pull, so say so.
+        toast.info(`${branch.name} is behind ${branch.upstream} — pull first`);
+      } else if (tracksOrigin) {
         toast.info(`${branch.name} has nothing to push`);
+      } else if (branch.upstream && !branch.upstreamRemote) {
+        // Tracks a LOCAL branch (`git branch --track x main`):
+        // `%(upstream:remotename)` is empty → null upstreamRemote. There's
+        // nothing remote-related to say — and the context menu is the same
+        // authority (it offers neither Push nor Publish for these).
+        toast.info(
+          `${branch.name} tracks a local branch (${branch.upstream}), not a remote`,
+        );
       } else if (tracksOtherKnownRemote) {
         toast.info(
           `${branch.name} tracks ${branch.upstreamRemote} — push it from its context menu`,

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -181,9 +181,11 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // undefined) with the effective shortcut appended, e.g. "Push (Ctrl+P)".
   // When the action is explicitly unbound (null), the title stays exactly
   // today's value — the raw description, possibly undefined. `aria-keyshortcuts`
-  // carries the shortcut on the proper ARIA channel so it stays OUT of the
-  // accessible name (which remains the description alone), and is omitted when
-  // unbound.
+  // carries the shortcut on the proper ARIA channel so it stays OUT of each
+  // button's accessible name — for Push/Pull that name is the description-only
+  // `aria-label`; Fetch sets none, so its name is the visible "Fetch" label
+  // (deliberate: its description is the volatile "Last fetched …" string, which
+  // must stay tooltip-only, never a name). Omitted when unbound.
   const pushBinding = bindings.get("push") ?? null;
   const pullBinding = bindings.get("pull") ?? null;
   const fetchBinding = bindings.get("fetch") ?? null;

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -39,7 +39,11 @@ import {
   useRepoStatus,
   useUpdateFromUpstream,
 } from "@/lib/git/queries";
-import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import {
+  bindingToAriaKeyshortcuts,
+  formatBinding,
+} from "@/lib/hotkeys/binding";
+import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useSettings } from "@/lib/settings/queries";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
@@ -55,6 +59,11 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   const updateUpstream = useUpdateFromUpstream(repoPath);
   const markFetched = useFetchStatusStore((s) => s.markFetched);
   const lastFetchedAt = useLastFetchedAt(repoPath);
+  // Effective bindings drive the discoverability hints on the sync buttons:
+  // the formatted combo is appended to each button's tooltip, and its ARIA
+  // form goes on `aria-keyshortcuts`. `null` = user explicitly unbound → no
+  // hint. These respect Settings → Keyboard rebindings for free.
+  const bindings = useEffectiveBindings();
   const [forceConfirmOpen, setForceConfirmOpen] = useState(false);
 
   // A repo with no `origin` (e.g. created locally in GitDesktop) can't push;
@@ -168,6 +177,35 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           ? "Pull — no upstream branch to pull from yet; publish the branch first"
           : behindLabel;
 
+  // Tooltip = the button's description (or its bare label when synced +
+  // undefined) with the effective shortcut appended, e.g. "Push (Ctrl+P)".
+  // When the action is explicitly unbound (null), the title stays exactly
+  // today's value — the raw description, possibly undefined. `aria-keyshortcuts`
+  // carries the shortcut on the proper ARIA channel so it stays OUT of the
+  // accessible name (which remains the description alone), and is omitted when
+  // unbound.
+  const pushBinding = bindings.get("push") ?? null;
+  const pullBinding = bindings.get("pull") ?? null;
+  const fetchBinding = bindings.get("fetch") ?? null;
+  const pushTitle =
+    pushBinding === null
+      ? pushDescription
+      : `${pushDescription ?? pushLabel} (${formatBinding(pushBinding)})`;
+  const pullTitle =
+    pullBinding === null
+      ? pullDescription
+      : `${pullDescription ?? "Pull"} (${formatBinding(pullBinding)})`;
+  const fetchHintTitle =
+    fetchBinding === null
+      ? fetchTitle
+      : `${fetchTitle} (${formatBinding(fetchBinding)})`;
+  const pushKeyshortcuts =
+    pushBinding === null ? undefined : bindingToAriaKeyshortcuts(pushBinding);
+  const pullKeyshortcuts =
+    pullBinding === null ? undefined : bindingToAriaKeyshortcuts(pullBinding);
+  const fetchKeyshortcuts =
+    fetchBinding === null ? undefined : bindingToAriaKeyshortcuts(fetchBinding);
+
   function doPull(mode: PullMode) {
     pull.mutate(mode, {
       onSuccess: () => {
@@ -265,45 +303,30 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           `*:focus-visible:z-10` also can't reach the Buttons through the spans,
           so each Button carries `focus-visible:relative focus-visible:z-10`. */}
       <ButtonGroup>
-        <span className="inline-flex" title={pushDescription}>
+        <span className="inline-flex" title={fetchHintTitle}>
           <Button
             variant="outline"
             size="sm"
-            disabled={busy || detached}
-            aria-label={pushDescription}
+            disabled={busy}
+            aria-keyshortcuts={fetchKeyshortcuts}
             className="focus-visible:relative focus-visible:z-10"
-            onClick={() => {
-              if (diverged) {
-                setForceConfirmOpen(true);
-              } else {
-                doPush(false);
-              }
-            }}
+            onClick={() => doFetch(false)}
           >
-            {push.isPending ? (
+            {fetchRemote.isPending ? (
               <Spinner data-icon="inline-start" />
-            ) : diverged ? (
-              <WarningIcon data-icon="inline-start" />
             ) : (
-              <ArrowUpIcon data-icon="inline-start" />
+              <ArrowsClockwiseIcon data-icon="inline-start" />
             )}
-            {pushLabel}
-            {aheadCount > 0 && (
-              <span
-                aria-hidden="true"
-                className="text-muted-foreground tabular-nums"
-              >
-                {aheadCount}
-              </span>
-            )}
+            Fetch
           </Button>
         </span>
-        <span className="inline-flex" title={pullDescription}>
+        <span className="inline-flex" title={pullTitle}>
           <Button
             variant="outline"
             size="sm"
             disabled={busy || !hasUpstream || diverged}
             aria-label={pullDescription}
+            aria-keyshortcuts={pullKeyshortcuts}
             className="border-l-0 focus-visible:relative focus-visible:z-10"
             onClick={() => doPull("ffOnly")}
           >
@@ -364,20 +387,38 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             </DropdownMenuContent>
           </DropdownMenu>
         </span>
-        <span className="inline-flex" title={fetchTitle}>
+        <span className="inline-flex" title={pushTitle}>
           <Button
             variant="outline"
             size="sm"
-            disabled={busy}
+            disabled={busy || detached}
+            aria-label={pushDescription}
+            aria-keyshortcuts={pushKeyshortcuts}
             className="border-l-0 focus-visible:relative focus-visible:z-10"
-            onClick={() => doFetch(false)}
+            onClick={() => {
+              if (diverged) {
+                setForceConfirmOpen(true);
+              } else {
+                doPush(false);
+              }
+            }}
           >
-            {fetchRemote.isPending ? (
+            {push.isPending ? (
               <Spinner data-icon="inline-start" />
+            ) : diverged ? (
+              <WarningIcon data-icon="inline-start" />
             ) : (
-              <ArrowsClockwiseIcon data-icon="inline-start" />
+              <ArrowUpIcon data-icon="inline-start" />
             )}
-            Fetch
+            {pushLabel}
+            {aheadCount > 0 && (
+              <span
+                aria-hidden="true"
+                className="text-muted-foreground tabular-nums"
+              >
+                {aheadCount}
+              </span>
+            )}
           </Button>
         </span>
       </ButtonGroup>

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -28,9 +28,25 @@ export const isWindows =
 export function eventToBinding(
   e: KeyboardEvent | React.KeyboardEvent,
 ): string | null {
+  // AltGr (right-Alt on many layouts) is character input, not a chord: it
+  // reports ctrlKey+altKey, which would otherwise masquerade as a `mod+alt+…`
+  // binding and swallow the character being typed. Left-Ctrl+Alt still works —
+  // only the AltGraph composition path is excluded.
+  if (e.getModifierState?.("AltGraph")) return null;
   const raw = e.key.toLowerCase();
   if (MODIFIER_KEYS.has(raw)) return null;
-  const key = KEY_NAMES[raw] ?? raw;
+  // Option/Alt composes a glyph on macOS (Option+P → "π"), so `e.key` is the
+  // composed character, not the physical key — the chord would never match its
+  // canonical `mod+alt+p`. When Alt is held and the key is a single character
+  // that ISN'T a plain ascii letter/digit, recover the physical key from
+  // `e.code` (KeyP → "p", Digit1 → "1"); anything else keeps `e.key`.
+  let key = KEY_NAMES[raw] ?? raw;
+  if (e.altKey && raw.length === 1 && !/^[a-z0-9]$/.test(raw)) {
+    const letter = /^Key([A-Za-z])$/.exec(e.code);
+    const digit = /^Digit([0-9])$/.exec(e.code);
+    if (letter) key = letter[1].toLowerCase();
+    else if (digit) key = digit[1];
+  }
   const parts: string[] = [];
   if (e.ctrlKey || e.metaKey) parts.push("mod");
   if (e.altKey) parts.push("alt");
@@ -64,6 +80,28 @@ export function formatBinding(binding: string): string {
       if (named) return named;
       if (/^f\d{1,2}$/.test(part)) return part.toUpperCase();
       return part.length === 1 ? part.toUpperCase() : part;
+    })
+    .join("+");
+}
+
+/**
+ * A canonical binding as an ARIA `aria-keyshortcuts` token string, e.g.
+ * "mod+p" → "Control+P" (Windows/Linux) or "Meta+P" (macOS), "f5" → "F5".
+ * The vocabulary is intentionally minimal — it only needs to cover the keys
+ * that appear in real bindings (see KEY_NAMES/DISPLAY_NAMES above).
+ */
+export function bindingToAriaKeyshortcuts(binding: string): string {
+  return binding
+    .split("+")
+    .map((part) => {
+      if (part === "mod") return isMac ? "Meta" : "Control";
+      if (part === "alt") return "Alt";
+      if (part === "shift") return "Shift";
+      if (/^f\d{1,2}$/.test(part)) return part.toUpperCase();
+      // Single letters uppercase; named keys (enter, space, …) capitalize.
+      return part.length === 1
+        ? part.toUpperCase()
+        : part.charAt(0).toUpperCase() + part.slice(1);
     })
     .join("+");
 }

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -90,6 +90,15 @@ export function formatBinding(binding: string): string {
  * The vocabulary is intentionally minimal — it only needs to cover the keys
  * that appear in real bindings (see KEY_NAMES/DISPLAY_NAMES above).
  */
+/** Canonical binding tokens whose ARIA (UI Events) key value isn't just a
+ *  capitalization — see `KEY_NAMES`, which shortens these on the way in. */
+const ARIA_KEY_NAMES: Record<string, string> = {
+  up: "ArrowUp",
+  down: "ArrowDown",
+  left: "ArrowLeft",
+  right: "ArrowRight",
+};
+
 export function bindingToAriaKeyshortcuts(binding: string): string {
   return binding
     .split("+")
@@ -97,6 +106,11 @@ export function bindingToAriaKeyshortcuts(binding: string): string {
       if (part === "mod") return isMac ? "Meta" : "Control";
       if (part === "alt") return "Alt";
       if (part === "shift") return "Shift";
+      // ARIA wants UI Events key values: our canonical arrow tokens ("up",
+      // from KEY_NAMES) must map back to "ArrowUp" etc., or AT ignores them
+      // (review-caught; reachable via user-recorded arrow chords).
+      const arrow = ARIA_KEY_NAMES[part];
+      if (arrow) return arrow;
       if (/^f\d{1,2}$/.test(part)) return part.toUpperCase();
       // Single letters uppercase; named keys (enter, space, …) capitalize.
       return part.length === 1

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -84,12 +84,6 @@ export function formatBinding(binding: string): string {
     .join("+");
 }
 
-/**
- * A canonical binding as an ARIA `aria-keyshortcuts` token string, e.g.
- * "mod+p" → "Control+P" (Windows/Linux) or "Meta+P" (macOS), "f5" → "F5".
- * The vocabulary is intentionally minimal — it only needs to cover the keys
- * that appear in real bindings (see KEY_NAMES/DISPLAY_NAMES above).
- */
 /** Canonical binding tokens whose ARIA (UI Events) key value isn't just a
  *  capitalization — see `KEY_NAMES`, which shortens these on the way in. */
 const ARIA_KEY_NAMES: Record<string, string> = {
@@ -99,6 +93,12 @@ const ARIA_KEY_NAMES: Record<string, string> = {
   right: "ArrowRight",
 };
 
+/**
+ * A canonical binding as an ARIA `aria-keyshortcuts` token string, e.g.
+ * "mod+p" → "Control+P" (Windows/Linux) or "Meta+P" (macOS), "f5" → "F5".
+ * The vocabulary is intentionally minimal — it only needs to cover the keys
+ * that appear in real bindings (see KEY_NAMES/DISPLAY_NAMES above).
+ */
 export function bindingToAriaKeyshortcuts(binding: string): string {
   return binding
     .split("+")

--- a/src/lib/hotkeys/hotkeys.tsx
+++ b/src/lib/hotkeys/hotkeys.tsx
@@ -138,7 +138,19 @@ export function useHotkeysListener() {
     if (!binding) return;
     if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
     const id = byBinding.get(binding);
-    if (id && dispatchAction(id)) e.preventDefault();
+    // Registered-vs-unregistered rule. A chord an on-screen surface OWNS (has
+    // at least one live handler, even if currently disabled) must never leak to
+    // the webview's browser accelerators — Ctrl+P → print, F5/Ctrl+R → reload —
+    // so we preventDefault whenever the action is registered, dispatching only
+    // if an enabled handler exists. But a chord that NOTHING on screen owns
+    // (the action exists in the registry but no component registered it — e.g.
+    // Ctrl+W / Ctrl+F on the repositories list, where RepositoryView is
+    // unmounted) keeps its native meaning: we leave it alone. (The
+    // editable-target guard above already exits for typing contexts.)
+    if (id && (liveHandlers.get(id)?.length ?? 0) > 0) {
+      dispatchAction(id);
+      e.preventDefault();
+    }
   });
 
   useEffect(() => {

--- a/src/lib/hotkeys/hotkeys.tsx
+++ b/src/lib/hotkeys/hotkeys.tsx
@@ -138,9 +138,10 @@ export function useHotkeysListener() {
     if (!binding) return;
     if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
     const id = byBinding.get(binding);
-    // Registered-vs-unregistered rule. A chord an on-screen surface OWNS (has
-    // at least one live handler, even if currently disabled) must never leak to
-    // the webview's browser accelerators — Ctrl+P → print, F5/Ctrl+R → reload —
+    // Registered-vs-unregistered rule. A chord OWNED by an on-screen surface —
+    // an action with at least one live handler, even a disabled one — must
+    // never leak to the webview's browser accelerators (Ctrl+P → print,
+    // F5/Ctrl+R → reload) —
     // so we preventDefault whenever the action is registered, dispatching only
     // if an enabled handler exists. But a chord that NOTHING on screen owns
     // (the action exists in the registry but no component registered it — e.g.

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -181,6 +181,12 @@ export const ACTIONS = [
   },
   { id: "fetch", label: "Fetch", category: "Repository", defaultBinding: "f5" },
   {
+    id: "push-to-origin",
+    label: "Push to origin",
+    category: "Repository",
+    defaultBinding: "mod+alt+p",
+  },
+  {
     id: "update-from-upstream",
     label: "Update from upstream",
     category: "Repository",
@@ -683,7 +689,7 @@ export const BUILT_IN_KEYS: {
   { keys: "Esc", what: "Close dialogs, menus, and settings" },
   {
     keys: "Ctrl+Enter",
-    what: "Submit a PR comment from its text box",
+    what: "Submit a comment or the Create PR dialog from its text box",
     binding: "mod+enter",
   },
 ];

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -689,7 +689,7 @@ export const BUILT_IN_KEYS: {
   { keys: "Esc", what: "Close dialogs, menus, and settings" },
   {
     keys: "Ctrl+Enter",
-    what: "Submit a comment or the Create PR dialog from its text box",
+    what: "Submit a comment from its text box, or a Create PR dialog from any field",
     binding: "mod+enter",
   },
 ];


### PR DESCRIPTION
Add keyboard-driven workflows for creating pull requests and pushing branches to `origin`, while making sync actions easier to discover and safer to use. The update also prevents shortcuts owned by visible surfaces from triggering browser or underlying webview actions when those controls are temporarily unavailable.

### Keyboard shortcuts

- Adds the rebindable `push-to-origin` action in `src/lib/hotkeys/registry.ts`, with a default `Ctrl+Alt+P` / `Cmd+Option+P` binding.
- Implements origin-scoped push and publish behavior in `src/features/repository/BranchSwitcher.tsx`, targeting the highlighted branch when the branch list is open and the current branch otherwise.
- Adds `Ctrl/Cmd+Enter` submission handling to `src/features/pulls/CreatePrDialog.tsx` and `src/features/pulls/CreateLocalPrDialog.tsx`, including platform-specific submit hints.
- Reuses the configured `generate-commit-message` binding for pull request generation in `src/features/pulls/CreatePrDialog.tsx` and `src/features/pulls/CreateLocalPrDialog.tsx`.
- Updates `src/lib/hotkeys/hotkeys.tsx` so shortcuts owned by visible surfaces are prevented from falling through to browser or webview accelerators even when their actions are disabled.
- Improves binding detection and accessibility conversion in `src/lib/hotkeys/binding.ts`, including AltGr handling, macOS Option key recovery, and `aria-keyshortcuts` formatting.

### Sync controls

- Reorders the header controls in `src/features/repository/SyncControls.tsx` to **Fetch / Pull / Push** to match the fetch → pull → push workflow.
- Moves ahead and behind counts directly onto the Push and Pull buttons in `src/features/repository/SyncControls.tsx`.
- Adds configured shortcut hints to sync button tooltips and ARIA metadata in `src/features/repository/SyncControls.tsx`.

### Documentation and changelog

- Documents the new shortcuts and Fetch / Pull / Push ordering in `src/features/help/content.ts`.
- Updates the syncing description in `README.md`.
- Adds changelog entries for PR submission shortcuts, push-to-origin, sync control ordering, and hotkey fallthrough behavior in `changelog.d/`.