### PR TITLE
fix(settings,fsops): detect and launch macOS and Linux apps

### DIFF
--- a/changelog.d/fixed-terminal-editor-detection-mac-linux.md
+++ b/changelog.d/fixed-terminal-editor-detection-mac-linux.md
@@ -1,0 +1,6 @@
+- Terminal and editor auto-detection now works on macOS and Linux, not just
+  Windows. Settings → Terminal / External editor populate with the terminals and
+  editors you actually have installed (Terminal, iTerm, Warp, Ghostty, VS Code,
+  Cursor, Sublime Text, Zed, Xcode, JetBrains IDEs, and more), and "Open in
+  terminal" / "Open in editor" now honor the one you pick instead of always
+  falling back to the system default.

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -300,15 +300,47 @@ fn launch_terminal_unix(kind: &str, program: &str, path: &str) -> AppResult<()> 
     use std::process::Command;
     #[cfg(target_os = "macos")]
     {
-        // `open -a <app> <dir>` opens the chosen terminal rooted at the folder.
-        // `<app>` is the detected `.app` bundle path when we have one (most
-        // robust), else a well-known app name for the kind, else Terminal.app.
-        let app = mac_terminal_app(kind, program);
-        Command::new("open")
-            .args(["-a", app.as_str(), path])
-            .spawn()
-            .map(|_| ())
-            .map_err(AppError::Io)
+        let bundle = Path::new(program);
+        // A stored bundle path that no longer exists (the app was uninstalled
+        // after being picked) would make `open -a <missing>` a silent no-op that
+        // still returns Ok from spawn(); fall back to Terminal.app instead.
+        if !program.is_empty() && !bundle.exists() {
+            return Command::new("open")
+                .args(["-a", "Terminal", path])
+                .spawn()
+                .map(|_| ())
+                .map_err(AppError::Io);
+        }
+        // `open -a <app> <dir>` only roots the window at the folder for apps that
+        // register as folder handlers (Terminal, iTerm). Pure-GUI emulators
+        // (Alacritty, kitty, WezTerm) ignore the dir arg, so spawn their inner
+        // binary with the tool's own working-directory flag. Warp/Hyper/Ghostty
+        // have no stable such flag → best-effort `open -a` (may open at $HOME).
+        let inner = |bin: &str| bundle.join("Contents").join("MacOS").join(bin);
+        let mut cmd = match kind {
+            "alacritty" if !program.is_empty() => {
+                let mut c = Command::new(inner("alacritty"));
+                c.args(["--working-directory", path]);
+                c
+            }
+            "kitty" if !program.is_empty() => {
+                let mut c = Command::new(inner("kitty"));
+                c.args(["--directory", path]);
+                c
+            }
+            "wezterm" if !program.is_empty() => {
+                let mut c = Command::new(inner("wezterm"));
+                c.args(["start", "--cwd", path]);
+                c
+            }
+            _ => {
+                let app = mac_terminal_app(kind, program);
+                let mut c = Command::new("open");
+                c.args(["-a", app.as_str(), path]);
+                c
+            }
+        };
+        cmd.spawn().map(|_| ()).map_err(AppError::Io)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -485,7 +517,12 @@ fn scan_jetbrains(dirs: &[PathBuf]) -> Vec<DetectedEditor> {
                 continue;
             };
             let lower = stem.to_ascii_lowercase();
-            if !JETBRAINS_PREFIXES.iter().any(|&p| lower.starts_with(p)) {
+            // Match a product name exactly or followed by a space (edition/version
+            // suffix), so a short prefix like "aqua" doesn't catch "Aquamacs".
+            if !JETBRAINS_PREFIXES
+                .iter()
+                .any(|&p| lower == p || lower.strip_prefix(p).is_some_and(|r| r.starts_with(' ')))
+            {
                 continue;
             }
             if found.iter().any(|e| e.name == stem) {
@@ -988,6 +1025,7 @@ mod tests {
         let apps = tmp.path().join("Applications");
         make_bundle(&apps, "IntelliJ IDEA.app");
         make_bundle(&apps, "PyCharm Community Edition.app");
+        make_bundle(&apps, "Aquamacs.app"); // NOT JetBrains "aqua" (no word boundary)
         make_bundle(&apps, "Some Random App.app"); // not JetBrains
         make_bundle(&apps, "Cursor.app"); // not JetBrains
 
@@ -997,6 +1035,8 @@ mod tests {
         assert!(names.contains(&"IntelliJ IDEA"));
         // Edition suffix is preserved (display name = bundle stem).
         assert!(names.contains(&"PyCharm Community Edition"));
+        // "aqua" prefix must not swallow "Aquamacs" (word-boundary match).
+        assert!(!names.contains(&"Aquamacs"));
         assert!(!names.iter().any(|n| n.contains("Random")));
         assert!(!names.contains(&"Cursor"));
     }

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -233,8 +233,7 @@ pub async fn open_in_terminal(
     }
     #[cfg(not(windows))]
     {
-        let _ = (&kind, &program);
-        launch_terminal_unix(&path)
+        launch_terminal_unix(&kind, &program, &path)
     }
 }
 
@@ -297,18 +296,37 @@ fn launch_terminal_windows(kind: &str, program: &str, path: &str) -> AppResult<(
 }
 
 #[cfg(not(windows))]
-fn launch_terminal_unix(path: &str) -> AppResult<()> {
+fn launch_terminal_unix(kind: &str, program: &str, path: &str) -> AppResult<()> {
     use std::process::Command;
     #[cfg(target_os = "macos")]
     {
+        // `open -a <app> <dir>` opens the chosen terminal rooted at the folder.
+        // `<app>` is the detected `.app` bundle path when we have one (most
+        // robust), else a well-known app name for the kind, else Terminal.app.
+        let app = mac_terminal_app(kind, program);
         Command::new("open")
-            .args(["-a", "Terminal", path])
+            .args(["-a", app.as_str(), path])
             .spawn()
             .map(|_| ())
             .map_err(AppError::Io)
     }
     #[cfg(not(target_os = "macos"))]
     {
+        // Honor the picked emulator (its stored path, or the id which equals the
+        // binary name); fall back to the common emulators when none was chosen
+        // or the pick fails to spawn.
+        let chosen = if !program.is_empty() {
+            Some(program.to_string())
+        } else if !kind.is_empty() && kind != "custom" {
+            Some(kind.to_string())
+        } else {
+            None
+        };
+        if let Some(bin) = chosen {
+            if Command::new(&bin).current_dir(path).spawn().is_ok() {
+                return Ok(());
+            }
+        }
         for term in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"] {
             if Command::new(term).current_dir(path).spawn().is_ok() {
                 return Ok(());
@@ -377,9 +395,238 @@ fn detect_terminals_sync() -> Vec<DetectedTerminal> {
     found
 }
 
-#[cfg(not(windows))]
+// ---- Shared detection cores (platform-neutral, dependency-injected so the
+// logic is unit-tested regardless of host OS; the `#[cfg]` wrappers below just
+// supply each platform's search dirs / probe tables) ----
+
+/// A macOS application to probe for: (kind id, display name, `.app` bundle name).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+type MacApp = (&'static str, &'static str, &'static str);
+
+/// Scans `dirs` for the terminal `.app` bundles in `table`, one entry per
+/// distinct id (first directory match wins). Pure filesystem probing — never
+/// PATH — so a Finder-launched app (minimal launchd PATH) detects the same set.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn scan_app_terminals(dirs: &[PathBuf], table: &[MacApp]) -> Vec<DetectedTerminal> {
+    let mut found: Vec<DetectedTerminal> = Vec::new();
+    for &(id, name, bundle) in table {
+        if found.iter().any(|t| t.id == id) {
+            continue;
+        }
+        for dir in dirs {
+            let p = dir.join(bundle);
+            if p.exists() {
+                found.push(DetectedTerminal {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    path: p.to_string_lossy().into_owned(),
+                });
+                break;
+            }
+        }
+    }
+    found
+}
+
+/// Scans `dirs` for the editor `.app` bundles in `table` (display name, bundle
+/// name), one entry per distinct name.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn scan_app_editors(dirs: &[PathBuf], table: &[(&str, &str)]) -> Vec<DetectedEditor> {
+    let mut found: Vec<DetectedEditor> = Vec::new();
+    for &(name, bundle) in table {
+        if found.iter().any(|e| e.name == name) {
+            continue;
+        }
+        for dir in dirs {
+            let p = dir.join(bundle);
+            if p.exists() {
+                found.push(DetectedEditor {
+                    name: name.to_string(),
+                    path: p.to_string_lossy().into_owned(),
+                });
+                break;
+            }
+        }
+    }
+    found
+}
+
+/// Lowercased JetBrains product-name prefixes recognized among `*.app` bundles.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const JETBRAINS_PREFIXES: &[&str] = &[
+    "intellij idea",
+    "pycharm",
+    "webstorm",
+    "goland",
+    "clion",
+    "rider",
+    "rubymine",
+    "phpstorm",
+    "datagrip",
+    "rustrover",
+    "dataspell",
+    "aqua",
+    "android studio",
+];
+
+/// Scans `dirs` for JetBrains IDE `.app` bundles (standalone or Toolbox),
+/// matching by product-name prefix. Display name is the bundle's file stem, so
+/// edition suffixes ("PyCharm Community") are preserved. Deduped by name.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn scan_jetbrains(dirs: &[PathBuf]) -> Vec<DetectedEditor> {
+    let mut found: Vec<DetectedEditor> = Vec::new();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+            let Some(stem) = file_name.strip_suffix(".app") else {
+                continue;
+            };
+            let lower = stem.to_ascii_lowercase();
+            if !JETBRAINS_PREFIXES.iter().any(|&p| lower.starts_with(p)) {
+                continue;
+            }
+            if found.iter().any(|e| e.name == stem) {
+                continue;
+            }
+            found.push(DetectedEditor {
+                name: stem.to_string(),
+                path: entry.path().to_string_lossy().into_owned(),
+            });
+        }
+    }
+    found
+}
+
+/// Assembles detected terminals from `(id, name, bin-names)` rows via `resolve`
+/// (a name→path lookup). The injected resolver keeps assembly pure/testable; the
+/// real caller passes the Homebrew-aware `crate::agent::find_executable`.
+#[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
+fn probe_terminal_bins<F>(table: &[(&str, &str, &[&str])], resolve: F) -> Vec<DetectedTerminal>
+where
+    F: Fn(&[&str]) -> Option<PathBuf>,
+{
+    let mut found = Vec::new();
+    for &(id, name, names) in table {
+        if let Some(path) = resolve(names) {
+            found.push(DetectedTerminal {
+                id: id.to_string(),
+                name: name.to_string(),
+                path: path.to_string_lossy().into_owned(),
+            });
+        }
+    }
+    found
+}
+
+/// Assembles detected editors from `(name, bin-names)` rows via `resolve`.
+#[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
+fn probe_editor_bins<F>(table: &[(&str, &[&str])], resolve: F) -> Vec<DetectedEditor>
+where
+    F: Fn(&[&str]) -> Option<PathBuf>,
+{
+    let mut found = Vec::new();
+    for &(name, names) in table {
+        if let Some(path) = resolve(names) {
+            found.push(DetectedEditor {
+                name: name.to_string(),
+                path: path.to_string_lossy().into_owned(),
+            });
+        }
+    }
+    found
+}
+
+/// True when `program` points at a macOS `.app` bundle (a directory launched via
+/// `open -a`, not executed directly).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn is_app_bundle(program: &str) -> bool {
+    program
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+        .ends_with(".app")
+}
+
+/// The macOS application name to pass to `open -a` for a terminal `kind` when no
+/// explicit bundle path was stored (the stored bundle path wins when present).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn mac_terminal_app(kind: &str, program: &str) -> String {
+    if !program.is_empty() {
+        return program.to_string();
+    }
+    match kind {
+        "iterm" => "iTerm",
+        "warp" => "Warp",
+        "alacritty" => "Alacritty",
+        "kitty" => "kitty",
+        "wezterm" => "WezTerm",
+        "hyper" => "Hyper",
+        "ghostty" => "Ghostty",
+        _ => "Terminal",
+    }
+    .to_string()
+}
+
+#[cfg(target_os = "macos")]
+fn unix_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(target_os = "macos")]
+fn mac_app_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![
+        PathBuf::from("/Applications"),
+        PathBuf::from("/Applications/Utilities"),
+        PathBuf::from("/System/Applications"),
+        PathBuf::from("/System/Applications/Utilities"),
+    ];
+    if let Some(home) = unix_home() {
+        dirs.push(home.join("Applications"));
+    }
+    dirs
+}
+
+#[cfg(target_os = "macos")]
+const MAC_TERMINALS: &[MacApp] = &[
+    ("macos-terminal", "Terminal", "Terminal.app"),
+    ("iterm", "iTerm", "iTerm.app"),
+    ("warp", "Warp", "Warp.app"),
+    ("alacritty", "Alacritty", "Alacritty.app"),
+    ("kitty", "kitty", "kitty.app"),
+    ("wezterm", "WezTerm", "WezTerm.app"),
+    ("hyper", "Hyper", "Hyper.app"),
+    ("ghostty", "Ghostty", "Ghostty.app"),
+];
+
+#[cfg(target_os = "macos")]
 fn detect_terminals_sync() -> Vec<DetectedTerminal> {
-    Vec::new()
+    scan_app_terminals(&mac_app_dirs(), MAC_TERMINALS)
+}
+
+// Linux/other unix: terminal emulators are PATH binaries, resolved through the
+// Homebrew-aware `find_executable` (which searches PATH + the well-known bin
+// dirs); the id equals the binary name so the launcher can honor a pick even
+// without a stored path.
+#[cfg(all(not(windows), not(target_os = "macos")))]
+const LINUX_TERMINALS: &[(&str, &str, &[&str])] = &[
+    ("gnome-terminal", "GNOME Terminal", &["gnome-terminal"]),
+    ("konsole", "Konsole", &["konsole"]),
+    ("alacritty", "Alacritty", &["alacritty"]),
+    ("kitty", "kitty", &["kitty"]),
+    ("wezterm", "WezTerm", &["wezterm"]),
+    ("tilix", "Tilix", &["tilix"]),
+    ("xfce4-terminal", "Xfce Terminal", &["xfce4-terminal"]),
+    ("terminator", "Terminator", &["terminator"]),
+    ("xterm", "XTerm", &["xterm"]),
+];
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn detect_terminals_sync() -> Vec<DetectedTerminal> {
+    probe_terminal_bins(LINUX_TERMINALS, |names| {
+        crate::agent::find_executable(names)
+    })
 }
 
 /// Probes well-known install locations for editors/IDEs, GitHub Desktop
