### PR TITLE
feat(tasks,ai,terminal): add interactive script task runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,8 +528,8 @@ you **adjust the arguments per run**. Runs happen in an **interactive** in-app t
 the repo's folder, so scripts that prompt you (a version to release, a yes/no) work and
 keep their colour; **Stop** kills the run and its child processes, **Rerun** starts a
 fresh one. Pick the interpreter — **PowerShell**, **cmd**, **Git Bash**, **bash/sh/zsh**,
-**Node**, **Deno**, **Bun**, **Python**, or **Ruby** — with the editor showing **which are
-installed** on your machine (and where). Task definitions live in your app data — never
+**Node**, **Deno**, **Bun**, **Python**, or **Ruby** — with the editor showing **which it
+detected** on your machine (and where). Task definitions live in your app data — never
 read from repository content, so a cloned repo can't plant one — running is **off until you
 enable it**, and each task can **confirm before it runs**.
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,19 @@ commit as a different author in one repo without changing your global identity.
 **Git hooks** — view, edit, enable/disable, and template `.git/hooks`, with
 husky / pre-commit / lefthook detection and install integration.
 
+**Tasks** — save your own scripts (your release or build flow, say) and run them from
+a dedicated **Tasks** tab or the command palette ("**Run a task…**"), without dropping
+to a terminal. Point a task at an **existing script in the repo** — it runs the live file,
+so edits take effect next run — or write one **inline**; with an AI provider connected,
+**generate** an inline script from a plain description. Each runs in an **interactive**
+in-app terminal in the repo's folder, so scripts that prompt you (a version to release, a
+yes/no) work and keep their colour; **Stop** kills the run and its child processes,
+**Rerun** starts a fresh one. Pick the interpreter (PowerShell, cmd, bash/sh/zsh, Node, or
+Python) and pass any **arguments** (e.g. `--preview` — quoted values stay intact). Task
+definitions live in your app data — never read from repository content, so a cloned repo
+can't plant one — running is **off until you enable it**, and each task can **confirm
+before it runs**.
+
 **Automations** — a lifecycle grid (on commit / on PR opened / on new commits to a
 reviewed PR) that runs AI review or security audit automatically, with per-action
 branch conditions, Save/Discard drafts, global defaults, and per-repo overrides.

--- a/README.md
+++ b/README.md
@@ -520,11 +520,14 @@ husky / pre-commit / lefthook detection and install integration.
 a dedicated **Tasks** tab or the command palette ("**Run a task…**"), without dropping
 to a terminal. Point a task at an **existing script in the repo** — it runs the live file,
 so edits take effect next run — or write one **inline**; with an AI provider connected,
-**generate** an inline script from a plain description. Each runs in an **interactive**
-in-app terminal in the repo's folder, so scripts that prompt you (a version to release, a
-yes/no) work and keep their colour; **Stop** kills the run and its child processes,
-**Rerun** starts a fresh one. Pick the interpreter (PowerShell, cmd, bash/sh/zsh, Node, or
-Python) and pass any **arguments** (e.g. `--preview` — quoted values stay intact). Task
+**generate** an inline script from a plain description, or **Analyze with AI** to read the
+script and fill in its name, description, and the **arguments it accepts** (`--help`-style
+docs, shown as a reference when you run). Each task carries a description and default
+**arguments** (e.g. `--preview` — quoted values stay intact), and a confirm-gated run lets
+you **adjust the arguments per run**. Runs happen in an **interactive** in-app terminal in
+the repo's folder, so scripts that prompt you (a version to release, a yes/no) work and
+keep their colour; **Stop** kills the run and its child processes, **Rerun** starts a
+fresh one. Pick the interpreter (PowerShell, cmd, bash/sh/zsh, Node, or Python). Task
 definitions live in your app data — never read from repository content, so a cloned repo
 can't plant one — running is **off until you enable it**, and each task can **confirm
 before it runs**.

--- a/README.md
+++ b/README.md
@@ -527,10 +527,11 @@ docs, shown as a reference when you run). Each task carries a description and de
 you **adjust the arguments per run**. Runs happen in an **interactive** in-app terminal in
 the repo's folder, so scripts that prompt you (a version to release, a yes/no) work and
 keep their colour; **Stop** kills the run and its child processes, **Rerun** starts a
-fresh one. Pick the interpreter (PowerShell, cmd, bash/sh/zsh, Node, or Python). Task
-definitions live in your app data — never read from repository content, so a cloned repo
-can't plant one — running is **off until you enable it**, and each task can **confirm
-before it runs**.
+fresh one. Pick the interpreter — **PowerShell**, **cmd**, **Git Bash**, **bash/sh/zsh**,
+**Node**, **Deno**, **Bun**, **Python**, or **Ruby** — with the editor showing **which are
+installed** on your machine (and where). Task definitions live in your app data — never
+read from repository content, so a cloned repo can't plant one — running is **off until you
+enable it**, and each task can **confirm before it runs**.
 
 **Automations** — a lifecycle grid (on commit / on PR opened / on new commits to a
 reviewed PR) that runs AI review or security audit automatically, with per-action

--- a/changelog.d/added-tasks.md
+++ b/changelog.d/added-tasks.md
@@ -11,6 +11,6 @@
   you (a version to release, a yes/no) work and keep their colour; **Stop** kills the run
   and its child processes, **Rerun** starts a fresh one. Choose the interpreter — PowerShell,
   cmd, Git Bash, bash/sh/zsh, Node, Deno, Bun, Python, or Ruby, with the editor showing which
-  are installed on your machine. Task definitions live in your app data
+  it detected on your machine. Task definitions live in your app data
   and are never read from repository content, running is off until you enable it, and each
   task can ask for confirmation before it runs.

--- a/changelog.d/added-tasks.md
+++ b/changelog.d/added-tasks.md
@@ -1,0 +1,12 @@
+- **Tasks — save scripts and run them in-app.** A new **Tasks** tab (and a
+  command-palette **Run a task…**) lets you register your own scripts — a release or
+  build flow, say — and run them without dropping to a terminal. Point a task at an
+  **existing script in the repo** (it runs the live file, so edits take effect on the next
+  run) or write one **inline**; with an AI provider connected, **Generate** writes an
+  inline script from a plain description. Each runs in an **interactive** terminal in the
+  repository's folder, so scripts that prompt you (a version to release, a yes/no) work and
+  keep their colour; **Stop** kills the run and its child processes, **Rerun** starts a
+  fresh one. Choose the interpreter (PowerShell, cmd, bash/sh/zsh, Node, or Python) and pass
+  arguments (e.g. `--preview`, with quoted values kept intact). Task
+  definitions live in your app data and are never read from repository content, running is
+  off until you enable it, and each task can ask for confirmation before it runs.

--- a/changelog.d/added-tasks.md
+++ b/changelog.d/added-tasks.md
@@ -3,10 +3,13 @@
   build flow, say — and run them without dropping to a terminal. Point a task at an
   **existing script in the repo** (it runs the live file, so edits take effect on the next
   run) or write one **inline**; with an AI provider connected, **Generate** writes an
-  inline script from a plain description. Each runs in an **interactive** terminal in the
-  repository's folder, so scripts that prompt you (a version to release, a yes/no) work and
-  keep their colour; **Stop** kills the run and its child processes, **Rerun** starts a
-  fresh one. Choose the interpreter (PowerShell, cmd, bash/sh/zsh, Node, or Python) and pass
-  arguments (e.g. `--preview`, with quoted values kept intact). Task
-  definitions live in your app data and are never read from repository content, running is
-  off until you enable it, and each task can ask for confirmation before it runs.
+  inline script from a plain description, and **Analyze with AI** reads a script and fills
+  in its name, description, and the arguments it accepts. Each task carries a description
+  and default arguments (quoted values kept intact), documents its arguments
+  `--help`-style, and a confirm-gated run lets you adjust the arguments per run. Runs
+  happen in an **interactive** terminal in the repository's folder, so scripts that prompt
+  you (a version to release, a yes/no) work and keep their colour; **Stop** kills the run
+  and its child processes, **Rerun** starts a fresh one. Choose the interpreter
+  (PowerShell, cmd, bash/sh/zsh, Node, or Python). Task definitions live in your app data
+  and are never read from repository content, running is off until you enable it, and each
+  task can ask for confirmation before it runs.

--- a/changelog.d/added-tasks.md
+++ b/changelog.d/added-tasks.md
@@ -9,7 +9,8 @@
   `--help`-style, and a confirm-gated run lets you adjust the arguments per run. Runs
   happen in an **interactive** terminal in the repository's folder, so scripts that prompt
   you (a version to release, a yes/no) work and keep their colour; **Stop** kills the run
-  and its child processes, **Rerun** starts a fresh one. Choose the interpreter
-  (PowerShell, cmd, bash/sh/zsh, Node, or Python). Task definitions live in your app data
+  and its child processes, **Rerun** starts a fresh one. Choose the interpreter — PowerShell,
+  cmd, Git Bash, bash/sh/zsh, Node, Deno, Bun, Python, or Ruby, with the editor showing which
+  are installed on your machine. Task definitions live in your app data
   and are never read from repository content, running is off until you enable it, and each
   task can ask for confirmation before it runs.

--- a/marker3.txt
+++ b/marker3.txt
@@ -1,0 +1,1 @@
+INJECTED3 

--- a/marker3.txt
+++ b/marker3.txt
@@ -1,1 +1,0 @@
-INJECTED3 

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -289,6 +289,12 @@ export const capabilities: Capability[] = [
     highlight: true,
   },
   { group: "Repository & workspace", label: "Submodule status & update" },
