### PR TITLE
feat(ai,settings): add Review timeout setting, raise agentic default

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,10 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   - **Sized to your model** — a **Review context** setting scales the review's context
     budget to the reviewing model's window (Auto probes a local **Ollama** model's context
     length live), so a larger model sees more of the PR before agentic review is needed
-  - **Timeboxed on your terms** — agentic reviews get 20 minutes before they're stopped
-    (plain reviews 5; Codex reviews are always agentic), and a **Review timeout** setting
-    pins a fixed limit when your reviews need more room — the timeout error itself points
-    at the knob
+  - **Timeboxed on your terms** — agent-CLI reviews are timeboxed: agentic ones get 20
+    minutes before they're stopped (plain 5; Codex reviews are always agentic), and a
+    **Review timeout** setting pins a fixed limit when your reviews need more room — the
+    timeout error itself points at the knob. HTTP/API reviews stream without a deadline.
   - **Notes for reviewers** — hand the reviewer context up front: an agent deposits
     per-branch notes via the GitDesktop MCP, or you type them in the Create PR dialog; on
     create they post as the PR's first comment and reach the automated review as

--- a/README.md
+++ b/README.md
@@ -272,8 +272,9 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
     budget to the reviewing model's window (Auto probes a local **Ollama** model's context
     length live), so a larger model sees more of the PR before agentic review is needed
   - **Timeboxed on your terms** — agentic reviews get 20 minutes before they're stopped
-    (plain reviews 5), and a **Review timeout** setting pins a fixed limit when your
-    reviews need more room — the timeout error itself points at the knob
+    (plain reviews 5; Codex reviews are always agentic), and a **Review timeout** setting
+    pins a fixed limit when your reviews need more room — the timeout error itself points
+    at the knob
   - **Notes for reviewers** — hand the reviewer context up front: an agent deposits
     per-branch notes via the GitDesktop MCP, or you type them in the Create PR dialog; on
     create they post as the PR's first comment and reach the automated review as

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   - **Sized to your model** — a **Review context** setting scales the review's context
     budget to the reviewing model's window (Auto probes a local **Ollama** model's context
     length live), so a larger model sees more of the PR before agentic review is needed
+  - **Timeboxed on your terms** — agentic reviews get 20 minutes before they're stopped
+    (plain reviews 5), and a **Review timeout** setting pins a fixed limit when your
+    reviews need more room — the timeout error itself points at the knob
   - **Notes for reviewers** — hand the reviewer context up front: an agent deposits
     per-branch notes via the GitDesktop MCP, or you type them in the Create PR dialog; on
     create they post as the PR's first comment and reach the automated review as

--- a/changelog.d/changed-review-timeout.md
+++ b/changelog.d/changed-review-timeout.md
@@ -1,0 +1,3 @@
+- Agentic AI reviews now get 20 minutes before timing out (up from 10), and a new
+  **Review timeout** setting under *Settings → AI* lets you raise or pin the limit
+  for agent-CLI reviews.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -21,11 +21,58 @@ use crate::state::AppState;
 
 pub(crate) const DETECT_TIMEOUT: Duration = Duration::from_secs(20);
 const REVIEW_TIMEOUT: Duration = Duration::from_secs(300);
-/// Repo-aware (Tier 2) runs explore the tree with tools and take longer.
-const REVIEW_TIMEOUT_AGENTIC: Duration = Duration::from_secs(600);
+/// Repo-aware (Tier 2) runs explore the tree with tools and take longer — a
+/// self-MCP review pulling the full diff routinely runs past ten minutes, so
+/// the default budget is twenty. Users can override it in Settings.
+const REVIEW_TIMEOUT_AGENTIC: Duration = Duration::from_secs(1200);
 /// A write-capable agent session implements a real task, so it gets a much
 /// longer budget than a review. Generous for the slice; configurable later.
 const SESSION_TIMEOUT: Duration = Duration::from_secs(1800);
+
+/// Effective kill timeout for a review run: the user's override (clamped to
+/// 1–120 minutes) when set and non-zero, else the tier default.
+fn review_timeout(agentic: bool, override_secs: Option<u64>) -> Duration {
+    match override_secs {
+        Some(s) if s > 0 => Duration::from_secs(s.clamp(60, 7200)),
+        _ => {
+            if agentic {
+                REVIEW_TIMEOUT_AGENTIC
+            } else {
+                REVIEW_TIMEOUT
+            }
+        }
+    }
+}
+
+/// Human-readable duration for timeout copy: whole minutes when it divides
+/// evenly ("20 minutes"), else seconds ("90 seconds").
+fn human_duration(secs: u64) -> String {
+    if secs >= 60 && secs.is_multiple_of(60) {
+        let mins = secs / 60;
+        if mins == 1 {
+            "1 minute".to_string()
+        } else {
+            format!("{mins} minutes")
+        }
+    } else {
+        format!("{secs} seconds")
+    }
+}
+
+/// Copy for a run killed by its deadline. `hint` points at the setting that
+/// governs the limit — set only by the review flows the "Review timeout"
+/// setting actually reaches, so generation / Debug-with-AI (which share the
+/// "review" noun) and sessions never advertise a knob that can't help them.
+fn timeout_message(noun: &str, timeout: Duration, hint: bool) -> String {
+    let mut msg = format!(
+        "The {noun} timed out after {}.",
+        human_duration(timeout.as_secs())
+    );
+    if hint {
+        msg.push_str(" You can raise the limit in Settings → AI.");
+    }
+    msg
+}
 
 /// Which agent CLI to drive. Frontend sends `"claude"` / `"codex"` / `"copilot"` /
 /// `"opencode"`. All four are fully wired for sessions + reviews; opencode runs
