### PR TITLE
feat(settings,theme,hotkeys): add selectable application themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **Keyboard-first** — rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (Ctrl+/), a command palette (Ctrl+K), and
   arrow-key navigation everywhere.
+- **Themes** — System, Light, Dark, and a softer **Dark Dimmed** that lifts
+  surfaces off pure black and text off pure white to ease eye strain; switch in
+  **Settings → Appearance** or cycle from the command palette.
 - **Self-updating** — signed, verified auto-updates from GitHub Releases, checked at
   launch and periodically in the background, with a persistent in-app indicator when
   one is ready — always installed on your consent.

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **Keyboard-first** — rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (Ctrl+/), a command palette (Ctrl+K), and
   arrow-key navigation everywhere.
-- **Themes** — System, Light, Dark, and a softer **Dark Dimmed** that lifts
-  surfaces off pure black and text off pure white to ease eye strain; switch in
-  **Settings → Appearance** or cycle from the command palette.
+- **Themes** — System, Light, Dark, and a softer **Slate** (a cool, lifted
+  blue-gray) that eases eye strain; switch in **Settings → Appearance** or cycle
+  from the command palette.
 - **Self-updating** — signed, verified auto-updates from GitHub Releases, checked at
   launch and periodically in the background, with a persistent in-app indicator when
   one is ready — always installed on your consent.

--- a/changelog.d/added-theme-picker.md
+++ b/changelog.d/added-theme-picker.md
@@ -1,4 +1,4 @@
 - **Themes.** Choose how GitDesktop looks in **Settings → Appearance**: **System**
-  (follow your OS), **Light**, **Dark**, or a softer **Dark Dimmed** that lifts
-  surfaces off pure black and text off pure white to ease eye strain on long
-  sessions. Cycle themes from the command palette too.
+  (follow your OS), **Light**, **Dark**, or a softer **Slate** — a cool, lifted
+  blue-gray that eases eye strain on long sessions. Cycle themes from the command
+  palette too.

--- a/changelog.d/added-theme-picker.md
+++ b/changelog.d/added-theme-picker.md
@@ -1,0 +1,4 @@
+- **Themes.** Choose how GitDesktop looks in **Settings → Appearance**: **System**
+  (follow your OS), **Light**, **Dark**, or a softer **Dark Dimmed** that lifts
+  surfaces off pure black and text off pure white to ease eye strain on long
+  sessions. Cycle themes from the command palette too.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -309,7 +309,7 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
-    label: "Themes — System, Light, Dark & a softer Dark Dimmed",
+    label: "Themes — System, Light, Dark & a softer Slate",
   },
 
   // — Admin & settings —

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -307,6 +307,10 @@ export const capabilities: Capability[] = [
     group: "Repository & workspace",
     label: "Remembers window size & position",
   },
+  {
+    group: "Repository & workspace",
+    label: "Themes — System, Light, Dark & a softer Dark Dimmed",
+  },
 
   // — Admin & settings —
   { group: "Admin & settings", label: "Repo settings & webhooks (admin)" },

--- a/src/App.css
+++ b/src/App.css
@@ -139,6 +139,31 @@
   --sidebar-ring: oklch(0.82 0.11 175);
 }
 
+/* "Dark Dimmed" — a softer dark variant (Settings → Appearance). It lifts the
+   surfaces off pure black and pulls body text off pure white to cut the
+   halation / eye-strain of the maximum-contrast default (foreground↔background
+   drops from ~19:1 to ~14:1), following Material + GitHub Primer guidance. It
+   overrides ONLY the neutral ramp — the mint brand accent, semantic state
+   colors, borders, and charts all inherit from `.dark`. Applied as `.dark.dimmed`
+   so every `.dark`-keyed style (shiki, recharts, the diff viewer, and `dark:`
+   utilities) keeps working; the `.dimmed` class is only ever set alongside
+   `.dark` (see theme.ts). */
+.dark.dimmed {
+  --background: oklch(0.17 0 0);
+  --foreground: oklch(0.9 0 0);
+  --card: oklch(0.235 0 0);
+  --card-foreground: oklch(0.9 0 0);
+  --popover: oklch(0.235 0 0);
+  --popover-foreground: oklch(0.9 0 0);
+  --secondary: oklch(0.285 0 0);
+  --secondary-foreground: oklch(0.9 0 0);
+  --muted: oklch(0.285 0 0);
+  --accent-foreground: oklch(0.9 0 0);
+  --sidebar: oklch(0.235 0 0);
+  --sidebar-foreground: oklch(0.9 0 0);
+  --sidebar-accent-foreground: oklch(0.9 0 0);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/App.css
+++ b/src/App.css
@@ -57,6 +57,10 @@
 }
 
 :root {
+  /* Native controls (scrollbars, form fields, the webview's default canvas)
+     follow `color-scheme`, so driving it from the theme class — not the OS —
+     keeps them in sync when the user forces a theme against their OS setting. */
+  color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -100,6 +104,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/App.css
+++ b/src/App.css
@@ -139,29 +139,47 @@
   --sidebar-ring: oklch(0.82 0.11 175);
 }
 
