### PR TITLE
feat(lan,companion): add read-only tags, code TODOs, and Discussions

### DIFF
--- a/changelog.d/added-lan-companion-preview.md
+++ b/changelog.d/added-lan-companion-preview.md
@@ -2,10 +2,13 @@
   phone over your local network from **Settings → Phone companion**: pair a device by
   scanning a QR code and typing a PIN. Scanning opens a slim companion web app right
   in your phone's browser — pair with the PIN, then read a repo's **Status, pull
-  requests, issues, working-tree changes, commit history, branches, and CI** from your
+  requests, issues, working-tree changes, commit history, branches, CI, tags, and
+  code TODOs** from your
   phone, read-only. The Status tab is a hub that drills into those surfaces; open a pull
   request or issue for its full conversation, browse file diffs and per-commit changes,
-  and watch live **AI PR reviews and agent sessions** stream in as they happen. Your
+  and watch live **AI PR reviews and agent sessions** stream in as they happen. The
+  companion can also browse **GitHub Discussions** — categories, threads, and answers —
+  on repositories that have them. Your
   phone always sees the repository open on this desktop, and you can **share and unshare
   additional repositories** (from the panel or the command palette) to keep them
   reachable while you work in another —

--- a/companion/src/App.tsx
+++ b/companion/src/App.tsx
@@ -17,12 +17,15 @@ import { AgentsBody, AgentWatch } from "./screens/Agents";
 import { BranchesBody } from "./screens/Branches";
 import { ChangesBody, ChangesFileBody } from "./screens/Changes";
 import { CiBody, CiDetail } from "./screens/Ci";
+import { DiscussionDetailBody, DiscussionsBody } from "./screens/Discussions";
 import { CommitBody, CommitFileBody, HistoryBody } from "./screens/History";
 import { IssueDetailBody, IssuesBody } from "./screens/Issues";
 import { Pair } from "./screens/Pair";
 import { PrDetail, PrsBody } from "./screens/Prs";
 import { ReposBody } from "./screens/Repos";
 import { StatusBody } from "./screens/Status";
+import { TagsBody } from "./screens/Tags";
+import { TodosBody } from "./screens/Todos";
 
 // The app shell. It owns the cross-cutting states so every screen inherits them:
 //   • 401 anywhere → route to #pair (token revoked / never paired)
@@ -217,6 +220,8 @@ function tabTail(route: Route): string {
     return `ci/${route.detailId}`;
   if (route.tab === "agents" && route.streamId != null)
     return `agents/${route.streamId}`;
+  if (route.tab === "discussions" && route.detailId != null)
+    return `discussions/${route.detailId}`;
   return route.tab;
 }
 
@@ -362,6 +367,19 @@ function Screen({
       <IssueDetailBody repoId={repoId} number={route.detailId} />
     ) : (
       <IssuesBody repoId={repoId} active />
+    );
+  }
+  if (route.tab === "tags") {
+    return <TagsBody repoId={repoId} active />;
+  }
+  if (route.tab === "todos") {
+    return <TodosBody repoId={repoId} active />;
+  }
+  if (route.tab === "discussions") {
+    return route.detailId != null ? (
+      <DiscussionDetailBody repoId={repoId} number={route.detailId} />
+    ) : (
+      <DiscussionsBody repoId={repoId} active />
     );
   }
   return <StatusBody repoId={repoId} active />;