+  {
+    group: "Repository & workspace",
+    label:
+      "Tasks — register a repo script or write one inline, run it in an interactive terminal",
+    highlight: true,
+  },
   { group: "Repository & workspace", label: "Manage tracked & ignored files" },
   { group: "Repository & workspace", label: "--force-with-lease by default" },
   {
@@ -386,6 +392,11 @@ export const capabilities: Capability[] = [
     group: "AI · generate & review",
     ai: true,
     label: "AI repo descriptions & topics",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
+    label: "Generate a task's script from a plain-English description",
   },
   {
     group: "AI · generate & review",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -396,7 +396,8 @@ export const capabilities: Capability[] = [
   {
     group: "AI · generate & review",
     ai: true,
-    label: "Generate a task's script from a plain-English description",
+    label:
+      "Generate a task's script from plain English — or analyze one to document it",
   },
   {
     group: "AI · generate & review",

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -312,7 +312,7 @@ fn probe_dir(dir: &Path, names: &[&str], exts: &[String]) -> Option<PathBuf> {
     None
 }
 
-fn find_executable(names: &[&str]) -> Option<PathBuf> {
+pub(crate) fn find_executable(names: &[&str]) -> Option<PathBuf> {
     let exts = exe_exts();
     // PATH first, then the known per-tool install dirs.
     let mut dirs: Vec<PathBuf> = std::env::var_os("PATH")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             pty::pty_write,
             pty::pty_resize,
             pty::pty_close,
+            pty::detect_interpreters,
             pty::task_open_terminal,
             git::ops::git_checkout_commit,
             git::ops::git_revert,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             pty::pty_write,
             pty::pty_resize,
             pty::pty_close,
+            pty::task_open_terminal,
             git::ops::git_checkout_commit,
             git::ops::git_revert,
             git::ops::git_cherry_pick,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,13 +1,16 @@
 //! In-app **terminal** backend: real PTYs streamed to the frontend's xterm.js.
 //!
 //! Each terminal is a pseudo-terminal (ConPTY on Windows via `portable-pty`)
-//! running either a **host shell** in the session worktree, or — for a container
-//! session — a shell *inside* the worktree's test container (reusing the exact
-//! run-or-exec + port-publish + cleanup logic the external "Test in container"
-//! launcher uses, see `agent_sandbox::container_shell_command`). Output is streamed
-//! to the UI over a Tauri `Channel` (base64 chunks, so binary + partial-UTF-8 are
-//! safe); input/resize/close come back as commands. PTYs are held in app state
-//! keyed by a frontend id and torn down on close (or when the shell exits).
+//! running either a **host shell** in the session worktree, a shell *inside* the
+//! worktree's test container (reusing the exact run-or-exec + port-publish +
+//! cleanup logic the external "Test in container" launcher uses, see
+//! `agent_sandbox::container_shell_command`), or — for the **Tasks** feature — a
+//! user-registered script: its body is written to a temp file and run by the
+//! chosen interpreter (argv-only; the body is never interpolated into a `-c`
+//! shell string). Output is streamed to the UI over a Tauri `Channel` (base64
+//! chunks, so binary + partial-UTF-8 are safe); input/resize/close come back as
+//! commands. PTYs are held in app state keyed by a frontend id and torn down on
+//! close (or when the process exits).
 //!
 //! **Windows dev caveat (known limitation, not a bug — do not re-chase):** the
 //! in-app terminal works in a RELEASE install but NOT under `pnpm tauri dev`. The
@@ -23,6 +26,7 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use base64::Engine;
@@ -31,6 +35,7 @@ use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
 use tauri::State;
 
+use crate::agent::resolve_named;
 use crate::agent_sandbox::container_shell_command;
 use crate::error::{AppError, AppResult};
 
@@ -47,22 +52,44 @@ struct PtyHandle {
     master: Box<dyn MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     child: Box<dyn Child + Send + Sync>,
+    /// A temp script file to delete once the process exits (Tasks runs write the
+    /// script body to a temp file); `None` for host/container shells.
+    cleanup: Option<PathBuf>,
+    /// Kill the whole process tree on teardown. Tasks spawn their own children
+    /// (git, node, pnpm…) that a single-process kill would orphan; a shell's
+    /// children are reached by the PTY hangup, so this stays off for those.
+    tree_kill: bool,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PtyOpts {
     /// "host" — a shell in `cwd`; "container" — a shell in the worktree's test
-    /// container (publishing `ports`).
+    /// container (publishing `ports`); "task" — run `interpreter` on a temp file
+    /// holding `body`, in `cwd`.
     kind: String,
-    /// The session worktree path: the cwd for a host shell, and the mount + key
-    /// for a container shell.
+    /// The cwd: a host shell's / task's working directory, and (container) the
+    /// mount + key.
     cwd: String,
-    /// Dev-server ports to publish (container only; ignored for host).
+    /// Dev-server ports to publish (container only; ignored otherwise).
     #[serde(default)]
     ports: Vec<String>,
     cols: u16,
     rows: u16,
+    /// Task only: the interpreter key (see `task_interp`) to run the script with.
+    #[serde(default)]
+    interpreter: Option<String>,
+    /// Task only, inline source: the script body written to a temp file and run.
+    #[serde(default)]
+    body: Option<String>,
+    /// Task only, file source: an existing script file to run in place (relative
+    /// to `cwd`, or absolute). Takes precedence over `body` when set.
+    #[serde(default)]
+    path: Option<String>,
+    /// Task only: extra arguments passed to the script after its path. Argv form
+    /// (already split by the frontend), so no shell re-parsing happens here.
+    #[serde(default)]
+    args: Vec<String>,
 }
 
 /// Streamed to the frontend terminal. `Output` carries base64-encoded bytes.
@@ -70,8 +97,8 @@ pub struct PtyOpts {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum PtyEvent {
     Output { data: String },
-    /// The shell process exited; `code` is its exit status when known (surfaced in
-    /// the UI so a silent/erroring exit is diagnosable, not just "exited").
+    /// The process exited; `code` is its exit status when known (surfaced in the
+    /// UI so a silent/erroring exit is diagnosable, not just "exited").
     Exit { code: Option<u32> },
 }
 
@@ -88,28 +115,192 @@ fn host_shell() -> String {
     }
 }
 
-/// Builds the PTY command for the requested kind. Returns the command plus an
-/// optional one-line tip to print first (the container port hint).
+/// Maps a Tasks interpreter key to the binary names to resolve, the temp-file
+/// extension, and the argv that runs the script *file*. Argv-only by design: the
+/// script body is executed as a file, never interpolated into a `-c` string (which
+/// is the one shell-injection class the rest of the app has zero instances of, and
+/// avoids the Windows `.cmd`-shim multi-line-argv rejection).
+///
+/// The frontend's interpreter dropdown mirrors these keys; an unknown key errors
+/// at run time rather than silently doing nothing.
+type TaskArgs = fn(&str) -> Vec<String>;
+fn task_interp(interpreter: &str) -> Option<(&'static [&'static str], &'static str, TaskArgs)> {
+    let ps: TaskArgs = |p| {
+        vec![
+            "-NoProfile".into(),
+            "-ExecutionPolicy".into(),
+            "Bypass".into(),
+            "-File".into(),
+            p.into(),
+        ]
+    };
+    let file_arg: TaskArgs = |p| vec![p.into()];
+    let cmd_c: TaskArgs = |p| vec!["/c".into(), p.into()];
+    match interpreter {
+        // Prefer PowerShell 7 (`pwsh`), fall back to Windows PowerShell 5.1.
+        "powershell" => Some((&["pwsh", "powershell"], "ps1", ps)),
+        "cmd" => Some((&["cmd"], "cmd", cmd_c)),
+        "bash" => Some((&["bash"], "sh", file_arg)),
+        "sh" => Some((&["sh"], "sh", file_arg)),
+        "zsh" => Some((&["zsh"], "sh", file_arg)),
+        "node" => Some((&["node"], "mjs", file_arg)),
+        "python" => Some((&["python3", "python"], "py", file_arg)),
+        _ => None,
+    }
+}
+
+/// The built PTY child plus teardown metadata.
+struct BuiltCommand {
+    cmd: CommandBuilder,
+    /// A dim first line to print (the container port hint), if any.
+    tip: Option<String>,
+    /// Temp script file to remove on teardown (task runs).
+    cleanup: Option<PathBuf>,
+    tree_kill: bool,
+}
+
+/// Builds the PTY command for the requested kind.
 ///
 /// `docker` is spawned directly as the PTY child: the vendored portable-pty patch
 /// (NULL std handles) makes the child attach to the pseudoconsole, so its TTY check
 /// passes and `-t` allocates a real container TTY.
-async fn build_command(opts: &PtyOpts) -> AppResult<(CommandBuilder, Option<String>)> {
+async fn build_command(opts: &PtyOpts, id: &str) -> AppResult<BuiltCommand> {
     if opts.kind == "container" {
         let (bin, args, tip) = container_shell_command(&opts.cwd, &opts.ports).await?;
         let mut cmd = CommandBuilder::new(bin);
         for a in args {
             cmd.arg(a);
         }
-        return Ok((cmd, Some(tip)));
+        return Ok(BuiltCommand {
+            cmd,
+            tip: Some(tip),
+            cleanup: None,
+            tree_kill: false,
+        });
     }
+
+    if opts.kind == "task" {
+        let interpreter = opts.interpreter.as_deref().unwrap_or_default();
+        let (names, ext, build_args) = task_interp(interpreter).ok_or_else(|| {
+            AppError::Command(format!("unknown task interpreter '{interpreter}'"))
+        })?;
+        let bin = resolve_named(names, None).await.ok_or_else(|| {
+            AppError::Command(format!(
+                "couldn't find the '{interpreter}' interpreter on your PATH — is it installed?"
+            ))
+        })?;
+
+        // File source: run an EXISTING script file in place — never written, never
+        // deleted (it's the user's own file, run live so edits take effect). Inline
+        // source: write the body to a temp file (unique per run) and run that.
+        let (script_path, cleanup) = match opts.path.as_deref().filter(|p| !p.is_empty()) {
+            Some(file) => {
+                let full = if std::path::Path::new(file).is_absolute() {
+                    std::path::PathBuf::from(file)
+                } else {
+                    std::path::Path::new(&opts.cwd).join(file)
+                };
+                if !full.exists() {
+                    return Err(AppError::Command(format!(
+                        "script file not found: {}",
+                        full.display()
+                    )));
+                }
+                (full.to_string_lossy().into_owned(), None)
+            }
+            None => {
+                let body = opts.body.as_deref().unwrap_or_default();
+                // Sanitize the (unique-per-run) id to safe filename chars.
+                let safe: String = id
+                    .chars()
+                    .map(|c| {
+                        if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                            c
+                        } else {
+                            '-'
+                        }
+                    })
+                    .collect();
+                let tmp = std::env::temp_dir().join(format!("gd-task-{safe}.{ext}"));
+                std::fs::write(&tmp, body).map_err(AppError::Io)?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(meta) = std::fs::metadata(&tmp) {
+                        let mut perm = meta.permissions();
+                        perm.set_mode(0o755);
+                        let _ = std::fs::set_permissions(&tmp, perm);
+                    }
+                }
+                (tmp.to_string_lossy().into_owned(), Some(tmp))
+            }
+        };
+
+        let mut cmd = CommandBuilder::new(bin);
+        for a in build_args(&script_path) {
+            cmd.arg(a);
+        }
+        // The user's arguments, after the script path (argv, never shell-parsed).
+        for a in &opts.args {
+            cmd.arg(a);
+        }
+        cmd.cwd(&opts.cwd);
+        return Ok(BuiltCommand {
+            cmd,
+            tip: None,
+            cleanup,
+            tree_kill: true,
+        });
+    }
+
     let mut cmd = CommandBuilder::new(host_shell());
     cmd.cwd(&opts.cwd);
-    Ok((cmd, None))
+    Ok(BuiltCommand {
+        cmd,
+        tip: None,
+        cleanup: None,
+        tree_kill: false,
+    })
 }
 
 fn encode(bytes: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Kills a PTY's child. Tasks tree-kill (Windows `taskkill /F /T`) so their git /
+/// node / pnpm descendants don't orphan; a shell relies on the PTY hangup reaching
+/// its foreground group, so `child.kill()` alone is enough there.
+fn kill_handle(h: &mut PtyHandle) {
+    if h.tree_kill {
+        kill_tree(&mut h.child);
+    }
+    let _ = h.child.kill();
+}
+
+/// Best-effort process-tree kill for a task run. On Windows `taskkill /T` reaches
+/// the whole tree (git/node/pnpm children a bare `TerminateProcess` would orphan).
+/// On Unix the PTY hangup (SIGHUP to the foreground group when the master drops)
+/// plus the caller's `child.kill()` already reach descendants, so there's nothing
+/// extra to do.
+fn kill_tree(child: &mut Box<dyn Child + Send + Sync>) {
+    #[cfg(windows)]
+    if let Some(pid) = child.process_id() {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn();
+    }
+    #[cfg(not(windows))]
+    let _ = child;
+}
+
+/// Deletes a task's temp script file (best-effort). No-op for shells.
+fn cleanup_handle(h: &mut PtyHandle) {
+    if let Some(p) = h.cleanup.take() {
+        let _ = std::fs::remove_file(p);
+    }
 }
 
 /// Opens a PTY, starts streaming its output to `on_event`, and registers it under
@@ -121,7 +312,12 @@ pub async fn pty_open(
     opts: PtyOpts,
     on_event: Channel<PtyEvent>,
 ) -> AppResult<()> {
-    let (mut cmd, tip) = build_command(&opts).await?;
+    let BuiltCommand {
+        mut cmd,
+        tip,
+        cleanup,
+        tree_kill,
+    } = build_command(&opts, &id).await?;
     // portable-pty's CommandBuilder already inherits the parent environment, so we
     // only advertise a capable terminal here (re-copying every var is redundant and
     // can introduce odd-cased duplicate Windows vars).
@@ -137,10 +333,13 @@ pub async fn pty_open(
         })
         .map_err(|e| AppError::Command(format!("failed to open a terminal: {e}")))?;
 
-    let child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| AppError::Command(format!("failed to start the shell: {e}")))?;
+    let child = pair.slave.spawn_command(cmd).map_err(|e| {
+        // The temp script file is orphaned if the spawn fails — clean it up.
+        if let Some(p) = &cleanup {
+            let _ = std::fs::remove_file(p);
+        }
+        AppError::Command(format!("failed to start the process: {e}"))
+    })?;
     // Drop the slave so the child owns the only handle to it (else close can hang).
     drop(pair.slave);
 
@@ -159,6 +358,8 @@ pub async fn pty_open(
             master: pair.master,
             writer,
             child,
+            cleanup,
+            tree_kill,
         },
     );
 
@@ -194,14 +395,17 @@ pub async fn pty_open(
         // the lock immediately), then a NON-blocking try_wait for the code. If the
         // child is still alive (the reader stopped early), kill it so it can't
         // orphan. (Holding the lock across a blocking wait() here froze the app.)
-        let mut handle = ptys.lock().unwrap().remove(&id);
-        let code = handle.as_mut().and_then(|h| match h.child.try_wait() {
-            Ok(Some(status)) => Some(status.exit_code()),
-            _ => {
-                let _ = h.child.kill();
-                None
+        // `pty_close` may have already removed + torn down the handle (Stop) — then
+        // this just reports the exit.
+        let handle = ptys.lock().unwrap().remove(&id);
+        let mut code = None;
+        if let Some(mut h) = handle {
+            match h.child.try_wait() {
+                Ok(Some(status)) => code = Some(status.exit_code()),
+                _ => kill_handle(&mut h),
             }
-        });
+            cleanup_handle(&mut h);
+        }
         let _ = on_event.send(PtyEvent::Exit { code });
     });
 
@@ -234,11 +438,246 @@ pub fn pty_resize(state: State<'_, PtyState>, id: String, cols: u16, rows: u16) 
     Ok(())
 }
 
-/// Kills the shell and drops the PTY (on terminal unmount / dock close). Idempotent.
+/// Kills the process and drops the PTY (on terminal unmount / dock close / task
+/// Stop). Tree-kills a task's descendants and removes its temp script. Idempotent.
 #[tauri::command]
 pub fn pty_close(state: State<'_, PtyState>, id: String) -> AppResult<()> {
-    if let Some(mut h) = state.ptys.lock().unwrap().remove(&id) {
-        let _ = h.child.kill();
+    let handle = state.ptys.lock().unwrap().remove(&id);
+    if let Some(mut h) = handle {
+        kill_handle(&mut h);
+        cleanup_handle(&mut h);
     }
     Ok(())
+}
+
+// ── Dev-only external-terminal fallback ─────────────────────────────────────
+// Runs a task in the user's OS terminal instead of the in-app PTY. This exists
+// ONLY for the Windows ConPTY-under-`pnpm tauri dev` limitation (see the module
+// header): the in-app terminal can't spawn in dev, so the frontend silently
+// routes Run here on Windows dev builds. **Compiled out of release binaries**
+// (`debug_assertions`) — a production build carries none of this; its frontend
+// gate is statically false there too, so nothing ever calls it. Structure
+// mirrors `agent_sandbox::launch_container_shell`.
+
+#[cfg(debug_assertions)]
+static TERM_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(all(unix, debug_assertions))]
+fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Windows: write a temp `.cmd` that cds to the repo, runs the (double-quoted)
+/// command, and pauses; `start` it so it gets a fresh, fully-wired console.
+#[cfg(all(windows, debug_assertions))]
+fn spawn_terminal(cwd: &str, bin: &str, argv: &[String]) -> AppResult<()> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let mut line = format!("\"{bin}\"");
+    for a in argv {
+        line.push_str(&format!(" \"{a}\""));
+    }
+    let script = format!(
+        "@echo off\r\ntitle GitDesktop task\r\ncd /d \"{cwd}\"\r\n{line}\r\necho.\r\necho (task exited) Press any key to close...\r\npause >nul\r\n"
+    );
+    let n = TERM_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("gd-task-run-{}-{n}.cmd", std::process::id()));
+    std::fs::write(&path, script).map_err(AppError::Io)?;
+    let mut c = std::process::Command::new("cmd");
+    c.raw_arg(format!("/c start \"GitDesktop\" \"{}\"", path.display()));
+    c.creation_flags(CREATE_NO_WINDOW);
+    c.spawn().map(|_| ()).map_err(AppError::Io)
+}
+
+/// macOS: write a temp `.command` (Terminal.app runs it on `open`).
+#[cfg(all(target_os = "macos", debug_assertions))]
+fn spawn_terminal(cwd: &str, bin: &str, argv: &[String]) -> AppResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut line = sh_quote(bin);
+    for a in argv {
+        line.push(' ');
+        line.push_str(&sh_quote(a));
+    }
+    let script = format!(
+        "#!/bin/bash\ncd {}\n{line}\necho\necho '(task exited)'\n",
+        sh_quote(cwd)
+    );
+    let n = TERM_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("gd-task-run-{}-{n}.command", std::process::id()));
+    std::fs::write(&path, script).map_err(AppError::Io)?;
+    let mut perm = std::fs::metadata(&path).map_err(AppError::Io)?.permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&path, perm).map_err(AppError::Io)?;
+    std::process::Command::new("open")
+        .arg(&path)
+        .spawn()
+        .map(|_| ())
+        .map_err(AppError::Io)
+}
+
+/// Linux: run the command in the first available terminal emulator, dropping into a
+/// shell afterwards so the window stays open.
+#[cfg(all(unix, not(target_os = "macos"), debug_assertions))]
+fn spawn_terminal(cwd: &str, bin: &str, argv: &[String]) -> AppResult<()> {
+    let mut line = sh_quote(bin);
+    for a in argv {
+        line.push(' ');
+        line.push_str(&sh_quote(a));
+    }
+    let cmd = format!(
+        "cd {}; {line}; echo; echo '(task exited)'; exec bash",
+        sh_quote(cwd)
+    );
+    for term in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"] {
+        if std::process::Command::new(term)
+            .args(["-e", "bash", "-c", &cmd])
+            .spawn()
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+    Err(AppError::Command(
+        "no terminal emulator found".to_string(),
+    ))
+}
+
+/// Launches a task in the user's OS terminal (rather than the in-app PTY) — the
+/// automatic dev fallback for the Windows ConPTY-under-`tauri dev` limitation.
+/// Dev builds only: in release the implementation is compiled out and this
+/// answers with an error (nothing routes here in production — the frontend's
+/// dev gate is statically false in a production bundle).
+#[tauri::command]
+pub async fn task_open_terminal(
+    cwd: String,
+    interpreter: String,
+    body: Option<String>,
+    path: Option<String>,
+    args: Vec<String>,
+) -> AppResult<()> {
+    #[cfg(debug_assertions)]
+    {
+        task_open_terminal_impl(cwd, interpreter, body, path, args).await
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = (cwd, interpreter, body, path, args);
+        Err(AppError::Command(
+            "opening a task in an external terminal is a dev-only fallback".to_string(),
+        ))
+    }
+}
+
+/// The dev-only body of [`task_open_terminal`]: resolves the interpreter,
+/// materializes the script (an existing file, or a temp file for an inline body),
+/// and opens a terminal window running `<interpreter> <script> <args>` in the repo
+/// directory. Argv-only, like the in-app path.
+#[cfg(debug_assertions)]
+async fn task_open_terminal_impl(
+    cwd: String,
+    interpreter: String,
+    body: Option<String>,
+    path: Option<String>,
+    args: Vec<String>,
+) -> AppResult<()> {
+    let (names, ext, build_args) = task_interp(&interpreter).ok_or_else(|| {
+        AppError::Command(format!("unknown task interpreter '{interpreter}'"))
+    })?;
+    let bin = resolve_named(names, None).await.ok_or_else(|| {
+        AppError::Command(format!(
+            "couldn't find the '{interpreter}' interpreter on your PATH — is it installed?"
+        ))
+    })?;
+
+    let script_path = match path.as_deref().filter(|p| !p.is_empty()) {
+        Some(file) => {
+            let full = if std::path::Path::new(file).is_absolute() {
+                std::path::PathBuf::from(file)
+            } else {
+                std::path::Path::new(&cwd).join(file)
+            };
+            if !full.exists() {
+                return Err(AppError::Command(format!(
+                    "script file not found: {}",
+                    full.display()
+                )));
+            }
+            full.to_string_lossy().into_owned()
+        }
+        None => {
+            // Inline body → a temp script the external terminal reads after we
+            // return. Not cleaned up here (we'd race the terminal); the OS clears
+            // its temp dir.
+            let body = body.as_deref().unwrap_or_default();
+            let n = TERM_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let tmp = std::env::temp_dir()
+                .join(format!("gd-task-inline-{}-{n}.{ext}", std::process::id()));
+            std::fs::write(&tmp, body).map_err(AppError::Io)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(meta) = std::fs::metadata(&tmp) {
+                    let mut perm = meta.permissions();
+                    perm.set_mode(0o755);
+                    let _ = std::fs::set_permissions(&tmp, perm);
+                }
+            }
+            tmp.to_string_lossy().into_owned()
+        }
+    };
+
+    let mut argv = build_args(&script_path);
+    argv.extend(args);
+    let bin = bin.to_string_lossy().into_owned();
+    spawn_terminal(&cwd, &bin, &argv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_interp_maps_every_known_key() {
+        for key in ["powershell", "cmd", "bash", "sh", "zsh", "node", "python"] {
+            assert!(task_interp(key).is_some(), "{key} should map to a command");
+        }
+    }
+
+    #[test]
+    fn task_interp_rejects_unknown_keys() {
+        // An unknown/empty interpreter must be rejected, not silently run something.
+        assert!(task_interp("ruby").is_none());
+        assert!(task_interp("").is_none());
+        assert!(task_interp("bash;rm").is_none());
+    }
+
+    #[test]
+    fn powershell_runs_the_script_file_not_a_command_string() {
+        let (_names, ext, build) = task_interp("powershell").unwrap();
+        assert_eq!(ext, "ps1");
+        let args = build("C:/tmp/gd-task-x.ps1");
+        // Argv form: the body is a FILE argument, never interpolated into `-Command`.
+        assert!(args.iter().any(|a| a == "-File"));
+        assert!(args.last().unwrap().ends_with("gd-task-x.ps1"));
+        assert!(!args.iter().any(|a| a == "-Command"));
+    }
+
+    #[test]
+    fn interpreters_pass_the_file_as_a_discrete_arg() {
+        for key in ["bash", "sh", "zsh", "node", "python"] {
+            let (_names, _ext, build) = task_interp(key).unwrap();
+            let path = "/tmp/gd-task-x";
+            let args = build(path);
+            assert!(
+                args.iter().any(|a| a == path),
+                "{key} should pass the script path as an argv element"
+            );
+        }
+        // cmd runs the file via `/c <file>`.
+        let (_n, ext, build) = task_interp("cmd").unwrap();
+        assert_eq!(ext, "cmd");
+        assert_eq!(build("x.cmd"), vec!["/c".to_string(), "x.cmd".to_string()]);
+    }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use base64::Engine;
@@ -203,7 +203,7 @@ fn find_git_bash() -> Option<PathBuf> {
     }
     for base in bases {
         for rel in ["Git\\bin\\bash.exe", "Git\\usr\\bin\\bash.exe"] {
-            let b = Path::new(&base).join(rel);
+            let b = std::path::Path::new(&base).join(rel);
             if b.is_file() {
                 return Some(b);
             }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use base64::Engine;
@@ -145,17 +145,125 @@ fn task_interp(interpreter: &str) -> Option<(&'static [&'static str], &'static s
     };
     let file_arg: TaskArgs = |p| vec![p.into()];
     let cmd_c: TaskArgs = |p| vec!["/c".into(), p.into()];
+    // Deno needs the `run` subcommand; `-A` grants full permissions — this is the
+    // user's own registered script, run as they would themselves.
+    let deno: TaskArgs = |p| vec!["run".into(), "-A".into(), p.into()];
     match interpreter {
         // Prefer PowerShell 7 (`pwsh`), fall back to Windows PowerShell 5.1.
         "powershell" => Some((&["pwsh", "powershell"], "ps1", ps)),
         "cmd" => Some((&["cmd"], "cmd", cmd_c)),
+        // Git Bash resolves specially (see `find_git_bash`); `bash` here is only a
+        // detection/fallback name, not what the run uses on Windows.
+        "git-bash" => Some((&["bash"], "sh", file_arg)),
         "bash" => Some((&["bash"], "sh", file_arg)),
         "sh" => Some((&["sh"], "sh", file_arg)),
         "zsh" => Some((&["zsh"], "sh", file_arg)),
         "node" => Some((&["node"], "mjs", file_arg)),
         "python" => Some((&["python3", "python"], "py", file_arg)),
+        "deno" => Some((&["deno"], "ts", deno)),
+        "bun" => Some((&["bun"], "ts", file_arg)),
+        "ruby" => Some((&["ruby"], "rb", file_arg)),
         _ => None,
     }
+}
+
+/// Every interpreter key, for detection. Mirrors the frontend's `INTERPRETERS`.
+const INTERPRETER_KEYS: &[&str] = &[
+    "powershell", "cmd", "git-bash", "bash", "sh", "zsh", "node", "python", "deno", "bun", "ruby",
+];
+
+/// Locates Git Bash's `bash.exe` — a bare `bash` on Windows resolves to WSL, not
+/// Git's, so this is separate. Derives it from the resolved `git` (walking up to
+/// the Git root's `bin\bash.exe` / `usr\bin\bash.exe`), then falls back to
+/// well-known install locations.
+#[cfg(windows)]
+fn find_git_bash() -> Option<PathBuf> {
+    if let Some(git) = crate::agent::find_executable(&["git"]) {
+        let mut anc = git.parent();
+        for _ in 0..4 {
+            let dir = anc?;
+            for rel in ["bin\\bash.exe", "usr\\bin\\bash.exe"] {
+                let b = dir.join(rel);
+                if b.is_file() {
+                    return Some(b);
+                }
+            }
+            anc = dir.parent();
+        }
+    }
+    let mut bases: Vec<String> = Vec::new();
+    if let Ok(p) = std::env::var("ProgramFiles") {
+        bases.push(p);
+    }
+    if let Ok(p) = std::env::var("ProgramFiles(x86)") {
+        bases.push(p);
+    }
+    if let Ok(l) = std::env::var("LOCALAPPDATA") {
+        bases.push(format!("{l}\\Programs"));
+    }
+    for base in bases {
+        for rel in ["Git\\bin\\bash.exe", "Git\\usr\\bin\\bash.exe"] {
+            let b = Path::new(&base).join(rel);
+            if b.is_file() {
+                return Some(b);
+            }
+        }
+    }
+    None
+}
+
+/// On non-Windows, "Git Bash" is just bash — the frontend doesn't offer it there,
+/// but detection stays honest if it's ever queried.
+#[cfg(not(windows))]
+fn find_git_bash() -> Option<PathBuf> {
+    crate::agent::find_executable(&["bash"])
+}
+
+/// Resolves an interpreter's binary for a RUN — full resolution (macOS login-shell
+/// PATH recovery, Windows live-registry PATH), with Git Bash special-cased.
+async fn resolve_interpreter_run(key: &str, names: &[&str]) -> Option<PathBuf> {
+    if key == "git-bash" {
+        return find_git_bash();
+    }
+    resolve_named(names, None).await
+}
+
+/// Resolves an interpreter's binary for DETECTION — cheap (PATH + install dirs, no
+/// login-shell probe, so probing missing ones can't hang). "Found" here means "on
+/// your PATH"; a run additionally recovers login-shell/registry PATH.
+fn detect_interpreter_bin(key: &str) -> Option<PathBuf> {
+    if key == "git-bash" {
+        return find_git_bash();
+    }
+    let names = task_interp(key)?.0;
+    crate::agent::find_executable(names)
+}
+
+/// One interpreter's availability for the task editor's dropdown.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectedInterpreter {
+    /// The interpreter key (matches the frontend `Interpreter` union).
+    id: String,
+    /// Resolved absolute path, or `None` when it isn't on PATH.
+    path: Option<String>,
+}
+
+/// Reports which task interpreters are installed, so the editor can show what a
+/// task can actually run with. Cheap + off-thread.
+#[tauri::command]
+pub async fn detect_interpreters() -> AppResult<Vec<DetectedInterpreter>> {
+    tauri::async_runtime::spawn_blocking(|| {
+        INTERPRETER_KEYS
+            .iter()
+            .map(|&key| DetectedInterpreter {
+                id: key.to_string(),
+                path: detect_interpreter_bin(key).map(|p| p.to_string_lossy().into_owned()),
+            })
+            .collect()
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))
 }
 
 /// The built PTY child plus teardown metadata.
