### PR TITLE
feat(ai,pulls,automations,activity): add dedicated security models and review runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,9 @@ workflow against any two branches with no remote at all).
   reviews and any "fixed in `<sha>`" / refutation replies) as soft, re-verifiable
   context, so an already-addressed finding isn't re-raised cold (the current diff is
   always the source of truth). Per PR, ignore the prior review, trim a false finding, or
-  opt out of external-bot folding. By default a **draft** PR waits for its first automated
+  opt out of external-bot folding. Pick a **review model** independent of the generation
+  model, and optionally a **separate model for security audits** (e.g. a stronger model
+  for audits, a faster one for general reviews). By default a **draft** PR waits for its first automated
   review until you mark it ready — flip **Review draft PRs when created** in Settings →
   Automations to review on creation instead.
 - **Line-anchored review comments** — from Copilot, CodeRabbit, or humans — render

--- a/changelog.d/added-review-runtimes.md
+++ b/changelog.d/added-review-runtimes.md
@@ -1,0 +1,5 @@
+- **See how long reviews take.** The Activity & notifications popover now shows a live
+  elapsed timer on a running AI review, notes how long a stopped (cancelled or failed)
+  automated run ran before it stopped, and the **Previous reviews** list shows each
+  finished review's total run duration. The PR review panel also ticks a live elapsed
+  timer beside Cancel while a review runs, and shows the total time it took once it's done.

--- a/changelog.d/added-security-review-model.md
+++ b/changelog.d/added-security-review-model.md
@@ -1,0 +1,6 @@
+- **Dedicated security-audit model.** Give AI security audits their own provider and model,
+  separate from the general review model — e.g. a stronger model for audits and a faster one
+  for everyday reviews. Toggle **Use a different model for security audits** under the review
+  model in Settings → AI; left off, audits keep using the review model exactly as before. The
+  choice applies to both automated audits and the **Security audit** button on a PR (an
+  in-panel model pick still overrides both for that one run).

