### PR TITLE
feat(pulls,jira): link related issues when opening or editing a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,15 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **The whole PR lifecycle, in-app** — review, comment, label, **assign**, **request
   reviewers**, approve, edit, and merge (merge/squash/rebase) GitHub PRs without the
   browser. Set **labels and assignees** right when you **open** a PR/MR (GitHub &
-  GitLab), and **link related issues** in the same dialog — chips **auto-detected**
-  from your branch name and commits (a `fix/123-…` branch seeds `#123`), or picked by
-  hand, each toggleable between **Closes** (auto-closes the issue on merge) and
-  **Relates to** (GitHub & GitLab). Request reviewers across GitHub, GitLab &
+  GitLab), and **link related issues** when you open *or* edit a PR — chips
+  **auto-detected** from your branch name and commits (a `fix/123-…` branch seeds
+  `#123`), or picked by hand, each toggleable between **Closes** (auto-closes the issue
+  on merge) and **Relates to** (GitHub & GitLab; also on **local PRs**, where the refs
+  carry into the promoted PR). On a **Bitbucket** repo with a **linked Jira project**,
+  the same row surfaces linked-Jira issues (`KEY-123`) as **mention-only** *Relates to*
+  chips (Jira tickets aren't closed from PR text). Editing a PR peels any trailing
+  `Closes #N` / `Relates to #N` lines back into chips, so the chips stay the single
+  editor for the ref block. Request reviewers across GitHub, GitLab &
   Bitbucket. Flip a PR between
   **draft and ready for review** either way — on GitHub, GitLab & Bitbucket — and
   **create new PRs as drafts by default** (Settings → General).
@@ -242,7 +247,8 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   you pick the agent and confirm — then it builds it in an isolated worktree.
 - **AI where it helps** — commit messages, branch names, PR and issue
   titles/descriptions (and **suggested labels** from the repo's existing set, plus
-  **proposed issue links** picked from a grounded shortlist of your open issues, when
+  **proposed issue links** picked from a grounded shortlist of your open issues — or, on
+  a Bitbucket repo with a linked Jira project, linked-Jira keys to mention — when
   you generate a PR/MR), repository descriptions and topics, and a streaming code
   review or security audit. Bring your own provider: cloud APIs, local **Ollama**,
   or a **keyless agent CLI** you already pay for (Claude Code, Codex, GitHub

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **The whole PR lifecycle, in-app** — review, comment, label, **assign**, **request
   reviewers**, approve, edit, and merge (merge/squash/rebase) GitHub PRs without the
   browser. Set **labels and assignees** right when you **open** a PR/MR (GitHub &
-  GitLab); request reviewers across GitHub, GitLab & Bitbucket. Flip a PR between
+  GitLab), and **link related issues** in the same dialog — chips **auto-detected**
+  from your branch name and commits (a `fix/123-…` branch seeds `#123`), or picked by
+  hand, each toggleable between **Closes** (auto-closes the issue on merge) and
+  **Relates to** (GitHub & GitLab). Request reviewers across GitHub, GitLab &
+  Bitbucket. Flip a PR between
   **draft and ready for review** either way — on GitHub, GitLab & Bitbucket — and
   **create new PRs as drafts by default** (Settings → General).
   - **Activity feed** — a PR's Conversation is a **date-sorted timeline** of reviews,
@@ -237,7 +241,8 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   GitHub issue (and on a finished plan) seeds the agent composer with the spec, so
   you pick the agent and confirm — then it builds it in an isolated worktree.
 - **AI where it helps** — commit messages, branch names, PR and issue
-  titles/descriptions (and **suggested labels** from the repo's existing set when
+  titles/descriptions (and **suggested labels** from the repo's existing set, plus
+  **proposed issue links** picked from a grounded shortlist of your open issues, when
   you generate a PR/MR), repository descriptions and topics, and a streaming code
   review or security audit. Bring your own provider: cloud APIs, local **Ollama**,
   or a **keyless agent CLI** you already pay for (Claude Code, Codex, GitHub

--- a/changelog.d/added-pr-linked-issues.md
+++ b/changelog.d/added-pr-linked-issues.md
@@ -1,6 +1,13 @@
-- **Link issues when you open a PR.** The Create PR dialog now has a **Linked issues**
-  row (GitHub & GitLab): reference real repo issues that are auto-detected from your
-  branch name and commit subjects, proposed for you when you **Generate** the
-  description (from a grounded shortlist of your open issues), or added by hand. Toggle
-  each between **Closes** (auto-closes the issue on merge) and **Relates to** — they're
-  appended to the description as `Closes #N` / `Relates to #N` lines on create.
+- **Link issues when you open or edit a PR.** The Create and Edit PR dialogs now have a
+  **Linked issues** row (GitHub & GitLab, wherever the repo has an issue tracker):
+  reference real repo issues that are auto-detected from your branch name and commit
+  subjects, proposed for you when you **Generate** the description (from a grounded
+  shortlist of your open issues), or added by hand. Toggle each between **Closes**
+  (auto-closes the issue on merge) and **Relates to** — they're appended to the
+  description as `Closes #N` / `Relates to #N` lines, and opening **Edit** peels any
+  trailing ref lines back into chips (keyword preserved) and re-appends them on save, so
+  the chips are the single editor for that block. **Local PRs** get the same row (create
+  and edit), and their ref lines survive **promotion** verbatim to become real closing
+  refs on the forge. On a **Bitbucket** repo with a **linked Jira project**, the row
+  surfaces linked-Jira issues (`KEY-123`) as **mention-only** *Relates to* chips (Jira
+  tickets are never closed from PR text).

--- a/changelog.d/added-pr-linked-issues.md
+++ b/changelog.d/added-pr-linked-issues.md
@@ -1,0 +1,6 @@
+- **Link issues when you open a PR.** The Create PR dialog now has a **Linked issues**
+  row (GitHub & GitLab): reference real repo issues that are auto-detected from your
+  branch name and commit subjects, proposed for you when you **Generate** the
+  description (from a grounded shortlist of your open issues), or added by hand. Toggle
+  each between **Closes** (auto-closes the issue on merge) and **Relates to** — they're
+  appended to the description as `Closes #N` / `Relates to #N` lines on create.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -158,6 +158,11 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Pull requests & review",
+    label:
+      "Link related issues as you open a PR — auto-detected from your branch and commits (GitHub & GitLab)",
+  },
+  {
+    group: "Pull requests & review",
     label: "Request reviewers on a PR/MR (GitHub, GitLab & Bitbucket)",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -159,7 +159,7 @@ export const capabilities: Capability[] = [
   {
     group: "Pull requests & review",
     label:
-      "Link related issues as you open a PR — auto-detected from your branch and commits (GitHub & GitLab)",
+      "Link related issues as you open or edit a PR — auto-detected from your branch and commits (GitHub & GitLab; Bitbucket via linked Jira)",
   },
   {
     group: "Pull requests & review",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -222,6 +222,9 @@ const forges = [
           One click reads your staged diff and drafts the commit message — and the PR
           title and description — in your conventions. It streams into the same fields
           you'd type in, so it's always editable and never blocks the manual path.
+          Generating a PR description can also propose which of your open issues it
+          <span class="text-ink">Closes</span> or relates to, chosen from a grounded
+          shortlist so it never invents an issue number.
         </p>
         <p class="mt-4 max-w-[60ch] leading-relaxed text-muted">
           Bring your own model: Anthropic, OpenAI, any OpenAI-compatible endpoint,

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -224,7 +224,8 @@ const forges = [
           you'd type in, so it's always editable and never blocks the manual path.
           Generating a PR description can also propose which of your open issues it
           <span class="text-ink">Closes</span> or relates to, chosen from a grounded
-          shortlist so it never invents an issue number.
+          shortlist so it never invents an issue number — or, on a Bitbucket repo with a
+          linked Jira project, which linked-Jira tickets to mention.
         </p>
         <p class="mt-4 max-w-[60ch] leading-relaxed text-muted">
           Bring your own model: Anthropic, OpenAI, any OpenAI-compatible endpoint,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -395,6 +395,132 @@ fn budget_diff(diff_text: &str) -> BudgetedDiff {
     }
 }
 
+/// Extract candidate issue numbers referenced in git text (branch name, commit
+/// subjects). Deduplicated, first-occurrence order. KEEP IN SYNC:
+/// `extractIssueNumbers` in src/lib/issues/extract.ts — both sides use explicit
+/// leading-boundary matching (no lookbehind) so behavior stays identical.
+///
+/// Three patterns, applied in order 1→2→3 each over the FULL text (matching the
+/// TS pass order); results deduped preserving first-occurrence order across all
+/// patterns. Case table:
+///   `fix/123-crash` → [123]   (pattern 2: after `/`, digits then `-`)
+///   `#45`           → [45]    (pattern 1: `#` not preceded by letter/digit/`&`)
+///   `123-fix`       → [123]   (pattern 2: string start, digits then `-`)
+///   `&#39;`         → []      (pattern 1's `&` exclusion keeps HTML entities out)
+///   `issue-7`       → [7]     (pattern 3, case-insensitive)
+///   `v2-123`        → []      (pattern 2 fires only at start or after `/`)
+fn extract_issue_numbers(text: &str) -> Vec<u64> {
+    let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut out: Vec<u64> = Vec::new();
+    let bytes = text.as_bytes();
+
+    // Parse a run of ASCII digits starting at `start`, returning (value, end).
+    // `None` when there are no digits or the value overflows u64.
+    fn parse_digits(bytes: &[u8], start: usize) -> Option<(u64, usize)> {
+        let mut i = start;
+        let mut value: u64 = 0;
+        let mut any = false;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            any = true;
+            value = value.checked_mul(10)?.checked_add((bytes[i] - b'0') as u64)?;
+            i += 1;
+        }
+        if any {
+            Some((value, i))
+        } else {
+            None
+        }
+    }
+
+    let push = |n: u64, seen: &mut std::collections::HashSet<u64>, out: &mut Vec<u64>| {
+        // Drop 0 and anything > 999_999_999 (mirrors the TS guard).
+        if n == 0 || n > 999_999_999 {
+            return;
+        }
+        if seen.insert(n) {
+            out.push(n);
+        }
+    };
+
+    // Pattern 1: `#123` where `#` is at start or preceded by a char that is NOT
+    // `[A-Za-z0-9&]` (the `&` guard excludes HTML entities like `&#39;`).
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'#' {
+            let prev_ok = if i == 0 {
+                true
+            } else {
+                let p = bytes[i - 1];
+                !(p.is_ascii_alphanumeric() || p == b'&')
+            };
+            if prev_ok {
+                if let Some((n, _)) = parse_digits(bytes, i + 1) {
+                    push(n, &mut seen, &mut out);
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // Pattern 2: a segment-leading `123-` where the digits are at start or
+    // preceded by `/`.
+    i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let at_boundary = i == 0 || bytes[i - 1] == b'/';
+            if at_boundary {
+                if let Some((n, end)) = parse_digits(bytes, i) {
+                    if end < bytes.len() && bytes[end] == b'-' {
+                        push(n, &mut seen, &mut out);
+                    }
+                    // Skip past this digit run either way (it can't start another
+                    // boundary match mid-run).
+                    i = end;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // Pattern 3: `issue-123` / `gh-123` case-insensitive, preceded by start or a
+    // non-alphanumeric.
+    i = 0;
+    while i < bytes.len() {
+        let prev_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+        if prev_ok {
+            let rest = &bytes[i..];
+            let prefix_len = if rest.len() >= 6 && rest[..5].eq_ignore_ascii_case(b"issue") {
+                Some(5usize)
+            } else if rest.len() >= 3 && rest[..2].eq_ignore_ascii_case(b"gh") {
+                Some(2usize)
+            } else {
+                None
+            };
+            if let Some(plen) = prefix_len {
+                if bytes[i + plen] == b'-' {
+                    if let Some((n, _)) = parse_digits(bytes, i + plen + 1) {
+                        push(n, &mut seen, &mut out);
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+
+    out
+}
+
+/// The set of ASCII-lowercased tokens of length ≥ 4 in `text`, splitting on any
+/// non-alphanumeric character. Used to score candidate-issue title overlap with
+/// the branch name + commit subjects when ranking fill candidates.
+fn long_tokens(text: &str) -> std::collections::HashSet<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| t.len() >= 4)
+        .map(|t| t.to_ascii_lowercase())
+        .collect()
+}
+
 /// The trailing recipe `note`, restating the output-format constraints in one
 /// sentence so the calling agent knows what to produce even if it skims the
 /// system prompt. `output` is the artifact name; `constraints` restates the
@@ -571,6 +697,15 @@ fn assemble_branch_recipe(p: BranchPieces) -> Recipe {
     }
 }
 
+/// A real issue from the repo's tracker the model may link. KEEP IN SYNC with the
+/// TS `PrPromptInput.issueCandidates` entries (src/lib/ai/types.ts).
+struct IssueCandidate {
+    number: u64,
+    title: String,
+    /// Neutral state: "OPEN" / "CLOSED".
+    state: String,
+}
+
 /// The gathered pieces a PR-description recipe is assembled from.
 struct PrPieces {
     diff_text: String,
@@ -583,6 +718,10 @@ struct PrPieces {
     /// label's stated purpose) is threaded into the prompt so the model weighs a
     /// label by what it's for, not just a name-plausible match.
     available_labels: Vec<(String, Option<String>)>,
+    /// Real candidate issues the model may link (best-effort, fetched server-side).
+    /// Empty ⇒ the prompt is byte-identical to before and the issue-reference ban
+    /// stands.
+    candidate_issues: Vec<IssueCandidate>,
     repo_instructions: Option<String>,
     global_instructions: String,
     /// Frontend provider tag: `"github"` / `"gitlab"` / `"bitbucket"`, or None
@@ -604,6 +743,22 @@ fn render_label_line(name: &str, description: &str) -> String {
     }
 }
 
+/// Render one candidate issue as a bullet for the `## Related issues` section:
+/// `- #123 — title`, ` (closed)` suffixed when closed, the ` — title` part omitted
+/// when the title is empty. Title capped at 140 chars. Mirrors the TS
+/// `renderIssueLine` (src/lib/ai/prompt.ts) — KEEP IN SYNC.
+fn render_issue_line(number: u64, title: &str, state: &str) -> String {
+    let closed = state.eq_ignore_ascii_case("CLOSED");
+    let suffix = if closed { " (closed)" } else { "" };
+    let title = title.trim();
+    if title.is_empty() {
+        format!("- #{number}{suffix}")
+    } else {
+        let capped: String = title.chars().take(140).collect();
+        format!("- #{number}{suffix} — {capped}")
+    }
+}
+
 /// Assemble the PR/MR-description recipe. Mirrors `buildPrPrompt`
 /// (src/lib/ai/prompt.ts) — provider-aware noun/markdown-flavor, the label
 /// proposal system section, and the closing instructions. KEEP IN SYNC.
@@ -616,7 +771,29 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
         "PR"
     };
 
-    let mut system_parts = vec![pr_system_for(p.provider.as_deref())];
+    // Real candidate issues the model may link (defensive cap 8, mirrored TS-side).
+    // Empty ⇒ the issue-reference ban stands and the recipe is byte-identical to
+    // before (no ban swap, no `## Related issues` section, unchanged note).
+    let candidates: Vec<&IssueCandidate> =
+        p.candidate_issues.iter().filter(|c| c.number > 0).take(8).collect();
+    let has_candidates = !candidates.is_empty();
+
+    let mut base_system = pr_system_for(p.provider.as_deref());
+    if has_candidates {
+        // Swap the issue-reference ban line for the relaxed rule that allows the
+        // final `Closes:`/`Relates:` trailer lines drawn from the Related issues
+        // section. Both lines are constructed with the in-scope `abbrev`, so the
+        // swap works cross-provider (GitHub `PR` / GitLab `MR`).
+        let ban = format!(
+            "- NEVER reference issue or {abbrev} numbers, tickets, milestones, or external links (e.g. \"Closes #123\", \"part of #60\", \"fixes JIRA-4\"). You have no access to the issue tracker, so any such reference is fabricated — leave them out entirely."
+        );
+        let relaxed = format!(
+            "- Do not put issue or {abbrev} numbers, tickets, milestones, or external links in the description body — the ONLY issue references you may make are the final Closes:/Relates: lines defined in the \"Related issues\" section, chosen from its list. Any other reference is fabricated — leave it out."
+        );
+        base_system = base_system.replacen(&ban, &relaxed, 1);
+    }
+
+    let mut system_parts = vec![base_system];
     push_instruction_sections(
         &mut system_parts,
         p.repo_instructions.as_deref(),
@@ -685,6 +862,21 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
         ));
     }
 
+    // Related-issues proposal — only when real candidates were found (server-side
+    // fetch). Pushed AFTER the Labels section so the `Closes:`/`Relates:` trailer
+    // lines land after any `Labels:` line. Empty ⇒ this section is absent and the
+    // ban above is untouched.
+    if has_candidates {
+        let issue_lines = candidates
+            .iter()
+            .map(|c| render_issue_line(c.number, &c.title, &c.state))
+            .collect::<Vec<_>>()
+            .join("\n");
+        system_parts.push(format!(
+            "## Related issues\n{issue_lines}\nThese are real, open-or-closed issues from this repository's tracker that MAY be related to this change — judge each by its title against what the diff actually does. Most changes genuinely address at most one or two, often none; never force a link. After the description (and after the Labels line when present), report qualifying issues on up to two final lines, exactly like:\nCloses: 123, 456\nRelates: 789\nUse Closes ONLY for an issue this change fully resolves — merging will close it automatically, so prefer Relates when unsure. Use Relates for an issue this change advances or clearly connects to without resolving it. List ONLY numbers from the list above, never any other number; omit either line (or both) when no issue qualifies."
+        ));
+    }
+
     let mut closing = format!(
         "Write the {pr_noun} title and description. Lead with a summary of the goal, then group \
          related changes by theme under `###` headings when the diff touches several areas, citing \
@@ -696,8 +888,22 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
              instructed.",
         );
     }
+    if has_candidates {
+        closing.push_str(
+            " Then, if any of the listed related issues qualify, end with the `Closes:` / `Relates:` \
+             line(s) as instructed.",
+        );
+    }
     prompt_parts.push(closing);
 
+    // The note's trailing clause: with candidates the `no issue/{abbrev} references`
+    // rule is replaced by the Closes:/Relates: allowance; without, it's byte-identical
+    // to before.
+    let note_tail = if has_candidates {
+        "; issue references may appear ONLY as the final Closes:/Relates: lines drawn from the Related issues section".to_string()
+    } else {
+        format!(" and no issue/{abbrev} references")
+    };
     Recipe {
         system: system_parts.join("\n\n"),
         prompt: prompt_parts.join("\n\n"),
@@ -705,8 +911,7 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
             &format!("{pr_noun} title and description"),
             &format!(
                 "The first line is the {pr_noun} title (imperative, no trailing period), then a \
-                 blank line, then the description in {}, with no code fences and no issue/{abbrev} \
-                 references.",
+                 blank line, then the description in {}, with no code fences{note_tail}.",
                 copy.markdown_flavor
             ),
         ),
@@ -905,6 +1110,11 @@ impl GitDesktopMcp {
             })
             .unwrap_or_default();
 
+        // Related-issue candidates are best-effort (mirrors the labels fetch): any
+        // error — including Bitbucket's issues-disabled error — yields an empty list
+        // and thus no `## Related issues` section.
+        let candidate_issues = self.gather_pr_candidates(&head, &commit_subjects).await;
+
         let provider = provider_tag(&self.repo).await;
         let repo_instructions = crate::instructions::read_repo_instructions(self.repo.clone())
             .await
@@ -919,10 +1129,100 @@ impl GitDesktopMcp {
             base_branch: base,
             head_branch: head,
             available_labels,
+            candidate_issues,
             repo_instructions,
             global_instructions: settings.global_instructions,
             provider,
         }))
+    }
+
+    /// Gather up to 8 real candidate issues for the PR-description prompt,
+    /// best-effort (any forge error → empty, matching the labels fetch). Numbers
+    /// referenced in the branch name + commit subjects are pinned first (extraction
+    /// order); remaining slots fill from the open-issue page ranked by title-token
+    /// overlap with the branch + subjects. Mirrors the TS candidate gathering.
+    async fn gather_pr_candidates(
+        &self,
+        head: &str,
+        commit_subjects: &[String],
+    ) -> Vec<IssueCandidate> {
+        // Text the extraction + ranking read from: branch name + each commit subject.
+        let subjects = commit_subjects.join("\n");
+        let extracted = extract_issue_numbers(&format!("{head}\n{subjects}"));
+
+        // The open-issue page (origin-pinned, like the labels fetch: `lens = None`).
+        // On any error (incl. Bitbucket's issues-disabled), there are no candidates.
+        let open_page: Vec<crate::github::issue::IssueInfo> =
+            crate::forge::forge_issue_list(self.repo.clone(), "open".to_string(), Some(50), None)
+                .await
+                .unwrap_or_default();
+
+        let mut out: Vec<IssueCandidate> = Vec::new();
+        let mut included: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        // 1. Extracted numbers first (pinned, extraction order). Prefer the open-page
+        //    entry; for numbers not on the page, probe the single-issue view and
+        //    include on success, dropping silently on any error.
+        for n in &extracted {
+            if included.contains(n) {
+                continue;
+            }
+            if let Some(info) = open_page.iter().find(|i| i.number == *n) {
+                included.insert(*n);
+                out.push(IssueCandidate {
+                    number: info.number,
+                    title: info.title.clone(),
+                    state: info.state.clone(),
+                });
+            } else if let Ok(details) =
+                crate::forge::forge_issue_view(self.repo.clone(), *n, None).await
+            {
+                included.insert(*n);
+                out.push(IssueCandidate {
+                    number: details.number,
+                    title: details.title,
+                    state: details.state,
+                });
+            }
+        }
+
+        // 2. Fill remaining slots (up to 8 total) from the open page, ranked by the
+        //    count of shared long (≥4-char) tokens between the issue title and the
+        //    branch + subjects, tie-broken by `updated_at` descending.
+        if out.len() < 8 {
+            let context = format!("{head}\n{subjects}");
+            let context_tokens = long_tokens(&context);
+            let mut ranked: Vec<(usize, &crate::github::issue::IssueInfo)> = open_page
+                .iter()
+                .filter(|i| !included.contains(&i.number))
+                .map(|i| {
+                    let title_tokens = long_tokens(&i.title);
+                    let score = title_tokens
+                        .iter()
+                        .filter(|t| context_tokens.contains(*t))
+                        .count();
+                    (score, i)
+                })
+                .collect();
+            // Score desc, then updated_at desc (string compare on ISO-8601 is
+            // chronological).
+            ranked.sort_by(|a, b| {
+                b.0.cmp(&a.0)
+                    .then_with(|| b.1.updated_at.cmp(&a.1.updated_at))
+            });
+            for (_, info) in ranked {
+                if out.len() >= 8 {
+                    break;
+                }
+                out.push(IssueCandidate {
+                    number: info.number,
+                    title: info.title.clone(),
+                    state: info.state.clone(),
+                });
+            }
+        }
+
+        out
     }
 
     /// Gather + assemble the branch-name recipe (WHOLE working tree). Errors with
@@ -1226,6 +1526,7 @@ mod tests {
             base_branch: "main".to_string(),
             head_branch: "feature/x".to_string(),
             available_labels: vec![],
+            candidate_issues: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1257,6 +1558,7 @@ mod tests {
                 ("bug".to_string(), None),
                 ("  ".to_string(), None),
             ],
+            candidate_issues: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("gitlab".to_string()),
@@ -1292,6 +1594,7 @@ mod tests {
                 "no-changelog".to_string(),
                 Some("Skip the changelog check".to_string()),
             )],
+            candidate_issues: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1315,6 +1618,7 @@ mod tests {
                 ("enhancement".to_string(), None),
                 ("chore".to_string(), Some("   ".to_string())),
             ],
+            candidate_issues: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1323,6 +1627,200 @@ mod tests {
         assert!(recipe.system.contains("- chore"));
         assert!(!recipe.system.contains("- enhancement —"));
         assert!(!recipe.system.contains("- chore —"));
+    }
+
+    // ---- Related issues (candidate plumbing + render) ----------------------
+
+    /// The exact PR_SYSTEM issue-reference ban line (post provider-swap for GitHub
+    /// it's byte-identical) — used to assert the ban is present without candidates
+    /// and absent with them.
+    const BAN_LINE: &str = "- NEVER reference issue or PR numbers, tickets, milestones, or external links (e.g. \"Closes #123\", \"part of #60\", \"fixes JIRA-4\"). You have no access to the issue tracker, so any such reference is fabricated — leave them out entirely.";
+    const RELAXED_LINE: &str = "- Do not put issue or PR numbers, tickets, milestones, or external links in the description body — the ONLY issue references you may make are the final Closes:/Relates: lines defined in the \"Related issues\" section, chosen from its list. Any other reference is fabricated — leave it out.";
+
+    fn candidate(number: u64, title: &str, state: &str) -> IssueCandidate {
+        IssueCandidate {
+            number,
+            title: title.to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    #[test]
+    fn pr_recipe_no_candidates_keeps_ban_and_old_note() {
+        // Byte-stability guard: with no candidates the ban stands, there's no
+        // `## Related issues` section, and the note ends with the old tail.
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
+            diff_truncated: false,
+            files: vec![file("x.rs", 1, 0, false)],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "topic".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![],
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("github".to_string()),
+        });
+        assert!(recipe.system.contains(BAN_LINE));
+        assert!(!recipe.system.contains(RELAXED_LINE));
+        assert!(!recipe.system.contains("## Related issues"));
+        assert!(!recipe.prompt.contains("## Related issues"));
+        assert!(recipe
+            .note
+            .ends_with("with no code fences and no issue/PR references."));
+        assert!(!recipe.note.contains("Closes:/Relates:"));
+    }
+
+    #[test]
+    fn pr_recipe_with_candidates_swaps_ban_and_renders_section() {
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
+            diff_truncated: false,
+            files: vec![file("x.rs", 1, 0, false)],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "fix/123-crash".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![
+                candidate(123, "Fix crash", "OPEN"),
+                candidate(7, "", "CLOSED"),
+                candidate(45, "Overlong title that should be capped ".repeat(10).trim(), "OPEN"),
+            ],
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("github".to_string()),
+        });
+        // Ban swapped for the relaxed rule.
+        assert!(recipe.system.contains(RELAXED_LINE));
+        assert!(!recipe.system.contains(BAN_LINE));
+        // Section present with the expected bullet forms.
+        assert!(recipe.system.contains("## Related issues"));
+        assert!(recipe.system.contains("- #123 — Fix crash"));
+        // Empty-title closed issue → bare form with closed marker, no ` — `.
+        assert!(recipe.system.contains("- #7 (closed)"));
+        assert!(!recipe.system.contains("- #7 (closed) —"));
+        // 140-char title cap (the rendered title portion is at most 140 chars).
+        let long_bullet = recipe
+            .system
+            .lines()
+            .find(|l| l.starts_with("- #45 "))
+            .expect("issue 45 bullet");
+        let rendered_title = long_bullet.trim_start_matches("- #45 — ");
+        assert_eq!(rendered_title.chars().count(), 140);
+        // Closing sentence and the swapped note tail.
+        assert!(recipe
+            .prompt
+            .contains("if any of the listed related issues qualify, end with the `Closes:` / `Relates:` line(s)"));
+        assert!(recipe.note.contains(
+            "issue references may appear ONLY as the final Closes:/Relates: lines drawn from the Related issues section."
+        ));
+        assert!(!recipe.note.contains("no issue/PR references"));
+    }
+
+    #[test]
+    fn pr_recipe_candidates_swap_uses_mr_on_gitlab() {
+        // The ban/relaxed lines are constructed with the in-scope abbrev, so the
+        // swap works cross-provider (GitLab → MR).
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: String::new(),
+            diff_truncated: false,
+            files: vec![],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "topic".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![candidate(9, "Thing", "OPEN")],
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("gitlab".to_string()),
+        });
+        // The GitLab ban line uses "issue or MR numbers"; after the swap the relaxed
+        // MR-worded line is present and neither ban form remains.
+        assert!(recipe
+            .system
+            .contains("the ONLY issue references you may make are the final Closes:/Relates: lines"));
+        assert!(recipe.system.contains("issue or MR numbers, tickets, milestones, or external links in the description body"));
+        assert!(!recipe
+            .system
+            .contains("NEVER reference issue or MR numbers"));
+        assert!(recipe.system.contains("## Related issues"));
+    }
+
+    #[test]
+    fn pr_recipe_candidates_capped_at_eight() {
+        let candidate_issues: Vec<IssueCandidate> =
+            (1..=9).map(|n| candidate(n, &format!("Issue {n}"), "OPEN")).collect();
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: String::new(),
+            diff_truncated: false,
+            files: vec![],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "topic".to_string(),
+            available_labels: vec![],
+            candidate_issues,
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("github".to_string()),
+        });
+        // Eight rendered, the ninth dropped by the defensive cap.
+        for n in 1..=8 {
+            assert!(recipe.system.contains(&format!("- #{n} — Issue {n}")));
+        }
+        assert!(!recipe.system.contains("- #9 — Issue 9"));
+    }
+
+    #[test]
+    fn render_issue_line_forms() {
+        assert_eq!(render_issue_line(123, "Fix crash", "OPEN"), "- #123 — Fix crash");
+        assert_eq!(render_issue_line(7, "", "CLOSED"), "- #7 (closed)");
+        assert_eq!(render_issue_line(7, "   ", "CLOSED"), "- #7 (closed)");
+        assert_eq!(render_issue_line(8, "Done", "CLOSED"), "- #8 (closed) — Done");
+        // Case-insensitive closed check.
+        assert_eq!(render_issue_line(9, "x", "closed"), "- #9 (closed) — x");
+        // 140-char title cap.
+        let long: String = "a".repeat(200);
+        let line = render_issue_line(1, &long, "OPEN");
+        let title = line.trim_start_matches("- #1 — ");
+        assert_eq!(title.chars().count(), 140);
+    }
+
+    // ---- extract_issue_numbers (mirror of extract.ts) ----------------------
+
+    #[test]
+    fn extract_issue_numbers_case_table() {
+        assert_eq!(extract_issue_numbers("fix/123-crash"), vec![123]);
+        assert_eq!(extract_issue_numbers("#45"), vec![45]);
+        assert_eq!(extract_issue_numbers("123-fix"), vec![123]);
+        assert_eq!(extract_issue_numbers("&#39;"), Vec::<u64>::new());
+        assert_eq!(extract_issue_numbers("issue-7"), vec![7]);
+        assert_eq!(extract_issue_numbers("gh-7"), vec![7]);
+        assert_eq!(extract_issue_numbers("GH-7"), vec![7]);
+        assert_eq!(extract_issue_numbers("v2-123"), Vec::<u64>::new());
+        // `#` preceded by a letter/digit does not match.
+        assert_eq!(extract_issue_numbers("abc#12"), Vec::<u64>::new());
+        assert_eq!(extract_issue_numbers("9#12"), Vec::<u64>::new());
+        // 0 and out-of-range dropped.
+        assert_eq!(extract_issue_numbers("#0"), Vec::<u64>::new());
+        assert_eq!(extract_issue_numbers("#1000000000"), Vec::<u64>::new());
+        assert_eq!(extract_issue_numbers("#999999999"), vec![999_999_999]);
+    }
+
+    #[test]
+    fn extract_issue_numbers_dedupes_first_occurrence_order() {
+        // Same number twice → kept once (first occurrence).
+        assert_eq!(extract_issue_numbers("#12 #12"), vec![12]);
+        // Patterns applied in order 1→2→3 over the full text: pattern 1 (`#45`),
+        // then pattern 2 (`123-`), then pattern 3 (`issue-7`).
+        assert_eq!(
+            extract_issue_numbers("fix/123-thing #45 issue-7"),
+            vec![45, 123, 7]
+        );
+        // A number reachable by BOTH pattern 1 (`#5`) and pattern 2 (`5-` at string
+        // start) is emitted once — during the pattern-1 pass, which runs first —
+        // even though the pattern-2 hit appears earlier in the text.
+        assert_eq!(extract_issue_numbers("5-x #5"), vec![5]);
     }
 
     // ---- budget_diff (mirror of truncate.ts budgetDiff) --------------------

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -511,6 +511,72 @@ fn extract_issue_numbers(text: &str) -> Vec<u64> {
     out
 }
 
