### PR TITLE
fix(github,jira,repository,git): edit commit comments on the right repo

### DIFF
--- a/changelog.d/fixed-commit-comment-fork-lens.md
+++ b/changelog.d/fixed-commit-comment-fork-lens.md
@@ -1,0 +1,3 @@
+- Editing or deleting a commit comment while viewing a fork through the
+  parent-repository (upstream) lens now targets the same repository the comment
+  was created on, instead of failing against the fork.

--- a/changelog.d/fixed-jira-estimate-stale-warning.md
+++ b/changelog.d/fixed-jira-estimate-stale-warning.md
@@ -1,0 +1,2 @@
+- Jira estimate fields no longer keep showing the "Enter a Jira duration" warning
+  after the value refreshes from the server.

--- a/changelog.d/fixed-relocate-duplicate-records.md
+++ b/changelog.d/fixed-relocate-duplicate-records.md
@@ -1,0 +1,2 @@
+- Relocating a repository no longer lets duplicate legacy records — including
+  records without ids — through when merging its old app data.

--- a/changelog.d/fixed-relocate-duplicate-records.md
+++ b/changelog.d/fixed-relocate-duplicate-records.md
@@ -1,2 +1,3 @@
-- Relocating a repository no longer lets duplicate legacy records — including
-  records without ids — through when merging its old app data.
+- Merging a repository's old app data — on relocate, or when older path-keyed
+  records are folded onto its stable identity — no longer lets duplicate legacy
+  records (including records without ids) through.

--- a/changelog.d/fixed-rewrite-error-garbled-dash.md
+++ b/changelog.d/fixed-rewrite-error-garbled-dash.md
@@ -1,0 +1,2 @@
+- The error shown when a history-rewrite operation is blocked by uncommitted
+  changes no longer contains garbled characters — the dash renders properly.

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -142,12 +142,21 @@ pub async fn commit_comment_create(
     crate::github::pr::commit_comment_create(repo_path, sha, body, path, position, lens).await
 }
 
