### PR TITLE
fix(ai,git,pulls): honor AI ignore patterns with gitignore semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   syntax-highlighted code in ~190 languages (light and dark).
 - **Privacy-first** — API keys live in the OS keychain (never in app files), local
   models keep code on your machine, AI-ignore patterns keep sensitive files out of
-  context, and a single switch hides every AI surface.
+  context unless you opt into repo-aware review, and a single switch hides every
+  AI surface.
 - **Keyboard-first** — rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (Ctrl+/), a command palette (Ctrl+K), and
   arrow-key navigation everywhere.
@@ -616,11 +617,17 @@ display can't strand it off-screen.
   - **Global** — Settings → AI instructions (e.g. "Follow Conventional Commits").
   - **Per-repo** — `.gitdesktop/instructions.md` in the repo. Takes precedence.
 - **AI ignore patterns** (keep files out of AI context; they still commit
-  normally), gitignore-style:
+  normally), in `.gitignore` syntax: `secrets.env` hides that file at any depth,
+  `/secrets.env` only the copy at the repo root, `node_modules` or `vendor/` a
+  folder wherever it sits, and `docs/*.log` just that folder's logs. `!`
+  re-include lines aren't supported. A model that reads your repository itself
+  isn't limited by them — that's what the PR panel's **Agentic review** toggle
+  turns on.
   - **Global** — Settings → Excluded files (one pattern per line).
   - **Per-repo** — `.gitdesktop/aiignore` in the repo. A changed file's
     context menu → **Exclude from AI** (file, folder, or file type — or a
-    multi-selection) creates and updates this file for you.
+    multi-selection) creates and updates this file for you, adding anchored
+    lines like `/src/config.ts` and `/vendor/` that mean exactly what you picked.
 - **Keys** live in the OS keychain (Windows Credential Manager, macOS Keychain,
   libsecret). **Hide AI** (Settings → General) hides every AI surface while
   keeping your config.

--- a/changelog.d/fixed-ai-ignore-gitignore-semantics.md
+++ b/changelog.d/fixed-ai-ignore-gitignore-semantics.md
@@ -1,0 +1,14 @@
+- **AI ignore patterns now follow `.gitignore`'s matching rules.** A bare name
+  matches at any depth (`secrets.env` also covers `config/secrets.env`), a bare
+  folder name hides that folder's contents wherever it sits (`node_modules`), a
+  leading `/` anchors a pattern to the repo root, and `*` stops at a `/`, so
+  `docs/*.log` covers `docs/a.log` but not `docs/sub/b.log`. **Patterns you
+  already have may hide more than they did:** saved lines carry no anchor —
+  including every one *Exclude from AI* added — so a stored `notes.md` now hides
+  each file of that name rather than only the copy at the root, and a stored
+  `build` or `node_modules` now hides those folders instead of nothing at all.
+  That only ever withholds more from a model, never less, but it's worth a look
+  at your lists. *Exclude from AI* now writes anchored lines
+  (`/src/config.ts`, `/vendor/`) that mean the one file or folder you picked,
+  matching what *Ignore* writes to `.gitignore`. `!` re-include lines aren't
+  supported.

--- a/changelog.d/fixed-ai-review-ai-ignore.md
+++ b/changelog.d/fixed-ai-review-ai-ignore.md
@@ -3,6 +3,6 @@
   your last review" delta they build on — where the whole diff previously
   reached the provider. The prompt states how many files were held back rather
   than passing the diff off as complete, and if every changed file is excluded,
-  nothing is sent at all. **Repo-aware (agentic) review is the exception:** it
-  reads your repository directly through its own tools, so ignore patterns don't
-  limit what it sees.
+  nothing is sent at all. As everywhere else, a model that reads your repository
+  itself isn't limited by these patterns — that's what **Agentic review** on a
+  pull request turns on.

--- a/changelog.d/fixed-ai-review-ai-ignore.md
+++ b/changelog.d/fixed-ai-review-ai-ignore.md
@@ -1,0 +1,8 @@
+- Your **AI ignore patterns** are now honored by AI reviews — the ones you start
+  from the PR panel and the automated ones alike, including the "changes since
+  your last review" delta they build on — where the whole diff previously
+  reached the provider. The prompt states how many files were held back rather
+  than passing the diff off as complete, and if every changed file is excluded,
+  nothing is sent at all. **Repo-aware (agentic) review is the exception:** it
+  reads your repository directly through its own tools, so ignore patterns don't
+  limit what it sees.

--- a/changelog.d/fixed-branch-diff-ai-ignore.md
+++ b/changelog.d/fixed-branch-diff-ai-ignore.md
@@ -4,5 +4,3 @@
   and when generating a reworded commit's message in Edit history — those paths
   previously sent the whole branch diff to the provider. The prompt states how
   many files were held back rather than passing the diff off as complete.
-  (Regenerating the description of an existing remote PR still uses the forge's
-  own diff, which has no path filtering to apply.)

--- a/changelog.d/fixed-ignore-untrack-special-characters.md
+++ b/changelog.d/fixed-ignore-untrack-special-characters.md
@@ -1,0 +1,8 @@
+- **File actions now affect exactly the file you picked when its path contains
+  `[`, `*` or `?`.** On a dynamic route like `src/app/[slug]/page.tsx`, staging,
+  unstaging, discarding, stashing, ignoring, untracking, force-adding and taking
+  one side of a conflict all act on that file alone. Those paths used to be
+  handled as match patterns, so a neighbouring file could be swept in alongside
+  the one you chose — most seriously, **discarding changes could throw away
+  another file's uncommitted work**, and resolving a conflict could silently
+  resolve a second file the same way.

