### PR TITLE
feat(terminal,automation): add custom terminal command and reclaim stale review claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,8 +537,9 @@ enable it**, and each task can **confirm before it runs**.
 reviewed PR) that runs AI review or security audit automatically, with per-action
 branch conditions, Save/Discard drafts, global defaults, and per-repo overrides.
 
-**Integrations** — open in any editor or terminal (auto-detected, or point at any
-executable), and tunable OS notifications for PR activity, checks, and CI runs.
+**Integrations** — open in any editor or terminal (auto-detected, point at any
+executable, or set a full custom command with a `{path}` placeholder), and tunable
+OS notifications for PR activity, checks, and CI runs.
 
 **Activity & notifications** — a persistent bell in the header that collects terminal
 events (a finished review, checks passing/failing, a PR approved/commented/merged, a

--- a/changelog.d/added-custom-terminal-command.md
+++ b/changelog.d/added-custom-terminal-command.md
@@ -1,0 +1,5 @@
+- Terminal settings gained a **Custom command…** mode — give a full command with a
+  `{path}` placeholder (for example `wt -d {path}` or `tmux new-window -c {path}`) for
+  multiplexers, wrappers, or any terminal the auto-detection doesn't know. The command
+  runs shell-free, and macOS "Custom…" now also launches plain (non-`.app`) executables
+  correctly.

--- a/changelog.d/fixed-automation-claim-starvation.md
+++ b/changelog.d/fixed-automation-claim-starvation.md
@@ -1,0 +1,5 @@
+- An automation review claim left behind by a crashed or outdated app instance no
+  longer blocks that pull request's review for other instances — a stale claim is
+  reclaimed after 30 minutes instead of waiting for the 30-day sweep. The
+  missed-review catch-up now works per review mode, so a failed general review is
+  retried even when the security audit already ran.

--- a/src-tauri/src/automation_claims.rs
+++ b/src-tauri/src/automation_claims.rs
@@ -47,6 +47,23 @@ use crate::error::{AppError, AppResult};
 /// run and longer than any head stays "current", so a sweep never races a live claim.
 const SWEEP_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
+/// A claim file this old with no accompanying release is treated as abandoned and
+/// reclaimed by the next claimant (the sweep only fires at 30 days). This closes the
+/// starvation bug where an instance that dies WITHOUT running its release arm (crash,
+/// kill, a version-skewed old build) leaves a claim that suppresses this exact
+/// `(repo, target, sha, action)` review across ALL instances until the 30-day sweep.
+///
+/// 30 minutes is safe because a DELIVERED review no longer relies on its claim for
+/// dedup: at delivery the runner writes a pr-reviews history record, and that record —
+/// not the claim — gates pr-open (per-mode) and pr-sync (same-sha skip). Reclaiming an
+/// old delivered claim therefore cannot cause a re-review. The residual risk is a
+/// legitimately still-RUNNING review that outlasts 30 minutes being double-claimed by a
+/// concurrently polling second instance — accepted, bounded to a single duplicate
+/// review, and strictly better than a 30-day starvation. A run whose delivery-record
+/// write failed (best-effort in the runner) is the same bounded case: one duplicate
+/// after 30 minutes, not a month of silence.
+const STALE_CLAIM_AGE: Duration = Duration::from_secs(30 * 60);
+
 /// The app-data subdir holding claim files.
 const CLAIMS_DIR: &str = "automation-claims";
 
@@ -120,20 +137,17 @@ fn sweep_older_than(dir: &Path, cutoff: SystemTime) {
     }
 }
 
