### PR TITLE
fix(notifications,activity): explain and re-run failed AI reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,9 @@ clearable history that survives a restart — so a review that finishes while yo
 never a missed click. Open it from the command palette; which events show follows your
 notification settings. A cancelled or failed **automated** review also lingers in a
 **Stopped** group with one-click **Re-run** (re-firing exactly that run's mode) and
-**Dismiss**, so a stopped automation isn't a dead end.
+**Dismiss**, so a stopped automation isn't a dead end. The *review failed* notification
+row itself also states why the run failed, and for automated runs carries the same
+one-click **Re-run** right on the row.
 
 **Environment check** — a Settings → **About** panel reports your app/OS/Tauri
 versions and the status of every CLI GitDesktop uses (git, the GitHub & GitLab

--- a/changelog.d/fixed-review-failed-notification-dead-end.md
+++ b/changelog.d/fixed-review-failed-notification-dead-end.md
@@ -1,0 +1,3 @@
+- A failed AI review notification is no longer a dead end: the **Activity &
+  notifications** inbox row now says why the run failed, and an automated
+  failure offers a one-click **Re-run** right from the row.

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -479,7 +479,10 @@ function NotificationRow({
             {n.title}
           </span>
           {n.subtitle && (
-            <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+            <span
+              className="mt-0.5 block truncate text-[11px] text-muted-foreground"
+              title={n.subtitle}
+            >
               {n.subtitle}
             </span>
           )}
@@ -519,6 +522,24 @@ function NotificationRow({
           {formatRelativeTime(new Date(n.ts).toISOString())}
         </span>
       </button>
+      {n.action && (
+        <Button
+          variant="ghost"
+          size="xs"
+          className="my-1.5 shrink-0 self-start"
+          // Self-contained: a row is ambiguous by its action label alone.
+          aria-label={`${n.action.label} — ${n.title}`}
+          onClick={() => {
+            // Mark read (it's now acted on) then fire — but keep the popover open
+            // and the row in place: the fresh run registers an "In progress" row in
+            // this same panel (that's the feedback), and the notification is history.
+            markNotificationRead(n.id);
+            n.action?.run();
+          }}
+        >
+          {n.action.label}
+        </Button>
+      )}
       <Button
         variant="ghost"
         size="icon-xs"

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1670,7 +1670,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
   **Dismiss** — a stopped row notes how long it ran before it stopped — and a failed
   automated run also lands a *review failed* row in the inbox (gated on the automations
-  notification preference), matching manual-run failures.{{/ai}}
+  notification preference) that shows why it failed and offers a one-click **Re-run** right
+  from the row, matching manual-run failures (which show their reason too).{{/ai}}
 - **Keyboard** — rebind any shortcut, with live key-capture.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -444,14 +444,22 @@ async function run(
       // too, gated on the same automations pref. Commit events have no PR target;
       // PR events carry a navigable one.
       if (notify) {
+        // Carry the failure reason into the durable subtitle so the inbox row
+        // (and the OS ping) say WHY — subject-only when the reason is empty.
+        const subject =
+          event.kind === "commit"
+            ? `"${event.hash.slice(0, 7)}"`
+            : `"${event.title}"`;
+        const subtitle = message.trim() ? `${subject} — ${message}` : subject;
+        // Local alias for the loop's `action: ReviewMode` — the Re-run closure's
+        // `run` body sees the outer `action` fine, but aliasing keeps the object
+        // literal (which also has a field named `action`) unambiguous to read.
+        const mode = action;
         pushNotification({
           kind: "review-failed",
           tone: "danger",
           title: `AI ${label} failed`,
-          subtitle:
-            event.kind === "commit"
-              ? `"${event.hash.slice(0, 7)}"`
-              : `"${event.title}"`,
+          subtitle,
           repoPath: event.repoPath,
           repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
           ...(event.kind === "commit"
@@ -463,11 +471,18 @@ async function run(
                   ref: targetRef(event),
                 },
               }),
+          // Re-fires exactly this event + mode. `selfKey` is this run's stopped
+          // dock row (already assigned); passing it when the row was dismissed is
+          // safe — resetReview no-ops on a gone key.
+          action: {
+            label: "Re-run",
+            run: () => rerunAutomation(event, mode, selfKey),
+          },
           dedupeKey: `automation-failed:${event.repoPath}:${event.kind}:${
             event.kind === "commit" ? event.hash : targetRef(event)
           }:${action}`,
         });
-        void notifyIfUnfocused(`AI ${label} failed`, `"${event.title}"`);
+        void notifyIfUnfocused(`AI ${label} failed`, subtitle);
       }
       // Persist a "Failed" stopped row (keeping its Re-run) instead of removing it.
       handle.fail(message);

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -102,8 +102,10 @@ function isValidNotification(x: unknown): x is AppNotification {
     typeof n.read === "boolean" &&
     typeof n.repoPath === "string" &&
     typeof n.repoName === "string" &&
-    // Optional author fields: absent entries stay valid (old files keep loading);
-    // present ones must be strings.
+    // Optional string fields: absent entries stay valid (old files keep
+    // loading); present ones must be strings. `subtitle` renders as a React
+    // child, so a non-string here would crash the row.
+    (n.subtitle === undefined || typeof n.subtitle === "string") &&
     (n.authorLogin === undefined || typeof n.authorLogin === "string") &&
     (n.authorAvatarUrl === undefined ||
       typeof n.authorAvatarUrl === "string") &&

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -47,6 +47,10 @@ export interface AppNotification {
    *  non-GitHub providers, where a login isn't avatar-derivable. */
   authorGhHost?: string;
   target?: NotificationTarget;
+  /** Inline action rendered on the row (e.g. Re-run). MEMORY-ONLY: never
+   *  persisted — stripped before every disk write and on hydrate — so a
+   *  restart degrades the row to navigate-only rather than a dead button. */
+  action?: { label: string; run: () => void };
   /** Collapses accidental double-fires of the same transition (a re-render or a
    *  poll seam) within a short window — NOT persisted-across-restart dedup. */
   dedupeKey?: string;
@@ -110,7 +114,13 @@ function isValidNotification(x: unknown): x is AppNotification {
 async function persist(items: AppNotification[]): Promise<void> {
   try {
     const store = await getStore();
-    await store.set(STORE_KEY, items);
+    // Strip the in-memory `action` closure before it ever hits disk: JSON would
+    // silently drop the function but keep the object (and its `label`), leaving a
+    // dead button on reload. Memory-only by contract.
+    await store.set(
+      STORE_KEY,
+      items.map(({ action: _action, ...rest }) => rest),
+    );
   } catch {
     // best-effort — a failed persist must never break the work that fired it
   }
@@ -167,8 +177,14 @@ void (async () => {
     const raw = (await store.get<unknown[]>(STORE_KEY)) ?? [];
     const clean = (Array.isArray(raw) ? raw.filter(isValidNotification) : [])
       // Coerce an out-of-enum tone (hand-edited / older file) to neutral so the
-      // glyph is never left uncolored.
-      .map((n) => (TONES.has(n.tone) ? n : { ...n, tone: "neutral" as const }))
+      // glyph is never left uncolored, AND drop any `action` key: it's memory-only,
+      // so a hand-edited disk value must render as navigate-only, never a button.
+      .map((n) => {
+        const { action: _action, ...rest } = n;
+        return TONES.has(rest.tone)
+          ? rest
+          : { ...rest, tone: "neutral" as const };
+      })
       .slice(0, CAP);
     useNotifStore.getState().hydrate(clean);
   } catch {
@@ -197,6 +213,8 @@ export function pushNotification(input: {
   authorAvatarUrl?: string;
   authorGhHost?: string;
   target?: NotificationTarget;
+  /** Optional inline action for the row (memory-only; see {@link AppNotification.action}). */
+  action?: { label: string; run: () => void };
   dedupeKey?: string;
 }): void {
   const now = Date.now();
@@ -223,6 +241,7 @@ export function pushNotification(input: {
     authorAvatarUrl: input.authorAvatarUrl,
     authorGhHost: input.authorGhHost,
     target: input.target,
+    action: input.action,
     dedupeKey: input.dedupeKey,
   });
 }

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -297,25 +297,34 @@ async function notifyReviewDone(
   mode: ReviewMode,
   ok: boolean,
   target: ReviewTarget,
+  /** Failure reason (from `errorMessage`), carried into the failed row's
+   *  subtitle so the durable inbox record says WHY. Ignored on success. No
+   *  Re-run action here (unlike the automation path): a manual re-fire closure
+   *  would capture a stale AiSettings snapshot, whereas the panel's Run button
+   *  re-resolves fresh config. */
+  error?: string,
 ): Promise<void> {
   try {
     const { notifications } = await loadSettings();
     if (!notifications.reviews) return;
     const label = mode === "security" ? "security audit" : "review";
     const headline = ok ? `AI ${label} ready` : `AI ${label} failed`;
+    // A failed review carries its reason in the subtitle; success stays subject-only.
+    const subtitle =
+      !ok && error?.trim() ? `"${title}" — ${error}` : `"${title}"`;
     // Durable record in the inbox (regardless of focus), plus the OS ping when
     // the window is hidden. Both ride the same `reviews` pref.
     pushNotification({
       kind: ok ? "review-ready" : "review-failed",
       tone: ok ? "success" : "danger",
       title: headline,
-      subtitle: `"${title}"`,
+      subtitle,
       repoPath: target.repoPath,
       repoName: target.repoName,
       target: { type: "pr", kind: target.kind, ref: target.ref },
       dedupeKey: `review:${target.kind}:${target.repoPath}:${target.ref}:${ok}`,
     });
-    void notifyIfUnfocused(headline, `"${title}"`);
+    void notifyIfUnfocused(headline, subtitle);
   } catch {
     // best-effort — a missed notification must never affect the review
   }
@@ -590,15 +599,18 @@ export async function startReview(
     }
   } catch (e) {
     if (!control.cancelled) {
+      // CLI failures reject with a plain AppError object (not an Error), so
+      // `String(e)` would print "[object Object]" — use the shared extractor.
+      // Computed once: the store patch AND the inbox notification's subtitle both
+      // read the same reason.
+      const message = errorMessage(e);
       patch({
         phase: "error",
         status: "",
-        // CLI failures reject with a plain AppError object (not an Error), so
-        // `String(e)` would print "[object Object]" — use the shared extractor.
-        error: errorMessage(e),
+        error: message,
         endedAt: Date.now(),
       });
-      void notifyReviewDone(title, mode, false, target);
+      void notifyReviewDone(title, mode, false, target, message);
     }
   } finally {
     // Release the lane slot for the next queued run (only if this run actually


### PR DESCRIPTION
A failed AI review notification used to be a dead end — it named the run but not why it failed, and gave no way to retry. This change makes the **Activity & notifications** inbox row carry the failure reason and, for automated runs, offer a one-click **Re-run** directly from the row.

### Notification data model
- Adds an optional, memory-only `action: { label; run }` field to `AppNotification` in `src/lib/stores/notifications.ts`, threaded through `pushNotification`.
- Strips the `action` closure before every disk write in `persist` and again on hydrate, so a JSON round-trip can't leave a dead button — a restart degrades the row to navigate-only. Comments document the memory-only contract.

### Activity dock row
- Renders an inline **Re-run** `Button` in `NotificationRow` (`src/features/activity/ActivityDock.tsx`) when `n.action` is present; its handler marks the notification read, fires `n.action.run()`, and keeps the popover open so the fresh "In progress" row provides feedback.
- Gives the button a self-contained `aria-label` (`${label} — ${title}`) and adds a `title` tooltip on the subtitle span so truncated reasons remain readable.

### Failure reasons and re-run wiring
- In `src/lib/automations/runner.ts`, builds a subtitle that appends the failure `message` to the subject and attaches a **Re-run** action that re-fires the exact event + mode via `rerunAutomation(event, mode, selfKey)`; the OS ping now shows the same subtitle.
- In `src/lib/stores/reviews.ts`, `notifyReviewDone` takes an `error` argument and folds it into the failed row's subtitle (success stays subject-only); `startReview` computes `errorMessage(e)` once and reuses it for both the store patch and the notification (no Re-run action here, since a manual re-fire closure would capture a stale `AiSettings` snapshot).

### Documentation
- Updates the automations section in `src/features/help/content.ts` to note that a failed row shows why it failed and offers a one-click **Re-run**.
- Adds `changelog.d/fixed-review-failed-notification-dead-end.md` describing the fix for humans.