--- a/src/components/elapsed-time.tsx
+++ b/src/components/elapsed-time.tsx
@@ -1,0 +1,57 @@
+import { useSyncExternalStore } from "react";
+import { formatDuration } from "@/lib/time";
+import { cn } from "@/lib/utils";
+
+// All mounted elapsed counters compute from ONE shared snapshot, refreshed every
+// second, so simultaneously-mounted rows tick in lockstep (the point of a shared
+// ticker) — and the React Compiler memoizes each row's output, so a bare
+// `Date.now()` read in render is invisible to it and the elapsed would freeze at
+// mount time. Threading `now` through useSyncExternalStore keeps the memo key
+// aware of the clock. The interval runs ONLY while at least one counter is
+// mounted (started at 0→1 subscribers, cleared at 1→0).
+const TICK_MS = 1000;
+let now = Date.now();
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function refresh() {
+  now = Date.now();
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (timer === null) {
+    // Going 0→1 subscribers: the snapshot may be stale from an idle spell —
+    // refresh once so the first mounted counter starts from real now.
+    timer = setInterval(refresh, TICK_MS);
+    refresh();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+const getNow = () => now;
+
+/** Live, ticking elapsed time since an epoch-ms instant, rendered as a compact
+ *  duration ("42s", "3m 12s"). `tabular-nums` keeps the width steady as it
+ *  ticks. Mount one only while the underlying run is actually in progress. */
+export function ElapsedTime({
+  since,
+  className,
+}: {
+  since: number;
+  className?: string;
+}) {
+  const nowMs = useSyncExternalStore(subscribe, getNow);
+  return (
+    <span className={cn("tabular-nums", className)}>
+      {formatDuration(nowMs - since)}
+    </span>
+  );
+}

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -15,6 +15,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { useRef, useState } from "react";
+import { ElapsedTime } from "@/components/elapsed-time";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,7 +43,7 @@ import {
   useReviewTasks,
 } from "@/lib/stores/reviews";
 import { useUiStore } from "@/lib/stores/ui";
-import { formatRelativeTime } from "@/lib/time";
+import { formatDuration, formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
 /**
@@ -338,11 +339,16 @@ function LiveTaskRow({
           {task.title || "Pull request"}
         </p>
         <p className="mt-0.5 flex items-center gap-1 text-[11px] text-muted-foreground">
-          <Spinner className="size-3 shrink-0" />
-          <span className="truncate">
-            {modeName} · {stateWord}
-            {crossRepo ? ` · ${task.target.repoName}` : ""}
+          <span className="flex min-w-0 items-center gap-1 truncate">
+            <Spinner className="size-3 shrink-0" />
+            <span className="truncate">
+              {modeName} · {stateWord}
+              {crossRepo ? ` · ${task.target.repoName}` : ""}
+            </span>
           </span>
+          {task.phase === "running" && task.startedAt && (
+            <ElapsedTime since={task.startedAt} className="ml-auto shrink-0" />
+          )}
         </p>
       </div>
       <Button
@@ -377,6 +383,12 @@ function StoppedTaskRow({
   const modeName = task.mode === "security" ? "Security audit" : "Review";
   const failed = task.phase === "error";
   const title = task.title || "Pull request";
+  // Static "ran for X" — only when both stamps exist and are ordered (a run
+  // cancelled while queued never entered "running", so it carries no start).
+  const ranFor =
+    task.startedAt && task.endedAt && task.endedAt > task.startedAt
+      ? formatDuration(task.endedAt - task.startedAt)
+      : null;
 
   return (
     <div className="flex items-start gap-2 px-3 py-2 not-last:border-b">
@@ -395,6 +407,7 @@ function StoppedTaskRow({
           ) : (
             "Cancelled"
           )}
+          {ranFor ? ` · ran ${ranFor}` : ""}
           {crossRepo ? ` · ${task.target.repoName}` : ""}
         </p>
       </div>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1621,8 +1621,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   persistent, click-to-open history (it survives a restart) so a finished review or a PR
   update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump to it,
-  arrow-key through the list, and clear items or mark all read. A review still running
-  shows a live **elapsed timer** so you can see how long it's taken.{{ai}} When an
+  arrow-key through the list, and clear items or mark all read.{{ai}} A review still
+  running shows a live **elapsed timer** so you can see how long it's taken. When an
   **automated** review or security audit is cancelled or fails, it stays in the popover
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
   **Dismiss** — a stopped row notes how long it ran before it stopped — and a failed

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1463,7 +1463,12 @@ Bring your own model:
   it's noticeably slower than an HTTP provider and draws on your plan's quota; the agent
   only completes the prepared prompt and never explores the repo on the generation path.
 
-You can set **separate models** for generation (commit/PR messages) versus review.
+You can set **separate models** for generation (commit/PR messages) versus review. Toggle
+**Use a different model for security audits** under the review model to give audits their own
+provider/model — e.g. a stronger model for audits and a faster one for general reviews.
+Left off, security audits use the review model. The choice applies to both automated audits
+and the **Security audit** button on a PR; picking a model in the PR panel still overrides
+both for that one run.
 
 **Custom & LAN servers — allowed hosts.** To reach an Ollama or OpenAI-compatible server
 that isn't \`localhost\` (a box on your network, or a self-hosted endpoint), enter its URL in
@@ -1499,8 +1504,8 @@ without you asking. It's a **lifecycle grid**: one section per moment — *On co
 request opened*, and *On new commits to a reviewed PR* — with **AI code review** and **AI
 security audit** as toggles under each. There's no "add a rule" — a given moment × action
 exists at most once, so you can't create conflicting duplicates. Reviews use the review model
-from the AI section; PR results are posted as a comment, commit results open from a
-notification. **Review draft PRs when created** (off by default) controls draft handling:
+from the AI section (security audits use the dedicated audit model when you've set one); PR
+results are posted as a comment, commit results open from a notification. **Review draft PRs when created** (off by default) controls draft handling:
 left off, a draft PR gets its automated first review when it's marked ready for review, not
 at creation — marking it ready **in GitDesktop** always fires that first review, while a
 draft readied elsewhere is picked up by the background catch-up poller within its window.
@@ -1616,11 +1621,13 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   persistent, click-to-open history (it survives a restart) so a finished review or a PR
   update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump to it,
-  arrow-key through the list, and clear items or mark all read.{{ai}} When an
+  arrow-key through the list, and clear items or mark all read. A review still running
+  shows a live **elapsed timer** so you can see how long it's taken.{{ai}} When an
   **automated** review or security audit is cancelled or fails, it stays in the popover
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
-  **Dismiss** — and a failed automated run also lands a *review failed* row in the inbox
-  (gated on the automations notification preference), matching manual-run failures.{{/ai}}
+  **Dismiss** — a stopped row notes how long it ran before it stopped — and a failed
+  automated run also lands a *review failed* row in the inbox (gated on the automations
+  notification preference), matching manual-run failures.{{/ai}}
 - **Keyboard** — rebind any shortcut, with live key-capture.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -190,6 +190,30 @@ export function PrReviewPanel({
   );
   const models = available.data?.models ?? [];
 
+  // Readiness signaling for the DEDICATED security model. The Security-audit
+  // button routes to `securityReviewAi` exactly when there's no in-panel override
+  // and one is configured (the same condition that shows the "Security audits use
+  // …" hint) — so when that config's provider needs a key / CLI the user hasn't
+  // set up, warn about IT specifically instead of letting the audit die into the
+  // generic error state. Skipped when the security provider matches the picker's:
+  // the picker's own warnings above already cover that case (no duplicate line).
+  // Hooks run every render (React rules); the render gate + query `enabled` keep
+  // them cheap when the security path doesn't apply.
+  const securityWarnApplies =
+    !reviewOverride &&
+    Boolean(securityReviewAi) &&
+    securityReviewAi?.provider !== provider;
+  const secProvider = securityReviewAi?.provider ?? "anthropic";
+  const secNeedsKey = PROVIDERS_REQUIRING_KEY.includes(secProvider);
+  const secKeyPreview = useSecretPreview(secProvider);
+  const secCliKind = providerKind(secProvider);
+  const secCliDetect = useQuery({
+    queryKey: ["agent-detect", secProvider, securityReviewAi?.cliPath ?? ""],
+    queryFn: () => detectAgentCli(secCliKind!, securityReviewAi?.cliPath),
+    enabled: Boolean(secCliKind) && securityWarnApplies,
+    staleTime: 60_000,
+  });
+
   function updateReview(patch: Partial<NonNullable<typeof reviewAi>>) {
     if (!reviewAi) return;
     setReviewOverride({ ...reviewAi, ...patch });
@@ -344,6 +368,40 @@ export function PrReviewPanel({
                       : "claude login"}
               </code>{" "}
               in a terminal.
+            </p>
+          )}
+        {securityWarnApplies && secNeedsKey && !secKeyPreview.data && (
+          <p className="text-xs text-warning">
+            No {PROVIDER_LABELS[secProvider]} API key saved — add one in
+            Settings to run a security audit.
+          </p>
+        )}
+        {securityWarnApplies &&
+          secCliKind &&
+          secCliDetect.data &&
+          !secCliDetect.data.found && (
+            <p className="text-xs text-warning">
+              {PROVIDER_LABELS[secProvider]} not found — install it or set its
+              path in Settings; security audits use it.
+            </p>
+          )}
+        {securityWarnApplies &&
+          secCliKind &&
+          secCliDetect.data?.found &&
+          secCliDetect.data.authed === "notAuthed" && (
+            <p className="text-xs text-warning">
+              {PROVIDER_LABELS[secProvider]} is installed but not signed in —
+              run{" "}
+              <code className="font-mono">
+                {secCliKind === "copilot"
+                  ? "copilot login"
+                  : secCliKind === "codex"
+                    ? "codex login"
+                    : secCliKind === "opencode"
+                      ? "opencode auth login"
+                      : "claude login"}
+              </code>{" "}
+              in a terminal to run a security audit.
             </p>
           )}
         <div className="flex flex-wrap items-center gap-2">

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -10,6 +10,7 @@ import { useQuery } from "@tanstack/react-query";
 import { AnimatePresence, m } from "motion/react";
 import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ElapsedTime } from "@/components/elapsed-time";
 import { Button } from "@/components/ui/button";
 import {
   Combobox,
@@ -51,7 +52,7 @@ import {
   useReviewRun,
 } from "@/lib/stores/reviews";
 import { useUiStore } from "@/lib/stores/ui";
-import { formatRelativeTime } from "@/lib/time";
+import { formatDuration, formatRelativeTime } from "@/lib/time";
 import { ReviewHistory } from "./ReviewHistory";
 import { ThoughtsDisclosure } from "./ThoughtsDisclosure";
 
@@ -113,6 +114,8 @@ export function PrReviewPanel({
     phase,
     error,
     thoughts,
+    startedAt,
+    endedAt,
   } = useReviewRun(target);
 
   // Prior reviews for this PR, used for the per-mode context banner. Read-only —
@@ -149,6 +152,10 @@ export function PrReviewPanel({
   const [ignoreExternal, setIgnoreExternal] = useState(false);
 
   const globalReviewAi = settings.data?.reviewAi;
+  // Optional dedicated config for security audits (Settings → AI). When set and
+  // no in-panel override is active, the Security-audit button runs it; the
+  // general Review button always uses `globalReviewAi`.
+  const securityReviewAi = settings.data?.securityReviewAi;
   // The provider/model picked in this panel is a per-run OVERRIDE — it changes
   // the model used for THIS review without rewriting the global default (set in
   // Settings → AI). Resets to the default when the panel remounts (e.g. a
@@ -189,9 +196,17 @@ export function PrReviewPanel({
   }
 
   function run(mode: ReviewMode) {
-    if (!reviewAi) return;
-    generate(reviewAi, mode, context, ignoredModes.has(mode), ignoreExternal);
-    const model = reviewAi.model.toLowerCase();
+    // An explicit in-panel pick wins for BOTH buttons; untouched, a security
+    // audit uses the dedicated `securityReviewAi` when configured, and every
+    // other mode uses the global review model.
+    const effective =
+      reviewOverride ??
+      (mode === "security" && securityReviewAi
+        ? securityReviewAi
+        : globalReviewAi);
+    if (!effective) return;
+    generate(effective, mode, context, ignoredModes.has(mode), ignoreExternal);
+    const model = effective.model.toLowerCase();
     const model_tier =
       model.includes("haiku") ||
       model.includes("mini") ||
@@ -201,12 +216,12 @@ export function PrReviewPanel({
             model.includes("gpt-4o") ||
             model.includes("sonnet-4")
           ? "powerful"
-          : reviewAi.provider === "ollama"
+          : effective.provider === "ollama"
             ? "local"
             : "balanced";
     track({
       name: "ai_review_triggered",
-      properties: { provider: reviewAi.provider, model_tier },
+      properties: { provider: effective.provider, model_tier },
     });
   }
 
@@ -291,6 +306,17 @@ export function PrReviewPanel({
             Model set for this review only — the default lives in Settings → AI.
           </p>
         )}
+        {!reviewOverride &&
+          securityReviewAi &&
+          globalReviewAi &&
+          (securityReviewAi.provider !== globalReviewAi.provider ||
+            securityReviewAi.model !== globalReviewAi.model) && (
+            <p className="text-xs text-muted-foreground">
+              Security audits use {PROVIDER_LABELS[securityReviewAi.provider]} ·{" "}
+              {securityReviewAi.model || "default model"} — set in Settings →
+              AI.
+            </p>
+          )}
         {needsKey && !keyPreview.data && (
           <p className="text-xs text-warning">
             No {PROVIDER_LABELS[provider]} API key saved — add one in Settings
@@ -325,6 +351,7 @@ export function PrReviewPanel({
             {generating ? (
               <m.div
                 key="cancel"
+                className="flex items-center gap-2"
                 initial={{ opacity: 0, scale: 0.96 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.96 }}
@@ -334,6 +361,14 @@ export function PrReviewPanel({
                   <XIcon data-icon="inline-start" />
                   Cancel
                 </Button>
+                {/* Queued runs have no startedAt yet — Cancel shows alone until
+                    the run is actually running. */}
+                {startedAt != null && (
+                  <ElapsedTime
+                    since={startedAt}
+                    className="text-xs text-muted-foreground"
+                  />
+                )}
               </m.div>
             ) : (
               <m.div
@@ -375,6 +410,16 @@ export function PrReviewPanel({
               Post as comment
             </Button>
           )}
+          {phase === "done" &&
+            text.trim() &&
+            !generating &&
+            startedAt != null &&
+            endedAt != null &&
+            endedAt > startedAt && (
+              <span className="text-xs text-muted-foreground">
+                took {formatDuration(endedAt - startedAt)}
+              </span>
+            )}
         </div>
         {(["general", "security"] as ReviewMode[]).map((m) => {
           const prior = latestByMode[m];

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -192,25 +192,41 @@ export function PrReviewPanel({
 
   // Readiness signaling for the DEDICATED security model. The Security-audit
   // button routes to `securityReviewAi` exactly when there's no in-panel override
-  // and one is configured (the same condition that shows the "Security audits use
-  // …" hint) — so when that config's provider needs a key / CLI the user hasn't
-  // set up, warn about IT specifically instead of letting the audit die into the
-  // generic error state. Skipped when the security provider matches the picker's:
-  // the picker's own warnings above already cover that case (no duplicate line).
-  // Hooks run every render (React rules); the render gate + query `enabled` keep
-  // them cheap when the security path doesn't apply.
-  const securityWarnApplies =
-    !reviewOverride &&
-    Boolean(securityReviewAi) &&
-    securityReviewAi?.provider !== provider;
+  // and one is configured (`securityPathActive` — the same condition that shows
+  // the "Security audits use …" hint) — so when that config needs a key / CLI the
+  // user hasn't set up, warn about IT specifically instead of letting the audit
+  // die into the generic error state. Two distinct trigger cases:
+  //  • `providerDiffers` — the security provider differs from the picker's active
+  //    one, so it may need its OWN key or CLI (all three warnings apply).
+  //  • `cliPathDiffers` — SAME provider (a CLI one) but a different `cliPath`, so
+  //    the audit could point at a missing/unauthed binary the picker's warnings
+  //    (keyed off the picker's path) never see (only the CLI warnings apply — a
+  //    shared provider shares its key, so no key warning here).
+  // When neither holds, the picker's own warnings above already cover the case, so
+  // nothing extra renders. Hooks run every render (React rules); the render gates +
+  // query `enabled` keep them cheap when the security path doesn't apply.
+  const securityPathActive = !reviewOverride && Boolean(securityReviewAi);
   const secProvider = securityReviewAi?.provider ?? "anthropic";
-  const secNeedsKey = PROVIDERS_REQUIRING_KEY.includes(secProvider);
-  const secKeyPreview = useSecretPreview(secProvider);
   const secCliKind = providerKind(secProvider);
+  const providerDiffers =
+    securityPathActive && securityReviewAi?.provider !== provider;
+  const cliPathDiffers =
+    securityPathActive &&
+    !providerDiffers &&
+    Boolean(secCliKind) &&
+    (securityReviewAi?.cliPath ?? "") !== (reviewAi?.cliPath ?? "");
+  const secNeedsKey = PROVIDERS_REQUIRING_KEY.includes(secProvider);
+  // Dedupes to the picker's own useSecretPreview(provider) at :174 when the
+  // security path doesn't apply or shares the provider (same provider-keyed cache
+  // entry, zero extra fetch); read only under `providerDiffers`, where the
+  // argument is `secProvider`.
+  const secKeyPreview = useSecretPreview(
+    providerDiffers ? secProvider : provider,
+  );
   const secCliDetect = useQuery({
     queryKey: ["agent-detect", secProvider, securityReviewAi?.cliPath ?? ""],
     queryFn: () => detectAgentCli(secCliKind!, securityReviewAi?.cliPath),
-    enabled: Boolean(secCliKind) && securityWarnApplies,
+    enabled: Boolean(secCliKind) && (providerDiffers || cliPathDiffers),
     staleTime: 60_000,
   });
 
@@ -370,13 +386,13 @@ export function PrReviewPanel({
               in a terminal.
             </p>
           )}
-        {securityWarnApplies && secNeedsKey && !secKeyPreview.data && (
+        {providerDiffers && secNeedsKey && !secKeyPreview.data && (
           <p className="text-xs text-warning">
             No {PROVIDER_LABELS[secProvider]} API key saved — add one in
             Settings to run a security audit.
           </p>
         )}
-        {securityWarnApplies &&
+        {(providerDiffers || cliPathDiffers) &&
           secCliKind &&
           secCliDetect.data &&
           !secCliDetect.data.found && (
@@ -385,7 +401,7 @@ export function PrReviewPanel({
               path in Settings; security audits use it.
             </p>
           )}
-        {securityWarnApplies &&
+        {(providerDiffers || cliPathDiffers) &&
           secCliKind &&
           secCliDetect.data?.found &&
           secCliDetect.data.authed === "notAuthed" && (

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -16,7 +16,7 @@ import {
   useReviewHistory,
   useUpdateReviewText,
 } from "@/lib/pulls/queries";
-import { formatRelativeTime } from "@/lib/time";
+import { formatDuration, formatRelativeTime } from "@/lib/time";
 import { ThoughtsDisclosure } from "./ThoughtsDisclosure";
 
 /**
@@ -132,6 +132,16 @@ export function ReviewHistory({
           {records.map((r) => {
             const expanded = expandedId === r.id;
             const editing = editingId === r.id;
+            // Total run duration — only on records with both stamps and a
+            // positive span. Note: records saved before the runtime-display
+            // change stamped `startedAt` at enqueue (queue wait included);
+            // newer ones stamp at run start — historical durations mix the two.
+            const duration =
+              typeof r.startedAt === "number" &&
+              typeof r.finishedAt === "number" &&
+              r.finishedAt - r.startedAt > 0
+                ? formatDuration(r.finishedAt - r.startedAt)
+                : null;
             return (
               <div key={r.id} role="listitem" className="border">
                 <div className="flex items-center gap-2 px-2 py-1">
@@ -156,8 +166,18 @@ export function ReviewHistory({
                     <span className="truncate font-mono text-muted-foreground">
                       {r.model || "model"}
                     </span>
-                    <span className="ml-auto shrink-0 text-muted-foreground">
-                      {formatRelativeTime(new Date(r.finishedAt).toISOString())}
+                    <span className="ml-auto flex shrink-0 items-center gap-1 text-muted-foreground">
+                      {duration && (
+                        <>
+                          <span className="tabular-nums">{duration}</span>
+                          <span aria-hidden>·</span>
+                        </>
+                      )}
+                      <span>
+                        {formatRelativeTime(
+                          new Date(r.finishedAt).toISOString(),
+                        )}
+                      </span>
                     </span>
                   </button>
                   <button

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -37,6 +37,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
 import { detectAgentCli, providerKind } from "@/lib/ai/agent";
 import {
   entryMatchesUrl,
@@ -579,6 +580,12 @@ export const AiProviderSection = withForm({
     const queryClient = useQueryClient();
     const ai = useSelector(form.store, (s) => s.values.ai);
     const reviewAi = useSelector(form.store, (s) => s.values.reviewAi);
+    // Optional dedicated security-audit config. `undefined` = off (security
+    // audits use `reviewAi`); an object = the toggle is on and its trio shows.
+    const securityReviewAi = useSelector(
+      form.store,
+      (s) => s.values.securityReviewAi,
+    );
     const reviewContextSize = useSelector(
       form.store,
       (s) => s.values.reviewContextSize ?? "auto",
@@ -605,9 +612,11 @@ export const AiProviderSection = withForm({
     const keyPreview = useSecretPreview(provider);
     // The Allowed-hosts manager is only relevant to the providers that take a
     // custom URL; keep it out of the way for the cloud-only majority.
-    const showAllowedHosts = [ai.provider, reviewAi.provider].some(
-      (p) => p === "ollama" || p === "openai-compatible",
-    );
+    const showAllowedHosts = [
+      ai.provider,
+      reviewAi.provider,
+      securityReviewAi?.provider,
+    ].some((p) => p === "ollama" || p === "openai-compatible");
     // The URLs the selected custom-host providers point at — so a host that's
     // keeping one reachable shows an "in use" hint before it's removed.
     const activeProviderUrls = [
@@ -616,6 +625,9 @@ export const AiProviderSection = withForm({
       reviewAi.provider === "ollama" && reviewAi.ollamaBaseUrl,
       reviewAi.provider === "openai-compatible" &&
         reviewAi.openaiCompatibleBaseUrl,
+      securityReviewAi?.provider === "ollama" && securityReviewAi.ollamaBaseUrl,
+      securityReviewAi?.provider === "openai-compatible" &&
+        securityReviewAi.openaiCompatibleBaseUrl,
     ].filter((u): u is string => Boolean(u));
 
     const [confirmClear, setConfirmClear] = useState(false);
@@ -864,6 +876,65 @@ export const AiProviderSection = withForm({
             allowedHosts={allowedHosts}
             onAllowHost={allowHost}
           />
+          <div className="space-y-1.5">
+            <label className="flex cursor-pointer items-center gap-2 text-xs">
+              <Switch
+                checked={Boolean(securityReviewAi)}
+                onCheckedChange={(checked) =>
+                  form.setFieldValue(
+                    "securityReviewAi",
+                    // Seed from the CURRENT DRAFT review config so the audit
+                    // model starts where the review model is; clear to undefined
+                    // (not a stale object) so the field is truly absent when off.
+                    checked ? { ...reviewAi } : undefined,
+                  )
+                }
+              />
+              Use a different model for security audits
+            </label>
+            {!securityReviewAi && (
+              <p className="text-xs text-muted-foreground">
+                Security audits use the review model above.
+              </p>
+            )}
+          </div>
+          {securityReviewAi && (
+            <div className="space-y-4">
+              <ModelPicker
+                idPrefix="security-review"
+                value={securityReviewAi}
+                onChange={(next) =>
+                  form.setFieldValue("securityReviewAi", next)
+                }
+                providerIds={ALL_PROVIDER_IDS}
+                allowedHosts={allowedHosts}
+              />
+              {isCliProvider(securityReviewAi.provider) && (
+                <CliProviderConfig
+                  idPrefix="security-review"
+                  value={securityReviewAi}
+                  onChange={(next) =>
+                    form.setFieldValue("securityReviewAi", next)
+                  }
+                  description={
+                    <>
+                      Uses the CLI's own subscription login — no API key needed.
+                      Security audits run read-only.
+                    </>
+                  }
+                />
+              )}
+              <ProviderUrlConfig
+                idPrefix="security-review"
+                value={securityReviewAi}
+                onChange={(next) =>
+                  form.setFieldValue("securityReviewAi", next)
+                }
+                allowedHosts={allowedHosts}
+                onAllowHost={allowHost}
+              />
+            </div>
+          )}
           <div className="space-y-2">
             <Label htmlFor="review-context-size">Review context</Label>
             <Select

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -29,7 +29,7 @@ import { notifyIfUnfocused } from "@/lib/notify";
 import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import { getLatestReview, saveReview } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
-import { loadSettings } from "@/lib/settings/api";
+import { effectiveReviewAi, loadSettings } from "@/lib/settings/api";
 import { pushNotification } from "@/lib/stores/notifications";
 import {
   type ReviewTarget,
@@ -311,6 +311,12 @@ async function run(
     };
 
     const label = modeLabel(action);
+    // The AI config this rule's mode runs under: security audits use the
+    // dedicated `securityReviewAi` when configured, else fall back to `reviewAi`
+    // (general reviews always use `reviewAi`). Resolved once so the lane pick,
+    // the review generation, the delivered comment's model label, and the
+    // persisted history model all agree.
+    const reviewCfg = effectiveReviewAi(settings, action);
     // Per-rule cancellation: HTTP providers stop via the AbortSignal; CLI
     // providers stop by killing the subprocess (`cancelAgentReview` once we know
     // its id). Both are driven by the shared reviews store: the run registers a
@@ -322,6 +328,10 @@ async function run(
     // Re-run that matches nothing can toast instead of dying silently).
     attempted++;
     const controller = new AbortController();
+    // Wall-clock run start, mirrored into the persisted history record so an
+    // automated review carries a real duration (registerAutomationRun stamps
+    // the live dock entry's own `startedAt` at the same moment).
+    const runStartedMs = Date.now();
     // Let-box so the rerun closure carries THIS run's own key (assigned right
     // after registration): a re-run of the fresh row must replace the fresh row,
     // not the stale one it grew from.
@@ -331,7 +341,7 @@ async function run(
       title: event.kind === "commit" ? event.hash.slice(0, 7) : event.title,
       mode: action,
       // Same provider-kind signal the manual panel path uses to pick its lane.
-      local: isLocalProvider(settings.reviewAi.provider),
+      local: isLocalProvider(reviewCfg.provider),
       target: automationTarget(event),
       abort: controller,
       // Re-fires THIS event + mode (closes over this iteration's action) when the
@@ -366,7 +376,7 @@ async function run(
     };
     try {
       const result = await generateReviewText(
-        settings.reviewAi,
+        reviewCfg,
         action,
         event,
         controller.signal,
@@ -393,7 +403,7 @@ async function run(
       // posted (buildAiCommentBody + deliver both take `text`).
       const body = buildAiCommentBody({
         kind: label,
-        model: settings.reviewAi.model,
+        model: reviewCfg.model,
         automated: true,
         text,
       });
@@ -407,8 +417,9 @@ async function run(
           event,
           action,
           text,
-          settings.reviewAi.model,
+          reviewCfg.model,
           thoughts,
+          runStartedMs,
         ).catch(() => undefined);
       }
       // Success: remove the dock row — a delivered review lands in Notifications.
@@ -862,6 +873,8 @@ async function persistReviewHistory(
   text: string,
   model: string,
   thoughts: string,
+  /** The run's wall-clock start — persisted so history shows a real duration. */
+  startedAtMs: number,
 ): Promise<void> {
   if (!text.trim()) return;
   const kind = event.target.type;
@@ -879,7 +892,7 @@ async function persistReviewHistory(
     // Display-only narration (omitted when empty; never fed to the next run).
     ...(thoughts.trim() ? { thoughts } : {}),
     headSha: event.headSha ?? "",
-    startedAt: now,
+    startedAt: startedAtMs,
     finishedAt: now,
   });
   await queryClient.invalidateQueries({

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -1,6 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import type { ReviewContextSize } from "@/lib/ai/context-budget";
-import type { AiSettings } from "@/lib/ai/types";
+import type { AiSettings, ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
 
@@ -178,6 +178,10 @@ export interface AppSettings {
   ai: AiSettings;
   /** Provider/model for AI PR review (independent of the commit model). */
   reviewAi: AiSettings;
+  /** Optional dedicated provider/model for AI security audits; absent = security
+   *  audits use `reviewAi`. Not in DEFAULT_SETTINGS — its absence is the meaningful
+   *  default, so existing users keep byte-identical behavior until they opt in. */
+  securityReviewAi?: AiSettings;
   /** How much diff + prior-discussion context AI reviews send, scaled to the
    *  reviewing model. `"auto"` fits the model's context window (probing Ollama
    *  live); the others force a fixed multiple of the default budget. */
@@ -344,6 +348,21 @@ export const DEFAULT_SETTINGS: AppSettings = {
   bitbucketTokenExpiresAt: null,
 };
 
+/**
+ * The AI config a review should use for `mode`. Security audits use the dedicated
+ * `securityReviewAi` when the user configured one, falling back to `reviewAi`
+ * otherwise; every other mode always uses `reviewAi`. Centralizes the fallback so
+ * the automation runner and the manual review panel agree on which model runs.
+ */
+export function effectiveReviewAi(
+  settings: AppSettings,
+  mode: ReviewMode,
+): AiSettings {
+  return mode === "security"
+    ? (settings.securityReviewAi ?? settings.reviewAi)
+    : settings.reviewAi;
+}
+
 const MAX_RECENT_REPOS = 200;
 
 let storePromise: Promise<Store> | null = null;
@@ -364,6 +383,17 @@ export async function loadSettings(): Promise<AppSettings> {
     ...saved,
     ai: { ...DEFAULT_SETTINGS.ai, ...saved?.ai },
     reviewAi: { ...DEFAULT_SETTINGS.reviewAi, ...saved?.reviewAi },
+    // Nested-merge only when present so a partial saved object heals against the
+    // reviewAi defaults; an absent one stays absent (security audits then fall
+    // back to reviewAi via effectiveReviewAi).
+    ...(saved?.securityReviewAi
+      ? {
+          securityReviewAi: {
+            ...DEFAULT_SETTINGS.reviewAi,
+            ...saved.securityReviewAi,
+          },
+        }
+      : {}),
     notifications: {
       ...DEFAULT_SETTINGS.notifications,
       ...saved?.notifications,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -88,6 +88,12 @@ export interface ReviewEntry {
   /** Monotonic start order — drives newest-first display and FIFO queue
    *  position exactly (a timestamp can collide within a millisecond). */
   seq: number;
+  /** Epoch ms stamped when the run actually enters "running" — the queue wait is
+   *  EXCLUDED, so the live elapsed measures real work time. Absent while queued. */
+  startedAt?: number;
+  /** Epoch ms stamped when the run reaches a terminal state (done/error/cancel).
+   *  With `startedAt` it yields the run's total duration. */
+  endedAt?: number;
   /** Failure message when `phase === "error"`. */
   error: string;
   /** When the run used prior-review context, how its "changes since" delta
@@ -375,11 +381,11 @@ export async function startReview(
     deltaState: undefined,
     truncatedCoverage: undefined,
     thoughts: undefined,
+    // Clear a prior run's stamps on this key so a re-run's live elapsed and
+    // persisted duration start fresh (stamped at the running transition below).
+    startedAt: undefined,
+    endedAt: undefined,
   });
-
-  // Wall-clock start for the persisted history record (the store itself orders
-  // by monotonic `seq`, not a timestamp).
-  const startedAtMs = Date.now();
 
   // Wait for a slot in this run's lane (immediate when under the cap). A cancel
   // while queued wakes this too — `control.cancelled` then short-circuits below.
@@ -387,7 +393,12 @@ export async function startReview(
 
   try {
     if (control.cancelled) return;
-    patch({ phase: "running" });
+    // Wall-clock start, stamped once the run leaves the queue and actually
+    // begins — the queue wait is excluded. One value feeds both the live entry
+    // (the dock's ticking elapsed) and the persisted history record below, so
+    // they measure the same span.
+    const startedAtMs = Date.now();
+    patch({ phase: "running", startedAt: startedAtMs });
     const diff = await context.loadDiff();
     if (control.cancelled) return;
     if (!diff.text.trim()) {
@@ -534,6 +545,7 @@ export async function startReview(
       phase: "done",
       status: "",
       truncatedCoverage: coverage.diffTruncated && !agenticRun,
+      endedAt: Date.now(),
     });
     void notifyReviewDone(title, mode, true, target);
     // Persist the finished review so the NEXT run can use it as soft context.
@@ -584,6 +596,7 @@ export async function startReview(
         // CLI failures reject with a plain AppError object (not an Error), so
         // `String(e)` would print "[object Object]" — use the shared extractor.
         error: errorMessage(e),
+        endedAt: Date.now(),
       });
       void notifyReviewDone(title, mode, false, target);
     }
@@ -625,7 +638,9 @@ export function cancelReview(key: string): void {
   // this patched "cancelled" phase and skips its own settle/remove for the row.
   // Both arms patch identically; the auto arm additionally caps retained stopped
   // rows so a long session can't accumulate them without bound.
-  useReviewStore.getState().patch(key, { phase: "cancelled", status: "" });
+  useReviewStore
+    .getState()
+    .patch(key, { phase: "cancelled", status: "", endedAt: Date.now() });
   if (key.startsWith("auto:")) enforceStoppedCap();
   controls.delete(key);
 }
@@ -688,6 +703,9 @@ export function registerAutomationRun(opts: {
     target: opts.target,
     seq,
     error: "",
+    // Automation rows are running from the moment they register — registration
+    // IS their start, so stamp it here (there's no queue wait to exclude).
+    startedAt: Date.now(),
     // Marks this as an automation row AND powers the stopped row's Re-run.
     rerun: opts.rerun,
   });
@@ -709,9 +727,12 @@ export function registerAutomationRun(opts: {
     // entry keeps its `rerun`) instead of removing it, then cap retained stopped
     // rows. Deletes only our own control, mirroring settle's own-control guard.
     fail(message) {
-      useReviewStore
-        .getState()
-        .patch(key, { phase: "error", error: message, status: "" });
+      useReviewStore.getState().patch(key, {
+        phase: "error",
+        error: message,
+        status: "",
+        endedAt: Date.now(),
+      });
       enforceStoppedCap();
       if (controls.get(key) === control) controls.delete(key);
     },
@@ -784,5 +805,11 @@ export function useReviewRun(target: ReviewTarget) {
     /** The finished agentic run's streamed narration — shown behind a collapsed
      *  "Thought process" disclosure. Empty on non-agentic / codex runs. */
     thoughts: entry.thoughts ?? "",
+    /** Epoch ms when the run entered "running" (queue wait excluded) — the anchor
+     *  for a live elapsed/duration surface. Absent while queued or idle. */
+    startedAt: entry.startedAt,
+    /** Epoch ms when the run reached a terminal state — with `startedAt` yields
+     *  the run's total duration. Absent while still running. */
+    endedAt: entry.endedAt,
   };
 }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -24,6 +24,20 @@ const UNITS: {
 
 const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
 
+/** A duration as a compact human string: `< 60s` → `"42s"` (seconds floored,
+ *  minimum `"0s"`); `< 1h` → `"3m 12s"` (seconds unpadded); `>= 1h` → `"1h 2m"`.
+ *  Non-finite or negative input clamps to `"0s"`. Used for run elapsed/duration
+ *  where a coarse "how long" reads better than a precise timestamp. */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0s";
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m ${totalSeconds % 60}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${hours}h ${totalMinutes % 60}m`;
+}
+
 /** "8 months ago", "2 hours ago", "just now". `now` defaults to the current
  *  time; callers that render many timestamps together (RelativeTime) pass one
  *  shared snapshot so simultaneously-mounted rows never disagree about the same


### PR DESCRIPTION
Add an optional security-audit model independent from the general review model, while preserving the existing review configuration as the fallback. Track review execution time across manual and automated runs so users can monitor active reviews and understand completed or stopped run durations.

### Security-audit model selection

- Adds optional `securityReviewAi` settings and centralized fallback logic in `src/lib/settings/api.ts`, keeping security audits on `reviewAi` unless a dedicated configuration is enabled.
- Adds the **Use a different model for security audits** toggle and provider/model configuration to `src/features/settings/AiProviderSection.tsx`.
- Applies the selected security model to manual PR audits in `src/features/pulls/PrReviewPanel.tsx`, while preserving per-run in-panel overrides.
- Applies the selected security model to automated audits in `src/lib/automations/runner.ts`, including provider lane selection, generated comment labels, and persisted review history.
- Documents the model configuration and fallback behavior in `README.md` and `src/features/help/content.ts`.
- Adds release notes in `changelog.d/added-security-review-model.md`.

### Review runtime tracking

- Adds `startedAt` and `endedAt` lifecycle timestamps to review entries in `src/lib/stores/reviews.ts`, excluding queue time from manually queued run durations.
- Adds shared ticking elapsed-time rendering in `src/components/elapsed-time.tsx` and compact duration formatting in `src/lib/time.ts`.
- Shows live elapsed time for active automated runs and durations for stopped runs in `src/features/activity/ActivityDock.tsx`.
- Shows a live timer while a PR review is running and the completed duration afterward in `src/features/pulls/PrReviewPanel.tsx`.
- Displays total run duration alongside finished review timestamps in `src/features/pulls/ReviewHistory.tsx`.
- Persists automated review start and finish timestamps in `src/lib/automations/runner.ts`.
- Documents runtime indicators in `changelog.d/added-review-runtimes.md` and `src/features/help/content.ts`.