@@ -193,11 +301,13 @@ async fn build_command(opts: &PtyOpts, id: &str) -> AppResult<BuiltCommand> {
         let (names, ext, build_args) = task_interp(interpreter).ok_or_else(|| {
             AppError::Command(format!("unknown task interpreter '{interpreter}'"))
         })?;
-        let bin = resolve_named(names, None).await.ok_or_else(|| {
-            AppError::Command(format!(
-                "couldn't find the '{interpreter}' interpreter on your PATH — is it installed?"
-            ))
-        })?;
+        let bin = resolve_interpreter_run(interpreter, names)
+            .await
+            .ok_or_else(|| {
+                AppError::Command(format!(
+                    "couldn't find the '{interpreter}' interpreter on your PATH — is it installed?"
+                ))
+            })?;
 
         // File source: run an EXISTING script file in place — never written, never
         // deleted (it's the user's own file, run live so edits take effect). Inline
@@ -660,11 +770,13 @@ async fn task_open_terminal_impl(
     let (names, ext, build_args) = task_interp(&interpreter).ok_or_else(|| {
         AppError::Command(format!("unknown task interpreter '{interpreter}'"))
     })?;
-    let bin = resolve_named(names, None).await.ok_or_else(|| {
-        AppError::Command(format!(
-            "couldn't find the '{interpreter}' interpreter on your PATH — is it installed?"
-        ))
-    })?;
+    let bin = resolve_interpreter_run(&interpreter, names)
+        .await
+        .ok_or_else(|| {
+            AppError::Command(format!(
+                "couldn't find the '{interpreter}' interpreter on your PATH — is it installed?"
+            ))
+        })?;
 
     let script_path = match path.as_deref().filter(|p| !p.is_empty()) {
         Some(file) => {
@@ -714,18 +826,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn task_interp_maps_every_known_key() {
-        for key in ["powershell", "cmd", "bash", "sh", "zsh", "node", "python"] {
-            assert!(task_interp(key).is_some(), "{key} should map to a command");
+    fn task_interp_maps_every_key_the_frontend_offers() {
+        // The frontend's INTERPRETERS list and this backend map must agree, or a
+        // dropdown choice errors at run time.
+        for key in INTERPRETER_KEYS {
+            assert!(
+                task_interp(key).is_some(),
+                "{key} is a detection key but has no task_interp mapping"
+            );
         }
     }
 
     #[test]
     fn task_interp_rejects_unknown_keys() {
         // An unknown/empty interpreter must be rejected, not silently run something.
-        assert!(task_interp("ruby").is_none());
+        assert!(task_interp("perl").is_none());
         assert!(task_interp("").is_none());
         assert!(task_interp("bash;rm").is_none());
+    }
+
+    #[test]
+    fn deno_prepends_run_then_the_file() {
+        // Deno is the one interpreter with a subcommand before the file.
+        let (_names, ext, build) = task_interp("deno").unwrap();
+        assert_eq!(ext, "ts");
+        let args = build("/tmp/gd-task-x.ts");
+        assert_eq!(args.first().unwrap(), "run");
+        assert!(args.last().unwrap().ends_with("gd-task-x.ts"));
     }
 
     #[test]
@@ -741,7 +868,7 @@ mod tests {
 
     #[test]
     fn interpreters_pass_the_file_as_a_discrete_arg() {
-        for key in ["bash", "sh", "zsh", "node", "python"] {
+        for key in ["bash", "git-bash", "sh", "zsh", "node", "python", "bun", "ruby"] {
             let (_names, _ext, build) = task_interp(key).unwrap();
             let path = "/tmp/gd-task-x";
             let args = build(path);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -59,7 +59,16 @@ struct PtyHandle {
     /// (git, node, pnpm…) that a single-process kill would orphan; a shell's
     /// children are reached by the PTY hangup, so this stays off for those.
     tree_kill: bool,
+    /// Registration generation — lets a reader thread prove the map entry under
+    /// its id is still ITS OWN before tearing it down. React StrictMode (dev)
+    /// double-mounts the terminal, firing two `pty_open`s for the same id; the
+    /// second insert clobbers the first, and without this guard the first
+    /// reader's exit teardown would kill the second's live process.
+    gen: u64,
 }
+
+/// Monotonic source for [`PtyHandle::gen`].
+static PTY_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -269,31 +278,39 @@ fn encode(bytes: &[u8]) -> String {
 
 /// Kills a PTY's child. Tasks tree-kill (Windows `taskkill /F /T`) so their git /
 /// node / pnpm descendants don't orphan; a shell relies on the PTY hangup reaching
-/// its foreground group, so `child.kill()` alone is enough there.
-fn kill_handle(h: &mut PtyHandle) {
-    if h.tree_kill {
-        kill_tree(&mut h.child);
-    }
+/// its foreground group, so `child.kill()` alone is enough there. Returns the
+/// still-running `taskkill` process (when one was spawned) so the caller can WAIT
+/// for it before deleting the temp script — deleting while a descendant still has
+/// the file open fails silently on Windows and leaks the file.
+fn kill_handle(h: &mut PtyHandle) -> Option<std::process::Child> {
+    let tk = if h.tree_kill {
+        kill_tree(&mut h.child)
+    } else {
+        None
+    };
     let _ = h.child.kill();
+    tk
 }
 
 /// Best-effort process-tree kill for a task run. On Windows `taskkill /T` reaches
-/// the whole tree (git/node/pnpm children a bare `TerminateProcess` would orphan).
-/// On Unix the PTY hangup (SIGHUP to the foreground group when the master drops)
-/// plus the caller's `child.kill()` already reach descendants, so there's nothing
-/// extra to do.
-fn kill_tree(child: &mut Box<dyn Child + Send + Sync>) {
+/// the whole tree (git/node/pnpm children a bare `TerminateProcess` would orphan);
+/// the spawned `taskkill` is returned for the caller to wait on. On Unix the PTY
+/// hangup (SIGHUP to the foreground group when the master drops) plus the caller's
+/// `child.kill()` already reach descendants, so there's nothing extra to do.
+fn kill_tree(child: &mut Box<dyn Child + Send + Sync>) -> Option<std::process::Child> {
     #[cfg(windows)]
     if let Some(pid) = child.process_id() {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        let _ = std::process::Command::new("taskkill")
+        return std::process::Command::new("taskkill")
             .args(["/F", "/T", "/PID", &pid.to_string()])
             .creation_flags(CREATE_NO_WINDOW)
-            .spawn();
+            .spawn()
+            .ok();
     }
     #[cfg(not(windows))]
     let _ = child;
+    None
 }
 
 /// Deletes a task's temp script file (best-effort). No-op for shells.
@@ -301,6 +318,19 @@ fn cleanup_handle(h: &mut PtyHandle) {
     if let Some(p) = h.cleanup.take() {
         let _ = std::fs::remove_file(p);
     }
+}
+
+/// Full teardown of a removed handle: kill (tree first), WAIT for the Windows
+/// `taskkill` to finish sweeping descendants, then delete the temp script. The
+/// wait is what makes the delete stick — a child that still holds the script
+/// open at delete time would otherwise leak it. Blocking: run this on a
+/// dedicated or detached thread, never the main thread (sync Tauri commands run
+/// there).
+fn teardown_handle(mut h: PtyHandle) {
+    if let Some(mut tk) = kill_handle(&mut h) {
+        let _ = tk.wait();
+    }
+    cleanup_handle(&mut h);
 }
 
 /// Opens a PTY, starts streaming its output to `on_event`, and registers it under
@@ -333,7 +363,7 @@ pub async fn pty_open(
         })
         .map_err(|e| AppError::Command(format!("failed to open a terminal: {e}")))?;
 
-    let child = pair.slave.spawn_command(cmd).map_err(|e| {
+    let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
         // The temp script file is orphaned if the spawn fails — clean it up.
         if let Some(p) = &cleanup {
             let _ = std::fs::remove_file(p);
@@ -343,16 +373,29 @@ pub async fn pty_open(
     // Drop the slave so the child owns the only handle to it (else close can hang).
     drop(pair.slave);
 
-    let reader = pair
-        .master
-        .try_clone_reader()
-        .map_err(|e| AppError::Command(format!("terminal reader: {e}")))?;
-    let writer = pair
-        .master
-        .take_writer()
-        .map_err(|e| AppError::Command(format!("terminal writer: {e}")))?;
+    // From here the child is LIVE: any error return must kill it and remove the
+    // temp script, or the process (and file) leak untracked — no PtyHandle
+    // exists yet for Stop/pty_close to reach. (A just-spawned interpreter has no
+    // descendants yet, so a plain kill suffices on these instant-failure paths.)
+    let mut fail = |e: String| {
+        let _ = child.kill();
+        if let Some(p) = &cleanup {
+            let _ = std::fs::remove_file(p);
+        }
+        AppError::Command(e)
+    };
+    let reader = match pair.master.try_clone_reader() {
+        Ok(r) => r,
+        Err(e) => return Err(fail(format!("terminal reader: {e}"))),
+    };
+    let writer = match pair.master.take_writer() {
+        Ok(w) => w,
+        Err(e) => return Err(fail(format!("terminal writer: {e}"))),
+    };
 
-    state.ptys.lock().unwrap().insert(
+    let gen = PTY_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let cleanup_path = cleanup.clone();
+    let prev = state.ptys.lock().unwrap().insert(
         id.clone(),
         PtyHandle {
             master: pair.master,
@@ -360,8 +403,19 @@ pub async fn pty_open(
             child,
             cleanup,
             tree_kill,
+            gen,
         },
     );
+    // A same-id re-open (React StrictMode double-mount in dev fires two opens
+    // whose closes can't catch them) — tear the stale process tree down so it
+    // can't orphan. Skip deleting its temp script when this run reuses the same
+    // path (inline tasks derive the name from the shared id).
+    if let Some(mut old) = prev {
+        if old.cleanup == cleanup_path {
+            old.cleanup = None;
+        }
+        std::thread::spawn(move || teardown_handle(old));
+    }
 
     // A dim first line with the container's reachable URL(s).
     if let Some(tip) = tip {
@@ -391,18 +445,38 @@ pub async fn pty_open(
                 }
             }
         }
-        // Reap WITHOUT holding the lock or blocking: take the handle out (releasing
-        // the lock immediately), then a NON-blocking try_wait for the code. If the
-        // child is still alive (the reader stopped early), kill it so it can't
-        // orphan. (Holding the lock across a blocking wait() here froze the app.)
-        // `pty_close` may have already removed + torn down the handle (Stop) — then
-        // this just reports the exit.
-        let handle = ptys.lock().unwrap().remove(&id);
+        // Reap WITHOUT holding the lock across anything blocking (a blocking
+        // wait() under the lock froze the app once). Remove OUR OWN entry only —
+        // gen-guarded, so if `pty_close` already tore us down (Stop) or a
+        // same-id re-open clobbered us (StrictMode dev), we leave the newer
+        // entry alone and just report the exit.
+        let handle = {
+            let mut map = ptys.lock().unwrap();
+            if map.get(&id).map(|h| h.gen) == Some(gen) {
+                map.remove(&id)
+            } else {
+                None
+            }
+        };
         let mut code = None;
         if let Some(mut h) = handle {
-            match h.child.try_wait() {
-                Ok(Some(status)) => code = Some(status.exit_code()),
-                _ => kill_handle(&mut h),
+            // EOF often lands a beat before the OS finalizes the exit status —
+            // poll briefly (dedicated thread; blocking is fine) so a clean exit
+            // reports its real code instead of a false "Stopped".
+            for _ in 0..50 {
+                if let Ok(Some(status)) = h.child.try_wait() {
+                    code = Some(status.exit_code());
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            if code.is_none() {
+                // Still alive after the grace window (the reader stopped early)
+                // — kill it (tree first) so it can't orphan, and wait for the
+                // Windows tree-kill so the temp delete below sticks.
+                if let Some(mut tk) = kill_handle(&mut h) {
+                    let _ = tk.wait();
+                }
             }
             cleanup_handle(&mut h);
         }
@@ -440,12 +514,13 @@ pub fn pty_resize(state: State<'_, PtyState>, id: String, cols: u16, rows: u16) 
 
 /// Kills the process and drops the PTY (on terminal unmount / dock close / task
 /// Stop). Tree-kills a task's descendants and removes its temp script. Idempotent.
+/// Sync command (main thread) — the teardown waits on the Windows tree-kill
+/// before deleting the temp script, so it runs detached rather than blocking UI.
 #[tauri::command]
 pub fn pty_close(state: State<'_, PtyState>, id: String) -> AppResult<()> {
     let handle = state.ptys.lock().unwrap().remove(&id);
-    if let Some(mut h) = handle {
-        kill_handle(&mut h);
-        cleanup_handle(&mut h);
+    if let Some(h) = handle {
+        std::thread::spawn(move || teardown_handle(h));
     }
     Ok(())
 }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1551,6 +1551,34 @@ the small programs Git runs at points like *before commit* or *before push*.
   for you.`,
   },
   {
+    id: "tasks",
+    label: "Tasks",
+    body: `# Tasks
+
+Save your own scripts — a release or build flow, say — and run them from inside
+GitDesktop, without dropping to a terminal. Open the **Tasks** tab from the **More ▾**
+tab menu, or from the command palette ({{kbd:command-palette}}).
+
+- **Turn it on first.** Running scripts is off until you enable it — the Tasks tab has an
+  **Enable task running** button. Your saved tasks live in GitDesktop's own data on this
+  machine and are **never read from a repository**, so opening or cloning a repo can never
+  add or run one.
+- **Add a task.** Give it a name and pick an interpreter — **PowerShell**, **cmd**,
+  **bash / sh / zsh**, **Node**, or **Python**. Then either **point it at an existing
+  script** in the repo (it runs the live file, so edits take effect on the next run) or
+  write one **inline** — a one-liner like \`node scripts/release.mjs\` or several lines with
+  pipes and \`&&\`.{{ai}} With an AI provider connected, **Generate** writes an inline script
+  from a short description.{{/ai}} You can also pass **arguments** (e.g. \`--preview\`; quote
+  values with spaces). Either way it runs in the open repository's folder.
+- **Run it.** Click a task, or use **Run a task…** from the command palette. Runs happen in
+  an **interactive** terminal, so a script that prompts you — the next version to release, a
+  yes/no — works, and output keeps its colour. **Stop** ends a run and the processes it
+  started; **Rerun** starts a fresh one.
+- **Confirm before running.** Each task can ask for confirmation first (on by default) —
+  turn it off per task once you trust it. Starting a task while another is still running
+  asks before it replaces it.`,
+  },
+  {
     id: "keyboard",
     label: "Keyboard & navigation",
     body: `# Keyboard & navigation

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1563,20 +1563,26 @@ tab menu, or from the command palette ({{kbd:command-palette}}).
   **Enable task running** button. Your saved tasks live in GitDesktop's own data on this
   machine and are **never read from a repository**, so opening or cloning a repo can never
   add or run one.
-- **Add a task.** Give it a name and pick an interpreter — **PowerShell**, **cmd**,
-  **bash / sh / zsh**, **Node**, or **Python**. Then either **point it at an existing
-  script** in the repo (it runs the live file, so edits take effect on the next run) or
-  write one **inline** — a one-liner like \`node scripts/release.mjs\` or several lines with
-  pipes and \`&&\`.{{ai}} With an AI provider connected, **Generate** writes an inline script
-  from a short description.{{/ai}} You can also pass **arguments** (e.g. \`--preview\`; quote
-  values with spaces). Either way it runs in the open repository's folder.
-- **Run it.** Click a task, or use **Run a task…** from the command palette. Runs happen in
-  an **interactive** terminal, so a script that prompts you — the next version to release, a
-  yes/no — works, and output keeps its colour. **Stop** ends a run and the processes it
-  started; **Rerun** starts a fresh one.
+- **Add a task.** Give it a name, an optional one-line description, and pick an
+  interpreter — **PowerShell**, **cmd**, **bash / sh / zsh**, **Node**, or **Python**. Then
+  either **point it at an existing script** in the repo (it runs the live file, so edits
+  take effect on the next run) or write one **inline** — a one-liner like
+  \`node scripts/release.mjs\` or several lines with pipes and \`&&\`.{{ai}} With an AI
+  provider connected, **Generate** writes an inline script from a short description, and
+  **Analyze with AI** reads the script and fills in the name, description, and the
+  arguments it accepts.{{/ai}} Either way it runs in the open repository's folder.
+- **Arguments.** A task carries default **arguments** (e.g. \`--preview\`; quote values with
+  spaces), and you can **document the arguments** the script accepts — each with a short
+  description, like a CLI's \`--help\` — shown as a reference wherever you set arguments.
+- **Run it.** Click a task, or use **Run a task…** from the command palette. A
+  confirm-gated run shows the arguments prefilled and lets you **adjust them for that run**
+  (the saved task is untouched) — press Enter to run. Runs happen in an **interactive**
+  terminal, so a script that prompts you — the next version to release, a yes/no — works,
+  and output keeps its colour. **Stop** ends a run and the processes it started; **Rerun**
+  starts a fresh one with the same arguments.
 - **Confirm before running.** Each task can ask for confirmation first (on by default) —
-  turn it off per task once you trust it. Starting a task while another is still running
-  asks before it replaces it.`,
+  turn it off per task once you trust it (it then always runs its saved arguments).
+  Starting a task while another is still running asks before it replaces it.`,
   },
   {
     id: "keyboard",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1565,11 +1565,12 @@ tab menu, or from the command palette ({{kbd:command-palette}}).
   add or run one.
 - **Add a task.** Give it a name, an optional one-line description, and pick an
   interpreter — **PowerShell**, **cmd**, **Git Bash**, **bash / sh / zsh**, **Node**,
-  **Deno**, **Bun**, **Python**, or **Ruby** (the editor shows which are installed on your
+  **Deno**, **Bun**, **Python**, or **Ruby** (the editor shows which it detected on your
   machine, and where). Then
   either **point it at an existing script** in the repo (it runs the live file, so edits
-  take effect on the next run) or write one **inline** — a one-liner like
-  \`node scripts/release.mjs\` or several lines with pipes and \`&&\`.{{ai}} With an AI
+  take effect on the next run) or write one **inline** — the script's contents, written
+  in your chosen interpreter's language (shell for PowerShell or bash, JavaScript for
+  Node, and so on).{{ai}} With an AI
   provider connected, **Generate** writes an inline script from a short description, and
   **Analyze with AI** reads the script and fills in the name, description, and the
   arguments it accepts.{{/ai}} Either way it runs in the open repository's folder.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1564,7 +1564,9 @@ tab menu, or from the command palette ({{kbd:command-palette}}).
   machine and are **never read from a repository**, so opening or cloning a repo can never
   add or run one.
 - **Add a task.** Give it a name, an optional one-line description, and pick an
-  interpreter — **PowerShell**, **cmd**, **bash / sh / zsh**, **Node**, or **Python**. Then
+  interpreter — **PowerShell**, **cmd**, **Git Bash**, **bash / sh / zsh**, **Node**,
+  **Deno**, **Bun**, **Python**, or **Ruby** (the editor shows which are installed on your
+  machine, and where). Then
   either **point it at an existing script** in the repo (it runs the live file, so edits
   take effect on the next run) or write one **inline** — a one-liner like
   \`node scripts/release.mjs\` or several lines with pipes and \`&&\`.{{ai}} With an AI

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -214,9 +214,7 @@ export function RepositoryView() {
   const tasksEnabled = scripts.data?.enabled ?? false;
   const hasTasks = (scripts.data?.tasks.length ?? 0) > 0;
   // A running task shows a dot on the "More" trigger when you're on another tab.
-  const taskRunning = useTaskRunStore(
-    (s) => s.activeRun?.status === "running",
-  );
+  const taskRunning = useTaskRunStore((s) => s.activeRun?.status === "running");
 
   // OS notifications for PR/check and workflow-run events while this repo is open.
   usePrNotifications(repoPath ?? "");

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -51,6 +51,10 @@ import { PullRequestsPanel } from "@/features/pulls/PullRequestsPanel";
 import { RemotePrView } from "@/features/pulls/RemotePrView";
 import { useCleanupResolveWorktrees } from "@/features/pulls/useCleanupResolveWorktrees";
 import { useWatchPrHeads } from "@/features/pulls/useWatchPrHeads";
+import { RunTaskPicker } from "@/features/scripts/RunTaskPicker";
+import { TaskRunConfirm } from "@/features/scripts/TaskRunConfirm";
+import { TaskRunView } from "@/features/scripts/TaskRunView";
+import { TasksPanel } from "@/features/scripts/TasksPanel";
 import { TagDetailView } from "@/features/tags/TagDetailView";
 import { TagsPanel } from "@/features/tags/TagsPanel";
 import {
@@ -62,7 +66,9 @@ import {
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink, useJiraPermissions } from "@/lib/jira/queries";
 import { useLensGate, useSetRepoLens } from "@/lib/repo-lens/queries";
+import { useScripts } from "@/lib/scripts/queries";
 import { useAiEnabled, useRepoAlias } from "@/lib/settings/queries";
+import { useTaskRunStore } from "@/lib/stores/taskRun";
 import { type RepoTab, useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import { ChangesPanel } from "./ChangesPanel";
@@ -121,6 +127,7 @@ const SECONDARY_TABS: { tab: RepoTab; label: string; ai?: boolean }[] = [
   { tab: "discussions", label: "Discussions" },
   { tab: "actions", label: "Actions" },
   { tab: "tags", label: "Tags" },
+  { tab: "tasks", label: "Tasks" },
   { tab: "insights", label: "Insights" },
 ];
 
@@ -200,6 +207,16 @@ export function RepositoryView() {
   // the palette can reach it from any tab.
   const [blamePickerOpen, setBlamePickerOpen] = useState(false);
   const [blamePath, setBlamePath] = useState<string | null>(null);
+  // Palette "Run a task…": the picker's open state, kept here (always mounted) so
+  // the palette can reach it from any tab. Gated on tasks being enabled + present.
+  const [runTaskPickerOpen, setRunTaskPickerOpen] = useState(false);
+  const scripts = useScripts();
+  const tasksEnabled = scripts.data?.enabled ?? false;
+  const hasTasks = (scripts.data?.tasks.length ?? 0) > 0;
+  // A running task shows a dot on the "More" trigger when you're on another tab.
+  const taskRunning = useTaskRunStore(
+    (s) => s.activeRun?.status === "running",
+  );
 
   // OS notifications for PR/check and workflow-run events while this repo is open.
   usePrNotifications(repoPath ?? "");
@@ -228,9 +245,17 @@ export function RepositoryView() {
   useHotkeyAction("tab-tags", () => changeTab("tags"));
   useHotkeyAction("tab-insights", () => changeTab("insights"));
   useHotkeyAction("tab-code-todos", () => changeTab("code-todos"));
+  useHotkeyAction("tab-tasks", () => changeTab("tasks"));
   // The Agent tab only exists when AI features are shown (palette-only binding).
   useHotkeyAction("tab-agent", () => changeTab("agent"), aiEnabled);
   useHotkeyAction("back-to-repositories", closeRepo);
+  // Palette "Run a task…": open the picker from any tab (only when there are
+  // tasks to run and running is enabled).
+  useHotkeyAction(
+    "run-task",
+    () => setRunTaskPickerOpen(true),
+    tasksEnabled && hasTasks,
+  );
 
   // Create actions registered here (always mounted) so the command palette can
   // reach them from any tab: each switches to the owning tab and flags its panel
@@ -362,6 +387,11 @@ export function RepositoryView() {
               </TabsTrigger>
               <DropdownMenu>
                 <DropdownMenuTrigger
+                  title={
+                    taskRunning && repoTab !== "tasks"
+                      ? "A task is running"
+                      : undefined
+                  }
                   render={
                     <button
                       type="button"
@@ -374,6 +404,12 @@ export function RepositoryView() {
                     />
                   }
                 >
+                  {taskRunning && repoTab !== "tasks" && (
+                    <span
+                      className="size-1.5 shrink-0 rounded-full bg-primary"
+                      aria-hidden
+                    />
+                  )}
                   {activeSecondary?.label ?? "More"}
                   <CaretDownIcon data-icon="inline-end" />
                 </DropdownMenuTrigger>
@@ -429,6 +465,9 @@ export function RepositoryView() {
               repoPath={repoPath}
               active={repoTab === "code-todos"}
             />
+          </Activity>
+          <Activity mode={mode("tasks")}>
+            <TasksPanel />
           </Activity>
           {aiEnabled && (
             <Activity mode={mode("agent")}>
@@ -557,6 +596,9 @@ export function RepositoryView() {
               <DiffPlaceholder icon={ListChecksIcon} message="Select a TODO" />
             )}
           </Activity>
+          <Activity mode={mode("tasks")}>
+            <TaskRunView />
+          </Activity>
           <Activity mode={mode("insights")}>
             {insightsSeen && (
               <Suspense fallback={null}>
@@ -609,6 +651,13 @@ export function RepositoryView() {
           if (!o) closeLocalPrCreate();
         }}
       />
+      {/* Palette "Run a task…" picker + the shared run-confirmation dialog.
+          Hoisted here so both are reachable from any tab. */}
+      <RunTaskPicker
+        open={runTaskPickerOpen}
+        onOpenChange={setRunTaskPickerOpen}
+      />
+      <TaskRunConfirm />
     </div>
   );
 }

--- a/src/features/scripts/RunTaskPicker.tsx
+++ b/src/features/scripts/RunTaskPicker.tsx
@@ -112,7 +112,10 @@ export function RunTaskPicker({
                 >
                   <PlayIcon className="mt-px size-3.5 shrink-0 text-muted-foreground" />
                   <span className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate" onMouseEnter={clipTitle(task.name)}>
+                    <span
+                      className="truncate"
+                      onMouseEnter={clipTitle(task.name)}
+                    >
                       {task.name}
                     </span>
                     {task.description !== "" && (

--- a/src/features/scripts/RunTaskPicker.tsx
+++ b/src/features/scripts/RunTaskPicker.tsx
@@ -37,7 +37,12 @@ export function RunTaskPicker({
   }, [open]);
 
   const q = query.trim().toLowerCase();
-  const items = tasks.filter((t) => !q || t.name.toLowerCase().includes(q));
+  const items = tasks.filter(
+    (t) =>
+      !q ||
+      t.name.toLowerCase().includes(q) ||
+      t.description.toLowerCase().includes(q),
+  );
   const highlighted = items[Math.min(highlight, items.length - 1)];
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: scrolls to whichever row carries the highlight
@@ -96,7 +101,7 @@ export function RunTaskPicker({
                   type="button"
                   data-highlighted={index === highlight || undefined}
                   className={cn(
-                    "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs",
+                    "flex w-full items-start gap-2 px-3 py-1.5 text-left text-xs",
                     index === highlight
                       ? "bg-accent text-accent-foreground"
                       : "hover:bg-muted/60",
@@ -104,8 +109,15 @@ export function RunTaskPicker({
                   onMouseMove={() => setHighlight(index)}
                   onClick={() => run(task.id)}
                 >
-                  <PlayIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1 truncate">{task.name}</span>
+                  <PlayIcon className="mt-px size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">{task.name}</span>
+                    {task.description !== "" && (
+                      <span className="truncate text-[11px] text-muted-foreground">
+                        {task.description}
+                      </span>
+                    )}
+                  </span>
                   <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
                     {INTERPRETER_LABELS[task.interpreter] ?? task.interpreter}
                   </span>

--- a/src/features/scripts/RunTaskPicker.tsx
+++ b/src/features/scripts/RunTaskPicker.tsx
@@ -1,0 +1,120 @@
+import { PlayIcon } from "@phosphor-icons/react";
+import { useEffect, useRef, useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useScripts } from "@/lib/scripts/queries";
+import { INTERPRETERS } from "@/lib/scripts/types";
+import { useTaskRunStore } from "@/lib/stores/taskRun";
+import { cn } from "@/lib/utils";
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+/**
+ * The command-palette "Run a task…" picker: search the registered tasks and run
+ * one. Hoisted at the repo level so it's reachable from any tab. Modeled on the
+ * command palette (Dialog + filtered list + arrow/Enter).
+ */
+export function RunTaskPicker({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const tasks = useScripts().data?.tasks ?? [];
+  const request = useTaskRunStore((s) => s.request);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setHighlight(0);
+    }
+  }, [open]);
+
+  const q = query.trim().toLowerCase();
+  const items = tasks.filter((t) => !q || t.name.toLowerCase().includes(q));
+  const highlighted = items[Math.min(highlight, items.length - 1)];
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scrolls to whichever row carries the highlight
+  useEffect(() => {
+    listRef.current
+      ?.querySelector('[data-highlighted="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  function run(taskId: string) {
+    const task = tasks.find((t) => t.id === taskId);
+    onOpenChange(false);
+    // Let the dialog close first so its confirm (if any) isn't fighting focus.
+    if (task) setTimeout(() => request(task), 0);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, items.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlighted) run(highlighted.id);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 p-0 sm:max-w-md" showCloseButton={false}>
+        <DialogTitle className="sr-only">Run a task</DialogTitle>
+        <div className="border-b p-2">
+          <Input
+            autoFocus
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setHighlight(0);
+            }}
+            onKeyDown={onKeyDown}
+            placeholder="Run a task…"
+            aria-label="Search tasks"
+          />
+        </div>
+        {items.length === 0 ? (
+          <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+            No matching tasks.
+          </p>
+        ) : (
+          <ul ref={listRef} className="max-h-80 overflow-y-auto py-1">
+            {items.map((task, index) => (
+              <li key={task.id}>
+                <button
+                  type="button"
+                  data-highlighted={index === highlight || undefined}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs",
+                    index === highlight
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-muted/60",
+                  )}
+                  onMouseMove={() => setHighlight(index)}
+                  onClick={() => run(task.id)}
+                >
+                  <PlayIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate">{task.name}</span>
+                  <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+                    {INTERPRETER_LABELS[task.interpreter] ?? task.interpreter}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/scripts/RunTaskPicker.tsx
+++ b/src/features/scripts/RunTaskPicker.tsx
@@ -2,6 +2,7 @@ import { PlayIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { clipTitle } from "@/lib/clip-title";
 import { useScripts } from "@/lib/scripts/queries";
 import { INTERPRETERS } from "@/lib/scripts/types";
 import { useTaskRunStore } from "@/lib/stores/taskRun";
@@ -111,9 +112,14 @@ export function RunTaskPicker({
                 >
                   <PlayIcon className="mt-px size-3.5 shrink-0 text-muted-foreground" />
                   <span className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate">{task.name}</span>
+                    <span className="truncate" onMouseEnter={clipTitle(task.name)}>
+                      {task.name}
+                    </span>
                     {task.description !== "" && (
-                      <span className="truncate text-[11px] text-muted-foreground">
+                      <span
+                        className="truncate text-[11px] text-muted-foreground"
+                        onMouseEnter={clipTitle(task.description)}
+                      >
                         {task.description}
                       </span>
                     )}

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -1,0 +1,403 @@
+import { SparkleIcon } from "@phosphor-icons/react";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+  DEFAULT_INTERPRETER,
+  type Interpreter,
+  INTERPRETERS,
+  interpreterForExt,
+  type TaskDef,
+  type TaskSource,
+} from "@/lib/scripts/types";
+import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
+import { useUiStore } from "@/lib/stores/ui";
+import { cn } from "@/lib/utils";
+import { useGenerateScript } from "./useGenerateScript";
+
+// CodeMirror is heavy; lazy-load it so its chunk stays off the boot path and only
+// loads when the task editor first opens (same as the git-hooks editor).
+const CodeEditor = lazy(() =>
+  import("@/components/code-editor").then((m) => ({ default: m.CodeEditor })),
+);
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+/** Make a picked absolute path relative to the repo root when it's inside it, so a
+ *  task like `scripts/release.mjs` works in any repo that has it. Outside the repo,
+ *  keep the absolute path (it's machine-specific). Windows paths compare
+ *  case-insensitively; store forward slashes either way. */
+function toRepoRelative(picked: string, repoRoot: string | null): string {
+  const norm = (p: string) => p.replace(/\\/g, "/");
+  const p = norm(picked);
+  if (!repoRoot) return p;
+  const root = norm(repoRoot).replace(/\/+$/, "");
+  return p.toLowerCase().startsWith(`${root.toLowerCase()}/`)
+    ? p.slice(root.length + 1)
+    : p;
+}
+
+/**
+ * Create or edit a task. The parent owns open state + persistence: `onSave`
+ * receives the full task (with a stable id) and `onDelete` its id. A task's script
+ * is either an **existing file** in the repo (run in place) or an **inline** body;
+ * inline bodies can be AI-generated. Definitions are app-data only — never repo
+ * content.
+ */
+export function TaskDialog({
+  task,
+  open,
+  onOpenChange,
+  onSave,
+  onDelete,
+}: {
+  /** An existing task to edit, `"new"` to create, or null when closed. */
+  task: TaskDef | "new" | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (task: TaskDef) => void;
+  onDelete: (id: string) => void;
+}) {
+  const editing = task !== "new" && task !== null ? task : null;
+  const repoPath = useUiStore((s) => s.repoPath);
+  const openSettings = useUiStore((s) => s.openSettings);
+  const aiEnabled = useAiEnabled();
+  const aiConfigured = useAiConfigured();
+  const scriptGen = useGenerateScript(repoPath ?? "");
+
+  const [name, setName] = useState("");
+  const [interpreter, setInterpreter] =
+    useState<Interpreter>(DEFAULT_INTERPRETER);
+  const [sourceKind, setSourceKind] = useState<TaskSource["kind"]>("file");
+  const [path, setPath] = useState("");
+  const [body, setBody] = useState("");
+  const [args, setArgs] = useState("");
+  const [describe, setDescribe] = useState("");
+  const [confirmBeforeRun, setConfirmBeforeRun] = useState(true);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Seed the fields when a task (or "new") opens. Keyed on the dialog opening so
+  // reopening the same task re-seeds from the saved value, discarding stray edits.
+  const seededFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!open) {
+      seededFor.current = null;
+      return;
+    }
+    const key = editing?.id ?? "new";
+    if (seededFor.current === key) return;
+    seededFor.current = key;
+    setName(editing?.name ?? "");
+    setInterpreter(editing?.interpreter ?? DEFAULT_INTERPRETER);
+    setSourceKind(editing?.source.kind ?? "file");
+    setPath(editing?.source.kind === "file" ? editing.source.path : "");
+    setBody(editing?.source.kind === "inline" ? editing.source.body : "");
+    setArgs(editing?.args ?? "");
+    setDescribe("");
+    setConfirmBeforeRun(editing?.confirmBeforeRun ?? true);
+    setConfirmDelete(false);
+  }, [open, editing]);
+
+  const trimmedName = name.trim();
+  const canSave =
+    trimmedName !== "" &&
+    (sourceKind === "file" ? path.trim() !== "" : body.trim() !== "");
+
+  async function choose() {
+    const picked = await openDialog({
+      title: "Choose a script to run",
+      defaultPath: repoPath ?? undefined,
+    });
+    if (typeof picked !== "string") return;
+    setPath(toRepoRelative(picked, repoPath));
+    // Pre-select the interpreter from the extension (still overridable).
+    const guess = interpreterForExt(picked);
+    if (guess) setInterpreter(guess);
+  }
+
+  function save() {
+    if (!canSave) return;
+    const source: TaskSource =
+      sourceKind === "file"
+        ? { kind: "file", path: path.trim() }
+        : { kind: "inline", body };
+    onSave({
+      id: editing?.id ?? crypto.randomUUID(),
+      name: trimmedName,
+      interpreter,
+      source,
+      args: args.trim(),
+      confirmBeforeRun,
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit task" : "New task"}</DialogTitle>
+          <DialogDescription>
+            A saved script you can run from here without a terminal. Point it at an
+            existing script in the repo, or write one inline. Either way it runs in
+            the repository's folder.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-[1fr_auto] gap-3">
+          <div className="min-w-0 space-y-1.5">
+            <Label htmlFor="task-name">Name</Label>
+            <Input
+              id="task-name"
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Release"
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="task-interpreter">Run with</Label>
+            <Select
+              items={INTERPRETER_LABELS}
+              value={interpreter}
+              onValueChange={(v) => v && setInterpreter(v as Interpreter)}
+            >
+              <SelectTrigger id="task-interpreter" className="w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {INTERPRETERS.map((i) => (
+                  <SelectItem key={i.id} value={i.id}>
+                    <span className="flex flex-col">
+                      <span>{i.label}</span>
+                      <span className="text-[11px] text-muted-foreground">
+                        {i.hint}
+                      </span>
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Source: an existing file, or an inline body. */}
+        <div className="inline-flex w-fit rounded-md border p-0.5 text-xs">
+          {(
+            [
+              ["file", "Existing file"],
+              ["inline", "Inline script"],
+            ] as const
+          ).map(([kind, label]) => (
+            <button
+              key={kind}
+              type="button"
+              onClick={() => setSourceKind(kind)}
+              className={cn(
+                "rounded px-2.5 py-1 transition-colors",
+                sourceKind === kind
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {sourceKind === "file" ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="task-path">Script file</Label>
+            <div className="flex gap-2">
+              <Input
+                id="task-path"
+                className="flex-1 font-mono"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                placeholder="scripts/release.mjs"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <Button type="button" variant="outline" onClick={choose}>
+                Choose…
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Relative to the repository root — runs the live file, so edits to it
+              take effect on the next run.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <Label>Script</Label>
+              {aiEnabled &&
+                (scriptGen.generating ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    className="text-muted-foreground"
+                    onClick={scriptGen.cancel}
+                  >
+                    <Spinner data-icon="inline-start" />
+                    Generating…
+                  </Button>
+                ) : !aiConfigured ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    className="text-muted-foreground"
+                    title="Connect an AI provider to generate scripts"
+                    onClick={() => {
+                      onOpenChange(false);
+                      openSettings("ai");
+                    }}
+                  >
+                    <SparkleIcon data-icon="inline-start" />
+                    Set up AI to generate
+                  </Button>
+                ) : null)}
+            </div>
+
+            {aiEnabled && aiConfigured && !scriptGen.generating && (
+              <div className="flex gap-2">
+                <Input
+                  value={describe}
+                  onChange={(e) => setDescribe(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      scriptGen.generate({
+                        description: describe,
+                        interpreter,
+                        onBody: setBody,
+                      });
+                    }
+                  }}
+                  placeholder="Describe what the script should do…"
+                  autoComplete="off"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={describe.trim() === ""}
+                  onClick={() =>
+                    scriptGen.generate({
+                      description: describe,
+                      interpreter,
+                      onBody: setBody,
+                    })
+                  }
+                >
+                  <SparkleIcon data-icon="inline-start" />
+                  Generate
+                </Button>
+              </div>
+            )}
+
+            <div className="h-56 overflow-hidden rounded-md border">
+              <Suspense fallback={<Skeleton className="h-full w-full" />}>
+                <CodeEditor value={body} onChange={setBody} />
+              </Suspense>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              A one-liner like{" "}
+              <span className="font-mono">node scripts/release.mjs</span> or
+              several lines with pipes and{" "}
+              <span className="font-mono">&amp;&amp;</span>.
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="task-args">
+            Arguments{" "}
+            <span className="font-normal text-muted-foreground">(optional)</span>
+          </Label>
+          <Input
+            id="task-args"
+            className="font-mono"
+            value={args}
+            onChange={(e) => setArgs(e.target.value)}
+            placeholder="--preview"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <p className="text-xs text-muted-foreground">
+            Passed to the script after its path. Quote values with spaces, e.g.{" "}
+            <span className="font-mono">--message "two words"</span>.
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 text-xs">
+          <Switch
+            checked={confirmBeforeRun}
+            onCheckedChange={setConfirmBeforeRun}
+          />
+          <span>Ask for confirmation before running</span>
+        </label>
+
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={save} disabled={!canSave}>
+            {editing ? "Save" : "Create task"}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <span className="flex-1" />
+          {editing &&
+            (confirmDelete ? (
+              <>
+                <span className="text-xs text-muted-foreground">Delete?</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setConfirmDelete(false)}
+                >
+                  Keep
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => onDelete(editing.id)}
+                >
+                  Delete
+                </Button>
+              </>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setConfirmDelete(true)}
+              >
+                Delete…
+              </Button>
+            ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -1,4 +1,4 @@
-import { SparkleIcon } from "@phosphor-icons/react";
+import { PlusIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import {
+  type ArgDoc,
   DEFAULT_INTERPRETER,
   type Interpreter,
   INTERPRETERS,
@@ -32,6 +33,7 @@ import {
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
+import { useAnalyzeScript } from "./useAnalyzeScript";
 import { useGenerateScript } from "./useGenerateScript";
 
 // CodeMirror is heavy; lazy-load it so its chunk stays off the boot path and only
@@ -43,6 +45,13 @@ const CodeEditor = lazy(() =>
 const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
   INTERPRETERS.map((i) => [i.id, i.label]),
 );
+
+/** An arg-doc row in the editor: the doc plus a dialog-local key, so removing a
+ *  row can't re-key its neighbours' inputs (index keys would). Stripped on save. */
+type ArgDocRow = ArgDoc & { key: string };
+
+const toRows = (docs: ArgDoc[]): ArgDocRow[] =>
+  docs.map((d) => ({ ...d, key: crypto.randomUUID() }));
 
 /** Make a picked absolute path relative to the repo root when it's inside it, so a
  *  task like `scripts/release.mjs` works in any repo that has it. Outside the repo,
@@ -62,8 +71,9 @@ function toRepoRelative(picked: string, repoRoot: string | null): string {
  * Create or edit a task. The parent owns open state + persistence: `onSave`
  * receives the full task (with a stable id) and `onDelete` its id. A task's script
  * is either an **existing file** in the repo (run in place) or an **inline** body;
- * inline bodies can be AI-generated. Definitions are app-data only — never repo
- * content.
+ * inline bodies can be AI-generated, and **Analyze with AI** documents either kind
+ * (name, description, accepted arguments) from the script itself. Definitions are
+ * app-data only — never repo content.
  */
 export function TaskDialog({
   task,
@@ -85,14 +95,17 @@ export function TaskDialog({
   const aiEnabled = useAiEnabled();
   const aiConfigured = useAiConfigured();
   const scriptGen = useGenerateScript(repoPath ?? "");
+  const scriptAnalyze = useAnalyzeScript(repoPath ?? "");
 
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [interpreter, setInterpreter] =
     useState<Interpreter>(DEFAULT_INTERPRETER);
   const [sourceKind, setSourceKind] = useState<TaskSource["kind"]>("file");
   const [path, setPath] = useState("");
   const [body, setBody] = useState("");
   const [args, setArgs] = useState("");
+  const [argDocs, setArgDocs] = useState<ArgDocRow[]>([]);
   const [describe, setDescribe] = useState("");
   const [confirmBeforeRun, setConfirmBeforeRun] = useState(true);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -100,29 +113,41 @@ export function TaskDialog({
   // Seed the fields when a task (or "new") opens. Keyed on the dialog opening so
   // reopening the same task re-seeds from the saved value, discarding stray edits.
   const seededFor = useRef<string | null>(null);
+  const cancelGenerate = scriptGen.cancel;
+  const cancelAnalyze = scriptAnalyze.cancel;
   useEffect(() => {
     if (!open) {
       seededFor.current = null;
+      // Abort any in-flight Generate/Analyze: this component instance stays
+      // mounted across open/close (only the Dialog hides), so a stream left
+      // running would resolve into whichever task is opened NEXT — its
+      // callbacks write through the same state setters.
+      cancelGenerate();
+      cancelAnalyze();
       return;
     }
     const key = editing?.id ?? "new";
     if (seededFor.current === key) return;
     seededFor.current = key;
     setName(editing?.name ?? "");
+    setDescription(editing?.description ?? "");
     setInterpreter(editing?.interpreter ?? DEFAULT_INTERPRETER);
     setSourceKind(editing?.source.kind ?? "file");
     setPath(editing?.source.kind === "file" ? editing.source.path : "");
     setBody(editing?.source.kind === "inline" ? editing.source.body : "");
     setArgs(editing?.args ?? "");
+    setArgDocs(toRows(editing?.argDocs ?? []));
     setDescribe("");
     setConfirmBeforeRun(editing?.confirmBeforeRun ?? true);
     setConfirmDelete(false);
-  }, [open, editing]);
+  }, [open, editing, cancelGenerate, cancelAnalyze]);
 
   const trimmedName = name.trim();
   const canSave =
     trimmedName !== "" &&
     (sourceKind === "file" ? path.trim() !== "" : body.trim() !== "");
+  const canAnalyze =
+    sourceKind === "file" ? path.trim() !== "" : body.trim() !== "";
 
   async function choose() {
     const picked = await openDialog({
@@ -136,6 +161,26 @@ export function TaskDialog({
     if (guess) setInterpreter(guess);
   }
 
+  function runAnalyze() {
+    scriptAnalyze.analyze({
+      interpreter,
+      ...(sourceKind === "file" ? { path: path.trim() } : { body }),
+      onResult: (r) => {
+        // Fill what the analysis produced; leave anything it couldn't derive
+        // untouched (and never clear hand-written docs on an empty result).
+        if (r.name) setName(r.name);
+        if (r.description) setDescription(r.description);
+        if (r.argDocs.length > 0) setArgDocs(toRows(r.argDocs));
+      },
+    });
+  }
+
+  function updateRow(key: string, patch: Partial<ArgDoc>) {
+    setArgDocs((rows) =>
+      rows.map((r) => (r.key === key ? { ...r, ...patch } : r)),
+    );
+  }
+
   function save() {
     if (!canSave) return;
     const source: TaskSource =
@@ -145,16 +190,20 @@ export function TaskDialog({
     onSave({
       id: editing?.id ?? crypto.randomUUID(),
       name: trimmedName,
+      description: description.trim(),
       interpreter,
       source,
       args: args.trim(),
+      argDocs: argDocs
+        .filter((r) => r.arg.trim() !== "")
+        .map(({ arg, description: d }) => ({ arg: arg.trim(), description: d })),
       confirmBeforeRun,
     });
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{editing ? "Edit task" : "New task"}</DialogTitle>
           <DialogDescription>
@@ -202,28 +251,84 @@ export function TaskDialog({
           </div>
         </div>
 
-        {/* Source: an existing file, or an inline body. */}
-        <div className="inline-flex w-fit rounded-md border p-0.5 text-xs">
-          {(
-            [
-              ["file", "Existing file"],
-              ["inline", "Inline script"],
-            ] as const
-          ).map(([kind, label]) => (
-            <button
-              key={kind}
-              type="button"
-              onClick={() => setSourceKind(kind)}
-              className={cn(
-                "rounded px-2.5 py-1 transition-colors",
-                sourceKind === kind
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {label}
-            </button>
-          ))}
+        <div className="space-y-1.5">
+          <Label htmlFor="task-description">
+            Description{" "}
+            <span className="font-normal text-muted-foreground">(optional)</span>
+          </Label>
+          <Input
+            id="task-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What running this does, in a sentence"
+            autoComplete="off"
+          />
+        </div>
+
+        {/* Source: an existing file, or an inline body — with the AI analyzer
+            alongside, since it documents whichever source is active. */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="inline-flex w-fit rounded-md border p-0.5 text-xs">
+            {(
+              [
+                ["file", "Existing file"],
+                ["inline", "Inline script"],
+              ] as const
+            ).map(([kind, label]) => (
+              <button
+                key={kind}
+                type="button"
+                onClick={() => setSourceKind(kind)}
+                className={cn(
+                  "rounded px-2.5 py-1 transition-colors",
+                  sourceKind === kind
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {aiEnabled &&
+            aiConfigured &&
+            (scriptAnalyze.analyzing ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="text-muted-foreground"
+                onClick={scriptAnalyze.cancel}
+              >
+                <Spinner data-icon="inline-start" />
+                Analyzing…
+              </Button>
+            ) : (
+              // A natively-disabled button swallows pointer events, so its own
+              // `title` never shows — the explanation lives on a wrapping span
+              // (the repo's established pattern for disabled-control tooltips).
+              <span
+                title={
+                  canAnalyze
+                    ? "Read the script and fill in the name, description, and documented arguments"
+                    : sourceKind === "file"
+                      ? "Choose a script file first"
+                      : "Write or generate a script first"
+                }
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="text-muted-foreground"
+                  disabled={!canAnalyze}
+                  onClick={runAnalyze}
+                >
+                  <SparkleIcon data-icon="inline-start" />
+                  Analyze with AI
+                </Button>
+              </span>
+            ))}
         </div>
 
         {sourceKind === "file" ? (
@@ -253,18 +358,8 @@ export function TaskDialog({
             <div className="flex items-center justify-between gap-2">
               <Label>Script</Label>
               {aiEnabled &&
-                (scriptGen.generating ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="xs"
-                    className="text-muted-foreground"
-                    onClick={scriptGen.cancel}
-                  >
-                    <Spinner data-icon="inline-start" />
-                    Generating…
-                  </Button>
-                ) : !aiConfigured ? (
+                !aiConfigured &&
+                (scriptGen.generating ? null : (
                   <Button
                     type="button"
                     variant="ghost"
@@ -279,7 +374,19 @@ export function TaskDialog({
                     <SparkleIcon data-icon="inline-start" />
                     Set up AI to generate
                   </Button>
-                ) : null)}
+                ))}
+              {aiEnabled && aiConfigured && scriptGen.generating && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="text-muted-foreground"
+                  onClick={scriptGen.cancel}
+                >
+                  <Spinner data-icon="inline-start" />
+                  Generating…
+                </Button>
+              )}
             </div>
 
             {aiEnabled && aiConfigured && !scriptGen.generating && (
@@ -318,7 +425,7 @@ export function TaskDialog({
               </div>
             )}
 
-            <div className="h-56 overflow-hidden rounded-md border">
+            <div className="h-48 overflow-hidden rounded-md border">
               <Suspense fallback={<Skeleton className="h-full w-full" />}>
                 <CodeEditor value={body} onChange={setBody} />
               </Suspense>
@@ -347,9 +454,74 @@ export function TaskDialog({
             spellCheck={false}
           />
           <p className="text-xs text-muted-foreground">
-            Passed to the script after its path. Quote values with spaces, e.g.{" "}
+            The default arguments; a run that asks for confirmation can adjust
+            them per run. Quote values with spaces, e.g.{" "}
             <span className="font-mono">--message "two words"</span>.
           </p>
+        </div>
+
+        <div
+          role="group"
+          aria-labelledby="task-argdocs-label"
+          className="space-y-1.5"
+        >
+          <Label id="task-argdocs-label">
+            Documented arguments{" "}
+            <span className="font-normal text-muted-foreground">
+              (optional — shown as a reference when running)
+            </span>
+          </Label>
+          {argDocs.map((row, index) => (
+            <div key={row.key} className="flex gap-2">
+              <Input
+                className="w-40 font-mono"
+                value={row.arg}
+                onChange={(e) => updateRow(row.key, { arg: e.target.value })}
+                placeholder="--flag"
+                autoComplete="off"
+                spellCheck={false}
+                aria-label={`Argument ${index + 1}`}
+              />
+              <Input
+                className="min-w-0 flex-1"
+                value={row.description}
+                onChange={(e) =>
+                  updateRow(row.key, { description: e.target.value })
+                }
+                placeholder="What it does"
+                autoComplete="off"
+                aria-label={`Argument ${index + 1} description`}
+              />
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                className="shrink-0 self-center text-muted-foreground"
+                onClick={() =>
+                  setArgDocs((rows) => rows.filter((r) => r.key !== row.key))
+                }
+                title={`Remove ${row.arg.trim() || "this argument"}`}
+                aria-label={`Remove argument ${index + 1}`}
+              >
+                <XIcon />
+              </Button>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="text-muted-foreground"
+            onClick={() =>
+              setArgDocs((rows) => [
+                ...rows,
+                { key: crypto.randomUUID(), arg: "", description: "" },
+              ])
+            }
+          >
+            <PlusIcon data-icon="inline-start" />
+            Add argument
+          </Button>
         </div>
 
         <label className="flex items-center gap-2 text-xs">

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -21,8 +21,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { clipTitle } from "@/lib/clip-title";
+import { useDetectedInterpreters } from "@/lib/scripts/interpreters";
 import {
   type ArgDoc,
+  availableInterpreters,
   DEFAULT_INTERPRETER,
   type Interpreter,
   INTERPRETERS,
@@ -96,6 +99,10 @@ export function TaskDialog({
   const aiConfigured = useAiConfigured();
   const scriptGen = useGenerateScript(repoPath ?? "");
   const scriptAnalyze = useAnalyzeScript(repoPath ?? "");
+  // Which interpreters are actually installed — shown per-option so you can see
+  // what a task can run with, and warned about when the chosen one is missing.
+  const detected = useDetectedInterpreters();
+  const options = availableInterpreters();
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -232,24 +239,57 @@ export function TaskDialog({
               value={interpreter}
               onValueChange={(v) => v && setInterpreter(v as Interpreter)}
             >
-              <SelectTrigger id="task-interpreter" className="w-44">
+              <SelectTrigger id="task-interpreter" className="w-48">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent>
-                {INTERPRETERS.map((i) => (
-                  <SelectItem key={i.id} value={i.id}>
-                    <span className="flex flex-col">
-                      <span>{i.label}</span>
-                      <span className="text-[11px] text-muted-foreground">
-                        {i.hint}
+              {/* Wider than the trigger: the popup defaults to the trigger's
+                  width (w-(--anchor-width)) and hard-clips overflow, which cut
+                  the detected interpreter paths mid-character. 320px gives the
+                  paths room; anything longer still ellipsizes inside the span
+                  (max-w-64) with the clipped-title tooltip. */}
+              <SelectContent className="w-80">
+                {options.map((i) => {
+                  const found = detected.data?.get(i.id)?.path ?? null;
+                  const missing = detected.isSuccess && found === null;
+                  return (
+                    <SelectItem key={i.id} value={i.id}>
+                      <span className="flex flex-col">
+                        <span className="flex items-center gap-1.5">
+                          {i.label}
+                          {missing && (
+                            <span className="text-[10px] text-muted-foreground">
+                              · not installed
+                            </span>
+                          )}
+                        </span>
+                        {found ? (
+                          <span
+                            className="max-w-64 truncate font-mono text-[10px] text-muted-foreground"
+                            onMouseEnter={clipTitle(found)}
+                          >
+                            {found}
+                          </span>
+                        ) : (
+                          <span className="text-[11px] text-muted-foreground">
+                            {i.hint}
+                          </span>
+                        )}
                       </span>
-                    </span>
-                  </SelectItem>
-                ))}
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
           </div>
         </div>
+
+        {detected.isSuccess &&
+          detected.data?.get(interpreter)?.path == null && (
+            <p className="text-xs text-warning">
+              {INTERPRETER_LABELS[interpreter] ?? interpreter} isn't on your PATH —
+              the task will fail to run until it's installed.
+            </p>
+          )}
 
         <div className="space-y-1.5">
           <Label htmlFor="task-description">

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { clipTitle } from "@/lib/clip-title";
+import { isMac, isWindows } from "@/lib/hotkeys/binding";
 import { useDetectedInterpreters } from "@/lib/scripts/interpreters";
 import {
   type ArgDoc,
@@ -58,16 +59,18 @@ const toRows = (docs: ArgDoc[]): ArgDocRow[] =>
 
 /** Make a picked absolute path relative to the repo root when it's inside it, so a
  *  task like `scripts/release.mjs` works in any repo that has it. Outside the repo,
- *  keep the absolute path (it's machine-specific). Windows paths compare
- *  case-insensitively; store forward slashes either way. */
+ *  keep the absolute path (it's machine-specific). Windows and macOS paths
+ *  compare case-insensitively; store forward slashes either way. */
 function toRepoRelative(picked: string, repoRoot: string | null): string {
   const norm = (p: string) => p.replace(/\\/g, "/");
   const p = norm(picked);
   if (!repoRoot) return p;
   const root = norm(repoRoot).replace(/\/+$/, "");
-  return p.toLowerCase().startsWith(`${root.toLowerCase()}/`)
-    ? p.slice(root.length + 1)
-    : p;
+  // Windows and macOS default to case-insensitive filesystems; Linux is
+  // case-sensitive, so folding the prefix there could wrongly relativize a
+  // sibling directory that differs only in case.
+  const fold = (s: string) => (isWindows || isMac ? s.toLowerCase() : s);
+  return fold(p).startsWith(`${fold(root)}/`) ? p.slice(root.length + 1) : p;
 }
 
 /**
@@ -261,7 +264,7 @@ export function TaskDialog({
                           {i.label}
                           {missing && (
                             <span className="text-[10px] text-muted-foreground">
-                              · not installed
+                              · not detected
                             </span>
                           )}
                         </span>
@@ -289,8 +292,9 @@ export function TaskDialog({
         {detected.isSuccess &&
           detected.data?.get(interpreter)?.path == null && (
             <p className="text-xs text-warning">
-              {INTERPRETER_LABELS[interpreter] ?? interpreter} isn't on your
-              PATH — the task will fail to run until it's installed.
+              {INTERPRETER_LABELS[interpreter] ?? interpreter} wasn't detected
+              on your PATH — it may still run if your shell resolves it,
+              otherwise you'll need to install it.
             </p>
           )}
 
@@ -476,10 +480,8 @@ export function TaskDialog({
               </Suspense>
             </div>
             <p className="text-xs text-muted-foreground">
-              A one-liner like{" "}
-              <span className="font-mono">node scripts/release.mjs</span> or
-              several lines with pipes and{" "}
-              <span className="font-mono">&amp;&amp;</span>.
+              The script's contents, run by the selected interpreter — shell
+              commands for PowerShell or bash, JavaScript for Node, and so on.
             </p>
           </div>
         )}

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -27,8 +27,8 @@ import {
   type ArgDoc,
   availableInterpreters,
   DEFAULT_INTERPRETER,
-  type Interpreter,
   INTERPRETERS,
+  type Interpreter,
   interpreterForExt,
   type TaskDef,
   type TaskSource,
@@ -203,7 +203,10 @@ export function TaskDialog({
       args: args.trim(),
       argDocs: argDocs
         .filter((r) => r.arg.trim() !== "")
-        .map(({ arg, description: d }) => ({ arg: arg.trim(), description: d })),
+        .map(({ arg, description: d }) => ({
+          arg: arg.trim(),
+          description: d,
+        })),
       confirmBeforeRun,
     });
   }
@@ -214,9 +217,9 @@ export function TaskDialog({
         <DialogHeader>
           <DialogTitle>{editing ? "Edit task" : "New task"}</DialogTitle>
           <DialogDescription>
-            A saved script you can run from here without a terminal. Point it at an
-            existing script in the repo, or write one inline. Either way it runs in
-            the repository's folder.
+            A saved script you can run from here without a terminal. Point it at
+            an existing script in the repo, or write one inline. Either way it
+            runs in the repository's folder.
           </DialogDescription>
         </DialogHeader>
 
@@ -286,15 +289,17 @@ export function TaskDialog({
         {detected.isSuccess &&
           detected.data?.get(interpreter)?.path == null && (
             <p className="text-xs text-warning">
-              {INTERPRETER_LABELS[interpreter] ?? interpreter} isn't on your PATH —
-              the task will fail to run until it's installed.
+              {INTERPRETER_LABELS[interpreter] ?? interpreter} isn't on your
+              PATH — the task will fail to run until it's installed.
             </p>
           )}
 
         <div className="space-y-1.5">
           <Label htmlFor="task-description">
             Description{" "}
-            <span className="font-normal text-muted-foreground">(optional)</span>
+            <span className="font-normal text-muted-foreground">
+              (optional)
+            </span>
           </Label>
           <Input
             id="task-description"
@@ -389,8 +394,8 @@ export function TaskDialog({
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Relative to the repository root — runs the live file, so edits to it
-              take effect on the next run.
+              Relative to the repository root — runs the live file, so edits to
+              it take effect on the next run.
             </p>
           </div>
         ) : (
@@ -482,7 +487,9 @@ export function TaskDialog({
         <div className="space-y-1.5">
           <Label htmlFor="task-args">
             Arguments{" "}
-            <span className="font-normal text-muted-foreground">(optional)</span>
+            <span className="font-normal text-muted-foreground">
+              (optional)
+            </span>
           </Label>
           <Input
             id="task-args"

--- a/src/features/scripts/TaskRunConfirm.tsx
+++ b/src/features/scripts/TaskRunConfirm.tsx
@@ -1,56 +1,143 @@
-import { ConfirmDialog } from "@/components/confirm-dialog";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { INTERPRETERS } from "@/lib/scripts/types";
 import { useTaskRunStore } from "@/lib/stores/taskRun";
-import { useUiStore } from "@/lib/stores/ui";
 
 const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
   INTERPRETERS.map((i) => [i.id, i.label]),
 );
 
 /**
- * The run-confirmation dialog, driven by the task-run store's `pending`. Hoisted
- * at the repo level so any run trigger (panel, palette picker) shares one dialog.
- * `confirm` = the task's own confirm-before-run; `replace` = a task is still
- * running (running it stops the current one).
+ * The run dialog, driven by the task-run store's `pending`. Hoisted at the repo
+ * level so any run trigger (panel, palette picker) shares one instance. Beyond
+ * confirming, it's where a run's **arguments** are adjusted: the field seeds from
+ * the task's saved args (the saved task is never changed here), with the task's
+ * documented arguments as reference below — Enter runs immediately.
+ * `reason: "replace"` additionally warns that the still-running task stops.
  */
 export function TaskRunConfirm() {
   const pending = useTaskRunStore((s) => s.pending);
   const activeRun = useTaskRunStore((s) => s.activeRun);
   const confirmPending = useTaskRunStore((s) => s.confirmPending);
   const cancelPending = useTaskRunStore((s) => s.cancelPending);
-  const repoName = useUiStore((s) => s.repoName);
+
+  const [args, setArgs] = useState("");
+  // Seed the args field from the task's saved string each time a run is
+  // requested (a new pending), discarding the previous request's edits.
+  const seededFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pending) {
+      seededFor.current = null;
+      return;
+    }
+    const key = `${pending.task.id}:${pending.reason}`;
+    if (seededFor.current === key) return;
+    seededFor.current = key;
+    setArgs(pending.task.args);
+  }, [pending]);
 
   const replacing = pending?.reason === "replace";
-  const interpreter = pending
-    ? (INTERPRETER_LABELS[pending.task.interpreter] ?? pending.task.interpreter)
+  const task = pending?.task ?? null;
+  const interpreter = task
+    ? (INTERPRETER_LABELS[task.interpreter] ?? task.interpreter)
     : "";
+  // Keys precomputed outside the JSX: `arg` alone isn't guaranteed unique (the
+  // editor doesn't forbid documenting the same flag twice), and the list is
+  // static per dialog-open, so a position-qualified key is stable and safe.
+  const docRows = (task?.argDocs ?? []).map((d, i) => ({
+    ...d,
+    key: `${i}:${d.arg}`,
+  }));
 
   return (
-    <ConfirmDialog
+    <Dialog
       open={pending !== null}
-      onCancel={cancelPending}
-      onConfirm={confirmPending}
-      title={
-        replacing
-          ? "A task is already running"
-          : `Run "${pending?.task.name}"?`
-      }
-      body={
-        replacing ? (
-          <>
-            Stop “{activeRun?.task.name}” and run “{pending?.task.name}”
-            instead?
-          </>
-        ) : (
-          <>
-            Runs the {interpreter} script
-            {repoName ? ` in ${repoName}` : ""}. Make sure you trust what it
-            does.
-          </>
-        )
-      }
-      confirmLabel={replacing ? "Stop & run" : "Run"}
-      confirmVariant={replacing ? "destructive" : "default"}
-    />
+      onOpenChange={(o) => {
+        if (!o) cancelPending();
+      }}
+    >
+      {/* Tall-content guard: a task may document many arguments; the footer must
+          stay reachable, so the dialog caps and scrolls (same as the editor). */}
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {replacing
+              ? "A task is already running"
+              : `Run “${task?.name}”?`}
+          </DialogTitle>
+          <DialogDescription>
+            {replacing ? (
+              <>
+                Stops “{activeRun?.task.name}” — still running — and runs “
+                {task?.name}” instead.
+              </>
+            ) : task?.description ? (
+              task.description
+            ) : (
+              <>
+                Runs the {interpreter} script in the repository's folder. Make
+                sure you trust what it does.
+              </>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="run-args">Arguments</Label>
+          <Input
+            id="run-args"
+            autoFocus
+            className="font-mono"
+            value={args}
+            onChange={(e) => setArgs(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                confirmPending(args);
+              }
+            }}
+            placeholder="none"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {docRows.length > 0 && (
+            <dl className="space-y-0.5 pt-1 text-xs">
+              {docRows.map((d) => (
+                <div key={d.key} className="flex gap-2">
+                  <dt className="shrink-0 font-mono text-muted-foreground">
+                    {d.arg}
+                  </dt>
+                  <dd className="min-w-0 flex-1 truncate text-muted-foreground">
+                    {d.description}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={cancelPending}>
+            Cancel
+          </Button>
+          <Button
+            variant={replacing ? "destructive" : "default"}
+            onClick={() => confirmPending(args)}
+          >
+            {replacing ? "Stop & run" : "Run"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/scripts/TaskRunConfirm.tsx
+++ b/src/features/scripts/TaskRunConfirm.tsx
@@ -1,0 +1,56 @@
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { INTERPRETERS } from "@/lib/scripts/types";
+import { useTaskRunStore } from "@/lib/stores/taskRun";
+import { useUiStore } from "@/lib/stores/ui";
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+/**
+ * The run-confirmation dialog, driven by the task-run store's `pending`. Hoisted
+ * at the repo level so any run trigger (panel, palette picker) shares one dialog.
+ * `confirm` = the task's own confirm-before-run; `replace` = a task is still
+ * running (running it stops the current one).
+ */
+export function TaskRunConfirm() {
+  const pending = useTaskRunStore((s) => s.pending);
+  const activeRun = useTaskRunStore((s) => s.activeRun);
+  const confirmPending = useTaskRunStore((s) => s.confirmPending);
+  const cancelPending = useTaskRunStore((s) => s.cancelPending);
+  const repoName = useUiStore((s) => s.repoName);
+
+  const replacing = pending?.reason === "replace";
+  const interpreter = pending
+    ? (INTERPRETER_LABELS[pending.task.interpreter] ?? pending.task.interpreter)
+    : "";
+
+  return (
+    <ConfirmDialog
+      open={pending !== null}
+      onCancel={cancelPending}
+      onConfirm={confirmPending}
+      title={
+        replacing
+          ? "A task is already running"
+          : `Run "${pending?.task.name}"?`
+      }
+      body={
+        replacing ? (
+          <>
+            Stop “{activeRun?.task.name}” and run “{pending?.task.name}”
+            instead?
+          </>
+        ) : (
+          <>
+            Runs the {interpreter} script
+            {repoName ? ` in ${repoName}` : ""}. Make sure you trust what it
+            does.
+          </>
+        )
+      }
+      confirmLabel={replacing ? "Stop & run" : "Run"}
+      confirmVariant={replacing ? "destructive" : "default"}
+    />
+  );
+}

--- a/src/features/scripts/TaskRunConfirm.tsx
+++ b/src/features/scripts/TaskRunConfirm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -111,16 +111,17 @@ export function TaskRunConfirm() {
             spellCheck={false}
           />
           {docRows.length > 0 && (
-            <dl className="space-y-0.5 pt-1 text-xs">
+            // --help-style reference: flag column + description that WRAPS —
+            // this is documentation the user is here to read, so it never
+            // truncates (the dialog itself scrolls if the list is long).
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pt-1 text-xs">
               {docRows.map((d) => (
-                <div key={d.key} className="flex gap-2">
-                  <dt className="shrink-0 font-mono text-muted-foreground">
-                    {d.arg}
-                  </dt>
-                  <dd className="min-w-0 flex-1 truncate text-muted-foreground">
+                <Fragment key={d.key}>
+                  <dt className="font-mono text-muted-foreground">{d.arg}</dt>
+                  <dd className="min-w-0 wrap-break-word text-muted-foreground">
                     {d.description}
                   </dd>
-                </div>
+                </Fragment>
               ))}
             </dl>
           )}

--- a/src/features/scripts/TaskRunConfirm.tsx
+++ b/src/features/scripts/TaskRunConfirm.tsx
@@ -71,9 +71,7 @@ export function TaskRunConfirm() {
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            {replacing
-              ? "A task is already running"
-              : `Run “${task?.name}”?`}
+            {replacing ? "A task is already running" : `Run “${task?.name}”?`}
           </DialogTitle>
           <DialogDescription>
             {replacing ? (

--- a/src/features/scripts/TaskRunView.tsx
+++ b/src/features/scripts/TaskRunView.tsx
@@ -1,0 +1,138 @@
+import {
+  ArrowClockwiseIcon,
+  CheckCircleIcon,
+  CircleNotchIcon,
+  PlayCircleIcon,
+  StopIcon,
+  WarningCircleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { Suspense, lazy } from "react";
+import { Button } from "@/components/ui/button";
+import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
+import { ptyClose } from "@/lib/pty";
+import { INTERPRETERS, parseArgs } from "@/lib/scripts/types";
+import { useTaskRunStore } from "@/lib/stores/taskRun";
+import { taskPtyId } from "@/lib/stores/taskRun";
+import { useUiStore } from "@/lib/stores/ui";
+
+// Reuse the interactive PTY terminal (xterm + Rust PTY). Lazy so its chunk loads
+// with the first run rather than on boot.
+const Terminal = lazy(() =>
+  import("@/features/terminal/Terminal").then((m) => ({ default: m.Terminal })),
+);
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+export function TaskRunView() {
+  const repoPath = useUiStore((s) => s.repoPath);
+  const activeRun = useTaskRunStore((s) => s.activeRun);
+  const rerun = useTaskRunStore((s) => s.rerun);
+  const markExited = useTaskRunStore((s) => s.markExited);
+  const clear = useTaskRunStore((s) => s.clear);
+
+  if (!activeRun || !repoPath) {
+    return (
+      <DiffPlaceholder
+        icon={PlayCircleIcon}
+        message="Run a task to see its output here"
+      />
+    );
+  }
+
+  const { task, status, code, token } = activeRun;
+  const ptyId = taskPtyId(activeRun);
+  const running = status === "running";
+  const succeeded = status === "exited" && code === 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2 text-xs">
+        <span className="shrink-0 truncate font-medium">{task.name}</span>
+        {task.source.kind === "file" && (
+          <span
+            className="min-w-0 truncate font-mono text-[10px] text-muted-foreground"
+            title={task.source.path}
+          >
+            {task.source.path}
+          </span>
+        )}
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {INTERPRETER_LABELS[task.interpreter] ?? task.interpreter}
+        </span>
+
+        {/* Status — icon + text, never color alone (WCAG AA). */}
+        {running ? (
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <CircleNotchIcon className="size-3.5 animate-spin" />
+            Running
+          </span>
+        ) : succeeded ? (
+          <span className="flex items-center gap-1 text-success">
+            <CheckCircleIcon className="size-3.5" />
+            Exited · 0
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 text-destructive">
+            <WarningCircleIcon className="size-3.5" />
+            {code === null ? "Stopped" : `Exited · ${code}`}
+          </span>
+        )}
+
+        <span className="flex-1" />
+
+        {running ? (
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={() => ptyClose(ptyId).catch(() => undefined)}
+            title="Stop the running task"
+          >
+            <StopIcon data-icon="inline-start" />
+            Stop
+          </Button>
+        ) : (
+          <>
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={rerun}
+              title="Run this task again"
+            >
+              <ArrowClockwiseIcon data-icon="inline-start" />
+              Rerun
+            </Button>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              className="text-muted-foreground"
+              onClick={clear}
+              title="Clear the run"
+              aria-label="Clear the run"
+            >
+              <XIcon />
+            </Button>
+          </>
+        )}
+      </div>
+
+      <Suspense fallback={null}>
+        <Terminal
+          key={ptyId}
+          ptyId={ptyId}
+          kind="task"
+          cwd={repoPath}
+          ports={[]}
+          interpreter={task.interpreter}
+          body={task.source.kind === "inline" ? task.source.body : undefined}
+          path={task.source.kind === "file" ? task.source.path : undefined}
+          args={parseArgs(task.args)}
+          onExit={(c) => markExited(token, c)}
+          className="min-h-0 flex-1 px-1 pb-1"
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/features/scripts/TaskRunView.tsx
+++ b/src/features/scripts/TaskRunView.tsx
@@ -10,6 +10,7 @@ import {
 import { Suspense, lazy } from "react";
 import { Button } from "@/components/ui/button";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
+import { clipTitle } from "@/lib/clip-title";
 import { ptyClose } from "@/lib/pty";
 import { INTERPRETERS, parseArgs } from "@/lib/scripts/types";
 import { useTaskRunStore } from "@/lib/stores/taskRun";
@@ -54,7 +55,7 @@ export function TaskRunView() {
         {task.source.kind === "file" && (
           <span
             className="min-w-0 truncate font-mono text-[10px] text-muted-foreground"
-            title={task.source.path}
+            onMouseEnter={clipTitle(task.source.path)}
           >
             {task.source.path}
           </span>
@@ -62,7 +63,7 @@ export function TaskRunView() {
         {args !== "" && (
           <span
             className="min-w-0 truncate font-mono text-[10px] text-muted-foreground"
-            title={args}
+            onMouseEnter={clipTitle(args)}
           >
             {args}
           </span>

--- a/src/features/scripts/TaskRunView.tsx
+++ b/src/features/scripts/TaskRunView.tsx
@@ -42,7 +42,7 @@ export function TaskRunView() {
     );
   }
 
-  const { task, status, code, token } = activeRun;
+  const { task, args, status, code, token } = activeRun;
   const ptyId = taskPtyId(activeRun);
   const running = status === "running";
   const succeeded = status === "exited" && code === 0;
@@ -57,6 +57,14 @@ export function TaskRunView() {
             title={task.source.path}
           >
             {task.source.path}
+          </span>
+        )}
+        {args !== "" && (
+          <span
+            className="min-w-0 truncate font-mono text-[10px] text-muted-foreground"
+            title={args}
+          >
+            {args}
           </span>
         )}
         <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
@@ -128,7 +136,7 @@ export function TaskRunView() {
           interpreter={task.interpreter}
           body={task.source.kind === "inline" ? task.source.body : undefined}
           path={task.source.kind === "file" ? task.source.path : undefined}
-          args={parseArgs(task.args)}
+          args={parseArgs(args)}
           onExit={(c) => markExited(token, c)}
           className="min-h-0 flex-1 px-1 pb-1"
         />

--- a/src/features/scripts/TaskRunView.tsx
+++ b/src/features/scripts/TaskRunView.tsx
@@ -7,14 +7,13 @@ import {
   WarningCircleIcon,
   XIcon,
 } from "@phosphor-icons/react";
-import { Suspense, lazy } from "react";
+import { lazy, Suspense } from "react";
 import { Button } from "@/components/ui/button";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { clipTitle } from "@/lib/clip-title";
 import { ptyClose } from "@/lib/pty";
 import { INTERPRETERS, parseArgs } from "@/lib/scripts/types";
-import { useTaskRunStore } from "@/lib/stores/taskRun";
-import { taskPtyId } from "@/lib/stores/taskRun";
+import { taskPtyId, useTaskRunStore } from "@/lib/stores/taskRun";
 import { useUiStore } from "@/lib/stores/ui";
 
 // Reuse the interactive PTY terminal (xterm + Rust PTY). Lazy so its chunk loads

--- a/src/features/scripts/TasksPanel.tsx
+++ b/src/features/scripts/TasksPanel.tsx
@@ -159,7 +159,11 @@ export function TasksPanel() {
                 <button
                   type="button"
                   data-row={task.id}
-                  tabIndex={index === activeIndex ? 0 : -1}
+                  // Roving tabindex: exactly one row is a tab stop. Until a row
+                  // is focused (activeIndex === -1) that's the first row, so the
+                  // list is keyboard-reachable from the start — otherwise nothing
+                  // is tabbable and the arrow-nav + Enter-to-run can't be reached.
+                  tabIndex={index === Math.max(activeIndex, 0) ? 0 : -1}
                   onFocus={() => setActiveIndex(index)}
                   onClick={() => request(task)}
                   className={cn(

--- a/src/features/scripts/TasksPanel.tsx
+++ b/src/features/scripts/TasksPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import { clipTitle } from "@/lib/clip-title";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
   useAddTask,
@@ -171,13 +172,16 @@ export function TasksPanel() {
                   <PlayIcon className="mt-px size-3.5 shrink-0 text-muted-foreground" />
                   <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                     <span className="flex items-center gap-2">
-                      <span className="min-w-0 flex-1 truncate">
+                      <span
+                        className="min-w-0 flex-1 truncate"
+                        onMouseEnter={clipTitle(task.name)}
+                      >
                         {task.name}
                       </span>
                       {task.args !== "" && (
                         <span
                           className="min-w-0 max-w-32 truncate font-mono text-[10px] text-muted-foreground"
-                          title={task.args}
+                          onMouseEnter={clipTitle(task.args)}
                         >
                           {task.args}
                         </span>
@@ -188,7 +192,10 @@ export function TasksPanel() {
                       </span>
                     </span>
                     {task.description !== "" && (
-                      <span className="truncate text-[11px] text-muted-foreground">
+                      <span
+                        className="truncate text-[11px] text-muted-foreground"
+                        onMouseEnter={clipTitle(task.description)}
+                      >
                         {task.description}
                       </span>
                     )}

--- a/src/features/scripts/TasksPanel.tsx
+++ b/src/features/scripts/TasksPanel.tsx
@@ -162,16 +162,36 @@ export function TasksPanel() {
                   onFocus={() => setActiveIndex(index)}
                   onClick={() => request(task)}
                   className={cn(
-                    "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-left text-xs",
+                    "flex min-w-0 flex-1 items-start gap-2 rounded px-2 py-1.5 text-left text-xs",
                     index === activeIndex
                       ? "bg-accent text-accent-foreground"
                       : "hover:bg-muted/60",
                   )}
                 >
-                  <PlayIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1 truncate">{task.name}</span>
-                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-                    {INTERPRETER_LABELS[task.interpreter] ?? task.interpreter}
+                  <PlayIcon className="mt-px size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex items-center gap-2">
+                      <span className="min-w-0 flex-1 truncate">
+                        {task.name}
+                      </span>
+                      {task.args !== "" && (
+                        <span
+                          className="min-w-0 max-w-32 truncate font-mono text-[10px] text-muted-foreground"
+                          title={task.args}
+                        >
+                          {task.args}
+                        </span>
+                      )}
+                      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                        {INTERPRETER_LABELS[task.interpreter] ??
+                          task.interpreter}
+                      </span>
+                    </span>
+                    {task.description !== "" && (
+                      <span className="truncate text-[11px] text-muted-foreground">
+                        {task.description}
+                      </span>
+                    )}
                   </span>
                 </button>
                 <DropdownMenu>

--- a/src/features/scripts/TasksPanel.tsx
+++ b/src/features/scripts/TasksPanel.tsx
@@ -1,0 +1,226 @@
+import {
+  DotsThreeVerticalIcon,
+  LightningIcon,
+  PencilSimpleIcon,
+  PlayIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import {
+  useAddTask,
+  useRemoveTask,
+  useScripts,
+  useSetTasksEnabled,
+  useUpdateTask,
+} from "@/lib/scripts/queries";
+import { INTERPRETERS, type TaskDef } from "@/lib/scripts/types";
+import { useTaskRunStore } from "@/lib/stores/taskRun";
+import { cn } from "@/lib/utils";
+import { TaskDialog } from "./TaskDialog";
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+export function TasksPanel() {
+  const scripts = useScripts();
+  const setEnabled = useSetTasksEnabled();
+  const addTask = useAddTask();
+  const updateTask = useUpdateTask();
+  const removeTask = useRemoveTask();
+  const request = useTaskRunStore((s) => s.request);
+
+  const [editing, setEditing] = useState<TaskDef | "new" | null>(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const enabled = scripts.data?.enabled ?? false;
+  const tasks = scripts.data?.tasks ?? [];
+
+  function saveTask(task: TaskDef) {
+    const isNew = editing === "new";
+    const mutation = isNew ? addTask : updateTask;
+    mutation.mutate(task, {
+      onSuccess: () => {
+        setEditing(null);
+        toast.success(isNew ? `Added "${task.name}"` : `Saved "${task.name}"`);
+      },
+      onError: (e) => toast.error(String(e)),
+    });
+  }
+
+  function deleteTask(id: string) {
+    const name = tasks.find((t) => t.id === id)?.name ?? "task";
+    removeTask.mutate(id, {
+      onSuccess: () => {
+        setEditing(null);
+        toast.success(`Deleted "${name}"`);
+      },
+      onError: (e) => toast.error(String(e)),
+    });
+  }
+
+  const nav = listKeyboardNav({
+    items: tasks,
+    activeIndex,
+    onActivate: (_item, to) => setActiveIndex(to),
+    rowKey: (t) => t.id,
+  });
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
+        <LightningIcon className="size-4 text-muted-foreground" />
+        <span className="text-xs font-medium">Tasks</span>
+        {enabled && tasks.length > 0 && (
+          <span className="text-xs text-muted-foreground">{tasks.length}</span>
+        )}
+        <span className="flex-1" />
+        {enabled && (
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            onClick={() => setEditing("new")}
+            title="New task"
+            aria-label="New task"
+          >
+            <PlusIcon />
+          </Button>
+        )}
+      </div>
+
+      {scripts.isPending ? (
+        <div className="space-y-2 p-3">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+      ) : !enabled ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+          <LightningIcon className="size-8 text-muted-foreground" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Run your scripts from here</p>
+            <p className="text-xs text-muted-foreground">
+              Save a script — like your release or build flow — and run it in an
+              interactive terminal without leaving GitDesktop. Scripts you save
+              stay on this machine and only run when you start them.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            disabled={setEnabled.isPending}
+            onClick={() =>
+              setEnabled.mutate(true, {
+                onError: (e) => toast.error(String(e)),
+              })
+            }
+          >
+            Enable task running
+          </Button>
+        </div>
+      ) : tasks.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+          <LightningIcon className="size-8 text-muted-foreground" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium">No tasks yet</p>
+            <p className="text-xs text-muted-foreground">
+              Register a script to run it here. Tasks are shared across your
+              repositories and run in whichever one is open.
+            </p>
+          </div>
+          <Button size="sm" onClick={() => setEditing("new")}>
+            <PlusIcon data-icon="inline-start" />
+            New task
+          </Button>
+        </div>
+      ) : (
+        <ScrollArea className="min-h-0 flex-1">
+          <div
+            ref={listRef}
+            role="group"
+            aria-label="Tasks"
+            onKeyDown={nav}
+            className="space-y-0.5 p-2"
+          >
+            {tasks.map((task, index) => (
+              <div key={task.id} className="flex items-center gap-1">
+                <button
+                  type="button"
+                  data-row={task.id}
+                  tabIndex={index === activeIndex ? 0 : -1}
+                  onFocus={() => setActiveIndex(index)}
+                  onClick={() => request(task)}
+                  className={cn(
+                    "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-left text-xs",
+                    index === activeIndex
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-muted/60",
+                  )}
+                >
+                  <PlayIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate">{task.name}</span>
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                    {INTERPRETER_LABELS[task.interpreter] ?? task.interpreter}
+                  </span>
+                </button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        size="icon-xs"
+                        variant="ghost"
+                        className="shrink-0 text-muted-foreground"
+                        title={`More actions for "${task.name}"`}
+                        aria-label={`More actions for ${task.name}`}
+                      />
+                    }
+                  >
+                    <DotsThreeVerticalIcon />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => request(task)}>
+                      <PlayIcon data-icon="inline-start" />
+                      Run
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setEditing(task)}>
+                      <PencilSimpleIcon data-icon="inline-start" />
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={() => deleteTask(task.id)}
+                    >
+                      <TrashIcon data-icon="inline-start" />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+
+      <TaskDialog
+        task={editing}
+        open={editing !== null}
+        onOpenChange={(o) => {
+          if (!o) setEditing(null);
+        }}
+        onSave={saveTask}
+        onDelete={deleteTask}
+      />
+    </div>
+  );
+}

--- a/src/features/scripts/useAnalyzeScript.ts
+++ b/src/features/scripts/useAnalyzeScript.ts
@@ -1,0 +1,122 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { useAiStream } from "@/features/conversations/useAiStream";
+import { readTextFile } from "@/lib/git/api";
+import { normalizeArgDocs } from "@/lib/scripts/store";
+import {
+  type ArgDoc,
+  type Interpreter,
+  INTERPRETERS,
+} from "@/lib/scripts/types";
+import { stripFences } from "./useGenerateScript";
+
+/** Prompt budget for the script content — release/build scripts are tiny; a
+ *  giant file gets truncated with a note rather than blowing the context. */
+const MAX_SCRIPT_CHARS = 48_000;
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+/** What analysis yields — every field optional-by-honesty: a field the model
+ *  didn't produce (or produced malformed) stays null/empty rather than being
+ *  filled with a confident guess. */
+export interface ScriptAnalysis {
+  name: string | null;
+  description: string | null;
+  argDocs: ArgDoc[];
+}
+
+/** Parses the model's answer into a {@link ScriptAnalysis}, type-guarding every
+ *  field (AI output is untrusted input). Returns null when it isn't JSON at all. */
+function parseAnalysis(buffer: string): ScriptAnalysis | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stripFences(buffer).trim());
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as { name?: unknown; description?: unknown; args?: unknown };
+  const str = (v: unknown): string | null =>
+    typeof v === "string" && v.trim() !== "" ? v.trim() : null;
+  return {
+    name: str(obj.name),
+    description: str(obj.description),
+    argDocs: normalizeArgDocs(obj.args),
+  };
+}
+
+/** True for an absolute path on either platform (`C:\…`, `C:/…`, or `/…`). */
+function isAbsolute(p: string): boolean {
+  return /^([A-Za-z]:[\\/]|\/)/.test(p);
+}
+
+/**
+ * Reads a task's script (the registered file, or the inline body) and asks AI to
+ * document it: a short name, a one-line description, and the arguments it
+ * accepts (`--help`-style). Results land via `onResult` into the editor's draft
+ * fields — nothing persists until the user saves. Mirrors the other one-shot
+ * generators: `useAiStream` owns the client, cancel, and missing-key handling.
+ */
+export function useAnalyzeScript(repoPath: string) {
+  const { generating: analyzing, cancel, run } = useAiStream(repoPath);
+
+  const analyze = useCallback(
+    async (opts: {
+      interpreter: Interpreter;
+      /** File source: the registered path (repo-relative or absolute). */
+      path?: string;
+      /** Inline source: the current body. */
+      body?: string;
+      onResult: (analysis: ScriptAnalysis) => void;
+    }) => {
+      const label = INTERPRETER_LABELS[opts.interpreter] ?? opts.interpreter;
+
+      const buffer = await run(async () => {
+        let content: string;
+        let sourceLine: string;
+        if (opts.path) {
+          const full = isAbsolute(opts.path)
+            ? opts.path
+            : `${repoPath}/${opts.path}`;
+          try {
+            content = await readTextFile(full);
+          } catch {
+            toast.error(`Couldn't read ${opts.path} — does the file exist?`);
+            return null;
+          }
+          sourceLine = `Script file: ${opts.path}`;
+        } else {
+          content = opts.body ?? "";
+          sourceLine = "Inline script";
+        }
+        if (content.trim() === "") {
+          toast.error("Nothing to analyze — the script is empty.");
+          return null;
+        }
+        const truncated = content.length > MAX_SCRIPT_CHARS;
+        if (truncated) content = content.slice(0, MAX_SCRIPT_CHARS);
+
+        const system = [
+          `You document developer scripts. Analyze the ${label} script and reply with ONLY a JSON object — no prose, no Markdown fences:`,
+          `{"name": string, "description": string, "args": [{"arg": string, "description": string}]}`,
+          `- "name": a short display name for the task (2–4 words, plain words not a filename).`,
+          `- "description": ONE sentence, plain language, what running it does.`,
+          `- "args": the command-line arguments/flags the script actually accepts (from its argv/flag parsing), each with a one-line description. [] when it takes none.`,
+          `Only document arguments the script really reads — never invent any.`,
+        ].join("\n");
+        const prompt = `${sourceLine}${truncated ? " (truncated)" : ""}\n\n${content}`;
+        return { system, prompt };
+      });
+
+      if (buffer === null) return;
+      const analysis = parseAnalysis(buffer);
+      if (analysis) opts.onResult(analysis);
+      else toast.error("Couldn't analyze the script — try again.");
+    },
+    [repoPath, run],
+  );
+
+  return { analyze, cancel, analyzing };
+}

--- a/src/features/scripts/useAnalyzeScript.ts
+++ b/src/features/scripts/useAnalyzeScript.ts
@@ -5,8 +5,8 @@ import { readTextFile } from "@/lib/git/api";
 import { normalizeArgDocs } from "@/lib/scripts/store";
 import {
   type ArgDoc,
-  type Interpreter,
   INTERPRETERS,
+  type Interpreter,
 } from "@/lib/scripts/types";
 import { stripFences } from "./useGenerateScript";
 

--- a/src/features/scripts/useGenerateScript.ts
+++ b/src/features/scripts/useGenerateScript.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
 import { readRepoInstructions } from "@/lib/git/api";
-import { type Interpreter, INTERPRETERS } from "@/lib/scripts/types";
+import { INTERPRETERS, type Interpreter } from "@/lib/scripts/types";
 
 const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
   INTERPRETERS.map((i) => [i.id, i.label]),
@@ -35,8 +35,7 @@ export function useGenerateScript(repoPath: string) {
         toast.error("Describe what the script should do first.");
         return;
       }
-      const label =
-        INTERPRETER_LABELS[opts.interpreter] ?? opts.interpreter;
+      const label = INTERPRETER_LABELS[opts.interpreter] ?? opts.interpreter;
 
       const buffer = await run(
         async () => {

--- a/src/features/scripts/useGenerateScript.ts
+++ b/src/features/scripts/useGenerateScript.ts
@@ -1,0 +1,63 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { useAiStream } from "@/features/conversations/useAiStream";
+import { readRepoInstructions } from "@/lib/git/api";
+import { type Interpreter, INTERPRETERS } from "@/lib/scripts/types";
+
+const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
+  INTERPRETERS.map((i) => [i.id, i.label]),
+);
+
+/** Strips a Markdown code fence (```lang … ```) the model may wrap the script in.
+ *  Tolerant of a partial buffer mid-stream (closing fence not yet arrived). */
+function stripFences(text: string): string {
+  return text.replace(/^\s*```[^\n]*\n/, "").replace(/\n?```\s*$/, "");
+}
+
+/**
+ * Generates a script body with AI from a natural-language description, streaming
+ * it into the editor (`onBody` fires per delta with fences stripped). Mirrors
+ * {@link useGenerateBranchName}: `useAiStream` owns the client, cancel, and
+ * missing-key handling; this only shapes the prompt and cleans the result.
+ */
+export function useGenerateScript(repoPath: string) {
+  const { generating, cancel, run } = useAiStream(repoPath);
+
+  const generate = useCallback(
+    async (opts: {
+      description: string;
+      interpreter: Interpreter;
+      onBody: (body: string) => void;
+    }) => {
+      const description = opts.description.trim();
+      if (!description) {
+        toast.error("Describe what the script should do first.");
+        return;
+      }
+      const label =
+        INTERPRETER_LABELS[opts.interpreter] ?? opts.interpreter;
+
+      const buffer = await run(
+        async () => {
+          const repoInstructions = await readRepoInstructions(repoPath);
+          const system = [
+            `You write ${label} scripts for a developer's Git repository.`,
+            "Return ONLY the script — no explanation and no Markdown code fences.",
+            `The script runs from the repository root; keep it correct and idiomatic for ${label}.`,
+            repoInstructions ? `Project notes:\n${repoInstructions}` : "",
+          ]
+            .filter(Boolean)
+            .join("\n");
+          return { system, prompt: description };
+        },
+        { onChunk: (buf) => opts.onBody(stripFences(buf)) },
+      );
+
+      if (buffer === null) return;
+      opts.onBody(stripFences(buffer));
+    },
+    [repoPath, run],
+  );
+
+  return { generate, cancel, generating };
+}

--- a/src/features/scripts/useGenerateScript.ts
+++ b/src/features/scripts/useGenerateScript.ts
@@ -9,8 +9,9 @@ const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
 );
 
 /** Strips a Markdown code fence (```lang … ```) the model may wrap the script in.
- *  Tolerant of a partial buffer mid-stream (closing fence not yet arrived). */
-function stripFences(text: string): string {
+ *  Tolerant of a partial buffer mid-stream (closing fence not yet arrived).
+ *  Shared with the analyze hook (JSON answers get fenced the same way). */
+export function stripFences(text: string): string {
   return text.replace(/^\s*```[^\n]*\n/, "").replace(/\n?```\s*$/, "");
 }
 

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -22,9 +22,13 @@ function decodeBase64(b64: string): Uint8Array {
 /**
  * An xterm.js terminal wired to a Rust PTY: output streams in over a Channel,
  * keystrokes go back via `pty_write`, and the grid is kept in sync with the
- * element size (`pty_resize`). The parent keys this by session id, so each
- * instance is bound to one session+PTY for its whole life — hence the one-shot
- * setup effect. Unmounting kills the shell.
+ * element size (`pty_resize`). The parent keys this by session id (or a task
+ * run id), so each instance is bound to one PTY for its whole life — hence the
+ * one-shot setup effect. Unmounting kills the process.
+ *
+ * For a Tasks run (`kind: "task"`), pass the `interpreter` + `body` to run and an
+ * `onExit` to surface the exit code in the run header. `onExit` is read through a
+ * ref so a re-render can't stale-capture it in the mount-once effect.
  */
 export function Terminal({
   ptyId,
@@ -32,16 +36,28 @@ export function Terminal({
   cwd,
   ports,
   className,
+  interpreter,
+  body,
+  path,
+  args,
+  onExit,
 }: {
   ptyId: string;
   kind: PtyOpts["kind"];
   cwd: string;
   ports: string[];
   className?: string;
+  interpreter?: string;
+  body?: string;
+  path?: string;
+  args?: string[];
+  onExit?: (code: number | null) => void;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
+  const onExitRef = useRef(onExit);
+  onExitRef.current = onExit;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once; props are fixed per instance (parent keys by session)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once; props are fixed per instance (parent keys by session / task run)
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -71,7 +87,14 @@ export function Terminal({
 
     ptyOpen(
       ptyId,
-      { kind, cwd, ports, cols: term.cols, rows: term.rows },
+      {
+        kind,
+        cwd,
+        ports,
+        cols: term.cols,
+        rows: term.rows,
+        ...(kind === "task" ? { interpreter, body, path, args } : {}),
+      },
       (e) => {
         if (e.type === "output") {
           term.write(decodeBase64(e.data));
@@ -79,10 +102,13 @@ export function Terminal({
           exited = true;
           const code = e.code != null ? ` (code ${e.code})` : "";
           term.write(`\r\n\x1b[2m[process exited${code}]\x1b[0m\r\n`);
+          onExitRef.current?.(e.code);
         }
       },
     ).catch((err) => {
       term.write(`\r\n\x1b[31m${String(err)}\x1b[0m\r\n`);
+      // A spawn failure (bad interpreter, missing binary) is a terminal exit too.
+      onExitRef.current?.(null);
     });
 
     // Refit + tell the PTY whenever the element resizes (dock drag, window, or

--- a/src/lib/clip-title.ts
+++ b/src/lib/clip-title.ts
@@ -1,0 +1,12 @@
+import type { MouseEvent } from "react";
+
+/**
+ * Sets a hover `title` only when the content is actually clipped by `truncate` —
+ * the repo's only-when-clipped tooltip pattern (PrTimeline, CommitsList,
+ * WorktreesDialog, …), hoisted for reuse. Measured lazily on mouse-enter, so it
+ * stays honest across resizes and never shows a tooltip for fully-visible text.
+ */
+export const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
+  const el = e.currentTarget;
+  el.title = el.scrollWidth > el.clientWidth ? value : "";
+};

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -148,6 +148,13 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "tab-tasks",
+    label: "Tasks tab",
+    category: "Navigation",
+    // Palette-only by default: mod+1–9 are already taken by the other tabs.
+    defaultBinding: null,
+  },
+  {
     id: "show-repositories",
     label: "Show repositories",
     category: "Navigation",
@@ -323,6 +330,12 @@ export const ACTIONS = [
   {
     id: "git-hooks",
     label: "Git hooks",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
+    id: "run-task",
+    label: "Run a task…",
     category: "Repository",
     defaultBinding: null,
   },

--- a/src/lib/pty.ts
+++ b/src/lib/pty.ts
@@ -1,16 +1,27 @@
 import { Channel } from "@tauri-apps/api/core";
 import { invoke } from "@/lib/tauri/invoke";
 
-/** What a terminal runs: a host shell in the worktree, or a shell inside the
- *  worktree's Docker/Podman test container (publishing its dev-server ports). */
+/** What a terminal runs: a host shell in the worktree, a shell inside the
+ *  worktree's Docker/Podman test container (publishing its dev-server ports), or —
+ *  for the Tasks feature — a registered script (`interpreter` runs a temp file
+ *  holding `body`) in `cwd`. */
 export interface PtyOpts {
-  kind: "host" | "container";
-  /** The session worktree path (cwd for host; mount + container key for container). */
+  kind: "host" | "container" | "task";
+  /** The working directory (cwd for host/task; mount + container key for container). */
   cwd: string;
   /** Dev-server ports to publish (container only) — `"5173"` or `"5174:5173"`. */
   ports: string[];
   cols: number;
   rows: number;
+  /** Task only: interpreter key (`"powershell"` | `"bash"` | `"node"` | …). */
+  interpreter?: string;
+  /** Task only, inline source: the script body run by `interpreter` (temp file). */
+  body?: string;
+  /** Task only, file source: an existing script file to run in place (relative to
+   *  `cwd`, or absolute). Takes precedence over `body`. */
+  path?: string;
+  /** Task only: extra arguments after the script (already split to argv). */
+  args?: string[];
 }
 
 /** Streamed from a PTY. `output.data` is base64 (binary- and partial-UTF-8-safe);

--- a/src/lib/scripts/interpreters.ts
+++ b/src/lib/scripts/interpreters.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { invoke } from "@/lib/tauri/invoke";
+import type { Interpreter } from "./types";
+
+/** One interpreter's detected availability (from the Rust `detect_interpreters`). */
+export interface DetectedInterpreter {
+  id: Interpreter;
+  /** Resolved absolute path, or null when it isn't on PATH. */
+  path: string | null;
+}
+
+const detectInterpreters = () =>
+  invoke<DetectedInterpreter[]>("detect_interpreters");
+
+/**
+ * Which task interpreters are installed on this machine, keyed by id for quick
+ * lookup. Session-stable-ish (a newly-installed interpreter appears within the
+ * stale window), so the task editor can show what a task can actually run with.
+ */
+export function useDetectedInterpreters() {
+  return useQuery({
+    queryKey: ["detected-interpreters"],
+    queryFn: async () => {
+      const list = await detectInterpreters();
+      return new Map(list.map((d) => [d.id, d]));
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/lib/scripts/launch.ts
+++ b/src/lib/scripts/launch.ts
@@ -16,16 +16,21 @@ import { parseArgs, type TaskDef } from "./types";
 export const TASKS_USE_EXTERNAL_TERMINAL = import.meta.env.DEV && isWindows;
 
 /**
- * Runs a task in the user's OS terminal — the dev escape hatch on Windows, and an
- * explicit convenience elsewhere. A real, interactive terminal window, so even a
- * prompting script (a release flow) works while iterating in dev.
+ * Runs a task in the user's OS terminal — the dev-only fallback for the Windows
+ * ConPTY limitation. A real, interactive terminal window, so even a prompting
+ * script (a release flow) works while iterating in dev. `args` is the effective
+ * argument string for THIS run (the run dialog may have adjusted it).
  */
-export function openTaskInTerminal(task: TaskDef, cwd: string): Promise<void> {
+export function openTaskInTerminal(
+  task: TaskDef,
+  cwd: string,
+  args: string,
+): Promise<void> {
   return invoke<void>("task_open_terminal", {
     cwd,
     interpreter: task.interpreter,
     body: task.source.kind === "inline" ? task.source.body : null,
     path: task.source.kind === "file" ? task.source.path : null,
-    args: parseArgs(task.args),
+    args: parseArgs(args),
   });
 }

--- a/src/lib/scripts/launch.ts
+++ b/src/lib/scripts/launch.ts
@@ -1,0 +1,31 @@
+import { isWindows } from "@/lib/hotkeys/binding";
+import { invoke } from "@/lib/tauri/invoke";
+import { parseArgs, type TaskDef } from "./types";
+
+/**
+ * Whether task runs use an external OS terminal instead of the in-app PTY. True
+ * only on **Windows under `pnpm tauri dev`**, where the in-app ConPTY can't spawn
+ * (a documented dev-only limitation — see `pty.rs`); a release install uses the
+ * in-app terminal. Everywhere else this is false and runs stay in-app.
+ *
+ * `import.meta.env.DEV` comes FIRST: it's statically replaced at build time, so a
+ * production bundle sees `false && isWindows` and folds the whole thing to
+ * `false` — with `isWindows` (a runtime value) first, the expression survives and
+ * drags this module into the bundle. Verified by grepping the built chunks.
+ */
+export const TASKS_USE_EXTERNAL_TERMINAL = import.meta.env.DEV && isWindows;
+
+/**
+ * Runs a task in the user's OS terminal — the dev escape hatch on Windows, and an
+ * explicit convenience elsewhere. A real, interactive terminal window, so even a
+ * prompting script (a release flow) works while iterating in dev.
+ */
+export function openTaskInTerminal(task: TaskDef, cwd: string): Promise<void> {
+  return invoke<void>("task_open_terminal", {
+    cwd,
+    interpreter: task.interpreter,
+    body: task.source.kind === "inline" ? task.source.body : null,
+    path: task.source.kind === "file" ? task.source.path : null,
+    args: parseArgs(task.args),
+  });
+}

--- a/src/lib/scripts/queries.ts
+++ b/src/lib/scripts/queries.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  addTask,
+  loadScripts,
+  removeTask,
+  setTasksEnabled,
+  updateTask,
+} from "./store";
+
+export const scriptsKeys = {
+  config: ["scripts"] as const,
+};
+
+/** The task config (enable flag + task list). Personal app-data, session-stable —
+ *  a plain query (staleTime Infinity), safe to read inside an `<Activity>` tab. */
+export function useScripts() {
+  return useQuery({
+    queryKey: scriptsKeys.config,
+    queryFn: loadScripts,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}
+
+function useScriptsMutation<A>(fn: (arg: A) => Promise<void>) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: fn,
+    onSuccess: () => qc.invalidateQueries({ queryKey: scriptsKeys.config }),
+  });
+}
+
+export const useSetTasksEnabled = () => useScriptsMutation(setTasksEnabled);
+export const useAddTask = () => useScriptsMutation(addTask);
+export const useUpdateTask = () => useScriptsMutation(updateTask);
+export const useRemoveTask = () => useScriptsMutation(removeTask);

--- a/src/lib/scripts/store.ts
+++ b/src/lib/scripts/store.ts
@@ -127,9 +127,7 @@ export function normalizeScripts(saved: unknown): ScriptsConfig {
   if (!saved || typeof saved !== "object") return { ...EMPTY_SCRIPTS };
   const obj = saved as { enabled?: unknown; tasks?: unknown };
   const tasks = Array.isArray(obj.tasks)
-    ? obj.tasks
-        .map(normalizeTask)
-        .filter((t): t is TaskDef => t !== undefined)
+    ? obj.tasks.map(normalizeTask).filter((t): t is TaskDef => t !== undefined)
     : [];
   // Drop duplicate ids (keep first) so list keys stay unique.
   const seen = new Set<string>();

--- a/src/lib/scripts/store.ts
+++ b/src/lib/scripts/store.ts
@@ -1,0 +1,150 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import { storeName } from "@/lib/test-mode";
+import {
+  EMPTY_SCRIPTS,
+  isInterpreter,
+  type ScriptsConfig,
+  type TaskDef,
+  type TaskSource,
+} from "./types";
+
+// Personal app-data — task definitions are the user's, NEVER read from repo
+// content, so a cloned/malicious repo can't plant a runnable task.
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("scripts.json"), {
+    autoSave: true,
+    defaults: {},
+  });
+  return storePromise;
+}
+
+// Serialize every read-modify-write through one in-process queue so two
+// overlapping saves can't each read the same pre-flush snapshot and drop each
+// other's change (the lost-update the automations/settings stores also guard).
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+/** Re-read `scripts.json` into the store, tolerating a missing file (until the
+ *  first `save()` creates it, `reload()` rejects — proceed with in-memory state). */
+async function reloadRaw(store: Store): Promise<void> {
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing/unreadable — the next save() bootstraps the file.
+  }
+}
+
+/** Serialized read-modify-write against fresh disk state. */
+function mutateConfig(
+  mutate: (current: ScriptsConfig) => ScriptsConfig,
+): Promise<void> {
+  return serialize(async () => {
+    const store = await getStore();
+    await reloadRaw(store);
+    const current = normalizeScripts(await store.get<unknown>("config"));
+    const next = mutate(current);
+    await store.set("config", next);
+    await store.save();
+  });
+}
+
+/** Type-checks a task's source, falling back to an inline body (including a
+ *  legacy flat `body` from before `source` existed) when malformed. */
+function normalizeSource(source: unknown, legacyBody: unknown): TaskSource {
+  if (source && typeof source === "object") {
+    const s = source as { kind?: unknown; path?: unknown; body?: unknown };
+    if (s.kind === "file" && typeof s.path === "string" && s.path !== "") {
+      return { kind: "file", path: s.path };
+    }
+    if (s.kind === "inline" && typeof s.body === "string") {
+      return { kind: "inline", body: s.body };
+    }
+  }
+  return {
+    kind: "inline",
+    body: typeof legacyBody === "string" ? legacyBody : "",
+  };
+}
+
+/** Type-checks one untrusted task, dropping it (undefined) when unusable. */
+function normalizeTask(v: unknown): TaskDef | undefined {
+  if (!v || typeof v !== "object") return undefined;
+  const obj = v as {
+    id?: unknown;
+    name?: unknown;
+    interpreter?: unknown;
+    source?: unknown;
+    body?: unknown;
+    args?: unknown;
+    confirmBeforeRun?: unknown;
+  };
+  if (typeof obj.id !== "string" || obj.id === "") return undefined;
+  if (!isInterpreter(obj.interpreter)) return undefined;
+  return {
+    id: obj.id,
+    name: typeof obj.name === "string" ? obj.name : "Untitled task",
+    interpreter: obj.interpreter,
+    source: normalizeSource(obj.source, obj.body),
+    args: typeof obj.args === "string" ? obj.args : "",
+    // Absent (older) or non-boolean → confirm, the safe default.
+    confirmBeforeRun: obj.confirmBeforeRun !== false,
+  };
+}
+
+/**
+ * Coerces a loosely-typed (older, hand-edited, or partially corrupt) value into a
+ * full ScriptsConfig, dropping malformed tasks rather than letting one bad entry
+ * sink the whole load. Mirrors `normalizeAutomations`.
+ */
+export function normalizeScripts(saved: unknown): ScriptsConfig {
+  if (!saved || typeof saved !== "object") return { ...EMPTY_SCRIPTS };
+  const obj = saved as { enabled?: unknown; tasks?: unknown };
+  const tasks = Array.isArray(obj.tasks)
+    ? obj.tasks
+        .map(normalizeTask)
+        .filter((t): t is TaskDef => t !== undefined)
+    : [];
+  // Drop duplicate ids (keep first) so list keys stay unique.
+  const seen = new Set<string>();
+  const deduped = tasks.filter((t) =>
+    seen.has(t.id) ? false : (seen.add(t.id), true),
+  );
+  return {
+    schemaVersion: 1,
+    enabled: obj.enabled === true,
+    tasks: deduped,
+  };
+}
+
+export async function loadScripts(): Promise<ScriptsConfig> {
+  const store = await getStore();
+  return normalizeScripts(await store.get<unknown>("config"));
+}
+
+/** Flip the one-time consent to run tasks. */
+export function setTasksEnabled(enabled: boolean): Promise<void> {
+  return mutateConfig((c) => ({ ...c, enabled }));
+}
+
+export function addTask(task: TaskDef): Promise<void> {
+  return mutateConfig((c) => ({ ...c, tasks: [...c.tasks, task] }));
+}
+
+export function updateTask(task: TaskDef): Promise<void> {
+  return mutateConfig((c) => ({
+    ...c,
+    tasks: c.tasks.map((t) => (t.id === task.id ? task : t)),
+  }));
+}
+
+export function removeTask(id: string): Promise<void> {
+  return mutateConfig((c) => ({
+    ...c,
+    tasks: c.tasks.filter((t) => t.id !== id),
+  }));
+}

--- a/src/lib/scripts/store.ts
+++ b/src/lib/scripts/store.ts
@@ -1,6 +1,7 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { storeName } from "@/lib/test-mode";
 import {
+  type ArgDoc,
   EMPTY_SCRIPTS,
   isInterpreter,
   type ScriptsConfig,
@@ -71,16 +72,35 @@ function normalizeSource(source: unknown, legacyBody: unknown): TaskSource {
   };
 }
 
+/** Type-checks an untrusted arg-docs list, dropping malformed entries. Also the
+ *  guard for AI-analyzed output before it reaches the editor. */
+export function normalizeArgDocs(v: unknown): ArgDoc[] {
+  if (!Array.isArray(v)) return [];
+  const out: ArgDoc[] = [];
+  for (const item of v) {
+    if (!item || typeof item !== "object") continue;
+    const doc = item as { arg?: unknown; description?: unknown };
+    if (typeof doc.arg !== "string" || doc.arg.trim() === "") continue;
+    out.push({
+      arg: doc.arg,
+      description: typeof doc.description === "string" ? doc.description : "",
+    });
+  }
+  return out;
+}
+
 /** Type-checks one untrusted task, dropping it (undefined) when unusable. */
 function normalizeTask(v: unknown): TaskDef | undefined {
   if (!v || typeof v !== "object") return undefined;
   const obj = v as {
     id?: unknown;
     name?: unknown;
+    description?: unknown;
     interpreter?: unknown;
     source?: unknown;
     body?: unknown;
     args?: unknown;
+    argDocs?: unknown;
     confirmBeforeRun?: unknown;
   };
   if (typeof obj.id !== "string" || obj.id === "") return undefined;
@@ -88,9 +108,11 @@ function normalizeTask(v: unknown): TaskDef | undefined {
   return {
     id: obj.id,
     name: typeof obj.name === "string" ? obj.name : "Untitled task",
+    description: typeof obj.description === "string" ? obj.description : "",
     interpreter: obj.interpreter,
     source: normalizeSource(obj.source, obj.body),
     args: typeof obj.args === "string" ? obj.args : "",
+    argDocs: normalizeArgDocs(obj.argDocs),
     // Absent (older) or non-boolean → confirm, the safe default.
     confirmBeforeRun: obj.confirmBeforeRun !== false,
   };

--- a/src/lib/scripts/types.ts
+++ b/src/lib/scripts/types.ts
@@ -72,6 +72,16 @@ export type TaskSource =
   | { kind: "file"; path: string }
   | { kind: "inline"; body: string };
 
+/** One documented argument a task's script accepts — `--help`-style reference
+ *  shown while editing args and in the run dialog. Documentation only; what
+ *  actually gets passed is the args string. */
+export interface ArgDoc {
+  /** The flag/argument as typed, e.g. `--preview`. */
+  arg: string;
+  /** What it does, one line. */
+  description: string;
+}
+
 /**
  * A registered runnable task (a saved script). Definitions live in app-data only
  * (`scripts.json`), never read from repository content — so a cloned or malicious
@@ -83,14 +93,21 @@ export interface TaskDef {
   id: string;
   /** Display name, e.g. "Release". */
   name: string;
+  /** One-line summary of what the task does — shown on the row, in the run
+   *  picker, and in the run dialog. Empty = none. */
+  description: string;
   /** Which interpreter runs the script. */
   interpreter: Interpreter;
   /** File (an existing script, run in place) or inline (a body saved here). Both
    *  run in the current repo's directory. */
   source: TaskSource;
   /** Extra arguments passed to the script (e.g. `--preview`), as the user typed
-   *  them; split to argv at run time by {@link parseArgs}. Empty = none. */
+   *  them; split to argv at run time by {@link parseArgs}. Empty = none. The run
+   *  dialog can adjust these per run (this string stays the saved default). */
   args: string;
+  /** `--help`-style documentation of the arguments the script accepts. Reference
+   *  only — shown in the editor and the run dialog. Empty = undocumented. */
+  argDocs: ArgDoc[];
   /** Confirm before each run. Defaults on; a trusted, frequently-run task can turn
    *  it off in its editor. */
   confirmBeforeRun: boolean;

--- a/src/lib/scripts/types.ts
+++ b/src/lib/scripts/types.ts
@@ -8,29 +8,50 @@ import { isWindows } from "@/lib/hotkeys/binding";
 export type Interpreter =
   | "powershell"
   | "cmd"
+  | "git-bash"
   | "bash"
   | "sh"
   | "zsh"
   | "node"
-  | "python";
+  | "python"
+  | "deno"
+  | "bun"
+  | "ruby";
 
 export interface InterpreterInfo {
   id: Interpreter;
   label: string;
   /** A short hint shown in the picker (what the body is written in). */
   hint: string;
+  /** Only offered on this platform; absent = every platform. cmd + Git Bash are
+   *  Windows-only concepts. */
+  os?: "windows";
 }
 
 /** Interpreter options for the task editor, in display order. */
 export const INTERPRETERS: InterpreterInfo[] = [
   { id: "powershell", label: "PowerShell", hint: "pwsh, or Windows PowerShell" },
-  { id: "cmd", label: "Command Prompt", hint: "cmd.exe batch" },
+  { id: "cmd", label: "Command Prompt", hint: "cmd.exe batch", os: "windows" },
+  {
+    id: "git-bash",
+    label: "Git Bash",
+    hint: "the bash that ships with Git",
+    os: "windows",
+  },
   { id: "bash", label: "Bash", hint: "bash script" },
   { id: "sh", label: "sh", hint: "POSIX shell" },
   { id: "zsh", label: "Zsh", hint: "zsh script" },
   { id: "node", label: "Node.js", hint: "JavaScript (ESM)" },
   { id: "python", label: "Python", hint: "python3, or python" },
+  { id: "deno", label: "Deno", hint: "TypeScript / JS (deno run -A)" },
+  { id: "bun", label: "Bun", hint: "TypeScript / JS" },
+  { id: "ruby", label: "Ruby", hint: "ruby script" },
 ];
+
+/** The interpreters offered on the current platform (Windows-only ones hidden
+ *  elsewhere). Detection still reflects whichever the backend probes. */
+export const availableInterpreters = (): InterpreterInfo[] =>
+  INTERPRETERS.filter((i) => i.os !== "windows" || isWindows);
 
 const INTERPRETER_IDS = new Set<string>(INTERPRETERS.map((i) => i.id));
 export function isInterpreter(v: unknown): v is Interpreter {
@@ -59,8 +80,12 @@ export function interpreterForExt(path: string): Interpreter | null {
     case "cjs":
     case "js":
       return "node";
+    case "ts":
+      return "deno";
     case "py":
       return "python";
+    case "rb":
+      return "ruby";
     default:
       return null;
   }

--- a/src/lib/scripts/types.ts
+++ b/src/lib/scripts/types.ts
@@ -1,0 +1,147 @@
+import { isWindows } from "@/lib/hotkeys/binding";
+
+/**
+ * The interpreters a Task can run with. The Rust side (pty.rs `task_interp`) maps
+ * each key to the binary names it resolves, the temp-file extension, and the argv
+ * that runs the script *file* — keep these keys in sync with that match.
+ */
+export type Interpreter =
+  | "powershell"
+  | "cmd"
+  | "bash"
+  | "sh"
+  | "zsh"
+  | "node"
+  | "python";
+
+export interface InterpreterInfo {
+  id: Interpreter;
+  label: string;
+  /** A short hint shown in the picker (what the body is written in). */
+  hint: string;
+}
+
+/** Interpreter options for the task editor, in display order. */
+export const INTERPRETERS: InterpreterInfo[] = [
+  { id: "powershell", label: "PowerShell", hint: "pwsh, or Windows PowerShell" },
+  { id: "cmd", label: "Command Prompt", hint: "cmd.exe batch" },
+  { id: "bash", label: "Bash", hint: "bash script" },
+  { id: "sh", label: "sh", hint: "POSIX shell" },
+  { id: "zsh", label: "Zsh", hint: "zsh script" },
+  { id: "node", label: "Node.js", hint: "JavaScript (ESM)" },
+  { id: "python", label: "Python", hint: "python3, or python" },
+];
+
+const INTERPRETER_IDS = new Set<string>(INTERPRETERS.map((i) => i.id));
+export function isInterpreter(v: unknown): v is Interpreter {
+  return typeof v === "string" && INTERPRETER_IDS.has(v);
+}
+
+/** The interpreter a new task defaults to, by platform (the host shell). */
+export const DEFAULT_INTERPRETER: Interpreter = isWindows ? "powershell" : "bash";
+
+/** Guess the interpreter for an existing script from its file extension — used
+ *  to pre-select the dropdown when the user picks a file. Returns null when the
+ *  extension isn't recognized (the user picks manually). */
+export function interpreterForExt(path: string): Interpreter | null {
+  const ext = path.toLowerCase().split(".").pop() ?? "";
+  switch (ext) {
+    case "ps1":
+      return "powershell";
+    case "cmd":
+    case "bat":
+      return "cmd";
+    case "sh":
+      return "bash";
+    case "zsh":
+      return "zsh";
+    case "mjs":
+    case "cjs":
+    case "js":
+      return "node";
+    case "py":
+      return "python";
+    default:
+      return null;
+  }
+}
+
+/** Where a task's script comes from: an existing file in the repo (run live, in
+ *  place) or an inline body saved with the task. */
+export type TaskSource =
+  | { kind: "file"; path: string }
+  | { kind: "inline"; body: string };
+
+/**
+ * A registered runnable task (a saved script). Definitions live in app-data only
+ * (`scripts.json`), never read from repository content — so a cloned or malicious
+ * repo can never plant a task that GitDesktop would run. (A `file` task points at a
+ * script in the repo; it's the user's own choice and only runs when they start it.)
+ */
+export interface TaskDef {
+  /** Stable id (uuid) — list key and run identity. */
+  id: string;
+  /** Display name, e.g. "Release". */
+  name: string;
+  /** Which interpreter runs the script. */
+  interpreter: Interpreter;
+  /** File (an existing script, run in place) or inline (a body saved here). Both
+   *  run in the current repo's directory. */
+  source: TaskSource;
+  /** Extra arguments passed to the script (e.g. `--preview`), as the user typed
+   *  them; split to argv at run time by {@link parseArgs}. Empty = none. */
+  args: string;
+  /** Confirm before each run. Defaults on; a trusted, frequently-run task can turn
+   *  it off in its editor. */
+  confirmBeforeRun: boolean;
+}
+
+/**
+ * Splits a task's argument string into an argv array, respecting single/double
+ * quotes so `--message "hello world"` is two args, not three. Deliberately does
+ * NOT interpret shell metacharacters (globs, `$VAR`, pipes) — the args go straight
+ * to the process as argv, never through a shell, matching the app's argv-only norm.
+ */
+export function parseArgs(input: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let quote: '"' | "'" | null = null;
+  let started = false;
+  for (const c of input) {
+    if (quote) {
+      if (c === quote) quote = null;
+      else cur += c;
+    } else if (c === '"' || c === "'") {
+      quote = c;
+      started = true;
+    } else if (c === " " || c === "\t" || c === "\n") {
+      if (started) {
+        out.push(cur);
+        cur = "";
+        started = false;
+      }
+    } else {
+      cur += c;
+      started = true;
+    }
+  }
+  if (started) out.push(cur);
+  return out;
+}
+
+/**
+ * The `scripts.json` store shape. `enabled` is the one-time consent to run tasks
+ * at all (off until the user opts in); `tasks` is a list shared across every repo
+ * (per-repo scoping is a later phase).
+ */
+export interface ScriptsConfig {
+  schemaVersion: 1;
+  enabled: boolean;
+  tasks: TaskDef[];
+}
+
+export const EMPTY_SCRIPTS: ScriptsConfig = {
+  schemaVersion: 1,
+  enabled: false,
+  tasks: [],
+};

--- a/src/lib/scripts/types.ts
+++ b/src/lib/scripts/types.ts
@@ -30,7 +30,11 @@ export interface InterpreterInfo {
 
 /** Interpreter options for the task editor, in display order. */
 export const INTERPRETERS: InterpreterInfo[] = [
-  { id: "powershell", label: "PowerShell", hint: "pwsh, or Windows PowerShell" },
+  {
+    id: "powershell",
+    label: "PowerShell",
+    hint: "pwsh, or Windows PowerShell",
+  },
   { id: "cmd", label: "Command Prompt", hint: "cmd.exe batch", os: "windows" },
   {
     id: "git-bash",
@@ -59,7 +63,9 @@ export function isInterpreter(v: unknown): v is Interpreter {
 }
 
 /** The interpreter a new task defaults to, by platform (the host shell). */
-export const DEFAULT_INTERPRETER: Interpreter = isWindows ? "powershell" : "bash";
+export const DEFAULT_INTERPRETER: Interpreter = isWindows
+  ? "powershell"
+  : "bash";
 
 /** Guess the interpreter for an existing script from its file extension — used
  *  to pre-select the dropdown when the user picks a file. Returns null when the

--- a/src/lib/stores/taskRun.ts
+++ b/src/lib/stores/taskRun.ts
@@ -1,0 +1,118 @@
+import { toast } from "sonner";
+import { create } from "zustand";
+import {
+  openTaskInTerminal,
+  TASKS_USE_EXTERNAL_TERMINAL,
+} from "@/lib/scripts/launch";
+import type { TaskDef } from "@/lib/scripts/types";
+import { useUiStore } from "@/lib/stores/ui";
+
+export type RunStatus = "running" | "exited";
+
+/** The one task currently shown in the run pane (v1 has a single run slot). */
+export interface ActiveRun {
+  task: TaskDef;
+  /** Bumped on every (re)run so the run terminal remounts with a fresh PTY. */
+  token: number;
+  status: RunStatus;
+  /** Exit code once `status === "exited"` (null = unknown / killed / spawn error). */
+  code: number | null;
+}
+
+/** A run awaiting the user's confirmation. `confirm` = the task's own
+ *  confirm-before-run; `replace` = a task is already running. */
+export interface PendingRun {
+  task: TaskDef;
+  reason: "confirm" | "replace";
+}
+
+interface TaskRunState {
+  activeRun: ActiveRun | null;
+  pending: PendingRun | null;
+  /** Ask to run `task`: runs immediately, or opens a confirm (its own
+   *  confirm-before-run, or replacing a still-running task). Always the entry
+   *  point — panel Run, Enter, and the palette picker all funnel through here. */
+  request: (task: TaskDef) => void;
+  /** The user confirmed the pending run → start it. */
+  confirmPending: () => void;
+  cancelPending: () => void;
+  /** Re-run the task currently in the pane (no confirm — explicit, same task). */
+  rerun: () => void;
+  /** Mark the run for `token` exited. Guards on the token so a stale terminal's
+   *  late exit can't clobber a newer run. */
+  markExited: (token: number, code: number | null) => void;
+  clear: () => void;
+}
+
+/** Actually start (or restart) a run and switch to the Tasks tab so its output is
+ *  visible. Kept internal so every caller goes through `request`.
+ *
+ *  On Windows under `pnpm tauri dev` the in-app PTY can't spawn, so the run is
+ *  handed to an external terminal instead (see {@link TASKS_USE_EXTERNAL_TERMINAL})
+ *  — no in-app run row is created there. */
+function begin(
+  set: (fn: (s: TaskRunState) => Partial<TaskRunState>) => void,
+  task: TaskDef,
+) {
+  set(() => ({ pending: null }));
+  // The literal `import.meta.env.DEV` guard (not just the imported flag) is what
+  // lets a production build statically drop this whole branch — and with it every
+  // reference to the dev-only external-terminal fallback (verified by grepping
+  // the built chunks; the imported const alone doesn't fold reliably).
+  if (import.meta.env.DEV && TASKS_USE_EXTERNAL_TERMINAL) {
+    // Silent hand-off: the terminal window opening IS the feedback. Only a
+    // failed spawn surfaces.
+    const cwd = useUiStore.getState().repoPath;
+    if (cwd) {
+      openTaskInTerminal(task, cwd).catch((e) => toast.error(String(e)));
+    }
+    return;
+  }
+  set((s) => ({
+    activeRun: {
+      task,
+      token: (s.activeRun?.token ?? 0) + 1,
+      status: "running",
+      code: null,
+    },
+  }));
+  useUiStore.getState().setRepoTab("tasks");
+}
+
+export const useTaskRunStore = create<TaskRunState>((set, get) => ({
+  activeRun: null,
+  pending: null,
+  request: (task) => {
+    const running = get().activeRun?.status === "running";
+    if (running) {
+      set(() => ({ pending: { task, reason: "replace" } }));
+    } else if (task.confirmBeforeRun) {
+      set(() => ({ pending: { task, reason: "confirm" } }));
+    } else {
+      begin(set, task);
+    }
+  },
+  confirmPending: () => {
+    const p = get().pending;
+    if (p) begin(set, p.task);
+  },
+  cancelPending: () => set(() => ({ pending: null })),
+  rerun: () => {
+    const cur = get().activeRun;
+    if (cur) begin(set, cur.task);
+  },
+  markExited: (token, code) =>
+    set((s) =>
+      s.activeRun &&
+      s.activeRun.token === token &&
+      s.activeRun.status === "running"
+        ? { activeRun: { ...s.activeRun, status: "exited", code } }
+        : {},
+    ),
+  clear: () => set(() => ({ activeRun: null })),
+}));
+
+/** The PTY id for a run — unique per (task, run) so a rerun gets a fresh PTY. */
+export function taskPtyId(run: ActiveRun): string {
+  return `task:${run.task.id}:${run.token}`;
+}

--- a/src/lib/stores/taskRun.ts
+++ b/src/lib/stores/taskRun.ts
@@ -12,6 +12,9 @@ export type RunStatus = "running" | "exited";
 /** The one task currently shown in the run pane (v1 has a single run slot). */
 export interface ActiveRun {
   task: TaskDef;
+  /** The arguments THIS run was started with — the task's saved string, or the
+   *  per-run adjustment made in the run dialog. Rerun reuses these. */
+  args: string;
   /** Bumped on every (re)run so the run terminal remounts with a fresh PTY. */
   token: number;
   status: RunStatus;
@@ -29,14 +32,16 @@ export interface PendingRun {
 interface TaskRunState {
   activeRun: ActiveRun | null;
   pending: PendingRun | null;
-  /** Ask to run `task`: runs immediately, or opens a confirm (its own
+  /** Ask to run `task`: runs immediately, or opens the run dialog (its own
    *  confirm-before-run, or replacing a still-running task). Always the entry
    *  point — panel Run, Enter, and the palette picker all funnel through here. */
   request: (task: TaskDef) => void;
-  /** The user confirmed the pending run → start it. */
-  confirmPending: () => void;
+  /** The user confirmed the pending run → start it with `args` (the dialog's
+   *  possibly-adjusted argument string; the saved task is untouched). */
+  confirmPending: (args: string) => void;
   cancelPending: () => void;
-  /** Re-run the task currently in the pane (no confirm — explicit, same task). */
+  /** Re-run the task currently in the pane with the same args (no confirm —
+   *  explicit, same task, same arguments). */
   rerun: () => void;
   /** Mark the run for `token` exited. Guards on the token so a stale terminal's
    *  late exit can't clobber a newer run. */
@@ -53,6 +58,7 @@ interface TaskRunState {
 function begin(
   set: (fn: (s: TaskRunState) => Partial<TaskRunState>) => void,
   task: TaskDef,
+  args: string,
 ) {
   set(() => ({ pending: null }));
   // The literal `import.meta.env.DEV` guard (not just the imported flag) is what
@@ -64,13 +70,14 @@ function begin(
     // failed spawn surfaces.
     const cwd = useUiStore.getState().repoPath;
     if (cwd) {
-      openTaskInTerminal(task, cwd).catch((e) => toast.error(String(e)));
+      openTaskInTerminal(task, cwd, args).catch((e) => toast.error(String(e)));
     }
     return;
   }
   set((s) => ({
     activeRun: {
       task,
+      args,
       token: (s.activeRun?.token ?? 0) + 1,
       status: "running",
       code: null,
@@ -89,17 +96,18 @@ export const useTaskRunStore = create<TaskRunState>((set, get) => ({
     } else if (task.confirmBeforeRun) {
       set(() => ({ pending: { task, reason: "confirm" } }));
     } else {
-      begin(set, task);
+      // No dialog → the saved arguments run as-is.
+      begin(set, task, task.args);
     }
   },
-  confirmPending: () => {
+  confirmPending: (args) => {
     const p = get().pending;
-    if (p) begin(set, p.task);
+    if (p) begin(set, p.task, args);
   },
   cancelPending: () => set(() => ({ pending: null })),
   rerun: () => {
     const cur = get().activeRun;
-    if (cur) begin(set, cur.task);
+    if (cur) begin(set, cur.task, cur.args);
   },
   markExited: (token, code) =>
     set((s) =>

--- a/src/lib/stores/taskRun.ts
+++ b/src/lib/stores/taskRun.ts
@@ -124,3 +124,19 @@ export const useTaskRunStore = create<TaskRunState>((set, get) => ({
 export function taskPtyId(run: ActiveRun): string {
   return `task:${run.task.id}:${run.token}`;
 }
+
+// A run belongs to the repo it was started in. `taskRun` is a separate store, so
+// the ui store's CROSS_REPO_RESET can't reach it — subscribe to repo changes and
+// drop the run here. Without this the run leaks across a repo switch:
+// RepositoryView unmounts on close and remounts on the next open, so the run
+// pane's Terminal mounts fresh and re-executes the task in the NEW repo's folder
+// (with a now-wrong repo-relative path), and the stale "running" status drives a
+// phantom run indicator plus a spurious "already running" dialog naming the old
+// task.
+useUiStore.subscribe((s, prev) => {
+  if (s.repoPath === prev.repoPath) return;
+  const { activeRun, pending } = useTaskRunStore.getState();
+  if (activeRun || pending) {
+    useTaskRunStore.setState({ activeRun: null, pending: null });
+  }
+});

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -14,6 +14,7 @@ export type RepoTab =
   | "tags"
   | "insights"
   | "code-todos"
+  | "tasks"
   | "agent";
 /** A create dialog the command palette / New menus can request from any tab. */
 export type CreateKind =


### PR DESCRIPTION
Add a user-managed Tasks feature so release, build, and other repository workflows can run inside GitDesktop instead of requiring a separate terminal. Tasks remain opt-in and app-owned, while interactive PTY execution, per-run arguments, and AI-assisted script generation and analysis support safer, more convenient workflows.

### Task management

- Adds the Tasks tab, task list, enablement flow, task editor, and task persistence in `src/features/repository/RepositoryView.tsx`, `src/features/scripts/TasksPanel.tsx`, `src/features/scripts/TaskDialog.tsx`, `src/lib/scripts/store.ts`, and `src/lib/scripts/types.ts`.
- Supports existing repository scripts and inline script bodies through `src/lib/scripts/types.ts` and `src/features/scripts/TaskDialog.tsx`.
- Stores task definitions in application data rather than repository content, defaults task execution to disabled, and enables confirmation before runs in `src/lib/scripts/store.ts` and `src/features/scripts/TasksPanel.tsx`.
- Adds interpreter selection for PowerShell, cmd, bash, sh, zsh, Node.js, and Python in `src/lib/scripts/types.ts` and `src-tauri/src/pty.rs`.
- Adds argument parsing, documented argument references, and per-run argument overrides in `src/lib/scripts/types.ts`, `src/features/scripts/TaskDialog.tsx`, and `src/features/scripts/TaskRunConfirm.tsx`.

### Interactive task execution

- Extends the Rust PTY backend in `src-tauri/src/pty.rs` and registers `pty::task_open_terminal` in `src-tauri/src/lib.rs` to execute task scripts through their selected interpreter.
- Runs inline scripts from temporary files and existing scripts by path, passing arguments as argv without interpolating script bodies into shell commands in `src-tauri/src/pty.rs`.
- Adds task run state, replacement confirmation, rerun support, exit status handling, and process-tree cleanup in `src/lib/stores/taskRun.ts`.
- Displays live interactive output, task status, exit codes, stop controls, and rerun controls in `src/features/scripts/TaskRunView.tsx` and `src/features/terminal/Terminal.tsx`.
- Adds a Windows development fallback for opening tasks in an external terminal through `src/lib/scripts/launch.ts` and `src-tauri/src/pty.rs`.

### AI assistance and navigation

- Adds AI script generation from natural-language descriptions in `src/features/scripts/useGenerateScript.ts`.
- Adds AI script analysis that fills in task names, descriptions, and accepted argument documentation in `src/features/scripts/useAnalyzeScript.ts`.
- Adds the command-palette task picker and task-related hotkeys in `src/features/scripts/RunTaskPicker.tsx`, `src/lib/hotkeys/registry.ts`, and `src/features/repository/RepositoryView.tsx`.
- Adds task-run indicators to the repository navigation in `src/features/repository/RepositoryView.tsx`.

### Documentation

- Documents task creation, AI generation and analysis, argument handling, interactive runs, safety defaults, and interpreter support in `README.md` and `src/features/help/content.ts`.
- Adds the task feature to the capability listings in `site/src/data/capabilities.ts`.
- Adds release notes in `changelog.d/added-tasks.md`.

### Additional files

- Adds `marker3.txt` with the content `INJECTED3`.