-/// Atomically claim `key` inside `dir`. Returns `Ok(true)` when THIS caller won the
-/// claim (the file did not exist and we created it), `Ok(false)` when another
-/// instance already owns it. `create_new` is the atomic exclusive-create: exactly one
-/// of two racing callers gets `Ok(File)`, the other gets `AlreadyExists`. The plain
-/// composite key is written as the file's content for debuggability; the mtime
-/// supplies the claim timestamp. This helper takes a `&Path` so it's unit-testable
-/// without an `AppHandle`.
-fn claim_in_dir(dir: &Path, key: &str) -> std::io::Result<bool> {
+/// Atomically create the claim file for `key` at `path`. `Ok(true)` = created by us,
+/// `Ok(false)` = it already existed. `create_new` is the atomic exclusive-create:
+/// exactly one of two racing callers gets `Ok(File)`, the other gets `AlreadyExists`.
+/// The plain composite key is written as the file's content for debuggability; the
+/// mtime supplies the claim timestamp.
+fn create_new_claim(path: &Path, key: &str) -> std::io::Result<bool> {
     use std::io::Write as _;
-    let path = dir.join(claim_filename(key));
     match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(&path)
+        .open(path)
     {
         Ok(mut file) => {
             // Best-effort content write; even if it fails the claim is already ours
@@ -144,6 +158,43 @@ fn claim_in_dir(dir: &Path, key: &str) -> std::io::Result<bool> {
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
         Err(e) => Err(e),
     }
+}
+
+/// Claim `key` inside `dir`. Returns `Ok(true)` when THIS caller won the claim (the
+/// file did not exist and we created it, OR we reclaimed a stale one), `Ok(false)` when
+/// another instance already owns a FRESH claim. This helper takes a `&Path` so it's
+/// unit-testable without an `AppHandle`.
+///
+/// Stale-claim reclaim: if the exclusive-create loses to an existing file, we stat that
+/// file — if its mtime is older than [`STALE_CLAIM_AGE`], the owning instance is assumed
+/// dead (it never ran its release arm), so we best-effort delete the file and retry the
+/// exclusive-create EXACTLY ONCE. A second `AlreadyExists` means a concurrent instance
+/// won the reclaim race, so we yield to it with `Ok(false)` rather than looping. A fresh
+/// (< `STALE_CLAIM_AGE`) existing claim keeps returning `Ok(false)` unchanged.
+fn claim_in_dir(dir: &Path, key: &str) -> std::io::Result<bool> {
+    let path = dir.join(claim_filename(key));
+    if create_new_claim(&path, key)? {
+        return Ok(true);
+    }
+    // The file already exists. Reclaim it only when it is older than STALE_CLAIM_AGE —
+    // a still-fresh claim is a live run and must keep excluding us.
+    let stale = match path.metadata().and_then(|m| m.modified()) {
+        Ok(modified) => SystemTime::now()
+            .duration_since(modified)
+            .map(|age| age >= STALE_CLAIM_AGE)
+            // A future mtime (clock skew) yields Err — treat as not-stale, keep excluding.
+            .unwrap_or(false),
+        // Can't stat the mtime (raced away, permission) → don't reclaim; behave as before.
+        Err(_) => false,
+    };
+    if !stale {
+        return Ok(false);
+    }
+    // Best-effort delete of the abandoned claim, then retry the exclusive-create ONCE.
+    // A failed delete or a lost retry race both resolve to Ok(false): another instance
+    // owns the (possibly just-reclaimed) claim, so we skip this run rather than loop.
+    let _ = std::fs::remove_file(&path);
+    create_new_claim(&path, key)
 }
 
 /// Best-effort release of `key`'s claim inside `dir` (delete the file). Errors are
@@ -311,6 +362,78 @@ mod tests {
         assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
         assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
         assert_ne!(fnv1a_64(b"review"), fnv1a_64(b"security"));
+    }
+
+    /// Backdate a claim file's mtime so it looks abandoned. Mirrors the sweep test:
+    /// `set_modified` needs a writable handle on Windows.
+    fn backdate(path: &Path, age: Duration) {
+        let when = SystemTime::now() - age;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(when)
+            .unwrap();
+    }
+
+    #[test]
+    fn stale_claim_is_reclaimed_and_caller_wins() {
+        let (_tmp, dir) = tmp_dir();
+        let key = composite_key(r"C:\repo\one", "42", "abc123", "review");
+
+        // An instance takes the claim, then "dies" without releasing (its mtime ages
+        // past the stale cutoff).
+        assert!(claim_in_dir(&dir, &key).unwrap(), "first claim should win");
+        let path = dir.join(claim_filename(&key));
+        backdate(&path, STALE_CLAIM_AGE + Duration::from_secs(60));
+
+        // The next claimant reclaims the abandoned file instead of being starved.
+        assert!(
+            claim_in_dir(&dir, &key).unwrap(),
+            "a stale claim must be reclaimed by the next claimant"
+        );
+    }
+
+    #[test]
+    fn fresh_existing_claim_still_denies() {
+        let (_tmp, dir) = tmp_dir();
+        let key = composite_key(r"C:\repo\one", "42", "abc123", "review");
+
+        // A just-taken (fresh) claim keeps excluding a second claimant — reclaim must
+        // NOT fire before STALE_CLAIM_AGE.
+        assert!(claim_in_dir(&dir, &key).unwrap(), "first claim should win");
+        assert!(
+            !claim_in_dir(&dir, &key).unwrap(),
+            "a fresh existing claim must still deny the second claimant"
+        );
+    }
+
+    #[test]
+    fn stale_reclaim_rewrites_file_with_new_key() {
+        let (_tmp, dir) = tmp_dir();
+        // Two DISTINCT composite keys whose sanitized tails + hash collide onto the SAME
+        // filename cannot be relied on, so assert the reclaimed file holds the CURRENT
+        // key's content. Both claims key the same run, so the filename is identical and
+        // the reclaim overwrites the file body with a fresh (identical) key. To prove the
+        // content is the NEW write and not the stale one, we re-key the file content and
+        // confirm it matches after reclaim.
+        let key = composite_key(r"C:\repo\one", "42", "abc123", "review");
+        assert!(claim_in_dir(&dir, &key).unwrap());
+        let path = dir.join(claim_filename(&key));
+        // Corrupt the stale file's content so we can tell a reclaim (rewrite) from a
+        // no-op, then backdate it past the cutoff.
+        std::fs::write(&path, b"STALE-LEFTOVER-CONTENT").unwrap();
+        backdate(&path, STALE_CLAIM_AGE + Duration::from_secs(60));
+
+        assert!(
+            claim_in_dir(&dir, &key).unwrap(),
+            "stale claim should be reclaimed"
+        );
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content, key,
+            "a reclaimed claim file must hold the NEW composite key, not the stale content"
+        );
     }
 
     #[test]

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -212,13 +212,15 @@ pub async fn open_with_default(path: String) -> AppResult<()> {
 }
 
 /// Opens a terminal rooted at `path`. `terminal` is a known kind id (e.g.
-/// "powershell", "windows-terminal", "git-bash", "custom") and `program` its
-/// executable; both empty means pick a sensible default.
+/// "powershell", "windows-terminal", "git-bash", "custom", "custom-command")
+/// and `program` its executable; both empty means pick a sensible default.
+/// `command` carries the free-text argv template for the "custom-command" mode.
 #[tauri::command]
 pub async fn open_in_terminal(
     path: String,
     terminal: Option<String>,
     program: Option<String>,
+    command: Option<String>,
 ) -> AppResult<()> {
     if !Path::new(&path).is_dir() {
         return Err(AppError::InvalidArgument(format!(
@@ -227,6 +229,15 @@ pub async fn open_in_terminal(
     }
     let kind = terminal.unwrap_or_default();
     let program = program.unwrap_or_default();
+    // The custom-command mode is a free-text argv template, resolved and spawned
+    // with no shell (see `launch_custom_command`); it is platform-neutral, so it
+    // dispatches ahead of the per-OS kind matchers below.
+    if kind == "custom-command" {
+        let command = command.unwrap_or_default();
+        if !command.trim().is_empty() {
+            return launch_custom_command(&command, &path).await;
+        }
+    }
     #[cfg(windows)]
     {
         launch_terminal_windows(&kind, &program, &path)
@@ -235,6 +246,136 @@ pub async fn open_in_terminal(
     {
         launch_terminal_unix(&kind, &program, &path)
     }
+}
+
+/// Splits a command template into argv tokens: whitespace-separated, with
+/// double-quotes grouping a run that may contain spaces (the quotes are
+/// stripped). There are no escape sequences beyond quote grouping — a literal
+/// double-quote inside a path is not supported, which is fine for the launcher
+/// templates this powers. Returns `InvalidArgument` for an empty/whitespace-only
+/// template.
+fn tokenize_command(command: &str) -> AppResult<Vec<String>> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut has_token = false;
+    for ch in command.chars() {
+        match ch {
+            '"' => {
+                // A quote toggles grouping and always starts a token (so `""`
+                // yields an empty argument rather than nothing).
+                in_quotes = !in_quotes;
+                has_token = true;
+            }
+            c if c.is_whitespace() && !in_quotes => {
+                if has_token {
+                    tokens.push(std::mem::take(&mut current));
+                    has_token = false;
+                }
+            }
+            c => {
+                current.push(c);
+                has_token = true;
+            }
+        }
+    }
+    if has_token {
+        tokens.push(current);
+    }
+    if tokens.is_empty() {
+        return Err(AppError::InvalidArgument(
+            "empty terminal command".to_string(),
+        ));
+    }
+    Ok(tokens)
+}
+
+/// Substitutes every `{path}` occurrence within each token by `path`. This is a
+/// per-token substring replace (not a re-tokenize), so `--cwd={path}` expands in
+/// place and a repository path containing spaces, `;`, or `$()` stays a single
+/// argv token — it is never re-split and never reaches a shell.
+fn substitute_path(tokens: &[String], path: &str) -> Vec<String> {
+    tokens.iter().map(|t| t.replace("{path}", path)).collect()
+}
+
+/// True when `program` ends in a Windows batch extension (`.cmd`/`.bat`,
+/// case-insensitive). Rust ≥1.77 routes batch files through `cmd.exe` (the
+/// BatBadBut CVE mitigation), which silently re-introduces a shell and `%VAR%`
+/// expansion — exactly what the shell-free custom-command mode must avoid — so
+/// a resolved batch file is rejected rather than launched.
+fn is_batch_file(program: &str) -> bool {
+    let lower = program.to_ascii_lowercase();
+    lower.ends_with(".cmd") || lower.ends_with(".bat")
+}
+
+/// True when the first command token looks like an explicit path (contains a
+/// `/` or `\` separator) rather than a bare program name to look up. This
+/// selects `resolve_named`'s two behaviors: a path-like token is exists-checked
+/// as given (`Some(token)`), a bare name goes through the real PATH/PATHEXT
+/// (and, on Unix, login-shell) lookup (`None`).
+fn first_token_is_pathlike(token: &str) -> bool {
+    token.contains(['/', '\\'])
+}
+
+/// Launches a user-supplied command template with no shell: tokenize → expand
+/// `{path}` → resolve the first token to an absolute executable → spawn it with
+/// the remaining tokens, rooted at the repository directory. Every step here is
+/// deliberately shell-free so a path with spaces/metacharacters can never be
+/// re-interpreted.
+async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
+    use std::process::Command;
+
+    let tokens = tokenize_command(command)?;
+    let tokens = substitute_path(&tokens, path);
+    // tokenize_command guarantees a non-empty list.
+    let (first, rest) = tokens.split_first().expect("tokens is non-empty");
+
+    // SECURITY: resolve the program to an ABSOLUTE path BEFORE building the
+    // Command with `current_dir(path)`. On Windows, `Command` resolves a bare
+    // program name against the child's current_dir (the repository!) ahead of
+    // PATH — so an unresolved bare token plus `current_dir(repo)` would execute a
+    // repo-committed `wt.exe` sitting next to a trusted-looking template.
+    //
+    // `resolve_named` only PATH-searches when its `bin_path` override is None; a
+    // Some(non-empty) value is taken as an explicit path and merely exists-checked
+    // (it never falls through to the lookup). So route by shape: a path-like first
+    // token (`./bin/wt`, `C:\tools\wt.exe`) is exists-checked as given, and a bare
+    // name (`wt`, `wezterm`, `tmux`) goes through the real PATH/PATHEXT/login-shell
+    // lookup — the whole reason the resolver is mandated here. Either branch yields
+    // an absolute path.
+    let bin_path = first_token_is_pathlike(first).then_some(first.as_str());
+    let resolved = crate::agent::resolve_named(&[first.as_str()], bin_path)
+        .await
+        .ok_or_else(|| {
+            AppError::InvalidArgument(format!(
+                "terminal command not found: {first}"
+            ))
+        })?;
+
+    // SECURITY: reject batch files on the RESOLVED path — a bare `foo` on PATH
+    // can resolve to `foo.cmd`, which Rust would run through cmd.exe.
+    if is_batch_file(&resolved.to_string_lossy()) {
+        return Err(AppError::InvalidArgument(format!(
+            "terminal command points at a batch file ({}); point at the real \
+             executable instead",
+            resolved.display()
+        )));
+    }
+
+    let mut cmd = Command::new(&resolved);
+    cmd.args(rest);
+    // Always root at the repository directory: harmless when `{path}` is used
+    // explicitly, and the only cwd signal for launchers that inherit it
+    // (multiplexers, wrappers) rather than taking a directory flag. No `open -a`
+    // anywhere — it does not propagate cwd into a `.app`; GUI `.app`s belong in
+    // the "Custom…" mode.
+    cmd.current_dir(path);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW — hide any transient console
+    }
+    cmd.spawn().map(|_| ()).map_err(AppError::Io)
 }
 
 #[cfg(windows)]
@@ -334,6 +475,16 @@ fn launch_terminal_unix(kind: &str, program: &str, path: &str) -> AppResult<()> 
             if Command::new(&prog).args(&args).spawn().is_ok() {
                 return Ok(());
             }
+        }
+        // A "Custom…" pick that is a plain executable (not a `.app` bundle) must
+        // be spawned directly rooted at the repo: routing it through `open -a`
+        // treats the raw binary as an application name and mis-launches it.
+        if kind == "custom" && !program.is_empty() && !is_app_bundle(program) {
+            return Command::new(program)
+                .current_dir(path)
+                .spawn()
+                .map(|_| ())
+                .map_err(AppError::Io);
         }
         let app = mac_terminal_app(kind, program);
         Command::new("open")
@@ -1081,5 +1232,92 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].name, "Zed");
         assert_eq!(found[0].path, "/usr/local/bin/zeditor");
+    }
+
+    // ---- Custom terminal-command parsing (pure; run on every OS) ----
+
+    #[test]
+    fn tokenize_command_plain_split() {
+        assert_eq!(
+            tokenize_command("wt -d {path}").unwrap(),
+            vec!["wt", "-d", "{path}"]
+        );
+        // Runs of whitespace collapse; leading/trailing whitespace is trimmed.
+        assert_eq!(
+            tokenize_command("  tmux   new-window  ").unwrap(),
+            vec!["tmux", "new-window"]
+        );
+    }
+
+    #[test]
+    fn tokenize_command_quotes_group_and_strip() {
+        // A quoted run with spaces stays a single token; the quotes are stripped.
+        assert_eq!(
+            tokenize_command("\"C:\\Program Files\\wt.exe\" -d {path}").unwrap(),
+            vec!["C:\\Program Files\\wt.exe", "-d", "{path}"]
+        );
+        // Quotes can open mid-token and still group.
+        assert_eq!(
+            tokenize_command("start=\"a b\"").unwrap(),
+            vec!["start=a b"]
+        );
+    }
+
+    #[test]
+    fn tokenize_command_empty_is_error() {
+        assert!(tokenize_command("").is_err());
+        assert!(tokenize_command("   ").is_err());
+    }
+
+    #[test]
+    fn substitute_path_replaces_standalone_and_embedded() {
+        let tokens = vec!["wezterm".into(), "--cwd={path}".into(), "{path}".into()];
+        assert_eq!(
+            substitute_path(&tokens, "/home/me/repo"),
+            vec!["wezterm", "--cwd=/home/me/repo", "/home/me/repo"]
+        );
+    }
+
+    #[test]
+    fn substitute_path_keeps_spaced_path_as_one_token() {
+        // A path with spaces is substituted into a single token — it is never
+        // re-split, so the launcher receives exactly one argv entry.
+        let tokens = vec!["kitty".into(), "--directory".into(), "{path}".into()];
+        let out = substitute_path(&tokens, "/Users/me/My Repo");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[2], "/Users/me/My Repo");
+    }
+
+    #[test]
+    fn substitute_path_without_placeholder_is_unchanged() {
+        let tokens = vec!["tmux".into(), "new-window".into()];
+        assert_eq!(
+            substitute_path(&tokens, "/home/me/repo"),
+            vec!["tmux", "new-window"]
+        );
+    }
+
+    #[test]
+    fn is_batch_file_rejects_cmd_and_bat_case_insensitively() {
+        assert!(is_batch_file("C:\\tools\\wt.cmd"));
+        assert!(is_batch_file("C:\\tools\\wt.CMD"));
+        assert!(is_batch_file("launch.bat"));
+        assert!(is_batch_file("launch.BAT"));
+        // Real executables / extensionless names pass.
+        assert!(!is_batch_file("C:\\tools\\wt.exe"));
+        assert!(!is_batch_file("/usr/bin/wezterm"));
+        assert!(!is_batch_file("wt"));
+    }
+
+    #[test]
+    fn first_token_is_pathlike_distinguishes_bare_names_from_paths() {
+        // Bare names (looked up on PATH) — not path-like.
+        assert!(!first_token_is_pathlike("wt"));
+        assert!(!first_token_is_pathlike("wezterm"));
+        assert!(!first_token_is_pathlike("tmux"));
+        // Explicit paths (exists-checked as given) — path-like.
+        assert!(first_token_is_pathlike("./bin/wt"));
+        assert!(first_token_is_pathlike("C:\\tools\\wt.exe"));
+        assert!(first_token_is_pathlike("/usr/local/bin/wezterm"));
     }
 }

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -253,7 +253,7 @@ pub async fn open_in_terminal(
 /// stripped). There are no escape sequences beyond quote grouping — a literal
 /// double-quote inside a path is not supported, which is fine for the launcher
 /// templates this powers. Returns `InvalidArgument` for an empty/whitespace-only
-/// template.
+/// template or one with an unbalanced (unterminated) double-quote.
 fn tokenize_command(command: &str) -> AppResult<Vec<String>> {
     let mut tokens: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -278,6 +278,13 @@ fn tokenize_command(command: &str) -> AppResult<Vec<String>> {
                 has_token = true;
             }
         }
+    }
+    if in_quotes {
+        // An unterminated quote is almost certainly a typo; parsing "the rest of
+        // the string is one token" would silently mis-launch. Reject it instead.
+        return Err(AppError::InvalidArgument(
+            "unbalanced quote in terminal command".to_string(),
+        ));
     }
     if has_token {
         tokens.push(current);
@@ -317,6 +324,21 @@ fn first_token_is_pathlike(token: &str) -> bool {
     token.contains(['/', '\\'])
 }
 
+/// Returns `p` unchanged if already absolute, else joins it onto `base`. Used to
+/// pin a relative resolved program (e.g. `./bin/wt`, which `resolve_named`
+/// exists-checks against the app's cwd but returns verbatim) to that same base
+/// BEFORE we `current_dir(repo)` the child — otherwise the path we exists-checked
+/// (against app cwd) and the path the OS execs (against the repo cwd, on Unix)
+/// would differ: a confused deputy. Joining (not `canonicalize`) keeps the bytes
+/// identical to what was checked and avoids Windows `\\?\` verbatim-path quirks.
+fn ensure_absolute(p: PathBuf, base: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p
+    } else {
+        base.join(p)
+    }
+}
+
 /// Launches a user-supplied command template with no shell: tokenize → expand
 /// `{path}` → resolve the first token to an absolute executable → spawn it with
 /// the remaining tokens, rooted at the repository directory. Every step here is
