### PR TITLE
docs(site,blog): add a merge-preview post and link the founder essay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,33 @@ capability line + changelog fragment — but make the call deliberately, don't s
 captured with the app's *Settings → General → Hide AI features* ON, so they match
 the AI-hidden experience. (See `memory/site-just-git-screenshots.md`.)
 
+## Blog-post copy — anti-AI-tell rules (`site/src/content/blog/`)
+
+Article prose ships under the owner's byline; readers (and the owner) flag AI-sounding
+copy on sight. Hard rules for post text, learned the expensive way on PR #132 — they
+govern phrasing only; technical claims stay empirically probe-verified as ever:
+
+- **No earnestness performance.** Never "honest", "genuinely", "truly" as sincerity
+  markers ("Two honest caveats"), and no valuation tics ("worth knowing", "worth the
+  whole article", "it's worth").
+- **No takeaway scaffolds.** "The thing to take away is…", "here's the part that…",
+  "the key insight…" — state the point, don't announce it.
+- **Antithesis budget.** "X, not Y" / "isn't X — it's Y" a couple of times per post at
+  most, never in adjacent paragraphs; keep it only where the contrast IS the technical
+  point being made.
+- **Em-dash budget.** ≈7 per 1k words (the shipped posts' rate). No paired
+  "— aside —" interrupters; recast with commas or parentheses.
+- **Closers written fresh every post.** The "Or don't do any of this" heading is a
+  series motif; the prose beats under it are not. Never reuse a prior post's scaffold
+  ("I write a Git client, so…", "Same X, same Y, minus Z", "Either way, the thing to
+  take away…").
+- **Numbers trace to transcripts.** Any figure in prose must be visible in a code
+  block the reader has already seen; drop or demonstrate, never assert.
+- **Wrap band.** Prose lines ~76 chars, 81 max; no orphaned short lines
+  mid-paragraph, no one-word paragraph trailers.
+- **Voice constants** (these ARE the house style, keep them): cold second-person
+  open, a one-line Git aphorism to close (new words each time), British spellings.
+
 ## Everyday commands
 
 ```sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,28 +46,39 @@ the AI-hidden experience. (See `memory/site-just-git-screenshots.md`.)
 
 Article prose ships under the owner's byline; readers (and the owner) flag AI-sounding
 copy on sight. Hard rules for post text, learned the expensive way on PR #132 — they
-govern phrasing only; technical claims stay empirically probe-verified as ever:
+govern phrasing only; technical claims stay empirically probe-verified as ever. They
+apply to **every** post, shipped ones included: when a rule tightens, sweep the
+back-catalogue in the same change rather than grandfathering it.
 
 - **No earnestness performance.** Never "honest", "genuinely", "truly" as sincerity
   markers ("Two honest caveats"), and no valuation tics ("worth knowing", "worth the
   whole article", "it's worth").
 - **No takeaway scaffolds.** "The thing to take away is…", "here's the part that…",
   "the key insight…" — state the point, don't announce it.
-- **Antithesis budget.** "X, not Y" / "isn't X — it's Y" a couple of times per post at
-  most, never in adjacent paragraphs; keep it only where the contrast IS the technical
-  point being made.
-- **Em-dash budget.** ≈7 per 1k words (the shipped posts' rate). No paired
-  "— aside —" interrupters; recast with commas or parentheses.
+- **Antithesis budget.** "X, not Y" / "isn't X — it's Y" is a density guide, not a
+  ban: keep every instance where the contrast IS the technical point being made, and
+  cut the rest — reflex-reaching for the scaffold is the tell, especially twice in
+  adjacent paragraphs.
+- **Em-dash budget.** ≈7 per 1k words of running prose — list-item glosses, tables,
+  and code don't count toward the rate. No paired "— aside —" interrupters; recast
+  with commas or parentheses.
 - **Closers written fresh every post.** The "Or don't do any of this" heading is a
   series motif; the prose beats under it are not. Never reuse a prior post's scaffold
   ("I write a Git client, so…", "Same X, same Y, minus Z", "Either way, the thing to
   take away…").
-- **Numbers trace to transcripts.** Any figure in prose must be visible in a code
-  block the reader has already seen; drop or demonstrate, never assert.
+- **Measured numbers trace to transcripts.** Any figure you *measured* must be
+  visible in a code block the reader has already seen — drop or demonstrate, never
+  assert. Documented facts (version numbers, release dates, config defaults) may be
+  cited directly.
 - **Wrap band.** Prose lines ~76 chars, 81 max; no orphaned short lines
-  mid-paragraph, no one-word paragraph trailers.
-- **Voice constants** (these ARE the house style, keep them): cold second-person
-  open, a one-line Git aphorism to close (new words each time), British spellings.
+  mid-paragraph, no one-word paragraph trailers. Bare URL / link-target lines are
+  exempt — never break a URL to satisfy the band.
+- **Voice constants** (house style for the series): cold second-person open and a
+  one-line Git aphorism close for technical posts (new words each time). Spelling
+  and personal voice follow the post's **byline author** — derive them from that
+  author's own writing, never from patterns shared by previously generated posts
+  (two generated texts agreeing is one drafting process sampled twice, not
+  evidence of a house style).
 
 ## Everyday commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,11 @@ For any **user-facing feature**, keep the docs in step in the same change:
 A truly minor feature can settle for just the capability line + changelog — but make
 that call on purpose.
 
+Writing a **blog post**? Post copy follows the anti-AI-tell rules in
+[CLAUDE.md](CLAUDE.md#blog-post-copy--anti-ai-tell-rules-sitesrccontentblog) —
+phrasing, wrap band, and voice; spelling and personal voice follow the post's
+byline author.
+
 ### UI changes
 
 GitDesktop is keyboard-first and aims for WCAG AA. When you add or change UI:

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -219,7 +219,7 @@ exit 0. When in doubt, run the specific case; the category name is a poor guide.
 
 So if you're predicting the result of a merge that will use a strategy option,
 **re-run `merge-tree` with that option** and report what it actually says.
-Taking a no-strategy conflict list and relabelling it "will auto-resolve" is
+Taking a no-strategy conflict list and relabeling it "will auto-resolve" is
 wrong for exactly the conflicts a person most needs warning about.
 
 ## What it costs

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -74,9 +74,9 @@ The exit code is the verdict:
 
 When the merge runs at all, line one is the OID of the merged tree. On a
 conflict, the lines after it are the conflicted paths, then a blank line, then
-the human-readable messages. On a clean merge you get line one and nothing else —
-here against a `sidebranch` that diverged before `main`'s edit and only adds a
-file `main` has never seen:
+the human-readable messages. On a clean merge you get line one and nothing else.
+Here it runs against a `sidebranch` that diverged before `main`'s edit and only
+adds a file `main` has never seen:
 
 ```sh
 $ git merge-tree --write-tree --name-only main sidebranch
@@ -86,8 +86,8 @@ $ echo $?
 ```
 
 Which leaves that qualifier on exit `1`. It does **not** mean "conflict" by
-itself. Ask to merge a branch that doesn't exist and you get `1` as well — with
-a completely empty stdout, the message going to stderr instead. So test stdout,
+itself. Ask to merge a branch that doesn't exist and you get `1` as well, with
+a completely empty stdout and the message going to stderr instead. So test stdout,
 not the code alone: empty output means Git refused, which is "unknown", not "a
 conflict in zero files".
 
@@ -111,7 +111,7 @@ other, without either one being checked out.
 
 ## The merged tree is a real object
 
-That OID on line one isn't a receipt. It's a tree in your object database, and
+That OID on line one is a real tree in your object database, and
 every read-only command that takes a tree will take it.
 
 Want to see what the conflict actually looks like before deciding? Read the file
@@ -145,8 +145,8 @@ you have to do. Set `merge.conflictStyle` to `diff3` or `zdiff3` and the same
 merge reports six, because each conflict also carries a `|||||||` section and the
 base text.
 
-Structural conflicts — where the sides disagree about whether a file exists or
-where it lives, which the next section gets into — vary more, so don't apply that
+Structural conflicts, where the sides disagree about whether a file exists or
+where it lives (more on those below), vary more, so don't apply that
 subtraction blindly. A `modify/delete` leaves one side's file whole with no
 markers at all, and its stat is pure real change. But a `rename/rename` where
 both sides also edited the file writes markers into *both* paths, so the count
@@ -155,13 +155,12 @@ path rather than a file you recognise. Treat the stat as a rough gauge, not an
 audit.
 
 Even with those caveats you know the rough size of the job, which files are
-involved, and — for the content conflicts — the exact shape of each one. All
+involved, and, for the content conflicts, the exact shape of each one. All
 without running a merge.
 
 ## The trap: `-X ours` does less than you think
 
-Here's the part that's worth the whole article, because it's the part that will
-quietly lie to you if you build on it.
+Now for the part that will lie to you if you build on it.
 
 If a preview says "conflict", the obvious next thought is: fine, I'll merge with
 a strategy option and let Git pick a side. So you re-run the preview mentally,
@@ -212,11 +211,11 @@ Git cannot pick a side there, because there is no "side" to pick; the question
 isn't which text wins, it's what the tree should contain. Those stop the merge
 no matter which `-X` you pass.
 
-The boundary isn't "does it look structural", though — it's whether there are
+Don't sort by whether it looks structural, though; sort by whether there are
 two texts to choose between. `add/add` looks structural, but both sides did
 produce a file at one path, so there *is* a text to pick, and `-X ours` resolves
-it to exit 0. Test the specific case rather than reasoning from the category
-name.
+it to exit 0. When in doubt, run the specific case; the category name is a poor
+guide.
 
 So if you're predicting the result of a merge that will use a strategy option,
 **re-run `merge-tree` with that option** and report what it actually says.
@@ -225,7 +224,7 @@ wrong for exactly the conflicts a person most needs warning about.
 
 ## What it costs
 
-Two honest caveats, because "touches nothing" is a slight overstatement.
+"Touches nothing" is a slight overstatement — in two ways.
 
 **It writes objects.** `--write-tree` means what it says: the merged tree and any
 merged blobs get written to the object database. How many depends on the merge.
@@ -266,18 +265,18 @@ DESCRIPTION" — a trivial merge that, in its own words, cannot "handle content
 merges of individual files, rename detection, proper directory/file conflict
 handling, etc."
 
-That mode is still reachable today as `--trivial-merge`, and it's worth knowing
-why you don't want it: it exits **0** even when it reports a conflict. A tool
+That mode is still reachable today as `--trivial-merge`, and the reason you don't
+want it matters: it exits **0** even when it reports a conflict. A tool
 that shells out without checking the version doesn't get an error on old Git —
 it gets a confidently clean answer about a merge that will not be clean. Check
 the version, and degrade to showing nothing rather than showing something wrong.
 
 ## Or don't do any of this
 
-I write a Git client, so the pitch is obvious enough that I'd rather just say it
+You can see the pitch coming (I make one of these clients), so here it is,
 plainly.
 
-Everything above is genuinely worth knowing. Knowing that Git will merge in
+None of this is wasted knowledge. Knowing that Git will merge in
 memory for free, and that `-X ours` can't rescue a `modify/delete`, makes you
 harder to surprise. But it's also a shell pipeline you have to remember, at the
 exact moment you're trying to decide something else.
@@ -286,8 +285,8 @@ In [GitDesktop](/features/) a `merge-base` check runs before the merge button
 does anything, and that same `merge-tree` call runs when it's needed: already up
 to date, fast-forward, clean, or conflicted with the file list already on screen
 — and if you change the on-conflict strategy, the preview re-runs with that
-strategy instead of guessing on your behalf. Same commands, same object database,
-no pipeline.
+strategy instead of guessing on your behalf. It's the same plumbing this post just
+walked through, minus the remembering.
 
-Either way, the thing to take away is that the answer was always available. A
+Shell or client, the point is the same: the answer was always available. A
 merge is not the only way to find out what a merge would do.

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -86,8 +86,8 @@ $ echo $?
 ```
 
 Which leaves that qualifier on exit `1`. It does **not** mean "conflict" by
-itself. Ask to merge a branch that doesn't exist and you get `1` as well, with
-a completely empty stdout and the message going to stderr instead. So test stdout,
+itself. Ask to merge a branch that doesn't exist and you get `1` as well, with a
+completely empty stdout and the message going to stderr instead. So test stdout,
 not the code alone: empty output means Git refused, which is "unknown", not "a
 conflict in zero files".
 
@@ -111,8 +111,8 @@ other, without either one being checked out.
 
 ## The merged tree is a real object
 
-That OID on line one is a real tree in your object database, and
-every read-only command that takes a tree will take it.
+That OID isn't just an identifier for the answer — it's a tree in your object
+database, and every read-only command that takes a tree will take it.
 
 Want to see what the conflict actually looks like before deciding? Read the file
 straight out of the merge result — conflict markers and all:
@@ -149,10 +149,10 @@ Structural conflicts, where the sides disagree about whether a file exists or
 where it lives (more on those below), vary more, so don't apply that
 subtraction blindly. A `modify/delete` leaves one side's file whole with no
 markers at all, and its stat is pure real change. But a `rename/rename` where
-both sides also edited the file writes markers into *both* paths, so the count
-inflates there too, and a `file/directory` clash reports a rename to a mangled
-path rather than a file you recognise. Treat the stat as a rough gauge, not an
-audit.
+both sides also edited the file writes markers into *both* paths, so the
+count inflates there too, and a `file/directory` clash reports a rename to a
+mangled path rather than a file you recognise. Treat the stat as a rough
+gauge, not an audit.
 
 Even with those caveats you know the rough size of the job, which files are
 involved, and, for the content conflicts, the exact shape of each one. All
@@ -197,10 +197,11 @@ Look at the tree OIDs. They're **identical**. `-X ours` didn't resolve it, didn'
 change the outcome, didn't change a single byte of the result. `-X theirs`
 produces that same OID too.
 
-The reason is that `-X ours` and `-X theirs` only arbitrate **content** conflicts
-— cases where one path ends up with two candidate texts and Git needs only to be
-told which one wins. They have nothing to say about **structural** ones, where
-the disagreement is about whether the file should exist, or where it lives:
+The reason is that `-X ours` and `-X theirs` only arbitrate **content**
+conflicts — cases where one path ends up with two candidate texts and Git
+needs only to be told which one wins. They have nothing to say about
+**structural** ones, where the disagreement is about whether the file should
+exist, or where it lives:
 
 - `modify/delete` — one side edited it, the other removed it
 - `rename/delete` — one side moved it, the other deleted it
@@ -211,11 +212,10 @@ Git cannot pick a side there, because there is no "side" to pick; the question
 isn't which text wins, it's what the tree should contain. Those stop the merge
 no matter which `-X` you pass.
 
-Don't sort by whether it looks structural, though; sort by whether there are
-two texts to choose between. `add/add` looks structural, but both sides did
-produce a file at one path, so there *is* a text to pick, and `-X ours` resolves
-it to exit 0. When in doubt, run the specific case; the category name is a poor
-guide.
+Don't sort by whether it looks structural, though; sort by whether there are two
+texts to choose between. `add/add` looks structural, but both sides did produce
+a file at one path, so there *is* a text to pick, and `-X ours` resolves it to
+exit 0. When in doubt, run the specific case; the category name is a poor guide.
 
 So if you're predicting the result of a merge that will use a strategy option,
 **re-run `merge-tree` with that option** and report what it actually says.
@@ -265,28 +265,28 @@ DESCRIPTION" — a trivial merge that, in its own words, cannot "handle content
 merges of individual files, rename detection, proper directory/file conflict
 handling, etc."
 
-That mode is still reachable today as `--trivial-merge`, and the reason you don't
-want it matters: it exits **0** even when it reports a conflict. A tool
-that shells out without checking the version doesn't get an error on old Git —
-it gets a confidently clean answer about a merge that will not be clean. Check
-the version, and degrade to showing nothing rather than showing something wrong.
+That mode is still reachable today as `--trivial-merge`, and you don't want it:
+it exits **0** even when it reports a conflict. A tool that shells out without
+checking the version doesn't get an error on old Git — it gets a confidently
+clean answer about a merge that will not be clean. Check the version, and
+degrade to showing nothing rather than showing something wrong.
 
 ## Or don't do any of this
 
 You can see the pitch coming (I make one of these clients), so here it is,
 plainly.
 
-None of this is wasted knowledge. Knowing that Git will merge in
-memory for free, and that `-X ours` can't rescue a `modify/delete`, makes you
-harder to surprise. But it's also a shell pipeline you have to remember, at the
+None of this is wasted knowledge. Knowing that Git will merge in memory for
+free, and that `-X ours` can't rescue a `modify/delete`, makes you harder to
+surprise. But it's also a shell pipeline you have to remember, at the
 exact moment you're trying to decide something else.
 
 In [GitDesktop](/features/) a `merge-base` check runs before the merge button
 does anything, and that same `merge-tree` call runs when it's needed: already up
 to date, fast-forward, clean, or conflicted with the file list already on screen
 — and if you change the on-conflict strategy, the preview re-runs with that
-strategy instead of guessing on your behalf. It's the same plumbing this post just
-walked through, minus the remembering.
+strategy instead of guessing on your behalf. It's the same plumbing this post
+just walked through, minus the remembering.
 
 Shell or client, the point is the same: the answer was always available. A
 merge is not the only way to find out what a merge would do.

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -179,17 +179,17 @@ The reason is that `-X ours` and `-X theirs` only arbitrate **content** conflict
 told which one wins. They have nothing to say about **structural** ones, where
 the disagreement is about whether the file should exist, or where it lives:
 
-- modify/delete — one side edited it, the other removed it
-- rename/delete — one side moved it, the other deleted it
-- rename/rename — one file moved to two different names
-- file/directory — one side made it a file, the other a directory
+- `modify/delete` — one side edited it, the other removed it
+- `rename/delete` — one side moved it, the other deleted it
+- `rename/rename` — one file moved to two different names
+- `file/directory` — one side made it a file, the other a directory
 
 Git cannot pick a side there, because there is no "side" to pick; the question
 isn't which text wins, it's what the tree should contain. Those stop the merge
 no matter which `-X` you pass.
 
 The boundary isn't "does it look structural", though — it's whether there are
-two texts to choose between. add/add looks structural, but both sides did
+two texts to choose between. `add/add` looks structural, but both sides did
 produce a file at one path, so there *is* a text to pick, and `-X ours` resolves
 it to exit 0. Test the specific case rather than reasoning from the category
 name.
@@ -205,11 +205,12 @@ Two honest caveats, because "touches nothing" is a slight overstatement.
 
 **It writes objects.** `--write-tree` means what it says: the merged tree and any
 merged blobs get written to the object database. How many depends on the merge.
-The `shared.txt` content conflict earlier writes two — a tree, and the blob
-holding the marked-up file. The `doomed.txt` modify/delete writes *none*, because
-its result is byte-identical to a tree Git already had:
+Back in the `shared.txt` repo from earlier, clear the loose-object count to zero
+first so what follows is a clean delta. That content conflict adds two — a tree,
+and the blob holding the marked-up file:
 
 ```sh
+$ git gc --prune=now                   # start from a clean baseline
 $ git count-objects -v | grep '^count:'
 count: 0
 $ git merge-tree --write-tree --name-only main feature >/dev/null
@@ -217,13 +218,19 @@ $ git count-objects -v | grep '^count:'
 count: 2
 ```
 
-They're unreachable the moment they're written — nothing refers to them — but
-"unreachable" is not "gone". Plain `git gc` **packs** them rather than deleting
-them, because `gc.pruneExpire` defaults to two weeks. The count above drops back
-to zero while `git cat-file -t <oid>` still cheerfully answers `tree`, so the
-measurement in that snippet will tell you they've vanished when they haven't.
-Only `git gc --prune=now` actually removes them. The cost is real but small, and
-it does clear itself — on Git's schedule, not on yours.
+Run the same thing in the `doomed.txt` repo and the count doesn't move at all.
+That merge's tree is byte-identical to one Git already had, so there is nothing
+new to write.
+
+The objects that *do* get written are unreachable the moment they land — but
+"unreachable" is not "gone". `git gc` will not delete them: `gc.pruneExpire`
+defaults to two weeks, so an ordinary gc sweeps them into a cruft pack instead.
+The loose count falls back to zero while `git cat-file -t <oid>` still
+cheerfully answers `tree` — so on a current Git the `count-objects` snippet
+above will tell you they have vanished when they have not. (Before 2.41, when
+cruft packs became the default, they simply stayed loose and the count stayed
+at two.) Only `git gc --prune=now` actually removes them. The cost is real but
+small, and it does clear itself — on Git's schedule, not on yours.
 
 **It needs a reasonably current Git.** Both `--write-tree` and `--name-only`
 arrived in Git 2.38, released on 2 October 2022. On anything older, the only
@@ -244,7 +251,7 @@ I write a Git client, so the pitch is obvious enough that I'd rather just say it
 plainly.
 
 Everything above is genuinely worth knowing. Knowing that Git will merge in
-memory for free, and that `-X ours` can't rescue a modify/delete, makes you
+memory for free, and that `-X ours` can't rescue a `modify/delete`, makes you
 harder to surprise. But it's also a shell pipeline you have to remember, at the
 exact moment you're trying to decide something else.
 

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -1,0 +1,239 @@
+---
+title: "Will this merge conflict? Find out without merging"
+description: "git merge-tree does the whole merge in memory and names every file that would conflict — without touching your working tree, your index, or your branch."
+pubDate: 2026-07-29
+author: theBGuy
+pillar: git-safety
+tags: ["git", "merge", "conflicts"]
+---
+
+You're about to merge a long-running branch and you'd like to know, first,
+whether it's going to hurt. Not "did it hurt" — *will* it. Ten files or two
+hundred, five minutes or an afternoon, safe to do now or better after lunch.
+
+Git has known the answer the whole time. It just isn't the answer you get from
+running `git merge` and reading the wreckage.
+
+## The usual answer costs you your working tree
+
+The standard trick is to merge without committing and look:
+
+```sh
+$ git merge --no-commit --no-ff feature
+Auto-merging shared.txt
+CONFLICT (content): Merge conflict in shared.txt
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+That did tell you. It also rewrote your working tree to tell you:
+
+```sh
+$ git status --porcelain
+UU shared.txt
+```
+
+Now you're sitting in a conflicted merge state you didn't want, and you have to
+back out of it:
+
+```sh
+$ git merge --abort
+```
+
+For a one-file toy repo that's a nuisance. On a real branch it's worse than a
+nuisance, because a branch hasn't been just a branch for years now. Touching the
+working tree restarts dev servers, invalidates caches, triggers file watchers,
+and re-runs whatever your editor does on change. You asked a question and paid
+for it with your environment — [the exact tax I built this client to
+stop](/blog/the-whole-loop-one-window/).
+
+And if you're merging into a branch you don't have checked out, this approach
+doesn't even apply. You'd have to check it out first.
+
+## Git will do the merge in memory instead
+
+Since version 2.38, `git merge-tree` can perform a complete, real merge —
+rename detection, the works — and write the result to the object database
+without going near your working tree, your index, or `HEAD`:
+
+```sh
+$ git merge-tree --write-tree --name-only main feature
+c9cc90770ebb9dee14e212f168dd40059cfb605a
+shared.txt
+
+Auto-merging shared.txt
+CONFLICT (content): Merge conflict in shared.txt
+```
+
+The exit code is the verdict, and it's binary:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Clean. The merge will succeed. |
+| `1` | Conflict. The files are listed for you. |
+| other | Git refused — bad ref, unrelated histories, out of memory. |
+
+The output shape follows from that. Line one is always the OID of the merged
+tree. On a conflict, the lines after it are the conflicted paths, then a blank
+line, then the human-readable messages. On a clean merge you get line one and
+nothing else:
+
+```sh
+$ git merge-tree --write-tree --name-only main sidebranch
+25f5a925378bfaca7638e006291edcb7374db5bf
+$ echo $?
+0
+```
+
+Parse to the blank line and you have your file list. One caveat worth coding
+against: if stdout comes back *empty*, Git declined to do the merge at all —
+that's "unknown", not "a conflict in zero files".
+
+And your working tree never moved:
+
+```sh
+$ git status --porcelain
+$ git rev-parse --abbrev-ref HEAD
+main
+```
+
+It's so thoroughly detached from your checkout that it runs fine in a bare repo,
+which has no working tree to touch in the first place. That's the property that
+makes it useful for a tool: you can preview merging *any* branch into *any*
+other, without either one being checked out.
+
+## The merged tree is a real object
+
+That OID on line one isn't a receipt. It's a tree in your object database, and
+every read-only command that takes a tree will take it.
+
+Want to see what the conflict actually looks like before deciding? Read the file
+straight out of the merge result — conflict markers and all:
+
+```sh
+$ TREE=$(git merge-tree --write-tree --name-only main feature | head -1)
+$ git cat-file -p "$TREE:shared.txt"
+line1
+<<<<<<< main
+MAIN
+=======
+FEATURE
+>>>>>>> feature
+line3
+```
+
+Want the diffstat of what merging would do to you?
+
+```sh
+$ git diff --stat main "$TREE"
+ shared.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+```
+
+You now know the size of the job, the shape of every conflict, and which files
+they're in — and you still haven't run a merge.
+
+## The trap: `-X ours` does less than you think
+
+Here's the part that's worth the whole article, because it's the part that will
+quietly lie to you if you build on it.
+
+If a preview says "conflict", the obvious next thought is: fine, I'll merge with
+a strategy option and let Git pick a side. So you re-run the preview mentally,
+decide `-X ours` will mop it up, and report "3 conflicts, all auto-resolvable".
+
+Sometimes that's true. `-X ours` really does resolve the content conflict above:
+
+```sh
+$ git merge-tree --write-tree --name-only -X ours main feature
+51c500ddf270e2f1f6bdf80e5af7fb598c95910b
+$ echo $?
+0
+```
+
+Clean. Different tree, no conflicts, exit 0.
+
+Now the same experiment where `feature` edited a file that `main` deleted:
+
+```sh
+$ git merge-tree --write-tree --name-only main feature
+61eb2660b922022a67457fa4d76a1687b447e0ee
+doomed.txt
+
+CONFLICT (modify/delete): doomed.txt deleted in main and modified in feature.
+
+$ git merge-tree --write-tree --name-only -X ours main feature
+61eb2660b922022a67457fa4d76a1687b447e0ee
+doomed.txt
+
+CONFLICT (modify/delete): doomed.txt deleted in main and modified in feature.
+```
+
+Look at the tree OIDs. They're **identical**. `-X ours` didn't resolve it, didn't
+change the outcome, didn't change a single byte of the result. `-X theirs`
+produces that same OID too.
+
+The reason is that `-X ours` and `-X theirs` only arbitrate **content** conflicts
+— two sides editing the same region of the same file. They have nothing to say
+about **structural** ones, where the disagreement is about whether the file
+should exist at all:
+
+- modify/delete — one side edited it, the other removed it
+- rename/rename — both sides moved it, to different names
+- add/add — both sides created it independently
+
+Git cannot pick a side there, because there is no "side" to pick; the question
+isn't which text wins, it's what the tree should contain. Those stop the merge
+no matter which `-X` you pass.
+
+So if you're predicting the result of a merge that will use a strategy option,
+**re-run `merge-tree` with that option** and report what it actually says.
+Taking a no-strategy conflict list and relabelling it "will auto-resolve" is
+wrong for exactly the conflicts a person most needs warning about.
+
+## What it costs
+
+Two honest caveats, because "touches nothing" is a slight overstatement.
+
+**It writes objects.** `--write-tree` means what it says: the merged tree and any
+merged blobs get written to the object database. On the conflict above, that's
+two objects:
+
+```sh
+$ git count-objects -v | grep '^count:'
+count: 0
+$ git merge-tree --write-tree --name-only main feature >/dev/null
+$ git count-objects -v | grep '^count:'
+count: 2
+```
+
+They're unreachable the moment they're written — nothing refers to them — so
+they're garbage in the ordinary Git sense and `gc` disposes of them like any
+other unreachable object. Preview a merge a thousand times and you've made a
+thousand trees nobody will ever look at. It's a real cost, just a small and
+self-cleaning one.
+
+**It needs a reasonably current Git.** Both `--write-tree` and `--name-only`
+arrived in Git 2.38, released on 2 October 2022. Older versions have a
+`git merge-tree` too, but it's an entirely different and much dumber command — a
+trivial three-way merge that doesn't do rename detection and doesn't report
+conflicts the same way. If you're writing a tool, check the version and degrade
+to showing nothing rather than showing something wrong.
+
+## Or don't do any of this
+
+I write a Git client, so the pitch is obvious enough that I'd rather just say it
+plainly.
+
+Everything above is genuinely worth knowing. Knowing that Git will merge in
+memory for free, and that `-X ours` can't rescue a modify/delete, makes you
+harder to surprise. But it's also a shell pipeline you have to remember, at the
+exact moment you're trying to decide something else.
+
+In [GitDesktop](/features/) that same `merge-tree` call runs before the merge
+button does anything: fast-forward, clean, or conflicted with the file list
+already on screen — and if you change the on-conflict strategy, the preview
+re-runs with that strategy instead of guessing on your behalf. Same command,
+same object database, no pipeline.
+
+Either way, the thing to take away is that the answer was always available. A
+merge is not the only way to find out what a merge would do.

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -51,8 +51,8 @@ doesn't even apply. You'd have to check it out first.
 
 ## Git will do the merge in memory instead
 
-Since version 2.38, `git merge-tree` can perform a complete, real merge —
-rename detection, the works — and write the result to the object database
+Since version 2.38, `git merge-tree` can perform a complete, real merge
+(rename detection, the works) and write the result to the object database
 without going near your working tree, your index, or `HEAD`:
 
 ```sh
@@ -142,8 +142,8 @@ holds the marked-up file, so the count includes the conflict markers themselves.
 With the default conflict style, three of those four added lines are the
 `<<<<<<<`, `=======` and `>>>>>>>` you saw in the `cat-file` output — not work
 you have to do. Set `merge.conflictStyle` to `diff3` or `zdiff3` and the same
-merge reports six, because each conflict also carries a `|||||||` section and the
-base text.
+merge reports six, because each conflict also carries a `|||||||` section
+and the base text.
 
 Structural conflicts, where the sides disagree about whether a file exists or
 where it lives (more on those below), vary more, so don't apply that
@@ -151,7 +151,7 @@ subtraction blindly. A `modify/delete` leaves one side's file whole with no
 markers at all, and its stat is pure real change. But a `rename/rename` where
 both sides also edited the file writes markers into *both* paths, so the
 count inflates there too, and a `file/directory` clash reports a rename to a
-mangled path rather than a file you recognise. Treat the stat as a rough
+mangled path rather than a file you recognize. Treat the stat as a rough
 gauge, not an audit.
 
 Even with those caveats you know the rough size of the job, which files are
@@ -245,8 +245,8 @@ count: 2
 ```
 
 Run the same thing in the `doomed.txt` repo and the count doesn't move at all.
-That merge's tree is byte-identical to one Git already had, so there is nothing
-new to write.
+That merge's tree is byte-identical to one Git already had, so there is
+nothing new to write.
 
 The objects that *do* get written are unreachable the moment they land — but
 "unreachable" is not "gone". `git gc` will not delete them: `gc.pruneExpire`
@@ -273,8 +273,8 @@ degrade to showing nothing rather than showing something wrong.
 
 ## Or don't do any of this
 
-You can see the pitch coming (I make one of these clients), so here it is,
-plainly.
+You can see the pitch coming (I make one of these clients), so here
+it is, plainly.
 
 None of this is wasted knowledge. Knowing that Git will merge in memory for
 free, and that `-X ours` can't rescue a `modify/delete`, makes you harder to

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -64,18 +64,17 @@ Auto-merging shared.txt
 CONFLICT (content): Merge conflict in shared.txt
 ```
 
-The exit code is the verdict, and it's binary:
+The exit code is the verdict:
 
 | Exit | Meaning |
 | --- | --- |
 | `0` | Clean. The merge will succeed. |
-| `1` | Conflict. The files are listed for you. |
-| other | Git refused — bad ref, unrelated histories, out of memory. |
+| `1` | Conflict — **or** Git declined the merge outright. |
+| other | Git couldn't start at all (unrelated histories exits `128`). |
 
-The output shape follows from that. Line one is always the OID of the merged
-tree. On a conflict, the lines after it are the conflicted paths, then a blank
-line, then the human-readable messages. On a clean merge you get line one and
-nothing else:
+When the merge runs at all, line one is the OID of the merged tree. On a
+conflict, the lines after it are the conflicted paths, then a blank line, then
+the human-readable messages. On a clean merge you get line one and nothing else:
 
 ```sh
 $ git merge-tree --write-tree --name-only main sidebranch
@@ -84,9 +83,12 @@ $ echo $?
 0
 ```
 
-Parse to the blank line and you have your file list. One caveat worth coding
-against: if stdout comes back *empty*, Git declined to do the merge at all —
-that's "unknown", not "a conflict in zero files".
+Parse to the blank line and you have your file list. Which brings us back to
+that qualifier on exit `1`: it does **not** mean "conflict" by itself. Ask to
+merge a branch that doesn't exist and you get `1` as well — with a completely
+empty stdout, the message going to stderr instead. So test stdout, not the code
+alone: empty output means Git refused, which is "unknown", not "a conflict in
+zero files".
 
 And your working tree never moved:
 
@@ -173,17 +175,24 @@ change the outcome, didn't change a single byte of the result. `-X theirs`
 produces that same OID too.
 
 The reason is that `-X ours` and `-X theirs` only arbitrate **content** conflicts
-— two sides editing the same region of the same file. They have nothing to say
-about **structural** ones, where the disagreement is about whether the file
-should exist at all:
+— cases where one path ends up with two candidate texts and Git needs only to be
+told which one wins. They have nothing to say about **structural** ones, where
+the disagreement is about whether the file should exist, or where it lives:
 
 - modify/delete — one side edited it, the other removed it
-- rename/rename — both sides moved it, to different names
-- add/add — both sides created it independently
+- rename/delete — one side moved it, the other deleted it
+- rename/rename — one file moved to two different names
+- file/directory — one side made it a file, the other a directory
 
 Git cannot pick a side there, because there is no "side" to pick; the question
 isn't which text wins, it's what the tree should contain. Those stop the merge
 no matter which `-X` you pass.
+
+The boundary isn't "does it look structural", though — it's whether there are
+two texts to choose between. add/add looks structural, but both sides did
+produce a file at one path, so there *is* a text to pick, and `-X ours` resolves
+it to exit 0. Test the specific case rather than reasoning from the category
+name.
 
 So if you're predicting the result of a merge that will use a strategy option,
 **re-run `merge-tree` with that option** and report what it actually says.
@@ -195,8 +204,10 @@ wrong for exactly the conflicts a person most needs warning about.
 Two honest caveats, because "touches nothing" is a slight overstatement.
 
 **It writes objects.** `--write-tree` means what it says: the merged tree and any
-merged blobs get written to the object database. On the conflict above, that's
-two objects:
+merged blobs get written to the object database. How many depends on the merge.
+The `shared.txt` content conflict earlier writes two — a tree, and the blob
+holding the marked-up file. The `doomed.txt` modify/delete writes *none*, because
+its result is byte-identical to a tree Git already had:
 
 ```sh
 $ git count-objects -v | grep '^count:'
@@ -206,18 +217,26 @@ $ git count-objects -v | grep '^count:'
 count: 2
 ```
 
-They're unreachable the moment they're written — nothing refers to them — so
-they're garbage in the ordinary Git sense and `gc` disposes of them like any
-other unreachable object. Preview a merge a thousand times and you've made a
-thousand trees nobody will ever look at. It's a real cost, just a small and
-self-cleaning one.
+They're unreachable the moment they're written — nothing refers to them — but
+"unreachable" is not "gone". Plain `git gc` **packs** them rather than deleting
+them, because `gc.pruneExpire` defaults to two weeks. The count above drops back
+to zero while `git cat-file -t <oid>` still cheerfully answers `tree`, so the
+measurement in that snippet will tell you they've vanished when they haven't.
+Only `git gc --prune=now` actually removes them. The cost is real but small, and
+it does clear itself — on Git's schedule, not on yours.
 
 **It needs a reasonably current Git.** Both `--write-tree` and `--name-only`
-arrived in Git 2.38, released on 2 October 2022. Older versions have a
-`git merge-tree` too, but it's an entirely different and much dumber command — a
-trivial three-way merge that doesn't do rename detection and doesn't report
-conflicts the same way. If you're writing a tool, check the version and degrade
-to showing nothing rather than showing something wrong.
+arrived in Git 2.38, released on 2 October 2022. On anything older, the only
+`merge-tree` you get is the one the manual now files under "DEPRECATED
+DESCRIPTION" — a trivial merge that, in its own words, cannot "handle content
+merges of individual files, rename detection, proper directory/file conflict
+handling, etc."
+
+That mode is still reachable today as `--trivial-merge`, and it's worth knowing
+why you don't want it: it exits **0** even when it reports a conflict. A tool
+that shells out without checking the version doesn't get an error on old Git —
+it gets a confidently clean answer about a merge that will not be clean. Check
+the version, and degrade to showing nothing rather than showing something wrong.
 
 ## Or don't do any of this
 

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -145,12 +145,14 @@ you have to do. Set `merge.conflictStyle` to `diff3` or `zdiff3` and the same
 merge reports six, because each conflict also carries a `|||||||` section and the
 base text.
 
-Structural conflicts vary, though, so don't apply that subtraction blindly. A
-`modify/delete` leaves one side's file whole with no markers at all, and its
-stat is pure real change. But a `rename/rename` where both sides also edited the
-file writes markers into *both* paths — thirteen counted insertions, six of them
-markers — and a `file/directory` clash reports a rename to a mangled path rather
-than a file you recognise. Treat the stat as a rough gauge, not an audit.
+Structural conflicts — where the sides disagree about whether a file exists or
+where it lives, which the next section gets into — vary more, so don't apply that
+subtraction blindly. A `modify/delete` leaves one side's file whole with no
+markers at all, and its stat is pure real change. But a `rename/rename` where
+both sides also edited the file writes markers into *both* paths, so the count
+inflates there too, and a `file/directory` clash reports a rename to a mangled
+path rather than a file you recognise. Treat the stat as a rough gauge, not an
+audit.
 
 Even with those caveats you know the rough size of the job, which files are
 involved, and — for the content conflicts — the exact shape of each one. All

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -74,14 +74,20 @@ The exit code is the verdict:
 
 When the merge runs at all, line one is the OID of the merged tree. On a
 conflict, the lines after it are the conflicted paths, then a blank line, then
-the human-readable messages. On a clean merge you get line one and nothing else:
+the human-readable messages. On a clean merge you get line one and nothing else —
+here against a `sidebranch` that diverged before `main`'s edit and only adds a
+file `main` has never seen:
 
 ```sh
 $ git merge-tree --write-tree --name-only main sidebranch
-25f5a925378bfaca7638e006291edcb7374db5bf
+bab3bcfcd19b35a6ecb2881d1602cf080e1cb547
 $ echo $?
 0
 ```
+
+Worth noting for tool authors: exit `0` covers both a real three-way merge and a
+plain fast-forward. `merge-tree` doesn't distinguish them, so if you care about
+the difference you still need `merge-base` to spot the fast-forward case.
 
 Parse to the blank line and you have your file list. Which brings us back to
 that qualifier on exit `1`: it does **not** mean "conflict" by itself. Ask to
@@ -131,8 +137,15 @@ $ git diff --stat main "$TREE"
  1 file changed, 4 insertions(+)
 ```
 
-You now know the size of the job, the shape of every conflict, and which files
-they're in — and you still haven't run a merge.
+Read that stat carefully, though: on a conflicted merge the tree holds the
+marked-up file, so the count includes the conflict markers themselves. With the
+default conflict style, three of those four added lines are the `<<<<<<<`,
+`=======` and `>>>>>>>` you saw in the `cat-file` output — not work you have to
+do. Set `merge.conflictStyle` to `diff3` or `zdiff3` and the same merge reports
+six, because each conflict also carries a `|||||||` section and the base text.
+
+Even so, you now know the rough size of the job, the shape of every conflict, and
+which files they're in — and you still haven't run a merge.
 
 ## The trap: `-X ours` does less than you think
 
@@ -205,12 +218,15 @@ Two honest caveats, because "touches nothing" is a slight overstatement.
 
 **It writes objects.** `--write-tree` means what it says: the merged tree and any
 merged blobs get written to the object database. How many depends on the merge.
-Back in the `shared.txt` repo from earlier, clear the loose-object count to zero
-first so what follows is a clean delta. That content conflict adds two — a tree,
-and the blob holding the marked-up file:
+Back in the throwaway `shared.txt` repo from earlier, clear the loose-object
+count to zero so what follows is a clean delta. Do that *only* in a throwaway
+repo: `git gc --prune=now` discards unreachable objects for good, including
+[stashes you could otherwise still recover](/blog/recover-a-dropped-git-stash/).
+With a clean baseline, the content conflict adds two — a tree, and the blob
+holding the marked-up file:
 
 ```sh
-$ git gc --prune=now                   # start from a clean baseline
+$ git gc --prune=now      # throwaway repos only — destroys unreachable objects
 $ git count-objects -v | grep '^count:'
 count: 0
 $ git merge-tree --write-tree --name-only main feature >/dev/null

--- a/site/src/content/blog/preview-a-merge-before-you-run-it.md
+++ b/site/src/content/blog/preview-a-merge-before-you-run-it.md
@@ -85,16 +85,16 @@ $ echo $?
 0
 ```
 
-Worth noting for tool authors: exit `0` covers both a real three-way merge and a
-plain fast-forward. `merge-tree` doesn't distinguish them, so if you care about
-the difference you still need `merge-base` to spot the fast-forward case.
+Which leaves that qualifier on exit `1`. It does **not** mean "conflict" by
+itself. Ask to merge a branch that doesn't exist and you get `1` as well — with
+a completely empty stdout, the message going to stderr instead. So test stdout,
+not the code alone: empty output means Git refused, which is "unknown", not "a
+conflict in zero files".
 
-Parse to the blank line and you have your file list. Which brings us back to
-that qualifier on exit `1`: it does **not** mean "conflict" by itself. Ask to
-merge a branch that doesn't exist and you get `1` as well — with a completely
-empty stdout, the message going to stderr instead. So test stdout, not the code
-alone: empty output means Git refused, which is "unknown", not "a conflict in
-zero files".
+Exit `0` is broad in its own way, which matters if you're building on this: it
+covers a real three-way merge, a plain fast-forward, and an already-up-to-date
+branch alike. `merge-tree` doesn't distinguish them, so if those mean different
+things in your interface, you need a `merge-base` check alongside it.
 
 And your working tree never moved:
 
@@ -137,15 +137,24 @@ $ git diff --stat main "$TREE"
  1 file changed, 4 insertions(+)
 ```
 
-Read that stat carefully, though: on a conflicted merge the tree holds the
-marked-up file, so the count includes the conflict markers themselves. With the
-default conflict style, three of those four added lines are the `<<<<<<<`,
-`=======` and `>>>>>>>` you saw in the `cat-file` output — not work you have to
-do. Set `merge.conflictStyle` to `diff3` or `zdiff3` and the same merge reports
-six, because each conflict also carries a `|||||||` section and the base text.
+Read that stat carefully, though: on a content conflict like this one the tree
+holds the marked-up file, so the count includes the conflict markers themselves.
+With the default conflict style, three of those four added lines are the
+`<<<<<<<`, `=======` and `>>>>>>>` you saw in the `cat-file` output — not work
+you have to do. Set `merge.conflictStyle` to `diff3` or `zdiff3` and the same
+merge reports six, because each conflict also carries a `|||||||` section and the
+base text.
 
-Even so, you now know the rough size of the job, the shape of every conflict, and
-which files they're in — and you still haven't run a merge.
+Structural conflicts vary, though, so don't apply that subtraction blindly. A
+`modify/delete` leaves one side's file whole with no markers at all, and its
+stat is pure real change. But a `rename/rename` where both sides also edited the
+file writes markers into *both* paths — thirteen counted insertions, six of them
+markers — and a `file/directory` clash reports a rename to a mangled path rather
+than a file you recognise. Treat the stat as a rough gauge, not an audit.
+
+Even with those caveats you know the rough size of the job, which files are
+involved, and — for the content conflicts — the exact shape of each one. All
+without running a merge.
 
 ## The trap: `-X ours` does less than you think
 
@@ -271,11 +280,12 @@ memory for free, and that `-X ours` can't rescue a `modify/delete`, makes you
 harder to surprise. But it's also a shell pipeline you have to remember, at the
 exact moment you're trying to decide something else.
 
-In [GitDesktop](/features/) that same `merge-tree` call runs before the merge
-button does anything: fast-forward, clean, or conflicted with the file list
-already on screen — and if you change the on-conflict strategy, the preview
-re-runs with that strategy instead of guessing on your behalf. Same command,
-same object database, no pipeline.
+In [GitDesktop](/features/) a `merge-base` check runs before the merge button
+does anything, and that same `merge-tree` call runs when it's needed: already up
+to date, fast-forward, clean, or conflicted with the file list already on screen
+— and if you change the on-conflict strategy, the preview re-runs with that
+strategy instead of guessing on your behalf. Same commands, same object database,
+no pipeline.
 
 Either way, the thing to take away is that the answer was always available. A
 merge is not the only way to find out what a merge would do.

--- a/site/src/content/blog/recover-a-dropped-git-stash.md
+++ b/site/src/content/blog/recover-a-dropped-git-stash.md
@@ -79,7 +79,7 @@ git fsck --unreachable | grep commit | awk '{print $3}' |
 ```
 
 That prints only real stash commits, each with the message you wrote — which is
-usually enough to recognise the one you want.
+usually enough to recognize the one you want.
 
 ## Getting the work back
 
@@ -109,7 +109,7 @@ straight to your tree:
 git stash store -m "recovered" 45199d06
 ```
 
-## The catch worth knowing
+## The catch
 
 This works because the objects are still there, and that isn't forever. `git gc`
 prunes unreachable objects once they age past `gc.pruneExpire`, which defaults to
@@ -117,7 +117,7 @@ two weeks. Garbage collection also runs automatically — `git gc --auto` fires
 during ordinary commands once enough loose objects pile up.
 
 So: a stash you dropped this morning is almost certainly recoverable. One from
-last quarter probably isn't. If you've just realised something important is
+last quarter probably isn't. If you've just realized something important is
 missing, do the `fsck` now and don't run `git gc` first.
 
 One thing that will *not* help: `git reflog`. The stash has its own reflog at
@@ -126,17 +126,17 @@ only covers `HEAD`.
 
 ## Or don't do any of this
 
-I write a Git client, so I'll be honest about the pitch: everything above is a
+This is where I mention that I make a Git client. Everything above is a
 recipe I'd rather nobody had to run under pressure. Knowing that a stash is two
-commits and that the real one has two parents is genuinely useful, and I think
-it's worth knowing. But at the moment you actually need it, you're stressed,
+commits and that the real one has two parents is useful; I'd teach it to
+anyone. But at the moment you actually need it, you're stressed,
 you're guessing at SHAs, and the failure mode is silently restoring the wrong
 half of your work.
 
-In [GitDesktop](/#recover) that same `fsck` walk runs behind a list: recoverable stashes,
-each with its message, its date, and a diff you can read before you commit to
-anything. Same objects, same operation, minus the shell pipeline and minus the
-chance of applying the index twin by mistake.
+In [GitDesktop](/#recover) that same `fsck` walk runs behind a list:
+recoverable stashes, each with its message, its date, and a diff you can read
+before you commit to anything. Same objects, same operation, minus the shell
+pipeline and minus the chance of applying the index twin by mistake.
 
-Either way, the thing to take away is the one that surprises people: it's still
-there. Git is much more reluctant to destroy your work than it looks.
+Either way, remember the part that surprises people: it's still there. Git is
+much more reluctant to destroy your work than it looks.

--- a/site/src/content/blog/recover-a-dropped-git-stash.md
+++ b/site/src/content/blog/recover-a-dropped-git-stash.md
@@ -129,9 +129,9 @@ only covers `HEAD`.
 This is where I mention that I make a Git client. Everything above is a
 recipe I'd rather nobody had to run under pressure. Knowing that a stash is two
 commits and that the real one has two parents is useful; I'd teach it to
-anyone. But at the moment you actually need it, you're stressed,
-you're guessing at SHAs, and the failure mode is silently restoring the wrong
-half of your work.
+anyone. But at the moment you actually need it, you're stressed, you're
+guessing at SHAs, and the failure mode is silently restoring the wrong half
+of your work.
 
 In [GitDesktop](/#recover) that same `fsck` walk runs behind a list:
 recoverable stashes, each with its message, its date, and a diff you can read

--- a/site/src/content/blog/the-whole-loop-one-window.md
+++ b/site/src/content/blog/the-whole-loop-one-window.md
@@ -121,7 +121,7 @@ alone.
 ## Monitoring shouldn't require hunting
 
 Another habit I've developed over the years is checking on my projects. Not
-because I enjoy dashboards, but because I genuinely like seeing whether people are
+because I enjoy dashboards, but because I like seeing whether people are
 using the things I've built. How many visitors showed up today? Where did they
 come from? Which repositories are getting attention?
 
@@ -156,9 +156,9 @@ features. I was questioning assumptions.
 
 Why does a pull request require a remote? Why do reviews begin after pushing? Why
 do I have to leave my Git client to understand my project? Why should switching
-AI models change my workflow? Why should updating another branch interrupt the one
-I'm actively working in? Why are some of the best guardrails only available after
-code leaves my machine?
+AI models change my workflow? Why should updating another branch interrupt the
+one I'm actively working in? Why are some of the best guardrails only available
+after code leaves my machine?
 
 Every feature traces back to one of those questions.
 
@@ -183,4 +183,4 @@ build another Git client. It's been to build the one I never have to leave.
 *A version of this essay first appeared
 [on LinkedIn](https://www.linkedin.com/pulse/whole-loop-one-window-evan-goldberg-wbmre/).
 If there's a part of your workflow that always makes you think "why do I have to
-leave?" — I'd genuinely like to hear it.*
+leave?" — I want to hear it.*

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -120,6 +120,13 @@ const forges = [
             not into AI? hide it →
           </button>
         </p>
+        <p data-reveal style="transition-delay:300ms" class="mt-4 text-sm">
+          <a
+            href={`${base}blog/the-whole-loop-one-window/`}
+            class="text-mint underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint"
+            >Why I built this →</a
+          >
+        </p>
       </div>
 
       <div data-reveal style="transition-delay:220ms" class="mint-glow relative min-w-0">
@@ -201,6 +208,13 @@ const forges = [
           <button type="button" data-mode-btn="ai" class="text-mint underline-offset-4 hover:underline">
             curious about the AI? →
           </button>
+        </p>
+        <p data-reveal style="transition-delay:300ms" class="mt-4 text-sm">
+          <a
+            href={`${base}blog/the-whole-loop-one-window/`}
+            class="text-mint underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint"
+            >Why I built this →</a
+          >
         </p>
       </div>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -17,6 +17,7 @@ import ForgeMark from "../components/ForgeMark.astro";
 import McpConfig from "../components/McpConfig.astro";
 import { highlightCapabilities } from "../data/capabilities";
 import SiteLayout from "../layouts/SiteLayout.astro";
+import { getPosts, postUrl } from "../lib/posts";
 import { getLatestRelease } from "../lib/release";
 
 const repo = "https://github.com/theBGuy/GitDesktop";
@@ -24,6 +25,19 @@ const base = import.meta.env.BASE_URL;
 // The Download CTAs go to the on-site, OS-aware download page (not straight to
 // GitHub Releases).
 const download = `${base}download/`;
+
+// Resolved from the collection rather than hardcoded, so renaming the post
+// fails the build here instead of silently 404ing the hero link in both views.
+// Asymmetry worth knowing: getPosts() hides drafts outside DEV/PUBLIC_SHOW_DRAFTS,
+// so marking this post `draft` would pass a Pages preview and fail production.
+const founderEssay = (await getPosts()).find(
+  (p) => p.id === "the-whole-loop-one-window",
+);
+if (!founderEssay) {
+  throw new Error(
+    'Hero link target missing: no blog post with id "the-whole-loop-one-window".',
+  );
+}
 
 // Build-time release facts (guarded fetch, package.json fallback) so the
 // version exists as text for crawlers; the runtime script still refreshes it.
@@ -122,7 +136,7 @@ const forges = [
         </p>
         <p data-reveal style="transition-delay:300ms" class="mt-4 text-sm">
           <a
-            href={`${base}blog/the-whole-loop-one-window/`}
+            href={postUrl(founderEssay)}
             class="text-mint underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint"
             >Why I built this →</a
           >
@@ -211,7 +225,7 @@ const forges = [
         </p>
         <p data-reveal style="transition-delay:300ms" class="mt-4 text-sm">
           <a
-            href={`${base}blog/the-whole-loop-one-window/`}
+            href={postUrl(founderEssay)}
             class="text-mint underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint"
             >Why I built this →</a
           >


### PR DESCRIPTION
Adds a long-form post on previewing a merge with `git merge-tree` — the same mechanism GitDesktop runs behind its merge button — and surfaces the existing founder essay from the home page hero so first-time visitors have a path into the blog. Together these give the site a second technical post in the `git-safety` pillar and a visible entry point to the writing.

### Blog post

- Adds `site/src/content/blog/preview-a-merge-before-you-run-it.md` (`pillar: git-safety`, tags `git` / `merge` / `conflicts`, `pubDate: 2026-07-29`), framed around answering "will this conflict?" without `git merge --no-commit` rewriting the working tree.
- Documents the `git merge-tree --write-tree --name-only` contract in detail: the exit-code verdict table (`0` clean / `1` conflict / other = Git refused), the output shape (tree OID on line one, conflicted paths, blank line, human-readable messages), and the caveat that empty stdout means "unknown", not "zero conflicts".
- Shows the merged tree being consumed as a real object — `git cat-file -p "$TREE:shared.txt"` for conflict markers and `git diff --stat main "$TREE"` for the size of the job.
- Centers the `-X ours` / `-X theirs` trap: strategy options arbitrate content conflicts only, and a modify/delete produces a byte-identical tree OID with or without them, so structural conflicts (modify/delete, rename/rename, add/add) must never be relabelled "auto-resolvable". Closes by advising tools to re-run `merge-tree` with the same strategy option the merge will use.
- Names the honest costs: `--write-tree` writes unreachable objects (demonstrated via `git count-objects -v`), and both flags require Git 2.38+, with older `git merge-tree` being a different, dumber command.
- Ends with a GitDesktop tie-in linking `/features/` and cross-linking the founder essay at `/blog/the-whole-loop-one-window/`.
- Note: the file currently ends without a trailing newline.

### Home page

- Adds a "Why I built this →" link to `${base}blog/the-whole-loop-one-window/` in `site/src/pages/index.astro`, placed under the existing view-toggle paragraph in the hero.
- Applies it to **both** synced hero views — the AI-native one (below "not into AI? hide it →") and the Just Git one (below "curious about the AI? →") — using the same `data-reveal` / `transition-delay:300ms` and mint underline styling so the two stay in parity.