### PR TITLE
feat(repository): locate a moved repo and re-home its app data

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ scaffolding), publish to GitHub, and fork.
   for an unrecognized remote, a folder for local-only — and a visibility icon: lock /
   buildings / globe for private / internal / public), aliases, and recycle-bin-safe
   removal. Star or unstar from the menu.
+- **Locate a moved repository** — when a repo's folder moves on disk, point GitDesktop at
+  its new home from the "no longer a git repository" notice; after you confirm the folder,
+  the entry keeps its alias and badges, and its local PRs, issues, review history, and
+  automations follow along.
 - **GitHub repo settings** (admin) — description & topics (with AI suggestions), merge
   options and default commit messages, template & forking, **collaborators &
   invitations**, **branch rulesets** (create/edit, reversible enable/disable), **code

--- a/changelog.d/added-relocate-missing-repo.md
+++ b/changelog.d/added-relocate-missing-repo.md
@@ -1,0 +1,5 @@
+- **Locate a moved repository.** Moved a repo on disk? The "no longer a git
+  repository" notice now offers **Locate…** to point GitDesktop at the folder's
+  new location — the entry keeps its alias, badges, and settings, and its app data
+  (local PRs and issues, review history, automations, and any Jira link) follows the
+  repo to its new home — alongside the existing Remove.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -290,6 +290,12 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
+    label:
+      "Locate a moved repo — repoint the entry and bring its local PRs, issues, review history & automations along",
+    ai: false,
+  },
+  {
+    group: "Repository & workspace",
     label: "Worktree manager — create, switch, promote & remove",
     highlight: true,
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ConfirmDialogHost } from "@/components/confirm-dialog-host";
 import { Spinner } from "@/components/ui/spinner";
 import { ReconnectDialog } from "@/features/accounts/ReconnectDialog";
 import { ActivityStrip } from "@/features/activity/ActivityDock";
@@ -205,6 +206,7 @@ function App() {
         <ActivityStrip />
       </div>
       <AutomationResultDialog />
+      <ConfirmDialogHost />
       <ReconnectDialog />
       <UpdateChecker />
       <WhatsNew />

--- a/src/components/confirm-dialog-host.tsx
+++ b/src/components/confirm-dialog-host.tsx
@@ -1,0 +1,25 @@
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { useConfirm } from "@/lib/stores/confirm";
+
+/**
+ * The single app-root host for {@link useConfirm}. Renders the pending
+ * confirmation request (if any) as a {@link ConfirmDialog}, so non-JSX callers
+ * (shared hooks, imperative handlers) can `await useConfirm.getState().ask(...)`.
+ * Mounted once in `App`; Cancel/Esc resolve the promise `false`, Confirm `true`.
+ */
+export function ConfirmDialogHost() {
+  const request = useConfirm((s) => s.request);
+  const answer = useConfirm((s) => s.answer);
+
+  return (
+    <ConfirmDialog
+      open={request !== null}
+      onCancel={() => answer(false)}
+      onConfirm={() => answer(true)}
+      title={request?.title ?? ""}
+      body={request?.body ?? ""}
+      confirmLabel={request?.confirmLabel ?? ""}
+      confirmVariant={request?.confirmVariant ?? "default"}
+    />
+  );
+}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -105,6 +105,10 @@ unrecognized host, a folder for a local-only repo) and, once resolved, a trailin
 **visibility** icon — a lock (private), buildings (internal), or globe (public) — plus a
 **fork** glyph when the repo is a fork of another (hover it for the upstream repo).
 
+If a repo's folder was moved or deleted, opening it offers to **Locate…** its new folder
+(keeping its alias and settings, and bringing its local PRs and issues, review history, and
+automations along to the new location) or **Remove** it from the list.
+
 ## The repository menu
 
 Click the **⋮** menu next to the repo name for repo-wide actions:

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -105,9 +105,10 @@ unrecognized host, a folder for a local-only repo) and, once resolved, a trailin
 **visibility** icon — a lock (private), buildings (internal), or globe (public) — plus a
 **fork** glyph when the repo is a fork of another (hover it for the upstream repo).
 
