### PR TITLE
feat(pr-review): queue a second AI review while one is streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ Codex agent, and never writes until you accept.
 workflow against any two branches with no remote at all).
 
 - **AI review + security audit** on any PR, with an activity indicator, a cancel, and a
-  concurrency-capped queue. Re-runs are **iterative** — they feed back the previous
+  concurrency-capped queue — and while one mode streams you can **queue the other to run
+  next** instead of waiting. Re-runs are **iterative** — they feed back the previous
   round, fold in other bots' findings, and read GitDesktop's own earlier comments (past
   reviews and any "fixed in `<sha>`" / refutation replies) as soft, re-verifiable
   context, so an already-addressed finding isn't re-raised cold (the current diff is

--- a/changelog.d/added-review-queue-second-mode.md
+++ b/changelog.d/added-review-queue-second-mode.md
@@ -1,0 +1,5 @@
+- **Queue a second AI review.** Run a code review and a security audit on the same
+  pull request without waiting: start one while the other is streaming and it
+  **queues**, then runs automatically when the first finishes. A chip shows what's
+  up next (with **Dismiss** to drop it), and cancelling the running review still
+  lets the queued one proceed.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -425,6 +425,11 @@ export const capabilities: Capability[] = [
   {
     group: "AI · generate & review",
     ai: true,
+    label: "Queue the other review mode while one streams — runs it next",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
     label: "Iterative reviews build on the last round & other bots' findings",
   },
   {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -827,6 +827,13 @@ controls how much diff and prior-discussion context reviews send — **Auto** fi
 reviewing model's context window (probing Ollama live), or pick Compact / Standard /
 Expanded.
 
+**One review at a time — queue the other.** A PR streams one AI review at a time,
+but you don't have to pick between a code review and a security audit: start one
+while the other is running and it **queues**, then starts automatically when the
+first finishes (whose result moves to **Previous reviews**). A chip shows what's up
+next; **Dismiss** drops it, and cancelling the running review still lets the queued
+one proceed.
+
 **Agentic review.** The panel's **Agentic review** toggle gives the reviewer read-only
 tools so that, instead of relying on the prompt's truncated summary, it pulls the **full PR
 diff**, reads any file at any ref, searches the repo, runs history, and reads the

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -41,7 +41,6 @@ import {
   PROVIDERS_REQUIRING_KEY,
 } from "@/lib/ai/providers";
 import type { AiProviderId, ReviewMode } from "@/lib/ai/types";
-import { track } from "@/lib/analytics";
 import { copyText } from "@/lib/clipboard";
 import { quickTransition } from "@/lib/motion";
 import { useExternalReviews, useReviewHistory } from "@/lib/pulls/queries";
@@ -248,24 +247,9 @@ export function PrReviewPanel({
         ? securityReviewAi
         : globalReviewAi);
     if (!effective) return;
+    // `ai_review_triggered` is emitted in startReview when the run actually begins
+    // (so it counts a drained queued run and skips a dismissed one), not here.
     generate(effective, mode, context, ignoredModes.has(mode), ignoreExternal);
-    const model = effective.model.toLowerCase();
-    const model_tier =
-      model.includes("haiku") ||
-      model.includes("mini") ||
-      model.includes("flash")
-        ? "fast"
-        : model.includes("opus") ||
-            model.includes("gpt-4o") ||
-            model.includes("sonnet-4")
-          ? "powerful"
-          : effective.provider === "ollama"
-            ? "local"
-            : "balanced";
-    track({
-      name: "ai_review_triggered",
-      properties: { provider: effective.provider, model_tier },
-    });
   }
 
   async function post() {

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  ClockIcon,
   CopyIcon,
   RobotIcon,
   ShieldCheckIcon,
@@ -104,6 +105,8 @@ export function PrReviewPanel({
     generate,
     cancel,
     reset,
+    dismissQueued,
+    queuedMode,
     generating,
     text,
     status,
@@ -425,7 +428,7 @@ export function PrReviewPanel({
             {generating ? (
               <m.div
                 key="cancel"
-                className="flex items-center gap-2"
+                className="flex flex-wrap items-center gap-2"
                 initial={{ opacity: 0, scale: 0.96 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.96 }}
@@ -442,6 +445,25 @@ export function PrReviewPanel({
                     since={startedAt}
                     className="text-xs text-muted-foreground"
                   />
+                )}
+                {/* Queue the OTHER mode to run next — one output surface, so it
+                    starts when this run finishes. Hidden once something's queued
+                    (only two modes exist). */}
+                {!queuedMode && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      run(mode === "security" ? "general" : "security")
+                    }
+                  >
+                    {mode === "security" ? (
+                      <SparkleIcon data-icon="inline-start" />
+                    ) : (
+                      <ShieldCheckIcon data-icon="inline-start" />
+                    )}
+                    Queue {mode === "security" ? "review" : "security audit"}
+                  </Button>
                 )}
               </m.div>
             ) : (
@@ -495,6 +517,23 @@ export function PrReviewPanel({
               </span>
             )}
         </div>
+        {queuedMode && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+            <ClockIcon className="size-3 shrink-0" />
+            <span className="min-w-0">
+              {queuedMode === "security" ? "Security audit" : "Review"} queued —
+              runs when the {mode === "security" ? "security audit" : "review"}{" "}
+              finishes.
+            </span>
+            <button
+              type="button"
+              className="cursor-pointer underline-offset-2 hover:underline"
+              onClick={dismissQueued}
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
         {(["general", "security"] as ReviewMode[]).map((m) => {
           const prior = latestByMode[m];
           if (!prior) return null;

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -484,8 +484,11 @@ export async function startReview(
     const diff = await context.loadDiff();
     if (control.cancelled) return;
     if (!diff.text.trim()) {
-      // A no-op run shouldn't linger in the dock; a momentary toast is enough.
+      // A no-op run shouldn't linger in the dock; a momentary toast is enough. Drop any
+      // queued second mode too — same PR, same empty diff, so it would only load nothing
+      // and toast "No changes" a second time.
       toast.info("No changes to review.");
+      queuedRuns.delete(key);
       useReviewStore.getState().remove(key);
       return;
     }

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -22,6 +22,7 @@ import type {
   ReviewDeltaState,
   ReviewMode,
 } from "@/lib/ai/types";
+import { track } from "@/lib/analytics";
 import type { DiffStatEntry } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
 import { saveReview } from "@/lib/pulls/reviews-history";
@@ -202,10 +203,6 @@ interface RunControl {
   wakeQueued: (() => void) | null;
   /** The lane this run draws its slot from (for release + queue removal). */
   lane: Limiter | null;
-  /** A second review mode requested while this run was in flight — started
-   *  automatically when this run settles (interim single-flight queue). Null when
-   *  nothing is queued; cleared by dismiss. */
-  queuedNext: QueuedRun | null;
 }
 
 /** A queued second review mode + the config captured when the user requested it.
@@ -220,6 +217,16 @@ interface QueuedRun {
 }
 
 const controls = new Map<string, RunControl>();
+
+/**
+ * A second review mode queued behind an in-flight run, keyed by reviewKey — the
+ * interim single-output-surface queue. Kept OUT of {@link RunControl} on purpose:
+ * `cancelReview` detaches the control immediately, so a control-bound queue couldn't
+ * be cleared by `dismissQueuedReview` in the cancel→settle window (the "dismissed"
+ * run would still drain). Keying it here lets Dismiss drop it — and the settle drain
+ * read it — regardless of the control's lifecycle.
+ */
+const queuedRuns = new Map<string, QueuedRun>();
 
 /** Monotonic counter stamped on each run for exact start-order display. */
 let reviewSeq = 0;
@@ -375,21 +382,21 @@ export async function startReview(
   const key = reviewKey(target);
   // Single-flight per key — one review streams into the single per-PR entry at a
   // time. A request for the OTHER mode while a run is in flight isn't dropped: it's
-  // remembered as `queuedNext` and started automatically when this run settles
-  // (interim single-output-surface queue). A repeat of the mode already running is a
-  // no-op, and the cap is one queued — there are only two modes.
+  // remembered in `queuedRuns` (keyed by key, independent of the run's control) and
+  // drained when this run settles (interim single-output-surface queue). A repeat of
+  // the running mode is a no-op, and the cap is one queued — there are only two modes.
   const activeEntry = useReviewStore.getState().entries[key];
   if (activeEntry?.phase === "running" || activeEntry?.phase === "queued") {
-    const active = controls.get(key);
-    if (active && mode !== activeEntry.mode) {
-      active.queuedNext = {
+    // The control check ensures there's a real in-flight run to queue behind.
+    if (controls.has(key) && mode !== activeEntry.mode) {
+      queuedRuns.set(key, {
         ai,
         mode,
         context,
         title,
         ignorePrior,
         ignoreExternal,
-      };
+      });
       useReviewStore.getState().patch(key, { queuedMode: mode });
     }
     return;
@@ -409,9 +416,12 @@ export async function startReview(
     hasSlot: false,
     wakeQueued: null,
     lane,
-    queuedNext: null,
   };
   controls.set(key, control);
+  // A fresh run owns the key now: drop any queue left behind by a cancelled/superseded
+  // predecessor, so that stale queued mode can't later drain onto THIS run (the
+  // cancel-then-fresh-run resurrection guard, on the queuedRuns side).
+  queuedRuns.delete(key);
   // Clear any text from a prior run on this key before the new stream appends.
   pushText("");
   patch({
@@ -448,6 +458,29 @@ export async function startReview(
     // they measure the same span.
     const startedAtMs = Date.now();
     patch({ phase: "running", startedAt: startedAtMs });
+    // Count a review when it actually starts — covers manual runs AND a drained queued
+    // run, and skips a queued-then-dismissed one (which never reaches here). The panel
+    // used to fire this at click time via `run()`, so a dismissed queue over-counted
+    // and a drained run went uncounted.
+    const tierModel = ai.model.toLowerCase();
+    track({
+      name: "ai_review_triggered",
+      properties: {
+        provider: ai.provider,
+        model_tier:
+          tierModel.includes("haiku") ||
+          tierModel.includes("mini") ||
+          tierModel.includes("flash")
+            ? "fast"
+            : tierModel.includes("opus") ||
+                tierModel.includes("gpt-4o") ||
+                tierModel.includes("sonnet-4")
+              ? "powerful"
+              : ai.provider === "ollama"
+                ? "local"
+                : "balanced",
+      },
+    });
     const diff = await context.loadDiff();
     if (control.cancelled) return;
     if (!diff.text.trim()) {
@@ -659,29 +692,28 @@ export async function startReview(
       control.hasSlot = false;
       releaseSlot(lane);
     }
-    // A second mode queued behind this run starts once this one settles — on ANY
-    // terminal outcome incl. user-cancel (it's independent work the user asked for;
-    // dismissing its chip is the only way to stop it). Captured before the handle is
-    // relinquished; startReview re-checks single-flight and this entry is already in
-    // a terminal phase, so the drain starts cleanly on the same key.
-    const next = control.queuedNext;
     // Only the owning run releases its handle — a cancel may have replaced us.
     if (controls.get(key) === control) controls.delete(key);
-    // Drain the queued mode only when the key is now unclaimed: a normal settle just
-    // freed it, and a bare cancel freed it too (so the queued run still proceeds). But
-    // if a DIFFERENT run has claimed the key since — a cancel followed by a fresh manual
-    // review on the same PR — draining would resurrect our queued mode onto that
-    // unrelated run, so skip it there.
-    if (next && !controls.has(key)) {
-      void startReview(
-        target,
-        next.title,
-        next.ai,
-        next.mode,
-        next.context,
-        next.ignorePrior,
-        next.ignoreExternal,
-      );
+    // Drain the queued second mode once this run settles — on ANY terminal outcome
+    // incl. user-cancel (it's independent work the user asked for; the chip's Dismiss
+    // is the only way to stop it). Only when the key is now unclaimed: a normal settle
+    // and a bare cancel both free it, but if a DIFFERENT run has since claimed the key
+    // (a cancel followed by a fresh review on the same PR), that run owns the queue now
+    // — draining here would resurrect our successor onto it, so leave queuedRuns be.
+    if (!controls.has(key)) {
+      const next = queuedRuns.get(key);
+      queuedRuns.delete(key);
+      if (next) {
+        void startReview(
+          target,
+          next.title,
+          next.ai,
+          next.mode,
+          next.context,
+          next.ignorePrior,
+          next.ignoreExternal,
+        );
+      }
     }
   }
 }
@@ -730,9 +762,15 @@ export function resetReview(key: string): void {
  * is queued.
  */
 export function dismissQueuedReview(key: string): void {
-  const control = controls.get(key);
-  if (control) control.queuedNext = null;
-  useReviewStore.getState().patch(key, { queuedMode: undefined });
+  // Drop the queued run regardless of the control's lifecycle — reachable even after
+  // `cancelReview` has detached the control (the cancel→settle window, where a
+  // control-bound queue would leak and drain despite the chip being dismissed).
+  queuedRuns.delete(key);
+  // Only clear the chip when the entry actually exists: patch() would otherwise
+  // synthesize a phantom idle entry (EMPTY_ENTRY) that useReviewTasks renders.
+  if (useReviewStore.getState().entries[key]) {
+    useReviewStore.getState().patch(key, { queuedMode: undefined });
+  }
 }
 
 /**
@@ -777,9 +815,6 @@ export function registerAutomationRun(opts: {
     hasSlot: false,
     wakeQueued: null,
     lane: null,
-    // Automation fires both modes as separate `auto:` entries — never a
-    // panel-style queued-second — so this stays null.
-    queuedNext: null,
   };
   controls.set(key, control);
   useReviewStore.getState().patch(key, {

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -109,6 +109,11 @@ export interface ReviewEntry {
    *  a single patch, so it lives on the entry, not the per-token `texts` map). The
    *  panel shows it behind a "Thought process" disclosure; the dock ignores it. */
   thoughts?: string;
+  /** The OTHER review mode a user queued behind this in-flight run (interim
+   *  single-output-surface queue) — drives the panel's "runs next" chip. Set only
+   *  while this entry is running/queued; cleared when the queued run starts or is
+   *  dismissed. */
+  queuedMode?: ReviewMode;
   /** Re-fires this run through the automation pipeline — set ONLY on automation
    *  rows (by {@link registerAutomationRun}). Its presence is the discriminator
    *  that a stopped (cancelled/error) row belongs in the dock's Stopped group: a
@@ -197,6 +202,21 @@ interface RunControl {
   wakeQueued: (() => void) | null;
   /** The lane this run draws its slot from (for release + queue removal). */
   lane: Limiter | null;
+  /** A second review mode requested while this run was in flight — started
+   *  automatically when this run settles (interim single-flight queue). Null when
+   *  nothing is queued; cleared by dismiss. */
+  queuedNext: QueuedRun | null;
+}
+
+/** A queued second review mode + the config captured when the user requested it.
+ *  Same target/key as the in-flight run — only the mode and its settings differ. */
+interface QueuedRun {
+  ai: AiSettings;
+  mode: ReviewMode;
+  context: ReviewContext;
+  title: string;
+  ignorePrior: boolean;
+  ignoreExternal: boolean;
 }
 
 const controls = new Map<string, RunControl>();
@@ -353,11 +373,27 @@ export async function startReview(
   ignoreExternal = false,
 ): Promise<void> {
   const key = reviewKey(target);
-  // Single-flight per key — the UI hides the run buttons while generating, but
-  // guard against a double-fire racing two streams into one entry (a queued run
-  // counts as already-started).
-  const phase = useReviewStore.getState().entries[key]?.phase;
-  if (phase === "running" || phase === "queued") return;
+  // Single-flight per key — one review streams into the single per-PR entry at a
+  // time. A request for the OTHER mode while a run is in flight isn't dropped: it's
+  // remembered as `queuedNext` and started automatically when this run settles
+  // (interim single-output-surface queue). A repeat of the mode already running is a
+  // no-op, and the cap is one queued — there are only two modes.
+  const activeEntry = useReviewStore.getState().entries[key];
+  if (activeEntry?.phase === "running" || activeEntry?.phase === "queued") {
+    const active = controls.get(key);
+    if (active && mode !== activeEntry.mode) {
+      active.queuedNext = {
+        ai,
+        mode,
+        context,
+        title,
+        ignorePrior,
+        ignoreExternal,
+      };
+      useReviewStore.getState().patch(key, { queuedMode: mode });
+    }
+    return;
+  }
 
   const patch = (p: Partial<ReviewEntry>) =>
     useReviewStore.getState().patch(key, p);
@@ -373,6 +409,7 @@ export async function startReview(
     hasSlot: false,
     wakeQueued: null,
     lane,
+    queuedNext: null,
   };
   controls.set(key, control);
   // Clear any text from a prior run on this key before the new stream appends.
@@ -390,6 +427,9 @@ export async function startReview(
     deltaState: undefined,
     truncatedCoverage: undefined,
     thoughts: undefined,
+    // A fresh run has nothing queued behind it yet; if this IS the drained queued
+    // run, clear the chip now that it has become the active run.
+    queuedMode: undefined,
     // Clear a prior run's stamps on this key so a re-run's live elapsed and
     // persisted duration start fresh (stamped at the running transition below).
     startedAt: undefined,
@@ -619,8 +659,30 @@ export async function startReview(
       control.hasSlot = false;
       releaseSlot(lane);
     }
+    // A second mode queued behind this run starts once this one settles — on ANY
+    // terminal outcome incl. user-cancel (it's independent work the user asked for;
+    // dismissing its chip is the only way to stop it). Captured before the handle is
+    // relinquished; startReview re-checks single-flight and this entry is already in
+    // a terminal phase, so the drain starts cleanly on the same key.
+    const next = control.queuedNext;
     // Only the owning run releases its handle — a cancel may have replaced us.
     if (controls.get(key) === control) controls.delete(key);
+    // Drain the queued mode only when the key is now unclaimed: a normal settle just
+    // freed it, and a bare cancel freed it too (so the queued run still proceeds). But
+    // if a DIFFERENT run has claimed the key since — a cancel followed by a fresh manual
+    // review on the same PR — draining would resurrect our queued mode onto that
+    // unrelated run, so skip it there.
+    if (next && !controls.has(key)) {
+      void startReview(
+        target,
+        next.title,
+        next.ai,
+        next.mode,
+        next.context,
+        next.ignorePrior,
+        next.ignoreExternal,
+      );
+    }
   }
 }
 
@@ -660,6 +722,17 @@ export function cancelReview(key: string): void {
 /** Clears a finished review's text — used after posting it as a comment. */
 export function resetReview(key: string): void {
   useReviewStore.getState().remove(key);
+}
+
+/**
+ * Drops a review mode queued behind an in-flight run (the interim single-flight
+ * queue) before it starts — the chip's Dismiss action. Safe to call when nothing
+ * is queued.
+ */
+export function dismissQueuedReview(key: string): void {
+  const control = controls.get(key);
+  if (control) control.queuedNext = null;
+  useReviewStore.getState().patch(key, { queuedMode: undefined });
 }
 
 /**
@@ -704,6 +777,9 @@ export function registerAutomationRun(opts: {
     hasSlot: false,
     wakeQueued: null,
     lane: null,
+    // Automation fires both modes as separate `auto:` entries — never a
+    // panel-style queued-second — so this stays null.
+    queuedNext: null,
   };
   controls.set(key, control);
   useReviewStore.getState().patch(key, {
@@ -796,11 +872,17 @@ export function useReviewRun(target: ReviewTarget) {
   );
   const cancel = useCallback(() => cancelReview(key), [key]);
   const reset = useCallback(() => resetReview(key), [key]);
+  const dismissQueued = useCallback(() => dismissQueuedReview(key), [key]);
   return {
     generate,
     cancel,
     reset,
+    dismissQueued,
     generating: entry.phase === "running" || entry.phase === "queued",
+    /** The OTHER review mode queued behind the in-flight run (interim
+     *  single-output-surface queue) — drives the "runs next" chip; undefined when
+     *  nothing is queued. */
+    queuedMode: entry.queuedMode,
     text,
     status: entry.status,
     mode: entry.mode,


### PR DESCRIPTION
Lets a reviewer run both a code review and a security audit on the same PR back-to-back without babysitting the panel: requesting the other mode while one is streaming now queues it and starts it automatically once the first settles, instead of being silently dropped by the single-flight guard.

### Review store queue logic
- Adds a `queuedNext` slot to `RunControl` and a `QueuedRun` shape (mode + captured config) in `src/lib/stores/reviews.ts`, plus a `queuedMode` field on `ReviewEntry` to drive the UI chip.
- Reworks the single-flight guard in `startReview`: a request for the *other* mode during an in-flight run is remembered as `queuedNext` and reflected via `patch(key, { queuedMode })`, while a repeat of the running mode stays a no-op.
- Drains the queued mode when a run settles on *any* terminal outcome (including user-cancel), but only when the key is now unclaimed — guarding against a cancel-then-fresh-review resurrecting the queued mode onto an unrelated run.
- Adds `dismissQueuedReview(key)` to clear a pending queued mode, and exposes `dismissQueued` / `queuedMode` from the `useReviewRun` hook.
- Sets `queuedNext: null` on the automation path in `registerAutomationRun`, since automation fires each mode as its own `auto:` entry rather than queuing.

### Panel UI
- In `src/features/pulls/PrReviewPanel.tsx`, adds a "Queue review" / "Queue security audit" ghost button (shown only while generating and nothing is queued yet) that runs the opposite of the current `mode`.
- Renders a "runs next" chip with a `ClockIcon` and a **Dismiss** action wired to `dismissQueued` when `queuedMode` is set, and allows the running-state controls to wrap (`flex-wrap`).

### Documentation
- Documents the one-review-at-a-time queue behavior in the in-app help guide (`src/features/help/content.ts`).
- Adds the `changelog.d/added-review-queue-second-mode.md` fragment describing the queue, the next-up chip, Dismiss, and cancel-still-proceeds behavior.