@@ -327,8 +349,15 @@ async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
 
     let tokens = tokenize_command(command)?;
     let tokens = substitute_path(&tokens, path);
-    // tokenize_command guarantees a non-empty list.
+    // tokenize_command guarantees a non-empty list — but a quoted-empty template
+    // ('"" -d …') yields an EMPTY first token, which would reach the resolver as an
+    // empty program name and fail with a confusing blank-named error. Reject it.
     let (first, rest) = tokens.split_first().expect("tokens is non-empty");
+    if first.is_empty() {
+        return Err(AppError::InvalidArgument(
+            "terminal command must start with a program name".to_string(),
+        ));
+    }
 
     // SECURITY: resolve the program to an ABSOLUTE path BEFORE building the
     // Command with `current_dir(path)`. On Windows, `Command` resolves a bare
@@ -341,8 +370,7 @@ async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
     // (it never falls through to the lookup). So route by shape: a path-like first
     // token (`./bin/wt`, `C:\tools\wt.exe`) is exists-checked as given, and a bare
     // name (`wt`, `wezterm`, `tmux`) goes through the real PATH/PATHEXT/login-shell
-    // lookup — the whole reason the resolver is mandated here. Either branch yields
-    // an absolute path.
+    // lookup — the whole reason the resolver is mandated here.
     let bin_path = first_token_is_pathlike(first).then_some(first.as_str());
     let resolved = crate::agent::resolve_named(&[first.as_str()], bin_path)
         .await