@@ -1619,6 +1666,9 @@ async fn stream_agent(
     timeout: Duration,
     cancel_id: &str,
     noun: &str,
+    // Whether a timeout message may point at the "Review timeout" setting — true
+    // only for the review flows that setting governs (see `timeout_message`).
+    timeout_hint: bool,
     // When the run is wrapped in a container (`binary` = docker/podman), the
     // `(runtime, container name)` to force-remove on cancel/timeout — killing the
     // `run` client alone leaves the engine's container running.
@@ -1764,7 +1814,7 @@ async fn stream_agent(
     }
     if timed_out {
         on_event.send(ReviewEvent::Error {
-            message: format!("The {noun} timed out after {}s.", timeout.as_secs()),
+            message: timeout_message(noun, timeout, timeout_hint),
         });
         return Ok(());
     }
@@ -1805,6 +1855,13 @@ pub async fn agent_review(
     // diff in the prompt. Honored for Claude / Copilot / opencode (Codex is exempt —
     // see below). `false` = today's behavior, byte-for-byte.
     mcp_self: bool,
+    // User's "Review timeout" override in seconds, clamped to 1–120 minutes here.
+    // `None` / `0` = the tier defaults below.
+    timeout_secs: Option<u64>,
+    // Whether that setting governs THIS run — true for the AI-review flows, absent
+    // (false) for generation / Debug-with-AI, which share the command but not the
+    // setting. Only gates the timeout message's "raise the limit" hint.
+    timeout_configurable: Option<bool>,
     review_id: String,
     on_event: Channel<ReviewEvent>,
 ) -> AppResult<()> {
@@ -1903,14 +1960,24 @@ pub async fn agent_review(
     // Codex always explores the repo, so it gets the longer agentic budget too — and
     // a self-MCP review is agentic regardless of `repo_aware` (the agent pulls the
     // full diff / reads files via the server), so it gets the agentic budget too.
-    let timeout = if repo_aware || self_mcp_wanted || matches!(kind, AgentKind::Codex) {
-        REVIEW_TIMEOUT_AGENTIC
-    } else {
-        REVIEW_TIMEOUT
-    };
+    let timeout = review_timeout(
+        repo_aware || self_mcp_wanted || matches!(kind, AgentKind::Codex),
+        timeout_secs,
+    );
     let result = stream_agent(
-        &state, kind, &binary, args, stdin_text, &repo_path, timeout, &review_id, "review", None,
-        &extra_env, &on_event,
+        &state,
+        kind,
+        &binary,
+        args,
+        stdin_text,
+        &repo_path,
+        timeout,
+        &review_id,
+        "review",
+        timeout_configurable.unwrap_or(false),
+        None,
+        &extra_env,
+        &on_event,
     )
     .await;
     // Remove the generated config on EVERY path (success, error), mirroring the
@@ -2332,6 +2399,7 @@ pub async fn agent_session(
             SESSION_TIMEOUT,
             &session_id,
             "session",
+            false,
             Some((runtime.clone(), name)),
             &extra_env,
             &on_event,
@@ -2370,6 +2438,7 @@ pub async fn agent_session(
         SESSION_TIMEOUT,
         &session_id,
         "session",
+        false,
         None,
         &host_extra_env,
         &on_event,
@@ -2922,5 +2991,49 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert!(matches!(&events[0], ReviewEvent::Delta { text } if text == "hello"));
         assert!(matches!(&events[1], ReviewEvent::Error { message } if message == "boom"));
+    }
+
+    #[test]
+    fn review_timeout_falls_back_to_the_tier_default() {
+        assert_eq!(review_timeout(false, None), Duration::from_secs(300));
+        assert_eq!(review_timeout(true, None), Duration::from_secs(1200));
+        // A zero override is "no override", not an instant kill.
+        assert_eq!(review_timeout(true, Some(0)), Duration::from_secs(1200));
+        assert_eq!(review_timeout(false, Some(0)), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn review_timeout_clamps_and_overrides_both_tiers() {
+        assert_eq!(review_timeout(true, Some(30)), Duration::from_secs(60));
+        assert_eq!(review_timeout(true, Some(999_999)), Duration::from_secs(7200));
+        // The override wins regardless of tier — even below the agentic default.
+        assert_eq!(review_timeout(false, Some(1500)), Duration::from_secs(1500));
+    }
+
+    #[test]
+    fn timeout_message_hints_only_when_the_flag_is_set() {
+        let msg = timeout_message("review", Duration::from_secs(1200), true);
+        assert_eq!(
+            msg,
+            "The review timed out after 20 minutes. You can raise the limit in Settings → AI."
+        );
+        assert!(msg.contains("Settings → AI."));
+        // Same noun, no flag — generation / Debug-with-AI also run `agent_review`,
+        // and the setting doesn't reach them.
+        let plain = timeout_message("review", Duration::from_secs(300), false);
+        assert_eq!(plain, "The review timed out after 5 minutes.");
+        assert!(!plain.contains("Settings"));
+        assert_eq!(
+            timeout_message("session", Duration::from_secs(1800), false),
+            "The session timed out after 30 minutes."
+        );
+    }
+
+    #[test]
+    fn human_duration_prefers_whole_minutes() {
+        assert_eq!(human_duration(60), "1 minute");
+        assert_eq!(human_duration(1200), "20 minutes");
+        assert_eq!(human_duration(90), "90 seconds");
+        assert_eq!(human_duration(7200), "120 minutes");
     }
 }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -69,7 +69,9 @@ fn timeout_message(noun: &str, timeout: Duration, hint: bool) -> String {
         human_duration(timeout.as_secs())
     );
     if hint {
-        msg.push_str(" You can raise the limit in Settings → AI.");
+        // "Adjust", not "raise" — a run that already used the largest offered
+        // option can only go down, and the hint must never be a dead end.
+        msg.push_str(" You can adjust the limit in Settings → AI.");
     }
     msg
 }
@@ -1860,7 +1862,7 @@ pub async fn agent_review(
     timeout_secs: Option<u64>,
     // Whether that setting governs THIS run — true for the AI-review flows, absent
     // (false) for generation / Debug-with-AI, which share the command but not the
-    // setting. Only gates the timeout message's "raise the limit" hint.
+    // setting. Only gates the timeout message's "adjust the limit" hint.
     timeout_configurable: Option<bool>,
     review_id: String,
     on_event: Channel<ReviewEvent>,
@@ -3015,7 +3017,7 @@ mod tests {
         let msg = timeout_message("review", Duration::from_secs(1200), true);
         assert_eq!(
             msg,
-            "The review timed out after 20 minutes. You can raise the limit in Settings → AI."
+            "The review timed out after 20 minutes. You can adjust the limit in Settings → AI."
         );
         assert!(msg.contains("Settings → AI."));
         // Same noun, no flag — generation / Debug-with-AI also run `agent_review`,

--- a/src-tauri/src/automation_claims.rs
+++ b/src-tauri/src/automation_claims.rs
@@ -208,11 +208,14 @@ fn claim_in_dir(dir: &Path, key: &str) -> std::io::Result<bool> {
 /// Best-effort liveness heartbeat: refresh the mtime of `key`'s claim file so a
 /// long-running automation keeps its claim "fresh" past [`STALE_CLAIM_AGE`]. All errors
 /// are ignored (fail-open philosophy — a failed heartbeat degrades to the old behavior,
-/// a reclaim after 30 quiet minutes). Opens WITHOUT `create`, so a claim that was
-/// already released or reclaimed is never resurrected by a late heartbeat — the open
-/// simply errs and is ignored. The write handle is required, not incidental: on Windows
-/// `set_modified` on a read-only handle fails with PermissionDenied (the tests'
-/// `backdate` helper documents the same constraint).
+/// a reclaim after 30 quiet minutes). Opens WITHOUT `create`, so a RELEASED claim is
+/// never resurrected by a late heartbeat — the open errs on the missing file and is
+/// ignored. A RECLAIMED claim is different: the filename derives from the run key, not
+/// the owning instance, so a late heartbeat from the old owner lands on (and refreshes)
+/// the new owner's file — harmless, since it only keeps the live owner's claim fresh.
+/// The write handle is required, not incidental: on Windows `set_modified` on a
+/// read-only handle fails with PermissionDenied (the tests' `backdate` helper documents
+/// the same constraint).
 fn touch_in_dir(dir: &Path, key: &str) {
     let _ = std::fs::OpenOptions::new()
         .write(true)

--- a/src-tauri/src/automation_claims.rs
+++ b/src-tauri/src/automation_claims.rs
@@ -56,12 +56,20 @@ const SWEEP_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 /// 30 minutes is safe because a DELIVERED review no longer relies on its claim for
 /// dedup: at delivery the runner writes a pr-reviews history record, and that record —
 /// not the claim — gates pr-open (per-mode) and pr-sync (same-sha skip). Reclaiming an
-/// old delivered claim therefore cannot cause a re-review. The residual risk is a
-/// legitimately still-RUNNING review that outlasts 30 minutes being double-claimed by a
-/// concurrently polling second instance — accepted, bounded to a single duplicate
-/// review, and strictly better than a 30-day starvation. A run whose delivery-record
-/// write failed (best-effort in the runner) is the same bounded case: one duplicate
+/// old delivered claim therefore cannot cause a re-review. A run whose delivery-record
+/// write failed (best-effort in the runner) is bounded the same way: one duplicate
 /// after 30 minutes, not a month of silence.
+///
+/// **This window measures heartbeat LIVENESS, not run length.** A running automation
+/// refreshes its own claim's mtime from the runner every few minutes (see
+/// [`touch_automation_claim`]) for as long as the AI call is in flight, so a long run
+/// stays "fresh" indefinitely and is never double-claimed. That heartbeat closes what
+/// used to be an accepted residual risk: reviews were once capped at 600s backend-side,
+/// making a 30-minute overrun unreachable, but the user-facing "Review timeout" setting
+/// now allows up to 60 minutes (and the backend clamp permits 7200s), so a legitimately
+/// still-RUNNING review can outlive this window. The crash story is unchanged: an
+/// instance that dies stops heartbeating, its claim ages out at 30 minutes, and the next
+/// claimant reclaims it instead of being starved until the 30-day sweep.
 const STALE_CLAIM_AGE: Duration = Duration::from_secs(30 * 60);
 
 /// The app-data subdir holding claim files.
@@ -197,6 +205,21 @@ fn claim_in_dir(dir: &Path, key: &str) -> std::io::Result<bool> {
     create_new_claim(&path, key)
 }
 
+/// Best-effort liveness heartbeat: refresh the mtime of `key`'s claim file so a
+/// long-running automation keeps its claim "fresh" past [`STALE_CLAIM_AGE`]. All errors
+/// are ignored (fail-open philosophy — a failed heartbeat degrades to the old behavior,
+/// a reclaim after 30 quiet minutes). Opens WITHOUT `create`, so a claim that was
+/// already released or reclaimed is never resurrected by a late heartbeat — the open
+/// simply errs and is ignored. The write handle is required, not incidental: on Windows
+/// `set_modified` on a read-only handle fails with PermissionDenied (the tests'
+/// `backdate` helper documents the same constraint).
+fn touch_in_dir(dir: &Path, key: &str) {
+    let _ = std::fs::OpenOptions::new()
+        .write(true)
+        .open(dir.join(claim_filename(key)))
+        .and_then(|f| f.set_modified(SystemTime::now()));
+}
+
 /// Best-effort release of `key`'s claim inside `dir` (delete the file). Errors are
 /// ignored — a release that fails or races another instance is harmless; the 30-day
 /// sweep is the backstop. Takes a `&Path` so it's unit-testable without an `AppHandle`.
@@ -257,6 +280,26 @@ pub async fn release_automation_claim(
     if let Ok(dir) = claims_dir(&app) {
         let key = composite_key(&repo_key, &target, &head_sha, &action);
         release_in_dir(&dir, &key);
+    }
+    Ok(())
+}
+
+/// Best-effort liveness heartbeat from a RUNNING automation: refreshes its claim's
+/// mtime so [`STALE_CLAIM_AGE`] measures "has this instance gone quiet", not "how long
+/// has this review taken". Called on an interval by the runner while the AI call is in
+/// flight. Always `Ok(())` — a failed heartbeat (missing file, permission, unresolvable
+/// dir) is silently tolerated, degrading to the pre-heartbeat reclaim behavior.
+#[tauri::command]
+pub async fn touch_automation_claim(
+    app: tauri::AppHandle,
+    repo_key: String,
+    target: String,
+    head_sha: String,
+    action: String,
+) -> AppResult<()> {
+    if let Ok(dir) = claims_dir(&app) {
+        let key = composite_key(&repo_key, &target, &head_sha, &action);
+        touch_in_dir(&dir, &key);
     }
     Ok(())
 }
@@ -391,6 +434,41 @@ mod tests {
         assert!(
             claim_in_dir(&dir, &key).unwrap(),
             "a stale claim must be reclaimed by the next claimant"
+        );
+    }
+
+    #[test]
+    fn heartbeat_keeps_a_long_running_claim_alive() {
+        let (_tmp, dir) = tmp_dir();
+        let key = composite_key(r"C:\repo\one", "42", "abc123", "review");
+
+        // A run takes the claim, then outlives STALE_CLAIM_AGE (a 45/60-minute
+        // Review-timeout override) — but keeps heartbeating.
+        assert!(claim_in_dir(&dir, &key).unwrap(), "first claim should win");
+        let path = dir.join(claim_filename(&key));
+        backdate(&path, STALE_CLAIM_AGE + Duration::from_secs(60));
+        touch_in_dir(&dir, &key);
+
+        // The refreshed mtime makes it fresh again, so a second instance is denied
+        // instead of reclaiming and posting a duplicate paid review.
+        assert!(
+            !claim_in_dir(&dir, &key).unwrap(),
+            "a heartbeated claim must keep denying a second claimant"
+        );
+    }
+
+    #[test]
+    fn heartbeat_on_a_missing_claim_is_a_no_op() {
+        let (_tmp, dir) = tmp_dir();
+        let key = composite_key(r"C:\repo\one", "42", "abc123", "review");
+        let path = dir.join(claim_filename(&key));
+
+        // A released/reclaimed claim must never be resurrected by a late heartbeat.
+        assert!(!path.exists(), "precondition: no claim file yet");
+        touch_in_dir(&dir, &key);
+        assert!(
+            !path.exists(),
+            "a heartbeat must not create a claim file that isn't there"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,6 +231,7 @@ pub fn run() {
             oplog::git_oplog_dismiss,
             automation_claims::claim_automation_run,
             automation_claims::release_automation_claim,
+            automation_claims::touch_automation_claim,
             git::ops::git_merge,
             git::ops::git_merge_preview,
             git::ops::git_rebase,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -902,7 +902,9 @@ accumulate past the prompt budget, the newest comments win, and the full history
 off. See *AI & automations* to pick the review model. The **Review context** size there
 controls how much diff and prior-discussion context reviews send — **Auto** fits it to the
 reviewing model's context window (probing Ollama live), or pick Compact / Standard /
-Expanded.
+Expanded. **Review timeout** (shown when an agent CLI drives reviews or security audits)
+caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
+the review is agentic), or pin a fixed limit that applies to every agent-CLI review.
 
 **One review at a time — queue the other.** A PR streams one AI review at a time,
 but you don't have to pick between a code review and a security audit: start one

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -904,7 +904,8 @@ controls how much diff and prior-discussion context reviews send — **Auto** fi
 reviewing model's context window (probing Ollama live), or pick Compact / Standard /
 Expanded. **Review timeout** (shown when an agent CLI drives reviews or security audits)
 caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
-the review is agentic), or pin a fixed limit that applies to every agent-CLI review.
+the review is agentic — always, for Codex), or pin a fixed limit that applies to every
+agent-CLI review.
 
 **One review at a time — queue the other.** A PR streams one AI review at a time,
 but you don't have to pick between a code review and a security audit: start one

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -1011,8 +1011,8 @@ export const AiProviderSection = withForm({
               </Select>
               <p className="text-xs text-muted-foreground">
                 How long an agent-CLI review may run before it's stopped. Auto
-                allows 5 minutes — 20 when the review is agentic; a fixed limit
-                applies to every review.
+                allows 5 minutes — 20 when the review is agentic (always, for
+                Codex); a fixed limit applies to every review.
               </p>
             </div>
           )}

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -56,6 +56,7 @@ import {
   PROVIDER_LABELS,
   PROVIDERS_REQUIRING_KEY,
 } from "@/lib/ai/providers";
+import type { ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiProviderId, AiSettings } from "@/lib/ai/types";
 import { required, useAppForm, withForm } from "@/lib/form";
 import { deleteSecret, setSecret } from "@/lib/git/api";
@@ -287,6 +288,30 @@ const REVIEW_CONTEXT_ITEMS: Record<ReviewContextSize, string> = {
   medium: "Standard (1×)",
   large: "Expanded (4×)",
 };
+
+/** Review-timeout labels — same `items` contract as REVIEW_CONTEXT_ITEMS above
+ *  (Base UI SelectValue renders the raw value without the map). */
+const REVIEW_TIMEOUT_ITEMS: Record<ReviewTimeout, string> = {
+  auto: "Auto — 5 min, 20 min agentic",
+  "10": "10 minutes",
+  "15": "15 minutes",
+  "20": "20 minutes",
+  "30": "30 minutes",
+  "45": "45 minutes",
+  "60": "60 minutes",
+};
+
+/** Explicit render order — `Object.keys` puts integer-like keys first, which
+ *  would bury "Auto" at the bottom of the list. */
+const REVIEW_TIMEOUT_ORDER: ReviewTimeout[] = [
+  "auto",
+  "10",
+  "15",
+  "20",
+  "30",
+  "45",
+  "60",
+];
 
 /** Ollama base-URL field — the URL the local/LAN Ollama server is reached at. */
 function OllamaConfig({
@@ -589,6 +614,10 @@ export const AiProviderSection = withForm({
     const reviewContextSize = useSelector(
       form.store,
       (s) => s.values.reviewContextSize ?? "auto",
+    );
+    const reviewTimeout = useSelector(
+      form.store,
+      (s) => s.values.reviewTimeout ?? "auto",
     );
     const agentIsolation = useSelector(
       form.store,
@@ -967,6 +996,38 @@ export const AiProviderSection = withForm({
               probes the model's context window where possible.
             </p>
           </div>
+          {/* Only the agent-CLI providers run under a kill timeout, so the row
+              shows when a CLI drives reviews or security audits. */}
+          {(isCliProvider(reviewAi.provider) ||
+            (securityReviewAi && isCliProvider(securityReviewAi.provider))) && (
+            <div className="space-y-2">
+              <Label htmlFor="review-timeout">Review timeout</Label>
+              <Select
+                items={REVIEW_TIMEOUT_ITEMS}
+                value={reviewTimeout}
+                onValueChange={(v) => {
+                  if (v)
+                    form.setFieldValue("reviewTimeout", v as ReviewTimeout);
+                }}
+              >
+                <SelectTrigger id="review-timeout" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {REVIEW_TIMEOUT_ORDER.map((id) => (
+                    <SelectItem key={id} value={id}>
+                      {REVIEW_TIMEOUT_ITEMS[id]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                How long an agent-CLI review may run before it's stopped. Auto
+                allows 5 minutes — 20 when the review is agentic; a fixed limit
+                applies to every review.
+              </p>
+            </div>
+          )}
         </div>
 
         {showAllowedHosts && (

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -56,7 +56,7 @@ import {
   PROVIDER_LABELS,
   PROVIDERS_REQUIRING_KEY,
 } from "@/lib/ai/providers";
-import type { ReviewTimeout } from "@/lib/ai/review-timeout";
+import { REVIEW_TIMEOUTS, type ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiProviderId, AiSettings } from "@/lib/ai/types";
 import { required, useAppForm, withForm } from "@/lib/form";
 import { deleteSecret, setSecret } from "@/lib/git/api";
@@ -300,18 +300,6 @@ const REVIEW_TIMEOUT_ITEMS: Record<ReviewTimeout, string> = {
   "45": "45 minutes",
   "60": "60 minutes",
 };
-
-/** Explicit render order — `Object.keys` puts integer-like keys first, which
- *  would bury "Auto" at the bottom of the list. */
-const REVIEW_TIMEOUT_ORDER: ReviewTimeout[] = [
-  "auto",
-  "10",
-  "15",
-  "20",
-  "30",
-  "45",
-  "60",
-];
 
 /** Ollama base-URL field — the URL the local/LAN Ollama server is reached at. */
 function OllamaConfig({
@@ -1014,7 +1002,7 @@ export const AiProviderSection = withForm({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {REVIEW_TIMEOUT_ORDER.map((id) => (
+                  {REVIEW_TIMEOUTS.map((id) => (
                     <SelectItem key={id} value={id}>
                       {REVIEW_TIMEOUT_ITEMS[id]}
                     </SelectItem>

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -169,6 +169,14 @@ export interface AgentReviewArgs {
    *  so an agentic reviewer can pull the full PR diff, read files at any ref, blame,
    *  and list PR comments. Reviews only; default off is byte-identical to today. */
   mcpSelf?: boolean;
+  /** Kill-timeout override for the run, in seconds (clamped backend-side to
+   *  60–7200); null/absent = the backend's tier defaults (300s, 1200s agentic). */
+  timeoutSecs?: number | null;
+  /** True only for flows whose timeout the user's Review-timeout setting governs
+   *  (the AI reviews). Drives the timed-out message's settings hint, so generation
+   *  and Debug-with-AI — which share this command — don't advertise a knob that
+   *  can't help them. */
+  timeoutConfigurable?: boolean;
   /** Caller-generated id used to cancel this run via `cancelAgentReview`. */
   reviewId: string;
   onEvent: (event: ReviewEvent) => void;
@@ -191,6 +199,8 @@ export async function runAgentReview(args: AgentReviewArgs): Promise<void> {
     repoPath: args.repoPath,
     repoAware: args.repoAware,
     mcpSelf: Boolean(args.mcpSelf),
+    timeoutSecs: args.timeoutSecs ?? null,
+    timeoutConfigurable: Boolean(args.timeoutConfigurable),
     reviewId: args.reviewId,
     onEvent: channel,
   });

--- a/src/lib/ai/review-timeout.ts
+++ b/src/lib/ai/review-timeout.ts
@@ -1,0 +1,14 @@
+/** How long an agent-CLI review may run before the backend kills it, in
+ *  minutes. `"auto"` keeps the backend's tier defaults (5 minutes for a plain
+ *  review, 20 for an agentic one); the others pin a fixed limit. Stored as
+ *  strings so the value binds to the settings `Select` directly. */
+export type ReviewTimeout = "auto" | "10" | "15" | "20" | "30" | "45" | "60";
+
+/** The `agent_review` override in seconds, or `null` for `"auto"`/absent (the
+ *  backend's tier defaults apply). The backend clamps to 60–7200. */
+export function reviewTimeoutSecs(t: ReviewTimeout | undefined): number | null {
+  if (!t || t === "auto") return null;
+  // Don't trust the union at runtime — settings.json is hand-editable.
+  const n = Number(t);
+  return Number.isFinite(n) && n > 0 ? n * 60 : null;
+}

--- a/src/lib/ai/review-timeout.ts
+++ b/src/lib/ai/review-timeout.ts
@@ -1,14 +1,33 @@
+/** The Review-timeout choices offered in Settings, in render order — "auto"
+ *  first (an integer-keyed object would enumerate numeric keys first and bury
+ *  it). The `ReviewTimeout` union derives from this list, so the Settings
+ *  labels map stays exhaustive and the menu can't silently drop an option. */
+export const REVIEW_TIMEOUTS = [
+  "auto",
+  "10",
+  "15",
+  "20",
+  "30",
+  "45",
+  "60",
+] as const;
+
 /** How long an agent-CLI review may run before the backend kills it, in
  *  minutes. `"auto"` keeps the backend's tier defaults (5 minutes for a plain
  *  review, 20 for an agentic one); the others pin a fixed limit. Stored as
  *  strings so the value binds to the settings `Select` directly. */
-export type ReviewTimeout = "auto" | "10" | "15" | "20" | "30" | "45" | "60";
+export type ReviewTimeout = (typeof REVIEW_TIMEOUTS)[number];
 
 /** The `agent_review` override in seconds, or `null` for `"auto"`/absent (the
- *  backend's tier defaults apply). The backend clamps to 60–7200. */
+ *  backend's tier defaults apply). Don't trust the union at runtime —
+ *  settings.json is hand-editable, and the wire needs an integral u64 (serde
+ *  rejects fractional JSON numbers, which would fail every CLI review), so the
+ *  value is rounded and saturated to the backend's accepted range here. The
+ *  Rust clamp (60–7200) stays authoritative. */
 export function reviewTimeoutSecs(t: ReviewTimeout | undefined): number | null {
   if (!t || t === "auto") return null;
-  // Don't trust the union at runtime — settings.json is hand-editable.
   const n = Number(t);
-  return Number.isFinite(n) && n > 0 ? n * 60 : null;
+  return Number.isFinite(n) && n > 0
+    ? Math.min(7200, Math.max(60, Math.round(n * 60)))
+    : null;
 }

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -35,6 +35,13 @@ export interface CliStreamOpts {
    *  agentic reviewer can pull the full PR diff and read files at any ref. Default
    *  off keeps every other CLI flow (Debug with AI, generation) byte-identical. */
   mcpSelf?: boolean;
+  /** Kill-timeout override for the run, in seconds. Review flows resolve it from
+   *  the user's Review-timeout setting; generation / Debug-with-AI callers omit
+   *  it and keep the backend's tier defaults. */
+  timeoutSecs?: number | null;
+  /** True only for the AI-review flows the Review-timeout setting governs; drives
+   *  the timed-out message's settings hint. Omitted by Debug with AI / generation. */
+  timeoutConfigurable?: boolean;
   /** Called at most once, at successful settle, with the narration that streamed
    *  before the final answer (a tool-using run's "Let me check…" prose). Never
    *  called when there is none — a codex run (no deltas) or a run whose whole
@@ -80,6 +87,8 @@ export async function runCliStream({
   onCost,
   effort,
   mcpSelf,
+  timeoutSecs,
+  timeoutConfigurable,
   onThoughts,
 }: CliStreamOpts): Promise<void> {
   const kind = providerKind(ai.provider);
@@ -117,6 +126,8 @@ export async function runCliStream({
         repoPath: cwd,
         repoAware: Boolean(ai.cliRepoAware),
         mcpSelf: Boolean(mcpSelf),
+        timeoutSecs: timeoutSecs ?? null,
+        timeoutConfigurable: Boolean(timeoutConfigurable),
         reviewId,
         onEvent: (event) => {
           if (event.kind === "delta") {
@@ -195,6 +206,13 @@ export interface StreamAiOpts {
    *  Omitted by non-review callers (Debug with AI, generation), keeping them
    *  byte-identical. */
   mcpSelf?: boolean;
+  /** Kill-timeout override in seconds for a CLI review run, from the user's
+   *  Review-timeout setting. CLI path only — the HTTP branch ignores it; other
+   *  callers omit it and keep the backend's tier defaults. */
+  timeoutSecs?: number | null;
+  /** True only for the AI-review flows the Review-timeout setting governs; drives
+   *  the timed-out message's settings hint. CLI path only. */
+  timeoutConfigurable?: boolean;
   /** Native AI-SDK review tools for an HTTP-provider agentic review — the model
    *  explores via a tool loop (no MCP, no worktree). HTTP agentic reviews only;
    *  CLI and non-review callers omit it, keeping their path byte-identical. */
@@ -226,6 +244,8 @@ export async function streamAi({
   repoPath,
   headSha,
   mcpSelf,
+  timeoutSecs,
+  timeoutConfigurable,
   reviewTools,
   setText,
   setStatus,
@@ -241,6 +261,8 @@ export async function streamAi({
       repoPath,
       headSha,
       mcpSelf,
+      timeoutSecs,
+      timeoutConfigurable,
       setText,
       setStatus,
       registerId: onCliId,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -102,6 +102,14 @@ type PrAutomationEvent = Extract<
 
 const DIFF_MAX_BYTES = 200_000;
 
+/** How often a running automation refreshes its cross-instance claim file's mtime.
+ *  Rust's `STALE_CLAIM_AGE` (automation_claims.rs) reclaims a claim after 30 minutes
+ *  of silence, so 5 minutes (30/6) leaves a generous margin for timer drift and OS
+ *  suspend while a long review — the Review-timeout setting allows up to 60 minutes —
+ *  keeps its claim alive. Without it, a second instance would reclaim a LIVE run and
+ *  post a duplicate paid review. */
+const CLAIM_HEARTBEAT_MS = 5 * 60 * 1000;
+
 /** The store key for a PR target, used to look up its review-history watermark. */
 function targetRef(event: PrAutomationEvent): string {
   return event.target.type === "remote"
@@ -322,6 +330,29 @@ async function run(
       if (!won) continue; // another instance owns this run
       claimKey = repoKey;
     }
+    // Liveness heartbeat for the claim we just won: while this run is in flight we
+    // refresh its claim file's mtime, so the Rust stale-reclaim window measures "this
+    // instance went quiet" rather than "this review is slow". A 45/60-minute Review
+    // timeout would otherwise outlive the 30-minute window and let a second instance
+    // reclaim a LIVE run. Best-effort, like claim/release. Cleared in the `finally`
+    // below so it never outlives the run on any path (success, error, cancel).
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+    const stopHeartbeat = () => {
+      if (heartbeat !== undefined) {
+        clearInterval(heartbeat);
+        heartbeat = undefined;
+      }
+    };
+    if (claimKey) {
+      heartbeat = setInterval(() => {
+        void invoke("touch_automation_claim", {
+          repoKey: claimKey,
+          target: claimTarget,
+          headSha,
+          action,
+        }).catch(() => undefined);
+      }, CLAIM_HEARTBEAT_MS);
+    }
     // Release this instance's claim (best-effort) so a non-delivering terminal path
     // (failure/cancel/no-op) doesn't permanently suppress the automation for this
     // head across instances. A successfully DELIVERED review keeps its claim.
@@ -511,6 +542,11 @@ async function run(
       }
       // Persist a "Failed" stopped row (keeping its Re-run) instead of removing it.
       handle.fail(message);
+    } finally {
+      // Every terminal path lands here — including the `continue`s in both arms and
+      // the delivered-success path, which keeps its claim but must still stop
+      // heartbeating it.
+      stopHeartbeat();
     }
   }
   return { matched, attempted };

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -112,14 +112,16 @@ const DIFF_MAX_BYTES = 200_000;
  *  residual as before the heartbeat.) */
 const CLAIM_HEARTBEAT_MS = 5 * 60 * 1000;
 
-/** Upper bound on heartbeats per run: 25 × 5 min = 125 minutes, past the backend's
- *  7200s max kill clamp with margin. A run still unsettled by then is wedged — an
+/** Upper bound on heartbeats per run: 30 × 5 min = 150 minutes. The cap runs from
+ *  the heartbeat's ARM (top of the try, before prompt building), so it must cover
+ *  the backend's 7200s max kill clamp — reachable by hand-editing settings.json;
+ *  the UI tops out at 60 min — PLUS the pre-stream phase (diff load, context
+ *  harvest, distill), with margin. A run still unsettled past that is wedged — an
  *  HTTP stream has no deadline at all, and a stalled fetch (e.g. a LAN Ollama box
  *  asleep mid-stream) never settles, so its `finally` never runs. Stopping the
  *  heartbeat lets the claim age out (`STALE_CLAIM_AGE` + this cap) so a second
- *  instance can recover the head — the recovery the stale-reclaim exists for.
- *  Every legitimately-running review is covered: CLI runs are hard-killed by 7200s. */
-const CLAIM_HEARTBEAT_MAX_BEATS = 25;
+ *  instance can recover the head — the recovery the stale-reclaim exists for. */
+const CLAIM_HEARTBEAT_MAX_BEATS = 30;
 
 /** The store key for a PR target, used to look up its review-history watermark. */
 function targetRef(event: PrAutomationEvent): string {

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -104,10 +104,12 @@ const DIFF_MAX_BYTES = 200_000;
 
 /** How often a running automation refreshes its cross-instance claim file's mtime.
  *  Rust's `STALE_CLAIM_AGE` (automation_claims.rs) reclaims a claim after 30 minutes
- *  of silence, so 5 minutes (30/6) leaves a generous margin for timer drift and OS
- *  suspend while a long review — the Review-timeout setting allows up to 60 minutes —
- *  keeps its claim alive. Without it, a second instance would reclaim a LIVE run and
- *  post a duplicate paid review. */
+ *  of silence, so 5 minutes (30/6) leaves a generous margin for timer drift while a
+ *  long review — the Review-timeout setting allows up to 60 minutes — keeps its
+ *  claim alive. Without it, a second instance would reclaim a LIVE run and post a
+ *  duplicate paid review. (Timers don't fire during OS suspend, so a 30+ minute
+ *  sleep mid-run can still go stale on resume — the same bounded single-duplicate
+ *  residual as before the heartbeat.) */
 const CLAIM_HEARTBEAT_MS = 5 * 60 * 1000;
 
 /** The store key for a PR target, used to look up its review-history watermark. */
@@ -334,8 +336,10 @@ async function run(
     // refresh its claim file's mtime, so the Rust stale-reclaim window measures "this
     // instance went quiet" rather than "this review is slow". A 45/60-minute Review
     // timeout would otherwise outlive the 30-minute window and let a second instance
-    // reclaim a LIVE run. Best-effort, like claim/release. Cleared in the `finally`
-    // below so it never outlives the run on any path (success, error, cancel).
+    // reclaim a LIVE run. Best-effort, like claim/release. Declared here, ARMED as the
+    // `try`'s first statement below: an interval leaked by a throw outside the
+    // `finally` would refresh the claim forever, defeating both the 30-minute reclaim
+    // and the 30-day sweep (both mtime-keyed) for the life of the process.
     let heartbeat: ReturnType<typeof setInterval> | undefined;
     const stopHeartbeat = () => {
       if (heartbeat !== undefined) {
@@ -343,16 +347,6 @@ async function run(
         heartbeat = undefined;
       }
     };
-    if (claimKey) {
-      heartbeat = setInterval(() => {
-        void invoke("touch_automation_claim", {
-          repoKey: claimKey,
-          target: claimTarget,
-          headSha,
-          action,
-        }).catch(() => undefined);
-      }, CLAIM_HEARTBEAT_MS);
-    }
     // Release this instance's claim (best-effort) so a non-delivering terminal path
     // (failure/cancel/no-op) doesn't permanently suppress the automation for this
     // head across instances. A successfully DELIVERED review keeps its claim.
@@ -431,6 +425,18 @@ async function run(
       ).catch(() => undefined);
     };
     try {
+      // First statement inside the try, so the arm and the `finally`'s disarm can
+      // never be separated by a throw (see the heartbeat comment above).
+      if (claimKey) {
+        heartbeat = setInterval(() => {
+          void invoke("touch_automation_claim", {
+            repoKey: claimKey,
+            target: claimTarget,
+            headSha,
+            action,
+          }).catch(() => undefined);
+        }, CLAIM_HEARTBEAT_MS);
+      }
       const result = await generateReviewText(
         reviewCfg,
         action,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -14,6 +14,7 @@ import {
 import { type PriorContext, resolvePriorContext } from "@/lib/ai/prior-context";
 import { buildReviewPrompt } from "@/lib/ai/prompt";
 import { isCliProvider, isLocalProvider } from "@/lib/ai/providers";
+import { reviewTimeoutSecs } from "@/lib/ai/review-timeout";
 import { runCliStream } from "@/lib/ai/stream";
 import type { AiSettings, PromptProvider, ReviewMode } from "@/lib/ai/types";
 import {
@@ -774,6 +775,9 @@ async function generateReviewText(
       // Read the reviewed commit / PR-head's files in a worktree, not whatever
       // branch happens to be checked out.
       headSha: event.kind === "commit" ? event.hash : event.headSha,
+      // The user's Review-timeout override (null = the backend's tier defaults).
+      timeoutSecs: reviewTimeoutSecs(appSettings.reviewTimeout),
+      timeoutConfigurable: true,
       // runCliStream replaces with the agent's final answer on done; the last
       // setText carries that clean review body (narration is peeled into onThoughts).
       setText: (t) => {

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -112,6 +112,15 @@ const DIFF_MAX_BYTES = 200_000;
  *  residual as before the heartbeat.) */
 const CLAIM_HEARTBEAT_MS = 5 * 60 * 1000;
 
+/** Upper bound on heartbeats per run: 25 × 5 min = 125 minutes, past the backend's
+ *  7200s max kill clamp with margin. A run still unsettled by then is wedged — an
+ *  HTTP stream has no deadline at all, and a stalled fetch (e.g. a LAN Ollama box
+ *  asleep mid-stream) never settles, so its `finally` never runs. Stopping the
+ *  heartbeat lets the claim age out (`STALE_CLAIM_AGE` + this cap) so a second
+ *  instance can recover the head — the recovery the stale-reclaim exists for.
+ *  Every legitimately-running review is covered: CLI runs are hard-killed by 7200s. */
+const CLAIM_HEARTBEAT_MAX_BEATS = 25;
+
 /** The store key for a PR target, used to look up its review-history watermark. */
 function targetRef(event: PrAutomationEvent): string {
   return event.target.type === "remote"
@@ -428,7 +437,15 @@ async function run(
       // First statement inside the try, so the arm and the `finally`'s disarm can
       // never be separated by a throw (see the heartbeat comment above).
       if (claimKey) {
+        let beats = 0;
         heartbeat = setInterval(() => {
+          // Bounded so a wedged, never-settling run can't keep its claim fresh
+          // forever (see CLAIM_HEARTBEAT_MAX_BEATS).
+          if (beats >= CLAIM_HEARTBEAT_MAX_BEATS) {
+            stopHeartbeat();
+            return;
+          }
+          beats += 1;
           void invoke("touch_automation_claim", {
             repoKey: claimKey,
             target: claimTarget,

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -1,5 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import type { ReviewContextSize } from "@/lib/ai/context-budget";
+import type { ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiSettings, ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
@@ -187,6 +188,11 @@ export interface AppSettings {
    *  reviewing model. `"auto"` fits the model's context window (probing Ollama
    *  live); the others force a fixed multiple of the default budget. */
   reviewContextSize?: ReviewContextSize;
+  /** How long an agent-CLI review may run before it's stopped — applies to
+   *  interactive PR reviews, automated first reviews, and security audits.
+   *  Absent (settings written before this shipped) reads as `"auto"`, the
+   *  backend's tier defaults. */
+  reviewTimeout?: ReviewTimeout;
   /** Hide every AI surface (commit/PR helpers, review panel, AI settings).
    *  Provider config and API keys are kept, just not shown. */
   hideAi: boolean;
@@ -314,6 +320,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     openaiCompatibleBaseUrl: "https://ai-gateway.vercel.sh/v1",
   },
   reviewContextSize: "auto",
+  reviewTimeout: "auto",
   hideAi: false,
   notifications: {
     automations: true,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -15,6 +15,7 @@ import { type PriorContext, resolvePriorContext } from "@/lib/ai/prior-context";
 import { buildReviewPrompt } from "@/lib/ai/prompt";
 import { isLocalProvider } from "@/lib/ai/providers";
 import { buildReviewTools } from "@/lib/ai/review-tools";
+import { reviewTimeoutSecs } from "@/lib/ai/review-timeout";
 import { streamAi } from "@/lib/ai/stream";
 import type {
   AiSettings,
@@ -510,10 +511,14 @@ export async function startReview(
     // BEFORE the own/external harvest so the own-comments distillation trigger +
     // ledger cap key off the SAME scaled budget as the rest of the prompt; reused
     // verbatim at buildReviewPrompt below (single resolution, used twice).
+    const appSettings = await loadSettings();
     const budgetProfile = await resolveBudgetProfile(
       ai,
-      (await loadSettings()).reviewContextSize,
+      appSettings.reviewContextSize,
     );
+    // The user's Review-timeout override (null = the backend's tier defaults).
+    // CLI providers only; the HTTP path ignores it.
+    const timeoutSecs = reviewTimeoutSecs(appSettings.reviewTimeout);
     if (control.cancelled) return;
     // Own-comments distillation runs a generation-model call that can outlast a
     // dock Cancel; the CLI/HTTP review stream only gets an abort handle later (via
@@ -612,6 +617,8 @@ export async function startReview(
       repoPath: context.repoPath,
       headSha: context.headSha,
       mcpSelf: mcpTools,
+      timeoutSecs,
+      timeoutConfigurable: true,
       reviewTools,
       setText: pushText,
       setStatus: (s) => patch({ status: s }),

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -14,8 +14,8 @@ import {
 import { type PriorContext, resolvePriorContext } from "@/lib/ai/prior-context";
 import { buildReviewPrompt } from "@/lib/ai/prompt";
 import { isLocalProvider } from "@/lib/ai/providers";
-import { buildReviewTools } from "@/lib/ai/review-tools";
 import { reviewTimeoutSecs } from "@/lib/ai/review-timeout";
+import { buildReviewTools } from "@/lib/ai/review-tools";
 import { streamAi } from "@/lib/ai/stream";
 import type {
   AiSettings,


### PR DESCRIPTION
Agentic AI reviews — especially self-MCP runs that pull the full PR diff and read files — routinely exceed the old 10-minute kill timeout and die mid-stream. This raises the agentic default to 20 minutes and adds a **Review timeout** setting under *Settings → AI* so users can pin a fixed limit for agent-CLI reviews, with the timed-out message pointing at the knob only where it actually applies.

### Backend timeout resolution (`src-tauri/src/agent.rs`)

- Raises `REVIEW_TIMEOUT_AGENTIC` from 600s to 1200s and extracts the tier choice into a new `review_timeout(agentic, override_secs)` helper that honors the user override, clamping it to 60–7200 seconds and treating `None`/`0` as "no override".
- Adds `timeout_secs` and `timeout_configurable` parameters to the `agent_review` command, threading the override into `review_timeout` and the hint flag into `stream_agent` (which gains a `timeout_hint` parameter; both `agent_session` call sites pass `false`).
- Replaces the raw `"timed out after {}s."` string with `timeout_message` + `human_duration`, so copy reads "The review timed out after 20 minutes." and only appends "You can raise the limit in Settings → AI." when the setting governs the run — generation and Debug-with-AI share the `agent_review` command and the "review" noun but not the setting.
- Adds four unit tests covering tier fallback, zero-override handling, clamping, override-wins-below-default, the hint flag, and whole-minute formatting.

### Frontend plumbing

- New `src/lib/ai/review-timeout.ts` defines the `ReviewTimeout` union (`"auto" | "10" | … | "60"`) and `reviewTimeoutSecs`, which converts to seconds and defensively re-validates the value at runtime since `settings.json` is hand-editable.
- `src/lib/settings/api.ts` adds the optional `reviewTimeout` field to `AppSettings` (absent reads as `"auto"`) and defaults it to `"auto"` in `DEFAULT_SETTINGS`.
- `src/lib/ai/agent.ts` and `src/lib/ai/stream.ts` carry `timeoutSecs` / `timeoutConfigurable` through `AgentReviewArgs`, `CliStreamOpts`, and `StreamAiOpts` down to the `agent_review` invocation; non-review callers omit them and keep the existing behavior.
- `src/lib/stores/reviews.ts` hoists the `loadSettings()` result into `appSettings`, resolves `timeoutSecs` from it, and passes it with `timeoutConfigurable: true` into `streamAi`; `src/lib/automations/runner.ts` does the same for automated reviews via `generateReviewText`.

### Settings UI and docs

- `src/features/settings/AiProviderSection.tsx` adds a **Review timeout** select with `REVIEW_TIMEOUT_ITEMS` labels and an explicit `REVIEW_TIMEOUT_ORDER` (so "Auto" isn't buried by integer-like key ordering), rendered only when the review or security-review provider is a CLI provider.
- `src/features/help/content.ts` extends the review section to describe the new setting and what **Auto** means.
- Adds `changelog.d/changed-review-timeout.md` for the user-facing change.