### PR TITLE
feat(pulls,ai,automations,mcp): add reviewer notes and draft review controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist-ssr
 /gitbutler-and-copilot-app.md
 /claude_strings.txt
 /conductor.md
+/.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   - **Sized to your model** — a **Review context** setting scales the review's context
     budget to the reviewing model's window (Auto probes a local **Ollama** model's context
     length live), so a larger model sees more of the PR before agentic review is needed
+  - **Notes for reviewers** — hand the reviewer context up front: an agent deposits
+    per-branch notes via the GitDesktop MCP, or you type them in the Create PR dialog; on
+    create they post as the PR's first comment and reach the automated review as
+    first-class context (by default a draft's review waits until it's marked ready),
+    so a deliberate, documented decision isn't re-flagged
   - **Clearly machine-authored** — a branded header/footer and a robot-avatar
     "GitDesktop" bot on local PRs; with a GitLab project/group access token, posts as
     the real **GitLab project bot** rather than your own account
@@ -399,7 +404,9 @@ workflow against any two branches with no remote at all).
   reviews and any "fixed in `<sha>`" / refutation replies) as soft, re-verifiable
   context, so an already-addressed finding isn't re-raised cold (the current diff is
   always the source of truth). Per PR, ignore the prior review, trim a false finding, or
-  opt out of external-bot folding.
+  opt out of external-bot folding. By default a **draft** PR waits for its first automated
+  review until you mark it ready — flip **Review draft PRs when created** in Settings →
+  Automations to review on creation instead.
 - **Line-anchored review comments** — from Copilot, CodeRabbit, or humans — render
   grouped by file in the Conversation and at their exact line in the Files diff, with
   reply-in-thread, resolve/unresolve, and edit/delete of your own; a reviewer's