@@ -351,6 +379,13 @@ async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
                 "terminal command not found: {first}"
             ))
         })?;
+    // A PATH/PATHEXT hit is already absolute, but a RELATIVE path-like token
+    // (`./bin/wt`) is exists-checked by `resolve_named` against the APP's cwd yet
+    // returned verbatim — and we are about to `current_dir(repo)` the child, so on
+    // Unix the OS would exec that relative path against the REPO dir instead: a
+    // different file than the one checked. Pin it to the app cwd now so the checked
+    // path and the executed path are byte-identical.
+    let resolved = ensure_absolute(resolved, &std::env::current_dir().map_err(AppError::Io)?);
 
     // SECURITY: reject batch files on the RESOLVED path — a bare `foo` on PATH
     // can resolve to `foo.cmd`, which Rust would run through cmd.exe.
@@ -1269,6 +1304,27 @@ mod tests {
         assert!(tokenize_command("   ").is_err());
     }
 
+    #[tokio::test]
+    async fn launch_custom_command_rejects_empty_program_token() {
+        // A quoted-empty first token ('"" -d …') must fail with a clear error
+        // before ever reaching the resolver (deterministic: returns pre-resolve).
+        assert!(launch_custom_command("\"\" -d {path}", "C:\\nowhere")
+            .await
+            .is_err());
+    }
+
+    #[test]
+    fn tokenize_command_unbalanced_quote_is_error() {
+        // An unterminated quote is a typo, not "the rest is one token".
+        assert!(tokenize_command("wt -d \"C:\\path").is_err());
+        assert!(tokenize_command("\"just an opening quote").is_err());
+        // A balanced pair around the same content is fine.
+        assert_eq!(
+            tokenize_command("wt -d \"C:\\path\"").unwrap(),
+            vec!["wt", "-d", "C:\\path"]
+        );
+    }
+
     #[test]
     fn substitute_path_replaces_standalone_and_embedded() {
         let tokens = vec!["wezterm".into(), "--cwd={path}".into(), "{path}".into()];
@@ -1319,5 +1375,25 @@ mod tests {
         assert!(first_token_is_pathlike("./bin/wt"));
         assert!(first_token_is_pathlike("C:\\tools\\wt.exe"));
         assert!(first_token_is_pathlike("/usr/local/bin/wezterm"));
+    }
+
+    #[test]
+    fn ensure_absolute_joins_relative_and_passes_absolute() {
+        let base = if cfg!(windows) {
+            Path::new("C:\\app\\cwd")
+        } else {
+            Path::new("/app/cwd")
+        };
+        // A relative path is joined onto the base.
+        let rel = ensure_absolute(PathBuf::from("bin/wt"), base);
+        assert_eq!(rel, base.join("bin/wt"));
+        assert!(rel.is_absolute());
+        // An already-absolute path is returned unchanged (bytes identical).
+        let abs = if cfg!(windows) {
+            PathBuf::from("C:\\tools\\wt.exe")
+        } else {
+            PathBuf::from("/usr/local/bin/wezterm")
+        };
+        assert_eq!(ensure_absolute(abs.clone(), base), abs);
     }
 }

