### PR TITLE
feat(pulls,automations,settings): expand draft controls and rerun automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **The whole PR lifecycle, in-app** — review, comment, label, **assign**, **request
   reviewers**, approve, edit, and merge (merge/squash/rebase) GitHub PRs without the
   browser. Set **labels and assignees** right when you **open** a PR/MR (GitHub &
-  GitLab); request reviewers across GitHub, GitLab & Bitbucket.
+  GitLab); request reviewers across GitHub, GitLab & Bitbucket. Flip a PR between
+  **draft and ready for review** either way — on GitHub, GitLab & Bitbucket — and
+  **create new PRs as drafts by default** (Settings → General).
   - **Activity feed** — a PR's Conversation is a **date-sorted timeline** of reviews,
     comments, grouped **pushed commits** (each SHA clickable), and events, every entry
     **timestamped** (hover for the exact time), with an
@@ -521,7 +523,9 @@ events (a finished review, checks passing/failing, a PR approved/commented/merge
 review requested from you, a completed CI run, or a finished agent / research / plan run) into a clickable,
 clearable history that survives a restart — so a review that finishes while you're away is
 never a missed click. Open it from the command palette; which events show follows your
-notification settings.
+notification settings. A cancelled or failed **automated** review also lingers in a
+**Stopped** group with one-click **Re-run** (re-firing exactly that run's mode) and
+**Dismiss**, so a stopped automation isn't a dead end.
 
 **Environment check** — a Settings → **About** panel reports your app/OS/Tauri
 versions and the status of every CLI GitDesktop uses (git, the GitHub & GitLab

--- a/changelog.d/added-automation-rerun.md
+++ b/changelog.d/added-automation-rerun.md
@@ -1,0 +1,6 @@
+- **Re-run a stopped automated review.** When an automation-triggered AI review or
+  security audit is cancelled or fails, it now stays in the Activity popover under a
+  **Stopped** group with **Re-run** and **Dismiss**, so you can retry exactly that run
+  (and mode) without hunting for the commit or PR again. A failed automated run also
+  lands a *review failed* notification in the inbox — matching manual runs — when
+  automation notifications are on.

--- a/changelog.d/added-default-draft-setting.md
+++ b/changelog.d/added-default-draft-setting.md
@@ -1,0 +1,5 @@
+- **Create pull requests as drafts by default.** A new Settings → General toggle,
+  **Create pull requests as drafts** (off by default), pre-checks the Create pull request
+  dialog's *Create as draft* box so you can open PRs as drafts without remembering to tick
+  it each time — still overridable per PR. Paired with *Review draft PRs when created*, a
+  draft's automated first review then waits until you mark it ready.

--- a/changelog.d/changed-draft-toggle-all-providers.md
+++ b/changelog.d/changed-draft-toggle-all-providers.md
@@ -1,0 +1,5 @@
+- **Toggle a PR between draft and ready on every provider.** The pull-request footer's
+  **Ready for review** / **Convert to draft** pair now works both ways on **GitHub**,
+  **GitLab**, and **Bitbucket** — not just Bitbucket, and no longer one-directional. Both
+  actions are also in the command palette, and the GitDesktop MCP `set_pull_request_draft`
+  tool now covers all three providers too.

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -1892,6 +1892,24 @@ pub async fn reopen_mr(repo_path: &str, number: u64) -> AppResult<()> {
     set_mr_state(repo_path, number, "reopen").await
 }
 
+/// Set a merge request's draft state via `glab mr update <iid> --ready | --draft`.
+/// A GitLab draft is a `Draft:` title prefix; `glab mr update` handles adding and
+/// stripping that prefix for us (both flags validated live), which is why this
+/// shells the `mr` subcommand rather than PATCHing the title itself. The project is
+/// resolved from the repo directory context (`Some(repo_path)`), matching the iid's
+/// scope; `number` is a u64 (digits only) so it's safe to pass positionally.
+pub async fn set_mr_draft(repo_path: &str, number: u64, draft: bool) -> AppResult<()> {
+    let iid = number.to_string();
+    let flag = if draft { "--draft" } else { "--ready" };
+    run_glab(
+        Some(repo_path),
+        &["mr", "update", &iid, flag],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await?;
+    Ok(())
+}
+
 /// Edit a merge request's title/description. Mirrors `gh_pr_edit` (empty-title
 /// guard; an empty body clears the description). Validated live: `-f` keeps
 /// multi-line/comma/`=`/`@`/leading-`-` values intact.

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1306,19 +1306,27 @@ pub async fn forge_pr_unrequest_changes(repo_path: String, number: u64) -> AppRe
     }
 }
 
-/// Toggle a merge/pull request's draft state. Bitbucket-only: Bitbucket flips
-/// `draft` both ways; GitHub keeps its one-way `gh pr ready` path, and a GitLab
-/// draft is a title prefix (unwired here).
+/// Toggle a merge/pull request's draft state — wired for all three providers, each
+/// via its own mechanism: Bitbucket PUTs `draft` both ways; GitLab shells
+/// `glab mr update <iid> --ready|--draft` (a draft is a `Draft:` title prefix glab
+/// manages); GitHub shells `gh pr ready [--undo]` — `draft = true` appends `--undo`
+/// to convert an open PR back to a draft, `draft = false` marks a draft ready.
+/// `lens` is GitHub-only (see `forge_pr_list`): it resolves a fork's PR against the
+/// chosen remote; the Bitbucket/GitLab arms ignore it. gh's own error on plans that
+/// don't support draft conversion passes through as the actionable message.
 #[tauri::command]
-pub async fn forge_pr_set_draft(repo_path: String, number: u64, draft: bool) -> AppResult<()> {
+pub async fn forge_pr_set_draft(
+    repo_path: String,
+    number: u64,
+    draft: bool,
+    lens: Option<String>,
+) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::Bitbucket, _)) => bitbucket::set_pr_draft(&repo_path, number, draft).await,
-        Some((Provider::GitLab, _)) => Err(AppError::InvalidArgument(
-            "GitLab drafts aren't toggleable here yet.".into(),
-        )),
-        _ => Err(AppError::InvalidArgument(
-            "GitHub marks a pull request ready via its own control.".into(),
-        )),
+        Some((Provider::GitLab, _)) => gitlab::set_mr_draft(&repo_path, number, draft).await,
+        // `draft = true` → convert back to draft (`gh pr ready --undo`); `false` →
+        // mark ready. The GitHub arm maps draft-state to the gh `ready` flag.
+        _ => crate::github::pr::gh_pr_set_ready(&repo_path, number, !draft, lens.as_deref()).await,
     }
 }
 

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -298,6 +298,13 @@ pub struct Implemented {
     /// request-changes verdict) in one action. All three providers wire it, so it's
     /// true for each.
     pub mr_review_submit: bool,
+    /// Toggling a merge/pull request's draft state BOTH ways from the shared
+    /// Ready / Convert-to-draft control. GitLab (`glab mr update --ready|--draft`)
+    /// and Bitbucket (PUT `draft`) drive that control off this flag. GitHub stays
+    /// `false`: its Ready/Convert path goes through `gh pr ready [--undo]` gated on
+    /// `canWrite` (the forge-gating convention for a shared control whose GitHub arm
+    /// has its own gate), so the frontend enables it there without this flag.
+    pub mr_draft_toggle: bool,
 }
 
 impl Implemented {
@@ -371,6 +378,9 @@ impl Implemented {
             commit_comments: true,
             mr_thread_create: true,
             mr_review_submit: true,
+            // GitHub's Ready / Convert-to-draft goes via `gh pr ready [--undo]`
+            // gated on `canWrite`, not this flag.
+            mr_draft_toggle: false,
         }
     }
 
@@ -428,6 +438,7 @@ impl Implemented {
             commit_comments: false,
             mr_thread_create: false,
             mr_review_submit: false,
+            mr_draft_toggle: false,
         }
     }
 
