### PR TITLE
fix(forge): authenticate Bitbucket HTTPS git over seeded credential

### DIFF
--- a/changelog.d/fixed-bitbucket-https-git-auth.md
+++ b/changelog.d/fixed-bitbucket-https-git-auth.md
@@ -1,0 +1,7 @@
+- Fixed cloning, fetching, pulling, and pushing **private Bitbucket** repositories
+  over HTTPS failing with `could not read Password for '…@bitbucket.org': terminal
+  prompts disabled` on macOS and Linux. GitDesktop now hands your stored Bitbucket
+  API token to git's credential store over STDIN (never placed on the command line),
+  so operations authenticate without a prompt wherever git has a credential helper —
+  the system keychain on macOS, Git Credential Manager on Windows, or a configured
+  helper on Linux. Cloning over SSH was unaffected.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -24,6 +24,8 @@
 //! pages) are workspace members, PR tasks, and PR comments — each documented at its
 //! call site.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use serde::{Deserialize, Serialize};
 use tauri_plugin_http::reqwest;
 
@@ -44,6 +46,12 @@ use crate::github::pr::{
     PrDetails, PrFileOut, PrInfo, PrListLabel, PrPollInfo, PrRef, PrThreadOut, PrTimelineEventOut,
     ReviewSubmitOut, ReviewThreadOut,
 };
+
+/// Whether this process has already seeded git's credential store this session (the
+/// seed persists in the OS store, so re-seeding — and re-reading the keyring, which
+/// re-prompts on macOS — every op is wasteful). Re-armed by `reset_credential_seed`
+/// when the stored token changes. See [`seed_git_credential`].
+static CREDENTIAL_SEEDED: AtomicBool = AtomicBool::new(false);
 
 /// Failed-step logs can run to many MB; keep the tail (failures land at the end).
 const CI_RUN_LOG_CAP: usize = 200_000;
@@ -254,6 +262,10 @@ pub async fn set_account(email: &str, token: &str) -> AppResult<BbAccountInfo> {
     .await
     .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))??;
 
+    // The stored token changed — re-arm the seed latch so the next git op re-seeds
+    // git's credential store with the new token.
+    reset_credential_seed();
+
     Ok(BbAccountInfo {
         email,
         username,
@@ -272,7 +284,11 @@ pub async fn clear_account() -> AppResult<()> {
         Ok::<_, AppError>(())
     })
     .await
-    .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))?
+    .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))??;
+    // Re-arm the seed latch so a future reconnect re-seeds (and a lingering seeded
+    // credential isn't silently reused by the next op after a disconnect).
+    reset_credential_seed();
+    Ok(())
 }
 
 /// The stored account (keyring existence read ONLY — no network). `None` when no
@@ -2724,6 +2740,10 @@ fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
 /// fetch/pull/push funnel, and `create_pr` can share it. Best-effort: no stored
 /// token, a missing credential helper, or a non-zero exit are all tolerated (the
 /// git op itself surfaces any real auth failure); it only ever ADDS a credential.
+/// Seeds at most ONCE per process (the seed persists in the OS store), re-armed
+/// when the stored token changes — otherwise every op would re-read the OS keyring
+/// and, on macOS, re-pop the "gitdesktop wants to use your confidential
+/// information" keychain prompt.
 ///
 /// Runs `git credential approve` OUTSIDE any repo (`run_git_input(None, …)`) and
 /// takes NO repo lock — deliberately, so it stays safe to call from ANY context,
