### PR TITLE
fix(tasks): confirm selected interpreter via login shell

### DIFF
--- a/changelog.d/fixed-task-interpreter-detection-shell.md
+++ b/changelog.d/fixed-task-interpreter-detection-shell.md
@@ -1,0 +1,7 @@
+- The task editor no longer warns that an interpreter "wasn't detected" when it's
+  actually installed. Interpreters installed through a version manager (nvm/fnm for
+  Node, and anything else that lives only on your shell's PATH) weren't found by the
+  editor's quick check when GitDesktop was launched from the Dock or Finder on macOS
+  — even though the task ran fine. The editor now confirms the selected interpreter
+  the same way a run resolves it (via your login shell), so it shows the real path
+  instead of a false "not detected" warning.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,6 +192,7 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_close,
             pty::detect_interpreters,
+            pty::resolve_task_interpreter,
             pty::task_open_terminal,
             git::ops::git_checkout_commit,
             git::ops::git_revert,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -266,6 +266,31 @@ pub async fn detect_interpreters() -> AppResult<Vec<DetectedInterpreter>> {
     .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))
 }
 
+/// Full run-resolution for a SINGLE interpreter — the same resolution an actual
+/// task run uses (macOS/Linux login-shell PATH recovery, Windows live-registry
+/// PATH), unlike the cheap PATH-only `detect_interpreters`. The task editor calls
+/// this lazily for the SELECTED interpreter when the cheap pass missed it, so a
+/// Finder/Dock-launched macOS app (which inherits launchd's minimal PATH) doesn't
+/// warn that an nvm/fnm-managed `node` is absent when it will actually run fine.
+/// Returns the resolved absolute path, or `None` when even the login shell can't
+/// find it. An unknown key resolves to `None`, matching `detect_interpreters`.
+#[tauri::command]
+pub async fn resolve_task_interpreter(key: String) -> AppResult<Option<String>> {
+    // git-bash resolves specially inside `resolve_interpreter_run` (names ignored);
+    // every other key maps through `task_interp`.
+    let names: &[&str] = if key == "git-bash" {
+        &[]
+    } else {
+        match task_interp(&key) {
+            Some((names, _, _)) => names,
+            None => return Ok(None),
+        }
+    };
+    Ok(resolve_interpreter_run(&key, names)
+        .await
+        .map(|p| p.to_string_lossy().into_owned()))
+}
+
 /// The built PTY child plus teardown metadata.
 struct BuiltCommand {
     cmd: CommandBuilder,

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -23,7 +23,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { clipTitle } from "@/lib/clip-title";
 import { isMac, isWindows } from "@/lib/hotkeys/binding";
-import { useDetectedInterpreters } from "@/lib/scripts/interpreters";
+import {
+  useDetectedInterpreters,
+  useResolvedInterpreter,
+} from "@/lib/scripts/interpreters";
 import {
   type ArgDoc,
   availableInterpreters,
@@ -119,6 +122,21 @@ export function TaskDialog({
   const [describe, setDescribe] = useState("");
   const [confirmBeforeRun, setConfirmBeforeRun] = useState(true);
   const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // The cheap `detected` pass above only checks PATH + known install dirs, so it
+  // misses nvm/fnm-managed binaries when the app was launched from Finder/Dock
+  // (launchd's minimal PATH). For the SELECTED interpreter only — and only while
+  // the editor is open and the cheap pass missed it — confirm the way an actual
+  // run resolves it (login shell), so we neither warn that a runnable interpreter
+  // is absent nor spawn a login shell we don't need (the dialog stays mounted
+  // across close, so the `open` guard keeps a stale selection from probing).
+  const cheapSelectedPath = detected.data?.get(interpreter)?.path ?? null;
+  const needsConfirm = open && detected.isSuccess && cheapSelectedPath === null;
+  const confirmed = useResolvedInterpreter(interpreter, needsConfirm);
+  // Authoritative path for the selected interpreter: cheap hit, else the confirm.
+  const selectedPath = cheapSelectedPath ?? confirmed.data ?? null;
+  const selectedMissing =
+    needsConfirm && confirmed.isSuccess && confirmed.data == null;
 
   // Seed the fields when a task (or "new") opens. Keyed on the dialog opening so
   // reopening the same task re-seeds from the saved value, discarding stray edits.
@@ -255,8 +273,16 @@ export function TaskDialog({
                   (max-w-64) with the clipped-title tooltip. */}
               <SelectContent className="w-80">
                 {options.map((i) => {
-                  const found = detected.data?.get(i.id)?.path ?? null;
-                  const missing = detected.isSuccess && found === null;
+                  // The selected interpreter reflects the login-shell confirm (what
+                  // a run actually resolves); others stay on cheap PATH detection.
+                  const isSelected = i.id === interpreter;
+                  const found = isSelected
+                    ? selectedPath
+                    : (detected.data?.get(i.id)?.path ?? null);
+                  const missing = isSelected
+                    ? selectedMissing
+                    : detected.isSuccess &&
+                      (detected.data?.get(i.id)?.path ?? null) === null;
                   return (
                     <SelectItem key={i.id} value={i.id}>
                       <span className="flex flex-col">
@@ -289,14 +315,13 @@ export function TaskDialog({
           </div>
         </div>
 
-        {detected.isSuccess &&
-          detected.data?.get(interpreter)?.path == null && (
-            <p className="text-xs text-warning">
-              {INTERPRETER_LABELS[interpreter] ?? interpreter} wasn't detected
-              on your PATH — it may still run if your shell resolves it,
-              otherwise you'll need to install it.
-            </p>
-          )}
+        {selectedMissing && (
+          <p className="text-xs text-warning">
+            {INTERPRETER_LABELS[interpreter] ?? interpreter} isn't installed, or
+            GitDesktop can't find it — install it, or make sure it's on your
+            shell's PATH.
+          </p>
+        )}
 
         <div className="space-y-1.5">
           <Label htmlFor="task-description">

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -125,18 +125,27 @@ export function TaskDialog({
 
   // The cheap `detected` pass above only checks PATH + known install dirs, so it
   // misses nvm/fnm-managed binaries when the app was launched from Finder/Dock
-  // (launchd's minimal PATH). For the SELECTED interpreter only — and only while
-  // the editor is open and the cheap pass missed it — confirm the way an actual
-  // run resolves it (login shell), so we neither warn that a runnable interpreter
-  // is absent nor spawn a login shell we don't need (the dialog stays mounted
-  // across close, so the `open` guard keeps a stale selection from probing).
+  // (launchd's minimal PATH). For the SELECTED interpreter, confirm the way an
+  // actual run resolves it (login shell) before warning.
   const cheapSelectedPath = detected.data?.get(interpreter)?.path ?? null;
-  const needsConfirm = open && detected.isSuccess && cheapSelectedPath === null;
+  const cheapMissed = detected.isSuccess && cheapSelectedPath === null;
+  // Only confirm off Windows — there `resolve_named` reduces to the same
+  // `find_executable` the cheap pass already ran (no login-shell probe), so a
+  // confirm can never change the outcome. And only while the editor is open (the
+  // dialog stays mounted across close, so `open` keeps a stale selection from
+  // probing) and the cheap pass missed — so we never spawn a shell we don't need.
+  const needsConfirm = open && !isWindows && cheapMissed;
   const confirmed = useResolvedInterpreter(interpreter, needsConfirm);
   // Authoritative path for the selected interpreter: cheap hit, else the confirm.
   const selectedPath = cheapSelectedPath ?? confirmed.data ?? null;
+  const selectedResolving = needsConfirm && confirmed.isLoading;
+  // Missing = the cheap pass found nothing AND either we're not confirming
+  // (Windows / dialog closed → cheap detection is authoritative) or the
+  // login-shell confirm also came back empty. While a confirm is in flight it is
+  // not yet "missing" — that window is `selectedResolving` instead.
   const selectedMissing =
-    needsConfirm && confirmed.isSuccess && confirmed.data == null;
+    cheapMissed &&
+    (needsConfirm ? confirmed.isSuccess && confirmed.data == null : true);
 
   // Seed the fields when a task (or "new") opens. Keyed on the dialog opening so
   // reopening the same task re-seeds from the saved value, discarding stray edits.
@@ -315,6 +324,13 @@ export function TaskDialog({
           </div>
         </div>
 
+        {selectedResolving && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Spinner className="size-3" />
+            Checking your shell for{" "}
+            {INTERPRETER_LABELS[interpreter] ?? interpreter}…
+          </p>
+        )}
         {selectedMissing && (
           <p className="text-xs text-warning">
             {INTERPRETER_LABELS[interpreter] ?? interpreter} isn't installed, or

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -310,6 +310,10 @@ export function TaskDialog({
                           >
                             {found}
                           </span>
+                        ) : isSelected && selectedResolving ? (
+                          <span className="text-[11px] text-muted-foreground">
+                            Checking your shell…
+                          </span>
                         ) : (
                           <span className="text-[11px] text-muted-foreground">
                             {i.hint}

--- a/src/lib/scripts/interpreters.ts
+++ b/src/lib/scripts/interpreters.ts
@@ -27,3 +27,24 @@ export function useDetectedInterpreters() {
     staleTime: 5 * 60 * 1000,
   });
 }
+
+const resolveTaskInterpreter = (key: Interpreter) =>
+  invoke<string | null>("resolve_task_interpreter", { key });
+
+/**
+ * Full run-resolution for the SELECTED interpreter — the same resolution an actual
+ * task run performs (login-shell PATH recovery on macOS/Linux), unlike the cheap
+ * PATH-only {@link useDetectedInterpreters}. Enabled lazily, only when the cheap
+ * pass missed the interpreter, so we never spawn a login shell we don't need: this
+ * is what stops a Finder/Dock-launched macOS app (which inherits launchd's minimal
+ * PATH) from warning that an nvm/fnm-managed `node` is absent when it runs fine.
+ * Resolves to the absolute path, or null when even the login shell can't find it.
+ */
+export function useResolvedInterpreter(key: Interpreter, enabled: boolean) {
+  return useQuery({
+    queryKey: ["resolve-interpreter", key],
+    queryFn: () => resolveTaskInterpreter(key),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}


### PR DESCRIPTION
Fixes the task editor falsely warning that an installed interpreter "wasn't detected." When GitDesktop is launched from the Dock or Finder on macOS it inherits launchd's minimal PATH, so the editor's cheap PATH-only check misses interpreters managed by a version manager (nvm/fnm for Node, and anything else that lives only on the shell's PATH) — even though the task runs fine. The editor now confirms the selected interpreter the same way an actual run resolves it (via the login shell) before deciding whether to warn.

### Backend resolution command
- Adds `resolve_task_interpreter` in `src-tauri/src/pty.rs`, a Tauri command that runs the full per-interpreter run-resolution (login-shell PATH recovery on macOS/Linux, live-registry PATH on Windows) for a single key, returning the resolved absolute path or `None`. It special-cases `git-bash` and maps other keys through `task_interp`, matching `detect_interpreters`' behavior for unknown keys.
- Registers the new command in the invoke handler in `src-tauri/src/lib.rs`.

### Frontend confirm hook and dialog
- Adds `useResolvedInterpreter` in `src/lib/scripts/interpreters.ts`, a lazily-enabled query wrapping `resolve_task_interpreter` so a login shell is only spawned when the cheap pass missed the interpreter.
- Updates `src/features/scripts/TaskDialog.tsx` to compute an authoritative `selectedPath` for the currently-selected interpreter (cheap hit, else the login-shell confirm) gated on the dialog being `open`, and derives `selectedMissing` from that. The select list now shows the confirmed path/state for the selected interpreter while other options stay on cheap PATH detection.
- Rewrites the warning copy in the same file so it no longer says the interpreter "wasn't detected on your PATH" and instead tells the user it isn't installed or can't be found, keying off the login-shell-confirmed `selectedMissing`.

### Changelog
- Adds `changelog.d/fixed-task-interpreter-detection-shell.md` describing the fixed false "not detected" warning.