### PR TITLE
fix(ai,repository,pulls): name branches from committed work and honor AI ignore patterns

### DIFF
--- a/changelog.d/fixed-branch-diff-ai-ignore.md
+++ b/changelog.d/fixed-branch-diff-ai-ignore.md
@@ -1,0 +1,7 @@
+- Your **AI ignore patterns** are now honored when generating the description
+  for a pull request you're creating (local PRs included, and the MCP
+  `generate_pr_description` tool) and when generating a squashed commit message
+  — those paths previously sent the whole branch diff to the provider. The
+  prompt says how many files were held back, so the generated text never speaks
+  for what it couldn't see. (Regenerating the description of an existing remote
+  PR still uses the forge's own diff, which has no path filtering to apply.)

--- a/changelog.d/fixed-branch-diff-ai-ignore.md
+++ b/changelog.d/fixed-branch-diff-ai-ignore.md
@@ -1,8 +1,8 @@
 - Your **AI ignore patterns** are now honored when generating the description
   for a pull request you're creating (local PRs included, and the MCP
-  `generate_pr_description` tool) and when generating a squashed or reworded
-  commit's message in Edit history — those paths previously sent the whole
-  branch diff to the provider. The
-  prompt states how many files were held back rather than passing the diff off
-  as complete. (Regenerating the description of an existing remote
-  PR still uses the forge's own diff, which has no path filtering to apply.)
+  `generate_pr_description` tool), when generating a squashed commit's message,
+  and when generating a reworded commit's message in Edit history — those paths
+  previously sent the whole branch diff to the provider. The prompt states how
+  many files were held back rather than passing the diff off as complete.
+  (Regenerating the description of an existing remote PR still uses the forge's
+  own diff, which has no path filtering to apply.)

--- a/changelog.d/fixed-branch-diff-ai-ignore.md
+++ b/changelog.d/fixed-branch-diff-ai-ignore.md
@@ -1,7 +1,8 @@
 - Your **AI ignore patterns** are now honored when generating the description
   for a pull request you're creating (local PRs included, and the MCP
-  `generate_pr_description` tool) and when generating a squashed commit message
-  — those paths previously sent the whole branch diff to the provider. The
+  `generate_pr_description` tool) and when generating a squashed or reworded
+  commit's message in Edit history — those paths previously sent the whole
+  branch diff to the provider. The
   prompt states how many files were held back rather than passing the diff off
   as complete. (Regenerating the description of an existing remote
   PR still uses the forge's own diff, which has no path filtering to apply.)

--- a/changelog.d/fixed-branch-diff-ai-ignore.md
+++ b/changelog.d/fixed-branch-diff-ai-ignore.md
@@ -2,6 +2,6 @@
   for a pull request you're creating (local PRs included, and the MCP
   `generate_pr_description` tool) and when generating a squashed commit message
   — those paths previously sent the whole branch diff to the provider. The