-/* "Dark Dimmed" — a softer dark variant (Settings → Appearance). It lifts the
-   surfaces off pure black and pulls body text off pure white to cut the
-   halation / eye-strain of the maximum-contrast default (foreground↔background
-   drops from ~19:1 to ~14:1), following Material + GitHub Primer guidance. It
-   overrides ONLY the neutral ramp — the mint brand accent, semantic state
-   colors, borders, and charts all inherit from `.dark`. Applied as `.dark.dimmed`
-   so every `.dark`-keyed style (shiki, recharts, the diff viewer, and `dark:`
-   utilities) keeps working; the `.dimmed` class is only ever set alongside
-   `.dark` (see theme.ts). */
-.dark.dimmed {
-  --background: oklch(0.17 0 0);
-  --foreground: oklch(0.9 0 0);
-  --card: oklch(0.235 0 0);
-  --card-foreground: oklch(0.9 0 0);
-  --popover: oklch(0.235 0 0);
-  --popover-foreground: oklch(0.9 0 0);
-  --secondary: oklch(0.285 0 0);
-  --secondary-foreground: oklch(0.9 0 0);
-  --muted: oklch(0.285 0 0);
-  --accent-foreground: oklch(0.9 0 0);
-  --sidebar: oklch(0.235 0 0);
-  --sidebar-foreground: oklch(0.9 0 0);
-  --sidebar-accent-foreground: oklch(0.9 0 0);
+/* "Slate" — a softer dark theme (Settings → Appearance) in the style of GitHub's
+   "Dark dimmed": a lifted, cool blue-gray canvas (hue ~257 — a NEUTRAL cool,
+   deliberately NOT the mint brand hue, so the chrome never reads as tinted toward
+   the brand) with cool off-white ink, plus accent colors desaturated so bright
+   status badges stop vibrating on the softer field. Foreground↔background lands
+   at ~11:1 (vs the default Dark's ~19:1), inside the dark-mode comfort band.
+   Applied as `.dark.slate` so every `.dark`-keyed style (shiki, recharts, the
+   diff viewer, and `dark:` utilities) keeps working; `.slate` is only ever set
+   alongside `.dark` (see theme.ts). Surface values are the resolved OKLCH of
+   #1c2128 / #22272e / #2d333b / #d1d7e0. */
+.dark.slate {
+  /* Cool, lifted neutral ramp (bg → card → muted). */
+  --background: oklch(0.245 0.015 257);
+  --card: oklch(0.285 0.015 257);
+  --popover: oklch(0.285 0.015 257);
+  --secondary: oklch(0.33 0.016 257);
+  --muted: oklch(0.33 0.016 257);
+  --sidebar: oklch(0.285 0.015 257);
+  /* Cool off-white ink + a legible cool-gray for secondary text. */
+  --foreground: oklch(0.877 0.014 258);
+  --card-foreground: oklch(0.877 0.014 258);
+  --popover-foreground: oklch(0.877 0.014 258);
+  --secondary-foreground: oklch(0.877 0.014 258);
+  --muted-foreground: oklch(0.69 0.02 255);
+  --sidebar-foreground: oklch(0.877 0.014 258);
+  --accent-foreground: oklch(0.877 0.014 258);
+  --sidebar-accent-foreground: oklch(0.877 0.014 258);
+  /* Selection / hover surfaces pick up the same cool tint. */
+  --accent: oklch(0.34 0.025 255);
+  --sidebar-accent: oklch(0.34 0.025 255);
+  /* Brand mint + focus ring, gently desaturated for the softer field. */
+  --primary: oklch(0.8 0.095 175);
+  --sidebar-primary: oklch(0.8 0.095 175);
+  --ring: oklch(0.8 0.095 175);
+  --sidebar-ring: oklch(0.8 0.095 175);
+  /* Semantic state colors, desaturated so they don't glow on the lighter field. */
+  --success: oklch(0.78 0.13 150);
+  --warning: oklch(0.8 0.12 75);
+  --info: oklch(0.72 0.115 250);
+  --merged: oklch(0.74 0.125 305);
+  --destructive: oklch(0.7 0.155 22);
 }
 
 @layer base {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { reloadReviewNotes } from "@/lib/review-notes/store";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { COLD_START } from "@/lib/test-mode";
+import { commitTheme, nextTheme, THEME_LABELS } from "@/lib/theme";
 import { useLatestRef } from "@/lib/use-latest-ref";
 
 function App() {
@@ -131,6 +132,16 @@ function App() {
   useHotkeyAction("toggle-notifications", toggleActivity);
   useHotkeyAction("show-shortcuts", () => setShortcutsOpen(true));
   useHotkeyAction("command-palette", () => setPaletteOpen(true));
+  useHotkeyAction("cycle-theme", () => {
+    const current = settingsRef.current;
+    if (!current) return;
+    // Step System → Light → Dark → Dark Dimmed. Apply-on-change like the picker:
+    // persist + toggle the class immediately (appearance prefs have no Save bar).
+    const next = nextTheme(current.theme);
+    saveSettings.mutate({ ...current, theme: next });
+    commitTheme(next);
+    toast.success(`Theme: ${THEME_LABELS[next]}`);
+  });
 
   // The webview stays "visible" when the window loses focus, so TanStack's
   // own focus refetch never fires in Tauri; bridge the native focus event.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,10 +23,14 @@ import { useGitInstalled } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { reloadLocalPrs } from "@/lib/pulls/local";
 import { reloadReviewNotes } from "@/lib/review-notes/store";
-import { useSaveSettings, useSettings } from "@/lib/settings/queries";
+import {
+  useApplyTheme,
+  useSaveSettings,
+  useSettings,
+} from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { COLD_START } from "@/lib/test-mode";
-import { commitTheme, nextTheme, THEME_LABELS } from "@/lib/theme";
+import { nextTheme, THEME_LABELS } from "@/lib/theme";
 import { useLatestRef } from "@/lib/use-latest-ref";
 
 function App() {
@@ -39,6 +43,7 @@ function App() {
   const queryClient = useQueryClient();
   const settings = useSettings();
   const saveSettings = useSaveSettings();
+  const applyTheme = useApplyTheme();
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
 
@@ -135,11 +140,10 @@ function App() {
   useHotkeyAction("cycle-theme", () => {
     const current = settingsRef.current;
     if (!current) return;
-    // Step System → Light → Dark → Slate. Apply-on-change like the picker:
-    // persist + toggle the class immediately (appearance prefs have no Save bar).
+    // Step System → Light → Dark → Slate. Shares useApplyTheme with the
+    // Appearance picker so both paths apply optimistically + persist identically.
     const next = nextTheme(current.theme);
-    saveSettings.mutate({ ...current, theme: next });
-    commitTheme(next);
+    applyTheme(current, next);
     toast.success(`Theme: ${THEME_LABELS[next]}`);
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,7 @@ function App() {
   useHotkeyAction("cycle-theme", () => {
     const current = settingsRef.current;
     if (!current) return;
-    // Step System → Light → Dark → Dark Dimmed. Apply-on-change like the picker:
+    // Step System → Light → Dark → Slate. Apply-on-change like the picker:
     // persist + toggle the class immediately (appearance prefs have no Save bar).
     const next = nextTheme(current.theme);
     saveSettings.mutate({ ...current, theme: next });

--- a/src/features/diff/code-highlight.css
+++ b/src/features/diff/code-highlight.css
@@ -1,6 +1,8 @@
 /* highlight.js token colors for read-only full-file code views (blame, the AI
    conflict-resolution side panes), scoped to .gd-code so they don't leak.
-   GitHub-ish palette; dark variant via the app's OS theme. */
+   GitHub-ish palette; the dark variant keys on the `.dark` class (set from the
+   resolved theme in theme.ts), so it follows a manual Light/Dark override — not
+   just the OS `prefers-color-scheme`. */
 .gd-code .hljs-comment,
 .gd-code .hljs-quote {
   color: #6e7781;
@@ -49,51 +51,49 @@
   color: #6e7781;
 }
 
-@media (prefers-color-scheme: dark) {
-  .gd-code .hljs-comment,
-  .gd-code .hljs-quote {
-    color: #8b949e;
-  }
-  .gd-code .hljs-keyword,
-  .gd-code .hljs-selector-tag,
-  .gd-code .hljs-doctag,
-  .gd-code .hljs-meta .hljs-keyword {
-    color: #ff7b72;
-  }
-  .gd-code .hljs-string,
-  .gd-code .hljs-regexp,
-  .gd-code .hljs-meta .hljs-string {
-    color: #a5d6ff;
-  }
-  .gd-code .hljs-number,
-  .gd-code .hljs-literal {
-    color: #79c0ff;
-  }
-  .gd-code .hljs-title,
-  .gd-code .hljs-title.function_,
-  .gd-code .hljs-section,
-  .gd-code .hljs-built_in {
-    color: #d2a8ff;
-  }
-  .gd-code .hljs-type,
-  .gd-code .hljs-class .hljs-title,
-  .gd-code .hljs-title.class_ {
-    color: #ffa657;
-  }
-  .gd-code .hljs-attr,
-  .gd-code .hljs-attribute,
-  .gd-code .hljs-property,
-  .gd-code .hljs-variable,
-  .gd-code .hljs-template-variable {
-    color: #79c0ff;
-  }
-  .gd-code .hljs-tag,
-  .gd-code .hljs-name,
-  .gd-code .hljs-symbol,
-  .gd-code .hljs-bullet {
-    color: #7ee787;
-  }
-  .gd-code .hljs-meta {
-    color: #8b949e;
-  }
+.dark .gd-code .hljs-comment,
+.dark .gd-code .hljs-quote {
+  color: #8b949e;
+}
+.dark .gd-code .hljs-keyword,
+.dark .gd-code .hljs-selector-tag,
+.dark .gd-code .hljs-doctag,
+.dark .gd-code .hljs-meta .hljs-keyword {
+  color: #ff7b72;
+}
+.dark .gd-code .hljs-string,
+.dark .gd-code .hljs-regexp,
+.dark .gd-code .hljs-meta .hljs-string {
+  color: #a5d6ff;
+}
+.dark .gd-code .hljs-number,
+.dark .gd-code .hljs-literal {
+  color: #79c0ff;
+}
+.dark .gd-code .hljs-title,
+.dark .gd-code .hljs-title.function_,
+.dark .gd-code .hljs-section,
+.dark .gd-code .hljs-built_in {
+  color: #d2a8ff;
+}
+.dark .gd-code .hljs-type,
+.dark .gd-code .hljs-class .hljs-title,
+.dark .gd-code .hljs-title.class_ {
+  color: #ffa657;
+}
+.dark .gd-code .hljs-attr,
+.dark .gd-code .hljs-attribute,
+.dark .gd-code .hljs-property,
+.dark .gd-code .hljs-variable,
+.dark .gd-code .hljs-template-variable {
+  color: #79c0ff;
+}
+.dark .gd-code .hljs-tag,
+.dark .gd-code .hljs-name,
+.dark .gd-code .hljs-symbol,
+.dark .gd-code .hljs-bullet {
+  color: #7ee787;
+}
+.dark .gd-code .hljs-meta {
+  color: #8b949e;
 }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -56,7 +56,7 @@ A few things worth knowing up front:
   the token is stored in your OS keychain. Then browse & clone your repositories, and
   read and act on pull requests and Pipelines. (See **Bitbucket repositories** below.)
 - **Make it yours.** Pick a theme — **System**, **Light**, **Dark**, or a softer
-  **Dark Dimmed** that's easier on the eyes — in **Settings → Appearance**, or cycle
+  **Slate** that's easier on the eyes — in **Settings → Appearance**, or cycle
   themes anytime from the command palette ({{kbd:command-palette}}).
 {{ai}}- **AI is optional.** Commit messages, PR descriptions, reviews, CI debugging, and
   agent sessions can use Anthropic, OpenAI, OpenRouter, Ollama (local or cloud), an

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -55,6 +55,9 @@ A few things worth knowing up front:
   API token** (created at id.atlassian.com, used with your Atlassian account email) —
   the token is stored in your OS keychain. Then browse & clone your repositories, and
   read and act on pull requests and Pipelines. (See **Bitbucket repositories** below.)
+- **Make it yours.** Pick a theme — **System**, **Light**, **Dark**, or a softer
+  **Dark Dimmed** that's easier on the eyes — in **Settings → Appearance**, or cycle
+  themes anytime from the command palette ({{kbd:command-palette}}).
 {{ai}}- **AI is optional.** Commit messages, PR descriptions, reviews, CI debugging, and
   agent sessions can use Anthropic, OpenAI, OpenRouter, Ollama (local or cloud), an
   OpenAI-compatible endpoint, or the Claude Code / Codex / GitHub Copilot / opencode

--- a/src/features/settings/AppearanceSection.tsx
+++ b/src/features/settings/AppearanceSection.tsx
@@ -1,0 +1,75 @@
+import { useId } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSaveSettings, useSettings } from "@/lib/settings/queries";
+import {
+  commitTheme,
+  THEME_LABELS,
+  THEME_ORDER,
+  type ThemeSetting,
+} from "@/lib/theme";
+
+/**
+ * Settings → Appearance. The theme picker is an apply-on-change preference owned
+ * by this control (not the bulk Save bar), mirroring `diffViewMode`: it persists
+ * and applies the class immediately, so picking a theme previews it live.
+ */
+export function AppearanceSection() {
+  const settings = useSettings();
+  const saveSettings = useSaveSettings();
+  const labelId = useId();
+  const theme = settings.data?.theme ?? "system";
+
+  function selectTheme(next: ThemeSetting) {
+    if (!settings.data || next === settings.data.theme) return;
+    saveSettings.mutate({ ...settings.data, theme: next });
+    commitTheme(next);
+  }
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-sm font-medium">Appearance</h2>
+        <p className="text-xs text-muted-foreground">
+          How GitDesktop looks. Changes apply immediately.
+        </p>
+      </div>
+      <div className="space-y-1.5">
+        <span id={labelId} className="text-xs font-medium">
+          Theme
+        </span>
+        <div className="max-w-xs">
+          <Select
+            items={THEME_LABELS}
+            value={theme}
+            onValueChange={(value) => selectTheme(value as ThemeSetting)}
+          >
+            <SelectTrigger aria-labelledby={labelId} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {THEME_ORDER.map((id) => (
+                <SelectItem key={id} value={id}>
+                  {THEME_LABELS[id]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">System</span> follows
+          your operating system's light/dark setting.{" "}
+          <span className="font-medium text-foreground">Dark Dimmed</span> is a
+          softer dark theme — surfaces lift off pure black and text off pure
+          white — to ease eye strain on long sessions. You can also cycle themes
+          from the command palette.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/features/settings/AppearanceSection.tsx
+++ b/src/features/settings/AppearanceSection.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useId } from "react";
 import {
   Select,
@@ -7,17 +6,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  settingsKeys,
-  useSaveSettings,
-  useSettings,
-} from "@/lib/settings/queries";
-import {
-  commitTheme,
-  THEME_LABELS,
-  THEME_ORDER,
-  type ThemeSetting,
-} from "@/lib/theme";
+import { useApplyTheme, useSettings } from "@/lib/settings/queries";
+import { THEME_LABELS, THEME_ORDER, type ThemeSetting } from "@/lib/theme";
 
 /**
  * Settings → Appearance. The theme picker is an apply-on-change preference owned
@@ -26,21 +16,12 @@ import {
  */
 export function AppearanceSection() {
   const settings = useSettings();
-  const saveSettings = useSaveSettings();
-  const queryClient = useQueryClient();
+  const applyTheme = useApplyTheme();
   const labelId = useId();
   const theme = settings.data?.theme ?? "system";
 
   function selectTheme(next: ThemeSetting) {
-    if (!settings.data || next === settings.data.theme) return;
-    const updated = { ...settings.data, theme: next };
-    // Optimistically patch the settings cache so the controlled <Select> reflects
-    // the pick immediately; the mutation's success-invalidate reconciles it.
-    // Without this the trigger briefly flickers back to the old value while the
-    // store write + refetch complete.
-    queryClient.setQueryData(settingsKeys.settings, updated);
-    saveSettings.mutate(updated);
-    commitTheme(next);
+    if (settings.data) applyTheme(settings.data, next);
   }
 
   return (

--- a/src/features/settings/AppearanceSection.tsx
+++ b/src/features/settings/AppearanceSection.tsx
@@ -64,10 +64,9 @@ export function AppearanceSection() {
         <p className="text-xs text-muted-foreground">
           <span className="font-medium text-foreground">System</span> follows
           your operating system's light/dark setting.{" "}
-          <span className="font-medium text-foreground">Dark Dimmed</span> is a
-          softer dark theme — surfaces lift off pure black and text off pure
-          white — to ease eye strain on long sessions. You can also cycle themes
-          from the command palette.
+          <span className="font-medium text-foreground">Slate</span> is a softer
+          dark theme — a lifted, cool blue-gray canvas that eases eye strain on
+          long sessions. You can also cycle themes from the command palette.
         </p>
       </div>
     </section>

--- a/src/features/settings/AppearanceSection.tsx
+++ b/src/features/settings/AppearanceSection.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useId } from "react";
 import {
   Select,
@@ -6,7 +7,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useSaveSettings, useSettings } from "@/lib/settings/queries";
+import {
+  settingsKeys,
+  useSaveSettings,
+  useSettings,
+} from "@/lib/settings/queries";
 import {
   commitTheme,
   THEME_LABELS,
@@ -22,12 +27,19 @@ import {
 export function AppearanceSection() {
   const settings = useSettings();
   const saveSettings = useSaveSettings();
+  const queryClient = useQueryClient();
   const labelId = useId();
   const theme = settings.data?.theme ?? "system";
 
   function selectTheme(next: ThemeSetting) {
     if (!settings.data || next === settings.data.theme) return;
-    saveSettings.mutate({ ...settings.data, theme: next });
+    const updated = { ...settings.data, theme: next };
+    // Optimistically patch the settings cache so the controlled <Select> reflects
+    // the pick immediately; the mutation's success-invalidate reconciles it.
+    // Without this the trigger briefly flickers back to the old value while the
+    // store write + refetch complete.
+    queryClient.setQueryData(settingsKeys.settings, updated);
+    saveSettings.mutate(updated);
     commitTheme(next);
   }
 

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -23,6 +23,7 @@ import { useLatestRef } from "@/lib/use-latest-ref";
 import { AboutSection } from "./AboutSection";
 import { AccountsSection } from "./AccountsSection";
 import { AiProviderSection } from "./AiProviderSection";
+import { AppearanceSection } from "./AppearanceSection";
 import { CommandsSection } from "./CommandsSection";
 import { EditorSection } from "./EditorSection";
 import { GeneralSection } from "./GeneralSection";
@@ -54,6 +55,7 @@ const SyntaxSection = lazy(() =>
 
 const PANELS = [
   { id: "general", label: "General" },
+  { id: "appearance", label: "Appearance" },
   { id: "ai", label: "AI" },
   { id: "commands", label: "Slash commands" },
   { id: "mcp-servers", label: "MCP servers" },
@@ -255,6 +257,7 @@ export function SettingsScreen() {
           <ScrollArea className="min-h-0 flex-1 overflow-hidden">
             <main className="mx-auto w-full max-w-2xl space-y-8 p-6">
               {activePanel === "general" && <GeneralSection form={form} />}
+              {activePanel === "appearance" && <AppearanceSection />}
               {activePanel === "ai" && (
                 <>
                   <AiProviderSection form={form} />

--- a/src/features/settings/settings-form.ts
+++ b/src/features/settings/settings-form.ts
@@ -8,13 +8,15 @@ import { type AppSettings, DEFAULT_SETTINGS } from "@/lib/settings/api";
  */
 export type SettingsDraft = Omit<
   AppSettings,
-  "recentRepos" | "diffViewMode" | "defaultBranch"
+  "recentRepos" | "diffViewMode" | "defaultBranch" | "theme"
 >;
 
 export function toDraft(settings: AppSettings): SettingsDraft {
   // defaultBranch is dropped: it now lives in global git config, edited by its
-  // own form in GitSection, not the bulk Save bar.
-  const { recentRepos, diffViewMode, defaultBranch, ...draft } = settings;
+  // own form in GitSection, not the bulk Save bar. theme + diffViewMode are
+  // apply-on-change prefs owned by their own controls, not the bulk Save bar.
+  const { recentRepos, diffViewMode, defaultBranch, theme, ...draft } =
+    settings;
   return draft;
 }
 

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -69,6 +69,12 @@ export const ACTIONS = [
     category: "Application",
     defaultBinding: null,
   },
+  {
+    id: "cycle-theme",
+    label: "Cycle theme",
+    category: "Application",
+    defaultBinding: null,
+  },
 
   // Navigation
   {

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -3,6 +3,7 @@ import type { ReviewContextSize } from "@/lib/ai/context-budget";
 import type { AiSettings, ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
+import type { ThemeSetting } from "@/lib/theme";
 
 export interface RecentRepo {
   path: string;
@@ -275,6 +276,13 @@ export interface AppSettings {
   /** Managed MCP servers an agent session can opt into. Empty = MCP stays off. */
   mcpServers: McpServer[];
   recentRepos: RecentRepo[];
+  /** Color theme (Settings → Appearance). "system" follows the OS scheme;
+   *  "light"/"dark" force it; "dark-dimmed" is a softer dark variant that lifts
+   *  surfaces off pure black and ink off pure white to reduce eye strain. Absent
+   *  on settings stored before this field existed → "system" via the
+   *  DEFAULT_SETTINGS spread in loadSettings (byte-identical prior behavior).
+   *  Applied outside the bulk settings form (apply-on-change), like diffViewMode. */
+  theme: ThemeSetting;
   diffViewMode: "unified" | "split";
   /** Which conversation-list sections the user has collapsed, keyed
    *  `"<feature>:<kind>"` — `pulls:local`, `pulls:remote`, `issues:local`,
@@ -343,6 +351,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   customCommands: [],
   mcpServers: [],
   recentRepos: [],
+  theme: "system",
   diffViewMode: "unified",
   collapsedConversationSections: [],
   bitbucketTokenExpiresAt: null,

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -277,7 +277,7 @@ export interface AppSettings {
   mcpServers: McpServer[];
   recentRepos: RecentRepo[];
   /** Color theme (Settings → Appearance). "system" follows the OS scheme;
-   *  "light"/"dark" force it; "dark-dimmed" is a softer dark variant that lifts
+   *  "light"/"dark" force it; "slate" is a softer dark variant that lifts
    *  surfaces off pure black and ink off pure white to reduce eye strain. Absent
    *  on settings stored before this field existed → "system" via the
    *  DEFAULT_SETTINGS spread in loadSettings (byte-identical prior behavior).

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -124,6 +124,13 @@ export function useApplyTheme() {
       commitTheme(next);
       saveSettings.mutate(updated, {
         onError: () => {
+          // Only roll back if this call's change is still the latest: otherwise a
+          // late-failing earlier write would stomp a newer successful one (two
+          // fast cycles where the first write rejects after the second lands).
+          const latest = queryClient.getQueryData<AppSettings>(
+            settingsKeys.settings,
+          );
+          if (latest?.theme !== next) return;
           queryClient.setQueryData(settingsKeys.settings, current);
           commitTheme(current.theme);
         },

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -1,9 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { PROVIDERS_REQUIRING_KEY } from "@/lib/ai/providers";
 import type { AiProviderId } from "@/lib/ai/types";
 import { getSecret } from "@/lib/git/api";
 import { repoIdentity } from "@/lib/git/repo-identity";
+import { commitTheme, type ThemeSetting } from "@/lib/theme";
 import {
   type AppSettings,
   addRecentRepo,
@@ -102,6 +103,34 @@ export function useSaveSettings() {
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
   });
+}
+
+/**
+ * Apply a theme change from any entry point — the Appearance picker and the
+ * `cycle-theme` command both go through this, so the two paths can't drift. It
+ * optimistically patches the settings cache (so a bound `<Select>` reflects the
+ * choice immediately, not a refetch later), persists it, applies the DOM class,
+ * and rolls all three back if the store write throws. `useSaveSettings`'s
+ * success-invalidate reconciles the cache on the happy path.
+ */
+export function useApplyTheme() {
+  const queryClient = useQueryClient();
+  const saveSettings = useSaveSettings();
+  return useCallback(
+    (current: AppSettings, next: ThemeSetting) => {
+      if (next === current.theme) return;
+      const updated = { ...current, theme: next };
+      queryClient.setQueryData(settingsKeys.settings, updated);
+      commitTheme(next);
+      saveSettings.mutate(updated, {
+        onError: () => {
+          queryClient.setQueryData(settingsKeys.settings, current);
+          commitTheme(current.theme);
+        },
+      });
+    },
+    [queryClient, saveSettings],
+  );
 }
 
 export function useAddRecentRepo() {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -2,30 +2,25 @@ import { darkQuery } from "@/lib/use-is-dark";
 
 /**
  * The user's theme preference (Settings → Appearance). `"system"` follows the OS
- * color scheme; `"light"` / `"dark"` force it; `"dark-dimmed"` is a softer dark
- * variant (surfaces lifted off pure black + off-white ink instead of pure white)
- * that reduces the halation/eye-strain of the maximum-contrast default. Persisted
- * in {@link AppSettings}; mirrored to `localStorage` so the very first paint on a
- * cold boot reflects a saved override with no flash before the async settings
- * store resolves.
+ * color scheme; `"light"` / `"dark"` force it; `"slate"` is a softer dark variant
+ * (a lifted, cool blue-gray canvas with off-white ink instead of near-black on
+ * near-white) that reduces the halation / eye-strain of the maximum-contrast
+ * default. Persisted in {@link AppSettings}; mirrored to `localStorage` so the
+ * very first paint on a cold boot reflects a saved override with no flash before
+ * the async settings store resolves.
  */
-export type ThemeSetting = "system" | "light" | "dark" | "dark-dimmed";
+export type ThemeSetting = "system" | "light" | "dark" | "slate";
 
 /** Human labels for the picker (also the source for the palette `items` map). */
 export const THEME_LABELS: Record<ThemeSetting, string> = {
   system: "System",
   light: "Light",
   dark: "Dark",
-  "dark-dimmed": "Dark Dimmed",
+  slate: "Slate",
 };
 
 /** Order the "Cycle theme" command steps through. */
-export const THEME_ORDER: ThemeSetting[] = [
-  "system",
-  "light",
-  "dark",
-  "dark-dimmed",
-];
+export const THEME_ORDER: ThemeSetting[] = ["system", "light", "dark", "slate"];
 
 /** The theme one step after `current` in {@link THEME_ORDER} (wraps around). */
 export function nextTheme(current: ThemeSetting): ThemeSetting {
@@ -40,7 +35,7 @@ function isTheme(value: unknown): value is ThemeSetting {
     value === "system" ||
     value === "light" ||
     value === "dark" ||
-    value === "dark-dimmed"
+    value === "slate"
   );
 }
 
@@ -51,13 +46,13 @@ let active: ThemeSetting = "system";
 function apply(): void {
   const dark =
     active === "dark" ||
-    active === "dark-dimmed" ||
+    active === "slate" ||
     (active === "system" && darkQuery.matches);
   const root = document.documentElement;
   root.classList.toggle("dark", dark);
-  // `dimmed` only ever rides alongside `dark` — "dark-dimmed" forces dark above,
-  // so the neutral-ramp override in App.css (`.dark.dimmed`) always has its base.
-  root.classList.toggle("dimmed", active === "dark-dimmed");
+  // `slate` only ever rides alongside `dark` (it forces dark above), so the
+  // cool-ramp override in App.css (`.dark.slate`) always has its base surface.
+  root.classList.toggle("slate", active === "slate");
 }
 
 /**

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -80,7 +80,14 @@ export function commitTheme(theme: ThemeSetting): void {
  * once it loads.
  */
 export function initTheme(): void {
-  const stored = localStorage.getItem(LS_KEY);
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(LS_KEY);
+  } catch {
+    // Some locked-down webviews throw on any localStorage access. initTheme runs
+    // before first paint, so an unguarded throw here would crash startup; fall
+    // back to "system" — the store still reconciles the real value via commitTheme.
+  }
   active = isTheme(stored) ? stored : "system";
   apply();
   darkQuery.addEventListener("change", apply);

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,92 @@
+import { darkQuery } from "@/lib/use-is-dark";
+
+/**
+ * The user's theme preference (Settings → Appearance). `"system"` follows the OS
+ * color scheme; `"light"` / `"dark"` force it; `"dark-dimmed"` is a softer dark
+ * variant (surfaces lifted off pure black + off-white ink instead of pure white)
+ * that reduces the halation/eye-strain of the maximum-contrast default. Persisted
+ * in {@link AppSettings}; mirrored to `localStorage` so the very first paint on a
+ * cold boot reflects a saved override with no flash before the async settings
+ * store resolves.
+ */
+export type ThemeSetting = "system" | "light" | "dark" | "dark-dimmed";
+
+/** Human labels for the picker (also the source for the palette `items` map). */
+export const THEME_LABELS: Record<ThemeSetting, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark",
+  "dark-dimmed": "Dark Dimmed",
+};
+
+/** Order the "Cycle theme" command steps through. */
+export const THEME_ORDER: ThemeSetting[] = [
+  "system",
+  "light",
+  "dark",
+  "dark-dimmed",
+];
+
+/** The theme one step after `current` in {@link THEME_ORDER} (wraps around). */
+export function nextTheme(current: ThemeSetting): ThemeSetting {
+  const i = THEME_ORDER.indexOf(current);
+  return THEME_ORDER[(i + 1) % THEME_ORDER.length];
+}
+
+const LS_KEY = "gd-theme";
+
+function isTheme(value: unknown): value is ThemeSetting {
+  return (
+    value === "system" ||
+    value === "light" ||
+    value === "dark" ||
+    value === "dark-dimmed"
+  );
+}
+
+// The last applied preference. The OS-change listener re-reads it so a `"system"`
+// user keeps tracking the OS while an explicit override stays pinned.
+let active: ThemeSetting = "system";
+
+function apply(): void {
+  const dark =
+    active === "dark" ||
+    active === "dark-dimmed" ||
+    (active === "system" && darkQuery.matches);
+  const root = document.documentElement;
+  root.classList.toggle("dark", dark);
+  // `dimmed` only ever rides alongside `dark` — "dark-dimmed" forces dark above,
+  // so the neutral-ramp override in App.css (`.dark.dimmed`) always has its base.
+  root.classList.toggle("dimmed", active === "dark-dimmed");
+}
+
+/**
+ * Apply a theme preference to the document, remember it as the source of truth
+ * for boot + OS-change reconciliation, and mirror it to `localStorage` for a
+ * flash-free next boot. Call on save (Settings picker, Cycle-theme command) and
+ * whenever the persisted value resolves from the store.
+ */
+export function commitTheme(theme: ThemeSetting): void {
+  active = theme;
+  try {
+    localStorage.setItem(LS_KEY, theme);
+  } catch {
+    // A locked-down webview can throw on localStorage; the class is still applied
+    // and the settings store stays the source of truth, so the only cost is a
+    // possible flash on the next cold boot.
+  }
+  apply();
+}
+
+/**
+ * Read the mirrored preference synchronously and apply it before first paint,
+ * then keep `"system"` tracking the OS. Called once from `main.tsx`; the
+ * authoritative value from the settings store reconciles via {@link commitTheme}
+ * once it loads.
+ */
+export function initTheme(): void {
+  const stored = localStorage.getItem(LS_KEY);
+  active = isTheme(stored) ? stored : "system";
+  apply();
+  darkQuery.addEventListener("change", apply);
+}

--- a/src/lib/use-is-dark.ts
+++ b/src/lib/use-is-dark.ts
@@ -1,19 +1,31 @@
 import { useSyncExternalStore } from "react";
 
-/** OS color-scheme media query, shared so we don't create one per module. */
+/**
+ * OS color-scheme media query, shared so we don't create one per module. The
+ * theme resolver (theme.ts) reads it for the `"system"` preference; the app's
+ * actual light/dark state is the `.dark` class on <html>, which the resolver is
+ * the sole writer of.
+ */
 export const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
 /**
- * Reactive `prefers-color-scheme: dark`, for components that theme themselves in
- * JS (the diff viewer, the code editor). The app follows the OS scheme; the
- * `.dark` class is toggled once in main.tsx.
+ * Reactive "is the app in dark mode?" for components that theme themselves in JS
+ * (the diff viewer, the code editor). Tracks the resolved theme — it reads the
+ * `.dark` class on <html> that theme.ts sets from the user's
+ * System/Light/Dark/Dark Dimmed choice — so a manual override reaches these
+ * surfaces, not just the OS `prefers-color-scheme`. (Dark Dimmed keeps `.dark`,
+ * so it correctly reads as dark here.)
  */
 export function useIsDark(): boolean {
   return useSyncExternalStore(
     (notify) => {
-      darkQuery.addEventListener("change", notify);
-      return () => darkQuery.removeEventListener("change", notify);
+      const observer = new MutationObserver(notify);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
+      return () => observer.disconnect();
     },
-    () => darkQuery.matches,
+    () => document.documentElement.classList.contains("dark"),
   );
 }

--- a/src/lib/use-is-dark.ts
+++ b/src/lib/use-is-dark.ts
@@ -12,8 +12,8 @@ export const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
  * Reactive "is the app in dark mode?" for components that theme themselves in JS
  * (the diff viewer, the code editor). Tracks the resolved theme — it reads the
  * `.dark` class on <html> that theme.ts sets from the user's
- * System/Light/Dark/Dark Dimmed choice — so a manual override reaches these
- * surfaces, not just the OS `prefers-color-scheme`. (Dark Dimmed keeps `.dark`,
+ * System/Light/Dark/Slate choice — so a manual override reaches these
+ * surfaces, not just the OS `prefers-color-scheme`. (Slate keeps `.dark`,
  * so it correctly reads as dark here.)
  */
 export function useIsDark(): boolean {

--- a/src/lib/use-is-dark.ts
+++ b/src/lib/use-is-dark.ts
@@ -8,6 +8,22 @@ import { useSyncExternalStore } from "react";
  */
 export const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
+// Stable subscribe/getSnapshot references so useSyncExternalStore subscribes once
+// per mount instead of tearing down and recreating the MutationObserver on every
+// render (useIsDark is read by the diff viewer and code editor).
+function subscribeToThemeClass(onChange: () => void): () => void {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => observer.disconnect();
+}
+
+function isDarkSnapshot(): boolean {
+  return document.documentElement.classList.contains("dark");
+}
+
 /**
  * Reactive "is the app in dark mode?" for components that theme themselves in JS
  * (the diff viewer, the code editor). Tracks the resolved theme — it reads the
@@ -17,15 +33,5 @@ export const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
  * so it correctly reads as dark here.)
  */
 export function useIsDark(): boolean {
-  return useSyncExternalStore(
-    (notify) => {
-      const observer = new MutationObserver(notify);
-      observer.observe(document.documentElement, {
-        attributes: true,
-        attributeFilter: ["class"],
-      });
-      return () => observer.disconnect();
-    },
-    () => document.documentElement.classList.contains("dark"),
-  );
+  return useSyncExternalStore(subscribeToThemeClass, isDarkSnapshot);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,7 +24,7 @@ import "./App.css";
 // at build time instead (see vite.config.ts), so no layering is needed.
 import "@git-diff-view/react/styles/diff-view.css";
 
-// Apply the saved theme (System / Light / Dark / Dark Dimmed) before first paint,
+// Apply the saved theme (System / Light / Dark / Slate) before first paint,
 // reading a localStorage mirror synchronously so a saved override doesn't flash
 // through the OS default; the authoritative store value reconciles below.
 initTheme();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import { initAnalytics, trackCaughtError } from "@/lib/analytics";
 import { calmTransition } from "@/lib/motion";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
-import { darkQuery } from "@/lib/use-is-dark";
+import { commitTheme, initTheme } from "@/lib/theme";
 import App from "./App.tsx";
 import "./App.css";
 // Position is load-bearing: the vendored diff-view CSS must be imported plain
@@ -24,16 +24,19 @@ import "./App.css";
 // at build time instead (see vite.config.ts), so no layering is needed.
 import "@git-diff-view/react/styles/diff-view.css";
 
-// Follow the OS color scheme; the theme css switches on the .dark class.
-const applyTheme = () =>
-  document.documentElement.classList.toggle("dark", darkQuery.matches);
-darkQuery.addEventListener("change", applyTheme);
-applyTheme();
+// Apply the saved theme (System / Light / Dark / Dark Dimmed) before first paint,
+// reading a localStorage mirror synchronously so a saved override doesn't flash
+// through the OS default; the authoritative store value reconciles below.
+initTheme();
 
 // Boot analytics after settings load — never blocks the render. Session replay
 // stays off unless the user opted in (recordReplay).
 loadSettings()
-  .then((s) => initAnalytics(s.analyticsEnabled, s.recordReplay))
+  .then((s) => {
+    // Reconcile the flash-mirror against the authoritative persisted value.
+    commitTheme(s.theme);
+    initAnalytics(s.analyticsEnabled, s.recordReplay);
+  })
   .catch(() => {
     // Analytics is best-effort — never surface its failures.
   });


### PR DESCRIPTION
Add user-selectable System, Light, Dark, and Slate themes so the application can follow the operating system or provide a more comfortable manual appearance. Themes apply immediately, persist across launches, and can also be cycled from the command palette.

### Theme resolution and styling

- Adds `ThemeSetting`, theme labels, ordering, persistence, and class application in `src/lib/theme.ts`.
- Initializes the saved theme before first paint and reconciles it with authoritative settings in `src/main.tsx`.
- Adds the softer cool blue-gray Slate palette in `src/App.css`, while preserving the existing `.dark` behavior for dark-mode surfaces.
- Updates `src/lib/use-is-dark.ts` to observe the resolved `.dark` class so editor and diff-related components follow manual theme overrides.
- Replaces OS-only syntax highlighting behavior in `src/features/diff/code-highlight.css` with `.dark`-class selectors.

### Settings and hotkeys

- Adds the apply-on-change theme picker in `src/features/settings/AppearanceSection.tsx`.
- Adds the Appearance panel to `src/features/settings/SettingsScreen.tsx`.
- Stores the selected theme in `AppSettings` with a System default in `src/lib/settings/api.ts`.
- Keeps the theme out of the bulk settings form in `src/features/settings/settings-form.ts`, since appearance changes save immediately.
- Adds the `cycle-theme` action in `src/lib/hotkeys/registry.ts` and connects it to theme persistence, application, and feedback in `src/App.tsx`.

### Documentation

- Documents the available themes and command-palette access in `README.md`.
- Adds the theme-picker release note in `changelog.d/added-theme-picker.md`.
- Lists theme support in `site/src/data/capabilities.ts`.
- Adds theme guidance to the in-app help content in `src/features/help/content.ts`.