-pub async fn commit_comment_edit(repo_path: &str, comment_id: &str, body: &str) -> AppResult<()> {
-    crate::github::pr::commit_comment_edit(repo_path, comment_id, body).await
+pub async fn commit_comment_edit(
+    repo_path: &str,
+    comment_id: &str,
+    body: &str,
+    lens: Option<&str>,
+) -> AppResult<()> {
+    crate::github::pr::commit_comment_edit(repo_path, comment_id, body, lens).await
 }
 
-pub async fn commit_comment_delete(repo_path: &str, comment_id: &str) -> AppResult<()> {
-    crate::github::pr::commit_comment_delete(repo_path, comment_id).await
+pub async fn commit_comment_delete(
+    repo_path: &str,
+    comment_id: &str,
+    lens: Option<&str>,
+) -> AppResult<()> {
+    crate::github::pr::commit_comment_delete(repo_path, comment_id, lens).await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1096,6 +1096,7 @@ pub async fn forge_commit_comment_edit(
     sha: String,
     comment_id: String,
     body: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -1104,8 +1105,9 @@ pub async fn forge_commit_comment_edit(
         Some((Provider::Bitbucket, _)) => {
             bitbucket::commit_comment_edit(&repo_path, &sha, &comment_id, &body).await
         }
-        // GitHub edits by comment id alone (sha unused, but kept for the neutral shape).
-        _ => github::commit_comment_edit(&repo_path, &comment_id, &body).await,
+        // GitHub edits by comment id alone (sha unused, but kept for the neutral shape);
+        // `lens` is a GitHub fork-network concept, so only this arm consumes it.
+        _ => github::commit_comment_edit(&repo_path, &comment_id, &body, lens.as_deref()).await,
     }
 }
 
@@ -1116,6 +1118,7 @@ pub async fn forge_commit_comment_delete(
     repo_path: String,
     sha: String,
     comment_id: String,
+    lens: Option<String>,
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => {
@@ -1124,7 +1127,7 @@ pub async fn forge_commit_comment_delete(
         Some((Provider::Bitbucket, _)) => {
             bitbucket::commit_comment_delete(&repo_path, &sha, &comment_id).await
         }
-        _ => github::commit_comment_delete(&repo_path, &comment_id).await,
+        _ => github::commit_comment_delete(&repo_path, &comment_id, lens.as_deref()).await,
     }
 }
 

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -110,9 +110,11 @@ pub async fn git_branch_diff(
     let range = format!("{base}...{compare}");
 
     // Translate ignore patterns into git pathspec excludes — pathspec globs are
-    // close to gitignore semantics, but `*` also matches `/` (wildmatch without
-    // WM_PATHNAME), so `src/*.rs` hides nested files too. ":(exclude)" needs at
-    // least one inclusive pathspec alongside it, hence the leading ".".
+    // close to gitignore semantics but not identical: `*` also matches `/`
+    // (wildmatch without WM_PATHNAME) so `src/*.rs` hides nested files too, and
+    // a bare `notes.md` is root-anchored where gitignore matches any depth
+    // (both measured, git 2.51.1). ":(exclude)" needs at least one inclusive
+    // pathspec alongside it, hence the leading ".".
     let mut pathspec: Vec<String> = Vec::new();
     for pattern in exclude.unwrap_or_default() {
         let pattern = pattern.trim();

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -67,9 +67,10 @@ async fn stage_blob(repo: &str, stage: u8, path: &str) -> AppResult<Option<Strin
 }
 
 /// Whether the path matches any of the user's AI-ignore `exclude` patterns,
-/// using git's own gitignore-style pathspec matching (the same engine the staged
-/// diff uses): list the path with `:(exclude)` magic pathspecs applied — if it
-/// drops out of the listing, a pattern matched it.
+/// using git's own pathspec matching (the same engine the staged diff uses;
+/// close to but not identical to gitignore semantics): list the path with
+/// `:(exclude)` magic pathspecs applied — if it drops out of the listing, a
+/// pattern matched it.
 async fn is_ai_ignored(repo: &str, path: &str, exclude: &[String]) -> AppResult<bool> {
     let patterns: Vec<&str> = exclude
         .iter()

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -404,9 +404,11 @@ pub async fn git_staged_diff(
     };
 
     // Translate ignore patterns into git pathspec excludes — pathspec globs are
-    // close to gitignore semantics, but `*` also matches `/` (wildmatch without
-    // WM_PATHNAME), so `src/*.rs` hides nested files too. ":(exclude)" needs at
-    // least one inclusive pathspec alongside it, hence the leading ".".
+    // close to gitignore semantics but not identical: `*` also matches `/`
+    // (wildmatch without WM_PATHNAME) so `src/*.rs` hides nested files too, and
+    // a bare `notes.md` is root-anchored where gitignore matches any depth
+    // (both measured, git 2.51.1). ":(exclude)" needs at least one inclusive
+    // pathspec alongside it, hence the leading ".".
     let mut pathspec: Vec<String> = Vec::new();
     for pattern in exclude.unwrap_or_default() {
         let pattern = pattern.trim();

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -403,9 +403,10 @@ pub async fn git_staged_diff(
         "--cached"
     };
 
-    // Translate ignore patterns into git pathspec excludes so matching has
-    // exact gitignore-style glob semantics. ":(exclude)" needs at least one
-    // inclusive pathspec alongside it, hence the leading ".".
+    // Translate ignore patterns into git pathspec excludes — pathspec globs are
+    // close to gitignore semantics, but `*` also matches `/` (wildmatch without
+    // WM_PATHNAME), so `src/*.rs` hides nested files too. ":(exclude)" needs at
+    // least one inclusive pathspec alongside it, hence the leading ".".
     let mut pathspec: Vec<String> = Vec::new();
     for pattern in exclude.unwrap_or_default() {
         let pattern = pattern.trim();

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -79,7 +79,7 @@ async fn rebase_stopped_for_edit(repo: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Which multi-step git operation, if any, is mid-flight â€” drives the
+/// Which multi-step git operation, if any, is mid-flight — drives the
 /// conflict-resolution banner.
 #[tauri::command]
 pub async fn git_op_state(repo_path: String) -> AppResult<RepoOpState> {
@@ -253,7 +253,7 @@ pub(crate) async fn git_revert_core(
 
 /// Returns true when a commit was created. Cherry-picking changes that are
 /// already present makes git stop with an in-progress empty pick; that's not
-/// an error worth surfacing raw â€” clean up with --skip and report false.
+/// an error worth surfacing raw — clean up with --skip and report false.
 #[tauri::command]
 pub async fn git_cherry_pick(
     state: State<'_, AppState>,
@@ -297,8 +297,8 @@ pub struct CherryPickRangeResult {
 /// Copies the given commits (oldest-first) onto `target_branch`, then leaves
 /// you on that branch. Commits whose changes already exist there are skipped
 /// rather than erroring. If any commit conflicts, the whole operation is
-/// rolled back â€” the target branch is reset to its prior tip and you return to
-/// where you started â€” so the repo is never left mid-conflict.
+/// rolled back — the target branch is reset to its prior tip and you return to
+/// where you started — so the repo is never left mid-conflict.
 #[tauri::command]
 pub async fn git_cherry_pick_onto(
     state: State<'_, AppState>,
@@ -1165,7 +1165,7 @@ pub async fn git_stash_list(repo_path: String) -> AppResult<Vec<StashEntry>> {
             else {
                 return None;
             };
-            // %gd is "stash@{N}" â€” the N is the index every other stash
+            // %gd is "stash@{N}" — the N is the index every other stash
             // command addresses.
             let index: u32 = refname
                 .strip_prefix("stash@{")?
@@ -1626,7 +1626,7 @@ pub async fn git_merge_preview(
 }
 
 /// Rebases the current branch onto another. Conflicts leave the rebase in
-/// progress â€” the changes panel's conflict banner takes it from there
+/// progress — the changes panel's conflict banner takes it from there
 /// (continue or abort).
 #[tauri::command]
 pub async fn git_rebase(
@@ -2454,7 +2454,7 @@ pub(crate) async fn rewrite_commits(
         // are all expressible.
     }
 
-    // reset --hard would destroy uncommitted work â€” refuse instead.
+    // reset --hard would destroy uncommitted work — refuse instead.
     let status = run_git(
         Some(repo_path),
         &["status", "--porcelain"],
@@ -2463,7 +2463,7 @@ pub(crate) async fn rewrite_commits(
     .await?;
     if !status.stdout_lossy().trim().is_empty() {
         return Err(AppError::InvalidArgument(
-            "the working tree has uncommitted changes â€” commit or stash them first".into(),
+            "the working tree has uncommitted changes — commit or stash them first".into(),
         ));
     }
 

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2777,9 +2777,9 @@ fn validate_commit_oid(oid: &str) -> AppResult<()> {
 ///
 /// Origin-pinned (this fn takes no `lens`) even for an upstream-only SHA the History
 /// tab surfaces on a fork: GitHub's fork-network storage serves ANY network SHA via
-/// the fork's own commits endpoint, so the pin does not 404. NOTE the cluster is NOT
-/// uniform — `commit_comments`/`commit_comment_create` are lens-resolved (default
-/// origin) while `commit_comment_edit`/`_delete` are origin-pinned.
+/// the fork's own commits endpoint, so the pin does not 404. The commit-comment ops
+/// around it all resolve through the lens (default origin) instead — a comment lives
+/// in one repo's namespace, so list/create/edit/delete must agree on which repo.
 pub async fn commit_diff(repo_path: &str, oid: &str) -> AppResult<String> {
     validate_commit_oid(oid)?;
     let slug = crate::github::gh_origin_slug(repo_path).await?;
@@ -2925,6 +2925,7 @@ pub async fn commit_comment_edit(
     repo_path: &str,
     comment_id: &str,
     body: &str,
+    lens: Option<&str>,
 ) -> AppResult<()> {
     if body.trim().is_empty() {
         return Err(AppError::InvalidArgument("a comment is required".into()));
@@ -2933,8 +2934,9 @@ pub async fn commit_comment_edit(
         .trim()
         .parse()
         .map_err(|_| AppError::InvalidArgument(format!("invalid comment id: {comment_id}")))?;
-    // Pin the origin slug so a fork's commit comment is edited on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // A comment must be edited on the repo it was created on, so this inherits the same
+    // lens resolution as list/create.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/comments/{id}");
     let payload = serde_json::json!({ "body": body });
     run_gh_input(
@@ -2949,13 +2951,18 @@ pub async fn commit_comment_edit(
 
 /// Delete a commit comment (`DELETE repos/{o}/{r}/comments/{id}`). Id parse runs
 /// before the request.
-pub async fn commit_comment_delete(repo_path: &str, comment_id: &str) -> AppResult<()> {
+pub async fn commit_comment_delete(
+    repo_path: &str,
+    comment_id: &str,
+    lens: Option<&str>,
+) -> AppResult<()> {
     let id: u64 = comment_id
         .trim()
         .parse()
         .map_err(|_| AppError::InvalidArgument(format!("invalid comment id: {comment_id}")))?;
-    // Pin the origin slug so a fork's commit comment is deleted on the fork, not the parent.
-    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    // A comment must be deleted on the repo it was created on, so this inherits the same
+    // lens resolution as list/create.
+    let slug = crate::github::gh_lens_slug(repo_path, lens).await?;
     let endpoint = format!("repos/{slug}/comments/{id}");
     run_gh(
         Some(repo_path),

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1410,10 +1410,11 @@ export function JiraTimeTrackingSection({
 
 /**
  * One estimate input (original or remaining). Uncontrolled-while-focused: `key`
- * on the display string + `defaultValue` reset it whenever the server value
- * changes (the GitLab TimeTrackingControls idiom). Commits on blur/Enter when
- * the trimmed value both changed and is a valid Jira duration; invalid grammar
- * surfaces an inline warning and blocks the commit. Clear sets it to `null`.
+ * on the display string + `defaultValue` reset the draft text whenever the server
+ * value changes (the GitLab TimeTrackingControls idiom), and the render-time reset
+ * below clears the invalid flag with it. Commits on blur/Enter when the trimmed
+ * value both changed and is a valid Jira duration; invalid grammar surfaces an
+ * inline warning and blocks the commit. Clear sets it to `null`.
  */
 function JiraEstimateInput({
   label,
@@ -1433,6 +1434,13 @@ function JiraEstimateInput({
   // Local invalid flag so the warning renders while the field is focused (the
   // input itself stays uncontrolled).
   const [invalid, setInvalid] = useState(false);
+  // A server-value change remounts the Input via `key` but not this component, so
+  // the flag is reset during render (React's adjust-state-on-prop-change pattern).
+  const [prevDisplay, setPrevDisplay] = useState(currentDisplay);
+  if (prevDisplay !== currentDisplay) {
+    setPrevDisplay(currentDisplay);
+    setInvalid(false);
+  }
 
   function commit(raw: string) {
     const next = raw.trim();

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -1402,22 +1402,26 @@ export const forgeCommitCommentCreate = (
 export const forgeCommitCommentEdit = (
   repoPath: string,
   args: { sha: string; commentId: string; body: string },
+  lens: RemoteLens,
 ) =>
   invoke<void>("forge_commit_comment_edit", {
     repoPath,
     sha: args.sha,
     commentId: args.commentId,
     body: args.body,
+    lens,
   });
 
 export const forgeCommitCommentDelete = (
   repoPath: string,
   args: { sha: string; commentId: string },
+  lens: RemoteLens,
 ) =>
   invoke<void>("forge_commit_comment_delete", {
     repoPath,
     sha: args.sha,
     commentId: args.commentId,
+    lens,
   });
 
 /** Provider-neutral PR poll for the notification poller + remote pr-sync — the

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1217,11 +1217,15 @@ export function useEditCommitComment(repo: string, lens: RemoteLens) {
     repo,
     lens,
     (args: { sha: string; commentId: string; body?: string }) =>
-      api.forgeCommitCommentEdit(repo, {
-        sha: args.sha,
-        commentId: args.commentId,
-        body: args.body ?? "",
-      }),
+      api.forgeCommitCommentEdit(
+        repo,
+        {
+          sha: args.sha,
+          commentId: args.commentId,
+          body: args.body ?? "",
+        },
+        lens,
+      ),
     (comment, args) => ({ ...comment, body: args.body ?? comment.body }),
   );
 }
@@ -1231,10 +1235,14 @@ export function useDeleteCommitComment(repo: string, lens: RemoteLens) {
     repo,
     lens,
     (args: { sha: string; commentId: string }) =>
-      api.forgeCommitCommentDelete(repo, {
-        sha: args.sha,
-        commentId: args.commentId,
-      }),
+      api.forgeCommitCommentDelete(
+        repo,
+        {
+          sha: args.sha,
+          commentId: args.commentId,
+        },
+        lens,
+      ),
     () => null,
   );
 }

--- a/src/lib/git/repo-identity.ts
+++ b/src/lib/git/repo-identity.ts
@@ -34,15 +34,22 @@ export function repoIdentity(repoPath: string): Promise<string> {
 }
 
 /** Merge two id-bearing lists, dropping duplicates by `id`; `keep`'s items come
- *  first and win on a shared id. Used to fold a legacy path-keyed record list into
- *  the identity key's list during migration. */
+ *  first and win on a shared id, and first occurrence wins within `extra` too.
+ *  `keep` itself passes through verbatim (never deduped). Used to fold a legacy
+ *  path-keyed record list into the identity key's list during migration. */
 export function mergeById<T extends { id: string }>(
   keep: T[] | undefined,
   extra: T[],
 ): T[] {
   const base = keep ?? [];
   const seen = new Set(base.map((x) => x.id));
-  return [...base, ...extra.filter((x) => !seen.has(x.id))];
+  const rest: T[] = [];
+  for (const x of extra) {
+    if (seen.has(x.id)) continue;
+    seen.add(x.id);
+    rest.push(x);
+  }
+  return [...base, ...rest];
 }
 
 // In-flight/settled fold per (store, path), so the legacy migration runs at most

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -111,9 +111,10 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 /** Merge two id-bearing arrays: `keep` first, then old records whose id isn't
  *  already present. First occurrence of an id wins — within `old` as well as
- *  across the two arrays — and `undefined` is an id like any other, so
- *  idless objects all collide and only the first one survives. Non-object old
- *  entries are dropped (undedupable). */
+ *  across the two arrays — and `undefined` is an id like any other, so an idless
+ *  record suppresses every later idless old one. `keep` itself passes through
+ *  verbatim (never deduped); non-object old entries are dropped (they can't be
+ *  deduplicated). */
 function mergeIds(keep: unknown[], old: unknown[]): unknown[] {
   const seen = new Set(
     keep.filter((r): r is { id: unknown } => isRecord(r)).map((r) => r.id),

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -110,17 +110,20 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 /** Merge two id-bearing arrays: `keep` first, then old records whose id isn't
- *  already present. Non-object old entries are dropped (undedupable); idless
- *  objects all collide on `id === undefined`, so an idless record in `keep`
- *  suppresses every idless old one. */
+ *  already present. First occurrence of an id wins — within `old` as well as
+ *  across the two arrays — and `undefined` is an id like any other, so
+ *  idless objects all collide and only the first one survives. Non-object old
+ *  entries are dropped (undedupable). */
 function mergeIds(keep: unknown[], old: unknown[]): unknown[] {
   const seen = new Set(
     keep.filter((r): r is { id: unknown } => isRecord(r)).map((r) => r.id),
   );
-  const extra = old.filter(
-    (r): r is { id: unknown } =>
-      isRecord(r) && !seen.has((r as { id: unknown }).id),
-  );
+  const extra: unknown[] = [];
+  for (const r of old) {
+    if (!isRecord(r) || seen.has(r.id)) continue;
+    seen.add(r.id);
+    extra.push(r);
+  }
   return [...keep, ...extra];
 }
 


### PR DESCRIPTION
Commit comments live in a single repository's namespace, but the GitHub edit and delete paths were origin-pinned while list and create resolved through the active remote lens — so editing or deleting a comment while viewing a fork through its parent (upstream) lens hit the wrong repo and failed. This threads the lens through the whole commit-comment cluster so all four operations agree, and picks up three unrelated fixes found alongside it (a sticky Jira estimate warning, a relocate merge that let duplicates through, and mojibake in a rewrite error).

### Commit-comment lens (GitHub)

- Adds a `lens: Option<&str>` parameter to `commit_comment_edit` and `commit_comment_delete` in `src-tauri/src/github/pr.rs`, swapping `gh_origin_slug` for `gh_lens_slug` so the comment is edited/deleted on the repo it was created on.
- Plumbs the same parameter through `src-tauri/src/forge/github.rs` and the neutral `forge_commit_comment_edit` / `forge_commit_comment_delete` commands in `src-tauri/src/forge/mod.rs`, where only the GitHub arm consumes it (lens is a fork-network concept; the GitLab and Bitbucket arms are untouched).
- Updates the `commit_diff` doc comment in `src-tauri/src/github/pr.rs`, which previously documented the cluster as deliberately non-uniform, to record that the comment ops now uniformly resolve through the lens while `commit_diff` stays origin-pinned.
- Frontend: `forgeCommitCommentEdit` and `forgeCommitCommentDelete` in `src/lib/git/api.ts` take a `RemoteLens` and pass it in the invoke payload; `useEditCommitComment` and `useDeleteCommitComment` in `src/lib/git/queries.ts` forward the lens they already receive.

### Jira estimate input

- `JiraEstimateInput` in `src/features/issues/JiraIssueView.tsx` now resets its local `invalid` flag during render when `currentDisplay` changes (the adjust-state-on-prop-change pattern), since the `key`-based reset remounts the `Input` but not the component — so the "Enter a Jira duration" warning no longer persists after the server value refreshes. The component's doc comment is updated to describe the added reset.

### Repository relocate merge

- `mergeIds` in `src/lib/repo-data-migration.ts` now adds each accepted old record's id to the `seen` set as it iterates, so duplicates *within* `old` are dropped too — previously only collisions against `keep` were filtered, letting repeated ids (and multiple idless records) through. The doc comment is rewritten to state the first-occurrence-wins rule.

### Encoding and comment cleanup

- Repairs mojibake em-dashes across doc comments in `src-tauri/src/git/ops.rs`, including the user-visible `InvalidArgument` message in `rewrite_commits` ("the working tree has uncommitted changes — commit or stash them first").
- Corrects the pathspec-exclude comment in `src-tauri/src/git/diff.rs`: git pathspec globs are only *close* to gitignore semantics — `*` also matches `/` (wildmatch without `WM_PATHNAME`), so a pattern like `src/*.rs` also hides nested files.

### Changelog

- Adds four fragments under `changelog.d/`: `fixed-commit-comment-fork-lens.md`, `fixed-jira-estimate-stale-warning.md`, `fixed-relocate-duplicate-records.md`, and `fixed-rewrite-error-garbled-dash.md`.