@@ -515,6 +526,8 @@ impl Implemented {
                 commit_comments: true,
                 mr_thread_create: true,
                 mr_review_submit: true,
+                // Draft toggle both ways via `glab mr update --ready|--draft`.
+                mr_draft_toggle: true,
             },
             // Bitbucket Cloud reads (Phase 3): PR list/view/diff, CI pipelines, and
             // repo View/URL are wired over direct HTTP. Phase 4 adds the WRITES: PR
@@ -569,6 +582,8 @@ impl Implemented {
                 commit_comments: true,
                 mr_thread_create: true,
                 mr_review_submit: true,
+                // Draft toggle both ways (PUT `draft`).
+                mr_draft_toggle: true,
                 ..Self::none()
             },
         }
@@ -736,6 +751,9 @@ mod tests {
         assert!(i.mr_review_threads && i.mr_thread_reply && i.mr_thread_resolve);
         // Commit comments, new-thread create, and batched review submit — all three.
         assert!(i.commit_comments && i.mr_thread_create && i.mr_review_submit);
+        // The draft toggle stays false for GitHub — its Ready/Convert path goes via
+        // `gh pr ready [--undo]` gated on canWrite, not this flag.
+        assert!(!i.mr_draft_toggle);
     }
 
     #[test]
@@ -785,6 +803,8 @@ mod tests {
         assert!(imp.mr_thread_comment_edit);
         // …plus commit comments, new-thread create, and batched review submit.
         assert!(imp.commit_comments && imp.mr_thread_create && imp.mr_review_submit);
+        // …and the draft toggle both ways (`glab mr update --ready|--draft`).
+        assert!(imp.mr_draft_toggle);
     }
 
     #[test]
@@ -837,5 +857,9 @@ mod tests {
         assert!(bb.mr_thread_comment_edit);
         // …plus commit comments, new-thread create, and batched review submit.
         assert!(bb.commit_comments && bb.mr_thread_create && bb.mr_review_submit);
+        // …and the draft toggle both ways (PUT `draft`).
+        assert!(bb.mr_draft_toggle);
+        // GitHub keeps the draft toggle off (its Ready/Convert path is gh-native).
+        assert!(!gh.mr_draft_toggle);
     }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1043,18 +1043,33 @@ pub async fn gh_repo_fork(repo_path: String, contribute_to_parent: bool) -> AppR
     Ok(fork_url)
 }
 