-If a repo's folder was moved or deleted, opening it offers to **Locate…** its new folder
-(keeping its alias and settings, and bringing its local PRs and issues, review history, and
-automations along to the new location) or **Remove** it from the list.
+If a repo's folder was moved or deleted, opening it offers to **Locate…** its new folder or
+**Remove** it from the list. After you confirm the folder, the entry keeps its alias and
+settings, and its local PRs and issues, review history, and automations follow along to the
+new location.
 
 ## The repository menu
 

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -3,37 +3,93 @@ import { useCallback } from "react";
 import { toast } from "sonner";
 import { track } from "@/lib/analytics";
 import { validateRepo } from "@/lib/git/api";
-import { useAddRecentRepo, useRemoveRecentRepo } from "@/lib/settings/queries";
+import type { RepoInfo } from "@/lib/git/types";
+import { migrateRepoData } from "@/lib/repo-data-migration";
+import {
+  useAddRecentRepo,
+  useRelocateRecentRepo,
+  useRemoveRecentRepo,
+} from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
 
 /**
  * Opens a repository by path: validates it, records it in recents, and switches
- * the app to it. A path that's no longer a git repo offers a "Remove" toast.
+ * the app to it. A path that's no longer a git repo offers a toast to **Locate…**
+ * the folder's new home (moved on disk) or **Remove** the stale row.
  * Shared by the welcome list and the in-app repo switcher.
  */
 export function useOpenRepoByPath() {
   const openRepo = useUiStore((s) => s.openRepo);
   const addRecent = useAddRecentRepo();
   const removeRecent = useRemoveRecentRepo();
+  const relocate = useRelocateRecentRepo();
+
+  // Shared tail for every successful open: record in recents (best-effort — a
+  // settings-write failure must never block opening), switch to the repo, track.
+  // Awaiting the recents write means the row exists before RepositoryView mounts
+  // and its open-time visibility probe persists onto it.
+  const recordOpenAndTrack = useCallback(
+    async (info: RepoInfo, source: "recent" | "picker" | "relocate") => {
+      await addRecent
+        .mutateAsync({ path: info.root, name: info.name })
+        .catch(() => undefined);
+      openRepo(info);
+      track({ name: "repo_opened", properties: { source } });
+    },
+    [addRecent, openRepo],
+  );
+
+  // A recents row whose folder moved: pick the new folder, validate it, repoint
+  // the existing row in place (preserving alias + probed metadata), then open.
+  const locateAndReopen = useCallback(
+    async (oldPath: string) => {
+      const picked = await openDialog({
+        directory: true,
+        title: "Locate repository",
+      });
+      if (typeof picked !== "string") return;
+      try {
+        const info = await validateRepo(picked);
+        // Best-effort, like the addRecent write below — a settings failure must
+        // never block opening. Repoint before addRecent so the follow-up write
+        // finds the row at its new path and just refreshes name/order.
+        await relocate
+          .mutateAsync({ oldPath, newPath: info.root })
+          .catch(() => undefined);
+        // Re-home every per-repo app-data store (local PRs/issues, review history,
+        // automations, Jira link, …) onto the new location's identity key. Purely
+        // best-effort — a migration failure must never block opening the repo.
+        await migrateRepoData(oldPath, info.root).catch(() => undefined);
+        await recordOpenAndTrack(info, "relocate");
+      } catch (e) {
+        if (isAppError(e) && e.kind === "notARepo") {
+          // The picked folder isn't a repo — no Locate/Remove actions here (no
+          // recursion; the original row is still in the list to re-offer).
+          toast.error(`${picked} is not a git repository.`);
+        } else {
+          toastError(e);
+        }
+      }
+    },
+    [relocate, recordOpenAndTrack],
+  );
 
   return useCallback(
     async (path: string, source: "recent" | "picker" = "recent") => {
       try {
         const info = await validateRepo(path);
-        // Await the recents write so the row exists before RepositoryView mounts
-        // and its open-time visibility probe persists onto it (best-effort — a
-        // settings-write failure must never block opening the repo).
-        await addRecent
-          .mutateAsync({ path: info.root, name: info.name })
-          .catch(() => undefined);
-        openRepo(info);
-        track({ name: "repo_opened", properties: { source } });
+        await recordOpenAndTrack(info, source);
       } catch (e) {
         if (isAppError(e) && e.kind === "notARepo") {
           toast.error(`${path} is no longer a git repository.`, {
+            duration: 10_000,
             action: {
+              label: "Locate…",
+              onClick: () => void locateAndReopen(path),
+            },
+            cancel: {
               label: "Remove",
               onClick: () => removeRecent.mutate(path),
             },
@@ -43,7 +99,7 @@ export function useOpenRepoByPath() {
         }
       }
     },
-    [openRepo, addRecent, removeRecent],
+    [recordOpenAndTrack, locateAndReopen, removeRecent],
   );
 }
 

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -9,7 +9,9 @@ import {
   useAddRecentRepo,
   useRelocateRecentRepo,
   useRemoveRecentRepo,
+  useSettings,
 } from "@/lib/settings/queries";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
@@ -25,6 +27,8 @@ export function useOpenRepoByPath() {
   const addRecent = useAddRecentRepo();
   const removeRecent = useRemoveRecentRepo();
   const relocate = useRelocateRecentRepo();
+  const settings = useSettings();
+  const recentRepos = settings.data?.recentRepos;
 
   // Shared tail for every successful open: record in recents (best-effort — a
   // settings-write failure must never block opening), switch to the repo, track.
@@ -52,6 +56,23 @@ export function useOpenRepoByPath() {
       if (typeof picked !== "string") return;
       try {
         const info = await validateRepo(picked);
+        // Any git repo validates, but the OLD folder is gone so we can't verify
+        // it's the SAME repo — picking a different one would irreversibly fold
+        // this repo's app data into another's identity keys. Confirm first (the
+        // house rule for destructive paths). The name comes from the recents row
+        // (alias or name), else the moved folder's basename.
+        const oldRow = recentRepos?.find((r) => r.path === oldPath);
+        const oldName =
+          oldRow?.alias?.trim() ||
+          oldRow?.name ||
+          oldPath.split(/[/\\]/).pop() ||
+          oldPath;
+        const confirmed = await useConfirm.getState().ask({
+          title: `Relocate "${oldName}"?`,
+          body: `GitDesktop will point this entry at ${info.root} — its alias, local PRs, issues, review history, and settings will follow the folder. If this is a different repository, that data is merged in and can't be undone.`,
+          confirmLabel: "Relocate",
+        });
+        if (!confirmed) return;
         // Best-effort, like the addRecent write below — a settings failure must
         // never block opening. Repoint before addRecent so the follow-up write
         // finds the row at its new path and just refreshes name/order.
@@ -73,7 +94,7 @@ export function useOpenRepoByPath() {
         }
       }
     },
-    [relocate, recordOpenAndTrack],
+    [relocate, recordOpenAndTrack, recentRepos],
   );
 
   return useCallback(

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -10,7 +10,9 @@ export type AnalyticsEvent =
   | { name: "screen_viewed"; properties: { screen: string } }
   | {
       name: "repo_opened";
-      properties: { source: "recent" | "clone" | "create" | "picker" };
+      properties: {
+        source: "recent" | "clone" | "create" | "picker" | "relocate";
+      };
     }
   | {
       name: "commit_created";

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -55,6 +55,12 @@ import { storeName } from "@/lib/test-mode";
 // whole-object write-back. The window is milliseconds wide and requires relocating
 // a repo at the exact moment a background writer fires; it matches the risk the
 // MCP-vs-GUI dual-writer stores already carry by design (reload-before-mutate).
+//
+// **Accepted residual — no retry:** when a single store throws mid-migration its
+// old-key data is orphaned permanently — nothing re-attempts the move on the next
+// reopen. The stores' own legacy folding only re-homes the *current* checkout's
+// raw-path key onto its identity, never the departed `<oldPath>/.git` key, so a
+// failed store stays split at the old location.
 
 /** Load a store with the exact shared-instance options every feature module uses,
  *  so we mutate the same cached instance rather than a private copy. */
@@ -123,8 +129,9 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 /** Merge two id-bearing arrays: keep-array records first, append old records whose
- *  id isn't already present. Non-object/idless entries in the old array are dropped
- *  (they can't be de-duped and shouldn't shadow real records). */
+ *  id isn't already present. Non-object entries in the old array are dropped (they
+ *  can't be de-duped); an idless object still passes `isRecord` and is kept (its
+ *  `id` is `undefined`, so at most one idless old record survives per merge). */
 function mergeIds(keep: unknown[], old: unknown[]): unknown[] {
   const seen = new Set(
     keep.filter((r): r is { id: unknown } => isRecord(r)).map((r) => r.id),
@@ -194,6 +201,8 @@ function combine(
     return Object.keys(result).length > 0 ? result : undefined;
   }
   // keep-new: the new key's value wins when present; else the first old value.
+  // `undefined` IS the missing-key sentinel: plugin-store's `get` maps absent
+  // keys to undefined (dist-js: `return exists ? value : undefined`), never null.
   return newVal !== undefined ? newVal : oldVals[0];
 }
 

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -1,0 +1,296 @@
+import { load } from "@tauri-apps/plugin-store";
+import { repoIdentity } from "@/lib/git/repo-identity";
+import { storeName } from "@/lib/test-mode";
+
+// Best-effort migration of every per-repo app-data store when a recents row is
+// *relocated* — the user pointed GitDesktop at a repo's new folder after it moved
+// on disk (see features/repository/useOpenRepoByPath.ts). The relocate row-rewrite
+// only moves the settings.json recents entry; every other per-repo store still keys
+// its data under the OLD location, which would orphan the repo's local PRs/issues,
+// review history + drafts, review notes, automations config, Jira link, etc. This
+// re-homes each store's entries onto the new identity key.
+//
+// **Why TS-side, not Rust:** every store here is a `@tauri-apps/plugin-store` file
+// that returns ONE shared instance per file app-wide. Loading a file here via the
+// same `storeName()` wrapper + load options mutates the exact instance the feature
+// modules cache, so the change is coherent with their in-memory state (a Rust-side
+// file rewrite behind the plugin's back would be silently overwritten on the next
+// autosave). We `reload()` before each mutation because `local-prs.json` and
+// `review-notes.json` are also written by the Rust MCP server — reload-before-mutate
+// is the repo's established reconcile pattern, and it's harmless for the rest.
+//
+// **Why the old key can't be recomputed:** a repo's identity key is
+// `git rev-parse --git-common-dir` on its checkout, but the old folder no longer
+// exists so git can't resolve it. Instead we match stored keys against the old path
+// in its two possible on-disk forms:
+//   - the identity form of a main checkout: `<oldPath>/.git`
+//   - a legacy raw-path key or an identity-fallback key: `<oldPath>` verbatim
+// (both forms may coexist across stores, or even within one store, so we collect
+// ALL matches). Matching is case-insensitive because Windows paths differ in case
+// in the wild (e.g. `C:\temp` vs `C:\Temp`); a false merge would require two
+// distinct repos on a case-sensitive filesystem at paths differing only by case,
+// one of them at the exact old location of an explicitly relocated row —
+// acceptable and documented.
+//
+// **Merge classes** (how an old value combines with any value already under the
+// new key):
+//   - `id-merge`   — arrays of `{ id }` records: keep new-key records, append old
+//                    records whose id isn't already present.
+//   - `inner-key`  — `Record`-valued maps: spread old then new, so the new key's
+//                    inner entries win per inner key.
+//   - `keep-new`   — single values: keep the new-key value if present, else move
+//                    the old one.
+// plans.json / research.json are handled separately: their items carry a RAW
+// checkout `repoPath` (not an identity key), rewritten from old to new in place.
+//
+// **Deliberate exclusions:** settings.json (the relocate row-rewrite already moved
+// it); sessions/*.jsonl (Rust-owned append-only, and a moved repo's session
+// worktrees are broken at the git level regardless); notifications.json (transient
+// 50-cap inbox); scripts / analytics / agent-numbers / jira-field-maps (global or
+// per-site, not per-repo).
+//
+// **Accepted residual — concurrent writers:** this surgery runs outside the feature
+// modules' own serialized write queues, so a peer write landing between a store's
+// `reload()` and `save()` (an automation runner, an MCP-server write) loses to our
+// whole-object write-back. The window is milliseconds wide and requires relocating
+// a repo at the exact moment a background writer fires; it matches the risk the
+// MCP-vs-GUI dual-writer stores already carry by design (reload-before-mutate).
+
+/** Load a store with the exact shared-instance options every feature module uses,
+ *  so we mutate the same cached instance rather than a private copy. */
+function loadStore(file: string) {
+  return load(storeName(file), { autoSave: true, defaults: {} });
+}
+
+/** Normalize a path/key for comparison: forward slashes, no trailing slash,
+ *  lower-cased (Windows paths differ in case in the wild). */
+function norm(s: string): string {
+  return s.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/** How a store's per-repo values combine when both the old and new keys hold data. */
+type MergeClass = "id-merge" | "inner-key" | "keep-new";
+
+/** An identity-keyed store: a top-level `Record<repoKey, V>` we re-home by key. */
+interface IdentityStore {
+  file: string;
+  merge: MergeClass;
+  /** For nested layouts (automations.json), the top-level key holding the config
+   *  object, plus how to read/write the per-repo `Record<repoKey, V>` within it. */
+  nested?: {
+    configKey: string;
+    getMap: (
+      config: Record<string, unknown>,
+    ) => Record<string, unknown> | undefined;
+  };
+}
+
+const IDENTITY_STORES: IdentityStore[] = [
+  { file: "local-prs.json", merge: "id-merge" },
+  { file: "local-issues.json", merge: "id-merge" },
+  { file: "pr-reviews.json", merge: "id-merge" },
+  { file: "pr-review-drafts.json", merge: "inner-key" },
+  { file: "review-notes.json", merge: "inner-key" },
+  { file: "automation-dismissals.json", merge: "inner-key" },
+  { file: "own-comments-digest.json", merge: "inner-key" },
+  { file: "jira-links.json", merge: "keep-new" },
+  { file: "repo-lens.json", merge: "keep-new" },
+  { file: "branch-rules.json", merge: "keep-new" },
+  {
+    file: "automations.json",
+    merge: "keep-new",
+    nested: {
+      configKey: "config",
+      getMap: (config) => {
+        const repos = (config as { repos?: unknown }).repos;
+        return repos && typeof repos === "object" && !Array.isArray(repos)
+          ? (repos as Record<string, unknown>)
+          : undefined;
+      },
+    },
+  },
+];
+
+/** plans.json / research.json: `Record<topKey, Item[]>` whose items carry a raw
+ *  checkout `repoPath` field (not an identity key). */
+const RAW_PATH_STORES: { file: string; key: string }[] = [
+  { file: "plans.json", key: "plans" },
+  { file: "research.json", key: "research" },
+];
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+/** Merge two id-bearing arrays: keep-array records first, append old records whose
+ *  id isn't already present. Non-object/idless entries in the old array are dropped
+ *  (they can't be de-duped and shouldn't shadow real records). */
+function mergeIds(keep: unknown[], old: unknown[]): unknown[] {
+  const seen = new Set(
+    keep.filter((r): r is { id: unknown } => isRecord(r)).map((r) => r.id),
+  );
+  const extra = old.filter(
+    (r): r is { id: unknown } =>
+      isRecord(r) && !seen.has((r as { id: unknown }).id),
+  );
+  return [...keep, ...extra];
+}
+
+/** Collect the old-key candidates present in `keys` that match `oldPath` (either
+ *  the `<oldPath>/.git` identity form or the raw `<oldPath>` form), ordered so the
+ *  `/.git` form comes first (it wins on inner-value collisions). Never returns
+ *  `newKey` itself. */
+function matchingOldKeys(
+  keys: string[],
+  oldPath: string,
+  newKey: string,
+): string[] {
+  const dotGit = `${norm(oldPath)}/.git`;
+  const raw = norm(oldPath);
+  const newNorm = norm(newKey);
+  const gitForm: string[] = [];
+  const rawForm: string[] = [];
+  for (const k of keys) {
+    const nk = norm(k);
+    if (nk === newNorm) continue;
+    if (nk === dotGit) gitForm.push(k);
+    else if (nk === raw) rawForm.push(k);
+  }
+  // `/.git`-form values win over raw-form on collision, so list them first.
+  return [...gitForm, ...rawForm];
+}
+
+/** Fold the values under all matched old keys into one, per the merge class (the
+ *  first-listed old key, the `/.git` form, wins on collision), then combine that
+ *  onto whatever's under `newKey`. Returns the value to store under `newKey`, or
+ *  `undefined` when the combined result should NOT create an entry (empty map). */
+function combine(
+  merge: MergeClass,
+  newVal: unknown,
+  oldVals: unknown[],
+): unknown {
+  if (merge === "id-merge") {
+    const keep = Array.isArray(newVal) ? newVal : [];
+    // Fold the old arrays together first (the `/.git` form, oldVals[0], wins on a
+    // shared id since it's the accumulator base), then fold that onto the new key.
+    let mergedOld: unknown[] = [];
+    for (const v of oldVals) {
+      if (Array.isArray(v)) mergedOld = mergeIds(mergedOld, v);
+    }
+    return mergeIds(keep, mergedOld);
+  }
+  if (merge === "inner-key") {
+    // Fold old maps together with the first-listed (`/.git`) form winning, then
+    // let the new key's inner entries win over all of them.
+    const mergedOld: Record<string, unknown> = {};
+    // Iterate in reverse so earlier-listed old keys overwrite later ones.
+    for (let i = oldVals.length - 1; i >= 0; i--) {
+      const v = oldVals[i];
+      if (isRecord(v)) Object.assign(mergedOld, v);
+    }
+    const newInner = isRecord(newVal) ? newVal : {};
+    const result = { ...mergedOld, ...newInner };
+    // Empty map → don't create an entry (review-notes treats empty as delete).
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+  // keep-new: the new key's value wins when present; else the first old value.
+  return newVal !== undefined ? newVal : oldVals[0];
+}
+
+/** Migrate one identity-keyed store (optionally nested inside a config object). */
+async function migrateIdentityStore(
+  desc: IdentityStore,
+  oldPath: string,
+  newKey: string,
+): Promise<void> {
+  const store = await loadStore(desc.file);
+  await store.reload();
+
+  if (desc.nested) {
+    const { configKey, getMap } = desc.nested;
+    const config = await store.get<unknown>(configKey);
+    if (!isRecord(config)) return;
+    const map = getMap(config);
+    if (!isRecord(map)) return;
+    const oldKeys = matchingOldKeys(Object.keys(map), oldPath, newKey);
+    if (oldKeys.length === 0) return;
+    const oldVals = oldKeys.map((k) => map[k]);
+    const combined = combine(desc.merge, map[newKey], oldVals);
+    if (combined !== undefined) map[newKey] = combined;
+    for (const k of oldKeys) delete map[k];
+    await store.set(configKey, config);
+    await store.save();
+    return;
+  }
+
+  const oldKeys = matchingOldKeys(await store.keys(), oldPath, newKey);
+  if (oldKeys.length === 0) return;
+  const oldVals = await Promise.all(oldKeys.map((k) => store.get<unknown>(k)));
+  const newVal = await store.get<unknown>(newKey);
+  const combined = combine(desc.merge, newVal, oldVals);
+  if (combined !== undefined) await store.set(newKey, combined);
+  for (const k of oldKeys) await store.delete(k);
+  await store.save();
+}
+
+/** Migrate one raw-path store: rewrite each item's `repoPath` from old to new. */
+async function migrateRawPathStore(
+  file: string,
+  key: string,
+  oldPath: string,
+  newPath: string,
+): Promise<void> {
+  const store = await loadStore(file);
+  await store.reload();
+  const items = await store.get<unknown>(key);
+  if (!Array.isArray(items)) return;
+  const rawOld = norm(oldPath);
+  let changed = false;
+  for (const item of items) {
+    if (
+      isRecord(item) &&
+      typeof item.repoPath === "string" &&
+      norm(item.repoPath) === rawOld
+    ) {
+      item.repoPath = newPath;
+      changed = true;
+    }
+  }
+  if (!changed) return;
+  await store.set(key, items);
+  await store.save();
+}
+
+/**
+ * Re-home every per-repo app-data store from `oldPath` to `newPath` after a repo
+ * was relocated on disk. Best-effort and never throws: each store is migrated in
+ * its own try/catch (a corrupt store can't sink the rest), and the whole function
+ * has a top-level catch. Skips any store where nothing matches — it never rewrites
+ * a file that didn't change.
+ */
+export async function migrateRepoData(
+  oldPath: string,
+  newPath: string,
+): Promise<void> {
+  try {
+    // Even a fallback (raw-path) new key is fine to proceed with — the stores' own
+    // legacy folding will re-home it onto the true identity later.
+    const newKey = await repoIdentity(newPath);
+    for (const desc of IDENTITY_STORES) {
+      try {
+        await migrateIdentityStore(desc, oldPath, newKey);
+      } catch {
+        // Unreadable/corrupt store — skip it, migrate the rest.
+      }
+    }
+    for (const { file, key } of RAW_PATH_STORES) {
+      try {
+        await migrateRawPathStore(file, key, oldPath, newPath);
+      } catch {
+        // Unreadable/corrupt store — skip it, migrate the rest.
+      }
+    }
+  } catch {
+    // Identity resolution or anything unforeseen — the open must never block on us.
+  }
+}

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -633,6 +633,67 @@ export function removeRecentRepo(path: string): Promise<void> {
 }
 
 /**
+ * Repoints a recent-repo row from `oldPath` to `newPath` when the folder was
+ * moved on disk. Rides the same serialized RMW chain as the other recent-repo
+ * writes (the lost-update race above is real).
+ *
+ * This ONLY rewrites the row's `path` — it deliberately leaves `name`,
+ * `lastOpenedAt`, list order, and every derived field (alias/owner/host/
+ * provider/visibility/isFork/forkParent) untouched. The `name`/`lastOpenedAt`
+ * refresh and the move-to-front happen in the standard `addRecentRepo` call that
+ * follows in the open flow; carrying the derived fields verbatim avoids
+ * reintroducing the wipe-on-reopen class fixed in `addRecentRepo` (see the
+ * comment there). Any staleness (the user pointed at a different repo) self-
+ * corrects: the open-time visibility probe re-persists owner + visibility on
+ * every open (see probeAndPersistVisibility).
+ *
+ * Cases:
+ *   - No row at `oldPath` (removed concurrently): no-op — the follow-up
+ *     `addRecentRepo` creates a fresh entry anyway.
+ *   - A row ALREADY exists at `newPath` (the user previously opened the repo at
+ *     its new location, so a broken old row and a live new row coexist): MERGE —
+ *     drop the old row, keep the new-path row in place, and carry the old row's
+ *     alias onto it only when the new row has none. Never leave two rows for one
+ *     path.
+ *   - Otherwise: rewrite the old row in place as `{ ...old, path: newPath }`.
+ */
+export function relocateRecentRepo(
+  oldPath: string,
+  newPath: string,
+): Promise<void> {
+  return serializedRecentRepoWrite(async () => {
+    const settings = await loadSettings();
+    // Windows paths are case-insensitive; compare them that way (see addRecentRepo).
+    const samePath = (a: string, b: string) =>
+      a.toLowerCase() === b.toLowerCase();
+    // Picking the folder at its ORIGINAL path (repo restored / moved back) is a
+    // no-op — the row already points there. Without this guard the merge branch
+    // below would match the row as both `old` and `existing` and drop it.
+    if (samePath(oldPath, newPath)) return;
+    const old = settings.recentRepos.find((r) => samePath(r.path, oldPath));
+    if (!old) return;
+    const existing = settings.recentRepos.find((r) =>
+      samePath(r.path, newPath),
+    );
+    const recentRepos = existing
+      ? // Merge: keep the live new-path row in place, drop the broken old row,
+        // and adopt the old alias only when the new row has none of its own.
+        settings.recentRepos
+          .filter((r) => !samePath(r.path, oldPath))
+          .map((r) =>
+            samePath(r.path, newPath)
+              ? { ...r, alias: existing.alias ?? old.alias }
+              : r,
+          )
+      : // Rewrite the old row in place — everything but `path` stays put.
+        settings.recentRepos.map((r) =>
+          samePath(r.path, oldPath) ? { ...r, path: newPath } : r,
+        );
+    await saveSettings({ ...settings, recentRepos });
+  });
+}
+
+/**
  * Sets (or clears, with null) the optional Bitbucket token expiry date. Rides the
  * same serialized load→modify→save chain as the recent-repo writes above: it's a
  * top-level settings RMW that writes the whole `settings` object, so running it

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -10,6 +10,7 @@ import {
   addRecentRepo,
   loadSettings,
   persistRepoOwners,
+  relocateRecentRepo,
   removeRecentRepo,
   saveSettings,
   setRepoAlias,
@@ -181,6 +182,18 @@ export function useRemoveRecentRepo() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (path: string) => removeRecentRepo(path),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
+  });
+}
+
+/** Repoints a recent-repo row to a moved folder's new path (see
+ *  `relocateRecentRepo`). */
+export function useRelocateRecentRepo() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { oldPath: string; newPath: string }) =>
+      relocateRecentRepo(args.oldPath, args.newPath),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
   });

--- a/src/lib/stores/confirm.ts
+++ b/src/lib/stores/confirm.ts
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { create } from "zustand";
+
+/** A pending confirmation request awaiting the user's Cancel/Confirm. */
+interface ConfirmRequest {
+  title: ReactNode;
+  body: ReactNode;
+  confirmLabel: ReactNode;
+  confirmVariant: "default" | "destructive";
+  /** Settles the `confirm()` promise: `true` = confirmed, `false` = cancelled. */
+  resolve: (ok: boolean) => void;
+}
+
+interface ConfirmState {
+  request: ConfirmRequest | null;
+  /** Open the confirm dialog and resolve when the user answers. Called from
+   *  non-JSX code (hooks, event handlers) that can't render a dialog itself. */
+  ask: (
+    opts: Omit<ConfirmRequest, "resolve" | "confirmVariant"> & {
+      confirmVariant?: "default" | "destructive";
+    },
+  ) => Promise<boolean>;
+  /** Answer the current request (host-only); a no-op if none is pending. */
+  answer: (ok: boolean) => void;
+}
+
+/**
+ * A promise-based confirmation prompt for code that has no JSX of its own (shared
+ * hooks, imperative handlers). Call `useConfirm.getState().ask({...})` and await
+ * the boolean; a single {@link ConfirmDialogHost} mounted at the app root renders
+ * the actual dialog. Only one request is live at a time — asking again while one
+ * is pending cancels (resolves `false`) the previous one.
+ */
+export const useConfirm = create<ConfirmState>()((set, get) => ({
+  request: null,
+  ask: (opts) => {
+    // A new ask supersedes any in-flight one — cancel the old so its awaiter
+    // doesn't hang forever.
+    get().request?.resolve(false);
+    return new Promise<boolean>((resolve) => {
+      set({
+        request: {
+          confirmVariant: "default",
+          ...opts,
+          resolve: (ok) => {
+            set({ request: null });
+            resolve(ok);
+          },
+        },
+      });
+    });
+  },
+  answer: (ok) => get().request?.resolve(ok),
+}));


### PR DESCRIPTION
When a repository's folder is moved on disk, GitDesktop previously could only offer to **Remove** the now-broken recents row, discarding the entry's alias, badges, settings, and all of its per-repo app data. This adds a **Locate…** action to that flow so the user can point GitDesktop at the folder's new home, keeping the existing entry intact and carrying its local PRs/issues, review history, automations, and Jira link along to the new location.

### Open flow & UI

- Reworks `src/features/repository/useOpenRepoByPath.ts` so the "no longer a git repository" toast now offers **Locate…** (as the primary action, alongside the existing **Remove** as the cancel action) and extends the toast `duration` to 10s.
- Adds a `locateAndReopen` helper that prompts for the new folder, validates it, repoints the recents row, migrates the repo's app data, then opens it; a picked folder that isn't a repo surfaces a plain error with no recursive Locate/Remove actions.
- Extracts the shared success tail into a `recordOpenAndTrack` callback (record in recents best-effort → open → track), reused by both the normal open path and the relocate path.

### Settings layer

- Adds `relocateRecentRepo` in `src/lib/settings/api.ts`, which rides the same serialized read-modify-write chain as the other recent-repo writes and rewrites only the row's `path`, deliberately preserving `name`, `lastOpenedAt`, order, and every derived field (alias/owner/host/provider/visibility/isFork/forkParent). It handles the missing-old-row, existing-new-row (merge, adopting the old alias only when the new row lacks one), and same-path no-op cases.
- Exposes it through a `useRelocateRecentRepo` mutation hook in `src/lib/settings/queries.ts` that invalidates the settings query on success.

### App-data migration

- Adds `src/lib/repo-data-migration.ts` with `migrateRepoData(oldPath, newPath)`, a best-effort, never-throwing routine that re-homes every per-repo `@tauri-apps/plugin-store` file from the old identity key to the new one. It defines an `IDENTITY_STORES` table with per-store merge classes (`id-merge`, `inner-key`, `keep-new`, plus a nested layout for `automations.json`) and a `RAW_PATH_STORES` table for `plans.json`/`research.json` whose items carry a raw checkout `repoPath`.
- Matches old keys in both their `<oldPath>/.git` identity form and raw `<oldPath>` form (case-insensitively), reloads each store before mutating to stay coherent with the Rust MCP writers, and migrates each store in its own try/catch so a corrupt store can't sink the rest. The module header documents the deliberate exclusions (settings, sessions, notifications, global stores) and the accepted concurrent-writer residual.

### Analytics & docs

- Adds `"relocate"` to the `repo_opened` event `source` union in `src/lib/analytics/track.ts`.
- Documents the Locate…/Remove choice in the repository section of `src/features/help/content.ts`.
- Adds the `changelog.d/added-relocate-missing-repo.md` fragment describing the new capability.