### PR TITLE
fix(actions,fsops,mcp,tests,ui): preserve IDs and report accurate counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ commit that hasn't been pushed yet.
   parallel folders without stashing — with one-click jumps to the main workspace right
   from the branch switcher.
 - **Push or publish a branch without switching to it** — from the branch switcher's
-  right-click menu, push a branch that's ahead of the remote it tracks (its own remote,
+  context menu, push a branch that's ahead of the remote it tracks (its own remote,
   not just `origin`) or publish an unpushed one (choosing the remote when there's more
   than one), without checking it out; it works even when the branch is checked out
   in another worktree.
@@ -444,7 +444,7 @@ workflow against any two branches with no remote at all).
   current step inline and a live step checklist when expanded, while finished **GitHub
   Actions** and **GitLab pipeline** jobs peek their log inline and **Bitbucket** and
   other external checks link out (name/state/URL, no fetchable logs).
-- **Record management** — right-click a local PR in the list to **Archive / Unarchive**
+- **Record management** — open a local PR's context menu in the list to **Archive / Unarchive**
   or **Delete** it (Delete confirms; the branches are untouched), also from the command
   palette.
 - **Fork · Upstream lens** — on a GitHub fork (a repo with an `upstream` remote), a
@@ -558,8 +558,8 @@ display can't strand it off-screen.
 - **AI ignore patterns** (keep files out of AI context; they still commit
   normally), gitignore-style:
   - **Global** — Settings → Excluded files (one pattern per line).
