### PR TITLE
fix(diff): guard generated and minified files from freezing the view

### DIFF
--- a/changelog.d/fixed-diff-generated-minified-freeze.md
+++ b/changelog.d/fixed-diff-generated-minified-freeze.md
@@ -1,0 +1,5 @@
+- Opening the diff of a generated or minified file (a `tsconfig.tsbuildinfo`,
+  minified bundle, or source map that is one enormous line) no longer freezes
+  the app: such files show a *generated or minified* notice with one-click
+  **Show diff anyway**, and extremely long lines are shortened for display in
+  every diff view.

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -519,14 +519,13 @@ function RenderedDiff({
   // a previously-expanded file doesn't carry over to the next one.
   const [showFull, setShowFull] = useState(false);
   // A generated/minified file (one enormous line) shows a placeholder rather
-  // than freezing the un-virtualized renderer; "Show diff anyway" opts in. Reset
-  // per file alongside showFull (derive-during-render, no effect — repo idiom).
+  // than freezing the un-virtualized renderer; "Show diff anyway" opts in.
+  // (Reset lives below, keyed on the DEFERRED path — see the comment there.)
   const [showAnyway, setShowAnyway] = useState(false);
   const [prevPath, setPrevPath] = useState(filePath);
   if (prevPath !== filePath) {
     setPrevPath(filePath);
     if (showFull) setShowFull(false);
-    if (showAnyway) setShowAnyway(false);
   }
 
   // Build the diff off deferred values so rapid arrow-key navigation isn't
@@ -534,6 +533,21 @@ function RenderedDiff({
   // screen and builds the new one at low priority, coalescing fast steps.
   const deferredText = useDeferredValue(text);
   const deferredPath = useDeferredValue(filePath);
+
+  // Reset the "Show diff anyway" opt-in when the file actually changes on the
+  // DEFERRED timeline — not the urgent `filePath` — because `blocked` derives
+  // from `deferredText`. Resetting on the urgent change would re-block the
+  // OUTGOING mega file for the transition frame(s) before the new file's
+  // deferred text lands, flashing the placeholder over its opted-in shortened
+  // render (spec-review finding). Keyed on deferredPath, it rides the same
+  // values `blocked` reads, so the outgoing file keeps its render through the
+  // transition — matching how every deferred transition holds the previous
+  // content on screen.
+  const [prevDeferredPath, setPrevDeferredPath] = useState(deferredPath);
+  if (prevDeferredPath !== deferredPath) {
+    setPrevDeferredPath(deferredPath);
+    if (showAnyway) setShowAnyway(false);
+  }
 
   // The longest single line drives both guards below. The renderer mounts the
   // longest line synchronously on the main thread, so a mega-line (minified

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -593,13 +593,22 @@ function RenderedDiff({
     // shortened (the safety invariant — no rendered diff can ever freeze). In
     // content mode `longestLine <= DIFF_MAX_LINE_CHARS` by construction (the
     // gate above), so this hits the fast-path with shortened=0.
-    const short = shortenLongLines(capped.text, DIFF_MAX_LINE_CHARS);
+    //
+    // `longestLine` is measured on the FULL deferredText, so ≤ cap on the full
+    // text implies ≤ cap on any subset (capped / showFull / content text) —
+    // skipping the shorten pass is always safe there and avoids its re-scan.
+    // When > cap we still call shortenLongLines, whose own fast-path also
+    // returns shortened=0 for the case where capDiffText cut the long line out.
+    const short =
+      longestLine <= DIFF_MAX_LINE_CHARS
+        ? { text: capped.text, shortened: 0 }
+        : shortenLongLines(capped.text, DIFF_MAX_LINE_CHARS);
     return {
       shown: short.text,
       hidden: capped.hidden,
       shortened: short.shortened,
     };
-  }, [deferredText, showFull, content, blocked]);
+  }, [deferredText, showFull, content, blocked, longestLine]);
 
   // Syntax prefs follow the active repo (repo-scoped custom languages); the
   // active repo owns every surface that supplies content, so this matches.

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -31,7 +31,14 @@ import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { useEffectiveSyntax } from "@/lib/syntax/queries";
 import { useIsDark } from "@/lib/use-is-dark";
-import { capDiffText, DIFF_LINE_CAP } from "./cap-diff";
+import {
+  capDiffText,
+  DIFF_LINE_CAP,
+  DIFF_MAX_LINE_CHARS,
+  DIFF_MEGA_LINE_CHARS,
+  longestLineLength,
+  shortenLongLines,
+} from "./cap-diff";
 import { DiffErrorBoundary } from "./DiffErrorBoundary";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
@@ -511,10 +518,15 @@ function RenderedDiff({
   // "Show full diff" opts into the whole thing. Reset when the file changes so
   // a previously-expanded file doesn't carry over to the next one.
   const [showFull, setShowFull] = useState(false);
+  // A generated/minified file (one enormous line) shows a placeholder rather
+  // than freezing the un-virtualized renderer; "Show diff anyway" opts in. Reset
+  // per file alongside showFull (derive-during-render, no effect — repo idiom).
+  const [showAnyway, setShowAnyway] = useState(false);
   const [prevPath, setPrevPath] = useState(filePath);
   if (prevPath !== filePath) {
     setPrevPath(filePath);
     if (showFull) setShowFull(false);
+    if (showAnyway) setShowAnyway(false);
   }
 
   // Build the diff off deferred values so rapid arrow-key navigation isn't
@@ -522,6 +534,17 @@ function RenderedDiff({
   // screen and builds the new one at low priority, coalescing fast steps.
   const deferredText = useDeferredValue(text);
   const deferredPath = useDeferredValue(filePath);
+
+  // The longest single line drives both guards below. The renderer mounts the
+  // longest line synchronously on the main thread, so a mega-line (minified
+  // bundle, source map, `.tsbuildinfo`) freezes the app — that file gets a
+  // placeholder; any rendered diff also hard-shortens over-long lines.
+  const longestLine = useMemo(
+    () => longestLineLength(deferredText),
+    [deferredText],
+  );
+  const isMegaLine = longestLine > DIFF_MEGA_LINE_CHARS;
+  const blocked = isMegaLine && !showAnyway;
 
   // Whole-file highlight context + collapsible expand for small diffs; `content`
   // is null when it shouldn't apply (big file / unreadable / truncated → capped
@@ -533,18 +556,36 @@ function RenderedDiff({
     repoPath,
     deferredPath,
     deferredText,
-    contentRevs,
+    // Shortened hunk text (long lines cut) would no longer line up with the
+    // whole-file reads content mode maps syntax onto, and the two whole-file
+    // IPC reads are pure waste when we're going to hunk-only anyway — skip
+    // content mode entirely once any line is over the shorten cap.
+    longestLine > DIFF_MAX_LINE_CHARS ? undefined : contentRevs,
   );
 
-  const { shown, hidden } = useMemo(() => {
+  const { shown, hidden, shortened } = useMemo(() => {
+    // On a blocked mega file we show a placeholder, not a diff — do no cap or
+    // shorten work on the (potentially ~1MB single-line) text.
+    if (blocked) return { shown: "", hidden: 0, shortened: 0 };
     // Content mode renders the full diff (the renderer collapses non-hunk
     // context into expandable gaps), so the cap doesn't apply there.
-    if (content) return { shown: deferredText, hidden: 0 };
-    const r = showFull
+    const capped = content
       ? { text: deferredText, hidden: 0 }
-      : capDiffText(deferredText, DIFF_LINE_CAP);
-    return { shown: r.text, hidden: r.hidden };
-  }, [deferredText, showFull, content]);
+      : showFull
+        ? { text: deferredText, hidden: 0 }
+        : capDiffText(deferredText, DIFF_LINE_CAP);
+    // Hard-shorten over-long lines UNCONDITIONALLY on whatever is about to
+    // render: "Show full diff" reveals hidden lines but long lines stay
+    // shortened (the safety invariant — no rendered diff can ever freeze). In
+    // content mode `longestLine <= DIFF_MAX_LINE_CHARS` by construction (the
+    // gate above), so this hits the fast-path with shortened=0.
+    const short = shortenLongLines(capped.text, DIFF_MAX_LINE_CHARS);
+    return {
+      shown: short.text,
+      hidden: capped.hidden,
+      shortened: short.shortened,
+    };
+  }, [deferredText, showFull, content, blocked]);
 
   // Syntax prefs follow the active repo (repo-scoped custom languages); the
   // active repo owns every surface that supplies content, so this matches.
@@ -568,6 +609,9 @@ function RenderedDiff({
   useEffect(() => {
     if (
       !lang ||
+      // A blocked mega file shows a placeholder, not a diff — don't fetch a
+      // grammar it will never render.
+      blocked ||
       !isBuiltinShikiLang(lang) ||
       isShikiLang(lang) ||
       grammarState[lang] !== undefined ||
@@ -586,7 +630,7 @@ function RenderedDiff({
     return () => {
       cancelled = true;
     };
-  }, [lang, grammarState, shown.length]);
+  }, [lang, grammarState, shown.length, blocked]);
 
   // A built-in Shiki grammar this diff needs is still loading (never seen a
   // "ready"/"failed" result for it): hold the paint. `isShikiLang(lang)` already
@@ -650,7 +694,7 @@ function RenderedDiff({
   // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>
-      contentPending || holdForGrammar
+      blocked || contentPending || holdForGrammar
         ? null
         : createDiffFile(
             deferredPath,
@@ -665,6 +709,7 @@ function RenderedDiff({
       syntaxMap,
       customLanguages,
       content,
+      blocked,
       contentPending,
       holdForGrammar,
       grammarState,
@@ -996,6 +1041,25 @@ function RenderedDiff({
   // for a grammar only the worker needs — the interim is the view clone's own
   // hljs pass (≤15K lines; plain past it), and correct Shiki swaps in when the
   // worker ASTs land.
+  // A generated/minified file (one enormous line) would freeze the renderer:
+  // show a placeholder with a one-click opt-in instead. Placed FIRST so a
+  // blocked mega file never flashes null while an irrelevant grammar loads.
+  if (blocked) {
+    return (
+      <DiffPlaceholder
+        message="Looks like a generated or minified file"
+        action={
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => setShowAnyway(true)}
+          >
+            Show diff anyway
+          </Button>
+        }
+      />
+    );
+  }
   if (contentPending || holdForGrammar) return null;
   if (!diffFile) return <DiffPlaceholder message="No changes to show" />;
   return (
@@ -1049,15 +1113,30 @@ function RenderedDiff({
           renderExtendLine={renderExtendLine}
         />
       )}
-      {hidden > 0 && (
+      {(hidden > 0 || shortened > 0) && (
         <div className="flex items-center justify-center gap-3 border-t bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-          <span>
-            {hidden.toLocaleString()} more {hidden === 1 ? "line" : "lines"}{" "}
-            hidden for performance
-          </span>
-          <Button size="xs" variant="outline" onClick={() => setShowFull(true)}>
-            Show full diff
-          </Button>
+          {hidden > 0 && (
+            <span>
+              {hidden.toLocaleString()} more {hidden === 1 ? "line" : "lines"}{" "}
+              hidden for performance
+            </span>
+          )}
+          {shortened > 0 && (
+            <span>
+              {shortened.toLocaleString()} long{" "}
+              {shortened === 1 ? "line" : "lines"} shortened
+              {hidden > 0 ? "" : " for performance"}
+            </span>
+          )}
+          {hidden > 0 && (
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => setShowFull(true)}
+            >
+              Show full diff
+            </Button>
+          )}
         </div>
       )}
     </>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -594,16 +594,21 @@ function StagingDiffView({
   // DISPLAY-ONLY: shortening preserves line COUNT and numbers, so the drag
   // manager, paint helpers, hunk anchors, and every mutation path (which all
   // work off the ORIGINAL text/parsed hunks in WorkingTreeDiff) stay correct.
-  // Normal files fast-path to the SAME string reference (shortened=0), keeping
-  // createDiffFile's inputs — and thus behavior — byte-identical.
-  const longestLine = useMemo(
-    () => longestLineLength(deferredText),
-    [deferredText],
-  );
-  const { text: displayText, shortened } = useMemo(
-    () => shortenLongLines(deferredText, DIFF_MAX_LINE_CHARS),
-    [deferredText],
-  );
+  // One scan: measure the longest line once, and only shorten when it overflows
+  // — normal files then fast-path to the SAME string reference (shortened=0),
+  // keeping createDiffFile's inputs — and thus behavior — byte-identical.
+  const { longestLine, displayText, shortened } = useMemo(() => {
+    const longest = longestLineLength(deferredText);
+    if (longest <= DIFF_MAX_LINE_CHARS) {
+      return { longestLine: longest, displayText: deferredText, shortened: 0 };
+    }
+    const short = shortenLongLines(deferredText, DIFF_MAX_LINE_CHARS);
+    return {
+      longestLine: longest,
+      displayText: short.text,
+      shortened: short.shortened,
+    };
+  }, [deferredText]);
   // Whole-file highlight context + expand. The staging view renders every hunk
   // regardless, so let content mode engage for big diffs too — bounded by the
   // file highlight budget, not the read-only surface's 200-line render cap.

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -45,6 +45,7 @@ import { useEffectiveSyntax } from "@/lib/syntax/queries";
 import { toastError } from "@/lib/toast";
 import { useIsDark } from "@/lib/use-is-dark";
 import { useLatestRef } from "@/lib/use-latest-ref";
+import { DIFF_MEGA_LINE_CHARS, longestLineLength } from "./cap-diff";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
 import {
@@ -121,8 +122,9 @@ export function DiffViewer({ repoPath }: { repoPath: string }) {
 /**
  * The working-tree variant of the diff pane: hunks render as individual cards
  * with whole-hunk stage/unstage/discard actions, plus drag-to-select for
- * staging an individual subset of lines. Untracked, binary, and truncated
- * diffs fall back to the plain whole-file surface.
+ * staging an individual subset of lines. Untracked, binary, truncated, and
+ * generated/minified (one enormous line) diffs fall back to the plain
+ * whole-file surface (which shows the generated/minified placeholder).
  */
 function WorkingTreeDiff({
   repoPath,
@@ -163,7 +165,16 @@ function WorkingTreeDiff({
 
   const parsed: ParsedDiff | null = useMemo(() => {
     const data = diff.data;
-    if (!data || data.isBinary || data.isTruncated) return null;
+    // A generated/minified file (one enormous line) would freeze the
+    // un-virtualized staging renderer — route it down the whole-file
+    // DiffSurface fallback, which shows the generated/minified placeholder.
+    if (
+      !data ||
+      data.isBinary ||
+      data.isTruncated ||
+      longestLineLength(data.text) > DIFF_MEGA_LINE_CHARS
+    )
+      return null;
     return parseHunks(data.text);
   }, [diff.data]);
 

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -45,7 +45,12 @@ import { useEffectiveSyntax } from "@/lib/syntax/queries";
 import { toastError } from "@/lib/toast";
 import { useIsDark } from "@/lib/use-is-dark";
 import { useLatestRef } from "@/lib/use-latest-ref";
-import { DIFF_MEGA_LINE_CHARS, longestLineLength } from "./cap-diff";
+import {
+  DIFF_MAX_LINE_CHARS,
+  DIFF_MEGA_LINE_CHARS,
+  longestLineLength,
+  shortenLongLines,
+} from "./cap-diff";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
 import {
@@ -583,6 +588,22 @@ function StagingDiffView({
   const { syntaxMap, customLanguages } = useEffectiveSyntax(activeRepo);
   const deferredText = useDeferredValue(diffText);
   const deferredPath = useDeferredValue(filePath);
+  // Hard-shorten over-long lines before rendering so a file with lines in the
+  // 4K–20K band (past the mega threshold it falls back to the whole-file
+  // surface entirely) can't freeze the un-virtualized renderer here either.
+  // DISPLAY-ONLY: shortening preserves line COUNT and numbers, so the drag
+  // manager, paint helpers, hunk anchors, and every mutation path (which all
+  // work off the ORIGINAL text/parsed hunks in WorkingTreeDiff) stay correct.
+  // Normal files fast-path to the SAME string reference (shortened=0), keeping
+  // createDiffFile's inputs — and thus behavior — byte-identical.
+  const longestLine = useMemo(
+    () => longestLineLength(deferredText),
+    [deferredText],
+  );
+  const { text: displayText, shortened } = useMemo(
+    () => shortenLongLines(deferredText, DIFF_MAX_LINE_CHARS),
+    [deferredText],
+  );
   // Whole-file highlight context + expand. The staging view renders every hunk
   // regardless, so let content mode engage for big diffs too — bounded by the
   // file highlight budget, not the read-only surface's 200-line render cap.
@@ -594,25 +615,30 @@ function StagingDiffView({
     repoPath,
     deferredPath,
     deferredText,
-    contentRevs,
+    // Shortened hunk text (long lines cut) no longer lines up with the
+    // whole-file reads content mode maps syntax onto, and the reads are wasted
+    // IPC there — skip content mode once any line is over the shorten cap.
+    longestLine > DIFF_MAX_LINE_CHARS ? undefined : contentRevs,
     HIGHLIGHT_MAX_LINES,
   );
   // The whole-file diff (every hunk) — never capped, so all hunks stay stageable.
-  // Null while content reads are pending: don't build an intermediate diff the
-  // arriving reads would immediately restructure.
+  // Built from the shortened DISPLAY text; the original text still backs every
+  // stage/unstage/discard patch (see WorkingTreeDiff). Null while content reads
+  // are pending: don't build an intermediate diff the arriving reads would
+  // immediately restructure.
   const diffFile = useMemo(
     () =>
       contentPending
         ? null
         : createDiffFile(
             deferredPath,
-            deferredText,
+            displayText,
             { syntaxMap, customLanguages },
             content ?? undefined,
           ),
     [
       deferredPath,
-      deferredText,
+      displayText,
       syntaxMap,
       customLanguages,
       content,
@@ -791,6 +817,14 @@ function StagingDiffView({
             />
           </div>
         ) : null,
+      )}
+      {shortened > 0 && (
+        <div className="flex items-center justify-center gap-3 border-t bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          <span>
+            {shortened.toLocaleString()} long{" "}
+            {shortened === 1 ? "line" : "lines"} shortened for performance
+          </span>
+        </div>
       )}
     </div>
   );

--- a/src/features/diff/cap-diff.ts
+++ b/src/features/diff/cap-diff.ts
@@ -6,6 +6,60 @@
 /** Past this many lines, a diff is capped to keep the render under ~1 frame. */
 export const DIFF_LINE_CAP = 200;
 
+/** Per-line display cap: any rendered diff line longer than this is hard-shortened. */
+export const DIFF_MAX_LINE_CHARS = 4_000;
+/** Longest-line threshold past which a diff is treated as generated/minified. */
+export const DIFF_MEGA_LINE_CHARS = 20_000;
+
+/**
+ * Length (in chars) of the longest line in `text`. Allocation-free scan (no
+ * `split` — a single-line minified blob would otherwise build a whole-string
+ * array). Mirrors {@link capDiffText}'s own newline-counting style.
+ */
+export function longestLineLength(text: string): number {
+  let longest = 0;
+  let start = 0;
+  for (let k = 0; k < text.length; k++) {
+    if (text.charCodeAt(k) === 10 /* \n */) {
+      if (k - start > longest) longest = k - start;
+      start = k + 1;
+    }
+  }
+  // The final line has no trailing \n.
+  if (text.length - start > longest) longest = text.length - start;
+  return longest;
+}
+
+/**
+ * Hard-shorten every line longer than `maxChars` so the un-virtualized renderer
+ * never mounts a mega-line that freezes the main thread. Shortening a line is a
+ * plain `line.slice(0, maxChars)`: the diff marker char (`+`/`-`/space/`\`/`@`)
+ * is index 0, so it's preserved, and NO marker/ellipsis text is appended — a
+ * diff viewer must not display characters that aren't in the file (the footer
+ * strip signals the shortening instead). Line COUNT is unchanged, so `@@` hunk
+ * headers stay valid and line numbers stay true. Fast-path: when no line
+ * exceeds the cap, return the ORIGINAL string with `shortened: 0` (no split, no
+ * allocation) — the common case.
+ */
+export function shortenLongLines(
+  text: string,
+  maxChars: number,
+): { text: string; shortened: number } {
+  if (longestLineLength(text) <= maxChars) return { text, shortened: 0 };
+  let shortened = 0;
+  const lines = text.split("\n").map((line) => {
+    if (line.length <= maxChars) return line;
+    shortened++;
+    // Surrogate-pair safety: if the last kept char is a high surrogate
+    // (0xD800–0xDBFF), cut one char earlier so an astral char / emoji is never
+    // split into a lone surrogate (repo bug class — PR #100).
+    const code = line.charCodeAt(maxChars - 1);
+    const cut = code >= 0xd800 && code <= 0xdbff ? maxChars - 1 : maxChars;
+    return line.slice(0, cut);
+  });
+  return { text: lines.join("\n"), shortened };
+}
+
 interface CappedDiff {
   /** The (possibly shortened) unified-diff text to render. */
   text: string;

--- a/src/features/diff/cap-diff.ts
+++ b/src/features/diff/cap-diff.ts
@@ -46,17 +46,22 @@ export function shortenLongLines(
   maxChars: number,
 ): { text: string; shortened: number } {
   if (longestLineLength(text) <= maxChars) return { text, shortened: 0 };
+  // Past the fast-path we know at least one line overflows. Split once and
+  // shorten in place — mutate only the overflowing entries — rather than
+  // building a second array with `.map`.
+  const lines = text.split("\n");
   let shortened = 0;
-  const lines = text.split("\n").map((line) => {
-    if (line.length <= maxChars) return line;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.length <= maxChars) continue;
     shortened++;
     // Surrogate-pair safety: if the last kept char is a high surrogate
     // (0xD800–0xDBFF), cut one char earlier so an astral char / emoji is never
     // split into a lone surrogate (repo bug class — PR #100).
     const code = line.charCodeAt(maxChars - 1);
     const cut = code >= 0xd800 && code <= 0xdbff ? maxChars - 1 : maxChars;
-    return line.slice(0, cut);
-  });
+    lines[i] = line.slice(0, cut);
+  }
   return { text: lines.join("\n"), shortened };
 }
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -270,6 +270,9 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 - **Image diffs** render side by side.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
   never freezes the view.
+- Files that look **generated or minified** (one enormous line — bundles, source maps,
+  \`.tsbuildinfo\`) show a placeholder instead of freezing the view — **Show diff anyway**
+  renders a safely shortened version.
 
 ## Committing
 


### PR DESCRIPTION
Opening the diff of a generated or minified file — a `tsconfig.tsbuildinfo`, a minified bundle, or a source map that is one enormous single line — could freeze the app, because the un-virtualized diff renderer mounts the longest line synchronously on the main thread. This change detects such files and shows a placeholder with an opt-in instead, and hard-shortens over-long lines everywhere a diff renders so no diff can ever freeze the view.

### Diff-shortening utilities

- Adds `longestLineLength` to `src/features/diff/cap-diff.ts`, an allocation-free scan (no `split`) that finds the longest line's length without building a whole-string array for a single-line blob.
- Adds `shortenLongLines` to the same file: a `line.slice(0, maxChars)` per over-long line that preserves the diff marker char at index 0, appends no marker/ellipsis text, keeps line count and `@@` headers valid, and guards against splitting a surrogate pair. It fast-paths to the original string reference with `shortened: 0` when nothing exceeds the cap.
- Adds the `DIFF_MAX_LINE_CHARS` (4,000) per-line display cap and `DIFF_MEGA_LINE_CHARS` (20,000) generated/minified threshold constants.

### Read-only diff surface

- In `src/features/diff/DiffSurface.tsx`, derives `longestLine`/`isMegaLine`/`blocked` from the deferred text; a blocked mega file renders a `DiffPlaceholder` ("Looks like a generated or minified file") with a **Show diff anyway** button gated by new `showAnyway` state.
- Resets `showAnyway` on the deferred path (not the urgent `filePath`) so the outgoing file keeps its opted-in render through the transition instead of flashing the placeholder.
- Skips content mode and grammar fetching for blocked files and for any diff whose longest line exceeds the shorten cap, and hard-shortens over-long lines on whatever is about to render (including under **Show full diff**).
- Extends the footer strip to report shortened-line counts alongside the existing hidden-line count.

### Staging diff surface

- In `src/features/diff/DiffViewer.tsx`, routes generated/minified files (longest line past `DIFF_MEGA_LINE_CHARS`) down the whole-file `DiffSurface` fallback by returning `null` from `WorkingTreeDiff`'s `parsed` memo.
- In `StagingDiffView`, builds `createDiffFile` from a display-only shortened `displayText` (preserving line count/numbers so drag-select and every stage/unstage/discard patch still work off the original text), skips content mode once any line exceeds the cap, and adds a footer strip reporting shortened lines.

### Docs

- Adds `changelog.d/fixed-diff-generated-minified-freeze.md` describing the fix.
- Documents the generated/minified placeholder and **Show diff anyway** behavior in the diff section of `src/features/help/content.ts`.