### PR TITLE
feat(lan,companion,git): add read-only repository views

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -2,11 +2,13 @@
   phone over your local network from **Settings → Phone companion**: pair a device by
   scanning a QR code and typing a PIN. Scanning opens a slim companion web app right
   in your phone's browser — pair with the PIN, then read a repo's **Status, pull
-  requests, and CI** from your phone, read-only. Open a pull request for its overview,
-  activity timeline, and review-thread conversation, and watch live **AI PR reviews and
-  agent sessions** stream in as they happen. Your phone always sees the repository open
-  on this desktop, and you can **share and unshare additional repositories** (from the
-  panel or the command palette) to keep them reachable while you work in another —
+  requests, issues, working-tree changes, commit history, branches, and CI** from your
+  phone, read-only. The Status tab is a hub that drills into those surfaces; open a pull
+  request or issue for its full conversation, browse file diffs and per-commit changes,
+  and watch live **AI PR reviews and agent sessions** stream in as they happen. Your
+  phone always sees the repository open on this desktop, and you can **share and unshare
+  additional repositories** (from the panel or the command palette) to keep them
+  reachable while you work in another —
   switching repos no longer cuts a phone watching a shared repository. The companion honors
   your **Hide AI features** setting — turn it on and the phone's Agents tab and live agent-run
   watching disappear too, matching the desktop. Off by default, with per-device tokens

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -14,7 +14,11 @@ import {
   useRoute,
 } from "./lib/router";
 import { AgentsBody, AgentWatch } from "./screens/Agents";
+import { BranchesBody } from "./screens/Branches";
+import { ChangesBody, ChangesFileBody } from "./screens/Changes";
 import { CiBody, CiDetail } from "./screens/Ci";
+import { CommitBody, CommitFileBody, HistoryBody } from "./screens/History";
+import { IssueDetailBody, IssuesBody } from "./screens/Issues";
 import { Pair } from "./screens/Pair";
 import { PrDetail, PrsBody } from "./screens/Prs";
 import { ReposBody } from "./screens/Repos";
