### PR TITLE
feat(sessions,sandbox): pick worktree or container per session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dist-ssr
 /claude_strings.txt
 /conductor.md
 /.playwright-mcp/
+/.env.claude

--- a/README.md
+++ b/README.md
@@ -171,9 +171,11 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   - **Several at once** — organized into **Active** and **Kept** tabs, searchable, with
     a notification when each finishes
   - **Sandbox** — confine writes to a **Docker/Podman container** (or rely on each CLI's
-    own worktree confinement on the host), and add per-repo tools (e.g. Playwright) via
-    a committed `.gitdesktop/agent.Dockerfile` that GitDesktop builds into a per-repo
-    image after you confirm it
+    own worktree confinement on the host), pick worktree or container **per session**
+    from the composer's **Options** (with an inline readiness check before it starts),
+    and add per-repo tools (e.g. Playwright) via a committed
+    `.gitdesktop/agent.Dockerfile` that GitDesktop builds into a per-repo image after you
+    confirm it
   - **Drive each turn** — **slash commands and skills** (built-in starters, custom
     commands, and the agent's own commands and **Agent Skills** — project *and* global,
     incl. the shared `.agents/skills`), `@file` mentions, a model/effort picker, and

--- a/changelog.d/added-per-session-isolation.md
+++ b/changelog.d/added-per-session-isolation.md
@@ -1,0 +1,6 @@
+- **Per-session isolation.** Pick **Worktree** or **Container** for a single agent session
+  from the composer's **Options**, overriding your Settings → AI default for that one run
+  (Best-of-N arms share the pick). Choosing a container checks readiness inline — Docker or
+  Podman installed, the engine running, the agent image built — and keeps **Send** disabled
+  until it is, naming what's missing and offering a jump to Settings where that's what it
+  takes to fix it.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -497,7 +497,8 @@ export const capabilities: Capability[] = [
   {
     group: "AI · agents & sessions",
     ai: true,
-    label: "Run agents in a Docker/Podman sandbox (opt-in)",
+    label:
+      "Run agents in a Docker/Podman sandbox (opt-in), per session or by default",
   },
   {
     group: "AI · agents & sessions",

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -2195,20 +2195,21 @@ pub async fn agent_session(
         let (runtime, runtime_name) = crate::agent_sandbox::detect_runtime().await.ok_or_else(|| {
             AppError::Command("Container isolation is on for this session, but Docker/Podman isn't available. Install and start it — or start a new session with Isolation set to Worktree (composer → Options), or turn container isolation off in Settings → AI.".to_string())
         })?;
-        // The binary being on PATH doesn't mean the engine is up — probe it here so a
-        // stopped daemon reports itself instead of surfacing as "image isn't built yet"
-        // (every check below needs the daemon).
-        if !crate::agent_sandbox::runtime_ready(&runtime).await {
-            let label = if runtime_name == "podman" {
-                "Podman"
-            } else {
-                "Docker"
-            };
-            return Err(AppError::Command(format!(
-                "{label} is installed but its engine isn't running. Start it, then try again."
-            )));
-        }
         if !crate::agent_sandbox::image_present(&runtime).await {
+            // `image inspect` needs the daemon, so a stopped engine fails here too — but
+            // this whole branch runs on EVERY turn, so the daemon probe is deliberately on
+            // the failure path only: a healthy session pays nothing, and a failing one
+            // still tells "engine stopped" apart from "image never built".
+            if !crate::agent_sandbox::runtime_ready(&runtime).await {
+                let label = if runtime_name == "podman" {
+                    "Podman"
+                } else {
+                    "Docker"
+                };
+                return Err(AppError::Command(format!(
+                    "{label} is installed but its engine isn't running. Start it, then try again."
+                )));
+            }
             return Err(AppError::Command(
                 "The agent container image isn't built yet. Open Settings → AI and click \"Build image\", then try again.".to_string(),
             ));

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1940,8 +1940,9 @@ pub async fn agent_review_cancel(
 /// `agent` picks the CLI. Each runs worktree-confined on the **host** (Claude full-
 /// auto via `bypassPermissions` — soft until its permission prompt lands; Codex via
 /// its own OS sandbox, `-s workspace-write`; Copilot via `--add-dir`; opencode via
-/// `--dangerously-skip-permissions`) or in a **container** (kernel boundary; Codex is
-/// container-only). Copilot's container authenticates from a `gh auth token` passed by
+/// `--dangerously-skip-permissions`) or in a **container** (kernel boundary; for Codex
+/// that's also what makes full-bypass safe, and it's the only mode where its MCP support
+/// works). Copilot's container authenticates from a `gh auth token` passed by
 /// env, since its login isn't a mountable creds file like the others'.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
@@ -2075,7 +2076,8 @@ pub async fn agent_session(
             (AgentKind::Codex, false) => {
                 return Err(AppError::Command(
                     "Codex runs MCP servers in container sessions only — host Codex can't \
-                     approve MCP tool calls. Turn on container isolation in Settings → AI."
+                     approve MCP tool calls. Turn on container isolation in Settings → AI, \
+                     or start a new session with Isolation set to Container (composer → Options)."
                         .into(),
                 ));
             }
@@ -2191,13 +2193,21 @@ pub async fn agent_session(
     // resolve a host binary; the runtime drives it.
     if container {
         let (runtime, runtime_name) = crate::agent_sandbox::detect_runtime().await.ok_or_else(|| {
-            AppError::Command(if matches!(kind, AgentKind::Codex) {
-                // Codex is container-only, so "turn isolation off" isn't an option.
-                "Codex sessions need Docker or Podman (they run only in a container). Install and start it, then build the image in Settings → AI — or use Claude instead.".to_string()
-            } else {
-                "Container isolation is on, but Docker/Podman isn't available. Install/start it or turn isolation off in Settings.".to_string()
-            })
+            AppError::Command("Container isolation is on for this session, but Docker/Podman isn't available. Install and start it — or start a new session with Isolation set to Worktree (composer → Options), or turn container isolation off in Settings → AI.".to_string())
         })?;
+        // The binary being on PATH doesn't mean the engine is up — probe it here so a
+        // stopped daemon reports itself instead of surfacing as "image isn't built yet"
+        // (every check below needs the daemon).
+        if !crate::agent_sandbox::runtime_ready(&runtime).await {
+            let label = if runtime_name == "podman" {
+                "Podman"
+            } else {
+                "Docker"
+            };
+            return Err(AppError::Command(format!(
+                "{label} is installed but its engine isn't running. Start it, then try again."
+            )));
+        }
         if !crate::agent_sandbox::image_present(&runtime).await {
             return Err(AppError::Command(
                 "The agent container image isn't built yet. Open Settings → AI and click \"Build image\", then try again.".to_string(),

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -21,9 +21,10 @@
 //! its container authenticates from a GitHub token (`gh auth token`) passed by env
 //! (`COPILOT_GITHUB_TOKEN`), never a file.
 //!
-//! Claude, opencode, and Copilot run on the host or in a container; **Codex is
-//! container-only** (its host `workspace-write` is trust-gated, but full-bypass is
-//! safe in the box). Validated end-to-end by spike + live runs (Codex 2026-06-22,
+//! Every agent — Codex included — runs on the host or in a container; on the host
+//! Codex is confined by its own OS sandbox (`-s workspace-write`), and the container
+//! is what makes its full-bypass safe. Only Codex's **MCP** support is container-only
+//! (see `mcp.rs`). Validated end-to-end by spike + live runs (Codex 2026-06-22,
 //! opencode 2026-06-23); see docs/agent-sandbox-docker.md.
 
 use std::path::{Path, PathBuf};
@@ -260,7 +261,7 @@ pub(crate) async fn detect_runtime() -> Option<(PathBuf, String)> {
 }
 
 /// True when `<rt> version` exits 0 (engine reachable, not just the client).
-async fn runtime_ready(bin: &Path) -> bool {
+pub(crate) async fn runtime_ready(bin: &Path) -> bool {
     matches!(
         run_capture(bin, &["version"], DETECT_TIMEOUT).await,
         Ok((0, _))

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -9,7 +9,8 @@
 //! each consumes a different config shape (`build_claude_config` /
 //! `build_copilot_config` / `build_opencode_config`) delivered a different way
 //! (Claude `--mcp-config`, Copilot `--additional-mcp-config @file`, opencode the
-//! `OPENCODE_CONFIG` env var). **Codex** is container-only (`build_codex_config`);
+//! `OPENCODE_CONFIG` env var). **Codex** MCP is container-only (`build_codex_config`)
+//! — host Codex runs fine, it just can't approve MCP tool calls;
 //! container delivery for the other CLIs is a later tier.
 
 use std::path::{Path, PathBuf};
@@ -411,7 +412,7 @@ pub fn cleanup_host_config(app: &tauri::AppHandle, session_id: &str) {
     }
 }
 
-// --- Codex (container only) --------------------------------------------------
+// --- Codex MCP (container only) --------------------------------------------------
 //
 // Codex reads MCP servers from its `~/.codex/config.toml`, NOT a `--mcp-config`
 // flag. A container session's `~/.codex` is a per-session mounted home seeded

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1362,6 +1362,8 @@ In the composer you can:
   or Codex) and your project's custom commands and **skills**.
 - Opt into **MCP servers** for the session from the **MCP** picker (appears once you've
   registered some — see below).
+- Choose this session's **isolation** — worktree or container — under **Options**
+  (see *Isolation* below).
 - Continue the conversation across turns; **↑ / ↓** recall previous prompts.
 
 ## MCP servers
@@ -1380,7 +1382,8 @@ server keeps working. In a container the servers run *inside* the sandbox,
 sharing an npm cache so an \`npx\` server is downloaded only once. A Claude run is **strict** —
 it gets *only* the servers you picked and never inherits others on your machine — while
 Copilot and opencode layer your picks onto their own config. The composer's **MCP** picker
-shows for every agent and tells you when to switch isolation. You can also change the
+shows for every agent and tells you when a pick needs a container session — with Codex it
+points you at the **Isolation** control in the same **Options** popover. You can also change the
 selection **mid-session** — the picker appears in a running session's reply box too, and a
 new choice applies from your next turn.
 
@@ -1508,7 +1511,24 @@ Every session is sandboxed. By default it runs in a **worktree** (a separate wor
 on a session branch). Optionally, run it inside a **Docker or Podman container** for a
 stronger sandbox — with a built-in **terminal** ({{kbd:agent-toggle-terminal}}) running
 *inside* the container, where you choose which dev-server port(s) to publish before it
-starts. Set the default in **Settings → AI**. A repo can also layer **extra tools** into
+starts. Set the default in **Settings → AI**.
+
+**Per session.** You don't have to take that default. The composer's **Options** popover
+carries an **Isolation** control — **Worktree** or **Container** — for the session you're
+about to start. It opens on your Settings default, and picking the other one overrides it
+for that session alone (the Options badge counts it only when it differs from your default;
+in Best-of-N every arm shares the pick). Isolation is settled when the session starts, so it
+never changes under a running agent — start a new session to switch. Choose **Container** and
+GitDesktop checks readiness right there — Docker or Podman installed, the engine running, the
+agent image built — and keeps **Send** disabled until it is, naming what's missing (the
+composer says so outside the popover too, so a disabled **Send** is never a mystery). Where
+**Settings → AI** is where you'd fix it — no container runtime, or the agent image not built
+yet — it offers a jump straight there; a stopped engine you start yourself. Overriding *down*
+to **Worktree** when your default is a container says
+so plainly: that run happens on your host, where **Codex** still applies its own OS-enforced
+sandbox and the other agents stay inside the worktree by convention.
+
+A repo can also layer **extra tools** into
 that container: commit a \`.gitdesktop/agent.Dockerfile\` (it must start
 \`FROM gitdesktop-agent:latest\`), and — after you review and confirm it in
 **Settings → AI** — GitDesktop builds it into a per-repo image this repo's container

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1518,18 +1518,19 @@ carries an **Isolation** control — **Worktree** or **Container** — for the s
 about to start. It opens on your Settings default, and picking the other one overrides it
 for that session alone (the Options badge counts it only when it differs from your default;
 in Best-of-N every arm shares the pick). Isolation is settled when the session starts, so it
-never changes under a running agent — start a new session to switch. Choose **Container** and
+never changes under a running agent — start a new session to switch; a running session shows
+the mode it got as a chip beside its branch in the header. Choose **Container** and
 GitDesktop checks readiness right there — Docker or Podman installed, the engine running, the
 agent image built — and keeps **Send** disabled until it is, naming what's missing (the
-composer says so outside the popover too, so a disabled **Send** is never a mystery). Where
-**Settings → AI** is where you'd fix it — no container runtime, or the agent image not built
-yet — it offers a jump straight there; a stopped engine you start yourself. Overriding *down*
-to **Worktree** when your default is a container says
-so plainly: that run happens on your host, where **Codex** still applies its own OS-enforced
-sandbox and the other agents stay inside the worktree by convention.
+composer says so outside the popover too, so a disabled **Send** is never a mystery). The
+states **Settings → AI** can fix — no container runtime, or the agent image not built yet —
+come with a jump straight there; a stopped engine you start yourself. Overriding *down* to
+**Worktree** when your default is a container says so plainly: that run happens on your host,
+where **Codex** still applies its own OS-enforced sandbox and the other agents stay inside
+the worktree by convention.
 
-A repo can also layer **extra tools** into
-that container: commit a \`.gitdesktop/agent.Dockerfile\` (it must start
+A repo can also layer **extra tools** into the agent container: commit a
+\`.gitdesktop/agent.Dockerfile\` (it must start
 \`FROM gitdesktop-agent:latest\`), and — after you review and confirm it in
 **Settings → AI** — GitDesktop builds it into a per-repo image this repo's container
 sessions then run in.

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -312,12 +312,15 @@ export function ComposerOptions({
   onMode?: (m: RunMode) => void;
   /** New-session isolation override. `isOverride` = the pick differs from the
    *  global setting (that's what the badge counts); `note` is the caller-computed
-   *  readiness warning / host-downgrade disclosure. */
+   *  readiness warning / host-downgrade disclosure. `onSettingsAction` runs the
+   *  note's "Set up in Settings…" jump — the caller owns it because navigating
+   *  unmounts the composer, so it has to stash its draft first. */
   isolation?: {
     value: Isolation;
     onChange: (v: Isolation) => void;
     isOverride: boolean;
     note?: IsolationNote;
+    onSettingsAction?: () => void;
   };
   mcp?: {
     servers: McpServer[];
@@ -438,7 +441,11 @@ export function ComposerOptions({
                   variant="ghost"
                   size="sm"
                   className="h-7 justify-start text-muted-foreground"
-                  onClick={() => openSettings("ai")}
+                  onClick={() =>
+                    isolation.onSettingsAction
+                      ? isolation.onSettingsAction()
+                      : openSettings("ai")
+                  }
                 >
                   Set up in Settings…
                 </Button>

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -6,7 +6,7 @@ import {
   UsersThreeIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
-import { type ReactNode, useRef } from "react";
+import { type ReactNode, useId, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -154,11 +154,15 @@ function Segmented<T extends string>({
   onChange,
   options,
   ariaLabel,
+  describedBy,
 }: {
   value: T;
   onChange: (v: T) => void;
   options: { value: T; label: string }[];
   ariaLabel: string;
+  /** Id of a caveat rendered beside the group (e.g. the Isolation readiness note),
+   *  so arrowing between options announces the warning with the selection. */
+  describedBy?: string;
 }) {
   const groupRef = useRef<HTMLDivElement>(null);
   // The tab stop. A value outside `options` (shouldn't happen) still leaves the
@@ -191,6 +195,7 @@ function Segmented<T extends string>({
       ref={groupRef}
       role="radiogroup"
       aria-label={ariaLabel}
+      aria-describedby={describedBy}
       className="flex overflow-hidden rounded-none border border-input"
     >
       {options.map((o, i) => (
@@ -322,6 +327,8 @@ export function ComposerOptions({
   };
 }) {
   const openSettings = useUiStore((s) => s.openSettings);
+  // Links the Isolation caveat to its radiogroup (announced with the selection).
+  const isolationNoteId = useId();
 
   const mcpListable = mcp && !mcp.disabledReason && mcp.servers.length > 0;
   const mcpCount = mcpListable
@@ -403,9 +410,11 @@ export function ComposerOptions({
                 value={isolation.value}
                 onChange={isolation.onChange}
                 options={ISOLATION_OPTIONS}
+                describedBy={isolation.note ? isolationNoteId : undefined}
               />
               {isolation.note && (
                 <p
+                  id={isolationNoteId}
                   className={cn(
                     "flex items-start gap-1.5 text-[11px]",
                     isolation.note.tone === "warn"

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -2,9 +2,11 @@ import {
   GaugeIcon,
   GearSixIcon,
   PlugsConnectedIcon,
+  ShieldCheckIcon,
   UsersThreeIcon,
+  WarningCircleIcon,
 } from "@phosphor-icons/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -143,8 +145,10 @@ export function EffortPicker({
 export type RunMode = "single" | "ensemble";
 
 /** A compact inline segmented control (radio-group of buttons). Used inside the
- *  composer Options popover for run mode and effort — no nested dropdown, fully
- *  keyboard-operable. */
+ *  composer Options popover for run mode, effort, and isolation — no nested
+ *  dropdown, fully keyboard-operable: the ARIA radiogroup pattern, so the group is
+ *  ONE tab stop (roving tabindex on the checked option) and the arrow keys move the
+ *  selection with focus following it. Clicking is unchanged. */
 function Segmented<T extends string>({
   value,
   onChange,
@@ -156,8 +160,35 @@ function Segmented<T extends string>({
   options: { value: T; label: string }[];
   ariaLabel: string;
 }) {
+  const groupRef = useRef<HTMLDivElement>(null);
+  // The tab stop. A value outside `options` (shouldn't happen) still leaves the
+  // group reachable rather than trapping the keyboard past it.
+  const checked = options.findIndex((o) => o.value === value);
+  const roving = checked < 0 ? 0 : checked;
+
+  // Arrow keys select-and-focus the neighbour, wrapping at the ends. The buttons
+  // are stable DOM children, so the new target can be focused straight away — the
+  // re-render then hands it the tab stop.
+  const move = (delta: number) => {
+    const next = (roving + delta + options.length) % options.length;
+    onChange(options[next].value);
+    const btn = groupRef.current?.children[next];
+    if (btn instanceof HTMLElement) btn.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      move(1);
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      move(-1);
+    }
+  };
+
   return (
     <div
+      ref={groupRef}
       role="radiogroup"
       aria-label={ariaLabel}
       className="flex overflow-hidden rounded-none border border-input"
@@ -168,7 +199,9 @@ function Segmented<T extends string>({
           type="button"
           role="radio"
           aria-checked={value === o.value}
+          tabIndex={i === roving ? 0 : -1}
           onClick={() => onChange(o.value)}
+          onKeyDown={onKeyDown}
           className={cn(
             "flex-1 px-1.5 py-1 text-[11px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
             i > 0 && "border-l border-input",
@@ -197,8 +230,31 @@ const RUN_MODE_OPTIONS: { value: RunMode; label: string }[] = [
   { value: "ensemble", label: "Best-of-N" },
 ];
 
+/** How a NEW session is sandboxed: a throwaway worktree on the host, or that
+ *  worktree inside an ephemeral container. Fixed once the session starts. */
+export type Isolation = "worktree" | "container";
+
+const ISOLATION_OPTIONS: { value: Isolation; label: string }[] = [
+  { value: "worktree", label: "Worktree" },
+  { value: "container", label: "Container" },
+];
+
+/** A one-line caveat under the Isolation control — a readiness warning for
+ *  container, or the host-downgrade disclosure. Computed by the call site (this
+ *  module stays presentational). */
+export interface IsolationNote {
+  tone: "warn" | "muted";
+  text: string;
+  /** Offer a jump to Settings → AI (where the runtime/image is set up). */
+  settingsAction?: boolean;
+}
+
 function effortLabel(value: string): string {
   return EFFORT_OPTIONS.find((o) => o.value === value)?.label ?? "Auto";
+}
+
+function isolationLabel(value: Isolation): string {
+  return ISOLATION_OPTIONS.find((o) => o.value === value)?.label ?? "Worktree";
 }
 
 /** A labeled field row inside the Options popover. */
@@ -224,27 +280,39 @@ function OptionField({
 
 /**
  * The composer's collapsed "Options" popover. Provider + model stay inline on the
- * toolbar for quick access; everything else — run mode, reasoning effort, and the
- * per-session MCP-server opt-in — lives here so the action row never overflows or
- * shifts as the box grows. Each control renders only when the parent passes its
- * props: run mode is new-session only; effort + MCP drop out in best-of-N (each
- * arm sets its own); MCP also self-hides when no servers are registered. The
- * trigger shows a count + summary tooltip of the non-default choices so collapsing
- * them stays discoverable. MCP rules (frozen at turn 1 for a new session, strict
- * "only these" for Claude, the container/host caveats) are unchanged — see the
- * call site.
+ * toolbar for quick access; everything else — run mode, reasoning effort, the
+ * per-session isolation override, and the per-session MCP-server opt-in — lives
+ * here so the action row never overflows or shifts as the box grows. Each control
+ * renders only when the parent passes its props: run mode + isolation are
+ * new-session only; effort + MCP drop out in best-of-N (each arm sets its own); MCP
+ * also self-hides when no servers are registered. Isolation sits directly above MCP
+ * because it gates it (Codex runs MCP only in a container), so the dependency reads
+ * top-down. The trigger shows a count + summary tooltip of the non-default choices
+ * so collapsing them stays discoverable. MCP rules (frozen at turn 1 for a new
+ * session, strict "only these" for Claude, the container/host caveats) are
+ * unchanged — see the call site.
  */
 export function ComposerOptions({
   effort,
   onEffort,
   mode,
   onMode,
+  isolation,
   mcp,
 }: {
   effort?: string;
   onEffort?: (e: string) => void;
   mode?: RunMode;
   onMode?: (m: RunMode) => void;
+  /** New-session isolation override. `isOverride` = the pick differs from the
+   *  global setting (that's what the badge counts); `note` is the caller-computed
+   *  readiness warning / host-downgrade disclosure. */
+  isolation?: {
+    value: Isolation;
+    onChange: (v: Isolation) => void;
+    isOverride: boolean;
+    note?: IsolationNote;
+  };
   mcp?: {
     servers: McpServer[];
     value: string[];
@@ -264,6 +332,10 @@ export function ComposerOptions({
   const summary: string[] = [];
   if (mode === "ensemble") summary.push("Best-of-N");
   if (effort) summary.push(`Effort: ${effortLabel(effort)}`);
+  // Only an EXPLICIT pick that differs from the global setting counts — following
+  // Settings → AI isn't a choice the user made here.
+  if (isolation?.isOverride)
+    summary.push(`Isolation: ${isolationLabel(isolation.value)}`);
   if (mcpCount > 0)
     summary.push(`${mcpCount} MCP server${mcpCount > 1 ? "s" : ""}`);
   const count = summary.length;
@@ -320,6 +392,49 @@ export function ComposerOptions({
               />
             </OptionField>
           )}
+          {isolation && (
+            <OptionField
+              icon={<ShieldCheckIcon className="size-3.5" />}
+              label="Isolation"
+            >
+              <Segmented
+                ariaLabel="Isolation"
+                value={isolation.value}
+                onChange={isolation.onChange}
+                options={ISOLATION_OPTIONS}
+              />
+              {isolation.note && (
+                <p
+                  className={cn(
+                    "flex items-start gap-1.5 text-[11px]",
+                    isolation.note.tone === "warn"
+                      ? "text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {/* Icon + text, never color alone. */}
+                  {isolation.note.tone === "warn" && (
+                    <WarningCircleIcon
+                      weight="fill"
+                      className="mt-px size-3.5 shrink-0"
+                      aria-hidden
+                    />
+                  )}
+                  <span>{isolation.note.text}</span>
+                </p>
+              )}
+              {isolation.note?.settingsAction && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 justify-start text-muted-foreground"
+                  onClick={() => openSettings("ai")}
+                >
+                  Set up in Settings…
+                </Button>
+              )}
+            </OptionField>
+          )}
           {mcp?.disabledReason ? (
             <OptionField
               icon={<PlugsConnectedIcon className="size-3.5" />}
@@ -372,10 +487,10 @@ export function ComposerOptions({
   );
 }
 
-/** Picks the CLI for a NEW session (fixed once it starts). Every agent honors the
- *  isolation setting — host (worktree-confined, soft) or container — provided that
- *  agent is baked into the image (Codex is container-only). Reused by the plan
- *  composer and the best-of-N arm editor. */
+/** Picks the CLI for a NEW session (fixed once it starts). Every agent runs either
+ *  way — host (worktree-confined; Codex adds its own OS-enforced sandbox) or
+ *  container, provided that agent is baked into the image. Only Codex's MCP support
+ *  is container-only. Reused by the plan composer and the best-of-N arm editor. */
 export function AgentPicker({
   value,
   onChange,

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -313,14 +313,15 @@ export function ComposerOptions({
   /** New-session isolation override. `isOverride` = the pick differs from the
    *  global setting (that's what the badge counts); `note` is the caller-computed
    *  readiness warning / host-downgrade disclosure. `onSettingsAction` runs the
-   *  note's "Set up in Settings…" jump — the caller owns it because navigating
-   *  unmounts the composer, so it has to stash its draft first. */
+   *  note's "Set up in Settings…" jump and is REQUIRED — navigating unmounts the
+   *  composer, so the caller must stash its start-state first; a convenience
+   *  fallback here would silently reintroduce that state loss. */
   isolation?: {
     value: Isolation;
     onChange: (v: Isolation) => void;
     isOverride: boolean;
     note?: IsolationNote;
-    onSettingsAction?: () => void;
+    onSettingsAction: () => void;
   };
   mcp?: {
     servers: McpServer[];
@@ -441,11 +442,7 @@ export function ComposerOptions({
                   variant="ghost"
                   size="sm"
                   className="h-7 justify-start text-muted-foreground"
-                  onClick={() =>
-                    isolation.onSettingsAction
-                      ? isolation.onSettingsAction()
-                      : openSettings("ai")
-                  }
+                  onClick={isolation.onSettingsAction}
                 >
                   Set up in Settings…
                 </Button>

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -284,8 +284,9 @@ function OptionField({
  * per-session isolation override, and the per-session MCP-server opt-in — lives
  * here so the action row never overflows or shifts as the box grows. Each control
  * renders only when the parent passes its props: run mode + isolation are
- * new-session only; effort + MCP drop out in best-of-N (each arm sets its own); MCP
- * also self-hides when no servers are registered. Isolation sits directly above MCP
+ * new-session only; effort drops out in best-of-N (each arm sets its own), while the
+ * MCP selection stays and is SHARED across every arm; MCP self-hides when no servers
+ * are registered. Isolation sits directly above MCP
  * because it gates it (Codex runs MCP only in a container), so the dependency reads
  * top-down. The trigger shows a count + summary tooltip of the non-default choices
  * so collapsing them stays discoverable. MCP rules (frozen at turn 1 for a new

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -420,8 +420,11 @@ export function SessionComposer({
   // gate above hasn't run — but start() reads settings itself and would happily
   // launch a container session. Hold Start for those few milliseconds rather than
   // let one slip past the gate. Deliberately silent: it's a load, not a problem.
-  // A settings load that FAILED is not pending — start() falls back to "worktree"
-  // there, which needs no gate, and holding Start forever would be the worse bug.
+  // A settings load that FAILED is deliberately not pending — holding Send forever
+  // would be the worse bug. Residual: start()'s own loadSettings() can succeed where
+  // the query errored and launch per the real setting while the row showed the
+  // worktree fallback — near-unreachable, it errs toward MORE confinement than
+  // displayed, and turn 1 re-checks readiness in Rust.
   const settingsPending = !session && !settings.data && !settings.isError;
   const canSubmit =
     !running &&

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -898,7 +898,6 @@ export function SessionComposer({
                 opening the Options popover; an engine that isn't running has no
                 `settingsAction` (Settings can't start a daemon) and gets no button. */}
             <p
-              id={blockedId}
               role="status"
               // Mounted unconditionally: a live region created together with its
               // text announces unreliably, so the region has to pre-exist and only
@@ -918,7 +917,10 @@ export function SessionComposer({
                     className="mt-px size-3.5 shrink-0"
                     aria-hidden
                   />
-                  <span>{blockedReason}</span>
+                  {/* The id sits on the REASON alone so Send's aria-describedby
+                      doesn't read the remedy button's label as its description;
+                      role="status" on the parent still announces both together. */}
+                  <span id={blockedId}>{blockedReason}</span>
                   {isolationNote?.settingsAction ? (
                     // Same handler as the popover's button — it stashes the whole
                     // start-state before navigating, so a bare openSettings here

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -390,9 +390,10 @@ export function SessionComposer({
   // own `session.isolation` governs, below). Derived during render — no effect.
   const globalIsolation: Isolation =
     settings.data?.agentIsolation ?? "worktree";
-  const effectiveIsolation = !session
-    ? (startIsolation ?? globalIsolation)
-    : undefined;
+  // Resolved ONCE (override ?? global) and reused by the gate, the note, and the
+  // radio value below, so the warn line and the Send gate can never disagree.
+  const resolvedStartIsolation: Isolation = startIsolation ?? globalIsolation;
+  const effectiveIsolation = !session ? resolvedStartIsolation : undefined;
   const isContainer = effectiveIsolation === "container";
   // Container readiness, probed lazily and shared with Settings → AI (same query
   // key, so one Docker/Podman check serves both). Only while a new session is
@@ -438,7 +439,7 @@ export function SessionComposer({
   const isolationNote = session
     ? undefined
     : isolationNoteFor({
-        effective: startIsolation ?? globalIsolation,
+        effective: resolvedStartIsolation,
         global: globalIsolation,
         agent: startAgent,
         // Best-of-N arms each pick their own agent, so no agent-specific claim
@@ -941,7 +942,7 @@ export function SessionComposer({
                   session
                     ? undefined
                     : {
-                        value: startIsolation ?? globalIsolation,
+                        value: resolvedStartIsolation,
                         onChange: setStartIsolation,
                         isOverride:
                           startIsolation !== null &&

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -893,7 +893,10 @@ export function SessionComposer({
                 put you here, in which case the Options badge doesn't move and a
                 hover-only tooltip would be the sole explanation. Carries the
                 SPECIFIC reason (engine down, image missing, …) and is what the Send
-                button points `aria-describedby` at while blocked. */}
+                button points `aria-describedby` at while blocked. Reasons Settings
+                can fix carry the remedy here too, so it's reachable without ever
+                opening the Options popover; an engine that isn't running has no
+                `settingsAction` (Settings can't start a daemon) and gets no button. */}
             <p
               id={blockedId}
               role="status"
@@ -916,6 +919,19 @@ export function SessionComposer({
                     aria-hidden
                   />
                   <span>{blockedReason}</span>
+                  {isolationNote?.settingsAction ? (
+                    // Same handler as the popover's button — it stashes the whole
+                    // start-state before navigating, so a bare openSettings here
+                    // would silently lose the draft and every pick.
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="-mt-0.5 h-6 shrink-0 px-1.5 text-[11px] text-muted-foreground"
+                      onClick={openIsolationSettings}
+                    >
+                      Set up in Settings…
+                    </Button>
+                  ) : null}
                 </>
               ) : null}
             </p>

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -2,12 +2,14 @@ import { StopIcon, WarningCircleIcon } from "@phosphor-icons/react";
 import { AnimatePresence, m } from "motion/react";
 import {
   useEffect,
+  useId,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import type { AgentKind } from "@/lib/ai/agent";
 import { estimateRunCost } from "@/lib/ai/cost";
@@ -100,13 +102,16 @@ function isolationNoteFor({
           : "Runs on the host for this session — file writes are confined by convention, not the kernel.",
     };
   }
-  if (probeFailed)
-    return {
-      tone: "warn",
-      text: "Couldn't check container status — the session will verify at start.",
-    };
-  // No probe result yet: say so rather than claim a state.
-  if (!status) return { tone: "muted", text: "Checking container status…" };
+  // A probe that failed with nothing to show for it. (Once there IS data, a later
+  // refetch failing — the recovery poll hitting a blip — shouldn't replace the
+  // specific reason Start is blocked with a vaguer one.)
+  if (!status)
+    return probeFailed
+      ? {
+          tone: "warn",
+          text: "Couldn't check container status — the session will verify at start.",
+        }
+      : { tone: "muted", text: "Checking container status…" };
   if (!status.runtime)
     return {
       tone: "warn",
@@ -128,8 +133,10 @@ function isolationNoteFor({
   // More specific than the generic "doesn't match" below — the backend rejects turn
   // 1 outright when the chosen agent isn't in the image, so name that agent. Still
   // only a warning: a stale image can legitimately carry MORE agents than the saved
-  // config lists, and blocking on that guess would be worse.
-  if (!agentInImage)
+  // config lists, and blocking on that guess would be worse. Skipped in best-of-N
+  // for the same reason as the downgrade copy — the arms pick their own agents, so
+  // naming the seed's would be as likely to mislead as to help.
+  if (!agentInImage && perAgentCopy)
     return {
       tone: "warn",
       text: `The agent image wasn't built with ${AGENT_LABELS[agent]} — add it under Settings → AI and rebuild.`,
@@ -226,6 +233,8 @@ export function SessionComposer({
   const [histIndex, setHistIndex] = useState<number | null>(null);
   const [histStash, setHistStash] = useState("");
   const ref = useRef<HTMLTextAreaElement>(null);
+  // Ties the disabled-Send explanation to the button via aria-describedby.
+  const blockedId = useId();
 
   const running = session?.running ?? false;
   const model = session ? session.model : startModel;
@@ -381,8 +390,36 @@ export function SessionComposer({
     isContainer &&
     !!probe &&
     (!probe.runtime || !probe.ready || !probe.imagePresent);
+  // Until settings resolve we don't yet know the global isolation, so the readiness
+  // gate above hasn't run — but start() reads settings itself and would happily
+  // launch a container session. Hold Start for those few milliseconds rather than
+  // let one slip past the gate. Deliberately silent: it's a load, not a problem.
+  // A settings load that FAILED is not pending — start() falls back to "worktree"
+  // there, which needs no gate, and holding Start forever would be the worse bug.
+  const settingsPending = !session && !settings.data && !settings.isError;
   const canSubmit =
-    !running && !creating && draft.trim().length > 0 && !containerBlocked;
+    !running &&
+    !creating &&
+    draft.trim().length > 0 &&
+    !containerBlocked &&
+    !settingsPending;
+  // The one line under the Isolation control — a container-readiness warning or the
+  // host-downgrade disclosure. Hoisted out of the JSX so the blocked strip and the
+  // best-of-N toast can name the SPECIFIC reason instead of the generic fallback.
+  const isolationNote = session
+    ? undefined
+    : isolationNoteFor({
+        effective: startIsolation ?? globalIsolation,
+        global: globalIsolation,
+        agent: startAgent,
+        // Best-of-N arms each pick their own agent, so no agent-specific claim
+        // (host sandbox, image membership) can be made.
+        perAgentCopy: mode !== "ensemble",
+        status: probe,
+        probeFailed,
+        agentInImage,
+      });
+  const blockedReason = isolationNote?.text ?? CONTAINER_BLOCKED_TEXT;
   // Servers the chosen agent can actually run (Codex = local/stdio only).
   const mcpServersForAgent = useMemo(
     () => mcpRegistry.filter((s) => mcpServerUsableBy(s, startAgent)),
@@ -498,9 +535,10 @@ export function SessionComposer({
   };
 
   const submit = () => {
-    // Container isolation that isn't ready: Enter must respect the same gate the
-    // Send button does (the Options popover explains why).
-    if (containerBlocked) return;
+    // Container isolation that isn't ready — or settings that haven't resolved, so
+    // readiness was never checked: Enter must respect the same gates the Send
+    // button does (the composer's warn line explains the first one).
+    if (containerBlocked || settingsPending) return;
     // Best-of-N mode: the primary action opens the arm/cost dialog instead of
     // starting one session (the dialog runs the fan-out).
     if (!session && mode === "ensemble") {
@@ -532,9 +570,14 @@ export function SessionComposer({
   const runEnsemble = (
     arms: { agent: AgentKind; model: string; effort: string }[],
   ) => {
-    // The probe can resolve blocked while the arm/cost dialog sits open — don't
-    // fan out N doomed arms (the composer's warn line explains it once it closes).
-    if (!pendingEnsemble || containerBlocked) return;
+    if (!pendingEnsemble) return;
+    // The probe can resolve blocked while the arm/cost dialog sits open. Confirming
+    // then would fan out N doomed arms — but the dialog has already closed itself,
+    // so say why rather than appear to do nothing.
+    if (containerBlocked) {
+      toast.error(blockedReason);
+      return;
+    }
     const mcp = mcpUsable
       ? effectiveMcp.filter((id) => mcpServersForAgent.some((s) => s.id === id))
       : undefined;
@@ -787,15 +830,21 @@ export function SessionComposer({
             />
             {/* Why Send is disabled, in layout flow — the global setting alone can
                 put you here, in which case the Options badge doesn't move and a
-                hover-only tooltip would be the sole explanation. */}
+                hover-only tooltip would be the sole explanation. Carries the
+                SPECIFIC reason (engine down, image missing, …) and is what the Send
+                button points `aria-describedby` at while blocked. */}
             {containerBlocked && (
-              <p className="flex items-start gap-1.5 text-[11px] text-foreground">
+              <p
+                id={blockedId}
+                role="status"
+                className="flex items-start gap-1.5 text-[11px] text-foreground"
+              >
                 <WarningCircleIcon
                   weight="fill"
                   className="mt-px size-3.5 shrink-0"
                   aria-hidden
                 />
-                <span>{CONTAINER_BLOCKED_TEXT}</span>
+                <span>{blockedReason}</span>
               </p>
             )}
             <div className="flex items-center gap-2 border-t pt-2">
@@ -829,17 +878,7 @@ export function SessionComposer({
                         isOverride:
                           startIsolation !== null &&
                           startIsolation !== globalIsolation,
-                        note: isolationNoteFor({
-                          effective: startIsolation ?? globalIsolation,
-                          global: globalIsolation,
-                          agent: startAgent,
-                          // Best-of-N arms each pick their own agent, so no
-                          // agent-specific host-sandbox claim can be made.
-                          perAgentCopy: mode !== "ensemble",
-                          status: probe,
-                          probeFailed,
-                          agentInImage,
-                        }),
+                        note: isolationNote,
                       }
                 }
                 mcp={composerMcp}
@@ -884,6 +923,9 @@ export function SessionComposer({
                         size="sm"
                         className="min-w-20"
                         disabled={!canSubmit}
+                        aria-describedby={
+                          containerBlocked ? blockedId : undefined
+                        }
                         onClick={submit}
                       >
                         {creating && !session

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -45,7 +45,7 @@ import {
   type RunMode,
 } from "./AgentPickers";
 import { EnsembleRunDialog } from "./EnsembleRunDialog";
-import { type AgentSession, useSessionsStore } from "./store";
+import { type AgentSession, type PendingTask, useSessionsStore } from "./store";
 
 const MAX_MENTIONS = 8;
 
@@ -235,9 +235,11 @@ export function SessionComposer({
   const ref = useRef<HTMLTextAreaElement>(null);
   // Ties the disabled-Send explanation to the button via aria-describedby.
   const blockedId = useId();
-  // Latched while this composer stashes its own state for a Settings round-trip,
-  // so the consume effect doesn't eat the record before the unmount.
-  const stashingRef = useRef(false);
+  // The record this composer stashed for a Settings round-trip. The consume effect
+  // skips exactly that record (by identity) rather than latching shut, so if the
+  // composer ever stops unmounting on the jump (e.g. an <Activity> refactor) a
+  // LATER handoff record still consumes normally. Dies with the unmount today.
+  const stashedRef = useRef<PendingTask | null>(null);
 
   const running = session?.running ?? false;
   const model = session ? session.model : startModel;
@@ -289,8 +291,8 @@ export function SessionComposer({
   useEffect(() => {
     if (
       session ||
-      stashingRef.current ||
       !pendingTask ||
+      pendingTask === stashedRef.current ||
       pendingTask.repoPath !== repoPath
     )
       return;
@@ -459,12 +461,11 @@ export function SessionComposer({
   const openIsolationSettings = () => {
     // `openSettings` flips the view inside a view-transition callback (see
     // lib/view-transition.ts — `doc.startViewTransition(() => flushSync(update))`),
-    // so the stash below commits a render BEFORE the unmount. Without this latch
-    // the consume effect would eat the record in that window and there'd be
-    // nothing left to restore. The ref dies with the unmount, so the remounted
-    // composer consumes normally.
-    stashingRef.current = true;
-    setPendingTask({
+    // so the stash below commits a render BEFORE the unmount. Without the ref the
+    // consume effect would eat the record in that window and there'd be nothing
+    // left to restore; holding the record itself skips it by IDENTITY, so the
+    // remounted composer (fresh ref) consumes normally.
+    const task: PendingTask = {
       repoPath,
       prompt: draft,
       // null = no explicit pick, so there's nothing to restore — collapse to absent.
@@ -475,7 +476,9 @@ export function SessionComposer({
       mode,
       // Verbatim: null here MEANS "follow the default set", so it must survive.
       mcpServers: startMcp,
-    });
+    };
+    stashedRef.current = task;
+    setPendingTask(task);
     openSettings("ai");
   };
   // Servers the chosen agent can actually run (Codex = local/stdio only).

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -298,10 +298,22 @@ export function SessionComposer({
     setSlash(null);
     setHistIndex(null);
     setDraftCaretEnd(pendingTask.prompt);
-    // A record stashed by the "Set up in Settings…" jump also carries the
-    // isolation pick, so returning from Settings restores it rather than silently
-    // falling back to the global setting. A plain handoff omits it.
-    if (pendingTask.isolation) setStartIsolation(pendingTask.isolation);
+    // A record stashed by the "Set up in Settings…" jump also carries the whole
+    // start-state, so the round-trip can't silently change what will run. A plain
+    // handoff carries none of it and the composer keeps its own values. Tested
+    // with `!== undefined` throughout: "" (default model / Auto effort) and null
+    // (follow the default MCP set) are real values, not absences. These are plain
+    // setState calls — the agent-change RESET (model + MCP) lives in AgentPicker's
+    // onChange handler, not an effect, so restoring an agent doesn't wipe the
+    // model or servers restored alongside it.
+    if (pendingTask.isolation !== undefined)
+      setStartIsolation(pendingTask.isolation);
+    if (pendingTask.agent !== undefined) setStartAgent(pendingTask.agent);
+    if (pendingTask.model !== undefined) setStartModel(pendingTask.model);
+    if (pendingTask.effort !== undefined) setStartEffort(pendingTask.effort);
+    if (pendingTask.mode !== undefined) setMode(pendingTask.mode);
+    if (pendingTask.mcpServers !== undefined)
+      setStartMcp(pendingTask.mcpServers);
     setPendingTask(null);
   }, [session, pendingTask, repoPath]);
 
@@ -451,7 +463,14 @@ export function SessionComposer({
     setPendingTask({
       repoPath,
       prompt: draft,
+      // null = no explicit pick, so there's nothing to restore — collapse to absent.
       isolation: startIsolation ?? undefined,
+      agent: startAgent,
+      model: startModel,
+      effort: startEffort,
+      mode,
+      // Verbatim: null here MEANS "follow the default set", so it must survive.
+      mcpServers: startMcp,
     });
     openSettings("ai");
   };

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -833,20 +833,31 @@ export function SessionComposer({
                 hover-only tooltip would be the sole explanation. Carries the
                 SPECIFIC reason (engine down, image missing, …) and is what the Send
                 button points `aria-describedby` at while blocked. */}
-            {containerBlocked && (
-              <p
-                id={blockedId}
-                role="status"
-                className="flex items-start gap-1.5 text-[11px] text-foreground"
-              >
-                <WarningCircleIcon
-                  weight="fill"
-                  className="mt-px size-3.5 shrink-0"
-                  aria-hidden
-                />
-                <span>{blockedReason}</span>
-              </p>
-            )}
+            <p
+              id={blockedId}
+              role="status"
+              // Mounted unconditionally: a live region created together with its
+              // text announces unreliably, so the region has to pre-exist and only
+              // its CONTENT change. `sr-only` (not `hidden`) keeps the empty state
+              // in the accessibility tree while taking it out of flow entirely, so
+              // the column's flex gap shows no phantom row.
+              className={
+                containerBlocked
+                  ? "flex items-start gap-1.5 text-[11px] text-foreground"
+                  : "sr-only"
+              }
+            >
+              {containerBlocked ? (
+                <>
+                  <WarningCircleIcon
+                    weight="fill"
+                    className="mt-px size-3.5 shrink-0"
+                    aria-hidden
+                  />
+                  <span>{blockedReason}</span>
+                </>
+              ) : null}
+            </p>
             <div className="flex items-center gap-2 border-t pt-2">
               {/* Provider + model stay inline for quick access; run mode, effort,
                   and MCP collapse into Options so the row never overflows. Best-of-N

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -235,6 +235,9 @@ export function SessionComposer({
   const ref = useRef<HTMLTextAreaElement>(null);
   // Ties the disabled-Send explanation to the button via aria-describedby.
   const blockedId = useId();
+  // Latched while this composer stashes its own state for a Settings round-trip,
+  // so the consume effect doesn't eat the record before the unmount.
+  const stashingRef = useRef(false);
 
   const running = session?.running ?? false;
   const model = session ? session.model : startModel;
@@ -284,11 +287,21 @@ export function SessionComposer({
   // point SessionActivation has forced "Delegate" mode and mounted this composer.
   // biome-ignore lint/correctness/useExhaustiveDependencies: stable setters/ref only
   useEffect(() => {
-    if (session || !pendingTask || pendingTask.repoPath !== repoPath) return;
+    if (
+      session ||
+      stashingRef.current ||
+      !pendingTask ||
+      pendingTask.repoPath !== repoPath
+    )
+      return;
     setMention(null);
     setSlash(null);
     setHistIndex(null);
     setDraftCaretEnd(pendingTask.prompt);
+    // A record stashed by the "Set up in Settings…" jump also carries the
+    // isolation pick, so returning from Settings restores it rather than silently
+    // falling back to the global setting. A plain handoff omits it.
+    if (pendingTask.isolation) setStartIsolation(pendingTask.isolation);
     setPendingTask(null);
   }, [session, pendingTask, repoPath]);
 
@@ -374,6 +387,7 @@ export function SessionComposer({
   // actually set to run in a container AND the Agent tab is showing — an
   // <Activity>-hidden subtree still fetches.
   const agentTabShowing = useUiStore((s) => s.repoTab === "agent");
+  const openSettings = useUiStore((s) => s.openSettings);
   const containerStatus = useContainerStatus({
     nodeVersion: settings.data?.agentImageNodeVersion ?? "",
     providers: settings.data?.agentImageProviders ?? NO_PROVIDERS,
@@ -420,6 +434,27 @@ export function SessionComposer({
         agentInImage,
       });
   const blockedReason = isolationNote?.text ?? CONTAINER_BLOCKED_TEXT;
+  // The note's "Set up in Settings…" jump. Opening Settings unmounts
+  // RepositoryView (App.tsx renders it behind `view === "repo"`), which would take
+  // this composer's draft AND its isolation pick with it — a task typed, switched
+  // to Container, then sent to Settings to build the image would come back empty
+  // and silently back on the host. Stash both on the existing pendingTask record
+  // first; the activation composer re-seeds from it on remount.
+  const openIsolationSettings = () => {
+    // `openSettings` flips the view inside a view-transition callback (see
+    // lib/view-transition.ts — `doc.startViewTransition(() => flushSync(update))`),
+    // so the stash below commits a render BEFORE the unmount. Without this latch
+    // the consume effect would eat the record in that window and there'd be
+    // nothing left to restore. The ref dies with the unmount, so the remounted
+    // composer consumes normally.
+    stashingRef.current = true;
+    setPendingTask({
+      repoPath,
+      prompt: draft,
+      isolation: startIsolation ?? undefined,
+    });
+    openSettings("ai");
+  };
   // Servers the chosen agent can actually run (Codex = local/stdio only).
   const mcpServersForAgent = useMemo(
     () => mcpRegistry.filter((s) => mcpServerUsableBy(s, startAgent)),
@@ -890,6 +925,7 @@ export function SessionComposer({
                           startIsolation !== null &&
                           startIsolation !== globalIsolation,
                         note: isolationNote,
+                        onSettingsAction: openIsolationSettings,
                       }
                 }
                 mcp={composerMcp}

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -1,4 +1,4 @@
-import { StopIcon } from "@phosphor-icons/react";
+import { StopIcon, WarningCircleIcon } from "@phosphor-icons/react";
 import { AnimatePresence, m } from "motion/react";
 import {
   useEffect,
@@ -11,6 +11,8 @@ import {
 import { Button } from "@/components/ui/button";
 import type { AgentKind } from "@/lib/ai/agent";
 import { estimateRunCost } from "@/lib/ai/cost";
+import type { ContainerStatus } from "@/lib/ai/sandbox";
+import { useContainerStatus } from "@/lib/ai/sandbox-queries";
 import {
   buildPrompt,
   filterCommands,
@@ -28,10 +30,14 @@ import {
   mcpSupportedFor,
 } from "@/lib/settings/mcp";
 import { useRepoKeys, useSettings } from "@/lib/settings/queries";
+import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import {
+  AGENT_LABELS,
   AgentPicker,
   ComposerOptions,
+  type Isolation,
+  type IsolationNote,
   ModelPicker,
   modelsForAgent,
   type RunMode,
@@ -40,6 +46,103 @@ import { EnsembleRunDialog } from "./EnsembleRunDialog";
 import { type AgentSession, useSessionsStore } from "./store";
 
 const MAX_MENTIONS = 8;
+
+/** Stable empty default so the container probe's props don't churn while settings load. */
+const NO_PROVIDERS: string[] = [];
+
+const RUNTIME_LABEL = { docker: "Docker", podman: "Podman" } as const;
+
+/** The always-visible reason a not-ready container disables Start — the same string
+ *  the Send button's wrapper carries as a `title`. */
+const CONTAINER_BLOCKED_TEXT =
+  "Container isolation isn't ready — open Options for details.";
+
+/**
+ * The single line shown under the composer's Isolation control. Container is
+ * pick-then-warn: choosing it (or inheriting it from Settings) surfaces the same
+ * readiness probe Settings runs, with a jump to Settings → AI where the runtime and
+ * image are actually set up. A missing runtime / stopped engine / unbuilt image also
+ * blocks Start (see `containerBlocked`); everything after that — a stale image, an
+ * agent missing from it, a probe that couldn't run — only warns, because the backend
+ * verifies at turn 1 anyway and over-blocking on a guess is worse than a warning. On
+ * the worktree side the only note is the downgrade disclosure — running on the host
+ * when the global setting says container — so the drop in confinement is never silent.
+ */
+function isolationNoteFor({
+  effective,
+  global,
+  agent,
+  perAgentCopy,
+  status,
+  probeFailed,
+  agentInImage,
+}: {
+  effective: Isolation;
+  global: Isolation;
+  /** The composer's seed agent — the one whose host-sandbox story is described. */
+  agent: AgentKind;
+  /** False in best-of-N, where the arms can each pick a different agent, so any
+   *  agent-specific claim about the host sandbox could be false for some of them. */
+  perAgentCopy: boolean;
+  status: ContainerStatus | undefined;
+  /** The probe ran and failed (not merely still loading). */
+  probeFailed: boolean;
+  /** `agent` is among the agent CLIs the saved image config bakes in. */
+  agentInImage: boolean;
+}): IsolationNote | undefined {
+  if (effective === "worktree") {
+    if (global !== "container") return undefined;
+    return {
+      tone: "muted",
+      text:
+        agent === "codex" && perAgentCopy
+          ? "Runs on the host for this session — Codex keeps its own OS-enforced sandbox."
+          : "Runs on the host for this session — file writes are confined by convention, not the kernel.",
+    };
+  }
+  if (probeFailed)
+    return {
+      tone: "warn",
+      text: "Couldn't check container status — the session will verify at start.",
+    };
+  // No probe result yet: say so rather than claim a state.
+  if (!status) return { tone: "muted", text: "Checking container status…" };
+  if (!status.runtime)
+    return {
+      tone: "warn",
+      text: "No Docker or Podman found — container sessions need one installed.",
+      settingsAction: true,
+    };
+  const runtime = RUNTIME_LABEL[status.runtime];
+  if (!status.ready)
+    return {
+      tone: "warn",
+      text: `${runtime} is installed but its engine isn't running. Start it, then try again.`,
+    };
+  if (!status.imagePresent)
+    return {
+      tone: "warn",
+      text: `${runtime} is ready — build the agent image first.`,
+      settingsAction: true,
+    };
+  // More specific than the generic "doesn't match" below — the backend rejects turn
+  // 1 outright when the chosen agent isn't in the image, so name that agent. Still
+  // only a warning: a stale image can legitimately carry MORE agents than the saved
+  // config lists, and blocking on that guess would be worse.
+  if (!agentInImage)
+    return {
+      tone: "warn",
+      text: `The agent image wasn't built with ${AGENT_LABELS[agent]} — add it under Settings → AI and rebuild.`,
+      settingsAction: true,
+    };
+  if (!status.imageMatches)
+    return {
+      tone: "warn",
+      text: "The agent image doesn't match the current Node / agent selection — rebuild in Settings to apply.",
+      settingsAction: true,
+    };
+  return undefined;
+}
 
 /** An in-progress `@file` mention: the query typed after `@` and the index of
  *  the `@` in the draft (so it can be replaced on selection). */
@@ -98,6 +201,10 @@ export function SessionComposer({
   // enabled registry server); a concrete array once the user picks. Frozen at
   // turn 1, so it only matters before a session exists.
   const [startMcp, setStartMcp] = useState<string[] | null>(null);
+  // Isolation for a NEW session. null = follow the global Settings → AI value; a
+  // concrete pick overrides it for THIS session only. Agent-independent, so it
+  // deliberately survives an agent switch.
+  const [startIsolation, setStartIsolation] = useState<Isolation | null>(null);
   // Run mode for a NEW task: a single session, or best-of-N. The mode picker is
   // always clickable (the Send button isn't, until you type), so you can choose
   // best-of-N first; Send then follows the mode.
@@ -134,7 +241,6 @@ export function SessionComposer({
   const onEffort = session
     ? (e: string) => setEffort(session.id, e)
     : setStartEffort;
-  const canSubmit = !running && !creating && draft.trim().length > 0;
   // Your sent prompts, oldest→newest, for Up/Down recall.
   const history = session ? session.turns.map((t) => t.prompt) : [];
 
@@ -245,7 +351,38 @@ export function SessionComposer({
       ),
     [settings.data?.mcpServers, repoKeys],
   );
-  const isContainer = settings.data?.agentIsolation === "container";
+  // Isolation for a NEW session: the global setting unless the composer's Options
+  // popover overrode it. Fixed at creation, so an ACTIVE session has none here (its
+  // own `session.isolation` governs, below). Derived during render — no effect.
+  const globalIsolation: Isolation =
+    settings.data?.agentIsolation ?? "worktree";
+  const effectiveIsolation = !session
+    ? (startIsolation ?? globalIsolation)
+    : undefined;
+  const isContainer = effectiveIsolation === "container";
+  // Container readiness, probed lazily and shared with Settings → AI (same query
+  // key, so one Docker/Podman check serves both). Only while a new session is
+  // actually set to run in a container AND the Agent tab is showing — an
+  // <Activity>-hidden subtree still fetches.
+  const agentTabShowing = useUiStore((s) => s.repoTab === "agent");
+  const containerStatus = useContainerStatus({
+    nodeVersion: settings.data?.agentImageNodeVersion ?? "",
+    providers: settings.data?.agentImageProviders ?? NO_PROVIDERS,
+    enabled: !session && isContainer && agentTabShowing && !!settings.data,
+  });
+  // A RESOLVED "can't run containers" blocks Start; loading (no data yet) never
+  // does, and a stale image, a missing agent, or a probe that couldn't run only warn.
+  const probe = containerStatus.data;
+  const probeFailed = containerStatus.isError;
+  // Whether the saved image config bakes in the agent this session would run.
+  const agentInImage =
+    settings.data?.agentImageProviders?.includes(startAgent) ?? false;
+  const containerBlocked =
+    isContainer &&
+    !!probe &&
+    (!probe.runtime || !probe.ready || !probe.imagePresent);
+  const canSubmit =
+    !running && !creating && draft.trim().length > 0 && !containerBlocked;
   // Servers the chosen agent can actually run (Codex = local/stdio only).
   const mcpServersForAgent = useMemo(
     () => mcpRegistry.filter((s) => mcpServerUsableBy(s, startAgent)),
@@ -264,7 +401,7 @@ export function SessionComposer({
   const mcpUsable = mcpSupportedFor(startAgent, isContainer);
   const mcpDisabledReason =
     !mcpUsable && startAgent === "codex"
-      ? "Codex runs MCP in container sessions — switch isolation in Settings → AI"
+      ? "Codex runs MCP in container sessions — switch Isolation to Container above"
       : undefined;
   // For an ACTIVE session the agent + isolation are fixed, so gate on the session's
   // own values and let the user re-pick servers (applies from the next turn).
@@ -338,6 +475,9 @@ export function SessionComposer({
               mcpServersForAgent.some((s) => s.id === id),
             )
           : undefined,
+        // Absent unless the user explicitly picked — start() then reads the global
+        // setting itself, exactly as before.
+        startIsolation ?? undefined,
       );
   };
 
@@ -358,6 +498,9 @@ export function SessionComposer({
   };
 
   const submit = () => {
+    // Container isolation that isn't ready: Enter must respect the same gate the
+    // Send button does (the Options popover explains why).
+    if (containerBlocked) return;
     // Best-of-N mode: the primary action opens the arm/cost dialog instead of
     // starting one session (the dialog runs the fan-out).
     if (!session && mode === "ensemble") {
@@ -389,11 +532,20 @@ export function SessionComposer({
   const runEnsemble = (
     arms: { agent: AgentKind; model: string; effort: string }[],
   ) => {
-    if (!pendingEnsemble) return;
+    // The probe can resolve blocked while the arm/cost dialog sits open — don't
+    // fan out N doomed arms (the composer's warn line explains it once it closes).
+    if (!pendingEnsemble || containerBlocked) return;
     const mcp = mcpUsable
       ? effectiveMcp.filter((id) => mcpServersForAgent.some((s) => s.id === id))
       : undefined;
-    void startEnsemble(repoPath, pendingEnsemble, arms, mcp);
+    void startEnsemble(
+      repoPath,
+      pendingEnsemble,
+      arms,
+      mcp,
+      // Every arm runs the same way — arms differ by agent/model/effort only.
+      startIsolation ?? undefined,
+    );
     clearDraft();
     setPendingEnsemble("");
   };
@@ -633,6 +785,19 @@ export function SessionComposer({
               }
               className="max-h-40 min-h-9 w-full resize-none overflow-y-auto bg-transparent text-xs leading-relaxed outline-none placeholder:text-muted-foreground"
             />
+            {/* Why Send is disabled, in layout flow — the global setting alone can
+                put you here, in which case the Options badge doesn't move and a
+                hover-only tooltip would be the sole explanation. */}
+            {containerBlocked && (
+              <p className="flex items-start gap-1.5 text-[11px] text-foreground">
+                <WarningCircleIcon
+                  weight="fill"
+                  className="mt-px size-3.5 shrink-0"
+                  aria-hidden
+                />
+                <span>{CONTAINER_BLOCKED_TEXT}</span>
+              </p>
+            )}
             <div className="flex items-center gap-2 border-t pt-2">
               {/* Provider + model stay inline for quick access; run mode, effort,
                   and MCP collapse into Options so the row never overflows. Best-of-N
@@ -655,6 +820,28 @@ export function SessionComposer({
                 onEffort={session || mode === "single" ? onEffort : undefined}
                 mode={!session ? mode : undefined}
                 onMode={!session ? setMode : undefined}
+                isolation={
+                  session
+                    ? undefined
+                    : {
+                        value: startIsolation ?? globalIsolation,
+                        onChange: setStartIsolation,
+                        isOverride:
+                          startIsolation !== null &&
+                          startIsolation !== globalIsolation,
+                        note: isolationNoteFor({
+                          effective: startIsolation ?? globalIsolation,
+                          global: globalIsolation,
+                          agent: startAgent,
+                          // Best-of-N arms each pick their own agent, so no
+                          // agent-specific host-sandbox claim can be made.
+                          perAgentCopy: mode !== "ensemble",
+                          status: probe,
+                          probeFailed,
+                          agentInImage,
+                        }),
+                      }
+                }
                 mcp={composerMcp}
               />
               <AnimatePresence mode="wait" initial={false}>
@@ -685,18 +872,27 @@ export function SessionComposer({
                     exit={{ opacity: 0, scale: 0.96 }}
                     transition={quickTransition}
                   >
-                    <Button
-                      size="sm"
-                      className="min-w-20"
-                      disabled={!canSubmit}
-                      onClick={submit}
+                    {/* A `title` on a DISABLED button never fires, so the
+                        container-not-ready reason rides a wrapper span. */}
+                    <span
+                      className="inline-flex"
+                      title={
+                        containerBlocked ? CONTAINER_BLOCKED_TEXT : undefined
+                      }
                     >
-                      {creating && !session
-                        ? "Starting…"
-                        : !session && mode === "ensemble"
-                          ? "Best-of-N…"
-                          : "Send"}
-                    </Button>
+                      <Button
+                        size="sm"
+                        className="min-w-20"
+                        disabled={!canSubmit}
+                        onClick={submit}
+                      >
+                        {creating && !session
+                          ? "Starting…"
+                          : !session && mode === "ensemble"
+                            ? "Best-of-N…"
+                            : "Send"}
+                      </Button>
+                    </span>
                   </m.div>
                 )}
               </AnimatePresence>

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -54,8 +54,8 @@ const NO_PROVIDERS: string[] = [];
 
 const RUNTIME_LABEL = { docker: "Docker", podman: "Podman" } as const;
 
-/** The always-visible reason a not-ready container disables Start — the same string
- *  the Send button's wrapper carries as a `title`. */
+/** FALLBACK reason a not-ready container disables Start, used only when the
+ *  isolation note hasn't produced a specific one (see `blockedReason`). */
 const CONTAINER_BLOCKED_TEXT =
   "Container isolation isn't ready — open Options for details.";
 
@@ -915,9 +915,7 @@ export function SessionComposer({
                         container-not-ready reason rides a wrapper span. */}
                     <span
                       className="inline-flex"
-                      title={
-                        containerBlocked ? CONTAINER_BLOCKED_TEXT : undefined
-                      }
+                      title={containerBlocked ? blockedReason : undefined}
                     >
                       <Button
                         size="sm"

--- a/src/features/sessions/SessionView.tsx
+++ b/src/features/sessions/SessionView.tsx
@@ -211,7 +211,10 @@ function SessionCanvas({
               <span className="text-muted-foreground" aria-hidden>
                 ·
               </span>
-              <IsolationChip isolation={session.isolation} />
+              <IsolationChip
+                isolation={session.isolation}
+                agent={session.agent}
+              />
               {prAudit && (
                 <>
                   <span className="text-muted-foreground" aria-hidden>
@@ -487,12 +490,15 @@ function SessionCanvas({
  * is fixed at creation and can now be overridden per session (the composer's Options
  * → Isolation row), so two Active sessions in the same repo can differ — the mode
  * has to be readable after the fact, not only at start. Mirrors the PrAuditChip
- * idiom: icon + text (never color alone), muted, with the caveat in the title.
+ * idiom: icon + text (never color alone), muted, with the caveat in the title. The
+ * host caveat is per-agent: only Codex brings its own OS-enforced sandbox there.
  */
 function IsolationChip({
   isolation,
+  agent,
 }: {
   isolation: AgentSession["isolation"];
+  agent: AgentSession["agent"];
 }) {
   const container = isolation === "container";
   const Icon = container ? CubeIcon : TreeStructureIcon;
@@ -502,7 +508,9 @@ function IsolationChip({
       title={
         container
           ? "Runs in an ephemeral container — file writes are confined by the kernel."
-          : "Runs on the host in a throwaway worktree — file writes are confined by convention, not the kernel."
+          : agent === "codex"
+            ? "Runs on the host in a throwaway worktree — Codex keeps its own OS-enforced sandbox."
+            : "Runs on the host in a throwaway worktree — file writes are confined by convention, not the kernel."
       }
     >
       <Icon weight="bold" className="size-3" />

--- a/src/features/sessions/SessionView.tsx
+++ b/src/features/sessions/SessionView.tsx
@@ -1,7 +1,9 @@
 import { Popover } from "@base-ui/react/popover";
 import {
+  CubeIcon,
   SparkleIcon,
   TerminalWindowIcon,
+  TreeStructureIcon,
   UsersThreeIcon,
 } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
@@ -206,6 +208,10 @@ function SessionCanvas({
               >
                 {session.branch}
               </span>
+              <span className="text-muted-foreground" aria-hidden>
+                ·
+              </span>
+              <IsolationChip isolation={session.isolation} />
               {prAudit && (
                 <>
                   <span className="text-muted-foreground" aria-hidden>
@@ -473,6 +479,35 @@ function SessionCanvas({
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+/**
+ * How this session is sandboxed, in the canvas header beside the branch. Isolation
+ * is fixed at creation and can now be overridden per session (the composer's Options
+ * → Isolation row), so two Active sessions in the same repo can differ — the mode
+ * has to be readable after the fact, not only at start. Mirrors the PrAuditChip
+ * idiom: icon + text (never color alone), muted, with the caveat in the title.
+ */
+function IsolationChip({
+  isolation,
+}: {
+  isolation: AgentSession["isolation"];
+}) {
+  const container = isolation === "container";
+  const Icon = container ? CubeIcon : TreeStructureIcon;
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-1 text-muted-foreground"
+      title={
+        container
+          ? "Runs in an ephemeral container — file writes are confined by the kernel."
+          : "Runs on the host in a throwaway worktree — file writes are confined by convention, not the kernel."
+      }
+    >
+      <Icon weight="bold" className="size-3" />
+      {container ? "Container" : "Worktree"}
+    </span>
   );
 }
 

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -548,13 +548,14 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
     // same way), so resolve it once here. Both agents honor the setting: on the
     // host each runs worktree-confined by its own OS sandbox (Codex via
     // `-s workspace-write`); "container" wraps either in a kernel boundary.
-    const setting =
-      (await loadSettings().catch(() => null))?.agentIsolation ?? "worktree";
     // Every agent honors the setting now — Copilot's container authenticates from a
     // `gh auth token` (no mountable creds file), so it no longer forces host-only.
-    // The composer's Isolation row can override the global setting for THIS session
-    // (absent = follow Settings → AI).
-    const isolation = isolationOverride ?? setting;
+    // The composer's Isolation row can override it for THIS session; the global
+    // setting is only read (`??` short-circuits the await) when it didn't.
+    const isolation =
+      isolationOverride ??
+      (await loadSettings().catch(() => null))?.agentIsolation ??
+      "worktree";
     let wt: Awaited<ReturnType<typeof createWorktree>>;
     try {
       wt = await createWorktree(repoPath);

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -126,16 +126,31 @@ const SYSTEM_PROMPT =
   "Do NOT commit — the app commits each turn so the user can review it. When " +
   "finished with a turn, briefly summarize what you changed.";
 
-/** The handoff record that seeds the new-session composer. */
+/**
+ * The handoff record that seeds the new-session composer.
+ *
+ * Everything past `prompt` is the composer's start-state, carried across a Settings
+ * round-trip: the isolation note's "Set up in Settings…" jump unmounts
+ * RepositoryView (App.tsx renders it behind `view === "repo"`), so the composer's
+ * local state would otherwise be lost — you'd come back from adding an agent to the
+ * container image only to find the composer re-seeded to a different agent, and the
+ * task would run as something you didn't choose. A plain handoff ("Implement this
+ * issue") sets none of them and the composer keeps its own values.
+ */
 export interface PendingTask {
   repoPath: string;
   prompt: string;
-  /** The composer's isolation pick, carried across a Settings round-trip: the
-   *  "Set up in Settings…" jump unmounts RepositoryView (App.tsx renders it behind
-   *  `view === "repo"`), so the composer's local state would otherwise be lost and
-   *  the session would silently fall back to the global setting. Absent (the plain
-   *  handoff case) = leave the composer's own pick alone. */
+  /** Absent = no explicit pick was made, so there's nothing to restore. */
   isolation?: "worktree" | "container";
+  agent?: "claude" | "codex" | "copilot" | "opencode";
+  /** "" = the account default model. */
+  model?: string;
+  /** "" = Auto. */
+  effort?: string;
+  mode?: "single" | "ensemble";
+  /** Stashed verbatim — `null` is meaningful (follow the per-repo default set),
+   *  and is NOT the same as absent. */
+  mcpServers?: string[] | null;
 }
 
 interface SessionsState {

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -154,6 +154,9 @@ interface SessionsState {
     effort: string,
     ensembleId?: string,
     mcpServers?: string[],
+    /** Per-session override of the global isolation setting (the composer's
+     *  Isolation row). Absent = follow Settings → AI. */
+    isolation?: "worktree" | "container",
   ) => Promise<string | null>;
   /** Best-of-N: start one session per `arm` on the SAME task, sharing one ensemble
    *  id, so they can be reviewed side by side and the best one kept. Each arm runs
@@ -171,6 +174,9 @@ interface SessionsState {
     /** MCP server ids shared across every arm (each arm drops the ones its own
      *  agent/isolation can't use). Absent/empty = no MCP. */
     mcpServers?: string[],
+    /** Per-session isolation override, shared by every arm. Absent = follow
+     *  Settings → AI. */
+    isolation?: "worktree" | "container",
   ) => Promise<string[]>;
   send: (id: string, prompt: string) => Promise<void>;
   setModel: (id: string, model: string) => void;
@@ -533,6 +539,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
     effort,
     ensembleId,
     mcpServers,
+    isolationOverride,
   ) => {
     const task = prompt.trim();
     if (!task || get().creating) return null;
@@ -545,7 +552,9 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
       (await loadSettings().catch(() => null))?.agentIsolation ?? "worktree";
     // Every agent honors the setting now — Copilot's container authenticates from a
     // `gh auth token` (no mountable creds file), so it no longer forces host-only.
-    const isolation = setting;
+    // The composer's Isolation row can override the global setting for THIS session
+    // (absent = follow Settings → AI).
+    const isolation = isolationOverride ?? setting;
     let wt: Awaited<ReturnType<typeof createWorktree>>;
     try {
       wt = await createWorktree(repoPath);
@@ -605,7 +614,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
     return wt.id;
   },
 
-  startEnsemble: async (repoPath, prompt, arms, mcpServers) => {
+  startEnsemble: async (repoPath, prompt, arms, mcpServers, isolation) => {
     const task = prompt.trim();
     if (!task || arms.length === 0) return [];
     // One shared id ties the arms together; each is otherwise a normal session
@@ -626,6 +635,9 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
         // The shared MCP selection; start() drops it for an arm whose
         // agent/isolation can't run MCP, and runTurn filters per-agent each turn.
         mcpServers,
+        // One shared isolation for the whole ensemble (arms differ by agent/model,
+        // never by how they're sandboxed).
+        isolation,
       );
       if (id) ids.push(id);
     }

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -126,6 +126,18 @@ const SYSTEM_PROMPT =
   "Do NOT commit — the app commits each turn so the user can review it. When " +
   "finished with a turn, briefly summarize what you changed.";
 
+/** The handoff record that seeds the new-session composer. */
+export interface PendingTask {
+  repoPath: string;
+  prompt: string;
+  /** The composer's isolation pick, carried across a Settings round-trip: the
+   *  "Set up in Settings…" jump unmounts RepositoryView (App.tsx renders it behind
+   *  `view === "repo"`), so the composer's local state would otherwise be lost and
+   *  the session would silently fall back to the global setting. Absent (the plain
+   *  handoff case) = leave the composer's own pick alone. */
+  isolation?: "worktree" | "container";
+}
+
 interface SessionsState {
   /** All sessions, in creation order. Each runs in its own worktree. */
   sessions: AgentSession[];
@@ -142,10 +154,10 @@ interface SessionsState {
    *  cleared by the activation composer once it loads it. Lets the handoff cross
    *  the tab/Activity boundary without an imperative ref. `repoPath` scopes it so
    *  only that repo's composer picks it up. */
-  pendingTask: { repoPath: string; prompt: string } | null;
+  pendingTask: PendingTask | null;
   hydrate: () => Promise<void>;
   setActive: (id: string | null) => void;
-  setPendingTask: (task: { repoPath: string; prompt: string } | null) => void;
+  setPendingTask: (task: PendingTask | null) => void;
   start: (
     repoPath: string,
     prompt: string,

--- a/src/features/settings/AgentSandboxField.tsx
+++ b/src/features/settings/AgentSandboxField.tsx
@@ -24,10 +24,10 @@ import {
   buildCustomImage,
   type ContainerStatus,
   customImageStatus,
-  detectContainerSandbox,
   prepareContainerSandbox,
   scaffoldCustomDockerfile,
 } from "@/lib/ai/sandbox";
+import { useContainerStatus } from "@/lib/ai/sandbox-queries";
 import { toastError } from "@/lib/toast";
 
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
@@ -71,16 +71,7 @@ export function AgentSandboxField({
   repoPath: string | null;
 }) {
   const enabled = value === "container";
-  const status = useQuery({
-    queryKey: [
-      "agentContainerStatus",
-      nodeVersion,
-      [...providers].sort().join(","),
-    ],
-    queryFn: () => detectContainerSandbox(nodeVersion, providers),
-    staleTime: 30_000,
-    enabled,
-  });
+  const status = useContainerStatus({ nodeVersion, providers, enabled });
   const queryClient = useQueryClient();
   const [building, setBuilding] = useState(false);
 

--- a/src/lib/ai/sandbox-queries.ts
+++ b/src/lib/ai/sandbox-queries.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { detectContainerSandbox } from "./sandbox";
+
+/**
+ * Container-sandbox readiness for one image config (Node base version + the agent
+ * CLIs baked in). Shared by Settings → AI and the session composer's Isolation row
+ * so the two read ONE cached probe instead of each shelling out to Docker/Podman —
+ * the query key is the config, so a build/rebuild invalidating
+ * `["agentContainerStatus"]` refreshes both.
+ *
+ * `enabled` is the caller's gate: Settings probes only while the container option
+ * is on, the composer only while a NEW session is actually set to run in one (and
+ * its tab is showing — an `<Activity>`-hidden subtree still fetches).
+ */
+export function useContainerStatus({
+  nodeVersion,
+  providers,
+  enabled,
+}: {
+  nodeVersion: string;
+  providers: string[];
+  enabled: boolean;
+}) {
+  return useQuery({
+    queryKey: [
+      "agentContainerStatus",
+      nodeVersion,
+      [...providers].sort().join(","),
+    ],
+    queryFn: () => detectContainerSandbox(nodeVersion, providers),
+    staleTime: 30_000,
+    enabled,
+  });
+}

--- a/src/lib/ai/sandbox-queries.ts
+++ b/src/lib/ai/sandbox-queries.ts
@@ -11,6 +11,11 @@ import { detectContainerSandbox } from "./sandbox";
  * `enabled` is the caller's gate: Settings probes only while the container option
  * is on, the composer only while a NEW session is actually set to run in one (and
  * its tab is showing — an `<Activity>`-hidden subtree still fetches).
+ *
+ * While the answer is "not usable" it re-probes on an interval, so starting the
+ * Docker/Podman daemon clears the warning (and the composer's Start block) on its
+ * own. Window focus alone isn't enough — the integrated terminal lets you start the
+ * daemon without ever leaving the window. Once healthy the polling stops.
  */
 export function useContainerStatus({
   nodeVersion,
@@ -29,6 +34,11 @@ export function useContainerStatus({
     ],
     queryFn: () => detectContainerSandbox(nodeVersion, providers),
     staleTime: 30_000,
+    // Recovery polling — only while unusable, and (react-query) only while enabled.
+    refetchInterval: (query) => {
+      const d = query.state.data;
+      return d?.ready && d.imagePresent ? false : 15_000;
+    },
     enabled,
   });
 }


### PR DESCRIPTION
Adds a per-session isolation override so a single agent run can use a worktree or a container without changing the global Settings → AI default. Choosing a container now checks readiness inline — runtime installed, engine running, image built — and blocks **Send** with a named reason instead of failing at turn 1. Along the way this corrects the long-standing "Codex is container-only" claim: Codex runs on the host too (with its own OS sandbox); only its *MCP* support requires a container.

### Composer UI

- Adds an **Isolation** control to the Options popover in `src/features/sessions/AgentPickers.tsx` (`ISOLATION_OPTIONS`, `Isolation`, `IsolationNote`), rendered above MCP because it gates it, with an optional caveat line (icon + text, never color alone) and a "Set up in Settings…" jump.
- Upgrades the shared `Segmented` control to the full ARIA radiogroup pattern — one tab stop via roving `tabIndex`, arrow keys select-and-focus the neighbour with wrapping.
- Tracks the override in `SessionComposer.tsx` as `startIsolation` (`null` = follow Settings), agent-independent so it survives an agent switch; it counts toward the Options badge only when it differs from the global default.
- Adds `isolationNoteFor()` in `SessionComposer.tsx` to compute the single note line: probe-loading, no runtime, stopped engine, unbuilt image, agent missing from the image, stale image, or the host-downgrade disclosure (Codex-specific wording only outside best-of-N, where arms may differ).
- Gates submission on `containerBlocked` — a *resolved* missing runtime / stopped engine / absent image disables `canSubmit`, short-circuits `submit()` so Enter honors the same gate, and aborts `runEnsemble()` if the probe resolves while the arm dialog is open. Stale images and failed probes only warn.
- Surfaces the reason in layout flow above the action row (`CONTAINER_BLOCKED_TEXT`) and wraps the disabled **Send** in a `<span title>` so the tooltip actually fires.
- Retargets the Codex MCP disabled reason at the new in-composer control rather than Settings.

### Readiness probe sharing

- Extracts `useContainerStatus()` into the new `src/lib/ai/sandbox-queries.ts`, keeping the `["agentContainerStatus", nodeVersion, providers]` key so Settings and the composer share one cached Docker/Podman probe and a rebuild invalidates both.
- `src/features/settings/AgentSandboxField.tsx` now consumes the shared hook instead of its inline `useQuery`.
- The composer enables the probe only for a new container-bound session **and** while the Agent tab is showing, since an `<Activity>`-hidden subtree still fetches.

### Session plumbing

- Threads an optional `isolation` argument through `start()` and `startEnsemble()` in `src/features/sessions/store.ts`; absent falls back to `agentIsolation` from settings exactly as before, and every best-of-N arm shares one pick.

### Backend

- `src-tauri/src/agent.rs` adds a `runtime_ready()` probe before the image check so a stopped daemon reports itself rather than masquerading as "image isn't built yet", and rewrites the runtime-missing error to mention the per-session control.
- Makes `runtime_ready` `pub(crate)` in `src-tauri/src/agent_sandbox.rs` and corrects its module docs — every agent runs host or container; Codex's host mode uses `-s workspace-write`.
- `src-tauri/src/mcp.rs` reframes the Codex section as *MCP* container-only, and its error now points at the composer's Isolation control.

### Docs

- `README.md`, `site/src/data/capabilities.ts`, and the Sandbox/MCP sections of `src/features/help/content.ts` document the per-session pick, the inline readiness check, and the host-downgrade disclosure.
- Adds `changelog.d/added-per-session-isolation.md`.