--- a/src/features/accounts/ReconnectDialog.tsx
+++ b/src/features/accounts/ReconnectDialog.tsx
@@ -186,6 +186,7 @@ function ReconnectFlow({
       repoPath,
       settings.data?.terminal,
       settings.data?.terminalPath,
+      settings.data?.terminalCommand,
     ).catch(toastError);
   }
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1698,8 +1698,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   identity override, and line endings (\`core.autocrlf\`).
 - **Syntax** — map file extensions to languages or add custom grammars, personally or
   shared with the repo via \`.gitdesktop/syntax.json\`.
-- **External editor / Terminal** — auto-detected, or point at any executable. These power
-  the "Open in…" actions throughout the app.
+- **External editor / Terminal** — auto-detected, point at any executable, or set a full
+  custom terminal command with a \`{path}\` placeholder (for multiplexers, wrappers, or a
+  terminal the detection doesn't know). These power the "Open in…" actions throughout the app.
 - **About** — app, OS, and component versions, a **health check** for your installed tools
   (Git, the GitHub / GitLab CLIs{{ai}}, and the Claude Code / Codex / Copilot / opencode
   agents{{/ai}}), and the current window position.

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -650,8 +650,9 @@ export function RemotePrView({
   // the user readies it here — the catch-up poller only covers PRs within its
   // 14-day window (sync.ts), so a long-lived draft readied in-app would
   // otherwise slip through. Gated by `prOpenEligible` — the SAME eligibility the
-  // external catch-up path enforces (no prior review in either mode, head not
-  // dismissed), so the two ready paths behave identically. This guard, not claim
+  // external catch-up path enforces (some mode still missing its review, head not
+  // dismissed; the runner's per-mode pr-open gate skips the modes that already
+  // ran), so the two ready paths behave identically. This guard, not claim
   // dedup, is what prevents a double review: a manual panel review saves via
   // `saveReview` WITHOUT taking an automation claim, so claim dedup can't see it
   // — only this prior-review check can (round-2 finding, PR #91). Mirrors the

--- a/src/features/repository/ChangesEmptyState.tsx
+++ b/src/features/repository/ChangesEmptyState.tsx
@@ -138,6 +138,7 @@ export function ChangesEmptyState({
                 repoPath,
                 settings.data?.terminal,
                 settings.data?.terminalPath,
+                settings.data?.terminalCommand,
               ).catch(onError)
             }
           >

--- a/src/features/repository/ForgeNotReady.tsx
+++ b/src/features/repository/ForgeNotReady.tsx
@@ -135,6 +135,7 @@ export function ForgeNotReady({
                   repoPath,
                   settings.data?.terminal,
                   settings.data?.terminalPath,
+                  settings.data?.terminalCommand,
                 ).catch(toastError)
               }
             >
@@ -271,6 +272,7 @@ export function ForgeNotReady({
                   repoPath,
                   settings.data?.terminal,
                   settings.data?.terminalPath,
+                  settings.data?.terminalCommand,
                 ).catch(toastError)
               }
             >

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -409,6 +409,7 @@ export function RepoList({
                 editorName={editorName}
                 terminal={settings.data?.terminal}
                 terminalPath={settings.data?.terminalPath}
+                terminalCommand={settings.data?.terminalCommand}
                 onAlias={onAliasRepo}
                 onRemove={onRemoveRepo}
               />
@@ -603,6 +604,7 @@ function RepoMenuItems({
   editorName,
   terminal,
   terminalPath,
+  terminalCommand,
   onAlias,
   onRemove,
 }: {
@@ -614,6 +616,7 @@ function RepoMenuItems({
   editorName: string;
   terminal?: string;
   terminalPath?: string;
+  terminalCommand?: string;
   onAlias: (repo: RecentRepo) => void;
   onRemove: (repo: RecentRepo) => void;
 }) {
@@ -649,7 +652,12 @@ function RepoMenuItems({
       )}
       <ContextMenuItem
         onClick={() =>
-          openInTerminal(repo.path, terminal, terminalPath).catch(toastError)
+          openInTerminal(
+            repo.path,
+            terminal,
+            terminalPath,
+            terminalCommand,
+          ).catch(toastError)
         }
       >
         Open in terminal

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -194,6 +194,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
       repoPath,
       settings.data?.terminal,
       settings.data?.terminalPath,
+      settings.data?.terminalCommand,
     ).catch(onError),
   );
   useHotkeyAction("show-in-explorer", () =>
@@ -320,6 +321,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
               repoPath,
               settings.data?.terminal,
               settings.data?.terminalPath,
+              settings.data?.terminalCommand,
             ).catch(onError)
           }
         >

--- a/src/features/sessions/SessionOpenMenu.tsx
+++ b/src/features/sessions/SessionOpenMenu.tsx
@@ -38,6 +38,7 @@ export function SessionOpenMenu({
     (settings.data?.externalEditorName ?? "").trim() || "editor";
   const terminal = (settings.data?.terminal ?? "").trim();
   const terminalPath = (settings.data?.terminalPath ?? "").trim();
+  const terminalCommand = (settings.data?.terminalCommand ?? "").trim();
   const onError = (e: unknown) => toastError(e);
   const container = isolation === "container";
 
@@ -71,6 +72,7 @@ export function SessionOpenMenu({
                 worktreePath,
                 terminal || undefined,
                 terminalPath || undefined,
+                terminalCommand || undefined,
               ).catch(onError)
             }
           >

--- a/src/features/settings/TerminalSection.tsx
+++ b/src/features/settings/TerminalSection.tsx
@@ -1,3 +1,4 @@
+import { WarningCircleIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -18,6 +19,7 @@ import { settingsFormOpts } from "./settings-form";
 
 const DEFAULT = "__default__";
 const CUSTOM = "__custom__";
+const CUSTOM_COMMAND = "__custom_command__";
 
 // The default terminal is platform-specific, so its label can't be hardcoded.
 const DEFAULT_LABEL = isWindows
@@ -30,6 +32,12 @@ const CUSTOM_PLACEHOLDER = isWindows
   : isMac
     ? "/Applications/iTerm.app"
     : "/usr/bin/alacritty";
+// A representative shell-free command per platform, showing the {path} token.
+const CUSTOM_COMMAND_PLACEHOLDER = isWindows
+  ? "wt -d {path}"
+  : isMac
+    ? "wezterm start --cwd {path}"
+    : "tmux new-window -c {path}";
 
 export const TerminalSection = withForm({
   ...settingsFormOpts,
@@ -42,21 +50,41 @@ export const TerminalSection = withForm({
 
     const terminal = useSelector(form.store, (s) => s.values.terminal);
     const terminalPath = useSelector(form.store, (s) => s.values.terminalPath);
+    const terminalCommand = useSelector(
+      form.store,
+      (s) => s.values.terminalCommand,
+    );
 
     const terminals = detected.data ?? [];
     const matched = terminals.find((t) => t.id === terminal);
     const isCustom = terminal === "custom";
-    const selectValue =
-      terminal === "" ? DEFAULT : isCustom ? CUSTOM : (matched?.id ?? CUSTOM);
+    const isCustomCommand = terminal === "custom-command";
+    const selectValue = isCustomCommand
+      ? CUSTOM_COMMAND
+      : terminal === ""
+        ? DEFAULT
+        : isCustom
+          ? CUSTOM
+          : (matched?.id ?? CUSTOM);
     const showCustom = selectValue === CUSTOM;
+    const showCustomCommand = selectValue === CUSTOM_COMMAND;
+    // Non-blocking hint: a template without {path} still runs (it starts in the
+    // repo directory), but the user probably meant to reference the repo.
+    const missingPathToken =
+      showCustomCommand &&
+      terminalCommand.trim() !== "" &&
+      !terminalCommand.includes("{path}");
 
     // Base UI's Select.Value renders the raw value unless given value→label items
     const selectItems: Record<string, string> = {
       [DEFAULT]: DEFAULT_LABEL,
       [CUSTOM]: "Custom…",
+      [CUSTOM_COMMAND]: "Custom command…",
       ...Object.fromEntries(terminals.map((t) => [t.id, t.name])),
     };
 
+    // Only ever writes `terminal`/`terminalPath`, leaving `terminalCommand`
+    // untouched — so switching between modes preserves the other mode's value.
     function setTerminal(kind: string, path: string) {
       form.setFieldValue("terminal", kind);
       form.setFieldValue("terminalPath", path);
@@ -92,7 +120,12 @@ export const TerminalSection = withForm({
               if (value === DEFAULT) {
                 setTerminal("", "");
               } else if (value === CUSTOM) {
+                // Flip the mode only; keep terminalPath (and terminalCommand)
+                // so switching back and forth doesn't wipe the other value.
                 if (!isCustom) form.setFieldValue("terminal", "custom");
+              } else if (value === CUSTOM_COMMAND) {
+                if (!isCustomCommand)
+                  form.setFieldValue("terminal", "custom-command");
               } else if (value) {
                 const t = terminals.find((x) => x.id === value);
                 if (t) setTerminal(t.id, t.path);
@@ -110,6 +143,7 @@ export const TerminalSection = withForm({
                 </SelectItem>
               ))}
               <SelectItem value={CUSTOM}>Custom…</SelectItem>
+              <SelectItem value={CUSTOM_COMMAND}>Custom command…</SelectItem>
             </SelectContent>
           </Select>
           {detected.isPending && (
@@ -142,6 +176,36 @@ export const TerminalSection = withForm({
             <p className="text-xs text-muted-foreground">
               Launched in a new window at the repository folder.
             </p>
+          </div>
+        )}
+        {showCustomCommand && (
+          <div className="space-y-2">
+            <Label htmlFor="custom-terminal-command">Command</Label>
+            <Input
+              id="custom-terminal-command"
+              className="font-mono"
+              placeholder={CUSTOM_COMMAND_PLACEHOLDER}
+              autoComplete="off"
+              value={terminalCommand}
+              onChange={(e) =>
+                form.setFieldValue("terminalCommand", e.target.value)
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              Runs without a shell.{" "}
+              <code className="font-mono">{"{path}"}</code> is replaced with the
+              repository path; when omitted, the command starts in the
+              repository directory. Use it for multiplexers, wrappers, or a
+              terminal that isn't auto-detected.
+            </p>
+            {missingPathToken && (
+              <p className="flex items-center gap-1 text-xs text-warning">
+                <WarningCircleIcon className="size-3.5 shrink-0" />
+                No <code className="font-mono">{"{path}"}</code> in the command
+                — it will start in the repository directory without receiving
+                the path as an argument.
+              </p>
+            )}
           </div>
         )}
       </section>

--- a/src/features/settings/TerminalSection.tsx
+++ b/src/features/settings/TerminalSection.tsx
@@ -186,6 +186,7 @@ export const TerminalSection = withForm({
               className="font-mono"
               placeholder={CUSTOM_COMMAND_PLACEHOLDER}
               autoComplete="off"
+              spellCheck={false}
               value={terminalCommand}
               onChange={(e) =>
                 form.setFieldValue("terminalCommand", e.target.value)
@@ -199,7 +200,10 @@ export const TerminalSection = withForm({
               terminal that isn't auto-detected.
             </p>
             {missingPathToken && (
-              <p className="flex items-center gap-1 text-xs text-warning">
+              <p
+                role="status"
+                className="flex items-center gap-1 text-xs text-warning"
+              >
                 <WarningCircleIcon className="size-3.5 shrink-0" />
                 No <code className="font-mono">{"{path}"}</code> in the command
                 — it will start in the repository directory without receiving

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -266,6 +266,30 @@ async function run(
         continue;
       }
     }
+    // pr-open is FIRST-review per mode: skip any mode that already has a review record
+    // for this PR (real pr-open events are then idempotent per mode, and per-mode
+    // catch-up synthesis is safe — a synthesized pr-open re-fires only the mode(s) that
+    // still have no record). Also skip a head this mode already dismissed. Mirrors the
+    // pr-sync gate above; the difference is pr-sync requires a prior (re-review), while
+    // pr-open requires the ABSENCE of one (first review).
+    if (event.kind === "pr-open") {
+      const prior = await getLatestReview(
+        event.repoPath,
+        event.target.type,
+        targetRef(event),
+        action,
+      );
+      if (prior) continue;
+      const dismissedHead = await getDismissedHead(
+        event.repoPath,
+        event.target.type,
+        targetRef(event),
+        action,
+      );
+      if (event.headSha && sameSha(dismissedHead ?? "", event.headSha)) {
+        continue;
+      }
+    }
     // Cross-instance dedup: claim this exact run atomically BEFORE any (paid) AI
     // work, so two instances watching the same repo (a main checkout + a linked
     // worktree share a worktree-stable identity) don't both post the same review.

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -122,12 +122,14 @@ export interface CatchUpCandidate {
  * `gh pr create` therefore falls between both triggers and never gets a first
  * pass. This closes that gap by detecting such a PR on the existing poll tick
  * and firing the same `pr-open` event an in-app create would — which then flows
- * through the untouched runner (claim dedup → review → post → record → toast).
+ * through the runner (per-mode pr-open gate → claim dedup → review → post →
+ * record → toast); the runner runs only the mode(s) still missing a review.
  * Do NOT "simplify" this away: without it, externally-opened PRs get zero signal.
  *
  * Scope is deliberately narrow (user-locked): the viewer's OWN, open, recent
- * PRs with no prior review (any mode) and no dismissed head. Drafts are included
- * only when `reviewDrafts` is set (the `reviewDraftPrs` setting); off (the
+ * PRs where AT LEAST ONE mode still needs a review (no prior record and no
+ * matching dismissed head for that mode — see {@link prOpenEligible}). Drafts are
+ * included only when `reviewDrafts` is set (the `reviewDraftPrs` setting); off (the
  * default) they're skipped until marked ready for review. At most ONE PR is
  * caught up per call (the oldest), bounding burst token spend — the next tick
  * takes the next one.
@@ -187,12 +189,16 @@ export function maybeCatchUpMissedOpen(
 }
 
 /**
- * Async eligibility to fire a first `pr-open` review for a remote PR: true only
- * when NO review record exists for it in EITHER mode (a manual OR automated
- * review in general or security counts as "the user knows this PR" and
- * suppresses it), and no dismissed head matches the current head in either mode.
- * Errors swallow to `false` (fail-closed) — a store hiccup must never fire a
- * redundant review.
+ * Async eligibility to fire a `pr-open` review for a remote PR: true when AT LEAST
+ * ONE mode still needs a first review — i.e. it has NO prior review record (neither
+ * a manual nor an automated general/security review) AND no dismissed head matching
+ * the current head. Previously this required BOTH modes to be missing, so a single
+ * stolen or failed mode could never be caught up once the other mode ran; now the
+ * synthesized `pr-open` fires whenever any mode is missing, and the runner's per-mode
+ * `pr-open` gate skips the mode(s) that already ran — so a failed general review is
+ * retried even when the security audit already delivered (and only the missing mode
+ * actually runs). Errors swallow to `false` (fail-closed) — a store hiccup must never
+ * fire a redundant review.
  *
  * Shared by the catch-up poller (via {@link catchUpEligible}) and the in-app
  * Mark-ready trigger (RemotePrView), so both ready paths stay behaviorally
@@ -209,11 +215,16 @@ export async function prOpenEligible(
     const modes = ["general", "security"] as const;
     for (const mode of modes) {
       const prior = await getLatestReview(repoPath, "remote", ref, mode);
-      if (prior) return false;
+      if (prior) continue; // this mode already reviewed — no need on its account
       const dismissed = await getDismissedHead(repoPath, "remote", ref, mode);
-      if (dismissed && sameSha(dismissed, currentHeadSha)) return false;
+      // A dismissed head matching the current head means this mode was deliberately
+      // skipped for this head — it doesn't need a review either.
+      if (dismissed && sameSha(dismissed, currentHeadSha)) continue;
+      // This mode has no prior and no matching dismissal → it needs a first review, so
+      // the PR is eligible. The runner filters out the already-covered modes.
+      return true;
     }
-    return true;
+    return false;
   } catch {
     return false;
   }

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -622,11 +622,13 @@ export const openInTerminal = (
   path: string,
   terminal?: string,
   program?: string,
+  command?: string,
 ) =>
   invoke<void>("open_in_terminal", {
     path,
     terminal: terminal || null,
     program: program || null,
+    command: command || null,
   });
 
 /** The repo's web URL on its provider (GitHub or GitLab). */

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -222,6 +222,9 @@ export interface AppSettings {
   terminal: string;
   /** Executable path for the chosen terminal (empty for default/built-ins). */
   terminalPath: string;
+  /** Argv command template for the "custom-command" terminal mode. `{path}` is
+   *  replaced with the repository path; runs with no shell. Empty otherwise. */
+  terminalCommand: string;
   /** @deprecated No longer read. The default branch for new repos now lives in
    *  global git config (`init.defaultBranch`), edited in Settings → Git. Kept so
    *  existing settings.json files round-trip without churn. */
@@ -331,6 +334,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   externalEditorName: "",
   terminal: "",
   terminalPath: "",
+  terminalCommand: "",
   defaultBranch: "main",
   hotkeys: {},
   confirmAmendForcePush: true,


### PR DESCRIPTION
Bundles two independent improvements: a new **Custom command…** terminal mode that lets you launch any shell-free command with a `{path}` placeholder (for multiplexers, wrappers, and terminals auto-detection doesn't know), and a fix for automation review claims that were starving PRs for up to 30 days when an app instance died before releasing them. The claim fix also makes missed-review catch-up work per review mode, so a failed general review is retried even after the security audit ran.

### Custom terminal command mode

- Adds `launch_custom_command` in `src-tauri/src/fsops.rs`, plus helpers `tokenize_command`, `substitute_path`, `is_batch_file`, and `first_token_is_pathlike`: it tokenizes the template (double-quote grouping, no shell), substitutes `{path}` per token so spaced paths stay a single argv entry, resolves the first token to an absolute executable via `agent::resolve_named`, and spawns it rooted at the repo. Batch files (`.cmd`/`.bat`) are rejected to avoid re-introducing a shell through `cmd.exe`.
- Extends `open_in_terminal` in `src-tauri/src/fsops.rs` with a `command` parameter and dispatches the new `custom-command` kind ahead of the per-OS matchers.
- Fixes macOS "Custom…" in `launch_terminal_unix` so a plain (non-`.app`) executable is spawned directly rooted at the repo instead of being mis-launched through `open -a`.
- Adds pure unit tests in `src-tauri/src/fsops.rs` for tokenizing, path substitution, batch-file detection, and path-like first-token detection.
- Adds the **Custom command…** UI in `src/features/settings/TerminalSection.tsx`: a new mode with a monospace command `Input`, per-platform placeholder, a non-blocking warning when `{path}` is missing, and mode-switching that preserves the other mode's stored value.
- Adds the `terminalCommand` field (and default) to `AppSettings` in `src/lib/settings/api.ts`, and threads `command` through `openInTerminal` in `src/lib/git/api.ts`.
- Passes the new `terminalCommand` at every "Open in terminal" call site: `ReconnectDialog.tsx`, `ChangesEmptyState.tsx`, `ForgeNotReady.tsx`, `RepoList.tsx`, `RepositoryMenu.tsx`, and `SessionOpenMenu.tsx`.

### Automation claim reclaim and per-mode catch-up

- Adds `STALE_CLAIM_AGE` (30 minutes) in `src-tauri/src/automation_claims.rs` and splits the exclusive-create into `create_new_claim`, so `claim_in_dir` now reclaims a claim whose mtime is older than the threshold (best-effort delete + one retry, yielding on a lost race) instead of waiting for the 30-day sweep. Adds tests covering reclaim, fresh-claim denial, and that the reclaimed file holds the new key.
- Makes `pr-open` first-review per mode in `src/lib/automations/runner.ts`: it skips any mode that already has a review record or a matching dismissed head, so synthesized `pr-open` events only fire the mode(s) still missing a review.
- Reworks `prOpenEligible` in `src/lib/automations/sync.ts` to return eligible when **at least one** mode still needs a review (previously required both modes missing), so a single failed or stolen mode can be caught up after the other mode ran.
- Updates the guard comment in `src/features/pulls/RemotePrView.tsx` to reflect the per-mode eligibility.

### Documentation

- Updates the *Integrations* highlight in `README.md` and the External editor / Terminal section in `src/features/help/content.ts` to describe the custom-command mode and `{path}` placeholder.
- Adds changelog fragments `changelog.d/added-custom-terminal-command.md` and `changelog.d/fixed-automation-claim-starvation.md`.