@@ -319,6 +323,45 @@ function Screen({
       />
     ) : (
       <AgentsBody repoId={repoId} active hideAi={hideAi} />
+    );
+  }
+  if (route.tab === "changes") {
+    // A file-diff route needs BOTH a section and a decoded file; the router only
+    // emits them together (a section without a file falls back to the list), but
+    // gate on both so a partial route always renders the list, never a half-formed
+    // detail.
+    return route.section != null && route.filePath != null ? (
+      <ChangesFileBody
+        repoId={repoId}
+        section={route.section}
+        filePath={route.filePath}
+      />
+    ) : (
+      <ChangesBody repoId={repoId} active />
+    );
+  }
+  if (route.tab === "history") {
+    if (route.sha != null) {
+      return route.filePath != null ? (
+        <CommitFileBody
+          repoId={repoId}
+          sha={route.sha}
+          filePath={route.filePath}
+        />
+      ) : (
+        <CommitBody repoId={repoId} sha={route.sha} />
+      );
+    }
+    return <HistoryBody repoId={repoId} active />;
+  }
+  if (route.tab === "branches") {
+    return <BranchesBody repoId={repoId} active />;
+  }
+  if (route.tab === "issues") {
+    return route.detailId != null ? (
+      <IssueDetailBody repoId={repoId} number={route.detailId} />
+    ) : (
+      <IssuesBody repoId={repoId} active />
     );
   }
   return <StatusBody repoId={repoId} active />;

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -73,9 +73,13 @@ const TABS: { tab: Tab; label: string; icon: ReactNode }[] = [
 
 /** Build a tab's hash for the current repo scope. With a repoId the tabs are
  *  scoped (`#r/{repoId}/{tab}`); without one (picker / mid-redirect) they fall
- *  back to the legacy hash, which the shell resolves to a scoped route. */
+ *  back to the legacy hash, which the shell resolves to a scoped route. Issues is
+ *  scoped-only (it has NO legacy grammar — an unknown legacy head parses as
+ *  status), so pre-scope it degrades to `#status` explicitly: the landing state
+ *  is identical either way, but the transient hash stays honest. */
 function tabHash(tab: Tab, repoId: string | null): string {
-  return repoId ? repoHash(repoId, tab) : `#${tab}`;
+  if (repoId) return repoHash(repoId, tab);
+  return tab === "issues" ? "#status" : `#${tab}`;
 }
 
 /** Bottom tab nav. Each tab is a real link (Tab-focusable) scoped to the selected

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -3,6 +3,7 @@ import {
   GitBranchIcon,
   GitPullRequestIcon,
   PlayCircleIcon,
+  RadioButtonIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
@@ -65,6 +66,7 @@ export function TopBar({
 const TABS: { tab: Tab; label: string; icon: ReactNode }[] = [
   { tab: "status", label: "Status", icon: <GitBranchIcon size={22} /> },
   { tab: "prs", label: "PRs", icon: <GitPullRequestIcon size={22} /> },
+  { tab: "issues", label: "Issues", icon: <RadioButtonIcon size={22} /> },
   { tab: "ci", label: "CI", icon: <PlayCircleIcon size={22} /> },
   { tab: "agents", label: "Agents", icon: <RobotIcon size={22} /> },
 ];
@@ -110,7 +112,7 @@ export function BottomNav({
   return (
     <nav
       className={`sticky bottom-0 z-10 grid border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)] ${
-        tabs.length === 3 ? "grid-cols-3" : "grid-cols-4"
+        tabs.length === 4 ? "grid-cols-4" : "grid-cols-5"
       }`}
       aria-label="Sections"
     >

--- a/companion/src/components/DiffText.tsx
+++ b/companion/src/components/DiffText.tsx
@@ -22,9 +22,12 @@ interface DiffLine {
 }
 
 // Multi-char META prefixes — the file/index/rename headers of a unified diff. These
-// MUST be checked before the 1-char +/- classes: `+++`/`---` (the file markers)
-// start with the same char as an added/removed line, so a naive `startsWith("+")`
-// would miscolor the `+++ b/…` header as an added line.
+// are matched ONLY in the header section of a file (before its first `@@` hunk).
+// Inside a hunk we classify by FIRST CHAR ONLY — a removed line whose CONTENT begins
+// with `--` reads as `---…` and an added line whose content begins with `++` reads
+// as `++…`, which would false-match the `---`/`+++` file markers if META_PREFIXES
+// were applied unconditionally. The state machine in `classifyLines` (header mode vs.
+// hunk mode) is what keeps content lines from being mistaken for headers.
 const META_PREFIXES = [
   "+++",
   "---",
@@ -36,17 +39,35 @@ const META_PREFIXES = [
   "similarity",
 ];
 
-/** Classify one diff line by its leading token. Order matters: multi-char meta
- *  prefixes first (`+++`/`---` collide with the +/- classes), then hunk headers,
- *  then the single-char add/remove markers, else context. */
-function classify(line: string): LineKind {
-  for (const p of META_PREFIXES) {
-    if (line.startsWith(p)) return "meta";
-  }
-  if (line.startsWith("@@")) return "hunk";
-  if (line.startsWith("+")) return "add";
-  if (line.startsWith("-")) return "del";
-  return "context";
+/** Classify every diff line with a running mode. A `diff --git` line starts a new
+ *  file's HEADER section; a `@@` line enters that file's HUNK section (and is itself
+ *  the hunk class). In header mode a line is meta if it matches a META_PREFIXES entry
+ *  (else context). In hunk mode we classify by first char ONLY — `+`→add, `-`→del,
+ *  else context (a `\ No newline at end of file` marker lands context, which is
+ *  fine) — so a content line beginning `--`/`++` is never mistaken for a file marker. */
+function classifyLines(text: string): DiffLine[] {
+  let inHunk = false;
+  return text.split("\n").map((line) => {
+    if (line.startsWith("diff --git")) {
+      inHunk = false; // a new file's header begins
+      return { kind: "meta", text: line };
+    }
+    if (line.startsWith("@@")) {
+      inHunk = true; // this file's hunks begin
+      return { kind: "hunk", text: line };
+    }
+    if (inHunk) {
+      const kind: LineKind = line.startsWith("+")
+        ? "add"
+        : line.startsWith("-")
+          ? "del"
+          : "context";
+      return { kind, text: line };
+    }
+    // Header section (before the first hunk): only the known header prefixes are meta.
+    const isMeta = META_PREFIXES.some((p) => line.startsWith(p));
+    return { kind: isMeta ? "meta" : "context", text: line };
+  });
 }
 
 // Per-kind line styling. The +/- backgrounds are a low-alpha token tint (subtle
@@ -77,7 +98,7 @@ export function DiffText({
   // binary file (no lines to render).
   const lines = useMemo<DiffLine[]>(() => {
     if (isBinary) return [];
-    return text.split("\n").map((t) => ({ kind: classify(t), text: t }));
+    return classifyLines(text);
   }, [text, isBinary]);
 
   if (isBinary) {

--- a/companion/src/components/DiffText.tsx
+++ b/companion/src/components/DiffText.tsx
@@ -10,8 +10,8 @@
 // sideways. No line numbers: raw unified text carries none, and the `@@` hunk
 // headers already carry position.
 
-import { useMemo } from "react";
 import { WarningCircleIcon } from "@phosphor-icons/react";
+import { useMemo } from "react";
 
 /** One classified diff line. `kind` drives the per-line styling; `text` is the raw
  *  line (glyph included). */

--- a/companion/src/components/DiffText.tsx
+++ b/companion/src/components/DiffText.tsx
@@ -1,0 +1,198 @@
+// A shared unified-diff renderer for the Changes/History file-diff views.
+// F0 froze the props type; this package (F23) fills the body: line coloring,
+// binary/truncated states, and the multi-file `splitCommitDiff` helper.
+//
+// Design (user-confirmed): SEMANTIC diff, no syntax highlighting in v1. Lines are
+// classified by their unified-diff prefix and colored with the design tokens
+// (success = added, destructive = removed). Meaning never rests on color alone —
+// every +/− line keeps its leading glyph, so the diff reads correctly in
+// monochrome too. Wide lines scroll inside the code block; the page never scrolls
+// sideways. No line numbers: raw unified text carries none, and the `@@` hunk
+// headers already carry position.
+
+import { useMemo } from "react";
+import { WarningCircleIcon } from "@phosphor-icons/react";
+
+/** One classified diff line. `kind` drives the per-line styling; `text` is the raw
+ *  line (glyph included). */
+type LineKind = "meta" | "hunk" | "add" | "del" | "context";
+interface DiffLine {
+  kind: LineKind;
+  text: string;
+}
+
+// Multi-char META prefixes — the file/index/rename headers of a unified diff. These
+// MUST be checked before the 1-char +/- classes: `+++`/`---` (the file markers)
+// start with the same char as an added/removed line, so a naive `startsWith("+")`
+// would miscolor the `+++ b/…` header as an added line.
+const META_PREFIXES = [
+  "+++",
+  "---",
+  "diff --git",
+  "index ",
+  "new file",
+  "deleted file",
+  "rename ",
+  "similarity",
+];
+
+/** Classify one diff line by its leading token. Order matters: multi-char meta
+ *  prefixes first (`+++`/`---` collide with the +/- classes), then hunk headers,
+ *  then the single-char add/remove markers, else context. */
+function classify(line: string): LineKind {
+  for (const p of META_PREFIXES) {
+    if (line.startsWith(p)) return "meta";
+  }
+  if (line.startsWith("@@")) return "hunk";
+  if (line.startsWith("+")) return "add";
+  if (line.startsWith("-")) return "del";
+  return "context";
+}
+
+// Per-kind line styling. The +/- backgrounds are a low-alpha token tint (subtle
+// enough that the token text color stays AA against it in BOTH themes); the text
+// color is the semantic token itself, the same success/destructive the chips use.
+// A hunk header gets a full-width muted band so a reader can scan hunk boundaries.
+const LINE_CLASS: Record<LineKind, string> = {
+  meta: "text-muted-foreground",
+  hunk: "bg-muted text-muted-foreground",
+  add: "bg-success/10 text-success",
+  del: "bg-destructive/10 text-destructive",
+  context: "text-foreground",
+};
+
+/** Render a unified diff. `text` is the diff body; `truncated` marks a diff cut off
+ *  at the server's size cap; `isBinary` marks a binary file (no textual diff). */
+export function DiffText({
+  text,
+  truncated,
+  isBinary = false,
+}: {
+  text: string;
+  truncated: boolean;
+  isBinary?: boolean;
+}) {
+  // Classify once per `text` (up to the server's 1MB cap). No virtualization in v1
+  // (recorded follow-up) — the cap bounds the worst case. Skipped entirely for a
+  // binary file (no lines to render).
+  const lines = useMemo<DiffLine[]>(() => {
+    if (isBinary) return [];
+    return text.split("\n").map((t) => ({ kind: classify(t), text: t }));
+  }, [text, isBinary]);
+
+  if (isBinary) {
+    return (
+      <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+        Binary file — no text diff.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="min-w-max font-mono text-xs leading-relaxed"
+        aria-label="File diff"
+      >
+        {lines.map((line, i) => (
+          <div
+            // Diff lines are a static, index-stable sequence (never reordered or
+            // filtered), so the index is a safe key here.
+            key={i}
+            className={`whitespace-pre px-4 ${LINE_CLASS[line.kind]}`}
+          >
+            {/* A blank line still needs height so the diff's spacing survives. */}
+            {line.text || " "}
+          </div>
+        ))}
+        {truncated ? (
+          <p className="flex items-center gap-2 border-t border-border bg-warning/15 px-4 py-2 text-xs whitespace-normal text-foreground">
+            <WarningCircleIcon size={14} className="shrink-0 text-warning" />
+            Diff truncated — view the full diff on the desktop.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Split a multi-file unified diff (a `StagedDiff.text` / commit diff) into one
+ * chunk per file. Splits on the `diff --git ` boundary (each chunk keeps its own
+ * `diff --git` header line) and registers each chunk under EVERY path it can extract:
+ * the `+++ b/<path>` path (when present), plus BOTH the `a/` and `b/` paths from the
+ * `diff --git a/<path> b/<path>` header. Registering one chunk under several keys is
+ * intentional — a lookup only needs one to hit.
+ *
+ * Why several keys: a pure RENAME (100% similarity, no content change) has no `+++`
+ * line at all, and the file-stat row navigates with the server's stat path for the
+ * NEW name (`git diff --numstat -z` reports the new path for a rename), which is the
+ * `b/` path — so the `b/`-from-header key is the one that matches. A deletion's `+++`
+ * is `/dev/null` (keyed by the `a/` path). Feeds CommitFileBody: it looks a file's
+ * chunk up by the path the file-stat row navigated with.
+ */
+export function splitCommitDiff(text: string): Map<string, string> {
+  const chunks = new Map<string, string>();
+  if (!text) return chunks;
+  // Split on the start-of-line `diff --git ` boundary, keeping the delimiter with
+  // the chunk it introduces (a lookahead split). Leading content before the first
+  // boundary (there shouldn't be any in git output) is dropped.
+  const parts = text.split(/(?=^diff --git )/m);
+  for (const part of parts) {
+    if (!part.startsWith("diff --git ")) continue;
+    for (const path of chunkPaths(part)) chunks.set(path, part);
+  }
+  return chunks;
+}
+
+/** Strip an optional surrounding double-quote pair (git quotes paths with special or
+ *  non-ASCII chars under `core.quotePath`'s default). Full C-style unescaping of the
+ *  inner bytes is out of scope — an escaped byte inside stays as-is, matching however
+ *  the server's stat path reports it. */
+function unquote(path: string): string {
+  return path.startsWith('"') && path.endsWith('"') ? path.slice(1, -1) : path;
+}
+
+/** All keys a chunk should be registered under: the `+++ b/<path>` path plus the `a/`
+ *  and `b/` paths from the `diff --git` header. Each regex tolerates an optional
+ *  surrounding double-quote pair (stripped). A `diff --git a/X b/Y` with SPACES in an
+ *  unquoted path is ambiguous — we split on the LAST ` b/` occurrence, which is
+ *  correct for the overwhelmingly common equal-path case (and rename-with-spaces
+ *  pathological cases aren't chased). */
+function chunkPaths(chunk: string): string[] {
+  const keys: string[] = [];
+  const plus = chunk.match(/^\+\+\+ ("?b\/.+"?)$/m);
+  if (plus) {
+    const inner = unquote(plus[1]);
+    if (inner.startsWith("b/")) keys.push(inner.slice(2));
+  }
+  const header = chunk.match(/^diff --git ("?a\/.+"?) ("?b\/.+"?)$/m);
+  if (header) {
+    // The header line: `diff --git a/X b/Y`. Prefer a quote-delimited split when the
+    // paths are quoted; otherwise fall back to the last ` b/` in the raw line.
+    const line = header[0].slice("diff --git ".length);
+    const split = splitHeaderPaths(line);
+    if (split) {
+      const a = unquote(split.a);
+      const b = unquote(split.b);
+      if (a.startsWith("a/")) keys.push(a.slice(2));
+      if (b.startsWith("b/")) keys.push(b.slice(2));
+    }
+  }
+  return keys;
+}
+
+/** Split a `diff --git` header's `a/X b/Y` remainder into its two path tokens. When
+ *  both are double-quoted, split on the `" "` between them; otherwise split on the
+ *  LAST ` b/` (correct for the common equal-path case — see chunkPaths). */
+function splitHeaderPaths(line: string): { a: string; b: string } | null {
+  if (line.startsWith('"') && line.endsWith('"')) {
+    const between = line.indexOf('" "');
+    if (between !== -1) {
+      return { a: line.slice(0, between + 1), b: line.slice(between + 2) };
+    }
+  }
+  const at = line.lastIndexOf(" b/");
+  if (at === -1) return null;
+  return { a: line.slice(0, at), b: line.slice(at + 1) };
+}

--- a/companion/src/components/chips.tsx
+++ b/companion/src/components/chips.tsx
@@ -7,6 +7,7 @@ import {
   GitPullRequestIcon,
   MagnifyingGlassIcon,
   ProhibitIcon,
+  RecordIcon,
   RobotIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
@@ -81,8 +82,38 @@ export function PrStateChip({
   );
 }
 
-/** An agent stream's kind chip — an AI PR **review** or an agent **session**.
- *  Icon + text so the distinction never rests on color alone (WCAG 1.4.1). */
+/** An issue's state chip — open/closed with GitHub's state vocabulary. Icon + text
+ *  so the state never rests on color alone (WCAG 1.4.1). */
+export function IssueStateChip({ state }: { state: string }) {
+  const s = state.toLowerCase();
+  if (s === "closed") {
+    return (
+      <Chip
+        icon={<CheckCircleIcon size={14} />}
+        label="Closed"
+        className="bg-merged/15 text-merged"
+      />
+    );
+  }
+  if (s === "open") {
+    return (
+      <Chip
+        icon={<RecordIcon size={14} />}
+        label="Open"
+        className="bg-success/15 text-success"
+      />
+    );
+  }
+  // Any other provider string - show it verbatim with a neutral look.
+  return (
+    <Chip
+      icon={<CircleIcon size={14} />}
+      label={state || "Unknown"}
+      className="bg-muted text-muted-foreground"
+    />
+  );
+}
+
 export function ReviewKindChip({ kind }: { kind: "review" | "session" }) {
   if (kind === "review") {
     return (

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -184,6 +184,146 @@ export const fetchRepos = () => getJson<ReposResponse>("/api/repos");
  *  router before it reaches here, but encode it anyway (defense in depth). */
 const scope = (repoId: string) => `/api/repos/${encodeURIComponent(repoId)}`;
 
+// ── Slice-6 read shapes (Changes · History · Branches · Issues) ───────────────
+// These mirror the desktop's serde camelCase types EXACTLY (verified against the
+// Rust handlers). They're declared HERE — not imported from `@/lib/git/types` — on
+// purpose: the desktop's git types.ts carries far more than the LAN routes return,
+// and a few (IssueComment, ForgeUserRef, IssueLabel) are re-named companion-side to
+// read naturally on this surface. The RepoSummary idiom (own local interfaces).
+
+/** One file's line-count summary in a diff (`StagedDiff.files[]`). */
+export interface DiffStatEntry {
+  path: string;
+  added: number;
+  deleted: number;
+  isBinary: boolean;
+}
+
+/** The working-tree diff (staged ∪ unstaged), with a per-file stat list. `text` is
+ *  the unified diff, `truncated` when it hit the server's 1MB cap; `excludedFiles`
+ *  counts files hidden from the diff by ignore patterns. */
+export interface StagedDiff {
+  text: string;
+  truncated: boolean;
+  files: DiffStatEntry[];
+  excludedFiles: number;
+}
+
+/** A single file's diff (`diff/file`). `text` is the unified diff for one path. */
+export interface FileDiff {
+  filePath: string;
+  isBinary: boolean;
+  isTruncated: boolean;
+  text: string;
+}
+
+/** One local branch, for the Branches list. */
+export interface Branch {
+  name: string;
+  isCurrent: boolean;
+  upstream: string | null;
+  lastCommitDate: string;
+  archived: boolean;
+  upstreamAhead: number;
+  upstreamBehind: number;
+  upstreamGone: boolean;
+  upstreamRemote: string | null;
+}
+
+/** One commit in the history log. `tags` are refs pointing at it; `isMerge` marks a
+ *  multi-parent commit. */
+export interface CommitSummary {
+  hash: string;
+  subject: string;
+  author: string;
+  authorEmail: string;
+  date: string;
+  tags: string[];
+  isMerge: boolean;
+}
+
+/** Full details for one commit (subject + full body). */
+export interface CommitDetails {
+  hash: string;
+  subject: string;
+  body: string;
+  author: string;
+  authorEmail: string;
+  date: string;
+}
+
+/** One issue in the Issues list. `state` is "OPEN"/"CLOSED"; `author` is null for a
+ *  ghost author; `labels` carries just the names for the list chips. */
+export interface IssueInfo {
+  number: number;
+  url: string;
+  title: string;
+  state: string;
+  createdAt: string;
+  updatedAt: string;
+  author: { login: string } | null;
+  labels: { name: string }[];
+}
+
+/** A neutral user reference (assignees) — carries an avatar the provider supplies
+ *  (GitLab) or the frontend derives from the login (GitHub). */
+export interface ForgeUserRef {
+  id: string;
+  label: string;
+  avatarUrl: string;
+  isBot: boolean;
+}
+
+/** One issue conversation comment. The server names this `PrThreadOut` (shared with
+ *  PRs); it's re-named `IssueComment` companion-side to read naturally on the Issues
+ *  surface. `state` is empty for a plain comment. */
+export interface IssueComment {
+  author: string;
+  authorAvatarUrl: string;
+  state: string;
+  body: string;
+  date: string;
+  id: string;
+  url: string;
+  viewerDidAuthor: boolean;
+  isMinimized: boolean;
+  minimizedReason: string;
+  reviewId: string;
+}
+
+/** One issue label (the server's `RepoLabel`). `color` is hex without the leading
+ *  '#', as GitHub returns it; `description` is absent/null when the source has none. */
+export interface IssueLabel {
+  id: string;
+  name: string;
+  color: string;
+  description?: string | null;
+}
+
+/** Full details for one issue's read view: body, assignees, labels, and the
+ *  conversation comments. Mirrors the desktop's `IssueDetails` exactly. */
+export interface IssueDetails {
+  id: string;
+  number: number;
+  title: string;
+  body: string;
+  author: string;
+  authorAvatarUrl: string;
+  state: string;
+  createdAt: string;
+  url: string;
+  assignees: ForgeUserRef[];
+  milestone: { number: number; title: string } | null;
+  issueType: { id: string; name: string; color: string } | null;
+  isPinned: boolean;
+  locked: boolean;
+  activeLockReason: string | null;
+  confidential: boolean;
+  dueDate: string | null;
+  comments: IssueComment[];
+  labels: IssueLabel[];
+}
+
 export const fetchStatus = (repoId: string) =>
   getJson<RepoStatus>(`${scope(repoId)}/status`);
 
@@ -210,6 +350,61 @@ export const fetchPrTimeline = (repoId: string, number: number) =>
  *  neutral shape the desktop's `forgePrReviewThreads` returns. */
 export const fetchPrThreads = (repoId: string, number: number) =>
   getJson<ReviewThreadOut[]>(`${scope(repoId)}/prs/${number}/threads`);
+
+// ── Slice-6 read fetchers (Changes · History · Branches · Issues) ─────────────
+
+/** The repo's local branches (`branches`). */
+export const fetchBranches = (repoId: string) =>
+  getJson<Branch[]>(`${scope(repoId)}/branches`);
+
+/** A page of the commit history (`log?limit&skip`). Named `fetchLog` to mirror the
+ *  route (not `fetchHistory`). */
+export const fetchLog = (repoId: string, limit = 50, skip = 0) =>
+  getJson<CommitSummary[]>(`${scope(repoId)}/log?limit=${limit}&skip=${skip}`);
+
+/** One commit's details (`commits/{hash}`). */
+export const fetchCommit = (repoId: string, hash: string) =>
+  getJson<CommitDetails>(
+    `${scope(repoId)}/commits/${encodeURIComponent(hash)}`,
+  );
+
+/** One commit's unified diff (`commits/{hash}/diff`). No `maxBytes` param — the
+ *  server applies its default 1MB cap and sets `truncated` when it's hit. */
+export const fetchCommitDiff = (repoId: string, hash: string) =>
+  getJson<StagedDiff>(
+    `${scope(repoId)}/commits/${encodeURIComponent(hash)}/diff`,
+  );
+
+/** The working-tree diff (`diff/working`) — staged ∪ unstaged, with per-file stats. */
+export const fetchWorkingDiff = (repoId: string) =>
+  getJson<StagedDiff>(`${scope(repoId)}/diff/working`);
+
+/** One file's diff (`diff/file?path&staged&untracked`). `staged` reads the index
+ *  side; `untracked` diffs an on-disk file with `--no-index`. The path is
+ *  `encodeURIComponent`-encoded into the query string (the router already decoded it
+ *  from the hash). */
+export const fetchFileDiff = (
+  repoId: string,
+  path: string,
+  opts: { staged?: boolean; untracked?: boolean },
+) =>
+  getJson<FileDiff>(
+    `${scope(repoId)}/diff/file?path=${encodeURIComponent(path)}&staged=${
+      opts.staged ?? false
+    }&untracked=${opts.untracked ?? false}`,
+  );
+
+/** The repo's issues (`issues?state&limit`). `state` is "open" or "closed". Errors
+ *  with a typed variant on a Bitbucket repo (issues unsupported) or a fork with
+ *  issues disabled — the screen renders a teaching state for those. */
+export const fetchIssues = (repoId: string, state = "open", limit = 30) =>
+  getJson<IssueInfo[]>(
+    `${scope(repoId)}/issues?state=${encodeURIComponent(state)}&limit=${limit}`,
+  );
+
+/** One issue's full read view (`issues/{number}`). */
+export const fetchIssue = (repoId: string, number: number) =>
+  getJson<IssueDetails>(`${scope(repoId)}/issues/${number}`);
 
 // ── Agent streams (live AI review / agent sessions) ───────────────────────────
 

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -1,8 +1,15 @@
 import { QueryCache, QueryClient, useQuery } from "@tanstack/react-query";
 import {
   ApiError,
+  fetchBranches,
   fetchCiRun,
   fetchCiRuns,
+  fetchCommit,
+  fetchCommitDiff,
+  fetchFileDiff,
+  fetchIssue,
+  fetchIssues,
+  fetchLog,
   fetchPr,
   fetchPrs,
   fetchPrThreads,
@@ -10,6 +17,7 @@ import {
   fetchRepos,
   fetchReviews,
   fetchStatus,
+  fetchWorkingDiff,
 } from "./api";
 import { navigate } from "./router";
 
@@ -177,6 +185,118 @@ export function usePrThreads(repoId: string | null, number: number | null) {
   return useQuery({
     queryKey: ["pr", repoId, number, "threads"],
     queryFn: () => fetchPrThreads(repoId as string, number as number),
+    enabled: on,
+    refetchInterval: on ? POLL_MS : (false as const),
+  });
+}
+
+// ── Slice-6 hooks (Changes · History · Branches · Issues) ─────────────────────
+
+/** The repo's local branches. `active` gates polling to the visible screen. */
+export function useBranches(repoId: string | null, active: boolean) {
+  return useQuery({
+    queryKey: ["branches", repoId],
+    queryFn: () => fetchBranches(repoId as string),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
+  });
+}
+
+/** A page of the commit history. `active` gates polling; `skip`/`limit` page the
+ *  log and are part of the cache key so each page caches independently. */
+export function useLog(
+  repoId: string | null,
+  active: boolean,
+  skip = 0,
+  limit = 50,
+) {
+  return useQuery({
+    queryKey: ["log", repoId, skip, limit],
+    queryFn: () => fetchLog(repoId as string, limit, skip),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
+  });
+}
+
+/** One commit's details. A commit is IMMUTABLE, so there's no `refetchInterval` —
+ *  once fetched it never changes (no poll, and the default staleTime is irrelevant). */
+export function useCommit(repoId: string | null, hash: string | null) {
+  const on = repoId != null && hash != null;
+  return useQuery({
+    queryKey: ["commit", repoId, hash],
+    queryFn: () => fetchCommit(repoId as string, hash as string),
+    enabled: on,
+  });
+}
+
+/** One commit's unified diff. Immutable like the commit itself — no polling. */
+export function useCommitDiff(repoId: string | null, hash: string | null) {
+  const on = repoId != null && hash != null;
+  return useQuery({
+    queryKey: ["commitDiff", repoId, hash],
+    queryFn: () => fetchCommitDiff(repoId as string, hash as string),
+    enabled: on,
+  });
+}
+
+/** The working-tree diff (staged ∪ unstaged), with per-file stats. `active` gates
+ *  polling — the working tree changes on the desktop, so the LIST view polls it. */
+export function useWorkingDiff(repoId: string | null, active: boolean) {
+  return useQuery({
+    queryKey: ["workingDiff", repoId],
+    queryFn: () => fetchWorkingDiff(repoId as string),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
+  });
+}
+
+/** One file's diff. Deliberately NOT polled: a file's content changing mid-read is
+ *  jarring on a detail view, and the Changes LIST screen's own poll is the freshness
+ *  mechanism (a re-visit refetches once the default staleTime lapses). `opts.staged`
+ *  / `opts.untracked` select the diff side and are part of the cache key (falling
+ *  back to their fetcher defaults so the key matches the request). */
+export function useFileDiff(
+  repoId: string | null,
+  path: string | null,
+  opts: { staged?: boolean; untracked?: boolean },
+) {
+  const on = repoId != null && path != null;
+  return useQuery({
+    queryKey: [
+      "fileDiff",
+      repoId,
+      path,
+      opts.staged ?? false,
+      opts.untracked ?? false,
+    ],
+    queryFn: () => fetchFileDiff(repoId as string, path as string, opts),
+    enabled: on,
+    refetchInterval: false,
+  });
+}
+
+/** The repo's issues. `active` gates polling; `state` ("open"/"closed") is part of
+ *  the cache key so switching filters caches independently. */
+export function useIssues(
+  repoId: string | null,
+  active: boolean,
+  state = "open",
+) {
+  return useQuery({
+    queryKey: ["issues", repoId, state],
+    queryFn: () => fetchIssues(repoId as string, state),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
+  });
+}
+
+/** One issue's full read view. Polls while open (comments do change) — a detail view
+ *  is a deliberate drill-in, so keep it fresh at the standard cadence. */
+export function useIssue(repoId: string | null, number: number | null) {
+  const on = repoId != null && number != null;
+  return useQuery({
+    queryKey: ["issue", repoId, number],
+    queryFn: () => fetchIssue(repoId as string, number as number),
     enabled: on,
     refetchInterval: on ? POLL_MS : (false as const),
   });

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -276,15 +276,18 @@ export function useFileDiff(
 }
 
 /** The repo's issues. `active` gates polling; `state` ("open"/"closed") is part of
- *  the cache key so switching filters caches independently. */
+ *  the cache key so switching filters caches independently. `limit` grows the page
+ *  (the "Load more" affordance) — like `useLog`, it's a single GROWING query keyed on
+ *  the limit (the server re-serves the whole prefix), NOT a stitched pages array. */
 export function useIssues(
   repoId: string | null,
   active: boolean,
   state = "open",
+  limit = 30,
 ) {
   return useQuery({
-    queryKey: ["issues", repoId, state],
-    queryFn: () => fetchIssues(repoId as string, state),
+    queryKey: ["issues", repoId, state, limit],
+    queryFn: () => fetchIssues(repoId as string, state, limit),
     enabled: repoId != null,
     refetchInterval: repoId != null ? poll(active) : false,
   });

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -1,4 +1,9 @@
-import { QueryCache, QueryClient, useQuery } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  QueryCache,
+  QueryClient,
+  useQuery,
+} from "@tanstack/react-query";
 import {
   ApiError,
   fetchBranches,
@@ -215,6 +220,11 @@ export function useLog(
     queryFn: () => fetchLog(repoId as string, limit, skip),
     enabled: repoId != null,
     refetchInterval: repoId != null ? poll(active) : false,
+    // "Load more" grows `limit`, which is part of the key — without a placeholder
+    // the new key has NO cache and the mounted list collapses to skeletons on
+    // every tap (review r2). Keep the prior page visible while the grown page
+    // loads; the screen gates its button on `isPlaceholderData`.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -290,6 +300,9 @@ export function useIssues(
     queryFn: () => fetchIssues(repoId as string, state, limit),
     enabled: repoId != null,
     refetchInterval: repoId != null ? poll(active) : false,
+    // Same growing-limit key as useLog: keep the prior page visible while the
+    // grown page loads (review r2 — no placeholder = skeleton collapse on tap).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -7,15 +7,46 @@ import { useMemo, useSyncExternalStore } from "react";
 // canonical scoped forms carry it:
 //   #r/{repoId}/status · #r/{repoId}/prs · #r/{repoId}/prs/{n} · #r/{repoId}/ci ·
 //   #r/{repoId}/ci/{id} · #r/{repoId}/agents · #r/{repoId}/agents/{streamId}
+// Slice 6 adds four read-only surfaces (SCOPED-ONLY — no legacy repo-less forms):
+//   #r/{repoId}/changes · #r/{repoId}/changes/{section}/{encodedFile}
+//   #r/{repoId}/history · #r/{repoId}/history/{sha} · #r/{repoId}/history/{sha}/{encodedFile}
+//   #r/{repoId}/branches
+//   #r/{repoId}/issues · #r/{repoId}/issues/{n}
 // Plus two global (repo-less) routes:
 //   #pair   — the pairing takeover (unchanged)
 //   #repos  — the repo picker
 // Legacy single-repo hashes (`#status`, `#prs/{n}`, `#ci/{id}`, `#agents/{id}`)
 // still parse — with `repoId: null` — so old bookmarks keep working; the shell
-// redirects them to the scoped equivalent once it knows which repo to use.
+// redirects them to the scoped equivalent once it knows which repo to use. The
+// slice-6 tabs are deliberately NOT part of the legacy grammar (an unknown head on
+// the legacy branch degrades to status, exactly as before).
 // Default (empty / unknown hash) resolves to #status with a null repoId.
 
-export type Tab = "status" | "prs" | "ci" | "agents";
+export type Tab =
+  | "status"
+  | "prs"
+  | "ci"
+  | "agents"
+  | "changes"
+  | "history"
+  | "branches"
+  | "issues";
+
+/** The working-tree section a Changes file-diff is scoped to. `unstaged` and
+ *  `untracked` both map to the working-tree side server-side, but they're distinct
+ *  routes so the file-diff fetch can pass the right `staged`/`untracked` flags. */
+export type ChangesSection = "staged" | "unstaged" | "untracked";
+
+const CHANGES_SECTIONS: readonly ChangesSection[] = [
+  "staged",
+  "unstaged",
+  "untracked",
+];
+
+// A commit sha segment: 7–40 hex chars. A tail that fails this guard is treated as
+// absent (`sha: null`) — the same "unknown detail → list" degradation the other
+// tabs use — so a malformed sha never reaches a scoped commit URL.
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
 
 // Agent-stream ids are opaque UUID-like STRINGS (not numbers like PR/CI ids), so
 // they parse into their own `streamId` field. A conservative charset guard keeps
@@ -52,32 +83,123 @@ export interface Route {
   /** A selected agent-stream id (`#…/agents/{id}`), else null. String because
    *  stream ids are UUID-like, not numeric. Only parsed on the agents tab. */
   streamId: string | null;
+  /** The working-tree section a Changes file-diff is scoped to
+   *  (`#…/changes/{section}/{file}`), else null. Null on every route but a
+   *  changes file-diff route with a recognized section. */
+  section: ChangesSection | null;
+  /** A selected file path (`#…/changes/{section}/{file}`,
+   *  `#…/history/{sha}/{file}`), already `decodeURIComponent`-decoded, else null. */
+  filePath: string | null;
+  /** A selected commit sha (`#…/history/{sha}[/…]`), else null. Only ever a
+   *  7–40 hex-char string or null — a malformed sha segment parses as null. */
+  sha: string | null;
   /** The raw normalized hash (without the leading `#`). */
   raw: string;
 }
 
-/** Parse the `{tab}[/detail]` portion shared by both the legacy and scoped forms
- *  into `{ tab, detailId, streamId }`. `head` is the tab segment, `tail` the
- *  optional detail segment. */
+/** The tab-and-detail portion shared by both forms. Legacy hashes never carry a
+ *  `section`/`filePath`/`sha` (the slice-6 tabs are scoped-only), so those stay
+ *  null there; the scoped parse fills them from the trailing segments. */
+interface TabParse {
+  tab: Tab;
+  detailId: number | null;
+  streamId: string | null;
+  section: ChangesSection | null;
+  filePath: string | null;
+  sha: string | null;
+}
+
+/** The all-null detail defaults every branch spreads over — keeps each `case`
+ *  focused on the one or two fields its tab actually uses. */
+const NO_DETAIL = {
+  detailId: null,
+  streamId: null,
+  section: null,
+  filePath: null,
+  sha: null,
+} as const;
+
+/** Parse the `{tab}[/detail…]` portion shared by both the legacy and scoped forms.
+ *  `head` is the tab segment, `tail` the first detail segment, `extra` the segment
+ *  after that (only the scoped slice-6 file-diff routes reach for it — a file path
+ *  under `changes/{section}/{file}` or `history/{sha}/{file}`).
+ *
+ *  `scoped` marks the caller as the scoped `#r/{id}/…` branch. The four slice-6
+ *  tabs (changes/history/branches/issues) are SCOPED-ONLY: on the legacy branch
+ *  (`scoped: false`) their heads are unknown and degrade to status, exactly like any
+ *  other unknown legacy head — the legacy grammar is deliberately NOT extended.
+ *  The original tabs (prs/ci/agents/status) parse identically under either branch. */
 function parseTab(
   head: string | undefined,
   tail: string | undefined,
-): { tab: Tab; detailId: number | null; streamId: string | null } {
+  extra: string | undefined,
+  scoped: boolean,
+): TabParse {
   const detailId = tail && /^\d+$/.test(tail) ? Number(tail) : null;
   switch (head) {
     case "prs":
-      return { tab: "prs", detailId, streamId: null };
+      return { ...NO_DETAIL, tab: "prs", detailId };
     case "ci":
-      return { tab: "ci", detailId, streamId: null };
+      return { ...NO_DETAIL, tab: "ci", detailId };
     case "agents": {
       // Stream ids are strings, so `detailId` never applies here; a tail that
       // fails the charset guard falls back to the list (streamId null).
       const streamId = tail && STREAM_ID_RE.test(tail) ? tail : null;
-      return { tab: "agents", detailId: null, streamId };
+      return { ...NO_DETAIL, tab: "agents", streamId };
     }
-    default:
-      return { tab: "status", detailId: null, streamId: null };
+    case "changes": {
+      if (!scoped) break; // scoped-only → unknown on the legacy branch
+      // `changes/{section}/{encodedFile}` → a file-diff route; `changes` alone →
+      // the list. A tail outside the three-value section set (or a missing file
+      // segment) is an unknown detail: fall back to the list, exactly as an
+      // unknown PR/CI tail does.
+      const section =
+        tail && (CHANGES_SECTIONS as readonly string[]).includes(tail)
+          ? (tail as ChangesSection)
+          : null;
+      const filePath = section && extra ? decodeSegment(extra) : null;
+      // A section without a file segment isn't a valid file-diff route; drop both
+      // so it renders the list (never a half-formed detail).
+      return filePath
+        ? { ...NO_DETAIL, tab: "changes", section, filePath }
+        : { ...NO_DETAIL, tab: "changes" };
+    }
+    case "history": {
+      if (!scoped) break; // scoped-only
+      // `history/{sha}[/{encodedFile}]`. A tail that isn't a 7–40 hex sha is an
+      // unknown detail → the list (sha null); a valid sha may carry a file tail.
+      const sha = tail && SHA_RE.test(tail) ? tail : null;
+      const filePath = sha && extra ? decodeSegment(extra) : null;
+      return { ...NO_DETAIL, tab: "history", sha, filePath };
+    }
+    case "branches":
+      if (!scoped) break; // scoped-only
+      return { ...NO_DETAIL, tab: "branches" };
+    case "issues":
+      if (!scoped) break; // scoped-only
+      // Numeric detail → the issue number (`detailId`), exactly like prs.
+      return { ...NO_DETAIL, tab: "issues", detailId };
   }
+  // Unknown head (or a scoped-only tab reached via the legacy branch) → status.
+  return { ...NO_DETAIL, tab: "status" };
+}
+
+/** Decode one `encodeURIComponent`-encoded path segment back to its raw path. A
+ *  malformed escape (a hand-crafted hash) throws in `decodeURIComponent`; treat
+ *  that as no file (null-equivalent "") rather than crashing the whole parse. */
+function decodeSegment(seg: string): string | null {
+  try {
+    return decodeURIComponent(seg);
+  } catch {
+    return null;
+  }
+}
+
+/** Encode a file path into a single hash segment (`encodeURIComponent` exactly
+ *  once, so `/` and other path chars survive the round-trip through the hash).
+ *  The inverse of the parser's `decodeSegment`. */
+export function encodeFileSegment(path: string): string {
+  return encodeURIComponent(path);
 }
 
 function parseHash(hash: string): Route {
@@ -88,8 +210,7 @@ function parseHash(hash: string): Route {
       isPairing: true,
       isRepos: false,
       repoId: null,
-      detailId: null,
-      streamId: null,
+      ...NO_DETAIL,
       raw,
     };
   }
@@ -99,36 +220,34 @@ function parseHash(hash: string): Route {
       isPairing: false,
       isRepos: true,
       repoId: null,
-      detailId: null,
-      streamId: null,
+      ...NO_DETAIL,
       raw,
     };
   }
   const parts = raw.split("/");
-  // Scoped form: `r/{repoId}/{tab}[/{detail}]`. A malformed repoId segment falls
-  // through to the legacy parse below (repoId stays null), so it degrades to the
-  // legacy meaning rather than routing to a repo that can't exist.
+  // Scoped form: `r/{repoId}/{tab}[/{detail}[/{extra}]]`. A malformed repoId segment
+  // falls through to the legacy parse below (repoId stays null), so it degrades to
+  // the legacy meaning rather than routing to a repo that can't exist. The scoped
+  // form is the ONLY one that passes `parts[4]` (the file segment) — the slice-6
+  // file-diff routes are scoped-only.
   if (parts[0] === "r" && parts[1] && REPO_ID_RE.test(parts[1])) {
-    const { tab, detailId, streamId } = parseTab(parts[2], parts[3]);
     return {
-      tab,
+      ...parseTab(parts[2], parts[3], parts[4], true),
       isPairing: false,
       isRepos: false,
       repoId: parts[1],
-      detailId,
-      streamId,
       raw,
     };
   }
-  // Legacy single-repo form: `{tab}[/{detail}]` with no repo scope.
-  const { tab, detailId, streamId } = parseTab(parts[0], parts[1]);
+  // Legacy single-repo form: `{tab}[/{detail}]` with no repo scope. `scoped: false`
+  // and no `extra` segment: the slice-6 tabs (changes/history/branches/issues) are
+  // scoped-only, so a legacy head that isn't status/prs/ci/agents degrades to status
+  // as before.
   return {
-    tab,
+    ...parseTab(parts[0], parts[1], undefined, false),
     isPairing: false,
     isRepos: false,
     repoId: null,
-    detailId,
-    streamId,
     raw,
   };
 }

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -91,7 +91,7 @@ export interface Route {
    *  `#…/history/{sha}/{file}`), already `decodeURIComponent`-decoded, else null. */
   filePath: string | null;
   /** A selected commit sha (`#…/history/{sha}[/…]`), else null. Only ever a
-   *  7–40 hex-char string or null — a malformed sha segment parses as null. */
+   *  7–64 hex-char string or null — a malformed sha segment parses as null. */
   sha: string | null;
   /** The raw normalized hash (without the leading `#`). */
   raw: string;

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -43,10 +43,10 @@ const CHANGES_SECTIONS: readonly ChangesSection[] = [
   "untracked",
 ];
 
-// A commit sha segment: 7–40 hex chars. A tail that fails this guard is treated as
+// A commit sha segment: 7–64 hex chars (64 covers SHA-256 object-format repos). A tail that fails this guard is treated as
 // absent (`sha: null`) — the same "unknown detail → list" degradation the other
 // tabs use — so a malformed sha never reaches a scoped commit URL.
-const SHA_RE = /^[0-9a-f]{7,40}$/i;
+const SHA_RE = /^[0-9a-f]{7,64}$/i;
 
 // Agent-stream ids are opaque UUID-like STRINGS (not numbers like PR/CI ids), so
 // they parse into their own `streamId` field. A conservative charset guard keeps
@@ -166,7 +166,7 @@ function parseTab(
     }
     case "history": {
       if (!scoped) break; // scoped-only
-      // `history/{sha}[/{encodedFile}]`. A tail that isn't a 7–40 hex sha is an
+      // `history/{sha}[/{encodedFile}]`. A tail that isn't a 7–64 hex sha is an
       // unknown detail → the list (sha null); a valid sha may carry a file tail.
       const sha = tail && SHA_RE.test(tail) ? tail : null;
       const filePath = sha && extra ? decodeSegment(extra) : null;

--- a/companion/src/screens/Branches.tsx
+++ b/companion/src/screens/Branches.tsx
@@ -12,6 +12,7 @@ import {
   StaleBanner,
 } from "../components/states";
 import type { Branch } from "../lib/api";
+import { useState } from "react";
 import { timeAgo } from "../lib/format";
 import { useBranches } from "../lib/queries";
 import { useRovingList } from "../lib/use-roving-list";
@@ -33,6 +34,11 @@ export function BranchesBody({
 }) {
   const { data, isError, error, refetch } = useBranches(repoId, active);
   const { register, onKeyDown } = useRovingList();
+  // True roving tabindex: the tab stop follows the last-focused row (arrow nav or
+  // click), so Tab-ing away and back returns to it, not row 0. `onFocus` keeps it
+  // in sync with useRovingList's .focus() calls; clamped in case a poll shrinks
+  // the list under a remembered index. (Review r6.)
+  const [focusIdx, setFocusIdx] = useState(0);
 
   // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
   // state even when a cached list is on hand (see isRepoGoneError).
@@ -70,7 +76,8 @@ export function BranchesBody({
                   // A focusable, roving list row (repo convention: every list gets
                   // keyboard nav) — but NOT a control: there's no branch detail to
                   // open, so it's a plain row, not a button/link.
-                  tabIndex={i === 0 ? 0 : -1}
+                  tabIndex={i === Math.min(focusIdx, branches.length - 1) ? 0 : -1}
+                  onFocus={() => setFocusIdx(i)}
                   className={`flex min-h-14 items-center gap-3 px-4 py-3 outline-none focus-visible:bg-muted/40 ${
                     branch.archived ? "opacity-60" : ""
                   }`}

--- a/companion/src/screens/Branches.tsx
+++ b/companion/src/screens/Branches.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUpIcon,
   GitBranchIcon,
 } from "@phosphor-icons/react";
+import { useState } from "react";
 import {
   EmptyState,
   ErrorState,
@@ -12,7 +13,6 @@ import {
   StaleBanner,
 } from "../components/states";
 import type { Branch } from "../lib/api";
-import { useState } from "react";
 import { timeAgo } from "../lib/format";
 import { useBranches } from "../lib/queries";
 import { useRovingList } from "../lib/use-roving-list";
@@ -35,10 +35,11 @@ export function BranchesBody({
   const { data, isError, error, refetch } = useBranches(repoId, active);
   const { register, onKeyDown } = useRovingList();
   // True roving tabindex: the tab stop follows the last-focused row (arrow nav or
-  // click), so Tab-ing away and back returns to it, not row 0. `onFocus` keeps it
-  // in sync with useRovingList's .focus() calls; clamped in case a poll shrinks
-  // the list under a remembered index. (Review r6.)
-  const [focusIdx, setFocusIdx] = useState(0);
+  // click), so Tab-ing away and back returns to it, not row 0. Keyed by branch
+  // NAME, not index — a poll can reorder the list under a remembered position,
+  // and identity keeps the stop on the same branch; an unknown/absent name falls
+  // back to row 0. `onFocus` syncs with useRovingList's .focus(). (Review r6+r7.)
+  const [focusName, setFocusName] = useState<string | null>(null);
 
   // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
   // state even when a cached list is on hand (see isRepoGoneError).
@@ -76,8 +77,17 @@ export function BranchesBody({
                   // A focusable, roving list row (repo convention: every list gets
                   // keyboard nav) — but NOT a control: there's no branch detail to
                   // open, so it's a plain row, not a button/link.
-                  tabIndex={i === Math.min(focusIdx, branches.length - 1) ? 0 : -1}
-                  onFocus={() => setFocusIdx(i)}
+                  tabIndex={
+                    (
+                      focusName != null &&
+                      branches.some((b) => b.name === focusName)
+                        ? branch.name === focusName
+                        : i === 0
+                    )
+                      ? 0
+                      : -1
+                  }
+                  onFocus={() => setFocusName(branch.name)}
                   className={`flex min-h-14 items-center gap-3 px-4 py-3 outline-none focus-visible:bg-muted/40 ${
                     branch.archived ? "opacity-60" : ""
                   }`}

--- a/companion/src/screens/Branches.tsx
+++ b/companion/src/screens/Branches.tsx
@@ -54,6 +54,13 @@ export function BranchesBody({
   }
 
   const branches = sortBranches(data);
+  // Hoisted membership check (once per render, not per row): the remembered
+  // focus name is active only while its branch is still in the list; otherwise
+  // the tab stop falls back to row 0.
+  const activeName =
+    focusName != null && branches.some((b) => b.name === focusName)
+      ? focusName
+      : null;
   // "Only the current branch exists" is a real (fresh-repo) state — show the single
   // row PLUS a teaching hint rather than an empty list.
   const onlyCurrent = branches.length === 1 && branches[0].isCurrent;
@@ -78,12 +85,7 @@ export function BranchesBody({
                   // keyboard nav) — but NOT a control: there's no branch detail to
                   // open, so it's a plain row, not a button/link.
                   tabIndex={
-                    (
-                      focusName != null &&
-                      branches.some((b) => b.name === focusName)
-                        ? branch.name === focusName
-                        : i === 0
-                    )
+                    (activeName != null ? branch.name === activeName : i === 0)
                       ? 0
                       : -1
                   }

--- a/companion/src/screens/Branches.tsx
+++ b/companion/src/screens/Branches.tsx
@@ -1,0 +1,179 @@
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  GitBranchIcon,
+} from "@phosphor-icons/react";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import type { Branch } from "../lib/api";
+import { timeAgo } from "../lib/format";
+import { useBranches } from "../lib/queries";
+import { useRovingList } from "../lib/use-roving-list";
+
+// The Branches tab: the repo's local-branch list (read-only in slice 6). Mirrors
+// the Prs list anatomy — SkeletonRows / ErrorState / RepoGoneState / EmptyState /
+// StaleBanner semantics, `<ul>` divide-y, roving keyboard nav — but rows are NOT
+// tappable (there's no branch-detail surface), so each row is a plain list item
+// (roving still moves focus for scanning/scroll). Order: current branch first,
+// then by lastCommitDate desc; archived branches are de-emphasized and sorted last.
+
+/** The local branches list. `repoId` scopes the query; `active` gates polling. */
+export function BranchesBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useBranches(repoId, active);
+  const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when a cached list is on hand (see isRepoGoneError).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  // Prefer stale data: keep the last-known list on screen even on error, with a
+  // StaleBanner above it. Full-screen ErrorState only when there's nothing to
+  // show; skeleton only while the first fetch is pending.
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  const branches = sortBranches(data);
+  // "Only the current branch exists" is a real (fresh-repo) state — show the single
+  // row PLUS a teaching hint rather than an empty list.
+  const onlyCurrent = branches.length === 1 && branches[0].isCurrent;
+
+  return (
+    <div className="flex flex-col">
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
+      {branches.length === 0 ? (
+        <EmptyState
+          title="No branches."
+          hint="This repository's local branches will show up here."
+        />
+      ) : (
+        <>
+          <ul className="flex flex-col divide-y divide-border">
+            {branches.map((branch, i) => (
+              <li key={branch.name}>
+                <div
+                  ref={register(i)}
+                  onKeyDown={onKeyDown}
+                  // A focusable, roving list row (repo convention: every list gets
+                  // keyboard nav) — but NOT a control: there's no branch detail to
+                  // open, so it's a plain row, not a button/link.
+                  tabIndex={i === 0 ? 0 : -1}
+                  className={`flex min-h-14 items-center gap-3 px-4 py-3 outline-none focus-visible:bg-muted/40 ${
+                    branch.archived ? "opacity-60" : ""
+                  }`}
+                >
+                  <BranchRow branch={branch} />
+                </div>
+              </li>
+            ))}
+          </ul>
+          {onlyCurrent ? (
+            <p className="px-4 py-3 text-sm text-muted-foreground">
+              No other branches.
+            </p>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Sort branches for display: the current branch first, then archived branches
+ *  last; within each group, most-recently-committed first. */
+function sortBranches(branches: Branch[]): Branch[] {
+  return [...branches].sort((a, b) => {
+    if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
+    if (a.archived !== b.archived) return a.archived ? 1 : -1;
+    return dateOrder(b.lastCommitDate) - dateOrder(a.lastCommitDate);
+  });
+}
+
+/** Sort key for a branch's last-commit date — parsed epoch ms, or 0 for an
+ *  empty/invalid date (Array.sort here is stable, so equal keys keep input order). */
+function dateOrder(iso: string): number {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function BranchRow({ branch }: { branch: Branch }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <GitBranchIcon
+          size={16}
+          className={`shrink-0 ${
+            branch.isCurrent ? "text-primary" : "text-muted-foreground"
+          }`}
+          aria-hidden
+        />
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          {branch.name}
+        </span>
+        {branch.isCurrent ? <TagChip label="current" /> : null}
+        {branch.archived ? <TagChip label="archived" /> : null}
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="min-w-0 truncate">
+          {branch.upstream
+            ? `${branch.upstream}${branch.upstreamGone ? " (gone)" : ""}`
+            : "No upstream"}
+        </span>
+        <Divergence branch={branch} />
+        <span className="shrink-0 tabular-nums">
+          {timeAgo(branch.lastCommitDate)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** The ahead/behind badges. Glyph + number so the divergence never rests on color
+ *  alone (WCAG 1.4.1) — the same info/warning icon colors Status uses for ahead
+ *  (info) / behind (warning). Nothing renders when the branch is even, has no
+ *  upstream, or its upstream is gone. */
+function Divergence({ branch }: { branch: Branch }) {
+  if (!branch.upstream || branch.upstreamGone) return null;
+  const { upstreamAhead: ahead, upstreamBehind: behind } = branch;
+  if (ahead === 0 && behind === 0) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-2 tabular-nums">
+      {ahead > 0 ? (
+        <span className="flex items-center gap-0.5">
+          <ArrowUpIcon size={12} className="text-info" aria-hidden />
+          {ahead}
+          <span className="sr-only"> ahead</span>
+        </span>
+      ) : null}
+      {behind > 0 ? (
+        <span className="flex items-center gap-0.5">
+          <ArrowDownIcon size={12} className="text-warning" aria-hidden />
+          {behind}
+          <span className="sr-only"> behind</span>
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** A small neutral marker chip (current / archived) — text-only, no color-coded
+ *  meaning, matching the companion's restrained register. */
+function TagChip({ label }: { label: string }) {
+  return (
+    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      {label}
+    </span>
+  );
+}

--- a/companion/src/screens/Changes.tsx
+++ b/companion/src/screens/Changes.tsx
@@ -1,0 +1,272 @@
+// The Changes tab: the working-tree diff list (staged · changed · untracked)
+// grouped by section, plus a per-file diff view. F0 froze the export names + props
+// and the shared router/api/queries; this package (F23) fills the bodies.
+
+import { ArrowLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { useMemo } from "react";
+import type { FileEntry } from "@/lib/git/types";
+import { DiffText } from "../components/DiffText";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import type { DiffStatEntry } from "../lib/api";
+import { useFileDiff, useStatus, useWorkingDiff } from "../lib/queries";
+import { encodeFileSegment, navigate, repoHash } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+// The three working-tree sections, in the order the desktop presents them. The
+// route section id is the discriminator (`staged`/`unstaged`/`untracked`); the
+// heading is its human label.
+type Section = "staged" | "unstaged" | "untracked";
+const SECTION_LABELS: Record<Section, string> = {
+  staged: "Staged",
+  unstaged: "Changes",
+  untracked: "Untracked",
+};
+
+/** One row's data: the file path, the section it belongs to (drives the diff-side
+ *  flags), and its optional line-count stats (joined from the working diff). */
+interface ChangeRow {
+  path: string;
+  section: Section;
+  added: number | null;
+  deleted: number | null;
+  isBinary: boolean;
+}
+
+/** Partition the status entries into the three sections. A file staged AND
+ *  unstaged appears in BOTH the Staged and Changes sections (git's index vs.
+ *  working-tree distinction). Untracked is the `unstaged === "untracked"` marker.
+ *  Stats come from the working diff, joined by path (a missing stat leaves the
+ *  numbers off — never blocks the row). */
+function buildRows(
+  entries: FileEntry[],
+  stats: Map<string, DiffStatEntry>,
+): { staged: ChangeRow[]; unstaged: ChangeRow[]; untracked: ChangeRow[] } {
+  const staged: ChangeRow[] = [];
+  const unstaged: ChangeRow[] = [];
+  const untracked: ChangeRow[] = [];
+  for (const e of entries) {
+    const stat = stats.get(e.path);
+    const base = {
+      path: e.path,
+      added: stat ? stat.added : null,
+      deleted: stat ? stat.deleted : null,
+      isBinary: stat ? stat.isBinary : false,
+    };
+    if (e.staged) staged.push({ ...base, section: "staged" });
+    if (e.unstaged === "untracked") {
+      untracked.push({ ...base, section: "untracked" });
+    } else if (e.unstaged) {
+      unstaged.push({ ...base, section: "unstaged" });
+    }
+  }
+  return { staged, unstaged, untracked };
+}
+
+/** The working-tree changes list, grouped by section. `active` gates polling. The
+ *  status query is the authoritative per-section truth (already cached/polled by
+ *  the hub); the working diff is a stats lookup joined by path — a failure there
+ *  never blocks the row list, only omits the `+n −n` numbers. */
+export function ChangesBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useStatus(repoId, active);
+  const workingDiff = useWorkingDiff(repoId, active);
+  const { register, onKeyDown } = useRovingList();
+
+  // Index the working diff's per-file stats by path for an O(1) join. Memoized on
+  // the diff data so the map is stable across renders (and cheap when it's absent).
+  const stats = useMemo(() => {
+    const map = new Map<string, DiffStatEntry>();
+    for (const f of workingDiff.data?.files ?? []) map.set(f.path, f);
+    return map;
+  }, [workingDiff.data]);
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when a cached status is on hand (mirrors StatusBody/PrsBody).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  const { staged, unstaged, untracked } = buildRows(data.entries, stats);
+  const sections: { id: Section; rows: ChangeRow[] }[] = [
+    { id: "staged", rows: staged },
+    { id: "unstaged", rows: unstaged },
+    { id: "untracked", rows: untracked },
+  ];
+  const empty = staged.length + unstaged.length + untracked.length === 0;
+
+  // A single running index across ALL sections so roving arrow-key nav flows
+  // through the whole list (not per-section). Bumped as each row registers.
+  let rowIndex = 0;
+
+  return (
+    <div className="flex flex-col">
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
+      {empty ? (
+        <EmptyState
+          title="Working tree clean."
+          hint="Changes you make on the desktop will show up here."
+        />
+      ) : (
+        <div className="flex flex-col">
+          {sections.map((s) =>
+            s.rows.length === 0 ? null : (
+              <section key={s.id} className="flex flex-col">
+                <h2 className="sticky top-0 z-10 bg-background/95 px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground backdrop-blur">
+                  {SECTION_LABELS[s.id]} · {s.rows.length}
+                </h2>
+                <ul className="flex flex-col divide-y divide-border">
+                  {s.rows.map((row) => {
+                    const i = rowIndex++;
+                    return (
+                      <li key={`${s.id}:${row.path}`}>
+                        <button
+                          type="button"
+                          ref={register(i)}
+                          onKeyDown={onKeyDown}
+                          onClick={() =>
+                            navigate(
+                              repoHash(
+                                repoId,
+                                `changes/${s.id}/${encodeFileSegment(row.path)}`,
+                              ),
+                            )
+                          }
+                          className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+                        >
+                          <ChangeRowContent row={row} />
+                          <CaretRightIcon
+                            size={16}
+                            className="shrink-0 text-muted-foreground"
+                          />
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One change row: the file path (tail kept visible when long) with its `+n −n`
+ *  stats or a binary chip. */
+function ChangeRowContent({ row }: { row: ChangeRow }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="truncate text-sm text-foreground" title={row.path}>
+        {row.path}
+      </p>
+      <p className="mt-0.5 flex items-center gap-2 text-xs">
+        {row.isBinary ? (
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground">
+            binary
+          </span>
+        ) : row.added !== null || row.deleted !== null ? (
+          <span className="tabular-nums">
+            <span className="text-success">+{row.added ?? 0}</span>{" "}
+            <span className="text-destructive">−{row.deleted ?? 0}</span>
+          </span>
+        ) : null}
+      </p>
+    </div>
+  );
+}
+
+/** A single file's diff, scoped to one working-tree section. `filePath` is the
+ *  decoded repo-relative path. The staged/untracked flags select the diff side. */
+export function ChangesFileBody({
+  repoId,
+  section,
+  filePath,
+}: {
+  repoId: string;
+  section: Section;
+  filePath: string;
+}) {
+  const { data, isPending, isError, error, refetch } = useFileDiff(
+    repoId,
+    filePath,
+    { staged: section === "staged", untracked: section === "untracked" },
+  );
+
+  // Definitive gone WINS: the whole detail (back-bar included) is replaced by the
+  // teaching state (mirrors PrDetail).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  return (
+    <div className="flex flex-col">
+      <DetailBackBar
+        label="Changes"
+        onBack={() => navigate(repoHash(repoId, "changes"))}
+        path={filePath}
+      />
+      {isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={4} />
+      ) : (
+        <DiffText
+          text={data.text}
+          truncated={data.isTruncated}
+          isBinary={data.isBinary}
+        />
+      )}
+    </div>
+  );
+}
+
+/** The sticky detail back bar shared by the Changes/History file-diff views — an
+ *  ArrowLeft + section label, plus the file path as a heading. Long paths keep
+ *  their TAIL visible (the filename matters more than the leading dirs), so the
+ *  path truncates from the START. */
+export function DetailBackBar({
+  label,
+  onBack,
+  path,
+}: {
+  label: string;
+  onBack: () => void;
+  path: string;
+}) {
+  return (
+    <div className="sticky top-0 z-10 flex flex-col gap-1 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex min-h-11 items-center gap-1 self-start rounded px-2 text-sm font-medium text-primary"
+      >
+        <ArrowLeftIcon size={16} />
+        {label}
+      </button>
+      {/* `direction: rtl` + text-align left flips the truncation ellipsis to the
+          START so the filename tail stays visible; `dir="ltr"` on an inner span
+          keeps the path text itself in normal reading order. */}
+      <p
+        className="truncate px-2 text-right font-mono text-xs text-foreground/90"
+        style={{ direction: "rtl" }}
+        title={path}
+      >
+        <span dir="ltr">{path}</span>
+      </p>
+    </div>
+  );
+}

--- a/companion/src/screens/Changes.tsx
+++ b/companion/src/screens/Changes.tsx
@@ -84,7 +84,11 @@ export function ChangesBody({
   const workingDiff = useWorkingDiff(repoId, active);
   const { register, onKeyDown } = useRovingList();
 
-  // Index the working diff's per-file stats by path for an O(1) join. Memoized on
+  // Index the working diff's per-file stats by path for an O(1) join. The diff is
+  // ONE payload (staged ∪ unstaged), so a file changed in BOTH sections shows its
+  // COMBINED +n −n in each row — a documented best-effort: a true per-side stat
+  // would need a second diff request per poll for a corner case, and the drill-in
+  // diffs (which pass the real staged/untracked flags) are always exact. Memoized on
   // the diff data so the map is stable across renders (and cheap when it's absent).
   const stats = useMemo(() => {
     const map = new Map<string, DiffStatEntry>();

--- a/companion/src/screens/History.tsx
+++ b/companion/src/screens/History.tsx
@@ -8,7 +8,7 @@ import {
   GitMergeIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { DiffText, splitCommitDiff } from "../components/DiffText";
 import {
   EmptyState,
@@ -332,6 +332,14 @@ export function CommitFileBody({
     repoId,
     sha,
   );
+  // Parse the multi-file commit text ONCE per commit (it can be up to the 1MB
+  // cap): navigating file-to-file within a commit changes only `filePath` while
+  // `data` stays cached, so the memo keys on `data`. ABOVE the early return —
+  // hooks must run unconditionally. (Review r3.)
+  const chunks = useMemo(
+    () => (data ? splitCommitDiff(data.text) : undefined),
+    [data],
+  );
 
   // Definitive gone WINS (mirrors PrDetail).
   if (isRepoGoneError(error)) return <RepoGoneState />;
@@ -339,7 +347,7 @@ export function CommitFileBody({
   // The matching file-stat entry (its `isBinary` flag), and the file's own diff
   // chunk sliced out of the commit's multi-file text.
   const fileStat = data?.files.find((f) => f.path === filePath);
-  const chunk = data ? splitCommitDiff(data.text).get(filePath) : undefined;
+  const chunk = chunks?.get(filePath);
 
   return (
     <div className="flex flex-col">
@@ -355,9 +363,12 @@ export function CommitFileBody({
       ) : chunk !== undefined ? (
         // The normal path: this file has a diff chunk. Honor the stat entry's binary
         // flag (a binary file with a chunk still renders as the binary note).
+        // `truncated` is COMMIT-wide (the 1MB cap), but the cut is a single point —
+        // only the chunk that is the TAIL of the text can be incomplete, so a fully
+        // present file doesn't carry a false truncation banner. (Review r3.)
         <DiffText
           text={chunk}
-          truncated={data.truncated}
+          truncated={data.truncated && data.text.endsWith(chunk)}
           isBinary={fileStat?.isBinary ?? false}
         />
       ) : data.truncated ? (

--- a/companion/src/screens/History.tsx
+++ b/companion/src/screens/History.tsx
@@ -1,0 +1,371 @@
+// The History tab: the commit log, a commit detail (message + changed files), and
+// a per-file commit diff. F0 froze the export names + props; this package (F23)
+// fills the bodies.
+
+import {
+  ArrowLeftIcon,
+  CaretRightIcon,
+  GitMergeIcon,
+} from "@phosphor-icons/react";
+import { useState } from "react";
+import { DiffText, splitCommitDiff } from "../components/DiffText";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import type { CommitSummary, DiffStatEntry } from "../lib/api";
+import { timeAgo } from "../lib/format";
+import { useCommit, useCommitDiff, useLog } from "../lib/queries";
+import { encodeFileSegment, navigate, repoHash } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+import { DetailBackBar } from "./Changes";
+
+// The log is paged with a single GROWING query keyed [log, repoId, 0, limit]: the
+// server re-serves the whole prefix each time, so "Load more" just bumps `limit`
+// (cheap + cache-friendly) rather than stitching a multi-query pages array.
+const PAGE = 50;
+
+/** The commit history list. `active` gates polling. */
+export function HistoryBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const [limit, setLimit] = useState(PAGE);
+  const { data, isError, error, refetch } = useLog(repoId, active, 0, limit);
+  const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over stale data (mirrors StatusBody/PrsBody).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  // The last page came back short (fewer commits than we asked for) → we've reached
+  // the root, so there's nothing more to load. Hide the button then.
+  const hasMore = data.length >= limit;
+
+  return (
+    <div className="flex flex-col">
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
+      {data.length === 0 ? (
+        <EmptyState
+          title="No commits yet."
+          hint="This repository's history will show up here."
+        />
+      ) : (
+        <>
+          <ul className="flex flex-col divide-y divide-border">
+            {data.map((commit, i) => (
+              <li key={commit.hash}>
+                <button
+                  type="button"
+                  ref={register(i)}
+                  onKeyDown={onKeyDown}
+                  onClick={() =>
+                    navigate(repoHash(repoId, `history/${commit.hash}`))
+                  }
+                  className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+                >
+                  <CommitRow commit={commit} />
+                  <CaretRightIcon
+                    size={16}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+          {hasMore ? (
+            <button
+              type="button"
+              onClick={() => setLimit((n) => n + PAGE)}
+              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary"
+            >
+              Load more
+            </button>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** One commit-log row: subject, author + relative date, short hash, tag chips, and
+ *  a merge marker. */
+function CommitRow({ commit }: { commit: CommitSummary }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        {commit.isMerge ? (
+          <GitMergeIcon
+            size={14}
+            className="shrink-0 text-merged"
+            aria-label="Merge commit"
+          />
+        ) : null}
+        <p className="truncate text-sm font-medium text-foreground">
+          {commit.subject}
+        </p>
+      </div>
+      <p className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="truncate">{commit.author}</span>
+        <span className="shrink-0">·</span>
+        <span className="shrink-0">{timeAgo(commit.date)}</span>
+        <span className="shrink-0 font-mono">{shortHash(commit.hash)}</span>
+      </p>
+      {commit.tags.length > 0 ? (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {commit.tags.slice(0, 2).map((tag) => (
+            <span
+              key={tag}
+              className="max-w-[12rem] truncate rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+            >
+              {tag}
+            </span>
+          ))}
+          {commit.tags.length > 2 ? (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              +{commit.tags.length - 2}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** One commit's detail: the message (subject + body) and its changed-file stats. */
+export function CommitBody({ repoId, sha }: { repoId: string; sha: string }) {
+  const commit = useCommit(repoId, sha);
+  const diff = useCommitDiff(repoId, sha);
+
+  // Definitive gone WINS on either query (mirrors PrDetail).
+  if (isRepoGoneError(commit.error) || isRepoGoneError(diff.error)) {
+    return <RepoGoneState />;
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => navigate(repoHash(repoId, "history"))}
+          className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+        >
+          <ArrowLeftIcon size={16} />
+          History
+        </button>
+      </div>
+
+      {commit.isError ? (
+        <ErrorState error={commit.error} onRetry={() => commit.refetch()} />
+      ) : commit.isPending || !commit.data ? (
+        <SkeletonRows count={3} />
+      ) : (
+        <article className="flex flex-col gap-4 px-4 py-5">
+          <header className="flex flex-col gap-2">
+            <h1 className="text-base font-semibold text-foreground">
+              {commit.data.subject}
+            </h1>
+            <p className="text-xs text-muted-foreground">
+              <span className="font-mono">{shortHash(commit.data.hash)}</span> ·{" "}
+              {commit.data.author}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {timeAgo(commit.data.date)}
+              {absoluteDate(commit.data.date)
+                ? ` · ${absoluteDate(commit.data.date)}`
+                : ""}
+            </p>
+          </header>
+
+          {/* Commit messages are NOT markdown — render the body as plain,
+              line-break-preserving text (never a Markdown parser). Omitted when the
+              body is empty. */}
+          {commit.data.body.trim() ? (
+            <p className="whitespace-pre-wrap text-sm text-foreground/90">
+              {commit.data.body}
+            </p>
+          ) : null}
+
+          <CommitFiles repoId={repoId} sha={sha} diff={diff} />
+        </article>
+      )}
+    </div>
+  );
+}
+
+/** The changed-file list for a commit, plus the truncation notice. Reads the SAME
+ *  `useCommitDiff` query the parent already has in flight (passed in), so there's no
+ *  second fetch. Its own pending/error state is inline — a diff failure must not
+ *  blank the commit message above it. */
+function CommitFiles({
+  repoId,
+  sha,
+  diff,
+}: {
+  repoId: string;
+  sha: string;
+  diff: ReturnType<typeof useCommitDiff>;
+}) {
+  if (diff.isError) {
+    return <ErrorState error={diff.error} onRetry={() => diff.refetch()} />;
+  }
+  if (diff.isPending || !diff.data) return <SkeletonRows count={2} />;
+
+  const { files, truncated, excludedFiles } = diff.data;
+  return (
+    <section className="flex flex-col gap-2">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+        {files.length} file{files.length === 1 ? "" : "s"} changed
+      </p>
+      {files.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No file changes.</p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border rounded-md border border-border">
+          {files.map((file) => (
+            <li key={file.path}>
+              <button
+                type="button"
+                onClick={() =>
+                  navigate(
+                    repoHash(
+                      repoId,
+                      `history/${sha}/${encodeFileSegment(file.path)}`,
+                    ),
+                  )
+                }
+                className="flex w-full min-h-12 items-center gap-3 px-3 py-2.5 text-left"
+              >
+                <CommitFileStat file={file} />
+                <CaretRightIcon
+                  size={16}
+                  className="shrink-0 text-muted-foreground"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {truncated || excludedFiles > 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {truncated
+            ? "Diff truncated — view the full diff on the desktop."
+            : `${excludedFiles} file${
+                excludedFiles === 1 ? "" : "s"
+              } hidden by ignore patterns.`}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+/** One commit-file stat row: the path (tail kept visible) with its `+n −n` or a
+ *  binary chip. */
+function CommitFileStat({ file }: { file: DiffStatEntry }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p
+        className="truncate font-mono text-xs text-foreground"
+        title={file.path}
+      >
+        {file.path}
+      </p>
+      <p className="mt-0.5 text-xs">
+        {file.isBinary ? (
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground">
+            binary
+          </span>
+        ) : (
+          <span className="tabular-nums">
+            <span className="text-success">+{file.added}</span>{" "}
+            <span className="text-destructive">−{file.deleted}</span>
+          </span>
+        )}
+      </p>
+    </div>
+  );
+}
+
+/** One file's diff within a commit. Slices the commit's multi-file diff by path via
+ *  `splitCommitDiff`. A file with no chunk is either a binary/stat-only file (git
+ *  emits no textual hunk → the binary note) or a pure rename with no content change
+ *  (the stat entry is non-binary → a "No content changes." note). */
+export function CommitFileBody({
+  repoId,
+  sha,
+  filePath,
+}: {
+  repoId: string;
+  sha: string;
+  filePath: string;
+}) {
+  const { data, isPending, isError, error, refetch } = useCommitDiff(
+    repoId,
+    sha,
+  );
+
+  // Definitive gone WINS (mirrors PrDetail).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  // The matching file-stat entry (its `isBinary` flag), and the file's own diff
+  // chunk sliced out of the commit's multi-file text.
+  const fileStat = data?.files.find((f) => f.path === filePath);
+  const chunk = data ? splitCommitDiff(data.text).get(filePath) : undefined;
+
+  return (
+    <div className="flex flex-col">
+      <DetailBackBar
+        label="Commit"
+        onBack={() => navigate(repoHash(repoId, `history/${sha}`))}
+        path={filePath}
+      />
+      {isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={4} />
+      ) : chunk === undefined && fileStat?.isBinary === false ? (
+        // A non-binary file with no diff chunk is a pure rename (100% similarity, no
+        // content change) — git emits stat/rename metadata but no textual hunk. Say
+        // so plainly rather than falling through to the misleading binary note.
+        <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+          No content changes.
+        </p>
+      ) : (
+        <DiffText
+          text={chunk ?? ""}
+          truncated={data.truncated}
+          // A file with no textual chunk is binary/stat-only (git emits no hunk) —
+          // render the binary note. Otherwise honor the stat entry's flag.
+          isBinary={fileStat?.isBinary ?? chunk === undefined}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Shorten a commit hash to its 7-char short form. */
+function shortHash(hash: string): string {
+  return hash.slice(0, 7);
+}
+
+/** An absolute, locale-formatted date for a commit ("Jul 20, 2026, 3:14 PM"), or
+ *  "" for an empty/invalid ISO string (so the caller can omit it). */
+function absoluteDate(iso: string): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  return new Date(t).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}

--- a/companion/src/screens/History.tsx
+++ b/companion/src/screens/History.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeftIcon,
   CaretRightIcon,
   GitMergeIcon,
+  WarningCircleIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import { DiffText, splitCommitDiff } from "../components/DiffText";
@@ -297,9 +298,19 @@ function CommitFileStat({ file }: { file: DiffStatEntry }) {
 }
 
 /** One file's diff within a commit. Slices the commit's multi-file diff by path via
- *  `splitCommitDiff`. A file with no chunk is either a binary/stat-only file (git
- *  emits no textual hunk → the binary note) or a pure rename with no content change
- *  (the stat entry is non-binary → a "No content changes." note). */
+ *  `splitCommitDiff` and renders the file's chunk in DiffText.
+ *
+ *  A file can have NO chunk for three distinct reasons, disambiguated below in
+ *  priority order:
+ *   1. The commit diff was TRUNCATED at the server's 1MB cap. Crucially the
+ *      `files[]` stat list is computed from a SEPARATE, uncapped numstat — so a file
+ *      whose diff block fell beyond the cut still has a (non-binary) stat entry but no
+ *      chunk. It is NOT "no content changes"; show the truncation notice.
+ *   2. The file is BINARY (git emits no textual hunk) — the binary note.
+ *   3. Genuinely no textual hunk on a non-binary, non-truncated file — a rare
+ *      metadata-only change such as a mode (permission) change. (A pure RENAME is NOT
+ *      this case: git emits a `diff --git` + `rename from/to` chunk for it, which
+ *      renders as meta lines through DiffText.) The "No content changes." note. */
 export function CommitFileBody({
   repoId,
   sha,
@@ -333,21 +344,33 @@ export function CommitFileBody({
         <ErrorState error={error} onRetry={() => refetch()} />
       ) : isPending || !data ? (
         <SkeletonRows count={4} />
-      ) : chunk === undefined && fileStat?.isBinary === false ? (
-        // A non-binary file with no diff chunk is a pure rename (100% similarity, no
-        // content change) — git emits stat/rename metadata but no textual hunk. Say
-        // so plainly rather than falling through to the misleading binary note.
+      ) : chunk !== undefined ? (
+        // The normal path: this file has a diff chunk. Honor the stat entry's binary
+        // flag (a binary file with a chunk still renders as the binary note).
+        <DiffText
+          text={chunk}
+          truncated={data.truncated}
+          isBinary={fileStat?.isBinary ?? false}
+        />
+      ) : data.truncated ? (
+        // No chunk because the diff was cut at the cap and this file's block fell
+        // beyond it — the stat entry (from the uncapped numstat) survived but the text
+        // didn't. Point at the desktop, NOT the misleading "no content changes".
+        <p className="flex items-center gap-2 border-b border-border bg-warning/15 px-4 py-2 text-xs text-foreground">
+          <WarningCircleIcon size={14} className="shrink-0 text-warning" />
+          Diff truncated — view the full diff on the desktop.
+        </p>
+      ) : fileStat?.isBinary ? (
+        // A binary file with no textual hunk.
+        <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+          Binary file — no text diff.
+        </p>
+      ) : (
+        // A non-binary, non-truncated file with no hunk — a rare metadata-only change
+        // (e.g. a file-mode change). NOT a rename (which emits a chunk).
         <p className="px-4 py-8 text-center text-sm text-muted-foreground">
           No content changes.
         </p>
-      ) : (
-        <DiffText
-          text={chunk ?? ""}
-          truncated={data.truncated}
-          // A file with no textual chunk is binary/stat-only (git emits no hunk) —
-          // render the binary note. Otherwise honor the stat entry's flag.
-          isBinary={fileStat?.isBinary ?? chunk === undefined}
-        />
       )}
     </div>
   );

--- a/companion/src/screens/History.tsx
+++ b/companion/src/screens/History.tsx
@@ -39,7 +39,12 @@ export function HistoryBody({
   active: boolean;
 }) {
   const [limit, setLimit] = useState(PAGE);
-  const { data, isError, error, refetch } = useLog(repoId, active, 0, limit);
+  const { data, isError, error, refetch, isPlaceholderData } = useLog(
+    repoId,
+    active,
+    0,
+    limit,
+  );
   const { register, onKeyDown } = useRovingList();
 
   // Definitive gone WINS over stale data (mirrors StatusBody/PrsBody).
@@ -51,8 +56,10 @@ export function HistoryBody({
   }
 
   // The last page came back short (fewer commits than we asked for) → we've reached
-  // the root, so there's nothing more to load. Hide the button then.
-  const hasMore = data.length >= limit;
+  // the root, so there's nothing more to load. While the grown page loads, `data`
+  // is the PRIOR page held as placeholder — its length looks short against the new
+  // limit, so keep the button visible (loading-labeled) instead of flickering it off.
+  const hasMore = data.length >= limit || isPlaceholderData;
 
   return (
     <div className="flex flex-col">
@@ -89,9 +96,10 @@ export function HistoryBody({
             <button
               type="button"
               onClick={() => setLimit((n) => n + PAGE)}
-              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary"
+              disabled={isPlaceholderData}
+              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary disabled:text-muted-foreground"
             >
-              Load more
+              {isPlaceholderData ? "Loading…" : "Load more"}
             </button>
           ) : null}
         </>

--- a/companion/src/screens/Issues.tsx
+++ b/companion/src/screens/Issues.tsx
@@ -1,0 +1,332 @@
+// The Issues tab: the issue list + an issue detail. Mirrors the Prs screen anatomy
+// (list/detail states, back bar, roving-list, Markdown bodies) — issues carry no
+// activity timeline over LAN, so there's no Activity/Threads section here.
+
+import {
+  ArrowLeftIcon,
+  CaretRightIcon,
+  EyeSlashIcon,
+  InfoIcon,
+  LockIcon,
+} from "@phosphor-icons/react";
+import { IssueStateChip } from "../components/chips";
+import { Markdown } from "../components/markdown";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import type { IssueComment, IssueDetails, IssueInfo } from "../lib/api";
+import { timeAgo } from "../lib/format";
+import { asApiError, useIssue, useIssues } from "../lib/queries";
+import { navigate, repoHash } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+/** Whether a query error is the DEFINITIVE "this repo has no usable issue tracker" —
+ *  a GitHub fork with issues turned off (`issuesDisabled`) or a Bitbucket repo
+ *  (issues deprecated → a 400 `invalidArgument`). The server sends a human-readable
+ *  `message`; the screens surface it as a calm teaching state (NOT the generic error,
+ *  and no retry — a retry can't turn the tracker on). Uses the `ApiError` fields — no
+ *  string matching. `issuesDisabled` is matched regardless of status: a newer desktop
+ *  sends it as a 400, but a phone talking to an OLDER desktop still gets a 502 with
+ *  that kind, and it's a stable state either way. */
+function isTrackerUnavailable(error: unknown): boolean {
+  const api = asApiError(error);
+  if (!api) return false;
+  return (
+    api.kind === "issuesDisabled" ||
+    (api.status === 400 && api.kind === "invalidArgument")
+  );
+}
+
+/** The calm teaching state for a repo whose issue tracker isn't usable. Mirrors the
+ *  states.tsx `CenteredState` markup (icon + title + hint), with the server's own
+ *  message as the hint and NO action button — the tab itself stays reachable, there's
+ *  just nothing to browse. (CenteredState isn't exported from states.tsx, and that
+ *  file is out of scope here, so the block is inlined — the same way Prs.tsx inlines
+ *  its own small presentational blocks.) */
+function TrackerUnavailableState({ message }: { message?: string }) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 px-8 py-16 text-center"
+      role="status"
+    >
+      <InfoIcon size={32} className="text-muted-foreground" />
+      <p className="text-sm font-medium text-foreground">
+        Issues aren't available for this repository
+      </p>
+      {message ? (
+        <div className="max-w-xs text-sm text-muted-foreground">{message}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/** The issues list. `repoId` scopes the query; `active` gates polling. */
+export function IssuesBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useIssues(repoId, active);
+  const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when a cached list is on hand (see isRepoGoneError).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  // Prefer stale data: keep the last-known list on screen even on error, with a
+  // StaleBanner above it. Full-screen states only when there's nothing to show;
+  // skeleton only while the first fetch is pending.
+  if (!data) {
+    // A repo with no usable issue tracker (Bitbucket / fork-with-issues-off) gets a
+    // calm teaching state carrying the server's message — never the generic error,
+    // and no retry (retrying can't turn the tracker on).
+    if (isTrackerUnavailable(error)) {
+      return <TrackerUnavailableState message={asApiError(error)?.message} />;
+    }
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
+      {data.length === 0 ? (
+        <EmptyState
+          title="No open issues."
+          hint="Open issues on this repository will show up here."
+        />
+      ) : (
+        <ul className="flex flex-col divide-y divide-border">
+          {data.map((issue, i) => (
+            <li key={issue.number}>
+              <button
+                type="button"
+                ref={register(i)}
+                onKeyDown={onKeyDown}
+                onClick={() =>
+                  navigate(repoHash(repoId, `issues/${issue.number}`))
+                }
+                className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+              >
+                <IssueRow issue={issue} />
+                <CaretRightIcon
+                  size={16}
+                  className="shrink-0 text-muted-foreground"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function IssueRow({ issue }: { issue: IssueInfo }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <IssueStateChip state={issue.state} />
+        <span className="text-xs text-muted-foreground">#{issue.number}</span>
+      </div>
+      <p className="mt-1 line-clamp-2 text-sm font-medium text-foreground">
+        {issue.title}
+      </p>
+      <p className="truncate text-xs text-muted-foreground">
+        {issue.author?.login ? `${issue.author.login} · ` : ""}
+        {timeAgo(issue.updatedAt)}
+      </p>
+      <LabelChips names={issue.labels.map((l) => l.name)} />
+    </div>
+  );
+}
+
+/** An issue's label names as neutral muted chips (max 2, then a "+n" overflow chip).
+ *  Labels carry NO color on the phone — contrast-correcting arbitrary label colors is
+ *  out of scope, so the chips are always neutral. Renders nothing when there are no
+ *  labels. */
+function LabelChips({ names }: { names: string[] }) {
+  if (names.length === 0) return null;
+  const shown = names.slice(0, 2);
+  const overflow = names.length - shown.length;
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-1">
+      {shown.map((name) => (
+        <span
+          key={name}
+          className="max-w-[10rem] truncate rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+        >
+          {name}
+        </span>
+      ))}
+      {overflow > 0 ? (
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          +{overflow}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** A read-only issue detail. */
+export function IssueDetailBody({
+  repoId,
+  number,
+}: {
+  repoId: string;
+  number: number;
+}) {
+  const { data, isPending, isError, error, refetch } = useIssue(repoId, number);
+
+  // Definitive gone WINS: the whole detail (back-bar included) is replaced by the
+  // teaching state — "Choose repository" is the only sensible action once the repo
+  // is unshared. (ErrorState also routes noSuchRepo here, but making it explicit
+  // keeps it robust if the error handling below is ever reordered.)
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => navigate(repoHash(repoId, "issues"))}
+          className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+        >
+          <ArrowLeftIcon size={16} />
+          Issues
+        </button>
+      </div>
+
+      {isTrackerUnavailable(error) ? (
+        <TrackerUnavailableState message={asApiError(error)?.message} />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={3} />
+      ) : (
+        <article className="flex flex-col gap-4 px-4 py-5">
+          <header className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <IssueStateChip state={data.state} />
+              <span className="text-xs text-muted-foreground">
+                #{data.number}
+              </span>
+            </div>
+            <h1 className="text-base font-semibold text-foreground">
+              {data.title}
+            </h1>
+            <p className="text-xs text-muted-foreground">
+              {data.author ? `${data.author} · ` : ""}
+              {timeAgo(data.createdAt)}
+            </p>
+            <IssueMeta detail={data} />
+            {data.locked ? (
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <LockIcon size={14} className="shrink-0" />
+                This issue is locked
+                {data.activeLockReason ? ` (${data.activeLockReason})` : ""}.
+              </p>
+            ) : null}
+          </header>
+
+          {data.body ? (
+            <Markdown className="text-foreground/90">{data.body}</Markdown>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">
+              No description.
+            </p>
+          )}
+
+          <CommentsSection detail={data} />
+        </article>
+      )}
+    </div>
+  );
+}
+
+/** The header's secondary metadata: label chips, assignees, and the milestone —
+ *  each rendered only when present. Assignees show by their neutral `label` text. */
+function IssueMeta({ detail }: { detail: IssueDetails }) {
+  const hasLabels = detail.labels.length > 0;
+  const hasAssignees = detail.assignees.length > 0;
+  const hasMilestone = detail.milestone !== null;
+  if (!hasLabels && !hasAssignees && !hasMilestone) return null;
+  return (
+    <div className="flex flex-col gap-1.5">
+      {hasLabels ? (
+        <LabelChips names={detail.labels.map((l) => l.name)} />
+      ) : null}
+      {hasAssignees ? (
+        <p className="text-xs text-muted-foreground">
+          Assigned to {detail.assignees.map((a) => a.label).join(", ")}
+        </p>
+      ) : null}
+      {detail.milestone ? (
+        <p className="text-xs text-muted-foreground">
+          Milestone: {detail.milestone.title}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** The issue's conversation: a flat list of comments, oldest-first as served. Reads
+ *  the EXISTING `useIssue` detail (no new query), so there's no separate
+ *  loading/error state — the surrounding detail already owns those. There is no
+ *  activity/timeline over LAN, so this is the only conversation section. */
+function CommentsSection({ detail }: { detail: IssueDetails }) {
+  const comments = detail.comments;
+  return (
+    <section className="flex flex-col gap-2">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+        Comments ({comments.length})
+      </p>
+      {comments.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No comments yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {comments.map((c) => (
+            <CommentCard key={c.id} comment={c} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/** One comment row — author + relative time + Markdown body. A minimized comment
+ *  collapses to a one-line muted "Hidden comment (reason)" row instead of its body
+ *  (no expand in v1). Body renders as GitHub-flavored Markdown (same as the issue
+ *  body). */
+function CommentCard({ comment }: { comment: IssueComment }) {
+  return (
+    <li className="flex flex-col gap-1 rounded-md border border-border px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-foreground/80">
+          {comment.author || "unknown"}
+        </span>
+        {comment.date ? (
+          <span className="text-xs text-muted-foreground">
+            {timeAgo(comment.date)}
+          </span>
+        ) : null}
+      </div>
+      {comment.isMinimized ? (
+        <p className="flex items-center gap-1.5 text-xs italic text-muted-foreground">
+          <EyeSlashIcon size={14} className="shrink-0" />
+          Hidden comment
+          {comment.minimizedReason ? ` (${comment.minimizedReason})` : ""}
+        </p>
+      ) : comment.body ? (
+        <Markdown className="text-foreground/90">{comment.body}</Markdown>
+      ) : null}
+    </li>
+  );
+}

--- a/companion/src/screens/Issues.tsx
+++ b/companion/src/screens/Issues.tsx
@@ -9,6 +9,7 @@ import {
   InfoIcon,
   LockIcon,
 } from "@phosphor-icons/react";
+import { useState } from "react";
 import { IssueStateChip } from "../components/chips";
 import { Markdown } from "../components/markdown";
 import {
@@ -65,6 +66,11 @@ function TrackerUnavailableState({ message }: { message?: string }) {
   );
 }
 
+// A single GROWING query pages the list: "Load more" bumps `limit` (the server
+// re-serves the whole prefix), mirroring HistoryBody. 30 to match the fetcher's
+// default page size.
+const PAGE = 30;
+
 /** The issues list. `repoId` scopes the query; `active` gates polling. */
 export function IssuesBody({
   repoId,
@@ -73,7 +79,13 @@ export function IssuesBody({
   repoId: string;
   active: boolean;
 }) {
-  const { data, isError, error, refetch } = useIssues(repoId, active);
+  const [limit, setLimit] = useState(PAGE);
+  const { data, isError, error, refetch } = useIssues(
+    repoId,
+    active,
+    "open",
+    limit,
+  );
   const { register, onKeyDown } = useRovingList();
 
   // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
@@ -94,6 +106,10 @@ export function IssuesBody({
     return <SkeletonRows />;
   }
 
+  // The last page came back short (fewer issues than we asked for) → there's nothing
+  // more to load. Hide the button then. Mirrors HistoryBody.
+  const hasMore = data.length >= limit;
+
   return (
     <div className="flex flex-col">
       {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
@@ -103,27 +119,38 @@ export function IssuesBody({
           hint="Open issues on this repository will show up here."
         />
       ) : (
-        <ul className="flex flex-col divide-y divide-border">
-          {data.map((issue, i) => (
-            <li key={issue.number}>
-              <button
-                type="button"
-                ref={register(i)}
-                onKeyDown={onKeyDown}
-                onClick={() =>
-                  navigate(repoHash(repoId, `issues/${issue.number}`))
-                }
-                className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
-              >
-                <IssueRow issue={issue} />
-                <CaretRightIcon
-                  size={16}
-                  className="shrink-0 text-muted-foreground"
-                />
-              </button>
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul className="flex flex-col divide-y divide-border">
+            {data.map((issue, i) => (
+              <li key={issue.number}>
+                <button
+                  type="button"
+                  ref={register(i)}
+                  onKeyDown={onKeyDown}
+                  onClick={() =>
+                    navigate(repoHash(repoId, `issues/${issue.number}`))
+                  }
+                  className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+                >
+                  <IssueRow issue={issue} />
+                  <CaretRightIcon
+                    size={16}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+          {hasMore ? (
+            <button
+              type="button"
+              onClick={() => setLimit((n) => n + PAGE)}
+              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary"
+            >
+              Load more
+            </button>
+          ) : null}
+        </>
       )}
     </div>
   );

--- a/companion/src/screens/Issues.tsx
+++ b/companion/src/screens/Issues.tsx
@@ -80,7 +80,7 @@ export function IssuesBody({
   active: boolean;
 }) {
   const [limit, setLimit] = useState(PAGE);
-  const { data, isError, error, refetch } = useIssues(
+  const { data, isError, error, refetch, isPlaceholderData } = useIssues(
     repoId,
     active,
     "open",
@@ -107,8 +107,11 @@ export function IssuesBody({
   }
 
   // The last page came back short (fewer issues than we asked for) → there's nothing
-  // more to load. Hide the button then. Mirrors HistoryBody.
-  const hasMore = data.length >= limit;
+  // more to load. Hide the button then. While the grown page loads, `data` is the
+  // PRIOR page held as placeholder — short-looking against the new limit, so keep
+  // the button visible (loading-labeled) instead of flickering it off. Mirrors
+  // HistoryBody.
+  const hasMore = data.length >= limit || isPlaceholderData;
 
   return (
     <div className="flex flex-col">
@@ -145,9 +148,10 @@ export function IssuesBody({
             <button
               type="button"
               onClick={() => setLimit((n) => n + PAGE)}
-              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary"
+              disabled={isPlaceholderData}
+              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary disabled:text-muted-foreground"
             >
-              Load more
+              {isPlaceholderData ? "Loading…" : "Load more"}
             </button>
           ) : null}
         </>

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -1,8 +1,10 @@
 import {
   ArrowDownIcon,
   ArrowUpIcon,
+  CaretRightIcon,
   GitBranchIcon,
 } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
 import type { FileEntry } from "@/lib/git/types";
 import {
   ErrorState,
@@ -11,10 +13,17 @@ import {
   SkeletonRows,
   StaleBanner,
 } from "../components/states";
-import { useStatus } from "../lib/queries";
+import type { CommitSummary } from "../lib/api";
+import { timeAgo } from "../lib/format";
+import { useLog, useStatus } from "../lib/queries";
+import { navigate, repoHash, type Tab } from "../lib/router";
 
-// Status is a calm glanceable column (not a dashboard): current branch, its
-// ahead/behind vs. upstream, and a small tally of working-tree changes.
+// Status is the repo HUB — still glanceable (each group ANSWERS at a glance:
+// branch + divergence, change counts, latest commit subjects), with drilling into
+// the fuller surface an optional tap deeper. Three full-width tappable groups
+// (Branches / Changes / History) plus a small recent-commits strip. Restrained
+// register: existing tokens only, chevron affordance, ≥44px targets, never
+// color-alone.
 
 function changeCounts(entries: FileEntry[]) {
   let staged = 0;
@@ -60,58 +69,148 @@ export function StatusBody({
   return (
     <div className="flex flex-col">
       {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
-      <div className="flex flex-col gap-6 px-4 py-6">
-        <section className="flex flex-col gap-1">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            Current branch
-          </p>
-          <p className="flex items-center gap-2 text-lg font-semibold text-foreground">
-            <GitBranchIcon size={20} className="shrink-0 text-primary" />
+      <div className="flex flex-col divide-y divide-border">
+        <HubGroup repoId={repoId} tab="branches" label="Branch">
+          <p className="flex items-center gap-2 text-base font-semibold text-foreground">
+            <GitBranchIcon size={18} className="shrink-0 text-primary" />
             <span className="truncate">
               {branch.detached ? "Detached HEAD" : (branch.name ?? "—")}
             </span>
           </p>
           {branch.upstream ? (
-            <p className="text-xs text-muted-foreground">
+            <p className="truncate text-xs text-muted-foreground">
               Tracking {branch.upstream}
               {branch.upstreamGone ? " (gone)" : ""}
             </p>
           ) : (
             <p className="text-xs text-muted-foreground">No upstream</p>
           )}
-        </section>
+          {branch.upstream && !branch.upstreamGone ? (
+            <div className="mt-1 flex gap-4">
+              <Stat
+                icon={<ArrowUpIcon size={14} className="text-info" />}
+                label="Ahead"
+                value={branch.ahead}
+              />
+              <Stat
+                icon={<ArrowDownIcon size={14} className="text-warning" />}
+                label="Behind"
+                value={branch.behind}
+              />
+            </div>
+          ) : null}
+        </HubGroup>
 
-        {branch.upstream && !branch.upstreamGone ? (
-          <section className="flex gap-6">
-            <Stat
-              icon={<ArrowUpIcon size={16} className="text-info" />}
-              label="Ahead"
-              value={branch.ahead}
-            />
-            <Stat
-              icon={<ArrowDownIcon size={16} className="text-warning" />}
-              label="Behind"
-              value={branch.behind}
-            />
-          </section>
-        ) : null}
-
-        <section className="flex flex-col gap-2">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            Working tree
-          </p>
+        <HubGroup repoId={repoId} tab="changes" label="Working tree">
           {clean ? (
             <p className="text-sm text-muted-foreground">Clean — no changes.</p>
           ) : (
-            <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <div className="flex flex-wrap gap-x-4 gap-y-1">
               <Stat label="Staged" value={counts.staged} />
               <Stat label="Changed" value={counts.unstaged} />
               <Stat label="Untracked" value={counts.untracked} />
             </div>
           )}
-        </section>
+        </HubGroup>
+
+        <HubGroup repoId={repoId} tab="history" label="Recent commits">
+          <RecentCommits repoId={repoId} active={active} />
+        </HubGroup>
       </div>
     </div>
+  );
+}
+
+/** One tappable hub group: a full-width link row that drills into `tab`, with a
+ *  right chevron affordance and a ≥44px target. The group still ANSWERS at a
+ *  glance (its children render live data) — drilling is optional depth. It's a
+ *  real `<a>` so it joins the screen's natural tab order (no roving for 3 items). */
+function HubGroup({
+  repoId,
+  tab,
+  label,
+  children,
+}: {
+  repoId: string;
+  tab: Tab;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <a
+      href={repoHash(repoId, tab)}
+      onClick={(e) => {
+        // Keep in-app hash navigation (adds a history entry) rather than a full
+        // document navigation, matching the rest of the companion's link rows.
+        e.preventDefault();
+        navigate(repoHash(repoId, tab));
+      }}
+      className="flex min-h-11 items-center gap-3 px-4 py-4"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          {label}
+        </p>
+        {children}
+      </div>
+      <CaretRightIcon
+        size={16}
+        className="shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+    </a>
+  );
+}
+
+/** The recent-commits strip inside the History hub group: up to 3 truncated
+ *  subjects + relative times. Deliberately non-blocking — while loading it shows a
+ *  quiet skeleton line, and on error it omits its rows entirely (the group row
+ *  itself stays tappable, so History can still load its own data). Fetches only 3
+ *  rows; the History tab pages the full log. */
+function RecentCommits({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isPending } = useLog(repoId, active, 0, 3);
+
+  if (isPending && !data) {
+    return (
+      <div className="flex flex-col gap-1.5" aria-hidden>
+        <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+        <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  // On error (data undefined, not pending) omit the strip's rows — never block the
+  // hub on the strip. The group header row stays tappable.
+  if (!data || data.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {data ? "No commits yet." : "Open to view history."}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {data.slice(0, 3).map((commit: CommitSummary) => (
+        <li
+          key={commit.hash}
+          className="flex items-baseline justify-between gap-2 text-sm"
+        >
+          <span className="min-w-0 truncate text-foreground/90">
+            {commit.subject}
+          </span>
+          <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+            {timeAgo(commit.date)}
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -126,7 +225,7 @@ function Stat({
 }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="flex items-center gap-1.5 text-2xl font-semibold tabular-nums text-foreground">
+      <span className="flex items-center gap-1.5 text-xl font-semibold tabular-nums text-foreground">
         {icon}
         {value}
       </span>

--- a/src-tauri/src/lan/auth.rs
+++ b/src-tauri/src/lan/auth.rs
@@ -1006,11 +1006,14 @@ fn bad_request(msg: &str) -> Response {
         .into_response()
 }
 
-/// Map an [`AppError`] to an HTTP response for the route handlers: `NotARepo` and
-/// `InvalidArgument` → 400; a "no such remote" git failure → a dedicated 400
-/// `noRemote` (see [`no_remote_response`]); everything else → 502. The body reuses
-/// the app's own `{ kind, message }` serialization so a phone client sees the same
-/// shape the desktop frontend does.
+/// Map an [`AppError`] to an HTTP response for the route handlers: `NotARepo`,
+/// `InvalidArgument`, and `IssuesDisabled` → 400; a "no such remote" git failure → a
+/// dedicated 400 `noRemote` (see [`no_remote_response`]); everything else → 502.
+/// `IssuesDisabled` is a stable repo state (a GitHub fork with issues turned off), not
+/// a server failure, so it must be a 400 the phone renders as a calm notice — a 502
+/// would read as a transient error and trigger the client's retry. The body reuses the
+/// app's own `{ kind, message }` serialization so a phone client sees the same shape
+/// the desktop frontend does.
 pub fn app_error_response(err: &AppError) -> Response {
     // A remoteless repo surfaces as a `Git` failure whose stderr is `error: No such
     // remote 'origin'` (chain: gh_lens_slug → git_remote_url). Its raw serialization
@@ -1025,7 +1028,9 @@ pub fn app_error_response(err: &AppError) -> Response {
         }
     }
     let status = match err {
-        AppError::NotARepo(_) | AppError::InvalidArgument(_) => StatusCode::BAD_REQUEST,
+        AppError::NotARepo(_) | AppError::InvalidArgument(_) | AppError::IssuesDisabled => {
+            StatusCode::BAD_REQUEST
+        }
         _ => StatusCode::BAD_GATEWAY,
     };
     let body = serde_json::to_value(err).unwrap_or_else(|_| {
@@ -1085,6 +1090,24 @@ mod tests {
             .unwrap();
         let body: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(body["kind"], "git");
+    }
+
+    #[tokio::test]
+    async fn issues_disabled_maps_to_400_issues_disabled() {
+        // A GitHub fork with issues turned off surfaces as `AppError::IssuesDisabled`.
+        // It's a stable repo state (the desktop shows a calm notice), NOT a server
+        // failure, so `app_error_response` must map it to a 400 — a 502 would read as
+        // transient and trigger the phone's retry. The body carries the stable
+        // `issuesDisabled` kind + a human-readable message.
+        let err = AppError::IssuesDisabled;
+        let resp = app_error_response(&err);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "issuesDisabled");
+        assert!(body["message"].as_str().is_some_and(|m| !m.is_empty()));
     }
 
     #[test]

--- a/src-tauri/src/lan/static_serve.rs
+++ b/src-tauri/src/lan/static_serve.rs
@@ -50,7 +50,13 @@ struct Companion;
 /// same-origin SSE stream (`EventSource`) the reviews monitor uses — no WebSocket
 /// scheme-source is needed (the monitor moved from `wss:` to SSE, partly because
 /// iOS Safari won't extend a self-signed-cert exception to `wss://`).
-pub const PAGE_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
+///
+/// `img-src` additionally allows `https:` (user-confirmed, parity slice): forge
+/// markdown (PR/issue bodies + comments) embeds externally hosted screenshots,
+/// and blocking them left broken images on the phone. Passive external image
+/// fetches are the norm for forge clients; scripts/styles/connect stay
+/// self-only, and plain `http:` images remain blocked.
+pub const PAGE_CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
 /// The 503 body shown when the companion bundle hasn't been built (CI, or a dev who
 /// skipped `pnpm build:companion`). Carries the literal `companion bundle not built`

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1584,7 +1584,8 @@ this desktop, plus any repositories you've explicitly **shared** so they stay re
 while you work elsewhere. Open it in **Settings → Phone companion**.
 
 This is an **early preview**. Once paired, your phone opens a slim companion web app in
-its browser that shows a repository's **Status**, **pull requests**, **CI**{{ai}}, and
+its browser that shows a repository's **Status**, **pull requests**, **issues**,
+**working-tree changes**, **commit history**, **branches**, and **CI**{{ai}}, plus
 live **agent** runs{{/ai}} — all **read-only**. It's **off by default**.
 
 ## Turning it on
@@ -1609,17 +1610,27 @@ Choose **Pair a device** (available once sharing is on). A dialog shows:
 
 Scanning the code (or opening the URL) loads the companion's **pairing page** in your
 phone's browser. Type the PIN there; once it matches, the phone is paired and drops
-straight into the companion app — a bottom tab bar with **Status**, **PRs**, **CI**{{ai}},
-and **Agents**{{/ai}}, each read-only.
+straight into the companion app — a bottom tab bar with **Status**, **PRs**, **Issues**,
+**CI**{{ai}}, and **Agents**{{/ai}}, each read-only.
 
 ## What you can see on your phone
 
-- **Status** — the current branch and connection for the repository you're viewing.
+- **Status** — a hub for the repository you're viewing: the current branch with its
+  ahead/behind against its upstream, the working-tree change counts, and the latest few
+  commit subjects. Each group is tappable to drill into its fuller surface.
 - **PRs** — the open pull-request list; open one for its **overview** (title,
   description, branches, diff totals), its **activity** timeline (force-pushes, label
   changes, review requests, and open/close/merge events), and its **review threads**
   (each file:line comment chain, with resolved/outdated markers). It's read-only — a
   place to catch up on a PR's conversation from your phone, not to reply.
+- **Issues** — the open-issue list; open one for its description, labels, assignees, and
+  comment conversation, read-only.
+- **Changes** — the working tree's staged, changed, and untracked files; open a file for
+  its diff.
+- **History** — the commit log; open a commit for its message and diff, or drill into a
+  single file's changes.
+- **Branches** — the local branches, each with its upstream, ahead/behind divergence, and
+  last-commit time (the current branch first).
 - **CI** — recent workflow runs and their jobs.
 {{ai}}- **Agents** — everything your desktop is currently broadcasting: **AI PR reviews**
   and **agent sessions**. Open one to **watch it live** — the assistant's prose streams in

--- a/src/features/settings/CompanionSection.tsx
+++ b/src/features/settings/CompanionSection.tsx
@@ -129,8 +129,8 @@ export function CompanionSection() {
           Share the open repository — and any repositories you add below — with
           your phone over your local network. Scanning the pairing code opens
           the companion app in your phone's browser —{" "}
-          <strong className="font-medium">read-only</strong> Status, pull
-          requests, and CI. Early preview.
+          <strong className="font-medium">read-only</strong> status, changes,
+          history, branches, pull requests, issues, and CI. Early preview.
         </p>
       </div>
 


### PR DESCRIPTION
Extend the LAN companion toward desktop parity by making more repository context available from a phone without introducing write operations. The companion now provides read-only views for working-tree changes, commit history, branches, and issues, with Status acting as a hub for navigating those surfaces.

### Companion navigation and views

- Adds scoped routes for changes, history, branches, and issues in `companion/src/lib/router.ts`, including file-diff and commit-detail paths.
- Registers the new screens in `companion/src/App.tsx` and adds Issues to the bottom navigation in `companion/src/components/Chrome.tsx`.
- Adds working-tree and per-file diff views in `companion/src/screens/Changes.tsx`.
- Adds commit history, commit details, and per-file commit diffs in `companion/src/screens/History.tsx`.
- Adds local branch browsing with upstream and ahead/behind information in `companion/src/screens/Branches.tsx`.
- Adds open-issue browsing and read-only issue conversations in `companion/src/screens/Issues.tsx`.
- Adds unified diff rendering, binary-file handling, truncation messaging, and multi-file diff splitting in `companion/src/components/DiffText.tsx`.
- Adds issue state presentation in `companion/src/components/chips.tsx`.

### Data access and Status hub

- Adds repository data types and fetchers for branches, logs, commits, diffs, and issues in `companion/src/lib/api.ts`.
- Adds React Query hooks with active-screen polling and immutable commit caching in `companion/src/lib/queries.ts`.
- Turns `companion/src/screens/Status.tsx` into a navigable hub for branch details, working-tree counts, and recent commits.

### LAN behavior and security

- Maps `AppError::IssuesDisabled` to a stable HTTP 400 response and adds coverage for that behavior in `src-tauri/src/lan/auth.rs`.
- Allows HTTPS-hosted images in the companion CSP so forge-hosted images in pull request and issue content render on phones while scripts, styles, and connections remain same-origin in `src-tauri/src/lan/static_serve.rs`.

### Documentation

- Updates the LAN companion preview description in `changelog.d/added-lan-companion-preview.md`.
- Documents the new read-only surfaces and navigation in `src/features/help/content.ts`.
- Updates the Phone companion settings description in `src/features/settings/CompanionSection.tsx`.