-/// Marks a draft PR as ready for review.
+/// Marks a draft PR as ready for review (the one-way Tauri command; kept
+/// backward-compatible). Delegates to [`gh_pr_set_ready`] with `ready = true`.
 #[tauri::command]
 pub async fn gh_pr_ready(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
+    gh_pr_set_ready(&repo_path, number, true, lens.as_deref()).await
+}
+
+/// Sets a pull request's draft state via `gh pr ready`: `ready = true` marks a
+/// draft ready for review; `ready = false` appends `--undo` to convert an open PR
+/// back to a draft ("Convert a pull request to draft"). Lens-aware, so a fork's PR
+/// resolves against the chosen remote rather than the parent gh auto-detects. gh's
+/// own error for plans that don't support draft conversion ("If supported by your
+/// plan") passes through as the actionable message — deliberately not pre-gated.
+pub(crate) async fn gh_pr_set_ready(
+    repo_path: &str,
+    number: u64,
+    ready: bool,
+    lens: Option<&str>,
+) -> AppResult<()> {
     let n = number.to_string();
-    // Resolve the lens slug so the PR is marked ready on the chosen repo.
-    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
-    run_gh(
-        Some(&repo_path),
-        &["pr", "ready", &n, "--repo", &slug],
-        GH_NETWORK_TIMEOUT,
-    )
-    .await?;
+    // Resolve the lens slug so the state change lands on the chosen repo.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
+    let mut args = vec!["pr", "ready", &n, "--repo", &slug];
+    if !ready {
+        args.push("--undo");
+    }
+    run_gh(Some(repo_path), &args, GH_NETWORK_TIMEOUT).await?;
     Ok(())
 }
 

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -123,8 +123,8 @@ struct UpdatePullRequestArgs {
 struct SetPullRequestDraftArgs {
     /// The pull request number.
     number: u64,
-    /// True to mark it a draft, false to mark it ready. (Provider support varies —
-    /// Bitbucket toggles both ways; the forge layer surfaces the limitation otherwise.)
+    /// True to mark it a draft, false to mark it ready. Works both ways on all three
+    /// providers (Bitbucket PUT, GitLab `glab mr update`, GitHub `gh pr ready [--undo]`).
     draft: bool,
 }
 
@@ -621,9 +621,11 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Set a pull request's draft state (by number) in the bound repository's forge \
-                       (per its remote). Provider support varies — Bitbucket toggles both ways; on \
-                       GitHub/GitLab the forge layer returns an actionable error where this control \
-                       doesn't apply. Requires --allow-remote-write.",
+                       (GitHub, GitLab, or Bitbucket, per its remote). Works on all three: Bitbucket \
+                       toggles the `draft` field both ways; GitLab shells `glab mr update --ready|\
+                       --draft`; GitHub shells `gh pr ready` (and `gh pr ready --undo` to convert an \
+                       open PR back to a draft) under the authenticated CLI. Requires \
+                       --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn set_pull_request_draft(
@@ -631,7 +633,8 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<SetPullRequestDraftArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_pr_set_draft(self.repo.clone(), args.number, args.draft)
+        // The MCP tool has no fork-lens concept — pass `None` (GitHub arm only reads it).
+        crate::forge::forge_pr_set_draft(self.repo.clone(), args.number, args.draft, None)
             .await
             .map_err(app_err)?;
         json_result(&serde_json::json!({ "pull_request": args.number, "draft": args.draft }))

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -359,7 +359,13 @@ function LiveTaskRow({
 
 /** A cancelled/failed automation run, kept in the dock (unlike a live row) with
  *  Re-run + Dismiss. Failed rows carry the error in the subtitle's tooltip and
- *  render "Failed" in the destructive token (word + color, never color alone). */
+ *  render "Failed" in the destructive token (word + color, never color alone).
+ *
+ *  Re-run just fires `task.rerun()` — it does NOT remove the row here. The row is
+ *  removed inside the runner only once the replacement run actually registers, so
+ *  a re-run that can't start (rule disabled since, or a claim/watermark still held
+ *  by the canceled run unwinding) leaves the row in place as a retry target and
+ *  toasts why. Dismiss removes the row outright. */
 function StoppedTaskRow({
   task,
   crossRepo,
@@ -397,12 +403,7 @@ function StoppedTaskRow({
         size="xs"
         className="shrink-0"
         aria-label={`Re-run ${title}`}
-        onClick={() => {
-          // Remove the stopped row first; the re-fired run registers a fresh
-          // "Running…" row through the normal automation path.
-          resetReview(task.key);
-          task.rerun?.();
-        }}
+        onClick={() => task.rerun?.()}
       >
         Re-run
       </Button>

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -38,6 +38,7 @@ import {
 import {
   cancelReview,
   type ReviewTask,
+  resetReview,
   useReviewTasks,
 } from "@/lib/stores/reviews";
 import { useUiStore } from "@/lib/stores/ui";
@@ -74,7 +75,15 @@ export function ActivityStrip() {
   // reachable even with an empty inbox on the welcome/settings/help screens).
   if (view === "repo") return null;
   const live = liveTasks(tasks);
-  if (live.length === 0 && notifs.length === 0 && !activityOpen) return null;
+  const stopped = stoppedTasks(tasks);
+  if (
+    live.length === 0 &&
+    stopped.length === 0 &&
+    notifs.length === 0 &&
+    !activityOpen
+  ) {
+    return null;
+  }
   return (
     <div className="flex h-7 shrink-0 items-center border-t bg-background px-1.5">
       <ActivityBell variant="strip" />
@@ -86,6 +95,15 @@ function liveTasks(tasks: ReviewTask[]): ReviewTask[] {
   return tasks.filter((t) => t.phase === "running" || t.phase === "queued");
 }
 
+/** Stopped automation runs — cancelled or failed rows that carry a `rerun`. The
+ *  `rerun` presence is the discriminator: a manual panel run also reaches
+ *  "cancelled"/"error" but never carries one, so it's kept out of the dock. */
+function stoppedTasks(tasks: ReviewTask[]): ReviewTask[] {
+  return tasks.filter(
+    (t) => (t.phase === "cancelled" || t.phase === "error") && t.rerun,
+  );
+}
+
 function ActivityBell({ variant }: { variant: "header" | "strip" }) {
   const tasks = useReviewTasks();
   const unread = useUnreadCount();
@@ -94,10 +112,13 @@ function ActivityBell({ variant }: { variant: "header" | "strip" }) {
   const open = useUiStore((s) => s.activityOpen);
   const setOpen = useUiStore((s) => s.setActivityOpen);
   const live = liveTasks(tasks).length;
+  const stopped = stoppedTasks(tasks).length;
 
   const label = `Activity & notifications${
     unread > 0 ? ` · ${unread} unread` : ""
-  }${live > 0 ? ` · ${live} in progress` : ""}`;
+  }${live > 0 ? ` · ${live} in progress` : ""}${
+    stopped > 0 ? ` · ${stopped} stopped` : ""
+  }`;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -144,6 +165,7 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   const listRef = useRef<HTMLDivElement>(null);
 
   const live = liveTasks(tasks);
+  const stopped = stoppedTasks(tasks);
   // Queue position per lane (local + cloud run independently), FIFO by seq.
   const queuePos = new Map<string, number>();
   for (const isLocal of [true, false]) {
@@ -213,6 +235,26 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
                 queuePosition={
                   task.phase === "queued" ? (queuePos.get(task.key) ?? 0) : 0
                 }
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {stopped.length > 0 && (
+        <div className="border-b">
+          <div className="flex items-center justify-between px-3 py-2">
+            <span className="text-xs font-medium">Stopped</span>
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              {stopped.length}
+            </span>
+          </div>
+          <div className="max-h-44 overflow-y-auto">
+            {stopped.map((task) => (
+              <StoppedTaskRow
+                key={task.key}
+                task={task}
+                crossRepo={task.target.repoPath !== repoPath}
               />
             ))}
           </div>
@@ -310,6 +352,68 @@ function LiveTaskRow({
         onClick={() => cancelReview(task.key)}
       >
         Cancel
+      </Button>
+    </div>
+  );
+}
+
+/** A cancelled/failed automation run, kept in the dock (unlike a live row) with
+ *  Re-run + Dismiss. Failed rows carry the error in the subtitle's tooltip and
+ *  render "Failed" in the destructive token (word + color, never color alone). */
+function StoppedTaskRow({
+  task,
+  crossRepo,
+}: {
+  task: ReviewTask;
+  crossRepo: boolean;
+}) {
+  const ModeIcon = task.mode === "security" ? ShieldCheckIcon : SparkleIcon;
+  const modeName = task.mode === "security" ? "Security audit" : "Review";
+  const failed = task.phase === "error";
+  const title = task.title || "Pull request";
+
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 not-last:border-b">
+      <ModeIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium" title={task.title}>
+          {title}
+        </p>
+        <p
+          className="mt-0.5 truncate text-[11px] text-muted-foreground"
+          title={failed ? task.error : undefined}
+        >
+          {modeName} ·{" "}
+          {failed ? (
+            <span className="text-destructive">Failed</span>
+          ) : (
+            "Cancelled"
+          )}
+          {crossRepo ? ` · ${task.target.repoName}` : ""}
+        </p>
+      </div>
+      <Button
+        variant="ghost"
+        size="xs"
+        className="shrink-0"
+        aria-label={`Re-run ${title}`}
+        onClick={() => {
+          // Remove the stopped row first; the re-fired run registers a fresh
+          // "Running…" row through the normal automation path.
+          resetReview(task.key);
+          task.rerun?.();
+        }}
+      >
+        Re-run
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        className="shrink-0 self-start text-muted-foreground"
+        aria-label={`Dismiss "${title}"`}
+        onClick={() => resetReview(task.key)}
+      >
+        <XIcon />
       </Button>
     </div>
   );

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1619,8 +1619,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   arrow-key through the list, and clear items or mark all read.{{ai}} When an
   **automated** review or security audit is cancelled or fails, it stays in the popover
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
-  **Dismiss** — and a failed automated run also lands a *review failed* row in the inbox,
-  matching a manual run (both gated on the automations notification preference).{{/ai}}
+  **Dismiss** — and a failed automated run also lands a *review failed* row in the inbox
+  (gated on the automations notification preference), matching manual-run failures.{{/ai}}
 - **Keyboard** — rebind any shortcut, with live key-capture.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -586,7 +586,9 @@ Browse open/closed PRs and open one in a full in-app view: description, commits,
 files with diffs, and CI checks. From there you can **comment** (with quote-reply),
 **review** (approve / comment / request changes), **edit** the title and body, manage
 **labels**, **assignees**, and **reviewers** (request a review from a collaborator — the
-picker excludes the PR author, whom GitHub won't let you request), mark a draft **ready**,
+picker excludes the PR author, whom GitHub won't let you request), flip a PR between
+**draft** and **ready for review** in either direction (a footer **Ready for review** /
+**Convert to draft** pair, also reachable from the command palette),
 **merge** (merge commit, squash, or rebase, with optional branch deletion), and **close**.
 Reviewers who've already reviewed show as read-only chips carrying their verdict — a check
 for **approved**, an X for **requested changes**, a speech bubble for **commented** (icon
@@ -736,7 +738,9 @@ were dropped), track **time** on it (a clock summary in the
 header opens a popover to set an estimate and log spent time), and **merge**
 it — merge or squash, optionally deleting
 the source branch, guarded so it never merges a head you didn't see (GitLab applies the project's
-configured merge method, so there's no separate "rebase" option). While a pipeline is running the
+configured merge method, so there's no separate "rebase" option). You can also flip the MR
+between **draft** and **ready for review** in either direction — a footer **Ready for review** /
+**Convert to draft** pair, also in the command palette. While a pipeline is running the
 merge menu also offers **auto-merge** (merge when the pipeline succeeds) — GitLab merges it for
 you once the pipeline passes, and an **Auto-merge enabled** indicator in the footer lets you cancel
 it in place. Its **line-anchored review comments** render too — grouped by file in the
@@ -1596,7 +1600,10 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 
 - **General** — hide AI features, keep running in the **system tray** on close (so
   background work continues; launching the app again while it's running —
-  tray-hidden or not — focuses the existing window), and privacy options.
+  tray-hidden or not — focuses the existing window), **create pull requests as drafts**
+  by default (off by default — pre-checks the Create-PR dialog's draft box, still
+  overridable per PR; pairs with *Review draft PRs when created* so a draft's automated
+  first review waits until it's marked ready), and privacy options.
 {{ai}}- **AI** — providers, models, keys, instructions, agent-session isolation
   (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.
@@ -1609,7 +1616,11 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   persistent, click-to-open history (it survives a restart) so a finished review or a PR
   update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump to it,
-  arrow-key through the list, and clear items or mark all read.
+  arrow-key through the list, and clear items or mark all read.{{ai}} When an
+  **automated** review or security audit is cancelled or fails, it stays in the popover
+  under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
+  **Dismiss** — and a failed automated run also lands a *review failed* row in the inbox,
+  matching a manual run (both gated on the automations notification preference).{{/ai}}
 - **Keyboard** — rebind any shortcut, with live key-capture.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -233,7 +233,10 @@ export function CreatePrDialog({
       base: "",
       title: "",
       body: "",
-      draft: false,
+      // Seed from the setting so a user who defaults new PRs to draft opens the
+      // dialog pre-ticked; undefined-safe (settings pending / pre-field store →
+      // false). The reset() on open re-applies this so a stored change takes.
+      draft: settings.data?.createPrsAsDraft ?? false,
       notes: "",
     },
     validators: {
@@ -388,7 +391,10 @@ export function CreatePrDialog({
         base: defaultBase ?? fallbackBase,
         title: "",
         body: "",
-        draft: false,
+        // Seed each open from the setting (undefined-safe → false), so the draft
+        // default reflects the current preference without leaking a prior open's
+        // per-dialog toggle.
+        draft: settings.data?.createPrsAsDraft ?? false,
         // Cleared on open; ReviewerNotesField re-seeds from the head branch's
         // deposit (if any) once its query resolves.
         notes: "",

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -99,7 +99,6 @@ import {
   usePrReactions,
   usePrReviewThreads,
   usePrTimeline,
-  useReadyPr,
   useReopenPr,
   useRepoStatus,
   useRequestChangesPr,
@@ -289,8 +288,7 @@ export function RemotePrView({
   const deleteReviewComment = useDeleteReviewComment(repoPath, lens);
   const minimizeComment = useMinimizeComment(repoPath);
   const unminimizeComment = useUnminimizeComment(repoPath);
-  const readyPr = useReadyPr(repoPath, lens);
-  const setDraft = useSetPrDraft(repoPath);
+  const setDraft = useSetPrDraft(repoPath, lens);
   const editPr = useEditPr(repoPath, lens);
   // File:line-anchored review threads (Copilot/CodeRabbit/human line comments).
   // The read serves both the Conversation block below and (later) the Files
@@ -375,6 +373,60 @@ export function RemotePrView({
     "discard-pending-review",
     () => setDiscardConfirmOpen(true),
     draftCount > 0,
+  );
+  // The shared Ready / Convert-to-draft pair is visible when a wired provider
+  // (GitLab/Bitbucket) flags `mrDraftToggle`, OR on GitHub via `canWrite` (its
+  // Ready/Convert routes through `gh pr ready [--undo]`, kept byte-identical). Used
+  // by both the footer buttons and the palette actions below.
+  const isGitHubProvider = providerKey === "github";
+  const draftPairVisible = canToggleDraft || (isGitHubProvider && canWrite);
+  // One in-flight PR mutation at a time: every footer/state control (and the
+  // palette twins below) disables while any of these runs. Declared here, above
+  // the palette wiring, so the actions can share the exact same gate.
+  const busy =
+    comment.isPending ||
+    mergePr.isPending ||
+    closePr.isPending ||
+    reopenPr.isPending ||
+    approvePr.isPending ||
+    unapprovePr.isPending ||
+    requestChangesPr.isPending ||
+    unrequestChangesPr.isPending ||
+    armAutoMerge.isPending ||
+    cancelAutoMerge.isPending ||
+    setDraft.isPending;
+  // Palette twins of the footer's draft controls (mounted here, so live only in an
+  // open remote-PR view with the applicable state). Each reuses the exact same
+  // `setDraft` mutation as its button — Ready fires the ready-review automation.
+  useHotkeyAction(
+    "pr-ready-for-review",
+    () =>
+      setDraft.mutate(
+        { number, draft: false },
+        {
+          onSuccess: () => {
+            toast.success("Marked ready for review");
+            void fireReadyReview();
+          },
+          onError,
+        },
+      ),
+    draftPairVisible && !!details.data?.isDraft && !busy,
+  );
+  useHotkeyAction(
+    "pr-convert-to-draft",
+    () =>
+      setDraft.mutate(
+        { number, draft: true },
+        {
+          onSuccess: () => toast.success("Converted to draft"),
+          onError,
+        },
+      ),
+    draftPairVisible &&
+      !details.data?.isDraft &&
+      details.data?.state === "OPEN" &&
+      !busy,
   );
 
   const [composeBody, setComposeBody] = useState("");
@@ -910,20 +962,6 @@ export function RemotePrView({
   // list filters these out to avoid a duplicate pending+completed chip. GitHub never
   // overlaps (its completed reviewers have already left `pr.reviewers`).
   const completedLogins = new Set(completedReviewers.map((c) => c.login));
-  const busy =
-    comment.isPending ||
-    mergePr.isPending ||
-    closePr.isPending ||
-    reopenPr.isPending ||
-    approvePr.isPending ||
-    unapprovePr.isPending ||
-    requestChangesPr.isPending ||
-    unrequestChangesPr.isPending ||
-    armAutoMerge.isPending ||
-    cancelAutoMerge.isPending ||
-    readyPr.isPending ||
-    setDraft.isPending;
-
   function saveCommentEdit(commentId: string, body: string) {
     editComment.mutate(
       { number, commentId, body },
@@ -1924,33 +1962,18 @@ export function RemotePrView({
         </div>
       )}
 
-      {/* The open-MR footer hosts Close + Merge (GitLab writes too) alongside Ready
-          (GitHub-only) — show it whenever any is available, and gate each control
-          individually. */}
+      {/* The open-MR footer hosts Close + Merge (GitLab writes too) alongside the
+          shared Ready / Convert-to-draft pair — show it whenever any is available,
+          and gate each control individually. */}
       {isOpen && (canChangeState || canMerge || canWrite) && (
         <div className="flex items-center gap-2 border-t p-3">
-          {canWrite && pr.isDraft && (
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={busy}
-              onClick={() =>
-                readyPr.mutate(number, {
-                  onSuccess: () => {
-                    toast.success("Marked ready for review");
-                    void fireReadyReview();
-                  },
-                  onError,
-                })
-              }
-            >
-              Ready for review
-            </Button>
-          )}
-          {/* Bitbucket toggles draft BOTH ways (GitHub's gh path above is
-              one-way): the same PUT flips it back, so a ready PR offers a
-              quieter Convert-to-draft alongside the primary Ready button. */}
-          {canToggleDraft && pr.isDraft && (
+          {/* One Ready / Convert-to-draft pair for all three providers. GitLab
+              (`glab mr update`) and Bitbucket (PUT `draft`) drive it off
+              `canToggleDraft`; GitHub folds in via `canWrite` and routes the same
+              `setDraft` mutation through `gh pr ready [--undo]`, so the Ready button
+              is byte-identical to before. Draft → primary Ready (fires the
+              ready-review automation); open → a quieter Convert-to-draft. */}
+          {draftPairVisible && pr.isDraft && (
             <Button
               variant="outline"
               size="sm"
@@ -1971,7 +1994,7 @@ export function RemotePrView({
               Ready for review
             </Button>
           )}
-          {canToggleDraft && !pr.isDraft && (
+          {draftPairVisible && !pr.isDraft && (
             <Button
               variant="ghost"
               size="sm"

--- a/src/features/pulls/usePrCapabilities.ts
+++ b/src/features/pulls/usePrCapabilities.ts
@@ -65,10 +65,13 @@ export function usePrCapabilities(
   // (GitHub diffs pending user requests via `gh pr edit`, GitLab PUTs
   // `reviewer_ids`, Bitbucket picks workspace members).
   const canEditReviewers = forgeFeatureReady(forgeData, "mrReviewers");
-  // Bitbucket toggles draft BOTH ways via the same edit surface (GitHub's
-  // one-way Ready button below stays on `canWrite` + `gh pr ready`).
-  const canToggleDraft =
-    provider === "bitbucket" && forgeFeatureReady(forgeData, "mrEdit");
+  // The shared draft toggle (both ways) for GitLab + Bitbucket, gated on the forge
+  // feature alone — never `canWrite || …`. GitHub is NOT in this flag: its
+  // Ready / Convert-to-draft path goes via `gh pr ready [--undo]` gated on
+  // `canWrite`, and the footer folds that in as `canToggleDraft || (isGitHub &&
+  // canWrite)`, so `mrDraftToggle` stays false for GitHub (see the forge-gating
+  // convention above).
+  const canToggleDraft = forgeFeatureReady(forgeData, "mrDraftToggle");
   // Time tracking is GitLab-only too (GitHub has no built-in time tracking).
   const canTrackTime = forgeFeatureReady(forgeData, "timeTracking");
   // PR tasks are a native Bitbucket concept (no GitHub/GitLab analogue wired), so

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -85,6 +85,21 @@ export const GeneralSection = withForm({
           )}
         </div>
         <div className="space-y-1.5">
+          <form.AppField name="createPrsAsDraft">
+            {(field) => (
+              <field.CheckboxField
+                label="Create pull requests as drafts"
+                className="flex cursor-pointer items-center gap-2 text-xs"
+              />
+            )}
+          </form.AppField>
+          <p className="text-xs text-muted-foreground">
+            New pull requests start as drafts. Automated first reviews then wait
+            until a PR is marked ready for review (unless review of drafts is
+            enabled). You can still change the draft toggle per pull request.
+          </p>
+        </div>
+        <div className="space-y-1.5">
           <form.AppField name="analyticsEnabled">
             {(field) => (
               <field.CheckboxField

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -77,3 +77,23 @@ export async function setDismissedHead(
   const all = (await store.get<DismissalMap>(key)) ?? {};
   await store.set(key, { ...all, [cellKey(kind, ref, mode)]: headSha });
 }
+
+/**
+ * Clears the dismissed-head watermark for a PR + mode. Called when a cancelled
+ * automation run is re-run: the cancel wrote a dismissed head, and without
+ * clearing it a subsequent pr-sync (or the re-run itself) silently no-ops at the
+ * runner's `sameSha(dismissedHead, headSha)` gate. Best-effort at the call site
+ * — a clear failure must not block the re-run.
+ */
+export async function clearDismissedHead(
+  repo: string,
+  kind: "remote" | "local",
+  ref: string,
+  mode: ReviewMode,
+): Promise<void> {
+  const store = await getStore();
+  const key = await keyFor(repo);
+  const all = (await store.get<DismissalMap>(key)) ?? {};
+  delete all[cellKey(kind, ref, mode)];
+  await store.set(key, all);
+}

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -30,9 +30,14 @@ import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import { getLatestReview, saveReview } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
+import { pushNotification } from "@/lib/stores/notifications";
 import { type ReviewTarget, registerAutomationRun } from "@/lib/stores/reviews";
-import { invoke } from "@/lib/tauri/invoke";
-import { getDismissedHead, setDismissedHead } from "./dismissals";
+import { errorMessage, invoke } from "@/lib/tauri/invoke";
+import {
+  clearDismissedHead,
+  getDismissedHead,
+  setDismissedHead,
+} from "./dismissals";
 import { useAutomationResults } from "./results";
 import { loadAutomations, repoAutomationsFor } from "./store";
 import { sameSha } from "./sync";
@@ -159,11 +164,19 @@ export function triggerAutomations(event: AutomationEvent): void {
   void run(event).catch(() => undefined);
 }
 
-async function run(event: AutomationEvent): Promise<void> {
+/**
+ * Runs the automation rules matching `event`. When `only` is set (a re-run of a
+ * single stopped row), every rule whose mode differs is skipped, so exactly that
+ * one mode re-fires. Returns the number of actions actually attempted (past the
+ * mode/branch/sync/claim gates) so a re-run can tell "nothing matched" (e.g. the
+ * rule was disabled since) from a real run and surface an informative toast.
+ */
+async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   const actions = effectiveActions(config, repo, event.kind);
-  if (actions.length === 0) return;
+  if (actions.length === 0) return 0;
+  let attempted = 0;
 
   // The branch(es) a branch-condition is tested against. Commit events carry the
   // committed branch; PR events carry head/base (added by the poll payload).
@@ -174,6 +187,10 @@ async function run(event: AutomationEvent): Promise<void> {
   const settings = await loadSettings();
   const notify = settings.notifications.automations;
   for (const { action, conditions } of actions) {
+    // Re-run scoping: a stopped-row Re-run targets exactly one mode, so skip every
+    // other rule this event would otherwise fire. Normal triggers pass `only`
+    // undefined and run every matching rule.
+    if (only && action !== only) continue;
     // Branch scoping: skip an action whose include/exclude globs don't admit
     // this event's branch(es). Undefined conditions always pass.
     if (
@@ -271,6 +288,9 @@ async function run(event: AutomationEvent): Promise<void> {
     // `cancelReview`, which aborts THIS controller and kills the CLI subprocess —
     // no floating persistent toast. `handle.isCancelled()` stays readable after a
     // dock Cancel, so the guards below skip delivery + the failure toast.
+    // Past every skip gate — this run is actually attempted (counted so a
+    // Re-run that matches nothing can toast instead of dying silently).
+    attempted++;
     const controller = new AbortController();
     const handle = registerAutomationRun({
       // TaskRow already prefixes the mode name, so pass the bare subject.
@@ -280,6 +300,9 @@ async function run(event: AutomationEvent): Promise<void> {
       local: isLocalProvider(settings.reviewAi.provider),
       target: automationTarget(event),
       abort: controller,
+      // Re-fires THIS event + mode (closes over this iteration's action) when the
+      // run's stopped row's Re-run is clicked.
+      rerun: () => rerunAutomation(event, action),
     });
     // On cancel, persist the dismissed PR head so a cancelled re-review doesn't
     // re-fire after an app relaunch (cancel advances no history watermark). PR
@@ -305,6 +328,9 @@ async function run(event: AutomationEvent): Promise<void> {
         handle.setCliId,
       );
       if (handle.isCancelled()) {
+        // The dock's Cancel already patched the row to "cancelled" (keeping its
+        // Re-run) and deleted the control — do NOT settle/remove it here. Keep
+        // the claim release + dismissed-head persist + toast exactly as before.
         releaseClaim();
         dismissOnCancel();
         toast.info(`AI ${label} cancelled.`, { duration: 4000 });
@@ -313,6 +339,7 @@ async function run(event: AutomationEvent): Promise<void> {
       if (result === null) {
         releaseClaim();
         toast.info(`AI ${label} skipped — no changes to review.`);
+        handle.settle(); // no-op run: remove the row as before
         continue;
       }
       const { text, thoughts } = result;
@@ -339,25 +366,96 @@ async function run(event: AutomationEvent): Promise<void> {
           thoughts,
         ).catch(() => undefined);
       }
+      // Success: remove the dock row — a delivered review lands in Notifications.
+      handle.settle();
     } catch (e) {
       // Release the claim on every failure/cancel path so a transient error doesn't
       // permanently suppress this automation for this head across instances.
       releaseClaim();
       if (handle.isCancelled()) {
+        // Cancelled mid-stream: same as the post-generate cancel arm — the dock
+        // already owns the "cancelled" row, so leave it (do not settle).
         dismissOnCancel();
         toast.info(`AI ${label} cancelled.`, { duration: 4000 });
         continue;
       }
-      toast.error(`AI ${label} failed: ${e instanceof Error ? e.message : e}`);
+      // errorMessage unwraps AppError/Error shapes — a raw interpolation renders
+      // Tauri invoke rejections as "[object Object]" (observed live).
+      const message = errorMessage(e);
+      toast.error(`AI ${label} failed: ${message}`);
+      // Inbox parity with manual runs (which land a review-failed inbox row via
+      // reviews.ts's notifyReviewDone): a genuine automation failure records one
+      // too, gated on the same automations pref. Commit events have no PR target;
+      // PR events carry a navigable one.
       if (notify) {
+        pushNotification({
+          kind: "review-failed",
+          tone: "danger",
+          title: `AI ${label} failed`,
+          subtitle:
+            event.kind === "commit"
+              ? `"${event.hash.slice(0, 7)}"`
+              : `"${event.title}"`,
+          repoPath: event.repoPath,
+          repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
+          ...(event.kind === "commit"
+            ? {}
+            : {
+                target: {
+                  type: "pr",
+                  kind: event.target.type,
+                  ref: targetRef(event),
+                },
+              }),
+          dedupeKey: `automation-failed:${event.repoPath}:${event.kind}:${
+            event.kind === "commit" ? event.hash : targetRef(event)
+          }:${action}`,
+        });
         void notifyIfUnfocused(`AI ${label} failed`, `"${event.title}"`);
       }
-    } finally {
-      // Every terminal path (success, skip, error, cancelled, thrown) removes the
-      // dock row — automation runs never linger in a finished state.
-      handle.settle();
+      // Persist a "Failed" stopped row (keeping its Re-run) instead of removing it.
+      handle.fail(message);
     }
   }
+  return attempted;
+}
+
+/**
+ * Re-fires a stopped (cancelled/failed) automation run for exactly one mode —
+ * invoked by a stopped row's Re-run button. Fire-and-forget, like
+ * {@link triggerAutomations}.
+ *
+ * For PR events it first clears the dismissed-head watermark for this (target,
+ * mode): a cancelled run wrote one, and without clearing it the re-run would
+ * silently no-op at the runner's `sameSha(dismissedHead, headSha)` pr-sync gate.
+ * The run then flows through the normal pipeline scoped to `only`, so it
+ * re-claims (canceled/failed runs released their claim) and re-reviews just that
+ * mode. If the rule was disabled since the run stopped, nothing matches and we
+ * surface an informative toast rather than a silent dead button.
+ */
+export function rerunAutomation(
+  event: AutomationEvent,
+  only: ReviewMode,
+): void {
+  const label = modeLabel(only);
+  const clear =
+    event.kind === "commit"
+      ? Promise.resolve()
+      : clearDismissedHead(
+          event.repoPath,
+          event.target.type,
+          targetRef(event),
+          only,
+        ).catch(() => undefined);
+  void clear
+    .then(() => run(event, only))
+    .then((attempted) => {
+      if (attempted === 0) {
+        const noun = event.kind === "commit" ? "commit" : "pull request";
+        toast.info(`Automated ${label} for this ${noun} is turned off.`);
+      }
+    })
+    .catch(() => undefined);
 }
 
 /** A completed automated review: the final answer `text` plus any agentic
@@ -397,7 +495,30 @@ async function generateReviewText(
       "origin",
     );
     diff = { text, truncated: false, files: filesFromDiff(text) };
+  } else if (event.target.type === "remote") {
+    // Remote pr-open: prefer the local branch diff (it carries numstat), but the
+    // head branch isn't guaranteed local — catch-up and ready-flip events cover
+    // PRs opened elsewhere (teammate / web), which reach this machine via the
+    // poller before any fetch lands the ref (observed live: `git diff` fails on
+    // an unfetched head). Fall back to the provider's authoritative PR diff,
+    // the same source the remote pr-sync arm above uses unconditionally.
+    try {
+      diff = await gitBranchDiff(
+        event.repoPath,
+        event.base,
+        event.head,
+        DIFF_MAX_BYTES,
+      );
+    } catch {
+      const text = await forgePrDiff(
+        event.repoPath,
+        event.target.number,
+        "origin",
+      );
+      diff = { text, truncated: false, files: filesFromDiff(text) };
+    }
   } else {
+    // Local PR targets: both branches are inherently local.
     diff = await gitBranchDiff(
       event.repoPath,
       event.base,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -31,7 +31,11 @@ import { getLatestReview, saveReview } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
 import { pushNotification } from "@/lib/stores/notifications";
-import { type ReviewTarget, registerAutomationRun } from "@/lib/stores/reviews";
+import {
+  type ReviewTarget,
+  registerAutomationRun,
+  resetReview,
+} from "@/lib/stores/reviews";
 import { errorMessage, invoke } from "@/lib/tauri/invoke";
 import {
   clearDismissedHead,
@@ -164,19 +168,41 @@ export function triggerAutomations(event: AutomationEvent): void {
   void run(event).catch(() => undefined);
 }
 
+/** What a {@link run} pass did, so a re-run can tell the outcomes apart:
+ *  - `matched`: rules that exist AND apply to this event (past the `only` +
+ *    branch-condition gates). 0 means the rule genuinely no longer applies
+ *    (e.g. disabled since) — the honest "turned off" case.
+ *  - `attempted`: runs actually started (past every gate incl. sync watermark +
+ *    cross-instance claim). `matched > 0 && attempted === 0` means a rule applies
+ *    but a claim/watermark blocked it — a retryable "already covered" case. */
+interface RunOutcome {
+  matched: number;
+  attempted: number;
+}
+
 /**
  * Runs the automation rules matching `event`. When `only` is set (a re-run of a
  * single stopped row), every rule whose mode differs is skipped, so exactly that
- * one mode re-fires. Returns the number of actions actually attempted (past the
- * mode/branch/sync/claim gates) so a re-run can tell "nothing matched" (e.g. the
- * rule was disabled since) from a real run and surface an informative toast.
+ * one mode re-fires. `replacesKey` is the stopped row a re-run replaces — removed
+ * the instant its replacement run registers (see below), so the stopped row never
+ * lingers next to its fresh Running row and is kept when nothing registers.
+ * Returns a {@link RunOutcome} so a re-run can distinguish "rule gone" from
+ * "blocked but retryable" from "started".
  */
-async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
+async function run(
+  event: AutomationEvent,
+  only?: ReviewMode,
+  replacesKey?: string,
+): Promise<RunOutcome> {
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   const actions = effectiveActions(config, repo, event.kind);
-  if (actions.length === 0) return 0;
+  if (actions.length === 0) return { matched: 0, attempted: 0 };
+  let matched = 0;
   let attempted = 0;
+  // Cleared once consumed so a second registering action can't double-remove
+  // (harmless — resetReview no-ops on a missing key — but keeps intent explicit).
+  let staleKey = replacesKey;
 
   // The branch(es) a branch-condition is tested against. Commit events carry the
   // committed branch; PR events carry head/base (added by the poll payload).
@@ -203,6 +229,10 @@ async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
     ) {
       continue;
     }
+    // Past the mode + branch gates — this rule exists AND applies. Counted so a
+    // re-run can tell "rule genuinely gone" (matched 0) from "rule applies but a
+    // claim/watermark blocked it" (matched > 0, attempted 0 → retryable).
+    matched++;
     // pr-sync is opt-in per PR: re-review only a PR already reviewed in this
     // mode, and only once its head has advanced past the last-reviewed commit
     // (the persisted review's headSha is the per-mode watermark). This scopes
@@ -292,6 +322,10 @@ async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
     // Re-run that matches nothing can toast instead of dying silently).
     attempted++;
     const controller = new AbortController();
+    // Let-box so the rerun closure carries THIS run's own key (assigned right
+    // after registration): a re-run of the fresh row must replace the fresh row,
+    // not the stale one it grew from.
+    let selfKey = "";
     const handle = registerAutomationRun({
       // TaskRow already prefixes the mode name, so pass the bare subject.
       title: event.kind === "commit" ? event.hash.slice(0, 7) : event.title,
@@ -301,9 +335,20 @@ async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
       target: automationTarget(event),
       abort: controller,
       // Re-fires THIS event + mode (closes over this iteration's action) when the
-      // run's stopped row's Re-run is clicked.
-      rerun: () => rerunAutomation(event, action),
+      // run's stopped row's Re-run is clicked, passing its own row key so the
+      // fresh run removes THIS row when it registers.
+      rerun: () => rerunAutomation(event, action, selfKey),
     });
+    selfKey = handle.key;
+    // The replacement run has now registered its fresh Running row — remove the
+    // stopped row it replaces (a re-run only). Done here (not at the Re-run click)
+    // so the old row is kept whenever nothing registers (rule gone / blocked),
+    // giving the user a retry target. Cleared so a second registering action in
+    // the same pass can't re-trigger the removal.
+    if (staleKey) {
+      resetReview(staleKey);
+      staleKey = undefined;
+    }
     // On cancel, persist the dismissed PR head so a cancelled re-review doesn't
     // re-fire after an app relaunch (cancel advances no history watermark). PR
     // events with a headSha only; best-effort — a persistence failure must never
@@ -417,7 +462,7 @@ async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
       handle.fail(message);
     }
   }
-  return attempted;
+  return { matched, attempted };
 }
 
 /**
@@ -436,26 +481,44 @@ async function run(event: AutomationEvent, only?: ReviewMode): Promise<number> {
 export function rerunAutomation(
   event: AutomationEvent,
   only: ReviewMode,
+  staleKey: string,
 ): void {
   const label = modeLabel(only);
-  const clear =
-    event.kind === "commit"
-      ? Promise.resolve()
-      : clearDismissedHead(
+  const noun = event.kind === "commit" ? "commit" : "pull request";
+  void (async () => {
+    try {
+      // Best-effort ONLY here: a cleared-dismissal failure must not block the
+      // re-run (it just means the pr-sync gate might skip; we then toast retryable).
+      if (event.kind !== "commit") {
+        await clearDismissedHead(
           event.repoPath,
           event.target.type,
           targetRef(event),
           only,
         ).catch(() => undefined);
-  void clear
-    .then(() => run(event, only))
-    .then((attempted) => {
-      if (attempted === 0) {
-        const noun = event.kind === "commit" ? "commit" : "pull request";
-        toast.info(`Automated ${label} for this ${noun} is turned off.`);
       }
-    })
-    .catch(() => undefined);
+      // The stopped row is removed inside run() the instant its replacement
+      // registers — so every non-registering outcome below keeps it as a retry
+      // target.
+      const { matched, attempted } = await run(event, only, staleKey);
+      if (matched === 0) {
+        // The rule genuinely no longer applies (disabled / conditions changed).
+        toast.info(`Automated ${label} for this ${noun} is turned off.`);
+      } else if (attempted === 0) {
+        // A rule applies, but a still-held claim or a sync watermark blocked the
+        // run (a canceled sibling still unwinding, or another instance covering
+        // this head). The stopped row is kept — retry once that clears.
+        toast.info(
+          `Couldn't re-run the ${label} — another run already covers this head (still finishing or ran elsewhere). The row is kept; try again in a moment.`,
+        );
+      }
+      // attempted > 0: the fresh Running row is the feedback — no toast.
+    } catch (e) {
+      // A throw anywhere (loadAutomations / store I/O before the loop, etc.) used
+      // to be swallowed, leaving no feedback. Surface it; the stopped row stays.
+      toast.error(`Couldn't re-run the ${label}: ${errorMessage(e)}`);
+    }
+  })();
 }
 
 /** A completed automated review: the final answer `text` plus any agentic

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2032,13 +2032,16 @@ export const forgePrRequestChanges = (
 export const forgePrUnrequestChanges = (repoPath: string, number: number) =>
   invoke<void>("forge_pr_unrequest_changes", { repoPath, number });
 
-/** Toggle a PR's draft state — Bitbucket-only (both directions; GitHub keeps its
- *  one-way `gh pr ready` path). */
+/** Toggle a PR's draft state both ways, for all three providers. Bitbucket PUTs
+ *  `draft`; GitLab shells `glab mr update --ready|--draft`; GitHub shells
+ *  `gh pr ready [--undo]`. `lens` is GitHub-only (fork identity) — passed through
+ *  and ignored by the GitLab/Bitbucket arms. */
 export const forgePrSetDraft = (
   repoPath: string,
   number: number,
   draft: boolean,
-) => invoke<void>("forge_pr_set_draft", { repoPath, number, draft });
+  lens?: RemoteLens,
+) => invoke<void>("forge_pr_set_draft", { repoPath, number, draft, lens });
 
 /** Replace a PR's reviewer list (ids from `forgePrReviewerCandidates`) — all
  *  three providers (`implemented.mrReviewers`); create-time reviewers remain
@@ -2828,9 +2831,6 @@ export const fundingSet = (repoPath: string, content: string) =>
 
 export const fundingDelete = (repoPath: string) =>
   invoke<void>("funding_delete", { repoPath });
-
-export const ghPrReady = (repoPath: string, number: number, lens: RemoteLens) =>
-  invoke<void>("gh_pr_ready", { repoPath, number, lens });
 
 export const forgePrEdit = (
   repoPath: string,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2590,6 +2590,7 @@ const NO_FORGE_STATUS: ForgeStatus = {
     commitComments: false,
     mrThreadCreate: false,
     mrReviewSubmit: false,
+    mrDraftToggle: false,
   },
 };
 
@@ -3800,13 +3801,42 @@ export function useUnrequestChangesPr(repo: string) {
   );
 }
 
-/** Toggle a PR's draft state (Bitbucket-only — both directions, unlike GitHub's
- *  one-way `gh pr ready`). Invalidation via useRepoMutation refreshes the badge
- *  and the merge gate. */
-export function useSetPrDraft(repo: string) {
-  return useRepoMutation(repo, (args: { number: number; draft: boolean }) =>
-    api.forgePrSetDraft(repo, args.number, args.draft),
-  );
+/** Toggle a PR's draft state both ways, for all three providers (Bitbucket PUT,
+ *  GitLab `glab mr update`, GitHub `gh pr ready [--undo]`). `lens` threads the
+ *  fork identity through to the GitHub arm. Optimistically patches the PR detail's
+ *  `isDraft` with field-scoped rollback (mirroring `useSetPrAssignees`) so the
+ *  badge flips instantly; the repo-wide invalidate on settle reconciles server
+ *  truth and refreshes the merge gate. */
+export function useSetPrDraft(repo: string, lens: RemoteLens) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { number: number; draft: boolean }) =>
+      api.forgePrSetDraft(repo, args.number, args.draft, lens),
+    onMutate: async (args) => {
+      const key = ["repo", repo, "pr", lens, args.number] as const;
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData<PrDetails>(key);
+      queryClient.setQueryData<PrDetails>(key, (d) =>
+        d ? { ...d, isDraft: args.draft } : d,
+      );
+      // Field-scoped rollback: capture only the isDraft we flipped, not the whole
+      // PrDetails, so a failed draft-set doesn't revert a concurrent
+      // assignee/reviewer-set sharing this PR key.
+      return { key, prevIsDraft: prev?.isDraft };
+    },
+    onError: (_e, _args, ctx) => {
+      const prevIsDraft = ctx?.prevIsDraft;
+      const key = ctx?.key;
+      if (prevIsDraft === undefined || key === undefined) return;
+      queryClient.setQueryData<PrDetails>(key, (cur) =>
+        cur ? { ...cur, isDraft: prevIsDraft } : cur,
+      );
+    },
+    // Repo-wide reconcile (what useRepoMutation's default gave before this went
+    // optimistic) so the PR badge AND the merge gate both refresh on settle.
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: repoKeys.all(repo) }),
+  });
 }
 
 /** The reviewer picker's candidates (Bitbucket: workspace members minus the user the
@@ -5448,12 +5478,6 @@ export function useSetRulesetEnforcement(repo: string) {
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: rulesetsKey(repo) }),
   });
-}
-
-export function useReadyPr(repo: string, lens: RemoteLens) {
-  return useRepoMutation(repo, (number: number) =>
-    api.ghPrReady(repo, number, lens),
-  );
 }
 
 export function useEditPr(repo: string, lens: RemoteLens) {

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -755,6 +755,11 @@ export interface ForgeImplemented {
   /** Submitting a batch review (verdict + summary + staged draft comments) — a
    *  shared control (GitHub review submit, GitLab batch note post). */
   mrReviewSubmit: boolean;
+  /** Toggling a PR/MR's draft state both ways from the shared Ready /
+   *  Convert-to-draft control. GitLab (`glab mr update --ready|--draft`) and
+   *  Bitbucket (PUT `draft`) true; GitHub keeps its Ready/Convert path via
+   *  `gh pr ready [--undo]` gated on `canWrite`, so it stays false here. */
+  mrDraftToggle: boolean;
 }
 
 /** One pull-request task (Bitbucket's PR checklist). `id`/`commentId` are numeric

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -644,6 +644,18 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "pr-ready-for-review",
+    label: "Ready for review",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
+  {
+    id: "pr-convert-to-draft",
+    label: "Convert to draft",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
+  {
     id: "submit-review",
     label: "Submit review…",
     category: "Pull requests",

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -245,6 +245,12 @@ export interface AppSettings {
    *  Read undefined-safe (absent on settings stored before this field existed →
    *  `false`) via the DEFAULT_SETTINGS spread in loadSettings. */
   reviewDraftPrs: boolean;
+  /** Default new pull requests to draft: the Create-PR dialog's "Create as
+   *  draft" checkbox starts ticked. Off by default (unchanged behavior); the
+   *  user can still untick it per-dialog. Read undefined-safe (absent on
+   *  settings stored before this field existed → `false`) via the
+   *  DEFAULT_SETTINGS spread in loadSettings. */
+  createPrsAsDraft: boolean;
   /** First-run nudge toward the user guide; set once the user opens or dismisses it. */
   seenGuideNudge: boolean;
   /** Send anonymous usage events to PostHog. Default on (opt-out). */
@@ -322,6 +328,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   autoFetch: true,
   autoFetchInterval: "10",
   reviewDraftPrs: false,
+  createPrsAsDraft: false,
   seenGuideNudge: false,
   analyticsEnabled: true,
   recordReplay: false,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -103,6 +103,12 @@ export interface ReviewEntry {
    *  a single patch, so it lives on the entry, not the per-token `texts` map). The
    *  panel shows it behind a "Thought process" disclosure; the dock ignores it. */
   thoughts?: string;
+  /** Re-fires this run through the automation pipeline — set ONLY on automation
+   *  rows (by {@link registerAutomationRun}). Its presence is the discriminator
+   *  that a stopped (cancelled/error) row belongs in the dock's Stopped group: a
+   *  manual panel run also reaches "cancelled"/"error" but never carries a rerun,
+   *  so it's kept out. */
+  rerun?: () => void;
 }
 
 /** A store entry tagged with its key — what the activity dock renders. */
@@ -191,6 +197,31 @@ const controls = new Map<string, RunControl>();
 
 /** Monotonic counter stamped on each run for exact start-order display. */
 let reviewSeq = 0;
+
+/** How many stopped (cancelled/error) automation rows the dock keeps at once. */
+const MAX_STOPPED_ROWS = 8;
+
+/**
+ * After a transition to a stopped state, cap the retained stopped automation
+ * rows — keep at most {@link MAX_STOPPED_ROWS} entries that are automation
+ * (`auto:` key) AND in a stopped phase (cancelled/error), evicting the oldest by
+ * `seq`. Manual panel runs and live/finished rows are never touched. Called from
+ * both terminal stopped paths (cancelReview's auto arm + a run handle's fail).
+ */
+function enforceStoppedCap(): void {
+  const { entries } = useReviewStore.getState();
+  const stopped = Object.entries(entries)
+    .filter(
+      ([key, e]) =>
+        key.startsWith("auto:") &&
+        (e.phase === "cancelled" || e.phase === "error"),
+    )
+    .sort((a, b) => a[1].seq - b[1].seq); // oldest first
+  const excess = stopped.length - MAX_STOPPED_ROWS;
+  for (let i = 0; i < excess; i++) {
+    useReviewStore.getState().remove(stopped[i][0]);
+  }
+}
 
 const clamp = (v: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, v));
@@ -588,15 +619,14 @@ export function cancelReview(key: string): void {
     if (i >= 0) control.lane.waiting.splice(i, 1);
     control.wakeQueued();
   }
-  // Automation rows (`auto:` keys) never persist a finished state — remove
-  // outright so the row can't flash a "Cancelled" state (with a live View
-  // button on a display-only target) before the runner's own settle() lands.
-  // Their cancel feedback is the runner's toast.
-  if (key.startsWith("auto:")) {
-    useReviewStore.getState().remove(key);
-  } else {
-    useReviewStore.getState().patch(key, { phase: "cancelled", status: "" });
-  }
+  // Automation rows (`auto:` keys) persist a "Cancelled" stopped row in the dock
+  // (keeping their `rerun`, so Re-run/Dismiss work) — that stopped row IS the
+  // cancel feedback now (the runner's toast still fires too). The runner sees
+  // this patched "cancelled" phase and skips its own settle/remove for the row.
+  // Both arms patch identically; the auto arm additionally caps retained stopped
+  // rows so a long session can't accumulate them without bound.
+  useReviewStore.getState().patch(key, { phase: "cancelled", status: "" });
+  if (key.startsWith("auto:")) enforceStoppedCap();
   controls.delete(key);
 }
 
@@ -627,11 +657,15 @@ export function registerAutomationRun(opts: {
   local: boolean;
   target: ReviewTarget;
   abort: AbortController;
+  /** Re-fires this exact run (event + mode) through the automation pipeline —
+   *  stored on the entry so a stopped row's Re-run button can invoke it. */
+  rerun: () => void;
 }): {
   key: string;
   setCliId(id: string): void;
   isCancelled(): boolean;
   settle(): void;
+  fail(message: string): void;
 } {
   const seq = ++reviewSeq;
   const key = `auto:${seq}`;
@@ -654,6 +688,8 @@ export function registerAutomationRun(opts: {
     target: opts.target,
     seq,
     error: "",
+    // Marks this as an automation row AND powers the stopped row's Re-run.
+    rerun: opts.rerun,
   });
   return {
     key,
@@ -667,6 +703,16 @@ export function registerAutomationRun(opts: {
     settle() {
       useReviewStore.getState().remove(key);
       // Only delete our own control — a dock Cancel may already have removed it.
+      if (controls.get(key) === control) controls.delete(key);
+    },
+    // A genuine failure (not a user cancel): persist a "Failed" stopped row (the
+    // entry keeps its `rerun`) instead of removing it, then cap retained stopped
+    // rows. Deletes only our own control, mirroring settle's own-control guard.
+    fail(message) {
+      useReviewStore
+        .getState()
+        .patch(key, { phase: "error", error: message, status: "" });
+      enforceStoppedCap();
       if (controls.get(key) === control) controls.delete(key);
     },
   };


### PR DESCRIPTION
Expand pull-request draft workflows across GitHub, GitLab, and Bitbucket while making stopped automated reviews recoverable in-app. The changes reduce repetitive setup for draft PRs and preserve failed or cancelled automation runs so users can retry the exact review mode.

### Pull-request draft workflows

- Adds `createPrsAsDraft` to `src/lib/settings/api.ts` and exposes the **Create pull requests as drafts** toggle in `src/features/settings/GeneralSection.tsx`.
- Initializes the Create PR dialog’s draft checkbox from the setting in `src/features/pulls/CreatePrDialog.tsx`, while retaining per-PR override support.
- Extends `forge_pr_set_draft` in `src-tauri/src/forge/mod.rs` to support both draft directions across GitHub, GitLab, and Bitbucket.
- Adds GitLab draft conversion through `set_mr_draft` in `src-tauri/src/forge/gitlab.rs`.
- Adds GitHub `gh pr ready --undo` support through `gh_pr_set_ready` in `src-tauri/src/github/pr.rs`, including fork-aware lens handling.
- Updates provider capability metadata in `src-tauri/src/forge/model.rs`, `src/lib/git/types.ts`, and `src/lib/git/queries.ts` for the shared draft toggle.
- Consolidates footer and command-palette actions in `src/features/pulls/RemotePrView.tsx` and `src/lib/hotkeys/registry.ts` for **Ready for review** and **Convert to draft**.
- Updates the GitDesktop MCP `set_pull_request_draft` tool in `src-tauri/src/mcp_server/write_forge.rs` and its API wrapper in `src/lib/git/api.ts`.
- Adds optimistic draft-state updates and rollback handling in `useSetPrDraft` within `src/lib/git/queries.ts`.

### Automation reruns

- Keeps cancelled and failed automated review rows in a **Stopped** group with **Re-run** and **Dismiss** actions in `src/features/activity/ActivityDock.tsx`.
- Stores the originating automation event and mode on review entries in `src/lib/stores/reviews.ts`, limits retained stopped rows, and preserves manual run behavior.
- Adds mode-scoped reruns in `src/lib/automations/runner.ts` so retrying a stopped row re-fires only that automation mode.
- Clears dismissed-head state before rerunning in `src/lib/automations/dismissals.ts`, preventing cancelled runs from being skipped by the existing watermark.
- Adds failed-automation inbox notifications and improves error extraction in `src/lib/automations/runner.ts`.
- Adds a provider-diff fallback in `src/lib/automations/runner.ts` when a remote pull-request head is not available locally.

### Documentation and release notes

- Documents draft controls, default draft creation, and stopped automation reruns in `README.md`.
- Updates user guidance in `src/features/help/content.ts`.
- Adds release notes in `changelog.d/added-automation-rerun.md`, `changelog.d/added-default-draft-setting.md`, and `changelog.d/changed-draft-toggle-all-providers.md`.