-  prompt says how many files were held back, so the generated text never speaks
-  for what it couldn't see. (Regenerating the description of an existing remote
+  prompt states how many files were held back rather than passing the diff off
+  as complete. (Regenerating the description of an existing remote
   PR still uses the forge's own diff, which has no path filtering to apply.)

--- a/changelog.d/fixed-branch-name-from-committed-work.md
+++ b/changelog.d/fixed-branch-name-from-committed-work.md
@@ -1,0 +1,6 @@
+- **Generate from changes** now works on a branch whose work is already
+  committed. With a clean working tree it names the branch from its committed
+  work instead — the diff and commit subjects vs. the default branch — which is
+  exactly the case a rename usually needs. Applies in the app and to the MCP
+  `generate_branch_name` tool and prompt, and when the button *is* disabled it
+  now says why.

--- a/changelog.d/fixed-branch-name-from-committed-work.md
+++ b/changelog.d/fixed-branch-name-from-committed-work.md
@@ -1,6 +1,7 @@
 - **Generate from changes** now works on a branch whose work is already
-  committed. With a clean working tree it names the branch from its committed
-  work instead — the diff and commit subjects vs. the default branch — which is
-  exactly the case a rename usually needs. Applies in the app and to the MCP
-  `generate_branch_name` tool and prompt, and when the button *is* disabled it
-  now says why.
+  committed. Whenever the working tree can't describe the branch being named —
+  it's clean, or you're renaming a branch you aren't on — it names the branch
+  from that branch's own committed work instead: the diff and commit subjects
+  vs. the default branch. That's exactly the case a rename usually needs.
+  Applies in the app and to the MCP `generate_branch_name` tool and prompt, and
+  when the button *is* disabled it now says why.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -398,6 +398,12 @@ export const capabilities: Capability[] = [
   {
     group: "AI · generate & review",
     ai: true,
+    label:
+      "AI branch names — from your in-progress changes, or the branch's own committed work",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
     label: "AI suggests PR/MR labels from your repo's existing set",
   },
   {

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -93,10 +93,12 @@ pub async fn git_branch_diff_files(
 }
 
 /// The full combined `base...compare` diff text plus its file summary, for
-/// feeding AI PR description generation. Mirrors `git_staged_diff`, including its
-/// `exclude` handling: the caller's AI-ignore patterns become git pathspec
-/// excludes, and `excluded_files` reports how many changed files they hid.
-/// `exclude: None` behaves exactly as an unfiltered three-dot diff.
+/// feeding AI PR description generation. The `exclude` handling mirrors
+/// `git_staged_diff` exactly — the caller's AI-ignore patterns become git pathspec
+/// excludes and `excluded_files` reports how many changed files they hid, with
+/// `exclude: None` behaving as an unfiltered three-dot diff. Truncation deliberately
+/// differs: this cuts at a char boundary with a 1 MB default, not at a file boundary
+/// with the AI budget.
 #[tauri::command]
 pub async fn git_branch_diff(
     repo_path: String,

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -111,9 +111,10 @@ pub async fn git_branch_diff(
     validate_ref(&compare)?;
     let range = format!("{base}...{compare}");
 
-    // Translate ignore patterns into git pathspec excludes so matching has
-    // exact gitignore-style glob semantics. ":(exclude)" needs at least one
-    // inclusive pathspec alongside it, hence the leading ".".
+    // Translate ignore patterns into git pathspec excludes — pathspec globs are
+    // close to gitignore semantics, but `*` also matches `/` (wildmatch without
+    // WM_PATHNAME), so `src/*.rs` hides nested files too. ":(exclude)" needs at
+    // least one inclusive pathspec alongside it, hence the leading ".".
     let mut pathspec: Vec<String> = Vec::new();
     for pattern in exclude.unwrap_or_default() {
         let pattern = pattern.trim();
@@ -742,12 +743,18 @@ mod tests {
         run(&repo, &["commit", "-qm", "seed"]).await;
         let base_sha = run(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
 
-        // Three changed files on top of the base: one of them is the one the
-        // user's ignore patterns will hide.
+        // Six changed files on top of the base, shaped to exercise the three
+        // pattern kinds a real AI-ignore list uses: a bare filename, a glob, and a
+        // directory — the glob and directory cases each with a NESTED member.
         std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("tools")).unwrap();
+        std::fs::create_dir_all(root.join("vendor").join("sub")).unwrap();
         std::fs::write(root.join("src").join("a.rs"), "fn a() {}\n").unwrap();
         std::fs::write(root.join("notes.md"), "notes\n").unwrap();
         std::fs::write(root.join("package-lock.json"), "{\"lock\": 1}\n").unwrap();
+        std::fs::write(root.join("tools").join("build.lock"), "locked\n").unwrap();
+        std::fs::write(root.join("vendor").join("lib.txt"), "vendored\n").unwrap();
+        std::fs::write(root.join("vendor").join("sub").join("x.txt"), "deep\n").unwrap();
         run(&repo, &["add", "-A"]).await;
         run(&repo, &["commit", "-qm", "work"]).await;
 
@@ -755,7 +762,7 @@ mod tests {
         let all = git_branch_diff(repo.clone(), base_sha.clone(), "HEAD".into(), None, None)
             .await
             .unwrap();
-        assert_eq!(all.files.len(), 3, "all three changed files are listed");
+        assert_eq!(all.files.len(), 6, "all six changed files are listed");
         assert!(all.text.contains("package-lock.json"));
         assert_eq!(all.excluded_files, 0);
 
@@ -770,7 +777,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(filtered.files.len(), 2);
+        assert_eq!(filtered.files.len(), 5);
         assert!(
             !filtered.files.iter().any(|f| f.path.contains("package-lock")),
             "the excluded file is absent from the file list"
@@ -781,6 +788,47 @@ mod tests {
         );
         assert!(filtered.text.contains("src/a.rs"), "other files survive");
         assert_eq!(filtered.excluded_files, 1);
+
+        // A GLOB pattern: `*` reaches into subdirectories, so a nested `.lock` is
+        // hidden too (`package-lock.json` is untouched — it doesn't end in `.lock`).
+        let globbed = git_branch_diff(
+            repo.clone(),
+            base_sha.clone(),
+            "HEAD".into(),
+            None,
+            Some(vec!["*.lock".into()]),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !globbed.files.iter().any(|f| f.path.ends_with(".lock")),
+            "both the root and the nested .lock are hidden"
+        );
+        assert!(!globbed.text.contains("tools/build.lock"));
+        assert!(
+            globbed.files.iter().any(|f| f.path == "package-lock.json"),
+            "a non-matching lock-ish name survives"
+        );
+        assert_eq!(globbed.files.len(), 5);
+        assert_eq!(globbed.excluded_files, 1);
+
+        // A DIRECTORY pattern hides the whole subtree, nested files included.
+        let dir = git_branch_diff(
+            repo.clone(),
+            base_sha.clone(),
+            "HEAD".into(),
+            None,
+            Some(vec!["vendor/".into()]),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !dir.files.iter().any(|f| f.path.starts_with("vendor/")),
+            "every file under the excluded directory is hidden, at any depth"
+        );
+        assert!(!dir.text.contains("vendor/sub/x.txt"));
+        assert_eq!(dir.files.len(), 4);
+        assert_eq!(dir.excluded_files, 2);
 
         // Blank and `#`-comment patterns are skipped, leaving no pathspec at all —
         // identical to the unfiltered call, including the zero count.
@@ -793,7 +841,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(noop.files.len(), 3);
+        assert_eq!(noop.files.len(), 6);
         assert_eq!(noop.excluded_files, 0);
         assert_eq!(noop.text, all.text);
     }

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -93,36 +93,72 @@ pub async fn git_branch_diff_files(
 }
 
 /// The full combined `base...compare` diff text plus its file summary, for
-/// feeding AI PR description generation. Mirrors `git_staged_diff`.
+/// feeding AI PR description generation. Mirrors `git_staged_diff`, including its
+/// `exclude` handling: the caller's AI-ignore patterns become git pathspec
+/// excludes, and `excluded_files` reports how many changed files they hid.
+/// `exclude: None` behaves exactly as an unfiltered three-dot diff.
 #[tauri::command]
 pub async fn git_branch_diff(
     repo_path: String,
     base: String,
     compare: String,
     max_bytes: Option<usize>,
+    exclude: Option<Vec<String>>,
 ) -> AppResult<StagedDiff> {
     validate_ref(&base)?;
     validate_ref(&compare)?;
     let range = format!("{base}...{compare}");
-    let text_out = run_git(
-        Some(&repo_path),
-        &["diff", "--no-color", &range],
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
+
+    // Translate ignore patterns into git pathspec excludes so matching has
+    // exact gitignore-style glob semantics. ":(exclude)" needs at least one
+    // inclusive pathspec alongside it, hence the leading ".".
+    let mut pathspec: Vec<String> = Vec::new();
+    for pattern in exclude.unwrap_or_default() {
+        let pattern = pattern.trim();
+        if pattern.is_empty() || pattern.starts_with('#') {
+            continue;
+        }
+        pathspec.push(format!(":(exclude){pattern}"));
+    }
+
+    let mut diff_args: Vec<&str> = vec!["diff", "--no-color", &range];
+    let mut stat_args: Vec<&str> = vec!["diff", "--numstat", "-z", &range];
+    if !pathspec.is_empty() {
+        for args in [&mut diff_args, &mut stat_args] {
+            args.push("--");
+            args.push(".");
+            args.extend(pathspec.iter().map(String::as_str));
+        }
+    }
+
+    let (text_out, files_out) = tokio::try_join!(
+        run_git(Some(&repo_path), &diff_args, DEFAULT_TIMEOUT),
+        run_git(Some(&repo_path), &stat_args, DEFAULT_TIMEOUT)
+    )?;
     let (text, truncated) =
         truncate_at_char_boundary(text_out.stdout_lossy(), max_bytes.unwrap_or(1_000_000));
-    let files_out = run_git(
-        Some(&repo_path),
-        &["diff", "--numstat", "-z", &range],
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
+    let files = parse_numstat_z(&files_out.stdout_lossy());
+
+    // Tell the caller how many changed files the excludes hid, so the AI
+    // prompt can mention that the diff is not the whole story.
+    let excluded_files = if pathspec.is_empty() {
+        0
+    } else {
+        let all = run_git(
+            Some(&repo_path),
+            &["diff", "--numstat", "-z", &range],
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+        let total = parse_numstat_z(&all.stdout_lossy()).len();
+        total.saturating_sub(files.len()) as u32
+    };
+
     Ok(StagedDiff {
         text,
         truncated,
-        files: parse_numstat_z(&files_out.stdout_lossy()),
-        excluded_files: 0,
+        files,
+        excluded_files,
     })
 }
 
@@ -688,6 +724,76 @@ mod tests {
         run(&repo_s, &["config", "user.email", "t@t.local"]).await;
         run(&repo_s, &["config", "user.name", "T"]).await;
         (base, repo_s)
+    }
+
+    /// `exclude` patterns hide matching files from BOTH the diff text and the file
+    /// list of the three-dot range, and `excluded_files` reports how many were
+    /// hidden. `None` (and a list of only blank/comment patterns) leaves the diff
+    /// unfiltered with a zero count.
+    #[tokio::test]
+    async fn branch_diff_applies_exclude_pathspecs() {
+        let (_base, repo) = seed_repo("branchdiff-exclude").await;
+        let root = std::path::Path::new(&repo);
+
+        std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        let base_sha = run(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        // Three changed files on top of the base: one of them is the one the
+        // user's ignore patterns will hide.
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src").join("a.rs"), "fn a() {}\n").unwrap();
+        std::fs::write(root.join("notes.md"), "notes\n").unwrap();
+        std::fs::write(root.join("package-lock.json"), "{\"lock\": 1}\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "work"]).await;
+
+        // No excludes → every file present, nothing reported hidden.
+        let all = git_branch_diff(repo.clone(), base_sha.clone(), "HEAD".into(), None, None)
+            .await
+            .unwrap();
+        assert_eq!(all.files.len(), 3, "all three changed files are listed");
+        assert!(all.text.contains("package-lock.json"));
+        assert_eq!(all.excluded_files, 0);
+
+        // Excluding one file drops it from both the text and the file list, and
+        // the hidden count is the real difference for this range.
+        let filtered = git_branch_diff(
+            repo.clone(),
+            base_sha.clone(),
+            "HEAD".into(),
+            None,
+            Some(vec!["package-lock.json".into()]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(filtered.files.len(), 2);
+        assert!(
+            !filtered.files.iter().any(|f| f.path.contains("package-lock")),
+            "the excluded file is absent from the file list"
+        );
+        assert!(
+            !filtered.text.contains("package-lock.json"),
+            "the excluded file is absent from the diff text"
+        );
+        assert!(filtered.text.contains("src/a.rs"), "other files survive");
+        assert_eq!(filtered.excluded_files, 1);
+
+        // Blank and `#`-comment patterns are skipped, leaving no pathspec at all —
+        // identical to the unfiltered call, including the zero count.
+        let noop = git_branch_diff(
+            repo.clone(),
+            base_sha,
+            "HEAD".into(),
+            None,
+            Some(vec!["   ".into(), "# a comment".into()]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(noop.files.len(), 3);
+        assert_eq!(noop.excluded_files, 0);
+        assert_eq!(noop.text, all.text);
     }
 
     /// A match at a rev is found even after the working tree (and later commits)

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -802,7 +802,7 @@ mod tests {
         .unwrap();
         assert!(
             !globbed.files.iter().any(|f| f.path.ends_with(".lock")),
-            "both the root and the nested .lock are hidden"
+            "the nested .lock is hidden — pathspec `*` reaches into subdirectories"
         );
         assert!(!globbed.text.contains("tools/build.lock"));
         assert!(

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1139,8 +1139,11 @@ impl GitDesktopMcp {
                        prompt the in-app AI feature builds (three-dot branch diff, the commit \
                        subjects the PR would introduce, a per-file summary, the repo's available \
                        labels when any, and project/user instructions). Defaults: base = the repo's \
-                       default branch, head = the current branch. This tool does NOT call a model; \
-                       complete the returned prompt with your own inference."
+                       default branch, head = the current branch. The user's AI-ignore patterns are \
+                       applied to the diff and the withheld file count is disclosed in the prompt. \
+                       This tool does NOT call a model; complete the returned prompt with your own \
+                       inference. Errors when the range has no changes, or when all of them match \
+                       those patterns."
     )]
     async fn generate_pr_description(
         &self,
@@ -1561,16 +1564,15 @@ impl GitDesktopMcp {
         // entirely of new files can still be named (mirrors the in-app call site).
         let untracked_paths = untracked_files(&self.repo).await.map_err(app_err)?;
 
-        // The base for the committed-work fallback below. Only that path reads the
-        // branch's commit subjects: on the working-tree path they'd describe the
-        // CURRENT branch, biasing the name toward the parent branch's story.
-        let base = committed_base_ref(&self.repo).await;
-
         // Nothing in progress → name the branch after what it has already committed.
         let (diff, untracked_paths, commit_subjects) = if diff.files.is_empty()
             && untracked_paths.is_empty()
         {
-            let Some(base) = base.as_deref() else {
+            // Resolve the base HERE, not above: only this path uses it, and the
+            // working-tree path shouldn't pay for its ref probes. That path also
+            // deliberately takes no commit subjects — they'd describe the CURRENT
+            // branch, biasing the name toward the parent branch's story.
+            let Some(base) = committed_base_ref(&self.repo).await else {
                 let msg = if diff.excluded_files > 0 {
                     "All in-progress changes match the AI ignore patterns — nothing to name a \
                      branch after."
@@ -1582,7 +1584,7 @@ impl GitDesktopMcp {
             };
             let mut committed = crate::git::compare::git_branch_diff(
                 self.repo.clone(),
-                base.to_string(),
+                base.clone(),
                 "HEAD".to_string(),
                 Some(RAW_DIFF_MAX_BYTES),
                 Some(exclude),
@@ -1620,7 +1622,7 @@ impl GitDesktopMcp {
             // is hidden is the safe direction — the number only tells the model the
             // diff isn't the whole story.
             committed.excluded_files += diff.excluded_files;
-            let subjects = branch_commit_subjects(&self.repo, base).await;
+            let subjects = branch_commit_subjects(&self.repo, &base).await;
             (committed, Vec::new(), subjects)
         } else {
             (diff, untracked_paths, Vec::new())
@@ -1700,8 +1702,10 @@ impl GitDesktopMcp {
                        branch range (branch diff, the commit subjects the PR would introduce, a \
                        per-file summary, the repo's labels when any, and project/user instructions) \
                        as one ready-to-complete message. Defaults: base = the repo's default branch, \
-                       head = the current branch. Your model completes it and the result is the \
-                       PR/MR title and description."
+                       head = the current branch. The user's AI-ignore patterns are applied to the \
+                       diff and the withheld file count is disclosed in the prompt. Your model \
+                       completes it and the result is the PR/MR title and description. Errors when \
+                       the range has no changes, or when all of them match those patterns."
     )]
     async fn pr_description_prompt(
         &self,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -695,6 +695,10 @@ struct BranchPieces {
     untracked_paths: Vec<String>,
     excluded_files: u32,
     recent_branches: Vec<String>,
+    /// Subjects of the commits this branch adds over its base, newest first —
+    /// the strongest naming signal when the work is already committed. Empty when
+    /// the base can't be resolved (or the branch adds no commits).
+    commit_subjects: Vec<String>,
     repo_instructions: Option<String>,
     global_instructions: String,
 }
@@ -736,6 +740,12 @@ fn assemble_branch_recipe(p: BranchPieces) -> Recipe {
         prompt_parts.push(format!(
             "## Existing branch names (convention reference)\n{}",
             p.recent_branches.join("\n")
+        ));
+    }
+    if !p.commit_subjects.is_empty() {
+        prompt_parts.push(format!(
+            "## Commits on this branch (newest first)\n{}",
+            p.commit_subjects.join("\n")
         ));
     }
     // Mirror the TS `budgeted.text || "(no text diff …)"` fallback.
@@ -786,6 +796,10 @@ struct PrPieces {
     diff_text: String,
     diff_truncated: bool,
     files: Vec<DiffStatEntry>,
+    /// How many changed files the user's AI ignore patterns hid from `files` /
+    /// `diff_text`, disclosed in the files section so the model knows the diff
+    /// isn't the whole story.
+    excluded_files: u32,
     commit_subjects: Vec<String>,
     base_branch: String,
     head_branch: String,
@@ -947,14 +961,21 @@ fn assemble_pr_recipe(p: PrPieces) -> Recipe {
                 .join("\n")
         ));
     }
-    prompt_parts.push(format!(
+    let mut files_section = format!(
         "## Files changed\n{}",
         if file_summary.is_empty() {
             "(none)"
         } else {
             &file_summary
         }
-    ));
+    );
+    if p.excluded_files > 0 {
+        files_section.push_str(&format!(
+            "\n[{} additional changed file(s) hidden by the user's AI ignore rules]",
+            p.excluded_files
+        ));
+    }
+    prompt_parts.push(files_section);
 
     let mut diff_section = format!("## Combined diff\n{}", budgeted.text);
     if budgeted.truncated || p.diff_truncated {
@@ -1132,9 +1153,11 @@ impl GitDesktopMcp {
                        tree (staged + unstaged vs HEAD, plus untracked file names): returns \
                        { system, prompt, note } — the same system + user prompt the in-app AI feature \
                        builds (worktree diff, file summary, existing branch names as a convention \
-                       reference, and project/user instructions). This tool does NOT call a model; \
-                       complete the returned prompt with your own inference and use the result as the \
-                       branch name."
+                       reference, and project/user instructions). When the working tree is clean it \
+                       falls back to the branch's COMMITTED work — the three-dot diff and commit \
+                       subjects vs the repo's default branch — so an already-committed branch can \
+                       still be named. This tool does NOT call a model; complete the returned prompt \
+                       with your own inference and use the result as the branch name."
     )]
     async fn generate_branch_name(&self) -> Result<CallToolResult, McpError> {
         let recipe = self.build_branch_recipe().await?;
@@ -1149,17 +1172,28 @@ impl GitDesktopMcp {
 // the recipe as JSON; the prompts render it as a single user PromptMessage. One
 // source of truth so a tool and its twin prompt can never drift.
 impl GitDesktopMcp {
+    /// The user's AI-ignore patterns for the bound repo: the repo's own ignore
+    /// file first, then the global setting's patterns — the merge every recipe
+    /// passes to the git layer as pathspec excludes. Takes the caller's already-read
+    /// `settings`, so one recipe call reads the settings store exactly once.
+    async fn ai_ignore_patterns(
+        &self,
+        settings: &crate::app_store::AiGenSettings,
+    ) -> Result<Vec<String>, McpError> {
+        let repo_ignore = crate::instructions::read_repo_ai_ignore(self.repo.clone())
+            .await
+            .map_err(app_err)?;
+        Ok(repo_ignore
+            .into_iter()
+            .chain(settings.ai_ignore_patterns.iter().cloned())
+            .collect())
+    }
+
     /// Gather + assemble the commit-message recipe (STAGED changes). Errors with
     /// `invalid_request` when nothing is staged.
     async fn build_commit_recipe(&self) -> Result<Recipe, McpError> {
         let settings = crate::app_store::read_ai_generation_settings();
-        let repo_ignore = crate::instructions::read_repo_ai_ignore(self.repo.clone())
-            .await
-            .map_err(app_err)?;
-        let exclude: Vec<String> = repo_ignore
-            .into_iter()
-            .chain(settings.ai_ignore_patterns.iter().cloned())
-            .collect();
+        let exclude = self.ai_ignore_patterns(&settings).await?;
 
         let staged = crate::git::diff::git_staged_diff(
             self.repo.clone(),
@@ -1201,6 +1235,9 @@ impl GitDesktopMcp {
     /// Gather + assemble the PR/MR-description recipe for a branch range, applying
     /// the in-app base/head defaults.
     async fn build_pr_recipe(&self, args: PrRecipeArgs) -> Result<Recipe, McpError> {
+        // One settings read per recipe: it feeds both the ignore-pattern merge and
+        // the user-instructions section below.
+        let settings = crate::app_store::read_ai_generation_settings();
         // Resolve base/head, applying the same defaults the in-app flow uses.
         let base = match args.base {
             Some(b) => b,
@@ -1222,11 +1259,17 @@ impl GitDesktopMcp {
         ensure_not_flag(&base, "base")?;
         ensure_not_flag(&head, "head")?;
 
+        // The user's AI-ignore patterns (repo ignore file first, then the global
+        // setting) — the same merge the commit/branch recipes do, so a file the user
+        // excluded never reaches the model.
+        let exclude = self.ai_ignore_patterns(&settings).await?;
+
         let diff = crate::git::compare::git_branch_diff(
             self.repo.clone(),
             base.clone(),
             head.clone(),
             Some(RAW_DIFF_MAX_BYTES),
+            Some(exclude),
         )
         .await
         .map_err(app_err)?;
@@ -1277,12 +1320,12 @@ impl GitDesktopMcp {
         let repo_instructions = crate::instructions::read_repo_instructions(self.repo.clone())
             .await
             .map_err(app_err)?;
-        let settings = crate::app_store::read_ai_generation_settings();
 
         Ok(assemble_pr_recipe(PrPieces {
             diff_text: diff.text,
             diff_truncated: diff.truncated,
             files: diff.files,
+            excluded_files: diff.excluded_files,
             commit_subjects,
             base_branch: base,
             head_branch: head,
@@ -1478,23 +1521,19 @@ impl GitDesktopMcp {
         out
     }
 
-    /// Gather + assemble the branch-name recipe (WHOLE working tree). Errors with
-    /// `invalid_request` when there are no in-progress changes.
+    /// Gather + assemble the branch-name recipe. The WHOLE working tree is the
+    /// primary source; when it's clean, the branch's COMMITTED work vs the default
+    /// branch is used instead (naming help is most wanted exactly then). Errors with
+    /// `invalid_request` — naming the true reason — when neither yields anything.
     async fn build_branch_recipe(&self) -> Result<Recipe, McpError> {
         let settings = crate::app_store::read_ai_generation_settings();
-        let repo_ignore = crate::instructions::read_repo_ai_ignore(self.repo.clone())
-            .await
-            .map_err(app_err)?;
-        let exclude: Vec<String> = repo_ignore
-            .into_iter()
-            .chain(settings.ai_ignore_patterns.iter().cloned())
-            .collect();
+        let exclude = self.ai_ignore_patterns(&settings).await?;
 
         // Whole-worktree diff vs HEAD (the TS uses git_staged_diff with worktree=true).
         let diff = crate::git::diff::git_staged_diff(
             self.repo.clone(),
             Some(RAW_DIFF_MAX_BYTES),
-            Some(exclude),
+            Some(exclude.clone()),
             Some(true),
         )
         .await
@@ -1504,15 +1543,82 @@ impl GitDesktopMcp {
         // entirely of new files can still be named (mirrors the in-app call site).
         let untracked_paths = untracked_files(&self.repo).await.map_err(app_err)?;
 
-        if diff.files.is_empty() && untracked_paths.is_empty() {
-            let msg = if diff.excluded_files > 0 {
-                "All in-progress changes match the AI ignore patterns — nothing to name a branch \
-                 after."
-            } else {
-                "No in-progress changes to name a branch after — make some edits first."
+        // Resolve the comparison base ONCE: it supplies the branch's own commit
+        // subjects (the strongest naming signal, worth one `git log` on either path)
+        // and the committed-work fallback below.
+        let base = committed_base_ref(&self.repo).await;
+        let commit_subjects = match &base {
+            Some(base) => crate::git::compare::git_compare_branches(
+                self.repo.clone(),
+                base.clone(),
+                "HEAD".to_string(),
+            )
+            .await
+            .map(|c| {
+                // `ahead` is `git log base..HEAD` order — already newest first.
+                c.ahead
+                    .into_iter()
+                    .take(BRANCH_FALLBACK_MAX_SUBJECTS)
+                    .map(|commit| commit.subject)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+            None => Vec::new(),
+        };
+
+        // Nothing in progress → name the branch after what it has already committed.
+        let (diff, untracked_paths) = if diff.files.is_empty() && untracked_paths.is_empty() {
+            let Some(base) = base.as_deref() else {
+                let msg = if diff.excluded_files > 0 {
+                    "All in-progress changes match the AI ignore patterns — nothing to name a \
+                     branch after."
+                } else {
+                    "No in-progress changes, and no default branch to compare committed work \
+                     against."
+                };
+                return Err(McpError::invalid_request(msg, None));
             };
-            return Err(McpError::invalid_request(msg, None));
-        }
+            let mut committed = crate::git::compare::git_branch_diff(
+                self.repo.clone(),
+                base.to_string(),
+                "HEAD".to_string(),
+                Some(RAW_DIFF_MAX_BYTES),
+                Some(exclude),
+            )
+            .await
+            .map_err(app_err)?;
+            if committed.files.is_empty() && committed.text.is_empty() {
+                // Name the side that actually hid something: claiming in-progress
+                // changes existed when the working tree was clean (or vice versa) is
+                // exactly the kind of confident-but-false reason an agent acts on.
+                let msg = match (diff.excluded_files > 0, committed.excluded_files > 0) {
+                    (true, true) => "All in-progress and committed changes match the AI ignore \
+                                     patterns — nothing to name a branch after."
+                        .to_string(),
+                    (false, true) => format!(
+                        "No in-progress changes, and all committed changes vs {base} match the AI \
+                         ignore patterns — nothing to name a branch after."
+                    ),
+                    (true, false) => format!(
+                        "All in-progress changes match the AI ignore patterns, and there are no \
+                         committed changes vs {base} — nothing to name a branch after."
+                    ),
+                    // Covers being ON the default branch and a fully-merged branch.
+                    (false, false) => format!(
+                        "No in-progress changes, and no committed changes vs {base} — nothing to \
+                         name a branch after."
+                    ),
+                };
+                return Err(McpError::invalid_request(msg, None));
+            }
+            // The committed diff has no untracked side. Fold the working tree's
+            // hidden files into the disclosure — they're also changes the model
+            // can't see (mirrors the TS fallback path).
+            committed.excluded_files += diff.excluded_files;
+            (committed, Vec::new())
+        } else {
+            (diff, untracked_paths)
+        };
 
         let branches = crate::git::branches::git_branches(self.repo.clone())
             .await
@@ -1536,6 +1642,7 @@ impl GitDesktopMcp {
             untracked_paths,
             excluded_files: diff.excluded_files,
             recent_branches: branches,
+            commit_subjects,
             repo_instructions,
             global_instructions: settings.global_instructions,
         }))
@@ -1602,8 +1709,11 @@ impl GitDesktopMcp {
         description = "Assemble GitDesktop's branch-name generation prompt from the WHOLE working \
                        tree (staged + unstaged vs HEAD, plus untracked file names; existing branch \
                        names as a convention reference, and project/user instructions) as one \
-                       ready-to-complete message. Your model completes it and the result is the \
-                       branch name. Errors if there are no in-progress changes."
+                       ready-to-complete message, falling back to the branch's COMMITTED work (the \
+                       three-dot diff and commit subjects vs the repo's default branch) when the \
+                       working tree is clean. Your model completes it and the result is the branch \
+                       name. Errors only when there is neither in-progress nor committed work to \
+                       name."
     )]
     async fn branch_name_prompt(&self) -> Result<GetPromptResult, McpError> {
         Ok(recipe_as_prompt(self.build_branch_recipe().await?))
@@ -1629,6 +1739,42 @@ async fn current_branch(repo: &str) -> Result<String, McpError> {
         ));
     }
     Ok(branch)
+}
+
+/// How many commit subjects the branch-name recipe feeds the model (newest first).
+const BRANCH_FALLBACK_MAX_SUBJECTS: usize = 30;
+
+/// Whether a fully-qualified ref resolves in `repo`. A spawn/timeout error counts
+/// as "absent" — the caller only ever uses this to pick a ref it can diff against.
+async fn ref_exists(repo: &str, full_ref: &str) -> bool {
+    crate::git::runner::run_git_raw(
+        Some(repo),
+        &["rev-parse", "--verify", "--quiet", full_ref],
+        crate::git::runner::DEFAULT_TIMEOUT,
+    )
+    .await
+    .map(|out| out.code == 0)
+    .unwrap_or(false)
+}
+
+/// The ref a branch's COMMITTED work is compared against for naming: the repo's
+/// default branch, preferring the remote-tracking `origin/<default>` over the local
+/// `<default>`. `git_default_branch` returns the SHORT LOCAL name even when it
+/// derived it from `origin/HEAD`, and that local branch may be stale (skewing the
+/// three-dot diff) or not exist at all — so verify both and prefer the remote.
+/// `None` = no default branch, or neither ref resolves ⇒ no fallback is possible.
+async fn committed_base_ref(repo: &str) -> Option<String> {
+    let default = crate::git::branches::git_default_branch(repo.to_string())
+        .await
+        .ok()
+        .flatten()?;
+    if ref_exists(repo, &format!("refs/remotes/origin/{default}")).await {
+        return Some(format!("origin/{default}"));
+    }
+    if ref_exists(repo, &format!("refs/heads/{default}")).await {
+        return Some(default);
+    }
+    None
 }
 
 /// Untracked (new) file paths, `git ls-files --others --exclude-standard`.
@@ -1752,6 +1898,7 @@ mod tests {
             untracked_paths: vec!["new.rs".to_string()],
             excluded_files: 0,
             recent_branches: vec!["feature/a".to_string(), "fix/b".to_string()],
+            commit_subjects: vec![],
             repo_instructions: None,
             global_instructions: String::new(),
         });
@@ -1767,6 +1914,42 @@ mod tests {
         assert!(recipe
             .prompt
             .ends_with("Generate the branch name for these changes."));
+        // No commits section when the list is empty.
+        assert!(!recipe.prompt.contains("## Commits on this branch"));
+    }
+
+    /// The committed-work signal: the commits section sits AFTER the existing branch
+    /// names and BEFORE the diff, one subject per line (mirrors the TS builder).
+    #[test]
+    fn branch_recipe_renders_commit_subjects_between_branches_and_diff() {
+        let recipe = assemble_branch_recipe(BranchPieces {
+            diff_text: "diff --git a/x.rs b/x.rs\n@@ -1 +1 @@\n-a\n+b\n".to_string(),
+            diff_truncated: false,
+            files: vec![file("x.rs", 1, 1, false)],
+            untracked_paths: vec![],
+            excluded_files: 2,
+            recent_branches: vec!["feature/a".to_string()],
+            commit_subjects: vec![
+                "fix: newest".to_string(),
+                "feat: older".to_string(),
+            ],
+            repo_instructions: None,
+            global_instructions: String::new(),
+        });
+        assert!(recipe
+            .prompt
+            .contains("## Commits on this branch (newest first)\nfix: newest\nfeat: older"));
+        let branches_at = recipe.prompt.find("## Existing branch names").unwrap();
+        let commits_at = recipe.prompt.find("## Commits on this branch").unwrap();
+        let diff_at = recipe.prompt.find("## Changes diff").unwrap();
+        assert!(
+            branches_at < commits_at && commits_at < diff_at,
+            "commits section sits between the branch names and the diff"
+        );
+        // The ignore-rules disclosure still rides along.
+        assert!(recipe
+            .prompt
+            .contains("[2 additional changed file(s) hidden by the user's AI ignore rules]"));
     }
 
     #[test]
@@ -1775,6 +1958,7 @@ mod tests {
             diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
             diff_truncated: false,
             files: vec![file("x.rs", 1, 0, false)],
+            excluded_files: 0,
             commit_subjects: vec!["feat: thing".to_string()],
             base_branch: "main".to_string(),
             head_branch: "feature/x".to_string(),
@@ -1799,12 +1983,40 @@ mod tests {
         assert!(!recipe.system.contains("## Labels"));
     }
 
+    /// The PR recipe discloses how many changed files the user's AI ignore rules hid,
+    /// in the files-summary section; a zero count adds no line.
+    #[test]
+    fn pr_recipe_reports_excluded_files() {
+        let pieces = |excluded: u32| PrPieces {
+            diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
+            diff_truncated: false,
+            files: vec![file("x.rs", 1, 0, false)],
+            excluded_files: excluded,
+            commit_subjects: vec![],
+            base_branch: "main".to_string(),
+            head_branch: "topic".to_string(),
+            available_labels: vec![],
+            candidate_issues: vec![],
+            jira_candidates: vec![],
+            repo_instructions: None,
+            global_instructions: String::new(),
+            provider: Some("github".to_string()),
+        };
+        let hidden = assemble_pr_recipe(pieces(4));
+        assert!(hidden
+            .prompt
+            .contains("## Files changed\nx.rs +1 -0\n[4 additional changed file(s) hidden by the user's AI ignore rules]"));
+        let none = assemble_pr_recipe(pieces(0));
+        assert!(!none.prompt.contains("hidden by the user's AI ignore rules"));
+    }
+
     #[test]
     fn pr_recipe_gitlab_swaps_noun_and_flavor() {
         let recipe = assemble_pr_recipe(PrPieces {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -1842,6 +2054,7 @@ mod tests {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -1867,6 +2080,7 @@ mod tests {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -1910,6 +2124,7 @@ mod tests {
             diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
             diff_truncated: false,
             files: vec![file("x.rs", 1, 0, false)],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -1936,6 +2151,7 @@ mod tests {
             diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
             diff_truncated: false,
             files: vec![file("x.rs", 1, 0, false)],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "fix/123-crash".to_string(),
@@ -1985,6 +2201,7 @@ mod tests {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -2015,6 +2232,7 @@ mod tests {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -2121,6 +2339,7 @@ mod tests {
             diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
             diff_truncated: false,
             files: vec![file("x.rs", 1, 0, false)],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "feature/MYT-123-fix".to_string(),
@@ -2166,6 +2385,7 @@ mod tests {
             diff_text: "diff --git a/x.rs b/x.rs\n+a\n".to_string(),
             diff_truncated: false,
             files: vec![file("x.rs", 1, 0, false)],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -2195,6 +2415,7 @@ mod tests {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
+            excluded_files: 0,
             commit_subjects: vec![],
             base_branch: "main".to_string(),
             head_branch: "topic".to_string(),
@@ -2335,5 +2556,60 @@ mod tests {
         for p in ["src/app.rs", "Cargo.toml", "lock.rs", "yarn.lockfile.md"] {
             assert!(!is_low_value_path(p), "expected NOT low-value: {p}");
         }
+    }
+
+    // ---- committed_base_ref (branch-name fallback base resolution) ----------
+
+    async fn git(repo: &str, args: &[&str]) -> String {
+        crate::git::runner::run_git_raw(Some(repo), args, crate::git::runner::DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+    }
+
+    /// Preference order: the remote-tracking `origin/<default>` wins when it exists,
+    /// the local `<default>` is the fallback, and neither ⇒ `None` (no fallback base).
+    #[tokio::test]
+    async fn committed_base_ref_prefers_remote_tracking() {
+        let base = tempfile::Builder::new()
+            .prefix("gd-basref-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        // Pin the branch name regardless of the host's init.defaultBranch.
+        git(&repo_s, &["symbolic-ref", "HEAD", "refs/heads/main"]).await;
+        std::fs::write(repo.join("a.txt"), "hello\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+
+        // Only the local branch exists → the local name.
+        assert_eq!(
+            committed_base_ref(&repo_s).await,
+            Some("main".to_string()),
+            "local default branch is the fallback base when there's no remote twin"
+        );
+
+        // Add the remote-tracking twin → it wins (the local one may be stale).
+        git(&repo_s, &["update-ref", "refs/remotes/origin/main", "HEAD"]).await;
+        assert_eq!(
+            committed_base_ref(&repo_s).await,
+            Some("origin/main".to_string()),
+            "the remote-tracking ref is preferred over the local branch"
+        );
+
+        // Neither a main/master branch nor an origin ref → no base at all.
+        git(&repo_s, &["branch", "-m", "main", "topic"]).await;
+        git(&repo_s, &["update-ref", "-d", "refs/remotes/origin/main"]).await;
+        assert_eq!(
+            committed_base_ref(&repo_s).await,
+            None,
+            "no resolvable default branch ⇒ no committed-work fallback"
+        );
     }
 }

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -54,7 +54,7 @@ Never reference issue or PR numbers, tickets, or links (e.g. \"Closes #123\") �
 Do not wrap the message in markdown fences. Do not add commentary before or after the message.";
 
 /// Mirrors `BRANCH_SYSTEM` in src/lib/ai/prompt.ts. KEEP IN SYNC.
-const BRANCH_SYSTEM: &str = "You generate a single git branch name for a set of in-progress changes.\n\
+const BRANCH_SYSTEM: &str = "You generate a single git branch name for a set of code changes.\n\
 Output ONLY the branch name — one line, nothing else: no quotes, no explanation, no markdown, no trailing period.\n\
 Use lowercase kebab-case, 2-5 words, specific to what the change does (avoid generic names like \"updates\" or \"changes\").\n\
 If the existing branch names below show a prefix convention (e.g. \"feature/\", \"fix/\", \"chore/\"), follow it; otherwise pick a fitting type prefix such as \"feature/\" or \"fix/\".\n\
@@ -696,8 +696,10 @@ struct BranchPieces {
     excluded_files: u32,
     recent_branches: Vec<String>,
     /// Subjects of the commits this branch adds over its base, newest first —
-    /// the strongest naming signal when the work is already committed. Empty when
-    /// the base can't be resolved (or the branch adds no commits).
+    /// the strongest naming signal when the work is already committed, and supplied
+    /// ONLY on that fallback path. Empty when the base can't be resolved, when the
+    /// branch adds no commits, and when the `git log` itself fails (best-effort) —
+    /// an empty list is never evidence that the branch has no commits.
     commit_subjects: Vec<String>,
     repo_instructions: Option<String>,
     global_instructions: String,
@@ -1274,6 +1276,22 @@ impl GitDesktopMcp {
         .await
         .map_err(app_err)?;
 
+        // An empty range must not yield a silent, contentless recipe: without this
+        // the agent would write a description from the commit subjects alone (and,
+        // with excludes, from files it was never shown). Mirrors the in-app toast
+        // and the commit/branch recipes' empty-input errors.
+        if diff.files.is_empty() {
+            let msg = if diff.excluded_files > 0 {
+                format!(
+                    "All changes between {base} and {head} match the AI ignore patterns — nothing \
+                     to describe."
+                )
+            } else {
+                format!("No changes between {base} and {head} to describe.")
+            };
+            return Err(McpError::invalid_request(msg, None));
+        }
+
         // The commits the PR would introduce = base..head "ahead" set (compare =
         // head), exactly as the in-app Create-PR flow derives `commitSubjects` from
         // `git_compare_branches(...).ahead`. Best-effort: an error yields no list.
@@ -1543,31 +1561,15 @@ impl GitDesktopMcp {
         // entirely of new files can still be named (mirrors the in-app call site).
         let untracked_paths = untracked_files(&self.repo).await.map_err(app_err)?;
 
-        // Resolve the comparison base ONCE: it supplies the branch's own commit
-        // subjects (the strongest naming signal, worth one `git log` on either path)
-        // and the committed-work fallback below.
+        // The base for the committed-work fallback below. Only that path reads the
+        // branch's commit subjects: on the working-tree path they'd describe the
+        // CURRENT branch, biasing the name toward the parent branch's story.
         let base = committed_base_ref(&self.repo).await;
-        let commit_subjects = match &base {
-            Some(base) => crate::git::compare::git_compare_branches(
-                self.repo.clone(),
-                base.clone(),
-                "HEAD".to_string(),
-            )
-            .await
-            .map(|c| {
-                // `ahead` is `git log base..HEAD` order — already newest first.
-                c.ahead
-                    .into_iter()
-                    .take(BRANCH_FALLBACK_MAX_SUBJECTS)
-                    .map(|commit| commit.subject)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default(),
-            None => Vec::new(),
-        };
 
         // Nothing in progress → name the branch after what it has already committed.
-        let (diff, untracked_paths) = if diff.files.is_empty() && untracked_paths.is_empty() {
+        let (diff, untracked_paths, commit_subjects) = if diff.files.is_empty()
+            && untracked_paths.is_empty()
+        {
             let Some(base) = base.as_deref() else {
                 let msg = if diff.excluded_files > 0 {
                     "All in-progress changes match the AI ignore patterns — nothing to name a \
@@ -1613,11 +1615,15 @@ impl GitDesktopMcp {
             }
             // The committed diff has no untracked side. Fold the working tree's
             // hidden files into the disclosure — they're also changes the model
-            // can't see (mirrors the TS fallback path).
+            // can't see (mirrors the TS fallback path). The sum is an UPPER BOUND:
+            // a file hidden in both diffs is counted twice. Over-disclosing how much
+            // is hidden is the safe direction — the number only tells the model the
+            // diff isn't the whole story.
             committed.excluded_files += diff.excluded_files;
-            (committed, Vec::new())
+            let subjects = branch_commit_subjects(&self.repo, base).await;
+            (committed, Vec::new(), subjects)
         } else {
-            (diff, untracked_paths)
+            (diff, untracked_paths, Vec::new())
         };
 
         let branches = crate::git::branches::git_branches(self.repo.clone())
@@ -1755,6 +1761,32 @@ async fn ref_exists(repo: &str, full_ref: &str) -> bool {
     .await
     .map(|out| out.code == 0)
     .unwrap_or(false)
+}
+
+/// Subjects of the commits `HEAD` adds over `base` (`git log base..HEAD`), newest
+/// first as git emits them, capped at [`BRANCH_FALLBACK_MAX_SUBJECTS`]. Deliberately
+/// scoped rather than reusing `git_compare_branches`: that one also walks the
+/// `behind` side, which this caller would discard, and the MCP server has no query
+/// cache to amortize it. Best-effort — a git failure yields an empty list rather
+/// than failing the recipe.
+async fn branch_commit_subjects(repo: &str, base: &str) -> Vec<String> {
+    let max = BRANCH_FALLBACK_MAX_SUBJECTS.to_string();
+    let range = format!("{base}..HEAD");
+    let Ok(out) = crate::git::runner::run_git(
+        Some(repo),
+        &["log", "--format=%s", "-n", &max, &range],
+        crate::git::runner::DEFAULT_TIMEOUT,
+    )
+    .await
+    else {
+        return Vec::new();
+    };
+    out.stdout_lossy()
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// The ref a branch's COMMITTED work is compared against for naming: the repo's
@@ -2565,6 +2597,44 @@ mod tests {
             .await
             .unwrap()
             .stdout_lossy()
+    }
+
+    /// The scoped subjects log returns `base..HEAD` newest-first, and an empty list
+    /// when HEAD adds nothing over the base (never an error).
+    #[tokio::test]
+    async fn branch_commit_subjects_are_newest_first() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-subjects-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        std::fs::write(repo.join("a.txt"), "seed\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+        let base_sha = git(&repo_s, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        // Nothing on top of the base yet.
+        assert!(
+            branch_commit_subjects(&repo_s, &base_sha).await.is_empty(),
+            "an empty range yields an empty list, not an error"
+        );
+
+        for (n, msg) in [("1", "feat: first"), ("2", "fix: second")] {
+            std::fs::write(repo.join(format!("f{n}.txt")), "x\n").unwrap();
+            git(&repo_s, &["add", "-A"]).await;
+            git(&repo_s, &["commit", "-qm", msg]).await;
+        }
+        assert_eq!(
+            branch_commit_subjects(&repo_s, &base_sha).await,
+            vec!["fix: second".to_string(), "feat: first".to_string()],
+            "git log order — newest first"
+        );
     }
 
     /// Preference order: the remote-tracking `origin/<default>` wins when it exists,

--- a/src/features/commit/useGenerateCommitMessage.ts
+++ b/src/features/commit/useGenerateCommitMessage.ts
@@ -1,11 +1,11 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
+import { aiExcludePatterns } from "@/lib/ai/ignore";
 import { buildCommitPrompt, splitCommitMessage } from "@/lib/ai/prompt";
 import {
   gitRecentCommits,
   gitStagedDiff,
-  readRepoAiIgnore,
   readRepoInstructions,
 } from "@/lib/git/api";
 import { useUiStore } from "@/lib/stores/ui";
@@ -27,12 +27,10 @@ export function useGenerateCommitMessage(repoPath: string) {
     setGenerating(true);
     const buffer = await run(
       async (settings) => {
-        const repoIgnore = await readRepoAiIgnore(repoPath);
-        const globalIgnore = settings.aiIgnorePatterns
-          .split("\n")
-          .map((line) => line.trim())
-          .filter((line) => line && !line.startsWith("#"));
-        const exclude = [...repoIgnore, ...globalIgnore];
+        const exclude = await aiExcludePatterns(
+          repoPath,
+          settings.aiIgnorePatterns,
+        );
 
         const [staged, commits, repoInstructions] = await Promise.all([
           gitStagedDiff(repoPath, { maxBytes: RAW_DIFF_MAX_BYTES, exclude }),

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -429,9 +429,11 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   (reversible) or **delete** them together. The current branch, the default branch, and
   protected branches are never included.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
-  or renaming one. With a clean working tree it falls back to the branch's own
-  committed work — its diff and commit subjects vs. the default branch — so a branch
-  whose work is already committed can still be renamed from what it actually does.
+  or renaming one. Whenever the working tree can't describe the branch being named —
+  it's clean, or you're renaming a branch you aren't on — it names it from that
+  branch's own committed work instead: its diff and commit subjects vs. the default
+  branch. (Creating from a base other than the branch you're on uses your in-progress
+  changes only, since the new branch won't carry that committed work.)
 {{/ai}}- Switching with **uncommitted changes** prompts you to bring them along or stash
   and switch.
 - {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -429,7 +429,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   (reversible) or **delete** them together. The current branch, the default branch, and
   protected branches are never included.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
-  or renaming one.
+  or renaming one. With a clean working tree it falls back to the branch's own
+  committed work — its diff and commit subjects vs. the default branch — so a branch
+  whose work is already committed can still be renamed from what it actually does.
 {{/ai}}- Switching with **uncommitted changes** prompts you to bring them along or stash
   and switch.
 - {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -190,10 +190,15 @@ export function SquashDialog({
               </Button>
             ) : (
               // Wrap so the title still shows when the button is disabled — a
-              // native-disabled button swallows the tooltip.
+              // native-disabled button swallows the tooltip. `runHead` is the
+              // collapsing step's tip, so without it there's no range to diff.
               <span
                 className="mr-auto"
-                title="Generate the commit message with AI"
+                title={
+                  runHead
+                    ? "Generate the commit message with AI"
+                    : "Nothing to generate from — this squash has no run of commits to combine"
+                }
               >
                 <Button
                   type="button"

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -11,12 +11,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { createAiClient } from "@/lib/ai/client";
+import { aiExcludePatterns } from "@/lib/ai/ignore";
 import { buildCommitPrompt } from "@/lib/ai/prompt";
 import { required, useAppForm } from "@/lib/form";
 import {
   gitBranchDiff,
   gitRecentCommits,
-  readRepoAiIgnore,
   readRepoInstructions,
 } from "@/lib/git/api";
 import { useRewriteCommits } from "@/lib/git/queries";
@@ -45,14 +45,12 @@ export function useGenerateSquashMessage(
     setGenerating(true);
     try {
       const settings = await loadSettings();
-      const repoIgnore = await readRepoAiIgnore(repoPath);
-      const globalIgnore = settings.aiIgnorePatterns
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line && !line.startsWith("#"));
-      const exclude = [...repoIgnore, ...globalIgnore];
+      // Only the diff depends on the ignore patterns — chain those two and let
+      // the batch run them alongside the commits and instructions reads.
       const [diff, commits, repoInstructions] = await Promise.all([
-        gitBranchDiff(repoPath, base, head, 200_000, exclude),
+        aiExcludePatterns(repoPath, settings.aiIgnorePatterns).then((exclude) =>
+          gitBranchDiff(repoPath, base, head, 200_000, exclude),
+        ),
         gitRecentCommits(repoPath, 10),
         readRepoInstructions(repoPath),
       ]);

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -16,6 +16,7 @@ import { required, useAppForm } from "@/lib/form";
 import {
   gitBranchDiff,
   gitRecentCommits,
+  readRepoAiIgnore,
   readRepoInstructions,
 } from "@/lib/git/api";
 import { useRewriteCommits } from "@/lib/git/queries";
@@ -44,20 +45,30 @@ export function useGenerateSquashMessage(
     setGenerating(true);
     try {
       const settings = await loadSettings();
+      const repoIgnore = await readRepoAiIgnore(repoPath);
+      const globalIgnore = settings.aiIgnorePatterns
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith("#"));
+      const exclude = [...repoIgnore, ...globalIgnore];
       const [diff, commits, repoInstructions] = await Promise.all([
-        gitBranchDiff(repoPath, base, head, 200_000),
+        gitBranchDiff(repoPath, base, head, 200_000, exclude),
         gitRecentCommits(repoPath, 10),
         readRepoInstructions(repoPath),
       ]);
       if (!diff.text.trim()) {
-        toast.error("These commits have no combined changes to describe.");
+        toast.error(
+          diff.excludedFiles > 0
+            ? "These commits' changes all match your AI ignore patterns — nothing to describe."
+            : "These commits have no combined changes to describe.",
+        );
         return;
       }
       const { system, prompt } = buildCommitPrompt({
         diffText: diff.text,
         diffTruncated: diff.truncated,
         files: diff.files,
-        excludedFiles: 0,
+        excludedFiles: diff.excludedFiles,
         recentSubjects: commits.map((c) => c.subject),
         repoInstructions,
         globalInstructions: settings.globalInstructions,

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -3,7 +3,12 @@ import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
 import { buildPrPrompt, extractPrDraft } from "@/lib/ai/prompt";
 import type { PromptProvider } from "@/lib/ai/types";
-import { gitBranchDiff, readRepoInstructions } from "@/lib/git/api";
+import {
+  gitBranchDiff,
+  readRepoAiIgnore,
+  readRepoInstructions,
+} from "@/lib/git/api";
+import type { AppSettings } from "@/lib/settings/api";
 
 /** Raw diff bytes requested from the backend; prompt budgeting trims further. */
 const RAW_DIFF_MAX_BYTES = 200_000;
@@ -13,6 +18,9 @@ interface SuppliedDiff {
   text: string;
   truncated: boolean;
   files: { path: string; added: number; deleted: number; isBinary: boolean }[];
+  /** Changed files the user's AI-ignore patterns hid, when the supplier applies
+   *  them. Absent (remote-PR diffs) ⇒ nothing was hidden to disclose. */
+  excludedFiles?: number;
 }
 
 /** A repo label the model may propose from — name plus its stated purpose. The
@@ -57,13 +65,14 @@ interface PrDraft {
 export function useGeneratePrDescription(repoPath: string) {
   const { generating, cancel, run } = useAiStream(repoPath);
 
-  /** Shared streaming core: gets the diff from `getDiff`, budgets it into a PR
-   *  prompt, and streams the parsed title/body/labels draft to `onUpdate`.
-   *  `availableLabels` are the repo's existing label names the model may propose
-   *  from (validated in the parser — invented labels are dropped). */
+  /** Shared streaming core: gets the diff from `getDiff` (handed the loaded
+   *  settings, so a supplier can honor the user's AI-ignore patterns), budgets
+   *  it into a PR prompt, and streams the parsed title/body/labels draft to
+   *  `onUpdate`. `availableLabels` are the repo's existing label names the model
+   *  may propose from (validated in the parser — invented labels are dropped). */
   const runFromDiff = useCallback(
     async (
-      getDiff: () => Promise<SuppliedDiff>,
+      getDiff: (settings: AppSettings) => Promise<SuppliedDiff>,
       base: string,
       head: string,
       commitSubjects: string[],
@@ -83,17 +92,22 @@ export function useGeneratePrDescription(repoPath: string) {
       await run(
         async (settings) => {
           const [diff, repoInstructions] = await Promise.all([
-            getDiff(),
+            getDiff(settings),
             readRepoInstructions(repoPath),
           ]);
           if (diff.files.length === 0) {
-            toast.error("No changes between these branches to describe.");
+            toast.error(
+              (diff.excludedFiles ?? 0) > 0
+                ? "All changes between these branches match your AI ignore patterns — nothing to describe."
+                : "No changes between these branches to describe.",
+            );
             return null;
           }
           return buildPrPrompt({
             diffText: diff.text,
             diffTruncated: diff.truncated,
             files: diff.files,
+            excludedFiles: diff.excludedFiles,
             commitSubjects,
             baseBranch: base,
             headBranch: head,
@@ -145,7 +159,21 @@ export function useGeneratePrDescription(repoPath: string) {
       jiraCandidates?: JiraCandidate[],
     ) =>
       runFromDiff(
-        () => gitBranchDiff(repoPath, base, head, RAW_DIFF_MAX_BYTES),
+        async (settings) => {
+          const repoIgnore = await readRepoAiIgnore(repoPath);
+          const globalIgnore = settings.aiIgnorePatterns
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line && !line.startsWith("#"));
+          const exclude = [...repoIgnore, ...globalIgnore];
+          return gitBranchDiff(
+            repoPath,
+            base,
+            head,
+            RAW_DIFF_MAX_BYTES,
+            exclude,
+          );
+        },
         base,
         head,
         commitSubjects,

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -1,13 +1,10 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
+import { aiExcludePatterns } from "@/lib/ai/ignore";
 import { buildPrPrompt, extractPrDraft } from "@/lib/ai/prompt";
 import type { PromptProvider } from "@/lib/ai/types";
-import {
-  gitBranchDiff,
-  readRepoAiIgnore,
-  readRepoInstructions,
-} from "@/lib/git/api";
+import { gitBranchDiff, readRepoInstructions } from "@/lib/git/api";
 import type { AppSettings } from "@/lib/settings/api";
 
 /** Raw diff bytes requested from the backend; prompt budgeting trims further. */
@@ -160,12 +157,10 @@ export function useGeneratePrDescription(repoPath: string) {
     ) =>
       runFromDiff(
         async (settings) => {
-          const repoIgnore = await readRepoAiIgnore(repoPath);
-          const globalIgnore = settings.aiIgnorePatterns
-            .split("\n")
-            .map((line) => line.trim())
-            .filter((line) => line && !line.startsWith("#"));
-          const exclude = [...repoIgnore, ...globalIgnore];
+          const exclude = await aiExcludePatterns(
+            repoPath,
+            settings.aiIgnorePatterns,
+          );
           return gitBranchDiff(
             repoPath,
             base,

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -452,7 +452,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // skews the three-dot diff, and when origin/HEAD resolved the default name the
   // local twin may not even exist. Null (⇒ no fallback) when neither side has it.
   const committedBase = useMemo(() => {
-    if (!branchDialogOpen || !defaultName || !remoteBranchesSettled)
+    // An errored remote list must not fall through to the local default — that
+    // base can't be trusted, so no base ⇒ no fallback ⇒ the error state renders.
+    if (
+      !branchDialogOpen ||
+      !defaultName ||
+      !remoteBranchesSettled ||
+      remoteBranchesQuery.isError
+    )
       return null;
     const onOrigin = (remoteBranchesQuery.data ?? []).some(
       (b) => b.remote === "origin" && b.name === defaultName,
@@ -463,6 +470,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     branchDialogOpen,
     defaultName,
     remoteBranchesSettled,
+    remoteBranchesQuery.isError,
     remoteBranchesQuery.data,
     localNames,
   ]);

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -397,8 +397,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     [sortedBranches, bq],
   );
   // Both branch dialogs are always mounted, so their AI name-generation queries
-  // gate on one of them actually being open.
-  const branchDialogOpen = createOpen || renameTarget !== null;
+  // gate on one of them actually being open — and on AI being usable at all:
+  // without it the generate button renders nothing (or the setup button, which
+  // reads none of this), so a Hide-AI or unconfigured user would be paying for
+  // `git branch -r` plus two `git log` walks that feed nothing.
+  const branchDialogOpen =
+    (createOpen || renameTarget !== null) && aiEnabled && aiConfigured;
   // Branches that live on a remote but aren't checked out locally yet — fetched
   // while the menu is open, and while a branch dialog is open (it resolves the
   // committed-work base off this list, and the palette can open it without ever
@@ -436,7 +440,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     renameTarget ?? (createOpen ? (currentName ?? "HEAD") : null);
   // Whether the remote list has settled. Until it has, a missing `origin/<default>`
   // means "not loaded yet", not "absent" — resolving the local default here is
-  // exactly the stale ref this base resolution exists to avoid.
+  // exactly the stale ref this base resolution exists to avoid. An ERRORED list
+  // settles too, and can't be trusted either: that case is reported as an error
+  // state below rather than silently falling through to the local default.
   const remoteBranchesSettled = !remoteBranchesQuery.isPending;
   // The default branch names the comparison base, so its own lookup gates the
   // fallback too: a null `defaultName` while it's still loading must not read as
@@ -483,7 +489,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         (Boolean(defaultName) && !remoteBranchesSettled) ||
         (comparing && committedCompare.isPending)
       ? "pending"
-      : defaultBranch.isError || (comparing && committedCompare.isError)
+      : defaultBranch.isError ||
+          remoteBranchesQuery.isError ||
+          (comparing && committedCompare.isError)
         ? "error"
         : "ready";
   const committedFallback = useMemo(() => {

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -427,12 +427,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   }, [remoteBranchesQuery.data, localNames, bq]);
   // The ref the branch dialogs are naming, and whose committed work the AI
   // fallback describes: the rename target (which need NOT be checked out — every
-  // branch row's menu opens it), or HEAD for a new branch. Null ⇒ both closed.
-  const namedRef = renameTarget ?? (createOpen ? "HEAD" : null);
+  // branch row's menu opens it), or the checked-out branch for a new one. Null ⇒
+  // both closed. The create side names the BRANCH, not the literal "HEAD", so the
+  // comparison's cache key changes when you switch branches — keyed on "HEAD" it
+  // would serve the previous branch's commits to a fast Generate. A detached HEAD
+  // has no branch name to key on and keeps the literal.
+  const namedRef =
+    renameTarget ?? (createOpen ? (currentName ?? "HEAD") : null);
   // Whether the remote list has settled. Until it has, a missing `origin/<default>`
   // means "not loaded yet", not "absent" — resolving the local default here is
   // exactly the stale ref this base resolution exists to avoid.
   const remoteBranchesSettled = !remoteBranchesQuery.isPending;
+  // The default branch names the comparison base, so its own lookup gates the
+  // fallback too: a null `defaultName` while it's still loading must not read as
+  // "this repo has no default branch".
+  const defaultBranchSettled = !defaultBranch.isPending;
   // Base for the fallback. Prefer the remote-tracking ref: a stale local default
   // skews the three-dot diff, and when origin/HEAD resolved the default name the
   // local twin may not even exist. Null (⇒ no fallback) when neither side has it.
@@ -460,16 +469,23 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     namedRef,
   );
   // Mirrors `useCompareBranches`' own enabled condition, so a query that never
-  // runs (e.g. renaming the default branch: base === compare) isn't read as
-  // "still loading" forever.
+  // runs isn't read as "still loading" forever. base === compare survives only
+  // when no `origin/<default>` exists and the named ref IS the local default —
+  // with the remote ref preferred, `origin/main` vs `main` does run.
   const comparing =
     committedBase !== null && namedRef !== null && committedBase !== namedRef;
-  // Neither enable the affordance nor let it claim there's no committed work
-  // while the inputs that would prove it are still in flight.
-  const committedPending =
-    branchDialogOpen &&
-    ((Boolean(defaultName) && !remoteBranchesSettled) ||
-      (comparing && committedCompare.isPending));
+  // Never let the affordance claim there's no committed work on evidence it
+  // doesn't have: while any input is in flight say so, and say so distinctly
+  // when the lookup failed outright.
+  const committedStatus: "ready" | "pending" | "error" = !branchDialogOpen
+    ? "ready"
+    : !defaultBranchSettled ||
+        (Boolean(defaultName) && !remoteBranchesSettled) ||
+        (comparing && committedCompare.isPending)
+      ? "pending"
+      : defaultBranch.isError || (comparing && committedCompare.isError)
+        ? "error"
+        : "ready";
   const committedFallback = useMemo(() => {
     const ahead = committedCompare.data?.ahead ?? [];
     if (!committedBase || !namedRef || ahead.length === 0) return null;
@@ -601,6 +617,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // branch is being renamed.
   function openRename(branch: string) {
     setOpen(false);
+    // The two branch dialogs are mutually exclusive: their palette actions can
+    // fire while the other is open, and both feed the SAME committed-work
+    // lookup — leaving both open would name a new branch from the rename
+    // target's diff.
+    setCreateOpen(false);
     setRenameTarget(branch);
   }
 
@@ -703,6 +724,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   function openCreate() {
     setOpen(false);
+    // Mutually exclusive with the rename dialog — see `openRename`.
+    setRenameTarget(null);
     setCreateOpen(true);
   }
 
@@ -1793,7 +1816,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         entries={status.data?.entries ?? []}
         allBranchNames={allBranches.map((b) => b.name)}
         committedFallback={committedFallback}
-        committedPending={committedPending}
+        committedStatus={committedStatus}
         currentName={currentName}
         defaultName={defaultName}
         onOpenSettings={openSettings}
@@ -1811,7 +1834,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         entries={status.data?.entries ?? []}
         allBranchNames={allBranches.map((b) => b.name)}
         committedFallback={committedFallback}
-        committedPending={committedPending}
+        committedStatus={committedStatus}
         onOpenSettings={openSettings}
       />
 

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -37,6 +37,7 @@ import {
   useBranches,
   useCheckoutBranch,
   useCheckoutRemoteBranch,
+  useCompareBranches,
   useDefaultBranch,
   useDeleteBranch,
   useDeleteRemoteBranch,
@@ -395,11 +396,19 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       ),
     [sortedBranches, bq],
   );
+  // Both branch dialogs are always mounted, so their AI name-generation queries
+  // gate on one of them actually being open.
+  const branchDialogOpen = createOpen || renameTarget !== null;
   // Branches that live on a remote but aren't checked out locally yet — fetched
-  // only while the menu is open. Drop ones already represented by a local branch
-  // (its row already shows ahead/behind + PR) and the internal session branches;
-  // dedupe a branch that exists on multiple remotes to one row.
-  const remoteBranchesQuery = useRemoteBranches(repoPath, open);
+  // while the menu is open, and while a branch dialog is open (it resolves the
+  // committed-work base off this list, and the palette can open it without ever
+  // opening the menu). Drop ones already represented by a local branch (its row
+  // already shows ahead/behind + PR) and the internal session branches; dedupe a
+  // branch that exists on multiple remotes to one row.
+  const remoteBranchesQuery = useRemoteBranches(
+    repoPath,
+    open || branchDialogOpen,
+  );
   const localNames = useMemo(
     () => new Set(allBranches.map((b) => b.name)),
     [allBranches],
@@ -416,6 +425,61 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       .filter((b) => (seen.has(b.name) ? false : (seen.add(b.name), true)))
       .sort((a, b) => b.lastCommitDate.localeCompare(a.lastCommitDate));
   }, [remoteBranchesQuery.data, localNames, bq]);
+  // The ref the branch dialogs are naming, and whose committed work the AI
+  // fallback describes: the rename target (which need NOT be checked out — every
+  // branch row's menu opens it), or HEAD for a new branch. Null ⇒ both closed.
+  const namedRef = renameTarget ?? (createOpen ? "HEAD" : null);
+  // Whether the remote list has settled. Until it has, a missing `origin/<default>`
+  // means "not loaded yet", not "absent" — resolving the local default here is
+  // exactly the stale ref this base resolution exists to avoid.
+  const remoteBranchesSettled = !remoteBranchesQuery.isPending;
+  // Base for the fallback. Prefer the remote-tracking ref: a stale local default
+  // skews the three-dot diff, and when origin/HEAD resolved the default name the
+  // local twin may not even exist. Null (⇒ no fallback) when neither side has it.
+  const committedBase = useMemo(() => {
+    if (!branchDialogOpen || !defaultName || !remoteBranchesSettled)
+      return null;
+    const onOrigin = (remoteBranchesQuery.data ?? []).some(
+      (b) => b.remote === "origin" && b.name === defaultName,
+    );
+    if (onOrigin) return `origin/${defaultName}`;
+    return localNames.has(defaultName) ? defaultName : null;
+  }, [
+    branchDialogOpen,
+    defaultName,
+    remoteBranchesSettled,
+    remoteBranchesQuery.data,
+    localNames,
+  ]);
+  // Commits the named ref has that the default branch doesn't — its committed
+  // work. A null base keeps the query disabled (both dialogs closed, or no
+  // resolvable default).
+  const committedCompare = useCompareBranches(
+    repoPath,
+    committedBase,
+    namedRef,
+  );
+  // Mirrors `useCompareBranches`' own enabled condition, so a query that never
+  // runs (e.g. renaming the default branch: base === compare) isn't read as
+  // "still loading" forever.
+  const comparing =
+    committedBase !== null && namedRef !== null && committedBase !== namedRef;
+  // Neither enable the affordance nor let it claim there's no committed work
+  // while the inputs that would prove it are still in flight.
+  const committedPending =
+    branchDialogOpen &&
+    ((Boolean(defaultName) && !remoteBranchesSettled) ||
+      (comparing && committedCompare.isPending));
+  const committedFallback = useMemo(() => {
+    const ahead = committedCompare.data?.ahead ?? [];
+    if (!committedBase || !namedRef || ahead.length === 0) return null;
+    // `ahead` is newest-first (plain `git log base..<ref>`); cap the subjects.
+    return {
+      base: committedBase,
+      compare: namedRef,
+      subjects: ahead.slice(0, 30).map((c) => c.subject),
+    };
+  }, [committedBase, namedRef, committedCompare.data]);
   // Only label rows with their remote when there's more than one to disambiguate.
   const multipleRemotes = useMemo(
     () =>
@@ -1728,6 +1792,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         headExists={headExists}
         entries={status.data?.entries ?? []}
         allBranchNames={allBranches.map((b) => b.name)}
+        committedFallback={committedFallback}
+        committedPending={committedPending}
         currentName={currentName}
         defaultName={defaultName}
         onOpenSettings={openSettings}
@@ -1736,6 +1802,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       <RenameBranchDialog
         repoPath={repoPath}
         target={renameTarget}
+        currentName={currentName}
         onClose={() => setRenameTarget(null)}
         aiEnabled={aiEnabled}
         aiConfigured={aiConfigured}
@@ -1743,6 +1810,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         headExists={headExists}
         entries={status.data?.entries ?? []}
         allBranchNames={allBranches.map((b) => b.name)}
+        committedFallback={committedFallback}
+        committedPending={committedPending}
         onOpenSettings={openSettings}
       />
 

--- a/src/features/repository/ConflictResolveView.tsx
+++ b/src/features/repository/ConflictResolveView.tsx
@@ -17,9 +17,10 @@ import {
   extractResolvedContent,
   hasConflictMarkers,
 } from "@/lib/ai/conflict-prompt";
+import { aiExcludePatterns } from "@/lib/ai/ignore";
 import { PROVIDER_LABELS } from "@/lib/ai/providers";
 import { useAiTextStream } from "@/lib/ai/stream";
-import { readRepoAiIgnore, readRepoInstructions } from "@/lib/git/api";
+import { readRepoInstructions } from "@/lib/git/api";
 import {
   type ConflictSides,
   conflictSides,
@@ -35,14 +36,6 @@ type Phase = "loading" | "streaming" | "ready" | "blocked" | "idle";
 type ViewKey = "diff" | "proposed" | "ours" | "theirs" | "base";
 
 const baseName = (path: string) => path.split("/").pop() || path;
-
-/** Lines of a newline-joined ignore-pattern string, dropping blanks + comments. */
-function ignoreLines(patterns: string): string[] {
-  return patterns
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l && !l.startsWith("#"));
-}
 
 /**
  * Inline resolution surface for one conflicted file: asks the configured review
@@ -92,12 +85,14 @@ export function ConflictResolveView({
 
     let resolved: ConflictSides;
     try {
-      const globalIgnore = ignoreLines(settings.data?.aiIgnorePatterns ?? "");
-      const repoIgnore = await readRepoAiIgnore(repoPath).catch(() => []);
-      resolved = await conflictSides(repoPath, path, [
-        ...repoIgnore,
-        ...globalIgnore,
-      ]);
+      // An unreadable repo ignore file must not abort a resolution the global
+      // patterns alone can still serve.
+      const exclude = await aiExcludePatterns(
+        repoPath,
+        settings.data?.aiIgnorePatterns ?? "",
+        { tolerateRepoReadError: true },
+      );
+      resolved = await conflictSides(repoPath, path, exclude);
     } catch (e) {
       if (gen === genRef.current) {
         toastError(e);

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -29,10 +29,10 @@ import type { CommittedNameSource } from "./useGenerateBranchName";
  * Create-branch dialog: names a new branch (with optional AI generation from
  * the working-tree changes, or — when it branches from HEAD with a clean tree —
  * the current branch's committed work), picks its base, and switches to it.
- * Owns its own
- * form + the create mutation + the branch-name generator — the switcher only
- * decides whether it's open and hands down the data it renders. Seeds the base
- * on open so it reflects the branch you were on when you triggered it.
+ * Owns its own form + the create mutation + the branch-name generator — the
+ * switcher only decides whether it's open and hands down the data it renders.
+ * Seeds the base on open so it reflects the branch you were on when you
+ * triggered it.
  */
 export function CreateBranchDialog({
   repoPath,

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -23,6 +23,7 @@ import {
   useSeedBase,
 } from "./BaseBranchCombobox";
 import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
+import type { CommittedNameSource } from "./useGenerateBranchName";
 
 /**
  * Create-branch dialog: names a new branch (with optional AI generation from
@@ -42,6 +43,8 @@ export function CreateBranchDialog({
   headExists,
   entries,
   allBranchNames,
+  committedFallback,
+  committedPending,
   currentName,
   defaultName,
   onOpenSettings,
@@ -56,6 +59,12 @@ export function CreateBranchDialog({
   headExists: boolean;
   entries: FileEntry[];
   allBranchNames: string[];
+  /** The checked-out branch's committed work vs the default branch (compared
+   *  against HEAD) — the AI name-generation fallback when the working tree is
+   *  clean. Only applies when the new branch is based on HEAD; see below. */
+  committedFallback: CommittedNameSource | null;
+  /** Whether `committedFallback` is still resolving. */
+  committedPending: boolean;
   currentName: string | null;
   defaultName: string | null;
   onOpenSettings: (section: "ai") => void;
@@ -102,6 +111,11 @@ export function CreateBranchDialog({
   });
   // Drives the "Branches from …" copy in the dialog description.
   const createBase = useSelector(createForm.store, (s) => s.values.base);
+  // The committed fallback describes HEAD's work, so it only describes the new
+  // branch when the new branch starts at HEAD ("" ⇒ no start point ⇒ HEAD).
+  // Branching off origin/main carries none of it. The working-tree path is
+  // unaffected — uncommitted changes come along whatever the base.
+  const baseIsHead = createBase === "" || createBase === currentName;
 
   // NOTE: seeding resets must pass keepDefaultValues — otherwise reset()
   // rewrites the form's defaultValues, and react-form's per-render options
@@ -174,6 +188,9 @@ export function CreateBranchDialog({
             headExists={headExists}
             entries={entries}
             recentBranches={allBranchNames}
+            nameTarget="new-branch"
+            committedFallback={baseIsHead ? committedFallback : null}
+            committedPending={baseIsHead && committedPending}
             onName={(name) => createForm.setFieldValue("name", name)}
             onSetupAi={() => {
               onOpenChange(false);

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -27,7 +27,9 @@ import type { CommittedNameSource } from "./useGenerateBranchName";
 
 /**
  * Create-branch dialog: names a new branch (with optional AI generation from
- * the working-tree changes), picks its base, and switches to it. Owns its own
+ * the working-tree changes, or — when it branches from HEAD with a clean tree —
+ * the current branch's committed work), picks its base, and switches to it.
+ * Owns its own
  * form + the create mutation + the branch-name generator — the switcher only
  * decides whether it's open and hands down the data it renders. Seeds the base
  * on open so it reflects the branch you were on when you triggered it.
@@ -44,7 +46,7 @@ export function CreateBranchDialog({
   entries,
   allBranchNames,
   committedFallback,
-  committedPending,
+  committedStatus,
   currentName,
   defaultName,
   onOpenSettings,
@@ -63,8 +65,9 @@ export function CreateBranchDialog({
    *  against HEAD) — the AI name-generation fallback when the working tree is
    *  clean. Only applies when the new branch is based on HEAD; see below. */
   committedFallback: CommittedNameSource | null;
-  /** Whether `committedFallback` is still resolving. */
-  committedPending: boolean;
+  /** How the committed-work lookup stands (pending/error are surfaced rather
+   *  than read as "there is none"). */
+  committedStatus: "ready" | "pending" | "error";
   currentName: string | null;
   defaultName: string | null;
   onOpenSettings: (section: "ai") => void;
@@ -190,7 +193,10 @@ export function CreateBranchDialog({
             recentBranches={allBranchNames}
             nameTarget="new-branch"
             committedFallback={baseIsHead ? committedFallback : null}
-            committedPending={baseIsHead && committedPending}
+            // Resolved by definition when the fallback can't apply — the button
+            // explains the picked base instead of waiting on a lookup it won't use.
+            committedStatus={baseIsHead ? committedStatus : "ready"}
+            basedElsewhere={baseIsHead ? null : createBase}
             onName={(name) => createForm.setFieldValue("name", name)}
             onSetupAi={() => {
               onOpenChange(false);

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -62,8 +62,9 @@ export function CreateBranchDialog({
   entries: FileEntry[];
   allBranchNames: string[];
   /** The checked-out branch's committed work vs the default branch (compared
-   *  against HEAD) — the AI name-generation fallback when the working tree is
-   *  clean. Only applies when the new branch is based on HEAD; see below. */
+   *  against the checked-out branch by name) — the AI name-generation fallback
+   *  when the working tree is clean. Only applies when the new branch is based
+   *  on HEAD; see below. */
   committedFallback: CommittedNameSource | null;
   /** How the committed-work lookup stands (pending/error are surfaced rather
    *  than read as "there is none"). */

--- a/src/features/repository/GenerateBranchNameButton.tsx
+++ b/src/features/repository/GenerateBranchNameButton.tsx
@@ -2,14 +2,33 @@ import { SparkleIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { FileEntry } from "@/lib/git/types";
-import { useGenerateBranchName } from "./useGenerateBranchName";
+import {
+  type CommittedNameSource,
+  useGenerateBranchName,
+} from "./useGenerateBranchName";
+
+/** What the generated name has to describe — decides whether the working tree
+ *  counts as a source and whether the branch's commit subjects describe it. */
+export type BranchNameTarget =
+  /** A new branch off the picked base (create dialog): the working tree comes
+   *  along, but the current branch's commits describe the parent, not it. */
+  | "new-branch"
+  /** The checked-out branch (rename): its working tree AND its commits both
+   *  describe it. */
+  | "checked-out-branch"
+  /** A branch that isn't checked out (rename from a row's menu): only its own
+   *  commits describe it — the working tree belongs to someone else. */
+  | "other-branch";
 
 /**
  * The "✧ Generate from changes" affordance shared by the create- and
- * rename-branch dialogs: suggests a branch name from the working-tree changes,
- * or points the user at AI setup when no provider is connected. Renders nothing
- * when AI is disabled. Owns its own generation stream, so each dialog only says
- * where the name lands (`onName`) and how to reach AI settings (`onSetupAi`).
+ * rename-branch dialogs: suggests a branch name from the working-tree changes
+ * (when they describe the branch being named) — or, failing that, from that
+ * branch's committed work (`committedFallback`) — or points the user at AI
+ * setup when no provider is connected. Renders nothing when AI is disabled.
+ * Owns its own generation stream, so each dialog only says what's being named
+ * (`nameTarget`), where the name lands (`onName`), and how to reach AI settings
+ * (`onSetupAi`).
  */
 export function GenerateBranchNameButton({
   repoPath,
@@ -19,6 +38,9 @@ export function GenerateBranchNameButton({
   headExists,
   entries,
   recentBranches,
+  nameTarget,
+  committedFallback,
+  committedPending,
   onName,
   onSetupAi,
 }: {
@@ -30,12 +52,39 @@ export function GenerateBranchNameButton({
   entries: FileEntry[];
   /** Existing branch names, used as a naming-convention reference (capped). */
   recentBranches: string[];
+  /** What the name must describe — see {@link BranchNameTarget}. */
+  nameTarget: BranchNameTarget;
+  /** The committed work of the branch being named, vs the default branch. Null
+   *  when it has none, when no default branch resolves, or when the host dialog
+   *  suppresses it (a create whose base isn't the branch you're on). */
+  committedFallback: CommittedNameSource | null;
+  /** Whether `committedFallback` is still being resolved — a null fallback
+   *  doesn't yet mean there's no committed work, so the button must say it's
+   *  still checking rather than claim there's nothing. */
+  committedPending: boolean;
   onName: (name: string) => void;
   /** Close the host dialog and open AI settings. */
   onSetupAi: () => void;
 }) {
   const branchNameGen = useGenerateBranchName(repoPath);
   if (!aiEnabled) return null;
+  // The working tree belongs to the checked-out branch, so it can only name a
+  // new branch or that branch itself.
+  const useWorkingTree = nameTarget !== "other-branch";
+  const fromWorkingTree = useWorkingTree && hasChanges;
+  const canGenerate =
+    headExists && (fromWorkingTree || committedFallback !== null);
+  const reason = !headExists
+    ? "Make your first commit before branching from changes"
+    : fromWorkingTree
+      ? "Suggest a name from your in-progress changes"
+      : committedFallback
+        ? "Suggest a name from this branch's committed changes"
+        : committedPending
+          ? "Checking this branch's committed work…"
+          : useWorkingTree
+            ? "No in-progress changes and no committed work vs the default branch — nothing to name a branch after"
+            : "This branch has no commits the default branch doesn't — nothing to name it after";
   return (
     <div className="flex justify-end">
       {!aiConfigured ? (
@@ -62,30 +111,34 @@ export function GenerateBranchNameButton({
           Generating…
         </Button>
       ) : (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          className="text-muted-foreground"
-          disabled={!hasChanges || !headExists}
-          title={
-            !headExists
-              ? "Make your first commit before branching from changes"
-              : !hasChanges
-                ? "No in-progress changes — make some edits to name a branch after them"
-                : "Suggest a name from your in-progress changes"
-          }
-          onClick={() =>
-            branchNameGen.generate({
-              entries,
-              recentBranches: recentBranches.slice(0, 20),
-              onName,
-            })
-          }
-        >
-          <SparkleIcon data-icon="inline-start" />
-          Generate from changes
-        </Button>
+        // Wrap so the reason still shows when the button is disabled — a
+        // native-disabled button swallows the tooltip.
+        <span className="inline-flex" title={reason}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="text-muted-foreground"
+            disabled={!canGenerate}
+            onClick={() =>
+              branchNameGen.generate({
+                entries,
+                recentBranches: recentBranches.slice(0, 20),
+                useWorkingTree,
+                // Only when naming the very branch those commits sit on.
+                workingTreeSubjects:
+                  nameTarget === "checked-out-branch"
+                    ? (committedFallback?.subjects ?? [])
+                    : [],
+                committedFallback,
+                onName,
+              })
+            }
+          >
+            <SparkleIcon data-icon="inline-start" />
+            Generate from changes
+          </Button>
+        </span>
       )}
     </div>
   );

--- a/src/features/repository/GenerateBranchNameButton.tsx
+++ b/src/features/repository/GenerateBranchNameButton.tsx
@@ -40,7 +40,8 @@ export function GenerateBranchNameButton({
   recentBranches,
   nameTarget,
   committedFallback,
-  committedPending,
+  committedStatus,
+  basedElsewhere,
   onName,
   onSetupAi,
 }: {
@@ -58,10 +59,15 @@ export function GenerateBranchNameButton({
    *  when it has none, when no default branch resolves, or when the host dialog
    *  suppresses it (a create whose base isn't the branch you're on). */
   committedFallback: CommittedNameSource | null;
-  /** Whether `committedFallback` is still being resolved — a null fallback
-   *  doesn't yet mean there's no committed work, so the button must say it's
-   *  still checking rather than claim there's nothing. */
-  committedPending: boolean;
+  /** How the committed-work lookup stands. Only `"ready"` makes a null
+   *  `committedFallback` mean "there is none" — while it's `"pending"` or
+   *  `"error"` the button must say so instead of claiming there's nothing. */
+  committedStatus: "ready" | "pending" | "error";
+  /** The base a new branch will start from, when that base ISN'T the branch
+   *  you're on — the committed fallback can't apply (the new branch contains
+   *  none of that work), and the disabled state must say THAT rather than
+   *  claim there's no committed work. Null whenever the fallback does apply. */
+  basedElsewhere: string | null;
   onName: (name: string) => void;
   /** Close the host dialog and open AI settings. */
   onSetupAi: () => void;
@@ -80,11 +86,15 @@ export function GenerateBranchNameButton({
       ? "Suggest a name from your in-progress changes"
       : committedFallback
         ? "Suggest a name from this branch's committed changes"
-        : committedPending
+        : committedStatus === "pending"
           ? "Checking this branch's committed work…"
-          : useWorkingTree
-            ? "No in-progress changes and no committed work vs the default branch — nothing to name a branch after"
-            : "This branch has no commits the default branch doesn't — nothing to name it after";
+          : committedStatus === "error"
+            ? "Couldn't check this branch's committed work"
+            : basedElsewhere
+              ? `Branching from ${basedElsewhere} — a name can only come from your in-progress changes`
+              : useWorkingTree
+                ? "No in-progress changes and no committed work vs the default branch — nothing to name a branch after"
+                : "This branch has no commits the default branch doesn't — nothing to name it after";
   return (
     <div className="flex justify-end">
       {!aiConfigured ? (

--- a/src/features/repository/RenameBranchDialog.tsx
+++ b/src/features/repository/RenameBranchDialog.tsx
@@ -15,15 +15,19 @@ import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
 import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
+import type { CommittedNameSource } from "./useGenerateBranchName";
 
 /**
  * Rename-branch dialog. Open when `target` is the branch being renamed (null =
  * closed). Owns its own form + the rename mutation; seeds the field with the
- * current name on open so the user edits from there.
+ * current name on open so the user edits from there. The target need not be the
+ * checked-out branch — every branch row's context menu opens this — so AI name
+ * generation reads the working tree only when it is.
  */
 export function RenameBranchDialog({
   repoPath,
   target,
+  currentName,
   onClose,
   aiEnabled,
   aiConfigured,
@@ -31,10 +35,15 @@ export function RenameBranchDialog({
   headExists,
   entries,
   allBranchNames,
+  committedFallback,
+  committedPending,
   onOpenSettings,
 }: {
   repoPath: string;
   target: string | null;
+  /** The checked-out branch — decides whether `target`'s working tree is its
+   *  own (null when HEAD is detached, which is never the rename target). */
+  currentName: string | null;
   onClose: () => void;
   aiEnabled: boolean;
   aiConfigured: boolean;
@@ -42,9 +51,16 @@ export function RenameBranchDialog({
   headExists: boolean;
   entries: FileEntry[];
   allBranchNames: string[];
+  /** The committed work of the branch being renamed, vs the default branch —
+   *  compared against `target` itself, not HEAD. */
+  committedFallback: CommittedNameSource | null;
+  /** Whether `committedFallback` is still resolving. */
+  committedPending: boolean;
   onOpenSettings: (section: "ai") => void;
 }) {
   const renameBranch = useRenameBranch(repoPath);
+  // Only the checked-out branch's own working tree describes it.
+  const targetIsCurrent = target !== null && target === currentName;
 
   const renameForm = useAppForm({
     defaultValues: { name: "" },
@@ -117,6 +133,9 @@ export function RenameBranchDialog({
             headExists={headExists}
             entries={entries}
             recentBranches={allBranchNames}
+            nameTarget={targetIsCurrent ? "checked-out-branch" : "other-branch"}
+            committedFallback={committedFallback}
+            committedPending={committedPending}
             onName={(name) => renameForm.setFieldValue("name", name)}
             onSetupAi={() => {
               onClose();

--- a/src/features/repository/RenameBranchDialog.tsx
+++ b/src/features/repository/RenameBranchDialog.tsx
@@ -36,7 +36,7 @@ export function RenameBranchDialog({
   entries,
   allBranchNames,
   committedFallback,
-  committedPending,
+  committedStatus,
   onOpenSettings,
 }: {
   repoPath: string;
@@ -54,8 +54,9 @@ export function RenameBranchDialog({
   /** The committed work of the branch being renamed, vs the default branch —
    *  compared against `target` itself, not HEAD. */
   committedFallback: CommittedNameSource | null;
-  /** Whether `committedFallback` is still resolving. */
-  committedPending: boolean;
+  /** How the committed-work lookup stands (pending/error are surfaced rather
+   *  than read as "there is none"). */
+  committedStatus: "ready" | "pending" | "error";
   onOpenSettings: (section: "ai") => void;
 }) {
   const renameBranch = useRenameBranch(repoPath);
@@ -135,7 +136,9 @@ export function RenameBranchDialog({
             recentBranches={allBranchNames}
             nameTarget={targetIsCurrent ? "checked-out-branch" : "other-branch"}
             committedFallback={committedFallback}
-            committedPending={committedPending}
+            committedStatus={committedStatus}
+            // Renaming never picks a base — the fallback always applies here.
+            basedElsewhere={null}
             onName={(name) => renameForm.setFieldValue("name", name)}
             onSetupAi={() => {
               onClose();

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
 import { buildBranchNamePrompt, extractBranchName } from "@/lib/ai/prompt";
 import {
+  gitBranchDiff,
   gitStagedDiff,
   readRepoAiIgnore,
   readRepoInstructions,
@@ -13,11 +14,24 @@ import type { FileEntry } from "@/lib/git/types";
 /** Raw diff bytes requested from the backend; prompt budgeting trims further. */
 const RAW_DIFF_MAX_BYTES = 200_000;
 
+/** The committed work of the ref being named: its three-dot diff against
+ *  `base` plus the subjects of the commits `compare` has that `base` doesn't.
+ *  `compare` is the ref being named — HEAD when creating a branch, the target
+ *  branch when renaming one that isn't checked out. */
+export interface CommittedNameSource {
+  base: string;
+  compare: string;
+  subjects: string[];
+}
+
 /**
- * Suggests a branch name from the repo's in-progress changes (the whole working
- * tree vs HEAD, plus untracked file names), using the existing branches as a
- * convention reference. The caller gates this on having changes — there's
- * nothing to name a branch after when the tree is clean.
+ * Suggests a name for a branch from the repo's in-progress changes (the whole
+ * working tree vs HEAD, plus untracked file names), using the existing branches
+ * as a convention reference. When the tree is clean — or when the branch being
+ * named isn't the checked-out one, so the working tree doesn't describe it at
+ * all (`useWorkingTree: false`) — it names the branch from `committedFallback`
+ * instead. The caller gates the affordance on at least one source being
+ * available and decides which of them the commit subjects describe.
  */
 export function useGenerateBranchName(repoPath: string) {
   const { generating, cancel, run } = useAiStream(repoPath);
@@ -26,6 +40,17 @@ export function useGenerateBranchName(repoPath: string) {
     async (opts: {
       entries: FileEntry[];
       recentBranches: string[];
+      /** Whether the working tree describes the branch being named. False when
+       *  renaming a branch that isn't checked out — its working tree belongs to
+       *  the checked-out branch, so it must not be read at all. */
+      useWorkingTree: boolean;
+      /** Subjects to accompany the WORKING-TREE prompt. Empty unless the
+       *  branch's commits describe the same work as the in-progress changes
+       *  (renaming the checked-out branch) — in the create dialog they describe
+       *  the parent branch and would bias the name away from the new work. */
+      workingTreeSubjects: string[];
+      /** The committed work of the branch being named, when it has any. */
+      committedFallback: CommittedNameSource | null;
       onName: (name: string) => void;
     }) => {
       const buffer = await run(async (settings) => {
@@ -37,39 +62,96 @@ export function useGenerateBranchName(repoPath: string) {
         const exclude = [...repoIgnore, ...globalIgnore];
 
         const [diff, repoInstructions] = await Promise.all([
-          gitStagedDiff(repoPath, {
-            maxBytes: RAW_DIFF_MAX_BYTES,
-            exclude,
-            worktree: true,
-          }),
+          opts.useWorkingTree
+            ? gitStagedDiff(repoPath, {
+                maxBytes: RAW_DIFF_MAX_BYTES,
+                exclude,
+                worktree: true,
+              })
+            : null,
           readRepoInstructions(repoPath),
         ]);
 
         // `git diff HEAD` omits untracked files; bring their names in so a
         // branch made of all-new files can still be named.
-        const untrackedPaths = opts.entries
-          .filter((e) => e.unstaged === "untracked")
-          .map((e) => e.path);
+        const untrackedPaths = opts.useWorkingTree
+          ? opts.entries
+              .filter((e) => e.unstaged === "untracked")
+              .map((e) => e.path)
+          : [];
 
-        if (diff.files.length === 0 && untrackedPaths.length === 0) {
-          toast.error(
-            diff.excludedFiles > 0
-              ? "All changes match your AI ignore patterns — nothing to name a branch after."
-              : "No in-progress changes to name a branch after.",
-          );
-          return null;
+        if (diff && (diff.files.length > 0 || untrackedPaths.length > 0)) {
+          return buildBranchNamePrompt({
+            diffText: diff.text,
+            diffTruncated: diff.truncated,
+            files: diff.files,
+            untrackedPaths,
+            excludedFiles: diff.excludedFiles,
+            commitSubjects: opts.workingTreeSubjects,
+            recentBranches: opts.recentBranches,
+            repoInstructions,
+            globalInstructions: settings.globalInstructions,
+          });
         }
 
-        return buildBranchNamePrompt({
-          diffText: diff.text,
-          diffTruncated: diff.truncated,
-          files: diff.files,
-          untrackedPaths,
-          excludedFiles: diff.excludedFiles,
-          recentBranches: opts.recentBranches,
-          repoInstructions,
-          globalInstructions: settings.globalInstructions,
-        });
+        // No usable working tree: name the branch from what it has already
+        // committed — the three-dot diff vs the default branch, the same set a
+        // PR would show, taken against the ref actually being named.
+        const fallback = opts.committedFallback;
+        const committed = fallback
+          ? await gitBranchDiff(
+              repoPath,
+              fallback.base,
+              fallback.compare,
+              RAW_DIFF_MAX_BYTES,
+              exclude,
+            )
+          : null;
+        if (
+          fallback &&
+          committed &&
+          (committed.files.length > 0 || committed.text !== "")
+        ) {
+          return buildBranchNamePrompt({
+            diffText: committed.text,
+            diffTruncated: committed.truncated,
+            files: committed.files,
+            untrackedPaths: [],
+            // Both sides' hidden files, so the count covers the in-progress
+            // changes this path skipped over as well as the committed ones.
+            excludedFiles: committed.excludedFiles + (diff?.excludedFiles ?? 0),
+            commitSubjects: fallback.subjects,
+            recentBranches: opts.recentBranches,
+            repoInstructions,
+            globalInstructions: settings.globalInstructions,
+          });
+        }
+
+        // Nothing to name it after — say which side (if either) was emptied by
+        // the ignore patterns rather than genuinely having no changes.
+        const treeHidden = diff !== null && diff.excludedFiles > 0;
+        const committedHidden =
+          committed !== null && committed.excludedFiles > 0;
+        let message: string;
+        if (treeHidden && committedHidden) {
+          message =
+            "All changes match your AI ignore patterns — nothing left in your working tree or this branch's commits to name it after.";
+        } else if (committedHidden) {
+          message =
+            "This branch's committed changes all match your AI ignore patterns — nothing to name it after.";
+        } else if (treeHidden) {
+          message = fallback
+            ? `All your in-progress changes match your AI ignore patterns, and there are no net changes vs ${fallback.base} to name a branch after.`
+            : "All changes match your AI ignore patterns — nothing to name a branch after.";
+        } else if (fallback) {
+          message = opts.useWorkingTree
+            ? `No in-progress changes, and no net changes vs ${fallback.base} to name a branch after.`
+            : `No net changes vs ${fallback.base} to name this branch after.`;
+        } else {
+          message = "No in-progress changes to name a branch after.";
+        }
+        toast.error(message);
+        return null;
       });
 
       if (buffer === null) return;

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -117,8 +117,9 @@ export function useGenerateBranchName(repoPath: string) {
             diffTruncated: committed.truncated,
             files: committed.files,
             untrackedPaths: [],
-            // Both sides' hidden files, so the count covers the in-progress
-            // changes this path skipped over as well as the committed ones.
+            // Both sides' hidden files. A file hidden in BOTH diffs counts
+            // twice — deliberately: the sum errs toward disclosing more than is
+            // hidden, never less, and there's no per-path list to dedupe on.
             excludedFiles: committed.excludedFiles + (diff?.excludedFiles ?? 0),
             commitSubjects: fallback.subjects,
             recentBranches: opts.recentBranches,
@@ -147,8 +148,12 @@ export function useGenerateBranchName(repoPath: string) {
           message = opts.useWorkingTree
             ? `No in-progress changes, and no net changes vs ${fallback.base} to name a branch after.`
             : `No net changes vs ${fallback.base} to name this branch after.`;
-        } else {
+        } else if (opts.useWorkingTree) {
           message = "No in-progress changes to name a branch after.";
+        } else {
+          // Defensive: the caller disables the affordance in this state, and
+          // with no working tree read there are no in-progress changes to cite.
+          message = "Nothing to name this branch after.";
         }
         toast.error(message);
         return null;

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -16,8 +16,10 @@ const RAW_DIFF_MAX_BYTES = 200_000;
 
 /** The committed work of the ref being named: its three-dot diff against
  *  `base` plus the subjects of the commits `compare` has that `base` doesn't.
- *  `compare` is the ref being named — HEAD when creating a branch, the target
- *  branch when renaming one that isn't checked out. */
+ *  `compare` is the ref being named — the checked-out branch's NAME when
+ *  creating (the literal `HEAD` only when HEAD is detached; keying on a name
+ *  keeps a branch switch from serving the previous branch's commits), the
+ *  target branch when renaming. */
 export interface CommittedNameSource {
   base: string;
   compare: string;

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -1,11 +1,11 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
+import { aiExcludePatterns } from "@/lib/ai/ignore";
 import { buildBranchNamePrompt, extractBranchName } from "@/lib/ai/prompt";
 import {
   gitBranchDiff,
   gitStagedDiff,
-  readRepoAiIgnore,
   readRepoInstructions,
 } from "@/lib/git/api";
 import { sanitizeRefName } from "@/lib/git/ref-name";
@@ -54,12 +54,10 @@ export function useGenerateBranchName(repoPath: string) {
       onName: (name: string) => void;
     }) => {
       const buffer = await run(async (settings) => {
-        const repoIgnore = await readRepoAiIgnore(repoPath);
-        const globalIgnore = settings.aiIgnorePatterns
-          .split("\n")
-          .map((line) => line.trim())
-          .filter((line) => line && !line.startsWith("#"));
-        const exclude = [...repoIgnore, ...globalIgnore];
+        const exclude = await aiExcludePatterns(
+          repoPath,
+          settings.aiIgnorePatterns,
+        );
 
         const [diff, repoInstructions] = await Promise.all([
           opts.useWorkingTree

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -1,0 +1,31 @@
+import { readRepoAiIgnore } from "@/lib/git/api";
+
+/** Lines of a newline-joined ignore-pattern string, dropping blanks + comments. */
+function ignoreLines(patterns: string): string[] {
+  return patterns
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+}
+
+/**
+ * The user's AI-ignore patterns for a repo: the repo's own
+ * `.gitdesktop/aiignore` entries first, then the global setting's lines — the
+ * exclude list every AI generation path hands the git layer as pathspec
+ * excludes, so a file the user excluded never reaches a model.
+ *
+ * `aiIgnorePatterns` is the raw newline-joined setting. Rejects when the repo
+ * file can't be read; the conflict-resolve surface passes
+ * `tolerateRepoReadError` because an unreadable repo file must not abort a
+ * resolution that the global patterns alone can still serve.
+ */
+export async function aiExcludePatterns(
+  repoPath: string,
+  aiIgnorePatterns: string,
+  opts?: { tolerateRepoReadError?: boolean },
+): Promise<string[]> {
+  const repoIgnore = opts?.tolerateRepoReadError
+    ? await readRepoAiIgnore(repoPath).catch(() => [])
+    : await readRepoAiIgnore(repoPath);
+  return [...repoIgnore, ...ignoreLines(aiIgnorePatterns)];
+}

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -112,6 +112,11 @@ export function buildBranchNamePrompt(input: BranchNamePromptInput): {
       `## Existing branch names (convention reference)\n${input.recentBranches.join("\n")}`,
     );
   }
+  if (input.commitSubjects.length > 0) {
+    promptParts.push(
+      `## Commits on this branch (newest first)\n${input.commitSubjects.join("\n")}`,
+    );
+  }
   const diffBody =
     budgeted.text ||
     "(no text diff — name the branch from the file list above)";
@@ -293,7 +298,11 @@ export function buildPrPrompt(input: PrPromptInput): {
       `## Commits in this ${abbrev}\n${input.commitSubjects.map((s) => `- ${s}`).join("\n")}`,
     );
   }
-  promptParts.push(`## Files changed\n${fileSummary || "(none)"}`);
+  let filesSection = `## Files changed\n${fileSummary || "(none)"}`;
+  if ((input.excludedFiles ?? 0) > 0) {
+    filesSection += `\n[${input.excludedFiles} additional changed file(s) hidden by the user's AI ignore rules]`;
+  }
+  promptParts.push(filesSection);
 
   // Author's "Notes for reviewers" — reflect the recorded decisions in the
   // description, don't paste them verbatim. Same trim + disclosed 8000-char cap as

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -73,7 +73,7 @@ export function buildCommitPrompt(input: CommitPromptInput): {
   };
 }
 
-const BRANCH_SYSTEM = `You generate a single git branch name for a set of in-progress changes.
+const BRANCH_SYSTEM = `You generate a single git branch name for a set of code changes.
 Output ONLY the branch name — one line, nothing else: no quotes, no explanation, no markdown, no trailing period.
 Use lowercase kebab-case, 2-5 words, specific to what the change does (avoid generic names like "updates" or "changes").
 If the existing branch names below show a prefix convention (e.g. "feature/", "fix/", "chore/"), follow it; otherwise pick a fitting type prefix such as "feature/" or "fix/".

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -66,6 +66,10 @@ export interface PrPromptInput {
   diffText: string;
   diffTruncated: boolean;
   files: { path: string; added: number; deleted: number; isBinary: boolean }[];
+  /** Changed files hidden from this context by the user's ignore patterns.
+   *  Absent/0 ⇒ no disclosure line (prompt unchanged) — the remote-PR path
+   *  supplies its own diff and applies no excludes. */
+  excludedFiles?: number;
   /** Subjects of the commits this PR would introduce (base..head). */
   commitSubjects: string[];
   baseBranch: string;
@@ -107,6 +111,9 @@ export interface BranchNamePromptInput {
   untrackedPaths: string[];
   /** Changed files hidden from this context by the user's ignore patterns. */
   excludedFiles: number;
+  /** Subjects of the commits already on this branch, newest first — the branch's
+   *  committed work. Empty when there are none (or when it isn't resolvable). */
+  commitSubjects: string[];
   /** Existing branch names, as a naming-convention / style reference. */
   recentBranches: string[];
   repoInstructions: string | null;

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -991,17 +991,23 @@ export const gitBranchFileDiff = (
     filePath,
   });
 
+/** Three-dot `base...compare` diff. `exclude` takes gitignore-style patterns the
+ *  backend filters out of the text and file list (counting them in
+ *  `excludedFiles`): generation callers pass the user's AI-ignore patterns;
+ *  review callers deliberately omit them — a review wants the full diff. */
 export const gitBranchDiff = (
   repoPath: string,
   base: string,
   compare: string,
   maxBytes?: number,
+  exclude?: string[],
 ) =>
   invoke<StagedDiff>("git_branch_diff", {
     repoPath,
     base,
     compare,
     maxBytes: maxBytes ?? null,
+    exclude: exclude ?? null,
   });
 
 /** The literal `fromRef..toRef` diff — "what changed since the last review".


### PR DESCRIPTION
Two related gaps in AI generation: **Generate from changes** was dead on a branch whose work is already committed — exactly when a rename is usually wanted — and the branch-range paths (PR description, squashed commit message) shipped the whole diff to the provider, ignoring the user's AI ignore patterns. This teaches branch naming to fall back to a branch's committed work (three-dot diff + commit subjects vs. the default branch), and threads ignore patterns through every `git_branch_diff`-backed generation path, disclosing in the prompt how many files were held back.

### Branch naming from committed work

- `src/features/repository/useGenerateBranchName.ts` gains a `CommittedNameSource` shape and `useWorkingTree` / `workingTreeSubjects` / `committedFallback` options: when the working tree is clean (or doesn't belong to the branch being named), it names the branch from `gitBranchDiff(base, compare)` plus the commit subjects, and its failure toasts now name which side was empty vs. emptied by ignore patterns.
- `src/features/repository/GenerateBranchNameButton.tsx` introduces a `BranchNameTarget` union (`new-branch` / `checked-out-branch` / `other-branch`) that decides whether the working tree and the commit subjects describe the branch at hand, computes `canGenerate` + a `reason` string covering every state — including a distinct "Checking this branch's committed work…", a lookup-error state, and "Branching from `<base>`…" when the create dialog's picked base means committed work can't apply — and wraps the button in a `<span title>` so the disabled state explains itself (a native-disabled button swallows the tooltip).
- `src/features/repository/BranchSwitcher.tsx` resolves the fallback once for both dialogs: `committedBase` prefers `origin/<default>` over a possibly-stale local default (and refuses the local fallback until the remote list has settled), `committedFallback` comes from `useCompareBranches` (subjects capped at 30) keyed on the branch name rather than the literal `HEAD` — so switching branches re-keys the cache instead of serving the previous branch's commits — and a `committedStatus` (`ready` / `pending` / `error`) keeps the button from claiming "nothing to name" while inputs are in flight or after a failed lookup. `useRemoteBranches` is now also enabled while a branch dialog is open, since the palette can open one without the menu, and the two branch dialogs are mutually exclusive (their palette actions clear each other).
- `src/features/repository/CreateBranchDialog.tsx` only passes the fallback through when the new branch starts at HEAD (`baseIsHead`); when the base is elsewhere, the button says that's the reason (`basedElsewhere`) rather than claiming there's no committed work. `src/features/repository/RenameBranchDialog.tsx` takes `currentName` and picks `checked-out-branch` vs. `other-branch` accordingly, so renaming a branch from another branch's row never reads the wrong working tree.
- `buildBranchNamePrompt` in `src/lib/ai/prompt.ts` renders a new `## Commits on this branch (newest first)` section between the branch-name reference and the diff, backed by `BranchNamePromptInput.commitSubjects` in `src/lib/ai/types.ts`. `BRANCH_SYSTEM` now says "a set of code changes" — on the fallback path the changes aren't in-progress.

### AI ignore patterns on branch-range diffs

- `git_branch_diff` in `src-tauri/src/git/compare.rs` takes an `exclude` list, translating each pattern into a `:(exclude)` pathspec (with the required leading `.`, skipping blank and `#` lines) and reporting `excluded_files` by diffing the filtered file count against an unfiltered `--numstat`. The text and numstat runs are now issued concurrently via `tokio::try_join!`, and the extra count query only fires when excludes are present; `exclude: None` is byte-identical to the old behavior.
- `gitBranchDiff` in `src/lib/git/api.ts` grows the optional `exclude` parameter, documented as opt-in for generation callers only — review callers keep the full diff on purpose.
- `src/features/pulls/useGeneratePrDescription.ts` hands the loaded `AppSettings` to its `getDiff` supplier so the local-branch supplier can merge `readRepoAiIgnore` with the global patterns; `excludedFiles` flows into the prompt, and the empty-diff toast distinguishes "no changes" from "all changes ignored". Remote-PR regeneration is unaffected (`SuppliedDiff.excludedFiles` is optional — the forge diff has no paths to filter).
- `useGenerateSquashMessage` in `src/features/history/RewriteDialogs.tsx` does the same merge before `gitBranchDiff`, passes the real `excludedFiles` into `buildCommitPrompt` (previously hardcoded `0`), gets the matching toast, and its Generate button's disabled state now explains itself too.
- `buildPrPrompt` in `src/lib/ai/prompt.ts` appends `[N additional changed file(s) hidden by the user's AI ignore rules]` to the *Files changed* section, driven by the new optional `PrPromptInput.excludedFiles` in `src/lib/ai/types.ts`.

### MCP server recipes

- `src-tauri/src/mcp_server/generate.rs` factors the repo-ignore + global-settings merge into a shared `ai_ignore_patterns` helper (one settings read per recipe) and uses it in `build_pr_recipe`, which now passes excludes to `git_branch_diff`, carries `excluded_files` into `PrPieces` / `assemble_pr_recipe`, and errors on a range whose visible diff is empty — naming whether the ignore patterns hid everything or there's genuinely nothing to describe — instead of returning a file-less recipe.
- `build_branch_recipe` gains the same committed-work fallback as the app: base resolution via new `committed_base_ref` / `ref_exists` helpers (preferring `refs/remotes/origin/<default>`, then `refs/heads/<default>`, else no fallback), commit subjects supplied **on the fallback path only** — mirroring the app's create-dialog gating — via a scoped `git log --format=%s -n 30` helper (`branch_commit_subjects`; no unbounded ahead/behind walk), and six distinct `invalid_request` messages so the true reason is named rather than guessed. Working-tree and committed hidden-file counts are summed for the disclosure (an upper bound: a file hidden in both diffs counts twice — over-disclosing is the deliberate direction).
- `BranchPieces` carries `commit_subjects`, rendered by `assemble_branch_recipe` between the existing branch names and the diff; the `generate_branch_name` tool and `branch_name_prompt` descriptions are updated to document the fallback.

### Tests

- `compare.rs`: `branch_diff_applies_exclude_pathspecs` covers filtered text + file list, the `excluded_files` count, and that blank/comment-only patterns are a no-op identical to `None`.
- `generate.rs`: `branch_recipe_renders_commit_subjects_between_branches_and_diff` pins the section ordering, `pr_recipe_reports_excluded_files` pins the disclosure line (and its absence at zero), `committed_base_ref_prefers_remote_tracking` exercises remote-preferred / local-fallback / no-base against a real temp repo, and `branch_commit_subjects_are_newest_first` covers the scoped subjects helper (empty range → empty list; newest-first order). Existing `PrPieces` fixtures are updated for the new field.

### Docs

- `src/features/help/content.ts` extends the branch-switcher AI bullet to describe the committed-work fallback (a clean tree, or renaming a branch you aren't on).
- Changelog fragments `changelog.d/fixed-branch-name-from-committed-work.md` and `changelog.d/fixed-branch-diff-ai-ignore.md`.