+/// Extract the linked project's Jira issue keys from git text (branch name,
+/// commit subjects) — `<PROJECTKEY>-\d+` case-insensitive, deduped,
+/// first-occurrence order, upper-cased. KEEP IN SYNC: `extractJiraKeys` in
+/// src/lib/jira/keys.ts (same boundary table; no lookbehind — hand-rolled scan).
+///
+/// Boundary semantics (copied from keys.ts's documented table):
+///   - LEFT: the char before the key must NOT be `[A-Za-z0-9]` — underscore
+///     adjacency IS allowed (`feature_MYT-5` → MYT-5); a letter/digit prefix
+///     rejects (`XMYT-1` → []).
+///   - RIGHT (after the digits): reject a letter suffix (`MYT-12a` → []) and a
+///     version-like `dot+digit` (`MYT-1.2` → []); a sentence-ending period still
+///     matches (`fixes MYT-1.` → MYT-1).
+///
+/// Case-insensitive on the key. Empty text or empty `project_key` → `[]`.
+/// Case table: `feature_MYT-5 → MYT-5`, `feat/myt-2-fix → MYT-2`, `XMYT-1 → []`,
+/// `MYT-12a → []`, `MYT-1.2 → []`, `fixes MYT-1. → MYT-1`.
+fn extract_jira_keys(text: &str, project_key: &str) -> Vec<String> {
+    if text.is_empty() || project_key.is_empty() {
+        return Vec::new();
+    }
+    let bytes = text.as_bytes();
+    let key_bytes = project_key.as_bytes();
+    let klen = key_bytes.len();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+
+    let mut i = 0usize;
+    while i < bytes.len() {
+        // LEFT boundary: at start, or the preceding byte is not [A-Za-z0-9].
+        let left_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+        // Case-insensitive prefix match on the project key.
+        let key_ok = i + klen <= bytes.len() && bytes[i..i + klen].eq_ignore_ascii_case(key_bytes);
+        if left_ok && key_ok {
+            // Must be followed by `-` then ≥1 ASCII digit.
+            let dash = i + klen;
+            if dash < bytes.len() && bytes[dash] == b'-' {
+                let mut j = dash + 1;
+                while j < bytes.len() && bytes[j].is_ascii_digit() {
+                    j += 1;
+                }
+                if j > dash + 1 {
+                    // At least one digit consumed. RIGHT boundary checks:
+                    //   - no trailing letter (`MYT-12a`)
+                    //   - no `dot+digit` (`MYT-1.2`), while `MYT-1.` still matches.
+                    let next = bytes.get(j).copied();
+                    let letter_suffix = next.is_some_and(|b| b.is_ascii_alphabetic());
+                    let dot_digit = next == Some(b'.')
+                        && bytes.get(j + 1).copied().is_some_and(|b| b.is_ascii_digit());
+                    if !letter_suffix && !dot_digit {
+                        // Canonical upper-case key so `myt-2` and `MYT-2` dedupe.
+                        let key = text[i..j].to_ascii_uppercase();
+                        if seen.insert(key.clone()) {
+                            out.push(key);
+                        }
+                        // Advance past this key (can't start another match mid-run).
+                        i = j;
+                        continue;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
 /// The set of ASCII-lowercased tokens of length ≥ 4 in `text`, splitting on any
 /// non-alphanumeric character. Used to score candidate-issue title overlap with
 /// the branch name + commit subjects when ranking fill candidates.
@@ -706,6 +772,15 @@ struct IssueCandidate {
     state: String,
 }
 
+/// A real issue from the repo's LINKED Jira project the model may mention.
+/// Mention-only: Jira tickets are never closed from PR-description text.
+struct JiraCandidate {
+    key: String,
+    summary: String,
+    /// Jira status category: "new" / "indeterminate" / "done" / "".
+    status_category: String,
+}
+
 /// The gathered pieces a PR-description recipe is assembled from.
 struct PrPieces {
     diff_text: String,
@@ -722,6 +797,12 @@ struct PrPieces {
     /// Empty ⇒ the prompt is byte-identical to before and the issue-reference ban
     /// stands.
     candidate_issues: Vec<IssueCandidate>,
+    /// Real candidate issues from the repo's LINKED Jira project the model may
+    /// MENTION (best-effort; Bitbucket-only). Mutually exclusive with
+    /// `candidate_issues` — the Bitbucket-only gather makes both-non-empty
+    /// impossible by construction; if both ever arrive, `candidate_issues` wins
+    /// and this is ignored (precedence encoded in `assemble_pr_recipe`).
+    jira_candidates: Vec<JiraCandidate>,
     repo_instructions: Option<String>,
     global_instructions: String,
     /// Frontend provider tag: `"github"` / `"gitlab"` / `"bitbucket"`, or None
@@ -759,6 +840,22 @@ fn render_issue_line(number: u64, title: &str, state: &str) -> String {
     }
 }
 
+/// Render one Jira candidate as a bullet for the `## Related issues` section:
+/// `- MYT-123 — summary`, ` (done)` suffixed when `status_category` is "done",
+/// bare `- MYT-123` when the summary is empty. Summary trimmed + 140-char cap.
+/// KEEP IN SYNC with the TS mirror (`renderJiraLine`, src/lib/ai/prompt.ts).
+fn render_jira_line(key: &str, summary: &str, status_category: &str) -> String {
+    let done = status_category.eq_ignore_ascii_case("done");
+    let suffix = if done { " (done)" } else { "" };
+    let summary = summary.trim();
+    if summary.is_empty() {
+        format!("- {key}{suffix}")
+    } else {
+        let capped: String = summary.chars().take(140).collect();
+        format!("- {key}{suffix} — {capped}")
+    }
+}
+
 /// Assemble the PR/MR-description recipe. Mirrors `buildPrPrompt`
 /// (src/lib/ai/prompt.ts) — provider-aware noun/markdown-flavor, the label
 /// proposal system section, and the closing instructions. KEEP IN SYNC.
@@ -778,6 +875,22 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
         p.candidate_issues.iter().filter(|c| c.number > 0).take(8).collect();
     let has_candidates = !candidates.is_empty();
 
+    // Jira candidates (Bitbucket repos with a linked project). Mention-only: they
+    // drive a `Relates:`-only variant, never a `Closes:` line. Precedence: native
+    // `candidate_issues` win — the Jira variant fires ONLY when there are no native
+    // candidates (the Bitbucket-only gather makes both-non-empty impossible, but the
+    // precedence is encoded here defensively). Filter empty keys, then cap at 8.
+    let jira_candidates: Vec<&JiraCandidate> = if has_candidates {
+        Vec::new()
+    } else {
+        p.jira_candidates
+            .iter()
+            .filter(|c| !c.key.is_empty())
+            .take(8)
+            .collect()
+    };
+    let has_jira = !jira_candidates.is_empty();
+
     let mut base_system = pr_system_for(p.provider.as_deref());
     if has_candidates {
         // Swap the issue-reference ban line for the relaxed rule that allows the
@@ -789,6 +902,17 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
         );
         let relaxed = format!(
             "- Do not put issue or {abbrev} numbers, tickets, milestones, or external links in the description body — the ONLY issue references you may make are the final Closes:/Relates: lines defined in the \"Related issues\" section, chosen from its list. Any other reference is fabricated — leave it out."
+        );
+        base_system = base_system.replacen(&ban, &relaxed, 1);
+    } else if has_jira {
+        // Jira mention-only variant: swap the ban for a RELAXED line that permits
+        // only the final `Relates:` line (no `Closes:` — Jira tickets aren't closed
+        // from PR text). `abbrev` is "PR" on Bitbucket.
+        let ban = format!(
+            "- NEVER reference issue or {abbrev} numbers, tickets, milestones, or external links (e.g. \"Closes #123\", \"part of #60\", \"fixes JIRA-4\"). You have no access to the issue tracker, so any such reference is fabricated — leave them out entirely."
+        );
+        let relaxed = format!(
+            "- Do not put issue or {abbrev} numbers, tickets, milestones, or external links in the description body — the ONLY ticket references you may make are the final Relates: line defined in the \"Related issues\" section, chosen from its list. Any other reference is fabricated — leave it out."
         );
         base_system = base_system.replacen(&ban, &relaxed, 1);
     }
@@ -875,6 +999,19 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
         system_parts.push(format!(
             "## Related issues\n{issue_lines}\nThese are real, open-or-closed issues from this repository's tracker that MAY be related to this change — judge each by its title against what the diff actually does. Most changes genuinely address at most one or two, often none; never force a link. After the description (and after the Labels line when present), report qualifying issues on up to two final lines, exactly like:\nCloses: 123, 456\nRelates: 789\nUse Closes ONLY for an issue this change fully resolves — merging will close it automatically, so prefer Relates when unsure. Use Relates for an issue this change advances or clearly connects to without resolving it. List ONLY numbers from the list above, never any other number; omit either line (or both) when no issue qualifies."
         ));
+    } else if has_jira {
+        // Jira mention-only variant of the Related-issues section (Bitbucket + linked
+        // project). Pushed AFTER the Labels section so the `Relates:` line lands after
+        // any `Labels:` line. Only a `Relates:` line is offered — Jira tickets are not
+        // closed from PR text.
+        let issue_lines = jira_candidates
+            .iter()
+            .map(|c| render_jira_line(&c.key, &c.summary, &c.status_category))
+            .collect::<Vec<_>>()
+            .join("\n");
+        system_parts.push(format!(
+            "## Related issues\n{issue_lines}\nThese are real issues from this repository's linked Jira project that MAY be related to this change — judge each by its title against what the diff actually does. Most changes genuinely address at most one or two, often none; never force a link. After the description (and after the Labels line when present), report qualifying issues on ONE final line, exactly like:\nRelates: MYT-123, MYT-456\nNever use a Closes line for these — Jira tickets are not closed from pull-request text. List ONLY keys from the list above, never any other key; omit the line when no issue qualifies."
+        ));
     }
 
     let mut closing = format!(
@@ -893,14 +1030,22 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
             " Then, if any of the listed related issues qualify, end with the `Closes:` / `Relates:` \
              line(s) as instructed.",
         );
+    } else if has_jira {
+        closing.push_str(
+            " Then, if any of the listed related issues qualify, end with the `Relates:` line as \
+             instructed.",
+        );
     }
     prompt_parts.push(closing);
 
-    // The note's trailing clause: with candidates the `no issue/{abbrev} references`
-    // rule is replaced by the Closes:/Relates: allowance; without, it's byte-identical
-    // to before.
+    // The note's trailing clause: with native candidates the `no issue/{abbrev}
+    // references` rule is replaced by the Closes:/Relates: allowance; with Jira
+    // candidates by the mention-only Relates: allowance; without either, it's
+    // byte-identical to before.
     let note_tail = if has_candidates {
         "; issue references may appear ONLY as the final Closes:/Relates: lines drawn from the Related issues section".to_string()
+    } else if has_jira {
+        "; ticket references may appear ONLY as the final Relates: line drawn from the Related issues section".to_string()
     } else {
         format!(" and no issue/{abbrev} references")
     };
@@ -1116,6 +1261,19 @@ impl GitDesktopMcp {
         let candidate_issues = self.gather_pr_candidates(&head, &commit_subjects).await;
 
         let provider = provider_tag(&self.repo).await;
+
+        // On a Bitbucket repo with NO native candidates (its issue tracker is
+        // deprecated, so `candidate_issues` is always empty there) but a linked Jira
+        // project, gather Jira candidates for a mention-only `Relates:` variant.
+        // Best-effort: never fails the recipe. Mutually exclusive with the native list.
+        let jira_candidates = if candidate_issues.is_empty()
+            && provider.as_deref() == Some("bitbucket")
+        {
+            self.gather_jira_candidates(&head, &commit_subjects).await
+        } else {
+            Vec::new()
+        };
+
         let repo_instructions = crate::instructions::read_repo_instructions(self.repo.clone())
             .await
             .map_err(app_err)?;
@@ -1130,6 +1288,7 @@ impl GitDesktopMcp {
             head_branch: head,
             available_labels,
             candidate_issues,
+            jira_candidates,
             repo_instructions,
             global_instructions: settings.global_instructions,
             provider,
@@ -1218,6 +1377,100 @@ impl GitDesktopMcp {
                     number: info.number,
                     title: info.title.clone(),
                     state: info.state.clone(),
+                });
+            }
+        }
+
+        out
+    }
+
+    /// Gather up to 8 Jira candidates for the PR-description prompt from the repo's
+    /// LINKED Jira project (Bitbucket repos), best-effort — any failure (no link, a
+    /// Jira API error) yields an empty list so the recipe NEVER fails because Jira
+    /// isn't linked. Keys referenced in the branch name + commit subjects are pinned
+    /// first (extraction order); remaining slots fill from the open-issue page ranked
+    /// by summary-token overlap. Mirrors `gather_pr_candidates`.
+    async fn gather_jira_candidates(
+        &self,
+        head: &str,
+        commit_subjects: &[String],
+    ) -> Vec<JiraCandidate> {
+        // Resolve the linked project (site + key). No link ⇒ no candidates (the recipe
+        // must never fail because Jira isn't linked, so map the error to empty).
+        let Ok(link) = self.jira_link().await else {
+            return Vec::new();
+        };
+
+        // Text the extraction + ranking read from: branch name + each commit subject.
+        let subjects = commit_subjects.join("\n");
+        let extracted = extract_jira_keys(&format!("{head}\n{subjects}"), &link.project_key);
+
+        // The open-issue page (single page, 50-cap internal). Any error ⇒ no candidates.
+        let open_page: Vec<crate::forge::jira::JiraIssueInfo> =
+            crate::forge::jira::issue_list(&link.site_host, &link.project_key, "open")
+                .await
+                .unwrap_or_default();
+
+        let mut out: Vec<JiraCandidate> = Vec::new();
+        let mut included: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        // 1. Extracted keys first (pinned, extraction order). Prefer the open-page
+        //    entry; for keys not on the page, probe the single-issue view (only after
+        //    confirming the key belongs to the linked project), including on success and
+        //    dropping silently on any error.
+        for key in &extracted {
+            if included.contains(key) {
+                continue;
+            }
+            if let Some(info) = open_page.iter().find(|i| i.key.eq_ignore_ascii_case(key)) {
+                included.insert(key.clone());
+                out.push(JiraCandidate {
+                    key: info.key.clone(),
+                    summary: info.summary.clone(),
+                    status_category: info.status_category.clone(),
+                });
+            } else if super::ensure_key_in_project(key, &link).is_ok() {
+                if let Ok(details) = crate::forge::jira::issue_view(&link.site_host, key).await {
+                    included.insert(key.clone());
+                    out.push(JiraCandidate {
+                        key: details.key,
+                        summary: details.summary,
+                        status_category: details.status_category,
+                    });
+                }
+            }
+        }
+
+        // 2. Fill remaining slots (up to 8 total) from the open page, ranked by the
+        //    count of shared long (≥4-char) tokens between the issue summary and the
+        //    branch + subjects, tie-broken by `updated_at` descending.
+        if out.len() < 8 {
+            let context = format!("{head}\n{subjects}");
+            let context_tokens = long_tokens(&context);
+            let mut ranked: Vec<(usize, &crate::forge::jira::JiraIssueInfo)> = open_page
+                .iter()
+                .filter(|i| !included.contains(&i.key))
+                .map(|i| {
+                    let summary_tokens = long_tokens(&i.summary);
+                    let score = summary_tokens
+                        .iter()
+                        .filter(|t| context_tokens.contains(*t))
+                        .count();
+                    (score, i)
+                })
+                .collect();
+            ranked.sort_by(|a, b| {
+                b.0.cmp(&a.0)
+                    .then_with(|| b.1.updated_at.cmp(&a.1.updated_at))
+            });
+            for (_, info) in ranked {
+                if out.len() >= 8 {
+                    break;
+                }
+                out.push(JiraCandidate {
+                    key: info.key.clone(),
+                    summary: info.summary.clone(),
+                    status_category: info.status_category.clone(),
                 });
             }
         }
@@ -1527,6 +1780,7 @@ mod tests {
             head_branch: "feature/x".to_string(),
             available_labels: vec![],
             candidate_issues: vec![],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1559,6 +1813,7 @@ mod tests {
                 ("  ".to_string(), None),
             ],
             candidate_issues: vec![],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("gitlab".to_string()),
@@ -1595,6 +1850,7 @@ mod tests {
                 Some("Skip the changelog check".to_string()),
             )],
             candidate_issues: vec![],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1619,6 +1875,7 @@ mod tests {
                 ("chore".to_string(), Some("   ".to_string())),
             ],
             candidate_issues: vec![],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1658,6 +1915,7 @@ mod tests {
             head_branch: "topic".to_string(),
             available_labels: vec![],
             candidate_issues: vec![],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1687,6 +1945,7 @@ mod tests {
                 candidate(7, "", "CLOSED"),
                 candidate(45, "Overlong title that should be capped ".repeat(10).trim(), "OPEN"),
             ],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1731,6 +1990,7 @@ mod tests {
             head_branch: "topic".to_string(),
             available_labels: vec![],
             candidate_issues: vec![candidate(9, "Thing", "OPEN")],
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("gitlab".to_string()),
@@ -1760,6 +2020,7 @@ mod tests {
             head_branch: "topic".to_string(),
             available_labels: vec![],
             candidate_issues,
+            jira_candidates: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
             provider: Some("github".to_string()),
@@ -1784,6 +2045,170 @@ mod tests {
         let line = render_issue_line(1, &long, "OPEN");
         let title = line.trim_start_matches("- #1 — ");
         assert_eq!(title.chars().count(), 140);
+    }
+
+    // ---- Jira candidates (mention-only Related-issues variant) --------------
+
+    fn jira_candidate(key: &str, summary: &str, status_category: &str) -> JiraCandidate {
+        JiraCandidate {
+            key: key.to_string(),
+            summary: summary.to_string(),
+            status_category: status_category.to_string(),
+        }
+    }
+
+    /// The Bitbucket (abbrev "PR") relaxed-ban line for the Jira variant.
+    const JIRA_RELAXED_LINE: &str = "- Do not put issue or PR numbers, tickets, milestones, or external links in the description body — the ONLY ticket references you may make are the final Relates: line defined in the \"Related issues\" section, chosen from its list. Any other reference is fabricated — leave it out.";
+
+    #[test]
+    fn extract_jira_keys_case_table() {
+        // Underscore adjacency allowed; letter/digit prefix rejected.
+        assert_eq!(extract_jira_keys("feature_MYT-5", "MYT"), vec!["MYT-5"]);
+        // Case-insensitive key, canonical upper-case output.
+        assert_eq!(extract_jira_keys("feat/myt-2-fix", "MYT"), vec!["MYT-2"]);
+        // Letter prefix → no match.
+        assert_eq!(extract_jira_keys("XMYT-1", "MYT"), Vec::<String>::new());
+        // Trailing letter → no match.
+        assert_eq!(extract_jira_keys("MYT-12a", "MYT"), Vec::<String>::new());
+        // dot+digit → no match.
+        assert_eq!(extract_jira_keys("MYT-1.2", "MYT"), Vec::<String>::new());
+        // Sentence-ending period still matches.
+        assert_eq!(extract_jira_keys("fixes MYT-1.", "MYT"), vec!["MYT-1"]);
+        // Greedy digits (no MYT-1 from MYT-12).
+        assert_eq!(extract_jira_keys("MYT-12", "MYT"), vec!["MYT-12"]);
+        // Digit prefix rejected (`9MYT-1`).
+        assert_eq!(extract_jira_keys("9MYT-1", "MYT"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn extract_jira_keys_dedupes_and_is_case_insensitive() {
+        // `myt-2` and `MYT-2` dedupe to one canonical entry, first-occurrence order.
+        assert_eq!(
+            extract_jira_keys("myt-2 and MYT-2 and MYT-3", "MYT"),
+            vec!["MYT-2", "MYT-3"]
+        );
+        // Lowercased project key argument still matches.
+        assert_eq!(extract_jira_keys("MYT-9", "myt"), vec!["MYT-9"]);
+    }
+
+    #[test]
+    fn extract_jira_keys_empty_inputs() {
+        assert_eq!(extract_jira_keys("", "MYT"), Vec::<String>::new());
+        assert_eq!(extract_jira_keys("MYT-1", ""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn render_jira_line_forms() {
+        assert_eq!(render_jira_line("MYT-1", "Fix login", "new"), "- MYT-1 — Fix login");
+        // Done marker (case-insensitive).
+        assert_eq!(render_jira_line("MYT-2", "Ship it", "done"), "- MYT-2 (done) — Ship it");
+        assert_eq!(render_jira_line("MYT-3", "x", "DONE"), "- MYT-3 (done) — x");
+        // Bare key when the summary is empty (no dangling ` — `).
+        assert_eq!(render_jira_line("MYT-4", "", "new"), "- MYT-4");
+        assert_eq!(render_jira_line("MYT-5", "   ", "done"), "- MYT-5 (done)");
+        // 140-char summary cap.
+        let long: String = "a".repeat(200);
+        let line = render_jira_line("MYT-6", &long, "new");
+        let summary = line.trim_start_matches("- MYT-6 — ");
+        assert_eq!(summary.chars().count(), 140);
+    }
+
+    #[test]
+    fn pr_recipe_jira_candidates_render_relates_only_variant() {
+        // Bitbucket repo, no native candidates, Jira candidates present → the
+        // mention-only `Relates:` variant renders (no `Closes:` example).
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
+            diff_truncated: false,
+            files: vec![file("x.rs", 1, 0, false)],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "feature/MYT-123-fix".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![],
+            jira_candidates: vec![
+                jira_candidate("MYT-1", "Fix login", "new"),
+                jira_candidate("MYT-2", "Ship it", "done"),
+            ],
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("bitbucket".to_string()),
+        });
+        // Relaxed Jira ban present; the native ban absent.
+        assert!(recipe.system.contains(JIRA_RELAXED_LINE));
+        assert!(!recipe.system.contains(BAN_LINE));
+        // Section renders the Jira bullets (done marker on MYT-2).
+        assert!(recipe.system.contains("## Related issues"));
+        assert!(recipe.system.contains("- MYT-1 — Fix login"));
+        assert!(recipe.system.contains("- MYT-2 (done) — Ship it"));
+        // The `Relates:` example is present; NO `Closes:` example anywhere.
+        assert!(recipe.system.contains("Relates: MYT-123, MYT-456"));
+        assert!(!recipe.system.contains("Closes: 123"));
+        assert!(recipe
+            .system
+            .contains("Never use a Closes line for these — Jira tickets are not closed"));
+        // Closing sentence for the Relates-only variant.
+        assert!(recipe
+            .prompt
+            .contains("if any of the listed related issues qualify, end with the `Relates:` line as instructed."));
+        // Note tail swapped to the ticket-variant.
+        assert!(recipe.note.contains(
+            "with no code fences; ticket references may appear ONLY as the final Relates: line drawn from the Related issues section."
+        ));
+        assert!(!recipe.note.contains("no issue/PR references"));
+    }
+
+    #[test]
+    fn pr_recipe_native_candidates_win_over_jira() {
+        // Both lists constructed non-empty (impossible in production, guarded here):
+        // native candidates win, no Jira section, Jira ban line absent.
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
+            diff_truncated: false,
+            files: vec![file("x.rs", 1, 0, false)],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "topic".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![candidate(123, "Native issue", "OPEN")],
+            jira_candidates: vec![jira_candidate("MYT-1", "Jira issue", "new")],
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("github".to_string()),
+        });
+        // Native relaxed line, native bullet; no Jira bullet or Relates-only copy.
+        assert!(recipe.system.contains(RELAXED_LINE));
+        assert!(recipe.system.contains("- #123 — Native issue"));
+        assert!(!recipe.system.contains("- MYT-1"));
+        assert!(!recipe.system.contains(JIRA_RELAXED_LINE));
+        assert!(!recipe.system.contains("Jira tickets are not closed"));
+        // Native Closes:/Relates: example is what renders.
+        assert!(recipe.system.contains("Closes: 123, 456"));
+    }
+
+    #[test]
+    fn pr_recipe_jira_candidates_capped_at_eight() {
+        let jira_candidates: Vec<JiraCandidate> = (1..=9)
+            .map(|n| jira_candidate(&format!("MYT-{n}"), &format!("Issue {n}"), "new"))
+            .collect();
+        let recipe = assemble_pr_recipe(PrPieces {
+            diff_text: String::new(),
+            diff_truncated: false,
+            files: vec![],
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "topic".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![],
+            jira_candidates,
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("bitbucket".to_string()),
+        });
+        for n in 1..=8 {
+            assert!(recipe.system.contains(&format!("- MYT-{n} — Issue {n}")));
+        }
+        assert!(!recipe.system.contains("- MYT-9 — Issue 9"));
     }
 
     // ---- extract_issue_numbers (mirror of extract.ts) ----------------------

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -84,6 +84,11 @@ interface EditTitleBodyDialogProps {
   /** Mirrors the Generate button's disabled state (undefined ⇒ false): the chord
    *  still swallows but doesn't run. */
   generateDisabled?: boolean;
+  /** Optional content rendered between the body field and the footer (e.g. the
+   *  linked-issue chip cluster on the PR edit paths). Optional exactly like
+   *  `onGenerate` — the issue views omit it, so they compile untouched and render
+   *  byte-identically. */
+  belowBody?: ReactNode;
 }
 
 export const EditTitleBodyDialog = withForm({
@@ -101,6 +106,7 @@ export const EditTitleBodyDialog = withForm({
     onGenerate: undefined as (() => void) | undefined,
     generating: undefined as boolean | undefined,
     generateDisabled: undefined as boolean | undefined,
+    belowBody: undefined as ReactNode,
   } as EditTitleBodyDialogProps,
   render: function EditTitleBodyDialogRender({
     form,
@@ -114,6 +120,7 @@ export const EditTitleBodyDialog = withForm({
     onGenerate,
     generating,
     generateDisabled,
+    belowBody,
   }) {
     // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
     // default) while this dialog is open — never a hardcoded chord, so a
@@ -190,6 +197,7 @@ export const EditTitleBodyDialog = withForm({
                 />
               )}
             </form.AppField>
+            {belowBody}
             <DialogFooter>
               <Button
                 type="button"

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -711,10 +711,21 @@ line, and the composer says so.
 Create a PR with **Create pull request** ({{kbd:create-pr}}) or from the Compare tab — as
 a **draft** if you like, and set its **labels** and **assignees** right in the dialog
 (GitHub and GitLab; Bitbucket PRs have neither, so it shows only its reviewers picker
-instead){{ai}}. You can also fill the title and description with an **AI-generated** draft
-from the branch diff and commit subjects — which additionally **proposes labels**, chosen
-only from the repository's existing labels and added to whatever you've already picked
-(never invented). The same **Generate** button is on the **Edit** dialog too, so you can
+instead). A **Linked issues** row (GitHub and GitLab, wherever the repo has an issue
+tracker) lets you reference real repo issues on create: chips are **auto-detected** from
+your branch name and commit subjects (a \`fix/123-…\` branch seeds \`#123\`, validated
+against your actual issues), and you can add more by hand with **Link issue**. Each chip
+starts as **Relates to** and a click — or Enter on the focused chip — flips it to
+**Closes**, which asks the forge to close that issue when the PR merges; the chips become
+\`Closes #N\` / \`Relates to #N\` lines appended to the description on create. The row is
+keyboard-operable: **← / →** move between chips, Enter or Space toggles Closes / Relates,
+and Delete removes a chip.{{ai}} You can also fill the title and description with an
+**AI-generated** draft from the branch diff and commit subjects — which additionally
+**proposes labels**, chosen only from the repository's existing labels and added to
+whatever you've already picked (never invented), and can **propose issue links** too,
+picked only from a grounded shortlist of your open issues (AI-picked chips carry a
+**sparkle**; a proposed *Closes* still lands as a safe *Relates to* you can toggle up).
+The same **Generate** button is on the **Edit** dialog too, so you can
 write or regenerate an existing PR's title and description at any time — including for pull
 requests from forks. The Create dialog also has an optional collapsed **Notes for
 reviewers** field below the description — it pre-fills from any notes an agent (or another

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -719,12 +719,23 @@ starts as **Relates to** and a click — or Enter on the focused chip — flips 
 **Closes**, which asks the forge to close that issue when the PR merges; the chips become
 \`Closes #N\` / \`Relates to #N\` lines appended to the description on create. The row is
 keyboard-operable: **← / →** move between chips, Enter or Space toggles Closes / Relates,
-and Delete removes a chip.{{ai}} You can also fill the title and description with an
+and Delete removes a chip. The **same row is on the Edit dialog** and on **local PRs**
+(create and edit, wherever the repo's forge has an issue tracker): opening Edit peels any
+trailing \`Closes #N\` / \`Relates to #N\` lines back out of the description into chips
+(keyword preserved) and re-appends them when you save, so the chips — not the raw text —
+are the single editor for that ref block. A local PR's ref lines survive **promotion**
+verbatim, becoming real closing refs on the forge once it's promoted to a real PR. On a
+**Bitbucket** repo with a **linked Jira project** (Create and Edit of a remote PR), the
+row instead surfaces linked-Jira issues (\`KEY-123\`) as **mention-only** chips — a fixed
+*Relates to* with no Closes, appended as \`Relates to KEY-123\` lines, since Jira tickets
+are never closed from PR text.{{ai}} You can also fill the title and description with an
 **AI-generated** draft from the branch diff and commit subjects — which additionally
 **proposes labels**, chosen only from the repository's existing labels and added to
 whatever you've already picked (never invented), and can **propose issue links** too,
 picked only from a grounded shortlist of your open issues (AI-picked chips carry a
-**sparkle**; a proposed *Closes* still lands as a safe *Relates to* you can toggle up).
+**sparkle**; a proposed *Closes* still lands as a safe *Relates to* you can toggle up) —
+or, on a Bitbucket repo with a linked Jira project, linked-Jira keys to mention, drawn
+from the same kind of grounded shortlist so it never invents a key.
 The same **Generate** button is on the **Edit** dialog too, so you can
 write or regenerate an existing PR's title and description at any time — including for pull
 requests from forks. The Create dialog also has an optional collapsed **Notes for

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -16,8 +16,10 @@ import { REVIEWER_NOTES_MARKER } from "@/lib/ai/notes-context";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { required, useAppForm } from "@/lib/form";
 import {
+  forgeFeatureReady,
   useCompareBranches,
   useDefaultBranch,
+  useForgeStatus,
   useRepoStatus,
 } from "@/lib/git/queries";
 import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
@@ -28,9 +30,14 @@ import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { LinkedIssuesField } from "./LinkedIssuesField";
 import { ReviewerNotesField } from "./ReviewerNotesField";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
+import {
+  composeBodyWithRefs,
+  useLinkedIssueChips,
+} from "./useLinkedIssueChips";
 
 /** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
  *  literal modifier (house platform-mod-key rule). */
@@ -57,6 +64,13 @@ export function CreateLocalPrDialog({
   const createPr = useCreateLocalPr(repoPath);
   const { generate, cancel, generating } = useGeneratePrDescription(repoPath);
   const aiEnabled = useAiEnabled();
+  // Linked issues: real repo issues to reference. A local PR's `Closes #N` lines
+  // survive promotion verbatim into the real forge PR, so these become real
+  // closing refs later — intended. Non-AI surface (shown under Hide-AI too),
+  // gated only on the forge having a usable issue tracker.
+  const ghStatus = useForgeStatus(repoPath);
+  const canLinkIssues =
+    !!ghStatus.data && forgeFeatureReady(ghStatus.data, "issues");
   const selectPr = useUiStore((s) => s.selectPr);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
   const queryClient = useQueryClient();
@@ -82,9 +96,14 @@ export function CreateLocalPrDialog({
     },
     onSubmit: async ({ value }) => {
       try {
+        // Append the linked-issue chips as their exact keyword lines via the
+        // shared composer (the single ref-block composition every create/edit
+        // save path uses). These `Closes #N` lines carry into a later promotion,
+        // and the review event below reads the same composed body.
+        const finalBody = composeBodyWithRefs(value.body, linkedIssues);
         const pr = await createPr.mutateAsync({
           title: value.title.trim(),
-          body: value.body,
+          body: finalBody,
           base: value.base,
           head: value.head,
         });
@@ -140,7 +159,7 @@ export function CreateLocalPrDialog({
           // `ahead` (git log) is newest-first, so the head is the first entry.
           headSha: ahead[0]?.hash,
           title: value.title.trim(),
-          body: value.body,
+          body: finalBody,
           commitSubjects: ahead.map((c) => c.subject),
           target: { type: "local", id: pr.id },
           reviewNotes: notes || undefined,
@@ -154,6 +173,10 @@ export function CreateLocalPrDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // seeded head/base back to empty (untouched form).
   const seedOnOpen = useEffectEvent(() => {
+    // Reset the linked-issue chips (and their dismissed/probed refs) to empty —
+    // the dialog opens with no seeded body refs; extraction/AI seeding then
+    // repopulates from the head branch + commits.
+    resetLinkedIssues([]);
     const h = defaultHead ?? currentName ?? names[0] ?? "";
     const fallbackBase =
       defaultBranch.data && defaultBranch.data !== h
@@ -185,6 +208,26 @@ export function CreateLocalPrDialog({
   const ahead = comparison.data?.ahead ?? [];
   const sameBranch = base === head;
 
+  // Shared chip state machine — enabled while the dialog is open and the tracker
+  // is usable. Local PRs have no lens concept, so read the forge's own issues
+  // ("origin"). Reset to empty on open (seedOnOpen); extraction/AI seeding then
+  // repopulates from the head branch + commits.
+  const {
+    chips: linkedIssues,
+    resetWith: resetLinkedIssues,
+    toggleKeyword: toggleIssueKeyword,
+    remove: removeIssue,
+    pick: pickIssue,
+    buildCandidates: buildIssueCandidates,
+    upsertFromDraft: upsertAiIssues,
+  } = useLinkedIssueChips({
+    repoPath,
+    lens: "origin",
+    enabled: open && canLinkIssues,
+    headBranch: head || null,
+    commitSubjects: ahead.map((c) => c.subject),
+  });
+
   // AI title+description generation — shared by the Generate button's onClick and
   // the dialog-local generate chord below. Verbatim the button's prior body.
   function runGenerate() {
@@ -195,13 +238,18 @@ export function CreateLocalPrDialog({
       (d) => {
         form.setFieldValue("title", d.title);
         form.setFieldValue("body", d.body);
+        // Union the model's proposed issue links into the chip cluster (same
+        // rules as create — relate-default, dismissed-set, AI sparkle).
+        upsertAiIssues({ closes: d.closes, relates: d.relates });
       },
       // Local PRs keep the base GitHub prompt wording (no provider) and propose
-      // no labels; the trailing arg is the author's reviewer notes, reflected
-      // into the generated description.
+      // no labels. The trailing args are the author's reviewer notes (reflected
+      // into the generated description) and the grounded issue candidates —
+      // chips pinned first, then top-ranked open issues.
       undefined,
       [],
       notes.trim() || undefined,
+      buildIssueCandidates(),
     );
   }
   // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
@@ -362,6 +410,21 @@ export function CreateLocalPrDialog({
                 />
               )}
             </form.AppField>
+
+            {/* Linked issues: real repo issues referenced on create. Non-AI
+                surface (shown under Hide-AI too), gated on the tracker being
+                usable. Composed into the body as `Closes #N`/`Relates to #N`. */}
+            {canLinkIssues && (
+              <LinkedIssuesField
+                repoPath={repoPath}
+                lens="origin"
+                chips={linkedIssues}
+                onToggleKeyword={toggleIssueKeyword}
+                onRemove={removeIssue}
+                onPick={pickIssue}
+                disabled={generating}
+              />
+            )}
 
             {/* Collapsed "Notes for reviewers": deposit-seeded author context,
                 appended as the local PR's first comment and fed to the AI

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -5,7 +5,7 @@ import {
   TagIcon,
   XIcon,
 } from "@phosphor-icons/react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
@@ -35,6 +35,7 @@ import {
   useCreatePr,
   useDefaultBranch,
   useForgeStatus,
+  useIssueList,
   usePrsForBranch,
   useRepoLabels,
   useRepoStatus,
@@ -46,6 +47,7 @@ import {
 } from "@/lib/git/types";
 import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { extractIssueNumbers } from "@/lib/issues/extract";
 import {
   useLensGate,
   useRemoteSlug,
@@ -54,10 +56,33 @@ import {
 import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
+import { type LinkedIssueChip, LinkedIssuesField } from "./LinkedIssuesField";
 import { ReviewerNotesField } from "./ReviewerNotesField";
 import { ReviewersPopover } from "./ReviewersPopover";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
+
+/** Issue-detail probe options mirroring `issueDetailsOptions` in queries.ts
+ *  (not exported there). Used to validate an extracted number that isn't on the
+ *  open-issues page before it becomes a chip. */
+function issueDetailsOptions(repo: string, number: number, lens: RemoteLens) {
+  return queryOptions({
+    queryKey: ["repo", repo, "issue", lens, number] as const,
+    queryFn: () => api.forgeIssueView(repo, number, lens),
+    staleTime: 30_000,
+  });
+}
+
+/** Lowercased tokens (length ≥ 4, split on non-alphanumerics) for ranking issue
+ *  titles against the branch + commit subjects by shared-token overlap. */
+function rankTokens(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 4),
+  );
+}
 
 /** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
  *  literal modifier (house platform-mod-key rule). */
@@ -158,6 +183,31 @@ export function CreatePrDialog({
   const [reviewers, setReviewers] = useState<ForgeUserRef[]>([]);
   const [labels, setLabels] = useState<Set<string>>(new Set());
   const [assignees, setAssignees] = useState<ForgeUserRef[]>([]);
+
+  // Linked issues: real repo issues to reference on create (extraction-seeded,
+  // AI-proposed, or manually added). These become `Closes #N`/`Relates to #N`
+  // lines appended to the body — body text, not create-mutation params — so
+  // unlike labels they work on the PARENT path too, with the parent's issues.
+  // Gated only on the forge having a usable issue tracker (not on `aiEnabled`:
+  // the cluster is a non-AI surface — Hide-AI still shows it, minus AI chips).
+  const canLinkIssues = !!forge.data && forgeFeatureReady(forge.data, "issues");
+  // Open issues (page of 50) to validate seeds against and to rank as prompt
+  // candidates. Uses the create lens, so the parent target reads the parent's
+  // issues.
+  const issueList = useIssueList(
+    repoPath,
+    open && canLinkIssues,
+    "open",
+    50,
+    createLens,
+  );
+  const [linkedIssues, setLinkedIssues] = useState<LinkedIssueChip[]>([]);
+  // A number the user removed (or that came in dismissed): upserts (seed/AI) skip
+  // it; a MANUAL pick clears it (explicit intent overrides). Reset in seedOnOpen.
+  const dismissedIssuesRef = useRef<Set<number>>(new Set());
+  // Numbers already probed this dialog-open (present-or-absent from the open
+  // page), so the fetchQuery probe runs at most once per number per open.
+  const probedIssuesRef = useRef<Set<number>>(new Set());
   // Group-label ids: these fields wrap trigger-style widgets (segmented buttons
   // and popover triggers) that carry their own aria-label, so the visible field
   // label names the surrounding group via aria-labelledby rather than htmlFor.
@@ -251,6 +301,19 @@ export function CreatePrDialog({
     },
     onSubmit: async ({ value }) => {
       try {
+        // Append the linked-issue chips as their exact keyword lines. The forge
+        // does the real linking/auto-closing on merge; here we only compose body
+        // text. Two blank lines separate the refs block from the description.
+        const refLines = linkedIssues.map((c) =>
+          c.keyword === "closes"
+            ? `Closes #${c.number}`
+            : `Relates to #${c.number}`,
+        );
+        const finalBody = refLines.length
+          ? [value.body.trimEnd(), refLines.join("\n")]
+              .filter(Boolean)
+              .join("\n\n")
+          : value.body;
         const { number, url } = await createPr.mutateAsync({
           base: value.base,
           // Head stays a bare LOCAL branch name either way: the backend pushes it
@@ -261,7 +324,7 @@ export function CreatePrDialog({
           // toastError below.
           head: value.head,
           title: value.title.trim(),
-          body: value.body,
+          body: finalBody,
           draft: value.draft,
           // Targets the fork ("origin") or its parent ("upstream"); the parent
           // path rejects reviewers/labels/assignees backend-side (their pickers
@@ -352,7 +415,7 @@ export function CreatePrDialog({
             // `ahead` (git log) is newest-first, so the head is the first entry.
             headSha: ahead[0]?.hash,
             title: value.title.trim(),
-            body: value.body,
+            body: finalBody,
             commitSubjects: ahead.map((c) => c.subject),
             target: { type: "remote", number },
             reviewNotes: notes || undefined,
@@ -373,6 +436,9 @@ export function CreatePrDialog({
     setReviewers([]);
     setLabels(new Set());
     setAssignees([]);
+    setLinkedIssues([]);
+    dismissedIssuesRef.current = new Set();
+    probedIssuesRef.current = new Set();
     // Reset the target to the default (parent) every open, so a prior fork/parent
     // choice doesn't leak into the next PR.
     setTarget("upstream");
@@ -481,6 +547,111 @@ export function CreatePrDialog({
   const branchPrs = usePrsForBranch(repoPath, head || null, open, createLens);
   const existingPr = (branchPrs.data ?? []).find((p) => p.baseRefName === base);
 
+  // ── Linked-issue chip mutations ──────────────────────────────────────────
+  function toggleIssueKeyword(issueNumber: number) {
+    setLinkedIssues((prev) =>
+      prev.map((c) =>
+        c.number === issueNumber
+          ? { ...c, keyword: c.keyword === "closes" ? "relates" : "closes" }
+          : c,
+      ),
+    );
+  }
+  function removeIssue(issueNumber: number) {
+    dismissedIssuesRef.current.add(issueNumber);
+    setLinkedIssues((prev) => prev.filter((c) => c.number !== issueNumber));
+  }
+  // Manual pick from the picker: an explicit user intent, so it clears any prior
+  // dismissal for that number and adds it as a `manual` relates chip. The picker
+  // already excludes current chips, so a duplicate can't arrive here.
+  function pickIssue(issueNumber: number) {
+    dismissedIssuesRef.current.delete(issueNumber);
+    const found = (issueList.data ?? []).find((i) => i.number === issueNumber);
+    setLinkedIssues((prev) => {
+      if (prev.some((c) => c.number === issueNumber)) return prev;
+      return [
+        ...prev,
+        {
+          number: issueNumber,
+          title: found?.title ?? `#${issueNumber}`,
+          state: found?.state ?? "OPEN",
+          keyword: "relates",
+          source: "manual",
+          aiSuggestedClose: false,
+        },
+      ];
+    });
+  }
+
+  // Extraction seeding: pull candidate issue numbers from the head branch name
+  // and the commit subjects, then add a chip for each that's a real repo issue —
+  // resolving from the open-issues page, or probing the tracker once for a number
+  // not on that page (dropping it on any error: it's a PR number, a deleted
+  // issue, or noise). Dismissed and already-present numbers are skipped. Runs
+  // once per number per dialog-open; re-runs when head/commits change.
+  const seedExtractedIssues = useEffectEvent(
+    (numbers: number[], openIssues: typeof issueList.data) => {
+      const existing = new Set(linkedIssues.map((c) => c.number));
+      for (const n of numbers) {
+        if (existing.has(n) || dismissedIssuesRef.current.has(n)) continue;
+        const hit = openIssues?.find((i) => i.number === n);
+        if (hit) {
+          setLinkedIssues((prev) =>
+            prev.some((c) => c.number === n)
+              ? prev
+              : [
+                  ...prev,
+                  {
+                    number: n,
+                    title: hit.title,
+                    state: hit.state,
+                    keyword: "relates",
+                    source: "extraction",
+                    aiSuggestedClose: false,
+                  },
+                ],
+          );
+          continue;
+        }
+        // Not on the open page — probe the tracker once. Skip if the open list
+        // hasn't loaded yet (a later run resolves it) so we don't probe numbers
+        // that would have matched the page.
+        if (!openIssues) continue;
+        if (probedIssuesRef.current.has(n)) continue;
+        probedIssuesRef.current.add(n);
+        queryClient
+          .fetchQuery(issueDetailsOptions(repoPath, n, createLens))
+          .then((issue) => {
+            if (dismissedIssuesRef.current.has(n)) return;
+            setLinkedIssues((prev) =>
+              prev.some((c) => c.number === n)
+                ? prev
+                : [
+                    ...prev,
+                    {
+                      number: issue.number,
+                      title: issue.title,
+                      state: issue.state,
+                      keyword: "relates",
+                      source: "extraction",
+                      aiSuggestedClose: false,
+                    },
+                  ],
+            );
+          })
+          .catch(() => undefined);
+      }
+    },
+  );
+  useEffect(() => {
+    if (!open || !canLinkIssues) return;
+    const numbers = extractIssueNumbers(
+      `${head}\n${ahead.map((c) => c.subject).join("\n")}`,
+    );
+    if (numbers.length === 0) return;
+    seedExtractedIssues(numbers, issueList.data);
+  }, [open, canLinkIssues, head, ahead, issueList.data]);
+
   function toggleLabel(name: string, on: boolean) {
     setLabels((prev) => {
       const next = new Set(prev);
@@ -498,6 +669,43 @@ export function CreatePrDialog({
   // the dialog-local generate chord below. Verbatim the button's prior body.
   function runGenerate() {
     aiDescriptionRef.current = true;
+    // Grounded issue candidates the model may link: current chips (extraction +
+    // manual + AI) pinned first, then the highest-scoring OPEN issues by
+    // shared-token overlap between the title and the branch + commit subjects,
+    // filling to a total cap of 8. Dismissed numbers are still eligible as
+    // candidates (the user dismissed a CHIP, not the model's judgment) — but the
+    // stream-union below skips re-adding a dismissed number as a chip.
+    const chipNumbers = new Set(linkedIssues.map((c) => c.number));
+    const chipCandidates = linkedIssues.map((c) => ({
+      number: c.number,
+      title: c.title,
+      state: c.state,
+    }));
+    const rankText = rankTokens(
+      `${head} ${ahead.map((c) => c.subject).join(" ")}`,
+    );
+    const ranked = (issueList.data ?? [])
+      .filter((i) => !chipNumbers.has(i.number))
+      .map((i) => {
+        const titleTokens = rankTokens(i.title);
+        let score = 0;
+        for (const t of titleTokens) if (rankText.has(t)) score++;
+        return { issue: i, score };
+      })
+      .sort(
+        (a, b) =>
+          b.score - a.score || (b.issue.updatedAt < a.issue.updatedAt ? -1 : 1),
+      )
+      .map((r) => ({
+        number: r.issue.number,
+        title: r.issue.title,
+        state: r.issue.state,
+      }));
+    const issueCandidates = canLinkIssues
+      ? [...chipCandidates, ...ranked].slice(0, 8)
+      : [];
+    // Resolve title/state for AI-proposed numbers from the exact set we fed.
+    const fedByNumber = new Map(issueCandidates.map((c) => [c.number, c]));
     generate(
       base,
       head,
@@ -508,6 +716,12 @@ export function CreatePrDialog({
         // Additive: union the model's (already repo-validated) labels with the
         // user's manual picks, never replace.
         setLabels((prev) => new Set([...prev, ...d.labels]));
+        // Union the model's proposed issue links into the chip cluster. A `closes`
+        // proposal marks `aiSuggestedClose` (sorts first, hint tooltip); both land
+        // as `relates` chips (the safe default the user can toggle up). Skip
+        // dismissed numbers; never downgrade an existing chip — only OR-in the
+        // `aiSuggestedClose` flag.
+        upsertAiIssues(d.closes, d.relates, fedByNumber);
       },
       // Provider-aware prompt copy (MR/merge-request noun, markdown flavor);
       // null host → base GitHub wording.
@@ -520,7 +734,51 @@ export function CreatePrDialog({
       })) ?? [],
       // Author's reviewer notes — reflected into the generated description.
       notes.trim() || undefined,
+      // Grounded issue candidates — empty ⇒ prompt's issue-reference ban intact.
+      issueCandidates,
     );
+  }
+
+  /** Merge the model's proposed close/relate numbers into the chip cluster. */
+  function upsertAiIssues(
+    closes: number[],
+    relates: number[],
+    fed: Map<number, { number: number; title: string; state: string }>,
+  ) {
+    // A number in both lists is a close proposal (stronger signal wins).
+    const closeSet = new Set(closes);
+    const all = [...new Set([...closes, ...relates])];
+    setLinkedIssues((prev) => {
+      let next = prev;
+      for (const n of all) {
+        if (dismissedIssuesRef.current.has(n)) continue;
+        const suggestedClose = closeSet.has(n);
+        const existingIdx = next.findIndex((c) => c.number === n);
+        if (existingIdx >= 0) {
+          // Never downgrade an existing chip — only OR-in the AI close hint.
+          if (suggestedClose && !next[existingIdx].aiSuggestedClose) {
+            next = next.map((c, i) =>
+              i === existingIdx ? { ...c, aiSuggestedClose: true } : c,
+            );
+          }
+          continue;
+        }
+        const meta = fed.get(n);
+        if (!meta) continue;
+        next = [
+          ...next,
+          {
+            number: n,
+            title: meta.title,
+            state: meta.state,
+            keyword: "relates",
+            source: "ai",
+            aiSuggestedClose: suggestedClose,
+          },
+        ];
+      }
+      return next;
+    });
   }
   // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
   // default) while this dialog is open — never a hardcoded chord, so a
@@ -888,6 +1146,22 @@ export function CreatePrDialog({
                 />
               )}
             </form.AppField>
+
+            {/* Linked issues: real repo issues referenced on create. Non-AI
+                surface (shown under Hide-AI too), gated on the tracker being
+                usable. Chips stay interactive while generating — the stream union
+                only adds/annotates, never fights a user edit. */}
+            {canLinkIssues && (
+              <LinkedIssuesField
+                repoPath={repoPath}
+                lens={createLens}
+                chips={linkedIssues}
+                onToggleKeyword={toggleIssueKeyword}
+                onRemove={removeIssue}
+                onPick={pickIssue}
+                disabled={generating}
+              />
+            )}
 
             {/* Collapsed "Notes for reviewers": deposit-seeded author context,
                 posted as the PR's first comment and fed to the AI review. AI-only. */}

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -5,7 +5,7 @@ import {
   TagIcon,
   XIcon,
 } from "@phosphor-icons/react";
-import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
@@ -35,7 +35,6 @@ import {
   useCreatePr,
   useDefaultBranch,
   useForgeStatus,
-  useIssueList,
   usePrsForBranch,
   useRepoLabels,
   useRepoStatus,
@@ -47,7 +46,7 @@ import {
 } from "@/lib/git/types";
 import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
-import { extractIssueNumbers } from "@/lib/issues/extract";
+import { useJiraLink } from "@/lib/jira/queries";
 import {
   useLensGate,
   useRemoteSlug,
@@ -56,33 +55,17 @@ import {
 import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
-import { type LinkedIssueChip, LinkedIssuesField } from "./LinkedIssuesField";
+import { LinkedIssuesField } from "./LinkedIssuesField";
 import { ReviewerNotesField } from "./ReviewerNotesField";
 import { ReviewersPopover } from "./ReviewersPopover";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
-
-/** Issue-detail probe options mirroring `issueDetailsOptions` in queries.ts
- *  (not exported there). Used to validate an extracted number that isn't on the
- *  open-issues page before it becomes a chip. */
-function issueDetailsOptions(repo: string, number: number, lens: RemoteLens) {
-  return queryOptions({
-    queryKey: ["repo", repo, "issue", lens, number] as const,
-    queryFn: () => api.forgeIssueView(repo, number, lens),
-    staleTime: 30_000,
-  });
-}
-
-/** Lowercased tokens (length ≥ 4, split on non-alphanumerics) for ranking issue
- *  titles against the branch + commit subjects by shared-token overlap. */
-function rankTokens(text: string): Set<string> {
-  return new Set(
-    text
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter((t) => t.length >= 4),
-  );
-}
+import {
+  composeBodyWithJiraRefs,
+  composeBodyWithRefs,
+  useJiraMentionChips,
+  useLinkedIssueChips,
+} from "./useLinkedIssueChips";
 
 /** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
  *  literal modifier (house platform-mod-key rule). */
@@ -191,23 +174,12 @@ export function CreatePrDialog({
   // Gated only on the forge having a usable issue tracker (not on `aiEnabled`:
   // the cluster is a non-AI surface — Hide-AI still shows it, minus AI chips).
   const canLinkIssues = !!forge.data && forgeFeatureReady(forge.data, "issues");
-  // Open issues (page of 50) to validate seeds against and to rank as prompt
-  // candidates. Uses the create lens, so the parent target reads the parent's
-  // issues.
-  const issueList = useIssueList(
-    repoPath,
-    open && canLinkIssues,
-    "open",
-    50,
-    createLens,
-  );
-  const [linkedIssues, setLinkedIssues] = useState<LinkedIssueChip[]>([]);
-  // A number the user removed (or that came in dismissed): upserts (seed/AI) skip
-  // it; a MANUAL pick clears it (explicit intent overrides). Reset in seedOnOpen.
-  const dismissedIssuesRef = useRef<Set<number>>(new Set());
-  // Numbers already probed this dialog-open (present-or-absent from the open
-  // page), so the fetchQuery probe runs at most once per number per open.
-  const probedIssuesRef = useRef<Set<number>>(new Set());
+  // Bitbucket repos have no native tracker (`canLinkIssues` is false), so a
+  // LINKED Jira project drives a mention-only cluster instead. Mutually exclusive
+  // with the native cluster — only ever one in the dialog.
+  const jiraLink = useJiraLink(repoPath);
+  const canJiraMention =
+    !canLinkIssues && forge.data?.provider === "bitbucket" && !!jiraLink.data;
   // Group-label ids: these fields wrap trigger-style widgets (segmented buttons
   // and popover triggers) that carry their own aria-label, so the visible field
   // label names the surrounding group via aria-labelledby rather than htmlFor.
@@ -301,19 +273,16 @@ export function CreatePrDialog({
     },
     onSubmit: async ({ value }) => {
       try {
-        // Append the linked-issue chips as their exact keyword lines. The forge
-        // does the real linking/auto-closing on merge; here we only compose body
-        // text. Two blank lines separate the refs block from the description.
-        const refLines = linkedIssues.map((c) =>
-          c.keyword === "closes"
-            ? `Closes #${c.number}`
-            : `Relates to #${c.number}`,
-        );
-        const finalBody = refLines.length
-          ? [value.body.trimEnd(), refLines.join("\n")]
-              .filter(Boolean)
-              .join("\n\n")
-          : value.body;
+        // Append the linked-issue chips as their exact keyword lines via the
+        // shared composer (the single ref-block composition used by every
+        // create/edit save path). The forge does the real linking/auto-closing on
+        // merge; here we only compose body text. On a Bitbucket repo with a Jira
+        // link, the Jira mention chips compose `Relates to KEY` lines instead (the
+        // two clusters are mutually exclusive).
+        const finalBody =
+          canJiraMention && jiraChips.length > 0
+            ? composeBodyWithJiraRefs(value.body, jiraChips)
+            : composeBodyWithRefs(value.body, linkedIssues);
         const { number, url } = await createPr.mutateAsync({
           base: value.base,
           // Head stays a bare LOCAL branch name either way: the backend pushes it
@@ -436,9 +405,12 @@ export function CreatePrDialog({
     setReviewers([]);
     setLabels(new Set());
     setAssignees([]);
-    setLinkedIssues([]);
-    dismissedIssuesRef.current = new Set();
-    probedIssuesRef.current = new Set();
+    // Reset the linked-issue chips (and their dismissed/probed refs) to empty —
+    // the create dialog opens with no seeded body refs; extraction/AI seeding
+    // then repopulates from the head branch + commits.
+    resetLinkedIssues([]);
+    // Same for the Jira mention cluster (Bitbucket + linked project).
+    resetJiraChips([]);
     // Reset the target to the default (parent) every open, so a prior fork/parent
     // choice doesn't leak into the next PR.
     setTarget("upstream");
@@ -547,110 +519,44 @@ export function CreatePrDialog({
   const branchPrs = usePrsForBranch(repoPath, head || null, open, createLens);
   const existingPr = (branchPrs.data ?? []).find((p) => p.baseRefName === base);
 
-  // ── Linked-issue chip mutations ──────────────────────────────────────────
-  function toggleIssueKeyword(issueNumber: number) {
-    setLinkedIssues((prev) =>
-      prev.map((c) =>
-        c.number === issueNumber
-          ? { ...c, keyword: c.keyword === "closes" ? "relates" : "closes" }
-          : c,
-      ),
-    );
-  }
-  function removeIssue(issueNumber: number) {
-    dismissedIssuesRef.current.add(issueNumber);
-    setLinkedIssues((prev) => prev.filter((c) => c.number !== issueNumber));
-  }
-  // Manual pick from the picker: an explicit user intent, so it clears any prior
-  // dismissal for that number and adds it as a `manual` relates chip. The picker
-  // already excludes current chips, so a duplicate can't arrive here.
-  function pickIssue(issueNumber: number) {
-    dismissedIssuesRef.current.delete(issueNumber);
-    const found = (issueList.data ?? []).find((i) => i.number === issueNumber);
-    setLinkedIssues((prev) => {
-      if (prev.some((c) => c.number === issueNumber)) return prev;
-      return [
-        ...prev,
-        {
-          number: issueNumber,
-          title: found?.title ?? `#${issueNumber}`,
-          state: found?.state ?? "OPEN",
-          keyword: "relates",
-          source: "manual",
-          aiSuggestedClose: false,
-        },
-      ];
-    });
-  }
+  // Linked-issue chip cluster — extraction seeding, AI union, candidate ranking,
+  // and the chip mutations all live in the shared hook (also used by the edit and
+  // local-create paths). Gated on the tracker being usable AND the dialog open;
+  // reset from empty in seedOnOpen. The parent target reads the parent's issues
+  // (createLens). Chips compose into the body as `Closes #N`/`Relates to #N`.
+  const {
+    chips: linkedIssues,
+    resetWith: resetLinkedIssues,
+    toggleKeyword: toggleIssueKeyword,
+    remove: removeIssue,
+    pick: pickIssue,
+    buildCandidates: buildIssueCandidates,
+    upsertFromDraft: upsertAiIssues,
+  } = useLinkedIssueChips({
+    repoPath,
+    lens: createLens,
+    enabled: open && canLinkIssues,
+    headBranch: head || null,
+    commitSubjects: ahead.map((c) => c.subject),
+  });
 
-  // Extraction seeding: pull candidate issue numbers from the head branch name
-  // and the commit subjects, then add a chip for each that's a real repo issue —
-  // resolving from the open-issues page, or probing the tracker once for a number
-  // not on that page (dropping it on any error: it's a PR number, a deleted
-  // issue, or noise). Dismissed and already-present numbers are skipped. Runs
-  // once per number per dialog-open; re-runs when head/commits change.
-  const seedExtractedIssues = useEffectEvent(
-    (numbers: number[], openIssues: typeof issueList.data) => {
-      const existing = new Set(linkedIssues.map((c) => c.number));
-      for (const n of numbers) {
-        if (existing.has(n) || dismissedIssuesRef.current.has(n)) continue;
-        const hit = openIssues?.find((i) => i.number === n);
-        if (hit) {
-          setLinkedIssues((prev) =>
-            prev.some((c) => c.number === n)
-              ? prev
-              : [
-                  ...prev,
-                  {
-                    number: n,
-                    title: hit.title,
-                    state: hit.state,
-                    keyword: "relates",
-                    source: "extraction",
-                    aiSuggestedClose: false,
-                  },
-                ],
-          );
-          continue;
-        }
-        // Not on the open page — probe the tracker once. Skip if the open list
-        // hasn't loaded yet (a later run resolves it) so we don't probe numbers
-        // that would have matched the page.
-        if (!openIssues) continue;
-        if (probedIssuesRef.current.has(n)) continue;
-        probedIssuesRef.current.add(n);
-        queryClient
-          .fetchQuery(issueDetailsOptions(repoPath, n, createLens))
-          .then((issue) => {
-            if (dismissedIssuesRef.current.has(n)) return;
-            setLinkedIssues((prev) =>
-              prev.some((c) => c.number === n)
-                ? prev
-                : [
-                    ...prev,
-                    {
-                      number: issue.number,
-                      title: issue.title,
-                      state: issue.state,
-                      keyword: "relates",
-                      source: "extraction",
-                      aiSuggestedClose: false,
-                    },
-                  ],
-            );
-          })
-          .catch(() => undefined);
-      }
-    },
-  );
-  useEffect(() => {
-    if (!open || !canLinkIssues) return;
-    const numbers = extractIssueNumbers(
-      `${head}\n${ahead.map((c) => c.subject).join("\n")}`,
-    );
-    if (numbers.length === 0) return;
-    seedExtractedIssues(numbers, issueList.data);
-  }, [open, canLinkIssues, head, ahead, issueList.data]);
+  // Jira mention chips — the Bitbucket-only sibling cluster. Enabled on
+  // `open && canJiraMention`; reset from empty in seedOnOpen. Chips compose into
+  // the body as `Relates to KEY` lines; there's no keyword toggle.
+  const {
+    chips: jiraChips,
+    resetWith: resetJiraChips,
+    remove: removeJiraChip,
+    pick: pickJiraChip,
+    buildCandidates: buildJiraCandidates,
+    upsertFromDraft: upsertAiJira,
+  } = useJiraMentionChips({
+    repoPath,
+    enabled: open && canJiraMention,
+    headBranch: head || null,
+    commitSubjects: ahead.map((c) => c.subject),
+    link: jiraLink.data ?? null,
+  });
 
   function toggleLabel(name: string, on: boolean) {
     setLabels((prev) => {
@@ -669,43 +575,13 @@ export function CreatePrDialog({
   // the dialog-local generate chord below. Verbatim the button's prior body.
   function runGenerate() {
     aiDescriptionRef.current = true;
-    // Grounded issue candidates the model may link: current chips (extraction +
-    // manual + AI) pinned first, then the highest-scoring OPEN issues by
-    // shared-token overlap between the title and the branch + commit subjects,
-    // filling to a total cap of 8. Dismissed numbers are still eligible as
-    // candidates (the user dismissed a CHIP, not the model's judgment) — but the
-    // stream-union below skips re-adding a dismissed number as a chip.
-    const chipNumbers = new Set(linkedIssues.map((c) => c.number));
-    const chipCandidates = linkedIssues.map((c) => ({
-      number: c.number,
-      title: c.title,
-      state: c.state,
-    }));
-    const rankText = rankTokens(
-      `${head} ${ahead.map((c) => c.subject).join(" ")}`,
-    );
-    const ranked = (issueList.data ?? [])
-      .filter((i) => !chipNumbers.has(i.number))
-      .map((i) => {
-        const titleTokens = rankTokens(i.title);
-        let score = 0;
-        for (const t of titleTokens) if (rankText.has(t)) score++;
-        return { issue: i, score };
-      })
-      .sort(
-        (a, b) =>
-          b.score - a.score || (b.issue.updatedAt < a.issue.updatedAt ? -1 : 1),
-      )
-      .map((r) => ({
-        number: r.issue.number,
-        title: r.issue.title,
-        state: r.issue.state,
-      }));
-    const issueCandidates = canLinkIssues
-      ? [...chipCandidates, ...ranked].slice(0, 8)
-      : [];
-    // Resolve title/state for AI-proposed numbers from the exact set we fed.
-    const fedByNumber = new Map(issueCandidates.map((c) => [c.number, c]));
+    // Grounded issue candidates the model may link: current chips pinned first,
+    // then the highest-scoring OPEN issues, capped at 8 (the hook records the set
+    // it fed so `upsertAiIssues` can resolve an AI-proposed number's title/state).
+    const issueCandidates = buildIssueCandidates();
+    // Grounded Jira mention candidates (Bitbucket + linked project). Empty unless
+    // the Jira cluster is active; mutually exclusive with `issueCandidates`.
+    const jiraCandidates = canJiraMention ? buildJiraCandidates() : undefined;
     generate(
       base,
       head,
@@ -721,7 +597,9 @@ export function CreatePrDialog({
         // as `relates` chips (the safe default the user can toggle up). Skip
         // dismissed numbers; never downgrade an existing chip — only OR-in the
         // `aiSuggestedClose` flag.
-        upsertAiIssues(d.closes, d.relates, fedByNumber);
+        upsertAiIssues({ closes: d.closes, relates: d.relates });
+        // Union the model's proposed Jira mentions into the mention cluster.
+        upsertAiJira({ jiraMentions: d.jiraMentions });
       },
       // Provider-aware prompt copy (MR/merge-request noun, markdown flavor);
       // null host → base GitHub wording.
@@ -736,49 +614,9 @@ export function CreatePrDialog({
       notes.trim() || undefined,
       // Grounded issue candidates — empty ⇒ prompt's issue-reference ban intact.
       issueCandidates,
+      // Grounded Jira mention candidates — empty/undefined ⇒ no Jira variant.
+      jiraCandidates,
     );
-  }
-
-  /** Merge the model's proposed close/relate numbers into the chip cluster. */
-  function upsertAiIssues(
-    closes: number[],
-    relates: number[],
-    fed: Map<number, { number: number; title: string; state: string }>,
-  ) {
-    // A number in both lists is a close proposal (stronger signal wins).
-    const closeSet = new Set(closes);
-    const all = [...new Set([...closes, ...relates])];
-    setLinkedIssues((prev) => {
-      let next = prev;
-      for (const n of all) {
-        if (dismissedIssuesRef.current.has(n)) continue;
-        const suggestedClose = closeSet.has(n);
-        const existingIdx = next.findIndex((c) => c.number === n);
-        if (existingIdx >= 0) {
-          // Never downgrade an existing chip — only OR-in the AI close hint.
-          if (suggestedClose && !next[existingIdx].aiSuggestedClose) {
-            next = next.map((c, i) =>
-              i === existingIdx ? { ...c, aiSuggestedClose: true } : c,
-            );
-          }
-          continue;
-        }
-        const meta = fed.get(n);
-        if (!meta) continue;
-        next = [
-          ...next,
-          {
-            number: n,
-            title: meta.title,
-            state: meta.state,
-            keyword: "relates",
-            source: "ai",
-            aiSuggestedClose: suggestedClose,
-          },
-        ];
-      }
-      return next;
-    });
   }
   // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
   // default) while this dialog is open — never a hardcoded chord, so a
@@ -1150,8 +988,10 @@ export function CreatePrDialog({
             {/* Linked issues: real repo issues referenced on create. Non-AI
                 surface (shown under Hide-AI too), gated on the tracker being
                 usable. Chips stay interactive while generating — the stream union
-                only adds/annotates, never fights a user edit. */}
-            {canLinkIssues && (
+                only adds/annotates, never fights a user edit. On a Bitbucket repo
+                with a linked Jira project the mention-only variant renders in the
+                SAME slot instead (the two clusters are mutually exclusive). */}
+            {canLinkIssues ? (
               <LinkedIssuesField
                 repoPath={repoPath}
                 lens={createLens}
@@ -1161,7 +1001,17 @@ export function CreatePrDialog({
                 onPick={pickIssue}
                 disabled={generating}
               />
-            )}
+            ) : canJiraMention ? (
+              <LinkedIssuesField
+                variant="jira"
+                repoPath={repoPath}
+                link={jiraLink.data ?? null}
+                jiraChips={jiraChips}
+                onRemove={removeJiraChip}
+                onPick={pickJiraChip}
+                disabled={generating}
+              />
+            ) : null}
 
             {/* Collapsed "Notes for reviewers": deposit-seeded author context,
                 posted as the PR's first comment and fed to the AI review. AI-only. */}

--- a/src/features/pulls/JiraIssuePicker.tsx
+++ b/src/features/pulls/JiraIssuePicker.tsx
@@ -1,0 +1,76 @@
+import { CheckCircleIcon, CircleDashedIcon } from "@phosphor-icons/react";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
+import { useJiraIssues } from "@/lib/jira/queries";
+import type { JiraLink } from "@/lib/jira/store";
+import type { JiraIssueInfo } from "@/lib/jira/types";
+
+/** Open/closed glyph for a Jira issue, so status isn't conveyed by text alone.
+ *  `done` maps to the closed/merged treatment (matching the native `StateIcon`
+ *  CLOSED pair); anything else to the open/success treatment. */
+export function JiraStatusIcon({ statusCategory }: { statusCategory: string }) {
+  return statusCategory.toLowerCase() === "done" ? (
+    <CheckCircleIcon className="size-3.5 shrink-0 text-merged" />
+  ) : (
+    <CircleDashedIcon className="size-3.5 shrink-0 text-success" />
+  );
+}
+
+/**
+ * Autocomplete over the linked Jira project's issues (all states), excluding the
+ * keys already chipped. Picking one fires `onPick`. The Jira twin of `IssuePicker`
+ * (src/features/issues/IssueRelations.tsx) — same Combobox composition, keyed by
+ * the human key (`PROJ-123`). The list loads only while this is mounted (open).
+ */
+export function JiraIssuePicker({
+  repoPath,
+  link,
+  exclude,
+  pending,
+  onPick,
+}: {
+  repoPath: string;
+  link: JiraLink | null;
+  exclude: Set<string>;
+  pending: boolean;
+  onPick: (key: string) => void;
+}) {
+  const issues = useJiraIssues(repoPath, link, "all");
+  const candidates = (issues.data ?? []).filter((i) => !exclude.has(i.key));
+  return (
+    <Combobox
+      items={candidates}
+      itemToStringLabel={(i: JiraIssueInfo) => `${i.key} ${i.summary}`}
+      value={null}
+      onValueChange={(item: JiraIssueInfo | null) => item && onPick(item.key)}
+      openOnInputClick
+    >
+      <ComboboxInput
+        autoFocus
+        className="w-full"
+        placeholder="Search issues by key or summary"
+        disabled={pending}
+      />
+      <ComboboxContent>
+        <ComboboxEmpty>No matching issues.</ComboboxEmpty>
+        <ComboboxList>
+          {(item: JiraIssueInfo) => (
+            <ComboboxItem key={item.key} value={item}>
+              <JiraStatusIcon statusCategory={item.statusCategory} />
+              <span className="font-mono text-muted-foreground">
+                {item.key}
+              </span>
+              <span className="truncate">{item.summary}</span>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}

--- a/src/features/pulls/LinkedIssuesField.tsx
+++ b/src/features/pulls/LinkedIssuesField.tsx
@@ -1,0 +1,198 @@
+import { Popover } from "@base-ui/react/popover";
+import { LinkIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
+import { type KeyboardEvent, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { IssuePicker, StateIcon } from "@/features/issues/IssueRelations";
+import type { RemoteLens } from "@/lib/git/types";
+
+/** One linked-issue chip: a real repo issue the PR will reference on create. The
+ *  keyword becomes a `Closes #N` / `Relates to #N` line appended to the body. */
+export interface LinkedIssueChip {
+  number: number;
+  title: string;
+  /** "OPEN" | "CLOSED" (neutral IssueInfo casing). */
+  state: string;
+  keyword: "closes" | "relates";
+  source: "extraction" | "ai" | "manual";
+  /** The model proposed this as a close — sorts first, keyword gets a hint tooltip. */
+  aiSuggestedClose: boolean;
+}
+
+/** The chip cluster in Create PR: extraction-seeded, AI-proposed, and
+ *  manually-added issue links. The parent owns the chip state; this renders the
+ *  band + the "Link issue" picker and reports toggles/removes/picks upward. */
+export function LinkedIssuesField({
+  repoPath,
+  lens,
+  chips,
+  onToggleKeyword,
+  onRemove,
+  onPick,
+  disabled,
+}: {
+  repoPath: string;
+  lens: RemoteLens;
+  chips: LinkedIssueChip[];
+  onToggleKeyword: (issueNumber: number) => void;
+  onRemove: (issueNumber: number) => void;
+  onPick: (issueNumber: number) => void;
+  disabled?: boolean;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  // Roving tabindex: the band is a single tab stop; ArrowLeft/Right move the
+  // roved index, which sets which chip is focusable + focused.
+  const [focusIndex, setFocusIndex] = useState(0);
+  const chipRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // AI-suggested closes sort first; ties keep insertion order (stable sort).
+  const ordered = [...chips].sort(
+    (a, b) => Number(b.aiSuggestedClose) - Number(a.aiSuggestedClose),
+  );
+  const excluded = new Set(chips.map((c) => c.number));
+
+  function focusChip(index: number) {
+    const clamped = Math.max(0, Math.min(index, ordered.length - 1));
+    setFocusIndex(clamped);
+    chipRefs.current[clamped]?.focus();
+  }
+
+  function onChipKeyDown(e: KeyboardEvent<HTMLButtonElement>, index: number) {
+    const chip = ordered[index];
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      if (index > 0) focusChip(index - 1);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      if (index < ordered.length - 1) focusChip(index + 1);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onToggleKeyword(chip.number);
+    } else if (e.key === "Delete" || e.key === "Backspace") {
+      e.preventDefault();
+      onRemove(chip.number);
+      // Focus the chip that slides into this slot (or the new last one).
+      const nextCount = ordered.length - 1;
+      if (nextCount > 0) focusChip(Math.min(index, nextCount - 1));
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <Label>Linked issues</Label>
+        <span className="flex-1" />
+        <Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
+          <Popover.Trigger
+            render={
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={disabled}
+                aria-label="Link an issue"
+              />
+            }
+          >
+            <LinkIcon data-icon="inline-start" />
+            Link issue
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner
+              align="end"
+              sideOffset={4}
+              className="isolate z-50"
+            >
+              <Popover.Popup className="w-72 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+                <IssuePicker
+                  repoPath={repoPath}
+                  exclude={excluded}
+                  pending={false}
+                  lens={lens}
+                  onPick={(n) => {
+                    setPickerOpen(false);
+                    onPick(n);
+                  }}
+                />
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      </div>
+
+      {ordered.length > 0 && (
+        <>
+          <div
+            role="group"
+            aria-label="Linked issues"
+            className="flex flex-wrap items-center gap-1.5"
+          >
+            {ordered.map((chip, index) => {
+              const keywordLabel =
+                chip.keyword === "closes" ? "Closes" : "Relates to";
+              const keywordHint =
+                chip.aiSuggestedClose && chip.keyword === "relates"
+                  ? `AI suggests this pull request closes #${chip.number} — click to switch to Closes.`
+                  : undefined;
+              const stateWord = chip.state === "CLOSED" ? "Closed" : "Open";
+              const switchTo =
+                chip.keyword === "closes" ? "Relates to" : "Closes";
+              return (
+                <span
+                  key={chip.number}
+                  className="inline-flex items-center gap-1 border py-0.5 pr-0.5 pl-1.5 text-xs"
+                >
+                  <StateIcon state={chip.state} />
+                  <button
+                    type="button"
+                    ref={(el) => {
+                      chipRefs.current[index] = el;
+                    }}
+                    tabIndex={index === focusIndex ? 0 : -1}
+                    title={keywordHint}
+                    aria-label={`${keywordLabel} issue ${chip.number}: ${chip.title}. ${stateWord} issue. Press Enter to switch to ${switchTo}, Delete to remove.`}
+                    onClick={() => onToggleKeyword(chip.number)}
+                    onFocus={() => setFocusIndex(index)}
+                    onKeyDown={(e) => onChipKeyDown(e, index)}
+                    className="inline-flex items-center gap-1 cursor-pointer rounded-none outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+                  >
+                    {chip.source === "ai" && (
+                      <SparkleIcon className="size-3 shrink-0 text-muted-foreground" />
+                    )}
+                    <span
+                      className={
+                        chip.keyword === "closes"
+                          ? "font-medium text-foreground"
+                          : "text-muted-foreground"
+                      }
+                    >
+                      {keywordLabel}
+                    </span>
+                    <span className="text-muted-foreground">
+                      #{chip.number}
+                    </span>
+                    <span className="max-w-40 truncate" title={chip.title}>
+                      {chip.title}
+                    </span>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    tabIndex={-1}
+                    aria-label={`Remove #${chip.number}`}
+                    className="text-muted-foreground"
+                    onClick={() => onRemove(chip.number)}
+                  >
+                    <XIcon />
+                  </Button>
+                </span>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Added to the description on create.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/pulls/LinkedIssuesField.tsx
+++ b/src/features/pulls/LinkedIssuesField.tsx
@@ -91,6 +91,13 @@ function NativeLinkedIssuesField({
     (a, b) => Number(b.aiSuggestedClose) - Number(a.aiSuggestedClose),
   );
   const excluded = new Set(chips.map((c) => c.number));
+  // Clamp the roved index at point of use: chips can shrink via the mouse ✕
+  // without touching `focusIndex`, and a stale index past the end would render
+  // EVERY chip tabIndex=-1 — the band would drop out of the tab order entirely.
+  const effectiveFocusIndex = Math.max(
+    0,
+    Math.min(focusIndex, ordered.length - 1),
+  );
 
   function focusChip(index: number) {
     const clamped = Math.max(0, Math.min(index, ordered.length - 1));
@@ -112,9 +119,15 @@ function NativeLinkedIssuesField({
     } else if (e.key === "Delete" || e.key === "Backspace") {
       e.preventDefault();
       onRemove(chip.number);
-      // Focus the chip that slides into this slot (or the new last one).
+      // Focus the chip that slides into this slot (or the new last one). Defer
+      // past the removal re-render: focusChip reads chipRefs, and reading them
+      // synchronously here would target the node being unmounted (focus drops to
+      // body for any non-last chip). rAF lands after the list has re-rendered.
       const nextCount = ordered.length - 1;
-      if (nextCount > 0) focusChip(Math.min(index, nextCount - 1));
+      if (nextCount > 0) {
+        const target = Math.min(index, nextCount - 1);
+        requestAnimationFrame(() => focusChip(target));
+      }
     }
   }
 
@@ -174,7 +187,15 @@ function NativeLinkedIssuesField({
                 chip.aiSuggestedClose && chip.keyword === "relates"
                   ? `AI suggests this pull request closes #${chip.number} — click to switch to Closes.`
                   : undefined;
-              const stateWord = chip.state === "CLOSED" ? "Closed" : "Open";
+              // State word omitted while unresolved (a just-picked closed issue
+              // seeds state "" until the probe resolves) — no "Open issue." lie
+              // and no dangling sentence.
+              const stateSentence =
+                chip.state === "CLOSED"
+                  ? "Closed issue. "
+                  : chip.state === "OPEN"
+                    ? "Open issue. "
+                    : "";
               const switchTo =
                 chip.keyword === "closes" ? "Relates to" : "Closes";
               return (
@@ -188,9 +209,9 @@ function NativeLinkedIssuesField({
                     ref={(el) => {
                       chipRefs.current[index] = el;
                     }}
-                    tabIndex={index === focusIndex ? 0 : -1}
+                    tabIndex={index === effectiveFocusIndex ? 0 : -1}
                     title={keywordHint}
-                    aria-label={`${keywordLabel} issue ${chip.number}: ${chip.title}. ${stateWord} issue. Press Enter to switch to ${switchTo}, Delete to remove.`}
+                    aria-label={`${keywordLabel} issue ${chip.number}: ${chip.title}. ${stateSentence}Press Enter to switch to ${switchTo}, Delete to remove.`}
                     onClick={() => onToggleKeyword(chip.number)}
                     onFocus={() => setFocusIndex(index)}
                     onKeyDown={(e) => onChipKeyDown(e, index)}
@@ -262,6 +283,13 @@ function JiraMentionsField({
     (a, b) => Number(b.source === "ai") - Number(a.source === "ai"),
   );
   const excluded = new Set(jiraChips.map((c) => c.key));
+  // Clamp the roved index at point of use (see the native band): a mouse ✕ can
+  // shrink the list without touching `focusIndex`, and a stale index past the end
+  // would render every chip tabIndex=-1, dropping the band out of the tab order.
+  const effectiveFocusIndex = Math.max(
+    0,
+    Math.min(focusIndex, ordered.length - 1),
+  );
 
   function focusChip(index: number) {
     const clamped = Math.max(0, Math.min(index, ordered.length - 1));
@@ -280,9 +308,14 @@ function JiraMentionsField({
     } else if (e.key === "Delete" || e.key === "Backspace") {
       e.preventDefault();
       onRemove(chip.key);
-      // Focus the chip that slides into this slot (or the new last one).
+      // Focus the slid-in chip, deferred past the removal re-render (reading
+      // chipRefs synchronously would target the unmounting node — focus drops to
+      // body for any non-last chip). Same rAF fix as the native band.
       const nextCount = ordered.length - 1;
-      if (nextCount > 0) focusChip(Math.min(index, nextCount - 1));
+      if (nextCount > 0) {
+        const target = Math.min(index, nextCount - 1);
+        requestAnimationFrame(() => focusChip(target));
+      }
     }
     // Enter/Space intentionally do nothing — there is no keyword toggle.
   }
@@ -337,8 +370,12 @@ function JiraMentionsField({
             className="flex flex-wrap items-center gap-1.5"
           >
             {ordered.map((chip, index) => {
-              const stateWord =
-                chip.statusCategory.toLowerCase() === "done" ? "Done" : "Open";
+              // State word omitted while unresolved (a just-picked issue seeds
+              // statusCategory "" until the probe resolves) — no wrong "Open" and
+              // no dangling sentence.
+              const cat = chip.statusCategory.toLowerCase();
+              const stateSentence =
+                cat === "done" ? "Done. " : cat ? "Open. " : "";
               const summary = chip.summary || chip.key;
               return (
                 <span
@@ -351,8 +388,8 @@ function JiraMentionsField({
                     ref={(el) => {
                       chipRefs.current[index] = el;
                     }}
-                    tabIndex={index === focusIndex ? 0 : -1}
-                    aria-label={`Relates to ${chip.key}: ${summary}. ${stateWord}. Press Delete to remove.`}
+                    tabIndex={index === effectiveFocusIndex ? 0 : -1}
+                    aria-label={`Relates to ${chip.key}: ${summary}. ${stateSentence}Press Delete to remove.`}
                     onFocus={() => setFocusIndex(index)}
                     onKeyDown={(e) => onChipKeyDown(e, index)}
                     className="inline-flex items-center gap-1 cursor-default rounded-none outline-none focus-visible:ring-1 focus-visible:ring-ring/50"

--- a/src/features/pulls/LinkedIssuesField.tsx
+++ b/src/features/pulls/LinkedIssuesField.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { IssuePicker, StateIcon } from "@/features/issues/IssueRelations";
 import type { RemoteLens } from "@/lib/git/types";
+import type { JiraLink } from "@/lib/jira/store";
+import { JiraIssuePicker, JiraStatusIcon } from "./JiraIssuePicker";
 
 /** One linked-issue chip: a real repo issue the PR will reference on create. The
  *  keyword becomes a `Closes #N` / `Relates to #N` line appended to the body. */
@@ -19,18 +21,22 @@ export interface LinkedIssueChip {
   aiSuggestedClose: boolean;
 }
 
-/** The chip cluster in Create PR: extraction-seeded, AI-proposed, and
- *  manually-added issue links. The parent owns the chip state; this renders the
- *  band + the "Link issue" picker and reports toggles/removes/picks upward. */
-export function LinkedIssuesField({
-  repoPath,
-  lens,
-  chips,
-  onToggleKeyword,
-  onRemove,
-  onPick,
-  disabled,
-}: {
+/** One Jira mention chip: a linked-project issue the PR MENTIONS (Bitbucket repos
+ *  with no native tracker). Mention-only — there is no keyword toggle and no close
+ *  semantics; it becomes a `Relates to KEY` line appended to the body. */
+export interface JiraMentionChip {
+  key: string;
+  summary: string;
+  /** Jira `statusCategory` key: "done" maps to the closed/merged glyph, anything
+   *  else to the open/success glyph. */
+  statusCategory: string;
+  source: "extraction" | "ai" | "manual";
+}
+
+/** Props for the native (GitHub/GitLab) issue-link cluster. `variant` is optional
+ *  (absent ⇒ native), so existing call sites compile unchanged. */
+interface NativeFieldProps {
+  variant?: "native";
   repoPath: string;
   lens: RemoteLens;
   chips: LinkedIssueChip[];
@@ -38,7 +44,42 @@ export function LinkedIssuesField({
   onRemove: (issueNumber: number) => void;
   onPick: (issueNumber: number) => void;
   disabled?: boolean;
-}) {
+}
+
+/** Props for the Jira mention-only cluster (Bitbucket + linked project). No
+ *  keyword toggle — the chips are mention-only. */
+interface JiraFieldProps {
+  variant: "jira";
+  repoPath: string;
+  /** The repo's Jira link (site + project) — drives the picker. */
+  link: JiraLink | null;
+  jiraChips: JiraMentionChip[];
+  onRemove: (key: string) => void;
+  onPick: (key: string) => void;
+  disabled?: boolean;
+}
+
+/** The linked-issue cluster in the PR create/edit dialogs. Two variants: the
+ *  native (GitHub/GitLab) issue-link band with a Closes/Relates keyword toggle,
+ *  and the Bitbucket Jira mention-only band. They're mutually exclusive — a repo
+ *  is exactly one provider — so a caller renders exactly one. */
+export function LinkedIssuesField(props: NativeFieldProps | JiraFieldProps) {
+  if (props.variant === "jira") return <JiraMentionsField {...props} />;
+  return <NativeLinkedIssuesField {...props} />;
+}
+
+/** The chip cluster in Create PR: extraction-seeded, AI-proposed, and
+ *  manually-added issue links. The parent owns the chip state; this renders the
+ *  band + the "Link issue" picker and reports toggles/removes/picks upward. */
+function NativeLinkedIssuesField({
+  repoPath,
+  lens,
+  chips,
+  onToggleKeyword,
+  onRemove,
+  onPick,
+  disabled,
+}: NativeFieldProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
   // Roving tabindex: the band is a single tab stop; ArrowLeft/Right move the
   // roved index, which sets which chip is focusable + focused.
@@ -181,6 +222,159 @@ export function LinkedIssuesField({
                     aria-label={`Remove #${chip.number}`}
                     className="text-muted-foreground"
                     onClick={() => onRemove(chip.number)}
+                  >
+                    <XIcon />
+                  </Button>
+                </span>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Added to the description on create.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** The Jira mention-only cluster (Bitbucket + linked project). Same band shape as
+ *  the native field minus the keyword toggle: each chip shows a fixed muted
+ *  "Relates to" label, the key, and its summary; the only chip action is remove.
+ *  Roving tabindex identical to native minus the Enter/Space toggle. */
+function JiraMentionsField({
+  repoPath,
+  link,
+  jiraChips,
+  onRemove,
+  onPick,
+  disabled,
+}: JiraFieldProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  // Roving tabindex: the band is a single tab stop; ArrowLeft/Right move the
+  // roved index, which sets which chip is focusable + focused.
+  const [focusIndex, setFocusIndex] = useState(0);
+  const chipRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // AI-suggested chips sort first (parity with the native band's sparkle-first
+  // ordering); ties keep insertion order (stable sort).
+  const ordered = [...jiraChips].sort(
+    (a, b) => Number(b.source === "ai") - Number(a.source === "ai"),
+  );
+  const excluded = new Set(jiraChips.map((c) => c.key));
+
+  function focusChip(index: number) {
+    const clamped = Math.max(0, Math.min(index, ordered.length - 1));
+    setFocusIndex(clamped);
+    chipRefs.current[clamped]?.focus();
+  }
+
+  function onChipKeyDown(e: KeyboardEvent<HTMLButtonElement>, index: number) {
+    const chip = ordered[index];
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      if (index > 0) focusChip(index - 1);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      if (index < ordered.length - 1) focusChip(index + 1);
+    } else if (e.key === "Delete" || e.key === "Backspace") {
+      e.preventDefault();
+      onRemove(chip.key);
+      // Focus the chip that slides into this slot (or the new last one).
+      const nextCount = ordered.length - 1;
+      if (nextCount > 0) focusChip(Math.min(index, nextCount - 1));
+    }
+    // Enter/Space intentionally do nothing — there is no keyword toggle.
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <Label>Linked issues</Label>
+        <span className="flex-1" />
+        <Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
+          <Popover.Trigger
+            render={
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={disabled}
+                aria-label="Link an issue"
+              />
+            }
+          >
+            <LinkIcon data-icon="inline-start" />
+            Link issue
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Positioner
+              align="end"
+              sideOffset={4}
+              className="isolate z-50"
+            >
+              <Popover.Popup className="w-72 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+                <JiraIssuePicker
+                  repoPath={repoPath}
+                  link={link}
+                  exclude={excluded}
+                  pending={false}
+                  onPick={(key) => {
+                    setPickerOpen(false);
+                    onPick(key);
+                  }}
+                />
+              </Popover.Popup>
+            </Popover.Positioner>
+          </Popover.Portal>
+        </Popover.Root>
+      </div>
+
+      {ordered.length > 0 && (
+        <>
+          <div
+            role="group"
+            aria-label="Linked issues"
+            className="flex flex-wrap items-center gap-1.5"
+          >
+            {ordered.map((chip, index) => {
+              const stateWord =
+                chip.statusCategory.toLowerCase() === "done" ? "Done" : "Open";
+              const summary = chip.summary || chip.key;
+              return (
+                <span
+                  key={chip.key}
+                  className="inline-flex items-center gap-1 border py-0.5 pr-0.5 pl-1.5 text-xs"
+                >
+                  <JiraStatusIcon statusCategory={chip.statusCategory} />
+                  <button
+                    type="button"
+                    ref={(el) => {
+                      chipRefs.current[index] = el;
+                    }}
+                    tabIndex={index === focusIndex ? 0 : -1}
+                    aria-label={`Relates to ${chip.key}: ${summary}. ${stateWord}. Press Delete to remove.`}
+                    onFocus={() => setFocusIndex(index)}
+                    onKeyDown={(e) => onChipKeyDown(e, index)}
+                    className="inline-flex items-center gap-1 cursor-default rounded-none outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+                  >
+                    {chip.source === "ai" && (
+                      <SparkleIcon className="size-3 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="text-muted-foreground">Relates to</span>
+                    <span className="font-mono text-muted-foreground">
+                      {chip.key}
+                    </span>
+                    <span className="max-w-40 truncate" title={summary}>
+                      {summary}
+                    </span>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    tabIndex={-1}
+                    aria-label={`Remove ${chip.key}`}
+                    className="text-muted-foreground"
+                    onClick={() => onRemove(chip.key)}
                   >
                     <XIcon />
                   </Button>

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -64,6 +64,7 @@ import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
+import { LinkedIssuesField } from "./LinkedIssuesField";
 import { LocalPrLifecycleRow } from "./LocalPrTimeline";
 import { PromoteLocalPrDialog } from "./PromoteLocalPrDialog";
 import { PrReviewPanel } from "./PrReviewPanel";
@@ -74,6 +75,11 @@ import {
 } from "./PrTimeline";
 import { ResolveConflictsView } from "./ResolveConflictsView";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
+import {
+  composeBodyWithRefs,
+  splitBodyRefBlock,
+  useLinkedIssueChips,
+} from "./useLinkedIssueChips";
 
 type Section = "conversation" | "commits" | "files" | "review";
 
@@ -140,12 +146,21 @@ export function LocalPrView({
   });
   const [promoteOpen, setPromoteOpen] = useState(false);
   const ghStatus = useForgeStatus(repoPath);
+  // Linked-issue chips on the local-PR edit path: the chips OWN the trailing ref
+  // block (peeled at open, re-composed on save). A local PR's `Closes #N` lines
+  // survive promotion verbatim into the real forge PR, so these become real
+  // closing refs later — that's intended.
+  const canLinkIssues =
+    !!ghStatus.data && forgeFeatureReady(ghStatus.data, "issues");
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {
       if (!pr) return;
+      const finalBody = canLinkIssues
+        ? composeBodyWithRefs(body, linkedIssues)
+        : body;
       await update.mutateAsync({
         id: pr.id,
-        mutate: (cur) => ({ ...cur, title, body }),
+        mutate: (cur) => ({ ...cur, title, body: finalBody }),
       });
     },
   });
@@ -163,6 +178,25 @@ export function LocalPrView({
     pr?.base ?? null,
     pr?.head ?? null,
   );
+  // Shared chip state machine — enabled only while the edit dialog is open (and
+  // the tracker is usable). Local PRs have no lens concept, so read the forge's
+  // own issues ("origin"). Body refs are peeled into chips at open (`resetWith`
+  // in openEdit), so the body and the chips are never two sources of truth.
+  const {
+    chips: linkedIssues,
+    resetWith: resetLinkedIssues,
+    toggleKeyword: toggleIssueKeyword,
+    remove: removeIssue,
+    pick: pickIssue,
+    buildCandidates: buildIssueCandidates,
+    upsertFromDraft: upsertAiIssues,
+  } = useLinkedIssueChips({
+    repoPath,
+    lens: "origin",
+    enabled: canLinkIssues && edit.open,
+    headBranch: pr?.head ?? null,
+    commitSubjects: comparison.data?.ahead?.map((c) => c.subject) ?? [],
+  });
   const diffFiles = useBranchDiffFiles(
     repoPath,
     pr?.base ?? null,
@@ -208,7 +242,9 @@ export function LocalPrView({
   const prForGen = pr;
   function runGenerate() {
     // Local PRs have real local branches — the base..head branch-diff path works,
-    // and (like create) keeps base GitHub prompt wording.
+    // and (like create) keeps base GitHub prompt wording (no provider) and
+    // proposes no labels. The trailing args are reviewer notes (none on an edit)
+    // and the grounded issue candidates.
     prGen.generate(
       prForGen.base,
       prForGen.head,
@@ -216,7 +252,14 @@ export function LocalPrView({
       (d) => {
         edit.form.setFieldValue("title", d.title);
         edit.form.setFieldValue("body", d.body);
+        // Union the model's proposed issue links into the chip cluster (same
+        // rules as create — relate-default, dismissed-set, AI sparkle).
+        upsertAiIssues({ closes: d.closes, relates: d.relates });
       },
+      undefined,
+      [],
+      undefined,
+      buildIssueCandidates(),
     );
   }
   const fileCount = diffFiles.data?.length;
@@ -239,7 +282,17 @@ export function LocalPrView({
 
   function openEdit() {
     if (!pr) return;
-    edit.openEdit({ title: pr.title, body: pr.body });
+    // The chips OWN the trailing ref block: peel any exact `Closes #N` /
+    // `Relates to #N` lines off the end of the body into chips (keyword
+    // preserved) and open the editor with the STRIPPED text. On save the block is
+    // re-appended from chips. With the tracker unavailable there are no chips.
+    if (canLinkIssues) {
+      const { text, refs } = splitBodyRefBlock(pr.body, "native");
+      edit.openEdit({ title: pr.title, body: text });
+      resetLinkedIssues(refs);
+    } else {
+      edit.openEdit({ title: pr.title, body: pr.body });
+    }
   }
 
   function doMerge(strategy: MergeStrategy) {
@@ -998,6 +1051,19 @@ export function LocalPrView({
         onGenerate={aiEnabled ? runGenerate : undefined}
         generating={prGen.generating}
         generateDisabled={ahead.length === 0}
+        belowBody={
+          canLinkIssues ? (
+            <LinkedIssuesField
+              repoPath={repoPath}
+              lens="origin"
+              chips={linkedIssues}
+              onToggleKeyword={toggleIssueKeyword}
+              onRemove={removeIssue}
+              onPick={pickIssue}
+              disabled={prGen.generating}
+            />
+          ) : undefined
+        }
         bodyActions={
           !aiEnabled ? undefined : prGen.generating ? (
             <Button

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -74,6 +74,7 @@ import { displayLogin } from "@/lib/git/bot-login";
 import { splitUnifiedDiff } from "@/lib/git/diff-split";
 import { useForgeGhHost } from "@/lib/git/host";
 import {
+  forgeFeatureReady,
   PIPELINE_IN_FLIGHT,
   prDiffOptions,
   useApplySuggestion,
@@ -123,6 +124,7 @@ import {
 } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useJiraLink } from "@/lib/jira/queries";
 import {
   useClearReviewDrafts,
   useReviewDrafts,
@@ -133,6 +135,7 @@ import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { ChecksRollup } from "./ChecksRollup";
+import { LinkedIssuesField } from "./LinkedIssuesField";
 import { PendingReviewBar } from "./PendingReviewBar";
 import { PrCommitDetail } from "./PrCommitDetail";
 import { PrReviewPanel } from "./PrReviewPanel";
@@ -161,6 +164,13 @@ import {
 } from "./ReviewThreads";
 import { SubmitReviewDialog } from "./SubmitReviewDialog";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
+import {
+  composeBodyWithJiraRefs,
+  composeBodyWithRefs,
+  splitBodyRefBlock,
+  useJiraMentionChips,
+  useLinkedIssueChips,
+} from "./useLinkedIssueChips";
 import { usePrCapabilities } from "./usePrCapabilities";
 
 type Section = "conversation" | "commits" | "files" | "review";
@@ -444,11 +454,67 @@ export function RemotePrView({
   // Whether the open merge dialog is arming auto-merge (vs merging now) — set by
   // the dropdown item that opened it, read by confirmMerge + the dialog copy.
   const [mergeAuto, setMergeAuto] = useState(false);
+  // Linked-issue chips on the EDIT path: the chips OWN the trailing ref block, so
+  // on save the body is re-composed from the (stripped) text + the chips' refs —
+  // never a raw body that would double the refs the chips already carry.
+  const canLinkIssues = !!forge.data && forgeFeatureReady(forge.data, "issues");
+  // Bitbucket repos have no native tracker, so a LINKED Jira project drives a
+  // mention-only cluster on the edit path instead. Mutually exclusive with the
+  // native cluster.
+  const jiraLink = useJiraLink(repoPath);
+  const canJiraMention =
+    !canLinkIssues && provider === "bitbucket" && !!jiraLink.data;
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {
-      await editPr.mutateAsync({ number, title, body });
+      await editPr.mutateAsync({
+        number,
+        title,
+        // The active cluster owns the trailing ref block, so re-compose from the
+        // stripped text + its chips. Jira mention chips emit `Relates to KEY`
+        // lines; the native chips emit `Closes/Relates to #N`.
+        body:
+          canJiraMention && jiraChips.length > 0
+            ? composeBodyWithJiraRefs(body, jiraChips)
+            : canLinkIssues
+              ? composeBodyWithRefs(body, linkedIssues)
+              : body,
+      });
     },
     successToast: "Pull request updated",
+  });
+  // Shared chip state machine — enabled only while the edit dialog is open (and
+  // the tracker is usable). Extraction/AI seeds follow the create rules; the
+  // body's own trailing refs are peeled into chips at open (`resetWith` in
+  // openEdit below), so the two never fight as two sources of truth.
+  const {
+    chips: linkedIssues,
+    resetWith: resetLinkedIssues,
+    toggleKeyword: toggleIssueKeyword,
+    remove: removeIssue,
+    pick: pickIssue,
+    buildCandidates: buildIssueCandidates,
+    upsertFromDraft: upsertAiIssues,
+  } = useLinkedIssueChips({
+    repoPath,
+    lens,
+    enabled: canLinkIssues && edit.open,
+    headBranch: details.data?.headRefName ?? null,
+    commitSubjects: details.data?.commits.map((c) => c.headline) ?? [],
+  });
+  // Jira mention chips — the Bitbucket-only sibling cluster on the edit path.
+  const {
+    chips: jiraChips,
+    resetWith: resetJiraChips,
+    remove: removeJiraChip,
+    pick: pickJiraChip,
+    buildCandidates: buildJiraCandidates,
+    upsertFromDraft: upsertAiJira,
+  } = useJiraMentionChips({
+    repoPath,
+    enabled: canJiraMention && edit.open,
+    headBranch: details.data?.headRefName ?? null,
+    commitSubjects: details.data?.commits.map((c) => c.headline) ?? [],
+    link: jiraLink.data ?? null,
   });
   const prGen = useGeneratePrDescription(repoPath);
   const composerRef = useRef<MarkdownEditorHandle>(null);
@@ -844,10 +910,35 @@ export function RemotePrView({
     );
   }
 
-  // AI title+description generation — shared by the Edit dialog's Generate button
-  // and its mod+g chord. Verbatim the button's prior onClick body. `pr` is aliased
-  // to a narrowed const so the (hoisted) function body sees it as defined.
+  // Open the Edit dialog: the chips OWN the trailing ref block, so peel any exact
+  // `Closes #N` / `Relates to #N` lines off the end of the body into chips
+  // (keyword preserved) and open the editor with the STRIPPED text — the user
+  // never edits the ref block as text, and on save it's re-appended from chips.
+  // With the tracker unavailable there are no chips: open with the raw body.
+  // `pr` is aliased to a narrowed const (`prForGen`) below so these hoisted
+  // function bodies see it as defined — TS doesn't carry the outer `!pr` guard
+  // into a nested closure.
   const prForGen = pr;
+  function openEditWithChips() {
+    if (canLinkIssues) {
+      // Native active: numeric refs → chips; any trailing Jira line rides back in
+      // `text` so an unedited save can't drop it.
+      const { text, refs } = splitBodyRefBlock(prForGen.body, "native");
+      edit.openEdit({ title: prForGen.title, body: text });
+      resetLinkedIssues(refs);
+    } else if (canJiraMention) {
+      // Jira active: mention keys → chips; any trailing numeric line rides back in
+      // `text` (mirror preservation).
+      const { text, jiraRefs } = splitBodyRefBlock(prForGen.body, "jira");
+      edit.openEdit({ title: prForGen.title, body: text });
+      resetJiraChips(jiraRefs);
+    } else {
+      edit.openEdit({ title: prForGen.title, body: prForGen.body });
+    }
+  }
+
+  // AI title+description generation — shared by the Edit dialog's Generate button
+  // and its mod+g chord. Verbatim the button's prior onClick body.
   function runGenerate() {
     prGen.generateFromDiff(
       // Reuse the diff already cached by usePrDiff — and, crucially,
@@ -872,9 +963,24 @@ export function RemotePrView({
       (d) => {
         edit.form.setFieldValue("title", d.title);
         edit.form.setFieldValue("body", d.body);
+        // Union the model's proposed issue links into the chip cluster (same
+        // rules as create — relate-default, dismissed-set, AI sparkle).
+        upsertAiIssues({ closes: d.closes, relates: d.relates });
+        // Union the model's proposed Jira mentions into the mention cluster.
+        upsertAiJira({ jiraMentions: d.jiraMentions });
       },
       // Provider-aware prompt copy; null host → base GitHub wording.
       provider ?? undefined,
+      // Labels aren't wired on the edit path — keep the create default of no
+      // proposed labels; reviewer notes aren't part of an edit either.
+      [],
+      undefined,
+      // Grounded issue candidates — chips pinned first, then top-ranked open
+      // issues (empty ⇒ the prompt's issue-reference ban stays intact).
+      buildIssueCandidates(),
+      // Grounded Jira mention candidates (Bitbucket + linked project); empty
+      // unless the Jira cluster is active.
+      canJiraMention ? buildJiraCandidates() : undefined,
     );
   }
 
@@ -1047,7 +1153,7 @@ export function RemotePrView({
             <Button
               variant="outline"
               size="xs"
-              onClick={() => edit.openEdit({ title: pr.title, body: pr.body })}
+              onClick={openEditWithChips}
               title="Edit the title and description"
             >
               <PencilSimpleIcon data-icon="inline-start" />
@@ -1355,11 +1461,7 @@ export function RemotePrView({
                         Copy markdown
                       </DropdownMenuItem>
                       {isOpen && canEdit && (
-                        <DropdownMenuItem
-                          onClick={() =>
-                            edit.openEdit({ title: pr.title, body: pr.body })
-                          }
-                        >
+                        <DropdownMenuItem onClick={openEditWithChips}>
                           Edit
                         </DropdownMenuItem>
                       )}
@@ -2224,6 +2326,29 @@ export function RemotePrView({
         bodyTextareaClassName="max-h-72 min-h-24 resize-y font-mono"
         onGenerate={aiEnabled ? runGenerate : undefined}
         generating={prGen.generating}
+        belowBody={
+          canLinkIssues ? (
+            <LinkedIssuesField
+              repoPath={repoPath}
+              lens={lens}
+              chips={linkedIssues}
+              onToggleKeyword={toggleIssueKeyword}
+              onRemove={removeIssue}
+              onPick={pickIssue}
+              disabled={prGen.generating}
+            />
+          ) : canJiraMention ? (
+            <LinkedIssuesField
+              variant="jira"
+              repoPath={repoPath}
+              link={jiraLink.data ?? null}
+              jiraChips={jiraChips}
+              onRemove={removeJiraChip}
+              onPick={pickJiraChip}
+              disabled={prGen.generating}
+            />
+          ) : undefined
+        }
         bodyActions={
           !aiEnabled ? undefined : prGen.generating ? (
             <Button

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -30,14 +30,24 @@ interface IssueCandidate {
   state: string;
 }
 
+/** A mention-only Jira candidate from the repo's linked project (Bitbucket
+ *  repos). The parser validates a proposed `Relates:` key against this set. */
+interface JiraCandidate {
+  key: string;
+  summary: string;
+  statusCategory: string;
+}
+
 /** The parsed draft streamed to `onUpdate` — title/body plus the validated
- *  labels and the model's proposed `Closes:` / `Relates:` issue numbers. */
+ *  labels, the model's proposed `Closes:` / `Relates:` issue numbers, and any
+ *  validated linked-Jira mention keys. */
 interface PrDraft {
   title: string;
   body: string;
   labels: string[];
   closes: number[];
   relates: number[];
+  jiraMentions: string[];
 }
 
 /**
@@ -65,6 +75,10 @@ export function useGeneratePrDescription(repoPath: string) {
       /** Validated real issues the model may link (grounded candidates). Empty ⇒
        *  no issue links proposed. */
       issueCandidates?: IssueCandidate[],
+      /** Mention-only Jira candidates (Bitbucket repos with a linked project).
+       *  Empty ⇒ no Jira mentions proposed. Mutually exclusive with
+       *  `issueCandidates` — `buildPrPrompt` gives natives precedence. */
+      jiraCandidates?: JiraCandidate[],
     ) => {
       await run(
         async (settings) => {
@@ -88,6 +102,7 @@ export function useGeneratePrDescription(repoPath: string) {
             reviewNotes,
             availableLabels,
             issueCandidates,
+            jiraCandidates,
             provider,
           });
         },
@@ -98,6 +113,7 @@ export function useGeneratePrDescription(repoPath: string) {
                 buffer,
                 availableLabels.map((l) => l.name),
                 (issueCandidates ?? []).map((c) => c.number),
+                (jiraCandidates ?? []).map((c) => c.key),
               ),
             ),
         },
@@ -125,6 +141,8 @@ export function useGeneratePrDescription(repoPath: string) {
       reviewNotes?: string,
       /** Validated real issues the model may link (grounded candidates). */
       issueCandidates?: IssueCandidate[],
+      /** Mention-only Jira candidates (Bitbucket + linked project). */
+      jiraCandidates?: JiraCandidate[],
     ) =>
       runFromDiff(
         () => gitBranchDiff(repoPath, base, head, RAW_DIFF_MAX_BYTES),
@@ -136,6 +154,7 @@ export function useGeneratePrDescription(repoPath: string) {
         provider,
         reviewNotes,
         issueCandidates,
+        jiraCandidates,
       ),
     [repoPath, runFromDiff],
   );
@@ -159,6 +178,8 @@ export function useGeneratePrDescription(repoPath: string) {
       reviewNotes?: string,
       /** Validated real issues the model may link (grounded candidates). */
       issueCandidates?: IssueCandidate[],
+      /** Mention-only Jira candidates (Bitbucket + linked project). */
+      jiraCandidates?: JiraCandidate[],
     ) =>
       runFromDiff(
         getDiff,
@@ -170,6 +191,7 @@ export function useGeneratePrDescription(repoPath: string) {
         provider,
         reviewNotes,
         issueCandidates,
+        jiraCandidates,
       ),
     [runFromDiff],
   );

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -22,6 +22,24 @@ interface AvailableLabel {
   description?: string | null;
 }
 
+/** A validated real issue the model may link (fed as a grounded candidate). The
+ *  parser validates a proposed link's number against this set. */
+interface IssueCandidate {
+  number: number;
+  title: string;
+  state: string;
+}
+
+/** The parsed draft streamed to `onUpdate` — title/body plus the validated
+ *  labels and the model's proposed `Closes:` / `Relates:` issue numbers. */
+interface PrDraft {
+  title: string;
+  body: string;
+  labels: string[];
+  closes: number[];
+  relates: number[];
+}
+
 /**
  * Streams an AI-written PR title + body from the branch diff and the commits
  * the PR would introduce. `onUpdate` fires with the parsed draft on each chunk.
@@ -39,15 +57,14 @@ export function useGeneratePrDescription(repoPath: string) {
       base: string,
       head: string,
       commitSubjects: string[],
-      onUpdate: (draft: {
-        title: string;
-        body: string;
-        labels: string[];
-      }) => void,
+      onUpdate: (draft: PrDraft) => void,
       availableLabels: AvailableLabel[],
       provider?: PromptProvider,
       /** Author's "Notes for reviewers" — reflected into the description. */
       reviewNotes?: string,
+      /** Validated real issues the model may link (grounded candidates). Empty ⇒
+       *  no issue links proposed. */
+      issueCandidates?: IssueCandidate[],
     ) => {
       await run(
         async (settings) => {
@@ -70,6 +87,7 @@ export function useGeneratePrDescription(repoPath: string) {
             globalInstructions: settings.globalInstructions,
             reviewNotes,
             availableLabels,
+            issueCandidates,
             provider,
           });
         },
@@ -79,6 +97,7 @@ export function useGeneratePrDescription(repoPath: string) {
               extractPrDraft(
                 buffer,
                 availableLabels.map((l) => l.name),
+                (issueCandidates ?? []).map((c) => c.number),
               ),
             ),
         },
@@ -94,11 +113,7 @@ export function useGeneratePrDescription(repoPath: string) {
       base: string,
       head: string,
       commitSubjects: string[],
-      onUpdate: (draft: {
-        title: string;
-        body: string;
-        labels: string[];
-      }) => void,
+      onUpdate: (draft: PrDraft) => void,
       /** Target host — swaps the change-request noun + markdown flavor in the
        *  prompt. Omit (local PRs) to keep the base GitHub wording. */
       provider?: PromptProvider,
@@ -108,6 +123,8 @@ export function useGeneratePrDescription(repoPath: string) {
       availableLabels: AvailableLabel[] = [],
       /** Author's "Notes for reviewers" — reflected into the description. */
       reviewNotes?: string,
+      /** Validated real issues the model may link (grounded candidates). */
+      issueCandidates?: IssueCandidate[],
     ) =>
       runFromDiff(
         () => gitBranchDiff(repoPath, base, head, RAW_DIFF_MAX_BYTES),
@@ -118,6 +135,7 @@ export function useGeneratePrDescription(repoPath: string) {
         availableLabels,
         provider,
         reviewNotes,
+        issueCandidates,
       ),
     [repoPath, runFromDiff],
   );
@@ -131,11 +149,7 @@ export function useGeneratePrDescription(repoPath: string) {
       base: string,
       head: string,
       commitSubjects: string[],
-      onUpdate: (draft: {
-        title: string;
-        body: string;
-        labels: string[];
-      }) => void,
+      onUpdate: (draft: PrDraft) => void,
       provider?: PromptProvider,
       /** The repo's existing labels (name + description) to propose from. Empty ⇒
        *  no labels proposed. Invented labels the model returns are dropped by the
@@ -143,6 +157,8 @@ export function useGeneratePrDescription(repoPath: string) {
       availableLabels: AvailableLabel[] = [],
       /** Author's "Notes for reviewers" — reflected into the description. */
       reviewNotes?: string,
+      /** Validated real issues the model may link (grounded candidates). */
+      issueCandidates?: IssueCandidate[],
     ) =>
       runFromDiff(
         getDiff,
@@ -153,6 +169,7 @@ export function useGeneratePrDescription(repoPath: string) {
         availableLabels,
         provider,
         reviewNotes,
+        issueCandidates,
       ),
     [runFromDiff],
   );

--- a/src/features/pulls/useLinkedIssueChips.ts
+++ b/src/features/pulls/useLinkedIssueChips.ts
@@ -1,0 +1,866 @@
+import { useQueryClient } from "@tanstack/react-query";
+import type React from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { issueDetailsOptions, useIssueList } from "@/lib/git/queries";
+import type { RemoteLens } from "@/lib/git/types";
+import { extractIssueNumbers } from "@/lib/issues/extract";
+import { jiraIssueView } from "@/lib/jira/api";
+import { extractJiraKeys } from "@/lib/jira/keys";
+import { useJiraIssues } from "@/lib/jira/queries";
+import type { JiraLink } from "@/lib/jira/store";
+import type { JiraMentionChip, LinkedIssueChip } from "./LinkedIssuesField";
+
+/** A validated real issue the model may link (grounded candidate for the AI
+ *  generate). Structurally matches `useGeneratePrDescription`'s IssueCandidate. */
+export interface IssueCandidate {
+  number: number;
+  title: string;
+  state: string;
+}
+
+/** One ref peeled from a body's trailing block or seeded manually: the issue
+ *  number plus the keyword to preserve (a pre-existing `Closes` stays closes). */
+export interface BodyRef {
+  number: number;
+  keyword: "closes" | "relates";
+}
+
+// A trailing-block line: `Closes #N` or `Relates to #N` (case-insensitive),
+// optional surrounding whitespace. The block is the run of these lines at the
+// very end of the body (blank lines between/after are consumed).
+const REF_LINE = /^(closes|relates to)\s+#(\d+)\s*$/i;
+// A trailing Jira mention line: `Relates to KEY-123` (case-insensitive). Only
+// `Relates to` is recognized — `Closes KEY` is deliberately NOT a form (Jira
+// tickets are never closed from PR text, so we neither peel nor compose it).
+const JIRA_REF_LINE = /^relates to\s+([A-Z][A-Z0-9_]*-\d+)\s*$/i;
+
+/**
+ * Peel the EXACT trailing ref block off a PR body for the ACTIVE tracker `kind`.
+ * The trailing block is the run of final lines each matching EITHER the numeric
+ * form (`Closes #N` / `Relates to #N`) OR the Jira mention form
+ * (`Relates to KEY-123`) — blank lines between/after are consumed. The whole
+ * block is traversed (an interleaved block is fully walked), but only lines of
+ * the ACTIVE kind are EXTRACTED into chips; lines of the INACTIVE kind are
+ * RE-APPENDED to the returned `text` (canonical form, original relative order,
+ * separated from any retained prose above by one blank line). Nothing that isn't
+ * extracted ever leaves `text` — an unedited save re-composes from `text` + the
+ * active chips and loses no line of either kind.
+ *
+ * Contract: exactly ONE of `refs` / `jiraRefs` is populated (the active kind);
+ * the other is always `[]`. For `kind === "native"`, numeric refs are extracted
+ * (a repeated number keeps the LAST line's keyword) and any Jira line rides back
+ * in `text`. For `kind === "jira"`, mention keys are extracted (first occurrence
+ * wins) and any numeric line rides back in `text`. Prose refs elsewhere in the
+ * body are untouched.
+ *
+ * Reasoning (no test runner), kind = "native":
+ *   ""                                    → { text: "", refs: [] }
+ *   "hi"                                  → { text: "hi", refs: [] }
+ *   "hi\n\nCloses #6\nRelates to #5"      → { text: "hi", refs: [C#6, R#5] }
+ *   "Closes #6"                           → { text: "", refs: [C#6] }
+ *   "see #12 mid\n\nCloses #6"            → { text: "see #12 mid", refs: [C#6] }
+ *   "x\n\nCloses #6\nCloses #6"           → { text: "x", refs: [C#6] } (last, deduped)
+ *   "x\n\nRelates to #6\nCloses #6"       → { text: "x", refs: [C#6] } (last keyword)
+ *   "x\n\nCloses #6\nRelates to JIRA-4"   → { text: "x\n\nRelates to JIRA-4", refs: [C#6] }
+ *                                            (inactive Jira line re-appended, kept)
+ * kind = "jira":
+ *   "x\n\nCloses #6\nRelates to JIRA-4"   → { text: "x\n\nCloses #6", jiraRefs: [JIRA-4] }
+ *                                            (inactive numeric line re-appended, kept)
+ */
+export function splitBodyRefBlock(
+  body: string,
+  kind: "native" | "jira",
+): {
+  text: string;
+  refs: BodyRef[];
+  jiraRefs: string[];
+} {
+  const lines = body.split("\n");
+  // Walk up from the end, collecting block lines (either kind); blank lines
+  // inside/after the block are consumed but not treated as refs. Stop at the
+  // first non-blank, non-ref line — that's the end of the description text. The
+  // two forms never overlap (the numeric form requires `#\d+`).
+  let cut = lines.length; // index where the block (incl. its leading blanks) starts
+  // Each block line captured bottom-to-top, tagged by kind so the inactive ones
+  // can be re-appended in original (top-to-bottom) order.
+  type BlockLine =
+    | { kind: "native"; ref: BodyRef }
+    | { kind: "jira"; key: string };
+  const block: BlockLine[] = [];
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      // A trailing/inside blank before any ref is consumed. Keep scanning; `cut`
+      // only advances past a ref line.
+      cut = i;
+      continue;
+    }
+    const m = REF_LINE.exec(line);
+    if (m) {
+      block.push({
+        kind: "native",
+        ref: {
+          number: Number.parseInt(m[2], 10),
+          keyword: m[1].toLowerCase() === "closes" ? "closes" : "relates",
+        },
+      });
+      cut = i;
+      continue;
+    }
+    const jm = JIRA_REF_LINE.exec(line);
+    if (!jm) break;
+    block.push({ kind: "jira", key: jm[1].toUpperCase() });
+    cut = i;
+  }
+  // No block at all → whole body is text; leave it as-is.
+  if (block.length === 0) {
+    return { text: body.trimEnd(), refs: [], jiraRefs: [] };
+  }
+  // `block` is bottom-to-top; reverse to original order.
+  block.reverse();
+
+  // Extract the ACTIVE kind; collect INACTIVE lines to re-append (canonical
+  // form, so no stray CRLF/whitespace from the raw source rides along).
+  const refs: BodyRef[] = [];
+  const jiraRefs: string[] = [];
+  const inactiveLines: string[] = [];
+  if (kind === "native") {
+    // Dedupe by number keeping the LAST line's keyword (original order → later
+    // entry wins), mirroring the pre-`kind` behavior exactly.
+    const byNumber = new Map<number, "closes" | "relates">();
+    for (const b of block)
+      if (b.kind === "native") byNumber.set(b.ref.number, b.ref.keyword);
+    const emitted = new Set<number>();
+    for (const b of block) {
+      if (b.kind === "native") {
+        if (emitted.has(b.ref.number)) continue;
+        emitted.add(b.ref.number);
+        const keyword = byNumber.get(b.ref.number);
+        if (keyword) refs.push({ number: b.ref.number, keyword });
+      } else {
+        inactiveLines.push(`Relates to ${b.key}`);
+      }
+    }
+  } else {
+    // Jira active: extract mention keys (first occurrence wins — no keyword to
+    // carry). Inactive numeric lines re-appended in canonical form.
+    const emittedJira = new Set<string>();
+    for (const b of block) {
+      if (b.kind === "jira") {
+        if (emittedJira.has(b.key)) continue;
+        emittedJira.add(b.key);
+        jiraRefs.push(b.key);
+      } else {
+        inactiveLines.push(
+          b.ref.keyword === "closes"
+            ? `Closes #${b.ref.number}`
+            : `Relates to #${b.ref.number}`,
+        );
+      }
+    }
+  }
+
+  // Prose above the block, then any inactive-kind lines re-appended below it
+  // (separated by one blank line when prose remains). `filter(Boolean)` collapses
+  // an empty prose half so a block-only body doesn't gain a leading blank line.
+  const prose = lines.slice(0, cut).join("\n").trimEnd();
+  const text =
+    inactiveLines.length > 0
+      ? [prose, inactiveLines.join("\n")].filter(Boolean).join("\n\n")
+      : prose;
+  return { text, refs, jiraRefs };
+}
+
+/**
+ * Compose the final body: text + the chips' ref lines (`Closes #N` /
+ * `Relates to #N`, one per chip, chip order), joined by a blank line; either
+ * part absent degrades cleanly ([text] alone / lines alone / ""). This is the
+ * single composition used by ALL create/edit save paths.
+ *
+ * Reasoning:
+ *   ("hi", [C#6])   → "hi\n\nCloses #6"
+ *   ("hi", [])      → "hi"
+ *   ("", [C#6])     → "Closes #6"
+ *   ("", [])        → ""
+ */
+export function composeBodyWithRefs(
+  text: string,
+  chips: LinkedIssueChip[],
+): string {
+  const refLines = chips.map((c) =>
+    c.keyword === "closes" ? `Closes #${c.number}` : `Relates to #${c.number}`,
+  );
+  if (refLines.length === 0) return text;
+  return [text.trimEnd(), refLines.join("\n")].filter(Boolean).join("\n\n");
+}
+
+/**
+ * Compose the final body for the Jira-mention variant: text + the chips'
+ * `Relates to KEY` lines (one per chip, chip order), joined by a blank line;
+ * same degrade-cleanly joining rules as {@link composeBodyWithRefs}. Only
+ * `Relates to` is emitted — there is no close form for Jira.
+ */
+export function composeBodyWithJiraRefs(
+  text: string,
+  chips: JiraMentionChip[],
+): string {
+  const refLines = chips.map((c) => `Relates to ${c.key}`);
+  if (refLines.length === 0) return text;
+  return [text.trimEnd(), refLines.join("\n")].filter(Boolean).join("\n\n");
+}
+
+/** Lowercased tokens (length ≥ 4, split on non-alphanumerics) for ranking issue
+ *  titles against the branch + commit subjects by shared-token overlap. Shared by
+ *  the native and Jira candidate rankers. */
+function rankTokens(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 4),
+  );
+}
+
+/** Count shared ≥4-char tokens between a title/summary and the rank text (the
+ *  branch + commit subjects). Shared scoring for both hooks' candidate ranking. */
+function sharedTokenScore(title: string, rankText: Set<string>): number {
+  let score = 0;
+  for (const t of rankTokens(title)) if (rankText.has(t)) score++;
+  return score;
+}
+
+/**
+ * The shared linked-issue chip state machine. Extracted from CreatePrDialog so
+ * the create, edit, and local-create paths share ONE implementation (chips,
+ * dismissed/probed refs, extraction seeding, AI union, candidate ranking).
+ *
+ * The hook is fully inert while `enabled` is false (no queries, no seeding),
+ * so a caller can mount it unconditionally and gate on forge/dialog state.
+ *
+ * A differently-shaped chip source (e.g. Bitbucket/Jira) is intended to plug in
+ * later behind the same `chips`/candidate surface — this hook only knows about
+ * the forge's own issue tracker for now.
+ */
+export function useLinkedIssueChips(opts: {
+  repoPath: string;
+  lens: RemoteLens;
+  /** Master gate — when false the hook is fully inert (no queries, no seeding). */
+  enabled: boolean;
+  /** Extraction text sources; re-seed when they change. */
+  headBranch: string | null;
+  commitSubjects: string[];
+}): {
+  chips: LinkedIssueChip[];
+  setChips: React.Dispatch<React.SetStateAction<LinkedIssueChip[]>>;
+  resetWith: (refs: BodyRef[]) => void;
+  toggleKeyword: (n: number) => void;
+  remove: (n: number) => void;
+  pick: (n: number) => void;
+  buildCandidates: () => IssueCandidate[];
+  upsertFromDraft: (draft: { closes: number[]; relates: number[] }) => void;
+} {
+  const { repoPath, lens, enabled, headBranch, commitSubjects } = opts;
+  const queryClient = useQueryClient();
+
+  // Open issues (page of 50) to validate seeds against and to rank as prompt
+  // candidates. Uses the caller's lens, so the parent target reads the parent's
+  // issues.
+  const issueList = useIssueList(repoPath, enabled, "open", 50, lens);
+
+  const [chips, setChips] = useState<LinkedIssueChip[]>([]);
+  // A number the user removed (or that came in dismissed): upserts (seed/AI) skip
+  // it; a MANUAL pick clears it (explicit intent overrides). Reset in resetWith.
+  const dismissedIssuesRef = useRef<Set<number>>(new Set());
+  // Numbers already probed this reset-cycle (present-or-absent from the open
+  // page), so the fetchQuery probe runs at most once per number per reset.
+  const probedIssuesRef = useRef<Set<number>>(new Set());
+  // The exact candidate set last fed to the AI generate — `upsertFromDraft`
+  // resolves an AI-proposed number's title/state from here.
+  const lastCandidatesRef = useRef<Map<number, IssueCandidate>>(new Map());
+
+  // Reset the chip state and seed from body-parsed refs. An unresolvable
+  // body-parsed ref KEEPS its chip with title "" (the author's existing content
+  // must never be silently dropped; contrast extraction seeds, which drop when
+  // unverified). Resolves titles/states lazily from the open page or a one-shot
+  // probe.
+  const resetWith = useEffectEvent((refs: BodyRef[]) => {
+    dismissedIssuesRef.current = new Set();
+    probedIssuesRef.current = new Set();
+    lastCandidatesRef.current = new Map();
+    // Seed a chip per body ref, keyword preserved, source "manual". Title/state
+    // start empty/OPEN and are filled in lazily below; a repeated number keeps
+    // its first appearance.
+    const seen = new Set<number>();
+    const seeded: LinkedIssueChip[] = [];
+    for (const r of refs) {
+      if (seen.has(r.number)) continue;
+      seen.add(r.number);
+      const hit = (issueList.data ?? []).find((i) => i.number === r.number);
+      seeded.push({
+        number: r.number,
+        title: hit?.title ?? "",
+        state: hit?.state ?? "OPEN",
+        keyword: r.keyword,
+        source: "manual",
+        aiSuggestedClose: false,
+      });
+      // Not on the open page yet — probe once to resolve title/state, but keep
+      // the chip regardless of the probe outcome (author content is preserved).
+      if (!hit && enabled) {
+        probedIssuesRef.current.add(r.number);
+        queryClient
+          .fetchQuery(issueDetailsOptions(repoPath, r.number, lens))
+          .then((issue) => {
+            setChips((prev) =>
+              prev.map((c) =>
+                c.number === r.number && c.title === ""
+                  ? { ...c, title: issue.title, state: issue.state }
+                  : c,
+              ),
+            );
+          })
+          .catch(() => undefined);
+      }
+    }
+    setChips(seeded);
+  });
+
+  // Backfill a body-parsed chip's title/state once the open-issues page arrives
+  // (a chip seeded with title "" before the list loaded). Only touches chips
+  // still missing a title, so it never fights a probe result or a user edit.
+  // A chip NOT on the open page (e.g. `Closes #<closed-issue>`) is probed once
+  // here — resetWith's own probe is skipped when `enabled` still reflects the
+  // pre-open render, so this effect is the reliable resolution point. The
+  // preservation rule stands: a failed probe leaves the chip intact (title "").
+  useEffect(() => {
+    if (!enabled || !issueList.data) return;
+    setChips((prev) => {
+      let changed = false;
+      const next = prev.map((c) => {
+        if (c.title !== "") return c;
+        const hit = issueList.data?.find((i) => i.number === c.number);
+        if (!hit) return c;
+        changed = true;
+        return { ...c, title: hit.title, state: hit.state };
+      });
+      return changed ? next : prev;
+    });
+    // Probe any still-unresolved chip not on the open page, once per number.
+    for (const c of chips) {
+      if (c.title !== "" || probedIssuesRef.current.has(c.number)) continue;
+      if (issueList.data.some((i) => i.number === c.number)) continue;
+      probedIssuesRef.current.add(c.number);
+      queryClient
+        .fetchQuery(issueDetailsOptions(repoPath, c.number, lens))
+        .then((issue) => {
+          setChips((prev) =>
+            prev.map((cc) =>
+              cc.number === c.number && cc.title === ""
+                ? { ...cc, title: issue.title, state: issue.state }
+                : cc,
+            ),
+          );
+        })
+        .catch(() => undefined);
+    }
+  }, [enabled, issueList.data, chips, queryClient, repoPath, lens]);
+
+  function toggleKeyword(issueNumber: number) {
+    setChips((prev) =>
+      prev.map((c) =>
+        c.number === issueNumber
+          ? { ...c, keyword: c.keyword === "closes" ? "relates" : "closes" }
+          : c,
+      ),
+    );
+  }
+  function remove(issueNumber: number) {
+    dismissedIssuesRef.current.add(issueNumber);
+    setChips((prev) => prev.filter((c) => c.number !== issueNumber));
+  }
+  // Manual pick from the picker: an explicit user intent, so it clears any prior
+  // dismissal for that number and adds it as a `manual` relates chip. The picker
+  // already excludes current chips, so a duplicate can't arrive here.
+  function pick(issueNumber: number) {
+    dismissedIssuesRef.current.delete(issueNumber);
+    const found = (issueList.data ?? []).find((i) => i.number === issueNumber);
+    setChips((prev) => {
+      if (prev.some((c) => c.number === issueNumber)) return prev;
+      return [
+        ...prev,
+        {
+          number: issueNumber,
+          title: found?.title ?? `#${issueNumber}`,
+          state: found?.state ?? "OPEN",
+          keyword: "relates",
+          source: "manual",
+          aiSuggestedClose: false,
+        },
+      ];
+    });
+  }
+
+  // Extraction seeding: pull candidate issue numbers from the head branch name
+  // and the commit subjects, then add a chip for each that's a real repo issue —
+  // resolving from the open-issues page, or probing the tracker once for a number
+  // not on that page (dropping it on any error: it's a PR number, a deleted
+  // issue, or noise). Dismissed and already-present numbers are skipped. Runs
+  // once per number per reset-cycle; re-runs when head/commits change.
+  const seedExtractedIssues = useEffectEvent(
+    (numbers: number[], openIssues: typeof issueList.data) => {
+      const existing = new Set(chips.map((c) => c.number));
+      for (const n of numbers) {
+        if (existing.has(n) || dismissedIssuesRef.current.has(n)) continue;
+        const hit = openIssues?.find((i) => i.number === n);
+        if (hit) {
+          setChips((prev) =>
+            prev.some((c) => c.number === n)
+              ? prev
+              : [
+                  ...prev,
+                  {
+                    number: n,
+                    title: hit.title,
+                    state: hit.state,
+                    keyword: "relates",
+                    source: "extraction",
+                    aiSuggestedClose: false,
+                  },
+                ],
+          );
+          continue;
+        }
+        // Not on the open page — probe the tracker once. Skip if the open list
+        // hasn't loaded yet (a later run resolves it) so we don't probe numbers
+        // that would have matched the page.
+        if (!openIssues) continue;
+        if (probedIssuesRef.current.has(n)) continue;
+        probedIssuesRef.current.add(n);
+        queryClient
+          .fetchQuery(issueDetailsOptions(repoPath, n, lens))
+          .then((issue) => {
+            if (dismissedIssuesRef.current.has(n)) return;
+            setChips((prev) =>
+              prev.some((c) => c.number === n)
+                ? prev
+                : [
+                    ...prev,
+                    {
+                      number: issue.number,
+                      title: issue.title,
+                      state: issue.state,
+                      keyword: "relates",
+                      source: "extraction",
+                      aiSuggestedClose: false,
+                    },
+                  ],
+            );
+          })
+          .catch(() => undefined);
+      }
+    },
+  );
+  // Join the subjects into a stable string so callers passing a fresh
+  // `commitSubjects` array each render don't re-fire this effect on every render
+  // (the seeder is idempotent, but the string dep keeps it to real changes).
+  const subjectsText = commitSubjects.join("\n");
+  useEffect(() => {
+    if (!enabled) return;
+    const numbers = extractIssueNumbers(`${headBranch ?? ""}\n${subjectsText}`);
+    if (numbers.length === 0) return;
+    seedExtractedIssues(numbers, issueList.data);
+  }, [enabled, headBranch, subjectsText, issueList.data]);
+
+  // chips ∪ validated extraction ∪ top-ranked open issues, cap 8 — for generate().
+  // Current chips are pinned first; then the highest-scoring OPEN issues by
+  // shared-token overlap between the title and the branch + commit subjects.
+  // Records the exact set fed so `upsertFromDraft` can resolve title/state.
+  function buildCandidates(): IssueCandidate[] {
+    if (!enabled) {
+      lastCandidatesRef.current = new Map();
+      return [];
+    }
+    const chipNumbers = new Set(chips.map((c) => c.number));
+    const chipCandidates: IssueCandidate[] = chips.map((c) => ({
+      number: c.number,
+      title: c.title,
+      state: c.state,
+    }));
+    const rankText = rankTokens(
+      `${headBranch ?? ""} ${commitSubjects.join(" ")}`,
+    );
+    const ranked = (issueList.data ?? [])
+      .filter((i) => !chipNumbers.has(i.number))
+      .map((i) => ({ issue: i, score: sharedTokenScore(i.title, rankText) }))
+      .sort(
+        (a, b) =>
+          b.score - a.score || (b.issue.updatedAt < a.issue.updatedAt ? -1 : 1),
+      )
+      .map((r) => ({
+        number: r.issue.number,
+        title: r.issue.title,
+        state: r.issue.state,
+      }));
+    const candidates = [...chipCandidates, ...ranked].slice(0, 8);
+    lastCandidatesRef.current = new Map(candidates.map((c) => [c.number, c]));
+    return candidates;
+  }
+
+  // Union the model's proposed close/relate numbers into the chip cluster. A
+  // `closes` proposal marks `aiSuggestedClose`; both land as `relates` chips
+  // (the safe default the user can toggle up). Skip dismissed numbers; never
+  // downgrade an existing chip — only OR-in the `aiSuggestedClose` flag. Resolve
+  // a new chip's title/state from the last-built candidates.
+  function upsertFromDraft(draft: { closes: number[]; relates: number[] }) {
+    const fed = lastCandidatesRef.current;
+    const closeSet = new Set(draft.closes);
+    const all = [...new Set([...draft.closes, ...draft.relates])];
+    setChips((prev) => {
+      let next = prev;
+      for (const n of all) {
+        if (dismissedIssuesRef.current.has(n)) continue;
+        const suggestedClose = closeSet.has(n);
+        const existingIdx = next.findIndex((c) => c.number === n);
+        if (existingIdx >= 0) {
+          // Never downgrade an existing chip — only OR-in the AI close hint.
+          if (suggestedClose && !next[existingIdx].aiSuggestedClose) {
+            next = next.map((c, i) =>
+              i === existingIdx ? { ...c, aiSuggestedClose: true } : c,
+            );
+          }
+          continue;
+        }
+        const meta = fed.get(n);
+        if (!meta) continue;
+        next = [
+          ...next,
+          {
+            number: n,
+            title: meta.title,
+            state: meta.state,
+            keyword: "relates",
+            source: "ai",
+            aiSuggestedClose: suggestedClose,
+          },
+        ];
+      }
+      return next;
+    });
+  }
+
+  return {
+    chips,
+    setChips,
+    resetWith,
+    toggleKeyword,
+    remove,
+    pick,
+    buildCandidates,
+    upsertFromDraft,
+  };
+}
+
+/** A validated Jira issue the model may MENTION (grounded candidate for the AI
+ *  generate). Structurally matches `useGeneratePrDescription`'s JiraCandidate. */
+export interface JiraCandidate {
+  key: string;
+  summary: string;
+  statusCategory: string;
+}
+
+/**
+ * The Jira twin of {@link useLinkedIssueChips} for Bitbucket repos with a linked
+ * project (no native issue tracker). Same state-machine shape — dismissed set,
+ * manual picks, extraction seeding, AI union, candidate ranking — but keyed by
+ * the human key (`PROJ-123`) and MENTION-ONLY: chips carry no keyword and no
+ * close semantics, and they compose into the body as `Relates to KEY` lines.
+ *
+ * Fully inert while `enabled` is false (no queries, no seeding), so a caller can
+ * mount it unconditionally and gate on forge/dialog + link state.
+ */
+export function useJiraMentionChips(opts: {
+  repoPath: string;
+  /** Master gate — when false the hook is fully inert (no queries, no seeding). */
+  enabled: boolean;
+  /** Extraction text sources; re-seed when they change. */
+  headBranch: string | null;
+  commitSubjects: string[];
+  /** The repo's Jira link (site + project). Null ⇒ the hook is inert regardless
+   *  of `enabled` (nothing to fetch or extract against). */
+  link: JiraLink | null;
+}): {
+  chips: JiraMentionChip[];
+  resetWith: (keys: string[]) => void;
+  remove: (key: string) => void;
+  pick: (key: string) => void;
+  buildCandidates: () => JiraCandidate[];
+  upsertFromDraft: (draft: { jiraMentions: string[] }) => void;
+} {
+  const { repoPath, enabled, headBranch, commitSubjects, link } = opts;
+
+  // Open page of the linked project's issues to validate seeds against and to
+  // rank as prompt candidates. `useJiraIssues` gates on `!!link`, so pass null to
+  // disable when the hook is inert (or the repo is unlinked).
+  const active = enabled && !!link;
+  const issueList = useJiraIssues(repoPath, active ? link : null, "open");
+
+  const [chips, setChips] = useState<JiraMentionChip[]>([]);
+  // A key the user removed (or that came in dismissed): upserts (seed/AI) skip it;
+  // a MANUAL pick clears it (explicit intent overrides). Reset in resetWith.
+  const dismissedRef = useRef<Set<string>>(new Set());
+  // Keys already probed this reset-cycle (present-or-absent from the open page),
+  // so the per-key fetch runs at most once per key per reset.
+  const probedRef = useRef<Set<string>>(new Set());
+  // The exact candidate set last fed to the AI generate — `upsertFromDraft`
+  // resolves an AI-proposed key's summary/status from here.
+  const lastCandidatesRef = useRef<Map<string, JiraCandidate>>(new Map());
+
+  // Reset the chip state and seed from body-parsed refs (keys). An unresolvable
+  // body-parsed key KEEPS its chip with summary "" (the author's existing content
+  // must never be silently dropped; contrast extraction seeds, which drop when
+  // unverified). Resolves summary/status lazily from the open page or a one-shot
+  // per-key probe.
+  const resetWith = useEffectEvent((keys: string[]) => {
+    dismissedRef.current = new Set();
+    probedRef.current = new Set();
+    lastCandidatesRef.current = new Map();
+    const seen = new Set<string>();
+    const seeded: JiraMentionChip[] = [];
+    for (const key of keys) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const hit = (issueList.data ?? []).find((i) => i.key === key);
+      seeded.push({
+        key,
+        summary: hit?.summary ?? "",
+        statusCategory: hit?.statusCategory ?? "",
+        source: "manual",
+      });
+      // Not on the open page yet — probe once to resolve summary/status, but keep
+      // the chip regardless of the probe outcome (author content is preserved).
+      if (!hit && active && link) {
+        probedRef.current.add(key);
+        jiraIssueView(link.siteHost, key)
+          .then((issue) => {
+            setChips((prev) =>
+              prev.map((c) =>
+                c.key === key && c.summary === ""
+                  ? {
+                      ...c,
+                      summary: issue.summary,
+                      statusCategory: issue.statusCategory,
+                    }
+                  : c,
+              ),
+            );
+          })
+          .catch(() => undefined);
+      }
+    }
+    setChips(seeded);
+  });
+
+  // Backfill a body-parsed chip's summary/status once the open page arrives (a
+  // chip seeded with summary "" before the list loaded). Only touches chips still
+  // missing a summary, so it never fights a probe result or a user edit. A chip
+  // NOT on the open page is probed once here — resetWith's own probe is skipped
+  // when `active` still reflects the pre-open render, so this effect is the
+  // reliable resolution point. A failed probe leaves the chip intact (summary "").
+  useEffect(() => {
+    if (!active || !issueList.data || !link) return;
+    setChips((prev) => {
+      let changed = false;
+      const next = prev.map((c) => {
+        if (c.summary !== "") return c;
+        const hit = issueList.data?.find((i) => i.key === c.key);
+        if (!hit) return c;
+        changed = true;
+        return {
+          ...c,
+          summary: hit.summary,
+          statusCategory: hit.statusCategory,
+        };
+      });
+      return changed ? next : prev;
+    });
+    // Probe any still-unresolved chip not on the open page, once per key.
+    for (const c of chips) {
+      if (c.summary !== "" || probedRef.current.has(c.key)) continue;
+      if (issueList.data.some((i) => i.key === c.key)) continue;
+      probedRef.current.add(c.key);
+      jiraIssueView(link.siteHost, c.key)
+        .then((issue) => {
+          setChips((prev) =>
+            prev.map((cc) =>
+              cc.key === c.key && cc.summary === ""
+                ? {
+                    ...cc,
+                    summary: issue.summary,
+                    statusCategory: issue.statusCategory,
+                  }
+                : cc,
+            ),
+          );
+        })
+        .catch(() => undefined);
+    }
+  }, [active, issueList.data, link, chips]);
+
+  function remove(key: string) {
+    dismissedRef.current.add(key);
+    setChips((prev) => prev.filter((c) => c.key !== key));
+  }
+  // Manual pick from the picker: an explicit user intent, so it clears any prior
+  // dismissal for that key and adds it as a `manual` chip. The picker already
+  // excludes current chips, so a duplicate can't arrive here.
+  function pick(key: string) {
+    dismissedRef.current.delete(key);
+    const found = (issueList.data ?? []).find((i) => i.key === key);
+    setChips((prev) => {
+      if (prev.some((c) => c.key === key)) return prev;
+      return [
+        ...prev,
+        {
+          key,
+          summary: found?.summary ?? key,
+          statusCategory: found?.statusCategory ?? "",
+          source: "manual",
+        },
+      ];
+    });
+  }
+
+  // Extraction seeding: pull linked-project keys from the head branch name and the
+  // commit subjects, then add a chip for each that's a real project issue —
+  // resolving from the open page, or probing the project once for a key not on
+  // that page (dropping it on any error). Dismissed and already-present keys are
+  // skipped. Runs once per key per reset-cycle; re-runs when head/commits change.
+  const seedExtractedKeys = useEffectEvent(
+    (keys: string[], openIssues: typeof issueList.data) => {
+      const existing = new Set(chips.map((c) => c.key));
+      for (const key of keys) {
+        if (existing.has(key) || dismissedRef.current.has(key)) continue;
+        const hit = openIssues?.find((i) => i.key === key);
+        if (hit) {
+          setChips((prev) =>
+            prev.some((c) => c.key === key)
+              ? prev
+              : [
+                  ...prev,
+                  {
+                    key,
+                    summary: hit.summary,
+                    statusCategory: hit.statusCategory,
+                    source: "extraction",
+                  },
+                ],
+          );
+          continue;
+        }
+        // Not on the open page — probe the project once. Skip if the open list
+        // hasn't loaded yet (a later run resolves it) so we don't probe keys that
+        // would have matched the page.
+        if (!openIssues) continue;
+        if (probedRef.current.has(key) || !link) continue;
+        probedRef.current.add(key);
+        jiraIssueView(link.siteHost, key)
+          .then((issue) => {
+            if (dismissedRef.current.has(key)) return;
+            setChips((prev) =>
+              prev.some((c) => c.key === key)
+                ? prev
+                : [
+                    ...prev,
+                    {
+                      key: issue.key,
+                      summary: issue.summary,
+                      statusCategory: issue.statusCategory,
+                      source: "extraction",
+                    },
+                  ],
+            );
+          })
+          .catch(() => undefined);
+      }
+    },
+  );
+  const subjectsText = commitSubjects.join("\n");
+  useEffect(() => {
+    if (!active || !link) return;
+    const keys = extractJiraKeys(
+      `${headBranch ?? ""}\n${subjectsText}`,
+      link.projectKey,
+    );
+    if (keys.length === 0) return;
+    seedExtractedKeys(keys, issueList.data);
+  }, [active, link, headBranch, subjectsText, issueList.data]);
+
+  // chips ∪ extraction ∪ top-ranked open issues, cap 8 — for generate(). Current
+  // chips pinned first; then the highest-scoring open issues by shared-token
+  // overlap between the summary and the branch + commit subjects, `updatedAt` desc
+  // tie-break. Records the exact set fed so `upsertFromDraft` can resolve
+  // summary/status.
+  function buildCandidates(): JiraCandidate[] {
+    if (!active) {
+      lastCandidatesRef.current = new Map();
+      return [];
+    }
+    const chipKeys = new Set(chips.map((c) => c.key));
+    const chipCandidates: JiraCandidate[] = chips.map((c) => ({
+      key: c.key,
+      summary: c.summary,
+      statusCategory: c.statusCategory,
+    }));
+    const rankText = rankTokens(
+      `${headBranch ?? ""} ${commitSubjects.join(" ")}`,
+    );
+    const ranked = (issueList.data ?? [])
+      .filter((i) => !chipKeys.has(i.key))
+      .map((i) => ({ issue: i, score: sharedTokenScore(i.summary, rankText) }))
+      .sort(
+        (a, b) =>
+          b.score - a.score || (b.issue.updatedAt < a.issue.updatedAt ? -1 : 1),
+      )
+      .map((r) => ({
+        key: r.issue.key,
+        summary: r.issue.summary,
+        statusCategory: r.issue.statusCategory,
+      }));
+    const candidates = [...chipCandidates, ...ranked].slice(0, 8);
+    // Key the fed map by UPPERCASED key: AI mention keys arrive uppercased from
+    // `extractPrDraft`, while candidate keys come raw from the Jira API — so a
+    // case-insensitive lookup in `upsertFromDraft` reliably resolves the meta.
+    lastCandidatesRef.current = new Map(
+      candidates.map((c) => [c.key.toUpperCase(), c]),
+    );
+    return candidates;
+  }
+
+  // Union the model's proposed mention keys into the chip cluster, marked `ai`.
+  // Skip dismissed keys; skip existing chips. Resolve a new chip's summary/status
+  // from the last-built candidates (looked up case-insensitively).
+  function upsertFromDraft(draft: { jiraMentions: string[] }) {
+    const fed = lastCandidatesRef.current;
+    setChips((prev) => {
+      let next = prev;
+      for (const key of draft.jiraMentions) {
+        if (dismissedRef.current.has(key)) continue;
+        if (next.some((c) => c.key === key)) continue;
+        const meta = fed.get(key.toUpperCase());
+        if (!meta) continue;
+        next = [
+          ...next,
+          {
+            key,
+            summary: meta.summary,
+            statusCategory: meta.statusCategory,
+            source: "ai",
+          },
+        ];
+      }
+      return next;
+    });
+  }
+
+  return { chips, resetWith, remove, pick, buildCandidates, upsertFromDraft };
+}

--- a/src/features/pulls/useLinkedIssueChips.ts
+++ b/src/features/pulls/useLinkedIssueChips.ts
@@ -229,6 +229,16 @@ function sharedTokenScore(title: string, rankText: Set<string>): number {
   return score;
 }
 
+/** Tie-break comparator: newest `updatedAt` first, as a proper three-way that
+ *  returns 0 for equal timestamps (a comparator that never returns 0 violates the
+ *  sort contract). ISO-8601 strings compare correctly as plain strings — no
+ *  locale-sensitive `localeCompare`. */
+function byUpdatedAtDesc(a: string, b: string): number {
+  if (a > b) return -1;
+  if (a < b) return 1;
+  return 0;
+}
+
 /**
  * The shared linked-issue chip state machine. Extracted from CreatePrDialog so
  * the create, edit, and local-create paths share ONE implementation (chips,
@@ -380,9 +390,14 @@ export function useLinkedIssueChips(opts: {
   }
   // Manual pick from the picker: an explicit user intent, so it clears any prior
   // dismissal for that number and adds it as a `manual` relates chip. The picker
-  // already excludes current chips, so a duplicate can't arrive here.
+  // already excludes current chips, so a duplicate can't arrive here. The picker
+  // offers CLOSED issues too, which aren't on the open page — seed those with an
+  // empty title/state so the backfill-probe effect resolves them (a placeholder
+  // `#N`/OPEN would be a permanent lie, since that effect only targets empty
+  // titles). Clear the probed marker so the effect re-probes this number.
   function pick(issueNumber: number) {
     dismissedIssuesRef.current.delete(issueNumber);
+    probedIssuesRef.current.delete(issueNumber);
     const found = (issueList.data ?? []).find((i) => i.number === issueNumber);
     setChips((prev) => {
       if (prev.some((c) => c.number === issueNumber)) return prev;
@@ -390,8 +405,8 @@ export function useLinkedIssueChips(opts: {
         ...prev,
         {
           number: issueNumber,
-          title: found?.title ?? `#${issueNumber}`,
-          state: found?.state ?? "OPEN",
+          title: found?.title ?? "",
+          state: found?.state ?? "",
           keyword: "relates",
           source: "manual",
           aiSuggestedClose: false,
@@ -494,7 +509,8 @@ export function useLinkedIssueChips(opts: {
       .map((i) => ({ issue: i, score: sharedTokenScore(i.title, rankText) }))
       .sort(
         (a, b) =>
-          b.score - a.score || (b.issue.updatedAt < a.issue.updatedAt ? -1 : 1),
+          b.score - a.score ||
+          byUpdatedAtDesc(a.issue.updatedAt, b.issue.updatedAt),
       )
       .map((r) => ({
         number: r.issue.number,
@@ -712,9 +728,14 @@ export function useJiraMentionChips(opts: {
   }
   // Manual pick from the picker: an explicit user intent, so it clears any prior
   // dismissal for that key and adds it as a `manual` chip. The picker already
-  // excludes current chips, so a duplicate can't arrive here.
+  // excludes current chips, so a duplicate can't arrive here. The picker offers
+  // ALL states (incl. done/closed), which aren't on the open page — seed those
+  // with an empty summary so the backfill-probe effect resolves them (a `key`
+  // placeholder would be a permanent lie, since that effect only targets empty
+  // summaries). Clear the probed marker so the effect re-probes this key.
   function pick(key: string) {
     dismissedRef.current.delete(key);
+    probedRef.current.delete(key);
     const found = (issueList.data ?? []).find((i) => i.key === key);
     setChips((prev) => {
       if (prev.some((c) => c.key === key)) return prev;
@@ -722,7 +743,7 @@ export function useJiraMentionChips(opts: {
         ...prev,
         {
           key,
-          summary: found?.summary ?? key,
+          summary: found?.summary ?? "",
           statusCategory: found?.statusCategory ?? "",
           source: "manual",
         },
@@ -819,7 +840,8 @@ export function useJiraMentionChips(opts: {
       .map((i) => ({ issue: i, score: sharedTokenScore(i.summary, rankText) }))
       .sort(
         (a, b) =>
-          b.score - a.score || (b.issue.updatedAt < a.issue.updatedAt ? -1 : 1),
+          b.score - a.score ||
+          byUpdatedAtDesc(a.issue.updatedAt, b.issue.updatedAt),
       )
       .map((r) => ({
         key: r.issue.key,

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -213,6 +213,21 @@ function renderIssueLine(number: number, title: string, state: string): string {
   return state.toUpperCase() === "CLOSED" ? `${base} (closed)` : base;
 }
 
+/** Render one Jira candidate as a bullet for the `## Related issues` section:
+ *  `- KEY — summary`, ` (done)` suffixed on the key when `statusCategory` is
+ *  "done", bare `- KEY` when the summary is empty. Summary trimmed + 140-char
+ *  cap. Mention-only — there is no closed/close notion. KEEP IN SYNC:
+ *  `render_jira_line` in src-tauri/src/mcp_server/generate.rs. */
+function renderJiraLine(
+  key: string,
+  summary: string,
+  statusCategory: string,
+): string {
+  const suffix = statusCategory.toLowerCase() === "done" ? " (done)" : "";
+  const s = [...summary.trim()].slice(0, 140).join("");
+  return s ? `- ${key}${suffix} — ${s}` : `- ${key}${suffix}`;
+}
+
 // KEEP IN SYNC: src-tauri/src/mcp_server/generate.rs mirrors this for the MCP recipe tools.
 export function buildPrPrompt(input: PrPromptInput): {
   system: string;
@@ -229,10 +244,25 @@ export function buildPrPrompt(input: PrPromptInput): {
   const candidates = (input.issueCandidates ?? [])
     .filter((c) => Number.isInteger(c.number) && c.number > 0)
     .slice(0, 8);
+  // Mention-only Jira candidates (Bitbucket repos with a linked project). Native
+  // `candidates` win — the Jira variant fires ONLY when there are no native
+  // candidates (the Bitbucket-only gather makes both-non-empty impossible, but the
+  // precedence is encoded here defensively). Filter empty keys, then cap at 8.
+  const jira =
+    candidates.length > 0
+      ? []
+      : (input.jiraCandidates ?? []).filter((c) => c.key.trim()).slice(0, 8);
   if (candidates.length > 0) {
     // Both strings built with the in-scope `abbrev`; swap the first occurrence.
     const ban = `- NEVER reference issue or ${abbrev} numbers, tickets, milestones, or external links (e.g. "Closes #123", "part of #60", "fixes JIRA-4"). You have no access to the issue tracker, so any such reference is fabricated — leave them out entirely.`;
     const relaxed = `- Do not put issue or ${abbrev} numbers, tickets, milestones, or external links in the description body — the ONLY issue references you may make are the final Closes:/Relates: lines defined in the "Related issues" section, chosen from its list. Any other reference is fabricated — leave it out.`;
+    systemParts[0] = systemParts[0].replace(ban, relaxed);
+  } else if (jira.length > 0) {
+    // Jira mention-only variant: swap the ban for a RELAXED line that permits only
+    // the final `Relates:` line (no `Closes:` — Jira tickets aren't closed from PR
+    // text). `abbrev` is "PR" on Bitbucket. KEEP IN SYNC with generate.rs.
+    const ban = `- NEVER reference issue or ${abbrev} numbers, tickets, milestones, or external links (e.g. "Closes #123", "part of #60", "fixes JIRA-4"). You have no access to the issue tracker, so any such reference is fabricated — leave them out entirely.`;
+    const relaxed = `- Do not put issue or ${abbrev} numbers, tickets, milestones, or external links in the description body — the ONLY ticket references you may make are the final Relates: line defined in the "Related issues" section, chosen from its list. Any other reference is fabricated — leave it out.`;
     systemParts[0] = systemParts[0].replace(ban, relaxed);
   }
 
@@ -308,6 +338,16 @@ export function buildPrPrompt(input: PrPromptInput): {
     systemParts.push(
       `## Related issues\n${issueLines}\nThese are real, open-or-closed issues from this repository's tracker that MAY be related to this change — judge each by its title against what the diff actually does. Most changes genuinely address at most one or two, often none; never force a link. After the description (and after the Labels line when present), report qualifying issues on up to two final lines, exactly like:\nCloses: 123, 456\nRelates: 789\nUse Closes ONLY for an issue this change fully resolves — merging will close it automatically, so prefer Relates when unsure. Use Relates for an issue this change advances or clearly connects to without resolving it. List ONLY numbers from the list above, never any other number; omit either line (or both) when no issue qualifies.`,
     );
+  } else if (jira.length > 0) {
+    // Jira mention-only variant of the Related-issues section (Bitbucket + linked
+    // project). Only a `Relates:` line is offered — Jira tickets aren't closed from
+    // PR text. KEEP IN SYNC with generate.rs.
+    const issueLines = jira
+      .map((c) => renderJiraLine(c.key, c.summary, c.statusCategory))
+      .join("\n");
+    systemParts.push(
+      `## Related issues\n${issueLines}\nThese are real issues from this repository's linked Jira project that MAY be related to this change — judge each by its title against what the diff actually does. Most changes genuinely address at most one or two, often none; never force a link. After the description (and after the Labels line when present), report qualifying issues on ONE final line, exactly like:\nRelates: MYT-123, MYT-456\nNever use a Closes line for these — Jira tickets are not closed from pull-request text. List ONLY keys from the list above, never any other key; omit the line when no issue qualifies.`,
+    );
   }
 
   let closing = `Write the ${prNoun} title and description. Lead with a summary of the goal, then group related changes by theme under \`###\` headings when the diff touches several areas, citing the files involved.`;
@@ -316,6 +356,8 @@ export function buildPrPrompt(input: PrPromptInput): {
   }
   if (candidates.length > 0) {
     closing += ` Then, if any of the listed related issues qualify, end with the \`Closes:\` / \`Relates:\` line(s) as instructed.`;
+  } else if (jira.length > 0) {
+    closing += ` Then, if any of the listed related issues qualify, end with the \`Relates:\` line as instructed.`;
   }
   promptParts.push(closing);
 
@@ -781,17 +823,23 @@ export function splitCommitMessage(raw: string): {
  *   validated against `candidateIssueNumbers`, and deduped. A number appearing in
  *   BOTH lines lands in `relates` only (the safe default). Both are `[]` when
  *   `candidateIssueNumbers` is empty (the lines are STILL peeled from the body).
+ * - `Relates:` KEY-shaped tokens (e.g. `MYT-123`) are validated (case-insensitively)
+ *   against `candidateJiraKeys` → `jiraMentions` (canonical uppercase, deduped);
+ *   `jiraMentions` is `[]` when `candidateJiraKeys` is empty. A key-shaped token on
+ *   a `Closes:` line is DROPPED always — Jira tickets are never closed from PR text.
  */
 export function extractPrDraft(
   raw: string,
   availableLabels: string[],
   candidateIssueNumbers: number[] = [],
+  candidateJiraKeys: string[] = [],
 ): {
   title: string;
   body: string;
   labels: string[];
   closes: number[];
   relates: number[];
+  jiraMentions: string[];
 } {
   const { title, body: fullBody } = splitCommitMessage(raw);
 
@@ -881,7 +929,29 @@ export function extractPrDraft(
     (n) => !relatesSet.has(n),
   );
 
-  return { title, body, labels, closes, relates };
+  // Validate Jira keys against the fed candidate set (canonical uppercase). Only
+  // the `Relates:` line contributes — a key-shaped token on `Closes:` is dropped
+  // (Jira tickets are never closed from PR text). `jiraMentions` is empty when the
+  // candidate set is empty (the line is still peeled regardless).
+  const jiraMentions: string[] = [];
+  if (candidateJiraKeys.length > 0 && captured.relates) {
+    const canonicalKeys = new Set<string>();
+    for (const k of candidateJiraKeys) {
+      const trimmed = k.trim().toUpperCase();
+      if (trimmed) canonicalKeys.add(trimmed);
+    }
+    const seen = new Set<string>();
+    for (const part of captured.relates.split(",")) {
+      const token = part.trim().toUpperCase();
+      if (!/^[A-Z][A-Z0-9_]*-\d+$/.test(token)) continue;
+      if (canonicalKeys.has(token) && !seen.has(token)) {
+        seen.add(token);
+        jiraMentions.push(token);
+      }
+    }
+  }
+
+  return { title, body, labels, closes, relates, jiraMentions };
 }
 
 /** The branch name from a branch-name response, tolerant of a leaked preamble

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -204,13 +204,14 @@ function renderLabelLine(name: string, description?: string | null): string {
 }
 
 /** Render one candidate issue as a bullet for the `## Related issues` section:
- *  `- #123 — title`, ` (closed)` suffixed when the issue is closed, the ` — title`
- *  part omitted when the title is empty. Title code-point-capped at 140. KEEP IN
- *  SYNC: `render_issue_line` in src-tauri/src/mcp_server/generate.rs. */
+ *  `- #123 — title`, ` (closed)` suffixed on the number (before ` — title`) when
+ *  the issue is closed, the ` — title` part omitted when the title is empty. Title
+ *  code-point-capped at 140. KEEP IN SYNC: `render_issue_line` in
+ *  src-tauri/src/mcp_server/generate.rs (number-adjacent suffix placement). */
 function renderIssueLine(number: number, title: string, state: string): string {
+  const suffix = state.toUpperCase() === "CLOSED" ? " (closed)" : "";
   const t = [...title.trim()].slice(0, 140).join("");
-  const base = t ? `- #${number} — ${t}` : `- #${number}`;
-  return state.toUpperCase() === "CLOSED" ? `${base} (closed)` : base;
+  return t ? `- #${number}${suffix} — ${t}` : `- #${number}${suffix}`;
 }
 
 /** Render one Jira candidate as a bullet for the `## Related issues` section:
@@ -827,6 +828,13 @@ export function splitCommitMessage(raw: string): {
  *   against `candidateJiraKeys` → `jiraMentions` (canonical uppercase, deduped);
  *   `jiraMentions` is `[]` when `candidateJiraKeys` is empty. A key-shaped token on
  *   a `Closes:` line is DROPPED always — Jira tickets are never closed from PR text.
+ *
+ * Note: the trailing `Labels:` / `Closes:` / `Relates:` lines are peeled off the
+ * body even when NO candidates were fed (mirroring the pre-existing `Labels:`
+ * behavior) — the peel is unconditional so a partial directive line never flickers
+ * into the rendered body mid-stream. A genuine prose final line that happens to
+ * start with one of those tokens is intentionally sacrificed to that flicker-free
+ * guarantee.
  */
 export function extractPrDraft(
   raw: string,

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -203,6 +203,16 @@ function renderLabelLine(name: string, description?: string | null): string {
   return `- ${name} — ${[...desc].slice(0, 140).join("")}`;
 }
 
+/** Render one candidate issue as a bullet for the `## Related issues` section:
+ *  `- #123 — title`, ` (closed)` suffixed when the issue is closed, the ` — title`
+ *  part omitted when the title is empty. Title code-point-capped at 140. KEEP IN
+ *  SYNC: `render_issue_line` in src-tauri/src/mcp_server/generate.rs. */
+function renderIssueLine(number: number, title: string, state: string): string {
+  const t = [...title.trim()].slice(0, 140).join("");
+  const base = t ? `- #${number} — ${t}` : `- #${number}`;
+  return state.toUpperCase() === "CLOSED" ? `${base} (closed)` : base;
+}
+
 // KEEP IN SYNC: src-tauri/src/mcp_server/generate.rs mirrors this for the MCP recipe tools.
 export function buildPrPrompt(input: PrPromptInput): {
   system: string;
@@ -211,6 +221,21 @@ export function buildPrPrompt(input: PrPromptInput): {
   const { prNoun } = platformCopy(input.provider);
   const abbrev = prNoun === "merge request" ? "MR" : "PR";
   const systemParts = [prSystemFor(input.provider)];
+
+  // Grounded issue-linking: real, validated candidate issues the model MAY link
+  // (defensive cap 8 — mirrored Rust-side). When present, the system prompt's
+  // fabrication ban is swapped for a grounded rule and a `## Related issues`
+  // section is added; the parser drops any number not in this set.
+  const candidates = (input.issueCandidates ?? [])
+    .filter((c) => Number.isInteger(c.number) && c.number > 0)
+    .slice(0, 8);
+  if (candidates.length > 0) {
+    // Both strings built with the in-scope `abbrev`; swap the first occurrence.
+    const ban = `- NEVER reference issue or ${abbrev} numbers, tickets, milestones, or external links (e.g. "Closes #123", "part of #60", "fixes JIRA-4"). You have no access to the issue tracker, so any such reference is fabricated — leave them out entirely.`;
+    const relaxed = `- Do not put issue or ${abbrev} numbers, tickets, milestones, or external links in the description body — the ONLY issue references you may make are the final Closes:/Relates: lines defined in the "Related issues" section, chosen from its list. Any other reference is fabricated — leave it out.`;
+    systemParts[0] = systemParts[0].replace(ban, relaxed);
+  }
+
   if (input.repoInstructions) {
     systemParts.push(`## Project instructions\n${input.repoInstructions}`);
   }
@@ -273,9 +298,24 @@ export function buildPrPrompt(input: PrPromptInput): {
     );
   }
 
+  // Related-issue proposal — only when the caller fed validated candidates. The
+  // model chooses ONLY from this list (the parser drops anything not in it), so a
+  // fabricated number is silently discarded rather than surfaced.
+  if (candidates.length > 0) {
+    const issueLines = candidates
+      .map((c) => renderIssueLine(c.number, c.title, c.state))
+      .join("\n");
+    systemParts.push(
+      `## Related issues\n${issueLines}\nThese are real, open-or-closed issues from this repository's tracker that MAY be related to this change — judge each by its title against what the diff actually does. Most changes genuinely address at most one or two, often none; never force a link. After the description (and after the Labels line when present), report qualifying issues on up to two final lines, exactly like:\nCloses: 123, 456\nRelates: 789\nUse Closes ONLY for an issue this change fully resolves — merging will close it automatically, so prefer Relates when unsure. Use Relates for an issue this change advances or clearly connects to without resolving it. List ONLY numbers from the list above, never any other number; omit either line (or both) when no issue qualifies.`,
+    );
+  }
+
   let closing = `Write the ${prNoun} title and description. Lead with a summary of the goal, then group related changes by theme under \`###\` headings when the diff touches several areas, citing the files involved.`;
   if (labels.length > 0) {
     closing += ` Then, if any of the repository's labels qualify, end with a single \`Labels:\` line as instructed.`;
+  }
+  if (candidates.length > 0) {
+    closing += ` Then, if any of the listed related issues qualify, end with the \`Closes:\` / \`Relates:\` line(s) as instructed.`;
   }
   promptParts.push(closing);
 
@@ -722,71 +762,126 @@ export function splitCommitMessage(raw: string): {
 }
 
 /**
- * Splits a (possibly still streaming) PR/MR response into title, body, and a
- * validated set of label NAMES. Reuses {@link splitCommitMessage} for the
- * title/body split, then:
- * - Strips a trailing `Labels: …` line from the body so it never shows in the
- *   description. This runs on EVERY chunk, so a partial `Labels:` line that
- *   appears mid-stream (e.g. `Labels` or `Labels: bu`) is peeled off too and
- *   never flickers into the rendered body.
- * - Parses the comma-separated names and validates each (case-insensitively)
- *   against `availableLabels`, returning the canonical repo casing and DROPPING
- *   anything not in the set — the model can only surface labels that truly exist.
- * `labels` is `[]` when `availableLabels` is empty (nothing to match against).
+ * Splits a (possibly still streaming) PR/MR response into title, body, a
+ * validated set of label NAMES, and validated `closes` / `relates` issue
+ * numbers. Reuses {@link splitCommitMessage} for the title/body split, then
+ * PEELS any combination of trailing `Labels:` / `Closes:` / `Relates:` lines
+ * (in any order, one per kind) off the end of the body:
+ * - The peel is iterative from the end: it examines the last non-empty line and,
+ *   while it matches one of the three kinds (or is a nascent bare prefix still
+ *   streaming — `Labels` / `Closes` / `Relates` with no colon yet), records it
+ *   (first-from-end wins per kind; a second occurrence of an already-seen kind
+ *   STOPS the loop) and keeps peeling. It stops at the first non-matching
+ *   non-empty line. This runs on EVERY chunk, so a partial trailing line never
+ *   flickers into the rendered body. Body = everything above the peeled block.
+ * - `Labels:` names are validated (case-insensitively) against `availableLabels`,
+ *   returning the canonical repo casing and DROPPING anything not in the set.
+ *   `labels` is `[]` when `availableLabels` is empty.
+ * - `Closes:` / `Relates:` numbers are comma-split, `#`-stripped, digit-required,
+ *   validated against `candidateIssueNumbers`, and deduped. A number appearing in
+ *   BOTH lines lands in `relates` only (the safe default). Both are `[]` when
+ *   `candidateIssueNumbers` is empty (the lines are STILL peeled from the body).
  */
 export function extractPrDraft(
   raw: string,
   availableLabels: string[],
-): { title: string; body: string; labels: string[] } {
+  candidateIssueNumbers: number[] = [],
+): {
+  title: string;
+  body: string;
+  labels: string[];
+  closes: number[];
+  relates: number[];
+} {
   const { title, body: fullBody } = splitCommitMessage(raw);
 
-  // Peel a trailing line that begins with `Labels:` (or a partial `Labels`
-  // prefix still streaming in) off the end of the body. Only the LAST
-  // non-empty line is a candidate, so a legitimate "Labels:" mention earlier
-  // in the description is untouched.
   const lines = fullBody.split("\n");
-  let lastIdx = lines.length - 1;
-  while (lastIdx >= 0 && lines[lastIdx].trim() === "") lastIdx--;
-  const lastLine = lastIdx >= 0 ? lines[lastIdx].trim() : "";
-  // Require the colon so a normal sentence that merely starts with "Labels"
-  // (e.g. "Labels are applied by CI.") is NOT mistaken for the label line and
-  // dropped from the body; the nascent pre-colon case is handled just below.
-  const labelLineMatch = lastLine.match(/^labels\s*:\s*(.*)$/i);
-  // A trailing bare `Label`/`Labels` prefix mid-stream (no colon yet) also counts
-  // as a nascent label line to strip, so it doesn't briefly render as body text.
-  const isNascentLabelLine =
-    !labelLineMatch && /^labels?$/i.test(lastLine.replace(/[:\s]*$/, ""));
-
-  let body = fullBody;
-  if (labelLineMatch || isNascentLabelLine) {
-    body = lines.slice(0, lastIdx).join("\n").trimEnd();
+  // The raw captured value for each kind (post-colon text), first-from-end. A
+  // bare nascent prefix records "" (nothing to parse yet, but the line is peeled).
+  const captured: Partial<Record<"labels" | "closes" | "relates", string>> = {};
+  // Index of the first body line NOT part of the peeled trailing block.
+  let bodyEnd = lines.length;
+  let cursor = lines.length - 1;
+  while (cursor >= 0) {
+    if (lines[cursor].trim() === "") {
+      cursor--;
+      continue;
+    }
+    const line = lines[cursor].trim();
+    // Require the colon so a normal sentence merely starting with the keyword
+    // (e.g. "Closes the gap …") is not mistaken for a directive line; the nascent
+    // pre-colon case is handled just below.
+    const m = line.match(/^(labels|closes|relates)\s*:\s*(.*)$/i);
+    // A trailing bare `Labels`/`Closes`/`Relates` prefix mid-stream (no colon
+    // yet) also counts as a nascent line to strip so it doesn't briefly render.
+    const nascent =
+      !m && /^(labels?|closes?|relates?)$/i.test(line.replace(/[:\s]*$/, ""));
+    if (!m && !nascent) break;
+    const kindRaw = (m ? m[1] : line.replace(/[:\s]*$/, "")).toLowerCase();
+    // Normalize the nascent singular forms (`label`/`close`/`relate`) to the key.
+    const kind = kindRaw.startsWith("label")
+      ? "labels"
+      : kindRaw.startsWith("close")
+        ? "closes"
+        : "relates";
+    // A second occurrence of an already-seen kind STOPS the loop (that earlier
+    // line is real body content, not another directive).
+    if (kind in captured) break;
+    captured[kind] = m ? (m[2] ?? "").trim() : "";
+    bodyEnd = cursor;
+    cursor--;
   }
 
-  if (availableLabels.length === 0) {
-    return { title, body, labels: [] };
-  }
+  const body =
+    bodyEnd < lines.length
+      ? lines.slice(0, bodyEnd).join("\n").trimEnd()
+      : fullBody;
 
-  // Canonical lookup keyed by lowercased name → the repo's own casing.
-  const canonical = new Map<string, string>();
-  for (const name of availableLabels) {
-    const trimmed = name.trim();
-    if (trimmed) canonical.set(trimmed.toLowerCase(), trimmed);
-  }
-
-  const rawNames = labelLineMatch?.[1]?.trim() ?? "";
-  const seen = new Set<string>();
+  // Validate the label names against the repo's set (canonical casing).
   const labels: string[] = [];
-  for (const part of rawNames.split(",")) {
-    const key = part.trim().toLowerCase();
-    if (!key) continue;
-    const match = canonical.get(key);
-    if (match && !seen.has(key)) {
-      seen.add(key);
-      labels.push(match);
+  if (availableLabels.length > 0 && captured.labels) {
+    const canonical = new Map<string, string>();
+    for (const name of availableLabels) {
+      const trimmed = name.trim();
+      if (trimmed) canonical.set(trimmed.toLowerCase(), trimmed);
+    }
+    const seen = new Set<string>();
+    for (const part of captured.labels.split(",")) {
+      const key = part.trim().toLowerCase();
+      if (!key) continue;
+      const match = canonical.get(key);
+      if (match && !seen.has(key)) {
+        seen.add(key);
+        labels.push(match);
+      }
     }
   }
 
-  return { title, body, labels };
+  // Validate issue numbers against the fed candidate set. A `#` prefix is
+  // accepted; only bare digits count; a number in both lines lands in `relates`.
+  const candidateSet = new Set(candidateIssueNumbers);
+  const parseNumbers = (rawLine: string | undefined): number[] => {
+    if (!rawLine) return [];
+    const seen = new Set<number>();
+    const out: number[] = [];
+    for (const part of rawLine.split(",")) {
+      const token = part.trim().replace(/^#/, "");
+      if (!/^\d+$/.test(token)) continue;
+      const n = Number.parseInt(token, 10);
+      if (candidateSet.has(n) && !seen.has(n)) {
+        seen.add(n);
+        out.push(n);
+      }
+    }
+    return out;
+  };
+  const relates = parseNumbers(captured.relates);
+  const relatesSet = new Set(relates);
+  const closes = parseNumbers(captured.closes).filter(
+    (n) => !relatesSet.has(n),
+  );
+
+  return { title, body, labels, closes, relates };
 }
 
 /** The branch name from a branch-name response, tolerant of a leaked preamble

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -88,6 +88,12 @@ export interface PrPromptInput {
    *  `Closes:` / `Relates:` lines choosing ONLY from these numbers; the parser
    *  drops anything not in this set. Empty/absent ⇒ prompt unchanged, ban intact. */
   issueCandidates?: { number: number; title: string; state: string }[];
+  /** Mention-only candidates from the repo's LINKED Jira project (Bitbucket
+   *  repos — no native tracker). Mutually exclusive with issueCandidates by
+   *  construction; when both are somehow non-empty, issueCandidates wins and
+   *  these are ignored (mirrors the Rust precedence). Model may end with ONE
+   *  `Relates:` line choosing ONLY these keys; never a Closes line. */
+  jiraCandidates?: { key: string; summary: string; statusCategory: string }[];
   /** Target host — swaps the change-request noun + markdown flavor in the prompt.
    *  Absent/`"github"` keeps the original GitHub wording byte-for-byte. */
   provider?: PromptProvider;

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -82,6 +82,12 @@ export interface PrPromptInput {
    *  this set (no invented labels). The description is shown so the model judges a
    *  label by what it's for, not a name-plausible match. Empty ⇒ no label line. */
   availableLabels: { name: string; description?: string | null }[];
+  /** Real issues from the target repo's tracker the model MAY link (already
+   *  validated to exist). When non-empty, the system prompt's issue-reference ban
+   *  is swapped for a grounded rule: the model may end its output with
+   *  `Closes:` / `Relates:` lines choosing ONLY from these numbers; the parser
+   *  drops anything not in this set. Empty/absent ⇒ prompt unchanged, ban intact. */
+  issueCandidates?: { number: number; title: string; state: string }[];
   /** Target host — swaps the change-request noun + markdown flavor in the prompt.
    *  Absent/`"github"` keeps the original GitHub wording byte-for-byte. */
   provider?: PromptProvider;

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1483,7 +1483,11 @@ export function useIssueList(
   });
 }
 
-const issueDetailsOptions = (repo: string, number: number, lens: RemoteLens) =>
+export const issueDetailsOptions = (
+  repo: string,
+  number: number,
+  lens: RemoteLens,
+) =>
   queryOptions({
     queryKey: ["repo", repo, "issue", lens, number] as const,
     queryFn: () => api.forgeIssueView(repo, number, lens),

--- a/src/lib/issues/extract.ts
+++ b/src/lib/issues/extract.ts
@@ -1,0 +1,58 @@
+/**
+ * Extract candidate issue numbers referenced in git text (branch name, commit
+ * subjects). Deduplicated, first-occurrence order. Matches:
+ *   - `#123` (not preceded by a letter/digit, and not `&#123` HTML entities)
+ *   - a branch segment starting `123-` (e.g. `123-fix-crash`, `fix/123-crash`)
+ *   - `issue-123` / `gh-123` (case-insensitive, boundary-guarded)
+ * Numbers are validated against real repo issues by the caller — this is
+ * extraction only. KEEP IN SYNC: extract_issue_numbers in
+ * src-tauri/src/mcp_server/generate.rs (which has no lookbehind — both sides
+ * use explicit leading-boundary capture groups so behavior stays identical).
+ *
+ * The three patterns are run in order over the WHOLE text; capture group 1 is
+ * parsed as an integer, `0` and anything > 999_999_999 dropped, and the results
+ * deduped preserving first-occurrence order across patterns (1 → 2 → 3).
+ *
+ * Case table (verified against the patterns below):
+ *   `fix/123-crash` → 123   (pattern 2: after `/`, digits then `-`)
+ *   `123-fix`       → 123   (pattern 2: string start, digits then `-`)
+ *   `#45`           → 45    (pattern 1: `#` not preceded by letter/digit/`&`)
+ *   `&#39;`         → []    (pattern 1's `&` exclusion keeps HTML entities out)
+ *   `issue-7`       → 7     (pattern 3, case-insensitive)
+ *   `gh-7`          → 7     (pattern 3, case-insensitive)
+ *   `v2-123`        → []    (pattern 2 fires only at string start or after `/`,
+ *                            and the segment here starts `v2`, not digits; the
+ *                            mid-token `2-1` is preceded by `v`, so nothing)
+ *   `abc#12`        → []    (pattern 1: `#` preceded by a letter)
+ *   `#12 #12`       → [12]  (deduped, first occurrence kept)
+ */
+export function extractIssueNumbers(text: string | null | undefined): number[] {
+  if (!text) return [];
+
+  // Explicit leading-boundary capture groups (no lookbehind) so the Rust `regex`
+  // crate twin behaves identically.
+  const patterns = [
+    // `#123`, where `#` is at the start or after a non-alphanumeric that isn't
+    // `&` (so `&#39;`-style HTML entities never match).
+    /(?:^|[^A-Za-z0-9&])#(\d+)/g,
+    // A branch segment starting with a number: `123-…` at the string start or
+    // right after a `/` (`fix/123-crash`).
+    /(?:^|\/)(\d+)-/g,
+    // `issue-123` / `gh-123`, boundary-guarded on the left.
+    /(?:^|[^A-Za-z0-9])(?:issue|gh)-(\d+)/gi,
+  ];
+
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const re of patterns) {
+    for (const m of text.matchAll(re)) {
+      const n = Number.parseInt(m[1], 10);
+      if (!Number.isInteger(n) || n <= 0 || n > 999_999_999) continue;
+      if (!seen.has(n)) {
+        seen.add(n);
+        out.push(n);
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Adds a **Linked issues** row to the PR create and edit dialogs so authors can attach real repo issues to a pull request without leaving the app. Chips are auto-detected from the branch name and commit subjects, proposed by the AI generator from a grounded shortlist, or added by hand, and each toggles between **Closes** (auto-closes on merge) and **Relates to** — composed into the body as `Closes #N` / `Relates to #N` lines. The feature spans GitHub, GitLab, local PRs (where refs survive promotion), and Bitbucket repos with a linked Jira project (mention-only `KEY-123` chips).

### Chip UI and state
- Adds `src/features/pulls/LinkedIssuesField.tsx` — the two-variant cluster: the native GitHub/GitLab band with a keyboard-operable Closes/Relates toggle (roving tabindex, ←/→ nav, Enter/Space toggle, Delete removal) and the Bitbucket Jira mention-only band.
- Adds `src/features/pulls/JiraIssuePicker.tsx` — an autocomplete over the linked Jira project's issues, with a `JiraStatusIcon` so status isn't color-only.
- Adds `src/features/pulls/useLinkedIssueChips.ts` — the shared chip state machine (extraction seeding, AI union, candidate ranking, mutations) plus the body composers (`composeBodyWithRefs`, `composeBodyWithJiraRefs`) and the `splitBodyRefBlock` peeler that makes the chips the single editor for the trailing ref block on edit.

### Issue-number extraction (TS + Rust)
- Adds `src/lib/issues/extract.ts` with `extractIssueNumbers`, matching `#123`, `123-…` branch segments, and `issue-123` / `gh-123`, deduped in first-occurrence order.
- Mirrors it in `src-tauri/src/mcp_server/generate.rs` as `extract_issue_numbers` (hand-rolled, no lookbehind) alongside `extract_jira_keys` for `<PROJECTKEY>-\d+`, with case tables documenting the kept-in-sync boundary semantics.

### AI generation
- Extends `src/lib/ai/prompt.ts` with `renderIssueLine` / `renderJiraLine` and a grounded `## Related issues` section that swaps the fabrication ban for a relaxed rule when validated candidates are supplied (native `Closes:`/`Relates:` or Jira `Relates:` only).
- Adds `issueCandidates` / `jiraCandidates` to `PrPromptInput` in `src/lib/ai/types.ts`.
- Threads the candidates through `useGeneratePrDescription.ts` and introduces the `PrDraft` shape carrying `closes`, `relates`, and `jiraMentions` back to callers.

### Dialog integration
- Wires the cluster into `CreatePrDialog.tsx`, `CreateLocalPrDialog.tsx`, `RemotePrView.tsx`, and `LocalPrView.tsx` — seeding on open, unioning AI proposals, and composing the final body on save; Bitbucket paths use `useJiraLink` to gate the mention-only cluster.
- Adds an optional `belowBody` slot to `EditTitleBodyDialog.tsx` so the edit dialogs render the chip cluster without changing the non-PR call sites.
- Exports `issueDetailsOptions` from `src/lib/git/queries.ts` for reuse by the chip hook.

### Documentation
- Updates `README.md`, `site/src/data/capabilities.ts`, `site/src/pages/index.astro`, and the in-app guide `src/features/help/content.ts` to describe linked issues and AI-proposed links.
- Adds the changelog fragment `changelog.d/added-pr-linked-issues.md`.