--- a/changelog.d/fixed-remote-pr-regenerate-ai-ignore.md
+++ b/changelog.d/fixed-remote-pr-regenerate-ai-ignore.md
@@ -1,0 +1,5 @@
+- Your **AI ignore patterns** now apply when you regenerate the description of an
+  already-open pull request or merge request, not only when you create one.
+  Excluded files are dropped from the forge's own diff before it reaches the
+  provider, and the prompt states how many were held back rather than passing the
+  diff off as complete; if every changed file is excluded, nothing is sent at all.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -461,7 +461,7 @@ export const capabilities: Capability[] = [
     group: "AI · generate & review",
     ai: true,
     label:
-      "AI ignore patterns — .gitignore syntax, honored by every generation and review",
+      "AI ignore patterns — .gitignore syntax, keeping chosen files out of generation and review",
   },
   {
     group: "AI · generate & review",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -460,6 +460,12 @@ export const capabilities: Capability[] = [
   {
     group: "AI · generate & review",
     ai: true,
+    label:
+      "AI ignore patterns — .gitignore syntax, honored by every generation and review",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
     label: "Iterative reviews build on the last round & other bots' findings",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -279,6 +279,7 @@ export const capabilities: Capability[] = [
     label:
       "Explore repositories — search GitHub, GitLab & Bitbucket, then clone, fork or star",
     ai: false,
+    highlight: true,
   },
   {
     group: "Repository & workspace",
@@ -453,6 +454,12 @@ export const capabilities: Capability[] = [
   {
     group: "AI · generate & review",
     ai: true,
+    label:
+      "Review timeout — agentic reviews get 20 minutes, or pin your own limit",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
     label: "Iterative reviews build on the last round & other bots' findings",
   },
   {
@@ -460,6 +467,24 @@ export const capabilities: Capability[] = [
     ai: true,
     label:
       "Re-reviews remember the discussion — triage replies honored, context sized to your model",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
+    label:
+      "Reviews converge — a fuller first round, non-blocking leftovers listed apart",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
+    label:
+      "Every re-review ends with a verdict — blocking issues remain, or merge when ready",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
+    label:
+      "Reviews know where your docs live — one finding names every stale surface",
   },
   {
     group: "AI · generate & review",

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -279,8 +279,10 @@ const agentAbilities = [
           <p class="mt-2 text-sm leading-relaxed text-muted">
             Open a changed file's context menu to keep it out of AI context (the file, its folder,
             or its file type); it's appended to
-            <code class="text-ink">.gitdesktop/aiignore</code>. Patterns also work globally
-            or per repo, and excluded files still commit normally.
+            <code class="text-ink">.gitdesktop/aiignore</code> as a line that means exactly what
+            you picked. Patterns are plain <code class="text-ink">.gitignore</code> syntax, work
+            globally or per repo, and excluded files still commit normally. A repo-aware review
+            reads your files directly, so ignore patterns don't limit it.
           </p>
         </div>
         <div class="min-w-0">

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,7 +59,8 @@ sha1 = "0.10"
 # only the user's patterns apply (git::ai_ignore). TempDir gives it an
 # unpredictable, exclusively-created path: a guessable one in a shared /tmp lets a
 # local attacker pre-seed `.git/info/exclude`, which outranks core.excludesFile and
-# would silently un-ignore a file. Also a dev-dependency, for test fixtures.
+# would silently un-ignore a file. Test fixtures use it as RAII temp dirs too, so
+# a killed or panicking run leaks nothing.
 tempfile = "3"
 
 # Desktop-only: the updater plugin doesn't build for mobile.
@@ -87,7 +88,3 @@ windows-sys = { version = "0.61", features = [
 portable-pty = { path = "vendor/portable-pty" }
 
 [dev-dependencies]
-# RAII temp dirs for tests: a killed or panicking run must not leak fixtures
-# into the system temp dir — TempDir removes the directory on Drop.
-# Already in the dependency graph transitively, so near-zero cost.
-tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -86,5 +86,3 @@ windows-sys = { version = "0.61", features = [
 # vendor/portable-pty/src/win/psuedocon.rs. Drop this when fixed upstream (wezterm).
 [patch.crates-io]
 portable-pty = { path = "vendor/portable-pty" }
-
-[dev-dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # `sha1_hex(file_path)_<old_pos>_<new_pos>` (see forge/gitlab.rs `gl_line_code`).
 # RustCrypto sha1 — hashing only, no extra default features needed.
 sha1 = "0.10"
+# The AI-ignore gitignore engine evaluates patterns in a throwaway EMPTY repo, so
+# only the user's patterns apply (git::ai_ignore). TempDir gives it an
+# unpredictable, exclusively-created path: a guessable one in a shared /tmp lets a
+# local attacker pre-seed `.git/info/exclude`, which outranks core.excludesFile and
+# would silently un-ignore a file. Also a dev-dependency, for test fixtures.
+tempfile = "3"
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -16,9 +16,10 @@
 //! This is a privacy boundary: a pattern that fails to match is a file that
 //! reaches a third-party model.
 
+use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 
+use tempfile::TempPath;
 use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
@@ -129,14 +130,20 @@ pub fn pathspecs_for(patterns: &[String], icase: bool) -> AiIgnorePathspecs {
 /// filesystem. Both engines must be driven from THIS one value so they fold case
 /// alike — and from the user's repo, never from wherever a temp dir happens to
 /// live.
+///
+/// `--type=bool` is required, not tidiness: git accepts `1`, `yes`, `on` and a
+/// valueless key as true, and the raw value is whatever the user wrote. Reading
+/// it raw computes false for those, which then FORCES `-c core.ignorecase=false`
+/// onto `check-ignore` — so a `Secrets.env` pattern stops hiding `secrets.env` on
+/// both engines at once (measured, git 2.51.1).
 async fn repo_ignorecase(repo_path: &str) -> bool {
     run_git_raw(
         Some(repo_path),
-        &["config", "--get", "core.ignorecase"],
+        &["config", "--type=bool", "--get", "core.ignorecase"],
         DEFAULT_TIMEOUT,
     )
     .await
-    .map(|out| out.code == 0 && out.stdout_lossy().trim().eq_ignore_ascii_case("true"))
+    .map(|out| out.code == 0 && out.stdout_lossy().trim() == "true")
     .unwrap_or(false)
 }
 
@@ -178,6 +185,11 @@ async fn neutral_repo() -> AppResult<PathBuf> {
                 .map_err(AppError::Io)?;
             let path = dir.path().to_string_lossy().into_owned();
             run_git(Some(&path), &["init", "-q"], DEFAULT_TIMEOUT).await?;
+            // A user's `init.templateDir` can seed `.git/info/exclude`, which
+            // outranks `core.excludesFile` and would join the ruleset.
+            tokio::fs::write(dir.path().join(".git/info/exclude"), "")
+                .await
+                .map_err(AppError::Io)?;
             Ok::<tempfile::TempDir, AppError>(dir)
         })
         .await?;
@@ -212,6 +224,14 @@ async fn neutral_repo() -> AppResult<PathBuf> {
 /// returns a path that no longer compares equal to the one the caller sent — on
 /// a privacy boundary that fails OPEN. It also makes a path containing a newline
 /// representable at all.
+///
+/// The excludes file carries that boundary too, so it must be unguessable and
+/// exclusively created: an emptied or substituted list reports NOTHING ignored.
+/// It is created with `O_EXCL` inside [`neutral_repo`]'s owner-only directory and
+/// written through that same handle, never re-opened by name — so no other user
+/// can pre-create the path, and nothing can be swapped in between the write and
+/// git's read. Removed explicitly below on both arms, with the handle's own drop
+/// as a backstop.
 pub async fn filter_ignored(
     repo_path: &str,
     paths: &[String],
@@ -224,23 +244,22 @@ pub async fn filter_ignored(
     let icase = repo_ignorecase(repo_path).await;
     let neutral = neutral_repo().await?.to_string_lossy().into_owned();
 
-    // pid + nanos + counter: concurrent callers (one per conflicted file) must
-    // not share a name, and the clock alone is too coarse to guarantee that.
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let excludes_file = std::env::temp_dir().join(format!(
-        "gd-aiignore-{}-{}-{}.txt",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-        SEQ.fetch_add(1, Ordering::Relaxed),
-    ));
     let mut body = lines.join("\n");
     body.push('\n');
-    tokio::fs::write(&excludes_file, body)
-        .await
-        .map_err(AppError::Io)?;
+    // Created and written through one exclusive handle, inside the neutral repo's
+    // own directory — see the security note on this function.
+    let dir = neutral.clone();
+    let excludes_file = tokio::task::spawn_blocking(move || -> std::io::Result<TempPath> {
+        let mut file = tempfile::Builder::new()
+            .prefix("excludes-")
+            .suffix(".txt")
+            .tempfile_in(dir)?;
+        file.as_file_mut().write_all(body.as_bytes())?;
+        Ok(file.into_temp_path())
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+    .map_err(AppError::Io)?;
 
     let result = async {
         // Forward slashes: a `-c` value is config-parsed, and a Windows temp path's
@@ -609,9 +628,12 @@ mod tests {
         assert_eq!(specs("NOTES.MD")[0], ":(exclude,glob)**/NOTES.MD");
 
         // Flip the REPO's setting; both engines must follow it, and each other.
+        // Written as `1`, NOT `true`: git accepts `1`/`yes`/`on`/a valueless key
+        // as true, so a raw string compare reads this repo as case-SENSITIVE and
+        // forces that onto both engines — agreeing with each other and wrong.
         run_git(
             Some(&repo),
-            &["config", "core.ignorecase", "true"],
+            &["config", "core.ignorecase", "1"],
             DEFAULT_TIMEOUT,
         )
         .await

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -1,0 +1,806 @@
+//! The one AI-ignore matcher.
+//!
+//! The app documents its AI-ignore lists (`.gitdesktop/aiignore` + the global
+//! settings list) as "gitignore-style", so matching has to BE gitignore. This
+//! module owns the two ways we evaluate those patterns, and a test pins them to
+//! the same truth table so they cannot drift:
+//!
+//! * [`pathspecs_for`] — pure translation to `:(exclude,glob)` pathspec terms,
+//!   for the call sites that filter a whole git command's output
+//!   (`git_staged_diff`, `git_branch_diff`).
+//! * [`filter_ignored`] / [`git_filter_ai_ignored`] — git's real gitignore
+//!   engine (`check-ignore --no-index --stdin`), for deciding a list of paths
+//!   that need not exist in the working tree or index (a remote PR's changed
+//!   files, or one conflicted path).
+//!
+//! This is a privacy boundary: a pattern that fails to match is a file that
+//! reaches a third-party model.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::OnceCell;
+
+use crate::error::{AppError, AppResult};
+use crate::git::runner::{run_git, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT};
+
+/// The pathspec translation of one AI-ignore list.
+pub struct AiIgnorePathspecs {
+    /// `:(exclude,glob)…` terms, ready to append after a caller's own positive
+    /// pathspec. Empty when nothing translatable was supplied.
+    pub specs: Vec<String>,
+    /// How many `!` un-ignore lines were dropped — by BOTH engines, not just
+    /// this one (see [`actionable_lines`]); callers may surface the count as
+    /// "un-ignore lines aren't supported". No consumer discloses it yet, and the
+    /// crate's staticlib/cdylib targets make `pub` no defence against dead_code.
+    #[allow(dead_code)]
+    pub skipped_negations: usize,
+}
+
+/// The lines of an AI-ignore list that either engine acts on: trimmed, with
+/// blanks, `#` comments and `!` un-ignore lines dropped. Returns them with the
+/// number of `!` lines dropped.
+///
+/// One definition, deliberately shared: the two engines must decide every list
+/// identically, and `!` is the case that can only be made uniform by dropping
+/// it. A pathspec has no un-exclude, so honoring negations is impossible on that
+/// side; letting the gitignore side honor them anyway would hide a file when the
+/// user opens a PR from a local branch and send that same file to a model when
+/// they regenerate an open PR's description. Of the two uniform behaviors,
+/// refusing an un-ignore withholds more — the right way for a privacy feature to
+/// fail.
+fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
+    let mut lines: Vec<&str> = Vec::new();
+    let mut skipped_negations = 0usize;
+    for raw in patterns {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('!') {
+            skipped_negations += 1;
+            continue;
+        }
+        lines.push(line);
+    }
+    (lines, skipped_negations)
+}
+
+/// Translates gitignore-style lines into `:(exclude,glob)` pathspec terms.
+///
+/// Pure — no git call, no IO. Blanks, comments and `!` lines are dropped by the
+/// shared [`actionable_lines`]. Per surviving line: a trailing `/` marks a
+/// directory, and a line is *anchored* when it starts with `/` or still contains
+/// a `/` (exactly gitignore's rule). Unanchored lines get a `**/` prefix so they
+/// match at any depth; a non-directory line also emits a `<pattern>/**` term,
+/// which is what makes a bare `node_modules` hide the directory's contents and
+/// matches nothing extra for a real file.
+///
+/// Every term carries `,glob` magic, and that is load-bearing twice over: it
+/// makes a leading `**/` match at depth zero (so a bare name hits the repo root
+/// too), and it stops `*` from crossing `/` (so `docs/*.log` does not
+/// over-match `docs/sub/b.log`). Never `,literal` — gitignore reads `[1]` as a
+/// character class, so we must too.
+///
+/// `icase` comes from the repo's `core.ignorecase` (see [`repo_ignorecase`]) and
+/// adds `,icase`. It is required for parity, not a nicety: pathspec matching is
+/// case-SENSITIVE whatever `core.ignorecase` says, while real gitignore folds
+/// case when it is set — so on the case-insensitive filesystems Windows and
+/// macOS default to, a `Secrets.env` pattern would hide `secrets.env` from the
+/// gitignore engine and leak it through every pathspec caller (measured, git
+/// 2.51.1).
+///
+/// ⚠ The caller's own positive pathspec must NOT carry a directory component —
+/// `.` is the shape that works. Git's `common_prefix_len()` skips exclude items
+/// when computing the leading prefix it strips, then `match_pathspec_item()`
+/// advances each *negative* pattern by that many bytes: with a positive
+/// pathspec of `docs/file.txt`, `**/file.txt` is compared as `ile.txt` and
+/// silently matches nothing (measured, git 2.51.1). Ask about a single path via
+/// [`filter_ignored`] instead.
+pub fn pathspecs_for(patterns: &[String], icase: bool) -> AiIgnorePathspecs {
+    let (lines, skipped_negations) = actionable_lines(patterns);
+    let magic = if icase {
+        "exclude,glob,icase"
+    } else {
+        "exclude,glob"
+    };
+    let mut specs: Vec<String> = Vec::new();
+
+    for line in lines {
+        let is_dir = line.ends_with('/');
+        let core = line.strip_suffix('/').unwrap_or(line);
+        let anchored = core.starts_with('/') || core.contains('/');
+        let core = core.strip_prefix('/').unwrap_or(core);
+        if core.is_empty() {
+            continue;
+        }
+        let prefix = if anchored { "" } else { "**/" };
+        if !is_dir {
+            specs.push(format!(":({magic}){prefix}{core}"));
+        }
+        specs.push(format!(":({magic}){prefix}{core}/**"));
+    }
+
+    AiIgnorePathspecs {
+        specs,
+        skipped_negations,
+    }
+}
+
+/// The repo's effective `core.ignorecase`. Unset (or unreadable) means `false`,
+/// which is git's own default; `git init` sets it true on a case-insensitive
+/// filesystem. Both engines must be driven from THIS one value so they fold case
+/// alike — and from the user's repo, never from wherever a temp dir happens to
+/// live.
+async fn repo_ignorecase(repo_path: &str) -> bool {
+    run_git_raw(
+        Some(repo_path),
+        &["config", "--get", "core.ignorecase"],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .map(|out| out.code == 0 && out.stdout_lossy().trim().eq_ignore_ascii_case("true"))
+    .unwrap_or(false)
+}
+
+/// [`pathspecs_for`] with the repo's own case sensitivity applied — what the
+/// diff call sites should use, so they never have to know about `core.ignorecase`.
+pub async fn pathspecs_for_repo(repo_path: &str, patterns: &[String]) -> AiIgnorePathspecs {
+    // Only worth a spawn when there is something to translate.
+    if actionable_lines(patterns).0.is_empty() {
+        return pathspecs_for(patterns, false);
+    }
+    pathspecs_for(patterns, repo_ignorecase(repo_path).await)
+}
+
+/// An empty throwaway repo, created once per process, that [`filter_ignored`]
+/// runs `check-ignore` inside.
+///
+/// The AI-ignore patterns must be the ONLY rules in play. Running in the user's
+/// repo adds that repo's `.gitignore` files to the ruleset, which both
+/// over-reports (a tracked-but-gitignored file — a committed lockfile, a
+/// checked-in build artifact — would be declared AI-ignored and the conflict UI
+/// would tell the user it "matches your AI ignore patterns", with no bypass) and
+/// breaks the invariant that this engine and `pathspecs_for` decide alike. An
+/// empty work tree leaves `core.excludesFile` as the only active source.
+///
+/// Created once and reused: `is_ai_ignored` runs per conflicted file, so a
+/// per-call `git init` would be a spawn storm. Only a successful init is cached
+/// (`get_or_try_init` leaves the cell empty on error).
+///
+/// `TempDir` rather than a pid-derived name because the path must be
+/// unpredictable and never adopted: in a shared `/tmp`, a guessable name lets a
+/// local attacker pre-create `.git/info/exclude` holding `!secrets.env`, which
+/// outranks `core.excludesFile` and would make the conflict gate fail open — and
+/// a reused pid alone could wedge a session on a directory this process cannot
+/// write. TempDir creates exclusively, with owner-only permissions. It lives in a
+/// static, so the OS temp reaper rather than `Drop` is what eventually removes it.
+static NEUTRAL_REPO: OnceCell<tempfile::TempDir> = OnceCell::const_new();
+
+async fn neutral_repo() -> AppResult<PathBuf> {
+    let dir = NEUTRAL_REPO
+        .get_or_try_init(|| async {
+            let dir = tempfile::Builder::new()
+                .prefix("gd-aiignore-")
+                .tempdir()
+                .map_err(AppError::Io)?;
+            let path = dir.path().to_string_lossy().into_owned();
+            run_git(Some(&path), &["init", "-q"], DEFAULT_TIMEOUT).await?;
+            Ok::<tempfile::TempDir, AppError>(dir)
+        })
+        .await?;
+    Ok(dir.path().to_path_buf())
+}
+
+/// The subset of `paths` that the AI-ignore `exclude` lines hide, evaluated by
+/// git's own gitignore engine.
+///
+/// `check-ignore --no-index --stdin` matches *arbitrary* paths — they need not
+/// exist in the working tree or the index — which is what lets callers ask about
+/// a remote PR's changed-file list, or about one conflicted path without
+/// depending on how the index happens to hold it. The pattern lines go into a
+/// temp excludes file, so semantics are gitignore's own rather than our pathspec
+/// translation of them — but only the lines [`actionable_lines`] keeps, so a `!`
+/// un-ignore is dropped here exactly as it is on the pathspec side. Git would
+/// honor it natively; letting it would split the two engines on the same list.
+///
+/// `paths` are repo-relative, forward-slashed. Empty `paths`, or an `exclude`
+/// with no actionable line in it, short-circuits to `[]` without spawning git;
+/// so does "nothing matched" (check-ignore's exit code 1, which is not an
+/// error).
+///
+/// Matching runs in [`neutral_repo`] rather than the user's repo, so their AI
+/// patterns are the only rules in play — but `repo_path` still decides case
+/// folding: `core.ignorecase` is read from it and forced onto the invocation, so
+/// the answer follows the user's repo instead of whatever filesystem the temp
+/// dir happens to sit on, and agrees with [`pathspecs_for`].
+///
+/// `-z` is load-bearing, not cosmetic: without it git C-dequotes an input path
+/// that happens to be quoted and C-quotes non-ASCII output, either of which
+/// returns a path that no longer compares equal to the one the caller sent — on
+/// a privacy boundary that fails OPEN. It also makes a path containing a newline
+/// representable at all.
+pub async fn filter_ignored(
+    repo_path: &str,
+    paths: &[String],
+    exclude: &[String],
+) -> AppResult<Vec<String>> {
+    let (lines, _) = actionable_lines(exclude);
+    if paths.is_empty() || lines.is_empty() {
+        return Ok(Vec::new());
+    }
+    let icase = repo_ignorecase(repo_path).await;
+    let neutral = neutral_repo().await?.to_string_lossy().into_owned();
+
+    // pid + nanos + counter: concurrent callers (one per conflicted file) must
+    // not share a name, and the clock alone is too coarse to guarantee that.
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let excludes_file = std::env::temp_dir().join(format!(
+        "gd-aiignore-{}-{}-{}.txt",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+        SEQ.fetch_add(1, Ordering::Relaxed),
+    ));
+    let mut body = lines.join("\n");
+    body.push('\n');
+    tokio::fs::write(&excludes_file, body)
+        .await
+        .map_err(AppError::Io)?;
+
+    let result = async {
+        // Forward slashes: a `-c` value is config-parsed, and a Windows temp path's
+        // backslashes would be read as escapes. Git accepts `/` on every platform.
+        let config = format!(
+            "core.excludesFile={}",
+            excludes_file.to_string_lossy().replace('\\', "/")
+        );
+        let mut stdin = paths.join("\0");
+        stdin.push('\0');
+        let case = format!("core.ignorecase={icase}");
+        let out = run_git_raw_input(
+            Some(&neutral),
+            &[
+                "-c",
+                &config,
+                "-c",
+                &case,
+                "check-ignore",
+                "--no-index",
+                "--stdin",
+                "-z",
+            ],
+            Some(&stdin),
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+        // 0 = at least one path matched, 1 = none matched (not an error).
+        if out.code > 1 {
+            return Err(AppError::Git {
+                code: out.code,
+                stderr: out.stderr,
+            });
+        }
+        // `-z` output is NUL-TERMINATED, so the split yields a trailing empty
+        // element; nothing else needs trimming (no CR, no quoting).
+        Ok(out
+            .stdout_lossy()
+            .split('\0')
+            .filter(|p| !p.is_empty())
+            .map(String::from)
+            .collect())
+    }
+    .await;
+
+    let _ = tokio::fs::remove_file(&excludes_file).await;
+    result
+}
+
+/// [`filter_ignored`] as a command: which of `paths` the user's AI-ignore
+/// patterns hide. The frontend uses it for path lists it holds itself (a remote
+/// PR's changed files), where there is no git command whose output we could
+/// filter with pathspecs.
+#[tauri::command]
+pub async fn git_filter_ai_ignored(
+    repo_path: String,
+    paths: Vec<String>,
+    exclude: Vec<String>,
+) -> AppResult<Vec<String>> {
+    filter_ignored(&repo_path, &paths, &exclude).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::runner::run_git;
+    use std::collections::BTreeSet;
+    use std::path::Path;
+
+    fn specs_icase(pattern: &str) -> Vec<String> {
+        pathspecs_for(&[pattern.to_string()], true).specs
+    }
+
+    fn specs(pattern: &str) -> Vec<String> {
+        pathspecs_for(&[pattern.to_string()], false).specs
+    }
+
+    #[test]
+    fn emits_the_measured_terms_per_pattern() {
+        // A bare name matches at any depth (both the file and, harmlessly, its
+        // "contents"); a leading slash anchors it to the repo root.
+        assert_eq!(
+            specs("notes.md"),
+            [
+                ":(exclude,glob)**/notes.md",
+                ":(exclude,glob)**/notes.md/**"
+            ]
+        );
+        assert_eq!(
+            specs("/notes.md"),
+            [":(exclude,glob)notes.md", ":(exclude,glob)notes.md/**"]
+        );
+        // A trailing slash is a directory: one term, contents only.
+        assert_eq!(specs("build/"), [":(exclude,glob)**/build/**"]);
+        assert_eq!(specs("docs/build/"), [":(exclude,glob)docs/build/**"]);
+        // A bare directory NAME needs the second term to hide its contents.
+        assert_eq!(
+            specs("node_modules"),
+            [
+                ":(exclude,glob)**/node_modules",
+                ":(exclude,glob)**/node_modules/**"
+            ]
+        );
+        assert_eq!(
+            specs("build"),
+            [":(exclude,glob)**/build", ":(exclude,glob)**/build/**"]
+        );
+        // An embedded `/` anchors without a leading slash.
+        assert_eq!(
+            specs("docs/*.log"),
+            [":(exclude,glob)docs/*.log", ":(exclude,glob)docs/*.log/**"]
+        );
+        assert_eq!(
+            specs("docs/notes.md"),
+            [
+                ":(exclude,glob)docs/notes.md",
+                ":(exclude,glob)docs/notes.md/**"
+            ]
+        );
+        assert_eq!(
+            specs("*.log"),
+            [":(exclude,glob)**/*.log", ":(exclude,glob)**/*.log/**"]
+        );
+        assert_eq!(
+            specs("*.md"),
+            [":(exclude,glob)**/*.md", ":(exclude,glob)**/*.md/**"]
+        );
+        // Brackets pass through untouched — git reads them as a character class
+        // on both sides, so neither engine matches the literal name.
+        assert_eq!(
+            specs("weird[1].txt"),
+            [
+                ":(exclude,glob)**/weird[1].txt",
+                ":(exclude,glob)**/weird[1].txt/**"
+            ]
+        );
+        assert!(specs("!docs/notes.md").is_empty());
+    }
+
+    #[test]
+    fn drops_blanks_comments_and_negations() {
+        let out = pathspecs_for(
+            &[
+                "  ".to_string(),
+                "# a comment".to_string(),
+                "!docs/notes.md".to_string(),
+                "  *.log  ".to_string(),
+                "/".to_string(),
+            ],
+            false,
+        );
+        assert_eq!(
+            out.specs,
+            [":(exclude,glob)**/*.log", ":(exclude,glob)**/*.log/**"]
+        );
+        assert_eq!(out.skipped_negations, 1);
+    }
+
+    /// Every fixture path in the parity repo, repo-relative and sorted.
+    const FIXTURE: [&str; 15] = [
+        "a/b/notes.md",
+        "app.log",
+        "build/x.txt",
+        "buildfile.txt",
+        "deep/app.log",
+        "docs/a.log",
+        "docs/build/y.txt",
+        "docs/notes.md",
+        "docs/sub/b.log",
+        // CJK ideographs have no NFC/NFD variance, so this round-trips through a
+        // real filesystem on every CI platform; the decomposable case (`café.md`)
+        // is covered by the filesystem-free test below.
+        "docs/日本語.md",
+        "keep.txt",
+        "node_modules/pkg/i.js",
+        "notes.md",
+        "src/node_modules/j.js",
+        "weird[1].txt",
+    ];
+
+    /// The measured truth table (git 2.51.1): for each AI-ignore pattern LIST,
+    /// exactly which of `FIXTURE` it hides. Both engines must agree with it.
+    const PARITY: [(&[&str], &[&str]); 17] = [
+        (
+            &["notes.md"],
+            &["a/b/notes.md", "docs/notes.md", "notes.md"],
+        ),
+        (&["/notes.md"], &["notes.md"]),
+        (
+            &["*.log"],
+            &["app.log", "deep/app.log", "docs/a.log", "docs/sub/b.log"],
+        ),
+        (
+            &["*.md"],
+            &[
+                "a/b/notes.md",
+                "docs/notes.md",
+                "docs/日本語.md",
+                "notes.md",
+            ],
+        ),
+        (&["build/"], &["build/x.txt", "docs/build/y.txt"]),
+        (&["build"], &["build/x.txt", "docs/build/y.txt"]),
+        (
+            &["node_modules"],
+            &["node_modules/pkg/i.js", "src/node_modules/j.js"],
+        ),
+        (&["docs/notes.md"], &["docs/notes.md"]),
+        (&["docs/*.log"], &["docs/a.log"]),
+        (&["docs/build/"], &["docs/build/y.txt"]),
+        // A bracket is a character class in gitignore, so it never matches the
+        // literal name — `,literal` pathspec magic would silently diverge here.
+        (&["weird[1].txt"], &[]),
+        // `!` un-ignore lines are unsupported and dropped by BOTH engines: a lone
+        // negation hides nothing, and a negation after a matching pattern
+        // re-includes nothing. Git's own engine would honor the second case, so
+        // this row is what holds the two engines together on negations.
+        (&["!docs/notes.md"], &[]),
+        (
+            &["*.md", "!docs/notes.md"],
+            &[
+                "a/b/notes.md",
+                "docs/notes.md",
+                "docs/日本語.md",
+                "notes.md",
+            ],
+        ),
+        // Blanks and comments are dropped everywhere too.
+        (&["  ", "# a comment", "docs/*.log"], &["docs/a.log"]),
+        // Case: the fixture pins `core.ignorecase=false`, so a case-differing
+        // pattern matches nothing — on BOTH engines. `case_folding_follows_the_repo`
+        // covers the `true` half, which is the platform default on Windows/macOS.
+        (&["NOTES.MD"], &[]),
+        // A concrete path carrying glob metacharacters, escaped the way the UI's
+        // *Exclude from AI* actions emit it: `[` wrapped as `[[]`. Unescaped it is
+        // a character class and protects nothing — the `weird[1].txt` row above.
+        (&["weird[[]1].txt"], &["weird[1].txt"]),
+        (&["/weird[[]1].txt"], &["weird[1].txt"]),
+    ];
+
+    /// A `.gitignore` line the fixture repo carries but the AI-ignore lists never
+    /// mention: nothing either engine reports may ever be traceable to it.
+    const REPO_GITIGNORE_ONLY: &str = "keep.txt";
+
+    /// Builds a repo whose index holds `FIXTURE` (added with `-f` so a user's
+    /// global excludes can't drop `node_modules` from the fixture), plus a
+    /// `.gitignore` covering `REPO_GITIGNORE_ONLY` so every assertion below also
+    /// proves the repo's own ignore rules stay out of AI-ignore matching.
+    async fn parity_repo() -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-aiignore-parity-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+            // PINNED, not inherited: `git init` sets this true on Windows/macOS and
+            // false on Linux, which would make every case-sensitive expectation in
+            // PARITY platform-dependent.
+            vec!["config", "core.ignorecase", "false"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        for rel in FIXTURE {
+            let path = Path::new(&repo).join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "x\n").unwrap();
+        }
+        std::fs::write(
+            Path::new(&repo).join(".gitignore"),
+            format!("{REPO_GITIGNORE_ONLY}\n"),
+        )
+        .unwrap();
+        run_git(Some(&repo), &["add", "-A", "-f"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        (dir, repo)
+    }
+
+    /// What the pathspec terms hide: `FIXTURE` minus what `ls-files` still lists.
+    /// Goes through `pathspecs_for_repo`, so case folding is resolved from the
+    /// repo exactly as the real diff call sites do it.
+    async fn hidden_by_pathspec(repo: &str, patterns: &[&str]) -> BTreeSet<String> {
+        let owned: Vec<String> = patterns.iter().map(|p| p.to_string()).collect();
+        let terms = pathspecs_for_repo(repo, &owned).await.specs;
+        let mut args: Vec<String> = vec!["ls-files".into()];
+        if !terms.is_empty() {
+            args.push("--".into());
+            args.push(".".into());
+            args.extend(terms);
+        }
+        let argref: Vec<&str> = args.iter().map(String::as_str).collect();
+        let listed: BTreeSet<String> = run_git(Some(repo), &argref, DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+        FIXTURE
+            .iter()
+            .map(|p| p.to_string())
+            .filter(|p| !listed.contains(p))
+            .collect()
+    }
+
+    /// The two engines agree with each other AND with the measured table, for
+    /// every pattern shape the UI can produce. This is the test that stops the
+    /// pathspec translation drifting away from real gitignore.
+    #[tokio::test]
+    async fn both_engines_match_the_measured_table() {
+        let (_dir, repo) = parity_repo().await;
+        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
+
+        for (patterns, expected) in PARITY {
+            let want: BTreeSet<String> = expected.iter().map(|p| p.to_string()).collect();
+
+            let by_pathspec = hidden_by_pathspec(&repo, patterns).await;
+            assert_eq!(by_pathspec, want, "pathspec engine, patterns {patterns:?}");
+
+            let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
+                repo.clone(),
+                all.clone(),
+                patterns.iter().map(|p| p.to_string()).collect(),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+            assert_eq!(
+                by_gitignore, want,
+                "gitignore engine, patterns {patterns:?}"
+            );
+        }
+    }
+
+    /// Case folding follows the USER'S REPO, identically on both engines.
+    ///
+    /// The failure this pins is asymmetric and silent: pathspec matching is
+    /// case-sensitive whatever `core.ignorecase` says, while real gitignore folds
+    /// when it is set — the default on Windows and macOS. Without `,icase` a
+    /// `NOTES.MD` pattern would hide `notes.md` from the conflict gate and the
+    /// remote-PR filter while every diff path still shipped it to the model.
+    #[tokio::test]
+    async fn case_folding_follows_the_repo() {
+        let (_dir, repo) = parity_repo().await;
+        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
+        let pattern = vec!["NOTES.MD".to_string()];
+        let want_folded: BTreeSet<String> = ["a/b/notes.md", "docs/notes.md", "notes.md"]
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        // The fixture pins ignorecase=false: a case-differing pattern matches
+        // nothing, on either engine.
+        assert!(hidden_by_pathspec(&repo, &["NOTES.MD"]).await.is_empty());
+        assert!(
+            git_filter_ai_ignored(repo.clone(), all.clone(), pattern.clone())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(specs("NOTES.MD")[0], ":(exclude,glob)**/NOTES.MD");
+
+        // Flip the REPO's setting; both engines must follow it, and each other.
+        run_git(
+            Some(&repo),
+            &["config", "core.ignorecase", "true"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        // Behavior first: an emitted-magic assertion ahead of it would mask which
+        // half actually broke.
+        let by_pathspec = hidden_by_pathspec(&repo, &["NOTES.MD"]).await;
+        assert_eq!(by_pathspec, want_folded, "pathspec engine folds case");
+
+        let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(repo, all, pattern)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(by_gitignore, want_folded, "gitignore engine folds case");
+        assert_eq!(by_pathspec, by_gitignore, "and the two agree");
+        assert_eq!(
+            specs_icase("NOTES.MD")[0],
+            ":(exclude,glob,icase)**/NOTES.MD"
+        );
+    }
+
+    /// A returned path is byte-identical to the one that went in, whatever
+    /// characters it holds. The caller intersects this result with its own path
+    /// list, so any rewriting silently drops the path from the ignored set and
+    /// sends the file to a model. Needs no files on disk (`--no-index` matches
+    /// path strings), which also keeps it clear of filesystem normalization.
+    #[tokio::test]
+    async fn returned_paths_are_byte_identical_to_the_input() {
+        let (_dir, repo) = parity_repo().await;
+        let paths = vec![
+            "café.md".to_string(),
+            "docs/日本語.md".to_string(),
+            // Quotes as literal filename characters: git C-dequotes these without
+            // `-z` and hands back the unquoted name.
+            "\"quoted\".md".to_string(),
+            "plain.md".to_string(),
+            "keep.txt".to_string(),
+        ];
+
+        let hit = git_filter_ai_ignored(repo.clone(), paths.clone(), vec!["*.md".into()])
+            .await
+            .unwrap();
+        assert_eq!(
+            hit,
+            vec![
+                "café.md".to_string(),
+                "docs/日本語.md".to_string(),
+                "\"quoted\".md".to_string(),
+                "plain.md".to_string(),
+            ],
+            "every matched path comes back exactly as sent"
+        );
+        for p in &hit {
+            assert!(paths.contains(p), "`{p}` is not one of the input strings");
+        }
+
+        // The non-ASCII paths must be reachable by a pattern of their own, not
+        // just swept up by `*.md`.
+        let precise =
+            git_filter_ai_ignored(repo, paths, vec!["café.md".into(), "docs/日本語.md".into()])
+                .await
+                .unwrap();
+        assert_eq!(
+            precise,
+            vec!["café.md".to_string(), "docs/日本語.md".to_string()]
+        );
+    }
+
+    /// The repo's OWN `.gitignore` is not an AI-ignore list. Matching runs in an
+    /// empty neutral repo, so `keep.txt` — gitignored by the fixture, named by no
+    /// AI pattern — stays visible to both engines. Running check-ignore inside
+    /// the user's repo instead reports it, which would both silently
+    /// over-withhold and split the two engines apart.
+    #[tokio::test]
+    async fn repo_gitignore_never_counts_as_an_ai_pattern() {
+        let (_dir, repo) = parity_repo().await;
+        // Sanity: git really does ignore it there, so the negative below has teeth.
+        let native = run_git(
+            Some(&repo),
+            &["check-ignore", "--no-index", "--", REPO_GITIGNORE_ONLY],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            native.stdout_lossy().trim(),
+            REPO_GITIGNORE_ONLY,
+            "fixture precondition: the repo's .gitignore covers this path"
+        );
+
+        let ai_patterns = vec!["notes.md".to_string()];
+        let by_gitignore = git_filter_ai_ignored(
+            repo.clone(),
+            vec![REPO_GITIGNORE_ONLY.to_string(), "notes.md".to_string()],
+            ai_patterns.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            by_gitignore,
+            vec!["notes.md".to_string()],
+            "only the AI pattern matched — the repo's .gitignore did not leak in"
+        );
+
+        let by_pathspec = hidden_by_pathspec(&repo, &["notes.md"]).await;
+        assert!(
+            !by_pathspec.contains(REPO_GITIGNORE_ONLY),
+            "the pathspec engine agrees the gitignored path is not AI-ignored"
+        );
+    }
+
+    /// `git_filter_ai_ignored` matches paths that exist nowhere in the repo (the
+    /// remote-PR case), returns `[]` rather than erroring when nothing matches,
+    /// and short-circuits on empty input.
+    #[tokio::test]
+    async fn filter_handles_absent_paths_and_empty_input() {
+        let (_dir, repo) = parity_repo().await;
+        let ghost = vec![
+            "never/existed/secrets.env".to_string(),
+            "never/existed/app.rs".to_string(),
+        ];
+
+        let hit = git_filter_ai_ignored(repo.clone(), ghost.clone(), vec!["*.env".into()])
+            .await
+            .unwrap();
+        assert_eq!(hit, vec!["never/existed/secrets.env".to_string()]);
+
+        let miss = git_filter_ai_ignored(repo.clone(), ghost.clone(), vec!["*.lock".into()])
+            .await
+            .unwrap();
+        assert!(miss.is_empty(), "no match is Ok([]), not an error");
+
+        assert!(
+            git_filter_ai_ignored(repo.clone(), vec![], vec!["*.env".into()])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(git_filter_ai_ignored(repo, ghost, vec![])
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    /// A `!` un-ignore line is unsupported: adding one changes NOTHING on either
+    /// engine. Git's own matcher would re-include the negated path, so without
+    /// the shared drop the same list would hide a file on the pathspec paths and
+    /// hand it to a model on this one.
+    #[tokio::test]
+    async fn negation_lines_change_nothing_on_either_engine() {
+        let (_dir, repo) = parity_repo().await;
+        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
+        let plain = vec!["*.md".to_string()];
+        let negated = vec!["*.md".to_string(), "!docs/notes.md".to_string()];
+
+        let translated = pathspecs_for(&negated, false);
+        assert_eq!(translated.skipped_negations, 1);
+        assert_eq!(translated.specs, pathspecs_for(&plain, false).specs);
+
+        let with = git_filter_ai_ignored(repo.clone(), all.clone(), negated)
+            .await
+            .unwrap();
+        let without = git_filter_ai_ignored(repo.clone(), all, plain)
+            .await
+            .unwrap();
+        assert_eq!(with, without, "the `!` line did not re-include anything");
+        assert!(
+            with.contains(&"docs/notes.md".to_string()),
+            "the negated path stays hidden"
+        );
+
+        // An exclude list of nothing BUT droppable lines matches nothing at all,
+        // and never spawns git.
+        let only_droppable = git_filter_ai_ignored(
+            repo,
+            vec!["docs/notes.md".to_string()],
+            vec!["!docs/notes.md".into(), "# c".into(), "  ".into()],
+        )
+        .await
+        .unwrap();
+        assert!(only_droppable.is_empty());
+    }
+}

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -41,14 +41,11 @@ pub struct AiIgnorePathspecs {
 /// blanks, `#` comments and `!` un-ignore lines dropped. Returns them with the
 /// number of `!` lines dropped.
 ///
-/// One definition, deliberately shared: the two engines must decide every list
-/// identically, and `!` is the case that can only be made uniform by dropping
-/// it. A pathspec has no un-exclude, so honoring negations is impossible on that
-/// side; letting the gitignore side honor them anyway would hide a file when the
-/// user opens a PR from a local branch and send that same file to a model when
-/// they regenerate an open PR's description. Of the two uniform behaviors,
-/// refusing an un-ignore withholds more — the right way for a privacy feature to
-/// fail.
+/// One definition, deliberately shared: both engines must decide every list
+/// identically, and `!` can only be made uniform by dropping it — a pathspec has
+/// no un-exclude, so honoring negations on the gitignore side alone would hide a
+/// file on one generation path and hand it to a model on another. Of the two
+/// uniform behaviors, refusing an un-ignore withholds more.
 fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
     let mut lines: Vec<&str> = Vec::new();
     let mut skipped_negations = 0usize;
@@ -156,25 +153,20 @@ pub async fn pathspecs_for_repo(repo_path: &str, patterns: &[String]) -> AiIgnor
 /// An empty throwaway repo, created once per process, that [`filter_ignored`]
 /// runs `check-ignore` inside.
 ///
-/// The AI-ignore patterns must be the ONLY rules in play. Running in the user's
-/// repo adds that repo's `.gitignore` files to the ruleset, which both
-/// over-reports (a tracked-but-gitignored file — a committed lockfile, a
-/// checked-in build artifact — would be declared AI-ignored and the conflict UI
-/// would tell the user it "matches your AI ignore patterns", with no bypass) and
-/// breaks the invariant that this engine and `pathspecs_for` decide alike. An
-/// empty work tree leaves `core.excludesFile` as the only active source.
+/// The AI-ignore patterns must be the ONLY rules in play: running in the user's
+/// repo would add that repo's `.gitignore` files, which both over-reports (a
+/// committed-but-gitignored lockfile declared AI-ignored, with no bypass in the
+/// conflict UI) and breaks the invariant that this engine and `pathspecs_for`
+/// decide alike. An empty work tree leaves `core.excludesFile` as the only
+/// active source. Reused across calls because `is_ai_ignored` runs per
+/// conflicted file; only a successful init is cached (`get_or_try_init` leaves
+/// the cell empty on error).
 ///
-/// Created once and reused: `is_ai_ignored` runs per conflicted file, so a
-/// per-call `git init` would be a spawn storm. Only a successful init is cached
-/// (`get_or_try_init` leaves the cell empty on error).
-///
-/// `TempDir` rather than a pid-derived name because the path must be
-/// unpredictable and never adopted: in a shared `/tmp`, a guessable name lets a
-/// local attacker pre-create `.git/info/exclude` holding `!secrets.env`, which
-/// outranks `core.excludesFile` and would make the conflict gate fail open — and
-/// a reused pid alone could wedge a session on a directory this process cannot
-/// write. TempDir creates exclusively, with owner-only permissions. It lives in a
-/// static, so the OS temp reaper rather than `Drop` is what eventually removes it.
+/// `TempDir` rather than a pid-derived name: in a shared `/tmp` a guessable path
+/// lets a local attacker pre-create `.git/info/exclude` holding `!secrets.env`,
+/// which outranks `core.excludesFile` and fails the conflict gate OPEN. TempDir
+/// creates exclusively, with owner-only permissions; it lives in a static, so the
+/// OS temp reaper rather than `Drop` eventually removes it.
 static NEUTRAL_REPO: OnceCell<tempfile::TempDir> = OnceCell::const_new();
 
 async fn neutral_repo() -> AppResult<PathBuf> {

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -109,9 +109,9 @@ pub async fn git_branch_diff(
     validate_ref(&compare)?;
     let range = format!("{base}...{compare}");
 
-    // AI-ignore patterns → pathspec excludes, via the one shared engine
-    // (`git::ai_ignore`, which pins gitignore parity with tests). ":(exclude)"
-    // needs at least one inclusive pathspec alongside it, hence the leading ".".
+    // AI-ignore patterns → pathspec excludes (`git::ai_ignore` owns the
+    // translation). ":(exclude)" needs an inclusive pathspec alongside it,
+    // hence the leading ".".
     let pathspec =
         crate::git::ai_ignore::pathspecs_for_repo(&repo_path, &exclude.unwrap_or_default())
             .await

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -109,20 +109,13 @@ pub async fn git_branch_diff(
     validate_ref(&compare)?;
     let range = format!("{base}...{compare}");
 
-    // Translate ignore patterns into git pathspec excludes — pathspec globs are
-    // close to gitignore semantics but not identical: `*` also matches `/`
-    // (wildmatch without WM_PATHNAME) so `src/*.rs` hides nested files too, and
-    // a bare `notes.md` is root-anchored where gitignore matches any depth
-    // (both measured, git 2.51.1). ":(exclude)" needs at least one inclusive
-    // pathspec alongside it, hence the leading ".".
-    let mut pathspec: Vec<String> = Vec::new();
-    for pattern in exclude.unwrap_or_default() {
-        let pattern = pattern.trim();
-        if pattern.is_empty() || pattern.starts_with('#') {
-            continue;
-        }
-        pathspec.push(format!(":(exclude){pattern}"));
-    }
+    // AI-ignore patterns → pathspec excludes, via the one shared engine
+    // (`git::ai_ignore`, which pins gitignore parity with tests). ":(exclude)"
+    // needs at least one inclusive pathspec alongside it, hence the leading ".".
+    let pathspec =
+        crate::git::ai_ignore::pathspecs_for_repo(&repo_path, &exclude.unwrap_or_default())
+            .await
+            .specs;
 
     let mut diff_args: Vec<&str> = vec!["diff", "--no-color", &range];
     let mut stat_args: Vec<&str> = vec!["diff", "--numstat", "-z", &range];
@@ -817,6 +810,82 @@ mod tests {
         assert_eq!(noop.files.len(), 6);
         assert_eq!(noop.excluded_files, 0);
         assert_eq!(noop.text, all.text);
+    }
+
+    /// AI-ignore patterns are gitignore-style, so a bare NAME matches at any
+    /// depth (not just the repo root), a bare DIRECTORY name hides that
+    /// directory's contents wherever it sits, and a leading `/` anchors to the
+    /// root instead of blanking the whole diff.
+    #[tokio::test]
+    async fn branch_diff_bare_name_matches_at_any_depth() {
+        let (_base, repo) = seed_repo("branchdiff-anydepth").await;
+        let root = std::path::Path::new(&repo);
+
+        std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        let base_sha = run(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::create_dir_all(root.join("src").join("node_modules")).unwrap();
+        std::fs::write(root.join("notes.md"), "root\n").unwrap();
+        std::fs::write(root.join("docs").join("notes.md"), "nested\n").unwrap();
+        std::fs::write(root.join("keep.txt"), "keep\n").unwrap();
+        std::fs::write(root.join("src").join("node_modules").join("j.js"), "dep\n").unwrap();
+        // `-f`: a user's GLOBAL excludes file may ignore node_modules.
+        run(&repo, &["add", "-A", "-f"]).await;
+        run(&repo, &["commit", "-qm", "work"]).await;
+
+        let bare = git_branch_diff(
+            repo.clone(),
+            base_sha.clone(),
+            "HEAD".into(),
+            None,
+            Some(vec!["notes.md".into()]),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !bare.files.iter().any(|f| f.path == "docs/notes.md"),
+            "a bare name hides the NESTED copy, not just the root one"
+        );
+        assert!(!bare.files.iter().any(|f| f.path == "notes.md"));
+        assert!(bare.files.iter().any(|f| f.path == "keep.txt"));
+        assert_eq!(bare.excluded_files, 2);
+
+        // A leading `/` anchors to the repo root — the nested copy survives, and
+        // the diff is not silently emptied (git used to read it as an abs path).
+        let anchored = git_branch_diff(
+            repo.clone(),
+            base_sha.clone(),
+            "HEAD".into(),
+            None,
+            Some(vec!["/notes.md".into()]),
+        )
+        .await
+        .unwrap();
+        assert!(
+            anchored.files.iter().any(|f| f.path == "docs/notes.md"),
+            "the anchored pattern spares the nested copy"
+        );
+        assert!(!anchored.files.iter().any(|f| f.path == "notes.md"));
+        assert_eq!(anchored.excluded_files, 1);
+
+        // A bare DIRECTORY name (no trailing slash) hides its contents at depth.
+        let dir = git_branch_diff(
+            repo,
+            base_sha,
+            "HEAD".into(),
+            None,
+            Some(vec!["node_modules".into()]),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !dir.files.iter().any(|f| f.path.contains("node_modules")),
+            "`node_modules` hides src/node_modules/j.js"
+        );
+        assert_eq!(dir.excluded_files, 1);
     }
 
     /// A match at a rev is found even after the working tree (and later commits)

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -160,6 +160,15 @@ pub async fn git_checkout_conflict_side(
     path: String,
     side: String,
 ) -> AppResult<()> {
+    git_checkout_conflict_side_core(&state, repo_path, path, side).await
+}
+
+pub(crate) async fn git_checkout_conflict_side_core(
+    state: &AppState,
+    repo_path: String,
+    path: String,
+    side: String,
+) -> AppResult<()> {
     validate_rel_path(&path)?;
     let flag = match side.as_str() {
         "ours" => "--ours",
@@ -175,13 +184,13 @@ pub async fn git_checkout_conflict_side(
     // never opened.
     let spec = crate::git::pathspec::literal(&path);
     run_git_mutating(
-        &state,
+        state,
         &repo_path,
         &["checkout", flag, "--", &spec],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    run_git_mutating(&state, &repo_path, &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
+    run_git_mutating(state, &repo_path, &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -264,9 +273,15 @@ mod tests {
         (dir, repo)
     }
 
-    /// Builds a real merge conflict on `file.txt` (base → "base", ours → "ours",
-    /// theirs → "theirs") and leaves the repo mid-merge.
-    async fn conflicted_repo(tag: &str) -> (tempfile::TempDir, String) {
+    /// Builds a real merge conflict on `path` (base → "base", ours → "ours",
+    /// theirs → "theirs") and leaves the repo mid-merge. `also_tracked` files are
+    /// committed at the base and never touched by the merge, so a test can modify
+    /// one and assert an operation left it alone.
+    async fn conflicted_repo(
+        tag: &str,
+        path: &str,
+        also_tracked: &[&str],
+    ) -> (tempfile::TempDir, String) {
         let (dir, repo) = temp_repo(tag);
         let git = |args: Vec<&'static str>| {
             let repo = repo.clone();
@@ -275,7 +290,13 @@ mod tests {
         git(vec!["init"]).await;
         git(vec!["config", "user.email", "t@t"]).await;
         git(vec!["config", "user.name", "t"]).await;
-        let file = Path::new(&repo).join("file.txt");
+        let file = Path::new(&repo).join(path);
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        for extra in also_tracked {
+            let p = Path::new(&repo).join(extra);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, "sibling base\n").unwrap();
+        }
         std::fs::write(&file, "base\n").unwrap();
         git(vec!["add", "."]).await;
         git(vec!["commit", "-m", "base"]).await;
@@ -294,7 +315,7 @@ mod tests {
 
     #[tokio::test]
     async fn sides_carry_each_stage_and_markers() {
-        let (_dir, repo) = conflicted_repo("sides").await;
+        let (_dir, repo) = conflicted_repo("sides", "file.txt", &[]).await;
         let sides = git_conflict_sides(repo.clone(), "file.txt".into(), vec![])
             .await
             .unwrap();
@@ -309,7 +330,7 @@ mod tests {
     #[tokio::test]
     async fn checkout_side_takes_one_side_and_clears() {
         // ours → the current branch's version, conflict cleared.
-        let (_dir, repo) = conflicted_repo("ours-side").await;
+        let (_dir, repo) = conflicted_repo("ours-side", "file.txt", &[]).await;
         run_git(Some(&repo), &["checkout", "--ours", "--", "file.txt"], DEFAULT_TIMEOUT)
             .await
             .unwrap();
@@ -331,7 +352,7 @@ mod tests {
             .is_empty());
 
         // theirs → the incoming version.
-        let (_dir2, repo2) = conflicted_repo("theirs-side").await;
+        let (_dir2, repo2) = conflicted_repo("theirs-side", "file.txt", &[]).await;
         run_git(Some(&repo2), &["checkout", "--theirs", "--", "file.txt"], DEFAULT_TIMEOUT)
             .await
             .unwrap();
@@ -346,9 +367,63 @@ mod tests {
         );
     }
 
+    /// Taking one side touches ONLY the chosen path. Pathspecs glob, so a raw
+    /// `src/app/[slug]/page.tsx` also sweeps the character-class sibling
+    /// `src/app/s/page.tsx`: `checkout` reverts the user's separate edit to it
+    /// from the index and `add` stages the result, both exiting 0 (measured, git
+    /// 2.51.1).
+    #[tokio::test]
+    async fn checkout_side_does_not_touch_glob_siblings() {
+        let (_dir, repo) = conflicted_repo(
+            "conflict-glob",
+            "src/app/[slug]/page.tsx",
+            &["src/app/s/page.tsx"],
+        )
+        .await;
+        let sibling = Path::new(&repo).join("src/app/s/page.tsx");
+        std::fs::write(&sibling, "SIBLING WIP\n").unwrap();
+
+        let state = AppState::default();
+        git_checkout_conflict_side_core(
+            &state,
+            repo.clone(),
+            "src/app/[slug]/page.tsx".into(),
+            "theirs".into(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(Path::new(&repo).join("src/app/[slug]/page.tsx"))
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "theirs\n",
+            "the chosen file took its side"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&sibling)
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "SIBLING WIP\n",
+            "the glob-sibling keeps its uncommitted edit"
+        );
+        let staged = run_git(
+            Some(&repo),
+            &["diff", "--cached", "--name-only"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap()
+        .stdout_lossy();
+        assert!(
+            !staged.contains("src/app/s/page.tsx"),
+            "the glob-sibling was staged: {staged}"
+        );
+    }
+
     #[tokio::test]
     async fn ai_ignore_pattern_flags_the_path() {
-        let (_dir, repo) = conflicted_repo("ignore").await;
+        let (_dir, repo) = conflicted_repo("ignore", "file.txt", &[]).await;
         let hit = git_conflict_sides(repo.clone(), "file.txt".into(), vec!["*.txt".into()])
             .await
             .unwrap();
@@ -387,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_writes_and_clears_the_conflict() {
-        let (_dir, repo) = conflicted_repo("resolve").await;
+        let (_dir, repo) = conflicted_repo("resolve", "file.txt", &[]).await;
         // Before: the path is unmerged (`ls-files -u` lists it).
         let unmerged = run_git(Some(&repo), &["ls-files", "-u"], DEFAULT_TIMEOUT)
             .await

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -67,8 +67,7 @@ async fn stage_blob(repo: &str, stage: u8, path: &str) -> AppResult<Option<Strin
 }
 
 /// Whether the path matches any of the user's AI-ignore `exclude` patterns —
-/// the highest-consequence AI-ignore gate in the app, since it decides whether
-/// a conflicted file's contents go to a model.
+/// the gate that decides whether a conflicted file's contents go to a model.
 ///
 /// Must stay on the gitignore engine (`git::ai_ignore::filter_ignored`), which
 /// a test pins to the same truth table as the pathspec side. An `ls-files` +
@@ -143,7 +142,8 @@ pub async fn git_resolve_conflict(
         .await
         .map_err(AppError::Io)?;
     if stage {
-        run_git_mutating(&state, &repo_path, &["add", "--", &path], DEFAULT_TIMEOUT).await?;
+        let spec = crate::git::pathspec::literal(&path);
+        run_git_mutating(&state, &repo_path, &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
     }
     Ok(())
 }
@@ -170,14 +170,18 @@ pub async fn git_checkout_conflict_side(
             )))
         }
     };
+    // Literal pathspec on both steps: a `[slug]`-style path would otherwise take
+    // this side for its glob-siblings too, silently resolving conflicts the user
+    // never opened.
+    let spec = crate::git::pathspec::literal(&path);
     run_git_mutating(
         &state,
         &repo_path,
-        &["checkout", flag, "--", &path],
+        &["checkout", flag, "--", &spec],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    run_git_mutating(&state, &repo_path, &["add", "--", &path], DEFAULT_TIMEOUT).await?;
+    run_git_mutating(&state, &repo_path, &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -355,8 +359,7 @@ mod tests {
         assert!(!miss.ai_ignored);
 
         // A NESTED copy of the same name: patterns are gitignore-style, so a bare
-        // `file.txt` must flag `docs/file.txt` too — this gate decides whether a
-        // file's contents reach a model, so a missed depth is a leak.
+        // `file.txt` must flag `docs/file.txt` too — a missed depth is a leak.
         std::fs::create_dir_all(Path::new(&repo).join("docs")).unwrap();
         std::fs::write(Path::new(&repo).join("docs").join("file.txt"), "nested\n").unwrap();
         run_git(Some(&repo), &["add", "--", "docs/file.txt"], DEFAULT_TIMEOUT)

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
-use crate::git::runner::{run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT};
+use crate::git::runner::{run_git_mutating, run_git_raw, DEFAULT_TIMEOUT};
 use crate::state::AppState;
 
 /// Cap on a conflicted file's working-tree size for AI resolution. Past this the
@@ -66,30 +66,20 @@ async fn stage_blob(repo: &str, stage: u8, path: &str) -> AppResult<Option<Strin
     Ok((out.code == 0).then(|| out.stdout_lossy()))
 }
 
-/// Whether the path matches any of the user's AI-ignore `exclude` patterns,
-/// using git's own pathspec matching (the same engine the staged diff uses;
-/// close to but not identical to gitignore semantics): list the path with
-/// `:(exclude)` magic pathspecs applied — if it drops out of the listing, a
-/// pattern matched it.
+/// Whether the path matches any of the user's AI-ignore `exclude` patterns —
+/// the highest-consequence AI-ignore gate in the app, since it decides whether
+/// a conflicted file's contents go to a model.
+///
+/// Must stay on the gitignore engine (`git::ai_ignore::filter_ignored`), which
+/// a test pins to the same truth table as the pathspec side. An `ls-files` +
+/// `:(exclude)` listing CANNOT decide a single path: git strips the positive
+/// pathspec's leading directory off every negative pattern as well, so with
+/// `docs/secrets.env` as the positive term the pattern `secrets.env` is
+/// compared as `rets.env` and silently matches nothing (measured, git 2.51.1).
 async fn is_ai_ignored(repo: &str, path: &str, exclude: &[String]) -> AppResult<bool> {
-    let patterns: Vec<&str> = exclude
-        .iter()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty() && !s.starts_with('#'))
-        .collect();
-    if patterns.is_empty() {
-        return Ok(false);
-    }
-    // An unmerged path normally lists (once per stage); with a matching exclude
-    // pathspec it lists nothing. `:(exclude)` needs at least one positive
-    // pathspec, which `path` provides.
-    let mut args: Vec<String> = vec!["ls-files".into(), "--".into(), path.into()];
-    for p in &patterns {
-        args.push(format!(":(exclude){p}"));
-    }
-    let argref: Vec<&str> = args.iter().map(String::as_str).collect();
-    let out = run_git(Some(repo), &argref, DEFAULT_TIMEOUT).await?;
-    Ok(out.stdout_lossy().trim().is_empty())
+    let one = [path.to_string()];
+    let hits = crate::git::ai_ignore::filter_ignored(repo, &one, exclude).await?;
+    Ok(!hits.is_empty())
 }
 
 /// The base/ours/theirs blobs plus the marked working file for a conflicted
@@ -247,6 +237,7 @@ pub async fn git_diff_contents(old: String, new: String) -> AppResult<String> {
 /// test), so the resolve path is exercised end-to-end against a real repo.
 #[cfg(test)]
 pub(crate) async fn resolve_for_test(repo: &str, path: &str, content: &str) {
+    use crate::git::runner::run_git;
     tokio::fs::write(Path::new(repo).join(path), content)
         .await
         .unwrap();
@@ -362,6 +353,33 @@ mod tests {
             .await
             .unwrap();
         assert!(!miss.ai_ignored);
+
+        // A NESTED copy of the same name: patterns are gitignore-style, so a bare
+        // `file.txt` must flag `docs/file.txt` too — this gate decides whether a
+        // file's contents reach a model, so a missed depth is a leak.
+        std::fs::create_dir_all(Path::new(&repo).join("docs")).unwrap();
+        std::fs::write(Path::new(&repo).join("docs").join("file.txt"), "nested\n").unwrap();
+        run_git(Some(&repo), &["add", "--", "docs/file.txt"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        let nested = git_conflict_sides(repo.clone(), "docs/file.txt".into(), vec!["file.txt".into()])
+            .await
+            .unwrap();
+        assert!(nested.ai_ignored, "a bare name matches at any depth");
+
+        // ...while a leading `/` anchors to the repo root: the nested copy is
+        // free, the root one is still flagged.
+        let anchored_nested =
+            git_conflict_sides(repo.clone(), "docs/file.txt".into(), vec!["/file.txt".into()])
+                .await
+                .unwrap();
+        assert!(!anchored_nested.ai_ignored);
+        let anchored_root =
+            git_conflict_sides(repo, "file.txt".into(), vec!["/file.txt".into()])
+                .await
+                .unwrap();
+        assert!(anchored_root.ai_ignored);
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -403,20 +403,13 @@ pub async fn git_staged_diff(
         "--cached"
     };
 
-    // Translate ignore patterns into git pathspec excludes — pathspec globs are
-    // close to gitignore semantics but not identical: `*` also matches `/`
-    // (wildmatch without WM_PATHNAME) so `src/*.rs` hides nested files too, and
-    // a bare `notes.md` is root-anchored where gitignore matches any depth
-    // (both measured, git 2.51.1). ":(exclude)" needs at least one inclusive
-    // pathspec alongside it, hence the leading ".".
-    let mut pathspec: Vec<String> = Vec::new();
-    for pattern in exclude.unwrap_or_default() {
-        let pattern = pattern.trim();
-        if pattern.is_empty() || pattern.starts_with('#') {
-            continue;
-        }
-        pathspec.push(format!(":(exclude){pattern}"));
-    }
+    // AI-ignore patterns → pathspec excludes, via the one shared engine
+    // (`git::ai_ignore`, which pins gitignore parity with tests). ":(exclude)"
+    // needs at least one inclusive pathspec alongside it, hence the leading ".".
+    let pathspec =
+        crate::git::ai_ignore::pathspecs_for_repo(&repo_path, &exclude.unwrap_or_default())
+            .await
+            .specs;
 
     let mut diff_args: Vec<&str> = vec!["diff", base, "--no-color"];
     let mut stat_args: Vec<&str> = vec!["diff", base, "--numstat", "-z"];
@@ -576,6 +569,84 @@ mod tests {
         let (out, truncated) = truncate_at_file_boundary("diff --git a/a b/a\n+x\n".into(), 1000);
         assert!(!truncated);
         assert!(out.contains("+x"));
+    }
+
+    /// `exclude` filters the staged diff with real gitignore semantics (via
+    /// `git::ai_ignore`): a bare name hides every copy at any depth, a leading
+    /// `/` anchors to the repo root, and `excluded_files` counts what was hidden.
+    #[tokio::test]
+    async fn staged_diff_applies_gitignore_style_excludes() {
+        let _tmp = tempfile::Builder::new()
+            .prefix("gd-staged-exclude-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let dir = _tmp.path().to_path_buf();
+        let repo = dir.to_string_lossy().into_owned();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        std::fs::write(dir.join("seed.txt"), "seed\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        run_git(Some(&repo), &["commit", "-qm", "seed"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // Two copies of the same file name, one nested, plus an unrelated file.
+        std::fs::create_dir_all(dir.join("docs")).unwrap();
+        std::fs::write(dir.join("notes.md"), "root\n").unwrap();
+        std::fs::write(dir.join("docs").join("notes.md"), "nested\n").unwrap();
+        std::fs::write(dir.join("app.rs"), "fn main() {}\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // No excludes → everything staged is present, nothing reported hidden.
+        let all = git_staged_diff(repo.clone(), None, None, None).await.unwrap();
+        assert_eq!(all.files.len(), 3);
+        assert_eq!(all.excluded_files, 0);
+
+        // A bare name hides BOTH copies — gitignore matches at any depth.
+        let bare = git_staged_diff(repo.clone(), None, Some(vec!["notes.md".into()]), None)
+            .await
+            .unwrap();
+        assert_eq!(bare.files.len(), 1);
+        assert!(bare.files.iter().any(|f| f.path == "app.rs"));
+        assert!(
+            !bare.text.contains("docs/notes.md"),
+            "the nested copy is hidden too"
+        );
+        assert_eq!(bare.excluded_files, 2);
+
+        // A leading `/` anchors to the root, sparing the nested copy — and does
+        // NOT wipe the whole diff (it used to read as an absolute path).
+        let anchored = git_staged_diff(repo.clone(), None, Some(vec!["/notes.md".into()]), None)
+            .await
+            .unwrap();
+        assert_eq!(anchored.files.len(), 2);
+        assert!(
+            anchored.files.iter().any(|f| f.path == "docs/notes.md"),
+            "an anchored pattern spares the nested copy"
+        );
+        assert!(!anchored.files.iter().any(|f| f.path == "notes.md"));
+        assert_eq!(anchored.excluded_files, 1);
+
+        // Blank / `#` lines translate to no pathspec at all — same as no excludes.
+        let noop = git_staged_diff(
+            repo,
+            None,
+            Some(vec!["  ".into(), "# comment".into()]),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(noop.files.len(), 3);
+        assert_eq!(noop.excluded_files, 0);
     }
 
     const FILE_HEADER: &str = "diff --git a/f.txt b/f.txt\nindex 000..111 100644\n--- a/f.txt\n+++ b/f.txt\n";

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -403,9 +403,9 @@ pub async fn git_staged_diff(
         "--cached"
     };
 
-    // AI-ignore patterns → pathspec excludes, via the one shared engine
-    // (`git::ai_ignore`, which pins gitignore parity with tests). ":(exclude)"
-    // needs at least one inclusive pathspec alongside it, hence the leading ".".
+    // AI-ignore patterns → pathspec excludes (`git::ai_ignore` owns the
+    // translation). ":(exclude)" needs an inclusive pathspec alongside it,
+    // hence the leading ".".
     let pathspec =
         crate::git::ai_ignore::pathspecs_for_repo(&repo_path, &exclude.unwrap_or_default())
             .await

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,3 +1,4 @@
+pub mod ai_ignore;
 pub mod branches;
 pub mod commit;
 pub mod compare;

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -7,6 +7,7 @@ pub mod conflict;
 pub mod diff;
 pub mod history;
 pub mod ops;
+pub mod pathspec;
 pub mod remote;
 pub mod repo;
 pub mod runner;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -156,7 +156,8 @@ pub async fn git_discard(
         .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;
         return Ok(());
     }
-    run_git_mutating(&state, &repo_path, &["restore", "--", &path], DEFAULT_TIMEOUT).await?;
+    let spec = crate::git::pathspec::literal(&path);
+    run_git_mutating(&state, &repo_path, &["restore", "--", &spec], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -555,10 +556,13 @@ pub(crate) async fn git_discard_paths_core(
         .filter(|p| p.untracked)
         .map(|p| p.path.clone())
         .collect();
+    // Literal pathspecs: a `[slug]`-style path would otherwise also restore its
+    // glob-siblings, discarding edits the user never selected. The untracked half
+    // below takes the path as a filesystem name instead, so it must stay raw.
     let tracked: Vec<String> = paths
         .iter()
         .filter(|p| !p.untracked)
-        .map(|p| p.path.clone())
+        .map(|p| crate::git::pathspec::literal(&p.path))
         .collect();
 
     if !untracked.is_empty() {
@@ -1061,10 +1065,12 @@ pub(crate) async fn replace_file_lines(
     }
 
     // Dirty check BEFORE the edit: any porcelain output for this path means the
-    // file already had staged/unstaged changes, so we must not auto-stage.
+    // file already had staged/unstaged changes, so we must not auto-stage. Literal
+    // pathspec — a glob-sibling's dirtiness must not decide this file's fate.
+    let spec = crate::git::pathspec::literal(file_path);
     let status = run_git(
         Some(repo_path),
-        &["status", "--porcelain", "--", file_path],
+        &["status", "--porcelain", "--", &spec],
         DEFAULT_TIMEOUT,
     )
     .await?;
@@ -1122,12 +1128,7 @@ pub(crate) async fn replace_file_lines(
     // exactly this edit. Lock-free `run_git` — we already hold the repo lock.
     let staged = stage_when_clean && !had_local_changes;
     if staged {
-        run_git(
-            Some(repo_path),
-            &["add", "--", file_path],
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
+        run_git(Some(repo_path), &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
     }
 
     Ok(ApplyLinesResult {
@@ -3880,6 +3881,45 @@ detached
         assert!(
             !std::path::Path::new(&wt_path).exists(),
             "worktree removed after abort"
+        );
+    }
+
+    /// Discarding a path holding glob metacharacters touches ONLY that path.
+    /// Pathspecs glob, so a raw `src/app/[slug]/page.tsx` also restores the
+    /// character-class sibling `src/app/s/page.tsx` — silently destroying
+    /// uncommitted work the user never selected (measured, git 2.51.1).
+    #[tokio::test]
+    async fn discard_paths_does_not_restore_glob_siblings() {
+        let (dir, repo) = setup_repo("discard-glob-sibling").await;
+        std::fs::create_dir_all(dir.path().join("src/app/[slug]")).unwrap();
+        std::fs::create_dir_all(dir.path().join("src/app/s")).unwrap();
+        commit_file(&repo, dir.path(), "src/app/[slug]/page.tsx", "v0\n", "add route").await;
+        commit_file(&repo, dir.path(), "src/app/s/page.tsx", "v0\n", "add sibling").await;
+
+        std::fs::write(dir.path().join("src/app/[slug]/page.tsx"), "throw away\n").unwrap();
+        std::fs::write(dir.path().join("src/app/s/page.tsx"), "PRECIOUS\n").unwrap();
+
+        let state = AppState::default();
+        git_discard_paths_core(
+            &state,
+            repo.clone(),
+            vec![DiscardPath {
+                path: "src/app/[slug]/page.tsx".into(),
+                untracked: false,
+            }],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            nlf(std::fs::read_to_string(dir.path().join("src/app/[slug]/page.tsx")).unwrap()),
+            "v0\n",
+            "the selected file is discarded"
+        );
+        assert_eq!(
+            nlf(std::fs::read_to_string(dir.path().join("src/app/s/page.tsx")).unwrap()),
+            "PRECIOUS\n",
+            "the glob-sibling keeps its uncommitted work"
         );
     }
 

--- a/src-tauri/src/git/pathspec.rs
+++ b/src-tauri/src/git/pathspec.rs
@@ -1,0 +1,19 @@
+//! Concrete paths handed to git as pathspecs.
+//!
+//! Every command here takes paths the USER picked from a list, never a pattern
+//! they typed, so each one must match itself and nothing else. Commands whose
+//! callers may legitimately pass a glob — `git_untrack`'s `*.log` form, and the
+//! MCP `stage_files` tool, whose description promises pathspec support — are
+//! deliberately NOT routed through this; they discriminate at the call site.
+
+/// A concrete path as a pathspec that matches only itself.
+///
+/// Pathspecs glob, and git tries a literal match FIRST, so a raw path is not
+/// safe merely because it names a real file: with a sibling `src/app/s/page.tsx`
+/// present, `git restore -- src/app/[slug]/page.tsx` discards BOTH files'
+/// uncommitted changes (measured, git 2.51.1). `:(literal)` turns globbing off
+/// for the term. Escaping the metacharacters instead does not work here — the
+/// escaped form of a directory matches nothing at all.
+pub(crate) fn literal(path: &str) -> String {
+    format!(":(literal){path}")
+}

--- a/src-tauri/src/git/pathspec.rs
+++ b/src-tauri/src/git/pathspec.rs
@@ -14,6 +14,7 @@
 /// uncommitted changes (measured, git 2.51.1). `:(literal)` turns globbing off
 /// for the term. Escaping the metacharacters instead does not work here — the
 /// escaped form of a directory matches nothing at all.
+///
 /// An empty path stays empty: a bare `:(literal)` matches EVERYTHING, and the
 /// callers' `!is_empty()` guards would wave it through.
 pub(crate) fn literal(path: &str) -> String {
@@ -21,4 +22,16 @@ pub(crate) fn literal(path: &str) -> String {
         return String::new();
     }
     format!(":(literal){path}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stays_empty_and_metacharacters_are_disarmed() {
+        // A bare `:(literal)` would match the whole repo past an is_empty guard.
+        assert_eq!(literal(""), "");
+        assert_eq!(literal("a[b]"), ":(literal)a[b]");
+    }
 }

--- a/src-tauri/src/git/pathspec.rs
+++ b/src-tauri/src/git/pathspec.rs
@@ -14,6 +14,11 @@
 /// uncommitted changes (measured, git 2.51.1). `:(literal)` turns globbing off
 /// for the term. Escaping the metacharacters instead does not work here — the
 /// escaped form of a directory matches nothing at all.
+/// An empty path stays empty: a bare `:(literal)` matches EVERYTHING, and the
+/// callers' `!is_empty()` guards would wave it through.
 pub(crate) fn literal(path: &str) -> String {
+    if path.is_empty() {
+        return String::new();
+    }
     format!(":(literal){path}")
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -35,22 +35,17 @@ pub async fn read_repo_ai_ignore(repo_path: String) -> AppResult<Vec<String>> {
 }
 
 /// Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore`, creating the
-/// `.gitdesktop` directory and the file (with a header comment) if absent.
-/// Mirrors `append_to_gitignore` (trim + in-batch de-dupe + skip lines already
-/// present), with one delta: a fresh file is seeded with a header comment
-/// (`parse_patterns` and `git::ai_ignore` both skip `#` lines). Lines are stored
-/// verbatim, gitignore-style — in particular a leading `/` is preserved and
-/// anchors the pattern to the repo root, which is how the UI's "exclude THIS
-/// file" actions mean one file rather than every file with that name. Returns
-/// the number of patterns actually appended (0 when every pattern was empty or
-/// already present).
+/// `.gitdesktop` directory and the file (seeded with a `#` header comment) if
+/// absent. Mirrors `append_to_gitignore`: trim, de-dupe in batch, skip lines
+/// already present. Lines are stored verbatim, gitignore-style — a leading `/`
+/// is preserved and anchors the pattern to the repo root. Returns how many
+/// patterns were appended (0 when all were empty or already present).
 #[tauri::command]
 pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> AppResult<usize> {
     const HEADER: &str =
         "# Files excluded from AI context — gitignore-style patterns, one per line.";
 
-    // Normalize (trim only — a leading '/' is meaningful anchoring) and de-dupe
-    // within the batch (preserving order).
+    // Trim only — a leading '/' is meaningful anchoring — then de-dupe in order.
     let mut wanted: Vec<String> = Vec::new();
     for p in patterns {
         let t = p.trim().to_string();

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -37,22 +37,23 @@ pub async fn read_repo_ai_ignore(repo_path: String) -> AppResult<Vec<String>> {
 /// Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore`, creating the
 /// `.gitdesktop` directory and the file (with a header comment) if absent.
 /// Mirrors `append_to_gitignore` (trim + in-batch de-dupe + skip lines already
-/// present) with two deltas: any leading `/` is stripped — these lines are
-/// consumed as git pathspecs via `:(exclude)<pattern>`, where a leading slash
-/// makes git treat it as an absolute path outside the repo — and a fresh file
-/// is seeded with a header comment (`parse_patterns` and the pathspec builders
-/// both skip `#` lines). Returns the number of patterns actually appended (0
-/// when every pattern was empty or already present).
+/// present), with one delta: a fresh file is seeded with a header comment
+/// (`parse_patterns` and `git::ai_ignore` both skip `#` lines). Lines are stored
+/// verbatim, gitignore-style — in particular a leading `/` is preserved and
+/// anchors the pattern to the repo root, which is how the UI's "exclude THIS
+/// file" actions mean one file rather than every file with that name. Returns
+/// the number of patterns actually appended (0 when every pattern was empty or
+/// already present).
 #[tauri::command]
 pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> AppResult<usize> {
     const HEADER: &str =
         "# Files excluded from AI context — gitignore-style patterns, one per line.";
 
-    // Normalize (trim + strip leading '/') and de-dupe within the batch
-    // (preserving order).
+    // Normalize (trim only — a leading '/' is meaningful anchoring) and de-dupe
+    // within the batch (preserving order).
     let mut wanted: Vec<String> = Vec::new();
     for p in patterns {
-        let t = p.trim().trim_start_matches('/').to_string();
+        let t = p.trim().to_string();
         if !t.is_empty() && !wanted.contains(&t) {
             wanted.push(t);
         }
@@ -552,22 +553,30 @@ mod tests {
         let (_tmp, dir) = ai_ignore_test_repo();
         let repo = dir.to_string_lossy().into_owned();
 
-        // Leading slash stripped, whitespace-only skipped, in-batch dupes collapsed.
+        // Leading slash PRESERVED (it anchors the pattern to the repo root),
+        // whitespace trimmed, whitespace-only skipped, in-batch dupes collapsed.
         let added = append_repo_ai_ignore(
             repo.clone(),
             vec![
                 "/foo".to_string(),
                 "   ".to_string(),
-                "bar".to_string(),
+                "  bar  ".to_string(),
                 "bar".to_string(),
             ],
         )
         .await
         .unwrap();
-        // The whitespace-only entry and the in-batch dupe collapse: "foo" + "bar".
+        // The whitespace-only entry and the in-batch dupe collapse: "/foo" + "bar".
         assert_eq!(added, 2);
         let parsed = read_repo_ai_ignore(repo.clone()).await.unwrap();
-        assert_eq!(parsed, vec!["foo".to_string(), "bar".to_string()]);
+        assert_eq!(parsed, vec!["/foo".to_string(), "bar".to_string()]);
+
+        // `/foo` and `foo` are DIFFERENT patterns (anchored vs any-depth), so the
+        // unanchored twin is a new line, not a duplicate.
+        let added_unanchored = append_repo_ai_ignore(repo.clone(), vec!["foo".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(added_unanchored, 1);
 
         // An all-duplicates batch leaves the file byte-identical and appends nothing.
         let path = dir.join(".gitdesktop").join("aiignore");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,7 @@ pub fn run() {
             git::ops::git_abort_local_pr_merge,
             git::ops::git_cleanup_orphaned_resolve_worktrees,
             git::ops::git_conflict_preview,
+            git::ai_ignore::git_filter_ai_ignored,
             git::conflict::git_conflict_sides,
             git::conflict::git_resolve_conflict,
             git::conflict::git_checkout_conflict_side,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -933,6 +933,10 @@ caps how long such a review may run before it's stopped: **Auto** allows 5 minut
 the review is agentic — always, for Codex), or pin a fixed limit that applies to every
 agent-CLI review.
 
+**Critical** is the top severity an audit finding can carry — remote code execution,
+execution triggered by content you only clone or open, full compromise, or a mass data
+breach.
+
 **One review at a time — queue the other.** A PR streams one AI review at a time,
 but you don't have to pick between a code review and a security audit: start one
 while the other is running and it **queues**, then starts automatically when the
@@ -951,8 +955,10 @@ Ollama) get a **native, read-only tool loop** instead — with **no review works
 prepare**, so those reviews start instantly (no "Preparing review workspace…" wait).
 Either way it's **read-only end to end** — only read tools exist in the loop, so the
 reviewer can explore but never modify — and the status line shows what it's reading as it
-goes. When a review's diff outgrows the prompt budget, the panel offers one click to turn
-on agentic review for full coverage. A couple of caveats: each tool step is an extra model
+goes. An agentic review reads your repository directly, so your **AI ignore patterns**
+don't limit what it sees — turning it on widens what the reviewer can reach, not just how
+deeply it looks. When a review's diff outgrows the prompt budget, the panel offers one
+click to turn on agentic review for full coverage. A couple of caveats: each tool step is an extra model
 call, so agentic runs are slower and pricier than a one-shot review; and small local models
 (some Ollama models) may not support tool calling — the review fails with a clear message
 suggesting you turn agentic off or pick another model. (Codex reviews already explore the
@@ -1630,9 +1636,16 @@ notes**, and **repository descriptions**.
   \`.gitdesktop/instructions.md\` that takes precedence.
 - **AI-ignore patterns** keep sensitive or noisy files (lockfiles, vendored folders) out
   of the AI's context while still committing them normally — global in Settings, or
-  per-repo via \`.gitdesktop/aiignore\`. No need to hand-edit it: {{secondaryclick}} a changed
-  file → *Exclude from AI* (the file, its folder, or its file type — or a
-  multi-selection) appends to \`.gitdesktop/aiignore\`, creating it if needed.
+  per-repo via \`.gitdesktop/aiignore\`. A model that reads your repository itself isn't
+  limited by them — that's what **Agentic review** on a pull request turns on (see
+  *Pull requests*). They're \`.gitignore\` patterns: \`secrets.env\` hides
+  that file at any depth, \`/secrets.env\` only the copy at the repo root, \`node_modules\`
+  or \`vendor/\` a folder wherever it sits, and \`docs/*.log\` just that folder's logs.
+  \`!\` re-include lines aren't supported. No
+  need to hand-edit the file: {{secondaryclick}} a changed file → *Exclude from AI* (the
+  file, its folder, or its file type — or a multi-selection) appends to
+  \`.gitdesktop/aiignore\`, creating it if needed — an anchored line (\`/src/config.ts\`,
+  \`/vendor/\`) for exactly the file or folder you picked.
 - **Hide AI** (Settings → General) removes every AI surface from the app while keeping
   your configuration.
 

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -923,12 +923,10 @@ export function RemotePrView({
           deleted: f.deletions,
           isBinary: false,
         }));
-        // The forge hands us the whole diff, so unlike the branch-diff path
-        // there are no pathspecs to exclude with — derive a filtered copy with
-        // the shared recipe (also used by both review funnels). NEVER write it
-        // back into the query cache: the same string feeds the Files tab, the
-        // review threads and the AI review panel, all of which want the full
-        // diff.
+        // A forge-supplied diff arrives whole, so it is filtered client-side.
+        // NEVER write the result back into the query cache: the same string
+        // feeds the Files tab, the review threads and the AI review panel, all
+        // of which want the full diff.
         const hidden = await filterDiffByAiIgnore({
           repoPath,
           text,

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -60,6 +60,7 @@ import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import type { LineWidget } from "@/features/diff/DiffSurface";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
+import { aiExcludePatterns, filterDiffByAiIgnore } from "@/lib/ai/ignore";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { prOpenEligible } from "@/lib/automations/sync";
 import {
@@ -911,19 +912,36 @@ export function RemotePrView({
       // Reuse the diff already cached by usePrDiff — and, crucially,
       // resolve it from the PR's own diff (not local base..head refs),
       // so this works for fork PRs / unfetched head branches.
-      () =>
-        queryClient
-          .ensureQueryData(prDiffOptions(repoPath, number, lens))
-          .then((text) => ({
-            text,
-            truncated: false,
-            files: prForGen.files.map((f) => ({
-              path: f.path,
-              added: f.additions,
-              deleted: f.deletions,
-              isBinary: false,
-            })),
-          })),
+      async (settings) => {
+        const [text, exclude] = await Promise.all([
+          queryClient.ensureQueryData(prDiffOptions(repoPath, number, lens)),
+          aiExcludePatterns(repoPath, settings.aiIgnorePatterns),
+        ]);
+        const files = prForGen.files.map((f) => ({
+          path: f.path,
+          added: f.additions,
+          deleted: f.deletions,
+          isBinary: false,
+        }));
+        // The forge hands us the whole diff, so unlike the branch-diff path
+        // there are no pathspecs to exclude with — derive a filtered copy with
+        // the shared recipe (also used by both review funnels). NEVER write it
+        // back into the query cache: the same string feeds the Files tab, the
+        // review threads and the AI review panel, all of which want the full
+        // diff.
+        const hidden = await filterDiffByAiIgnore({
+          repoPath,
+          text,
+          files,
+          exclude,
+        });
+        return {
+          text: hidden.text,
+          truncated: false,
+          files: hidden.files,
+          excludedFiles: hidden.excludedFiles,
+        };
+      },
       prForGen.baseRefName,
       prForGen.headRefName,
       prForGen.commits.map((c) => c.headline),

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -85,10 +85,8 @@ export function useGeneratePrDescription(repoPath: string) {
        *  Empty ⇒ no Jira mentions proposed. Mutually exclusive with
        *  `issueCandidates` — `buildPrPrompt` gives natives precedence. */
       jiraCandidates?: JiraCandidate[],
-      /** Which set of changes the "nothing to describe" toasts name. The
-       *  branch-diff path really is describing `base..head`; the open-PR
-       *  supplier describes the change request itself, whose noun follows
-       *  `provider` (GitLab calls it a merge request). */
+      /** Which set of changes the "nothing to describe" toasts name; the
+       *  change-request noun follows `provider` (GitLab: merge request). */
       emptyScope: "branch-diff" | "change-request" = "branch-diff",
     ) => {
       await run(
@@ -194,8 +192,7 @@ export function useGeneratePrDescription(repoPath: string) {
   /** Explicit-supplier path (remote PRs): the caller provides the diff — e.g. an
    *  existing PR's own diff query — so it works even when the head branch isn't
    *  present locally (fork PRs, unfetched branches). The supplier is handed the
-   *  loaded settings so it can apply the user's AI-ignore patterns itself (the
-   *  branch-diff path gets that from the git layer's pathspec excludes). */
+   *  loaded settings so it can apply the user's AI-ignore patterns itself. */
   const generateFromDiff = useCallback(
     (
       getDiff: (settings: AppSettings) => Promise<SuppliedDiff>,

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -15,8 +15,8 @@ interface SuppliedDiff {
   text: string;
   truncated: boolean;
   files: { path: string; added: number; deleted: number; isBinary: boolean }[];
-  /** Changed files the user's AI-ignore patterns hid, when the supplier applies
-   *  them. Absent (remote-PR diffs) ⇒ nothing was hidden to disclose. */
+  /** Changed files the user's AI-ignore patterns hid. Every supplier applies the
+   *  patterns; absent or `0` ⇒ nothing was hidden to disclose. */
   excludedFiles?: number;
 }
 
@@ -85,6 +85,11 @@ export function useGeneratePrDescription(repoPath: string) {
        *  Empty ⇒ no Jira mentions proposed. Mutually exclusive with
        *  `issueCandidates` — `buildPrPrompt` gives natives precedence. */
       jiraCandidates?: JiraCandidate[],
+      /** Which set of changes the "nothing to describe" toasts name. The
+       *  branch-diff path really is describing `base..head`; the open-PR
+       *  supplier describes the change request itself, whose noun follows
+       *  `provider` (GitLab calls it a merge request). */
+      emptyScope: "branch-diff" | "change-request" = "branch-diff",
     ) => {
       await run(
         async (settings) => {
@@ -93,10 +98,14 @@ export function useGeneratePrDescription(repoPath: string) {
             readRepoInstructions(repoPath),
           ]);
           if (diff.files.length === 0) {
+            const scope =
+              emptyScope === "change-request"
+                ? `in this ${provider === "gitlab" ? "merge request" : "pull request"}`
+                : "between these branches";
             toast.error(
               (diff.excludedFiles ?? 0) > 0
-                ? "All changes between these branches match your AI ignore patterns — nothing to describe."
-                : "No changes between these branches to describe.",
+                ? `All changes ${scope} match your AI ignore patterns — nothing to describe.`
+                : `No changes ${scope} to describe.`,
             );
             return null;
           }
@@ -184,10 +193,12 @@ export function useGeneratePrDescription(repoPath: string) {
 
   /** Explicit-supplier path (remote PRs): the caller provides the diff — e.g. an
    *  existing PR's own diff query — so it works even when the head branch isn't
-   *  present locally (fork PRs, unfetched branches). */
+   *  present locally (fork PRs, unfetched branches). The supplier is handed the
+   *  loaded settings so it can apply the user's AI-ignore patterns itself (the
+   *  branch-diff path gets that from the git layer's pathspec excludes). */
   const generateFromDiff = useCallback(
     (
-      getDiff: () => Promise<SuppliedDiff>,
+      getDiff: (settings: AppSettings) => Promise<SuppliedDiff>,
       base: string,
       head: string,
       commitSubjects: string[],
@@ -215,6 +226,7 @@ export function useGeneratePrDescription(repoPath: string) {
         reviewNotes,
         issueCandidates,
         jiraCandidates,
+        "change-request",
       ),
     [runFromDiff],
   );

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -5,13 +5,13 @@ import {
   ContextMenuSubContent,
   ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
-import { aiIgnorePathPattern } from "@/lib/ai/ignore";
 import { copyText } from "@/lib/clipboard";
 import {
   openWithDefault,
   openWithProgram,
   revealInExplorer,
 } from "@/lib/git/api";
+import { globLiteralPath, literalPathspec } from "@/lib/git/glob";
 import type { FileEntry } from "@/lib/git/types";
 import { isWindows } from "@/lib/hotkeys/binding";
 import {
@@ -45,6 +45,9 @@ export interface ChangesMenuActions {
   viewHistory: (path: string) => void;
   blame: (path: string) => void;
   ignore: (pattern: string) => void;
+  /** `pathspec` reaches `git rm --cached` as given: a concrete path must arrive
+   *  through `literalPathspec`, a deliberate glob (`*.log`) raw. `label` is
+   *  display only. */
   untrack: (pathspec: string, ignorePattern: string, label: string) => void;
   aiExclude: (pattern: string) => void;
   aiExcludeSelected: () => void;
@@ -187,7 +190,9 @@ export function ChangesContextMenuItems({
         </>
       )}
       <ContextMenuSeparator />
-      <ContextMenuItem onClick={() => actions.ignore(`/${entry.path}`)}>
+      <ContextMenuItem
+        onClick={() => actions.ignore(`/${globLiteralPath(entry.path)}`)}
+      >
         Ignore file (add to .gitignore)
       </ContextMenuItem>
       {folders.length > 0 && (
@@ -199,7 +204,7 @@ export function ChangesContextMenuItems({
             {folders.map((folder) => (
               <ContextMenuItem
                 key={folder}
-                onClick={() => actions.ignore(`/${folder}/`)}
+                onClick={() => actions.ignore(`/${globLiteralPath(folder)}/`)}
               >
                 <span className="font-mono">{folder}/</span>
               </ContextMenuItem>
@@ -217,7 +222,11 @@ export function ChangesContextMenuItems({
           <ContextMenuSeparator />
           <ContextMenuItem
             onClick={() =>
-              actions.untrack(entry.path, `/${entry.path}`, `"${entry.path}"`)
+              actions.untrack(
+                literalPathspec(entry.path),
+                `/${globLiteralPath(entry.path)}`,
+                `"${entry.path}"`,
+              )
             }
           >
             Untrack file (keep on disk)
@@ -232,7 +241,11 @@ export function ChangesContextMenuItems({
                   <ContextMenuItem
                     key={folder}
                     onClick={() =>
-                      actions.untrack(folder, `/${folder}/`, `"${folder}/"`)
+                      actions.untrack(
+                        literalPathspec(folder),
+                        `/${globLiteralPath(folder)}/`,
+                        `"${folder}/"`,
+                      )
                     }
                   >
                     <span className="font-mono">{folder}/</span>
@@ -260,9 +273,7 @@ export function ChangesContextMenuItems({
         <>
           <ContextMenuSeparator />
           <ContextMenuItem
-            onClick={() =>
-              actions.aiExclude(`/${aiIgnorePathPattern(entry.path)}`)
-            }
+            onClick={() => actions.aiExclude(`/${globLiteralPath(entry.path)}`)}
           >
             Exclude from AI (add to .gitdesktop/aiignore)
           </ContextMenuItem>
@@ -276,7 +287,7 @@ export function ChangesContextMenuItems({
                   <ContextMenuItem
                     key={folder}
                     onClick={() =>
-                      actions.aiExclude(`/${aiIgnorePathPattern(folder)}/`)
+                      actions.aiExclude(`/${globLiteralPath(folder)}/`)
                     }
                   >
                     <span className="font-mono">{folder}/</span>

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -44,12 +44,15 @@ export interface ChangesMenuActions {
   stashFile: (entry: FileEntry) => void;
   viewHistory: (path: string) => void;
   blame: (path: string) => void;
-  /** Every action here takes what git gets and, separately, what the user reads:
-   *  a concrete path is glob-escaped (or `literalPathspec`'d, for the `pathspec`
-   *  that reaches `git rm --cached`) while `label` stays the plain path. A
-   *  deliberate glob (`*.log`) is identical in both. */
+  // The three below take what git gets and, separately, what the user reads: a
+  // concrete path is glob-escaped while `label` stays the plain path. A
+  // deliberate glob (`*.log`) is identical in both.
+  /** `pattern` is a gitignore line — glob-escape a concrete path. */
   ignore: (pattern: string, label: string) => void;
+  /** `pathspec` reaches `git rm --cached` as given, so a concrete path must
+   *  arrive through `literalPathspec` or it removes its glob-siblings too. */
   untrack: (pathspec: string, ignorePattern: string, label: string) => void;
+  /** `pattern` is an AI-ignore line — glob-escape a concrete path. */
   aiExclude: (pattern: string, label: string) => void;
   aiExcludeSelected: () => void;
 }

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -44,12 +44,13 @@ export interface ChangesMenuActions {
   stashFile: (entry: FileEntry) => void;
   viewHistory: (path: string) => void;
   blame: (path: string) => void;
-  ignore: (pattern: string) => void;
-  /** `pathspec` reaches `git rm --cached` as given: a concrete path must arrive
-   *  through `literalPathspec`, a deliberate glob (`*.log`) raw. `label` is
-   *  display only. */
+  /** Every action here takes what git gets and, separately, what the user reads:
+   *  a concrete path is glob-escaped (or `literalPathspec`'d, for the `pathspec`
+   *  that reaches `git rm --cached`) while `label` stays the plain path. A
+   *  deliberate glob (`*.log`) is identical in both. */
+  ignore: (pattern: string, label: string) => void;
   untrack: (pathspec: string, ignorePattern: string, label: string) => void;
-  aiExclude: (pattern: string) => void;
+  aiExclude: (pattern: string, label: string) => void;
   aiExcludeSelected: () => void;
 }
 
@@ -191,7 +192,9 @@ export function ChangesContextMenuItems({
       )}
       <ContextMenuSeparator />
       <ContextMenuItem
-        onClick={() => actions.ignore(`/${globLiteralPath(entry.path)}`)}
+        onClick={() =>
+          actions.ignore(`/${globLiteralPath(entry.path)}`, `/${entry.path}`)
+        }
       >
         Ignore file (add to .gitignore)
       </ContextMenuItem>
@@ -204,7 +207,9 @@ export function ChangesContextMenuItems({
             {folders.map((folder) => (
               <ContextMenuItem
                 key={folder}
-                onClick={() => actions.ignore(`/${globLiteralPath(folder)}/`)}
+                onClick={() =>
+                  actions.ignore(`/${globLiteralPath(folder)}/`, `/${folder}/`)
+                }
               >
                 <span className="font-mono">{folder}/</span>
               </ContextMenuItem>
@@ -213,7 +218,9 @@ export function ChangesContextMenuItems({
         </ContextMenuSub>
       )}
       {extension && (
-        <ContextMenuItem onClick={() => actions.ignore(`*.${extension}`)}>
+        <ContextMenuItem
+          onClick={() => actions.ignore(`*.${extension}`, `*.${extension}`)}
+        >
           Ignore all .{extension} files (add to .gitignore)
         </ContextMenuItem>
       )}
@@ -273,7 +280,12 @@ export function ChangesContextMenuItems({
         <>
           <ContextMenuSeparator />
           <ContextMenuItem
-            onClick={() => actions.aiExclude(`/${globLiteralPath(entry.path)}`)}
+            onClick={() =>
+              actions.aiExclude(
+                `/${globLiteralPath(entry.path)}`,
+                `/${entry.path}`,
+              )
+            }
           >
             Exclude from AI (add to .gitdesktop/aiignore)
           </ContextMenuItem>
@@ -287,7 +299,10 @@ export function ChangesContextMenuItems({
                   <ContextMenuItem
                     key={folder}
                     onClick={() =>
-                      actions.aiExclude(`/${globLiteralPath(folder)}/`)
+                      actions.aiExclude(
+                        `/${globLiteralPath(folder)}/`,
+                        `/${folder}/`,
+                      )
                     }
                   >
                     <span className="font-mono">{folder}/</span>
@@ -298,7 +313,9 @@ export function ChangesContextMenuItems({
           )}
           {extension && (
             <ContextMenuItem
-              onClick={() => actions.aiExclude(`*.${extension}`)}
+              onClick={() =>
+                actions.aiExclude(`*.${extension}`, `*.${extension}`)
+              }
             >
               Exclude all .{extension} files from AI (add to
               .gitdesktop/aiignore)

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -5,6 +5,7 @@ import {
   ContextMenuSubContent,
   ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
+import { aiIgnorePathPattern } from "@/lib/ai/ignore";
 import { copyText } from "@/lib/clipboard";
 import {
   openWithDefault,
@@ -258,7 +259,11 @@ export function ChangesContextMenuItems({
       {aiEnabled && (
         <>
           <ContextMenuSeparator />
-          <ContextMenuItem onClick={() => actions.aiExclude(entry.path)}>
+          <ContextMenuItem
+            onClick={() =>
+              actions.aiExclude(`/${aiIgnorePathPattern(entry.path)}`)
+            }
+          >
             Exclude from AI (add to .gitdesktop/aiignore)
           </ContextMenuItem>
           {folders.length > 0 && (
@@ -270,7 +275,9 @@ export function ChangesContextMenuItems({
                 {folders.map((folder) => (
                   <ContextMenuItem
                     key={folder}
-                    onClick={() => actions.aiExclude(`${folder}/`)}
+                    onClick={() =>
+                      actions.aiExclude(`/${aiIgnorePathPattern(folder)}/`)
+                    }
                   >
                     <span className="font-mono">{folder}/</span>
                   </ContextMenuItem>

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -417,24 +417,24 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
 
   // Single-file ignore / untrack (the per-row menu); the bulk equivalents are
   // ignoreSelected / untrackSelected below.
-  function ignoreOne(pattern: string) {
+  function ignoreOne(pattern: string, label: string) {
     appendIgnore.mutate([pattern], {
       onSuccess: (added) =>
         toast.success(
           added === 0
-            ? `"${pattern}" is already in .gitignore`
-            : `Added "${pattern}" to .gitignore`,
+            ? `"${label}" is already in .gitignore`
+            : `Added "${label}" to .gitignore`,
         ),
       onError,
     });
   }
-  function aiExcludeOne(pattern: string) {
+  function aiExcludeOne(pattern: string, label: string) {
     appendAiIgnore.mutate([pattern], {
       onSuccess: (added) =>
         toast.success(
           added === 0
-            ? `"${pattern}" is already in .gitdesktop/aiignore`
-            : `Added "${pattern}" to .gitdesktop/aiignore`,
+            ? `"${label}" is already in .gitdesktop/aiignore`
+            : `Added "${label}" to .gitdesktop/aiignore`,
         ),
       onError,
     });

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BlameDialog } from "@/features/history/BlameDialog";
 import { FileHistoryDialog } from "@/features/history/FileHistoryDialog";
+import { aiIgnorePathPattern } from "@/lib/ai/ignore";
 import {
   useAppendRepoAiIgnore,
   useAppendToGitignore,
@@ -517,11 +518,15 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     });
   }
 
-  // Bulk AI-exclude: add a root-relative pathspec per selected file. The Rust
-  // side strips leading slashes, de-dupes, and skips lines already present.
+  // Bulk AI-exclude: add a `/path` line per selected file — the leading slash
+  // anchors each pattern to THIS file rather than every file with that name, and
+  // glob metacharacters in the path are escaped so it matches literally. The
+  // Rust side de-dupes and skips lines already present.
   function aiExcludeSelected() {
     if (selectionCount === 0) return;
-    const patterns = selectedEntries.map((e) => e.path);
+    const patterns = selectedEntries.map(
+      (e) => `/${aiIgnorePathPattern(e.path)}`,
+    );
     appendAiIgnore.mutate(patterns, {
       onSuccess: (added) => {
         toast.success(

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -57,13 +57,10 @@ import { ConflictBanner } from "./ConflictBanner";
 import { FileRow } from "./FileRow";
 import { StashesDialog } from "./StashesDialog";
 
-/**
- * A staged rename is "delete old path + add new path"; restoring only the
- * new path would leave the old path's deletion staged, so include both.
- */
-/** The pathspecs that unstage one entry — a rename needs both halves. Literal:
- *  these are paths the user picked, and a `[slug]`-style one would otherwise
- *  unstage its glob-siblings too. */
+/** The pathspecs that unstage one entry — a staged rename is "delete old path +
+ *  add new path", so both halves are needed or the old path's deletion stays
+ *  staged. Literal: these are paths the user picked, and a `[slug]`-style one
+ *  would otherwise unstage its glob-siblings too. */
 function unstagePaths(entry: FileEntry): string[] {
   return (entry.origPath ? [entry.path, entry.origPath] : [entry.path]).map(
     literalPathspec,

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BlameDialog } from "@/features/history/BlameDialog";
 import { FileHistoryDialog } from "@/features/history/FileHistoryDialog";
-import { aiIgnorePathPattern } from "@/lib/ai/ignore";
+import { globLiteralPath, literalPathspec } from "@/lib/git/glob";
 import {
   useAppendRepoAiIgnore,
   useAppendToGitignore,
@@ -61,8 +61,13 @@ import { StashesDialog } from "./StashesDialog";
  * A staged rename is "delete old path + add new path"; restoring only the
  * new path would leave the old path's deletion staged, so include both.
  */
+/** The pathspecs that unstage one entry — a rename needs both halves. Literal:
+ *  these are paths the user picked, and a `[slug]`-style one would otherwise
+ *  unstage its glob-siblings too. */
 function unstagePaths(entry: FileEntry): string[] {
-  return entry.origPath ? [entry.path, entry.origPath] : [entry.path];
+  return (entry.origPath ? [entry.path, entry.origPath] : [entry.path]).map(
+    literalPathspec,
+  );
 }
 
 /**
@@ -407,7 +412,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   // Toggle one file's staged state — the row's +/- button and the single menu.
   function handleToggle(entry: FileEntry, staged: boolean) {
     if (staged) unstage.mutate(unstagePaths(entry), { onError });
-    else stage.mutate([entry.path], { onError });
+    else stage.mutate([literalPathspec(entry.path)], { onError });
   }
 
   // Single-file ignore / untrack (the per-row menu); the bulk equivalents are
@@ -466,7 +471,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
 
   function stageAll() {
     stage.mutate(
-      unstagedEntries.map((e) => e.path),
+      unstagedEntries.map((e) => literalPathspec(e.path)),
       { onError },
     );
   }
@@ -481,7 +486,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   function stageSelected() {
     if (selectionCount === 0) return;
     stage.mutate(
-      selectedEntries.map((e) => e.path),
+      selectedEntries.map((e) => literalPathspec(e.path)),
       { onError, onSuccess: () => setSelectedKeys(new Set()) },
     );
   }
@@ -508,7 +513,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   // de-dupes and skips lines already present.
   function ignoreSelected() {
     if (selectionCount === 0) return;
-    const patterns = selectedEntries.map((e) => `/${e.path}`);
+    const patterns = selectedEntries.map((e) => `/${globLiteralPath(e.path)}`);
     appendIgnore.mutate(patterns, {
       onSuccess: (added) => {
         toast.success(ignoreToast(added, patterns.length, ".gitignore"));
@@ -519,14 +524,11 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   }
 
   // Bulk AI-exclude: add a `/path` line per selected file — the leading slash
-  // anchors each pattern to THIS file rather than every file with that name, and
-  // glob metacharacters in the path are escaped so it matches literally. The
-  // Rust side de-dupes and skips lines already present.
+  // anchors each pattern to THIS file rather than every file with that name.
+  // The Rust side de-dupes and skips lines already present.
   function aiExcludeSelected() {
     if (selectionCount === 0) return;
-    const patterns = selectedEntries.map(
-      (e) => `/${aiIgnorePathPattern(e.path)}`,
-    );
+    const patterns = selectedEntries.map((e) => `/${globLiteralPath(e.path)}`);
     appendAiIgnore.mutate(patterns, {
       onSuccess: (added) => {
         toast.success(
@@ -544,8 +546,10 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     if (selectedTracked.length === 0) return;
     untrack.mutate(
       {
-        pathspecs: selectedTracked.map((e) => e.path),
-        ignorePatterns: selectedTracked.map((e) => `/${e.path}`),
+        pathspecs: selectedTracked.map((e) => literalPathspec(e.path)),
+        ignorePatterns: selectedTracked.map(
+          (e) => `/${globLiteralPath(e.path)}`,
+        ),
       },
       {
         onSuccess: () => {
@@ -618,7 +622,9 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
       return;
     }
     const targets = stashScope.entries.map((e) => e.path);
-    stashPaths.mutate(targets, {
+    // Literal pathspecs so a `[slug]`-style path can't sweep a sibling's work
+    // into the stash; `targets` stays raw for the toast below.
+    stashPaths.mutate(targets.map(literalPathspec), {
       onSuccess: () => {
         toast.success(
           targets.length === 1

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { globLiteralPath, literalPathspec } from "@/lib/git/glob";
 import {
   useForceAdd,
   useIgnoredFiles,
@@ -33,8 +34,9 @@ import { cn } from "@/lib/utils";
 
 type Tab = "tracked" | "ignored";
 
-/** The .gitignore rule that untracking a file adds, anchored to the repo root. */
-const ignorePattern = (path: string) => `/${path}`;
+/** The .gitignore rule that untracking a file adds, anchored to the repo root
+ *  and escaped so a path holding `[`, `*` or `?` matches only itself. */
+const ignorePattern = (path: string) => `/${globLiteralPath(path)}`;
 
 /** What a pending confirm dialog will do once accepted. */
 type Pending =
@@ -177,7 +179,10 @@ export function RepositoryFilesDialog({
 
   function runUntrack(paths: string[]) {
     untrack.mutate(
-      { pathspecs: paths, ignorePatterns: paths.map(ignorePattern) },
+      {
+        pathspecs: paths.map(literalPathspec),
+        ignorePatterns: paths.map(ignorePattern),
+      },
       {
         onSuccess: () => {
           toast.success(
@@ -195,7 +200,7 @@ export function RepositoryFilesDialog({
   }
 
   function runForceAdd(paths: string[]) {
-    forceAdd.mutate(paths, {
+    forceAdd.mutate(paths.map(literalPathspec), {
       onSuccess: () => {
         toast.success(`Force-added ${paths.length} items`);
         setSelected(new Set());

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -38,6 +38,10 @@ type Tab = "tracked" | "ignored";
  *  and escaped so a path holding `[`, `*` or `?` matches only itself. */
 const ignorePattern = (path: string) => `/${globLiteralPath(path)}`;
 
+/** How that rule reads to a human — the same anchored path without the glob
+ *  escapes, which are noise to everyone but git. */
+const ignoreLabel = (path: string) => `/${path}`;
+
 /** What a pending confirm dialog will do once accepted. */
 type Pending =
   | { kind: "untrack"; paths: string[] }
@@ -412,7 +416,7 @@ export function RepositoryFilesDialog({
             <ul className="max-h-40 overflow-auto border p-2 text-xs">
               {pending.paths.map((p) => (
                 <li key={p} className="truncate font-mono" title={p}>
-                  {ignorePattern(p)}
+                  {ignoreLabel(p)}
                 </li>
               ))}
             </ul>

--- a/src/features/settings/InstructionsSection.tsx
+++ b/src/features/settings/InstructionsSection.tsx
@@ -38,9 +38,17 @@ export const InstructionsSection = withForm({
             )}
           </form.AppField>
           <p className="text-xs text-muted-foreground">
-            gitignore-style patterns, one per line. Matching files stay staged
-            and committed as usual, but their diffs are left out of what the AI
-            sees, so noisy folders don't dominate the message.
+            gitignore-style patterns, one per line:{" "}
+            <code className="rounded bg-muted px-1 py-0.5">secrets.env</code>{" "}
+            matches that file at any depth,{" "}
+            <code className="rounded bg-muted px-1 py-0.5">/secrets.env</code>{" "}
+            only the copy at the repo root, and{" "}
+            <code className="rounded bg-muted px-1 py-0.5">vendor/</code> a
+            folder wherever it sits.{" "}
+            <code className="rounded bg-muted px-1 py-0.5">!</code> re-include
+            lines aren't supported. Matching files stay staged and committed as
+            usual, but their diffs are left out of what the AI sees, so noisy
+            folders don't dominate the message.
           </p>
         </div>
         <p className="text-xs text-muted-foreground">

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -1,22 +1,6 @@
 import { gitFilterAiIgnored, readRepoAiIgnore } from "@/lib/git/api";
 import { splitUnifiedDiff } from "@/lib/git/diff-split";
 
-/**
- * A concrete file/folder path turned into an AI-ignore pattern that matches
- * exactly that path.
- *
- * `[`, `*` and `?` are glob metacharacters, so an unescaped path protects
- * nothing the moment it holds one — a Next.js/SvelteKit dynamic route like
- * `app/[slug]/page.tsx` reads as a character class and matches no real file.
- * Each is wrapped as a one-character class (`[` → `[[]`), which both matching
- * engines honor; a backslash escape does NOT work on the pathspec side. `]`
- * outside a class is already literal. A literal backslash in a name is not
- * expressible on either engine and is left alone (it cannot occur on Windows).
- */
-export function aiIgnorePathPattern(path: string): string {
-  return path.replace(/[[*?]/g, (c) => `[${c}]`);
-}
-
 /** Lines of a newline-joined ignore-pattern string, dropping blanks + comments. */
 function ignoreLines(patterns: string): string[] {
   return patterns
@@ -27,14 +11,13 @@ function ignoreLines(patterns: string): string[] {
 
 /**
  * The user's AI-ignore patterns for a repo: the repo's own
- * `.gitdesktop/aiignore` entries first, then the global setting's lines — the
- * exclude list every AI generation path hands the git layer as pathspec
- * excludes, so a file the user excluded never reaches a model.
+ * `.gitdesktop/aiignore` entries first, then the global setting's lines
+ * (`aiIgnorePatterns`, raw and newline-joined).
  *
- * `aiIgnorePatterns` is the raw newline-joined setting. Rejects when the repo
- * file can't be read; the conflict-resolve surface passes
- * `tolerateRepoReadError` because an unreadable repo file must not abort a
- * resolution that the global patterns alone can still serve.
+ * Rejects when the repo file can't be read — except under
+ * `tolerateRepoReadError`, which the conflict-resolve surface passes so an
+ * unreadable repo file can't abort a resolution the global patterns alone can
+ * still serve.
  */
 export async function aiExcludePatterns(
   repoPath: string,
@@ -49,27 +32,19 @@ export async function aiExcludePatterns(
 
 /**
  * Drops every AI-ignored file from an already-resolved unified diff and its
- * changed-file list, client-side.
+ * changed-file list, client-side — the one recipe for both diff sources, since
+ * the pathspec-exclude route (`gitBranchDiff`'s `exclude`) only exists where
+ * GitDesktop runs the diff itself and a forge-supplied PR diff arrives whole.
  *
- * The pathspec-exclude route (`gitBranchDiff`'s `exclude`) only exists where
- * GitDesktop itself runs the diff; a forge-supplied PR diff arrives whole, and
- * the review funnels mix both sources. This is the one recipe for both:
+ * Candidates are the UNION of the diff's own section keys and the file list,
+ * and the keys are the load-bearing half: a provider's file list can be capped
+ * (gh tops a 100-entry GraphQL page up from REST only best-effort) while the
+ * diff text still carries every file. `excludedFiles` counts the deduped hidden
+ * union, not `files.length` minus the survivors, which a capped list would
+ * undercount. An empty `exclude` returns the input untouched, before any IPC.
  *
- * - An empty `exclude` returns the input untouched, BEFORE any IPC — no
- *   patterns must cost nothing on any path.
- * - Candidates are the UNION of the diff's own section keys and the file
- *   list, and the section keys are the load-bearing half: a provider's file
- *   list can be capped (gh tops a 100-entry GraphQL page up from REST only on
- *   a best-effort basis) while the diff text still carries every file, so
- *   anything filtered by the short list alone would reach the model
- *   unexamined. Each side is then filtered by its own keys, which keeps that
- *   impossible whatever a provider's list omits.
- * - `excludedFiles` counts the deduped hidden union — not `files.length`
- *   minus the survivors, which a capped list would undercount.
- *
- * Callers must treat the result as a local derivation: the input `text` is
- * typically a cached query string that also feeds the Files tab and the review
- * threads, and those want the full diff.
+ * The result is a local derivation — the input `text` is typically a cached
+ * query string the Files tab and review threads want in full.
  */
 export async function filterDiffByAiIgnore<F extends { path: string }>(input: {
   repoPath: string;
@@ -78,17 +53,12 @@ export async function filterDiffByAiIgnore<F extends { path: string }>(input: {
   exclude: string[];
 }): Promise<{ text: string; files: F[]; excludedFiles: number }> {
   const { repoPath, text, files, exclude } = input;
-  // No patterns ⇒ the pre-filter behavior, and no git spawn (the command
-  // short-circuits on an empty list too, but don't pay the IPC hop).
   if (exclude.length === 0) return { text, files, excludedFiles: 0 };
   const sections = splitUnifiedDiff(text);
   const candidates = [
     ...new Set([...sections.keys(), ...files.map((f) => f.path)]),
   ];
-  // Nothing to hide (an empty diff) — same reason: skip the hop.
   if (candidates.length === 0) return { text, files, excludedFiles: 0 };
-  // Ask git's own gitignore engine which paths the patterns hide — the same
-  // matcher the diff-side pathspec translation is pinned to.
   const hidden = new Set(
     await gitFilterAiIgnored(repoPath, candidates, exclude),
   );

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -1,4 +1,21 @@
-import { readRepoAiIgnore } from "@/lib/git/api";
+import { gitFilterAiIgnored, readRepoAiIgnore } from "@/lib/git/api";
+import { splitUnifiedDiff } from "@/lib/git/diff-split";
+
+/**
+ * A concrete file/folder path turned into an AI-ignore pattern that matches
+ * exactly that path.
+ *
+ * `[`, `*` and `?` are glob metacharacters, so an unescaped path protects
+ * nothing the moment it holds one — a Next.js/SvelteKit dynamic route like
+ * `app/[slug]/page.tsx` reads as a character class and matches no real file.
+ * Each is wrapped as a one-character class (`[` → `[[]`), which both matching
+ * engines honor; a backslash escape does NOT work on the pathspec side. `]`
+ * outside a class is already literal. A literal backslash in a name is not
+ * expressible on either engine and is left alone (it cannot occur on Windows).
+ */
+export function aiIgnorePathPattern(path: string): string {
+  return path.replace(/[[*?]/g, (c) => `[${c}]`);
+}
 
 /** Lines of a newline-joined ignore-pattern string, dropping blanks + comments. */
 function ignoreLines(patterns: string): string[] {
@@ -28,4 +45,63 @@ export async function aiExcludePatterns(
     ? await readRepoAiIgnore(repoPath).catch(() => [])
     : await readRepoAiIgnore(repoPath);
   return [...repoIgnore, ...ignoreLines(aiIgnorePatterns)];
+}
+
+/**
+ * Drops every AI-ignored file from an already-resolved unified diff and its
+ * changed-file list, client-side.
+ *
+ * The pathspec-exclude route (`gitBranchDiff`'s `exclude`) only exists where
+ * GitDesktop itself runs the diff; a forge-supplied PR diff arrives whole, and
+ * the review funnels mix both sources. This is the one recipe for both:
+ *
+ * - An empty `exclude` returns the input untouched, BEFORE any IPC — no
+ *   patterns must cost nothing on any path.
+ * - Candidates are the UNION of the diff's own section keys and the file
+ *   list, and the section keys are the load-bearing half: a provider's file
+ *   list can be capped (gh tops a 100-entry GraphQL page up from REST only on
+ *   a best-effort basis) while the diff text still carries every file, so
+ *   anything filtered by the short list alone would reach the model
+ *   unexamined. Each side is then filtered by its own keys, which keeps that
+ *   impossible whatever a provider's list omits.
+ * - `excludedFiles` counts the deduped hidden union — not `files.length`
+ *   minus the survivors, which a capped list would undercount.
+ *
+ * Callers must treat the result as a local derivation: the input `text` is
+ * typically a cached query string that also feeds the Files tab and the review
+ * threads, and those want the full diff.
+ */
+export async function filterDiffByAiIgnore<F extends { path: string }>(input: {
+  repoPath: string;
+  text: string;
+  files: F[];
+  exclude: string[];
+}): Promise<{ text: string; files: F[]; excludedFiles: number }> {
+  const { repoPath, text, files, exclude } = input;
+  // No patterns ⇒ the pre-filter behavior, and no git spawn (the command
+  // short-circuits on an empty list too, but don't pay the IPC hop).
+  if (exclude.length === 0) return { text, files, excludedFiles: 0 };
+  const sections = splitUnifiedDiff(text);
+  const candidates = [
+    ...new Set([...sections.keys(), ...files.map((f) => f.path)]),
+  ];
+  // Nothing to hide (an empty diff) — same reason: skip the hop.
+  if (candidates.length === 0) return { text, files, excludedFiles: 0 };
+  // Ask git's own gitignore engine which paths the patterns hide — the same
+  // matcher the diff-side pathspec translation is pinned to.
+  const hidden = new Set(
+    await gitFilterAiIgnored(repoPath, candidates, exclude),
+  );
+  if (hidden.size === 0) return { text, files, excludedFiles: 0 };
+  // Each section keeps its own `diff --git` header, so the survivors rejoin
+  // into a valid unified diff in their original order.
+  const filtered = [...sections]
+    .filter(([path]) => !hidden.has(path))
+    .map(([, section]) => section)
+    .join("");
+  return {
+    text: filtered,
+    files: files.filter((f) => !hidden.has(f.path)),
+    excludedFiles: hidden.size,
+  };
 }

--- a/src/lib/ai/prior-context.ts
+++ b/src/lib/ai/prior-context.ts
@@ -13,6 +13,9 @@ export interface PriorContext {
   deltaDiffText?: string;
   deltaTruncated?: boolean;
   deltaState?: ReviewDeltaState;
+  /** Files the AI-ignore patterns hid from the delta. An emptied delta is
+   *  indistinguishable from "nothing changed" without this. */
+  deltaExcludedFiles?: number;
 }
 
 /**
@@ -32,7 +35,8 @@ export interface PriorContext {
  * The delta is a SECOND diff, so filtering only the main one would leak the
  * very files the user withheld. Filtered inside the try below, which fails
  * closed: a filter failure drops the delta rather than carrying an unfiltered
- * one.
+ * one. The hidden-file count comes back out as `deltaExcludedFiles` — a delta
+ * the filter emptied must not reach the model as "no changes".
  */
 export async function resolvePriorContext(
   repoPath: string,
@@ -85,6 +89,7 @@ export async function resolvePriorContext(
         deltaDiffText: filtered.text,
         deltaTruncated: delta.truncated,
         deltaState: "ok",
+        deltaExcludedFiles: filtered.excludedFiles,
       };
     }
     if (delta.reason === "rewritten") {

--- a/src/lib/ai/prior-context.ts
+++ b/src/lib/ai/prior-context.ts
@@ -1,5 +1,6 @@
 import { gitDiffBetweenRefs, gitFetchObjects } from "@/lib/git/api";
 import { getLatestReview } from "@/lib/pulls/reviews-history";
+import { filterDiffByAiIgnore } from "./ignore";
 import type { ReviewDeltaState, ReviewMode } from "./types";
 
 /** Upper bound on the delta fetched from git; the prompt budget trims further. */
@@ -24,6 +25,14 @@ export interface PriorContext {
  * Shared by the interactive review (`src/lib/stores/reviews.ts`) and the
  * automation runner's pr-open / pr-sync paths — both build on a prior the same
  * way. Takes primitives (not a `ReviewTarget`) to avoid a circular import.
+ *
+ * `exclude` is the caller's AI-ignore pattern list, empty for an agentic run.
+ * The delta is a SECOND diff, so filtering only the main one would leak the
+ * very files the user withheld; the backing `gitDiffBetweenRefs` command is
+ * shared with the agentic `diff_refs` tool and deliberately grew no `exclude`
+ * parameter, so the filtering happens here instead. It sits inside the try
+ * below, which fails closed: a filter failure drops the delta rather than
+ * carrying an unfiltered one.
  */
 export async function resolvePriorContext(
   repoPath: string,
@@ -31,6 +40,7 @@ export async function resolvePriorContext(
   ref: string,
   mode: ReviewMode,
   currentHeadSha: string | undefined,
+  exclude: string[] = [],
 ): Promise<PriorContext> {
   const prior = await getLatestReview(repoPath, kind, ref, mode);
   if (!prior?.text.trim()) return {};
@@ -62,9 +72,17 @@ export async function resolvePriorContext(
       DELTA_MAX_BYTES,
     );
     if (delta.reason === "ok") {
+      // No file list to pair with a two-dot delta — its own section keys are
+      // the whole candidate set (and an empty `exclude` costs nothing).
+      const filtered = await filterDiffByAiIgnore({
+        repoPath,
+        text: delta.text,
+        files: [],
+        exclude,
+      });
       return {
         ...base,
-        deltaDiffText: delta.text,
+        deltaDiffText: filtered.text,
         deltaTruncated: delta.truncated,
         deltaState: "ok",
       };

--- a/src/lib/ai/prior-context.ts
+++ b/src/lib/ai/prior-context.ts
@@ -26,7 +26,9 @@ export interface PriorContext {
  * automation runner's pr-open / pr-sync paths — both build on a prior the same
  * way. Takes primitives (not a `ReviewTarget`) to avoid a circular import.
  *
- * `exclude` is the caller's AI-ignore pattern list, empty for an agentic run.
+ * `exclude` is the caller's AI-ignore pattern list — required, not defaulted:
+ * an omitted privacy argument is how the next caller leaks. Empty for an
+ * agentic run.
  * The delta is a SECOND diff, so filtering only the main one would leak the
  * very files the user withheld. Filtered inside the try below, which fails
  * closed: a filter failure drops the delta rather than carrying an unfiltered
@@ -38,7 +40,7 @@ export async function resolvePriorContext(
   ref: string,
   mode: ReviewMode,
   currentHeadSha: string | undefined,
-  exclude: string[] = [],
+  exclude: string[],
 ): Promise<PriorContext> {
   const prior = await getLatestReview(repoPath, kind, ref, mode);
   if (!prior?.text.trim()) return {};

--- a/src/lib/ai/prior-context.ts
+++ b/src/lib/ai/prior-context.ts
@@ -28,11 +28,9 @@ export interface PriorContext {
  *
  * `exclude` is the caller's AI-ignore pattern list, empty for an agentic run.
  * The delta is a SECOND diff, so filtering only the main one would leak the
- * very files the user withheld; the backing `gitDiffBetweenRefs` command is
- * shared with the agentic `diff_refs` tool and deliberately grew no `exclude`
- * parameter, so the filtering happens here instead. It sits inside the try
- * below, which fails closed: a filter failure drops the delta rather than
- * carrying an unfiltered one.
+ * very files the user withheld. Filtered inside the try below, which fails
+ * closed: a filter failure drops the delta rather than carrying an unfiltered
+ * one.
  */
 export async function resolvePriorContext(
   repoPath: string,
@@ -72,8 +70,8 @@ export async function resolvePriorContext(
       DELTA_MAX_BYTES,
     );
     if (delta.reason === "ok") {
-      // No file list to pair with a two-dot delta — its own section keys are
-      // the whole candidate set (and an empty `exclude` costs nothing).
+      // No file list pairs with a two-dot delta — its section keys are the
+      // whole candidate set.
       const filtered = await filterDiffByAiIgnore({
         repoPath,
         text: delta.text,

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -701,7 +701,15 @@ export function buildReviewPrompt(
       `## Commits\n${input.commitSubjects.map((s) => `- ${s}`).join("\n")}`,
     );
   }
-  promptParts.push(`## Files changed\n${fileSummary || "(none)"}`);
+  // A reviewer that invents findings about files it can't see is worse than a
+  // generator that does, so this takes the "do not speculate" wording. Only a
+  // non-agentic run ever supplies a count — an agentic one is unfiltered, and
+  // its prompt stays byte-identical.
+  let filesSection = `## Files changed\n${fileSummary || "(none)"}`;
+  if ((input.excludedFiles ?? 0) > 0) {
+    filesSection += `\n[${input.excludedFiles} additional changed file(s) hidden by the user's AI ignore rules — do not speculate about them]`;
+  }
+  promptParts.push(filesSection);
 
   // Soft context — our own prior review (+ "changes since" delta), our own PR
   // comments, and third-party AI findings — each gated independently. Placed AFTER

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -621,6 +621,7 @@ function deltaSection(
   state: ReviewDeltaState | undefined,
   extras: ReviewExtras,
   upstreamTruncated: boolean,
+  excludedFiles: number,
 ): string {
   const header = "## Changes since that review";
   if (state === "rewritten") {
@@ -637,7 +638,13 @@ function deltaSection(
     // dropped to keep the authoritative diff in budget — don't say "no changes".
     return `${header}\n(The delta was omitted to keep the current diff in context — re-review the full diff below.)`;
   }
-  const body = extras.delta.text.trim() || "(no textual changes)";
+  // An empty body with files hidden is NOT "nothing changed" — saying so would
+  // pass a filtered delta off as complete.
+  const body =
+    extras.delta.text.trim() ||
+    (excludedFiles > 0
+      ? "(every file changed since that review is hidden by the user's AI ignore rules)"
+      : "(no textual changes)");
   let section = `${header}\n${body}`;
   if (upstreamTruncated || extras.delta.truncated) {
     section +=
@@ -743,7 +750,12 @@ export function buildReviewPrompt(
       }
       promptParts.push(priorSection);
       promptParts.push(
-        deltaSection(input.deltaState, extras, Boolean(input.deltaTruncated)),
+        deltaSection(
+          input.deltaState,
+          extras,
+          Boolean(input.deltaTruncated),
+          input.deltaExcludedFiles ?? 0,
+        ),
       );
     }
     // Our own prior comments — highest-signal soft context, so it sits above

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -701,10 +701,8 @@ export function buildReviewPrompt(
       `## Commits\n${input.commitSubjects.map((s) => `- ${s}`).join("\n")}`,
     );
   }
-  // A reviewer that invents findings about files it can't see is worse than a
-  // generator that does, so this takes the "do not speculate" wording. Only a
-  // non-agentic run ever supplies a count — an agentic one is unfiltered, and
-  // its prompt stays byte-identical.
+  // Stronger wording than the generator's twin: an invented finding about a
+  // file the reviewer can't see reads as a real one.
   let filesSection = `## Files changed\n${fileSummary || "(none)"}`;
   if ((input.excludedFiles ?? 0) > 0) {
     filesSection += `\n[${input.excludedFiles} additional changed file(s) hidden by the user's AI ignore rules — do not speculate about them]`;

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -158,6 +158,9 @@ export interface ReviewPromptInput {
   deltaTruncated?: boolean;
   /** Why the delta is present or absent — frames the "Changes since" section. */
   deltaState?: ReviewDeltaState;
+  /** Files the AI-ignore patterns hid from the delta. Distinguishes an emptied
+   *  delta from a genuinely unchanged one. */
+  deltaExcludedFiles?: number;
   /** Pre-formatted findings posted on the remote PR by third-party AI reviewers
    *  (GitHub Copilot, CodeRabbit, …) — soft, re-verifiable context like
    *  `priorFindings`. Absent for local PRs and when none were found. */

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -139,10 +139,8 @@ export interface ReviewPromptInput {
   diffTruncated: boolean;
   files: { path: string; added: number; deleted: number; isBinary: boolean }[];
   /** Changed files hidden from this review's diff by the user's AI-ignore
-   *  patterns. Absent/0 ⇒ no disclosure line, so the prompt is byte-for-byte
-   *  identical to an unfiltered review. Mutually exclusive with `agentic` by
-   *  construction: only a NON-agentic run filters its diff, because an agentic
-   *  reviewer reads the worktree (or its own tools) directly. */
+   *  patterns; absent/0 ⇒ no disclosure line. Always 0 alongside `agentic` —
+   *  only a non-agentic run filters its diff. */
   excludedFiles?: number;
   /** Author-provided "Notes for reviewers" — the author's deliberate calls behind
    *  the change. Treated as author input like `body` (NOT soft bot context), so it

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -138,6 +138,12 @@ export interface ReviewPromptInput {
   diffText: string;
   diffTruncated: boolean;
   files: { path: string; added: number; deleted: number; isBinary: boolean }[];
+  /** Changed files hidden from this review's diff by the user's AI-ignore
+   *  patterns. Absent/0 ⇒ no disclosure line, so the prompt is byte-for-byte
+   *  identical to an unfiltered review. Mutually exclusive with `agentic` by
+   *  construction: only a NON-agentic run filters its diff, because an agentic
+   *  reviewer reads the worktree (or its own tools) directly. */
+  excludedFiles?: number;
   /** Author-provided "Notes for reviewers" — the author's deliberate calls behind
    *  the change. Treated as author input like `body` (NOT soft bot context), so it
    *  is fed to both review modes and never subject to the extras budget. Absent ⇒

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -589,6 +589,51 @@ interface ReviewResult {
   thoughts: string;
 }
 
+/** The whole unified diff a review event covers, from whichever source can serve
+ *  it — every branch here lands unfiltered text that the caller then filters. */
+async function resolveDiff(
+  event: AutomationEvent,
+): Promise<{ text: string; truncated: boolean; files: DiffStatEntry[] }> {
+  if (event.kind === "commit") {
+    return gitCommitDiff(event.repoPath, event.hash, DIFF_MAX_BYTES);
+  }
+  if (event.kind === "pr-sync" && event.target.type === "remote") {
+    // Remote pr-sync comes from the provider-neutral head-OID poll: no local base/head
+    // branch, and the head may not be local (fork / pushed elsewhere). Use the provider's
+    // PR diff; it has no numstat, so derive the file summary from the diff text.
+    // Origin-pinned — the poller is origin-scoped, so this tracks the fork's own PRs.
+    const text = await forgePrDiff(
+      event.repoPath,
+      event.target.number,
+      "origin",
+    );
+    return { text, truncated: false, files: filesFromDiff(text) };
+  }
+  if (event.target.type === "remote") {
+    // Remote pr-open: prefer the local branch diff (it carries numstat), but the head
+    // branch isn't guaranteed local — catch-up / ready-flip events cover PRs opened
+    // elsewhere that reach this machine before any fetch lands the ref (observed live:
+    // `git diff` fails on an unfetched head). Fall back to the provider's PR diff.
+    try {
+      return await gitBranchDiff(
+        event.repoPath,
+        event.base,
+        event.head,
+        DIFF_MAX_BYTES,
+      );
+    } catch {
+      const text = await forgePrDiff(
+        event.repoPath,
+        event.target.number,
+        "origin",
+      );
+      return { text, truncated: false, files: filesFromDiff(text) };
+    }
+  }
+  // Local PR targets: both branches are inherently local.
+  return gitBranchDiff(event.repoPath, event.base, event.head, DIFF_MAX_BYTES);
+}
+
 /**
  * Resolves the diff, builds the prompt, and runs the model to completion.
  * `signal` aborts the HTTP stream; `onCliId` reports the CLI run's id so the
@@ -602,9 +647,15 @@ async function generateReviewText(
   signal: AbortSignal,
   onCliId: (id: string) => void,
 ): Promise<ReviewResult | null> {
-  // Must resolve before the diff loads — it decides how the diff is filtered.
-  // The budget profile below reuses this one read.
-  const appSettings = await loadSettings();
+  // Independent of each other, and the settings are only needed by the filter
+  // below (the budget profile reuses the same read) — so they resolve alongside
+  // the diff rather than in front of it.
+  const [diff, appSettings] = await Promise.all([
+    resolveDiff(event),
+    loadSettings(),
+  ]);
+  if (!diff.text.trim()) return null;
+  // Cancelled while the diff loaded — don't start the model.
   if (signal.aborted) return null;
   // An automated review is agentic only when the toggle is on AND the provider is
   // a CLI one: `runCliStream` honors `cliRepoAware` with a detached worktree, but
@@ -616,55 +667,8 @@ async function generateReviewText(
     : await aiExcludePatterns(event.repoPath, appSettings.aiIgnorePatterns);
   if (signal.aborted) return null;
 
-  let diff: { text: string; truncated: boolean; files: DiffStatEntry[] };
-  if (event.kind === "commit") {
-    diff = await gitCommitDiff(event.repoPath, event.hash, DIFF_MAX_BYTES);
-  } else if (event.kind === "pr-sync" && event.target.type === "remote") {
-    // Remote pr-sync comes from the provider-neutral head-OID poll: no local base/head
-    // branch, and the head may not be local (fork / pushed elsewhere). Use the provider's
-    // PR diff; it has no numstat, so derive the file summary from the diff text.
-    // Origin-pinned — the poller is origin-scoped, so this tracks the fork's own PRs.
-    const text = await forgePrDiff(
-      event.repoPath,
-      event.target.number,
-      "origin",
-    );
-    diff = { text, truncated: false, files: filesFromDiff(text) };
-  } else if (event.target.type === "remote") {
-    // Remote pr-open: prefer the local branch diff (it carries numstat), but the head
-    // branch isn't guaranteed local — catch-up / ready-flip events cover PRs opened
-    // elsewhere that reach this machine before any fetch lands the ref (observed live:
-    // `git diff` fails on an unfetched head). Fall back to the provider's PR diff.
-    try {
-      diff = await gitBranchDiff(
-        event.repoPath,
-        event.base,
-        event.head,
-        DIFF_MAX_BYTES,
-      );
-    } catch {
-      const text = await forgePrDiff(
-        event.repoPath,
-        event.target.number,
-        "origin",
-      );
-      diff = { text, truncated: false, files: filesFromDiff(text) };
-    }
-  } else {
-    // Local PR targets: both branches are inherently local.
-    diff = await gitBranchDiff(
-      event.repoPath,
-      event.base,
-      event.head,
-      DIFF_MAX_BYTES,
-    );
-  }
-  if (!diff.text.trim()) return null;
-  // Cancelled while the diff loaded — don't start the model.
-  if (signal.aborted) return null;
-
-  // One filter for every resolution path above: each lands a whole unified diff
-  // here, and only `gitBranchDiff` could have excluded server-side.
+  // One filter for every resolution path in `resolveDiff`: each lands a whole
+  // unified diff here, and only `gitBranchDiff` could have excluded server-side.
   const filtered = await filterDiffByAiIgnore({
     repoPath: event.repoPath,
     text: diff.text,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -7,6 +7,7 @@ import {
   type ExternalContext,
   resolveExternalContext,
 } from "@/lib/ai/external-context";
+import { aiExcludePatterns, filterDiffByAiIgnore } from "@/lib/ai/ignore";
 import { resolveReviewerNotesContext } from "@/lib/ai/notes-context";
 import {
   type OwnCommentsContext,
@@ -601,6 +602,21 @@ async function generateReviewText(
   signal: AbortSignal,
   onCliId: (id: string) => void,
 ): Promise<ReviewResult | null> {
+  // Read up front so the AI-ignore patterns are in hand before the diff resolves;
+  // the budget profile below still consumes the same single read.
+  const appSettings = await loadSettings();
+  if (signal.aborted) return null;
+  // An automated review is agentic only when the toggle is on AND the provider is
+  // a CLI one: `runCliStream` honors `cliRepoAware` with a detached worktree, but
+  // an automated HTTP review gets no MCP tools and no tool loop, so it can only
+  // ever see the diff we hand it. Non-agentic ⇒ the user's AI-ignore patterns
+  // apply, exactly as they do on every generation path.
+  const agenticRun = Boolean(ai.cliRepoAware) && isCliProvider(ai.provider);
+  const excludePatterns = agenticRun
+    ? []
+    : await aiExcludePatterns(event.repoPath, appSettings.aiIgnorePatterns);
+  if (signal.aborted) return null;
+
   let diff: { text: string; truncated: boolean; files: DiffStatEntry[] };
   if (event.kind === "commit") {
     diff = await gitCommitDiff(event.repoPath, event.hash, DIFF_MAX_BYTES);
@@ -648,8 +664,25 @@ async function generateReviewText(
   // Cancelled while the diff loaded — don't start the model.
   if (signal.aborted) return null;
 
+  // One filter for all five resolution paths above (forge PR diff, branch diff,
+  // commit diff): every one of them lands a whole unified diff here, and only
+  // `gitBranchDiff` could have excluded server-side. Empty patterns ⇒ the input
+  // straight back, no IPC.
+  const filtered = await filterDiffByAiIgnore({
+    repoPath: event.repoPath,
+    text: diff.text,
+    files: diff.files,
+    exclude: excludePatterns,
+  });
+  // Everything the change touched is AI-ignored — same outcome as an empty diff
+  // (the caller reports "skipped — no changes to review"), and nothing to send.
+  if (!filtered.text.trim()) return null;
+  if (signal.aborted) return null;
+
   // Build on a prior review of this PR + mode (no-op when none) so a re-review focuses on
-  // new/unresolved issues — the same soft context the interactive path uses.
+  // new/unresolved issues — the same soft context the interactive path uses. Takes the
+  // same patterns: its "changes since" delta is a second diff, and filtering only the
+  // main one would leak through it.
   const prior: PriorContext =
     event.kind === "commit"
       ? {}
@@ -659,6 +692,7 @@ async function generateReviewText(
           targetRef(event),
           mode,
           event.headSha,
+          excludePatterns,
         );
   if (signal.aborted) return null;
 
@@ -675,7 +709,6 @@ async function generateReviewText(
   // ledger cap key off the SAME budget as the rest of the prompt; reused verbatim at
   // buildReviewPrompt below. Best-effort, never blocks the review. (external + own stay
   // separate harvests — a shared-fetch dedup is the forge-dispatch-dedup backlog item.)
-  const appSettings = await loadSettings();
   const budgetProfile = await resolveBudgetProfile(
     ai,
     appSettings.reviewContextSize,
@@ -749,14 +782,17 @@ async function generateReviewText(
       title: event.title,
       body: event.kind === "commit" ? "" : event.body,
       commitSubjects: event.kind === "commit" ? [] : event.commitSubjects,
-      diffText: diff.text,
+      diffText: filtered.text,
       diffTruncated: diff.truncated,
-      files: diff.files.map((f) => ({
+      files: filtered.files.map((f) => ({
         path: f.path,
         added: f.added,
         deleted: f.deleted,
         isBinary: f.isBinary,
       })),
+      // Always 0 on an agentic run (nothing was filtered), so its prompt is
+      // byte-identical to before — the disclosure line is skipped entirely.
+      excludedFiles: filtered.excludedFiles,
       provider,
       budgetProfile,
       repoInstructions,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -602,15 +602,14 @@ async function generateReviewText(
   signal: AbortSignal,
   onCliId: (id: string) => void,
 ): Promise<ReviewResult | null> {
-  // Read up front so the AI-ignore patterns are in hand before the diff resolves;
-  // the budget profile below still consumes the same single read.
+  // Must resolve before the diff loads — it decides how the diff is filtered.
+  // The budget profile below reuses this one read.
   const appSettings = await loadSettings();
   if (signal.aborted) return null;
   // An automated review is agentic only when the toggle is on AND the provider is
   // a CLI one: `runCliStream` honors `cliRepoAware` with a detached worktree, but
   // an automated HTTP review gets no MCP tools and no tool loop, so it can only
-  // ever see the diff we hand it. Non-agentic ⇒ the user's AI-ignore patterns
-  // apply, exactly as they do on every generation path.
+  // ever see the diff we hand it.
   const agenticRun = Boolean(ai.cliRepoAware) && isCliProvider(ai.provider);
   const excludePatterns = agenticRun
     ? []
@@ -664,25 +663,21 @@ async function generateReviewText(
   // Cancelled while the diff loaded — don't start the model.
   if (signal.aborted) return null;
 
-  // One filter for all five resolution paths above (forge PR diff, branch diff,
-  // commit diff): every one of them lands a whole unified diff here, and only
-  // `gitBranchDiff` could have excluded server-side. Empty patterns ⇒ the input
-  // straight back, no IPC.
+  // One filter for every resolution path above: each lands a whole unified diff
+  // here, and only `gitBranchDiff` could have excluded server-side.
   const filtered = await filterDiffByAiIgnore({
     repoPath: event.repoPath,
     text: diff.text,
     files: diff.files,
     exclude: excludePatterns,
   });
-  // Everything the change touched is AI-ignored — same outcome as an empty diff
-  // (the caller reports "skipped — no changes to review"), and nothing to send.
+  // Everything the change touched is AI-ignored ⇒ the empty-diff outcome (the
+  // caller reports "skipped — no changes to review").
   if (!filtered.text.trim()) return null;
   if (signal.aborted) return null;
 
   // Build on a prior review of this PR + mode (no-op when none) so a re-review focuses on
-  // new/unresolved issues — the same soft context the interactive path uses. Takes the
-  // same patterns: its "changes since" delta is a second diff, and filtering only the
-  // main one would leak through it.
+  // new/unresolved issues — the same soft context the interactive path uses.
   const prior: PriorContext =
     event.kind === "commit"
       ? {}
@@ -790,8 +785,6 @@ async function generateReviewText(
         deleted: f.deleted,
         isBinary: f.isBinary,
       })),
-      // Always 0 on an agentic run (nothing was filtered), so its prompt is
-      // byte-identical to before — the disclosure line is skipped entirely.
       excludedFiles: filtered.excludedFiles,
       provider,
       budgetProfile,

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -989,11 +989,8 @@ export const gitBranchFileDiff = (
 /** Three-dot `base...compare` diff. `exclude` takes gitignore-style patterns the
  *  backend filters out of the text and file list (counting them in
  *  `excludedFiles`); generation callers pass the user's AI-ignore patterns here.
- *  Reviews apply the same patterns but filter client-side after the diff
- *  resolves (`filterDiffByAiIgnore`) — one recipe for this path and the
- *  forge-supplied PR diff alike — and only for a NON-agentic run: an agentic
- *  reviewer reads the worktree and its own tools directly, so filtering the
- *  diff handed to it would protect nothing. */
+ *  Review callers omit them and filter client-side instead
+ *  (`filterDiffByAiIgnore`), which covers forge-supplied PR diffs too. */
 export const gitBranchDiff = (
   repoPath: string,
   base: string,

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -988,8 +988,12 @@ export const gitBranchFileDiff = (
 
 /** Three-dot `base...compare` diff. `exclude` takes gitignore-style patterns the
  *  backend filters out of the text and file list (counting them in
- *  `excludedFiles`): generation callers pass the user's AI-ignore patterns;
- *  review callers deliberately omit them — a review wants the full diff. */
+ *  `excludedFiles`); generation callers pass the user's AI-ignore patterns here.
+ *  Reviews apply the same patterns but filter client-side after the diff
+ *  resolves (`filterDiffByAiIgnore`) — one recipe for this path and the
+ *  forge-supplied PR diff alike — and only for a NON-agentic run: an agentic
+ *  reviewer reads the worktree and its own tools directly, so filtering the
+ *  diff handed to it would protect nothing. */
 export const gitBranchDiff = (
   repoPath: string,
   base: string,
@@ -2991,6 +2995,17 @@ export const readRepoAiIgnore = (repoPath: string) =>
  *  ones are skipped). */
 export const appendRepoAiIgnore = (repoPath: string, patterns: string[]) =>
   invoke<number>("append_repo_ai_ignore", { repoPath, patterns });
+
+/** Which of `paths` the user's AI-ignore patterns hide, decided by git's own
+ *  gitignore engine — the same matcher the diff-side pathspec translation is
+ *  pinned to. For path lists the frontend holds itself (a remote PR's changed
+ *  files): the paths need not exist in the working tree or index. Returns `[]`
+ *  when nothing matches, or when either list is empty. */
+export const gitFilterAiIgnored = (
+  repoPath: string,
+  paths: string[],
+  exclude: string[],
+) => invoke<string[]>("git_filter_ai_ignored", { repoPath, paths, exclude });
 
 /** Raw contents of `<repo>/.gitdesktop/branch-rules.json`, or null if absent. */
 export const readRepoBranchRules = (repoPath: string) =>

--- a/src/lib/git/conflict.ts
+++ b/src/lib/git/conflict.ts
@@ -16,7 +16,8 @@ export interface ConflictSides {
 
 /** Reads a conflicted file's base/ours/theirs blobs + the marked working file,
  *  plus whether it's AI-ignored. `exclude` is the combined (repo + global)
- *  AI-ignore pattern list, matched with git's own pathspec semantics. */
+ *  AI-ignore pattern list, decided by git's own gitignore engine — the same
+ *  truth table a test pins the diff-side pathspec translation to. */
 export const conflictSides = (
   repoPath: string,
   path: string,

--- a/src/lib/git/glob.ts
+++ b/src/lib/git/glob.ts
@@ -31,7 +31,10 @@ export function globLiteralPath(path: string): string {
  * term. [`globLiteralPath`] is NOT an alternative here — its escaped folder
  * form (`src/app/[[]slug]`) matches nothing at all, since git's directory
  * recursion only runs on the literal branch.
+ *
+ * An empty path stays empty: a bare `:(literal)` matches EVERYTHING, and the
+ * Rust commands' `!isEmpty()` guards would wave it through.
  */
 export function literalPathspec(path: string): string {
-  return `:(literal)${path}`;
+  return path ? `:(literal)${path}` : path;
 }

--- a/src/lib/git/glob.ts
+++ b/src/lib/git/glob.ts
@@ -1,0 +1,37 @@
+// Feeding concrete paths to git's matchers. The split these two draw is the
+// point: a path the user PICKED must match only itself, so it goes through one
+// of these; a glob the user or a menu wrote as a pattern (`*.log`, `*.tsx`) is
+// meant to match broadly and goes to git raw. Only the call site knows which it
+// holds, so neither is applied centrally in the Rust commands.
+
+/**
+ * A concrete path turned into a glob pattern that matches exactly that path —
+ * for .gitignore lines and AI-ignore entries.
+ *
+ * `[`, `*` and `?` are metacharacters, so a raw path holding one matches the
+ * wrong files: `app/[slug]/page.tsx` reads as a character class. Wrapping each
+ * as a one-character class (`[` → `[[]`) is the only form BOTH engines honor —
+ * pathspec ignores the backslash escapes .gitignore accepts (measured, git
+ * 2.51.1). `]` outside a class is already literal; a literal backslash is
+ * inexpressible on either engine and is left alone (impossible on Windows).
+ */
+export function globLiteralPath(path: string): string {
+  return path.replace(/[[*?]/g, (c) => `[${c}]`);
+}
+
+/**
+ * A concrete path as a pathspec that matches only itself — for the commands
+ * that take pathspecs (`git rm --cached`, and anything else given a path the
+ * user picked from a list).
+ *
+ * Pathspecs glob too, and git tries a literal match FIRST, so a raw path is not
+ * safe merely because it names a real file: `git rm --cached -r --
+ * src/app/[slug]/page.tsx` drops that file AND `src/app/s/page.tsx` from the
+ * index (measured, git 2.51.1). `:(literal)` magic turns globbing off for the
+ * term. [`globLiteralPath`] is NOT an alternative here — its escaped folder
+ * form (`src/app/[[]slug]`) matches nothing at all, since git's directory
+ * recursion only runs on the literal branch.
+ */
+export function literalPathspec(path: string): string {
+  return `:(literal)${path}`;
+}

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -11,6 +11,7 @@ import {
   type ExternalContext,
   resolveExternalContext,
 } from "@/lib/ai/external-context";
+import { aiExcludePatterns, filterDiffByAiIgnore } from "@/lib/ai/ignore";
 import { resolveReviewerNotesContext } from "@/lib/ai/notes-context";
 import {
   type OwnCommentsContext,
@@ -496,19 +497,57 @@ export async function startReview(
                 : "balanced",
       },
     });
-    const diff = await context.loadDiff();
+    // Agentic run: in repo-aware mode the reviewer explores. Resolved up here
+    // because it also decides whether this run's diff is AI-ignore filtered —
+    // see `excludePatterns` below; the capability breakdown it feeds stays with
+    // the prompt further down.
+    const agenticRun = Boolean(ai.cliRepoAware);
+    // Settings are read here rather than after the diff so the AI-ignore
+    // patterns are in hand before it loads.
+    const appSettings = await loadSettings();
     if (control.cancelled) return;
+    // The user's AI-ignore patterns, applied to a NON-agentic review's diff so a
+    // file the user withheld from generation is withheld from review too. An
+    // agentic run is deliberately unfiltered — its agent reads the checked-out
+    // worktree (CLI) or holds `read_file`/`grep`/`pull_request_diff` (HTTP), so
+    // filtering the diff we hand it would protect nothing. Empty ⇒ every step
+    // below is a no-op, with no extra IPC.
+    const excludePatterns = agenticRun
+      ? []
+      : await aiExcludePatterns(target.repoPath, appSettings.aiIgnorePatterns);
+    if (control.cancelled) return;
+    const loaded = await context.loadDiff();
+    if (control.cancelled) return;
+    const filtered = await filterDiffByAiIgnore({
+      repoPath: target.repoPath,
+      text: loaded.text,
+      files: loaded.files,
+      exclude: excludePatterns,
+    });
+    if (control.cancelled) return;
+    const diff = {
+      text: filtered.text,
+      truncated: loaded.truncated,
+      files: filtered.files,
+    };
     if (!diff.text.trim()) {
       // A no-op run shouldn't linger in the dock; a momentary toast is enough. Drop any
       // queued second mode too — same PR, same empty diff, so it would only load nothing
-      // and toast "No changes" a second time.
-      toast.info("No changes to review.");
+      // and toast "No changes" a second time. An all-excluded diff lands here too, and
+      // says so — "no changes" on a PR that visibly has some reads as a bug.
+      toast.info(
+        filtered.excludedFiles > 0
+          ? "Every changed file matches your AI ignore patterns — nothing to review."
+          : "No changes to review.",
+      );
       queuedRuns.delete(key);
       useReviewStore.getState().remove(key);
       return;
     }
     // Soft prior-review context (skipped when the user asked to ignore it). Runs
-    // on a held slot after the diff loads — never during the queued wait.
+    // on a held slot after the diff loads — never during the queued wait. Takes the
+    // same patterns: its "changes since" delta is a second diff, and filtering only
+    // the main one would leak through it.
     const prior: PriorContext = ignorePrior
       ? {}
       : await resolvePriorContext(
@@ -517,6 +556,7 @@ export async function startReview(
           target.ref,
           mode,
           context.headSha,
+          excludePatterns,
         );
     if (control.cancelled) return;
     patch({ deltaState: prior.deltaState });
@@ -524,7 +564,6 @@ export async function startReview(
     // Review-context knob) — best-effort, never throws. Resolved BEFORE the own/external
     // harvest so the own-comments distill trigger + ledger cap key off the SAME scaled
     // budget, and reused verbatim at buildReviewPrompt (one resolution, used twice).
-    const appSettings = await loadSettings();
     const budgetProfile = await resolveBudgetProfile(
       ai,
       appSettings.reviewContextSize,
@@ -603,14 +642,13 @@ export async function startReview(
     // stream's own `setStatus`. AFTER the cancel check, like every other post-await
     // patch: otherwise a cancel-then-rerun would blank the successor's status.
     patch({ status: "" });
-    // Agentic run: in repo-aware mode the reviewer explores. A CLI provider
-    // reviews with the PR's files on disk and (for the tool-capable CLIs —
+    // What an agentic run (`agenticRun`, resolved above) can actually do. A CLI
+    // provider reviews with the PR's files on disk and (for the tool-capable CLIs —
     // everything but codex) GitDesktop's own read-only MCP tools attached; an
     // HTTP provider (null kind) instead drives a native AI-SDK tool loop with no
     // worktree. Computed before the prompt so it can frame truncation honestly,
     // and to gate `mcpSelf` / `reviewTools` on the stream.
     const kind = providerKind(ai.provider);
-    const agenticRun = Boolean(ai.cliRepoAware);
     const mcpTools = agenticRun && kind !== null && kind !== "codex";
     const httpTools = agenticRun && kind === null;
     const agentic = agenticRun
@@ -648,6 +686,9 @@ export async function startReview(
           deleted: f.deleted,
           isBinary: f.isBinary,
         })),
+        // Always 0 on an agentic run (nothing was filtered), so its prompt is
+        // byte-identical to before — the disclosure line is skipped entirely.
+        excludedFiles: filtered.excludedFiles,
         provider: context.provider,
         budgetProfile,
         agentic,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -500,8 +500,12 @@ export async function startReview(
     // Agentic run: in repo-aware mode the reviewer explores (what it can
     // actually reach is worked out with the prompt below).
     const agenticRun = Boolean(ai.cliRepoAware);
-    // Must resolve before the diff loads — it decides how the diff is filtered.
-    const appSettings = await loadSettings();
+    // Independent of each other, and the settings are only needed by the filter
+    // below — so they ride alongside the diff rather than in front of it.
+    const [loaded, appSettings] = await Promise.all([
+      context.loadDiff(),
+      loadSettings(),
+    ]);
     if (control.cancelled) return;
     // Applied to a NON-agentic review's diff, so a file withheld from generation
     // is withheld from review too. An agentic run is deliberately unfiltered —
@@ -511,8 +515,6 @@ export async function startReview(
     const excludePatterns = agenticRun
       ? []
       : await aiExcludePatterns(target.repoPath, appSettings.aiIgnorePatterns);
-    if (control.cancelled) return;
-    const loaded = await context.loadDiff();
     if (control.cancelled) return;
     const filtered = await filterDiffByAiIgnore({
       repoPath: target.repoPath,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -497,21 +497,17 @@ export async function startReview(
                 : "balanced",
       },
     });
-    // Agentic run: in repo-aware mode the reviewer explores. Resolved up here
-    // because it also decides whether this run's diff is AI-ignore filtered —
-    // see `excludePatterns` below; the capability breakdown it feeds stays with
-    // the prompt further down.
+    // Agentic run: in repo-aware mode the reviewer explores (what it can
+    // actually reach is worked out with the prompt below).
     const agenticRun = Boolean(ai.cliRepoAware);
-    // Settings are read here rather than after the diff so the AI-ignore
-    // patterns are in hand before it loads.
+    // Must resolve before the diff loads — it decides how the diff is filtered.
     const appSettings = await loadSettings();
     if (control.cancelled) return;
-    // The user's AI-ignore patterns, applied to a NON-agentic review's diff so a
-    // file the user withheld from generation is withheld from review too. An
-    // agentic run is deliberately unfiltered — its agent reads the checked-out
-    // worktree (CLI) or holds `read_file`/`grep`/`pull_request_diff` (HTTP), so
-    // filtering the diff we hand it would protect nothing. Empty ⇒ every step
-    // below is a no-op, with no extra IPC.
+    // Applied to a NON-agentic review's diff, so a file withheld from generation
+    // is withheld from review too. An agentic run is deliberately unfiltered —
+    // its agent reads the checked-out worktree (CLI) or holds
+    // `read_file`/`grep`/`pull_request_diff` (HTTP), so filtering the diff we
+    // hand it would protect nothing.
     const excludePatterns = agenticRun
       ? []
       : await aiExcludePatterns(target.repoPath, appSettings.aiIgnorePatterns);
@@ -534,7 +530,7 @@ export async function startReview(
       // A no-op run shouldn't linger in the dock; a momentary toast is enough. Drop any
       // queued second mode too — same PR, same empty diff, so it would only load nothing
       // and toast "No changes" a second time. An all-excluded diff lands here too, and
-      // says so — "no changes" on a PR that visibly has some reads as a bug.
+      // says so rather than claiming a PR with visible changes has none.
       toast.info(
         filtered.excludedFiles > 0
           ? "Every changed file matches your AI ignore patterns — nothing to review."
@@ -545,9 +541,7 @@ export async function startReview(
       return;
     }
     // Soft prior-review context (skipped when the user asked to ignore it). Runs
-    // on a held slot after the diff loads — never during the queued wait. Takes the
-    // same patterns: its "changes since" delta is a second diff, and filtering only
-    // the main one would leak through it.
+    // on a held slot after the diff loads — never during the queued wait.
     const prior: PriorContext = ignorePrior
       ? {}
       : await resolvePriorContext(
@@ -686,8 +680,6 @@ export async function startReview(
           deleted: f.deleted,
           isBinary: f.isBinary,
         })),
-        // Always 0 on an agentic run (nothing was filtered), so its prompt is
-        // byte-identical to before — the disclosure line is skipped entirely.
         excludedFiles: filtered.excludedFiles,
         provider: context.provider,
         budgetProfile,


### PR DESCRIPTION
AI-ignore lists are documented as "gitignore-style", but they were evaluated as raw `:(exclude)` pathspecs — so a bare `notes.md` was root-anchored where gitignore matches at any depth, `docs/*.log` swept nested files, and a bare `node_modules` matched nothing at all. This PR makes matching actually *be* gitignore, extends the patterns to every review and PR-description path that previously shipped an unfiltered diff to the provider, and — since the same globbing hazard applies to concrete paths — routes user-picked paths through literal pathspecs so a `src/app/[slug]/page.tsx` can no longer sweep its glob-siblings into a discard, stash or conflict resolution.

### AI-ignore matching engine

- Adds `src-tauri/src/git/ai_ignore.rs`: one module owning both evaluation routes — `pathspecs_for` (pure translation to `:(exclude,glob)` terms for the callers that filter a whole git command's output) and `filter_ignored` / the new `git_filter_ai_ignored` command (git's real `check-ignore --no-index --stdin` engine, for path lists that need not exist in the tree or index). A test pins the two to the same truth table.
- Handles the semantics the old translation got wrong: unanchored lines gain a `**/` prefix, non-directory lines also emit `<pattern>/**`, `,glob` magic stops `*` at `/`, and `,icase` follows the repo's `core.ignorecase` so a case-insensitive filesystem can't leak a file past the pathspec side.
- `!` re-include lines are dropped by a shared `actionable_lines`, deliberately, so both engines decide every list identically; the drop count is carried on `AiIgnorePathspecs.skipped_negations`.
- Evaluates patterns in a throwaway empty repo via `tempfile` (added to `src-tauri/Cargo.toml`) — the comment there explains why an unpredictable, exclusively-created path matters, since a pre-seeded `.git/info/exclude` would outrank `core.excludesFile`.
- Rewires the existing callers: `git/diff.rs` (`git_staged_diff`) and `git/compare.rs` (`git_branch_diff`) now call `pathspecs_for_repo`, and `git/conflict.rs`'s `is_ai_ignored` moves off its `ls-files` + `:(exclude)` listing, which cannot decide a single path (git strips the positive pathspec's prefix off the negative patterns too).
- `instructions.rs` stops stripping the leading `/` from stored patterns — it is meaningful anchoring — and updates `append_repo_ai_ignore`'s tests to prove `/foo` and `foo` are distinct lines.
- Registers `git::ai_ignore::git_filter_ai_ignored` in `src-tauri/src/lib.rs`.

### Reviews and PR descriptions now filtered

- `src/lib/ai/ignore.ts` gains `filterDiffByAiIgnore`, a client-side filter over an already-resolved unified diff — the union of the diff's own section keys and the file list is the candidate set, since a provider's file list can be capped while the diff text is complete.
- `src/lib/stores/reviews.ts` and `src/lib/automations/runner.ts` apply it to interactive and automated reviews; the runner resolves patterns before the diff loads, skips filtering for genuinely agentic CLI runs, and returns `null` when every changed file is excluded.
- `src/lib/ai/prior-context.ts` filters the "changes since your last review" delta too — a second diff that would otherwise leak the withheld files — inside the fail-closed `try`.
- `src/features/pulls/RemotePrView.tsx` filters the forge-supplied diff before regenerating an existing PR's description, without writing the result back into the query cache that the Files tab and review threads share.
- `src/features/pulls/useGeneratePrDescription.ts` takes the loaded settings into the diff supplier and adds an `emptyScope` argument so the "nothing to describe" toast names the pull/merge request rather than "these branches".
- `src/lib/ai/prompt.ts` + `src/lib/ai/types.ts` add an `excludedFiles` disclosure line to the review prompt, worded more firmly than the generator's twin so the model doesn't invent findings about files it can't see.
- `src/lib/git/api.ts` documents the new split (server-side `exclude` vs client-side filtering) and exports `gitFilterAiIgnored`.

### Literal pathspecs for user-picked paths

- Adds `src-tauri/src/git/pathspec.rs` (`literal`) and `src/lib/git/glob.ts` (`literalPathspec` for pathspec-taking commands, `globLiteralPath` for `.gitignore` / AI-ignore lines), with the reasoning for why each engine needs a different form.
- Applies them in `git/ops.rs` (`git_discard`, `git_discard_paths_core`'s tracked half, `replace_file_lines`' dirty check and auto-stage) and `git/conflict.rs` (resolve + checkout-side), so discarding or resolving one file can't touch a glob-sibling.
- Frontend call sites follow: `ChangesPanel.tsx` (stage, unstage, stage-all/selected, ignore, AI-exclude, untrack, stash), `ChangesContextMenu.tsx` (ignore / untrack / exclude entries, now documenting which argument may be a deliberate glob) and `RepositoryFilesDialog.tsx` (untrack, force-add, ignore pattern).
- `ChangesPanel.tsx`'s bulk AI-exclude and the context menu now write anchored `/path` and `/folder/` lines, so *Exclude from AI* means exactly the file or folder that was picked.
- New Rust tests cover the behaviour: `discard_paths_does_not_restore_glob_siblings` in `ops.rs`, plus any-depth / anchored / bare-directory cases in `compare.rs`, `diff.rs` and `conflict.rs`.

### Documentation

- `README.md` spells out the pattern syntax with examples, notes that `!` lines aren't supported, that *Exclude from AI* writes anchored lines, and that a repo-aware review isn't limited by the patterns.
- `src/features/help/content.ts` mirrors that in the AI guide section, adds the agentic-review caveat to the pull-request section, and documents the **Critical** severity level.
- `src/features/settings/InstructionsSection.tsx` replaces the bare "gitignore-style patterns" hint with concrete `secrets.env` / `/secrets.env` / `vendor/` examples.
- `site/src/pages/ai.astro` and `site/src/data/capabilities.ts` update the AI-ignore copy and add capability lines (review timeout, convergence, verdicts, docs-surface findings; `Explore repositories` promoted to `highlight`).
- Changelog fragments: `fixed-ai-ignore-gitignore-semantics.md` (including the migration warning that existing unanchored patterns may now hide more), `fixed-ai-review-ai-ignore.md`, `fixed-remote-pr-regenerate-ai-ignore.md`, `fixed-ignore-untrack-special-characters.md`, plus a trim to `fixed-branch-diff-ai-ignore.md` now that remote-PR regeneration is covered.