@@ -391,6 +638,7 @@ pub async fn detect_editors() -> AppResult<Vec<DetectedEditor>> {
         .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))
 }
 
+#[cfg(windows)]
 fn detect_editors_sync() -> Vec<DetectedEditor> {
     let local = std::env::var("LOCALAPPDATA").unwrap_or_default();
     let pf = std::env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".into());
@@ -483,12 +731,81 @@ fn detect_editors_sync() -> Vec<DetectedEditor> {
     found
 }
 
+// macOS editors are `.app` bundles under /Applications (+ ~/Applications for
+// user/Toolbox installs), never `.exe`. Pure-terminal editors (nvim/vim) are
+// deliberately omitted: launched from the GUI file menu they have no controlling
+// tty and would fail — GUI-capable editors only (Emacs.app is fine).
+#[cfg(target_os = "macos")]
+const MAC_EDITORS: &[(&str, &str)] = &[
+    ("Visual Studio Code", "Visual Studio Code.app"),
+    ("VS Code Insiders", "Visual Studio Code - Insiders.app"),
+    ("Cursor", "Cursor.app"),
+    ("Sublime Text", "Sublime Text.app"),
+    ("Zed", "Zed.app"),
+    ("Xcode", "Xcode.app"),
+    ("Nova", "Nova.app"),
+    ("BBEdit", "BBEdit.app"),
+    ("Emacs", "Emacs.app"),
+];
+
+#[cfg(target_os = "macos")]
+fn detect_editors_sync() -> Vec<DetectedEditor> {
+    let dirs = mac_app_dirs();
+    let mut found = scan_app_editors(&dirs, MAC_EDITORS);
+    // JetBrains IDEs: standalone in /Applications, or Toolbox under
+    // ~/Applications (some Toolbox versions nest a "JetBrains Toolbox" folder).
+    let mut jb_dirs = dirs.clone();
+    if let Some(home) = unix_home() {
+        jb_dirs.push(home.join("Applications").join("JetBrains Toolbox"));
+    }
+    found.extend(scan_jetbrains(&jb_dirs));
+    found.sort_by(|a, b| a.name.cmp(&b.name));
+    found.dedup_by(|a, b| a.name == b.name);
+    found
+}
+
+// Linux/other unix: editors are PATH binaries. GUI editors launch fine via
+// `open_with_program`'s direct spawn; terminal-only editors are omitted for the
+// same reason as macOS.
+#[cfg(all(not(windows), not(target_os = "macos")))]
+const LINUX_EDITORS: &[(&str, &[&str])] = &[
+    ("Visual Studio Code", &["code"]),
+    ("VS Code Insiders", &["code-insiders"]),
+    ("Cursor", &["cursor"]),
+    ("Sublime Text", &["subl"]),
+    ("Zed", &["zed", "zeditor"]),
+    ("Gedit", &["gedit"]),
+    ("Kate", &["kate"]),
+    ("GNOME Text Editor", &["gnome-text-editor"]),
+    ("Emacs", &["emacs"]),
+];
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn detect_editors_sync() -> Vec<DetectedEditor> {
+    let mut found =
+        probe_editor_bins(LINUX_EDITORS, |names| crate::agent::find_executable(names));
+    found.sort_by(|a, b| a.name.cmp(&b.name));
+    found.dedup_by(|a, b| a.name == b.name);
+    found
+}
+
 /// Opens a file in a user-configured program (e.g. an editor).
 #[tauri::command]
 pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
     let program = program.trim().to_string();
     if program.is_empty() {
         return Err(AppError::InvalidArgument("no program configured".into()));
+    }
+    // macOS `.app` bundles (e.g. "/Applications/Visual Studio Code.app") are
+    // directories, not executables — launch them with `open -a <bundle> <file>`
+    // rather than trying to spawn the bundle directory as a command.
+    #[cfg(target_os = "macos")]
+    if is_app_bundle(&program) {
+        std::process::Command::new("open")
+            .args(["-a", program.as_str(), path.as_str()])
+            .spawn()
+            .map_err(AppError::Io)?;
+        return Ok(());
     }
     let lower = program.to_lowercase();
     // .cmd/.bat shims (like VS Code's `code.cmd`) can't be spawned directly
@@ -590,5 +907,142 @@ mod tests {
         assert_eq!(added, 0);
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(before, after);
+    }
+
+    // ---- Terminal/editor detection cores (platform-neutral; run on every OS) ----
+
+    fn make_bundle(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir.join(name)).expect("create bundle dir");
+    }
+
+    #[test]
+    fn is_app_bundle_classifies_paths() {
+        assert!(is_app_bundle("/Applications/Visual Studio Code.app"));
+        assert!(is_app_bundle("/Applications/iTerm.app/")); // trailing slash
+        assert!(is_app_bundle("Cursor.APP")); // case-insensitive
+        assert!(!is_app_bundle("/usr/local/bin/code"));
+        assert!(!is_app_bundle("/Applications/foo.app.bak"));
+        assert!(!is_app_bundle(""));
+    }
+
+    #[test]
+    fn mac_terminal_app_prefers_program_then_kind_then_default() {
+        // A stored bundle path always wins.
+        assert_eq!(
+            mac_terminal_app("iterm", "/Applications/iTerm.app"),
+            "/Applications/iTerm.app"
+        );
+        // No path: map the known kind id to its app name.
+        assert_eq!(mac_terminal_app("warp", ""), "Warp");
+        assert_eq!(mac_terminal_app("ghostty", ""), "Ghostty");
+        // Unknown/empty kind falls back to Terminal.app.
+        assert_eq!(mac_terminal_app("", ""), "Terminal");
+        assert_eq!(mac_terminal_app("custom", ""), "Terminal");
+    }
+
+    #[test]
+    fn scan_app_terminals_detects_and_dedups_by_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let apps = tmp.path().join("Applications");
+        let utils = tmp.path().join("Utilities");
+        make_bundle(&apps, "iTerm.app");
+        make_bundle(&apps, "Warp.app");
+        make_bundle(&utils, "iTerm.app"); // same id in a later dir → ignored
+
+        let table: &[MacApp] = &[
+            ("iterm", "iTerm", "iTerm.app"),
+            ("warp", "Warp", "Warp.app"),
+            ("kitty", "kitty", "kitty.app"), // not installed
+        ];
+        let found = scan_app_terminals(&[apps.clone(), utils], table);
+
+        assert_eq!(found.len(), 2);
+        let iterm = found.iter().find(|t| t.id == "iterm").unwrap();
+        assert_eq!(iterm.name, "iTerm");
+        // First matching directory wins.
+        assert_eq!(iterm.path, apps.join("iTerm.app").to_string_lossy());
+        assert!(found.iter().any(|t| t.id == "warp"));
+        assert!(!found.iter().any(|t| t.id == "kitty"));
+    }
+
+    #[test]
+    fn scan_app_editors_detects_installed_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let apps = tmp.path().join("Applications");
+        make_bundle(&apps, "Visual Studio Code.app");
+        make_bundle(&apps, "Zed.app");
+
+        let table: &[(&str, &str)] = &[
+            ("Visual Studio Code", "Visual Studio Code.app"),
+            ("Zed", "Zed.app"),
+            ("Cursor", "Cursor.app"), // not installed
+        ];
+        let found = scan_app_editors(&[apps], table);
+
+        assert_eq!(found.len(), 2);
+        assert!(found.iter().any(|e| e.name == "Visual Studio Code"));
+        assert!(found.iter().any(|e| e.name == "Zed"));
+        assert!(!found.iter().any(|e| e.name == "Cursor"));
+    }
+
+    #[test]
+    fn scan_jetbrains_matches_product_prefixes_and_keeps_edition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let apps = tmp.path().join("Applications");
+        make_bundle(&apps, "IntelliJ IDEA.app");
+        make_bundle(&apps, "PyCharm Community Edition.app");
+        make_bundle(&apps, "Some Random App.app"); // not JetBrains
+        make_bundle(&apps, "Cursor.app"); // not JetBrains
+
+        let found = scan_jetbrains(&[apps]);
+
+        let names: Vec<&str> = found.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"IntelliJ IDEA"));
+        // Edition suffix is preserved (display name = bundle stem).
+        assert!(names.contains(&"PyCharm Community Edition"));
+        assert!(!names.iter().any(|n| n.contains("Random")));
+        assert!(!names.contains(&"Cursor"));
+    }
+
+    #[test]
+    fn probe_terminal_bins_resolves_via_injected_lookup() {
+        // Fake resolver: only "konsole" and "kitty" are "installed".
+        let resolve = |names: &[&str]| -> Option<PathBuf> {
+            names
+                .iter()
+                .find(|n| matches!(**n, "konsole" | "kitty"))
+                .map(|n| PathBuf::from(format!("/usr/bin/{n}")))
+        };
+        let table: &[(&str, &str, &[&str])] = &[
+            ("gnome-terminal", "GNOME Terminal", &["gnome-terminal"]),
+            ("konsole", "Konsole", &["konsole"]),
+            ("kitty", "kitty", &["kitty"]),
+        ];
+        let found = probe_terminal_bins(table, resolve);
+
+        assert_eq!(found.len(), 2);
+        let konsole = found.iter().find(|t| t.id == "konsole").unwrap();
+        assert_eq!(konsole.path, "/usr/bin/konsole");
+        assert!(!found.iter().any(|t| t.id == "gnome-terminal"));
+    }
+
+    #[test]
+    fn probe_editor_bins_resolves_first_matching_name() {
+        // Zed ships as either `zed` or `zeditor`; only `zeditor` is present here.
+        let resolve = |names: &[&str]| -> Option<PathBuf> {
+            names
+                .iter()
+                .find(|n| **n == "zeditor")
+                .map(|_| PathBuf::from("/usr/local/bin/zeditor"))
+        };
+        let table: &[(&str, &[&str])] = &[
+            ("Zed", &["zed", "zeditor"]),
+            ("Cursor", &["cursor"]), // not installed
+        ];
+        let found = probe_editor_bins(table, resolve);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "Zed");
+        assert_eq!(found[0].path, "/usr/local/bin/zeditor");
     }
 }

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -624,9 +624,7 @@ const LINUX_TERMINALS: &[(&str, &str, &[&str])] = &[
 
 #[cfg(all(not(windows), not(target_os = "macos")))]
 fn detect_terminals_sync() -> Vec<DetectedTerminal> {
-    probe_terminal_bins(LINUX_TERMINALS, |names| {
-        crate::agent::find_executable(names)
-    })
+    probe_terminal_bins(LINUX_TERMINALS, crate::agent::find_executable)
 }
 
 /// Probes well-known install locations for editors/IDEs, GitHub Desktop
@@ -782,8 +780,7 @@ const LINUX_EDITORS: &[(&str, &[&str])] = &[
 
 #[cfg(all(not(windows), not(target_os = "macos")))]
 fn detect_editors_sync() -> Vec<DetectedEditor> {
-    let mut found =
-        probe_editor_bins(LINUX_EDITORS, |names| crate::agent::find_executable(names));
+    let mut found = probe_editor_bins(LINUX_EDITORS, crate::agent::find_executable);
     found.sort_by(|a, b| a.name.cmp(&b.name));
     found.dedup_by(|a, b| a.name == b.name);
     found

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -317,30 +317,30 @@ fn launch_terminal_unix(kind: &str, program: &str, path: &str) -> AppResult<()> 
         // binary with the tool's own working-directory flag. Warp/Hyper/Ghostty
         // have no stable such flag → best-effort `open -a` (may open at $HOME).
         let inner = |bin: &str| bundle.join("Contents").join("MacOS").join(bin);
-        let mut cmd = match kind {
+        let flag_launch = match kind {
             "alacritty" if !program.is_empty() => {
-                let mut c = Command::new(inner("alacritty"));
-                c.args(["--working-directory", path]);
-                c
+                Some((inner("alacritty"), vec!["--working-directory", path]))
             }
-            "kitty" if !program.is_empty() => {
-                let mut c = Command::new(inner("kitty"));
-                c.args(["--directory", path]);
-                c
-            }
+            "kitty" if !program.is_empty() => Some((inner("kitty"), vec!["--directory", path])),
             "wezterm" if !program.is_empty() => {
-                let mut c = Command::new(inner("wezterm"));
-                c.args(["start", "--cwd", path]);
-                c
+                Some((inner("wezterm"), vec!["start", "--cwd", path]))
             }
-            _ => {
-                let app = mac_terminal_app(kind, program);
-                let mut c = Command::new("open");
-                c.args(["-a", app.as_str(), path]);
-                c
-            }
+            _ => None,
         };
-        cmd.spawn().map(|_| ()).map_err(AppError::Io)
+        // If the emulator's inner binary is missing/renamed (a future release or a
+        // divergent bundle layout), fall through to `open -a` rather than
+        // hard-failing — mirroring the Linux branch's fallback posture.
+        if let Some((prog, args)) = flag_launch {
+            if Command::new(&prog).args(&args).spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        let app = mac_terminal_app(kind, program);
+        Command::new("open")
+            .args(["-a", app.as_str(), path])
+            .spawn()
+            .map(|_| ())
+            .map_err(AppError::Io)
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/src/features/settings/EditorSection.tsx
+++ b/src/features/settings/EditorSection.tsx
@@ -14,10 +14,14 @@ import {
 } from "@/components/ui/select";
 import { withForm } from "@/lib/form";
 import { detectEditors } from "@/lib/git/api";
+import { isWindows } from "@/lib/hotkeys/binding";
 import { settingsFormOpts } from "./settings-form";
 
 const CUSTOM = "__custom__";
 const NONE = "__none__";
+const CUSTOM_PLACEHOLDER = isWindows
+  ? "C:\\path\\to\\editor.exe"
+  : "/Applications/Visual Studio Code.app";
 
 export const EditorSection = withForm({
   ...settingsFormOpts,
@@ -60,7 +64,11 @@ export const EditorSection = withForm({
     async function choose() {
       const picked = await openDialog({
         title: "Choose a program",
-        filters: [{ name: "Programs", extensions: ["exe", "cmd", "bat"] }],
+        // macOS editors are `.app` bundles and Linux ones are bare binaries;
+        // only Windows uses .exe/.cmd/.bat, so don't filter elsewhere.
+        filters: isWindows
+          ? [{ name: "Programs", extensions: ["exe", "cmd", "bat"] }]
+          : undefined,
       });
       if (picked) setEditor(picked, programLabel(picked));
     }
@@ -123,7 +131,7 @@ export const EditorSection = withForm({
               <Input
                 id="external-editor"
                 className="flex-1 font-mono"
-                placeholder="C:\\path\\to\\editor.exe"
+                placeholder={CUSTOM_PLACEHOLDER}
                 autoComplete="off"
                 value={externalEditor}
                 onChange={(e) =>
@@ -141,8 +149,8 @@ export const EditorSection = withForm({
   },
 });
 
-/** "C:\\apps\\Code.exe" -> "Code" for labels. */
+/** "C:\\apps\\Code.exe" or "/Applications/Cursor.app" -> "Code"/"Cursor". */
 function programLabel(program: string): string {
   const base = program.replaceAll("\\", "/").split("/").pop() ?? program;
-  return base.replace(/\.(exe|cmd|bat)$/i, "") || "Custom";
+  return base.replace(/\.(exe|cmd|bat|app)$/i, "") || "Custom";
 }

--- a/src/features/settings/EditorSection.tsx
+++ b/src/features/settings/EditorSection.tsx
@@ -14,14 +14,16 @@ import {
 } from "@/components/ui/select";
 import { withForm } from "@/lib/form";
 import { detectEditors } from "@/lib/git/api";
-import { isWindows } from "@/lib/hotkeys/binding";
+import { isMac, isWindows } from "@/lib/hotkeys/binding";
 import { settingsFormOpts } from "./settings-form";
 
 const CUSTOM = "__custom__";
 const NONE = "__none__";
 const CUSTOM_PLACEHOLDER = isWindows
   ? "C:\\path\\to\\editor.exe"
-  : "/Applications/Visual Studio Code.app";
+  : isMac
+    ? "/Applications/Visual Studio Code.app"
+    : "/usr/bin/code";
 
 export const EditorSection = withForm({
   ...settingsFormOpts,

--- a/src/features/settings/TerminalSection.tsx
+++ b/src/features/settings/TerminalSection.tsx
@@ -27,7 +27,9 @@ const DEFAULT_LABEL = isWindows
     : "Default terminal";
 const CUSTOM_PLACEHOLDER = isWindows
   ? "C:\\path\\to\\terminal.exe"
-  : "/Applications/iTerm.app";
+  : isMac
+    ? "/Applications/iTerm.app"
+    : "/usr/bin/alacritty";
 
 export const TerminalSection = withForm({
   ...settingsFormOpts,

--- a/src/features/settings/TerminalSection.tsx
+++ b/src/features/settings/TerminalSection.tsx
@@ -13,10 +13,21 @@ import {
 } from "@/components/ui/select";
 import { withForm } from "@/lib/form";
 import { detectTerminals } from "@/lib/git/api";
+import { isMac, isWindows } from "@/lib/hotkeys/binding";
 import { settingsFormOpts } from "./settings-form";
 
 const DEFAULT = "__default__";
 const CUSTOM = "__custom__";
+
+// The default terminal is platform-specific, so its label can't be hardcoded.
+const DEFAULT_LABEL = isWindows
+  ? "Default (Command Prompt)"
+  : isMac
+    ? "Default (Terminal)"
+    : "Default terminal";
+const CUSTOM_PLACEHOLDER = isWindows
+  ? "C:\\path\\to\\terminal.exe"
+  : "/Applications/iTerm.app";
 
 export const TerminalSection = withForm({
   ...settingsFormOpts,
@@ -39,7 +50,7 @@ export const TerminalSection = withForm({
 
     // Base UI's Select.Value renders the raw value unless given value→label items
     const selectItems: Record<string, string> = {
-      [DEFAULT]: "Default (Command Prompt)",
+      [DEFAULT]: DEFAULT_LABEL,
       [CUSTOM]: "Custom…",
       ...Object.fromEntries(terminals.map((t) => [t.id, t.name])),
     };
@@ -52,7 +63,11 @@ export const TerminalSection = withForm({
     async function choose() {
       const picked = await openDialog({
         title: "Choose a terminal program",
-        filters: [{ name: "Programs", extensions: ["exe", "cmd", "bat"] }],
+        // Windows programs are .exe/.cmd/.bat; macOS terminals are `.app`
+        // bundles and Linux ones are bare binaries, so don't filter there.
+        filters: isWindows
+          ? [{ name: "Programs", extensions: ["exe", "cmd", "bat"] }]
+          : undefined,
       });
       if (picked) setTerminal("custom", picked);
     }
@@ -86,7 +101,7 @@ export const TerminalSection = withForm({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={DEFAULT}>Default (Command Prompt)</SelectItem>
+              <SelectItem value={DEFAULT}>{DEFAULT_LABEL}</SelectItem>
               {terminals.map((t) => (
                 <SelectItem key={t.id} value={t.id}>
                   {t.name}
@@ -113,7 +128,7 @@ export const TerminalSection = withForm({
               <Input
                 id="custom-terminal"
                 className="flex-1 font-mono"
-                placeholder="C:\\path\\to\\terminal.exe"
+                placeholder={CUSTOM_PLACEHOLDER}
                 autoComplete="off"
                 value={terminalPath}
                 onChange={(e) => setTerminal("custom", e.target.value)}


### PR DESCRIPTION
Extend terminal and external-editor detection beyond Windows so users on macOS and Linux can select the applications installed on their system and have those selections honored when opening terminals or files.

### Cross-platform detection and launching

- Adds macOS `.app` bundle detection for terminals and editors in `src-tauri/src/fsops.rs`, including standard application directories, user applications, JetBrains IDEs, and Toolbox installations.
- Adds Linux terminal detection in `src-tauri/src/fsops.rs` using PATH and Homebrew-aware executable lookup for GNOME Terminal, Konsole, Alacritty, Kitty, WezTerm, Tilix, and other common emulators.
- Adds Linux GUI editor detection in `src-tauri/src/fsops.rs` for VS Code, Cursor, Sublime Text, Zed, Gedit, Kate, GNOME Text Editor, and Emacs.
- Updates `launch_terminal_unix` in `src-tauri/src/fsops.rs` to launch the selected terminal, use macOS `open -a` for application bundles, and fall back to common Linux terminal emulators when needed.
- Updates `open_with_program` in `src-tauri/src/fsops.rs` to open macOS application bundles with `open -a` instead of attempting to execute the bundle directory.

### Settings UI

- Updates `src/features/settings/EditorSection.tsx` with platform-specific custom-program placeholders, non-Windows file selection behavior, and `.app`-aware program labels.
- Updates `src/features/settings/TerminalSection.tsx` with platform-specific default labels and custom-terminal placeholders, while removing Windows-only file filters on macOS and Linux.

### Tests and changelog

- Adds platform-neutral detection and launch helper tests in `src-tauri/src/fsops.rs` covering bundle classification, macOS terminal mapping, application scanning, JetBrains detection, and executable resolution.
- Documents the cross-platform terminal and editor detection improvements in `changelog.d/fixed-terminal-editor-detection-mac-linux.md`.