@@ -2738,8 +2758,18 @@ fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
 /// account email authenticates the REST API but NOT git (probe-validated — see
 /// `publish_repo`). Do not change the username to the email; it will fail auth.
 pub async fn seed_git_credential() {
+    // Latch BEFORE the keyring read so concurrent callers don't each pop the macOS
+    // keychain prompt; if already latched, another op has seeded this process.
+    if CREDENTIAL_SEEDED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
     let Ok(creds) = http::load_credentials().await else {
-        return; // no stored token → seed nothing; ambient auth is unchanged
+        // No stored token → nothing to seed; un-latch so a later connect re-seeds.
+        CREDENTIAL_SEEDED.store(false, Ordering::Release);
+        return;
     };
     let approve_input = format!(
         "protocol=https\nhost=bitbucket.org\nusername=x-bitbucket-api-token-auth\npassword={}\n\n",
@@ -2752,6 +2782,13 @@ pub async fn seed_git_credential() {
         crate::git::runner::DEFAULT_TIMEOUT,
     )
     .await;
+}
+
+/// Re-arm the once-per-process seed latch so the next Bitbucket git op re-seeds git's
+/// credential store — called whenever the stored token changes (connect / disconnect),
+/// so a re-authenticated token replaces the persisted git credential.
+pub(crate) fn reset_credential_seed() {
+    CREDENTIAL_SEEDED.store(false, Ordering::Release);
 }
 
 /// Strip an embedded `user@` from an `https://` URL's authority so git's credential

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -47,11 +47,16 @@ use crate::github::pr::{
     ReviewSubmitOut, ReviewThreadOut,
 };
 
-/// Whether this process has already seeded git's credential store this session (the
-/// seed persists in the OS store, so re-seeding — and re-reading the keyring, which
-/// re-prompts on macOS — every op is wasteful). Re-armed by `reset_credential_seed`
-/// when the stored token changes. See [`seed_git_credential`].
+/// Whether this process has SUCCESSFULLY seeded git's credential store this session
+/// (the seed persists in the OS store, so re-seeding every op is wasteful). Set only
+/// AFTER `git credential approve` exits 0 — a failed attempt leaves it false so a
+/// later op retries. Re-armed by `reset_credential_seed` when the stored token
+/// changes. See [`seed_git_credential`].
 static CREDENTIAL_SEEDED: AtomicBool = AtomicBool::new(false);
+/// Serializes concurrent seed attempts so the first ops of a session (e.g. fetches
+/// on two repos at once) don't race: losers WAIT here until the winner's seed lands,
+/// instead of proceeding unauthenticated into their git op.
+static CREDENTIAL_SEED_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Failed-step logs can run to many MB; keep the tail (failures land at the end).
 const CI_RUN_LOG_CAP: usize = 200_000;
@@ -2758,33 +2763,49 @@ fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
 /// SECURITY: the token is fed on STDIN ONLY — never argv / env / git config —
 /// matching the discipline the rest of the Bitbucket git path holds. NOTE:
 /// git-over-HTTPS REQUIRES the `x-bitbucket-api-token-auth` sentinel username; the
-/// account email authenticates the REST API but NOT git (probe-validated — see
-/// `publish_repo`). Do not change the username to the email; it will fail auth.
-pub async fn seed_git_credential() {
-    // Latch BEFORE the keyring read so concurrent callers don't each pop the macOS
-    // keychain prompt; if already latched, another op has seeded this process.
-    if CREDENTIAL_SEEDED
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
-        return;
+/// account email authenticates the REST API but NOT git (probe-validated:
+/// `git ls-remote` succeeds with the sentinel and fails with the email). Do not
+/// change the username to the email; it will fail auth.
+///
+/// Returns whether a credential is (now) in the store — `true` when this or an
+/// earlier successful seed landed, `false` when no token is stored or the seed
+/// failed. Callers use it to gate credential-dependent `-c` entries (e.g.
+/// `credential.interactive=false`) so an unconfigured user keeps git's ambient —
+/// possibly interactive — behavior, fail-open.
+pub async fn seed_git_credential() -> bool {
+    // Fast path: a prior seed this session already succeeded (latch is set only
+    // AFTER `approve` exits 0, so `true` means the credential is really stored).
+    if CREDENTIAL_SEEDED.load(Ordering::Acquire) {
+        return true;
+    }
+    // Serialize attempts: concurrent first ops WAIT here for the in-flight seed
+    // (which may be blocked on the first macOS keychain prompt) instead of racing
+    // ahead unauthenticated; each waiter re-checks once it holds the lock.
+    let _guard = CREDENTIAL_SEED_LOCK.lock().await;
+    if CREDENTIAL_SEEDED.load(Ordering::Acquire) {
+        return true;
     }
     let Ok(creds) = http::load_credentials().await else {
-        // No stored token → nothing to seed; un-latch so a later connect re-seeds.
-        CREDENTIAL_SEEDED.store(false, Ordering::Release);
-        return;
+        return false; // no stored token → nothing to seed; ambient auth unchanged
     };
     let approve_input = format!(
-        "protocol=https\nhost=bitbucket.org\nusername=x-bitbucket-api-token-auth\npassword={}\n\n",
+        "protocol=https\nhost={BB_HOST}\nusername=x-bitbucket-api-token-auth\npassword={}\n\n",
         creds.token
     );
-    let _ = crate::git::runner::run_git_input(
+    let seeded = crate::git::runner::run_git_input(
         None,
         &["credential", "approve"],
         Some(&approve_input),
         crate::git::runner::DEFAULT_TIMEOUT,
     )
-    .await;
+    .await
+    .is_ok();
+    if seeded {
+        // Latch ONLY on success — a transient helper failure must not stop a later
+        // op from retrying the seed.
+        CREDENTIAL_SEEDED.store(true, Ordering::Release);
+    }
+    seeded
 }
 
 /// Re-arm the once-per-process seed latch so the next Bitbucket git op re-seeds git's
@@ -2817,6 +2838,30 @@ pub(crate) fn strip_https_userinfo(url: &str) -> String {
         Some(p) => format!("https://{hostport}/{p}"),
         None => format!("https://{hostport}"),
     }
+}
+
+/// The one-shot `-c` entries for a SEEDED Bitbucket network op (the funnel's
+/// Bitbucket analogue of `github_credential_entries`). Pure/format-only:
+///
+///  - `credential.interactive=false` — the seeded credential answers the fill, so an
+///    interactive helper GUI (e.g. GCM's dialog) must not pop on a stale/rejected
+///    token; matches `publish_repo`'s push. Callers only apply these entries when
+///    the seed SUCCEEDED, so an unconfigured user keeps ambient interactive auth.
+///  - When the remote URL embeds userinfo (`https://user@bitbucket.org/…`, the form
+///    Bitbucket's web UI hands out): a one-shot `url.<stripped>.insteadOf=<url>`
+///    rewrite, so git resolves the remote to the bare host and its credential
+///    lookup finds the host-keyed sentinel seed (see [`strip_https_userinfo`]).
+///    Transient — the repo's stored remote is never mutated, no lock is needed, and
+///    the entry rides the same `-c` prefix mechanism as the GitHub/GitLab helpers.
+///    (Safe as a `-c` key: Bitbucket remote URLs contain no `=`, so the key can't
+///    be mis-split.)
+pub(crate) fn bitbucket_credential_entries(url: &str) -> Vec<String> {
+    let mut entries = vec!["credential.interactive=false".to_string()];
+    let stripped = strip_https_userinfo(url);
+    if stripped != url {
+        entries.push(format!("url.{stripped}.insteadOf={url}"));
+    }
+    entries
 }
 
 /// Push `head` to origin, then open a pull request from `head` into `base`. Mirrors
@@ -2870,16 +2915,20 @@ pub async fn create_pr(
 
     // A PR needs the branch on the remote first. Bitbucket has no CLI credential
     // helper, so seed the token into git's credential store (STDIN only — never
-    // argv/env/git config) and a plain push then authenticates from it (cross-
-    // platform, not just via an ambient Windows GCM).
-    seed_git_credential().await;
+    // argv/env/git config) and the push authenticates from it (cross-platform, not
+    // just via an ambient Windows GCM). Only a SUCCESSFUL seed suppresses
+    // interactive helpers (`credential.interactive=false`, matching `publish_repo` —
+    // GIT_TERMINAL_PROMPT=0 doesn't block a GUI dialog); an unconfigured user keeps
+    // git's ambient, possibly interactive, behavior — fail-open.
+    let push_args: &[&str] = if seed_git_credential().await {
+        &["-c", "credential.interactive=false", "push", "-u", "origin", head]
+    } else {
+        &["push", "-u", "origin", head]
+    };
     crate::git::runner::run_git_mutating(
         state,
         repo_path,
-        // `credential.interactive=false` suppresses an interactive helper GUI (e.g.
-        // GCM's dialog) that GIT_TERMINAL_PROMPT=0 does not block — matching the
-        // proven `publish_repo` seed+push.
-        &["-c", "credential.interactive=false", "push", "-u", "origin", head],
+        push_args,
         crate::git::runner::NETWORK_TIMEOUT,
     )
     .await?;
@@ -4933,26 +4982,11 @@ pub async fn publish_repo(
     let created_hint =
         format!("The Bitbucket repository was created at {html_url}, but ");
 
-    // ── Seed git's credential store so the push authenticates non-interactively.
-    //    The token is fed on STDIN ONLY — never argv / env / git config. A missing
-    //    helper / non-zero exit is tolerated (the push surfaces any auth failure).
-    //    NOTE: git-over-HTTPS REQUIRES the `x-bitbucket-api-token-auth` sentinel as
-    //    the username — the Atlassian account email does NOT authenticate here
-    //    (probe-validated: `git ls-remote` succeeds with the sentinel, fails with the
-    //    email). The email:token Basic pair is the REST-API contract only; do not
-    //    "fix" this username to `creds.email`, it will break the push. ──
-    let approve_input = format!(
-        "protocol=https\nhost=bitbucket.org\nusername=x-bitbucket-api-token-auth\npassword={}\n\n",
-        creds.token
-    );
-    let _ = crate::git::runner::run_git_mutating_input(
-        state,
-        repo_path,
-        &["credential", "approve"],
-        Some(&approve_input),
-        crate::git::runner::DEFAULT_TIMEOUT,
-    )
-    .await;
+    // ── Seed git's credential store so the push authenticates non-interactively —
+    //    the shared sentinel-username STDIN seed (see `seed_git_credential`, which
+    //    carries the probe-validated do-not-use-the-email warning). Best-effort: a
+    //    failed seed is tolerated (the push surfaces any auth failure). ──
+    let _ = seed_git_credential().await;
 
     // ── Add origin, then push the current branch. ──
     let remote_url = format!("https://bitbucket.org/{workspace}/{created_slug}.git");
@@ -4984,6 +5018,24 @@ pub async fn publish_repo(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn credential_entries_suppress_interactive_and_rewrite_userinfo_urls() {
+        // user@ remote → interactive suppression + the transient insteadOf rewrite.
+        assert_eq!(
+            bitbucket_credential_entries("https://alice@bitbucket.org/ws/repo.git"),
+            vec![
+                "credential.interactive=false".to_string(),
+                "url.https://bitbucket.org/ws/repo.git.insteadOf=https://alice@bitbucket.org/ws/repo.git"
+                    .to_string(),
+            ]
+        );
+        // Bare-host remote → suppression only, no rewrite entry.
+        assert_eq!(
+            bitbucket_credential_entries("https://bitbucket.org/ws/repo.git"),
+            vec!["credential.interactive=false".to_string()]
+        );
+    }
 
     #[test]
     fn strip_https_userinfo_removes_embedded_username() {

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -14,7 +14,9 @@
 //! app passwords are dead — with the token stored in the OS keyring under
 //! `forge/bitbucket.org/*`. git-over-HTTPS is the exception: it authenticates with the
 //! literal `x-bitbucket-api-token-auth` sentinel username (NOT the account email) plus
-//! the same token (see `publish_repo`).
+//! the same token, seeded into git's credential store on STDIN by
+//! [`seed_git_credential`] (shared by clone, fetch/pull/push, `create_pr`, and
+//! `publish_repo`).
 //!
 //! Pagination policy matches GitLab: a single page at the endpoint's max `pagelen`,
 //! no `next`-following loops (documented per call). The PR-list endpoint caps at 50;
@@ -2716,6 +2718,67 @@ fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
         .map(|p| p.number)
 }
 
+/// Seed git's credential store with the Bitbucket API token so a subsequent HTTPS
+/// clone / fetch / pull / push authenticates non-interactively — the same mechanism
+/// `publish_repo`'s post-create push has always used, lifted out so clone, the
+/// fetch/pull/push funnel, and `create_pr` can share it. Best-effort: no stored
+/// token, a missing credential helper, or a non-zero exit are all tolerated (the
+/// git op itself surfaces any real auth failure); it only ever ADDS a credential.
+///
+/// Runs `git credential approve` OUTSIDE any repo (`run_git_input(None, …)`) and
+/// takes NO repo lock — deliberately, so it stays safe to call from ANY context,
+/// including a future caller that already holds the per-repo mutating lock. (Today's
+/// callers compute the credential config BEFORE the op takes its lock, so there is
+/// no present-day deadlock; the non-locking runner is defensive, not load-bearing.)
+/// Do NOT switch this to a locking runner.
+///
+/// SECURITY: the token is fed on STDIN ONLY — never argv / env / git config —
+/// matching the discipline the rest of the Bitbucket git path holds. NOTE:
+/// git-over-HTTPS REQUIRES the `x-bitbucket-api-token-auth` sentinel username; the
+/// account email authenticates the REST API but NOT git (probe-validated — see
+/// `publish_repo`). Do not change the username to the email; it will fail auth.
+pub async fn seed_git_credential() {
+    let Ok(creds) = http::load_credentials().await else {
+        return; // no stored token → seed nothing; ambient auth is unchanged
+    };
+    let approve_input = format!(
+        "protocol=https\nhost=bitbucket.org\nusername=x-bitbucket-api-token-auth\npassword={}\n\n",
+        creds.token
+    );
+    let _ = crate::git::runner::run_git_input(
+        None,
+        &["credential", "approve"],
+        Some(&approve_input),
+        crate::git::runner::DEFAULT_TIMEOUT,
+    )
+    .await;
+}
+
+/// Strip an embedded `user@` from an `https://` URL's authority so git's credential
+/// lookup keys on the host alone and finds the seeded `x-bitbucket-api-token-auth`
+/// entry. Bitbucket's API/web clone links embed the account username
+/// (`https://<user>@bitbucket.org/…`); git SCOPES its credential lookup by the URL
+/// username when present, so a `user@` URL asks the helper for account=`user` and
+/// misses the sentinel-account seed — re-prompting. This is git's protocol behavior,
+/// so it bites BOTH macOS osxkeychain and Windows GCM, not just macOS. Non-`https`
+/// URLs and URLs without userinfo pass through unchanged.
+pub(crate) fn strip_https_userinfo(url: &str) -> String {
+    let Some(rest) = url.strip_prefix("https://") else {
+        return url.to_string();
+    };
+    let (authority, path) = match rest.split_once('/') {
+        Some((a, p)) => (a, Some(p)),
+        None => (rest, None),
+    };
+    let Some((_userinfo, hostport)) = authority.rsplit_once('@') else {
+        return url.to_string(); // no userinfo → unchanged
+    };
+    match path {
+        Some(p) => format!("https://{hostport}/{p}"),
+        None => format!("https://{hostport}"),
+    }
+}
+
 /// Push `head` to origin, then open a pull request from `head` into `base`. Mirrors
 /// `gitlab::create_mr`, with two Bitbucket-specific differences:
 ///
@@ -2725,11 +2788,11 @@ fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
 ///    ""). So BEFORE any mutation we read the open PRs from `head` (via the same query
 ///    `prs_for_branch` uses) and, if one already targets `base`, error out naming its
 ///    number — nothing is pushed or changed.
-///  - **No credential config on the push.** Unlike glab (whose token isn't in git's
-///    store, so it injects a one-shot helper), Bitbucket repos in this app are
-///    cloned/pushed with the user's ambient git credentials (GCM), so a plain
-///    `git push origin <head>` works. The keyring token is NEVER put on argv / env /
-///    git config of the push process.
+///  - **Seeded credential, no `-c` helper on the push.** Bitbucket has no CLI
+///    credential helper, so instead of glab's one-shot `-c` helper the token is
+///    seeded into git's credential store on STDIN (`seed_git_credential`) and a
+///    plain `git push origin <head>` then authenticates from it. The keyring token
+///    is NEVER put on argv / env / git config of the push process.
 ///
 /// Order: duplicate pre-check (read-only) → validate → push → POST create. If the POST
 /// fails after a successful push, the error discloses the partial state (the branch was
@@ -2765,13 +2828,18 @@ pub async fn create_pr(
         )));
     }
 
-    // A PR needs the branch on the remote first. Bitbucket uses the user's ambient git
-    // credentials (GCM) — no token-derived credential helper, so the keyring token
-    // never reaches the git process.
+    // A PR needs the branch on the remote first. Bitbucket has no CLI credential
+    // helper, so seed the token into git's credential store (STDIN only — never
+    // argv/env/git config) and a plain push then authenticates from it (cross-
+    // platform, not just via an ambient Windows GCM).
+    seed_git_credential().await;
     crate::git::runner::run_git_mutating(
         state,
         repo_path,
-        &["push", "-u", "origin", head],
+        // `credential.interactive=false` suppresses an interactive helper GUI (e.g.
+        // GCM's dialog) that GIT_TERMINAL_PROMPT=0 does not block — matching the
+        // proven `publish_repo` seed+push.
+        &["-c", "credential.interactive=false", "push", "-u", "origin", head],
         crate::git::runner::NETWORK_TIMEOUT,
     )
     .await?;
@@ -4876,6 +4944,30 @@ pub async fn publish_repo(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_https_userinfo_removes_embedded_username() {
+        // Bitbucket's API clone link embeds the account username.
+        assert_eq!(
+            strip_https_userinfo("https://alice-admin@bitbucket.org/ws/repo.git"),
+            "https://bitbucket.org/ws/repo.git"
+        );
+        // No userinfo → unchanged.
+        assert_eq!(
+            strip_https_userinfo("https://bitbucket.org/ws/repo.git"),
+            "https://bitbucket.org/ws/repo.git"
+        );
+        // Authority only, no path → unchanged host.
+        assert_eq!(
+            strip_https_userinfo("https://bob@bitbucket.org"),
+            "https://bitbucket.org"
+        );
+        // Non-https (scp-style SSH) → untouched.
+        assert_eq!(
+            strip_https_userinfo("git@bitbucket.org:ws/repo.git"),
+            "git@bitbucket.org:ws/repo.git"
+        );
+    }
 
     fn pr(json: &str) -> PrInfo {
         from_bb_pr(serde_json::from_str(json).expect("PR should parse"))

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -269,8 +269,15 @@ pub async fn set_account(email: &str, token: &str) -> AppResult<BbAccountInfo> {
 
     // The stored token changed — drop the cached credential and re-arm the seed
     // latch so the next load reads the new token and the next git op re-seeds.
-    http::invalidate_credential_cache();
-    reset_credential_seed();
+    // Taken UNDER the seed lock: once we hold it, no seed is in flight, so an
+    // old-token seed that raced this connect has fully finished — our reset then
+    // guarantees the next op re-seeds (upserting the store entry with the NEW
+    // token) instead of fast-pathing on the stale latch.
+    {
+        let _seed_guard = CREDENTIAL_SEED_LOCK.lock().await;
+        http::invalidate_credential_cache();
+        reset_credential_seed();
+    }
 
     Ok(BbAccountInfo {
         email,
@@ -294,7 +301,12 @@ pub async fn clear_account() -> AppResult<()> {
     // Drop the cached credential, re-arm the seed latch, and evict the seeded
     // entry from git's OS credential store — git's store is separate from our
     // keyring, so without the eviction a disconnected account would keep
-    // authenticating git ops until the token expired.
+    // authenticating git ops until the token expired. All UNDER the seed lock:
+    // once we hold it, no seed is in flight, so an in-flight first-op seed that
+    // raced this disconnect has fully finished (its entry written, its latch
+    // stored) — the reset + evict below then clear exactly that state, instead of
+    // being silently undone by the seed completing after us.
+    let _seed_guard = CREDENTIAL_SEED_LOCK.lock().await;
     http::invalidate_credential_cache();
     reset_credential_seed();
     evict_git_credential().await;

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -2878,13 +2878,19 @@ pub(crate) fn strip_https_userinfo(url: &str) -> String {
 ///    (Safe as a `-c` key: Bitbucket remote URLs contain no `=`, so the key can't
 ///    be mis-split.)
 pub(crate) fn bitbucket_credential_entries(url: &str) -> Vec<String> {
-    let mut entries = vec!["credential.interactive=false".to_string()];
+    let mut entries = vec![CREDENTIAL_NONINTERACTIVE.to_string()];
     let stripped = strip_https_userinfo(url);
     if stripped != url {
         entries.push(format!("url.{stripped}.insteadOf={url}"));
     }
     entries
 }
+
+/// The one-shot `-c` entry suppressing interactive credential-helper GUIs (e.g.
+/// GCM's dialog — `GIT_TERMINAL_PROMPT=0` doesn't block those). Shared by
+/// [`bitbucket_credential_entries`] and `forge_clone`'s Bitbucket arm so the
+/// literal lives in one place.
+pub(crate) const CREDENTIAL_NONINTERACTIVE: &str = "credential.interactive=false";
 
 /// Push `head` to origin, then open a pull request from `head` into `base`. Mirrors
 /// `gitlab::create_mr`, with two Bitbucket-specific differences:

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -2895,11 +2895,12 @@ pub(crate) fn bitbucket_credential_entries(url: &str) -> Vec<String> {
 ///    ""). So BEFORE any mutation we read the open PRs from `head` (via the same query
 ///    `prs_for_branch` uses) and, if one already targets `base`, error out naming its
 ///    number — nothing is pushed or changed.
-///  - **Seeded credential, no `-c` helper on the push.** Bitbucket has no CLI
-///    credential helper, so instead of glab's one-shot `-c` helper the token is
-///    seeded into git's credential store on STDIN (`seed_git_credential`) and a
-///    plain `git push origin <head>` then authenticates from it. The keyring token
-///    is NEVER put on argv / env / git config of the push process.
+///  - **Funnel credentials on the push.** The push routes through the same
+///    `credential_config_for_remote` funnel as every other network op: on a
+///    Bitbucket HTTPS origin the token is seeded into git's credential store on
+///    STDIN (`seed_git_credential`) and the one-shot `-c` pair (interactive
+///    suppression + `insteadOf` rewrite for `user@` origins) rides the push. The
+///    keyring token is NEVER put on argv / env / git config of the push process.
 ///
 /// Order: duplicate pre-check (read-only) → validate → push → POST create. If the POST
 /// fails after a successful push, the error discloses the partial state (the branch was
@@ -2935,22 +2936,22 @@ pub async fn create_pr(
         )));
     }
 
-    // A PR needs the branch on the remote first. Bitbucket has no CLI credential
-    // helper, so seed the token into git's credential store (STDIN only — never
-    // argv/env/git config) and the push authenticates from it (cross-platform, not
-    // just via an ambient Windows GCM). Only a SUCCESSFUL seed suppresses
-    // interactive helpers (`credential.interactive=false`, matching `publish_repo` —
-    // GIT_TERMINAL_PROMPT=0 doesn't block a GUI dialog); an unconfigured user keeps
-    // git's ambient, possibly interactive, behavior — fail-open.
-    let push_args: &[&str] = if seed_git_credential().await {
-        &["-c", "credential.interactive=false", "push", "-u", "origin", head]
-    } else {
-        &["push", "-u", "origin", head]
-    };
+    // A PR needs the branch on the remote first. Route the push's credentials
+    // through the SAME funnel every other network op uses
+    // (`credential_config_for_remote`): on a Bitbucket HTTPS origin it seeds the
+    // token into git's credential store (STDIN only) and returns the one-shot `-c`
+    // pair — interactive-helper suppression + the `insteadOf` host rewrite a
+    // `user@`-form origin needs for git's credential lookup to find the sentinel
+    // seed. An unconfigured user (or an SSH origin) gets no entries, keeping git's
+    // ambient, possibly interactive, behavior — fail-open, funnel-identical.
+    let cred = crate::forge::credential_config_for_remote(repo_path, "origin").await?;
+    let push_args =
+        crate::git::remote::with_credentials(&cred, &["push", "-u", "origin", head]);
+    let push_refs: Vec<&str> = push_args.iter().map(String::as_str).collect();
     crate::git::runner::run_git_mutating(
         state,
         repo_path,
-        push_args,
+        &push_refs,
         crate::git::runner::NETWORK_TIMEOUT,
     )
     .await?;

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -262,8 +262,9 @@ pub async fn set_account(email: &str, token: &str) -> AppResult<BbAccountInfo> {
     .await
     .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))??;
 
-    // The stored token changed — re-arm the seed latch so the next git op re-seeds
-    // git's credential store with the new token.
+    // The stored token changed — drop the cached credential and re-arm the seed
+    // latch so the next load reads the new token and the next git op re-seeds.
+    http::invalidate_credential_cache();
     reset_credential_seed();
 
     Ok(BbAccountInfo {
@@ -285,8 +286,9 @@ pub async fn clear_account() -> AppResult<()> {
     })
     .await
     .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))??;
-    // Re-arm the seed latch so a future reconnect re-seeds (and a lingering seeded
-    // credential isn't silently reused by the next op after a disconnect).
+    // Drop the cached credential and re-arm the seed latch so a future reconnect
+    // re-reads the keyring and re-seeds.
+    http::invalidate_credential_cache();
     reset_credential_seed();
     Ok(())
 }
@@ -2741,9 +2743,10 @@ fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
 /// token, a missing credential helper, or a non-zero exit are all tolerated (the
 /// git op itself surfaces any real auth failure); it only ever ADDS a credential.
 /// Seeds at most ONCE per process (the seed persists in the OS store), re-armed
-/// when the stored token changes — otherwise every op would re-read the OS keyring
-/// and, on macOS, re-pop the "gitdesktop wants to use your confidential
-/// information" keychain prompt.
+/// when the stored token changes — otherwise every op would re-run `git credential
+/// approve` (a subprocess) redundantly. (The keyring READ is separately cached in
+/// `http::load_credentials`, so neither this nor the REST layer re-pops the macOS
+/// "gitdesktop wants to use your confidential information" prompt after the first.)
 ///
 /// Runs `git credential approve` OUTSIDE any repo (`run_git_input(None, …)`) and
 /// takes NO repo lock — deliberately, so it stays safe to call from ANY context,

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -291,10 +291,13 @@ pub async fn clear_account() -> AppResult<()> {
     })
     .await
     .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))??;
-    // Drop the cached credential and re-arm the seed latch so a future reconnect
-    // re-reads the keyring and re-seeds.
+    // Drop the cached credential, re-arm the seed latch, and evict the seeded
+    // entry from git's OS credential store — git's store is separate from our
+    // keyring, so without the eviction a disconnected account would keep
+    // authenticating git ops until the token expired.
     http::invalidate_credential_cache();
     reset_credential_seed();
+    evict_git_credential().await;
     Ok(())
 }
 
