### PR TITLE
feat(ai,pr-review): use author notes in manual reviews and fair-share review-context budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,10 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
     timeout error itself points at the knob. HTTP/API reviews stream without a deadline.
   - **Notes for reviewers** — hand the reviewer context up front: an agent deposits
     per-branch notes via the GitDesktop MCP, or you type them in the Create PR dialog; on
-    create they post as the PR's first comment and reach the automated review as
-    first-class context (by default a draft's review waits until it's marked ready),
-    so a deliberate, documented decision isn't re-flagged
+    create they post as the PR's first comment and reach **every** review as first-class
+    context — the automated one (by default a draft's review waits until it's marked
+    ready) and the reviews you run yourself — so a deliberate, documented decision isn't
+    re-flagged; an **Ignore author notes** toggle in the review panel sets them aside
   - **Clearly machine-authored** — a branded header/footer and a robot-avatar
     "GitDesktop" bot on local PRs; with a GitLab project/group access token, posts as
     the real **GitLab project bot** rather than your own account

--- a/README.md
+++ b/README.md
@@ -285,10 +285,11 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
     timeout error itself points at the knob. HTTP/API reviews stream without a deadline.
   - **Notes for reviewers** — hand the reviewer context up front: an agent deposits
     per-branch notes via the GitDesktop MCP, or you type them in the Create PR dialog; on