--- a/changelog.d/added-reviewer-notes.md
+++ b/changelog.d/added-reviewer-notes.md
@@ -1,0 +1,8 @@
+- **Notes for reviewers.** Hand review context to the AI reviewer: an agent (or any
+  MCP client with write access) deposits per-branch notes via the GitDesktop MCP, and
+  the Create pull request dialog shows an optional **Notes for reviewers** field that
+  pre-fills from that deposit for the head branch. On create the notes are posted as the
+  PR's first comment and fed to the automated review as first-class context, so
+  deliberate, documented decisions stop getting re-flagged. A new *Review draft PRs when
+  created* automation setting (off by default) holds a draft PR's first review until it's
+  marked ready for review.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -140,6 +140,7 @@ export const capabilities: Capability[] = [
   { group: "AI · generate & review", ai: true, label: "AI issue drafting from your repo's templates" },
   { group: "AI · generate & review", ai: true, label: "AI repo descriptions & topics" },
   { group: "AI · generate & review", ai: true, label: "AI code review & security audit on any PR", highlight: true },
+  { group: "AI · generate & review", ai: true, label: "Hand review context to the AI reviewer — per-branch notes deposited by your agent, posted with the PR" },
   { group: "AI · generate & review", ai: true, label: "Agentic review — reads the full diff, files, search & history, read-only" },
   { group: "AI · generate & review", ai: true, label: "Reviews keep running in the background & finish in the tray" },
   { group: "AI · generate & review", ai: true, label: "Iterative reviews build on the last round & other bots' findings" },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod oplog;
 mod path_launcher;
 mod pty;
 mod research;
+mod review_notes;
 mod secrets;
 mod sessions;
 mod state;

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -864,10 +864,10 @@ mod tests {
     }
 
     /// The COMBINED router's tool count must equal the sum of the per-module router
-    /// counts, and currently == 118. Deriving each term from the module's own router
+    /// counts, and currently == 119. Deriving each term from the module's own router
     /// means a package growing a module updates both sides of the equality
     /// automatically — this test never needs editing as modules gain tools.
-    /// (The `== 117` literal is the one line a package updates, and only if it
+    /// (The `== 119` literal is the one line a package updates, and only if it
     /// intends to change the current total.)
     #[test]
     fn combined_router_tool_count_is_sum_of_modules() {
@@ -881,7 +881,7 @@ mod tests {
             + GitDesktopMcp::write_git_router().list_all().len()
             + GitDesktopMcp::generate_router().list_all().len();
         assert_eq!(handler.tool_router.list_all().len(), per_module);
-        assert_eq!(per_module, 118);
+        assert_eq!(per_module, 119);
     }
 
     /// `ensure_key_in_project` gates a key-taking Jira tool to the linked project: the

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -81,6 +81,15 @@ struct SetLocalIssueStatusArgs {
     status: String,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SetReviewNotesArgs {
+    /// The branch the note is for. Must exist as a local branch in the repo.
+    branch: String,
+    /// The reviewer-note body (markdown). An empty/whitespace-only body CLEARS the deposit
+    /// for this branch.
+    body: String,
+}
+
 /// An optional local-record status filter (the read tools accept it to narrow results).
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct LocalStatusFilterArgs {
@@ -226,6 +235,31 @@ impl GitDesktopMcp {
         let record =
             crate::local_issues::set_status(&repo, &args.id, &args.status).map_err(app_err)?;
         json_result(&record)
+    }
+
+    // ---- Reviewer notes: per-branch "Notes for reviewers" deposits ---------
+
+    #[tool(
+        description = "Deposit a per-branch \"Notes for reviewers\" note for the bound repository. \
+                       The note is stored LOCALLY in GitDesktop's app data — it is NEVER sent to \
+                       any forge by this tool. It seeds the Create-PR dialog's \"Notes for \
+                       reviewers\" field for that branch when a PR is opened from GitDesktop. \
+                       Verifies `branch` exists as a local branch first. An empty (or \
+                       whitespace-only) body CLEARS any existing deposit for the branch. Returns \
+                       `{ branch, saved }` where `saved` is false when an empty body cleared it.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
+    async fn set_review_notes(
+        &self,
+        Parameters(args): Parameters<SetReviewNotesArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_write()?;
+        // Pre-mutation guard FIRST: the branch must resolve as a local branch, else error
+        // naming it — before any app-data write.
+        verify_branch(&self.repo, &args.branch).await?;
+        let repo = crate::git::repo::repo_identity(&self.repo).await;
+        let saved = crate::review_notes::set(&repo, &args.branch, &args.body).map_err(app_err)?;
+        json_result(&serde_json::json!({ "branch": args.branch, "saved": saved }))
     }
 
     // ---- Local READ tools (ungated — the user's own app-data) --------------
@@ -419,6 +453,10 @@ mod tests {
                 status: "open".into(),
             }))
         );
+        assert_gated!(h.set_review_notes(Parameters(SetReviewNotesArgs {
+            branch: "feat".into(),
+            body: "b".into(),
+        })));
     }
 
     /// The local READ tools are UNGATED (the user's own app-data) — with all flags off

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -1,0 +1,332 @@
+//! Reviewer-notes storage core for the MCP server's write tool and the GUI.
+//!
+//! **Reviewer notes are GitDesktop's own app-data deposits** — no forge or remote writes
+//! are involved. An agent session deposits a per-branch note ("Notes for reviewers") keyed
+//! by repo + branch; the GUI later seeds its Create-PR dialog's "Notes for reviewers" field
+//! from this store. The GUI persists them via the Tauri Store plugin (`src/lib/…`); this
+//! module is the headless mirror the MCP server (which has NO `AppHandle`) uses to write the
+//! SAME file. It is a leaner parallel of [`crate::local_issues`] / [`crate::local_prs`] — see
+//! either for the full storage-dir / Value-round-trip / statelessness contract, which applies
+//! identically here (only the store filename and the record shape differ).
+//!
+//! ## Storage-dir mirroring contract
+//!
+//! `tauri-plugin-store` v2 resolves a relative store path against `BaseDirectory::AppData`
+//! (`dirs::data_dir()/<identifier>`), and our identifier is `com.thebguy.gitdesktop`. So the
+//! file is:
+//!
+//! ```text
+//!   Windows: %APPDATA%\com.thebguy.gitdesktop\review-notes.json
+//!   macOS:   ~/Library/Application Support/com.thebguy.gitdesktop/review-notes.json
+//!   Linux:   $XDG_DATA_HOME (or ~/.local/share)/com.thebguy.gitdesktop/review-notes.json
+//! ```
+//!
+//! We resolve it here with the SAME `dirs::data_dir()` the Tauri path layer uses, joined with
+//! the identifier (reusing [`crate::local_prs::APP_IDENTIFIER`]) — so the two processes always
+//! agree on the file.
+//!
+//! ## Shape
+//!
+//! ```text
+//!   { "<identityKey>": { "<branchName>": { "body": string, "savedAt": string } } }
+//! ```
+//!
+//! `identityKey` is [`crate::git::repo::repo_identity`]'s output (the worktree-stable common
+//! git dir). This store is **identity-keyed from day one** — there are NO legacy checkout-path
+//! keys to fold, so (unlike `local_prs`/`local_issues`) there is deliberately no
+//! `consolidate`/`fold_legacy_key` machinery here. Don't add any.
+//!
+//! ## Value-based round-trip (never drop unknown fields)
+//!
+//! The whole file is read as a `serde_json::Value`, and only the target repo/branch entry is
+//! mutated. Existing entries are never deserialized into a struct and re-serialized (that would
+//! silently drop any field a future GUI adds); the new record is built as a small `Value`.
+//! Writes are atomic (temp file in the same dir + rename over the target).
+//!
+//! ## Statelessness
+//!
+//! The GUI holds this store in memory (`autoSave`), so every call here does a FRESH
+//! read → modify → atomic write. We never cache across calls.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::error::{AppError, AppResult};
+use crate::local_prs::APP_IDENTIFIER;
+
+/// The store filename the GUI's reviewer-notes store writes.
+const STORE_FILE: &str = "review-notes.json";
+
+/// Resolve the absolute path of the `review-notes.json` the frontend store writes.
+/// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
+/// (`dirs::data_dir()/<identifier>`) — see the module contract and [`crate::local_prs`].
+pub(crate) fn store_path() -> AppResult<PathBuf> {
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
+}
+
+/// Read the whole store file as a JSON object. A missing file is an empty object;
+/// a present-but-malformed file is a hard error (we must never clobber it).
+fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Command(format!(
+                    "review-notes store at {} is not valid JSON: {e}",
+                    path.display()
+                ))
+            })?;
+            match value {
+                Value::Object(map) => Ok(map),
+                _ => Err(AppError::Command(format!(
+                    "review-notes store at {} is not a JSON object",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(AppError::Io(e)),
+    }
+}
+
+/// Serialize the store object (pretty) and write it back atomically — temp file in the
+/// same dir + rename over the target (via [`crate::fsops::atomic_write`]).
+fn write_store(path: &Path, store: &Map<String, Value>) -> AppResult<()> {
+    let body = serde_json::to_string_pretty(&Value::Object(store.clone()))
+        .map_err(|e| AppError::Command(format!("serialize review-notes store: {e}")))?;
+    crate::fsops::atomic_write(path, body.as_bytes())
+}
+
+/// The current UTC timestamp in JS `Date.prototype.toISOString()` format —
+/// RFC3339 with millisecond precision and a `Z` suffix (e.g. `2026-06-20T20:45:33.666Z`).
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Set (upsert or clear) the reviewer note for `branch` under `repo` in the real app-data
+/// store. `repo` is the worktree-stable identity key ([`crate::git::repo::repo_identity`]).
+///
+/// A non-empty `body` upserts `{ body, savedAt: <now> }`; a body that is empty or
+/// whitespace-only CLEARS the branch entry (and removes the repo key entirely once its map
+/// empties, so an emptied store stays tidy). Returns `true` when a note was saved, `false`
+/// when the empty-body rule cleared the deposit.
+pub fn set(repo: &str, branch: &str, body: &str) -> AppResult<bool> {
+    let path = store_path()?;
+    set_at(&path, repo, branch, body)
+}
+
+/// The pure store logic behind [`set`], taking an explicit path so tests can drive it against
+/// a temp file without touching the real app-data store.
+fn set_at(path: &Path, repo: &str, branch: &str, body: &str) -> AppResult<bool> {
+    let mut store = read_store(path)?;
+    let saved = if body.trim().is_empty() {
+        clear_branch(&mut store, repo, branch);
+        false
+    } else {
+        upsert_branch(&mut store, repo, branch, body);
+        true
+    };
+    write_store(path, &store)?;
+    Ok(saved)
+}
+
+/// Upsert `{ body, savedAt: <now> }` for `branch` under `repo`, creating the repo's branch
+/// map if absent. Only the target branch entry is replaced — sibling branches and any unknown
+/// fields on other entries are left untouched.
+fn upsert_branch(store: &mut Map<String, Value>, repo: &str, branch: &str, body: &str) {
+    let record = serde_json::json!({ "body": body, "savedAt": now_iso() });
+    let entry = store
+        .entry(repo.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if let Some(branches) = entry.as_object_mut() {
+        branches.insert(branch.to_string(), record);
+    } else {
+        // A non-object repo entry (corrupt/foreign shape) is replaced with a fresh map
+        // holding just this branch, rather than silently failing the write.
+        let mut branches = Map::new();
+        branches.insert(branch.to_string(), record);
+        *entry = Value::Object(branches);
+    }
+}
+
+/// Remove `branch` from `repo`'s map, and drop the repo key entirely if that leaves it empty.
+fn clear_branch(store: &mut Map<String, Value>, repo: &str, branch: &str) {
+    let Some(entry) = store.get_mut(repo) else {
+        return;
+    };
+    let Some(branches) = entry.as_object_mut() else {
+        return;
+    };
+    branches.remove(branch);
+    if branches.is_empty() {
+        store.remove(repo);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // These tests exercise the pure store logic (read/mutate/write over a Value map)
+    // against a temp file, bypassing `store_path()` so they never touch the real
+    // app-data store. `set` wraps this same logic + the fixed path.
+
+    fn tmp_store() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "gd-review-notes-test-{}-{}.json",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        p
+    }
+
+    #[test]
+    fn store_path_is_under_identifier_and_named() {
+        let path = store_path().unwrap();
+        // …/com.thebguy.gitdesktop/review-notes.json
+        assert!(path.ends_with(STORE_FILE), "path: {}", path.display());
+        assert!(
+            path.to_string_lossy().contains(APP_IDENTIFIER),
+            "path: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn read_missing_file_is_empty_object() {
+        let path = tmp_store();
+        let store = read_store(&path).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn malformed_store_is_an_error_not_a_clobber() {
+        let path = tmp_store();
+        std::fs::write(&path, b"{ this is not json").unwrap();
+        let err = read_store(&path).unwrap_err();
+        assert!(err.to_string().contains("not valid JSON"));
+        // The bad file is left intact.
+        assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn set_upserts_body_and_stamps_saved_at() {
+        let path = tmp_store();
+        let repo = "C:/repo/one/.git";
+        let saved = set_at(&path, repo, "feature", "please look at the migration").unwrap();
+        assert!(saved);
+
+        let back = read_store(&path).unwrap();
+        let note = &back[repo]["feature"];
+        assert_eq!(note["body"], "please look at the migration");
+        assert!(note["savedAt"].is_string());
+        let ts = note["savedAt"].as_str().unwrap();
+        assert!(ts.ends_with('Z'), "expected ISO Z suffix: {ts}");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn set_overwrites_an_existing_branch_note() {
+        let path = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "feature", "first").unwrap();
+        set_at(&path, repo, "feature", "second").unwrap();
+
+        let back = read_store(&path).unwrap();
+        assert_eq!(back[repo]["feature"]["body"], "second");
+        // Only one branch entry — an upsert, not an append.
+        assert_eq!(back[repo].as_object().unwrap().len(), 1);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn empty_body_clears_the_branch_but_keeps_siblings() {
+        let path = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "feature", "note A").unwrap();
+        set_at(&path, repo, "other", "note B").unwrap();
+
+        // Clear "feature" with a whitespace-only body.
+        let saved = set_at(&path, repo, "feature", "   \n\t ").unwrap();
+        assert!(!saved);
+
+        let back = read_store(&path).unwrap();
+        assert!(back[repo].get("feature").is_none());
+        // The sibling branch is untouched.
+        assert_eq!(back[repo]["other"]["body"], "note B");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn clearing_last_branch_removes_the_repo_key() {
+        let path = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "feature", "note").unwrap();
+        // Clearing the only branch drops the repo key entirely.
+        let saved = set_at(&path, repo, "feature", "").unwrap();
+        assert!(!saved);
+
+        let back = read_store(&path).unwrap();
+        assert!(
+            back.get(repo).is_none(),
+            "repo key should be gone: {back:?}"
+        );
+        assert!(back.is_empty());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn clearing_a_missing_branch_is_a_harmless_noop() {
+        let path = tmp_store();
+        let repo = "C:/repo/one/.git";
+        // No prior entry — clearing a never-set branch just writes an empty store.
+        let saved = set_at(&path, repo, "ghost", "").unwrap();
+        assert!(!saved);
+        let back = read_store(&path).unwrap();
+        assert!(back.is_empty());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn upsert_preserves_sibling_repos_and_unknown_fields() {
+        let path = tmp_store();
+        let other_repo = "C:/repo/other/.git";
+        let repo = "C:/repo/one/.git";
+        // Seed a store with a sibling repo carrying a note that has an unknown field, plus
+        // a sibling branch under our repo.
+        let mut store = Map::new();
+        store.insert(
+            other_repo.to_string(),
+            json!({ "main": { "body": "keep me", "savedAt": "2026-01-01T00:00:00.000Z", "futureField": 7 } }),
+        );
+        store.insert(
+            repo.to_string(),
+            json!({ "sibling": { "body": "sib", "savedAt": "2026-01-01T00:00:00.000Z" } }),
+        );
+        write_store(&path, &store).unwrap();
+
+        set_at(&path, repo, "feature", "new note").unwrap();
+
+        let back = read_store(&path).unwrap();
+        // The other repo's note (and its unknown field) is untouched.
+        assert_eq!(back[other_repo]["main"]["body"], "keep me");
+        assert_eq!(back[other_repo]["main"]["futureField"], 7);
+        // Our repo now has both the sibling branch and the new one.
+        assert_eq!(back[repo]["sibling"]["body"], "sib");
+        assert_eq!(back[repo]["feature"]["body"], "new note");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn now_iso_matches_js_toisostring_shape() {
+        let ts = now_iso();
+        assert!(ts.ends_with('Z'), "expected Z suffix: {ts}");
+        let dot = ts.find('.').expect("expected millisecond fraction");
+        assert_eq!(&ts[dot + 4..], "Z", "expected 3-digit millis: {ts}");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { useBackgroundPrSync } from "@/lib/automations/useBackgroundPrSync";
 import { useGitInstalled } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { reloadLocalPrs } from "@/lib/pulls/local";
+import { reloadReviewNotes } from "@/lib/review-notes/store";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { COLD_START } from "@/lib/test-mode";
@@ -144,6 +145,16 @@ function App() {
           reloadLocalPrs()
             .then(() =>
               queryClient.invalidateQueries({ queryKey: ["local-prs"] }),
+            )
+            .catch(() => {
+              // Best-effort: a failed reload just leaves the last known state.
+            });
+          // Same story for review-notes.json — the MCP server can deposit a
+          // per-branch reviewer note while we're unfocused; reload the store
+          // from disk BEFORE invalidating so the refetch sees it.
+          reloadReviewNotes()
+            .then(() =>
+              queryClient.invalidateQueries({ queryKey: ["review-notes"] }),
             )
             .catch(() => {
               // Best-effort: a failed reload just leaves the last known state.

--- a/src/features/automations/AutomationsSection.tsx
+++ b/src/features/automations/AutomationsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { settingsFormOpts } from "@/features/settings/settings-form";
 import { useAutomations, useSaveAutomations } from "@/lib/automations/queries";
 import {
   type ActionId,
@@ -8,6 +9,7 @@ import {
   type LifecycleConfig,
   type LifecycleEvent,
 } from "@/lib/automations/types";
+import { withForm } from "@/lib/form";
 import { toastError } from "@/lib/toast";
 import { useLatestRef } from "@/lib/use-latest-ref";
 import {
@@ -62,142 +64,167 @@ function sortedJson(value: unknown): string {
  * Global automation defaults — the lifecycle grid every repository inherits.
  * Edited as a draft behind a Save/Discard bar (no per-toggle autosave); a repo
  * can then override individual cells from its ⋯ menu.
+ *
+ * The `reviewDraftPrs` toggle at the top is a plain AppSettings field, so it
+ * rides the settings form (`form.AppField`) and the SettingsScreen Save/Discard
+ * footer like every other app-wide preference — separate from the lifecycle
+ * grid's own draft below.
  */
-export function AutomationsSection({
-  onDirtyChange,
-  onRegisterSave,
-}: {
-  onDirtyChange?: (dirty: boolean) => void;
-  /** Lets the host (Settings) fire this panel's save imperatively — e.g. from
-   *  its confirm-close "Save and close". Called with the save fn while there are
-   *  unsaved edits, and with `null` when clean or unmounted. */
-  onRegisterSave?: (save: (() => void) | null) => void;
-}) {
-  const automations = useAutomations();
-  const save = useSaveAutomations();
-  const [draft, setDraft] = useState<LifecycleDraft>({});
+export const AutomationsSection = withForm({
+  ...settingsFormOpts,
+  props: {
+    onDirtyChange: undefined as ((dirty: boolean) => void) | undefined,
+    /** Lets the host (Settings) fire this panel's save imperatively — e.g. from
+     *  its confirm-close "Save and close". Called with the save fn while there
+     *  are unsaved edits, and with `null` when clean or unmounted. */
+    onRegisterSave: undefined as
+      | ((save: (() => void) | null) => void)
+      | undefined,
+  },
+  render: function AutomationsSectionRender({
+    form,
+    onDirtyChange,
+    onRegisterSave,
+  }) {
+    const automations = useAutomations();
+    const save = useSaveAutomations();
+    const [draft, setDraft] = useState<LifecycleDraft>({});
 
-  // Seed the editable draft once the config loads; afterwards the draft owns the
-  // truth until Save or Discard (Save re-invalidates → this re-seeds).
-  const seeded = useRef(false);
-  useEffect(() => {
-    if (automations.data && !seeded.current) {
-      seeded.current = true;
-      setDraft(automations.data.lifecycles);
+    // Seed the editable draft once the config loads; afterwards the draft owns
+    // the truth until Save or Discard (Save re-invalidates → this re-seeds).
+    const seeded = useRef(false);
+    useEffect(() => {
+      if (automations.data && !seeded.current) {
+        seeded.current = true;
+        setDraft(automations.data.lifecycles);
+      }
+    }, [automations.data]);
+
+    const saved = automations.data?.lifecycles ?? {};
+    const dirty = seeded.current && sortedJson(draft) !== sortedJson(saved);
+
+    // Surface dirtiness to the Settings screen so closing with unsaved
+    // automations draft routes through its confirm-close path.
+    useEffect(() => {
+      onDirtyChange?.(dirty);
+      return () => onDirtyChange?.(false);
+    }, [dirty, onDirtyChange]);
+
+    function cellState(lifecycle: LifecycleEvent, action: ActionId): CellState {
+      const cfg = draft[lifecycle]?.actions[action];
+      return {
+        enabled: cfg?.enabled ?? false,
+        conditions: cfg?.conditions,
+        overridden: false,
+      };
     }
-  }, [automations.data]);
 
-  const saved = automations.data?.lifecycles ?? {};
-  const dirty = seeded.current && sortedJson(draft) !== sortedJson(saved);
+    function patchCell(
+      lifecycle: LifecycleEvent,
+      action: ActionId,
+      patch: CellPatch,
+    ) {
+      setDraft((d) => {
+        const life = d[lifecycle] ?? { actions: {} };
+        const existing = life.actions[action] ?? { enabled: false };
+        const nextEnabled = patch.enabled ?? existing.enabled;
+        const nextConditions: BranchConditions | undefined =
+          "conditions" in patch ? patch.conditions : existing.conditions;
 
-  // Surface dirtiness to the Settings screen so closing with unsaved automations
-  // draft routes through its confirm-close path.
-  useEffect(() => {
-    onDirtyChange?.(dirty);
-    return () => onDirtyChange?.(false);
-  }, [dirty, onDirtyChange]);
+        const nextActions = { ...life.actions };
+        // Turning a cell off with no conditions is a net no-op (an absent cell
+        // is already "off") — drop it so the draft doesn't grow or read dirty
+        // for nothing. A disabled cell that still carries conditions is kept
+        // (the user may re-enable it later).
+        if (!nextEnabled && !hasConditions(nextConditions)) {
+          delete nextActions[action];
+        } else {
+          nextActions[action] = {
+            enabled: nextEnabled,
+            conditions: nextConditions,
+          };
+        }
 
-  function cellState(lifecycle: LifecycleEvent, action: ActionId): CellState {
-    const cfg = draft[lifecycle]?.actions[action];
-    return {
-      enabled: cfg?.enabled ?? false,
-      conditions: cfg?.conditions,
-      overridden: false,
-    };
-  }
+        const nextDraft = { ...d };
+        if (Object.keys(nextActions).length === 0) {
+          delete nextDraft[lifecycle];
+        } else {
+          nextDraft[lifecycle] = { ...life, actions: nextActions };
+        }
+        return nextDraft;
+      });
+    }
 
-  function patchCell(
-    lifecycle: LifecycleEvent,
-    action: ActionId,
-    patch: CellPatch,
-  ) {
-    setDraft((d) => {
-      const life = d[lifecycle] ?? { actions: {} };
-      const existing = life.actions[action] ?? { enabled: false };
-      const nextEnabled = patch.enabled ?? existing.enabled;
-      const nextConditions: BranchConditions | undefined =
-        "conditions" in patch ? patch.conditions : existing.conditions;
+    function discard() {
+      setDraft(saved);
+    }
 
-      const nextActions = { ...life.actions };
-      // Turning a cell off with no conditions is a net no-op (an absent cell is
-      // already "off") — drop it so the draft doesn't grow or read dirty for
-      // nothing. A disabled cell that still carries conditions is kept (the user
-      // may re-enable it later).
-      if (!nextEnabled && !hasConditions(nextConditions)) {
-        delete nextActions[action];
-      } else {
-        nextActions[action] = {
-          enabled: nextEnabled,
-          conditions: nextConditions,
-        };
-      }
+    function doSave() {
+      if (!automations.data) return;
+      save.mutate(
+        { ...automations.data, lifecycles: sanitizeLifecycles(draft) },
+        { onError: toastError },
+      );
+    }
 
-      const nextDraft = { ...d };
-      if (Object.keys(nextActions).length === 0) {
-        delete nextDraft[lifecycle];
-      } else {
-        nextDraft[lifecycle] = { ...life, actions: nextActions };
-      }
-      return nextDraft;
-    });
-  }
+    // Register/deregister the imperative save with the host, so Settings' "Save
+    // and close" persists this panel too. Kept in a latest-ref so the registered
+    // fn always saves the current draft without re-registering on every keystroke.
+    const doSaveRef = useLatestRef(doSave);
+    useEffect(() => {
+      if (!onRegisterSave) return;
+      onRegisterSave(dirty ? () => doSaveRef.current() : null);
+      return () => onRegisterSave(null);
+    }, [dirty, onRegisterSave]);
 
-  function discard() {
-    setDraft(saved);
-  }
-
-  function doSave() {
-    if (!automations.data) return;
-    save.mutate(
-      { ...automations.data, lifecycles: sanitizeLifecycles(draft) },
-      { onError: toastError },
-    );
-  }
-
-  // Register/deregister the imperative save with the host, so Settings' "Save and
-  // close" persists this panel too. Kept in a latest-ref so the registered fn
-  // always saves the current draft without re-registering on every keystroke.
-  const doSaveRef = useLatestRef(doSave);
-  useEffect(() => {
-    if (!onRegisterSave) return;
-    onRegisterSave(dirty ? () => doSaveRef.current() : null);
-    return () => onRegisterSave(null);
-  }, [dirty, onRegisterSave]);
-
-  return (
-    <section className="space-y-3">
-      <div>
-        <h2 className="text-sm font-medium">Automations</h2>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Run an AI action automatically when something happens. These defaults
-          apply to every repository; a repository can override them from its ⋯
-          menu. Reviews use the review model configured in the AI section — PR
-          results are posted as a comment, commit results open from a
-          notification.
-        </p>
-      </div>
-      {automations.isPending ? (
-        <Skeleton className="h-40 w-full" />
-      ) : (
-        <>
-          <LifecycleEditor cellState={cellState} onCellPatch={patchCell} />
-          {dirty && (
-            <div className="flex items-center justify-between gap-3 border-t pt-3">
-              <span className="text-xs text-muted-foreground">
-                You have unsaved changes
-              </span>
-              <div className="flex gap-2">
-                <Button variant="outline" size="sm" onClick={discard}>
-                  Discard
-                </Button>
-                <Button size="sm" onClick={doSave} disabled={save.isPending}>
-                  Save changes
-                </Button>
+    return (
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-sm font-medium">Automations</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Run an AI action automatically when something happens. These
+            defaults apply to every repository; a repository can override them
+            from its ⋯ menu. Reviews use the review model configured in the AI
+            section — PR results are posted as a comment, commit results open
+            from a notification.
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <form.AppField name="reviewDraftPrs">
+            {(field) => (
+              <field.CheckboxField
+                label="Review draft PRs when created"
+                className="flex cursor-pointer items-center gap-2 text-xs"
+              />
+            )}
+          </form.AppField>
+          <p className="text-xs text-muted-foreground">
+            Off: automated review runs when a draft is marked ready for review.
+          </p>
+        </div>
+        {automations.isPending ? (
+          <Skeleton className="h-40 w-full" />
+        ) : (
+          <>
+            <LifecycleEditor cellState={cellState} onCellPatch={patchCell} />
+            {dirty && (
+              <div className="flex items-center justify-between gap-3 border-t pt-3">
+                <span className="text-xs text-muted-foreground">
+                  You have unsaved changes
+                </span>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={discard}>
+                    Discard
+                  </Button>
+                  <Button size="sm" onClick={doSave} disabled={save.isPending}>
+                    Save changes
+                  </Button>
+                </div>
               </div>
-            </div>
-          )}
-        </>
-      )}
-    </section>
-  );
-}
+            )}
+          </>
+        )}
+      </section>
+    );
+  },
+});

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1497,8 +1497,9 @@ security audit** as toggles under each. There's no "add a rule" — a given mome
 exists at most once, so you can't create conflicting duplicates. Reviews use the review model
 from the AI section; PR results are posted as a comment, commit results open from a
 notification. **Review draft PRs when created** (off by default) controls draft handling:
-left off, a draft PR gets its automated first review when you mark it ready for review, not
-at creation.
+left off, a draft PR gets its automated first review when it's marked ready for review, not
+at creation — marking it ready **in GitDesktop** always fires that first review, while a
+draft readied elsewhere is picked up by the background catch-up poller within its window.
 
 - **Branch conditions.** Each enabled action can be scoped to branches: *only these branches*
   (include globs) and *except these* (exclude globs — an exclude always wins; an empty include

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -708,7 +708,14 @@ from the branch diff and commit subjects — which additionally **proposes label
 only from the repository's existing labels and added to whatever you've already picked
 (never invented). The same **Generate** button is on the **Edit** dialog too, so you can
 write or regenerate an existing PR's title and description at any time — including for pull
-requests from forks{{/ai}}. Press {{key:mod+enter}} from any field to submit either the
+requests from forks. The Create dialog also has an optional collapsed **Notes for
+reviewers** field below the description — it pre-fills from any notes an agent (or another
+MCP client with write access) deposited for the head branch via the GitDesktop MCP, and
+you can edit or clear it. When you create the PR, the notes post as its **first
+conversation comment** (under a *🗒️ Notes for reviewers* header, from your own account)
+before any automated review runs, and that review reads them as context — so a deliberate,
+documented decision isn't re-flagged. Notes present here also ground the **AI-generated**
+description{{/ai}}. Press {{key:mod+enter}} from any field to submit either the
 **Create** or the **Edit** dialog.{{ai}} While a PR dialog is open, {{kbd:generate-commit-message}}
 runs its **Generate** for you.{{/ai}}
 
@@ -798,7 +805,11 @@ using your chosen review model, and optionally post the result as a comment. A g
 review builds on **soft context** where it exists: your prior review of the PR, findings
 other AI reviewers (Copilot, CodeRabbit) left, and **GitDesktop's own earlier comments on
 the PR** — replies GitDesktop itself posted inside review threads included — so on a re-review it treats a finding
-it already refuted or marked fixed as resolved instead of raising it cold. When rounds
+it already refuted or marked fixed as resolved instead of raising it cold. It also reads
+any **Notes for reviewers** the author left — deposited per branch by an agent through the
+GitDesktop MCP, or typed into the Create PR dialog and posted as the PR's first comment —
+as first-class grounding context, so a deliberate, documented decision isn't re-flagged.
+When rounds
 accumulate past the prompt budget, the newest comments win, and the full history is
 **distilled into a compact decision ledger** (via your generation model) rather than cut
 off. See *AI & automations* to pick the review model. The **Review context** size there
@@ -1485,7 +1496,9 @@ request opened*, and *On new commits to a reviewed PR* — with **AI code review
 security audit** as toggles under each. There's no "add a rule" — a given moment × action
 exists at most once, so you can't create conflicting duplicates. Reviews use the review model
 from the AI section; PR results are posted as a comment, commit results open from a
-notification.
+notification. **Review draft PRs when created** (off by default) controls draft handling:
+left off, a draft PR gets its automated first review when you mark it ready for review, not
+at creation.
 
 - **Branch conditions.** Each enabled action can be scoped to branches: *only these branches*
   (include globs) and *except these* (exclude globs — an exclude always wins; an empty include

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -1,4 +1,5 @@
 import { SparkleIcon, XIcon } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { useEffect, useEffectEvent } from "react";
 import { toast } from "sonner";
@@ -11,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { REVIEWER_NOTES_MARKER } from "@/lib/ai/notes-context";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { required, useAppForm } from "@/lib/form";
 import {
@@ -20,10 +22,13 @@ import {
 } from "@/lib/git/queries";
 import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { updateLocalPr } from "@/lib/pulls/local";
 import { useCreateLocalPr } from "@/lib/pulls/queries";
+import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { ReviewerNotesField } from "./ReviewerNotesField";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
 
@@ -54,6 +59,7 @@ export function CreateLocalPrDialog({
   const aiEnabled = useAiEnabled();
   const selectPr = useUiStore((s) => s.selectPr);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
+  const queryClient = useQueryClient();
 
   const currentName = status.data?.branch?.name ?? null;
   // Branch options with per-branch worktree chips; drops the app-internal
@@ -68,7 +74,7 @@ export function CreateLocalPrDialog({
   ]);
 
   const form = useAppForm({
-    defaultValues: { head: "", base: "", title: "", body: "" },
+    defaultValues: { head: "", base: "", title: "", body: "", notes: "" },
     validators: {
       // Same branch on both sides proposes nothing — gate the submit.
       onChange: ({ value }) =>
@@ -82,10 +88,50 @@ export function CreateLocalPrDialog({
           base: value.base,
           head: value.head,
         });
+        const notes = value.notes.trim();
+        // Reviewer notes are an AI-only surface (the field renders only when AI
+        // is enabled), so append + consume are gated on `aiEnabled` — Hide-AI
+        // adds no comment and consumes no deposit (no behavior change).
+        if (aiEnabled) {
+          // Append the author's reviewer notes as the local PR's first comment —
+          // the marker header + blank line + notes, matching the remote wire
+          // shape (notes-context.ts lifts them by that marker). Author-authored
+          // shape (no synthetic `author`, mirroring useLocalConversation
+          // .addComment), so it renders as the user's own comment. The
+          // `updateLocalPr` path reloads disk first, so a concurrent write is
+          // merged, not clobbered. For local PRs the event below is the ONLY
+          // notes carrier the review sees (the runner's marker-comment fetchers
+          // are remote-only), so this comment is for the user, not the AI.
+          if (notes) {
+            try {
+              await updateLocalPr(repoPath, pr.id, (cur) => ({
+                ...cur,
+                comments: [
+                  ...cur.comments,
+                  {
+                    id: crypto.randomUUID(),
+                    body: `${REVIEWER_NOTES_MARKER}\n\n${notes}`,
+                    createdAt: new Date().toISOString(),
+                  },
+                ],
+              }));
+              await queryClient.invalidateQueries({
+                queryKey: ["local-prs", repoPath],
+              });
+            } catch {
+              toast.error("Local PR created — adding reviewer notes failed.");
+            }
+          }
+          // Consume the deposit — the create consumed the note. Best-effort.
+          void deleteReviewNote(repoPath, value.head).catch(() => undefined);
+        }
         toast.success(`Created local PR: ${pr.title}`);
         setRepoTab("pulls");
         selectPr({ kind: "local", id: pr.id });
         onOpenChange(false);
+        // Local PRs have no draft concept — always fire. The event carries the
+        // notes (the runner's marker-comment fetchers are remote-only, so for a
+        // local PR this is the sole path the review sees them).
         triggerAutomations({
           kind: "pr-open",
           repoPath,
@@ -97,6 +143,7 @@ export function CreateLocalPrDialog({
           body: value.body,
           commitSubjects: ahead.map((c) => c.subject),
           target: { type: "local", id: pr.id },
+          reviewNotes: notes || undefined,
         });
       } catch (e) {
         toastError(e);
@@ -118,6 +165,9 @@ export function CreateLocalPrDialog({
         base: defaultBase ?? fallbackBase,
         title: "",
         body: "",
+        // Cleared on open; ReviewerNotesField re-seeds from the head branch's
+        // deposit (if any) once its query resolves.
+        notes: "",
       },
       { keepDefaultValues: true },
     );
@@ -129,6 +179,8 @@ export function CreateLocalPrDialog({
   // Live head/base drive the "N commits to merge" hint and AI generation.
   const head = useSelector(form.store, (s) => s.values.head);
   const base = useSelector(form.store, (s) => s.values.base);
+  // Live notes feed the AI-description prompt and the ReviewerNotesField seeding.
+  const notes = useSelector(form.store, (s) => s.values.notes);
   const comparison = useCompareBranches(repoPath, base || null, head || null);
   const ahead = comparison.data?.ahead ?? [];
   const sameBranch = base === head;
@@ -144,6 +196,12 @@ export function CreateLocalPrDialog({
         form.setFieldValue("title", d.title);
         form.setFieldValue("body", d.body);
       },
+      // Local PRs keep the base GitHub prompt wording (no provider) and propose
+      // no labels; the trailing arg is the author's reviewer notes, reflected
+      // into the generated description.
+      undefined,
+      [],
+      notes.trim() || undefined,
     );
   }
   // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
@@ -304,6 +362,21 @@ export function CreateLocalPrDialog({
                 />
               )}
             </form.AppField>
+
+            {/* Collapsed "Notes for reviewers": deposit-seeded author context,
+                appended as the local PR's first comment and fed to the AI
+                review via the event. AI-only. */}
+            {aiEnabled && (
+              <form.AppField name="notes">
+                {(field) => (
+                  <ReviewerNotesField
+                    repoPath={repoPath}
+                    head={head || null}
+                    field={field}
+                  />
+                )}
+              </form.AppField>
+            )}
           </div>
 
           <DialogFooter>

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -5,7 +5,7 @@ import {
   TagIcon,
   XIcon,
 } from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
@@ -23,6 +23,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { LabelChip } from "@/features/conversations/Thread";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
+import { REVIEWER_NOTES_MARKER } from "@/lib/ai/notes-context";
 import { track } from "@/lib/analytics";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { required, useAppForm } from "@/lib/form";
@@ -50,8 +51,10 @@ import {
   useRemoteSlug,
   useSetRepoLens,
 } from "@/lib/repo-lens/queries";
+import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
+import { ReviewerNotesField } from "./ReviewerNotesField";
 import { ReviewersPopover } from "./ReviewersPopover";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
@@ -80,6 +83,7 @@ export function CreatePrDialog({
   const createPr = useCreatePr(repoPath);
   const setRepoLens = useSetRepoLens(repoPath);
   const forge = useForgeStatus(repoPath);
+  const queryClient = useQueryClient();
 
   // Fork PR-create: on a GitHub fork (upstream remote present) the dialog offers
   // an explicit "Create in" target — the parent (lens "upstream") or the fork
@@ -224,7 +228,14 @@ export function CreatePrDialog({
   const baseLoading = targetIsParent && parentBranches.isPending;
 
   const form = useAppForm({
-    defaultValues: { head: "", base: "", title: "", body: "", draft: false },
+    defaultValues: {
+      head: "",
+      base: "",
+      title: "",
+      body: "",
+      draft: false,
+      notes: "",
+    },
     validators: {
       // Same branch on both sides proposes nothing — gate the submit. On the
       // parent target the base is an `upstream/<name>` ref, so a local head that
@@ -265,13 +276,48 @@ export function CreatePrDialog({
             ? { assignees: assignees.map((a) => a.id) }
             : {}),
         });
+        const notes = value.notes.trim();
         track({
           name: "pull_request_created",
           properties: {
             is_draft: value.draft,
             has_ai_description: aiDescriptionRef.current,
+            has_review_notes: notes.length > 0,
           },
         });
+        // Reviewer notes are an AI-only surface (the field renders only when AI
+        // is enabled), so the whole post + consume is gated on `aiEnabled` —
+        // Hide-AI must post nothing and consume no deposit (no behavior change).
+        if (aiEnabled) {
+          // Post the author's reviewer notes as the FIRST comment, before the
+          // review fires — this is the whole point of the feature: the automated
+          // review reads the conversation, so the notes must land ahead of it.
+          // `asBot: false` — this is the user's own author content, not a
+          // GitDesktop-branded post. Its own try/catch: a failed post must not
+          // abort the create (the PR exists) — the review still gets the notes
+          // via the `reviewNotes` event below.
+          if (notes) {
+            try {
+              await api.forgePrComment(
+                repoPath,
+                number,
+                `${REVIEWER_NOTES_MARKER}\n\n${notes}`,
+                false,
+                createLens,
+              );
+              // Mirror runner.ts's post-comment invalidation: narrow to this
+              // PR's own key family under the lens it landed on.
+              await queryClient.invalidateQueries({
+                queryKey: ["repo", repoPath, "pr", createLens, number],
+              });
+            } catch {
+              toast.error("PR created — posting reviewer notes failed.");
+            }
+          }
+          // Consume the deposit regardless of whether the comment posted — the
+          // create itself consumed the note. Best-effort; app-data, not the PR.
+          void deleteReviewNote(repoPath, value.head).catch(() => undefined);
+        }
         // Creating on the parent means the new PR lives under the upstream lens —
         // flip the persisted lens so the PRs tab shows it (setter is a no-op when
         // already "upstream").
@@ -288,18 +334,26 @@ export function CreatePrDialog({
         // defer the close and strand the dialog). Want navigation? Hoist it to
         // RepositoryView first, like CreateLocalPrDialog.
         onOpenChange(false);
-        triggerAutomations({
-          kind: "pr-open",
-          repoPath,
-          base: value.base,
-          head: value.head,
-          // `ahead` (git log) is newest-first, so the head is the first entry.
-          headSha: ahead[0]?.hash,
-          title: value.title.trim(),
-          body: value.body,
-          commitSubjects: ahead.map((c) => c.subject),
-          target: { type: "remote", number },
-        });
+        // Draft gate: a draft PR fires no review unless the user opted into
+        // reviewing drafts. A gated-out draft is NOT a lost review — the
+        // background catch-up poller picks it up once the PR is marked ready
+        // (that path landed in wave 1), so don't "fix" this by dropping the gate.
+        const reviewDraftPrs = settings.data?.reviewDraftPrs ?? false;
+        if (!value.draft || reviewDraftPrs) {
+          triggerAutomations({
+            kind: "pr-open",
+            repoPath,
+            base: value.base,
+            head: value.head,
+            // `ahead` (git log) is newest-first, so the head is the first entry.
+            headSha: ahead[0]?.hash,
+            title: value.title.trim(),
+            body: value.body,
+            commitSubjects: ahead.map((c) => c.subject),
+            target: { type: "remote", number },
+            reviewNotes: notes || undefined,
+          });
+        }
       } catch (e) {
         toastError(e);
       }
@@ -334,6 +388,9 @@ export function CreatePrDialog({
         title: "",
         body: "",
         draft: false,
+        // Cleared on open; ReviewerNotesField re-seeds from the head branch's
+        // deposit (if any) once its query resolves.
+        notes: "",
       },
       { keepDefaultValues: true },
     );
@@ -345,6 +402,9 @@ export function CreatePrDialog({
   // Live head/base drive the "N commits" hint, AI generation, and submit gate.
   const head = useSelector(form.store, (s) => s.values.head);
   const base = useSelector(form.store, (s) => s.values.base);
+  // Live notes feed the AI-description prompt (so a generated description can
+  // reflect the reviewer notes) and the ReviewerNotesField's seeding provenance.
+  const notes = useSelector(form.store, (s) => s.values.notes);
 
   // Compute the fork-side fallback base (used both here and when reconciling back
   // from the parent target). Mirrors the seed logic: default branch, else the
@@ -451,6 +511,8 @@ export function CreatePrDialog({
         name: l.name,
         description: l.description,
       })) ?? [],
+      // Author's reviewer notes — reflected into the generated description.
+      notes.trim() || undefined,
     );
   }
   // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
@@ -819,6 +881,20 @@ export function CreatePrDialog({
                 />
               )}
             </form.AppField>
+
+            {/* Collapsed "Notes for reviewers": deposit-seeded author context,
+                posted as the PR's first comment and fed to the AI review. AI-only. */}
+            {aiEnabled && (
+              <form.AppField name="notes">
+                {(field) => (
+                  <ReviewerNotesField
+                    repoPath={repoPath}
+                    head={head || null}
+                    field={field}
+                  />
+                )}
+              </form.AppField>
+            )}
           </div>
 
           <DialogFooter className="sm:items-center">

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -335,9 +335,10 @@ export function CreatePrDialog({
         // RepositoryView first, like CreateLocalPrDialog.
         onOpenChange(false);
         // Draft gate: a draft PR fires no review unless the user opted into
-        // reviewing drafts. A gated-out draft is NOT a lost review — the
-        // background catch-up poller picks it up once the PR is marked ready
-        // (that path landed in wave 1), so don't "fix" this by dropping the gate.
+        // reviewing drafts. A gated-out draft is NOT a lost review — marking it
+        // ready gets it one: an in-app Mark-ready (RemotePrView) fires pr-open
+        // directly, while an EXTERNAL ready flip rides the background catch-up
+        // poller and its 14-day window. So don't "fix" this by dropping the gate.
         const reviewDraftPrs = settings.data?.reviewDraftPrs ?? false;
         if (!value.draft || reviewDraftPrs) {
           triggerAutomations({

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -60,6 +60,7 @@ import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import type { LineWidget } from "@/features/diff/DiffSurface";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
+import { triggerAutomations } from "@/lib/automations/runner";
 import {
   isDeletionBlocked,
   isMergeMethodAllowed,
@@ -591,6 +592,33 @@ export function RemotePrView({
   }
 
   const pr = details.data;
+  // A successful in-app Mark-ready fires a fresh pr-open review directly, so a
+  // draft created with `reviewDraftPrs: false` still gets its first review when
+  // the user readies it here — the catch-up poller only covers PRs within its
+  // 14-day window (sync.ts), so a long-lived draft readied in-app would
+  // otherwise slip through. No eligibility guard is needed: the runner's
+  // per-headSha claim dedup makes this safe — a review already DELIVERED for
+  // this head keeps its claim (a draft reviewed under `reviewDraftPrs: true`
+  // won't double-review), while a cancelled/failed run released it (so a re-fire
+  // proceeds). Mirrors the catch-up event shape (sync.ts); the marker-comment
+  // lift recovers any reviewer notes, so the event carries none.
+  function fireReadyReview() {
+    if (!pr) return;
+    triggerAutomations({
+      kind: "pr-open",
+      repoPath,
+      base: pr.baseRefName,
+      head: pr.headRefName,
+      // gh GraphQL returns commits oldest-first, so the head is the last.
+      headSha: pr.commits.at(-1)?.oid,
+      title: pr.title,
+      // No body/commit subjects on this path — the PR diff is the source of
+      // truth (catch-up + pr-sync fire them empty the same way).
+      body: "",
+      commitSubjects: [],
+      target: { type: "remote", number },
+    });
+  }
   // Each rendered review "claims" the line-comment threads it owns (GitHub
   // `reviewId`; always "" on GitLab/Bitbucket, which don't model reviews).
   // Claimed threads render inline under their review in the timeline; the rest
@@ -1902,7 +1930,10 @@ export function RemotePrView({
               disabled={busy}
               onClick={() =>
                 readyPr.mutate(number, {
-                  onSuccess: () => toast.success("Marked ready for review"),
+                  onSuccess: () => {
+                    toast.success("Marked ready for review");
+                    fireReadyReview();
+                  },
                   onError,
                 })
               }
@@ -1922,7 +1953,10 @@ export function RemotePrView({
                 setDraft.mutate(
                   { number, draft: false },
                   {
-                    onSuccess: () => toast.success("Marked ready for review"),
+                    onSuccess: () => {
+                      toast.success("Marked ready for review");
+                      fireReadyReview();
+                    },
                     onError,
                   },
                 )

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -61,6 +61,7 @@ import type { LineWidget } from "@/features/diff/DiffSurface";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
 import { triggerAutomations } from "@/lib/automations/runner";
+import { prOpenEligible } from "@/lib/automations/sync";
 import {
   isDeletionBlocked,
   isMergeMethodAllowed,
@@ -596,21 +597,26 @@ export function RemotePrView({
   // draft created with `reviewDraftPrs: false` still gets its first review when
   // the user readies it here — the catch-up poller only covers PRs within its
   // 14-day window (sync.ts), so a long-lived draft readied in-app would
-  // otherwise slip through. No eligibility guard is needed: the runner's
-  // per-headSha claim dedup makes this safe — a review already DELIVERED for
-  // this head keeps its claim (a draft reviewed under `reviewDraftPrs: true`
-  // won't double-review), while a cancelled/failed run released it (so a re-fire
-  // proceeds). Mirrors the catch-up event shape (sync.ts); the marker-comment
-  // lift recovers any reviewer notes, so the event carries none.
-  function fireReadyReview() {
+  // otherwise slip through. Gated by `prOpenEligible` — the SAME eligibility the
+  // external catch-up path enforces (no prior review in either mode, head not
+  // dismissed), so the two ready paths behave identically. This guard, not claim
+  // dedup, is what prevents a double review: a manual panel review saves via
+  // `saveReview` WITHOUT taking an automation claim, so claim dedup can't see it
+  // — only this prior-review check can (round-2 finding, PR #91). Mirrors the
+  // catch-up event shape (sync.ts); the marker-comment lift recovers any reviewer
+  // notes, so the event carries none.
+  async function fireReadyReview() {
     if (!pr) return;
+    const headSha = pr.commits.at(-1)?.oid;
+    if (!(await prOpenEligible(repoPath, String(number), headSha ?? "")))
+      return;
     triggerAutomations({
       kind: "pr-open",
       repoPath,
       base: pr.baseRefName,
       head: pr.headRefName,
       // gh GraphQL returns commits oldest-first, so the head is the last.
-      headSha: pr.commits.at(-1)?.oid,
+      headSha,
       title: pr.title,
       // No body/commit subjects on this path — the PR diff is the source of
       // truth (catch-up + pr-sync fire them empty the same way).
@@ -1932,7 +1938,7 @@ export function RemotePrView({
                 readyPr.mutate(number, {
                   onSuccess: () => {
                     toast.success("Marked ready for review");
-                    fireReadyReview();
+                    void fireReadyReview();
                   },
                   onError,
                 })
@@ -1955,7 +1961,7 @@ export function RemotePrView({
                   {
                     onSuccess: () => {
                       toast.success("Marked ready for review");
-                      fireReadyReview();
+                      void fireReadyReview();
                     },
                     onError,
                   },

--- a/src/features/pulls/ReviewerNotesField.tsx
+++ b/src/features/pulls/ReviewerNotesField.tsx
@@ -1,0 +1,160 @@
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
+import { RelativeTime } from "@/components/relative-time";
+import { Button } from "@/components/ui/button";
+import { useReviewNote } from "@/lib/review-notes/queries";
+import { deleteReviewNote } from "@/lib/review-notes/store";
+
+/** The subset of a `form.AppField` child this field needs: the bound
+ *  `MarkdownField` component plus enough of the field api to read the current
+ *  value and to imperatively set/clear it. Kept structural so it fits either
+ *  Create-PR dialog's differently-typed form. */
+interface NotesField {
+  MarkdownField: (props: {
+    placeholder?: string;
+    rows?: number;
+    textareaClassName?: string;
+  }) => ReactNode;
+  state: { value: string };
+  handleChange: (value: string) => void;
+}
+
+const PLACEHOLDER =
+  "Deliberate calls, tradeoffs, and context reviewers should ground against…";
+
+/**
+ * The collapsed "Notes for reviewers" disclosure shared by both Create-PR
+ * dialogs. Gated on AI being enabled by the caller (rendered only then). Seeds
+ * itself from a per-branch note deposit (`useReviewNote`) written earlier — by
+ * this app or the MCP server — and auto-expands when it does, so the author sees
+ * the recovered context. Seeding NEVER clobbers hand-typed content: it applies a
+ * deposit only while the field is pristine (empty, or still exactly the last
+ * value we seeded), tracked via `lastSeedRef`. A head-branch switch on a pristine
+ * field re-seeds from the new branch's deposit (or clears back to empty when the
+ * new branch has none).
+ */
+export function ReviewerNotesField({
+  repoPath,
+  head,
+  field,
+}: {
+  repoPath: string;
+  /** The live head branch the PR merges — keys the note deposit lookup. */
+  head: string | null;
+  /** The form's bound `notes` field (from `<form.AppField name="notes">`). */
+  field: NotesField;
+}) {
+  const [open, setOpen] = useState(false);
+  const regionId = useId();
+  // The exact value we last applied from a deposit. While the field still equals
+  // this (or is empty), it's "pristine" and safe to re-seed; once the user edits
+  // it to anything else, seeding stands down (the PR #40 `userPicked` lesson — an
+  // effect that re-fires must never override an explicit edit).
+  const lastSeedRef = useRef<string | null>(null);
+  // The deposit currently reflected in the field, so the provenance line + Clear
+  // only show for a prefilled (not hand-typed) value. Cleared the moment the user
+  // diverges from the seed.
+  const [seededAt, setSeededAt] = useState<string | null>(null);
+
+  const note = useReviewNote(repoPath, head);
+  const value = field.state.value;
+
+  // Apply the resolved deposit to the field, but ONLY while pristine (empty, or
+  // still exactly the last value we seeded) — never over a hand-typed edit (the
+  // PR #40 `userPicked` lesson). Read as a non-retriggering effect event so the
+  // seed reacts to the deposit/branch, not to every keystroke in `value`.
+  const applyDeposit = useEffectEvent(
+    (body: string, savedAt: string | null) => {
+      const pristine = value === "" || value === lastSeedRef.current;
+      if (!pristine) return;
+      if (body) {
+        if (value !== body) {
+          field.handleChange(body);
+          lastSeedRef.current = body;
+        }
+        setSeededAt(savedAt);
+        setOpen(true);
+      } else if (
+        lastSeedRef.current !== null &&
+        value === lastSeedRef.current
+      ) {
+        // Pristine field still showing a prior branch's seed, new branch has no
+        // deposit — clear it out.
+        field.handleChange("");
+        lastSeedRef.current = null;
+        setSeededAt(null);
+      }
+    },
+  );
+
+  // Seed whenever a deposit is (or becomes) available. A head-branch switch
+  // re-keys `useReviewNote`, so `note.isSuccess`/`note.data` already reflect the
+  // new branch — no separate `head` dep needed. `applyDeposit` is a stable
+  // effect event, so it's intentionally not a dependency. The pristine guard
+  // lives inside `applyDeposit`.
+  useEffect(() => {
+    if (!note.isSuccess) return;
+    applyDeposit(note.data?.body ?? "", note.data?.savedAt ?? null);
+  }, [note.isSuccess, note.data?.body, note.data?.savedAt]);
+
+  // Once the user edits away from the seeded value, drop the provenance affordance
+  // (it no longer reflects what's in the box).
+  useEffect(() => {
+    if (seededAt !== null && value !== lastSeedRef.current) {
+      setSeededAt(null);
+    }
+  }, [value, seededAt]);
+
+  function clear() {
+    field.handleChange("");
+    lastSeedRef.current = null;
+    setSeededAt(null);
+    setOpen(false);
+    // Best-effort: consume the deposit so it won't re-seed. A failure is silent —
+    // the note is app-data, not the PR.
+    if (head) void deleteReviewNote(repoPath, head).catch(() => undefined);
+  }
+
+  return (
+    <div className="text-xs">
+      <button
+        type="button"
+        className="flex items-center gap-1 text-muted-foreground hover:text-foreground"
+        aria-expanded={open}
+        aria-controls={regionId}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? (
+          <CaretDownIcon className="size-3" />
+        ) : (
+          <CaretRightIcon className="size-3" />
+        )}
+        Notes for reviewers
+      </button>
+      {open && (
+        <div id={regionId} className="mt-2 space-y-1.5">
+          <field.MarkdownField
+            placeholder={PLACEHOLDER}
+            rows={4}
+            textareaClassName="ph-no-capture max-h-48 min-h-20 resize-y font-mono"
+          />
+          {seededAt && (
+            <div className="flex items-center justify-between gap-2 text-muted-foreground">
+              <span>
+                Prefilled from a note saved <RelativeTime date={seededAt} />
+              </span>
+              <Button type="button" variant="ghost" size="xs" onClick={clear}>
+                Clear
+              </Button>
+            </div>
+          )}
+          <p className="text-muted-foreground">
+            Posted as the first comment when the PR is created and given to the
+            AI review as context.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -46,6 +46,8 @@ export function useGeneratePrDescription(repoPath: string) {
       }) => void,
       availableLabels: AvailableLabel[],
       provider?: PromptProvider,
+      /** Author's "Notes for reviewers" — reflected into the description. */
+      reviewNotes?: string,
     ) => {
       await run(
         async (settings) => {
@@ -66,6 +68,7 @@ export function useGeneratePrDescription(repoPath: string) {
             headBranch: head,
             repoInstructions,
             globalInstructions: settings.globalInstructions,
+            reviewNotes,
             availableLabels,
             provider,
           });
@@ -103,6 +106,8 @@ export function useGeneratePrDescription(repoPath: string) {
        *  no labels proposed. Invented labels the model returns are dropped by the
        *  parser (which validates on name only). */
       availableLabels: AvailableLabel[] = [],
+      /** Author's "Notes for reviewers" — reflected into the description. */
+      reviewNotes?: string,
     ) =>
       runFromDiff(
         () => gitBranchDiff(repoPath, base, head, RAW_DIFF_MAX_BYTES),
@@ -112,6 +117,7 @@ export function useGeneratePrDescription(repoPath: string) {
         onUpdate,
         availableLabels,
         provider,
+        reviewNotes,
       ),
     [repoPath, runFromDiff],
   );
@@ -135,6 +141,8 @@ export function useGeneratePrDescription(repoPath: string) {
        *  no labels proposed. Invented labels the model returns are dropped by the
        *  parser (which validates on name only). */
       availableLabels: AvailableLabel[] = [],
+      /** Author's "Notes for reviewers" — reflected into the description. */
+      reviewNotes?: string,
     ) =>
       runFromDiff(
         getDiff,
@@ -144,6 +152,7 @@ export function useGeneratePrDescription(repoPath: string) {
         onUpdate,
         availableLabels,
         provider,
+        reviewNotes,
       ),
     [runFromDiff],
   );

--- a/src/features/repository/usePrNotifications.ts
+++ b/src/features/repository/usePrNotifications.ts
@@ -135,7 +135,12 @@ export function usePrNotifications(repoPath: string) {
           createdAt: pr.createdAt,
           isDraft: pr.isDraft,
         }));
-      maybeCatchUpMissedOpen(repoPath, candidates, gh.data?.login ?? null);
+      maybeCatchUpMissedOpen(
+        repoPath,
+        candidates,
+        gh.data?.login ?? null,
+        settings.data?.reviewDraftPrs ?? false,
+      );
     }
 
     if (!before || !prefs) return;

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -267,6 +267,7 @@ export function SettingsScreen() {
               )}
               {activePanel === "automations" && (
                 <AutomationsSection
+                  form={form}
                   onDirtyChange={setAutomationsDirty}
                   onRegisterSave={(fn) => {
                     saveAutomationsRef.current = fn;

--- a/src/lib/ai/notes-context.ts
+++ b/src/lib/ai/notes-context.ts
@@ -1,4 +1,4 @@
-import { forgePrExternalReviews } from "@/lib/git/api";
+import { forgePrExternalReviews, forgePrView } from "@/lib/git/api";
 
 /**
  * Lifts the author's "Notes for reviewers" from the newest conversation comment
@@ -9,6 +9,13 @@ import { forgePrExternalReviews } from "@/lib/git/api";
  * marker comment the dialog posts. Best-effort and remote-only, mirroring the
  * own-comments harvest in `own-context.ts`: any fetch failure, no comments, or no
  * marker match yields `{}`. Never ground truth; the current diff always wins.
+ *
+ * The lifted comment MUST be the PR author's own: the notes section carries
+ * author-level trust in the security review prompt (a documented accepted-risk
+ * disposition), so an ungated lift would let any commenter on a public-repo PR
+ * post a marker-headed comment and be treated as the author (round-1 security
+ * finding, PR #91). Dialog- and MCP-posted notes are the author's own login, so
+ * they pass; do not remove this gate.
  */
 
 /** Wire format: the "Notes for reviewers" dialog posts a conversation comment
@@ -32,18 +39,34 @@ export async function resolveReviewerNotesContext(
   if (!Number.isInteger(prNumber) || prNumber <= 0) return {};
 
   let items: Awaited<ReturnType<typeof forgePrExternalReviews>>;
+  let prAuthor: string;
   try {
     // Origin-pinned, matching `own-context.ts`: notes belong to the fork's own PR.
-    items = await forgePrExternalReviews(repoPath, prNumber, "origin");
+    // The PR fetch gives us the author login to gate the lift on (see module doc).
+    const [reviews, pr] = await Promise.all([
+      forgePrExternalReviews(repoPath, prNumber, "origin"),
+      forgePrView(repoPath, prNumber, "origin"),
+    ]);
+    items = reviews;
+    prAuthor = pr.author;
   } catch {
     return {};
   }
+  // No usable author to compare against ⇒ can't establish authorship ⇒ lift
+  // nothing rather than trust an arbitrary commenter.
+  if (!prAuthor.trim()) return {};
+  const prAuthorKey = prAuthor.trim().toLowerCase();
 
-  // Newest conversation comment whose first non-empty line carries the notes
-  // anchor. Reader is looser than the poster on purpose (see the anchor's doc).
+  // Newest conversation comment BY THE PR AUTHOR whose first non-empty line
+  // carries the notes anchor. Reader is looser than the poster on the marker text
+  // (see the anchor's doc), but authorship is a hard security gate: the notes feed
+  // an author-trusted prompt section (round-1 finding, PR #91). Case-insensitive
+  // to tolerate forge login-casing drift — a stricter compare can only DROP the
+  // author's own notes, never let a non-author through.
   let newest: (typeof items)[number] | undefined;
   for (const it of items) {
     if (it.kind !== "comment") continue;
+    if (it.author.trim().toLowerCase() !== prAuthorKey) continue;
     if (extractNotesBody(it.body) === undefined) continue;
     if (!newest || it.createdAt > newest.createdAt) newest = it;
   }

--- a/src/lib/ai/notes-context.ts
+++ b/src/lib/ai/notes-context.ts
@@ -1,0 +1,73 @@
+import { forgePrExternalReviews } from "@/lib/git/api";
+
+/**
+ * Lifts the author's "Notes for reviewers" from the newest conversation comment
+ * that carries the notes marker, so catch-up and re-review rounds see them even
+ * though those rounds have no dialog event carrying the notes: the fresh-event
+ * path threads the notes straight into the prompt, but a re-review triggered
+ * later (no new event) would otherwise lose them — so we recover them from the
+ * marker comment the dialog posts. Best-effort and remote-only, mirroring the
+ * own-comments harvest in `own-context.ts`: any fetch failure, no comments, or no
+ * marker match yields `{}`. Never ground truth; the current diff always wins.
+ */
+
+/** Wire format: the "Notes for reviewers" dialog posts a conversation comment
+ *  whose body begins with exactly this marker followed by a blank line. Exported
+ *  so the poster and this lifter share one string — never inline it twice. */
+export const REVIEWER_NOTES_MARKER = "🗒️ **Notes for reviewers**";
+
+/** The stable ASCII anchor inside the marker. The READER matches on this — not
+ *  the full `REVIEWER_NOTES_MARKER` — because forge APIs (GitLab/Bitbucket
+ *  especially) may normalize returned comment bodies: CRLF line endings, a
+ *  stripped emoji variation selector (🗒️ is multi-codepoint, U+1F5D2 U+FE0F),
+ *  or leading whitespace all silently break an emoji-anchored `startsWith`.
+ *  Anchoring on this bold literal survives that normalization. Do NOT tighten
+ *  the reader back to the emoji-bearing constant. */
+const REVIEWER_NOTES_ANCHOR = "**Notes for reviewers**";
+
+export async function resolveReviewerNotesContext(
+  repoPath: string,
+  prNumber: number,
+): Promise<{ reviewNotes?: string }> {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) return {};
+
+  let items: Awaited<ReturnType<typeof forgePrExternalReviews>>;
+  try {
+    // Origin-pinned, matching `own-context.ts`: notes belong to the fork's own PR.
+    items = await forgePrExternalReviews(repoPath, prNumber, "origin");
+  } catch {
+    return {};
+  }
+
+  // Newest conversation comment whose first non-empty line carries the notes
+  // anchor. Reader is looser than the poster on purpose (see the anchor's doc).
+  let newest: (typeof items)[number] | undefined;
+  for (const it of items) {
+    if (it.kind !== "comment") continue;
+    if (extractNotesBody(it.body) === undefined) continue;
+    if (!newest || it.createdAt > newest.createdAt) newest = it;
+  }
+  if (!newest) return {};
+
+  const reviewNotes = extractNotesBody(newest.body);
+  if (!reviewNotes) return {};
+  return { reviewNotes };
+}
+
+/** Returns the notes body from a comment whose FIRST non-empty line is the notes
+ *  header (that trimmed line — trailing `\r` tolerated — CONTAINS the ASCII
+ *  anchor), stripping that whole header line and any following blank lines;
+ *  `undefined` when it is not a notes comment, `""` when it is but carries no
+ *  body. Line-scanned rather than `startsWith` so forge body normalization
+ *  (CRLF, stripped variation selector, leading whitespace) can't hide the notes. */
+function extractNotesBody(body: string): string | undefined {
+  const lines = body.split("\n");
+  const firstNonBlank = lines.findIndex((l) => l.trim() !== "");
+  if (firstNonBlank < 0) return undefined;
+  if (!lines[firstNonBlank].trim().includes(REVIEWER_NOTES_ANCHOR))
+    return undefined;
+  return lines
+    .slice(firstNonBlank + 1)
+    .join("\n")
+    .trim();
+}

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -233,6 +233,15 @@ export function buildPrPrompt(input: PrPromptInput): {
   }
   promptParts.push(`## Files changed\n${fileSummary || "(none)"}`);
 
+  // Author's "Notes for reviewers" — reflect the recorded decisions in the
+  // description, don't paste them verbatim. Same trim + 8000-char slice guard as
+  // the review prompt's notes section.
+  if (input.reviewNotes?.trim()) {
+    promptParts.push(
+      `## Author's notes for reviewers (context — reflect the decisions, don't paste verbatim)\n${input.reviewNotes.trim().slice(0, 8000)}`,
+    );
+  }
+
   let diffSection = `## Combined diff\n${budgeted.text}`;
   if (budgeted.truncated || input.diffTruncated) {
     const omitted =
@@ -281,7 +290,7 @@ Write the review in GitHub-flavored Markdown:
   - the problem — and for **blocker**/**should-fix**, the concrete case that makes it real (the input, state, or code path that triggers it, not just an assertion);
   - a concrete suggested fix.
 - Cover real issues across correctness (bugs, logic errors, unhandled edge cases or errors), security smells, performance traps, clarity and naming, and missing or weak tests. Breadth is welcome — but only where each finding is genuinely useful.
-- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't flag missing tests for changes that introduce no new behavior (renames, reformatting, or pure reorganization). Before flagging a possible null/undefined or missing-value issue, check the typed contract: a field the types declare non-optional, or that every code path visibly always sets, is not a finding. If a finding claims a specific value flows into a specific parameter or limit (e.g. "X arrives as \`goal\`, then gets sliced to 6,000 chars"), you must trace that value INTO that parameter at a real call site shown in the diff or in code you have read — a same-named local variable or a mention in a doc comment is NOT a trace; if you cannot show the call-site mapping, omit the finding.
+- Signal over volume: include a finding only if you are confident it is real; if you are unsure, leave it out. Prefer a few high-value findings over an exhaustive list, and keep nits few — never let them crowd out the real issues. Don't flag formatting a linter/formatter handles, don't restate the same nit across files, and don't flag missing tests for changes that introduce no new behavior (renames, reformatting, or pure reorganization). Before flagging a convention, docs-sync, scope, or missing-hardening omission, check the author's description AND the "Author's notes for reviewers" section for an explicit deliberate-decision note covering it; if one is present, acknowledge the recorded decision in one line instead of re-flagging it as new. Before flagging a possible null/undefined or missing-value issue, check the typed contract: a field the types declare non-optional, or that every code path visibly always sets, is not a finding. If a finding claims a specific value flows into a specific parameter or limit (e.g. "X arrives as \`goal\`, then gets sliced to 6,000 chars"), you must trace that value INTO that parameter at a real call site shown in the diff or in code you have read — a same-named local variable or a mention in a doc comment is NOT a trace; if you cannot show the call-site mapping, omit the finding.
 - Be specific and grounded strictly in the diff — do not invent code, files, or behavior you cannot see. If the change looks solid, say so plainly in a line or two and stop.
 
 No filler: don't summarize what you reviewed, don't pad, don't add compliments — just the assessment and the findings. Do not wrap the whole review in a code fence. Do not restate the entire diff.`;
@@ -291,6 +300,7 @@ const SECURITY_REVIEW_SYSTEM = `You are a senior application security engineer p
 Guiding rules:
 - False positives are worse than misses. Flag an issue only when you can name a concrete attack path from attacker-controlled input to impact and are >80% confident it is real.
 - Before dismissing a risky sink as safe, name the specific guard that makes it safe (the sanitizer, the safe-by-default API, the trust boundary). If you cannot name it, investigate further — do not assume.
+- A documented, scoped accepted tradeoff in the author's description or the "Author's notes for reviewers" section is a disposition to verify against, not a fresh finding — treat it as the author's recorded risk decision. Still flag it if the note's claimed guard does not actually exist in the code you can see.
 
 Examine these categories where the diff touches them. The Non-Issues are NOT findings:
 - Injection (SQL/NoSQL, command, path traversal, XXE, template/SSTI, eval/dynamic code, unsafe deserialization). Issue: building queries/commands/markup from untrusted input by concatenation when a safe-by-default API exists, or insufficient/wrongly-ordered escaping. Non-issue: safe-by-default APIs that escape for you; inputs you cannot establish as untrusted.
@@ -474,6 +484,15 @@ export function buildReviewPrompt(
   }
   if (input.body.trim()) {
     promptParts.push(`## Author's description\n${input.body.trim()}`);
+  }
+  // Author's deliberate "Notes for reviewers" — author input like the description
+  // above, NOT bot soft-context, so it lives OUTSIDE `budgetReviewExtras` and is
+  // capped only by the 8000-char slice (same guard idiom as the plan-prompt
+  // issueBody slice below). Mode-agnostic: it feeds both general and security runs.
+  if (input.reviewNotes?.trim()) {
+    promptParts.push(
+      `## Author's notes for reviewers\n${input.reviewNotes.trim().slice(0, 8000)}`,
+    );
   }
   if (input.commitSubjects.length > 0) {
     promptParts.push(

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -72,6 +72,10 @@ export interface PrPromptInput {
   headBranch: string;
   repoInstructions: string | null;
   globalInstructions: string;
+  /** Author-provided "Notes for reviewers" — the deliberate calls behind the
+   *  change. Reflected into the generated description (never pasted verbatim) so
+   *  it captures the recorded decisions. Absent ⇒ the section is omitted. */
+  reviewNotes?: string;
   /** The repo's existing labels, each with its stated purpose (description) when
    *  it has one. When non-empty, the model is asked to end its output with a
    *  `Labels:` line choosing ONLY from these; the parser drops anything not in
@@ -115,6 +119,11 @@ export interface ReviewPromptInput {
   diffText: string;
   diffTruncated: boolean;
   files: { path: string; added: number; deleted: number; isBinary: boolean }[];
+  /** Author-provided "Notes for reviewers" — the author's deliberate calls behind
+   *  the change. Treated as author input like `body` (NOT soft bot context), so it
+   *  is fed to both review modes and never subject to the extras budget. Absent ⇒
+   *  the section is omitted; the prompt is byte-for-byte identical to before. */
+  reviewNotes?: string;
   /** Prior review's raw finding markdown — soft, re-verifiable context. When
    *  absent, the prompt is byte-for-byte identical to a first-ever review. */
   priorFindings?: string;

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -22,7 +22,11 @@ export type AnalyticsEvent =
     }
   | {
       name: "pull_request_created";
-      properties: { is_draft: boolean; has_ai_description: boolean };
+      properties: {
+        is_draft: boolean;
+        has_ai_description: boolean;
+        has_review_notes: boolean;
+      };
     }
   | {
       name: "ai_review_triggered";

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -6,6 +6,7 @@ import {
   type ExternalContext,
   resolveExternalContext,
 } from "@/lib/ai/external-context";
+import { resolveReviewerNotesContext } from "@/lib/ai/notes-context";
 import {
   type OwnCommentsContext,
   resolveOwnCommentsContext,
@@ -57,6 +58,11 @@ export type AutomationEvent =
       title: string;
       body: string;
       commitSubjects: string[];
+      /** The author's "Notes for reviewers", carried straight from the Create-PR
+       *  dialogs so the review that fires on open sees them without a comment
+       *  round-trip. Absent on catch-up / synthesized events (those recover the
+       *  notes from the marker comment via `resolveReviewerNotesContext`). */
+      reviewNotes?: string;
       target:
         | { type: "remote"; number: number }
         | { type: "local"; id: string };
@@ -446,8 +452,24 @@ async function generateReviewText(
   );
   if (signal.aborted) return null;
 
+  // The author's reviewer notes. Fresh pr-open events carry them straight from
+  // the create dialog (no round-trip); catch-up / pr-sync rounds have no such
+  // event, so fall back to lifting them from the marker comment the dialog posted
+  // (remote PRs only — the runner's comment fetchers are remote-only). The
+  // event-carried notes win when present.
+  const eventNotes =
+    event.kind === "pr-open" && event.reviewNotes?.trim()
+      ? { reviewNotes: event.reviewNotes }
+      : undefined;
+
   const isRemotePr = event.kind !== "commit" && event.target.type === "remote";
-  const [external, own]: [ExternalContext, OwnCommentsContext] = isRemotePr
+  // Resolve external + own + (when not event-carried) reviewer-notes context in
+  // parallel — all three are independent, best-effort remote harvests.
+  const [external, own, resolvedNotes]: [
+    ExternalContext,
+    OwnCommentsContext,
+    { reviewNotes?: string },
+  ] = isRemotePr
     ? await Promise.all([
         resolveExternalContext(
           event.repoPath,
@@ -468,9 +490,19 @@ async function generateReviewText(
             ownBudgetChars: budgetProfile.ownCharBudget,
           },
         ),
+        // Skip the fetch when the event already carries the notes.
+        eventNotes
+          ? Promise.resolve({})
+          : resolveReviewerNotesContext(
+              event.repoPath,
+              (event.target as { type: "remote"; number: number }).number,
+            ),
       ])
-    : [{}, {}];
+    : [{}, {}, {}];
   if (signal.aborted) return null;
+
+  // Event-carried notes take precedence over the lifted marker comment.
+  const notes = eventNotes ?? resolvedNotes;
 
   const { system, prompt } = buildReviewPrompt(
     {
@@ -490,6 +522,7 @@ async function generateReviewText(
       ...prior,
       ...own,
       ...external,
+      ...notes,
     },
     mode,
   );

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -125,15 +125,18 @@ export interface CatchUpCandidate {
  * through the untouched runner (claim dedup → review → post → record → toast).
  * Do NOT "simplify" this away: without it, externally-opened PRs get zero signal.
  *
- * Scope is deliberately narrow (user-locked): the viewer's OWN, non-draft, open,
- * recent PRs with no prior review (any mode) and no dismissed head. At most ONE
- * PR is caught up per call (the oldest), bounding burst token spend — the next
- * tick takes the next one.
+ * Scope is deliberately narrow (user-locked): the viewer's OWN, open, recent
+ * PRs with no prior review (any mode) and no dismissed head. Drafts are included
+ * only when `reviewDrafts` is set (the `reviewDraftPrs` setting); off (the
+ * default) they're skipped until marked ready for review. At most ONE PR is
+ * caught up per call (the oldest), bounding burst token spend — the next tick
+ * takes the next one.
  */
 export function maybeCatchUpMissedOpen(
   repoPath: string,
   candidates: CatchUpCandidate[],
   viewerLogin: string | null,
+  reviewDrafts: boolean,
 ): void {
   // A null login means we can't tell which PRs are the viewer's — never guess.
   if (!viewerLogin) return;
@@ -146,7 +149,9 @@ export function maybeCatchUpMissedOpen(
     .filter((c) => {
       if (!c.currentHeadSha) return false;
       if (c.author !== viewerLogin) return false;
-      if (c.isDraft) return false;
+      // Drafts are caught up only when the reviewDraftPrs setting is on;
+      // otherwise they wait until marked ready for review.
+      if (c.isDraft && !reviewDrafts) return false;
       const opened = Date.parse(c.createdAt);
       if (Number.isNaN(opened)) return false;
       if (now - opened > CATCH_UP_WINDOW_MS) return false;

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -187,32 +187,45 @@ export function maybeCatchUpMissedOpen(
 }
 
 /**
- * Async eligibility for a catch-up: true only when NO review record exists for
- * this PR in EITHER mode (a manual OR automated review in general or security
- * counts as "the user knows this PR" and suppresses catch-up), and no dismissed
- * head matches the current head in either mode. Errors swallow to `false` — a
- * store hiccup must never fire a redundant review. Runs after the synchronous
+ * Async eligibility to fire a first `pr-open` review for a remote PR: true only
+ * when NO review record exists for it in EITHER mode (a manual OR automated
+ * review in general or security counts as "the user knows this PR" and
+ * suppresses it), and no dismissed head matches the current head in either mode.
+ * Errors swallow to `false` (fail-closed) — a store hiccup must never fire a
+ * redundant review.
+ *
+ * Shared by the catch-up poller (via {@link catchUpEligible}) and the in-app
+ * Mark-ready trigger (RemotePrView), so both ready paths stay behaviorally
+ * identical. It's the ONLY guard that covers a manual panel review: those save
+ * via `saveReview` without taking an automation claim, so the runner's
+ * per-headSha claim dedup can't see them — this prior-review check can.
+ */
+export async function prOpenEligible(
+  repoPath: string,
+  ref: string,
+  currentHeadSha: string,
+): Promise<boolean> {
+  try {
+    const modes = ["general", "security"] as const;
+    for (const mode of modes) {
+      const prior = await getLatestReview(repoPath, "remote", ref, mode);
+      if (prior) return false;
+      const dismissed = await getDismissedHead(repoPath, "remote", ref, mode);
+      if (dismissed && sameSha(dismissed, currentHeadSha)) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Catch-up wrapper over {@link prOpenEligible}. Runs after the synchronous
  * attempt-mark, so a failure here won't re-enter the same PR this session.
  */
 async function catchUpEligible(
   repoPath: string,
   pick: CatchUpCandidate,
 ): Promise<boolean> {
-  try {
-    const modes = ["general", "security"] as const;
-    for (const mode of modes) {
-      const prior = await getLatestReview(repoPath, "remote", pick.ref, mode);
-      if (prior) return false;
-      const dismissed = await getDismissedHead(
-        repoPath,
-        "remote",
-        pick.ref,
-        mode,
-      );
-      if (dismissed && sameSha(dismissed, pick.currentHeadSha)) return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
+  return prOpenEligible(repoPath, pick.ref, pick.currentHeadSha);
 }

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -122,7 +122,12 @@ export function useBackgroundPrSync(): void {
                 createdAt: pr.createdAt,
                 isDraft: pr.isDraft,
               }));
-            maybeCatchUpMissedOpen(path, candidates, status.login ?? null);
+            maybeCatchUpMissedOpen(
+              path,
+              candidates,
+              status.login ?? null,
+              settings.reviewDraftPrs,
+            );
           }
         } catch {
           // One bad repo (deleted/moved path, transient forge error) must not

--- a/src/lib/review-notes/queries.ts
+++ b/src/lib/review-notes/queries.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { deleteReviewNote, getReviewNote } from "./store";
+
+export const reviewNoteKey = (repo: string, branch: string) =>
+  ["review-notes", repo, branch] as const;
+
+/** The stored "Notes for reviewers" deposit for a branch, or null when none
+ *  exists. Disabled until a non-empty branch is known. */
+export function useReviewNote(repo: string, branch: string | null) {
+  return useQuery({
+    queryKey: reviewNoteKey(repo, branch ?? ""),
+    // Only runs when enabled, so `branch` is guaranteed a non-empty string.
+    queryFn: () => getReviewNote(repo, branch as string),
+    enabled: Boolean(branch),
+  });
+}
+
+/** Deletes a branch's reviewer note, invalidating every review-note query for
+ *  the repo on settle (mirrors `useLocalPrMutation`'s invalidate-on-settle). */
+export function useDeleteReviewNote(repo: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (branch: string) => deleteReviewNote(repo, branch),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: ["review-notes", repo] }),
+  });
+}

--- a/src/lib/review-notes/store.ts
+++ b/src/lib/review-notes/store.ts
@@ -1,0 +1,125 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import { repoIdentity } from "@/lib/git/repo-identity";
+import { storeName } from "@/lib/test-mode";
+
+/** A per-branch "Notes for reviewers" deposit, keyed by the repo's
+ *  worktree-stable identity then the branch name. Written by the GUI's
+ *  Create-PR dialogs and, out-of-process, by the MCP server. */
+export interface ReviewNote {
+  body: string;
+  savedAt: string;
+}
+
+/** The branch → note map stored at a single identity key. The store's TOP-LEVEL
+ *  keys are identity keys (no wrapper) — the exact layout the Rust mirror
+ *  (`src-tauri/src/review_notes.rs`) reads/writes, matching the local-prs
+ *  precedent (`store.set(identityKey, …)`). */
+type BranchNotes = Record<string, ReviewNote>;
+
+// Personal app-data, keyed by the repo's worktree-stable identity — never
+// written into the repo itself.
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("review-notes.json"), {
+    autoSave: true,
+    defaults: {},
+  });
+  return storePromise;
+}
+
+// Serialize every read-modify-write on this store (and the reconcile reload)
+// through one in-process queue. Without it, two overlapping mutations each
+// reload the SAME pre-flush disk snapshot — autoSave persists on a ~100ms
+// debounce, so the first write isn't on disk yet — and the later write drops
+// the earlier one's change (a lost update; the settings-store write-race rule).
+// Running them one at a time, plus the force-save in writeBranch, guarantees
+// each reload sees a current snapshot.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  // Tolerate a missing store file. Asymmetry: `load()` tolerates a missing file
+  // but `reload()` rejects with a raw io error ("The system cannot find the file
+  // specified. (os error 2)") — the file only exists after the first `save()`.
+  // Without this guard the first-ever mutation throws before reaching `save()`,
+  // so the store can never bootstrap; an external delete of the file breaks every
+  // mutation the same way. Fall back to the loaded in-memory state on ANY reload
+  // failure — the serialized op-chain + force-save still protect the write path.
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing/unreadable file — proceed with in-memory state; the next save()
+    // creates it.
+  }
+}
+
+/** Re-read `review-notes.json` from disk into the in-memory store. The MCP
+ *  server (with `--allow-write`) can mutate this file externally; without a
+ *  reload the autoSave store would clobber those writes on the next GUI
+ *  mutation. `ignoreDefaults` fully matches the store to disk (so external
+ *  deletes drop). Serialized so it can't land between another mutation's set and
+ *  its flush. */
+export async function reloadReviewNotes(): Promise<void> {
+  return serialize(reloadRaw);
+}
+
+// This store has NO legacy checkout-path keys (it postdates identity-keying), so
+// we key on the identity directly — no `identityKeyFor` fold is needed.
+async function keyFor(repo: string): Promise<string> {
+  return repoIdentity(repo);
+}
+
+async function writeBranch(
+  key: string,
+  branch: string,
+  note: ReviewNote | null,
+): Promise<void> {
+  const store = await getStore();
+  const branches = { ...((await store.get<BranchNotes>(key)) ?? {}) };
+  if (note === null) {
+    delete branches[branch];
+  } else {
+    branches[branch] = note;
+  }
+  // Mirror the Rust writer's semantics exactly: an emptied branch map DROPS the
+  // identity key from the store (never a lingering empty object), so the two
+  // processes agree on the file layout.
+  if (Object.keys(branches).length === 0) {
+    await store.delete(key);
+  } else {
+    await store.set(key, branches);
+  }
+  // Flush now instead of on autoSave's debounce, so the next serialized reload
+  // can't re-read a pre-write disk snapshot and drop this change.
+  await store.save();
+}
+
+/** The reviewer note for `repo`'s `branch`, or null if none is stored. */
+export async function getReviewNote(
+  repo: string,
+  branch: string,
+): Promise<ReviewNote | null> {
+  const store = await getStore();
+  const id = await repoIdentity(repo);
+  const branches = await store.get<BranchNotes>(id);
+  return branches?.[branch] ?? null;
+}
+
+/** Removes the reviewer note for `repo`'s `branch` (no-op if absent). */
+export async function deleteReviewNote(
+  repo: string,
+  branch: string,
+): Promise<void> {
+  return serialize(async () => {
+    // Fresh disk state first, so we don't drop a concurrent external MCP write.
+    await reloadRaw();
+    const key = await keyFor(repo);
+    await writeBranch(key, branch, null);
+  });
+}

--- a/src/lib/review-notes/store.ts
+++ b/src/lib/review-notes/store.ts
@@ -3,8 +3,9 @@ import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
 
 /** A per-branch "Notes for reviewers" deposit, keyed by the repo's
- *  worktree-stable identity then the branch name. Written by the GUI's
- *  Create-PR dialogs and, out-of-process, by the MCP server. */
+ *  worktree-stable identity then the branch name. Written (out-of-process) by
+ *  the MCP server's `set_review_notes`; the GUI's Create-PR dialogs only read
+ *  (`getReviewNote`) and consume (`deleteReviewNote`) deposits. */
 export interface ReviewNote {
   body: string;
   savedAt: string;

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -240,6 +240,11 @@ export interface AppSettings {
   autoFetch: boolean;
   /** How often the background fetch runs, in minutes. */
   autoFetchInterval: AutoFetchInterval;
+  /** Run the automated first review when a draft PR is created. Off by default:
+   *  the automated review then waits until the draft is marked ready for review.
+   *  Read undefined-safe (absent on settings stored before this field existed →
+   *  `false`) via the DEFAULT_SETTINGS spread in loadSettings. */
+  reviewDraftPrs: boolean;
   /** First-run nudge toward the user guide; set once the user opens or dismisses it. */
   seenGuideNudge: boolean;
   /** Send anonymous usage events to PostHog. Default on (opt-out). */
@@ -316,6 +321,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   autoCheckUpdates: true,
   autoFetch: true,
   autoFetchInterval: "10",
+  reviewDraftPrs: false,
   seenGuideNudge: false,
   analyticsEnabled: true,
   recordReplay: false,


### PR DESCRIPTION
Give authors a way to record deliberate implementation decisions before review so AI reviewers can use that context and avoid re-flagging accepted tradeoffs. Reviewer notes can be deposited per branch through MCP or entered during PR creation, while draft PRs can now defer their first automated review until they are marked ready.

### Reviewer notes

- Adds per-repository, per-branch reviewer-note storage in `src-tauri/src/review_notes.rs` and `src/lib/review-notes/store.ts`, including atomic writes, app-data mirroring, reload handling, and serialized updates.
- Adds the `set_review_notes` MCP tool in `src-tauri/src/mcp_server/write_local.rs` for agents and other write-enabled MCP clients to create, update, or clear local notes after validating the branch.
- Adds `ReviewerNotesField` in `src/features/pulls/ReviewerNotesField.tsx`, which pre-fills notes for the selected head branch without overwriting user edits and allows authors to clear deposited notes.
- Integrates reviewer notes into remote and local PR creation in `src/features/pulls/CreatePrDialog.tsx` and `src/features/pulls/CreateLocalPrDialog.tsx`; remote notes are posted as the first PR comment, local notes are stored as the first local conversation comment, and consumed deposits are removed after creation.
- Updates `src/features/pulls/useGeneratePrDescription.ts`, `src/lib/ai/types.ts`, and `src/lib/ai/prompt.ts` so generated descriptions can reflect reviewer notes and review prompts treat them as author-provided context.
- Adds marker-based recovery in `src/lib/ai/notes-context.ts` and integrates it with `src/lib/automations/runner.ts` so later remote reviews can recover notes from the first PR comment.
- Reloads externally written notes when the app regains focus in `src/App.tsx` and invalidates the related queries.

### Draft review controls

- Adds the `reviewDraftPrs` setting, defaulting to `false`, in `src/lib/settings/api.ts`.
- Connects the setting to the shared settings form and Automations panel in `src/features/automations/AutomationsSection.tsx` and `src/features/settings/SettingsScreen.tsx`.
- Gates initial review triggering for draft PRs in `src/features/pulls/CreatePrDialog.tsx`.
- Updates missed-open catch-up behavior in `src/lib/automations/sync.ts`, `src/lib/automations/useBackgroundPrSync.ts`, and `src/features/repository/usePrNotifications.ts` so drafts remain deferred unless the setting is enabled.

### Documentation and product metadata

- Documents reviewer notes and draft review behavior in `README.md`, `src/features/help/content.ts`, and `changelog.d/added-reviewer-notes.md`.
- Advertises reviewer-note support in `site/src/data/capabilities.ts`.
- Adds analytics tracking for whether created PRs include reviewer notes in `src/lib/analytics/track.ts`.
- Ignores Playwright MCP artifacts through `.gitignore`.