### PR TITLE
feat(lan,companion,settings): mirror Hide AI preference in companion

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -7,7 +7,9 @@
   agent sessions** stream in as they happen. Your phone always sees the repository open
   on this desktop, and you can **share and unshare additional repositories** (from the
   panel or the command palette) to keep them reachable while you work in another —
-  switching repos no longer cuts a phone watching a shared repository. Off by default, with per-device tokens
+  switching repos no longer cuts a phone watching a shared repository. The companion honors
+  your **Hide AI features** setting — turn it on and the phone's Agents tab and live agent-run
+  watching disappear too, matching the desktop. Off by default, with per-device tokens
   you can review and revoke at any time (even while sharing is off), and connected
   phones are disconnected the moment you stop sharing, unshare a repository, or revoke their
   device. While sharing is on, GitDesktop keeps your computer awake so a phone can keep

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -44,7 +44,12 @@ export default function App() {
   // PR-75 lockout budget). See `useRepos`.
   const reposQuery = useRepos(!route.isPairing);
   const reposErr = asApiError(reposQuery.error);
-  const repos = reposQuery.data;
+  // `/api/repos` is now an envelope `{ repos, hideAi }`. Destructure the list (what
+  // every downstream consumer expects) and the desktop's "Hide AI features"
+  // preference. `hideAi` defaults false until the list loads — AI surfaces show by
+  // default and hide only once the desktop says so, matching the desktop's own gate.
+  const repos = reposQuery.data?.repos;
+  const hideAi = reposQuery.data?.hideAi ?? false;
 
   // Remember the last SCOPED route context (which repo + tab the user was on) so
   // the picker — reached via `#repos`, whose hash carries NO repo segment — can
@@ -104,6 +109,21 @@ export default function App() {
     }
   }, [route, repos]);
 
+  // Hide AI: when the desktop has "Hide AI features" on, the Agents tab and the
+  // agent-watch screen must be unreachable on the phone, matching the desktop. Any
+  // agents route (scoped `#r/{id}/agents[/streamId]` OR the legacy repo-less
+  // `#agents[/streamId]`) REPLACES to the status tab for the same scope. Gate
+  // strictly on the list having LOADED (`reposQuery.data !== undefined`) so we never
+  // redirect on the stale-undefined default and flicker the tab away mid-load. A flag
+  // flip mid-watch converges on the next poll (≤15s): this effect re-runs when
+  // `hideAi` turns true and unmounts the live stream — the intended behavior.
+  useEffect(() => {
+    if (reposQuery.data === undefined) return; // wait for the real value
+    if (!hideAi || route.tab !== "agents" || route.isPairing || route.isRepos)
+      return;
+    replace(route.repoId != null ? repoHash(route.repoId, "status") : "#status");
+  }, [reposQuery.data, hideAi, route]);
+
   if (route.isPairing) {
     return <Pair />;
   }
@@ -149,6 +169,7 @@ export default function App() {
           repos={repos}
           selectedRepo={selectedRepo}
           pickerContext={chromeContext}
+          hideAi={hideAi}
           reposError={reposQuery.error}
           onReposRetry={() => reposQuery.refetch()}
         />
@@ -159,7 +180,7 @@ export default function App() {
           remembered repo they navigate to that repo's tabs (a real leave-the-picker
           affordance). Off the picker it always shows, scoped to the live repo. */}
       {route.isRepos && !chromeContext ? null : (
-        <BottomNav repoId={chromeContext?.repoId ?? null} />
+        <BottomNav repoId={chromeContext?.repoId ?? null} hideAi={hideAi} />
       )}
     </div>
   );