-    create they post as the PR's first comment and reach **every** review as first-class
-    context — the automated one (by default a draft's review waits until it's marked
-    ready) and the reviews you run yourself — so a deliberate, documented decision isn't
-    re-flagged; an **Ignore author notes** toggle in the review panel sets them aside
+    create they post as the PR's first comment and reach **every** review of a GitHub or
+    GitLab PR as first-class context — the automated one (by default a draft's review
+    waits until it's marked ready) and the reviews you run yourself — so a deliberate,
+    documented decision isn't re-flagged; an **Ignore author notes** toggle in the review
+    panel sets them aside
   - **Clearly machine-authored** — a branded header/footer and a robot-avatar
     "GitDesktop" bot on local PRs; with a GitLab project/group access token, posts as
     the real **GitLab project bot** rather than your own account

--- a/changelog.d/added-review-notes-interactive-toggle.md
+++ b/changelog.d/added-review-notes-interactive-toggle.md
@@ -1,0 +1,4 @@
+- **Reviews you run yourself now read the author's Notes for reviewers.** Until now only
+  automated reviews saw them; the Review and Security audit buttons feed them to the model
+  too. A new **Ignore author notes** toggle in the review panel sets them aside for a run,
+  alongside the existing opt-outs for your previous review and external bot findings.

--- a/changelog.d/fixed-external-findings-budget.md
+++ b/changelog.d/fixed-external-findings-budget.md
@@ -1,0 +1,3 @@
+- External AI-reviewer findings now fair-share the review-context budget instead of each
+  being cut at a small fixed size, a trimmed finding says so explicitly, and the **Review
+  context** size setting now reaches that section of the prompt.

--- a/changelog.d/fixed-own-comment-context-cap.md
+++ b/changelog.d/fixed-own-comment-context-cap.md
@@ -1,0 +1,5 @@
+- AI re-reviews now read long GitDesktop-posted PR comments (context briefs, triage
+  summaries) in full when the review-context budget has room — previously every such comment
+  was silently cut to 1,500 characters no matter how much budget was free, so a reviewer
+  could be handed a numbered list that stopped after item 2. A comment that still has to be
+  trimmed now says so explicitly in the prompt instead of trailing off in a bare ellipsis.

--- a/changelog.d/fixed-own-comments-opening-pin.md
+++ b/changelog.d/fixed-own-comments-opening-pin.md
@@ -1,0 +1,2 @@
+- When a PR's own-comments context outgrows its budget, the opening context comment is now
+  kept alongside the newest follow-ups instead of being the first thing dropped.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -426,7 +426,7 @@ export const capabilities: Capability[] = [
     group: "AI · generate & review",
     ai: true,
     label:
-      "Hand review context to the AI reviewer — per-branch notes deposited by your agent, posted with the PR",
+      "Hand review context to the AI reviewer — per-branch notes deposited by your agent, read by every review (automated or one you start) with a per-run opt-out",
   },
   {
     group: "AI · generate & review",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -798,9 +798,10 @@ reviewers** field below the description — it pre-fills from any notes an agent
 MCP client with write access) deposited for the head branch via the GitDesktop MCP, and
 you can edit or clear it. When you create the PR, the notes post as its **first
 conversation comment** (under a *🗒️ Notes for reviewers* header, from your own account)
-before any automated review runs, and that review reads them as context — so a deliberate,
-documented decision isn't re-flagged. Notes present here also ground the **AI-generated**
-description{{/ai}}. Press {{key:mod+enter}} from any field to submit either the
+before any automated review runs, and that review reads them as context; on GitHub and
+GitLab the code reviews and security audits you start yourself read them too — so a
+deliberate, documented decision isn't re-flagged. Notes present here also ground the
+**AI-generated** description{{/ai}}. Press {{key:mod+enter}} from any field to submit either the
 **Create** or the **Edit** dialog.{{ai}} While a PR dialog is open, {{kbd:generate-commit-message}}
 runs its **Generate** for you.{{/ai}}
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -896,6 +896,11 @@ it already refuted or marked fixed as resolved instead of raising it cold. It al
 any **Notes for reviewers** the author left — deposited per branch by an agent through the
 GitDesktop MCP, or typed into the Create PR dialog and posted as the PR's first comment —
 as first-class grounding context, so a deliberate, documented decision isn't re-flagged.
+Those notes reach **every** review of a GitHub or GitLab PR: the automated ones, and the
+code reviews and security audits you start yourself. Any of this context can also be **held
+back**: the panel offers *Ignore previous review*, *Ignore external reviews*, and *Ignore
+author notes*, each shown only when there's something to ignore and each one click away
+from being restored — nothing is deleted, the next review simply leaves it out.
 When rounds
 accumulate past the prompt budget, the newest comments win, and the full history is
 **distilled into a compact decision ledger** (via your generation model) rather than cut

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -261,17 +261,14 @@ export function PrReviewPanel({
     if (!effective) return;
     // `ai_review_triggered` is emitted in startReview when the run actually begins
     // (so it counts a drained queued run and skips a dismissed one), not here.
-    generate(
-      effective,
-      mode,
-      context,
-      ignoredModes.has(mode),
+    generate(effective, mode, context, {
+      ignorePrior: ignoredModes.has(mode),
       ignoreExternal,
       // Only suppress the notes while the toggle is actually ON SCREEN: the row
       // hides when the query refetches into an error/empty result, and a stale
       // `ignoreNotes` would then keep skipping them with no affordance to undo.
-      ignoreNotes && hasNotes,
-    );
+      ignoreNotes: ignoreNotes && hasNotes,
+    });
   }
 
   async function post() {

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -1,6 +1,7 @@
 import {
   ClockIcon,
   CopyIcon,
+  NotePencilIcon,
   RobotIcon,
   ShieldCheckIcon,
   SparkleIcon,
@@ -43,7 +44,11 @@ import {
 import type { AiProviderId, ReviewMode } from "@/lib/ai/types";
 import { copyText } from "@/lib/clipboard";
 import { quickTransition } from "@/lib/motion";
-import { useExternalReviews, useReviewHistory } from "@/lib/pulls/queries";
+import {
+  useExternalReviews,
+  useReviewerNotes,
+  useReviewHistory,
+} from "@/lib/pulls/queries";
 import type { PersistedReview } from "@/lib/pulls/reviews-history";
 import { useSecretPreview, useSettings } from "@/lib/settings/queries";
 import {
@@ -153,6 +158,13 @@ export function PrReviewPanel({
   const externalCount = external.data?.items.length ?? 0;
   const [ignoreExternal, setIgnoreExternal] = useState(false);
 
+  // The author's "Notes for reviewers" on this remote PR (author-gated in the
+  // resolver). The run re-resolves them itself; this only drives the row + its
+  // per-run opt-out. No notes (or a local/Bitbucket PR) ⇒ the row stays hidden.
+  const notes = useReviewerNotes(context.repoPath, prKind, prRef);
+  const hasNotes = Boolean(notes.data?.reviewNotes?.trim());
+  const [ignoreNotes, setIgnoreNotes] = useState(false);
+
   const globalReviewAi = settings.data?.reviewAi;
   // Optional dedicated config for security audits (Settings → AI). When set and
   // no in-panel override is active, the Security-audit button runs it; the
@@ -249,7 +261,17 @@ export function PrReviewPanel({
     if (!effective) return;
     // `ai_review_triggered` is emitted in startReview when the run actually begins
     // (so it counts a drained queued run and skips a dismissed one), not here.
-    generate(effective, mode, context, ignoredModes.has(mode), ignoreExternal);
+    generate(
+      effective,
+      mode,
+      context,
+      ignoredModes.has(mode),
+      ignoreExternal,
+      // Only suppress the notes while the toggle is actually ON SCREEN: the row
+      // hides when the query refetches into an error/empty result, and a stale
+      // `ignoreNotes` would then keep skipping them with no affordance to undo.
+      ignoreNotes && hasNotes,
+    );
   }
 
   async function post() {
@@ -548,6 +570,25 @@ export function PrReviewPanel({
             </div>
           );
         })}
+        {hasNotes && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+            <NotePencilIcon className="size-3 shrink-0" />
+            <span className="min-w-0">
+              {ignoreNotes
+                ? "Ignoring the author's notes for reviewers."
+                : "Next review reads the author's notes for reviewers."}
+            </span>
+            <button
+              type="button"
+              aria-pressed={ignoreNotes}
+              disabled={generating}
+              className="cursor-pointer underline-offset-2 hover:underline disabled:opacity-50"
+              onClick={() => setIgnoreNotes((v) => !v)}
+            >
+              {ignoreNotes ? "Use author notes" : "Ignore author notes"}
+            </button>
+          </div>
+        )}
         {externalCount > 0 && (
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
             <RobotIcon className="size-3 shrink-0" />

--- a/src/lib/ai/external-context.ts
+++ b/src/lib/ai/external-context.ts
@@ -175,11 +175,11 @@ function locationTag(item: ExternalReviewItem): string {
  *
  * Two passes, because each body's cap depends on all the others: pass 1 groups,
  * sorts and de-noises, dropping whatever condenses to nothing, then the surviving
- * lengths are fair-shared across `budget` (see `allocateBodyCaps`) — ALL
- * reviewers pooled, since the budget is section-wide — and pass 2 renders each
- * body under its own cap. Capping per item BEFORE knowing the section budget was
- * the old bug: a bot's 5K review body was cut to 1.5K even with most of the
- * external budget unspent.
+ * lengths are fair-shared across `budget` net of the rendered scaffolding (see
+ * `allocateBodyCaps` and the reserve below) — ALL reviewers pooled, since the
+ * budget is section-wide — and pass 2 renders each body under its own cap.
+ * Capping per item BEFORE knowing the section budget was the old bug: a bot's 5K
+ * review body was cut to 1.5K even with most of the external budget unspent.
  */
 function formatExternalFindings(
   items: ExternalReviewItem[],
@@ -207,34 +207,70 @@ function formatExternalFindings(
     reviewer: string;
     item: ExternalReviewItem;
     body: string;
+    /** The item's rendered line prefix, resolved in pass 1 so the scaffolding
+     *  reserve is charged against exactly what pass 2 emits. */
+    prefix: string;
   }[] = [];
   for (const [reviewer, list] of byReviewer) {
     const sorted = [...list].sort((a, b) => order[a.kind] - order[b.kind]);
     for (const it of sorted) {
       const body = condense(it.body);
       if (!body) continue;
-      cleaned.push({ reviewer, item: it, body });
+      let prefix: string;
+      if (it.kind === "inline") {
+        const tag = locationTag(it);
+        prefix = `- ${tag ? `${tag} — ` : ""}`;
+      } else if (it.kind === "review") {
+        prefix = "- (review) ";
+      } else {
+        prefix = "- (summary) ";
+      }
+      cleaned.push({ reviewer, item: it, body, prefix });
     }
   }
 
+  // The caps govern BODY length, but the rendered section also carries
+  // scaffolding: each line's prefix and the newline joining it to the next, two
+  // more characters for every newline inside a body (the `\n  ` continuation
+  // indent), and a `### <reviewer>` header plus blank-line joiner per group.
+  // Reserving it buys right-sized SHARES — without it the fair split is computed
+  // over a budget the render then blows past, so the bodies are collectively
+  // sized wrong. It is NOT a guarantee that the result fits `budget`: the floors
+  // can lift a cap back above any netted budget, and `fit` (truncate.ts) is the
+  // real enforcement point — it now cuts through `capBody`, so an overflow ends
+  // in a marked cut rather than a bare one.
+  //
+  // The newline term is charged against `body.slice(0, provisionalCap)`, not the
+  // whole body: a 40K walkthrough with 2,000 newlines would otherwise reserve
+  // ~4,000 characters for a body that will be cut to ~1,200, starving every other
+  // finding of its share. Round 1 allocates with no scaffolding to get those
+  // provisional caps; since a smaller budget never yields a LARGER share, round
+  // 2's caps are ≤ round 1's, so the measured newline count stays an upper bound
+  // (+1 covers the line `capBody` adds for its note) and the only failure mode is
+  // slightly under-using the budget.
+  const lengths = cleaned.map((c) => c.body.length);
+  const bodyFloors = cleaned.map((c) => floors[c.item.kind]);
+  const provisional = allocateBodyCaps(lengths, budget, bodyFloors);
+  let scaffold = 0;
+  cleaned.forEach(({ prefix, body }, i) => {
+    scaffold +=
+      prefix.length + 1 + 2 * body.slice(0, provisional[i]).split("\n").length;
+  });
+  for (const reviewer of new Set(cleaned.map((c) => c.reviewer))) {
+    scaffold += `### ${reviewer}\n`.length + 2;
+  }
+
   const caps = allocateBodyCaps(
-    cleaned.map((c) => c.body.length),
-    budget,
-    cleaned.map((c) => floors[c.item.kind]),
+    lengths,
+    Math.max(0, budget - scaffold),
+    bodyFloors,
   );
 
   const linesByReviewer = new Map<string, string[]>();
-  cleaned.forEach(({ reviewer, item, body }, i) => {
+  cleaned.forEach(({ reviewer, body, prefix }, i) => {
     const capped = capBody(body, caps[i]).replace(/\n/g, "\n  ");
     const lines = linesByReviewer.get(reviewer) ?? [];
-    if (item.kind === "inline") {
-      const tag = locationTag(item);
-      lines.push(`- ${tag ? `${tag} — ` : ""}${capped}`);
-    } else if (item.kind === "review") {
-      lines.push(`- (review) ${capped}`);
-    } else {
-      lines.push(`- (summary) ${capped}`);
-    }
+    lines.push(`${prefix}${capped}`);
     linesByReviewer.set(reviewer, lines);
   });
 

--- a/src/lib/ai/external-context.ts
+++ b/src/lib/ai/external-context.ts
@@ -1,6 +1,10 @@
 import { forgePrExternalReviews } from "@/lib/git/api";
 import type { ExternalReviewItem } from "@/lib/git/types";
-import { safeSlice } from "./truncate";
+import {
+  allocateBodyCaps,
+  capBody,
+  EXTERNAL_FINDINGS_CHAR_BUDGET,
+} from "./truncate";
 
 /** What `buildReviewPrompt` needs about third-party AI reviews on a PR. */
 export interface ExternalContext {
@@ -126,24 +130,31 @@ export function externalReviewerNames(items: ExternalReviewItem[]): string[] {
   return names;
 }
 
-/** Per-item body caps before the global budget allocator — keep inline findings
- *  tight and hard-cap the giant conversation summaries (CodeRabbit walkthroughs). */
-const INLINE_BODY_CAP = 700;
-const REVIEW_BODY_CAP = 1_500;
-const COMMENT_BODY_CAP = 1_200;
+/** Per-kind body FLOORS under the fair-share allocator — every kept finding is
+ *  guaranteed at least this many characters, so a giant conversation summary
+ *  (a CodeRabbit walkthrough) can never crowd out a later inline finding. They
+ *  are NOT ceilings: a finding's actual cap is its max-min share of the section
+ *  budget (see `allocateBodyCaps`), which is larger whenever the other findings
+ *  leave slack — an inline finding stays tight because it IS short, not because
+ *  it's clamped. When the floors alone exceed the budget the allocation
+ *  degenerates to floor-for-all and over-allocates; `fit` in `budgetReviewExtras`
+ *  stays the hard enforcement. */
+const INLINE_BODY_FLOOR = 700;
+const REVIEW_BODY_FLOOR = 1_500;
+const COMMENT_BODY_FLOOR = 1_200;
 
 /** Crudely de-noises a bot comment body: drops HTML comments and collapsible
  *  `<details>` blocks (walkthroughs / sequence diagrams), unwraps the remaining
  *  tags, and collapses blank runs. The actionable findings live in inline
- *  comments; this is only to make a summary comment cheap to include. */
-function condense(body: string, cap: number): string {
-  const cleaned = body
+ *  comments; this is only to make a summary comment cheap to include. Length is
+ *  not this function's business — the fair-share caps land in pass 2. */
+function condense(body: string): string {
+  return body
     .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<details[\s\S]*?<\/details>/gi, "")
     .replace(/<\/?[a-z][^>]*>/gi, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-  return cleaned.length > cap ? `${safeSlice(cleaned, cap)}…` : cleaned;
 }
 
 /** A short "where" tag for an inline finding. */
@@ -161,8 +172,19 @@ function locationTag(item: ExternalReviewItem): string {
  * Formats the kept findings into a grouped markdown block, reviewer by reviewer:
  * inline (line-anchored) findings first — the actionable ones — then submitted
  * review bodies, then a condensed conversation summary. Returns "" when empty.
+ *
+ * Two passes, because each body's cap depends on all the others: pass 1 groups,
+ * sorts and de-noises, dropping whatever condenses to nothing, then the surviving
+ * lengths are fair-shared across `budget` (see `allocateBodyCaps`) — ALL
+ * reviewers pooled, since the budget is section-wide — and pass 2 renders each
+ * body under its own cap. Capping per item BEFORE knowing the section budget was
+ * the old bug: a bot's 5K review body was cut to 1.5K even with most of the
+ * external budget unspent.
  */
-function formatExternalFindings(items: ExternalReviewItem[]): string {
+function formatExternalFindings(
+  items: ExternalReviewItem[],
+  budget: number,
+): string {
   const byReviewer = new Map<string, ExternalReviewItem[]>();
   for (const it of items) {
     const name = displayName(it.author);
@@ -174,28 +196,51 @@ function formatExternalFindings(items: ExternalReviewItem[]): string {
   // `reply` never reaches here (filtered out of the external set upstream), but
   // it's in the union, so it's mapped for typechecking + defense if one ever does.
   const order = { inline: 0, review: 1, comment: 2, reply: 3 } as const;
-  const blocks: string[] = [];
+  const floors = {
+    inline: INLINE_BODY_FLOOR,
+    review: REVIEW_BODY_FLOOR,
+    comment: COMMENT_BODY_FLOOR,
+    reply: COMMENT_BODY_FLOOR,
+  } as const;
+
+  const cleaned: {
+    reviewer: string;
+    item: ExternalReviewItem;
+    body: string;
+  }[] = [];
   for (const [reviewer, list] of byReviewer) {
     const sorted = [...list].sort((a, b) => order[a.kind] - order[b.kind]);
-    const lines: string[] = [];
     for (const it of sorted) {
-      if (it.kind === "inline") {
-        const tag = locationTag(it);
-        const body = condense(it.body, INLINE_BODY_CAP).replace(/\n/g, "\n  ");
-        lines.push(`- ${tag ? `${tag} — ` : ""}${body}`);
-      } else if (it.kind === "review") {
-        const body = condense(it.body, REVIEW_BODY_CAP);
-        if (body) lines.push(`- (review) ${body.replace(/\n/g, "\n  ")}`);
-      } else {
-        const body = condense(it.body, COMMENT_BODY_CAP);
-        if (body) lines.push(`- (summary) ${body.replace(/\n/g, "\n  ")}`);
-      }
-    }
-    if (lines.length > 0) {
-      blocks.push(`### ${reviewer}\n${lines.join("\n")}`);
+      const body = condense(it.body);
+      if (!body) continue;
+      cleaned.push({ reviewer, item: it, body });
     }
   }
-  return blocks.join("\n\n");
+
+  const caps = allocateBodyCaps(
+    cleaned.map((c) => c.body.length),
+    budget,
+    cleaned.map((c) => floors[c.item.kind]),
+  );
+
+  const linesByReviewer = new Map<string, string[]>();
+  cleaned.forEach(({ reviewer, item, body }, i) => {
+    const capped = capBody(body, caps[i]).replace(/\n/g, "\n  ");
+    const lines = linesByReviewer.get(reviewer) ?? [];
+    if (item.kind === "inline") {
+      const tag = locationTag(item);
+      lines.push(`- ${tag ? `${tag} — ` : ""}${capped}`);
+    } else if (item.kind === "review") {
+      lines.push(`- (review) ${capped}`);
+    } else {
+      lines.push(`- (summary) ${capped}`);
+    }
+    linesByReviewer.set(reviewer, lines);
+  });
+
+  return [...linesByReviewer]
+    .map(([reviewer, lines]) => `### ${reviewer}\n${lines.join("\n")}`)
+    .join("\n\n");
 }
 
 /**
@@ -204,6 +249,11 @@ function formatExternalFindings(items: ExternalReviewItem[]): string {
  * — `ignore`, a non-remote kind, a non-numeric ref, or any fetch failure yields
  * `{}`. Mirrors `resolvePriorContext`: takes primitives, never throws, never the
  * source of truth.
+ *
+ * `opts.budgetChars` is the section budget the per-finding caps are fair-shared
+ * across — the same budget the rest of the prompt scales to (the user's
+ * Review-context knob), so the knob actually reaches this section. The constant
+ * is a defensive default for a caller that doesn't resolve it.
  */
 export async function resolveExternalContext(
   repoPath: string,
@@ -212,6 +262,7 @@ export async function resolveExternalContext(
   currentHeadSha: string | undefined,
   ignore: boolean,
   provider: string = "github",
+  opts?: { budgetChars?: number },
 ): Promise<ExternalContext> {
   if (ignore || kind !== "remote") return {};
   const prNumber = Number(ref);
@@ -220,7 +271,10 @@ export async function resolveExternalContext(
   const items = await fetchExternalFindings(repoPath, prNumber, provider);
   if (items.length === 0) return {};
 
-  const externalFindings = formatExternalFindings(items);
+  const externalFindings = formatExternalFindings(
+    items,
+    opts?.budgetChars ?? EXTERNAL_FINDINGS_CHAR_BUDGET,
+  );
   if (!externalFindings.trim()) return {};
 
   // Stale = an included finding was made against a commit other than the current

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -4,7 +4,12 @@ import { loadSettings } from "@/lib/settings/api";
 import { GD_COMMENT_ANCHOR } from "./comment-branding";
 import { getDigest, saveDigest } from "./own-digest-store";
 import { distillOwnComments } from "./own-distill";
-import { OWN_COMMENTS_CHAR_BUDGET, safeSlice } from "./truncate";
+import {
+  allocateBodyCaps,
+  capBody,
+  OWN_COMMENTS_CHAR_BUDGET,
+  safeSlice,
+} from "./truncate";
 
 /** What `buildReviewPrompt` needs about GitDesktop's OWN prior comments on a PR. */
 export interface OwnCommentsContext {
@@ -33,79 +38,10 @@ export interface OwnCommentsContext {
  *  When `OWN_BODY_CAP × count > budget` the allocation degenerates to
  *  floor-for-all and the caps therefore over-allocate the section budget — that
  *  is by design, not a bug: these caps decide how the budget is SHARED, while
- *  `fitOwn` (truncate.ts) stays the hard enforcement and drops oldest-first, with
+ *  `fitOwn` (truncate.ts) stays the hard enforcement — dropping the MIDDLE
+ *  comments first, keeping the opening brief and the newest follow-ups — with
  *  distillation firing before it in the over-budget regime. */
 const OWN_BODY_CAP = 1_500;
-
-/** The note appended in place of the text `capBody` cuts — split so its fixed
- *  length can be charged against the cap before the omitted count is known. */
-const TRUNCATION_NOTE_HEAD = "[comment truncated — ";
-const TRUNCATION_NOTE_TAIL = " more characters on the PR thread]";
-
-/**
- * Max-min fair share of `budget` across blocks of the given `lengths`: walking
- * shortest-first, each block may claim an equal share of what's left, a block
- * that fits under its share takes only what it needs and donates the slack to
- * the longer ones, and the first block to exceed its share freezes that share
- * for itself and every longer block. So a lone 6K brief inside an 18K budget
- * survives whole, while a dozen 6K comments converge on the floor.
- *
- * `floor` is a guaranteed minimum per block (`OWN_BODY_CAP`), so the returned
- * caps can sum past `budget` when `floor × n > budget` — deliberate, see
- * `OWN_BODY_CAP`. Returned in the caller's original index order.
- */
-function allocateBodyCaps(
-  lengths: number[],
-  budget: number,
-  floor: number,
-): number[] {
-  const caps = new Array<number>(lengths.length).fill(floor);
-  // Shortest-first: only that order lets a short block's slack reach the long
-  // ones (indices, so the result maps back to the caller's order).
-  const order = lengths
-    .map((_, i) => i)
-    .sort((a, b) => lengths[a] - lengths[b] || a - b);
-  let remaining = budget;
-  let remainingCount = order.length;
-  for (let k = 0; k < order.length; k++) {
-    // `remainingCount` is > 0 for every iteration, so this never divides by zero;
-    // a non-positive budget yields a non-positive share and thus the floor.
-    const share = Math.floor(remaining / remainingCount);
-    if (lengths[order[k]] > share) {
-      // This block and every longer one are capped at the frozen share.
-      for (let j = k; j < order.length; j++) {
-        caps[order[j]] = Math.max(floor, share);
-      }
-      break;
-    }
-    caps[order[k]] = Math.max(floor, share);
-    remaining -= lengths[order[k]];
-    remainingCount--;
-  }
-  return caps;
-}
-
-/**
- * Head-keeps `text` within `cap`, saying so explicitly when it cuts — a bare `…`
- * left the model guessing whether the author's list simply ended. The note's own
- * length (worst-case digit count) is charged against `cap`, so the result never
- * exceeds it. `safeSlice`, never a raw slice: a cut through a surrogate pair
- * makes the whole prompt unserializable.
- */
-function capBody(text: string, cap: number): string {
-  if (text.length <= cap) return text;
-  const reserve =
-    1 + // the note's own line break
-    TRUNCATION_NOTE_HEAD.length +
-    String(text.length).length + // omitted count ≤ the whole text
-    TRUNCATION_NOTE_TAIL.length;
-  const keep = cap - reserve;
-  // Cap too small to hold the note at all — cut bare rather than overflow.
-  if (keep <= 0) return safeSlice(text, cap);
-  const head = safeSlice(text, keep);
-  const omitted = text.length - head.length;
-  return `${head}\n${TRUNCATION_NOTE_HEAD}${omitted}${TRUNCATION_NOTE_TAIL}`;
-}
 
 /**
  * Strips the branded wrapper from a GitDesktop-authored comment so only the

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -259,11 +259,17 @@ export async function resolveOwnCommentsContext(
       // serving a stale-sized ledger, and the joined post-cap length so an IN-PLACE
       // edit to a comment (which moves neither the count nor the newest timestamp)
       // still invalidates. Existing cached digests miss once and re-distill.
+      //
+      // The `v2` prefix retires every ledger cached with the old truncation-note
+      // wording: `stripTruncationNote` only matches the current note, so a stale
+      // ledger re-cut by `fitOwn` would stack a second note under the first
+      // instead of restating one cumulative count. One re-distill per PR buys the
+      // self-heal — the same accepted cost as the fingerprint's last change.
       const newest = survivors.reduce(
         (max, it) => (it.createdAt > max ? it.createdAt : max),
         survivors[0].createdAt,
       );
-      const fingerprint = `${survivors.length}#${newest}#${budget}#${joinedLen}`;
+      const fingerprint = `v2#${survivors.length}#${newest}#${budget}#${joinedLen}`;
       const cacheKey = `${kind}#${ref}`;
 
       const cached = await getDigest(repoPath, kind, ref);

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -261,9 +261,13 @@ export async function resolveOwnCommentsContext(
       // still invalidates. Existing cached digests miss once and re-distill.
       //
       // The `v2` prefix retires every ledger cached with the old truncation-note
-      // wording: `stripTruncationNote` only matches the current note, so a stale
-      // ledger re-cut by `fitOwn` would stack a second note under the first
-      // instead of restating one cumulative count. One re-distill per PR buys the
+      // wording. Not because anything breaks on a re-cut — a cached note only ever
+      // sits at the ledger's END, and `fitOwn`'s head-cut either drops it with the
+      // tail or hits the partial-note guard, which keys off the note's HEAD (the
+      // half both wordings share) — but because a cached ledger that is NEVER
+      // re-cut carries the old "…on the PR thread" claim straight into the prompt,
+      // pointing an agentic reviewer at a thread that has no such text. That claim
+      // is exactly what the reworded note retired. One re-distill per PR buys the
       // self-heal — the same accepted cost as the fingerprint's last change.
       const newest = survivors.reduce(
         (max, it) => (it.createdAt > max ? it.createdAt : max),

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -8,7 +8,6 @@ import {
   allocateBodyCaps,
   capBody,
   OWN_COMMENTS_CHAR_BUDGET,
-  safeSlice,
 } from "./truncate";
 
 /** What `buildReviewPrompt` needs about GitDesktop's OWN prior comments on a PR. */
@@ -35,13 +34,13 @@ export interface OwnCommentsContext {
  *  shorter comments leave slack. Head-kept: reviews front-load their blockers and
  *  a "fixed in `<sha>`" reply is short anyway.
  *
- *  When `OWN_BODY_CAP × count > budget` the allocation degenerates to
+ *  When `OWN_BODY_FLOOR × count > budget` the allocation degenerates to
  *  floor-for-all and the caps therefore over-allocate the section budget — that
  *  is by design, not a bug: these caps decide how the budget is SHARED, while
  *  `fitOwn` (truncate.ts) stays the hard enforcement — dropping the MIDDLE
  *  comments first, keeping the opening brief and the newest follow-ups — with
  *  distillation firing before it in the over-budget regime. */
-const OWN_BODY_CAP = 1_500;
+const OWN_BODY_FLOOR = 1_500;
 
 /**
  * Strips the branded wrapper from a GitDesktop-authored comment so only the
@@ -126,10 +125,11 @@ function isOwnAiReviewBody(body: string): boolean {
  *
  *  Two passes, because each body's cap depends on all the others: pass 1 strips
  *  the wrappers and drops the excluded/empty comments, then the surviving lengths
- *  are fair-shared across `budget` (see `allocateBodyCaps`) and pass 2 renders
- *  each body under its own cap. Capping per comment BEFORE knowing the section
- *  budget was the old bug — a single long brief was cut to the floor even with
- *  the budget almost entirely unspent. */
+ *  are fair-shared across `budget` net of the rendered scaffolding (see
+ *  `allocateBodyCaps` and the reserve below) and pass 2 renders each body under
+ *  its own cap. Capping per comment BEFORE knowing the section budget was the old
+ *  bug — a single long brief was cut to the floor even with the budget almost
+ *  entirely unspent. */
 function formatOwnComments(
   items: ExternalReviewItem[],
   budget: number,
@@ -140,21 +140,49 @@ function formatOwnComments(
   const ordered = [...items].sort((a, b) =>
     a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0,
   );
-  const cleaned: { item: ExternalReviewItem; body: string }[] = [];
+  const cleaned: { item: ExternalReviewItem; body: string; prefix: string }[] =
+    [];
   for (const it of ordered) {
     if (isOwnAiReviewBody(it.body)) continue;
     const body = condenseOwnComment(it.body);
     if (!body) continue;
-    cleaned.push({ item: it, body });
+    // Resolved once, so the reserve below is charged against exactly what pass 2
+    // renders.
+    cleaned.push({
+      item: it,
+      body,
+      prefix: `- (${it.author}${ownLocationTag(it)})\n  `,
+    });
   }
+
+  // Same scaffolding reserve as the external section: the caps govern BODY
+  // length, but each rendered block also carries its `- (author …)` line, the
+  // two-space continuation indent on every body newline, and the `\n\n` joiner to
+  // the next block — all of which count against the budget `fitOwn` and the
+  // distill trigger measure. Charging it here is what makes those two comparisons
+  // apples-to-apples; unreserved, the blocks were over-allocated by construction,
+  // so `fitOwn` trimmed comments that would have fit and the distill trigger
+  // fired on scaffolding. The newline term uses `body.slice(0, provisionalCap)`
+  // (round 1 allocates with no scaffolding) so a long multi-line comment can't
+  // reserve for newlines its cap will cut away; round 2's caps are ≤ round 1's,
+  // keeping the count an upper bound (+1 covers `capBody`'s note line), and the
+  // only failure mode is slightly under-using the budget.
+  const lengths = cleaned.map((c) => c.body.length);
+  const provisional = allocateBodyCaps(lengths, budget, OWN_BODY_FLOOR);
+  let scaffold = 0;
+  cleaned.forEach(({ prefix, body }, i) => {
+    scaffold +=
+      prefix.length + 2 + 2 * body.slice(0, provisional[i]).split("\n").length;
+  });
+
   const caps = allocateBodyCaps(
-    cleaned.map((c) => c.body.length),
-    budget,
-    OWN_BODY_CAP,
+    lengths,
+    Math.max(0, budget - scaffold),
+    OWN_BODY_FLOOR,
   );
-  const blocks = cleaned.map(({ item, body }, i) => {
+  const blocks = cleaned.map(({ body, prefix }, i) => {
     const capped = capBody(body, caps[i]);
-    return `- (${item.author}${ownLocationTag(item)})\n  ${capped.replace(/\n/g, "\n  ")}`;
+    return `${prefix}${capped.replace(/\n/g, "\n  ")}`;
   });
   return { blocks, survivors: cleaned.map((c) => c.item) };
 }
@@ -213,7 +241,12 @@ export async function resolveOwnCommentsContext(
   // asked (interactive/automation callers opt in) and only when the joined blocks
   // still exceed the section budget once each has been fair-shared down to its own
   // cap — i.e. only in the regime where the comments genuinely can't all fit, so
-  // one long-but-affordable brief no longer calls the model. Best-effort
+  // one long-but-affordable brief no longer calls the model. Both sides of that
+  // comparison now measure the same thing: `formatOwnComments` reserves the
+  // block scaffolding out of the budget, so `joinedLen` (bodies AND scaffolding)
+  // exceeding `budget` means the rendered section genuinely doesn't fit —
+  // previously the unreserved `- (author …)` lines and indents could push it over
+  // on their own and call the model for comments that actually fit. Best-effort
   // throughout: ANY failure (missing key, network, abort, empty output) falls back
   // silently to the raw recency-first blocks, so distillation can never fail or
   // delay-fail a review.
@@ -269,7 +302,10 @@ export async function resolveOwnCommentsContext(
 
 /** Safety net: hard-cap the distilled ledger at the resolved own-comments section
  *  budget (the model is asked to stay ~3500 chars, well under, but never trust
- *  that). The cap is the profile-scaled budget, not the fixed constant. */
+ *  that). The cap is the profile-scaled budget, not the fixed constant. Through
+ *  `capBody`, so the cut is disclosed in the same note format as every other one:
+ *  a bare `…` is invisible to `stripTruncationNote`, so a ledger cut here and
+ *  again by `fitOwn` would have disclosed only the second cut's count. */
 function capLedger(ledger: string, cap: number): string {
-  return ledger.length > cap ? `${safeSlice(ledger, cap)}…` : ledger;
+  return capBody(ledger, cap);
 }

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -23,10 +23,89 @@ export interface OwnCommentsContext {
   ownDistilled?: boolean;
 }
 
-/** Per-comment body cap before the global budget allocator — keep one verbose
- *  review from crowding out a later, shorter refutation. Head-kept: reviews
- *  front-load their blockers and a "fixed in `<sha>`" reply is short anyway. */
+/** Per-comment body FLOOR under the fair-share allocator — every comment is
+ *  guaranteed at least this many characters, so one verbose review can never
+ *  crowd out a later, shorter refutation. It is NOT a ceiling: a comment's actual
+ *  cap is its max-min share of the section budget, which is larger whenever
+ *  shorter comments leave slack. Head-kept: reviews front-load their blockers and
+ *  a "fixed in `<sha>`" reply is short anyway.
+ *
+ *  When `OWN_BODY_CAP × count > budget` the allocation degenerates to
+ *  floor-for-all and the caps therefore over-allocate the section budget — that
+ *  is by design, not a bug: these caps decide how the budget is SHARED, while
+ *  `fitOwn` (truncate.ts) stays the hard enforcement and drops oldest-first, with
+ *  distillation firing before it in the over-budget regime. */
 const OWN_BODY_CAP = 1_500;
+
+/** The note appended in place of the text `capBody` cuts — split so its fixed
+ *  length can be charged against the cap before the omitted count is known. */
+const TRUNCATION_NOTE_HEAD = "[comment truncated — ";
+const TRUNCATION_NOTE_TAIL = " more characters on the PR thread]";
+
+/**
+ * Max-min fair share of `budget` across blocks of the given `lengths`: walking
+ * shortest-first, each block may claim an equal share of what's left, a block
+ * that fits under its share takes only what it needs and donates the slack to
+ * the longer ones, and the first block to exceed its share freezes that share
+ * for itself and every longer block. So a lone 6K brief inside an 18K budget
+ * survives whole, while a dozen 6K comments converge on the floor.
+ *
+ * `floor` is a guaranteed minimum per block (`OWN_BODY_CAP`), so the returned
+ * caps can sum past `budget` when `floor × n > budget` — deliberate, see
+ * `OWN_BODY_CAP`. Returned in the caller's original index order.
+ */
+function allocateBodyCaps(
+  lengths: number[],
+  budget: number,
+  floor: number,
+): number[] {
+  const caps = new Array<number>(lengths.length).fill(floor);
+  // Shortest-first: only that order lets a short block's slack reach the long
+  // ones (indices, so the result maps back to the caller's order).
+  const order = lengths
+    .map((_, i) => i)
+    .sort((a, b) => lengths[a] - lengths[b] || a - b);
+  let remaining = budget;
+  let remainingCount = order.length;
+  for (let k = 0; k < order.length; k++) {
+    // `remainingCount` is > 0 for every iteration, so this never divides by zero;
+    // a non-positive budget yields a non-positive share and thus the floor.
+    const share = Math.floor(remaining / remainingCount);
+    if (lengths[order[k]] > share) {
+      // This block and every longer one are capped at the frozen share.
+      for (let j = k; j < order.length; j++) {
+        caps[order[j]] = Math.max(floor, share);
+      }
+      break;
+    }
+    caps[order[k]] = Math.max(floor, share);
+    remaining -= lengths[order[k]];
+    remainingCount--;
+  }
+  return caps;
+}
+
+/**
+ * Head-keeps `text` within `cap`, saying so explicitly when it cuts — a bare `…`
+ * left the model guessing whether the author's list simply ended. The note's own
+ * length (worst-case digit count) is charged against `cap`, so the result never
+ * exceeds it. `safeSlice`, never a raw slice: a cut through a surrogate pair
+ * makes the whole prompt unserializable.
+ */
+function capBody(text: string, cap: number): string {
+  if (text.length <= cap) return text;
+  const reserve =
+    1 + // the note's own line break
+    TRUNCATION_NOTE_HEAD.length +
+    String(text.length).length + // omitted count ≤ the whole text
+    TRUNCATION_NOTE_TAIL.length;
+  const keep = cap - reserve;
+  // Cap too small to hold the note at all — cut bare rather than overflow.
+  if (keep <= 0) return safeSlice(text, cap);
+  const head = safeSlice(text, keep);
+  const omitted = text.length - head.length;
+  return `${head}\n${TRUNCATION_NOTE_HEAD}${omitted}${TRUNCATION_NOTE_TAIL}`;
+}
 
 /**
  * Strips the branded wrapper from a GitDesktop-authored comment so only the
@@ -42,7 +121,7 @@ const OWN_BODY_CAP = 1_500;
  * the URL in the body. The header is only ever the first line, so we strip it
  * only when the first non-blank line is the branded one.
  */
-function condenseOwnComment(body: string, cap: number): string {
+function condenseOwnComment(body: string): string {
   const lines = body.split("\n");
   // Footer: everything from the last anchor-bearing line to the end.
   let end = lines.length;
@@ -66,11 +145,10 @@ function condenseOwnComment(body: string, cap: number): string {
   const isRuleOrBlank = (l: string) => l.trim() === "" || /^\s*---\s*$/.test(l);
   while (kept.length > 0 && isRuleOrBlank(kept[0])) kept.shift();
   while (kept.length > 0 && isRuleOrBlank(kept[kept.length - 1])) kept.pop();
-  const cleaned = kept
+  return kept
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
-  return cleaned.length > cap ? `${safeSlice(cleaned, cap)}…` : cleaned;
 }
 
 /** A short "where + state" tag for an inline comment or a thread reply. Plain
@@ -108,26 +186,41 @@ function isOwnAiReviewBody(body: string): boolean {
  *  `<sha>`" follow-up under it. Our own AI review/audit bodies are excluded
  *  first (redundant with the prior-review section). Returns the rendered blocks
  *  alongside the raw items that survived filtering (same order), so the caller can
- *  fingerprint the cache off the exact comments the blocks were built from. */
-function formatOwnComments(items: ExternalReviewItem[]): {
+ *  fingerprint the cache off the exact comments the blocks were built from.
+ *
+ *  Two passes, because each body's cap depends on all the others: pass 1 strips
+ *  the wrappers and drops the excluded/empty comments, then the surviving lengths
+ *  are fair-shared across `budget` (see `allocateBodyCaps`) and pass 2 renders
+ *  each body under its own cap. Capping per comment BEFORE knowing the section
+ *  budget was the old bug — a single long brief was cut to the floor even with
+ *  the budget almost entirely unspent. */
+function formatOwnComments(
+  items: ExternalReviewItem[],
+  budget: number,
+): {
   blocks: string[];
   survivors: ExternalReviewItem[];
 } {
   const ordered = [...items].sort((a, b) =>
     a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0,
   );
-  const blocks: string[] = [];
-  const survivors: ExternalReviewItem[] = [];
+  const cleaned: { item: ExternalReviewItem; body: string }[] = [];
   for (const it of ordered) {
     if (isOwnAiReviewBody(it.body)) continue;
-    const body = condenseOwnComment(it.body, OWN_BODY_CAP);
+    const body = condenseOwnComment(it.body);
     if (!body) continue;
-    blocks.push(
-      `- (${it.author}${ownLocationTag(it)})\n  ${body.replace(/\n/g, "\n  ")}`,
-    );
-    survivors.push(it);
+    cleaned.push({ item: it, body });
   }
-  return { blocks, survivors };
+  const caps = allocateBodyCaps(
+    cleaned.map((c) => c.body.length),
+    budget,
+    OWN_BODY_CAP,
+  );
+  const blocks = cleaned.map(({ item, body }, i) => {
+    const capped = capBody(body, caps[i]);
+    return `- (${item.author}${ownLocationTag(item)})\n  ${capped.replace(/\n/g, "\n  ")}`;
+  });
+  return { blocks, survivors: cleaned.map((c) => c.item) };
 }
 
 /**
@@ -167,35 +260,41 @@ export async function resolveOwnCommentsContext(
   const own = items.filter((it) => it.body.includes(GD_COMMENT_ANCHOR));
   if (own.length === 0) return {};
 
-  const { blocks: ownItems, survivors } = formatOwnComments(own);
+  // The per-comment caps, the distill trigger, and the ledger cap all key off the
+  // SAME budget the rest of the prompt scales to (the user's Review-context knob,
+  // resolved before this call and threaded in as `ownBudgetChars`) — not the fixed
+  // 6K constant — so the knob actually reaches the own-comments section. The
+  // constant is a defensive default: every caller today resolves the knob and
+  // passes it, but a future one that doesn't still gets a sane section size.
+  const budget = opts?.ownBudgetChars ?? OWN_COMMENTS_CHAR_BUDGET;
+
+  const { blocks: ownItems, survivors } = formatOwnComments(own, budget);
   if (ownItems.length === 0) return {};
 
   // Over-budget own comments accumulate across review rounds until even
   // recency-first selection drops recorded decisions, so distill ALL of them
   // into a compact per-finding ledger via the app's generation model. Only when
-  // asked (interactive/automation callers opt in) and only when the joined raw
-  // blocks actually exceed the section budget — under-budget comments never call
-  // the model. Best-effort throughout: ANY failure (missing key, network, abort,
-  // empty output) falls back silently to the raw recency-first blocks, so
-  // distillation can never fail or delay-fail a review.
-  // The distill trigger and the ledger cap both key off the SAME budget the rest
-  // of the prompt scales to (the user's Review-context knob, resolved before this
-  // call and threaded in as `ownBudgetChars`) — not the fixed 6K constant — so the
-  // knob actually reaches the own-comments section. Defaults to the constant when
-  // no profile is supplied (the non-review generation paths).
-  const budget = opts?.ownBudgetChars ?? OWN_COMMENTS_CHAR_BUDGET;
+  // asked (interactive/automation callers opt in) and only when the joined blocks
+  // still exceed the section budget once each has been fair-shared down to its own
+  // cap — i.e. only in the regime where the comments genuinely can't all fit, so
+  // one long-but-affordable brief no longer calls the model. Best-effort
+  // throughout: ANY failure (missing key, network, abort, empty output) falls back
+  // silently to the raw recency-first blocks, so distillation can never fail or
+  // delay-fail a review.
   const joinedLen = ownItems.join("\n\n").length;
   if (opts?.distill && joinedLen > budget) {
     try {
       // Fingerprint the distilled comments so a repeat resolve with unchanged
       // comments hits the cache and never re-runs the model. Include the budget so
       // changing the Review-context knob re-distills to the right size rather than
-      // serving a stale-sized ledger.
+      // serving a stale-sized ledger, and the joined post-cap length so an IN-PLACE
+      // edit to a comment (which moves neither the count nor the newest timestamp)
+      // still invalidates. Existing cached digests miss once and re-distill.
       const newest = survivors.reduce(
         (max, it) => (it.createdAt > max ? it.createdAt : max),
         survivors[0].createdAt,
       );
-      const fingerprint = `${survivors.length}#${newest}#${budget}`;
+      const fingerprint = `${survivors.length}#${newest}#${budget}#${joinedLen}`;
       const cacheKey = `${kind}#${ref}`;
 
       const cached = await getDigest(repoPath, kind, ref);

--- a/src/lib/ai/own-digest-store.ts
+++ b/src/lib/ai/own-digest-store.ts
@@ -6,7 +6,8 @@ import { storeName } from "@/lib/test-mode";
  * A distilled decision ledger for one PR's over-budget GitDesktop-own comments,
  * cached so re-review only re-runs the generation model when the comments
  * actually change. `fingerprint` couples the ledger to the raw comments it was
- * distilled from (their count + newest timestamp); a mismatch forces a re-distill.
+ * distilled from (their count and newest timestamp, the section budget, and the
+ * joined capped-block length); a mismatch forces a re-distill.
  * `ledger` is the model's own markdown — never parsed into structured data, and
  * always re-verified against the current diff by the reviewer that consumes it.
  */
@@ -14,7 +15,11 @@ export interface OwnCommentsDigest {
   schemaVersion: 1;
   /** `${kind}#${ref}` — one PR's ledger. */
   key: string;
-  /** Invalidation token: `${count}#${newestCreatedAt}` of the distilled comments. */
+  /** Invalidation token:
+   *  `${count}#${newestCreatedAt}#${budget}#${joinedBlockChars}` — the distilled
+   *  comments' count and newest timestamp, the section budget they were sized to,
+   *  and the joined length of the capped blocks (which moves on an in-place edit
+   *  that changes neither of the first two). */
   fingerprint: string;
   /** The distilled ledger markdown — the cached soft context. */
   ledger: string;

--- a/src/lib/ai/own-digest-store.ts
+++ b/src/lib/ai/own-digest-store.ts
@@ -20,11 +20,12 @@ export interface OwnCommentsDigest {
    *  distilled comments' count and newest timestamp, the section budget they were
    *  sized to, and the joined length of the capped blocks (which moves on an
    *  in-place edit that changes neither of the first two). The leading version
-   *  tag retires ledgers whose FORMAT no longer round-trips — it was bumped to
-   *  `v2` when the truncation note's wording changed, since a `v1` ledger carrying
-   *  the old note can't be re-cut without stacking a second one. Bump it again for
-   *  any future change to what a cached ledger's text looks like; records with a
-   *  stale token simply miss once and re-distill. */
+   *  tag retires ledgers whose cached TEXT is no longer what we would produce
+   *  today — it went to `v2` when the truncation note stopped claiming the omitted
+   *  characters are "on the PR thread", a claim that is false for a ledger and
+   *  would otherwise be served from cache into a prompt indefinitely. Bump it
+   *  again for any future change to what a cached ledger's text says; records with
+   *  a stale token simply miss once and re-distill. */
   fingerprint: string;
   /** The distilled ledger markdown — the cached soft context. */
   ledger: string;

--- a/src/lib/ai/own-digest-store.ts
+++ b/src/lib/ai/own-digest-store.ts
@@ -16,10 +16,15 @@ export interface OwnCommentsDigest {
   /** `${kind}#${ref}` — one PR's ledger. */
   key: string;
   /** Invalidation token:
-   *  `${count}#${newestCreatedAt}#${budget}#${joinedBlockChars}` — the distilled
-   *  comments' count and newest timestamp, the section budget they were sized to,
-   *  and the joined length of the capped blocks (which moves on an in-place edit
-   *  that changes neither of the first two). */
+   *  `v2#${count}#${newestCreatedAt}#${budget}#${joinedBlockChars}` — the
+   *  distilled comments' count and newest timestamp, the section budget they were
+   *  sized to, and the joined length of the capped blocks (which moves on an
+   *  in-place edit that changes neither of the first two). The leading version
+   *  tag retires ledgers whose FORMAT no longer round-trips — it was bumped to
+   *  `v2` when the truncation note's wording changed, since a `v1` ledger carrying
+   *  the old note can't be re-cut without stacking a second one. Bump it again for
+   *  any future change to what a cached ledger's text looks like; records with a
+   *  stale token simply miss once and re-distill. */
   fingerprint: string;
   /** The distilled ledger markdown — the cached soft context. */
   ledger: string;

--- a/src/lib/ai/own-distill.ts
+++ b/src/lib/ai/own-distill.ts
@@ -1,11 +1,16 @@
 import { loadSettings } from "@/lib/settings/api";
 import { createAiClient } from "./client";
-import { safeSlice } from "./truncate";
+import { capBody, stripTruncationNote } from "./truncate";
 
 /** Per-block head cap before the blocks are joined into the distillation prompt —
- *  keeps one verbose review from crowding out later follow-ups. Head-kept:
- *  reviews front-load their blockers. This bounds each block, but NOT the total,
- *  which grows with block count — {@link DISTILL_INPUT_CAP} bounds the request. */
+ *  keeps one verbose review from crowding out later follow-ups. Head-kept WITH an
+ *  explicit truncation note (`capBody`), so the ledger model can tell a block was
+ *  clipped rather than reading a mid-sentence stop as the comment's end; reviews
+ *  front-load their blockers, so the head is the part worth keeping. A block may
+ *  already carry a note from its own per-comment cap — the count restated here is
+ *  CUMULATIVE across both cuts, never a note nested inside a note. This bounds
+ *  each block, but NOT the total, which grows with block count —
+ *  {@link DISTILL_INPUT_CAP} bounds the request. */
 const DISTILL_BLOCK_CAP = 6_000;
 
 /** Overall input cap for the joined distillation prompt. After per-block capping,
@@ -41,9 +46,12 @@ export async function distillOwnComments(input: {
   // overall input cap (walk from the array end, joined "\n\n" length ≤ cap),
   // dropping the oldest overflow — so the request stays bounded regardless of how
   // many review rounds have accumulated.
-  const capped = input.blocks.map((b) =>
-    b.length > DISTILL_BLOCK_CAP ? safeSlice(b, DISTILL_BLOCK_CAP) : b,
-  );
+  // `capBody` is a no-op for a block that already fits and carries no note, so it
+  // replaces the old length conditional outright.
+  const capped = input.blocks.map((b) => {
+    const { text, omitted } = stripTruncationNote(b);
+    return capBody(text, DISTILL_BLOCK_CAP, omitted);
+  });
   let keptCount = 0;
   let running = 0;
   for (let i = capped.length - 1; i >= 0; i--) {
@@ -52,11 +60,15 @@ export async function distillOwnComments(input: {
     running += cost;
     keptCount++;
   }
-  // If not even the newest block fits, include it alone, head-sliced to the cap.
+  // If not even the newest block fits, include it alone, head-kept to the cap —
+  // through the same strip/cap pair, so this cut discloses itself too and its
+  // count still folds in the block-cap cut above.
+  const newestAlone = () => {
+    const { text, omitted } = stripTruncationNote(capped[capped.length - 1]);
+    return capBody(text, DISTILL_INPUT_CAP, omitted);
+  };
   const selected =
-    keptCount === 0
-      ? [safeSlice(capped[capped.length - 1], DISTILL_INPUT_CAP)]
-      : capped.slice(capped.length - keptCount);
+    keptCount === 0 ? [newestAlone()] : capped.slice(capped.length - keptCount);
   const body = selected.join("\n\n");
 
   // Bound the model call: combine the caller's signal (a dock Cancel) with a 60s

--- a/src/lib/ai/own-distill.ts
+++ b/src/lib/ai/own-distill.ts
@@ -6,11 +6,11 @@ import { capBody, stripTruncationNote } from "./truncate";
  *  keeps one verbose review from crowding out later follow-ups. Head-kept WITH an
  *  explicit truncation note (`capBody`), so the ledger model can tell a block was
  *  clipped rather than reading a mid-sentence stop as the comment's end; reviews
- *  front-load their blockers, so the head is the part worth keeping. A block may
- *  already carry a note from its own per-comment cap — the count restated here is
- *  CUMULATIVE across both cuts, never a note nested inside a note. This bounds
- *  each block, but NOT the total, which grows with block count —
- *  {@link DISTILL_INPUT_CAP} bounds the request. */
+ *  front-load their blockers, so the head is the part worth keeping. A block that
+ *  exceeds this cap may already carry a note from its own per-comment cap — the
+ *  count restated here is CUMULATIVE across both cuts, never a note nested inside
+ *  a note. This bounds each block, but NOT the total, which grows with block
+ *  count — {@link DISTILL_INPUT_CAP} bounds the request. */
 const DISTILL_BLOCK_CAP = 6_000;
 
 /** Overall input cap for the joined distillation prompt. After per-block capping,
@@ -46,9 +46,14 @@ export async function distillOwnComments(input: {
   // overall input cap (walk from the array end, joined "\n\n" length ≤ cap),
   // dropping the oldest overflow — so the request stays bounded regardless of how
   // many review rounds have accumulated.
-  // `capBody` is a no-op for a block that already fits and carries no note, so it
-  // replaces the old length conditional outright.
+  // Only OVER-cap blocks go through the strip/re-cap pair. A block that already
+  // fits must pass through byte-identical: re-emitting it would move a legitimate
+  // note off `formatOwnComments`' continuation indent, and `stripTruncationNote`
+  // matches on SHAPE — a block whose last line merely quotes the note format (our
+  // own PR comments do this routinely) would be "stripped" and re-emitted with a
+  // fabricated omitted-count.
   const capped = input.blocks.map((b) => {
+    if (b.length <= DISTILL_BLOCK_CAP) return b;
     const { text, omitted } = stripTruncationNote(b);
     return capBody(text, DISTILL_BLOCK_CAP, omitted);
   });
@@ -62,7 +67,10 @@ export async function distillOwnComments(input: {
   }
   // If not even the newest block fits, include it alone, head-kept to the cap —
   // through the same strip/cap pair, so this cut discloses itself too and its
-  // count still folds in the block-cap cut above.
+  // count still folds in the block-cap cut above. Unreachable while
+  // DISTILL_BLOCK_CAP (6,000) < DISTILL_INPUT_CAP (48,000) — every capped block
+  // fits the loop's first iteration, so `keptCount` is at least 1 — kept so the
+  // fallback is correct if the constants ever converge.
   const newestAlone = () => {
     const { text, omitted } = stripTruncationNote(capped[capped.length - 1]);
     return capBody(text, DISTILL_INPUT_CAP, omitted);

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -3,6 +3,7 @@ import { distillReadme } from "./readme";
 import {
   budgetDiff,
   budgetReviewExtras,
+  capBody,
   type ReviewExtras,
   safeSlice,
 } from "./truncate";
@@ -295,11 +296,12 @@ export function buildPrPrompt(input: PrPromptInput): {
   promptParts.push(`## Files changed\n${fileSummary || "(none)"}`);
 
   // Author's "Notes for reviewers" — reflect the recorded decisions in the
-  // description, don't paste them verbatim. Same trim + 8000-char slice guard as
-  // the review prompt's notes section.
+  // description, don't paste them verbatim. Same trim + disclosed 8000-char cap as
+  // the review prompt's notes section: the model should know the notes were
+  // clipped rather than treat a mid-sentence stop as the author's last word.
   if (input.reviewNotes?.trim()) {
     promptParts.push(
-      `## Author's notes for reviewers (context — reflect the decisions, don't paste verbatim)\n${safeSlice(input.reviewNotes.trim(), 8000)}`,
+      `## Author's notes for reviewers (context — reflect the decisions, don't paste verbatim)\n${capBody(input.reviewNotes.trim(), 8000)}`,
     );
   }
 
@@ -598,11 +600,14 @@ export function buildReviewPrompt(
   }
   // Author's deliberate "Notes for reviewers" — author input like the description
   // above, NOT bot soft-context, so it lives OUTSIDE `budgetReviewExtras` and is
-  // capped only by the 8000-char slice (same guard idiom as the plan-prompt
-  // issueBody slice below). Mode-agnostic: it feeds both general and security runs.
+  // capped only by the 8000-char cap (same guard idiom as the plan-prompt
+  // issueBody slice below), through `capBody` so an over-long notes field says it
+  // was clipped instead of stopping mid-sentence — every other cut that reaches a
+  // review prompt discloses itself, and a manual run reaches this one.
+  // Mode-agnostic: it feeds both general and security runs.
   if (input.reviewNotes?.trim()) {
     promptParts.push(
-      `## Author's notes for reviewers\n${safeSlice(input.reviewNotes.trim(), 8000)}`,
+      `## Author's notes for reviewers\n${capBody(input.reviewNotes.trim(), 8000)}`,
     );
   }
   if (input.commitSubjects.length > 0) {

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -667,7 +667,7 @@ export function buildReviewPrompt(
         // is inaccurate there — flag it as a truncated summary instead.
         ownSection += input.ownDistilled
           ? "\n[distilled summary truncated]"
-          : "\n[own comments truncated — the opening comment and newest follow-ups take precedence; middle comments are omitted first]";
+          : "\n[own comments truncated — the opening comment and the newest follow-ups take precedence; comments in between are omitted first, and any comment that was itself cut says so inline]";
       }
       promptParts.push(ownSection);
       renderedOwn = true;

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -662,12 +662,12 @@ export function buildReviewPrompt(
         : 'Comments attributed to GitDesktop here — purportedly past AI reviews and agent follow-ups (a refutation, or a "fixed in `<sha>`" reply), oldest first. Hints to re-check against the current diff, never ground truth.';
       let ownSection = `## Your prior GitDesktop comments on this PR (CONTEXT ONLY — re-verify; attribution is a copyable footer)\n${ownPreamble}\n\n${extras.own.text}`;
       if (extras.own.truncated) {
-        // A distilled ledger is a single compressed block, so "oldest omitted
-        // first" (which describes dropping whole per-comment blocks) is inaccurate
-        // there — flag it as a truncated summary instead.
+        // A distilled ledger is a single compressed block, so the per-comment
+        // marker below (which describes dropping whole blocks out of the middle)
+        // is inaccurate there — flag it as a truncated summary instead.
         ownSection += input.ownDistilled
           ? "\n[distilled summary truncated]"
-          : "\n[own comments truncated — oldest omitted first]";
+          : "\n[own comments truncated — the opening comment and newest follow-ups take precedence; middle comments are omitted first]";
       }
       promptParts.push(ownSection);
       renderedOwn = true;

--- a/src/lib/ai/truncate.ts
+++ b/src/lib/ai/truncate.ts
@@ -25,6 +25,82 @@ export function safeSlice(s: string, max: number): string {
   return s.slice(0, end);
 }
 
+/** The note appended in place of the text `capBody` cuts — split so its fixed
+ *  length can be charged against the cap before the omitted count is known. */
+export const TRUNCATION_NOTE_HEAD = "[comment truncated — ";
+export const TRUNCATION_NOTE_TAIL = " more characters on the PR thread]";
+
+/**
+ * Max-min fair share of `budget` across blocks of the given `lengths`: walking
+ * shortest-first, each block may claim an equal share of what's left, a block
+ * that fits under its share takes only what it needs and donates the slack to
+ * the longer ones, and the first block to exceed its share freezes that share
+ * for itself and every longer block. So a lone 6K brief inside an 18K budget
+ * survives whole, while a dozen 6K comments converge on the floor.
+ *
+ * `floor` is a guaranteed minimum per block — either one value for all blocks
+ * (own comments) or a per-index array the same length as `lengths` (the external
+ * section, whose floor differs by finding kind). It only ever LIFTS a block's
+ * final cap, so the returned caps can sum past `budget` when the floors alone
+ * exceed it — deliberate: these caps decide how the budget is SHARED between
+ * blocks, while each section's own fitter (`fitOwn` / `fit` in
+ * `budgetReviewExtras`) stays the hard enforcement. Returned in the caller's
+ * original index order.
+ */
+export function allocateBodyCaps(
+  lengths: number[],
+  budget: number,
+  floor: number | number[],
+): number[] {
+  const floorAt = (i: number) => (typeof floor === "number" ? floor : floor[i]);
+  const caps = lengths.map((_, i) => floorAt(i));
+  // Shortest-first: only that order lets a short block's slack reach the long
+  // ones (indices, so the result maps back to the caller's order).
+  const order = lengths
+    .map((_, i) => i)
+    .sort((a, b) => lengths[a] - lengths[b] || a - b);
+  let remaining = budget;
+  let remainingCount = order.length;
+  for (let k = 0; k < order.length; k++) {
+    // `remainingCount` is > 0 for every iteration, so this never divides by zero;
+    // a non-positive budget yields a non-positive share and thus the floor.
+    const share = Math.floor(remaining / remainingCount);
+    if (lengths[order[k]] > share) {
+      // This block and every longer one are capped at the frozen share.
+      for (let j = k; j < order.length; j++) {
+        caps[order[j]] = Math.max(floorAt(order[j]), share);
+      }
+      break;
+    }
+    caps[order[k]] = Math.max(floorAt(order[k]), share);
+    remaining -= lengths[order[k]];
+    remainingCount--;
+  }
+  return caps;
+}
+
+/**
+ * Head-keeps `text` within `cap`, saying so explicitly when it cuts — a bare `…`
+ * left the model guessing whether the author's list simply ended. The note's own
+ * length (worst-case digit count) is charged against `cap`, so the result never
+ * exceeds it. `safeSlice`, never a raw slice: a cut through a surrogate pair
+ * makes the whole prompt unserializable.
+ */
+export function capBody(text: string, cap: number): string {
+  if (text.length <= cap) return text;
+  const reserve =
+    1 + // the note's own line break
+    TRUNCATION_NOTE_HEAD.length +
+    String(text.length).length + // omitted count ≤ the whole text
+    TRUNCATION_NOTE_TAIL.length;
+  const keep = cap - reserve;
+  // Cap too small to hold the note at all — cut bare rather than overflow.
+  if (keep <= 0) return safeSlice(text, cap);
+  const head = safeSlice(text, keep);
+  const omitted = text.length - head.length;
+  return `${head}\n${TRUNCATION_NOTE_HEAD}${omitted}${TRUNCATION_NOTE_TAIL}`;
+}
+
 const LOW_VALUE_PATH =
   /(^|\/)(pnpm-lock\.yaml|package-lock\.json|yarn\.lock|Cargo\.lock|bun\.lockb?|composer\.lock|Gemfile\.lock|go\.sum)$|\.min\.(js|css)$|\.(map|snap)$/;
 
@@ -134,9 +210,11 @@ export interface ReviewExtras {
   prior: { text: string; truncated: boolean };
   /** Prior findings dropped entirely for budget. */
   priorDropped: boolean;
-  /** Budgeted GitDesktop's-own prior PR comments — a contiguous NEWEST-first
-   *  suffix of the comment blocks, rendered back in oldest-first order.
-   *  `truncated` when any block was excluded or the newest was head-sliced. */
+  /** Budgeted GitDesktop's-own prior PR comments — everything when it all fits,
+   *  otherwise the OLDEST block (the PR-opening context brief) pinned plus a
+   *  contiguous NEWEST-first suffix of the rest, rendered in oldest-first order;
+   *  the middle blocks are the ones that drop. `truncated` when any block was
+   *  excluded or head-sliced. */
   own: { text: string; truncated: boolean };
   /** Own comments dropped entirely for budget. */
   ownDropped: boolean;
@@ -155,9 +233,10 @@ export interface ReviewExtras {
  * under pressure external drops first, then our comments, then prior, then the
  * delta, never the diff. `diffLen` is the length of the already-budgeted main diff.
  *
- * Our own comments (`ownItems`) fit RECENCY-FIRST rather than head-first: the
- * newest, highest-signal follow-ups are kept and the oldest drop when the cap
- * bites (the reverse of prior/external, which head-slice a single blob).
+ * Our own comments (`ownItems`) fit RECENCY-FIRST with the oldest block PINNED
+ * rather than head-first: the newest, highest-signal follow-ups are kept, the
+ * PR-opening brief is held on to, and the middle drops when the cap bites (the
+ * reverse of prior/external, which head-slice a single blob).
  */
 export function budgetReviewExtras(input: {
   diffLen: number;
@@ -211,12 +290,27 @@ export function budgetReviewExtras(input: {
     return { result, dropped: false };
   };
 
-  // Our own comments fit recency-first: walk from the NEWEST block (array end)
-  // backwards, accumulating each block's length plus a 2-char "\n\n" joiner for
-  // every block after the first, and keep a CONTIGUOUS newest suffix while it fits
-  // the cap — stopping at the first block that doesn't (no skip-and-continue). If
-  // not even the newest block fits, the newest alone is head-sliced to the cap.
-  // The kept blocks render in ORIGINAL oldest-first order.
+  // How many blocks a contiguous NEWEST-first suffix of `blocks` fits into
+  // `budget`: walk from the array end backwards, charging each block's length
+  // plus a 2-char "\n\n" joiner for every block after the first, and stop at the
+  // first block that doesn't fit (no skip-and-continue).
+  const newestSuffixCount = (blocks: string[], budget: number) => {
+    let keptCount = 0;
+    let running = 0;
+    for (let i = blocks.length - 1; i >= 0; i--) {
+      const cost = blocks[i].length + (keptCount > 0 ? 2 : 0);
+      if (running + cost > budget) break;
+      running += cost;
+      keptCount++;
+    }
+    return keptCount;
+  };
+
+  // Our own comments fit recency-first with the OLDEST block PINNED, rendered in
+  // ORIGINAL oldest-first order. A pure newest-first suffix dropped `present[0]`
+  // first, but that block is by construction the PR-opening context brief — the
+  // one comment nothing later supersedes. Under pressure we therefore keep it (up
+  // to a reserve) and let the MIDDLE blocks drop instead.
   const fitOwn = (items: string[] | undefined, max: number) => {
     const present = items?.filter((t) => t.trim()) ?? [];
     if (present.length === 0)
@@ -225,28 +319,64 @@ export function budgetReviewExtras(input: {
     if (cap <= 0)
       return { result: { text: "", truncated: false }, dropped: true };
 
-    let keptCount = 0;
-    let running = 0;
-    for (let i = present.length - 1; i >= 0; i--) {
-      const cost = present[i].length + (keptCount > 0 ? 2 : 0);
-      if (running + cost > cap) break;
-      running += cost;
-      keptCount++;
+    // A single block (also the distilled-ledger case) has no middle and no pin to
+    // apply: head-slice it, exactly as before.
+    if (present.length === 1) {
+      const only = present[0];
+      const text = only.length <= cap ? only : safeSlice(only, cap);
+      remaining -= text.length;
+      return {
+        result: { text, truncated: text.length < only.length },
+        dropped: false,
+      };
     }
 
-    let text: string;
-    let truncated: boolean;
-    if (keptCount === 0) {
-      // Not even the newest block fits — include it alone, head-sliced.
-      text = safeSlice(present[present.length - 1], cap);
-      truncated = true;
-    } else {
-      const selected = present.slice(present.length - keptCount);
-      text = selected.join("\n\n");
-      truncated = keptCount < present.length;
+    // Everything fits — take it whole, byte-identical to the pre-pin behavior.
+    if (newestSuffixCount(present, cap) === present.length) {
+      const text = present.join("\n\n");
+      remaining -= text.length;
+      return { result: { text, truncated: false }, dropped: false };
     }
+
+    // Pressure regime. The pin gets at most ~a third of the cap: the opening brief
+    // records design intent nothing supersedes, but the newest follow-ups carry
+    // the live dispositions (refutations, "fixed in `<sha>`"), so the pin must
+    // never crowd out the majority of the recency signal.
+    const reserve = Math.min(present[0].length, Math.floor(cap * 0.35));
+    let pinned =
+      present[0].length <= reserve
+        ? present[0]
+        : safeSlice(present[0], reserve);
+    // Degenerate cap (a handful of characters): rather than render an empty pin,
+    // fall back to the oldest block head-sliced to the whole cap.
+    if (!pinned) pinned = safeSlice(present[0], cap);
+
+    const rest = present.slice(1);
+    // `- 2` = the "\n\n" joiner between the pin and the suffix.
+    const restCap = cap - pinned.length - 2;
+    const keptCount = restCap > 0 ? newestSuffixCount(rest, restCap) : 0;
+    let selected = keptCount > 0 ? rest.slice(rest.length - keptCount) : [];
+    if (keptCount === 0 && restCap > 0) {
+      // Not even the newest follow-up fits WHOLE, but the leftover is real: head-
+      // slice it in rather than render the pin alone. Two ordinary comments (a
+      // 510-char opener + a 5,560-char follow-up at a 6,000 cap) land here, and
+      // dropping the follow-up would throw away every live disposition to keep an
+      // opening brief that fit ten times over. `safeSlice` can still come back
+      // empty at a tiny leftover, hence the guard.
+      const sliced = safeSlice(rest[rest.length - 1], restCap);
+      if (sliced) selected = [sliced];
+    }
+    const text = [pinned, ...selected].join("\n\n");
+    // A degenerate cap (a couple of characters, and an astral char at the head of
+    // the oldest block) can slice BOTH parts away. Reporting that as an empty-but-
+    // present section renders neither the section nor the truncation marker, so
+    // the model reads "nothing on record" — report it as dropped instead, which
+    // prompt.ts renders as the explicit omitted-for-budget marker.
+    if (!text) return { result: { text: "", truncated: false }, dropped: true };
     remaining -= text.length;
-    return { result: { text, truncated }, dropped: false };
+    // Always truncated here: we only reach this branch because the full set
+    // didn't fit the cap, so something was sliced or dropped by definition.
+    return { result: { text, truncated: true }, dropped: false };
   };
 
   const priorFit = fit(input.priorText, priorBudget);

--- a/src/lib/ai/truncate.ts
+++ b/src/lib/ai/truncate.ts
@@ -45,8 +45,10 @@ const TRUNCATION_NOTE_TAIL = " more characters omitted]";
  * the count it disclosed (0 when there is no note). Lets a second cut of an
  * already-cut block re-state the CUMULATIVE omission instead of nesting a note
  * inside a note or — worse — slicing the first note away and leaving the block
- * looking complete. The note may be indented, since both callers render bodies
- * with a `\n  ` continuation indent.
+ * looking complete. The note may be indented: `formatOwnComments` and
+ * `formatExternalFindings` both render bodies under a `\n  ` continuation indent,
+ * so a note produced inside one of their blocks carries it (own-distill.ts, which
+ * re-cuts blocks those renderers already produced, passes them in as they are).
  */
 export function stripTruncationNote(text: string): {
   text: string;

--- a/src/lib/ai/truncate.ts
+++ b/src/lib/ai/truncate.ts
@@ -26,9 +26,37 @@ export function safeSlice(s: string, max: number): string {
 }
 
 /** The note appended in place of the text `capBody` cuts — split so its fixed
- *  length can be charged against the cap before the omitted count is known. */
-export const TRUNCATION_NOTE_HEAD = "[comment truncated — ";
-export const TRUNCATION_NOTE_TAIL = " more characters on the PR thread]";
+ *  length can be charged against the cap before the omitted count is known.
+ *  "content", not "comment": the same note lands on inline findings and submitted
+ *  review bodies, not only on conversation comments. Module-private — `capBody`
+ *  and `stripTruncationNote` are the whole contract. */
+const TRUNCATION_NOTE_HEAD = "[content truncated — ";
+const TRUNCATION_NOTE_TAIL = " more characters on the PR thread]";
+
+/**
+ * Splits a trailing `capBody` note off `text`, returning the body without it and
+ * the count it disclosed (0 when there is no note). Lets a second cut of an
+ * already-cut block re-state the CUMULATIVE omission instead of nesting a note
+ * inside a note or — worse — slicing the first note away and leaving the block
+ * looking complete. The note may be indented, since both callers render bodies
+ * with a `\n  ` continuation indent.
+ */
+function stripTruncationNote(text: string): { text: string; omitted: number } {
+  const nl = text.lastIndexOf("\n");
+  if (nl < 0) return { text, omitted: 0 };
+  const lastLine = text.slice(nl + 1).trimStart();
+  if (
+    !lastLine.startsWith(TRUNCATION_NOTE_HEAD) ||
+    !lastLine.endsWith(TRUNCATION_NOTE_TAIL)
+  )
+    return { text, omitted: 0 };
+  const digits = lastLine.slice(
+    TRUNCATION_NOTE_HEAD.length,
+    lastLine.length - TRUNCATION_NOTE_TAIL.length,
+  );
+  if (!/^\d+$/.test(digits)) return { text, omitted: 0 };
+  return { text: text.slice(0, nl), omitted: Number(digits) };
+}
 
 /**
  * Max-min fair share of `budget` across blocks of the given `lengths`: walking
@@ -85,20 +113,63 @@ export function allocateBodyCaps(
  * length (worst-case digit count) is charged against `cap`, so the result never
  * exceeds it. `safeSlice`, never a raw slice: a cut through a surrogate pair
  * makes the whole prompt unserializable.
+ *
+ * `priorOmitted` carries the count from an EARLIER cut of the same text (pair it
+ * with `stripTruncationNote`, which produces both the note-free body and that
+ * count): it is folded into the rendered number, so a twice-cut block discloses
+ * the cumulative omission under exactly one note. Non-zero `priorOmitted` also
+ * means the note is re-attached even when the body itself now fits — dropping it
+ * would make a cut block read as complete.
+ *
+ * `indent` prefixes the note line, for callers whose blocks carry a continuation
+ * indent (the own-comments blocks use two spaces); it is charged against `cap`
+ * like the rest of the note. `stripTruncationNote` trims it back off, so an
+ * indented note still round-trips through a later cut.
  */
-export function capBody(text: string, cap: number): string {
-  if (text.length <= cap) return text;
+export function capBody(
+  text: string,
+  cap: number,
+  priorOmitted = 0,
+  indent = "",
+): string {
+  if (priorOmitted <= 0 && text.length <= cap) return text;
   const reserve =
     1 + // the note's own line break
+    indent.length +
     TRUNCATION_NOTE_HEAD.length +
-    String(text.length).length + // omitted count ≤ the whole text
+    String(text.length + priorOmitted).length + // omitted count ≤ text + prior
     TRUNCATION_NOTE_TAIL.length;
   const keep = cap - reserve;
-  // Cap too small to hold the note at all — cut bare rather than overflow.
-  if (keep <= 0) return safeSlice(text, cap);
-  const head = safeSlice(text, keep);
-  const omitted = text.length - head.length;
-  return `${head}\n${TRUNCATION_NOTE_HEAD}${omitted}${TRUNCATION_NOTE_TAIL}`;
+  if (keep <= 0) {
+    // Cap too small to hold the note at all. This IS live, not defensive: `fitOwn`
+    // caps at `min(remaining, ownBudget)`, so a nearly-spent prompt budget (say
+    // 120 chars left) puts the pin's 35% reserve at ~42 — well under the ~59-char
+    // note. Disclosure is deliberately lossy here: the ellipsis marks the cut,
+    // a non-zero `priorOmitted` is DROPPED rather than rendered in some second
+    // note format, and the section-level "[own comments truncated …]" marker in
+    // prompt.ts is what tells the model the section was cut at all.
+    return cap >= 1 ? `${safeSlice(text, cap - 1)}…` : safeSlice(text, cap);
+  }
+  let head = safeSlice(text, keep);
+  // The text being cut may already CONTAIN notes — `fit` cuts a whole rendered
+  // section whose items were each capped — and the cut can land inside one,
+  // leaving `[content truncated — 1360 more characters on the` dangling in front
+  // of the note we are about to add. A note always occupies its own line, so drop
+  // a final line that is a partial one (an unterminated note, or a prefix of the
+  // opener). Cheap and one-directional: it only ever removes characters, and the
+  // omitted count below is computed from what actually survived.
+  const lastNl = head.lastIndexOf("\n");
+  if (lastNl >= 0) {
+    const lastLine = head.slice(lastNl + 1).trimStart();
+    const partialNote =
+      lastLine.length > 0 &&
+      (TRUNCATION_NOTE_HEAD.startsWith(lastLine) ||
+        (lastLine.startsWith(TRUNCATION_NOTE_HEAD) &&
+          !lastLine.endsWith(TRUNCATION_NOTE_TAIL)));
+    if (partialNote) head = head.slice(0, lastNl);
+  }
+  const omitted = text.length - head.length + priorOmitted;
+  return `${head}\n${indent}${TRUNCATION_NOTE_HEAD}${omitted}${TRUNCATION_NOTE_TAIL}`;
 }
 
 const LOW_VALUE_PATH =
@@ -201,6 +272,11 @@ export const OWN_COMMENTS_CHAR_BUDGET = 6_000;
 /** Cap for third-party AI-reviewer findings (lowest priority — noisier, theirs). */
 export const EXTERNAL_FINDINGS_CHAR_BUDGET = 8_000;
 
+/** The continuation indent own-comment blocks render their bodies under (see
+ *  `formatOwnComments` in own-context.ts) — `fitOwn`'s re-cuts pass it to
+ *  `capBody` so a re-stated note stays inside its list item. */
+const OWN_BLOCK_INDENT = "  ";
+
 export interface ReviewExtras {
   /** Budgeted delta diff (empty when absent or dropped for budget). */
   delta: BudgetedDiff;
@@ -211,10 +287,10 @@ export interface ReviewExtras {
   /** Prior findings dropped entirely for budget. */
   priorDropped: boolean;
   /** Budgeted GitDesktop's-own prior PR comments — everything when it all fits,
-   *  otherwise the OLDEST block (the PR-opening context brief) pinned plus a
+   *  otherwise the OLDEST block (typically the opening brief) pinned plus a
    *  contiguous NEWEST-first suffix of the rest, rendered in oldest-first order;
    *  the middle blocks are the ones that drop. `truncated` when any block was
-   *  excluded or head-sliced. */
+   *  excluded or head-sliced — a sliced block also says so inline. */
   own: { text: string; truncated: boolean };
   /** Own comments dropped entirely for budget. */
   ownDropped: boolean;
@@ -276,6 +352,12 @@ export function budgetReviewExtras(input: {
     }
   }
 
+  // THE enforcement point for the head-sliced sections, and therefore where the
+  // disclosure guarantee lives: the section formatters can only size their shares
+  // approximately (their own floors can lift a body back over any budget they
+  // netted, and `remaining` here — what the diff and delta actually left — is
+  // unknowable at format time), so whatever arrives oversized is cut HERE, and
+  // `capBody` makes that cut say so instead of ending mid-word or mid-note.
   const fit = (text: string | undefined, max: number) => {
     if (!text?.trim())
       return { result: { text: "", truncated: false }, dropped: false };
@@ -285,7 +367,7 @@ export function budgetReviewExtras(input: {
     const result =
       text.length <= cap
         ? { text, truncated: false }
-        : { text: safeSlice(text, cap), truncated: true };
+        : { text: capBody(text, cap), truncated: true };
     remaining -= result.text.length;
     return { result, dropped: false };
   };
@@ -308,9 +390,10 @@ export function budgetReviewExtras(input: {
 
   // Our own comments fit recency-first with the OLDEST block PINNED, rendered in
   // ORIGINAL oldest-first order. A pure newest-first suffix dropped `present[0]`
-  // first, but that block is by construction the PR-opening context brief — the
-  // one comment nothing later supersedes. Under pressure we therefore keep it (up
-  // to a reserve) and let the MIDDLE blocks drop instead.
+  // first, but that block is typically the opening brief — the context nothing
+  // later supersedes (only typically: it's just our oldest anchor-bearing comment,
+  // which an early thread reply can also be). Under pressure we therefore keep it
+  // (up to a reserve) and let the MIDDLE blocks drop instead.
   const fitOwn = (items: string[] | undefined, max: number) => {
     const present = items?.filter((t) => t.trim()) ?? [];
     if (present.length === 0)
@@ -320,15 +403,20 @@ export function budgetReviewExtras(input: {
       return { result: { text: "", truncated: false }, dropped: true };
 
     // A single block (also the distilled-ledger case) has no middle and no pin to
-    // apply: head-slice it, exactly as before.
+    // apply: head-keep it alone.
     if (present.length === 1) {
       const only = present[0];
-      const text = only.length <= cap ? only : safeSlice(only, cap);
+      if (only.length <= cap) {
+        remaining -= only.length;
+        return { result: { text: only, truncated: false }, dropped: false };
+      }
+      // `OWN_BLOCK_INDENT`: own blocks render their body under a two-space
+      // continuation indent, so the re-cut note has to sit inside the list item
+      // rather than at column 0.
+      const { text: body, omitted } = stripTruncationNote(only);
+      const text = capBody(body, cap, omitted, OWN_BLOCK_INDENT);
       remaining -= text.length;
-      return {
-        result: { text, truncated: text.length < only.length },
-        dropped: false,
-      };
+      return { result: { text, truncated: true }, dropped: false };
     }
 
     // Everything fits — take it whole, byte-identical to the pre-pin behavior.
@@ -338,15 +426,18 @@ export function budgetReviewExtras(input: {
       return { result: { text, truncated: false }, dropped: false };
     }
 
-    // Pressure regime. The pin gets at most ~a third of the cap: the opening brief
-    // records design intent nothing supersedes, but the newest follow-ups carry
-    // the live dispositions (refutations, "fixed in `<sha>`"), so the pin must
-    // never crowd out the majority of the recency signal.
+    // Pressure regime. The pin gets at most ~a third of the cap: the opening
+    // comment records design intent nothing later supersedes, but the newest
+    // follow-ups carry the live dispositions (refutations, "fixed in `<sha>`"), so
+    // the pin must never crowd out the majority of the recency signal.
     const reserve = Math.min(present[0].length, Math.floor(cap * 0.35));
-    let pinned =
-      present[0].length <= reserve
-        ? present[0]
-        : safeSlice(present[0], reserve);
+    let pinned: string;
+    if (present[0].length <= reserve) {
+      pinned = present[0];
+    } else {
+      const { text: body, omitted } = stripTruncationNote(present[0]);
+      pinned = capBody(body, reserve, omitted, OWN_BLOCK_INDENT);
+    }
     // Degenerate cap (a handful of characters): rather than render an empty pin,
     // fall back to the oldest block head-sliced to the whole cap.
     if (!pinned) pinned = safeSlice(present[0], cap);
@@ -361,9 +452,11 @@ export function budgetReviewExtras(input: {
       // slice it in rather than render the pin alone. Two ordinary comments (a
       // 510-char opener + a 5,560-char follow-up at a 6,000 cap) land here, and
       // dropping the follow-up would throw away every live disposition to keep an
-      // opening brief that fit ten times over. `safeSlice` can still come back
+      // opening comment that fit ten times over. `capBody` can still come back
       // empty at a tiny leftover, hence the guard.
-      const sliced = safeSlice(rest[rest.length - 1], restCap);
+      const newest = rest[rest.length - 1];
+      const { text: body, omitted } = stripTruncationNote(newest);
+      const sliced = capBody(body, restCap, omitted, OWN_BLOCK_INDENT);
       if (sliced) selected = [sliced];
     }
     const text = [pinned, ...selected].join("\n\n");

--- a/src/lib/ai/truncate.ts
+++ b/src/lib/ai/truncate.ts
@@ -33,7 +33,10 @@ export function safeSlice(s: string, max: number): string {
  *  history — a review that was never posted has no thread copy at all), and the
  *  distilled ledger (exists only in the digest store). Naming a thread would send
  *  an agentic reviewer with forge tools looking for text that isn't there.
- *  Module-private — `capBody` and `stripTruncationNote` are the whole contract. */
+ *  The constants stay module-private: `capBody` and `stripTruncationNote` are the
+ *  contract, so every producer and consumer of the note goes through the pair
+ *  rather than re-deriving its shape (own-distill.ts re-cuts blocks that already
+ *  carry one). */
 const TRUNCATION_NOTE_HEAD = "[content truncated — ";
 const TRUNCATION_NOTE_TAIL = " more characters omitted]";
 
@@ -45,7 +48,10 @@ const TRUNCATION_NOTE_TAIL = " more characters omitted]";
  * looking complete. The note may be indented, since both callers render bodies
  * with a `\n  ` continuation indent.
  */
-function stripTruncationNote(text: string): { text: string; omitted: number } {
+export function stripTruncationNote(text: string): {
+  text: string;
+  omitted: number;
+} {
   const nl = text.lastIndexOf("\n");
   if (nl < 0) return { text, omitted: 0 };
   const lastLine = text.slice(nl + 1).trimStart();

--- a/src/lib/ai/truncate.ts
+++ b/src/lib/ai/truncate.ts
@@ -27,11 +27,15 @@ export function safeSlice(s: string, max: number): string {
 
 /** The note appended in place of the text `capBody` cuts — split so its fixed
  *  length can be charged against the cap before the omitted count is known.
- *  "content", not "comment": the same note lands on inline findings and submitted
- *  review bodies, not only on conversation comments. Module-private — `capBody`
- *  and `stripTruncationNote` are the whole contract. */
+ *  Deliberately source-neutral in both halves, because four different things get
+ *  cut with it and only two of them live on a PR thread: our own comments and
+ *  third-party findings (on the thread), the prior-review text (local review
+ *  history — a review that was never posted has no thread copy at all), and the
+ *  distilled ledger (exists only in the digest store). Naming a thread would send
+ *  an agentic reviewer with forge tools looking for text that isn't there.
+ *  Module-private — `capBody` and `stripTruncationNote` are the whole contract. */
 const TRUNCATION_NOTE_HEAD = "[content truncated — ";
-const TRUNCATION_NOTE_TAIL = " more characters on the PR thread]";
+const TRUNCATION_NOTE_TAIL = " more characters omitted]";
 
 /**
  * Splits a trailing `capBody` note off `text`, returning the body without it and
@@ -410,9 +414,11 @@ export function budgetReviewExtras(input: {
         remaining -= only.length;
         return { result: { text: only, truncated: false }, dropped: false };
       }
-      // `OWN_BLOCK_INDENT`: own blocks render their body under a two-space
-      // continuation indent, so the re-cut note has to sit inside the list item
-      // rather than at column 0.
+      // `OWN_BLOCK_INDENT`: a per-comment block renders its body under a
+      // two-space continuation indent, so the re-cut note has to sit inside the
+      // list item rather than at column 0. The other single-block input, a
+      // distilled ledger, arrives bare (no `- (author …)` line, no indent) — the
+      // two spaces are simply inert there, not wrong.
       const { text: body, omitted } = stripTruncationNote(only);
       const text = capBody(body, cap, omitted, OWN_BLOCK_INDENT);
       remaining -= text.length;

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -774,6 +774,7 @@ async function generateReviewText(
           event.headSha,
           false,
           provider,
+          { budgetChars: budgetProfile.externalCharBudget },
         ),
         resolveOwnCommentsContext(
           event.repoPath,

--- a/src/lib/pulls/queries.ts
+++ b/src/lib/pulls/queries.ts
@@ -3,6 +3,7 @@ import {
   externalReviewerNames,
   fetchExternalFindings,
 } from "@/lib/ai/external-context";
+import { resolveReviewerNotesContext } from "@/lib/ai/notes-context";
 import { useForgeStatus } from "@/lib/git/queries";
 import {
   createLocalPr,
@@ -142,6 +143,33 @@ export function useExternalReviews(repo: string, kind: PrKind, ref: string) {
       );
       return { items, reviewers: externalReviewerNames(items) };
     },
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+/** The author's "Notes for reviewers" on a remote PR — lifted from the marker
+ *  conversation comment (author-gated inside the resolver). Drives the Review
+ *  panel's per-run "Ignore author notes" row; the run re-resolves them itself.
+ *  Remote PRs only; best-effort (a failure just hides the row). */
+export function useReviewerNotes(repo: string, kind: PrKind, ref: string) {
+  // Same gating as `useExternalReviews`, for the same reasons: wait for the forge
+  // status to RESOLVE (an unknown provider must not run under a default-"github"
+  // assumption), and skip Bitbucket — the notes harvest reads the same conversation
+  // comments the external path does, so a Bitbucket round trip buys nothing.
+  const forge = useForgeStatus(repo);
+  const provider = forge.data?.provider;
+  const enabled =
+    forge.isSuccess &&
+    provider != null &&
+    provider !== "bitbucket" &&
+    kind === "remote" &&
+    repo !== "" &&
+    /^\d+$/.test(ref);
+  return useQuery({
+    queryKey: ["reviewer-notes", repo, ref, provider ?? "pending"],
+    queryFn: () => resolveReviewerNotesContext(repo, Number(ref)),
     enabled,
     staleTime: 60_000,
     retry: false,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -207,6 +207,19 @@ interface RunControl {
   lane: Limiter | null;
 }
 
+/** Per-run opt-outs for {@link startReview}'s soft context. One object rather than
+ *  a tail of same-typed booleans: transposing two positional flags would silently
+ *  suppress the WRONG context with no type error. Every field defaults to false
+ *  (nothing suppressed). */
+export interface ReviewIgnoreOptions {
+  /** Skip the previous review's findings + the "changes since" delta. */
+  ignorePrior?: boolean;
+  /** Skip third-party AI-reviewer findings (Copilot/CodeRabbit/…). */
+  ignoreExternal?: boolean;
+  /** Skip the author's "Notes for reviewers". */
+  ignoreNotes?: boolean;
+}
+
 /** A queued second review mode + the config captured when the user requested it.
  *  Same target/key as the in-flight run — only the mode and its settings differ. */
 interface QueuedRun {
@@ -214,9 +227,9 @@ interface QueuedRun {
   mode: ReviewMode;
   context: ReviewContext;
   title: string;
-  ignorePrior: boolean;
-  ignoreExternal: boolean;
-  ignoreNotes: boolean;
+  /** The opt-outs as they stood when the user queued this run — replayed verbatim
+   *  when it drains, so the queued run honors the toggles it was requested with. */
+  opts: ReviewIgnoreOptions;
 }
 
 const controls = new Map<string, RunControl>();
@@ -368,12 +381,12 @@ async function notifyReviewDone(
  * the Vercel AI SDK for HTTP providers or a local agent CLI for CLI providers.
  *
  * On a re-run, the PREVIOUS review's findings + a "changes since" delta ride
- * along as soft, re-verifiable context (unless `ignorePrior`); on a remote PR,
- * findings posted by third-party AI reviewers (Copilot/CodeRabbit) ride along
- * too (unless `ignoreExternal`). On a remote PR the author's "Notes for
- * reviewers" ride along as well (unless `ignoreNotes`) — the same author-gated
- * lift the automation runner uses, fed to BOTH modes. The result is persisted on
- * success so the NEXT run can build on it.
+ * along as soft, re-verifiable context; on a remote PR, findings posted by
+ * third-party AI reviewers (Copilot/CodeRabbit) ride along too, as do the
+ * author's "Notes for reviewers" — the same author-gated lift the automation
+ * runner uses, fed to BOTH modes. Each of the three is suppressed by its own flag
+ * in {@link ReviewIgnoreOptions} (`opts`), which defaults to suppressing nothing.
+ * The result is persisted on success so the NEXT run can build on it.
  */
 export async function startReview(
   target: ReviewTarget,
@@ -381,10 +394,13 @@ export async function startReview(
   ai: AiSettings,
   mode: ReviewMode,
   context: ReviewContext,
-  ignorePrior = false,
-  ignoreExternal = false,
-  ignoreNotes = false,
+  opts: ReviewIgnoreOptions = {},
 ): Promise<void> {
+  const {
+    ignorePrior = false,
+    ignoreExternal = false,
+    ignoreNotes = false,
+  } = opts;
   const key = reviewKey(target);
   // Single-flight per key — one review streams into the single per-PR entry at a
   // time. A request for the OTHER mode while a run is in flight isn't dropped: it's
@@ -400,9 +416,9 @@ export async function startReview(
         mode,
         context,
         title,
-        ignorePrior,
-        ignoreExternal,
-        ignoreNotes,
+        // The destructured defaults, not the raw `opts` — a queued run replays
+        // exactly the flags this call resolved.
+        opts: { ignorePrior, ignoreExternal, ignoreNotes },
       });
       useReviewStore.getState().patch(key, { queuedMode: mode });
     }
@@ -743,9 +759,7 @@ export async function startReview(
           next.ai,
           next.mode,
           next.context,
-          next.ignorePrior,
-          next.ignoreExternal,
-          next.ignoreNotes,
+          next.opts,
         );
       }
     }
@@ -924,20 +938,9 @@ export function useReviewRun(target: ReviewTarget) {
       ai: AiSettings,
       mode: ReviewMode,
       context: ReviewContext,
-      ignorePrior?: boolean,
-      ignoreExternal?: boolean,
-      ignoreNotes?: boolean,
+      opts?: ReviewIgnoreOptions,
     ) => {
-      void startReview(
-        target,
-        context.title,
-        ai,
-        mode,
-        context,
-        ignorePrior,
-        ignoreExternal,
-        ignoreNotes,
-      );
+      void startReview(target, context.title, ai, mode, context, opts);
     },
     [target],
   );

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -7,6 +7,7 @@ import {
   type ExternalContext,
   resolveExternalContext,
 } from "@/lib/ai/external-context";
+import { resolveReviewerNotesContext } from "@/lib/ai/notes-context";
 import {
   type OwnCommentsContext,
   resolveOwnCommentsContext,
@@ -215,6 +216,7 @@ interface QueuedRun {
   title: string;
   ignorePrior: boolean;
   ignoreExternal: boolean;
+  ignoreNotes: boolean;
 }
 
 const controls = new Map<string, RunControl>();
@@ -368,8 +370,10 @@ async function notifyReviewDone(
  * On a re-run, the PREVIOUS review's findings + a "changes since" delta ride
  * along as soft, re-verifiable context (unless `ignorePrior`); on a remote PR,
  * findings posted by third-party AI reviewers (Copilot/CodeRabbit) ride along
- * too (unless `ignoreExternal`). The result is persisted on success so the NEXT
- * run can build on it.
+ * too (unless `ignoreExternal`). On a remote PR the author's "Notes for
+ * reviewers" ride along as well (unless `ignoreNotes`) — the same author-gated
+ * lift the automation runner uses, fed to BOTH modes. The result is persisted on
+ * success so the NEXT run can build on it.
  */
 export async function startReview(
   target: ReviewTarget,
@@ -379,6 +383,7 @@ export async function startReview(
   context: ReviewContext,
   ignorePrior = false,
   ignoreExternal = false,
+  ignoreNotes = false,
 ): Promise<void> {
   const key = reviewKey(target);
   // Single-flight per key — one review streams into the single per-PR entry at a
@@ -397,6 +402,7 @@ export async function startReview(
         title,
         ignorePrior,
         ignoreExternal,
+        ignoreNotes,
       });
       useReviewStore.getState().patch(key, { queuedMode: mode });
     }
@@ -527,33 +533,49 @@ export async function startReview(
     // null at this point, and streamAi reassigns it once the stream opens.
     const preAbort = new AbortController();
     control.abort = preAbort;
-    // Third-party AI-reviewer findings AND GitDesktop's own prior comments on the
-    // remote PR — both best-effort, remote-only soft context. Resolved
-    // concurrently (independent harvests of the PR's review activity); kept
-    // separate so the battle-tested external path is untouched — a shared-fetch
-    // dedup is a later efficiency win (forge-dispatch-dedup backlog).
-    const [external, own]: [ExternalContext, OwnCommentsContext] =
-      await Promise.all([
-        resolveExternalContext(
-          target.repoPath,
-          target.kind,
-          target.ref,
-          context.headSha,
-          ignoreExternal,
-          context.provider,
-        ),
-        resolveOwnCommentsContext(
-          target.repoPath,
-          target.kind,
-          target.ref,
-          context.provider,
-          {
-            distill: true,
-            signal: preAbort.signal,
-            ownBudgetChars: budgetProfile.ownCharBudget,
-          },
-        ),
-      ]);
+    // Third-party AI-reviewer findings, GitDesktop's own prior comments, AND the
+    // author's "Notes for reviewers" on the remote PR — all best-effort,
+    // remote-only soft context. Resolved concurrently (independent harvests of
+    // the PR's review activity); kept separate so the battle-tested external path
+    // is untouched — a shared-fetch dedup is a later efficiency win
+    // (forge-dispatch-dedup backlog).
+    const [external, own, notes]: [
+      ExternalContext,
+      OwnCommentsContext,
+      { reviewNotes?: string },
+    ] = await Promise.all([
+      resolveExternalContext(
+        target.repoPath,
+        target.kind,
+        target.ref,
+        context.headSha,
+        ignoreExternal,
+        context.provider,
+        { budgetChars: budgetProfile.externalCharBudget },
+      ),
+      resolveOwnCommentsContext(
+        target.repoPath,
+        target.kind,
+        target.ref,
+        context.provider,
+        {
+          distill: true,
+          signal: preAbort.signal,
+          ownBudgetChars: budgetProfile.ownCharBudget,
+        },
+      ),
+      // The notes are lifted from the marker comment the Create-PR dialog (or an
+      // MCP client) posted, author-gated inside the resolver. Mode-agnostic —
+      // they ground a security audit exactly as they do a general review, the
+      // same as the automation runner. Bitbucket is skipped for the same reason
+      // the panel's query is: its conversation harvest yields nothing here.
+      target.kind === "remote" &&
+      /^\d+$/.test(target.ref) &&
+      context.provider !== "bitbucket" &&
+      !ignoreNotes
+        ? resolveReviewerNotesContext(target.repoPath, Number(target.ref))
+        : Promise.resolve({}),
+    ]);
     if (control.cancelled) return;
     // Agentic run: in repo-aware mode the reviewer explores. A CLI provider
     // reviews with the PR's files on disk and (for the tool-capable CLIs —
@@ -606,6 +628,7 @@ export async function startReview(
         ...prior,
         ...own,
         ...external,
+        ...notes,
       },
       mode,
     );
@@ -722,6 +745,7 @@ export async function startReview(
           next.context,
           next.ignorePrior,
           next.ignoreExternal,
+          next.ignoreNotes,
         );
       }
     }
@@ -902,6 +926,7 @@ export function useReviewRun(target: ReviewTarget) {
       context: ReviewContext,
       ignorePrior?: boolean,
       ignoreExternal?: boolean,
+      ignoreNotes?: boolean,
     ) => {
       void startReview(
         target,
@@ -911,6 +936,7 @@ export function useReviewRun(target: ReviewTarget) {
         context,
         ignorePrior,
         ignoreExternal,
+        ignoreNotes,
       );
     },
     [target],


### PR DESCRIPTION
Reviews you start yourself (Review / Security audit) now receive the author's **Notes for reviewers** — until now only the automated review saw them — and the review-context budget is allocated fair-share across comments and findings instead of clamping every body at a small fixed size regardless of how much budget was free. The net effect: a long GitDesktop context brief or bot review body reaches the model whole when there's room, and when it can't, the prompt says so explicitly rather than trailing off in a bare ellipsis.

### Author notes in manual reviews

- Threads a new `ignoreNotes` flag through the whole review path in `src/lib/stores/reviews.ts`: `startReview`, the `QueuedRun` shape (so a drained queued run keeps the choice), and the `generate` callback returned by `useReviewRun`.
- Resolves `resolveReviewerNotesContext` in the same `Promise.all` as the external/own-comment harvests in `startReview`, gated on a remote PR with a numeric ref on a non-Bitbucket provider, and spreads `...notes` into the `buildReviewPrompt` input — mode-agnostic, so a security audit is grounded the same way a general review is.
- Adds `useReviewerNotes` to `src/lib/pulls/queries.ts`, mirroring `useExternalReviews`' forge-status gating (wait for the provider to resolve, skip Bitbucket), with `staleTime: 60_000` and `retry: false` so a failure just hides the affordance.
- Adds an **Ignore author notes** row to `src/features/pulls/PrReviewPanel.tsx` (`NotePencilIcon`, `aria-pressed` toggle, disabled while generating), rendered only when notes exist; the run passes `ignoreNotes && hasNotes` so a stale flag can't silently suppress notes once the row disappears.

### Fair-share context budgeting

- Adds `allocateBodyCaps` to `src/lib/ai/truncate.ts` — a max-min fair share of a section budget across block lengths, shortest-first, with a per-block floor given either as one value or a per-index array. Slack from short blocks flows to long ones, so a lone 6K brief inside an 18K budget survives whole while a dozen 6K comments converge on the floor.
- Adds `capBody` plus the `TRUNCATION_NOTE_HEAD` / `TRUNCATION_NOTE_TAIL` constants in the same file: head-keeps within the cap, charges the note's own worst-case length against the cap so the result never overflows, and cuts via `safeSlice` to avoid splitting a surrogate pair.
- Reworks `src/lib/ai/own-context.ts` into two passes: `condenseOwnComment` now only strips wrappers (no length concern), `formatOwnComments(items, budget)` fair-shares the surviving lengths, and `OWN_BODY_CAP` is reinterpreted as a floor rather than a ceiling. Distillation now fires only when the *capped* blocks still exceed the budget, so one long-but-affordable brief no longer calls the generation model.
- Applies the same two-pass restructuring in `src/lib/ai/external-context.ts`: `condense` drops its cap argument, `formatExternalFindings(items, budget)` pools all reviewers and fair-shares across them, and `INLINE_BODY_CAP` / `REVIEW_BODY_CAP` / `COMMENT_BODY_CAP` become per-kind floors. `resolveExternalContext` gains `opts.budgetChars` (defaulting to `EXTERNAL_FINDINGS_CHAR_BUDGET`).
- Wires the resolved knob through at both call sites — `src/lib/stores/reviews.ts` and `generateReviewText` in `src/lib/automations/runner.ts` now pass `{ budgetChars: budgetProfile.externalCharBudget }` — so the **Review context** size setting actually reaches the external section.
- Extends the own-digest cache fingerprint to `${count}#${newest}#${budget}#${joinedLen}` in `src/lib/ai/own-context.ts`, with the doc comments in `src/lib/ai/own-digest-store.ts` updated to match; the added joined length catches an in-place comment edit that moves neither the count nor the newest timestamp.

### Opening-comment pin when own comments overflow

- Rewrites `fitOwn` in `src/lib/ai/truncate.ts`: extracts the newest-first suffix walk into `newestSuffixCount`, keeps byte-identical fast paths for the single-block (distilled ledger) and everything-fits cases, and in the pressure regime pins the oldest block — the PR-opening context brief — to at most 35% of the cap alongside a newest-first suffix of the rest, so the *middle* comments drop instead of the opener.
- Handles the edge cases in that branch: head-slices the newest follow-up when nothing fits whole but leftover budget is real, falls back to a whole-cap slice of the oldest block at a degenerate cap, and reports a fully-sliced-away result as `dropped` so `prompt.ts` renders the explicit omitted-for-budget marker instead of a silent empty section.
- Updates the truncation marker in `src/lib/ai/prompt.ts` to "the opening comment and newest follow-ups take precedence; middle comments are omitted first", and refreshes the `ReviewExtras.own` doc comment to describe the pinned selection.

### Documentation

- Updates the *Notes for reviewers* bullet in `README.md` to say the notes reach **every** review and to mention the new toggle.
- Extends the review section of the in-app guide in `src/features/help/content.ts` with the manual-review coverage and the three per-run opt-outs (*Ignore previous review*, *Ignore external reviews*, *Ignore author notes*).
- Adds four changelog fragments: `changelog.d/added-review-notes-interactive-toggle.md`, `fixed-own-comment-context-cap.md`, `fixed-external-findings-budget.md`, and `fixed-own-comments-opening-pin.md`.