### PR TITLE
fix(repository,settings): keep fork badge on first open, label API key

### DIFF
--- a/changelog.d/fixed-api-key-field-label.md
+++ b/changelog.d/fixed-api-key-field-label.md
@@ -1,0 +1,2 @@
+- The Settings **API key** field is now properly associated with its label, so
+  screen readers announce the input and clicking the label text focuses it.

--- a/changelog.d/fixed-fork-badge-fresh-clone.md
+++ b/changelog.d/fixed-fork-badge-fresh-clone.md
@@ -1,0 +1,4 @@
+- The fork badge, provider label, and **Leave fork network** row now appear on
+  the first open after cloning a fork. Previously they could take a second open
+  (or a visit to the repo list) to show up, and a repo's stored forge metadata
+  briefly reset on every open.

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -40,6 +40,7 @@ export function TextField({
   disabled,
   className,
   warning,
+  id,
 }: {
   label?: ReactNode;
   placeholder?: string;
@@ -48,14 +49,18 @@ export function TextField({
   disabled?: boolean;
   className?: string;
   warning?: (value: string) => string | null;
+  /** Override the auto-generated input id — for call sites that render their
+   *  own label outside the field and need to target the input via `htmlFor`. */
+  id?: string;
 }) {
   const field = useFieldContext<string>();
-  const id = useId();
+  const autoId = useId();
+  const inputId = id ?? autoId;
   return (
     <div className="space-y-2">
-      {label && <Label htmlFor={id}>{label}</Label>}
+      {label && <Label htmlFor={inputId}>{label}</Label>}
       <Input
-        id={id}
+        id={inputId}
         type={type}
         placeholder={placeholder}
         autoFocus={autoFocus}

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -22,7 +22,12 @@ export function useOpenRepoByPath() {
     async (path: string, source: "recent" | "picker" = "recent") => {
       try {
         const info = await validateRepo(path);
-        addRecent.mutate({ path: info.root, name: info.name });
+        // Await the recents write so the row exists before RepositoryView mounts
+        // and its open-time visibility probe persists onto it (best-effort — a
+        // settings-write failure must never block opening the repo).
+        await addRecent
+          .mutateAsync({ path: info.root, name: info.name })
+          .catch(() => undefined);
         openRepo(info);
         track({ name: "repo_opened", properties: { source } });
       } catch (e) {

--- a/src/features/repository/useRepoVisibilityProbe.ts
+++ b/src/features/repository/useRepoVisibilityProbe.ts
@@ -36,9 +36,9 @@ export async function probeAndPersistVisibility(
     // No resolvable provider (remote removed/absent): persistRepoOwners with a
     // null provider clears owner/host/provider AND, because visibility/isFork/
     // forkParent can't outlive the provider, those three too — all six derived
-    // fields cleared in one write. (owner is undefined here only when the repo
-    // has no recentRepos row yet; pass a null-filled entry so the clear still
-    // targets this path.)
+    // fields cleared in one write. (owner is undefined when gitRepoOwners
+    // returns no entry for this path — e.g. no remote at all; the null-filled
+    // entry still targets this path so the clear lands.)
     await persistRepoOwners([
       {
         path: repoPath,
@@ -49,11 +49,15 @@ export async function probeAndPersistVisibility(
     ]);
     return null;
   }
-  // Persist owners FIRST (owner has a non-null provider, so persistRepoVisibility
-  // fields it preserves are left intact), then the visibility/fork result —
-  // deterministic order under the serialized write chain.
-  await persistRepoOwners([owner]);
-  const probe = await forgeRepoVisibility(repoPath);
+  // The owners write and the visibility probe are independent once gitRepoOwners
+  // resolved, so run them in parallel; the Promise.all barrier still guarantees
+  // the owners write completes before the visibility/fork persist below, and
+  // persistRepoOwners (non-null provider) preserves the visibility fields it
+  // doesn't own — so the ordering that matters is kept.
+  const [, probe] = await Promise.all([
+    persistRepoOwners([owner]),
+    forgeRepoVisibility(repoPath),
+  ]);
   await persistRepoVisibility([
     {
       path: repoPath,

--- a/src/features/repository/useRepoVisibilityProbe.ts
+++ b/src/features/repository/useRepoVisibilityProbe.ts
@@ -5,17 +5,24 @@ import {
   gitRepoOwners,
   type RepoVisibility,
 } from "@/lib/git/api";
-import { persistRepoVisibility } from "@/lib/settings/api";
+import { persistRepoOwners, persistRepoVisibility } from "@/lib/settings/api";
 import { settingsKeys } from "@/lib/settings/queries";
 
 /**
  * Probe a repo's hosted visibility + fork provenance and persist the result,
  * returning the fresh probe (or `null` when the repo has no known provider — a
- * removed/absent remote, which persists `{ visibility: null }` so a stale badge
+ * removed/absent remote, which clears every derived field so a stale badge
  * clears). Shared by the ambient open-time probe below and the Danger zone's
  * "Re-check fork status" affordance, so the fork badge + persisted `isFork`
  * converge without an app restart after the user leaves the fork network on
  * GitHub. Persistence is serialized against the other recentRepos writers.
+ *
+ * The owner/host/provider from `gitRepoOwners` are ALSO persisted here (not just
+ * visibility/fork) — that's what makes a fresh clone's provider label, host, and
+ * fork badge land on the FIRST open, without waiting for a RepoList render to
+ * backfill them. The Danger-zone "Re-check fork status" therefore also refreshes
+ * owners now, which is desired: after the user re-points origin then re-checks,
+ * the provider label heals in the same action.
  *
  * A rejection propagates to the caller (the ambient probe swallows it; the
  * Danger-zone re-check surfaces it as a toast). Does NOT invalidate the settings
@@ -26,9 +33,26 @@ export async function probeAndPersistVisibility(
 ): Promise<RepoVisibility | null> {
   const [owner] = await gitRepoOwners([repoPath]);
   if (!owner?.provider) {
-    await persistRepoVisibility([{ path: repoPath, visibility: null }]);
+    // No resolvable provider (remote removed/absent): persistRepoOwners with a
+    // null provider clears owner/host/provider AND, because visibility/isFork/
+    // forkParent can't outlive the provider, those three too — all six derived
+    // fields cleared in one write. (owner is undefined here only when the repo
+    // has no recentRepos row yet; pass a null-filled entry so the clear still
+    // targets this path.)
+    await persistRepoOwners([
+      {
+        path: repoPath,
+        owner: owner?.owner ?? null,
+        host: owner?.host ?? null,
+        provider: null,
+      },
+    ]);
     return null;
   }
+  // Persist owners FIRST (owner has a non-null provider, so persistRepoVisibility
+  // fields it preserves are left intact), then the visibility/fork result —
+  // deterministic order under the serialized write chain.
+  await persistRepoOwners([owner]);
   const probe = await forgeRepoVisibility(repoPath);
   await persistRepoVisibility([
     {
@@ -46,12 +70,17 @@ export async function probeAndPersistVisibility(
  * app-relaunch restore), fire-and-forget refreshes the repo's stored
  * visibility badge:
  *
- * - Resolve the provider via `gitRepoOwners` (a cheap local read). When it's
- *   null (no remote, or the remote was removed), persist `{ visibility: null }`
- *   so a stale badge clears.
+ * - Resolve the provider via `gitRepoOwners` (a cheap local read) and persist
+ *   the owner/host/provider onto the record. When it's null (no remote, or the
+ *   remote was removed), that clears all six derived fields so a stale badge
+ *   clears.
  * - When the provider is known, probe `forgeRepoVisibility` and persist the
- *   result. A rejection (signed out, API failure) persists nothing — the prior
- *   value is left alone.
+ *   result. A rejection (signed out, API failure) persists nothing beyond the
+ *   owners already stored — the prior visibility/fork value is left alone.
+ *
+ * Because the owner/host/provider land here, a freshly cloned repo shows its
+ * provider label and fork badge on the FIRST open, not the second — this probe
+ * runs even when the repo list never rendered to backfill them.
  *
  * Never blocks or delays repo open, and swallows every error silently: this is
  * ambient metadata, not a user-facing action (no toasts).

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -757,7 +757,7 @@ export const AiProviderSection = withForm({
             }}
           >
             <div className="space-y-2">
-              <Label>
+              <Label htmlFor="ai-api-key">
                 API key{" "}
                 <span className="font-normal text-muted-foreground">
                   {keyPreview.data
@@ -773,6 +773,7 @@ export const AiProviderSection = withForm({
                   >
                     {(field) => (
                       <field.TextField
+                        id="ai-api-key"
                         type="password"
                         placeholder={
                           keyPreview.data

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -104,7 +104,12 @@ export function CloneRepoDialog({
             ? await cloneRepo(cloneUrl, dest)
             : await forgeClone(provider, cloneUrl, dest, selected?.name);
         const info = await validateRepo(clonedPath);
-        addRecent.mutate({ path: info.root, name: info.name });
+        // Await the recents write so the row exists before RepositoryView mounts
+        // and its open-time visibility probe persists onto it (best-effort — a
+        // settings-write failure must never block opening the repo).
+        await addRecent
+          .mutateAsync({ path: info.root, name: info.name })
+          .catch(() => undefined);
         onOpenChange(false);
         openRepo(info);
       } catch (e) {

--- a/src/features/welcome/CreateRepoDialog.tsx
+++ b/src/features/welcome/CreateRepoDialog.tsx
@@ -62,7 +62,12 @@ export function CreateRepoDialog({
           defaultBranch,
         });
         const info = await validateRepo(root);
-        addRecent.mutate({ path: info.root, name: info.name });
+        // Await the recents write so the row exists before RepositoryView mounts
+        // and its open-time visibility probe persists onto it (best-effort — a
+        // settings-write failure must never block opening the repo).
+        await addRecent
+          .mutateAsync({ path: info.root, name: info.name })
+          .catch(() => undefined);
         onOpenChange(false);
         openRepo(info);
         toast.success(`Created ${info.name}`);

--- a/src/features/welcome/useRepoDrop.ts
+++ b/src/features/welcome/useRepoDrop.ts
@@ -22,7 +22,12 @@ export function useRepoDrop() {
       if (!path) return;
       try {
         const info = await validateRepo(path);
-        addRecentRef.current.mutate({ path: info.root, name: info.name });
+        // Await the recents write so the row exists before RepositoryView mounts
+        // and its open-time visibility probe persists onto it (best-effort — a
+        // settings-write failure must never block opening the repo).
+        await addRecentRef.current
+          .mutateAsync({ path: info.root, name: info.name })
+          .catch(() => undefined);
         useUiStore.getState().openRepo(info);
       } catch (e) {
         // Not a git repo (or a file, not a folder) — surface why.

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -445,14 +445,23 @@ export function addRecentRepo(repo: {
     // Windows paths are case-insensitive; compare them that way to dedupe
     const samePath = (a: string, b: string) =>
       a.toLowerCase() === b.toLowerCase();
-    // Reopening a repo must not wipe the alias on its previous entry.
+    // Reopening a repo must PRESERVE everything backfilled onto its previous
+    // entry — not just the alias, but the derived forge metadata (owner/host/
+    // provider/visibility/isFork/forkParent). Rebuilding the moved-to-front
+    // record as `{...repo, ...}` wiped those every open, so a fresh clone lost
+    // its fork badge / provider label until the repo list next rendered and
+    // re-backfilled. Spreading `previous` first, then `repo`, keeps the derived
+    // fields while letting the fresh `path`/`name` win (Windows case refresh); a
+    // brand-new repo (no `previous`) starts with just its own fields, unchanged.
+    // Any staleness self-corrects: the open-time visibility probe re-persists
+    // owner + visibility on every open (see probeAndPersistVisibility).
     const previous = settings.recentRepos.find((r) =>
       samePath(r.path, repo.path),
     );
     const recentRepos = [
       {
+        ...previous,
         ...repo,
-        alias: previous?.alias,
         lastOpenedAt: new Date().toISOString(),
       },
       ...settings.recentRepos.filter((r) => !samePath(r.path, repo.path)),


### PR DESCRIPTION
Fixes two unrelated regressions: a freshly cloned fork now shows its fork badge, provider label, and **Leave fork network** row on the *first* open (previously they could take a second open, and a repo's stored forge metadata briefly reset on every open), and the Settings **API key** input is now properly associated with its label for screen readers and click-to-focus.

### Fork metadata persistence

- Reworks `addRecentRepo` in `src/lib/settings/api.ts` to spread `previous` before `repo` when moving a record to the front, preserving all backfilled forge metadata (owner/host/provider/visibility/isFork/forkParent) instead of only the alias — the old `{...repo, alias}` rebuild wiped those on every open.
- Expands `probeAndPersistVisibility` in `src/features/repository/useRepoVisibilityProbe.ts` to also persist owner/host/provider via `persistRepoOwners`, so a fresh clone's provider label, host, and fork badge land on first open without waiting for a repo-list render to backfill them. The no-provider path now clears all six derived fields in one write, and the Danger-zone "Re-check fork status" refreshes owners too.
- Switches the open-time recents write from `mutate` to `await …mutateAsync(...).catch(() => undefined)` in `useOpenRepoByPath.ts`, `CloneRepoDialog.tsx`, `CreateRepoDialog.tsx`, and `useRepoDrop.ts`, so the recents row exists before `RepositoryView` mounts and its visibility probe can persist onto it — while a settings-write failure still never blocks opening the repo.

### API key label association

- Adds an optional `id` prop to `TextField` in `src/components/form/fields.tsx`, letting call sites that render their own label target the input via `htmlFor` while keeping the auto-generated id as the default.
- Wires `htmlFor="ai-api-key"` on the label and `id="ai-api-key"` on the field in `src/features/settings/AiProviderSection.tsx`.

### Changelog

- Adds `changelog.d/fixed-fork-badge-fresh-clone.md` and `changelog.d/fixed-api-key-field-label.md`.