@@ -202,6 +223,7 @@ function Shell({
   repos,
   selectedRepo,
   pickerContext,
+  hideAi,
   reposError,
   onReposRetry,
 }: {
@@ -209,6 +231,7 @@ function Shell({
   repos: RepoSummary[] | undefined;
   selectedRepo: RepoSummary | null;
   pickerContext: { repoId: string; tab: Tab } | null;
+  hideAi: boolean;
   reposError: unknown;
   onReposRetry: () => void;
 }) {
@@ -248,10 +271,18 @@ function Shell({
     return <ReposBody currentRepoId={route.repoId} currentTab={route.tab} />;
   }
 
-  return <Screen route={route} repoId={route.repoId} />;
+  return <Screen route={route} repoId={route.repoId} hideAi={hideAi} />;
 }
 
-function Screen({ route, repoId }: { route: Route; repoId: string }) {
+function Screen({
+  route,
+  repoId,
+  hideAi,
+}: {
+  route: Route;
+  repoId: string;
+  hideAi: boolean;
+}) {
   if (route.tab === "prs") {
     return route.detailId != null ? (
       <PrDetail repoId={repoId} number={route.detailId} />
@@ -273,14 +304,19 @@ function Screen({ route, repoId }: { route: Route; repoId: string }) {
     // a change of either forces a fresh mount (resetting the SSE reducer state) —
     // no current path swaps them under a mounted watch, but keying makes that a
     // non-footgun rather than relying on it never happening.
+    // `hideAi` is a defensive guard: the redirect effect in App already bounces any
+    // agents route to status when Hide AI is on, so this branch normally can't render
+    // hidden. It covers the one-frame race before that effect runs (both components
+    // render null when `hideAi`).
     return route.streamId != null ? (
       <AgentWatch
         key={`${repoId}:${route.streamId}`}
         repoId={repoId}
         id={route.streamId}
+        hideAi={hideAi}
       />
     ) : (
-      <AgentsBody repoId={repoId} active />
+      <AgentsBody repoId={repoId} active hideAi={hideAi} />
     );
   }
   return <StatusBody repoId={repoId} active />;

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -121,7 +121,9 @@ export default function App() {
     if (reposQuery.data === undefined) return; // wait for the real value
     if (!hideAi || route.tab !== "agents" || route.isPairing || route.isRepos)
       return;
-    replace(route.repoId != null ? repoHash(route.repoId, "status") : "#status");
+    replace(
+      route.repoId != null ? repoHash(route.repoId, "status") : "#status",
+    );
   }, [reposQuery.data, hideAi, route]);
 
   if (route.isPairing) {

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -79,19 +79,29 @@ function tabHash(tab: Tab, repoId: string | null): string {
 /** Bottom tab nav. Each tab is a real link (Tab-focusable) scoped to the selected
  *  repo; the active tab is marked with `aria-current`. Left/Right arrows move
  *  between tabs (roving). No tab is active on the picker (`#repos`) — it isn't a
- *  tab. */
-export function BottomNav({ repoId }: { repoId: string | null }) {
+ *  tab. When `hideAi` is set (the desktop's "Hide AI features" preference) the
+ *  Agents tab is dropped so the phone matches the desktop; the grid and the
+ *  arrow-key modulo both key off the FILTERED list so nav never lands on a hidden
+ *  tab and the remaining tabs fill the bar evenly. */
+export function BottomNav({
+  repoId,
+  hideAi,
+}: {
+  repoId: string | null;
+  hideAi: boolean;
+}) {
   const route = useRoute();
   // Only highlight a tab when a repo tab is actually showing — not on the picker
   // or the pairing takeover (both set `route.tab` to its default `status`).
   const tabActive = !route.isPairing && !route.isRepos;
+  const tabs = hideAi ? TABS.filter((t) => t.tab !== "agents") : TABS;
 
   function onKeyDown(e: React.KeyboardEvent, index: number) {
     if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
     e.preventDefault();
     const dir = e.key === "ArrowRight" ? 1 : -1;
-    const next = (index + dir + TABS.length) % TABS.length;
-    navigate(tabHash(TABS[next].tab, repoId));
+    const next = (index + dir + tabs.length) % tabs.length;
+    navigate(tabHash(tabs[next].tab, repoId));
     // Canonical roving-tablist behavior: DOM focus follows the arrow selection.
     const links = e.currentTarget.closest("nav")?.querySelectorAll("a");
     links?.[next]?.focus();
@@ -99,10 +109,12 @@ export function BottomNav({ repoId }: { repoId: string | null }) {
 
   return (
     <nav
-      className="sticky bottom-0 z-10 grid grid-cols-4 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)]"
+      className={`sticky bottom-0 z-10 grid border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)] ${
+        tabs.length === 3 ? "grid-cols-3" : "grid-cols-4"
+      }`}
       aria-label="Sections"
     >
-      {TABS.map((t, i) => {
+      {tabs.map((t, i) => {
         const active = tabActive && route.tab === t.tab;
         return (
           <a

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -159,9 +159,20 @@ export interface RepoSummary {
   active: boolean;
 }
 
-/** The repositories shared from the desktop. Bearer-authed, NOT repo-scoped (no
- *  resolver) — may return 0, 1, or N. Order is unspecified; callers sort. */
-export const fetchRepos = () => getJson<RepoSummary[]>("/api/repos");
+/** The `/api/repos` envelope: the shared-repos list plus the desktop's "Hide AI
+ *  features" preference. `hideAi` mirrors the desktop setting — when true the
+ *  companion hides its AI surfaces (the Agents tab + agent-watch screen) to match.
+ *  It rides this endpoint (rather than a dedicated one) because the companion
+ *  already polls it, so a desktop toggle converges here within one poll. */
+export interface ReposResponse {
+  repos: RepoSummary[];
+  hideAi: boolean;
+}
+
+/** The repositories shared from the desktop (plus the `hideAi` preference), as an
+ *  envelope. Bearer-authed, NOT repo-scoped (no resolver) — `repos` may hold 0, 1,
+ *  or N entries. Order is unspecified; callers sort. */
+export const fetchRepos = () => getJson<ReposResponse>("/api/repos");
 
 // ── Read routes (repo-scoped) ─────────────────────────────────────────────────
 // Every data fetcher is scoped to a `repoId` (slice 4): the path is

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -79,6 +79,11 @@ export function useRepos(enabled = true) {
     enabled,
     staleTime: 30_000,
     refetchOnWindowFocus: true,
+    // Poll at the screens' cadence: the envelope carries `hideAi` (and the shared
+    // set), and a phone left OPEN on a screen gets no focus event — without an
+    // interval a desktop toggle would never converge until a manual reload
+    // (live-caught in the slice-5 E2E).
+    refetchInterval: enabled ? poll(true) : false,
   });
 }
 

--- a/companion/src/screens/Agents.tsx
+++ b/companion/src/screens/Agents.tsx
@@ -32,16 +32,25 @@ import { useRovingList } from "../lib/use-roving-list";
 // killer feature. Read-only by design: no approve/deny/write affordances here.
 
 /** The agent-stream list. `repoId` scopes the query; `active` gates polling (false
- *  while a watch is open). */
+ *  while a watch is open). `hideAi` is a defensive guard: the desktop's "Hide AI
+ *  features" preference should have already redirected any agents route away (App's
+ *  redirect effect), so this render null only covers the one-frame race before that
+ *  effect runs. */
 export function AgentsBody({
   repoId,
   active,
+  hideAi,
 }: {
   repoId: string;
   active: boolean;
+  hideAi: boolean;
 }) {
   const { data, isError, error, refetch } = useReviews(repoId, active);
   const { register, onKeyDown } = useRovingList();
+
+  // Defensive: render nothing when AI is hidden (the redirect normally beats this).
+  // AFTER the hooks so the hook order stays stable across a mid-mount flag flip.
+  if (hideAi) return null;
 
   // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
   // state even when a cached list is on hand (see isRepoGoneError). The watch
@@ -111,9 +120,23 @@ function prefersReducedMotion(): boolean {
   );
 }
 
-/** The live watch screen for one agent stream, scoped to `repoId`. */
-export function AgentWatch({ repoId, id }: { repoId: string; id: string }) {
+/** The live watch screen for one agent stream, scoped to `repoId`. `hideAi` is the
+ *  same defensive guard as {@link AgentsBody}: normally the redirect effect has
+ *  already left this route, so this only covers the one-frame race. */
+export function AgentWatch({
+  repoId,
+  id,
+  hideAi,
+}: {
+  repoId: string;
+  id: string;
+  hideAi: boolean;
+}) {
   const stream = useReviewStream(repoId, id);
+
+  // AFTER the hook so hook order is stable across a mid-watch flag flip (the flip
+  // also converges via App's redirect on the next poll, unmounting this screen).
+  if (hideAi) return null;
 
   return (
     <div className="flex flex-col">

--- a/companion/src/screens/Repos.tsx
+++ b/companion/src/screens/Repos.tsx
@@ -56,7 +56,8 @@ export function ReposBody({
   const { data, isError, error, refetch } = useRepos(true);
   const { register, onKeyDown } = useRovingList();
 
-  const repos = useMemo(() => (data ? sortRepos(data) : []), [data]);
+  // `/api/repos` is an envelope `{ repos, hideAi }`; the picker only needs the list.
+  const repos = useMemo(() => (data ? sortRepos(data.repos) : []), [data]);
 
   // Preserve the tab the user came from (if any) so a switch keeps context; the
   // bootstrap entry (no current tab) lands on Status.

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -615,6 +615,14 @@ pub struct RouterState {
     /// worktree path while the desktop is open on another (both map to one id, a path
     /// compare would miss). Read only by [`crate::lan::routes::list_repos`].
     pub active_repo_id: Arc<Mutex<Option<String>>>,
+    /// The desktop's "Hide AI features" preference. The SAME `Arc`
+    /// [`crate::lan::LanState`] owns, pushed from the frontend via
+    /// [`crate::lan::lan_set_hide_ai`]. Read only by
+    /// [`crate::lan::routes::list_repos`], which surfaces it as `hideAi` on
+    /// `/api/repos` so the companion hides its AI surfaces to match. `Ordering::Relaxed`
+    /// everywhere (a UI-preference flag, no ordering dependency). A preference, NOT a
+    /// capability gate — the `/api/reviews*` routes keep serving regardless.
+    pub hide_ai: Arc<std::sync::atomic::AtomicBool>,
     /// The repo registry (opaque-id → [`crate::lan::RegisteredRepo`]) backing the
     /// scoped `/api/repos/{repoId}/…` routes. The SAME `Arc` [`crate::lan::LanState`]
     /// owns, so `lan_set_active_repo` refreshes it live. The scoped resolver looks a

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -117,6 +117,15 @@ pub struct LanState {
     /// may be A; a path compare against active path B would wrongly report `active:
     /// false`, but the id matches. A `std::Mutex` — short, sync accesses only.
     active_repo_id: Arc<Mutex<Option<String>>>,
+    /// The desktop's "Hide AI features" preference, pushed from the frontend via
+    /// [`lan_set_hide_ai`] and surfaced on `/api/repos` so the phone companion hides
+    /// its AI surfaces (the Agents tab + agent-watch screen) to match. Shared
+    /// (per-field `Arc`) with the router state, and — like [`active_repo_id`] — it
+    /// outlives the server task, so a push works whether or not the server is running.
+    /// A UI-preference flag with no ordering dependency, so every access is
+    /// `Ordering::Relaxed`. This is a preference, NOT a capability gate: the
+    /// `/api/reviews*` routes keep serving regardless (see [`routes::reviews`]).
+    hide_ai: Arc<std::sync::atomic::AtomicBool>,
     /// The running server handle (bound port + shutdown signal + task), or `None`
     /// when disabled. Guarded so enable/disable are serialized.
     running: Mutex<Option<RunningServer>>,
@@ -169,6 +178,7 @@ impl Default for LanState {
             repos: Arc::new(Mutex::new(HashMap::new())),
             shared_index: tokio::sync::Mutex::new(HashMap::new()),
             active_repo_id: Arc::new(Mutex::new(None)),
+            hide_ai: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             running: Mutex::new(None),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -736,6 +746,7 @@ pub async fn lan_enable(
         bind_lan,
         state.active_repo.clone(),
         state.active_repo_id.clone(),
+        state.hide_ai.clone(),
         state.repos.clone(),
         state.pairing.clone(),
         state.rate_limit.clone(),
@@ -805,6 +816,22 @@ pub async fn lan_set_active_repo(
     repo_path: Option<String>,
 ) -> AppResult<()> {
     state.set_active_repo(repo_path).await;
+    Ok(())
+}
+
+/// Push the desktop's "Hide AI features" preference to the LAN state. The phone
+/// companion reads it off `GET /api/repos` (which it already polls) and hides its
+/// AI surfaces (the Agents tab + agent-watch screen) to match the desktop. Stores
+/// into the `hide_ai` Arc, which outlives the server task, so this works whether or
+/// not sharing is currently on — the flag is picked up the next time the server
+/// binds and is live for an already-running server. `Ordering::Relaxed`: a
+/// UI-preference flag with no ordering dependency. A preference, NOT a capability
+/// gate — the `/api/reviews*` routes keep serving either way.
+#[tauri::command]
+pub async fn lan_set_hide_ai(state: State<'_, LanState>, hide_ai: bool) -> AppResult<()> {
+    state
+        .hide_ai
+        .store(hide_ai, std::sync::atomic::Ordering::Relaxed);
     Ok(())
 }
 
@@ -956,6 +983,7 @@ mod tests {
         auth::RouterState {
             active_repo: Arc::new(Mutex::new(active)),
             active_repo_id: Arc::new(Mutex::new(None)),
+            hide_ai: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             repos: Arc::new(Mutex::new(std::collections::HashMap::new())),
             pairing: Arc::new(Mutex::new(None)),
             rate_limit: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -970,6 +998,14 @@ mod tests {
     /// an entry and mark it active BY ID — the same identity `list_repos` flags on.
     fn set_active_id(state: &auth::RouterState, repo_id: &str) {
         *state.active_repo_id.lock().unwrap() = Some(repo_id.to_string());
+    }
+
+    /// Set a test router's "Hide AI features" flag (the value `/api/repos` surfaces as
+    /// `hideAi`, which the companion reads to hide its AI surfaces).
+    fn set_hide_ai(state: &auth::RouterState, hide_ai: bool) {
+        state
+            .hide_ai
+            .store(hide_ai, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Pre-register a repo entry in a test router's registry (opaque-id → path), so
@@ -2703,10 +2739,11 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn list_repos_lists_the_registered_repo_and_is_empty_when_none() {
-        // `GET /api/repos` returns the registered repos as `[{ id, name, active }]`
-        // with a 16-hex id + basename name + a bool `active` flag (camelCase), and `[]`
-        // when none is registered. No path is on the wire. Wire-shape pin for the
-        // frozen contract the companion + desktop build against.
+        // `GET /api/repos` returns an envelope `{ "repos": [{ id, name, active }...],
+        // "hideAi": bool }` (camelCase): each entry has a 16-hex id + basename name + a
+        // bool `active` flag, and `repos` is `[]` when none is registered. No path is on
+        // the wire. Wire-shape pin for the frozen contract the companion + desktop build
+        // against (the companion is the only consumer and reads `data.repos`).
         let _lock = auth::store_test_lock();
         let tmp = temp_store();
         let prev = auth::set_store_path_for_test(Some(tmp.clone()));
@@ -2730,8 +2767,13 @@ mod tests {
         let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
             .await
             .unwrap();
-        let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let arr = arr.as_array().unwrap();
+        let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // The envelope pins the two camelCase top-level keys; `hideAi` defaults false.
+        assert_eq!(
+            envelope["hideAi"], false,
+            "hideAi present + camelCase bool, false by default: {envelope}"
+        );
+        let arr = envelope["repos"].as_array().unwrap();
         assert_eq!(arr.len(), 2);
         for entry in arr {
             // Each entry pins the exact camelCase wire keys and NO path leak.
@@ -2770,8 +2812,8 @@ mod tests {
         let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
             .await
             .unwrap();
-        let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let arr = arr.as_array().unwrap();
+        let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = envelope["repos"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["id"], "feedfacecafebeef");
         assert_eq!(
@@ -2779,7 +2821,7 @@ mod tests {
             "shared-under-path-A + active-on-path-B still flags active by id"
         );
 
-        // (2) No registered repo → [].
+        // (2) No registered repo → `repos: []` (still an envelope).
         let empty_state = test_router(None);
         let empty_router = server::build_router(empty_state);
         let resp = empty_router
@@ -2790,8 +2832,43 @@ mod tests {
         let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
             .await
             .unwrap();
-        let arr: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(arr.as_array().unwrap().len(), 0);
+        let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(envelope["repos"].as_array().unwrap().len(), 0);
+        assert_eq!(envelope["hideAi"], false);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn list_repos_reflects_the_hide_ai_flag() {
+        // The "Hide AI features" preference the desktop pushes (via `lan_set_hide_ai`)
+        // surfaces on `/api/repos` as `hideAi`. Set it true → the envelope reports true;
+        // the default (verified in the sibling test) is false. The companion reads this
+        // to hide its AI surfaces (Agents tab + agent-watch) to match the desktop.
+        let _lock = auth::store_test_lock();
+        let tmp = temp_store();
+        let prev = auth::set_store_path_for_test(Some(tmp.clone()));
+        let (device, bearer, token_hash) = auth::mint_device("HideAI Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+
+        let state = test_router(Some("C:/work/my-repo".to_string()));
+        register_repo(&state, "abcdef0123456789", "C:/work/my-repo");
+        set_hide_ai(&state, true);
+        let router = server::build_router(state);
+        let resp = router
+            .oneshot(authed_get("/api/repos", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(envelope["hideAi"], true, "the pushed flag surfaces: {envelope}");
+        // The repos list is unaffected by the flag — the entry is still enumerated.
+        assert_eq!(envelope["repos"].as_array().unwrap().len(), 1);
 
         auth::set_store_path_for_test(prev);
         std::fs::remove_file(&tmp).ok();
@@ -3043,6 +3120,7 @@ mod tests {
             false, // loopback
             Arc::new(Mutex::new(Some("C:/repo".to_string()))),
             Arc::new(Mutex::new(None)), // active_repo_id
+            Arc::new(std::sync::atomic::AtomicBool::new(false)), // hide_ai
             Arc::new(Mutex::new(std::collections::HashMap::new())),
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(std::collections::HashMap::new())),

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -204,16 +204,23 @@ fn no_such_repo() -> Response {
         .into_response()
 }
 
-/// GET /api/repos — the registered repos as `[{ id, name, active }]` (camelCase):
-/// the desktop's ACTIVE repo ∪ the persisted SHARED set. `active` is `true` for the
-/// entry whose opaque id equals the desktop's current active id — at most one, and
-/// none when no repo is active. Flagging BY ID (not by path) matches the id-based
-/// identity the registry dedups on: a repo shared under one worktree path while the
-/// desktop is open on another occupies one entry (same id) whose stored path may
-/// differ from the active path, so a path compare would wrongly report `active:
-/// false`. Only the opaque id + display name + `active` flag reach the wire — never a
-/// filesystem path. (An id compare also avoids a filesystem `canonicalize` under the
-/// `repos` lock.)
+/// GET /api/repos — an envelope `{ "repos": [{ id, name, active }...], "hideAi": bool }`
+/// (camelCase). `repos` is the desktop's ACTIVE repo ∪ the persisted SHARED set;
+/// `active` is `true` for the entry whose opaque id equals the desktop's current active
+/// id — at most one, and none when no repo is active. Flagging BY ID (not by path)
+/// matches the id-based identity the registry dedups on: a repo shared under one
+/// worktree path while the desktop is open on another occupies one entry (same id) whose
+/// stored path may differ from the active path, so a path compare would wrongly report
+/// `active: false`. Only the opaque id + display name + `active` flag reach the wire —
+/// never a filesystem path. (An id compare also avoids a filesystem `canonicalize` under
+/// the `repos` lock.)
+///
+/// `hideAi` mirrors the desktop's "Hide AI features" preference (pushed via
+/// [`crate::lan::lan_set_hide_ai`]). The companion polls this endpoint, so surfacing the
+/// flag here lets a flip converge on the phone with no extra request — it hides its AI
+/// surfaces (Agents tab + agent-watch) to match. This is a UI-preference signal, NOT a
+/// capability gate: the `/api/reviews*` routes keep serving regardless (see
+/// [`crate::lan::routes::reviews`]).
 ///
 /// The active id and the entries are read under separate short locks (never nested).
 /// Any transient skew between `active_repo_id` and the registry during a slow install
@@ -244,7 +251,10 @@ pub(crate) async fn list_repos(
             json!({ "id": id, "name": repo.name, "active": is_active })
         })
         .collect();
-    (StatusCode::OK, Json(items)).into_response()
+    let hide_ai = state
+        .hide_ai
+        .load(std::sync::atomic::Ordering::Relaxed);
+    (StatusCode::OK, Json(json!({ "repos": items, "hideAi": hide_ai }))).into_response()
 }
 
 /// Wrap an `AppResult<T: Serialize>` into a JSON response or the mapped error.

--- a/src-tauri/src/lan/routes/reviews.rs
+++ b/src-tauri/src/lan/routes/reviews.rs
@@ -14,6 +14,16 @@
 //! WebSocket impl drained and ignored all inbound client frames anyway, so nothing
 //! is lost by the switch.
 //!
+//! ## Hide AI is a preference, not a capability gate
+//!
+//! The desktop's "Hide AI features" setting is surfaced to the phone as `hideAi` on
+//! `/api/repos` (see [`crate::lan::routes::list_repos`]), and the companion hides its
+//! Agents tab + this watch screen when it's set. These `/api/reviews*` routes keep
+//! serving REGARDLESS — deliberately. Hide AI hides surfaces on the desktop too; it
+//! never disables the underlying capability. Blocking these routes server-side would
+//! make Hide AI a security boundary it was never meant to be, so the flag stays a
+//! UI-preference signal the client honors and the server does not enforce.
+//!
 //! ## Why SSE and not a WebSocket
 //!
 //! Serving over self-signed HTTPS (see [`crate::lan::tls`]) hits a load-bearing

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -386,6 +386,7 @@ pub async fn start(
     bind_lan: bool,
     active_repo: Arc<std::sync::Mutex<Option<String>>>,
     active_repo_id: Arc<std::sync::Mutex<Option<String>>>,
+    hide_ai: Arc<std::sync::atomic::AtomicBool>,
     repos: crate::lan::RepoRegistry,
     pairing: Arc<std::sync::Mutex<Option<auth::PairingSession>>>,
     rate_limit: auth::RateLimitMap,
@@ -404,6 +405,7 @@ pub async fn start(
     let state = RouterState {
         active_repo,
         active_repo_id,
+        hide_ai,
         repos,
         pairing,
         rate_limit,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -672,6 +672,7 @@ pub fn run() {
             lan::lan_enable,
             lan::lan_disable,
             lan::lan_set_active_repo,
+            lan::lan_set_hide_ai,
             lan::lan_pairing_start,
             lan::lan_pairing_cancel,
             lan::lan_devices_list,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,17 @@ function App() {
     );
   }, [repoPath]);
 
+  // Mirror the "Hide AI features" preference to the LAN state so the phone
+  // companion hides its AI surfaces to match. The phone reads it off `/api/repos`
+  // (which it already polls), so a flip converges within one poll with no extra
+  // request. Skip until settings load — never push a guessed default that would
+  // briefly un-hide AI on the phone before the real value arrives.
+  const hideAi = settings.data?.hideAi;
+  useEffect(() => {
+    if (hideAi === undefined) return;
+    invoke("lan_set_hide_ai", { hideAi }).catch(() => undefined);
+  }, [hideAi]);
+
   // Drop a repo folder anywhere on the window to open it.
   useRepoDrop();
 


### PR DESCRIPTION
Mirror the desktop’s **Hide AI features** preference to the LAN companion so both interfaces present the same AI surfaces. The companion now removes the Agents tab and redirects agent routes when the preference is enabled, while preserving the underlying review API capability.

### Companion UI

- Updates `companion/src/lib/api.ts` and `companion/src/screens/Repos.tsx` for the new `/api/repos` response envelope containing `repos` and `hideAi`.
- Polls the preference in `companion/src/lib/queries.ts` so an open companion converges after the desktop setting changes.
- Filters the Agents tab and adjusts keyboard navigation and grid layout in `companion/src/components/Chrome.tsx`.
- Redirects hidden Agents routes to the status view in `companion/src/App.tsx`.
- Adds defensive rendering guards to `AgentsBody` and `AgentWatch` in `companion/src/screens/Agents.tsx`.

### LAN preference and API

- Adds shared `hide_ai` state and the `lan_set_hide_ai` Tauri command in `src-tauri/src/lan/mod.rs`, registered in `src-tauri/src/lib.rs`.
- Passes the preference into the LAN router through `src-tauri/src/lan/server.rs` and `src-tauri/src/lan/auth.rs`.
- Changes `GET /api/repos` in `src-tauri/src/lan/routes/mod.rs` to return the repository list alongside the camelCase `hideAi` flag.
- Keeps the review endpoints available regardless of the preference, as documented in `src-tauri/src/lan/routes/reviews.rs`.

### Desktop integration and coverage

- Pushes the loaded desktop setting to LAN state from `src/App.tsx`, avoiding guessed defaults before settings finish loading.
- Updates LAN route tests in `src-tauri/src/lan/mod.rs` to cover the response envelope and both default and enabled `hideAi` values.
- Documents the companion behavior in `changelog.d/added-lan-companion-preview.md`.