-  - **Per-repo** — `.gitdesktop/aiignore` in the repo. Right-click a changed
-    file → **Exclude from AI** (file, folder, or file type — or a
+  - **Per-repo** — `.gitdesktop/aiignore` in the repo. A changed file's
+    context menu → **Exclude from AI** (file, folder, or file type — or a
     multi-selection) creates and updates this file for you.
 - **Keys** live in the OS keychain (Windows Credential Manager, macOS Keychain,
   libsecret). **Hide AI** (Settings → General) hides every AI surface while

--- a/changelog.d/changed-actions-log-string-ids.md
+++ b/changelog.d/changed-actions-log-string-ids.md
@@ -1,0 +1,4 @@
+- CI run and job log lookups now thread ids as strings end-to-end, so they stay
+  precise even above JavaScript's safe-integer limit (2^53). The MCP workflow
+  tools accept a run/job id as either a number or a numeric string, so existing
+  callers keep working.

--- a/changelog.d/fixed-ignore-toast-count.md
+++ b/changelog.d/fixed-ignore-toast-count.md
@@ -1,0 +1,3 @@
+- Ignore and AI-exclude toasts now report how many patterns were actually
+  added, rather than the size of the selection — so a fully-covered selection
+  says everything was already ignored instead of claiming entries were added.

--- a/changelog.d/fixed-secondary-click-copy.md
+++ b/changelog.d/fixed-secondary-click-copy.md
@@ -1,0 +1,4 @@
+- User-facing copy no longer hardcodes "right-click": on macOS the in-app guide
+  and branch-status tooltips now say **Control-click**, matching how context
+  menus actually open on trackpads and swapped-button mice. References to "its
+  right-click menu" are now the platform-neutral "context menu".

--- a/changelog.d/fixed-secondary-click-copy.md
+++ b/changelog.d/fixed-secondary-click-copy.md
@@ -1,4 +1,5 @@
 - User-facing copy no longer hardcodes "right-click": on macOS the in-app guide
   and branch-status tooltips now say **Control-click**, matching how context
   menus actually open on trackpads and swapped-button mice. References to "its
-  right-click menu" are now the platform-neutral "context menu".
+  right-click menu" are now the platform-neutral "context menu" — across the
+  in-app guide, README, and marketing site.

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -276,7 +276,7 @@ const agentAbilities = [
         <div class="min-w-0">
           <h3 class="text-sm text-ink">Exclude from AI</h3>
           <p class="mt-2 text-sm leading-relaxed text-muted">
-            Right-click a changed file to keep it out of AI context (the file, its folder,
+            Open a changed file's context menu to keep it out of AI context (the file, its folder,
             or its file type); it's appended to
             <code class="text-ink">.gitdesktop/aiignore</code>. Patterns also work globally
             or per repo, and excluded files still commit normally.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1454,6 +1454,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "trash",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,3 +79,9 @@ windows-sys = { version = "0.61", features = [
 # vendor/portable-pty/src/win/psuedocon.rs. Drop this when fixed upstream (wezterm).
 [patch.crates-io]
 portable-pty = { path = "vendor/portable-pty" }
+
+[dev-dependencies]
+# RAII temp dirs for tests: a killed or panicking run must not leak fixtures
+# into the system temp dir — TempDir removes the directory on Drop.
+# Already in the dependency graph transitively, so near-zero cost.
+tempfile = "3"

--- a/src-tauri/src/app_store.rs
+++ b/src-tauri/src/app_store.rs
@@ -106,14 +106,13 @@ mod tests {
     // These tests drive the pure parse/read logic against a temp file, bypassing
     // `store_path()` so they never touch the real app-data store.
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-settings-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-settings-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     /// The shared read+extract the public fn wraps (minus the fixed path), so a
@@ -128,29 +127,27 @@ mod tests {
 
     #[test]
     fn missing_file_yields_defaults() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         assert_eq!(read_from(&path), AiGenSettings::default());
     }
 
     #[test]
     fn malformed_json_yields_defaults_not_an_error() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, b"{ not json").unwrap();
         assert_eq!(read_from(&path), AiGenSettings::default());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn missing_settings_key_yields_defaults() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, json!({ "other": 1 }).to_string()).unwrap();
         assert_eq!(read_from(&path), AiGenSettings::default());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn well_formed_settings_are_parsed() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(
             &path,
             json!({
@@ -167,12 +164,11 @@ mod tests {
         assert_eq!(got.global_instructions, "Be terse.");
         // Trimmed; blanks and `#` comments dropped; the rest kept in order.
         assert_eq!(got.ai_ignore_patterns, vec!["*.lock", "dist/"]);
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn wrong_typed_fields_default_per_field() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(
             &path,
             json!({
@@ -187,12 +183,11 @@ mod tests {
         .unwrap();
         // Each wrong-typed field falls back to its own empty default.
         assert_eq!(read_from(&path), AiGenSettings::default());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn one_wrong_field_does_not_poison_the_other() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(
             &path,
             json!({
@@ -207,6 +202,5 @@ mod tests {
         let got = read_from(&path);
         assert_eq!(got.global_instructions, "Kept.");
         assert!(got.ai_ignore_patterns.is_empty());
-        std::fs::remove_file(&path).ok();
     }
 }

--- a/src-tauri/src/automation_claims.rs
+++ b/src-tauri/src/automation_claims.rs
@@ -214,20 +214,18 @@ pub async fn release_automation_claim(
 mod tests {
     use super::*;
 
-    fn tmp_dir() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-automation-claims-test-{}-{}",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&p).unwrap();
-        p
+    fn tmp_dir() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-automation-claims-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     #[test]
     fn claim_release_reclaim_cycle() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let key = composite_key(r"C:\repo\one", "42", "abc123", "review");
 
         // First claim wins; a second claim for the SAME key loses.
@@ -243,13 +241,11 @@ mod tests {
             claim_in_dir(&dir, &key).unwrap(),
             "claim after release should win again"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn different_action_or_head_are_independent_claims() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let base = composite_key(r"C:\repo\one", "42", "abc123", "review");
         let other_action = composite_key(r"C:\repo\one", "42", "abc123", "security");
         let other_head = composite_key(r"C:\repo\one", "42", "def456", "review");
@@ -265,8 +261,6 @@ mod tests {
             claim_in_dir(&dir, &other_head).unwrap(),
             "a different head sha is an independent claim"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -321,7 +315,7 @@ mod tests {
 
     #[test]
     fn sweep_removes_old_claims_but_keeps_fresh_ones() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let old_key = composite_key(r"C:\repo\one", "1", "oldhead", "review");
         let fresh_key = composite_key(r"C:\repo\one", "2", "freshhead", "review");
 
@@ -353,7 +347,5 @@ mod tests {
             dir.join(claim_filename(&fresh_key)).exists(),
             "a fresh claim must survive the sweep"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1540,8 +1540,13 @@ pub async fn forge_ci_run_list(
 #[tauri::command]
 pub async fn forge_ci_run_view(
     repo_path: String,
-    run_id: u64,
+    run_id: String,
 ) -> AppResult<crate::github::actions::RunDetail> {
+    // Ids ride the wire as strings (they can exceed 2^53) but providers address
+    // them as u64 — parse once here, keep everything downstream numeric.
+    let run_id: u64 = run_id
+        .parse()
+        .map_err(|_| AppError::InvalidArgument(format!("Invalid run id: {run_id}")))?;
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::view_run(&repo_path, run_id).await,
         Some((Provider::Bitbucket, _)) => bitbucket::view_run(&repo_path, run_id).await,
@@ -1551,7 +1556,10 @@ pub async fn forge_ci_run_view(
 
 /// The failed jobs' logs for one CI run, behind the abstraction.
 #[tauri::command]
-pub async fn forge_ci_run_failed_logs(repo_path: String, run_id: u64) -> AppResult<String> {
+pub async fn forge_ci_run_failed_logs(repo_path: String, run_id: String) -> AppResult<String> {
+    let run_id: u64 = run_id
+        .parse()
+        .map_err(|_| AppError::InvalidArgument(format!("Invalid run id: {run_id}")))?;
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::run_failed_logs(&repo_path, run_id).await,
         Some((Provider::Bitbucket, _)) => bitbucket::run_failed_logs(&repo_path, run_id).await,
@@ -1561,7 +1569,10 @@ pub async fn forge_ci_run_failed_logs(repo_path: String, run_id: u64) -> AppResu
 
 /// One CI job's log, behind the abstraction.
 #[tauri::command]
-pub async fn forge_ci_job_logs(repo_path: String, job_id: u64) -> AppResult<String> {
+pub async fn forge_ci_job_logs(repo_path: String, job_id: String) -> AppResult<String> {
+    let job_id: u64 = job_id
+        .parse()
+        .map_err(|_| AppError::InvalidArgument(format!("Invalid job id: {job_id}")))?;
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::job_logs(&repo_path, job_id).await,
         // Bitbucket steps are addressed by braced UUID, not a numeric id — the

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -88,8 +88,10 @@ pub struct DetectedTerminal {
 /// Appends one or more ignore patterns to the repo root .gitignore (created if
 /// absent). Trims and de-duplicates the batch and skips any pattern already
 /// present as an exact line, so bulk-ignoring a selection can't add duplicates.
+/// Returns the number of patterns actually appended (0 when every pattern was
+/// empty or already present).
 #[tauri::command]
-pub async fn append_to_gitignore(repo_path: String, patterns: Vec<String>) -> AppResult<()> {
+pub async fn append_to_gitignore(repo_path: String, patterns: Vec<String>) -> AppResult<usize> {
     // Normalize + de-dupe within the batch (preserving order).
     let mut wanted: Vec<String> = Vec::new();
     for p in patterns {
@@ -99,7 +101,7 @@ pub async fn append_to_gitignore(repo_path: String, patterns: Vec<String>) -> Ap
         }
     }
     if wanted.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
 
     let path = Path::new(&repo_path).join(".gitignore");
@@ -120,8 +122,9 @@ pub async fn append_to_gitignore(repo_path: String, patterns: Vec<String>) -> Ap
             .collect()
     };
     if to_add.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
+    let added = to_add.len();
 
     if !content.is_empty() && !content.ends_with('\n') {
         content.push('\n');
@@ -130,7 +133,8 @@ pub async fn append_to_gitignore(repo_path: String, patterns: Vec<String>) -> Ap
         content.push_str(&p);
         content.push('\n');
     }
-    tokio::fs::write(&path, content).await.map_err(AppError::Io)
+    tokio::fs::write(&path, content).await.map_err(AppError::Io)?;
+    Ok(added)
 }
 
 /// Reads a small text file the user picked (e.g. a VSCode
@@ -511,4 +515,80 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
     }
     cmd.spawn().map_err(AppError::Io)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gitignore_test_repo() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-gitignore-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn append_gitignore_creates_file_and_returns_full_count() {
+        let (_tmp, dir) = gitignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+
+        let added =
+            append_to_gitignore(repo, vec!["target/".to_string(), "*.log".to_string()])
+                .await
+                .unwrap();
+        // A fresh .gitignore: both patterns are appended.
+        assert_eq!(added, 2);
+
+        let path = dir.join(".gitignore");
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("target/\n"));
+        assert!(text.contains("*.log\n"));
+    }
+
+    #[tokio::test]
+    async fn append_gitignore_skips_present_and_returns_partial_count() {
+        let (_tmp, dir) = gitignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+
+        let first = append_to_gitignore(repo.clone(), vec!["target/".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(first, 1);
+
+        // Re-add the same line plus a new one: only the new line counts.
+        let second =
+            append_to_gitignore(repo, vec!["target/".to_string(), "dist/".to_string()])
+                .await
+                .unwrap();
+        assert_eq!(second, 1);
+
+        let path = dir.join(".gitignore");
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text.matches("target/\n").count(), 1);
+        assert!(text.contains("dist/\n"));
+    }
+
+    #[tokio::test]
+    async fn append_gitignore_all_duplicates_returns_zero_and_no_write() {
+        let (_tmp, dir) = gitignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+
+        append_to_gitignore(repo.clone(), vec!["target/".to_string(), "*.log".to_string()])
+            .await
+            .unwrap();
+        let path = dir.join(".gitignore");
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        // An all-duplicates batch appends nothing and leaves the file byte-identical.
+        let added =
+            append_to_gitignore(repo, vec!["target/".to_string(), "*.log".to_string()])
+                .await
+                .unwrap();
+        assert_eq!(added, 0);
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after);
+    }
 }

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -969,17 +969,15 @@ mod tests {
             .stdout_lossy()
     }
 
-    /// A unique temp base dir for a test, cleaned up by the caller.
-    fn temp_base(tag: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "gd-branches-{}-{}-{}",
-            tag,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ))
+    /// A unique temp base dir for a test — the returned `TempDir` guard removes it
+    /// on Drop, so a panicking or killed run cannot leak the fixture.
+    fn temp_base(tag: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-branches-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     async fn init_repo(repo_s: &str, seed_file: &str) {
@@ -1001,7 +999,7 @@ mod tests {
     /// checkout arm shares the same `--no-track` placement per the argv table.
     #[tokio::test]
     async fn create_branch_honors_no_track_against_real_repo() {
-        let base = temp_base("no-track");
+        let (_base, base) = temp_base("no-track");
         let repo = base.join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
@@ -1073,8 +1071,6 @@ mod tests {
             run(&repo_s, &["rev-parse", "origin/x"]).await.trim(),
             "z should start at origin/x"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// `git_branches` must surface git's authoritative `%(upstream:remotename)`
@@ -1083,7 +1079,7 @@ mod tests {
     /// re-deriving the remote from the upstream string.
     #[tokio::test]
     async fn git_branches_reports_upstream_remote() {
-        let base = temp_base("upstream-remote");
+        let (_base, base) = temp_base("upstream-remote");
         let repo = base.join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
@@ -1140,7 +1136,5 @@ mod tests {
             solo.upstream_remote, None,
             "an untracked branch carries no upstream remote"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -641,14 +641,11 @@ mod tests {
     /// NO remote configured (a fetch would fail), proving the network path was skipped.
     #[tokio::test]
     async fn fetch_objects_short_circuits_when_all_present() {
-        let base = std::env::temp_dir().join(format!(
-            "gd-fetchobj-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let _base = tempfile::Builder::new()
+            .prefix("gd-fetchobj-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let base = _base.path().to_path_buf();
         let repo = base.join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
@@ -675,22 +672,16 @@ mod tests {
             .await
             .expect("a failed fetch is Ok(false), not an error");
         assert!(!ok, "an absent object falls through to the (failing) fetch");
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
-    /// Seeds a fresh repo and returns `(base_dir, repo_path)`. Caller removes
-    /// `base_dir`.
-    async fn seed_repo(tag: &str) -> (std::path::PathBuf, String) {
-        let base = std::env::temp_dir().join(format!(
-            "gd-{tag}-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let repo = base.join("repo");
+    /// Seeds a fresh repo and returns `(base_guard, repo_path)`. The `TempDir`
+    /// guard removes the base dir on Drop, so a panicking run cannot leak it.
+    async fn seed_repo(tag: &str) -> (tempfile::TempDir, String) {
+        let base = tempfile::Builder::new()
+            .prefix(&format!("gd-{tag}-test-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
         run(&repo_s, &["init", "-q"]).await;
@@ -703,7 +694,7 @@ mod tests {
     /// no longer contain the needle — grep reads the rev's tree, not the checkout.
     #[tokio::test]
     async fn grep_at_ref_reads_the_rev_not_the_worktree() {
-        let (base, repo) = seed_repo("grep-rev").await;
+        let (_base, repo) = seed_repo("grep-rev").await;
 
         std::fs::write(
             std::path::Path::new(&repo).join("a.txt"),
@@ -737,15 +728,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(gone, "", "no match at HEAD → Ok(empty), not an error");
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The `<ref>:` prefix git prepends when grepping a rev is stripped, while
     /// colons embedded in the path/content are preserved.
     #[tokio::test]
     async fn grep_at_ref_strips_only_the_ref_prefix() {
-        let (base, repo) = seed_repo("grep-prefix").await;
+        let (_base, repo) = seed_repo("grep-prefix").await;
 
         std::fs::write(
             std::path::Path::new(&repo).join("cfg.txt"),
@@ -760,8 +749,6 @@ mod tests {
             .unwrap();
         // Only the leading `HEAD:` is gone; every content colon survives.
         assert_eq!(hit, "cfg.txt:1:endpoint: http://host:8080/path FINDME");
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// More returned lines than `max_hits` → the kept lines plus a count-less
@@ -776,7 +763,7 @@ mod tests {
     /// out of git, which the caller's `take(2)` then trims — the realistic path.
     #[tokio::test]
     async fn grep_at_ref_caps_hits_with_marker() {
-        let (base, repo) = seed_repo("grep-cap").await;
+        let (_base, repo) = seed_repo("grep-cap").await;
 
         // 2 matching lines in each of 3 files (a.txt, b.txt, c.txt).
         for name in ["a.txt", "b.txt", "c.txt"] {
@@ -801,8 +788,6 @@ mod tests {
             lines[2], "[... additional matches truncated]",
             "count-less marker: -m makes the true total unknowable"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The unknown-option matcher recognizes git's real phrasings (so a git < 2.38
@@ -826,7 +811,7 @@ mod tests {
     /// A ref that looks like an option is rejected before any git runs.
     #[tokio::test]
     async fn grep_at_ref_rejects_option_like_ref() {
-        let (base, repo) = seed_repo("grep-badref").await;
+        let (_base, repo) = seed_repo("grep-badref").await;
 
         let err = git_grep_at_ref(repo.clone(), "x".into(), "-oops".into(), None)
             .await
@@ -841,8 +826,6 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::InvalidArgument(_)));
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The review-husk sweep removes only EMPTY `gd-review-*` dirs: a non-empty
@@ -850,15 +833,11 @@ mod tests {
     /// are both spared.
     #[test]
     fn sweep_review_husks_removes_only_empty_gd_review_dirs() {
-        let base = std::env::temp_dir().join(format!(
-            "gd-sweep-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&base).unwrap();
+        let _base = tempfile::Builder::new()
+            .prefix("gd-sweep-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let base = _base.path().to_path_buf();
 
         // An empty gd-review-* husk → removed.
         let empty_husk = base.join("gd-review-abc123-42");
@@ -876,8 +855,6 @@ mod tests {
         assert!(!empty_husk.exists(), "empty gd-review-* husk was removed");
         assert!(live.exists(), "non-empty gd-review-* (live review) is kept");
         assert!(other.exists(), "non-matching name is kept");
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The `remove_dir_all` fallback guard admits only `gd-review-*` dirs directly

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -259,23 +259,19 @@ mod tests {
     use super::*;
     use crate::git::runner::run_git;
 
-    fn temp_repo(tag: &str) -> String {
-        let dir = std::env::temp_dir().join(format!(
-            "gd-conflict-test-{tag}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir.to_string_lossy().into_owned()
+    fn temp_repo(tag: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-conflict-test-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        (dir, repo)
     }
 
     /// Builds a real merge conflict on `file.txt` (base → "base", ours → "ours",
     /// theirs → "theirs") and leaves the repo mid-merge.
-    async fn conflicted_repo(tag: &str) -> String {
-        let repo = temp_repo(tag);
+    async fn conflicted_repo(tag: &str) -> (tempfile::TempDir, String) {
+        let (dir, repo) = temp_repo(tag);
         let git = |args: Vec<&'static str>| {
             let repo = repo.clone();
             async move { run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap() }
@@ -297,12 +293,12 @@ mod tests {
         run_git_raw(Some(&repo), &["merge", "feature"], DEFAULT_TIMEOUT)
             .await
             .unwrap();
-        repo
+        (dir, repo)
     }
 
     #[tokio::test]
     async fn sides_carry_each_stage_and_markers() {
-        let repo = conflicted_repo("sides").await;
+        let (_dir, repo) = conflicted_repo("sides").await;
         let sides = git_conflict_sides(repo.clone(), "file.txt".into(), vec![])
             .await
             .unwrap();
@@ -312,13 +308,12 @@ mod tests {
         assert_eq!(sides.ours.as_deref(), Some("ours\n"));
         assert_eq!(sides.theirs.as_deref(), Some("theirs\n"));
         assert!(!sides.ai_ignored);
-        let _ = std::fs::remove_dir_all(&repo);
     }
 
     #[tokio::test]
     async fn checkout_side_takes_one_side_and_clears() {
         // ours → the current branch's version, conflict cleared.
-        let repo = conflicted_repo("ours-side").await;
+        let (_dir, repo) = conflicted_repo("ours-side").await;
         run_git(Some(&repo), &["checkout", "--ours", "--", "file.txt"], DEFAULT_TIMEOUT)
             .await
             .unwrap();
@@ -338,10 +333,9 @@ mod tests {
             .stdout_lossy()
             .trim()
             .is_empty());
-        let _ = std::fs::remove_dir_all(&repo);
 
         // theirs → the incoming version.
-        let repo2 = conflicted_repo("theirs-side").await;
+        let (_dir2, repo2) = conflicted_repo("theirs-side").await;
         run_git(Some(&repo2), &["checkout", "--theirs", "--", "file.txt"], DEFAULT_TIMEOUT)
             .await
             .unwrap();
@@ -354,12 +348,11 @@ mod tests {
                 .replace("\r\n", "\n"),
             "theirs\n"
         );
-        let _ = std::fs::remove_dir_all(&repo2);
     }
 
     #[tokio::test]
     async fn ai_ignore_pattern_flags_the_path() {
-        let repo = conflicted_repo("ignore").await;
+        let (_dir, repo) = conflicted_repo("ignore").await;
         let hit = git_conflict_sides(repo.clone(), "file.txt".into(), vec!["*.txt".into()])
             .await
             .unwrap();
@@ -368,12 +361,11 @@ mod tests {
             .await
             .unwrap();
         assert!(!miss.ai_ignored);
-        let _ = std::fs::remove_dir_all(&repo);
     }
 
     #[tokio::test]
     async fn resolve_writes_and_clears_the_conflict() {
-        let repo = conflicted_repo("resolve").await;
+        let (_dir, repo) = conflicted_repo("resolve").await;
         // Before: the path is unmerged (`ls-files -u` lists it).
         let unmerged = run_git(Some(&repo), &["ls-files", "-u"], DEFAULT_TIMEOUT)
             .await
@@ -396,7 +388,6 @@ mod tests {
             .unwrap()
             .stdout_lossy();
         assert!(staged.contains("file.txt"));
-        let _ = std::fs::remove_dir_all(&repo);
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -648,15 +648,11 @@ mod tests {
     async fn partial_patch_stages_a_single_added_line() {
         use crate::git::runner::run_git_input;
 
-        let dir = std::env::temp_dir().join(format!(
-            "gd-partial-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let _tmp = tempfile::Builder::new()
+            .prefix("gd-partial-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let dir = _tmp.path().to_path_buf();
         let repo = dir.to_string_lossy().into_owned();
         let git = |args: Vec<&'static str>| {
             let repo = repo.clone();
@@ -692,8 +688,6 @@ mod tests {
         assert!(staged.contains("NEW A"));
         assert!(!staged.contains("NEW B"));
         assert!(unstaged.contains("NEW B"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// End-to-end check of the hunk-staging plumbing: a single hunk cut out
@@ -704,15 +698,11 @@ mod tests {
     async fn apply_patch_stages_and_unstages_a_single_hunk() {
         use crate::git::runner::run_git_input;
 
-        let dir = std::env::temp_dir().join(format!(
-            "gd-apply-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let _tmp = tempfile::Builder::new()
+            .prefix("gd-apply-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let dir = _tmp.path().to_path_buf();
         let repo = dir.to_string_lossy().into_owned();
         let git = |args: Vec<&'static str>| {
             let repo = repo.clone();
@@ -765,8 +755,6 @@ mod tests {
         .unwrap();
         let staged = git(vec!["diff", "--cached", "--no-color"]).await.stdout_lossy();
         assert!(staged.trim().is_empty());
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// `git_session_file_diff` shows a file's CUMULATIVE change vs the session
@@ -775,15 +763,11 @@ mod tests {
     /// surfaces a brand-new untracked file as a full add via the fallback.
     #[tokio::test]
     async fn session_file_diff_is_cumulative_against_base() {
-        let dir = std::env::temp_dir().join(format!(
-            "gd-session-diff-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let _tmp = tempfile::Builder::new()
+            .prefix("gd-session-diff-")
+            .tempdir()
+            .expect("create temp dir");
+        let dir = _tmp.path().to_path_buf();
         let repo = dir.to_string_lossy().into_owned();
         let git = |args: Vec<&'static str>| {
             let repo = repo.clone();
@@ -823,7 +807,5 @@ mod tests {
             .unwrap();
         assert!(added.text.contains("+hello new file"), "{}", added.text);
         assert!(added.text.contains("new.txt"), "{}", added.text);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/git/history.rs
+++ b/src-tauri/src/git/history.rs
@@ -413,17 +413,13 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    fn temp_repo(tag: &str) -> String {
-        let dir = std::env::temp_dir().join(format!(
-            "gd-blame-test-{tag}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir.to_string_lossy().into_owned()
+    fn temp_repo(tag: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-blame-test-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        (dir, repo)
     }
 
     async fn git(repo: &str, args: &[&str]) {
@@ -433,8 +429,8 @@ mod tests {
     /// Builds a repo where `file.txt` gets two commits: line one is written in the
     /// first commit and a second line is appended in the second. Returns the repo
     /// path plus the two commit shas (first, second).
-    async fn two_commit_repo(tag: &str) -> (String, String, String) {
-        let repo = temp_repo(tag);
+    async fn two_commit_repo(tag: &str) -> (tempfile::TempDir, String, String, String) {
+        let (dir, repo) = temp_repo(tag);
         git(&repo, &["init"]).await;
         git(&repo, &["config", "user.email", "t@t"]).await;
         git(&repo, &["config", "user.name", "t"]).await;
@@ -456,12 +452,12 @@ mod tests {
             .stdout_lossy()
             .trim()
             .to_string();
-        (repo, first, second)
+        (dir, repo, first, second)
     }
 
     #[tokio::test]
     async fn blame_at_rev_shows_that_revs_content() {
-        let (repo, first, second) = two_commit_repo("at-rev").await;
+        let (_dir, repo, first, second) = two_commit_repo("at-rev").await;
 
         // At the first commit, the file has only one line, all attributed to `first`.
         let at_first = git_blame(repo.clone(), "file.txt".into(), Some(first.clone()))
@@ -479,13 +475,11 @@ mod tests {
         assert_eq!(at_worktree[0].hash, first);
         assert_eq!(at_worktree[1].content, "second");
         assert_eq!(at_worktree[1].hash, second);
-
-        let _ = std::fs::remove_dir_all(&repo);
     }
 
     #[tokio::test]
     async fn blame_unborn_head_errors() {
-        let repo = temp_repo("unborn");
+        let (_dir, repo) = temp_repo("unborn");
         git(&repo, &["init"]).await;
         git(&repo, &["config", "user.email", "t@t"]).await;
         git(&repo, &["config", "user.name", "t"]).await;
@@ -499,19 +493,15 @@ mod tests {
             }
             other => panic!("expected InvalidArgument, got {other:?}"),
         }
-
-        let _ = std::fs::remove_dir_all(&repo);
     }
 
     #[tokio::test]
     async fn blame_dash_prefixed_rev_rejected() {
-        let (repo, _first, _second) = two_commit_repo("dash-rev").await;
+        let (_dir, repo, _first, _second) = two_commit_repo("dash-rev").await;
 
         let err = git_blame(repo.clone(), "file.txt".into(), Some("-HEAD".into()))
             .await
             .unwrap_err();
         assert!(matches!(err, crate::error::AppError::InvalidArgument(_)));
-
-        let _ = std::fs::remove_dir_all(&repo);
     }
 }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -1,4 +1,4 @@
-﻿use std::path::Path;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -2915,21 +2915,16 @@ mod tests {
         git(repo, &["commit", "-m", msg]).await;
     }
 
-    async fn setup_repo(marker: &str) -> (std::path::PathBuf, String) {
-        let dir = std::env::temp_dir().join(format!(
-            "gd-rewrite-{marker}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let repo = dir.to_string_lossy().into_owned();
+    async fn setup_repo(marker: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-rewrite-{marker}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
         git(&repo, &["init"]).await;
         git(&repo, &["config", "user.email", "t@t"]).await;
         git(&repo, &["config", "user.name", "t"]).await;
-        commit_file(&repo, &dir, "a.txt", "v0\n", "base").await;
+        commit_file(&repo, dir.path(), "a.txt", "v0\n", "base").await;
         (dir, repo)
     }
 
@@ -2959,25 +2954,24 @@ mod tests {
         // Clean tree → Ok.
         assert!(ensure_clean_tree(&repo).await.is_ok());
         // Untracked file → still Ok (`reset --hard` never removes it).
-        std::fs::write(dir.join("scratch.txt"), "x\n").unwrap();
+        std::fs::write(dir.path().join("scratch.txt"), "x\n").unwrap();
         assert!(ensure_clean_tree(&repo).await.is_ok());
         // Unstaged tracked change → refused (this is the reset --hard loss surface).
-        std::fs::write(dir.join("a.txt"), "v1\n").unwrap();
+        std::fs::write(dir.path().join("a.txt"), "v1\n").unwrap();
         assert!(ensure_clean_tree(&repo).await.is_err());
         // Staged tracked change → refused (the exact incident state).
         git(&repo, &["add", "a.txt"]).await;
         assert!(ensure_clean_tree(&repo).await.is_err());
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn reorder_swaps_independent_commits() {
         let (dir, repo) = setup_repo("reorder").await;
         let base = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "b.txt", "b\n", "one").await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
         let c1 = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "c.txt", "c\n", "two").await;
+        commit_file(&repo, dir.path(), "c.txt", "c\n", "two").await;
         let c2 = rev(&repo, "HEAD").await;
 
         let state = AppState::default();
@@ -2987,16 +2981,15 @@ mod tests {
             .unwrap();
         assert_eq!(subjects(&repo).await, vec!["one", "two", "base"]);
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn squash_combines_commits() {
         let (dir, repo) = setup_repo("squash").await;
         let base = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "b.txt", "b\n", "one").await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
         let c1 = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "c.txt", "c\n", "two").await;
+        commit_file(&repo, dir.path(), "c.txt", "c\n", "two").await;
         let c2 = rev(&repo, "HEAD").await;
 
         let state = AppState::default();
@@ -3013,19 +3006,18 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(subjects(&repo).await, vec!["combined", "base"]);
-        assert!(dir.join("b.txt").exists());
-        assert!(dir.join("c.txt").exists());
+        assert!(dir.path().join("b.txt").exists());
+        assert!(dir.path().join("c.txt").exists());
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn fixup_keeps_leader_message() {
         let (dir, repo) = setup_repo("fixup").await;
         let base = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "b.txt", "b\n", "keep this message").await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "keep this message").await;
         let c1 = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "c.txt", "c\n", "discard me").await;
+        commit_file(&repo, dir.path(), "c.txt", "c\n", "discard me").await;
         let c2 = rev(&repo, "HEAD").await;
 
         let state = AppState::default();
@@ -3044,19 +3036,18 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(subjects(&repo).await, vec!["keep this message", "base"]);
-        assert!(dir.join("b.txt").exists());
-        assert!(dir.join("c.txt").exists());
+        assert!(dir.path().join("b.txt").exists());
+        assert!(dir.path().join("c.txt").exists());
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn conflicting_rewrite_rolls_back() {
         let (dir, repo) = setup_repo("conflict").await;
         let base = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "a.txt", "v1\n", "one").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "one").await;
         let c1 = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "a.txt", "v2\n", "two").await;
+        commit_file(&repo, dir.path(), "a.txt", "v2\n", "two").await;
         let c2 = rev(&repo, "HEAD").await;
         let orig = rev(&repo, "HEAD").await;
 
@@ -3068,14 +3059,13 @@ mod tests {
         let status = git(&repo, &["status", "--porcelain"]).await;
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn rebase_edit_refuses_a_concurrent_op() {
         let (dir, repo) = setup_repo("reentry").await;
         let base = rev(&repo, "HEAD").await;
-        commit_file(&repo, &dir, "x.txt", "x\n", "one").await;
+        commit_file(&repo, dir.path(), "x.txt", "x\n", "one").await;
         let c1 = rev(&repo, "HEAD").await;
         // Simulate an in-progress rebase via its marker dir.
         std::fs::create_dir_all(std::path::Path::new(&repo).join(".git/rebase-merge"))
@@ -3099,7 +3089,6 @@ mod tests {
             "scratch dir must not be touched when refused"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -3114,13 +3103,13 @@ mod tests {
             .trim()
             .to_string();
         git(&repo, &["checkout", "-b", "feature"]).await;
-        commit_file(&repo, &dir, "f.txt", "f\n", "feature one").await;
+        commit_file(&repo, dir.path(), "f.txt", "f\n", "feature one").await;
         git(&repo, &["checkout", "-b", "fix"]).await;
-        commit_file(&repo, &dir, "x.txt", "x\n", "fix one").await;
-        commit_file(&repo, &dir, "x.txt", "x2\n", "fix two").await;
+        commit_file(&repo, dir.path(), "x.txt", "x\n", "fix one").await;
+        commit_file(&repo, dir.path(), "x.txt", "x2\n", "fix two").await;
         // Advance the default branch so it diverges from feature.
         git(&repo, &["checkout", &main]).await;
-        commit_file(&repo, &dir, "a.txt", "v1\n", "main advance").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "main advance").await;
         let main_tip = rev(&repo, "HEAD").await;
         git(&repo, &["checkout", "fix"]).await;
 
@@ -3140,7 +3129,6 @@ mod tests {
             "fix's commits sit directly on the new base's tip"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -3150,11 +3138,11 @@ mod tests {
             .await
             .trim()
             .to_string();
-        commit_file(&repo, &dir, "shared.txt", "base\n", "base shared").await;
+        commit_file(&repo, dir.path(), "shared.txt", "base\n", "base shared").await;
 
         // up-to-date: a branch pinned at an ancestor of HEAD.
         git(&repo, &["branch", "old"]).await;
-        commit_file(&repo, &dir, "shared.txt", "main2\n", "advance main").await;
+        commit_file(&repo, dir.path(), "shared.txt", "main2\n", "advance main").await;
         let up = git_merge_preview(repo.clone(), "old".to_string(), "none".to_string())
             .await
             .unwrap();
@@ -3162,7 +3150,7 @@ mod tests {
 
         // fast-forward: a branch strictly ahead of HEAD.
         git(&repo, &["checkout", "-b", "ahead"]).await;
-        commit_file(&repo, &dir, "ahead.txt", "a\n", "ahead only").await;
+        commit_file(&repo, dir.path(), "ahead.txt", "a\n", "ahead only").await;
         git(&repo, &["checkout", &main]).await;
         let ff = git_merge_preview(repo.clone(), "ahead".to_string(), "none".to_string())
             .await
@@ -3171,9 +3159,9 @@ mod tests {
 
         // conflict: divergent edits to shared.txt (needs git merge-tree, 2.38+).
         git(&repo, &["checkout", "-b", "feat"]).await;
-        commit_file(&repo, &dir, "shared.txt", "feat\n", "feat edit").await;
+        commit_file(&repo, dir.path(), "shared.txt", "feat\n", "feat edit").await;
         git(&repo, &["checkout", &main]).await;
-        commit_file(&repo, &dir, "shared.txt", "main3\n", "main edit").await;
+        commit_file(&repo, dir.path(), "shared.txt", "main3\n", "main edit").await;
         let cf = git_merge_preview(repo.clone(), "feat".to_string(), "none".to_string())
             .await
             .unwrap();
@@ -3192,7 +3180,6 @@ mod tests {
                 .unwrap();
         assert_eq!(resolved.status, "clean", "{:?}", resolved.conflicts);
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -3205,9 +3192,9 @@ mod tests {
 
         // A non-conflicting feature: touches a different file than base advances.
         git(&repo, &["checkout", "-b", "clean-feat"]).await;
-        commit_file(&repo, &dir, "feat.txt", "feat\n", "feat only").await;
+        commit_file(&repo, dir.path(), "feat.txt", "feat\n", "feat only").await;
         git(&repo, &["checkout", &main]).await;
-        commit_file(&repo, &dir, "base-only.txt", "b\n", "base only").await;
+        commit_file(&repo, dir.path(), "base-only.txt", "b\n", "base only").await;
         let clean = git_conflict_preview(repo.clone(), main.clone(), "clean-feat".to_string())
             .await
             .unwrap();
@@ -3215,9 +3202,9 @@ mod tests {
 
         // A conflicting feature: divergent edits to the same file as base.
         git(&repo, &["checkout", "-b", "bad-feat"]).await;
-        commit_file(&repo, &dir, "a.txt", "feat-edit\n", "feat edit a").await;
+        commit_file(&repo, dir.path(), "a.txt", "feat-edit\n", "feat edit a").await;
         git(&repo, &["checkout", &main]).await;
-        commit_file(&repo, &dir, "a.txt", "main-edit\n", "main edit a").await;
+        commit_file(&repo, dir.path(), "a.txt", "main-edit\n", "main edit a").await;
         let conflict = git_conflict_preview(repo.clone(), main.clone(), "bad-feat".to_string())
             .await
             .unwrap();
@@ -3232,7 +3219,6 @@ mod tests {
             conflict.conflicts
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -3249,9 +3235,9 @@ mod tests {
 
         // Manufacture a real conflicted merge on `main`.
         git(&repo, &["checkout", "-b", "feat"]).await;
-        commit_file(&repo, &dir, "a.txt", "feat\n", "feat edit").await;
+        commit_file(&repo, dir.path(), "a.txt", "feat\n", "feat edit").await;
         git(&repo, &["checkout", &main]).await;
-        commit_file(&repo, &dir, "a.txt", "main\n", "main edit").await;
+        commit_file(&repo, dir.path(), "a.txt", "main\n", "main edit").await;
         // A conflicting merge exits non-zero and leaves unmerged paths in place.
         let merged = run_git_raw(
             Some(&repo),
@@ -3267,22 +3253,16 @@ mod tests {
             "expected a.txt among {paths:?}"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Makes a throwaway dir and writes `.gitignore` with the given raw bytes.
-    fn gitignore_dir(marker: &str, content: &str) -> (std::path::PathBuf, String) {
-        let dir = std::env::temp_dir().join(format!(
-            "gd-unignore-{marker}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join(".gitignore"), content).unwrap();
-        let repo = dir.to_string_lossy().into_owned();
+    fn gitignore_dir(marker: &str, content: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-unignore-{marker}-"))
+            .tempdir()
+            .expect("create temp dir");
+        std::fs::write(dir.path().join(".gitignore"), content).unwrap();
+        let repo = dir.path().to_string_lossy().into_owned();
         (dir, repo)
     }
 
@@ -3298,20 +3278,18 @@ mod tests {
         // A Windows .gitignore (CRLF) with a comment and two rules.
         let (dir, repo) = gitignore_dir("crlf", "# build artifacts\r\n*.log\r\nbuild/\r\n");
         git_unignore_rules(repo, vec![rule("*.log")]).await.unwrap();
-        let out = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+        let out = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         // CRLF kept, comment + the untouched rule kept, trailing CRLF kept.
         assert_eq!(out, "# build artifacts\r\nbuild/\r\n");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn unignore_last_rule_keeps_trailing_newline() {
         let (dir, repo) = gitignore_dir("last", "*.log\n");
         git_unignore_rules(repo, vec![rule("*.log")]).await.unwrap();
-        let out = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+        let out = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         // Removing the only rule leaves a single newline, not a 0-byte file.
         assert_eq!(out, "\n");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -3319,9 +3297,8 @@ mod tests {
         // A UTF-8 BOM ahead of the first (targeted) rule must not block the match.
         let (dir, repo) = gitignore_dir("bom", "\u{feff}*.log\nbuild/\n");
         git_unignore_rules(repo, vec![rule("*.log")]).await.unwrap();
-        let out = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
+        let out = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         assert_eq!(out, "\u{feff}build/\n");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn lines(v: &[&str]) -> Vec<String> {
@@ -3331,7 +3308,7 @@ mod tests {
     #[tokio::test]
     async fn replace_lines_clean_file_stages_exactly_the_edit() {
         let (dir, repo) = setup_repo("replace-clean").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\nc\n", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\nc\n", "seed").await;
 
         let state = AppState::default();
         let res = replace_file_lines(
@@ -3348,7 +3325,7 @@ mod tests {
         assert!(res.staged);
         assert!(!res.had_local_changes);
         assert_eq!(
-            std::fs::read_to_string(dir.join("src.txt")).unwrap(),
+            std::fs::read_to_string(dir.path().join("src.txt")).unwrap(),
             "a\nB1\nB2\nc\n"
         );
         // The index holds exactly this edit — the staged blob matches the file,
@@ -3356,15 +3333,14 @@ mod tests {
         let porcelain = git(&repo, &["status", "--porcelain", "--", "src.txt"]).await;
         assert_eq!(porcelain, "M  src.txt\n", "unexpected status: {porcelain:?}");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_dirty_file_does_not_stage() {
         let (dir, repo) = setup_repo("replace-dirty").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\nc\n", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\nc\n", "seed").await;
         // A pre-existing unstaged edit elsewhere in the same file.
-        std::fs::write(dir.join("src.txt"), "a\nb\nCHANGED\n").unwrap();
+        std::fs::write(dir.path().join("src.txt"), "a\nb\nCHANGED\n").unwrap();
 
         let state = AppState::default();
         let res = replace_file_lines(
@@ -3381,21 +3357,20 @@ mod tests {
         assert!(!res.staged, "must not stage a file with pre-existing changes");
         assert!(res.had_local_changes);
         assert_eq!(
-            std::fs::read_to_string(dir.join("src.txt")).unwrap(),
+            std::fs::read_to_string(dir.path().join("src.txt")).unwrap(),
             "a\nB\nCHANGED\n"
         );
         // Nothing staged: the change is unstaged-only (" M").
         let porcelain = git(&repo, &["status", "--porcelain", "--", "src.txt"]).await;
         assert_eq!(porcelain, " M src.txt\n", "unexpected status: {porcelain:?}");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_mismatch_leaves_file_untouched() {
         let (dir, repo) = setup_repo("replace-mismatch").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\nc\n", "seed").await;
-        let before = std::fs::read(dir.join("src.txt")).unwrap();
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\nc\n", "seed").await;
+        let before = std::fs::read(dir.path().join("src.txt")).unwrap();
 
         let state = AppState::default();
         // Expected "X" at line 2 but the file has "b" — drift, must be refused.
@@ -3411,16 +3386,15 @@ mod tests {
         .await;
         assert!(res.is_err());
         // File is byte-identical to before the attempted apply.
-        assert_eq!(std::fs::read(dir.join("src.txt")).unwrap(), before);
+        assert_eq!(std::fs::read(dir.path().join("src.txt")).unwrap(), before);
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_beyond_eof_is_a_mismatch() {
         let (dir, repo) = setup_repo("replace-eof").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\n", "seed").await;
-        let before = std::fs::read(dir.join("src.txt")).unwrap();
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\n", "seed").await;
+        let before = std::fs::read(dir.path().join("src.txt")).unwrap();
 
         let state = AppState::default();
         // start_line 2 with two expected lines runs past EOF → mismatch.
@@ -3435,15 +3409,14 @@ mod tests {
         )
         .await;
         assert!(res.is_err());
-        assert_eq!(std::fs::read(dir.join("src.txt")).unwrap(), before);
+        assert_eq!(std::fs::read(dir.path().join("src.txt")).unwrap(), before);
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_preserves_crlf() {
         let (dir, repo) = setup_repo("replace-crlf").await;
-        commit_file(&repo, &dir, "src.txt", "a\r\nb\r\nc\r\n", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\r\nb\r\nc\r\n", "seed").await;
 
         let state = AppState::default();
         let res = replace_file_lines(
@@ -3460,17 +3433,16 @@ mod tests {
         assert!(!res.staged);
         // Read as bytes to prove the CRLF flavor survived (no LF conversion).
         assert_eq!(
-            std::fs::read(dir.join("src.txt")).unwrap(),
+            std::fs::read(dir.path().join("src.txt")).unwrap(),
             b"a\r\nB1\r\nB2\r\nc\r\n"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_pure_deletion_removes_the_range() {
         let (dir, repo) = setup_repo("replace-delete").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\nc\nd\n", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\nc\nd\n", "seed").await;
 
         let state = AppState::default();
         // Empty replacement = delete lines 2..3 ("b","c").
@@ -3487,18 +3459,17 @@ mod tests {
         .unwrap();
         assert!(!res.staged);
         assert_eq!(
-            std::fs::read_to_string(dir.join("src.txt")).unwrap(),
+            std::fs::read_to_string(dir.path().join("src.txt")).unwrap(),
             "a\nd\n"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_preserves_missing_trailing_newline() {
         let (dir, repo) = setup_repo("replace-notrail").await;
         // No trailing newline on the seed file.
-        commit_file(&repo, &dir, "src.txt", "a\nb\nc", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\nc", "seed").await;
 
         let state = AppState::default();
         let res = replace_file_lines(
@@ -3515,11 +3486,10 @@ mod tests {
         assert!(!res.staged);
         // Still no trailing newline after the edit.
         assert_eq!(
-            std::fs::read_to_string(dir.join("src.txt")).unwrap(),
+            std::fs::read_to_string(dir.path().join("src.txt")).unwrap(),
             "a\nb\nC"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
@@ -3528,7 +3498,7 @@ mod tests {
         // ranges of one file, each verifying against the other's post-edit state,
         // both succeed and both edits survive (a race would clobber the first).
         let (dir, repo) = setup_repo("replace-seq").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\nc\nd\n", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\nc\nd\n", "seed").await;
         let state = AppState::default();
 
         replace_file_lines(&state, &repo, "src.txt", 1, &lines(&["a"]), &lines(&["A"]), false)
@@ -3541,17 +3511,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(dir.join("src.txt")).unwrap(),
+            std::fs::read_to_string(dir.path().join("src.txt")).unwrap(),
             "A\nb\nc\nD\n"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn replace_lines_rejects_invalid_arguments() {
         let (dir, repo) = setup_repo("replace-invalid").await;
-        commit_file(&repo, &dir, "src.txt", "a\nb\n", "seed").await;
+        commit_file(&repo, dir.path(), "src.txt", "a\nb\n", "seed").await;
         let state = AppState::default();
 
         // start_line 0 is not 1-based.
@@ -3579,15 +3548,14 @@ mod tests {
             .await
             .is_err());
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn orphaned_stashes_finds_a_dropped_stash() {
         let (dir, repo) = setup_repo("orphaned-stash").await;
         // Make a tracked change plus an untracked file, then stash both.
-        std::fs::write(dir.join("a.txt"), "changed\n").unwrap();
-        std::fs::write(dir.join("new.txt"), "fresh\n").unwrap();
+        std::fs::write(dir.path().join("a.txt"), "changed\n").unwrap();
+        std::fs::write(dir.path().join("new.txt"), "fresh\n").unwrap();
         git(&repo, &["stash", "push", "-u", "-m", "rescue me"]).await;
         let sha = rev(&repo, "stash@{0}").await;
         // Drop it → the commit becomes dangling but still reachable by sha.
@@ -3606,7 +3574,7 @@ mod tests {
         assert!(entry.file_count > 0, "file_count was {}", entry.file_count);
 
         // A live stash must NOT be reported as orphaned.
-        std::fs::write(dir.join("a.txt"), "changed again\n").unwrap();
+        std::fs::write(dir.path().join("a.txt"), "changed again\n").unwrap();
         git(&repo, &["stash", "push", "-m", "still live"]).await;
         let live_sha = rev(&repo, "stash@{0}").await;
         let found2 = git_orphaned_stashes(repo.clone()).await.unwrap();
@@ -3615,7 +3583,6 @@ mod tests {
             "live stash should be excluded"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -3722,21 +3689,18 @@ detached
         // return to base and DIRTY the tree + move onto another branch.
         git(&repo, &["branch", "feature"]).await;
         git(&repo, &["switch", "feature"]).await;
-        commit_file(&repo, &dir, "feat.txt", "feature\n", "feat commit").await;
+        commit_file(&repo, dir.path(), "feat.txt", "feature\n", "feat commit").await;
         git(&repo, &["switch", &base]).await;
         // Move the main tree OFF base onto `work`, and leave uncommitted changes.
         git(&repo, &["switch", "-c", "work"]).await;
-        std::fs::write(dir.join("wip.txt"), "uncommitted\n").unwrap();
-        std::fs::write(dir.join("a.txt"), "dirty\n").unwrap();
+        std::fs::write(dir.path().join("wip.txt"), "uncommitted\n").unwrap();
+        std::fs::write(dir.path().join("a.txt"), "dirty\n").unwrap();
 
-        let root = std::env::temp_dir().join(format!(
-            "gd-lpr-root-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        // The root dir is deliberately NOT pre-created here — production
+        // `merge_local_pr` is relied on to create it. The holder's TempDir is the
+        // dir ABOVE `root`, so `root` itself stays absent until the code makes it.
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
         let state = AppState::default();
         let outcome = merge_local_pr(
             &state,
@@ -3761,10 +3725,10 @@ detached
             "work"
         );
         assert_eq!(
-            std::fs::read_to_string(dir.join("a.txt")).unwrap(),
+            std::fs::read_to_string(dir.path().join("a.txt")).unwrap(),
             "dirty\n"
         );
-        assert!(dir.join("wip.txt").exists(), "untracked WIP survives");
+        assert!(dir.path().join("wip.txt").exists(), "untracked WIP survives");
 
         // base advanced: it now contains feature's commit. `cat-file -e` exits 0
         // only when the blob is reachable; `git()` unwraps, so a missing file
@@ -3779,9 +3743,6 @@ detached
             !wts.contains("gd-resolve-"),
             "resolve worktree removed: {wts}"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// A conflicting local-PR merge keeps the resolve worktree and reports the
@@ -3798,19 +3759,13 @@ detached
 
         // feature edits a.txt one way; base edits it another → conflict on merge.
         git(&repo, &["switch", "-c", "feature"]).await;
-        commit_file(&repo, &dir, "a.txt", "feature-side\n", "feat edit").await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
         git(&repo, &["switch", &base]).await;
-        commit_file(&repo, &dir, "a.txt", "base-side\n", "base edit").await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
         let base_before = rev(&repo, &base).await;
 
-        let root = std::env::temp_dir().join(format!(
-            "gd-lpr-croot-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
         std::fs::create_dir_all(&root).unwrap();
         let state = AppState::default();
         let outcome = merge_local_pr(
@@ -3848,8 +3803,5 @@ detached
             !std::path::Path::new(&wt_path).exists(),
             "worktree removed after abort"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -997,17 +997,16 @@ mod tests {
             .stdout_lossy()
     }
 
-    /// A unique temp base dir for a test, cleaned up by the caller.
-    fn temp_base(tag: &str) -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "gd-remote-{}-{}-{}",
-            tag,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ))
+    /// A unique temp base dir for a test — the returned `TempDir` guard removes it
+    /// (and every subdir under it) on Drop, so a panicking or killed run cannot
+    /// leak the fixture.
+    fn temp_base(tag: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-remote-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     async fn init_repo(repo_s: &str, seed_file: &str) {
@@ -1025,7 +1024,7 @@ mod tests {
     /// `branch.<b>.remote` config is unset, and `refs/remotes/upstream/` is empty.
     #[tokio::test]
     async fn remove_drops_remote_tracking_and_branch_upstream() {
-        let base = temp_base("remove");
+        let (_base, base) = temp_base("remove");
         let repo = base.join("repo");
         let up = base.join("upstream");
         std::fs::create_dir_all(&repo).unwrap();
@@ -1100,15 +1099,13 @@ mod tests {
                 .is_empty(),
             "refs/remotes/upstream/ is empty after removal"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// Removing a remote that doesn't exist is an honest `InvalidArgument`, not a
     /// raw git error — the `ensure_remote_exists` gate.
     #[tokio::test]
     async fn remove_nonexistent_remote_errors_invalid_argument() {
-        let base = temp_base("missing");
+        let (_base, base) = temp_base("missing");
         let repo = base.join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
@@ -1124,15 +1121,13 @@ mod tests {
             }
             other => panic!("expected InvalidArgument, got {other:?}"),
         }
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The real `for-each-ref` output shape feeding `parse_upstream_tracking` — the
     /// format assumption is otherwise only checked against hand-written strings.
     #[tokio::test]
     async fn parse_upstream_tracking_matches_real_for_each_ref_output() {
-        let base = temp_base("track");
+        let (_base, base) = temp_base("track");
         let origin = base.join("origin");
         let repo = base.join("repo");
         std::fs::create_dir_all(&origin).unwrap();
@@ -1201,7 +1196,5 @@ mod tests {
             matches!(g, Some((_, _, true))),
             "goner upstream should read gone: {g:?}"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/git/todos.rs
+++ b/src-tauri/src/git/todos.rs
@@ -442,16 +442,12 @@ mod tests {
             .stdout_lossy()
     }
 
-    async fn seed_repo(tag: &str) -> (std::path::PathBuf, String) {
-        let base = std::env::temp_dir().join(format!(
-            "gd-{tag}-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let repo = base.join("repo");
+    async fn seed_repo(tag: &str) -> (tempfile::TempDir, String) {
+        let base = tempfile::Builder::new()
+            .prefix(&format!("gd-{tag}-test-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
         run(&repo_s, &["init", "-q"]).await;
@@ -472,7 +468,7 @@ mod tests {
 
     #[tokio::test]
     async fn scans_a_real_repo() {
-        let (base, repo) = seed_repo("todo-scan").await;
+        let (_base, repo) = seed_repo("todo-scan").await;
 
         // Fixture content is assembled with `concat!` so the comment opener and
         // the real marker word never sit adjacent in THIS source file (which
@@ -518,13 +514,11 @@ mod tests {
             .expect("untracked file hit");
         assert_eq!(b.marker, "FIXME");
         assert_eq!(b.text, "(me): later");
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]
     async fn no_match_is_empty_not_error() {
-        let (base, repo) = seed_repo("todo-nomatch").await;
+        let (_base, repo) = seed_repo("todo-nomatch").await;
         std::fs::write(std::path::Path::new(&repo).join("a.rs"), "fn main() {}\n").unwrap();
         run(&repo, &["add", "-A"]).await;
         run(&repo, &["commit", "-qm", "seed"]).await;
@@ -532,29 +526,25 @@ mod tests {
         let scan = git_todo_scan(repo, markers(), None).await.unwrap();
         assert!(scan.items.is_empty());
         assert!(!scan.truncated);
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]
     async fn unborn_repo_is_empty_not_error() {
         // git init, nothing committed: git grep exits 1 → clean empty result.
-        let (base, repo) = seed_repo("todo-unborn").await;
+        let (_base, repo) = seed_repo("todo-unborn").await;
         let scan = git_todo_scan(repo, markers(), None).await.unwrap();
         assert!(scan.items.is_empty());
         assert!(!scan.truncated);
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]
     async fn empty_markers_rejected() {
-        let (base, repo) = seed_repo("todo-badmarker").await;
+        let (_base, repo) = seed_repo("todo-badmarker").await;
         let err = git_todo_scan(repo.clone(), vec![], None).await.unwrap_err();
         assert!(matches!(err, AppError::InvalidArgument(_)));
         let err = git_todo_scan(repo, vec!["TO DO".into()], None)
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::InvalidArgument(_)));
-        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -815,14 +815,11 @@ prunable gitdir file points to non-existent location
     /// remove + prune + delete its branch. Requires git on PATH (true for dev).
     #[tokio::test]
     async fn worktree_add_list_remove_roundtrip() {
-        let base = std::env::temp_dir().join(format!(
-            "gd-wt-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let _base = tempfile::Builder::new()
+            .prefix("gd-wt-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let base = _base.path().to_path_buf();
         let repo = base.join("repo");
         let wt = base.join("wt");
         std::fs::create_dir_all(&repo).unwrap();
@@ -858,8 +855,6 @@ prunable gitdir file points to non-existent location
             after.iter().all(|w| w.branch != "gd/session/test"),
             "session worktree is gone after remove"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// Keep (remove worktree, retain branch) then Resume (re-add the worktree on
@@ -867,14 +862,11 @@ prunable gitdir file points to non-existent location
     /// kept work and the branch is back in the worktree list.
     #[tokio::test]
     async fn worktree_keep_then_resume_reattaches_branch() {
-        let base = std::env::temp_dir().join(format!(
-            "gd-wt-resume-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let _base = tempfile::Builder::new()
+            .prefix("gd-wt-resume-")
+            .tempdir()
+            .expect("create temp dir");
+        let base = _base.path().to_path_buf();
         let repo = base.join("repo");
         let wt = base.join("wt");
         std::fs::create_dir_all(&repo).unwrap();
@@ -915,8 +907,6 @@ prunable gitdir file points to non-existent location
             list.iter().any(|w| w.branch == "gd/session/keep"),
             "branch is checked out in a worktree again after resume"
         );
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The safety gate for finishing a non-forced worktree removal ourselves:
@@ -926,14 +916,11 @@ prunable gitdir file points to non-existent location
     /// there's nothing left to protect.
     #[tokio::test]
     async fn worktree_has_uncommitted_changes_gates_on_real_work() {
-        let base = std::env::temp_dir().join(format!(
-            "gd-wt-dirty-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let _base = tempfile::Builder::new()
+            .prefix("gd-wt-dirty-")
+            .tempdir()
+            .expect("create temp dir");
+        let base = _base.path().to_path_buf();
         let repo = base.join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let repo_s = repo.to_string_lossy().into_owned();
@@ -970,7 +957,5 @@ prunable gitdir file points to non-existent location
         let non_repo = base.join("not-a-repo");
         std::fs::create_dir_all(&non_repo).unwrap();
         assert!(!worktree_has_uncommitted_changes(&non_repo.to_string_lossy()).await);
-
-        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -41,9 +41,10 @@ pub async fn read_repo_ai_ignore(repo_path: String) -> AppResult<Vec<String>> {
 /// consumed as git pathspecs via `:(exclude)<pattern>`, where a leading slash
 /// makes git treat it as an absolute path outside the repo — and a fresh file
 /// is seeded with a header comment (`parse_patterns` and the pathspec builders
-/// both skip `#` lines).
+/// both skip `#` lines). Returns the number of patterns actually appended (0
+/// when every pattern was empty or already present).
 #[tauri::command]
-pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> AppResult<()> {
+pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> AppResult<usize> {
     const HEADER: &str =
         "# Files excluded from AI context — gitignore-style patterns, one per line.";
 
@@ -57,7 +58,7 @@ pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> 
         }
     }
     if wanted.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
 
     let dir = Path::new(&repo_path).join(".gitdesktop");
@@ -78,8 +79,9 @@ pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> 
             .collect()
     };
     if to_add.is_empty() {
-        return Ok(());
+        return Ok(0);
     }
+    let added = to_add.len();
 
     tokio::fs::create_dir_all(&dir).await.map_err(AppError::Io)?;
 
@@ -93,7 +95,8 @@ pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> 
         content.push_str(&p);
         content.push('\n');
     }
-    tokio::fs::write(&path, content).await.map_err(AppError::Io)
+    tokio::fs::write(&path, content).await.map_err(AppError::Io)?;
+    Ok(added)
 }
 
 /// Per-repo SHARED branch rules, read from `<repo>/.gitdesktop/branch-rules.json`.
@@ -474,24 +477,26 @@ mod tests {
         assert_eq!(meta.argument_hint, "<file>");
     }
 
-    fn ai_ignore_test_repo() -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "gd-aiignore-test-{}-{}",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
+    fn ai_ignore_test_repo() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-aiignore-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     #[tokio::test]
     async fn append_ai_ignore_creates_file_with_header() {
-        let dir = ai_ignore_test_repo();
+        let (_tmp, dir) = ai_ignore_test_repo();
         let repo = dir.to_string_lossy().into_owned();
 
-        append_repo_ai_ignore(repo.clone(), vec!["src/foo.rs".to_string(), "*.log".to_string()])
-            .await
-            .unwrap();
+        let added =
+            append_repo_ai_ignore(repo.clone(), vec!["src/foo.rs".to_string(), "*.log".to_string()])
+                .await
+                .unwrap();
+        // A fresh file: both patterns are appended.
+        assert_eq!(added, 2);
 
         let path = dir.join(".gitdesktop").join("aiignore");
         let text = std::fs::read_to_string(&path).unwrap();
@@ -506,26 +511,28 @@ mod tests {
         // read_repo_ai_ignore / parse_patterns round-trips the patterns, header filtered.
         let parsed = read_repo_ai_ignore(repo).await.unwrap();
         assert_eq!(parsed, vec!["src/foo.rs".to_string(), "*.log".to_string()]);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn append_ai_ignore_appends_without_duplicating() {
-        let dir = ai_ignore_test_repo();
+        let (_tmp, dir) = ai_ignore_test_repo();
         let repo = dir.to_string_lossy().into_owned();
 
-        append_repo_ai_ignore(repo.clone(), vec!["a.txt".to_string()])
+        let added_first = append_repo_ai_ignore(repo.clone(), vec!["a.txt".to_string()])
             .await
             .unwrap();
+        assert_eq!(added_first, 1);
         let path = dir.join(".gitdesktop").join("aiignore");
         let after_first = std::fs::read_to_string(&path).unwrap();
 
         // Re-add the same line plus a new one: the existing line is not duplicated,
         // the new line is appended, existing content is preserved, no second header.
-        append_repo_ai_ignore(repo.clone(), vec!["a.txt".to_string(), "b.txt".to_string()])
-            .await
-            .unwrap();
+        let added_second =
+            append_repo_ai_ignore(repo.clone(), vec!["a.txt".to_string(), "b.txt".to_string()])
+                .await
+                .unwrap();
+        // Only the new line counts — the already-present one is skipped.
+        assert_eq!(added_second, 1);
         let after_second = std::fs::read_to_string(&path).unwrap();
 
         assert_eq!(after_second.matches("\na.txt\n").count(), 1);
@@ -538,17 +545,15 @@ mod tests {
                 .count(),
             1
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
     async fn append_ai_ignore_normalizes_patterns() {
-        let dir = ai_ignore_test_repo();
+        let (_tmp, dir) = ai_ignore_test_repo();
         let repo = dir.to_string_lossy().into_owned();
 
         // Leading slash stripped, whitespace-only skipped, in-batch dupes collapsed.
-        append_repo_ai_ignore(
+        let added = append_repo_ai_ignore(
             repo.clone(),
             vec![
                 "/foo".to_string(),
@@ -559,18 +564,19 @@ mod tests {
         )
         .await
         .unwrap();
+        // The whitespace-only entry and the in-batch dupe collapse: "foo" + "bar".
+        assert_eq!(added, 2);
         let parsed = read_repo_ai_ignore(repo.clone()).await.unwrap();
         assert_eq!(parsed, vec!["foo".to_string(), "bar".to_string()]);
 
-        // An all-duplicates batch leaves the file byte-identical.
+        // An all-duplicates batch leaves the file byte-identical and appends nothing.
         let path = dir.join(".gitdesktop").join("aiignore");
         let before = std::fs::read_to_string(&path).unwrap();
-        append_repo_ai_ignore(repo, vec!["/foo".to_string(), "bar".to_string()])
+        let added_dupe = append_repo_ai_ignore(repo, vec!["/foo".to_string(), "bar".to_string()])
             .await
             .unwrap();
+        assert_eq!(added_dupe, 0);
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(before, after);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/jira_field_maps.rs
+++ b/src-tauri/src/jira_field_maps.rs
@@ -246,14 +246,13 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-jira-field-maps-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-jira-field-maps-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     #[test]
@@ -281,7 +280,7 @@ mod tests {
 
     #[test]
     fn read_store_round_trips_via_disk() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let mut store = Map::new();
         store.insert(
             "team.atlassian.net".to_string(),
@@ -302,24 +301,22 @@ mod tests {
             Some("customfield_10016")
         );
         assert!(entry.sprint_field_id.is_none());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn malformed_file_degrades_to_empty_map() {
         // A CACHE — a garbage file is not an error; it reads as empty (→ rediscovery).
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, b"{ this is not json").unwrap();
         assert!(read_store(&path).is_empty());
         // A JSON non-object also degrades to empty.
         std::fs::write(&path, b"[1, 2, 3]").unwrap();
         assert!(read_store(&path).is_empty());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn missing_file_degrades_to_empty_map() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         assert!(read_store(&path).is_empty());
     }
 

--- a/src-tauri/src/jira_links.rs
+++ b/src-tauri/src/jira_links.rs
@@ -172,19 +172,18 @@ mod tests {
         })
     }
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-jira-links-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-jira-links-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     #[test]
     fn read_missing_file_is_empty_object() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let store = read_store(&path).unwrap();
         assert!(store.is_empty());
     }
@@ -192,19 +191,19 @@ mod tests {
     #[test]
     fn read_missing_file_yields_no_link() {
         // The end-to-end "no store file" case: read_store → empty map → lookup None.
-        let store = read_store(&tmp_store()).unwrap();
+        let (_tmp, path) = tmp_store();
+        let store = read_store(&path).unwrap();
         assert_eq!(lookup(&store, "C:/repo/.git", r"C:\repo"), None);
     }
 
     #[test]
     fn malformed_store_is_an_error_not_a_clobber() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, b"{ this is not json").unwrap();
         let err = read_store(&path).unwrap_err();
         assert!(err.to_string().contains("not valid JSON"));
         // The bad file is left intact (read-only).
         assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -293,7 +292,7 @@ mod tests {
 
     #[test]
     fn read_and_lookup_end_to_end_via_temp_file() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let identity = "C:/repo/reads/.git";
         let mut store = Map::new();
         store.insert(identity.to_string(), link_json());
@@ -302,6 +301,5 @@ mod tests {
         let back = read_store(&path).unwrap();
         let link = lookup(&back, identity, "C:/repo/reads").unwrap();
         assert_eq!(link.project_key, "PROJ");
-        std::fs::remove_file(&path).ok();
     }
 }

--- a/src-tauri/src/local_issues.rs
+++ b/src-tauri/src/local_issues.rs
@@ -339,14 +339,13 @@ mod tests {
     // against a temp file, bypassing `store_path()` so they never touch the real
     // app-data store. The public fns wrap this same logic + the fixed path.
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-local-issues-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-local-issues-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     #[test]
@@ -376,30 +375,28 @@ mod tests {
 
     #[test]
     fn read_missing_file_is_empty_object() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let store = read_store(&path).unwrap();
         assert!(store.is_empty());
     }
 
     #[test]
     fn malformed_store_is_an_error_not_a_clobber() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, b"{ this is not json").unwrap();
         let err = read_store(&path).unwrap_err();
         assert!(err.to_string().contains("not valid JSON"));
         assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn atomic_write_round_trips() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let mut store = Map::new();
         store.insert("repo".into(), json!([{ "id": "a" }]));
         write_store(&path, &store).unwrap();
         let back = read_store(&path).unwrap();
         assert_eq!(back["repo"][0]["id"], "a");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -407,7 +404,7 @@ mod tests {
         // A record carrying a field this Rust code has never heard of must survive a
         // mutation (the acceptance criterion for never dropping unknown fields a future
         // GUI adds — e.g. `archived`, `hidden` on comments, or anything newer).
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\one";
         let mut store = Map::new();
         store.insert(
@@ -450,7 +447,6 @@ mod tests {
         assert_eq!(iss["comments"][0]["body"], "hi");
         // Known fields unchanged.
         assert_eq!(iss["status"], "open");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -518,7 +514,7 @@ mod tests {
     #[test]
     fn set_status_stamps_and_clears_closed_at() {
         // Drive the status mutation over a temp file to check the closedAt behavior.
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\stamp";
         let mut store = Map::new();
         store.insert(
@@ -554,7 +550,6 @@ mod tests {
         let back = read_store(&path).unwrap();
         assert_eq!(back[repo][0]["status"], "open");
         assert!(back[repo][0].get("closedAt").is_none());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]

--- a/src-tauri/src/local_prs.rs
+++ b/src-tauri/src/local_prs.rs
@@ -365,14 +365,13 @@ mod tests {
     // against a temp file, bypassing `store_path()` so they never touch the real
     // app-data store. The public fns wrap this same logic + the fixed path.
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-local-prs-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-local-prs-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     #[test]
@@ -390,31 +389,29 @@ mod tests {
 
     #[test]
     fn read_missing_file_is_empty_object() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let store = read_store(&path).unwrap();
         assert!(store.is_empty());
     }
 
     #[test]
     fn malformed_store_is_an_error_not_a_clobber() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, b"{ this is not json").unwrap();
         let err = read_store(&path).unwrap_err();
         assert!(err.to_string().contains("not valid JSON"));
         // The bad file is left intact.
         assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn atomic_write_round_trips() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let mut store = Map::new();
         store.insert("repo".into(), json!([{ "id": "a" }]));
         write_store(&path, &store).unwrap();
         let back = read_store(&path).unwrap();
         assert_eq!(back["repo"][0]["id"], "a");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -422,7 +419,7 @@ mod tests {
         // A record carrying a field this Rust code has never heard of must survive a
         // mutation byte-meaningfully (the acceptance criterion for never dropping
         // unknown fields a future GUI adds).
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\one";
         let mut store = Map::new();
         store.insert(
@@ -466,7 +463,6 @@ mod tests {
         assert_eq!(pr["comments"][0]["body"], "hi");
         // Known fields unchanged.
         assert_eq!(pr["status"], "open");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -557,7 +553,7 @@ mod tests {
 
     #[test]
     fn list_and_get_read_records_tolerantly() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         // Bypass store_path() by exercising the same read logic the public fns use.
         let repo = r"C:\repo\reads";
         let mut store = Map::new();
@@ -578,6 +574,5 @@ mod tests {
             .iter()
             .find(|pr| pr.get("id").and_then(Value::as_str) == Some("pr-2"));
         assert_eq!(found.unwrap()["title"], "B");
-        std::fs::remove_file(&path).ok();
     }
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1114,15 +1114,13 @@ mod tests {
 
     // --- mcp_json_write ------------------------------------------------------
 
-    fn tmp_dir() -> std::path::PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-mcp-json-test-{}-{}",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&p).unwrap();
-        p
+    fn tmp_dir() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-mcp-json-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     fn entry() -> Value {
@@ -1131,7 +1129,7 @@ mod tests {
 
     #[tokio::test]
     async fn write_creates_file_when_missing() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let res = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), false)
             .await
             .unwrap();
@@ -1140,12 +1138,11 @@ mod tests {
         let doc: Value =
             serde_json::from_slice(&std::fs::read(dir.join(".mcp.json")).unwrap()).unwrap();
         assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "gitdesktop");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[tokio::test]
     async fn write_preserves_siblings_and_unknown_top_level_keys() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let path = dir.join(".mcp.json");
         std::fs::write(
             &path,
@@ -1170,12 +1167,11 @@ mod tests {
         assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "gitdesktop");
         // Unknown top-level key preserved.
         assert_eq!(doc["someUnknownTopKey"]["keep"], true);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[tokio::test]
     async fn write_detects_existing_and_refuses_without_overwrite() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let path = dir.join(".mcp.json");
         std::fs::write(
             &path,
@@ -1203,12 +1199,11 @@ mod tests {
         assert!(res.existed);
         let doc: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(doc["mcpServers"]["gitdesktop"]["command"], "gitdesktop");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[tokio::test]
     async fn write_errors_on_malformed_existing_file_without_clobber() {
-        let dir = tmp_dir();
+        let (_tmp, dir) = tmp_dir();
         let path = dir.join(".mcp.json");
         std::fs::write(&path, b"{ not valid json").unwrap();
         let err = mcp_json_write(dir.to_string_lossy().into_owned(), entry(), true)
@@ -1217,7 +1212,6 @@ mod tests {
         assert!(err.to_string().contains("not valid JSON"));
         // The bad file is untouched.
         assert_eq!(std::fs::read(&path).unwrap(), b"{ not valid json");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/mcp_launcher.rs
+++ b/src-tauri/src/mcp_launcher.rs
@@ -347,13 +347,13 @@ pub async fn mcp_launcher_path(app: tauri::AppHandle) -> AppResult<String> {
 mod tests {
     use super::*;
 
-    fn scratch_dir(tag: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "gd-mcp-launcher-test-{}-{}-{}",
-            tag,
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ))
+    fn scratch_dir(tag: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-mcp-launcher-test-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     #[test]
@@ -374,73 +374,65 @@ mod tests {
 
     /// Set up a temp bin dir with a copied launcher + marker and return
     /// (dir, dest, source, base_marker).
-    fn seeded() -> (PathBuf, PathBuf, PathBuf, Marker) {
-        let dir = scratch_dir("seed");
-        std::fs::create_dir_all(&dir).unwrap();
+    fn seeded() -> (tempfile::TempDir, PathBuf, PathBuf, Marker) {
+        let (guard, dir) = scratch_dir("seed");
         let dest = dir.join(LAUNCHER_FILE);
         // Copy the test binary itself as the "source" exe — a real file.
         let source = current_exe().unwrap();
         let want = marker_for(&source, "9.9.9").unwrap();
         ensure_in_dir(&source, &dest, &want).unwrap();
-        (dir, dest, source, want)
+        (guard, dest, source, want)
     }
 
     #[test]
     fn stale_when_marker_missing() {
-        let dir = scratch_dir("nomarker");
-        std::fs::create_dir_all(&dir).unwrap();
+        let (_dir, dir) = scratch_dir("nomarker");
         let dest = dir.join(LAUNCHER_FILE);
         // exe present but no marker file at all.
         std::fs::write(&dest, b"exe").unwrap();
         let want = marker_for(&current_exe().unwrap(), "1.0.0").unwrap();
         assert!(is_stale(&dest, &want));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn fresh_when_all_fields_match() {
-        let (dir, dest, _source, want) = seeded();
+        let (_dir, dest, _source, want) = seeded();
         assert!(!is_stale(&dest, &want), "just-copied should be fresh");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn stale_when_version_differs() {
-        let (dir, dest, _source, want) = seeded();
+        let (_dir, dest, _source, want) = seeded();
         let other = Marker {
             version: "0.0.1".into(),
             ..want
         };
         assert!(is_stale(&dest, &other));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn stale_when_source_len_differs() {
-        let (dir, dest, _source, want) = seeded();
+        let (_dir, dest, _source, want) = seeded();
         let other = Marker {
             source_len: want.source_len + 1,
             ..want.clone()
         };
         assert!(is_stale(&dest, &other));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn stale_when_source_mtime_differs() {
-        let (dir, dest, _source, want) = seeded();
+        let (_dir, dest, _source, want) = seeded();
         let other = Marker {
             source_mtime_ms: want.source_mtime_ms.wrapping_add(1),
             ..want.clone()
         };
         assert!(is_stale(&dest, &other));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn ensure_in_dir_creates_exe_and_marker() {
-        let dir = scratch_dir("create");
-        std::fs::create_dir_all(&dir).unwrap();
+        let (_dir, dir) = scratch_dir("create");
         let dest = dir.join(LAUNCHER_FILE);
         let source = current_exe().unwrap();
         let want = marker_for(&source, "3.1.4").unwrap();
@@ -463,8 +455,6 @@ mod tests {
         ensure_in_dir(&source, &dest, &want).unwrap();
         assert!(dest.exists());
         assert_eq!(read_marker(&dest).as_ref(), Some(&want));
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -472,8 +462,7 @@ mod tests {
         // Lazy: a never-copied launcher must not be materialized by a refresh.
         // Drive the real production core against a temp dir and assert NO
         // filesystem writes appear (neither the exe nor the marker).
-        let dir = scratch_dir("refresh-absent");
-        std::fs::create_dir_all(&dir).unwrap();
+        let (_dir, dir) = scratch_dir("refresh-absent");
         let dest = dir.join(LAUNCHER_FILE);
         let source = current_exe().unwrap();
         let want = marker_for(&source, "1.0.0").unwrap();
@@ -485,8 +474,6 @@ mod tests {
             !marker_path(&dest).exists(),
             "absent dest ⇒ no marker written"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -494,7 +481,7 @@ mod tests {
         // Seed a copy, then hand a DIFFERENT want marker (a bumped version) so
         // the present-but-stale branch fires. The refresh must re-copy and the
         // on-disk marker must now match the new want.
-        let (dir, dest, source, base) = seeded();
+        let (_dir, dest, source, base) = seeded();
         assert!(dest.exists());
         let bumped = Marker {
             version: "10.0.0".into(),
@@ -510,7 +497,5 @@ mod tests {
             "marker updated to the new want"
         );
         assert!(!is_stale(&dest, &bumped), "no longer stale after refresh");
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -158,12 +158,6 @@ impl CiId {
     }
 }
 
-impl std::fmt::Display for CiId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 impl<'de> serde::Deserialize<'de> for CiId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -138,16 +138,100 @@ pub(super) struct NumberArg {
     pub(super) number: u64,
 }
 
+/// A CI run/job id. It rides GitHub/GitLab APIs as an unsigned integer that can
+/// exceed JS's safe-integer range, so clients that thread it through JSON often
+/// carry it as a *string*. `CiId` accepts either form on the wire — a JSON number
+/// or a numeric string — and hands handlers the underlying `u64`. Existing MCP
+/// clients that send a plain number keep working unchanged.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CiId(pub u64);
+
+impl CiId {
+    /// The id as the string form the forge dispatchers (`forge_ci_*`) now take.
+    pub(super) fn as_string(self) -> String {
+        self.0.to_string()
+    }
+
+    /// The underlying `u64`, for handlers that call forge fns still taking a number.
+    pub(super) fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for CiId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CiId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct CiIdVisitor;
+        impl serde::de::Visitor<'_> for CiIdVisitor {
+            type Value = CiId;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a CI id as an unsigned integer or a numeric string")
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<CiId, E> {
+                Ok(CiId(v))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<CiId, E> {
+                u64::try_from(v)
+                    .map(CiId)
+                    .map_err(|_| E::custom(format!("CI id out of range: {v}")))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<CiId, E> {
+                v.parse::<u64>()
+                    .map(CiId)
+                    .map_err(|_| E::custom(format!("invalid CI id: {v:?}")))
+            }
+        }
+        // Any JSON scalar reaches the matching visit_* method; a number lands on
+        // visit_u64/visit_i64, a string on visit_str, and everything else errors.
+        deserializer.deserialize_any(CiIdVisitor)
+    }
+}
+
+impl schemars::JsonSchema for CiId {
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "CiId".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // Advertise BOTH accepted wire forms so a client sending a number and one
+        // sending a numeric string both validate against the tool's input schema.
+        schemars::json_schema!({
+            "description": "A CI run/job id — an unsigned integer, or a numeric string for ids beyond JS's safe-integer range.",
+            "oneOf": [
+                { "type": "integer", "minimum": 0 },
+                { "type": "string", "pattern": "^[0-9]+$" }
+            ]
+        })
+    }
+}
+
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(super) struct RunIdArg {
-    /// The GitHub Actions workflow run id.
-    pub(super) run_id: u64,
+    /// The GitHub Actions workflow run id — a number or a numeric string.
+    pub(super) run_id: CiId,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub(super) struct JobIdArg {
-    /// A CI job id, taken from a run's `jobs[].id` (see get_workflow_run).
-    pub(super) job_id: u64,
+    /// A CI job id, taken from a run's `jobs[].id` (see get_workflow_run) — a
+    /// number or a numeric string.
+    pub(super) job_id: CiId,
 }
 
 impl GitDesktopMcp {
@@ -907,6 +991,61 @@ mod tests {
         assert!(err.contains("MYT"), "err: {err}");
         // A key with no derivable project (no `-`) is refused.
         assert!(ensure_key_in_project("NODASH", &link).is_err());
+    }
+
+    /// `CiId` accepts a CI run/job id as EITHER a JSON number or a numeric string
+    /// (so existing clients sending numbers keep working, while string-carrying
+    /// clients avoid the 2^53 precision cliff), and rejects non-numeric input.
+    #[test]
+    fn ci_id_accepts_number_or_numeric_string() {
+        // A bare number deserializes.
+        let from_num: CiId = serde_json::from_value(serde_json::json!(123)).unwrap();
+        assert_eq!(from_num.as_u64(), 123);
+
+        // A numeric string deserializes to the same id.
+        let from_str: CiId = serde_json::from_value(serde_json::json!("123")).unwrap();
+        assert_eq!(from_str.as_u64(), 123);
+
+        // Beyond 2^53 survives as a string (the whole point).
+        let big: CiId = serde_json::from_value(serde_json::json!("9007199254740993")).unwrap();
+        assert_eq!(big.as_u64(), 9_007_199_254_740_993);
+
+        // Non-numeric string is rejected.
+        assert!(serde_json::from_value::<CiId>(serde_json::json!("abc")).is_err());
+        // A negative number is out of range for u64.
+        assert!(serde_json::from_value::<CiId>(serde_json::json!(-1)).is_err());
+        // A float is not an integer id.
+        assert!(serde_json::from_value::<CiId>(serde_json::json!(1.5)).is_err());
+    }
+
+    /// The wrapping arg structs deserialize with the id as a number OR a string —
+    /// the compat property the MCP tool schema must preserve.
+    #[test]
+    fn run_id_arg_accepts_number_or_string() {
+        let n: RunIdArg = serde_json::from_value(serde_json::json!({ "run_id": 123 })).unwrap();
+        assert_eq!(n.run_id.as_u64(), 123);
+        let s: RunIdArg = serde_json::from_value(serde_json::json!({ "run_id": "123" })).unwrap();
+        assert_eq!(s.run_id.as_u64(), 123);
+    }
+
+    /// The generated JSON Schema for `CiId` must advertise BOTH the integer and the
+    /// string wire forms, so a client validating either against the tool's input
+    /// schema passes. (Guards against the schema silently dropping the number form.)
+    #[test]
+    fn ci_id_schema_advertises_both_forms() {
+        let mut generator = schemars::SchemaGenerator::default();
+        let schema = <CiId as schemars::JsonSchema>::json_schema(&mut generator);
+        let json = serde_json::to_value(&schema).unwrap();
+        let variants = json
+            .get("oneOf")
+            .and_then(|v| v.as_array())
+            .expect("CiId schema should be a oneOf");
+        let types: Vec<&str> = variants
+            .iter()
+            .filter_map(|v| v.get("type").and_then(|t| t.as_str()))
+            .collect();
+        assert!(types.contains(&"integer"), "schema: {json}");
+        assert!(types.contains(&"string"), "schema: {json}");
     }
 
     /// The prompt router (separate from the tool router — prompts are NOT tools, so

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -328,7 +328,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<RunIdArg>,
     ) -> Result<CallToolResult, McpError> {
-        let run = crate::forge::forge_ci_run_view(self.repo.clone(), args.run_id)
+        let run = crate::forge::forge_ci_run_view(self.repo.clone(), args.run_id.as_string())
             .await
             .map_err(app_err)?;
         json_result(&run)
@@ -344,7 +344,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<RunIdArg>,
     ) -> Result<CallToolResult, McpError> {
-        let logs = crate::forge::forge_ci_run_failed_logs(self.repo.clone(), args.run_id)
+        let logs = crate::forge::forge_ci_run_failed_logs(self.repo.clone(), args.run_id.as_string())
             .await
             .map_err(app_err)?;
         text_result_untrusted(cap_tail(logs, GH_TEXT_MAX_BYTES))
@@ -361,7 +361,7 @@ impl GitDesktopMcp {
         &self,
         Parameters(args): Parameters<JobIdArg>,
     ) -> Result<CallToolResult, McpError> {
-        let logs = crate::forge::forge_ci_job_logs(self.repo.clone(), args.job_id)
+        let logs = crate::forge::forge_ci_job_logs(self.repo.clone(), args.job_id.as_string())
             .await
             .map_err(app_err)?;
         text_result_untrusted(cap_tail(logs, GH_TEXT_MAX_BYTES))

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -951,10 +951,10 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<RunIdArg>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_ci_run_rerun(self.repo.clone(), args.run_id, true)
+        crate::forge::forge_ci_run_rerun(self.repo.clone(), args.run_id.as_u64(), true)
             .await
             .map_err(app_err)?;
-        json_result(&serde_json::json!({ "run_id": args.run_id, "action": "rerun" }))
+        json_result(&serde_json::json!({ "run_id": args.run_id.as_u64(), "action": "rerun" }))
     }
 
     #[tool(
@@ -968,10 +968,10 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<RunIdArg>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        crate::forge::forge_ci_run_cancel(self.repo.clone(), args.run_id)
+        crate::forge::forge_ci_run_cancel(self.repo.clone(), args.run_id.as_u64())
             .await
             .map_err(app_err)?;
-        json_result(&serde_json::json!({ "run_id": args.run_id, "action": "cancelled" }))
+        json_result(&serde_json::json!({ "run_id": args.run_id.as_u64(), "action": "cancelled" }))
     }
 
     #[tool(
@@ -1464,6 +1464,7 @@ impl GitDesktopMcp {
 
 #[cfg(test)]
 mod tests {
+    use super::super::CiId;
     use super::*;
     use rmcp::handler::server::wrapper::Parameters;
 
@@ -1568,8 +1569,8 @@ mod tests {
             thread_id: "t".into(),
             resolved: true,
         })));
-        assert_gated!(h.rerun_workflow_run(Parameters(RunIdArg { run_id: 1 })));
-        assert_gated!(h.cancel_workflow_run(Parameters(RunIdArg { run_id: 1 })));
+        assert_gated!(h.rerun_workflow_run(Parameters(RunIdArg { run_id: CiId(1) })));
+        assert_gated!(h.cancel_workflow_run(Parameters(RunIdArg { run_id: CiId(1) })));
         assert_gated!(h.dispatch_workflow(Parameters(DispatchWorkflowArgs {
             workflow: "ci.yml".into(),
             git_ref: "main".into(),

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -954,7 +954,7 @@ impl GitDesktopMcp {
         crate::forge::forge_ci_run_rerun(self.repo.clone(), args.run_id.as_u64(), true)
             .await
             .map_err(app_err)?;
-        json_result(&serde_json::json!({ "run_id": args.run_id.as_u64(), "action": "rerun" }))
+        json_result(&serde_json::json!({ "run_id": args.run_id.as_string(), "action": "rerun" }))
     }
 
     #[tool(
@@ -971,7 +971,7 @@ impl GitDesktopMcp {
         crate::forge::forge_ci_run_cancel(self.repo.clone(), args.run_id.as_u64())
             .await
             .map_err(app_err)?;
-        json_result(&serde_json::json!({ "run_id": args.run_id.as_u64(), "action": "cancelled" }))
+        json_result(&serde_json::json!({ "run_id": args.run_id.as_string(), "action": "cancelled" }))
     }
 
     #[tool(

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -508,14 +508,13 @@ mod tests {
     // SAME read/mutate/write helpers the public fns use but with an explicit path,
     // so they never touch the real app-data store.
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-opslog-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-opslog-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     #[test]
@@ -620,7 +619,7 @@ mod tests {
 
     #[test]
     fn begin_then_list_yields_a_pending_entry() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\one";
         // Simulate begin's insert against our temp file.
         let mut store = Map::new();
@@ -640,12 +639,11 @@ mod tests {
         assert_eq!(parsed[0].id, "op-1");
         assert_eq!(parsed[0].status, "pending");
         assert!(parsed[0].finished_at.is_none());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn finish_flips_to_done_and_failed_with_finished_at() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\one";
         let mut store = Map::new();
         store.insert(
@@ -692,14 +690,13 @@ mod tests {
         assert_eq!(failed["status"], "failed");
         assert_eq!(failed["error"], "boom");
         assert_eq!(failed["finishedAt"], "2026-01-03T00:00:00.000Z");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn unknown_fields_survive_a_begin_finish_round_trip() {
         // A record carrying a field this Rust code has never heard of must survive a
         // status mutation untouched (never drop unknown fields a future GUI adds).
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\one";
         let mut store = Map::new();
         let mut rec = pending_record("op-1", "2026-01-01T00:00:00.000Z");
@@ -730,7 +727,6 @@ mod tests {
         assert_eq!(entry["futureField"], 42);
         assert_eq!(entry["nested"]["keep"], json!(["me", 2, true]));
         assert_eq!(entry["status"], "done");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -762,7 +758,7 @@ mod tests {
 
     #[test]
     fn dismiss_sets_dismissed_status() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = r"C:\repo\one";
         let mut store = Map::new();
         store.insert(
@@ -787,12 +783,11 @@ mod tests {
 
         let back = read_store(&path).unwrap();
         assert_eq!(back[repo][0]["status"], "dismissed");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn missing_repo_key_lists_empty() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let store = read_store(&path).unwrap();
         let entries = repo_entries(&store, r"C:\nope");
         assert!(entries.is_empty());

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -174,14 +174,13 @@ mod tests {
     // against a temp file, bypassing `store_path()` so they never touch the real
     // app-data store. `set` wraps this same logic + the fixed path.
 
-    fn tmp_store() -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
-            "gd-review-notes-test-{}-{}.json",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        p
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-review-notes-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
     }
 
     #[test]
@@ -198,25 +197,24 @@ mod tests {
 
     #[test]
     fn read_missing_file_is_empty_object() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let store = read_store(&path).unwrap();
         assert!(store.is_empty());
     }
 
     #[test]
     fn malformed_store_is_an_error_not_a_clobber() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         std::fs::write(&path, b"{ this is not json").unwrap();
         let err = read_store(&path).unwrap_err();
         assert!(err.to_string().contains("not valid JSON"));
         // The bad file is left intact.
         assert_eq!(std::fs::read(&path).unwrap(), b"{ this is not json");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn set_upserts_body_and_stamps_saved_at() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = "C:/repo/one/.git";
         let saved = set_at(&path, repo, "feature", "please look at the migration").unwrap();
         assert!(saved);
@@ -227,12 +225,11 @@ mod tests {
         assert!(note["savedAt"].is_string());
         let ts = note["savedAt"].as_str().unwrap();
         assert!(ts.ends_with('Z'), "expected ISO Z suffix: {ts}");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn set_overwrites_an_existing_branch_note() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = "C:/repo/one/.git";
         set_at(&path, repo, "feature", "first").unwrap();
         set_at(&path, repo, "feature", "second").unwrap();
@@ -241,12 +238,11 @@ mod tests {
         assert_eq!(back[repo]["feature"]["body"], "second");
         // Only one branch entry — an upsert, not an append.
         assert_eq!(back[repo].as_object().unwrap().len(), 1);
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn empty_body_clears_the_branch_but_keeps_siblings() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = "C:/repo/one/.git";
         set_at(&path, repo, "feature", "note A").unwrap();
         set_at(&path, repo, "other", "note B").unwrap();
@@ -259,12 +255,11 @@ mod tests {
         assert!(back[repo].get("feature").is_none());
         // The sibling branch is untouched.
         assert_eq!(back[repo]["other"]["body"], "note B");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn clearing_last_branch_removes_the_repo_key() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = "C:/repo/one/.git";
         set_at(&path, repo, "feature", "note").unwrap();
         // Clearing the only branch drops the repo key entirely.
@@ -277,24 +272,22 @@ mod tests {
             "repo key should be gone: {back:?}"
         );
         assert!(back.is_empty());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn clearing_a_missing_branch_is_a_harmless_noop() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let repo = "C:/repo/one/.git";
         // No prior entry — clearing a never-set branch just writes an empty store.
         let saved = set_at(&path, repo, "ghost", "").unwrap();
         assert!(!saved);
         let back = read_store(&path).unwrap();
         assert!(back.is_empty());
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]
     fn upsert_preserves_sibling_repos_and_unknown_fields() {
-        let path = tmp_store();
+        let (_tmp, path) = tmp_store();
         let other_repo = "C:/repo/other/.git";
         let repo = "C:/repo/one/.git";
         // Seed a store with a sibling repo carrying a note that has an unknown field, plus
@@ -319,7 +312,6 @@ mod tests {
         // Our repo now has both the sibling branch and the new one.
         assert_eq!(back[repo]["sibling"]["body"], "sib");
         assert_eq!(back[repo]["feature"]["body"], "new note");
-        std::fs::remove_file(&path).ok();
     }
 
     #[test]

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -686,14 +686,13 @@ pub async fn transcript_remove(app: AppHandle, id: String) -> AppResult<()> {
 mod tests {
     use super::*;
 
-    fn temp_dir(tag: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!(
-            "gd-transcript-{tag}-{}-{}",
-            std::process::id(),
-            now_ms()
-        ));
-        std::fs::create_dir_all(&d).unwrap();
-        d
+    fn temp_dir(tag: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-transcript-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().to_path_buf();
+        (dir, path)
     }
 
     fn header(id: &str, created: i64) -> Event {
@@ -836,7 +835,7 @@ mod tests {
 
     #[test]
     fn append_then_load_roundtrip_and_orders_by_creation() {
-        let dir = temp_dir("roundtrip");
+        let (_dir, dir) = temp_dir("roundtrip");
         // Two sessions written out of creation order on disk.
         append_to_dir(&dir, "bbb", &header("bbb", 200)).unwrap();
         append_to_dir(&dir, "aaa", &header("aaa", 100)).unwrap();
@@ -868,18 +867,17 @@ mod tests {
         .unwrap();
 
         let loaded = load_dir(&dir);
+
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0].id, "aaa"); // created 100 sorts before 200
         assert_eq!(loaded[1].id, "bbb");
         assert_eq!(loaded[0].turns[0].narration, "hello");
         assert_eq!(loaded[0].head_hash, "c9");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn read_events_skips_a_torn_final_line() {
-        let dir = temp_dir("torn");
+        let (_dir, dir) = temp_dir("torn");
         append_to_dir(&dir, "t1", &header("t1", 1)).unwrap();
         // Simulate a crash mid-append: a partial trailing line.
         let path = dir.join("t1.jsonl");
@@ -892,6 +890,5 @@ mod tests {
         let events = read_events(&path);
         assert_eq!(events.len(), 1); // header survived, torn line dropped
         assert!(fold(&events).is_some());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/features/help/HelpScreen.tsx
+++ b/src/features/help/HelpScreen.tsx
@@ -4,7 +4,7 @@ import { NavRail } from "@/components/NavRail";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { formatBinding } from "@/lib/hotkeys/binding";
+import { formatBinding, secondaryClickLabel } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import { ACTIONS, type ActionId } from "@/lib/hotkeys/registry";
 import { useAiEnabled } from "@/lib/settings/queries";
@@ -14,6 +14,9 @@ import { GUIDE_SECTIONS } from "./content";
 const BINDING_TOKEN = /\{\{(kbd|key):([a-z0-9+-]+)\}\}/g;
 const AI_BLOCK = /\{\{ai\}\}[\s\S]*?\{\{\/ai\}\}/g;
 const AI_MARKER = /\{\{\/?ai\}\}/g;
+// {{secondaryclick}} → the platform's word for a context-menu click; the capital
+// form {{Secondaryclick}} is sentence-initial and gets its first letter uppercased.
+const SECONDARY_CLICK_TOKEN = /\{\{(s|S)econdaryclick\}\}/g;
 
 // Actions that are palette-only by design (`defaultBinding: null`), so an unset
 // binding reads as "palette" — the chip idiom — rather than "unbound" (which
@@ -36,7 +39,15 @@ function resolveBody(
   const gated = aiEnabled
     ? md.replace(AI_MARKER, "")
     : md.replace(AI_BLOCK, "");
-  return gated.replace(BINDING_TOKEN, (_match, kind, ref) => {
+  const withSecondary = gated.replace(
+    SECONDARY_CLICK_TOKEN,
+    (_match, initial) =>
+      initial === "S"
+        ? secondaryClickLabel.charAt(0).toUpperCase() +
+          secondaryClickLabel.slice(1)
+        : secondaryClickLabel,
+  );
+  return withSecondary.replace(BINDING_TOKEN, (_match, kind, ref) => {
     if (kind === "key") return formatBinding(ref);
     const binding = bindings.get(ref as ActionId);
     if (binding) return formatBinding(binding);

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -255,7 +255,7 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   Discard buttons.
 - **Line-level staging** — drag across the line-number gutter to select specific lines,
   then stage or discard just those.
-- Select multiple files ({{key:mod}}-click, or Shift-click for a range), then right-click
+- Select multiple files ({{key:mod}}-click, or Shift-click for a range), then {{secondaryclick}}
   for **Stage / Unstage / Discard / Stash** of the whole selection.
 - Filter the list by path, or by category (new / modified / deleted, included /
   excluded) with the funnel button.
@@ -295,7 +295,7 @@ selection to compare a range.
 
 ## Commit actions
 
-Right-click a commit (or use the commit detail view) for:
+{{Secondaryclick}} a commit (or use the commit detail view) for:
 
 - **Amend** the most recent commit (reword, or fold in staged changes).
 - **Revert** — create a new commit that undoes a commit's changes.
@@ -330,7 +330,7 @@ push hint instead, and a local-only repo shows no comment pane at all.
   keyboard-focus) a line's commit in the gutter to preview it; click or press
   Enter to jump straight to that commit in **History**.
 
-Right-click any file row to reach both: in the **Changes** list, in a commit's file
+{{Secondaryclick}} any file row to reach both: in the **Changes** list, in a commit's file
 list (in **History**, or a PR's **Commits** tab), in a PR's **Files** tab, or in a
 **Compare** / local-PR file list. On those historical surfaces **Blame** is pinned at
 that commit or branch — you see the file *as of* that revision, not your working copy.
@@ -371,7 +371,7 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   or renaming one.
 {{/ai}}- Switching with **uncommitted changes** prompts you to bring them along or stash
   and switch.
-- Right-click a branch to **merge**, **squash and merge**, **rebase**, or **update it
+- {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it
   from the default branch** ({{kbd:update-from-default}}) — the last *without* checking it
   out.
 - **Change base…** — from the switcher's menu or the command palette — rebases the current
@@ -380,13 +380,13 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   commits move — the wrong base's commits are left behind. A preview lists exactly which
   commits will move before you run it, and any conflicts drop into the resolve flow below.
 - **Update a branch from its own upstream** without switching to it: when a branch is
-  behind the remote it tracks, its right-click menu offers **Update from _origin/…_**. This
+  behind the remote it tracks, its context menu offers **Update from _origin/…_**. This
   is the "just merged a PR — bring the default branch current before I switch back" flow;
   every branch's row shows its own push/pull state (↑/↓ vs. its upstream) after a fetch, so
   the branches with commits to pull are visible at a glance, and *Update default branch from
   its remote* is available from the command palette too.
 - **Push a branch without switching to it** — the outbound counterpart: a branch ahead
-  of the remote it tracks offers **Push to _its remote/…_** in its right-click menu — so a
+  of the remote it tracks offers **Push to _its remote/…_** in its context menu — so a
   branch tracking a fork's _upstream_ is pushed there, not to origin. An unpushed or
   upstream-deleted branch offers **Publish**; on a repo with several remotes you pick the
   destination (one **Publish to _…_** item per remote). Neither checks the branch out or
@@ -395,9 +395,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   with the **branches** list open it targets the **highlighted** branch, otherwise the
   **current** one, and pushes or publishes it to origin. A branch that tracks a different
   remote, has diverged, or has nothing to push says so in a short message — for those, use
-  the branch's right-click menu.
+  the branch's context menu.
 - The **Remote** section lists branches on your remotes you haven't checked out locally
-  yet — click one to check it out (creating a local tracking branch), or right-click to
+  yet — click one to check it out (creating a local tracking branch), or {{secondaryclick}} to
   **Delete on _origin_…**, a server-side delete that removes the branch from the remote for
   everyone (protected names are blocked, and it can't be undone from the app).
 - The **Merge** dialog previews the result before you commit to it — *fast-forward*, *clean
@@ -477,7 +477,7 @@ A branch can only be checked out in one worktree at a time, so the list excludes
 already in use. The **branch switcher** knows this too: a branch that's checked out in
 another worktree is badged, and choosing it offers to open that worktree instead of failing
 with a checkout error. You can also **Remove worktree…** straight from that badged branch's
-right-click menu — the branch stays, and its **Delete…** item un-disables once the worktree
+context menu — the branch stays, and its **Delete…** item un-disables once the worktree
 is gone. When you're in a linked worktree the switcher reminds you that a branch checkout
 lands *there* (not the main workspace) and offers a one-click **Open main workspace**, and its
 **Worktrees** section jumps you straight to any other worktree — no detour through a
@@ -543,7 +543,7 @@ stays disabled until every conflict is resolved.
 {{ai}}## Resolve conflicts with AI
 
 Select a conflicted file and click **Resolve with AI** in the conflict editor's header (also
-on the file's right-click menu, and via the command palette ({{kbd:command-palette}})). Your configured
+on the file's context menu, and via the command palette ({{kbd:command-palette}})). Your configured
 **Review** model (Settings → AI) merges the file's sides and streams a proposal; you review
 it as a diff against your side, flip to the proposed file or the *ours* / *theirs* / *base*
 versions, then **Accept & stage** to apply it — nothing is written until you accept.
@@ -795,7 +795,7 @@ conflicts*); once every conflict is resolved, **Finish merge** commits and marks
 merged, or **Abort** throws the merge away.
 
 **Managing the record** lives on the PR's list row, not the merge footer (which is just
-the merge decision): **right-click** a local PR to **Archive / Unarchive** it (archiving
+the merge decision): **{{Secondaryclick}}** a local PR to **Archive / Unarchive** it (archiving
 hides it and deselects the detail view) or **Delete** it — Delete confirms first and
 tells you how many comments go with it; the branches themselves are never touched. Both
 are also in the command palette ({{kbd:command-palette}}) as **Archive pull request** and
@@ -1217,7 +1217,7 @@ The **sidebar** lists your research, plans, and sessions. Each carries a stable 
 identifier, so an entry can point at what it became — a research run shows the **plan** it
 turned into (*Turned into plan #12*), and a plan shows the **session** that implemented it
 (*Implemented · Ready to review #10*). Each row also shows its **provider · model**;
-**right-click** for a row's actions — a plan's include opening its **session** or filing it as
+**{{Secondaryclick}}** for a row's actions — a plan's include opening its **session** or filing it as
 a **local issue**. The **step-by-step activity log** of each entry is kept across restarts.
 
 ## Research a topic (read-only)
@@ -1490,7 +1490,7 @@ notes**, and **repository descriptions**.
   takes precedence.
 - **AI-ignore patterns** keep sensitive or noisy files (lockfiles, vendored folders) out
   of the AI's context while still committing them normally — global in Settings, or
-  per-repo via \`.gitdesktop/aiignore\`. No need to hand-edit it: right-click a changed
+  per-repo via \`.gitdesktop/aiignore\`. No need to hand-edit it: {{secondaryclick}} a changed
   file → *Exclude from AI* (the file, its folder, or its file type — or a
   multi-selection) appends to \`.gitdesktop/aiignore\`, creating it if needed.
 - **Hide AI** (Settings → General) removes every AI surface from the app while keeping

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -114,8 +114,9 @@ function jobForCheck(
 ): RunJob | undefined {
   if (!jobs) return undefined;
   if (check.jobId) {
-    const id = Number(check.jobId);
-    const byId = jobs.find((j) => j.id === id);
+    // Compare as strings: `check.jobId` is a string (ids can exceed 2^53) while
+    // RunJob.id is still numeric — stringify the numeric side to match.
+    const byId = jobs.find((j) => String(j.id) === check.jobId);
     if (byId) return byId;
   }
   return jobs.find((j) => j.name === check.name);
@@ -160,16 +161,13 @@ function CheckLogTail({
   repoPath: string;
   check: PrCheckOut;
 }) {
-  // A job id gets the per-job log; a run without a parsed job id falls back to
-  // the run-wide failed-step logs (same as the Actions panel's failed-logs view).
-  // NOTE: run/job ids are kept as *strings* on PrCheckOut (they can exceed JS's
-  // safe-integer range), but the shared Actions log hooks (useJobLogs/
-  // useRunFailedLogs → forge_ci_*_logs) still take numeric ids, so we narrow here.
-  // Safe today — real GitHub/GitLab ids are ~1e10, far below 2^53 — but a
-  // follow-up should thread these as strings end-to-end through the Actions log
-  // path (commands + Actions panel + MCP callers) to make it precision-safe.
-  const jobId = check.jobId ? Number(check.jobId) : null;
-  const runId = check.runId ? Number(check.runId) : null;
+  // A job id gets the per-job log; a run without a job id falls back to the
+  // run-wide failed-step logs (same as the Actions panel's failed-logs view).
+  // Ids stay *strings* the whole way — they can exceed JS's safe-integer range,
+  // so the Actions log path (hooks → forge_ci_*_logs commands) threads them as
+  // strings end-to-end rather than narrowing through Number().
+  const jobId = check.jobId || null;
+  const runId = check.runId || null;
   const jobLogs = useJobLogs(
     repoPath,
     jobId !== null ? { id: jobId } : null,
@@ -408,7 +406,7 @@ function RunDetailFetcher({
   /** The parent's `setJobsByRun` state updater (stable across renders). */
   setJobs: Dispatch<SetStateAction<Record<string, RunJob[]>>>;
 }) {
-  const detail = useRunDetail(repoPath, Number(runId), true);
+  const detail = useRunDetail(repoPath, runId, true);
   const jobs = detail.data?.jobs;
   useEffect(() => {
     if (jobs) setJobs((prev) => ({ ...prev, [runId]: jobs }));

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/lib/git/queries";
 import type { Branch, RemoteBranch } from "@/lib/git/types";
 import { listUserWorktrees, type UserWorktree } from "@/lib/git/worktree";
+import { secondaryClickLabel } from "@/lib/hotkeys/binding";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useLocalPrs } from "@/lib/pulls/queries";
@@ -90,6 +91,11 @@ const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 /** Last path segment (folder name), tolerating either separator. */
 const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
+
+/** Sentence-initial form of the platform's secondary-click word — for
+ *  status-icon hints where the phrase leads a sentence. */
+const secondaryClickCapitalized =
+  secondaryClickLabel.charAt(0).toUpperCase() + secondaryClickLabel.slice(1);
 
 type PrState = "open" | "draft" | "merged" | "closed";
 
@@ -1126,7 +1132,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       );
                     }
                     if (branch.upstreamGone) {
-                      const label = `Upstream ${branch.upstream} was deleted on the remote — likely merged. Right-click to publish again or delete.`;
+                      const label = `Upstream ${branch.upstream} was deleted on the remote — likely merged. ${secondaryClickCapitalized} to publish again or delete.`;
                       return (
                         <span
                           role="img"
@@ -1139,12 +1145,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       );
                     }
                     // !branch.upstream
+                    const publishHint = `Local only — never published. ${secondaryClickCapitalized} to publish.`;
                     return (
                       <span
                         role="img"
-                        aria-label="Local only — never published. Right-click to publish."
+                        aria-label={publishHint}
                         className="flex shrink-0 items-center text-muted-foreground"
-                        title="Local only — never published. Right-click to publish."
+                        title={publishHint}
                       >
                         <CloudSlashIcon className="size-3" />
                       </span>

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -64,6 +64,23 @@ function unstagePaths(entry: FileEntry): string[] {
   return entry.origPath ? [entry.path, entry.origPath] : [entry.path];
 }
 
+/**
+ * Toast copy for a bulk ignore / AI-exclude of `total` selected entries, where
+ * `added` came back from the Rust command as the count actually appended
+ * (already-present ones are skipped). Reports the honest end state: nothing new
+ * when everything was already covered, a partial when some were skipped.
+ */
+function ignoreToast(added: number, total: number, file: string): string {
+  const entries = (n: number) => `entr${n === 1 ? "y" : "ies"}`;
+  if (added === 0)
+    return total === 1
+      ? `Entry already in ${file}`
+      : `All ${total} ${entries(total)} already in ${file}`;
+  if (added < total)
+    return `Added ${added} of ${total} ${entries(total)} to ${file}`;
+  return `Added ${added} ${entries(added)} to ${file}`;
+}
+
 type FilterKind = "included" | "excluded" | "new" | "modified" | "deleted";
 
 function hasKind(entry: FileEntry, kinds: ChangeKind[]): boolean {
@@ -396,14 +413,23 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   // ignoreSelected / untrackSelected below.
   function ignoreOne(pattern: string) {
     appendIgnore.mutate([pattern], {
-      onSuccess: () => toast.success(`Added "${pattern}" to .gitignore`),
+      onSuccess: (added) =>
+        toast.success(
+          added === 0
+            ? `"${pattern}" is already in .gitignore`
+            : `Added "${pattern}" to .gitignore`,
+        ),
       onError,
     });
   }
   function aiExcludeOne(pattern: string) {
     appendAiIgnore.mutate([pattern], {
-      onSuccess: () =>
-        toast.success(`Added "${pattern}" to .gitdesktop/aiignore`),
+      onSuccess: (added) =>
+        toast.success(
+          added === 0
+            ? `"${pattern}" is already in .gitdesktop/aiignore`
+            : `Added "${pattern}" to .gitdesktop/aiignore`,
+        ),
       onError,
     });
   }
@@ -483,8 +509,8 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     if (selectionCount === 0) return;
     const patterns = selectedEntries.map((e) => `/${e.path}`);
     appendIgnore.mutate(patterns, {
-      onSuccess: () => {
-        toast.success(`Added ${patterns.length} entries to .gitignore`);
+      onSuccess: (added) => {
+        toast.success(ignoreToast(added, patterns.length, ".gitignore"));
         setSelectedKeys(new Set());
       },
       onError,
@@ -497,9 +523,9 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     if (selectionCount === 0) return;
     const patterns = selectedEntries.map((e) => e.path);
     appendAiIgnore.mutate(patterns, {
-      onSuccess: () => {
+      onSuccess: (added) => {
         toast.success(
-          `Added ${patterns.length} entries to .gitdesktop/aiignore`,
+          ignoreToast(added, patterns.length, ".gitdesktop/aiignore"),
         );
         setSelectedKeys(new Set());
       },

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -584,8 +584,11 @@ export const ghReleaseDownloadAsset = (
 ) =>
   invoke<void>("gh_release_download_asset", { repoPath, tag, assetName, dir });
 
+/** Appends ignore patterns to the repo root `.gitignore` (created if absent),
+ *  returning the number of patterns actually appended (already-present ones are
+ *  skipped). */
 export const appendToGitignore = (repoPath: string, patterns: string[]) =>
-  invoke<void>("append_to_gitignore", { repoPath, patterns });
+  invoke<number>("append_to_gitignore", { repoPath, patterns });
 
 export const gitUntrack = (
   repoPath: string,
@@ -2923,9 +2926,11 @@ export const readRepoInstructions = (repoPath: string) =>
 export const readRepoAiIgnore = (repoPath: string) =>
   invoke<string[]>("read_repo_ai_ignore", { repoPath });
 
-/** Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore` (created if absent). */
+/** Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore` (created if
+ *  absent), returning the number of patterns actually appended (already-present
+ *  ones are skipped). */
 export const appendRepoAiIgnore = (repoPath: string, patterns: string[]) =>
-  invoke<void>("append_repo_ai_ignore", { repoPath, patterns });
+  invoke<number>("append_repo_ai_ignore", { repoPath, patterns });
 
 /** Raw contents of `<repo>/.gitdesktop/branch-rules.json`, or null if absent. */
 export const readRepoBranchRules = (repoPath: string) =>

--- a/src/lib/github/actions.ts
+++ b/src/lib/github/actions.ts
@@ -101,8 +101,8 @@ export const forgeCiRunList = (
     branch: branch?.trim() || null,
   });
 
-export const forgeCiRunView = (repoPath: string, runId: number) =>
-  invoke<RunDetail>("forge_ci_run_view", { repoPath, runId });
+export const forgeCiRunView = (repoPath: string, runId: number | string) =>
+  invoke<RunDetail>("forge_ci_run_view", { repoPath, runId: String(runId) });
 
 export const forgeCiRunRerun = (
   repoPath: string,
@@ -113,12 +113,18 @@ export const forgeCiRunRerun = (
 export const forgeCiRunCancel = (repoPath: string, runId: number) =>
   invoke<void>("forge_ci_run_cancel", { repoPath, runId });
 
-export const forgeCiRunFailedLogs = (repoPath: string, runId: number) =>
-  invoke<string>("forge_ci_run_failed_logs", { repoPath, runId });
+export const forgeCiRunFailedLogs = (
+  repoPath: string,
+  runId: number | string,
+) =>
+  invoke<string>("forge_ci_run_failed_logs", {
+    repoPath,
+    runId: String(runId),
+  });
 
 /** One job's failed-step logs (fallback: full job log), for AI debugging. */
-export const forgeCiJobLogs = (repoPath: string, jobId: number) =>
-  invoke<string>("forge_ci_job_logs", { repoPath, jobId });
+export const forgeCiJobLogs = (repoPath: string, jobId: number | string) =>
+  invoke<string>("forge_ci_job_logs", { repoPath, jobId: String(jobId) });
 
 /** A Bitbucket pipeline step's logs (cleaned/capped). Bitbucket jobs carry a
  *  `logRef` instead of a numeric job id, and `forge_ci_job_logs` errors for
@@ -131,7 +137,7 @@ export const forgeBbStepLogs = (repoPath: string, logRef: string) =>
  *  `forge_ci_job_logs`. */
 export const forgeJobLogs = (
   repoPath: string,
-  job: { id: number; logRef?: string },
+  job: { id: number | string; logRef?: string },
 ) =>
   job.logRef
     ? forgeBbStepLogs(repoPath, job.logRef)
@@ -186,11 +192,13 @@ export function useWorkflowRuns(
 
 export function useRunDetail(
   repo: string,
-  runId: number | null,
+  runId: number | string | null,
   active: boolean,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "actions", "run", runId ?? 0] as const,
+    // Normalize the id to a string in the key so number- and string-callers for
+    // the same run share one cache entry.
+    queryKey: ["repo", repo, "actions", "run", String(runId ?? 0)] as const,
     queryFn: () => forgeCiRunView(repo, runId ?? 0),
     enabled: runId !== null && active,
     refetchInterval: (query) =>
@@ -243,11 +251,19 @@ export function useBbCustomPipelines(repo: string, enabled: boolean) {
 /** Failed-step logs, fetched only when the user expands them. */
 export function useRunFailedLogs(
   repo: string,
-  runId: number | null,
+  runId: number | string | null,
   enabled: boolean,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "actions", "run", runId ?? 0, "logs"] as const,
+    // Normalize the id to a string in the key (see useRunDetail).
+    queryKey: [
+      "repo",
+      repo,
+      "actions",
+      "run",
+      String(runId ?? 0),
+      "logs",
+    ] as const,
     queryFn: () => forgeCiRunFailedLogs(repo, runId ?? 0),
     enabled: enabled && runId !== null,
     staleTime: 30_000,
@@ -260,7 +276,7 @@ export function useRunFailedLogs(
  *  The query key stays distinct per job either way. */
 export function useJobLogs(
   repo: string,
-  job: { id: number; logRef?: string } | null,
+  job: { id: number | string; logRef?: string } | null,
   enabled: boolean,
 ) {
   // Bitbucket steps are keyed by logRef (their numeric id can collide across a

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -22,6 +22,16 @@ export const isWindows =
   typeof navigator !== "undefined" && /win/i.test(navigator.platform);
 
 /**
+ * The word for the secondary (context-menu) click, derived from the platform.
+ * "right-click" is wrong for swapped-button (left-handed) mice, Mac trackpads,
+ * and touch, so — like the mod key — the phrase can't be hardcoded. Context
+ * menus themselves key off the `contextmenu` event and work for everyone; only
+ * the label needs to follow the platform. The macOS value is already
+ * capitalized, so uppercasing this value's first letter is idempotent there.
+ */
+export const secondaryClickLabel = isMac ? "Control-click" : "right-click";
+
+/**
  * The canonical binding a keyboard event represents, or null when the event
  * is a bare modifier or carries no usable key.
  */


### PR DESCRIPTION
This change fixes several user-visible correctness issues while making test fixtures safer to clean up. CI identifiers now remain precise across the Rust–JavaScript boundary, ignore operations report the number of patterns actually added, and platform-specific context-menu guidance uses the appropriate secondary-click wording.

### CI and MCP identifiers

- Changes CI run and job command parameters in `src-tauri/src/forge/mod.rs` to accept string IDs, parse them at the provider boundary, and return clear invalid-argument errors.
- Preserves numeric-string compatibility in `src-tauri/src/mcp_server/mod.rs`, `src-tauri/src/mcp_server/read_forge.rs`, and `src-tauri/src/mcp_server/write_forge.rs` so IDs above JavaScript’s safe-integer limit are not rounded.
- Threads string IDs through `src/lib/github/actions.ts` and `src/lib/git/api.ts` for CI run and job lookups.

### Ignore counts and user feedback

- Updates `src-tauri/src/fsops.rs::append_to_gitignore` to return the number of newly appended patterns, including zero for duplicates or empty input.
- Updates `src-tauri/src/instructions.rs::append_repo_ai_ignore` with the same count-returning behavior.
- Uses the returned counts in `src/features/repository/ChangesPanel.tsx` so ignore and AI-exclude toasts describe actual additions rather than the selection size.
- Adds coverage for full, partial, and zero-addition cases in `src-tauri/src/fsops.rs` and `src-tauri/src/instructions.rs`.

### Platform-specific UI copy

- Adds `secondaryClickLabel` in `src/lib/hotkeys/binding.ts` to distinguish macOS “Control-click” from “right-click” on other platforms.
- Updates context-menu guidance in `src/features/help/HelpScreen.tsx`, `src/features/help/content.ts`, `src/features/repository/BranchSwitcher.tsx`, and `src/features/pulls/ChecksRollup.tsx` to use platform-appropriate or platform-neutral wording.

### Test fixture cleanup

- Adds `tempfile` as a development dependency in `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock`.
- Replaces manually generated temporary paths and explicit cleanup with RAII `TempDir` fixtures across `src-tauri/src/git/`, `src-tauri/src/app_store.rs`, `src-tauri/src/automation_claims.rs`, `src-tauri/src/jira_field_maps.rs`, `src-tauri/src/jira_links.rs`, `src-tauri/src/local_issues.rs`, `src-tauri/src/local_prs.rs`, `src-tauri/src/mcp.rs`, and `src-tauri/src/mcp_launcher.rs`.
- Updates affected test helpers and path handling in `src-tauri/src/git/ops.rs`, `src-tauri/src/git/compare.rs`, `src-tauri/src/git/conflict.rs`, `src-tauri/src/git/history.rs`, `src-tauri/src/git/remote.rs`, `src-tauri/src/git/todos.rs`, and `src-tauri/src/git/worktree.rs` so fixtures are removed automatically on drop.

### Changelog

- Documents string-preserved CI IDs in `changelog.d/changed-actions-log-string-ids.md`.
- Documents accurate ignore-toast counts in `changelog.d/fixed-ignore-toast-count.md`.
- Documents platform-aware secondary-click copy in `changelog.d/fixed-secondary-click-copy.md`.