### PR TITLE
feat(pulls,conversations,hotkeys): add shortcuts to edit PR dialogs

### DIFF
--- a/changelog.d/added-create-pr-submit-shortcut.md
+++ b/changelog.d/added-create-pr-submit-shortcut.md
@@ -1,4 +1,6 @@
-- Press **Ctrl/Cmd+Enter** from any field in the **Create pull request** or **Create local
-  PR** dialog to submit it, matching the shortcut already used to send comments. When AI
-  features are on, the **generate commit message** shortcut (Ctrl/Cmd+G by default) runs the
-  dialog's own **Generate** for its title and description while it's open.
+- **Keyboard shortcuts in the PR and issue dialogs.** Press **Ctrl/Cmd+Enter** from any
+  field in the **Create pull request**, **Create local PR**, or **Edit title/description**
+  dialog (for pull requests and issues alike) to submit it, matching the shortcut already
+  used to send comments. When AI features are on, the **generate commit message** shortcut
+  (Ctrl/Cmd+G by default) runs **Generate** for the title and description while a create or
+  edit PR dialog is open.

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -199,7 +199,12 @@ export const EditTitleBodyDialog = withForm({
                 Cancel
               </Button>
               <form.AppForm>
-                <form.SubmitButton title={SUBMIT_HINT}>Save</form.SubmitButton>
+                {/* disabled while generating: the mouse path must match the chord
+                    path's !generating gate, or a click could persist a
+                    half-streamed title/body (create dialogs do the same). */}
+                <form.SubmitButton disabled={generating} title={SUBMIT_HINT}>
+                  Save
+                </form.SubmitButton>
               </form.AppForm>
             </DialogFooter>
           </form>

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -11,7 +11,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { required, useAppForm, withForm } from "@/lib/form";
+import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import { toastError } from "@/lib/toast";
+
+/** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
+ *  literal modifier (house platform-mod-key rule). Mirrors CreateLocalPrDialog. */
+const SUBMIT_HINT = formatBinding("mod+enter");
 
 /** Shared form shape so the hook's `useAppForm` and the `withForm` dialog agree. */
 export const editTitleBodyFormOpts = formOptions({
@@ -67,6 +73,17 @@ interface EditTitleBodyDialogProps {
   /** Optional actions rendered in the description field header (e.g. an AI
    *  "Generate" button). Absent ⇒ the field renders exactly as before. */
   bodyActions?: ReactNode;
+  /** Runs the consumer's AI Generate. Present ONLY when the consumer has a live
+   *  Generate surface (AI enabled); its presence is the gate for intercepting the
+   *  generate chord. The issue views omit it (no Generate), so the chord falls
+   *  through there untouched. */
+  onGenerate?: () => void;
+  /** True while a generation is in flight (undefined ⇒ false): the generate chord
+   *  swallows without re-triggering, and mod+enter swallows without submitting. */
+  generating?: boolean;
+  /** Mirrors the Generate button's disabled state (undefined ⇒ false): the chord
+   *  still swallows but doesn't run. */
+  generateDisabled?: boolean;
 }
 
 export const EditTitleBodyDialog = withForm({
@@ -81,6 +98,9 @@ export const EditTitleBodyDialog = withForm({
     contentClassName: undefined as string | undefined,
     bodyTextareaClassName: "max-h-72",
     bodyActions: undefined as ReactNode,
+    onGenerate: undefined as (() => void) | undefined,
+    generating: undefined as boolean | undefined,
+    generateDisabled: undefined as boolean | undefined,
   } as EditTitleBodyDialogProps,
   render: function EditTitleBodyDialogRender({
     form,
@@ -91,10 +111,56 @@ export const EditTitleBodyDialog = withForm({
     contentClassName,
     bodyTextareaClassName,
     bodyActions,
+    onGenerate,
+    generating,
+    generateDisabled,
   }) {
+    // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
+    // default) while this dialog is open — never a hardcoded chord, so a
+    // Settings → Keyboard rebinding drives it. null = explicitly unbound.
+    const generateBinding =
+      useEffectiveBindings().get("generate-commit-message") ?? null;
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className={contentClassName}>
+        <DialogContent
+          className={contentClassName}
+          // mod+enter submits from anywhere in the dialog, and (when the consumer
+          // has a Generate surface) the generate-commit-message chord runs its
+          // Generate — parity with the create dialogs (CreateLocalPrDialog). It's
+          // captured on DialogContent (the Popup), not the <form>: the X close
+          // button renders as a form SIBLING inside the Popup, so a form-level
+          // handler misses a chord pressed with focus on the X, which would then
+          // leak to the global commit / generate-commit-message actions behind the
+          // dialog. Capturing on the Popup covers the X and every field, so the
+          // UNCONDITIONAL preventDefault is what actually contains each chord.
+          //
+          // This dialog is shared with the ISSUE views, which pass no `onGenerate`
+          // (they have no Generate) — so the generate chord only arms when a
+          // consumer opts in, and otherwise falls through untouched.
+          onKeyDown={(e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+              e.preventDefault();
+              // While generating, swallow but don't submit — matches the create
+              // dialogs. Field validators still gate an invalid submit.
+              if (!generating) form.handleSubmit();
+              return;
+            }
+            // Run this consumer's Generate only when it has a Generate surface and
+            // the chord is bound. ALWAYS swallow it then: without this the chord
+            // would fire the global generate-commit-message action behind the
+            // dialog. Run Generate only when its button would be enabled; while
+            // generating we swallow but DON'T cancel (an accidental repeat must not
+            // abort a running generation).
+            if (
+              onGenerate &&
+              generateBinding !== null &&
+              eventToBinding(e) === generateBinding
+            ) {
+              e.preventDefault();
+              if (!generating && !generateDisabled) onGenerate();
+            }
+          }}
+        >
           {/* min-w-0: DialogContent is a grid; without this the form's content
               (long titles, code in the editor) can't shrink and overflows. */}
           <form
@@ -133,7 +199,7 @@ export const EditTitleBodyDialog = withForm({
                 Cancel
               </Button>
               <form.AppForm>
-                <form.SubmitButton>Save</form.SubmitButton>
+                <form.SubmitButton title={SUBMIT_HINT}>Save</form.SubmitButton>
               </form.AppForm>
             </DialogFooter>
           </form>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -708,8 +708,9 @@ from the branch diff and commit subjects — which additionally **proposes label
 only from the repository's existing labels and added to whatever you've already picked
 (never invented). The same **Generate** button is on the **Edit** dialog too, so you can
 write or regenerate an existing PR's title and description at any time — including for pull
-requests from forks{{/ai}}. Press {{key:mod+enter}} from any field to submit the dialog.{{ai}}
-While the dialog is open, {{kbd:generate-commit-message}} runs its **Generate** for you.{{/ai}}
+requests from forks{{/ai}}. Press {{key:mod+enter}} from any field to submit either the
+**Create** or the **Edit** dialog.{{ai}} While a PR dialog is open, {{kbd:generate-commit-message}}
+runs its **Generate** for you.{{/ai}}
 
 ## GitLab merge requests
 

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -58,6 +58,7 @@ import {
   useUpdateBranchFrom,
 } from "@/lib/git/queries";
 import { formatBinding } from "@/lib/hotkeys/binding";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import { useLocalPrs, useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -149,6 +150,13 @@ export function LocalPrView({
     },
   });
   const prGen = useGeneratePrDescription(repoPath);
+  // Context-sensitive reuse of the generate-commit-message binding (mod+g by
+  // default) for the Edit dialog's chord + button hint — a rebinding drives both.
+  const generateBinding =
+    useEffectiveBindings().get("generate-commit-message") ?? null;
+  const generateHint = generateBinding
+    ? ` (${formatBinding(generateBinding)})`
+    : "";
 
   const comparison = useCompareBranches(
     repoPath,
@@ -193,6 +201,24 @@ export function LocalPrView({
   // Commits on `base` that `head` lacks — i.e. how far the PR's head branch has
   // fallen behind base. Non-empty ⇒ offer GitHub's "Update branch".
   const behind = comparison.data?.behind ?? [];
+
+  // AI title+description generation — shared by the Edit dialog's Generate button
+  // and its mod+g chord. Verbatim the button's prior onClick body. `pr` is aliased
+  // to a narrowed const so the (hoisted) function body sees it as defined.
+  const prForGen = pr;
+  function runGenerate() {
+    // Local PRs have real local branches — the base..head branch-diff path works,
+    // and (like create) keeps base GitHub prompt wording.
+    prGen.generate(
+      prForGen.base,
+      prForGen.head,
+      ahead.map((c) => c.subject),
+      (d) => {
+        edit.form.setFieldValue("title", d.title);
+        edit.form.setFieldValue("body", d.body);
+      },
+    );
+  }
   const fileCount = diffFiles.data?.length;
   // Shared JiraRefRow sources for both header branches (conflict-takeover +
   // normal) so the two can't diverge. Branch name LAST so title/description
@@ -969,6 +995,9 @@ export function LocalPrView({
         description="Updates the title and description of this local pull request."
         contentClassName={undefined}
         bodyTextareaClassName="max-h-72"
+        onGenerate={aiEnabled ? runGenerate : undefined}
+        generating={prGen.generating}
+        generateDisabled={ahead.length === 0}
         bodyActions={
           !aiEnabled ? undefined : prGen.generating ? (
             <Button
@@ -986,20 +1015,8 @@ export function LocalPrView({
               variant="outline"
               size="xs"
               disabled={ahead.length === 0}
-              onClick={() =>
-                // Local PRs have real local branches — the base..head branch-diff
-                // path works, and (like create) keeps base GitHub prompt wording.
-                prGen.generate(
-                  pr.base,
-                  pr.head,
-                  ahead.map((c) => c.subject),
-                  (d) => {
-                    edit.form.setFieldValue("title", d.title);
-                    edit.form.setFieldValue("body", d.body);
-                  },
-                )
-              }
-              title="Generate the title and description with AI"
+              onClick={runGenerate}
+              title={`Generate the title and description with AI${generateHint}`}
             >
               <SparkleIcon data-icon="inline-start" />
               Generate

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -120,7 +120,8 @@ import {
   providerLabel,
   type ReviewThreadOut,
 } from "@/lib/git/types";
-import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { formatBinding } from "@/lib/hotkeys/binding";
+import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import {
   useClearReviewDrafts,
   useReviewDrafts,
@@ -397,6 +398,13 @@ export function RemotePrView({
   });
   const prGen = useGeneratePrDescription(repoPath);
   const composerRef = useRef<MarkdownEditorHandle>(null);
+  // Context-sensitive reuse of the generate-commit-message binding (mod+g by
+  // default) for the Edit dialog's chord + button hint — a rebinding drives both.
+  const generateBinding =
+    useEffectiveBindings().get("generate-commit-message") ?? null;
+  const generateHint = generateBinding
+    ? ` (${formatBinding(generateBinding)})`
+    : "";
 
   const onError = (e: unknown) => toastError(e);
 
@@ -746,6 +754,40 @@ export function RemotePrView({
           ) : undefined
         }
       />
+    );
+  }
+
+  // AI title+description generation — shared by the Edit dialog's Generate button
+  // and its mod+g chord. Verbatim the button's prior onClick body. `pr` is aliased
+  // to a narrowed const so the (hoisted) function body sees it as defined.
+  const prForGen = pr;
+  function runGenerate() {
+    prGen.generateFromDiff(
+      // Reuse the diff already cached by usePrDiff — and, crucially,
+      // resolve it from the PR's own diff (not local base..head refs),
+      // so this works for fork PRs / unfetched head branches.
+      () =>
+        queryClient
+          .ensureQueryData(prDiffOptions(repoPath, number, lens))
+          .then((text) => ({
+            text,
+            truncated: false,
+            files: prForGen.files.map((f) => ({
+              path: f.path,
+              added: f.additions,
+              deleted: f.deletions,
+              isBinary: false,
+            })),
+          })),
+      prForGen.baseRefName,
+      prForGen.headRefName,
+      prForGen.commits.map((c) => c.headline),
+      (d) => {
+        edit.form.setFieldValue("title", d.title);
+        edit.form.setFieldValue("body", d.body);
+      },
+      // Provider-aware prompt copy; null host → base GitHub wording.
+      provider ?? undefined,
     );
   }
 
@@ -2116,6 +2158,8 @@ export function RemotePrView({
         description={`Updates the title and description of #${number} on ${remoteLabel}.`}
         contentClassName="sm:max-w-lg"
         bodyTextareaClassName="max-h-72 min-h-24 resize-y font-mono"
+        onGenerate={aiEnabled ? runGenerate : undefined}
+        generating={prGen.generating}
         bodyActions={
           !aiEnabled ? undefined : prGen.generating ? (
             <Button
@@ -2132,36 +2176,8 @@ export function RemotePrView({
               type="button"
               variant="outline"
               size="xs"
-              onClick={() =>
-                prGen.generateFromDiff(
-                  // Reuse the diff already cached by usePrDiff — and, crucially,
-                  // resolve it from the PR's own diff (not local base..head refs),
-                  // so this works for fork PRs / unfetched head branches.
-                  () =>
-                    queryClient
-                      .ensureQueryData(prDiffOptions(repoPath, number, lens))
-                      .then((text) => ({
-                        text,
-                        truncated: false,
-                        files: pr.files.map((f) => ({
-                          path: f.path,
-                          added: f.additions,
-                          deleted: f.deletions,
-                          isBinary: false,
-                        })),
-                      })),
-                  pr.baseRefName,
-                  pr.headRefName,
-                  pr.commits.map((c) => c.headline),
-                  (d) => {
-                    edit.form.setFieldValue("title", d.title);
-                    edit.form.setFieldValue("body", d.body);
-                  },
-                  // Provider-aware prompt copy; null host → base GitHub wording.
-                  provider ?? undefined,
-                )
-              }
-              title="Generate the title and description with AI"
+              onClick={runGenerate}
+              title={`Generate the title and description with AI${generateHint}`}
             >
               <SparkleIcon data-icon="inline-start" />
               Generate

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -689,7 +689,7 @@ export const BUILT_IN_KEYS: {
   { keys: "Esc", what: "Close dialogs, menus, and settings" },
   {
     keys: "Ctrl+Enter",
-    what: "Submit a comment from its text box, or a Create PR dialog from any field",
+    what: "Submit a comment from its text box, or a create/edit dialog from any field",
     binding: "mod+enter",
   },
 ];

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -689,7 +689,7 @@ export const BUILT_IN_KEYS: {
   { keys: "Esc", what: "Close dialogs, menus, and settings" },
   {
     keys: "Ctrl+Enter",
-    what: "Submit a comment from its text box, or a create/edit dialog from any field",
+    what: "Submit a comment from its text box, or a PR or issue create/edit dialog from any field",
     binding: "mod+enter",
   },
 ];


### PR DESCRIPTION
Add keyboard shortcuts to create and edit pull request dialogs so users can submit forms and trigger AI-generated titles and descriptions without leaving the keyboard. The shortcuts respect configured bindings and remain contained within the open dialog.

### Dialog shortcuts

- Adds `Ctrl/Cmd+Enter` submission handling to `src/features/conversations/EditTitleBodyDialog.tsx` for editing pull request and issue titles and descriptions.
- Displays a platform-aware submit hint on the Save button in `src/features/conversations/EditTitleBodyDialog.tsx`.
- Uses `useEffectiveBindings` and `eventToBinding` in `src/features/conversations/EditTitleBodyDialog.tsx` so customized generate bindings work while preventing shortcuts from leaking to global actions.
- Preserves generation and submission safeguards in `src/features/conversations/EditTitleBodyDialog.tsx` while generation is running or disabled.

### Pull request generation

- Extracts the existing AI generation flows into shared `runGenerate` handlers in `src/features/pulls/LocalPrView.tsx` and `src/features/pulls/RemotePrView.tsx`.
- Passes generation callbacks and state into `EditTitleBodyDialog` from `src/features/pulls/LocalPrView.tsx` and `src/features/pulls/RemotePrView.tsx`.
- Shows the configured `generate-commit-message` binding in the Generate button hints in `src/features/pulls/LocalPrView.tsx` and `src/features/pulls/RemotePrView.tsx`.
- Keeps local PR generation based on branch differences in `src/features/pulls/LocalPrView.tsx` and remote PR generation based on the PR's cached diff in `src/features/pulls/RemotePrView.tsx`.

### Help and changelog

- Updates shortcut documentation in `src/features/help/content.ts` to cover both create and edit dialogs.
- Updates the built-in shortcut description in `src/lib/hotkeys/registry.ts`.
- Documents keyboard shortcuts for PR and issue dialogs in `changelog.d/added-create-pr-submit-shortcut.md`.