@@ -2813,6 +2816,25 @@ pub async fn seed_git_credential() -> bool {
 /// so a re-authenticated token replaces the persisted git credential.
 pub(crate) fn reset_credential_seed() {
     CREDENTIAL_SEEDED.store(false, Ordering::Release);
+}
+
+/// Evict the seeded entry from git's OS credential store (`git credential reject`,
+/// same protocol/host/username shape the seed wrote, no password — helpers match on
+/// those fields, so ONLY our sentinel-account entry is erased; a user's own ambient
+/// Bitbucket credential under a different username is untouched). Called on
+/// disconnect: git's store is SEPARATE from GitDesktop's keyring, so without this a
+/// disconnected account would keep authenticating git ops until the token expired.
+/// Best-effort — a missing helper or non-zero exit is tolerated.
+async fn evict_git_credential() {
+    let reject_input =
+        format!("protocol=https\nhost={BB_HOST}\nusername=x-bitbucket-api-token-auth\n\n");
+    let _ = crate::git::runner::run_git_input(
+        None,
+        &["credential", "reject"],
+        Some(&reject_input),
+        crate::git::runner::DEFAULT_TIMEOUT,
+    )
+    .await;
 }
 
 /// Strip an embedded `user@` from an `https://` URL's authority so git's credential

--- a/src-tauri/src/forge/http.rs
+++ b/src-tauri/src/forge/http.rs
@@ -8,7 +8,8 @@
 //! (`{atlassian_account_email}:{api_token}`) — app passwords are dead (removed
 //! 2026-07-28), so the API token is the only supported credential.
 
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{OnceLock, RwLock};
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -65,15 +66,44 @@ fn client() -> &'static Client {
 
 /// The stored Bitbucket credentials (email + token), loaded from the OS keyring.
 /// Never logged, never returned across IPC.
+#[derive(Clone)]
 pub struct BbCredentials {
     pub email: String,
     pub token: String,
 }
 
-/// Load the stored credentials from the keyring (blocking keyring reads run on a
-/// blocking thread). `BitbucketNotConfigured` when no token is stored — the signal
-/// the read commands turn into the "connect an account" state.
+/// Process cache of the loaded credentials so the OS keyring is read ONCE per
+/// session, not on every call. Each keyring read pops a macOS keychain-authorization
+/// prompt, and the Bitbucket layer loads credentials at 70+ call sites (every REST
+/// request + the git-credential seed), so reading each time was a prompt storm.
+/// Invalidated on connect/disconnect via [`invalidate_credential_cache`].
+static CREDENTIAL_CACHE: RwLock<Option<BbCredentials>> = RwLock::new(None);
+/// Serializes the first (uncached) load so a burst of concurrent callers on repo
+/// open triggers ONE keyring read (one prompt), not one per caller.
+static CREDENTIAL_LOAD_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+/// Bumped by every invalidation. A cold load captures it before the keyring read and
+/// only commits the read to the cache if it's unchanged — so a connect/disconnect
+/// that races an in-flight read can't be clobbered by a stale re-warm (the
+/// write-after-invalidate race). See [`load_credentials`] / [`invalidate_credential_cache`].
+static CREDENTIAL_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Load the stored credentials — from the process cache when warm, else the OS
+/// keyring (blocking reads run on a blocking thread), caching the result.
+/// `BitbucketNotConfigured` when no token is stored — the signal the read commands
+/// turn into the "connect an account" state.
 pub async fn load_credentials() -> AppResult<BbCredentials> {
+    // Fast path: reuse the cached credential (no keyring read → no macOS prompt).
+    if let Some(creds) = CREDENTIAL_CACHE.read().unwrap().clone() {
+        return Ok(creds);
+    }
+    // Serialize the cold load so concurrent first-callers don't each read the keyring.
+    let _guard = CREDENTIAL_LOAD_LOCK.lock().await;
+    if let Some(creds) = CREDENTIAL_CACHE.read().unwrap().clone() {
+        return Ok(creds); // another caller warmed the cache while we waited
+    }
+    // Capture the generation before the (slow) keyring read; if a connect/disconnect
+    // invalidates while we read, we must NOT cache the now-stale value.
+    let generation = CREDENTIAL_GENERATION.load(Ordering::Acquire);
     let (email, token) = tauri::async_runtime::spawn_blocking(|| {
         let email = crate::secrets::read_forge_secret(BB_HOST, KEY_EMAIL)?;
         let token = crate::secrets::read_forge_secret(BB_HOST, KEY_TOKEN)?;
@@ -83,10 +113,32 @@ pub async fn load_credentials() -> AppResult<BbCredentials> {
     .map_err(|e| AppError::Bitbucket(format!("keyring task failed: {e}")))??;
     match (email, token) {
         (Some(email), Some(token)) if !email.is_empty() && !token.is_empty() => {
-            Ok(BbCredentials { email, token })
+            let creds = BbCredentials { email, token };
+            // Commit only if no invalidation raced in during the read. The check and
+            // write are held under the cache write lock, and `invalidate` bumps the
+            // generation BEFORE clearing under the same lock — so either we skip the
+            // stale write, or our write is superseded by the clear; a stale value is
+            // never left cached.
+            {
+                let mut cache = CREDENTIAL_CACHE.write().unwrap();
+                if CREDENTIAL_GENERATION.load(Ordering::Acquire) == generation {
+                    *cache = Some(creds.clone());
+                }
+            }
+            Ok(creds)
         }
         _ => Err(AppError::BitbucketNotConfigured),
     }
+}
+
+/// Drop the cached credential so the next [`load_credentials`] re-reads the keyring —
+/// called on connect/disconnect (the stored token changed).
+pub(crate) fn invalidate_credential_cache() {
+    // Bump BEFORE clearing so an in-flight cold load sees the change and skips
+    // caching its stale read; the clear is serialized (cache write lock) against
+    // that load's commit.
+    CREDENTIAL_GENERATION.fetch_add(1, Ordering::AcqRel);
+    *CREDENTIAL_CACHE.write().unwrap() = None;
 }
 
 /// Bitbucket's error envelope. The common shape is

--- a/src-tauri/src/forge/http.rs
+++ b/src-tauri/src/forge/http.rs
@@ -93,12 +93,15 @@ static CREDENTIAL_GENERATION: AtomicU64 = AtomicU64::new(0);
 /// turn into the "connect an account" state.
 pub async fn load_credentials() -> AppResult<BbCredentials> {
     // Fast path: reuse the cached credential (no keyring read → no macOS prompt).
-    if let Some(creds) = CREDENTIAL_CACHE.read().unwrap().clone() {
+    // Poison recovery (`into_inner`) matches the oplog locks: nothing fallible runs
+    // under these guards, and the cache is atomically-assigned, so a recovered
+    // value is always coherent.
+    if let Some(creds) = CREDENTIAL_CACHE.read().unwrap_or_else(|p| p.into_inner()).clone() {
         return Ok(creds);
     }
     // Serialize the cold load so concurrent first-callers don't each read the keyring.
     let _guard = CREDENTIAL_LOAD_LOCK.lock().await;
-    if let Some(creds) = CREDENTIAL_CACHE.read().unwrap().clone() {
+    if let Some(creds) = CREDENTIAL_CACHE.read().unwrap_or_else(|p| p.into_inner()).clone() {
         return Ok(creds); // another caller warmed the cache while we waited
     }
     // Capture the generation before the (slow) keyring read; if a connect/disconnect
@@ -120,7 +123,7 @@ pub async fn load_credentials() -> AppResult<BbCredentials> {
             // stale write, or our write is superseded by the clear; a stale value is
             // never left cached.
             {
-                let mut cache = CREDENTIAL_CACHE.write().unwrap();
+                let mut cache = CREDENTIAL_CACHE.write().unwrap_or_else(|p| p.into_inner());
                 if CREDENTIAL_GENERATION.load(Ordering::Acquire) == generation {
                     *cache = Some(creds.clone());
                 }
@@ -138,7 +141,7 @@ pub(crate) fn invalidate_credential_cache() {
     // caching its stale read; the clear is serialized (cache write lock) against
     // that load's commit.
     CREDENTIAL_GENERATION.fetch_add(1, Ordering::AcqRel);
-    *CREDENTIAL_CACHE.write().unwrap() = None;
+    *CREDENTIAL_CACHE.write().unwrap_or_else(|p| p.into_inner()) = None;
 }
 
 /// Bitbucket's error envelope. The common shape is

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -694,7 +694,7 @@ pub async fn forge_clone(
         Provider::Bitbucket => {
             if bitbucket::seed_git_credential().await {
                 clone_url = bitbucket::strip_https_userinfo(&clone_url);
-                vec!["credential.interactive=false".to_string()]
+                vec![bitbucket::CREDENTIAL_NONINTERACTIVE.to_string()]
             } else {
                 Vec::new()
             }

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -161,13 +161,20 @@ pub(crate) async fn detect_non_github(repo_path: &str) -> Option<(Provider, Stri
 ///
 /// Empty (→ git's ambient behavior, unchanged, so this never breaks a local, SSH,
 /// or already-authenticated repo) for: SSH remotes (credential helpers don't
-/// apply), Bitbucket (its push flow injects auth its own way), a repo with no such
-/// remote, an unknown HTTPS host (the GitHub-default routing's gh gate injects the
-/// pair ONLY when gh holds a token for that host — e.g. a signed-in GitHub
-/// Enterprise host, which is what makes GHE work — and nothing otherwise), and —
-/// fail open — when the provider CLI isn't installed OR is installed but has no
-/// stored token/session for this host (ambient helpers like git-credential-manager
-/// keep working for both).
+/// apply), a repo with no such remote, an unknown HTTPS host (the GitHub-default
+/// routing's gh gate injects the pair ONLY when gh holds a token for that host —
+/// e.g. a signed-in GitHub Enterprise host, which is what makes GHE work — and
+/// nothing otherwise), and — fail open — when the provider CLI isn't installed OR
+/// is installed but has no stored token/session for this host (ambient helpers like
+/// git-credential-manager keep working for both).
+///
+/// Bitbucket is the exception to the `[reset, helper]` shape: it has no CLI, so
+/// rather than injecting `-c` entries it SEEDS git's credential store out of band
+/// with the `x-bitbucket-api-token-auth` sentinel + token (STDIN only, no repo
+/// lock — see [`bitbucket::seed_git_credential`]) and returns NO entries; the op
+/// then authenticates ambiently from the seeded store. Seeding is best-effort, so a
+/// repo with no stored token, or one already authenticated by an ambient BB helper,
+/// is unaffected.
 pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppResult<Vec<String>> {
     let url = match crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await
     {
@@ -195,7 +202,29 @@ pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppR
     // fail just because gh/glab isn't installed.
     match provider {
         Some(Provider::GitLab) => Ok(gitlab::clone_credential_config(&url).await.unwrap_or_default()),
-        Some(Provider::Bitbucket) => Ok(Vec::new()),
+        Some(Provider::Bitbucket) => {
+            // Bitbucket has no CLI helper. Two steps, then no `-c` entries:
+            //  1. If the stored remote embeds `user@` (Bitbucket's web-UI clone
+            //     form), rewrite it to the bare host. git scopes its credential
+            //     lookup by the URL username, so a `user@` remote would ask the
+            //     helper for that account and miss the host+sentinel-account seed
+            //     (on osxkeychain AND GCM). Best-effort, one-time, idempotent — the
+            //     op re-reads config, so the current op benefits too.
+            //  2. Seed the token into git's credential store (STDIN only) so the op
+            //     authenticates ambiently from it.
+            let stripped = bitbucket::strip_https_userinfo(&url);
+            if stripped != url {
+                let _ = crate::git::runner::run_git_input(
+                    Some(repo_path),
+                    &["remote", "set-url", remote, &stripped],
+                    None,
+                    crate::git::runner::DEFAULT_TIMEOUT,
+                )
+                .await;
+            }
+            bitbucket::seed_git_credential().await;
+            Ok(Vec::new())
+        }
         _ => Ok(github::clone_credential_config(&url).await.unwrap_or_default()),
     }
 }
@@ -657,12 +686,21 @@ pub async fn forge_clone(
     parent_dir: String,
     dir_name: Option<String>,
 ) -> AppResult<String> {
+    // Bitbucket needs the token seeded into git's credential store and the API's
+    // embedded `user@` stripped from the clone URL (so the host-keyed lookup finds
+    // the sentinel-account seed — osxkeychain matches by host+account); the others
+    // inject `-c` credential-helper entries.
+    let mut clone_url = url;
     let extra = match provider {
-        Provider::GitLab => gitlab::clone_credential_config(&url).await?,
-        Provider::GitHub => github::clone_credential_config(&url).await.unwrap_or_default(),
-        Provider::Bitbucket => Vec::new(),
+        Provider::GitLab => gitlab::clone_credential_config(&clone_url).await?,
+        Provider::GitHub => github::clone_credential_config(&clone_url).await.unwrap_or_default(),
+        Provider::Bitbucket => {
+            bitbucket::seed_git_credential().await;
+            clone_url = bitbucket::strip_https_userinfo(&clone_url);
+            Vec::new()
+        }
     };
-    crate::git::repo::clone_repo_core(&url, &parent_dir, dir_name, &extra).await
+    crate::git::repo::clone_repo_core(&clone_url, &parent_dir, dir_name, &extra).await
 }
 
 /// A repo's merge/pull requests, behind the provider abstraction. GitHub

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -168,13 +168,15 @@ pub(crate) async fn detect_non_github(repo_path: &str) -> Option<(Provider, Stri
 /// is installed but has no stored token/session for this host (ambient helpers like
 /// git-credential-manager keep working for both).
 ///
-/// Bitbucket is the exception to the `[reset, helper]` shape: it has no CLI, so
-/// rather than injecting `-c` entries it SEEDS git's credential store out of band
-/// with the `x-bitbucket-api-token-auth` sentinel + token (STDIN only, no repo
-/// lock — see [`bitbucket::seed_git_credential`]) and returns NO entries; the op
-/// then authenticates ambiently from the seeded store. Seeding is best-effort, so a
-/// repo with no stored token, or one already authenticated by an ambient BB helper,
-/// is unaffected.
+/// Bitbucket is the exception to the `[reset, helper]` shape: it has no CLI, so it
+/// SEEDS git's credential store out of band with the `x-bitbucket-api-token-auth`
+/// sentinel and token (STDIN only, no repo lock — see
+/// [`bitbucket::seed_git_credential`]), and on a successful seed returns the
+/// [`bitbucket::bitbucket_credential_entries`] pair — interactive-helper
+/// suppression plus a transient `insteadOf` host rewrite for `user@` remotes — so
+/// the op authenticates from the seeded store. No stored token or a failed seed
+/// yields no entries, leaving git's ambient behavior (including an interactive
+/// GCM) unchanged — fail-open.
 pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppResult<Vec<String>> {
     let url = match crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await
     {
@@ -203,27 +205,20 @@ pub async fn credential_config_for_remote(repo_path: &str, remote: &str) -> AppR
     match provider {
         Some(Provider::GitLab) => Ok(gitlab::clone_credential_config(&url).await.unwrap_or_default()),
         Some(Provider::Bitbucket) => {
-            // Bitbucket has no CLI helper. Two steps, then no `-c` entries:
-            //  1. If the stored remote embeds `user@` (Bitbucket's web-UI clone
-            //     form), rewrite it to the bare host. git scopes its credential
-            //     lookup by the URL username, so a `user@` remote would ask the
-            //     helper for that account and miss the host+sentinel-account seed
-            //     (on osxkeychain AND GCM). Best-effort, one-time, idempotent — the
-            //     op re-reads config, so the current op benefits too.
-            //  2. Seed the token into git's credential store (STDIN only) so the op
-            //     authenticates ambiently from it.
-            let stripped = bitbucket::strip_https_userinfo(&url);
-            if stripped != url {
-                let _ = crate::git::runner::run_git_input(
-                    Some(repo_path),
-                    &["remote", "set-url", remote, &stripped],
-                    None,
-                    crate::git::runner::DEFAULT_TIMEOUT,
-                )
-                .await;
+            // Bitbucket has no CLI helper: seed the token into git's credential
+            // store (STDIN only) so the op authenticates ambiently from it. On a
+            // SUCCESSFUL seed, inject the one-shot `-c` pair (interactive-helper
+            // suppression + a transient `insteadOf` rewrite when the stored remote
+            // embeds `user@`, so git's host-scoped lookup finds the sentinel seed —
+            // see `bitbucket_credential_entries`; the stored remote is never
+            // mutated). No token / failed seed → no entries, so git's ambient
+            // behavior (incl. an interactive GCM) is unchanged — fail-open, same
+            // philosophy as the gh/glab arms.
+            if bitbucket::seed_git_credential().await {
+                Ok(bitbucket::bitbucket_credential_entries(&url))
+            } else {
+                Ok(Vec::new())
             }
-            bitbucket::seed_git_credential().await;
-            Ok(Vec::new())
         }
         _ => Ok(github::clone_credential_config(&url).await.unwrap_or_default()),
     }
@@ -686,18 +681,23 @@ pub async fn forge_clone(
     parent_dir: String,
     dir_name: Option<String>,
 ) -> AppResult<String> {
-    // Bitbucket needs the token seeded into git's credential store and the API's
-    // embedded `user@` stripped from the clone URL (so the host-keyed lookup finds
-    // the sentinel-account seed — osxkeychain matches by host+account); the others
-    // inject `-c` credential-helper entries.
+    // Bitbucket seeds the token into git's credential store, then clones with the
+    // API's embedded `user@` stripped from the URL (git scopes credential lookup by
+    // the URL username, so the bare host is what finds the sentinel-account seed)
+    // and interactive helpers suppressed — but only on a SUCCESSFUL seed; with no
+    // stored token the URL and behavior are untouched so ambient (possibly
+    // interactive) helpers still work. The others inject `-c` helper entries.
     let mut clone_url = url;
     let extra = match provider {
         Provider::GitLab => gitlab::clone_credential_config(&clone_url).await?,
         Provider::GitHub => github::clone_credential_config(&clone_url).await.unwrap_or_default(),
         Provider::Bitbucket => {
-            bitbucket::seed_git_credential().await;
-            clone_url = bitbucket::strip_https_userinfo(&clone_url);
-            Vec::new()
+            if bitbucket::seed_git_credential().await {
+                clone_url = bitbucket::strip_https_userinfo(&clone_url);
+                vec!["credential.interactive=false".to_string()]
+            } else {
+                Vec::new()
+            }
         }
     };
     crate::git::repo::clone_repo_core(&clone_url, &parent_dir, dir_name, &extra).await

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -18,7 +18,9 @@ fn validate_remote_arg(value: &str, what: &str) -> AppResult<()> {
 }
 
 /// Prefix one-shot credential `-c` entries before a git subcommand's args.
-fn with_credentials(cred: &[String], sub: &[&str]) -> Vec<String> {
+/// `pub(crate)` so provider-side pushes (e.g. Bitbucket `create_pr`) can build
+/// funnel-identical args.
+pub(crate) fn with_credentials(cred: &[String], sub: &[&str]) -> Vec<String> {
     let mut v = Vec::with_capacity(cred.len() * 2 + sub.len());
     for c in cred {
         v.push("-c".to_string());


### PR DESCRIPTION
Cloning, fetching, pulling, and pushing private Bitbucket repos over HTTPS failed on macOS and Linux with `could not read Password for '…@bitbucket.org': terminal prompts disabled`, because — unlike GitHub/GitLab — Bitbucket has no CLI credential helper and the stored token never reached git. This change hands the stored Bitbucket API token to git's credential store over STDIN (never on argv/env/git config) so those operations authenticate non-interactively wherever git has a credential helper, and it seeds at most once per process to avoid re-popping the macOS keychain prompt on every op.

### Credential seeding (`src-tauri/src/forge/bitbucket.rs`)
- Adds `seed_git_credential`, which runs `git credential approve` outside any repo (via `run_git_input(None, …)`, no repo lock) and feeds the token on STDIN with the required `x-bitbucket-api-token-auth` sentinel username. Best-effort: a missing token, absent helper, or non-zero exit are all tolerated.
- Adds a `CREDENTIAL_SEEDED` `AtomicBool` latch so the process seeds only once, and `reset_credential_seed` to re-arm it. `set_account` and `clear_account` now call `reset_credential_seed` so a changed/cleared token re-seeds on the next op.
- Adds `strip_https_userinfo`, which removes an embedded `user@` from an `https://` authority so git's host-keyed credential lookup finds the sentinel-account seed instead of asking for the embedded account (affects both osxkeychain and Windows GCM).
- Updates `create_pr` to seed before its push and to pass `-c credential.interactive=false` to suppress an interactive helper GUI that `GIT_TERMINAL_PROMPT=0` doesn't block. Revises the `create_pr` doc comment and the module header to describe the seed-and-push mechanism.
- Adds a `strip_https_userinfo_removes_embedded_username` unit test covering embedded username, no-userinfo, authority-only, and scp-style SSH inputs.

### Clone and remote wiring (`src-tauri/src/forge/mod.rs`)
- `credential_config_for_remote` now, for the `Bitbucket` provider, rewrites a `user@` remote to the bare host via `git remote set-url`, seeds the token, and returns no `-c` entries (the op then authenticates ambiently from the seeded store).
- `forge_clone` seeds the token and strips `user@` from the clone URL for Bitbucket before calling `clone_repo_core`.
- Expands the `credential_config_for_remote` doc comment to explain Bitbucket's exception to the `[reset, helper]` shape.

### Changelog
- Adds `changelog.d/fixed-bitbucket-https-git-auth.md` describing the user-facing fix and noting SSH clones were unaffected.