--- a/companion/src/components/Chrome.tsx
+++ b/companion/src/components/Chrome.tsx
@@ -121,7 +121,13 @@ export function BottomNav({
       aria-label="Sections"
     >
       {tabs.map((t, i) => {
-        const active = tabActive && route.tab === t.tab;
+        // Discussions is a segmented sibling living UNDER the Issues tab (no tab of
+        // its own), so a discussions route highlights Issues. tags/todos are
+        // Status-hub drill-ins that (like branches/changes/history) highlight no tab.
+        const active =
+          tabActive &&
+          (route.tab === t.tab ||
+            (t.tab === "issues" && route.tab === "discussions"));
         return (
           <a
             key={t.tab}

--- a/companion/src/components/tab-segment.tsx
+++ b/companion/src/components/tab-segment.tsx
@@ -1,0 +1,89 @@
+// The [ Issues | Discussions ] segmented control that lives at the top of both the
+// Issues and Discussions screens (Discussions is a segmented sibling UNDER the Issues
+// tab, not a tab of its own — the bottom nav highlights Issues on both routes).
+//
+// VISIBILITY CONTRACT — the segment OWNS its own availability logic so neither screen
+// has to. It renders ONLY when the loaded meta says `hasDiscussionsEnabled === true`.
+// Gating is DATA-driven, not status-driven, with definitive-error precedence:
+//   • A `discussionsUnavailable` error (the 400 the server's forge gate mints for a
+//     GitLab/Bitbucket repo) is DEFINITIVE — it wins over any stale cached data and
+//     hides the segment, exactly the way `noSuchRepo`/RepoGone wins over stale data
+//     elsewhere.
+//   • Otherwise the segment tracks `meta.data.hasDiscussionsEnabled`. Reading the DATA
+//     rather than `isSuccess` is deliberate: on a transient background-refetch failure
+//     react-query v5 RETAINS the last good `data` while flipping `status` to 'error'
+//     (after retries) — so an `isSuccess` gate would make the segment VANISH and
+//     REAPPEAR on a wifi blip, contradicting its own no-flash promise. `data` stays
+//     `undefined` only until the FIRST load resolves, so a loading meta still yields
+//     null (no flash on first paint either).
+// Consequence: on a repo without Discussions the Issues screen is pixel-identical to a
+// build with no segment at all (zero extra layout), and a direct discussions URL on
+// such a repo shows the screen's calm teaching state with no segment (there's nothing
+// to switch to — the user reaches Issues via the bottom tab, which stays highlighted).
+
+import { asApiError, useDiscussionMeta } from "../lib/queries";
+import { navigate, repoHash } from "../lib/router";
+
+export function IssuesDiscussionsSegment({
+  repoId,
+  current,
+}: {
+  repoId: string;
+  current: "issues" | "discussions";
+}) {
+  const meta = useDiscussionMeta(repoId);
+
+  // Definitive unavailable wins over stale data; otherwise gate on the DATA value
+  // (see the data-driven, definitive-wins reasoning in the visibility contract above).
+  if (asApiError(meta.error)?.isDiscussionsUnavailable) return null;
+  if (meta.data?.hasDiscussionsEnabled !== true) return null;
+
+  return (
+    <div className="sticky top-0 z-10 flex items-stretch gap-1 border-b border-border bg-background/95 p-1 backdrop-blur">
+      <SegmentButton
+        repoId={repoId}
+        tab="issues"
+        label="Issues"
+        current={current}
+      />
+      <SegmentButton
+        repoId={repoId}
+        tab="discussions"
+        label="Discussions"
+        current={current}
+      />
+    </div>
+  );
+}
+
+/** One half of the segmented control. The selected half carries `aria-current="page"`
+ *  plus the accent fill AND `font-medium` — selection is never conveyed by color alone
+ *  (WCAG 1.4.1); the weight change and the aria semantics both survive a monochrome
+ *  render. */
+function SegmentButton({
+  repoId,
+  tab,
+  label,
+  current,
+}: {
+  repoId: string;
+  tab: "issues" | "discussions";
+  label: string;
+  current: "issues" | "discussions";
+}) {
+  const selected = current === tab;
+  return (
+    <button
+      type="button"
+      aria-current={selected ? "page" : undefined}
+      onClick={() => navigate(repoHash(repoId, tab))}
+      className={`min-h-11 flex-1 rounded text-sm ${
+        selected
+          ? "bg-primary font-medium text-primary-foreground"
+          : "font-normal text-muted-foreground"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -98,6 +98,21 @@ export class ApiError extends Error {
   get isNoSuchRepo(): boolean {
     return this.status === 404 && this.kind === "noSuchRepo";
   }
+  /**
+   * This repo can't serve Discussions — a non-GitHub repo (GitLab/Bitbucket have
+   * no Discussions equivalent) or a GitHub repo with the feature turned off. The
+   * server mints `400 { kind: "discussionsUnavailable", … }` for it; the screen
+   * renders a calm teaching state (NOT the generic error, and no retry — a retry
+   * can't turn the feature on). Both the status AND the kind must match so an
+   * unrelated 400 never reads as "no discussions here".
+   *
+   * The kind string `discussionsUnavailable` is a VERBATIM cross-layer contract
+   * with the Rust LAN server (`src-tauri/src/lan/routes/forge.rs` mints it) — keep
+   * the two spellings in lockstep.
+   */
+  get isDiscussionsUnavailable(): boolean {
+    return this.status === 400 && this.kind === "discussionsUnavailable";
+  }
 }
 
 interface ErrorBody {
@@ -405,6 +420,173 @@ export const fetchIssues = (repoId: string, state = "open", limit = 30) =>
 /** One issue's full read view (`issues/{number}`). */
 export const fetchIssue = (repoId: string, number: number) =>
   getJson<IssueDetails>(`${scope(repoId)}/issues/${number}`);
+
+// ── Companion-extras read shapes (Tags · Code TODOs · Discussions) ────────────
+// These mirror the desktop's serde camelCase types EXACTLY (verified against the
+// desktop Rust structs). Declared HERE (own local interfaces, like the slice-6
+// shapes above) rather than imported from `@/lib/git/types`.
+
+/** One tag ref for the Tags list (the desktop's `TagInfo`). `target` is the commit
+ *  sha the tag points at; `date` is the tagger date (annotated) or commit date
+ *  (lightweight); `annotated` distinguishes the two; `subject` is the annotation
+ *  message subject (empty for a lightweight tag). */
+export interface TagInfo {
+  name: string;
+  target: string;
+  date: string;
+  annotated: boolean;
+  subject: string;
+}
+
+/** One hit from a code-TODO scan (the desktop's `TodoScanItem`). `path` is the
+ *  repo-relative file, `line` the 1-based line number, `marker` the matched marker
+ *  (e.g. "TODO"/"FIXME"), `text` the trailing comment text. */
+export interface TodoScanItem {
+  path: string;
+  line: number;
+  marker: string;
+  text: string;
+}
+
+/** A code-TODO scan result (the desktop's `TodoScan`). `truncated` is true when the
+ *  scan hit the server's max-hits cap and the list is a prefix. */
+export interface TodoScan {
+  items: TodoScanItem[];
+  truncated: boolean;
+}
+
+/** One discussion category (the desktop's `DiscussionCategory`). `emoji` is the
+ *  rendered category emoji; `isAnswerable` marks a Q&A category. */
+export interface DiscussionCategory {
+  id: string;
+  name: string;
+  emoji: string;
+  isAnswerable: boolean;
+}
+
+/** The repo's discussions metadata (the desktop's `DiscussionMeta`): whether
+ *  Discussions are enabled and the available categories. */
+export interface DiscussionMeta {
+  repoId: string;
+  hasDiscussionsEnabled: boolean;
+  categories: DiscussionCategory[];
+}
+
+/** One discussion label (the desktop's `DiscussionLabel`). `color` is hex without
+ *  the leading '#', as GitHub returns it; `description` is null when the source has
+ *  none. Distinct from {@link IssueLabel} (whose `description` is optional) — the
+ *  discussion wire shape always carries the field. */
+export interface DiscussionLabel {
+  id: string;
+  name: string;
+  color: string;
+  description: string | null;
+}
+
+/** One discussion in the Discussions list (the desktop's `DiscussionInfo`). */
+export interface DiscussionInfo {
+  number: number;
+  title: string;
+  url: string;
+  createdAt: string;
+  isAnswered: boolean;
+  closed: boolean;
+  stateReason: string | null;
+  categoryName: string;
+  categoryEmoji: string;
+  author: string;
+  commentCount: number;
+  upvoteCount: number;
+  labels: DiscussionLabel[];
+}
+
+/** One reply under a discussion comment (the desktop's `DiscussionReply`). */
+export interface DiscussionReply {
+  id: string;
+  author: string;
+  body: string;
+  date: string;
+  url: string;
+  viewerDidAuthor: boolean;
+  isMinimized: boolean;
+  minimizedReason: string;
+}
+
+/** One top-level discussion comment (the desktop's `DiscussionComment`) — a
+ *  {@link DiscussionReply} plus upvotes, the answer flag, and its nested replies. */
+export interface DiscussionComment extends DiscussionReply {
+  upvoteCount: number;
+  viewerHasUpvoted: boolean;
+  isAnswer: boolean;
+  replies: DiscussionReply[];
+}
+
+/** Full details for one discussion's read view (the desktop's `DiscussionDetails`):
+ *  body, category, answer/lock/close state, labels, and the comment threads. */
+export interface DiscussionDetails {
+  id: string;
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  author: string;
+  createdAt: string;
+  categoryName: string;
+  categoryEmoji: string;
+  isAnswerable: boolean;
+  isAnswered: boolean;
+  upvoteCount: number;
+  viewerHasUpvoted: boolean;
+  locked: boolean;
+  activeLockReason: string | null;
+  closed: boolean;
+  stateReason: string | null;
+  labels: DiscussionLabel[];
+  comments: DiscussionComment[];
+}
+
+// ── Companion-extras read fetchers (Tags · Code TODOs · Discussions) ──────────
+
+/** The repo's tags (`tags`), newest first (server-ordered). */
+export const fetchTags = (repoId: string) =>
+  getJson<TagInfo[]>(`${scope(repoId)}/tags`);
+
+/** A code-TODO scan (`todos?markers&maxHits`). `markers` are comma-joined into the
+ *  query; `maxHits` caps the result (server default when omitted). */
+export const fetchTodoScan = (
+  repoId: string,
+  markers: string[],
+  maxHits?: number,
+) =>
+  getJson<TodoScan>(
+    `${scope(repoId)}/todos?markers=${encodeURIComponent(markers.join(","))}${
+      maxHits != null ? `&maxHits=${maxHits}` : ""
+    }`,
+  );
+
+/** The repo's discussions metadata (`discussions/meta`) — enablement + categories.
+ *  Errors with a typed `discussionsUnavailable` variant on a non-GitHub repo. */
+export const fetchDiscussionMeta = (repoId: string) =>
+  getJson<DiscussionMeta>(`${scope(repoId)}/discussions/meta`);
+
+/** The repo's discussions (`discussions?limit&category`). `category` filters by a
+ *  category NODE ID (a `DiscussionCategory.id`, not its name — the server forwards
+ *  it verbatim into the GraphQL category filter) when non-null; `limit` caps the
+ *  page. */
+export const fetchDiscussions = (
+  repoId: string,
+  category: string | null,
+  limit: number,
+) =>
+  getJson<DiscussionInfo[]>(
+    `${scope(repoId)}/discussions?limit=${limit}${
+      category != null ? `&category=${encodeURIComponent(category)}` : ""
+    }`,
+  );
+
+/** One discussion's full read view (`discussions/{number}`). */
+export const fetchDiscussion = (repoId: string, number: number) =>
+  getJson<DiscussionDetails>(`${scope(repoId)}/discussions/${number}`);
 
 // ── Agent streams (live AI review / agent sessions) ───────────────────────────
 

--- a/companion/src/lib/api.ts
+++ b/companion/src/lib/api.ts
@@ -99,12 +99,14 @@ export class ApiError extends Error {
     return this.status === 404 && this.kind === "noSuchRepo";
   }
   /**
-   * This repo can't serve Discussions — a non-GitHub repo (GitLab/Bitbucket have
-   * no Discussions equivalent) or a GitHub repo with the feature turned off. The
-   * server mints `400 { kind: "discussionsUnavailable", … }` for it; the screen
-   * renders a calm teaching state (NOT the generic error, and no retry — a retry
-   * can't turn the feature on). Both the status AND the kind must match so an
-   * unrelated 400 never reads as "no discussions here".
+   * This repo's HOST can't serve Discussions — a non-GitHub repo (GitLab/Bitbucket
+   * have no Discussions equivalent). The server mints
+   * `400 { kind: "discussionsUnavailable", … }` for exactly that case; a GitHub
+   * repo with the feature merely turned OFF is NOT an error — it answers 200 with
+   * `DiscussionMeta.hasDiscussionsEnabled: false` (a separate teaching state). The
+   * screen renders a calm teaching state for this kind (NOT the generic error, and
+   * no retry — a retry can't change the host). Both the status AND the kind must
+   * match so an unrelated 400 never reads as "no discussions here".
    *
    * The kind string `discussionsUnavailable` is a VERBATIM cross-layer contract
    * with the Rust LAN server (`src-tauri/src/lan/routes/forge.rs` mints it) — keep

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -53,13 +53,17 @@ export const queryClient = new QueryClient({
       staleTime: 10_000,
       // One retry for transient failures — but never for a definitive error: a
       // 401 (re-sending the dead cookie double-bills the per-IP lockout budget on
-      // every poll cycle), a 409 noActiveRepo, or a 404 noSuchRepo (the scoped
+      // every poll cycle), a 409 noActiveRepo, a 404 noSuchRepo (the scoped
       // repo is gone — a retry can't conjure it back and only delays the
-      // repo-gone state).
+      // repo-gone state), or a 400 discussionsUnavailable (the repo's HOST has no
+      // Discussions — a retry can't change the host).
       retry: (failureCount, err) =>
         !(
           err instanceof ApiError &&
-          (err.isUnauthorized || err.isNoActiveRepo || err.isNoSuchRepo)
+          (err.isUnauthorized ||
+            err.isNoActiveRepo ||
+            err.isNoSuchRepo ||
+            err.isDiscussionsUnavailable)
         ) && failureCount < 1,
       refetchOnWindowFocus: false,
     },

--- a/companion/src/lib/queries.ts
+++ b/companion/src/lib/queries.ts
@@ -11,6 +11,9 @@ import {
   fetchCiRuns,
   fetchCommit,
   fetchCommitDiff,
+  fetchDiscussion,
+  fetchDiscussionMeta,
+  fetchDiscussions,
   fetchFileDiff,
   fetchIssue,
   fetchIssues,
@@ -22,6 +25,8 @@ import {
   fetchRepos,
   fetchReviews,
   fetchStatus,
+  fetchTags,
+  fetchTodoScan,
   fetchWorkingDiff,
 } from "./api";
 import { navigate } from "./router";
@@ -313,6 +318,91 @@ export function useIssue(repoId: string | null, number: number | null) {
   return useQuery({
     queryKey: ["issue", repoId, number],
     queryFn: () => fetchIssue(repoId as string, number as number),
+    enabled: on,
+    refetchInterval: on ? POLL_MS : (false as const),
+  });
+}
+
+// ── Companion-extras hooks (Tags · Code TODOs · Discussions) ──────────────────
+
+/** The repo's tags. `active` gates polling to the visible screen — refs are cheap,
+ *  so the list polls at the standard cadence like the other list screens. */
+export function useTags(repoId: string | null, active: boolean) {
+  return useQuery({
+    queryKey: ["tags", repoId],
+    queryFn: () => fetchTags(repoId as string),
+    enabled: repoId != null,
+    refetchInterval: repoId != null ? poll(active) : false,
+  });
+}
+
+/** A code-TODO scan for the given markers. Deliberately NOT polled: a scan is a
+ *  git-grep sweep across the tree, so re-running it every 15s is pure waste — this is
+ *  a deliberate divergence from the other list hooks (which DO poll). A modest
+ *  `staleTime` lets a re-visit refetch without hammering. `markers` are sorted into
+ *  the cache key so `["TODO","FIXME"]` and `["FIXME","TODO"]` share one entry.
+ *  `enabled` (default true) plus a repo and at least one marker gate the query —
+ *  scanning with zero markers would match nothing. `keepPreviousData`: toggling a
+ *  marker chip re-keys the query, and without a placeholder the list would collapse
+ *  to skeletons on every toggle (same finding as useLog). */
+export function useTodoScan(
+  repoId: string | null,
+  markers: string[],
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ["todos", repoId, [...markers].sort().join(",")],
+    queryFn: () => fetchTodoScan(repoId as string, markers),
+    enabled: enabled && repoId != null && markers.length > 0,
+    refetchInterval: false,
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** The repo's discussions metadata (enablement + categories). No poll — categories
+ *  and enablement rarely change — and a long `staleTime` (the desktop uses the same
+ *  5-minute window). A null `repoId` disables it. */
+export function useDiscussionMeta(repoId: string | null) {
+  return useQuery({
+    queryKey: ["discussions", repoId, "meta"],
+    queryFn: () => fetchDiscussionMeta(repoId as string),
+    enabled: repoId != null,
+    staleTime: 300_000,
+  });
+}
+
+/** The repo's discussions, filtered by `category` (null = all) and paged by `limit`.
+ *  `active` gates polling to the visible screen; `enabled` (default true) additionally
+ *  gates the query (e.g. off while Discussions are known-unavailable). `category` and
+ *  `limit` are part of the cache key so each filter/page caches independently.
+ *  `keepPreviousData`: a growing limit or a category switch re-keys the query — keep
+ *  the prior page visible while the new one loads (same finding as useLog/useIssues). */
+export function useDiscussions(
+  repoId: string | null,
+  active: boolean,
+  category: string | null,
+  limit: number,
+  enabled = true,
+) {
+  const on = enabled && repoId != null;
+  return useQuery({
+    queryKey: ["discussions", repoId, category ?? "all", limit],
+    queryFn: () => fetchDiscussions(repoId as string, category, limit),
+    enabled: on,
+    refetchInterval: on ? poll(active) : false,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** One discussion's full read view. Polls while open (comments/answers change) — a
+ *  detail view is a deliberate drill-in, so keep it fresh at the standard cadence
+ *  (same as useIssue). */
+export function useDiscussion(repoId: string | null, number: number | null) {
+  const on = repoId != null && number != null;
+  return useQuery({
+    queryKey: ["discussion", repoId, number],
+    queryFn: () => fetchDiscussion(repoId as string, number as number),
     enabled: on,
     refetchInterval: on ? POLL_MS : (false as const),
   });

--- a/companion/src/lib/router.ts
+++ b/companion/src/lib/router.ts
@@ -12,6 +12,10 @@ import { useMemo, useSyncExternalStore } from "react";
 //   #r/{repoId}/history · #r/{repoId}/history/{sha} · #r/{repoId}/history/{sha}/{encodedFile}
 //   #r/{repoId}/branches
 //   #r/{repoId}/issues · #r/{repoId}/issues/{n}
+// The companion-extras slice adds three more read-only surfaces (also SCOPED-ONLY):
+//   #r/{repoId}/tags
+//   #r/{repoId}/todos
+//   #r/{repoId}/discussions · #r/{repoId}/discussions/{n}
 // Plus two global (repo-less) routes:
 //   #pair   — the pairing takeover (unchanged)
 //   #repos  — the repo picker
@@ -30,7 +34,10 @@ export type Tab =
   | "changes"
   | "history"
   | "branches"
-  | "issues";
+  | "issues"
+  | "tags"
+  | "todos"
+  | "discussions";
 
 /** The working-tree section a Changes file-diff is scoped to. `unstaged` and
  *  `untracked` both map to the working-tree side server-side, but they're distinct
@@ -124,11 +131,12 @@ const NO_DETAIL = {
  *  after that (only the scoped slice-6 file-diff routes reach for it — a file path
  *  under `changes/{section}/{file}` or `history/{sha}/{file}`).
  *
- *  `scoped` marks the caller as the scoped `#r/{id}/…` branch. The four slice-6
- *  tabs (changes/history/branches/issues) are SCOPED-ONLY: on the legacy branch
- *  (`scoped: false`) their heads are unknown and degrade to status, exactly like any
- *  other unknown legacy head — the legacy grammar is deliberately NOT extended.
- *  The original tabs (prs/ci/agents/status) parse identically under either branch. */
+ *  `scoped` marks the caller as the scoped `#r/{id}/…` branch. The slice-6 tabs
+ *  (changes/history/branches/issues) and the companion-extras tabs
+ *  (tags/todos/discussions) are SCOPED-ONLY: on the legacy branch (`scoped: false`)
+ *  their heads are unknown and degrade to status, exactly like any other unknown
+ *  legacy head — the legacy grammar is deliberately NOT extended. The original tabs
+ *  (prs/ci/agents/status) parse identically under either branch. */
 function parseTab(
   head: string | undefined,
   tail: string | undefined,
@@ -179,6 +187,17 @@ function parseTab(
       if (!scoped) break; // scoped-only
       // Numeric detail → the issue number (`detailId`), exactly like prs.
       return { ...NO_DETAIL, tab: "issues", detailId };
+    case "tags":
+      if (!scoped) break; // scoped-only
+      return { ...NO_DETAIL, tab: "tags" };
+    case "todos":
+      if (!scoped) break; // scoped-only
+      return { ...NO_DETAIL, tab: "todos" };
+    case "discussions":
+      if (!scoped) break; // scoped-only
+      // Numeric detail → the discussion number (`detailId`), exactly like issues;
+      // a malformed tail degrades to the list (detailId null).
+      return { ...NO_DETAIL, tab: "discussions", detailId };
   }
   // Unknown head (or a scoped-only tab reached via the legacy branch) → status.
   return { ...NO_DETAIL, tab: "status" };

--- a/companion/src/screens/Discussions.tsx
+++ b/companion/src/screens/Discussions.tsx
@@ -135,14 +135,30 @@ export function DiscussionsBody({
   }
 
   // ── List states (meta is confirmed available) ──
+  // Meta is loaded + enabled here, so the segment is a persistent sibling of the
+  // list — hoist it above the list's own early returns (mirrors IssuesBody) so the
+  // `[ Issues | Discussions ]` switch the user just tapped never flashes away during
+  // the list's first-load skeleton/error. (The meta-gated states above don't carry it
+  // on purpose: the segment self-hides until meta is enabled, so it'd render null
+  // there anyway.)
+  const segment = (
+    <IssuesDiscussionsSegment repoId={repoId} current="discussions" />
+  );
   // Prefer stale data: keep the last-known list on screen even on error, with a
   // StaleBanner above it. Full-screen states only when there's nothing to show;
   // skeleton only while the first fetch is pending.
   const data = list.data;
   if (!data) {
-    if (list.isError)
-      return <ErrorState error={list.error} onRetry={() => list.refetch()} />;
-    return <SkeletonRows />;
+    return (
+      <div className="flex flex-col">
+        {segment}
+        {list.isError ? (
+          <ErrorState error={list.error} onRetry={() => list.refetch()} />
+        ) : (
+          <SkeletonRows />
+        )}
+      </div>
+    );
   }
 
   // The last page came back short → nothing more to load; hide the button. While a
@@ -154,7 +170,7 @@ export function DiscussionsBody({
 
   return (
     <div className="flex flex-col">
-      <IssuesDiscussionsSegment repoId={repoId} current="discussions" />
+      {segment}
       {categories.length > 0 ? (
         <CategoryChips
           categories={categories}

--- a/companion/src/screens/Discussions.tsx
+++ b/companion/src/screens/Discussions.tsx
@@ -4,10 +4,11 @@
 // threads. Mirrors the Issues screen anatomy (rows, growing list, teaching-state
 // blocks, back bar, CommentCard) so the two screens read as one surface.
 //
-// Discussions are GitHub-only. On a GitLab/Bitbucket repo or a GitHub repo with the
-// feature turned off, the LAN server mints `400 { kind: "discussionsUnavailable" }`
-// (never a raw gh error), and the screen renders a calm teaching state — see the
-// state ladder in DiscussionsBody.
+// Discussions are GitHub-only, with TWO distinct unavailable shapes: a
+// GitLab/Bitbucket HOST gets the LAN server's `400 { kind: "discussionsUnavailable" }`
+// (never a raw gh error), while a GitHub repo with the feature turned OFF answers
+// 200 with `meta.hasDiscussionsEnabled: false`. Each gets its own calm teaching
+// state — see the state ladder in DiscussionsBody.
 
 import {
   ArrowLeftIcon,

--- a/companion/src/screens/Discussions.tsx
+++ b/companion/src/screens/Discussions.tsx
@@ -1,0 +1,648 @@
+// The Discussions tab — a segmented sibling UNDER the Issues tab (see
+// components/tab-segment.tsx). Read-only GitHub Discussions on the phone: a list of
+// discussions (category-filtered, growing) + a discussion detail with its comment
+// threads. Mirrors the Issues screen anatomy (rows, growing list, teaching-state
+// blocks, back bar, CommentCard) so the two screens read as one surface.
+//
+// Discussions are GitHub-only. On a GitLab/Bitbucket repo or a GitHub repo with the
+// feature turned off, the LAN server mints `400 { kind: "discussionsUnavailable" }`
+// (never a raw gh error), and the screen renders a calm teaching state — see the
+// state ladder in DiscussionsBody.
+
+import {
+  ArrowLeftIcon,
+  CaretRightIcon,
+  CaretUpIcon,
+  CheckCircleIcon,
+  EyeSlashIcon,
+  InfoIcon,
+  LockIcon,
+} from "@phosphor-icons/react";
+import { useState } from "react";
+import { Markdown } from "../components/markdown";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import { IssuesDiscussionsSegment } from "../components/tab-segment";
+import type {
+  DiscussionComment,
+  DiscussionDetails,
+  DiscussionInfo,
+  DiscussionReply,
+} from "../lib/api";
+import { timeAgo } from "../lib/format";
+import {
+  asApiError,
+  useDiscussion,
+  useDiscussionMeta,
+  useDiscussions,
+} from "../lib/queries";
+import { navigate, repoHash } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+/** The calm teaching state for a repo that can't serve Discussions — a non-GitHub
+ *  repo (`discussionsUnavailable`) or a GitHub repo with the feature disabled. Mirrors
+ *  Issues' `TrackerUnavailableState` anatomy (states.tsx `CenteredState` markup: icon
+ *  + title + optional hint) with NO action button — nothing to browse, and a retry
+ *  can't turn Discussions on. Inlined per the same convention Issues/Prs use for their
+ *  own small presentational blocks (CenteredState isn't exported). */
+function DiscussionsUnavailableState({
+  title,
+  hint,
+}: {
+  title: string;
+  hint?: string;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 px-8 py-16 text-center"
+      role="status"
+    >
+      <InfoIcon size={32} className="text-muted-foreground" />
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {hint ? (
+        <div className="max-w-xs text-sm text-muted-foreground">{hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+// A single GROWING query pages the list: "Load more" bumps `limit` (the server
+// re-serves the whole prefix), mirroring IssuesBody. 30 to match the fetcher's
+// default page size.
+const PAGE = 30;
+
+/** The discussions list. `repoId` scopes the query; `active` gates polling. */
+export function DiscussionsBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const [limit, setLimit] = useState(PAGE);
+  const [category, setCategory] = useState<string | null>(null);
+  const meta = useDiscussionMeta(repoId);
+  // The list query MUST NOT fire until meta confirms Discussions are enabled — the
+  // `enabled` gate exists precisely to avoid a doomed GraphQL roundtrip on an
+  // unavailable/disabled repo (only the cheap meta probe fires there). DATA-driven,
+  // not `isSuccess`: react-query v5 retains the last good `data` while flipping status
+  // to 'error' on a transient background-refetch failure — an `isSuccess` gate would
+  // kill live list polling on a wifi blip. `data.hasDiscussionsEnabled === true` keeps
+  // the list alive across a transient meta error (its own stale-prefer ladder handles
+  // the rest).
+  const metaOk = meta.data?.hasDiscussionsEnabled === true;
+  const list = useDiscussions(repoId, active, category, limit, metaOk);
+  const { register, onKeyDown } = useRovingList();
+
+  // Definitive gone WINS over everything else — either query can carry it.
+  if (isRepoGoneError(meta.error || list.error)) return <RepoGoneState />;
+
+  // ── Meta-gated states (before the list can meaningfully render) ──
+  // `discussionsUnavailable` is DEFINITIVE (a non-GitHub repo, or an older desktop):
+  // the calm teaching state wins even over stale cached data, no retry (a retry can't
+  // turn the feature on). Checked against `meta.error` regardless of whether `data` is
+  // still held — same definitive-wins precedence RepoGone uses above.
+  if (asApiError(meta.error)?.isDiscussionsUnavailable) {
+    return (
+      <DiscussionsUnavailableState
+        title="Discussions aren't available for this repository"
+        hint={asApiError(meta.error)?.message}
+      />
+    );
+  }
+  // No loaded meta yet: a genuine first-load error full-screens (retry refetches meta);
+  // otherwise it's still loading → skeleton. Once `data` is held, a TRANSIENT meta
+  // error is ignored here (data-driven) so a wifi blip never full-screens over a good
+  // cached list — the list keeps rendering below.
+  if (!meta.data) {
+    if (meta.isError)
+      return <ErrorState error={meta.error} onRetry={() => meta.refetch()} />;
+    return <SkeletonRows />;
+  }
+  // Meta loaded but the feature is turned off for this GitHub repo. No retry — a retry
+  // can't enable it.
+  if (!meta.data.hasDiscussionsEnabled) {
+    return (
+      <DiscussionsUnavailableState title="Discussions aren't enabled for this repository." />
+    );
+  }
+
+  // ── List states (meta is confirmed available) ──
+  // Prefer stale data: keep the last-known list on screen even on error, with a
+  // StaleBanner above it. Full-screen states only when there's nothing to show;
+  // skeleton only while the first fetch is pending.
+  const data = list.data;
+  if (!data) {
+    if (list.isError)
+      return <ErrorState error={list.error} onRetry={() => list.refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  // The last page came back short → nothing more to load; hide the button. While a
+  // grown page loads, `data` is the PRIOR page held as placeholder — short against
+  // the new limit — so keep the button visible (loading-labeled). Mirrors IssuesBody.
+  const hasMore = data.length >= limit || list.isPlaceholderData;
+  const categories = meta.data.categories;
+  const noneAtAll = data.length === 0 && category === null;
+
+  return (
+    <div className="flex flex-col">
+      <IssuesDiscussionsSegment repoId={repoId} current="discussions" />
+      {categories.length > 0 ? (
+        <CategoryChips
+          categories={categories}
+          selected={category}
+          onSelect={(id) => {
+            setCategory(id);
+            setLimit(PAGE); // a category switch resets to the first page
+          }}
+        />
+      ) : null}
+      {list.isError ? (
+        <StaleBanner error={list.error} onRetry={() => list.refetch()} />
+      ) : null}
+      {data.length === 0 ? (
+        noneAtAll ? (
+          <EmptyState
+            title="No discussions yet."
+            hint="Discussions on this repository will show up here."
+          />
+        ) : (
+          <EmptyState
+            title="No discussions in this category."
+            hint="Try “All” to see every discussion."
+          />
+        )
+      ) : (
+        <>
+          {/* While a category switch (or a grown page) loads, keepPreviousData holds
+              the OLD category's rows — dim + aria-busy them so the stale content reads
+              as refreshing, not final (mirrors the Todos screen). Load-more stays
+              outside the dim so its "Loading…" label reads at full contrast. */}
+          <ul
+            aria-busy={list.isPlaceholderData}
+            className={`flex flex-col divide-y divide-border ${
+              list.isPlaceholderData ? "opacity-60" : ""
+            }`}
+          >
+            {data.map((d, i) => (
+              <li key={d.number}>
+                <button
+                  type="button"
+                  ref={register(i)}
+                  onKeyDown={onKeyDown}
+                  onClick={() =>
+                    navigate(repoHash(repoId, `discussions/${d.number}`))
+                  }
+                  className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left"
+                >
+                  <DiscussionRow discussion={d} />
+                  <CaretRightIcon
+                    size={16}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+          {hasMore ? (
+            <button
+              type="button"
+              onClick={() => setLimit((n) => n + PAGE)}
+              disabled={list.isPlaceholderData}
+              className="min-h-11 border-t border-border px-4 py-3 text-sm font-medium text-primary disabled:text-muted-foreground"
+            >
+              {list.isPlaceholderData ? "Loading…" : "Load more"}
+            </button>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** The category filter — a horizontally scrollable row of chips ("All" + each
+ *  category). The selected chip carries `aria-pressed` AND `font-medium` on the accent
+ *  fill, so selection never rests on color alone (WCAG 1.4.1). `null` = All.
+ *
+ *  Keyboard nav (repo rule — every new selectable list gets arrow keys in the same
+ *  change): ArrowLeft/ArrowRight move focus between chips, Home/End jump to the ends.
+ *  Roving tabindex — exactly ONE chip is in the tab order (the selected one, falling
+ *  back to "All"), so Tab reaches the group once and arrows navigate within it.
+ *  Arrows move FOCUS only; selection stays a deliberate Enter/Space/tap (the
+ *  toggle-group convention). Adapted from the BottomNav roving pattern in Chrome.tsx. */
+function CategoryChips({
+  categories,
+  selected,
+  onSelect,
+}: {
+  categories: { id: string; name: string; emoji: string }[];
+  selected: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  // The chip index space is [All, ...categories]. The tab-stop index is the selected
+  // chip, or "All" (index 0) when nothing/an unknown id is selected.
+  const count = categories.length + 1;
+  const selectedIndex =
+    selected === null
+      ? 0
+      : Math.max(
+          0,
+          categories.findIndex((c) => c.id === selected) + 1, // -1 + 1 = 0 → All
+        );
+
+  function onKeyDown(e: React.KeyboardEvent, index: number) {
+    let next: number | null = null;
+    switch (e.key) {
+      case "ArrowRight":
+        next = Math.min(index + 1, count - 1);
+        break;
+      case "ArrowLeft":
+        next = Math.max(index - 1, 0);
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = count - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    // Focus follows the arrow selection (canonical roving behavior); selection itself
+    // stays on Enter/Space via the button semantics.
+    const chips = e.currentTarget.parentElement?.children;
+    (chips?.[next] as HTMLElement | undefined)?.focus();
+  }
+
+  return (
+    <div
+      className="flex gap-1.5 overflow-x-auto border-b border-border px-4 py-2"
+      role="group"
+      aria-label="Filter by category"
+    >
+      <CategoryChip
+        label="All"
+        pressed={selected === null}
+        tabStop={selectedIndex === 0}
+        onClick={() => onSelect(null)}
+        onKeyDown={(e) => onKeyDown(e, 0)}
+      />
+      {categories.map((c, i) => (
+        <CategoryChip
+          key={c.id}
+          label={`${c.emoji} ${c.name}`}
+          pressed={selected === c.id}
+          tabStop={selectedIndex === i + 1}
+          onClick={() => onSelect(c.id)}
+          onKeyDown={(e) => onKeyDown(e, i + 1)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CategoryChip({
+  label,
+  pressed,
+  tabStop,
+  onClick,
+  onKeyDown,
+}: {
+  label: string;
+  pressed: boolean;
+  tabStop: boolean;
+  onClick: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      tabIndex={tabStop ? 0 : -1}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      className={`inline-flex min-h-11 shrink-0 items-center whitespace-nowrap rounded-full px-3 py-1.5 text-xs ${
+        pressed
+          ? "bg-primary font-medium text-primary-foreground"
+          : "bg-muted font-normal text-muted-foreground"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function DiscussionRow({ discussion }: { discussion: DiscussionInfo }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-start gap-2">
+        <span className="shrink-0 text-sm" aria-hidden>
+          {discussion.categoryEmoji}
+        </span>
+        <p className="line-clamp-2 flex-1 text-sm font-medium text-foreground">
+          {discussion.title}
+        </p>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-1.5">
+        {discussion.isAnswered ? <NeutralChip>Answered</NeutralChip> : null}
+        {discussion.closed ? <NeutralChip>Closed</NeutralChip> : null}
+      </div>
+      <p className="mt-1 truncate text-xs text-muted-foreground">
+        #{discussion.number} · {discussion.author || "unknown"} ·{" "}
+        {discussion.categoryName}
+      </p>
+      <p className="flex items-center gap-2 text-xs text-muted-foreground tabular-nums">
+        <span>
+          {discussion.commentCount}{" "}
+          {discussion.commentCount === 1 ? "comment" : "comments"} ·{" "}
+          {timeAgo(discussion.createdAt)}
+        </span>
+        {discussion.upvoteCount > 0 ? (
+          <span className="inline-flex items-center gap-0.5">
+            <CaretUpIcon size={12} className="shrink-0" />
+            {discussion.upvoteCount}
+          </span>
+        ) : null}
+      </p>
+      <LabelChips names={discussion.labels.map((l) => l.name)} />
+    </div>
+  );
+}
+
+/** A neutral muted chip whose TEXT carries the meaning (answered / closed / a marker)
+ *  — never color alone (WCAG 1.4.1). */
+function NeutralChip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+/** A discussion's label names as neutral muted chips (max 2, then a "+n" overflow
+ *  chip). Labels carry NO color on the phone (contrast-correcting arbitrary label
+ *  colors is out of scope), so the chips are always neutral. Renders nothing when
+ *  there are no labels. Mirrors Issues' LabelChips. */
+function LabelChips({ names }: { names: string[] }) {
+  if (names.length === 0) return null;
+  const shown = names.slice(0, 2);
+  const overflow = names.length - shown.length;
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-1">
+      {shown.map((name) => (
+        <span
+          key={name}
+          className="max-w-[10rem] truncate rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+        >
+          {name}
+        </span>
+      ))}
+      {overflow > 0 ? (
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          +{overflow}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** A read-only discussion detail. */
+export function DiscussionDetailBody({
+  repoId,
+  number,
+}: {
+  repoId: string;
+  number: number;
+}) {
+  const { data, isPending, isError, error, refetch } = useDiscussion(
+    repoId,
+    number,
+  );
+
+  // Definitive gone WINS: the whole detail (back bar included) is replaced by the
+  // teaching state. (A gh "not found" for a bad discussion number arrives as a
+  // GENERIC server error, NOT `noSuchRepo` — the generic ErrorState below is the
+  // correct rendering for that; don't try to map it to repo-gone.)
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-2 py-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => navigate(repoHash(repoId, "discussions"))}
+          className="inline-flex min-h-11 items-center gap-1 rounded px-2 text-sm font-medium text-primary"
+        >
+          <ArrowLeftIcon size={16} />
+          Discussions
+        </button>
+      </div>
+
+      {asApiError(error)?.isDiscussionsUnavailable ? (
+        <DiscussionsUnavailableState
+          title="Discussions aren't available for this repository"
+          hint={asApiError(error)?.message}
+        />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} />
+      ) : isPending || !data ? (
+        <SkeletonRows count={3} />
+      ) : (
+        <article className="flex flex-col gap-4 px-4 py-5">
+          <header className="flex flex-col gap-2">
+            <NeutralChip>
+              {data.categoryEmoji} {data.categoryName}
+            </NeutralChip>
+            <DiscussionStateChips detail={data} />
+            <h1 className="text-base font-semibold text-foreground">
+              {data.title}
+            </h1>
+            <span className="text-xs text-muted-foreground">
+              #{data.number}
+            </span>
+            <p className="text-xs text-muted-foreground">
+              {data.author || "unknown"} · {timeAgo(data.createdAt)}
+            </p>
+            <LabelChips names={data.labels.map((l) => l.name)} />
+          </header>
+
+          {data.body ? (
+            <Markdown className="text-foreground/90">{data.body}</Markdown>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">
+              No description.
+            </p>
+          )}
+
+          <CommentsSection detail={data} />
+        </article>
+      )}
+    </div>
+  );
+}
+
+/** The discussion's state chips row — answered / locked / closed, each rendered only
+ *  when true. Neutral chips whose TEXT carries the state (locked also gets a lock icon,
+ *  mirroring Issues' locked row); never color alone (WCAG 1.4.1). Renders nothing when
+ *  the discussion is a plain open one. */
+function DiscussionStateChips({ detail }: { detail: DiscussionDetails }) {
+  if (!detail.isAnswered && !detail.locked && !detail.closed) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {detail.isAnswered ? <NeutralChip>Answered</NeutralChip> : null}
+      {detail.locked ? (
+        <NeutralChip>
+          <span className="inline-flex items-center gap-1">
+            <LockIcon size={12} className="shrink-0" />
+            Locked
+            {detail.activeLockReason ? ` (${detail.activeLockReason})` : ""}
+          </span>
+        </NeutralChip>
+      ) : null}
+      {detail.closed ? (
+        <NeutralChip>
+          Closed{detail.stateReason ? ` · ${detail.stateReason}` : ""}
+        </NeutralChip>
+      ) : null}
+    </div>
+  );
+}
+
+/** The discussion's comment threads — top-level comments, each with its nested replies
+ *  one level deep. Reads the EXISTING `useDiscussion` detail (no new query), so there's
+ *  no separate loading/error state here. The wire caps comments AND replies at 100 each
+ *  (GraphQL page caps); v1 shows the served prefix with no "load more" affordance. */
+function CommentsSection({ detail }: { detail: DiscussionDetails }) {
+  const comments = detail.comments;
+  return (
+    <section className="flex flex-col gap-2">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+        Comments ({comments.length})
+      </p>
+      {comments.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No comments yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {comments.map((c) => (
+            <CommentCard
+              key={c.id}
+              comment={c}
+              answerable={detail.isAnswerable}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/** One top-level comment — author + relative time, an "Answer" marker when it's the
+ *  accepted answer (only meaningful in an answerable/Q&A category), the Markdown body
+ *  (or a hidden-comment row when minimized), a display-only upvote count, and its
+ *  nested replies. */
+function CommentCard({
+  comment,
+  answerable,
+}: {
+  comment: DiscussionComment;
+  answerable: boolean;
+}) {
+  const showAnswer = comment.isAnswer && answerable;
+  return (
+    <li className="flex flex-col gap-1 rounded-md border border-border px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-foreground/80">
+          {comment.author || "unknown"}
+        </span>
+        {comment.date ? (
+          <span className="text-xs text-muted-foreground">
+            {timeAgo(comment.date)}
+          </span>
+        ) : null}
+        {showAnswer ? (
+          // Icon + the word "Answer" — the marker never rests on the success tint
+          // alone (WCAG 1.4.1).
+          <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+            <CheckCircleIcon size={12} weight="fill" />
+            Answer
+          </span>
+        ) : null}
+      </div>
+      <CommentBody
+        body={comment.body}
+        isMinimized={comment.isMinimized}
+        minimizedReason={comment.minimizedReason}
+      />
+      {comment.upvoteCount > 0 ? (
+        <p className="flex items-center gap-0.5 text-xs text-muted-foreground tabular-nums">
+          <CaretUpIcon size={12} className="shrink-0" />
+          {comment.upvoteCount}
+        </p>
+      ) : null}
+      {comment.replies.length > 0 ? (
+        <ul className="mt-1 ml-1 flex flex-col gap-2 border-l border-border pl-3">
+          {comment.replies.map((r) => (
+            <ReplyCard key={r.id} reply={r} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+/** A nested reply — the same author/time/body anatomy as a comment, minus the answer
+ *  marker and upvotes (replies carry no upvote count on the wire). */
+function ReplyCard({ reply }: { reply: DiscussionReply }) {
+  return (
+    <li className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-foreground/80">
+          {reply.author || "unknown"}
+        </span>
+        {reply.date ? (
+          <span className="text-xs text-muted-foreground">
+            {timeAgo(reply.date)}
+          </span>
+        ) : null}
+      </div>
+      <CommentBody
+        body={reply.body}
+        isMinimized={reply.isMinimized}
+        minimizedReason={reply.minimizedReason}
+      />
+    </li>
+  );
+}
+
+/** The body shared by comments and replies: a minimized one collapses to a one-line
+ *  muted "Hidden comment (reason)" row (no expand in v1); otherwise its Markdown body.
+ *  Mirrors Issues' CommentCard body. */
+function CommentBody({
+  body,
+  isMinimized,
+  minimizedReason,
+}: {
+  body: string;
+  isMinimized: boolean;
+  minimizedReason: string;
+}) {
+  if (isMinimized) {
+    return (
+      <p className="flex items-center gap-1.5 text-xs italic text-muted-foreground">
+        <EyeSlashIcon size={14} className="shrink-0" />
+        Hidden comment
+        {minimizedReason ? ` (${minimizedReason})` : ""}
+      </p>
+    );
+  }
+  if (body) return <Markdown className="text-foreground/90">{body}</Markdown>;
+  return null;
+}

--- a/companion/src/screens/Issues.tsx
+++ b/companion/src/screens/Issues.tsx
@@ -20,6 +20,7 @@ import {
   SkeletonRows,
   StaleBanner,
 } from "../components/states";
+import { IssuesDiscussionsSegment } from "../components/tab-segment";
 import type { IssueComment, IssueDetails, IssueInfo } from "../lib/api";
 import { timeAgo } from "../lib/format";
 import { asApiError, useIssue, useIssues } from "../lib/queries";
@@ -89,8 +90,17 @@ export function IssuesBody({
   const { register, onKeyDown } = useRovingList();
 
   // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
-  // state even when a cached list is on hand (see isRepoGoneError).
+  // state even when a cached list is on hand (see isRepoGoneError). No segment then —
+  // the repo is unshared, so there's nothing (issues OR discussions) to switch to.
   if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  // The Discussions segment is HOISTED above every other IssuesBody state so a repo
+  // where issues are unavailable but Discussions are enabled (a GitHub fork with the
+  // issue tracker off) still offers a path to Discussions — the issues content was the
+  // only entry point before, leaving Discussions unreachable. The segment self-hides on
+  // repos without Discussions, so every currently-pixel-identical case stays identical
+  // (it renders null, zero extra layout). Never on the issue DETAIL view.
+  const segment = <IssuesDiscussionsSegment repoId={repoId} current="issues" />;
 
   // Prefer stale data: keep the last-known list on screen even on error, with a
   // StaleBanner above it. Full-screen states only when there's nothing to show;
@@ -100,10 +110,26 @@ export function IssuesBody({
     // calm teaching state carrying the server's message — never the generic error,
     // and no retry (retrying can't turn the tracker on).
     if (isTrackerUnavailable(error)) {
-      return <TrackerUnavailableState message={asApiError(error)?.message} />;
+      return (
+        <div className="flex flex-col">
+          {segment}
+          <TrackerUnavailableState message={asApiError(error)?.message} />
+        </div>
+      );
     }
-    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
-    return <SkeletonRows />;
+    if (isError)
+      return (
+        <div className="flex flex-col">
+          {segment}
+          <ErrorState error={error} onRetry={() => refetch()} />
+        </div>
+      );
+    return (
+      <div className="flex flex-col">
+        {segment}
+        <SkeletonRows />
+      </div>
+    );
   }
 
   // The last page came back short (fewer issues than we asked for) → there's nothing
@@ -115,6 +141,7 @@ export function IssuesBody({
 
   return (
     <div className="flex flex-col">
+      {segment}
       {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
       {data.length === 0 ? (
         <EmptyState

--- a/companion/src/screens/Status.tsx
+++ b/companion/src/screens/Status.tsx
@@ -13,9 +13,9 @@ import {
   SkeletonRows,
   StaleBanner,
 } from "../components/states";
-import type { CommitSummary } from "../lib/api";
+import type { CommitSummary, TagInfo } from "../lib/api";
 import { timeAgo } from "../lib/format";
-import { useLog, useStatus } from "../lib/queries";
+import { useLog, useStatus, useTags } from "../lib/queries";
 import { navigate, repoHash, type Tab } from "../lib/router";
 
 // Status is the repo HUB — still glanceable (each group ANSWERS at a glance:
@@ -116,6 +116,19 @@ export function StatusBody({
         <HubGroup repoId={repoId} tab="history" label="Recent commits">
           <RecentCommits repoId={repoId} active={active} />
         </HubGroup>
+
+        <HubGroup repoId={repoId} tab="tags" label="Tags">
+          <TagsGlance repoId={repoId} active={active} />
+        </HubGroup>
+
+        <HubGroup repoId={repoId} tab="todos" label="Code TODOs">
+          {/* Deliberately a STATIC child, NOT a query: a TODO scan is a git-grep
+              sweep across the working tree, so the hub must never fire one — the
+              scan runs only once the user opens the tab. */}
+          <p className="text-sm text-muted-foreground">
+            Scan the working tree for TODO markers.
+          </p>
+        </HubGroup>
       </div>
     </div>
   );
@@ -211,6 +224,46 @@ function RecentCommits({
         </li>
       ))}
     </ul>
+  );
+}
+
+/** The tags glance inside the Tags hub group: the single newest tag as
+ *  `{name} · {timeAgo}`. Non-blocking exactly like RecentCommits — a quiet pulse
+ *  line while loading, a calm "Open to view tags." on error (the group row stays
+ *  tappable), and "No tags yet." when there are none. Fetches the full tags list
+ *  (the same query the Tags tab uses, so the hub warms its cache) and reads only
+ *  the first entry. */
+function TagsGlance({ repoId, active }: { repoId: string; active: boolean }) {
+  const { data, isPending } = useTags(repoId, active);
+
+  if (isPending && !data) {
+    return (
+      <div className="flex flex-col gap-1.5" aria-hidden>
+        <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  // On error (data undefined, not pending) omit the glance — never block the hub on
+  // it. The group header row stays tappable.
+  if (!data || data.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {data ? "No tags yet." : "Open to view tags."}
+      </p>
+    );
+  }
+
+  const tag: TagInfo = data[0];
+  return (
+    <p className="flex items-baseline gap-1.5 text-sm">
+      <span className="min-w-0 truncate font-medium text-foreground">
+        {tag.name}
+      </span>
+      <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+        · {timeAgo(tag.date)}
+      </span>
+    </p>
   );
 }
 

--- a/companion/src/screens/Tags.tsx
+++ b/companion/src/screens/Tags.tsx
@@ -1,0 +1,144 @@
+// The Tags tab (a Status-hub drill-in). Read-only list of the repo's tags. Mirrors
+// the Branches list anatomy — SkeletonRows / ErrorState / RepoGoneState / EmptyState /
+// StaleBanner semantics, `<ul>` divide-y, roving keyboard nav — but here the rows ARE
+// tappable: a tag points at a commit, so a tap drills into the EXISTING commit detail
+// (`history/{sha}`), exactly like a History row. Order is server-served (newest-first);
+// no client re-sort.
+
+import { CaretRightIcon, TagIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import type { TagInfo } from "../lib/api";
+import { timeAgo } from "../lib/format";
+import { useTags } from "../lib/queries";
+import { navigate, repoHash } from "../lib/router";
+import { useRovingList } from "../lib/use-roving-list";
+
+/** The tags list. `repoId` scopes the query; `active` gates polling. */
+export function TagsBody({
+  repoId,
+  active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  const { data, isError, error, refetch } = useTags(repoId, active);
+  const { register, onKeyDown } = useRovingList();
+  // True roving tabindex: the tab stop follows the last-focused row so Tab-ing away
+  // and back returns to it, not row 0. Keyed by tag NAME, not index — a poll can
+  // reorder the list under a remembered position, and identity keeps the stop on the
+  // same tag; an unknown/absent name falls back to row 0. (Mirrors Branches r6+r7.)
+  const [focusName, setFocusName] = useState<string | null>(null);
+
+  // Definitive gone WINS over stale data: a `noSuchRepo` 404 kicks to the teaching
+  // state even when a cached list is on hand (see isRepoGoneError).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  // Prefer stale data: keep the last-known list on screen even on error, with a
+  // StaleBanner above it. Full-screen ErrorState only when there's nothing to
+  // show; skeleton only while the first fetch is pending.
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={() => refetch()} />;
+    return <SkeletonRows />;
+  }
+
+  // Rendered as served — the server sorts newest-first; never re-sort client-side.
+  // Hoisted membership check (once per render, not per row): the remembered focus
+  // name is active only while its tag is still in the list; otherwise the tab stop
+  // falls back to row 0.
+  const activeName =
+    focusName != null && data.some((t) => t.name === focusName)
+      ? focusName
+      : null;
+
+  return (
+    <div className="flex flex-col">
+      {isError ? <StaleBanner error={error} onRetry={() => refetch()} /> : null}
+      {data.length === 0 ? (
+        <EmptyState
+          title="No tags yet."
+          hint="Tags on this repository will show up here."
+        />
+      ) : (
+        <ul className="flex flex-col divide-y divide-border">
+          {data.map((tag, i) => (
+            <li key={tag.name}>
+              <button
+                type="button"
+                ref={register(i)}
+                onKeyDown={onKeyDown}
+                // A tag points at a commit, so the row opens the EXISTING commit
+                // detail. `target` is the full dereferenced sha (annotated tags too),
+                // which the router's SHA_RE accepts.
+                onClick={() =>
+                  navigate(repoHash(repoId, `history/${tag.target}`))
+                }
+                onFocus={() => setFocusName(tag.name)}
+                tabIndex={
+                  (activeName != null ? tag.name === activeName : i === 0)
+                    ? 0
+                    : -1
+                }
+                className="flex w-full min-h-14 items-center gap-3 px-4 py-3 text-left outline-none focus-visible:bg-muted/40"
+              >
+                <TagRow tag={tag} />
+                <CaretRightIcon
+                  size={16}
+                  className="shrink-0 text-muted-foreground"
+                  aria-hidden
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function TagRow({ tag }: { tag: TagInfo }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <TagIcon
+          size={16}
+          className="shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          {tag.name}
+        </span>
+        {tag.annotated ? <TagChip label="annotated" /> : null}
+      </div>
+      {tag.subject ? (
+        <p className="mt-1 truncate text-xs text-muted-foreground">
+          {tag.subject}
+        </p>
+      ) : null}
+      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="shrink-0 font-mono tabular-nums">
+          {tag.target.slice(0, 7)}
+        </span>
+        <span className="shrink-0 tabular-nums">{timeAgo(tag.date)}</span>
+      </div>
+    </div>
+  );
+}
+
+/** A small neutral marker chip (annotated) — text-only, no color-coded meaning,
+ *  matching the companion's restrained register (copy of Branches' TagChip; the
+ *  screens inline their own presentational blocks). */
+function TagChip({ label }: { label: string }) {
+  return (
+    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      {label}
+    </span>
+  );
+}

--- a/companion/src/screens/Todos.tsx
+++ b/companion/src/screens/Todos.tsx
@@ -262,6 +262,18 @@ function TodoList({
   onKeyDown: (e: React.KeyboardEvent) => void;
 }) {
   const groups = groupByPath(items);
+  // True roving tabindex: the tab stop follows the last-focused row (by stable
+  // path:line identity, NOT index) so Tab-ing away and back returns to it, not row 0
+  // — and a rescan that reorders the list keeps the stop on the same hit. An
+  // unknown/absent key falls back to the first row. Mirrors TagsBody/BranchesBody.
+  const [focusKey, setFocusKey] = useState<string | null>(null);
+  const rowKey = (item: TodoScanItem) => `${item.path}:${item.line}`;
+  // Hoisted membership check (once per render): the remembered key is active only
+  // while its hit is still in the list; otherwise the tab stop falls back to row 0.
+  const activeKey =
+    focusKey != null && items.some((it) => rowKey(it) === focusKey)
+      ? focusKey
+      : null;
   // Roving index runs across ALL rows (flat), not per-group, so ArrowUp/Down scans
   // the whole scan continuously; `rowIndex` counts rows as we emit them.
   let rowIndex = 0;
@@ -280,19 +292,24 @@ function TodoList({
           <ul className="flex flex-col divide-y divide-border">
             {group.items.map((item) => {
               const i = rowIndex++;
+              const key = rowKey(item);
               return (
                 // Keyed by the hit's stable identity (path:line) — NOT the flat roving
                 // index, which would remount every subsequent row when a rescan shifts
                 // earlier rows (losing focus + the dimmed-placeholder transition).
-                <li key={`${item.path}:${item.line}`}>
+                <li key={key}>
                   <div
                     ref={register(i)}
                     onKeyDown={onKeyDown}
+                    onFocus={() => setFocusKey(key)}
                     // A focusable, roving list row (repo convention: every list gets
                     // keyboard nav) — but NOT a control: there's no file viewer to
-                    // open, so it's a plain row, not a button/link. First row is the
-                    // tab stop; roving moves it as the user arrows.
-                    tabIndex={i === 0 ? 0 : -1}
+                    // open, so it's a plain row, not a button/link. The tab stop
+                    // follows the last-focused hit (identity-keyed), falling back to
+                    // the first row.
+                    tabIndex={
+                      (activeKey != null ? key === activeKey : i === 0) ? 0 : -1
+                    }
                     className="flex min-h-11 items-center gap-3 px-4 py-2 outline-none focus-visible:bg-muted/40"
                   >
                     <MarkerChip label={item.marker} />

--- a/companion/src/screens/Todos.tsx
+++ b/companion/src/screens/Todos.tsx
@@ -1,0 +1,346 @@
+// The Code TODOs tab (a Status-hub drill-in). Read-only code-TODO scan results, run
+// against a toggleable marker set. Mirrors the other list screens' state vocabulary
+// (SkeletonRows / ErrorState / RepoGoneState / StaleBanner / EmptyState) and roving
+// keyboard nav, but the rows are NOT tappable (there's no file viewer on the phone) —
+// they're roving-focusable only, for keyboard scanning, exactly like Branches rows.
+
+import {
+  ArrowsClockwiseIcon,
+  CheckIcon,
+  InfoIcon,
+} from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import {
+  EmptyState,
+  ErrorState,
+  isRepoGoneError,
+  RepoGoneState,
+  SkeletonRows,
+  StaleBanner,
+} from "../components/states";
+import type { TodoScanItem } from "../lib/api";
+import { useTodoScan } from "../lib/queries";
+import { useRovingList } from "../lib/use-roving-list";
+
+// The default marker set the scan looks for. THREE copies of this list exist BY
+// DESIGN — keep them in sync: the desktop's `src/features/code-todos/markers.ts`
+// (`DEFAULT_MARKERS`), the LAN server's `src-tauri/src/lan/routes/git.rs`
+// (`DEFAULT_TODO_MARKERS`), and here. The toggle set is local (transient) state, NOT
+// in the URL — matching the desktop's transient toggles.
+const DEFAULT_MARKERS = ["TODO", "FIXME", "HACK", "BUG", "XXX"];
+
+/** The code-TODO scan screen. `repoId` scopes the query; `active` is accepted for
+ *  parity with the other drill-in bodies (the scan hook deliberately doesn't poll,
+ *  so it's unused here). */
+export function TodosBody({
+  repoId,
+  active: _active,
+}: {
+  repoId: string;
+  active: boolean;
+}) {
+  // The enabled marker set (transient, not URL-persisted — matches the desktop).
+  const [markers, setMarkers] = useState<string[]>(DEFAULT_MARKERS);
+  // The query auto-scans on open (it fires on mount) and re-keys on the sorted marker
+  // set; with zero markers selected the hook's own `markers.length > 0` gate keeps it
+  // from firing. `keepPreviousData` keeps the prior list up while a toggle re-keys.
+  const { data, isError, error, refetch, isFetching, isPlaceholderData } =
+    useTodoScan(repoId, markers, true);
+  const { register, onKeyDown } = useRovingList();
+
+  const toggleMarker = (marker: string) =>
+    setMarkers((prev) =>
+      prev.includes(marker)
+        ? prev.filter((m) => m !== marker)
+        : [...prev, marker],
+    );
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-3 py-2 backdrop-blur">
+        <MarkerToggles enabled={markers} onToggle={toggleMarker} />
+        <button
+          type="button"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className="inline-flex min-h-11 shrink-0 items-center gap-1 rounded px-2 text-sm font-medium text-primary disabled:text-muted-foreground"
+        >
+          <ArrowsClockwiseIcon
+            size={16}
+            // motion-safe so the spin honors the app's global reduced-motion rule.
+            className={isFetching ? "motion-safe:animate-spin" : ""}
+            aria-hidden
+          />
+          Rescan
+        </button>
+      </div>
+
+      <TodosResults
+        markers={markers}
+        data={data}
+        isError={isError}
+        error={error}
+        onRetry={() => refetch()}
+        isPlaceholderData={isPlaceholderData}
+        register={register}
+        onKeyDown={onKeyDown}
+      />
+    </div>
+  );
+}
+
+/** The five marker toggle chips as a horizontal roving-tabindex group (repo rule:
+ *  every selectable list gets arrow-key nav in the same change). ArrowLeft/ArrowRight
+ *  move focus between chips (wrapping), Home/End jump to first/last — focus ONLY; a
+ *  chip toggles on Enter/Space (native button activation) or a tap, never on arrow, so
+ *  arrowing across a multi-select never flips a marker. One chip is in the tab order at
+ *  a time (the roving stop follows the last-focused chip). The Rescan button is a plain
+ *  tab stop OUTSIDE this group — it's an action, not a selectable. Adapts BottomNav's
+ *  inline roving pattern (which we can't share directly — it's link/hash-based). */
+function MarkerToggles({
+  enabled,
+  onToggle,
+}: {
+  enabled: string[];
+  onToggle: (marker: string) => void;
+}) {
+  const chips = useRef<(HTMLButtonElement | null)[]>([]);
+  // The roving tab stop: the chip that currently holds tabIndex 0. Follows the
+  // last-focused chip so Tab-ing away and back returns to it, not chip 0.
+  const [focusIndex, setFocusIndex] = useState(0);
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    let next: number | null = null;
+    switch (e.key) {
+      case "ArrowRight":
+        next = (focusIndex + 1) % DEFAULT_MARKERS.length;
+        break;
+      case "ArrowLeft":
+        next =
+          (focusIndex - 1 + DEFAULT_MARKERS.length) % DEFAULT_MARKERS.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = DEFAULT_MARKERS.length - 1;
+        break;
+      default:
+        return; // Enter/Space fall through to native button activation (toggle).
+    }
+    e.preventDefault();
+    setFocusIndex(next);
+    chips.current[next]?.focus();
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label="TODO markers"
+      className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5"
+    >
+      {DEFAULT_MARKERS.map((marker, i) => {
+        const on = enabled.includes(marker);
+        return (
+          <button
+            key={marker}
+            type="button"
+            ref={(el) => {
+              chips.current[i] = el;
+            }}
+            aria-pressed={on}
+            tabIndex={i === focusIndex ? 0 : -1}
+            onKeyDown={onKeyDown}
+            onFocus={() => setFocusIndex(i)}
+            onClick={() => onToggle(marker)}
+            className={`inline-flex min-h-11 items-center gap-1 rounded-full px-3 text-xs font-medium ${
+              on
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground"
+            }`}
+          >
+            {/* Pressed state is never color-alone: aria-pressed carries the
+                semantics and a check glyph gives a visible non-color cue. */}
+            {on ? <CheckIcon size={12} weight="bold" aria-hidden /> : null}
+            {marker}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** The scan results below the control row. Split out so the sticky control row stays
+ *  mounted (and interactive) across every result state. */
+function TodosResults({
+  markers,
+  data,
+  isError,
+  error,
+  onRetry,
+  isPlaceholderData,
+  register,
+  onKeyDown,
+}: {
+  markers: string[];
+  data: { items: TodoScanItem[]; truncated: boolean } | undefined;
+  isError: boolean;
+  error: unknown;
+  onRetry: () => void;
+  isPlaceholderData: boolean;
+  register: (index: number) => (el: HTMLElement | null) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}) {
+  // Zero markers selected → the hook doesn't query; teach the toggle instead of
+  // showing an empty scan.
+  if (markers.length === 0) {
+    return (
+      <EmptyState
+        title="No markers selected."
+        hint="Turn on a marker above to scan the working tree."
+      />
+    );
+  }
+
+  // Definitive gone WINS over stale data (see isRepoGoneError).
+  if (isRepoGoneError(error)) return <RepoGoneState />;
+
+  // Prefer stale data: keep the last scan on screen even on error, with a StaleBanner
+  // above it. Full-screen ErrorState only when there's nothing to show; skeleton only
+  // while the first scan is pending.
+  if (!data) {
+    if (isError) return <ErrorState error={error} onRetry={onRetry} />;
+    return <SkeletonRows />;
+  }
+
+  if (data.items.length === 0) {
+    return (
+      <>
+        {isError ? <StaleBanner error={error} onRetry={onRetry} /> : null}
+        <EmptyState
+          title="Nothing found."
+          hint="No TODO-style markers match the selected set."
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {isError ? <StaleBanner error={error} onRetry={onRetry} /> : null}
+      {data.truncated ? (
+        <p className="flex items-center gap-2 border-b border-info/40 bg-info/10 px-4 py-2 text-xs text-foreground">
+          <InfoIcon size={14} className="shrink-0 text-info" aria-hidden />
+          Showing the first 2,000 matches — turn off markers to narrow the scan.
+        </p>
+      ) : null}
+      <TodoList
+        items={data.items}
+        // A marker toggle mid-flight keeps the previous list rendered (keepPreviousData)
+        // — dim it so the toggle feels responsive, never a skeleton collapse.
+        dimmed={isPlaceholderData}
+        register={register}
+        onKeyDown={onKeyDown}
+      />
+    </>
+  );
+}
+
+/** The scan hits, grouped by file. Items arrive GROUPED BY PATH (git-grep order —
+ *  consecutive items share a path); a single pass over `items` emits a file-group
+ *  header at each path-change boundary, its rows beneath. Rows are roving-focusable
+ *  (keyboard scanning) but not tappable. */
+function TodoList({
+  items,
+  dimmed,
+  register,
+  onKeyDown,
+}: {
+  items: TodoScanItem[];
+  dimmed: boolean;
+  register: (index: number) => (el: HTMLElement | null) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}) {
+  const groups = groupByPath(items);
+  // Roving index runs across ALL rows (flat), not per-group, so ArrowUp/Down scans
+  // the whole scan continuously; `rowIndex` counts rows as we emit them.
+  let rowIndex = 0;
+  return (
+    <div className={dimmed ? "opacity-60" : ""}>
+      {groups.map((group) => (
+        <section key={group.path} className="flex flex-col">
+          <header className="flex items-center justify-between gap-2 border-b border-border bg-muted/30 px-4 py-1.5">
+            <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+              {group.path}
+            </span>
+            <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+              {group.items.length}
+            </span>
+          </header>
+          <ul className="flex flex-col divide-y divide-border">
+            {group.items.map((item) => {
+              const i = rowIndex++;
+              return (
+                // Keyed by the hit's stable identity (path:line) — NOT the flat roving
+                // index, which would remount every subsequent row when a rescan shifts
+                // earlier rows (losing focus + the dimmed-placeholder transition).
+                <li key={`${item.path}:${item.line}`}>
+                  <div
+                    ref={register(i)}
+                    onKeyDown={onKeyDown}
+                    // A focusable, roving list row (repo convention: every list gets
+                    // keyboard nav) — but NOT a control: there's no file viewer to
+                    // open, so it's a plain row, not a button/link. First row is the
+                    // tab stop; roving moves it as the user arrows.
+                    tabIndex={i === 0 ? 0 : -1}
+                    className="flex min-h-11 items-center gap-3 px-4 py-2 outline-none focus-visible:bg-muted/40"
+                  >
+                    <MarkerChip label={item.marker} />
+                    {item.text ? (
+                      <span className="min-w-0 flex-1 truncate text-sm text-foreground/90">
+                        {item.text}
+                      </span>
+                    ) : (
+                      <span className="flex-1" />
+                    )}
+                    <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                      L{item.line}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+/** One file's group of consecutive hits. */
+interface TodoGroup {
+  path: string;
+  items: TodoScanItem[];
+}
+
+/** Group consecutive same-path items in a single pass (the server already emits them
+ *  contiguous, in git-grep order — never re-sort). */
+function groupByPath(items: TodoScanItem[]): TodoGroup[] {
+  const groups: TodoGroup[] = [];
+  for (const item of items) {
+    const last = groups[groups.length - 1];
+    if (last && last.path === item.path) last.items.push(item);
+    else groups.push({ path: item.path, items: [item] });
+  }
+  return groups;
+}
+
+/** A neutral marker chip (TODO / FIXME / …) — the marker WORD carries the meaning;
+ *  no per-marker color (matching the companion's neutral-chips rule). */
+function MarkerChip({ label }: { label: string }) {
+  return (
+    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      {label}
+    </span>
+  );
+}

--- a/companion/src/screens/Todos.tsx
+++ b/companion/src/screens/Todos.tsx
@@ -228,6 +228,9 @@ function TodosResults({
   return (
     <>
       {isError ? <StaleBanner error={error} onRetry={onRetry} /> : null}
+      {/* The "2,000" mirrors the server's `DEFAULT_MAX_HITS` in
+          src-tauri/src/git/todos.rs — the companion never sends `maxHits`, so that
+          default always applies. Keep the two in sync (grep DEFAULT_MAX_HITS). */}
       {data.truncated ? (
         <p className="flex items-center gap-2 border-b border-info/40 bg-info/10 px-4 py-2 text-xs text-foreground">
           <InfoIcon size={14} className="shrink-0 text-info" aria-hidden />

--- a/src-tauri/src/github/discussion.rs
+++ b/src-tauri/src/github/discussion.rs
@@ -243,8 +243,15 @@ pub async fn gh_discussion_list(
             format!("first={page}"),
         ];
         // Only pass categoryId when filtering; absent leaves the variable null.
+        // Pass it as a RAW string field (`-f`), never a typed field (`-F`): gh's
+        // `-F` magic-converts a value beginning with `@` into a FILE READ
+        // (`-F x=@/path` reads that file and sends its contents as the value). The
+        // category flows in from an attacker-reachable LAN query param, so `-F`
+        // here would be an arbitrary host-file read (SSH keys, tokens) exfiltrated
+        // to GitHub. The GraphQL `$category` is an `ID` (string-compatible), so
+        // `-f` is correct — and it matches the `after` cursor's handling below.
         if let Some(cat) = category.as_deref().filter(|c| !c.is_empty()) {
-            args.push("-F".to_string());
+            args.push("-f".to_string());
             args.push(format!("category={cat}"));
         }
         // The `after` cursor is server-opaque text, so it travels as a String

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -2632,6 +2632,54 @@ mod tests {
         std::fs::remove_file(&store).ok();
     }
 
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn discussions_list_rejects_category_injection() {
+        // A GitHub-origin repo: the host gate PASSES, so the request reaches the
+        // category boundary guard. A `@`-leading category is the `gh -F` file-read
+        // vector; the guard rejects it with 400 `invalidArgument` BEFORE any `gh`
+        // call, so this runs offline and proves the injection can't reach `gh`.
+        let _lock = auth::store_test_lock();
+        let store = temp_store();
+        let prev = auth::set_store_path_for_test(Some(store.clone()));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        git_in(root, &["init", "-q"]);
+        git_in(root, &["config", "user.email", "t@t.t"]);
+        git_in(root, &["config", "user.name", "t"]);
+        git_in(
+            root,
+            &["remote", "add", "origin", "https://github.com/x/y.git"],
+        );
+        let repo = root.to_string_lossy().to_string();
+
+        let (device, bearer, token_hash) = auth::mint_device("Cat Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(test_router(Some(repo)));
+
+        // %40 = '@'; %2F = '/'. The exploit value `@/etc/passwd` url-encoded.
+        let resp = router
+            .clone()
+            .oneshot(authed_get(
+                "/api/forge/discussions?category=%40%2Fetc%2Fpasswd",
+                &bearer,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "an `@`-leading category must be rejected at the boundary"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["kind"], "invalidArgument", "kind: {body}");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&store).ok();
+    }
+
     /// Insert a live stream into a router state's registry, tagged with the repo it
     /// operates on. Mirrors what `AppState::register_stream` stores, but built
     /// directly so the test doesn't need a whole `AppState`. Returns the sender so

--- a/src-tauri/src/lan/mod.rs
+++ b/src-tauri/src/lan/mod.rs
@@ -2419,6 +2419,219 @@ mod tests {
         std::fs::remove_dir_all(&repo_dir).ok();
     }
 
+    /// Run `git` in `cwd`, asserting success — the shared setup helper for the
+    /// companion-extras route tests (tags/todos/discussions) below.
+    fn git_in(cwd: &std::path::Path, args: &[&str]) {
+        git_in_at(cwd, args, None);
+    }
+
+    /// Like [`git_in`], but pins the author + committer date (an RFC-2822/ISO
+    /// timestamp) so `--sort=-creatordate` is deterministic: back-to-back commits
+    /// (and an annotated tag) would otherwise share a one-second timestamp and tie,
+    /// making the newest-first ordering flaky.
+    fn git_in_at(cwd: &std::path::Path, args: &[&str], date: Option<&str>) {
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(args).current_dir(cwd);
+        if let Some(date) = date {
+            cmd.env("GIT_AUTHOR_DATE", date)
+                .env("GIT_COMMITTER_DATE", date);
+        }
+        assert!(
+            cmd.output().unwrap().status.success(),
+            "git {args:?} failed in {cwd:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn tags_route_lists_annotated_and_lightweight_newest_first() {
+        // A real temp repo with one lightweight and one annotated tag on distinct
+        // commits: the route returns both, newest-first, with the full field set.
+        let _lock = auth::store_test_lock();
+        let store = temp_store();
+        let prev = auth::set_store_path_for_test(Some(store.clone()));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        git_in(root, &["init", "-q"]);
+        git_in(root, &["config", "user.email", "t@t.t"]);
+        git_in(root, &["config", "user.name", "t"]);
+        // Pin distinct, ordered dates so `--sort=-creatordate` is deterministic
+        // (a lightweight tag inherits its commit's date; an annotated tag uses the
+        // tag-creation date). Without this, same-second timestamps tie and the
+        // newest-first assertion flakes.
+        git_in_at(
+            root,
+            &["commit", "-q", "--allow-empty", "-m", "first"],
+            Some("2026-01-01T00:00:00"),
+        );
+        // Lightweight tag on the first (older) commit.
+        git_in(root, &["tag", "v0.1.0"]);
+        git_in_at(
+            root,
+            &["commit", "-q", "--allow-empty", "-m", "second"],
+            Some("2026-02-01T00:00:00"),
+        );
+        // Annotated tag on the second (newer) commit — must sort first.
+        git_in_at(
+            root,
+            &["tag", "-a", "v0.2.0", "-m", "release 0.2.0"],
+            Some("2026-02-01T00:00:00"),
+        );
+        let repo = root.to_string_lossy().to_string();
+
+        let (device, bearer, token_hash) = auth::mint_device("Tags Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(test_router(Some(repo)));
+
+        let resp = router
+            .oneshot(authed_get("/api/repo/tags", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let tags: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = tags.as_array().expect("tags is a JSON array");
+        assert_eq!(arr.len(), 2, "both tags present: {tags}");
+        // Newest first: the annotated v0.2.0 (on the newer commit) leads.
+        assert_eq!(arr[0]["name"], "v0.2.0");
+        assert_eq!(arr[0]["annotated"], true);
+        assert_eq!(arr[0]["subject"], "release 0.2.0");
+        assert_eq!(arr[1]["name"], "v0.1.0");
+        assert_eq!(arr[1]["annotated"], false);
+        // Every entry carries the full camelCase field set.
+        for entry in arr {
+            for field in ["name", "target", "date", "annotated", "subject"] {
+                assert!(entry.get(field).is_some(), "field {field} present: {entry}");
+            }
+        }
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&store).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn todos_route_scans_with_defaults_when_markers_absent() {
+        // A seeded `// TODO:` is found with NO `markers` param — the handler's
+        // default marker set (mirroring the desktop's) includes TODO.
+        let _lock = auth::store_test_lock();
+        let store = temp_store();
+        let prev = auth::set_store_path_for_test(Some(store.clone()));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        git_in(root, &["init", "-q"]);
+        git_in(root, &["config", "user.email", "t@t.t"]);
+        git_in(root, &["config", "user.name", "t"]);
+        std::fs::write(root.join("code.rs"), "fn main() {} // TODO: wire it up\n").unwrap();
+        git_in(root, &["add", "-A"]);
+        git_in(root, &["commit", "-q", "-m", "seed"]);
+        let repo = root.to_string_lossy().to_string();
+
+        let (device, bearer, token_hash) = auth::mint_device("Todos Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(test_router(Some(repo)));
+
+        // No `markers` param → the default set is used.
+        let resp = router
+            .oneshot(authed_get("/api/repo/todos", &bearer))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let scan: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let items = scan["items"].as_array().expect("items array");
+        assert!(!items.is_empty(), "the seeded TODO is found with defaults: {scan}");
+        assert_eq!(scan["truncated"], false);
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&store).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn todos_route_rejects_a_bad_marker() {
+        // The core fn's injection guard rejects a marker with illegal charset — it
+        // surfaces as the mapped 400 (InvalidArgument), not a 200.
+        let _lock = auth::store_test_lock();
+        let store = temp_store();
+        let prev = auth::set_store_path_for_test(Some(store.clone()));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        git_in(root, &["init", "-q"]);
+        git_in(root, &["config", "user.email", "t@t.t"]);
+        git_in(root, &["config", "user.name", "t"]);
+        git_in(root, &["commit", "-q", "--allow-empty", "-m", "init"]);
+        let repo = root.to_string_lossy().to_string();
+
+        let (device, bearer, token_hash) = auth::mint_device("Bad Marker Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(test_router(Some(repo)));
+
+        let resp = router
+            .oneshot(authed_get("/api/repo/todos?markers=BAD*MARKER", &bearer))
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), StatusCode::OK, "a bad marker must not 200");
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&store).ok();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn discussions_routes_gate_non_github_hosts() {
+        // A repo whose `origin` is a gitlab.com URL: all three discussions routes
+        // return 400 `discussionsUnavailable` from the server-side gate BEFORE any
+        // `gh` call — so no network is needed to run this test.
+        let _lock = auth::store_test_lock();
+        let store = temp_store();
+        let prev = auth::set_store_path_for_test(Some(store.clone()));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        git_in(root, &["init", "-q"]);
+        git_in(root, &["config", "user.email", "t@t.t"]);
+        git_in(root, &["config", "user.name", "t"]);
+        git_in(
+            root,
+            &["remote", "add", "origin", "https://gitlab.com/x/y.git"],
+        );
+        let repo = root.to_string_lossy().to_string();
+
+        let (device, bearer, token_hash) = auth::mint_device("Gate Phone");
+        auth::persist_device(&device, &token_hash).unwrap();
+        let router = server::build_router(test_router(Some(repo)));
+
+        for path in [
+            "/api/forge/discussions/meta",
+            "/api/forge/discussions",
+            "/api/forge/discussions/1",
+        ] {
+            let resp = router
+                .clone()
+                .oneshot(authed_get(path, &bearer))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "{path} must 400 on a non-GitHub host"
+            );
+            let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                body["kind"], "discussionsUnavailable",
+                "{path} kind: {body}"
+            );
+        }
+
+        auth::set_store_path_for_test(prev);
+        std::fs::remove_file(&store).ok();
+    }
+
     /// Insert a live stream into a router state's registry, tagged with the repo it
     /// operates on. Mirrors what `AppState::register_stream` stores, but built
     /// directly so the test doesn't need a whole `AppState`. Returns the sender so

--- a/src-tauri/src/lan/routes/forge.rs
+++ b/src-tauri/src/lan/routes/forge.rs
@@ -180,14 +180,34 @@ pub struct DiscussionListQuery {
     limit: Option<u32>,
 }
 
+/// Whether a `category` query value is a well-formed GitHub node id — the only
+/// thing this param is ever meant to carry (a `DiscussionCategory.id`). The charset
+/// covers both the modern (`DIC_kwDO…`, base64url) and legacy (`MDE…=`, padded
+/// base64) node-id forms: letters, digits, and `_ - = + /`. Defense-in-depth at the
+/// LAN boundary: `gh_discussion_list` now passes the value with `-f` (no magic), so
+/// this is belt-and-braces — but rejecting anything with an `@`/whitespace/other
+/// metacharacter keeps a hostile value from ever reaching `gh` at all.
+fn is_valid_category_id(cat: &str) -> bool {
+    !cat.is_empty()
+        && cat
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'=' | b'+' | b'/'))
+}
+
 /// GET discussion list (alias: `/api/forge/discussions?category&limit`). `category`
-/// is a category node id to filter by; absent keeps all categories.
+/// is a category node id to filter by; absent keeps all categories. A present but
+/// malformed `category` is rejected at the boundary (400) rather than forwarded.
 pub async fn discussions_list(
     Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
     Query(q): Query<DiscussionListQuery>,
 ) -> Response {
     if !discussions_allowed(&repo).await {
         return discussions_unavailable();
+    }
+    if let Some(cat) = q.category.as_deref() {
+        if !is_valid_category_id(cat) {
+            return bad_request("invalid category id");
+        }
     }
     respond(crate::github::discussion::gh_discussion_list(repo, q.category, q.limit).await)
 }
@@ -210,4 +230,28 @@ pub async fn discussions_view(
         Err(resp) => return *resp,
     };
     respond(crate::github::discussion::gh_discussion_view(repo, number).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_category_id;
+
+    #[test]
+    fn accepts_real_node_id_shapes() {
+        // Modern (base64url) and legacy (padded base64) GitHub node ids.
+        assert!(is_valid_category_id("DIC_kwDOS_FYH84Abc-_Xyz"));
+        assert!(is_valid_category_id("MDEwOlJlcG9zaXRvcnkx=="));
+        assert!(is_valid_category_id("abcABC0189_-=+/"));
+    }
+
+    #[test]
+    fn rejects_injection_and_junk() {
+        // The `@`-leading value is the `gh -F` file-read vector; also reject any
+        // whitespace or other metacharacter, and the empty string.
+        assert!(!is_valid_category_id("@/etc/passwd"));
+        assert!(!is_valid_category_id("@-")); // gh's stdin marker
+        assert!(!is_valid_category_id("DIC_kw@evil"));
+        assert!(!is_valid_category_id("has space"));
+        assert!(!is_valid_category_id(""));
+    }
 }

--- a/src-tauri/src/lan/routes/forge.rs
+++ b/src-tauri/src/lan/routes/forge.rs
@@ -15,6 +15,7 @@ use axum::response::Response;
 use axum::Extension;
 use serde::Deserialize;
 
+use crate::forge::model::Provider;
 use crate::lan::routes::{bad_request, path_param, respond, ScopedRepo};
 
 /// Read a `u64` path param by name (`number`/`id`), returning the app's standard
@@ -126,4 +127,87 @@ pub async fn ci_run_view(
         Err(resp) => return *resp,
     };
     respond(crate::forge::forge_ci_run_view(repo, id.to_string()).await)
+}
+
+/// The 400 returned when a discussions route is hit on a non-GitHub repo. The
+/// desktop gates discussions client-side (`forgeSupports`), so the `gh_discussion_*`
+/// core fns have no server-side host guard — without this they'd emit a raw
+/// `AppError::Gh` on a GitLab/Bitbucket repo. `discussionsUnavailable` is a VERBATIM
+/// cross-layer contract: the companion matches this `kind` exactly to render its
+/// teaching state — do not rename it. Mirrors the `bad_request`/`no_active_repo`
+/// response-builder style in [`crate::lan::routes`].
+fn discussions_unavailable() -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+    use serde_json::json;
+
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "kind": "discussionsUnavailable",
+            "message": "Discussions aren't available on this repository's host."
+        })),
+    )
+        .into_response()
+}
+
+/// Whether the repo's host supports GitHub Discussions. `detect_non_github` returns
+/// `Some((GitLab | Bitbucket, _))` for a known non-GitHub host → block; `None`
+/// (GitHub-or-unknown, the app's gh-default routing) or a `GitHub` arm (GHE hosts)
+/// → proceed. Runs BEFORE any `gh` invocation, so a non-GitHub repo short-circuits
+/// with no network call.
+async fn discussions_allowed(repo: &str) -> bool {
+    !matches!(
+        crate::forge::detect_non_github(repo).await,
+        Some((Provider::GitLab | Provider::Bitbucket, _))
+    )
+}
+
+/// GET discussion metadata (alias: `/api/forge/discussions/meta`). Node id, whether
+/// discussions are enabled, and the categories.
+pub async fn discussions_meta(Extension(ScopedRepo(repo)): Extension<ScopedRepo>) -> Response {
+    if !discussions_allowed(&repo).await {
+        return discussions_unavailable();
+    }
+    respond(crate::github::discussion::gh_discussion_categories(repo).await)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscussionListQuery {
+    category: Option<String>,
+    limit: Option<u32>,
+}
+
+/// GET discussion list (alias: `/api/forge/discussions?category&limit`). `category`
+/// is a category node id to filter by; absent keeps all categories.
+pub async fn discussions_list(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Query(q): Query<DiscussionListQuery>,
+) -> Response {
+    if !discussions_allowed(&repo).await {
+        return discussions_unavailable();
+    }
+    respond(crate::github::discussion::gh_discussion_list(repo, q.category, q.limit).await)
+}
+
+/// GET a discussion's full thread (alias: `/api/forge/discussions/{number}`). The
+/// `number` path param is read by name so the handler works under both mounts.
+///
+/// Route order: axum's matchit gives the static `discussions/meta` priority over
+/// this `discussions/{number}` pattern, so mounting both is safe regardless of
+/// registration order — don't "fix" the ordering.
+pub async fn discussions_view(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Path(params): Path<HashMap<String, String>>,
+) -> Response {
+    if !discussions_allowed(&repo).await {
+        return discussions_unavailable();
+    }
+    let number = match u64_param(&params, "number") {
+        Ok(n) => n,
+        Err(resp) => return *resp,
+    };
+    respond(crate::github::discussion::gh_discussion_view(repo, number).await)
 }

--- a/src-tauri/src/lan/routes/git.rs
+++ b/src-tauri/src/lan/routes/git.rs
@@ -101,6 +101,49 @@ pub struct FileDiffQuery {
     untracked: bool,
 }
 
+/// GET tags (alias: `/api/repo/tags`). Every tag, newest first — annotated tags
+/// carry their own message + date, lightweight ones fall back to the commit.
+pub async fn tags(Extension(ScopedRepo(repo)): Extension<ScopedRepo>) -> Response {
+    respond(crate::git::ops::git_list_tags(repo).await)
+}
+
+/// The default comment markers scanned when the request omits `markers` (or it
+/// parses empty). Three copies of this set exist BY DESIGN — keep them in sync:
+/// the desktop's `DEFAULT_MARKERS` in `src/features/code-todos/markers.ts`, the
+/// companion's marker chip row, and this server-side fallback.
+const DEFAULT_TODO_MARKERS: &[&str] = &["TODO", "FIXME", "HACK", "BUG", "XXX"];
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodoQuery {
+    markers: Option<String>,
+    max_hits: Option<u32>,
+}
+
+/// GET code-TODO scan (alias: `/api/repo/todos?markers=TODO,FIXME&maxHits=2000`).
+/// `markers` is a comma-separated list (split on `,`, trimmed, empties dropped);
+/// absent or empty-after-parse falls back to [`DEFAULT_TODO_MARKERS`]. The core
+/// fn validates the marker charset (injection guard) and caps hits at 2000, so no
+/// validation is duplicated here.
+pub async fn todos(
+    Extension(ScopedRepo(repo)): Extension<ScopedRepo>,
+    Query(q): Query<TodoQuery>,
+) -> Response {
+    let markers: Vec<String> = q
+        .markers
+        .as_deref()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| DEFAULT_TODO_MARKERS.iter().map(|m| m.to_string()).collect());
+    respond(crate::git::todos::git_todo_scan(repo, markers, q.max_hits).await)
+}
+
 /// GET file diff (alias: `/api/repo/diff/file?path&staged&untracked`).
 pub async fn diff_file(
     Extension(ScopedRepo(repo)): Extension<ScopedRepo>,

--- a/src-tauri/src/lan/routes/mod.rs
+++ b/src-tauri/src/lan/routes/mod.rs
@@ -1,6 +1,6 @@
 //! The read-only route handlers mounted by the LAN companion server.
 //!
-//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 17
+//! The allowlist is STRUCTURAL: [`crate::lan::server`] mounts exactly the 22
 //! handlers below and nothing else — there is no catch-all and no static serving,
 //! so any path outside the list 404s. Every handler operates on ONE resolved repo
 //! it reads from the `Extension<ScopedRepo>` a resolver middleware inserts, calls
@@ -29,6 +29,8 @@
 //! | `/api/repo/commits/{hash}/diff`       | `commits/{hash}/diff`                 |
 //! | `/api/repo/diff/working`              | `diff/working`                        |
 //! | `/api/repo/diff/file`                 | `diff/file`                           |
+//! | `/api/repo/tags`                      | `tags`                                |
+//! | `/api/repo/todos`                     | `todos`                               |
 //! | `/api/forge/prs`                      | `prs`                                 |
 //! | `/api/forge/prs/{number}`             | `prs/{number}`                        |
 //! | `/api/forge/prs/{number}/timeline`    | `prs/{number}/timeline`               |
@@ -37,6 +39,9 @@
 //! | `/api/forge/issues/{number}`          | `issues/{number}`                     |
 //! | `/api/forge/ci/runs`                  | `ci/runs`                             |
 //! | `/api/forge/ci/runs/{id}`             | `ci/runs/{id}`                        |
+//! | `/api/forge/discussions/meta`         | `discussions/meta`                    |
+//! | `/api/forge/discussions`              | `discussions`                         |
+//! | `/api/forge/discussions/{number}`     | `discussions/{number}`                |
 //! | `/api/reviews`                        | `reviews`                             |
 //! | `/api/reviews/{id}/stream`            | `reviews/{id}/stream`                 |
 //!

--- a/src-tauri/src/lan/server.rs
+++ b/src-tauri/src/lan/server.rs
@@ -2,7 +2,7 @@
 //! shutdown for the LAN companion server.
 //!
 //! The router mounts EXACTLY the pairing routes plus the read-only routes
-//! (structural allowlist — see [`crate::lan::routes`]): the 17 read handlers,
+//! (structural allowlist — see [`crate::lan::routes`]): the 22 read handlers,
 //! mounted TWICE — once as the frozen active-repo ALIAS surface (`/api/repo/…`,
 //! `/api/forge/…`, `/api/reviews…`) and once under the SCOPED
 //! `/api/repos/{repoId}/…` surface — plus `GET /api/repos`; anything else 404s.
@@ -80,6 +80,8 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/repo/commits/{hash}/diff", get(git::commit_diff))
         .route("/api/repo/diff/working", get(git::diff_working))
         .route("/api/repo/diff/file", get(git::diff_file))
+        .route("/api/repo/tags", get(git::tags))
+        .route("/api/repo/todos", get(git::todos))
         .route("/api/forge/prs", get(forge::pr_list))
         .route("/api/forge/prs/{number}", get(forge::pr_view))
         .route("/api/forge/prs/{number}/timeline", get(forge::pr_timeline))
@@ -88,6 +90,12 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/forge/issues/{number}", get(forge::issue_view))
         .route("/api/forge/ci/runs", get(forge::ci_run_list))
         .route("/api/forge/ci/runs/{id}", get(forge::ci_run_view))
+        // Discussions (GitHub-only; the handlers gate non-GitHub hosts). matchit
+        // gives the static `discussions/meta` priority over `discussions/{number}`,
+        // so both mount safely regardless of order — don't "fix" the ordering.
+        .route("/api/forge/discussions/meta", get(forge::discussions_meta))
+        .route("/api/forge/discussions", get(forge::discussions_list))
+        .route("/api/forge/discussions/{number}", get(forge::discussions_view))
         // Live-monitoring: enumerate active agent streams + watch one over SSE.
         .route("/api/reviews", get(reviews::list))
         .route("/api/reviews/{id}/stream", get(reviews::stream))
@@ -110,6 +118,8 @@ pub fn build_router(state: RouterState) -> Router {
         )
         .route("/api/repos/{repoId}/diff/working", get(git::diff_working))
         .route("/api/repos/{repoId}/diff/file", get(git::diff_file))
+        .route("/api/repos/{repoId}/tags", get(git::tags))
+        .route("/api/repos/{repoId}/todos", get(git::todos))
         .route("/api/repos/{repoId}/prs", get(forge::pr_list))
         .route("/api/repos/{repoId}/prs/{number}", get(forge::pr_view))
         .route(
@@ -124,6 +134,15 @@ pub fn build_router(state: RouterState) -> Router {
         .route("/api/repos/{repoId}/issues/{number}", get(forge::issue_view))
         .route("/api/repos/{repoId}/ci/runs", get(forge::ci_run_list))
         .route("/api/repos/{repoId}/ci/runs/{id}", get(forge::ci_run_view))
+        .route(
+            "/api/repos/{repoId}/discussions/meta",
+            get(forge::discussions_meta),
+        )
+        .route("/api/repos/{repoId}/discussions", get(forge::discussions_list))
+        .route(
+            "/api/repos/{repoId}/discussions/{number}",
+            get(forge::discussions_view),
+        )
         .route("/api/repos/{repoId}/reviews", get(reviews::list))
         .route(
             "/api/repos/{repoId}/reviews/{id}/stream",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1691,12 +1691,22 @@ straight into the companion app — a bottom tab bar with **Status**, **PRs**, *
   place to catch up on a PR's conversation from your phone, not to reply.
 - **Issues** — the open-issue list; open one for its description, labels, assignees, and
   comment conversation, read-only.
+- **Discussions** — on GitHub repositories with Discussions enabled, the Issues tab gains
+  an **Issues | Discussions** switch: browse the discussion list (filterable by category),
+  and open one for its body and threaded comments — answered questions carry their
+  accepted-answer marker. The switch stays hidden on repositories whose host has no
+  Discussions, or where the feature is turned off.
 - **Changes** — the working tree's staged, changed, and untracked files; open a file for
   its diff.
 - **History** — the commit log; open a commit for its message and diff, or drill into a
   single file's changes.
 - **Branches** — the local branches, each with its upstream, ahead/behind divergence, and
   last-commit time (the current branch first).
+- **Tags** — the repository's tags, newest first, each with its message and commit; tap
+  one to jump to that commit.
+- **Code TODOs** — scan the working tree for **TODO / FIXME / HACK / BUG / XXX** comment
+  markers, grouped by file with line numbers; toggle which markers to include and rescan
+  on demand.
 - **CI** — recent workflow runs and their jobs.
 {{ai}}- **Agents** — everything your desktop is currently broadcasting: **AI PR reviews**
   and **agent sessions**. Open one to **watch it live** — the assistant's prose streams in


### PR DESCRIPTION
Extends the LAN phone companion with three more read-only surfaces — repository tags, a code-TODO scan, and GitHub Discussions — so a paired phone can browse them alongside the existing Status/PR/issue/history views. Tags and code TODOs are Status-hub drill-ins; Discussions is a segmented sibling under the Issues tab that self-hides on repos that can't serve it.

### LAN server routes (Rust)
- Adds `git::tags` and `git::todos` handlers in `src-tauri/src/lan/routes/git.rs`, delegating to `git_list_tags` and `git_todo_scan`; `todos` parses a comma-separated `markers` query (falling back to `DEFAULT_TODO_MARKERS`) and honors `maxHits`.
- Adds the Discussions handlers in `src-tauri/src/lan/routes/forge.rs` (`discussions_meta`, `discussions_list`, `discussions_view`) backed by the `gh_discussion_*` core fns, with a `discussions_allowed` host guard that short-circuits non-GitHub repos into a `400 { kind: "discussionsUnavailable" }` before any `gh` call.
- Mounts all five new handlers twice in `src-tauri/src/lan/server.rs` — under both the frozen `/api/repo…`/`/api/forge…` alias surface and the scoped `/api/repos/{repoId}/…` surface — and updates the structural-allowlist docs/count (17 → 22) in `src-tauri/src/lan/routes/mod.rs`.
- Adds tokio route tests in `src-tauri/src/lan/mod.rs` (with `git_in`/`git_in_at` helpers that pin commit dates for deterministic newest-first ordering) covering annotated/lightweight tag listing and default-marker TODO scanning.

### Companion screens & navigation (frontend)
- New `companion/src/screens/Tags.tsx`, `Todos.tsx`, and `Discussions.tsx` screens, plus the `IssuesDiscussionsSegment` control in `companion/src/components/tab-segment.tsx` that owns Discussions' data-driven visibility gating.
- Wires the new `tags`/`todos`/`discussions` tabs into routing and rendering across `companion/src/lib/router.ts` (scoped-only heads, discussion detail id) and `companion/src/App.tsx`; `companion/src/components/Chrome.tsx` highlights the Issues tab on discussion routes.
- Adds fetchers/types and query hooks in `companion/src/lib/api.ts` (`TagInfo`, `TodoScan`, `DiscussionMeta`/`DiscussionDetails` shapes, `isDiscussionsUnavailable`) and `companion/src/lib/queries.ts` (`useTags`, `useTodoScan`, `useDiscussionMeta`, `useDiscussions`, `useDiscussion`).
- Surfaces the new views on the hub in `companion/src/screens/Status.tsx` (a Tags glance + a static Code TODOs entry) and hoists the Discussions segment above the Issues states in `companion/src/screens/Issues.tsx`.

### Documentation
- Extends the companion changelog fragment `changelog.d/added-lan-companion-preview.md` to mention tags, code TODOs, and GitHub Discussions.