### PR TITLE
feat(releases,ai,git,mcp): sync updater notes when editing a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,10 @@ commit that hasn't been pushed yet.
   them. Basing on a remote branch (e.g. `origin/epic/big-feature`) starts from the remote
   tip and leaves the new branch untracked, so its first push publishes it under its own name.
 
-Plus tag and submodule management.
+Plus tag and submodule management, and releases — publish, edit, and delete them
+with asset uploads; when a release carries a `latest.json` updater manifest,
+editing its notes can refresh the manifest in the same save, so apps updating
+from that release show the notes you just wrote.
 
 **Syncing** — fetch / pull / push, with the ahead/behind counts shown right on
 the Push and Pull buttons; pull is

--- a/README.md
+++ b/README.md
@@ -418,9 +418,9 @@ commit that hasn't been pushed yet.
   tip and leaves the new branch untracked, so its first push publishes it under its own name.
 
 Plus tag and submodule management, and releases — publish, edit, and delete them
-with asset uploads; when a release carries a `latest.json` updater manifest,
-editing its notes can refresh the manifest in the same save, so apps updating
-from that release show the notes you just wrote.
+with asset uploads; when a **GitHub** release carries a `latest.json` updater
+manifest, editing its notes can refresh the manifest in the same save, so apps
+updating from that release show the notes you just wrote.
 
 **Syncing** — fetch / pull / push, with the ahead/behind counts shown right on
 the Push and Pull buttons; pull is

--- a/changelog.d/added-updater-notes-sync.md
+++ b/changelog.d/added-updater-notes-sync.md
@@ -1,0 +1,5 @@
+- **Keep updater notes in step with the release.** When a GitHub release carries a
+  `latest.json` updater manifest, editing its notes offers to update the manifest's
+  notes in the same save (on by default), so the "what's new" your installed apps
+  show matches the release page. The manifest's version, dates, and platform
+  signatures are left untouched.

--- a/changelog.d/changed-release-notes-editor.md
+++ b/changelog.d/changed-release-notes-editor.md
@@ -1,4 +1,4 @@
 - **Room to write release notes.** The notes editor in the New release and Edit
-  release dialogs now fills the dialog instead of a short fixed box, so a long
-  release body is readable and editable at a glance instead of through a
-  keyhole — in Write and Preview alike.
+  release dialogs now fills the dialog — replacing the short fixed box and its
+  drag-to-resize handle — so a long release body is readable and editable at a
+  glance in Write and Preview alike. The Edit release dialog is wider to match.

--- a/changelog.d/changed-release-notes-editor.md
+++ b/changelog.d/changed-release-notes-editor.md
@@ -1,0 +1,4 @@
+- **Room to write release notes.** The notes editor in the New release and Edit
+  release dialogs now fills the dialog instead of a short fixed box, so a long
+  release body is readable and editable at a glance instead of through a
+  keyhole — in Write and Preview alike.

--- a/changelog.d/fixed-ai-ignore-trailing-space-windows.md
+++ b/changelog.d/fixed-ai-ignore-trailing-space-windows.md
@@ -1,0 +1,3 @@
+- On Windows, AI-ignore patterns that use a backslash escape — the form a file
+  whose name ends in a space needs — now hide that file from the staged and
+  branch diffs sent to AI, matching how the rest of the app reads the same list.

--- a/changelog.d/fixed-branch-name-ai-ignore.md
+++ b/changelog.d/fixed-branch-name-ai-ignore.md
@@ -1,0 +1,4 @@
+- Your **AI ignore patterns** now cover **new (untracked) files** when a
+  **branch name** is generated — in the app and over MCP — where their names
+  previously reached the provider whatever your patterns said. Names that match
+  are held back and counted in the prompt's hidden-files note instead.

--- a/changelog.d/fixed-stash-zero-match-report.md
+++ b/changelog.d/fixed-stash-zero-match-report.md
@@ -1,0 +1,2 @@
+- The MCP `stash_push` tool now says when the paths it was given matched nothing,
+  so an agent can tell an empty stash from a successful one.

--- a/changelog.d/fixed-unignore-exact-match.md
+++ b/changelog.d/fixed-unignore-exact-match.md
@@ -1,0 +1,2 @@
+- Removing an ignore rule deletes exactly the rule you picked, even when another
+  line in the same `.gitignore` differs from it only by a trailing escape.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -262,7 +262,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "CI, tags & releases",
-    label: "Tags, releases & cross-platform assets",
+    label:
+      "Tags, releases & cross-platform assets — edit notes, sync the updater manifest",
   },
   {
     group: "CI, tags & releases",

--- a/src-tauri/src/app_store.rs
+++ b/src-tauri/src/app_store.rs
@@ -36,29 +36,33 @@ pub(crate) struct AiGenSettings {
     pub(crate) ai_ignore_patterns: Vec<String>,
 }
 
-/// Pure resolution of the store's directory, in precedence order (arms 1 and 3 mirror
-/// [`crate::oplog::resolve_store_base`]; arm 2 differs deliberately — this module only
-/// READS, so a test needs no store at all where the oplog needs a writable temp one).
-/// Under `cfg(test)` an arm 0 precedes all of these: [`store_path`] consults
-/// [`TEST_STORE_DIR`] before calling here, and tests use only that.
-/// 1. a non-empty `GD_SETTINGS_DIR` override — the operator/headless escape hatch for
+/// Pure resolution of the store's directory, in precedence order. Under `cfg(test)`
+/// an arm 0 precedes all of these: [`store_path`] consults [`TEST_STORE_DIR`] before
+/// calling here, and that slot is the ONLY seam a test may use.
+/// 1. under `cfg!(test)`, NO store, whatever the environment says — an in-crate test
+///    can never read the developer's real settings, and a `GD_SETTINGS_DIR` exported
+///    in a dev or CI shell must not silently decide one either;
+/// 2. a non-empty `GD_SETTINGS_DIR` override — the operator/headless escape hatch for
 ///    pointing a run at a store outside the app-data dir (an oplog-sibling knob);
-/// 2. under `cfg!(test)`, NO store, so an in-crate test can never read the developer's
-///    real settings — a populated store would otherwise decide the test's result;
 /// 3. otherwise the real app-data dir, `tauri-plugin-store` v2's
 ///    `BaseDirectory::AppData` resolution (see [`crate::local_prs::store_path`]).
+///
+/// Arm 3 mirrors [`crate::oplog::resolve_store_base`]; the test arm deliberately
+/// diverges twice — it yields no store where the oplog needs a writable temp one
+/// (this module only READS), and it outranks the env var where the oplog's does not.
 fn resolve_store_dir(gd_settings_dir: Option<&str>, is_test: bool) -> Option<PathBuf> {
     match gd_settings_dir {
-        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
         _ if is_test => None,
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
         _ => Some(dirs::data_dir()?.join(APP_IDENTIFIER)),
     }
 }
 
-/// In-process test override, consulted before the env arm. A test that needs a store
-/// sets THIS rather than `GD_SETTINGS_DIR`: mutating process env would race every
-/// other test's env reads in the same binary, which on POSIX is unsound, not merely
-/// flaky (the oplog seam refuses env mutation for the same reason).
+/// In-process test override — arm 0, consulted by [`store_path`] before
+/// [`resolve_store_dir`] runs at all, and the only way a test can reach a store. It is
+/// set in-process rather than through `GD_SETTINGS_DIR` because mutating process env
+/// would race every other test's env reads in the same binary, which on POSIX is
+/// unsound, not merely flaky (the oplog seam refuses env mutation for the same reason).
 #[cfg(test)]
 static TEST_STORE_DIR: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
 
@@ -181,14 +185,20 @@ mod tests {
     /// The three resolution arms. Arm 3 pins the production output as stable —
     /// `dirs::data_dir()/<identifier>/settings.json` — so the seam can't quietly move
     /// it; agreement with the Tauri path layer's own resolution is a contract this
-    /// can't check (no Tauri code runs here). Arm 2 is why no test in this crate can
-    /// be decided by whatever the developer's real store happens to hold.
+    /// can't check (no Tauri code runs here). Arm 1 is why no test in this crate can
+    /// be decided by the developer's real store OR by their exported environment.
     #[test]
     fn store_dir_resolution_arms() {
         assert_eq!(
             resolve_store_dir(Some("C:/tmp/gd-store"), true),
+            None,
+            "an exported GD_SETTINGS_DIR must not reach a test build — the in-process \
+             slot is the only seam a test may use"
+        );
+        assert_eq!(
+            resolve_store_dir(Some("C:/tmp/gd-store"), false),
             Some(PathBuf::from("C:/tmp/gd-store")),
-            "an explicit override wins, in tests and out"
+            "outside tests, an explicit override wins"
         );
         assert_eq!(
             resolve_store_dir(Some(""), false),

--- a/src-tauri/src/app_store.rs
+++ b/src-tauri/src/app_store.rs
@@ -38,8 +38,11 @@ pub(crate) struct AiGenSettings {
 
 /// Pure resolution of the store's directory, in precedence order (arms 1 and 3 mirror
 /// [`crate::oplog::resolve_store_base`]; arm 2 differs deliberately — this module only
-/// READS, so a test needs no store at all where the oplog needs a writable temp one):
-/// 1. a non-empty `GD_SETTINGS_DIR` override — the escape hatch for headless/test callers;
+/// READS, so a test needs no store at all where the oplog needs a writable temp one).
+/// Under `cfg(test)` an arm 0 precedes all of these: [`store_path`] consults
+/// [`TEST_STORE_DIR`] before calling here, and tests use only that.
+/// 1. a non-empty `GD_SETTINGS_DIR` override — the operator/headless escape hatch for
+///    pointing a run at a store outside the app-data dir (an oplog-sibling knob);
 /// 2. under `cfg!(test)`, NO store, so an in-crate test can never read the developer's
 ///    real settings — a populated store would otherwise decide the test's result;
 /// 3. otherwise the real app-data dir, `tauri-plugin-store` v2's
@@ -52,9 +55,40 @@ fn resolve_store_dir(gd_settings_dir: Option<&str>, is_test: bool) -> Option<Pat
     }
 }
 
+/// In-process test override, consulted before the env arm. A test that needs a store
+/// sets THIS rather than `GD_SETTINGS_DIR`: mutating process env would race every
+/// other test's env reads in the same binary, which on POSIX is unsound, not merely
+/// flaky (the oplog seam refuses env mutation for the same reason).
+#[cfg(test)]
+static TEST_STORE_DIR: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+/// Installs (or clears) the in-process override, returning the previous value so a
+/// caller can restore it. Test-only — [`TEST_STORE_DIR`] does not exist otherwise.
+#[cfg(test)]
+pub(crate) fn swap_test_store_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
+    let mut slot = TEST_STORE_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::replace(&mut *slot, dir)
+}
+
+/// The in-process override currently installed, if any. Test-only.
+#[cfg(test)]
+pub(crate) fn test_store_dir() -> Option<PathBuf> {
+    TEST_STORE_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
 /// Absolute path of the `settings.json` the frontend store writes —
-/// `<store dir>/settings.json`; see [`resolve_store_dir`] for how the dir is chosen.
+/// `<store dir>/settings.json`. The in-process test override wins when one is
+/// installed; otherwise [`resolve_store_dir`] chooses the dir.
 fn store_path() -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(dir) = test_store_dir() {
+        return Some(dir.join(STORE_FILE));
+    }
     let dir = resolve_store_dir(std::env::var("GD_SETTINGS_DIR").ok().as_deref(), cfg!(test))?;
     Some(dir.join(STORE_FILE))
 }

--- a/src-tauri/src/app_store.rs
+++ b/src-tauri/src/app_store.rs
@@ -36,12 +36,26 @@ pub(crate) struct AiGenSettings {
     pub(crate) ai_ignore_patterns: Vec<String>,
 }
 
-/// Resolve the absolute path of the `settings.json` the frontend store writes.
-/// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
-/// (`dirs::data_dir()/<identifier>`) — see [`crate::local_prs::store_path`].
+/// Pure resolution of the store's directory, in precedence order (mirrors
+/// [`crate::oplog::resolve_store_base`]):
+/// 1. a non-empty `GD_SETTINGS_DIR` override — the escape hatch for headless/test callers;
+/// 2. under `cfg!(test)`, NO store, so an in-crate test can never read the developer's
+///    real settings — a populated store would otherwise decide the test's result;
+/// 3. otherwise the real app-data dir, `tauri-plugin-store` v2's
+///    `BaseDirectory::AppData` resolution (see [`crate::local_prs::store_path`]).
+fn resolve_store_dir(gd_settings_dir: Option<&str>, is_test: bool) -> Option<PathBuf> {
+    match gd_settings_dir {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ if is_test => None,
+        _ => Some(dirs::data_dir()?.join(APP_IDENTIFIER)),
+    }
+}
+
+/// Absolute path of the `settings.json` the frontend store writes —
+/// `<store dir>/settings.json`; see [`resolve_store_dir`] for how the dir is chosen.
 fn store_path() -> Option<PathBuf> {
-    let data = dirs::data_dir()?;
-    Some(data.join(APP_IDENTIFIER).join(STORE_FILE))
+    let dir = resolve_store_dir(std::env::var("GD_SETTINGS_DIR").ok().as_deref(), cfg!(test))?;
+    Some(dir.join(STORE_FILE))
 }
 
 /// Read the `"settings"` object from the store file, or `None` when the file is
@@ -127,6 +141,37 @@ mod tests {
             return AiGenSettings::default();
         };
         parse_ai_generation_settings(&settings)
+    }
+
+    /// The three resolution arms. Arm 3 pins PRODUCTION resolution byte-for-byte
+    /// against the rule the Tauri path layer uses; arm 2 is why no test in this crate
+    /// can be decided by whatever the developer's real store happens to hold.
+    #[test]
+    fn store_dir_resolution_arms() {
+        assert_eq!(
+            resolve_store_dir(Some("C:/tmp/gd-store"), true),
+            Some(PathBuf::from("C:/tmp/gd-store")),
+            "an explicit override wins, in tests and out"
+        );
+        assert_eq!(
+            resolve_store_dir(Some(""), false),
+            Some(dirs::data_dir().unwrap().join(APP_IDENTIFIER)),
+            "an EMPTY override is no override"
+        );
+        assert_eq!(resolve_store_dir(None, true), None, "no store under cfg(test)");
+        assert_eq!(
+            resolve_store_dir(None, false),
+            Some(dirs::data_dir().unwrap().join(APP_IDENTIFIER)),
+            "production: dirs::data_dir()/<identifier>, unchanged by the seam"
+        );
+        // …and the file the production arm points at is the frontend's own store.
+        assert_eq!(
+            resolve_store_dir(None, false).unwrap().join(STORE_FILE),
+            dirs::data_dir()
+                .unwrap()
+                .join(APP_IDENTIFIER)
+                .join("settings.json")
+        );
     }
 
     #[test]

--- a/src-tauri/src/app_store.rs
+++ b/src-tauri/src/app_store.rs
@@ -36,8 +36,9 @@ pub(crate) struct AiGenSettings {
     pub(crate) ai_ignore_patterns: Vec<String>,
 }
 
-/// Pure resolution of the store's directory, in precedence order (mirrors
-/// [`crate::oplog::resolve_store_base`]):
+/// Pure resolution of the store's directory, in precedence order (arms 1 and 3 mirror
+/// [`crate::oplog::resolve_store_base`]; arm 2 differs deliberately — this module only
+/// READS, so a test needs no store at all where the oplog needs a writable temp one):
 /// 1. a non-empty `GD_SETTINGS_DIR` override — the escape hatch for headless/test callers;
 /// 2. under `cfg!(test)`, NO store, so an in-crate test can never read the developer's
 ///    real settings — a populated store would otherwise decide the test's result;
@@ -143,9 +144,11 @@ mod tests {
         parse_ai_generation_settings(&settings)
     }
 
-    /// The three resolution arms. Arm 3 pins PRODUCTION resolution byte-for-byte
-    /// against the rule the Tauri path layer uses; arm 2 is why no test in this crate
-    /// can be decided by whatever the developer's real store happens to hold.
+    /// The three resolution arms. Arm 3 pins the production output as stable —
+    /// `dirs::data_dir()/<identifier>/settings.json` — so the seam can't quietly move
+    /// it; agreement with the Tauri path layer's own resolution is a contract this
+    /// can't check (no Tauri code runs here). Arm 2 is why no test in this crate can
+    /// be decided by whatever the developer's real store happens to hold.
     #[test]
     fn store_dir_resolution_arms() {
         assert_eq!(

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1891,9 +1891,10 @@ pub async fn forge_release_edit(
     }
 }
 
-/// Sync a release's `latest.json` updater manifest to the edited notes. GitHub-only:
-/// the manifest is a Tauri-updater asset, and neither GitLab nor Bitbucket carries
-/// the release-asset concept it hangs off.
+/// Sync a release's `latest.json` updater manifest to the edited notes. GitHub-only —
+/// not for want of release assets (GitLab has those), but because the Tauri updater
+/// feed this app ships is a `latest.json` attached to a GitHub release; a GitLab
+/// release simply isn't where any installed app looks for its update.
 #[tauri::command]
 pub async fn forge_release_sync_updater_notes(
     repo_path: String,
@@ -1902,7 +1903,7 @@ pub async fn forge_release_sync_updater_notes(
 ) -> AppResult<()> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => Err(AppError::InvalidArgument(
-            "GitLab releases have no updater manifest.".into(),
+            "The updater manifest is published on GitHub releases only.".into(),
         )),
         Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
             "Bitbucket releases aren't supported yet.".into(),

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1891,6 +1891,28 @@ pub async fn forge_release_edit(
     }
 }
 
+/// Sync a release's `latest.json` updater manifest to the edited notes. GitHub-only:
+/// the manifest is a Tauri-updater asset, and neither GitLab nor Bitbucket carries
+/// the release-asset concept it hangs off.
+#[tauri::command]
+pub async fn forge_release_sync_updater_notes(
+    repo_path: String,
+    tag: String,
+    notes: String,
+) -> AppResult<()> {
+    match detect_non_github(&repo_path).await {
+        Some((Provider::GitLab, _)) => Err(AppError::InvalidArgument(
+            "GitLab releases have no updater manifest.".into(),
+        )),
+        Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
+            "Bitbucket releases aren't supported yet.".into(),
+        )),
+        _ => {
+            crate::github::release::gh_release_sync_updater_notes(&repo_path, &tag, &notes).await
+        }
+    }
+}
+
 /// Delete a release (optionally its git tag too), behind the abstraction.
 #[tauri::command]
 pub async fn forge_release_delete(

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -36,6 +36,12 @@ pub struct AiIgnorePathspecs {
     /// crate's staticlib/cdylib targets make `pub` no defence against dead_code.
     #[allow(dead_code)]
     pub skipped_negations: usize,
+    /// How many backslash escapes could only be re-encoded as `?` rather than an
+    /// exact one-character class (see [`escapes_to_classes`]). Each one can
+    /// over-exclude a sibling name, never leak the escaped one. Unconsumed so
+    /// far, and `pub` is no defence against dead_code here.
+    #[allow(dead_code)]
+    pub widened: usize,
 }
 
 /// The lines of an AI-ignore list that either engine acts on: trimmed, with
@@ -64,15 +70,63 @@ fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
     (lines, skipped_negations)
 }
 
+/// Rewrites gitignore's `\<c>` escapes into the only spelling the pathspec engine
+/// reads the same way, returning the count that had to be widened.
+///
+/// A backslash inside a pathspec argv element is normalized to `/` before
+/// matching, so an escape that gitignore honors excludes NOTHING there — on this
+/// privacy boundary that fails open (measured, git 2.51.1.windows.1:
+/// `:(glob)sub\b.ts` matches `sub/b.ts`, `:(glob)sub/b\.ts` matches nothing).
+/// A one-character bracket class is exact on both engines, so `\<c>` becomes
+/// `[<c>]`.
+///
+/// Two characters take other routes. `/` becomes a bare `/`: no bracket class
+/// matches a separator under `,glob`, while gitignore's `\/` does, so the class
+/// form would open the same hole it closes. (A line ending `\/` therefore ends in
+/// a real `/` and classifies as a directory, which is what gitignore's own
+/// raw-byte scan for a trailing slash decides too.) `]`, `^`, `!`, `-`, `\` — and
+/// a trailing lone backslash — have their own meaning inside a class, so they
+/// degrade to `?`, a single-char wildcard that can only over-exclude.
+///
+/// A backslash here is ALWAYS a gitignore escape and never a Windows path
+/// separator — the lists are documented as .gitignore syntax. So a
+/// Windows-path-shaped rule matches nothing it looks like it should: `src\foo.ts`
+/// names the literal `srcfoo.ts`, uniformly on both engines.
+fn escapes_to_classes(pattern: &str) -> (String, usize) {
+    let mut out = String::with_capacity(pattern.len());
+    let mut widened = 0usize;
+    let mut chars = pattern.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('/') => out.push('/'),
+            Some(e) if !matches!(e, ']' | '^' | '!' | '-' | '\\') => {
+                out.push('[');
+                out.push(e);
+                out.push(']');
+            }
+            _ => {
+                out.push('?');
+                widened += 1;
+            }
+        }
+    }
+    (out, widened)
+}
+
 /// Translates gitignore-style lines into `:(exclude,glob)` pathspec terms.
 ///
 /// Pure — no git call, no IO. Blanks, comments and `!` lines are dropped by the
-/// shared [`actionable_lines`]. Per surviving line: a trailing `/` marks a
-/// directory, and a line is *anchored* when it starts with `/` or still contains
-/// a `/` (exactly gitignore's rule). Unanchored lines get a `**/` prefix so they
-/// match at any depth; a non-directory line also emits a `<pattern>/**` term,
-/// which is what makes a bare `node_modules` hide the directory's contents and
-/// matches nothing extra for a real file.
+/// shared [`actionable_lines`]. Per surviving line: backslash escapes are
+/// re-encoded by [`escapes_to_classes`] first (the pathspec engine cannot read
+/// them), then a trailing `/` marks a directory, and a line is *anchored* when it
+/// starts with `/` or still contains a `/` (exactly gitignore's rule). Unanchored
+/// lines get a `**/` prefix so they match at any depth; a non-directory line also
+/// emits a `<pattern>/**` term, which is what makes a bare `node_modules` hide
+/// the directory's contents and matches nothing extra for a real file.
 ///
 /// Every term carries `,glob` magic, and that is load-bearing twice over: it
 /// makes a leading `**/` match at depth zero (so a bare name hits the repo root
@@ -103,10 +157,16 @@ pub fn pathspecs_for(patterns: &[String], icase: bool) -> AiIgnorePathspecs {
         "exclude,glob"
     };
     let mut specs: Vec<String> = Vec::new();
+    let mut widened = 0usize;
 
     for line in lines {
+        // Escapes are re-encoded BEFORE anything classifies the line: `anchored`
+        // reads `/`, and Windows git reads a surviving backslash as one — so a
+        // raw `a\b.ts` would be filed unanchored and then matched as `a/b.ts`.
+        let (line, w) = escapes_to_classes(line);
+        widened += w;
         let is_dir = line.ends_with('/');
-        let core = line.strip_suffix('/').unwrap_or(line);
+        let core = line.strip_suffix('/').unwrap_or(line.as_str());
         let anchored = core.starts_with('/') || core.contains('/');
         let core = core.strip_prefix('/').unwrap_or(core);
         if core.is_empty() {
@@ -122,6 +182,7 @@ pub fn pathspecs_for(patterns: &[String], icase: bool) -> AiIgnorePathspecs {
     AiIgnorePathspecs {
         specs,
         skipped_negations,
+        widened,
     }
 }
 
@@ -325,7 +386,7 @@ pub async fn git_filter_ai_ignored(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::git::runner::run_git;
+    use crate::git::runner::{run_git, run_git_input};
     use std::collections::BTreeSet;
     use std::path::Path;
 
@@ -399,6 +460,76 @@ mod tests {
         assert!(specs("!docs/notes.md").is_empty());
     }
 
+    /// Backslash escapes come out as one-character classes, the only spelling
+    /// both engines read alike — a surviving backslash is a separator to Windows
+    /// git, so the term would exclude nothing and the file would reach a model.
+    #[test]
+    fn escapes_become_one_character_classes() {
+        assert_eq!(
+            specs("/notes\\ "),
+            [":(exclude,glob)notes[ ]", ":(exclude,glob)notes[ ]/**"]
+        );
+        assert_eq!(
+            specs("weird\\[1].txt"),
+            [
+                ":(exclude,glob)**/weird[[]1].txt",
+                ":(exclude,glob)**/weird[[]1].txt/**"
+            ]
+        );
+        assert_eq!(
+            specs("star\\*.txt"),
+            [
+                ":(exclude,glob)**/star[*].txt",
+                ":(exclude,glob)**/star[*].txt/**"
+            ]
+        );
+        assert_eq!(
+            specs("q\\?.txt"),
+            [":(exclude,glob)**/q[?].txt", ":(exclude,glob)**/q[?].txt/**"]
+        );
+        // `\#` and a hand-typed `\!` are how gitignore names a file whose name
+        // starts with a comment/negation marker; only the second needs widening.
+        assert_eq!(
+            specs("\\#notes.md")[0],
+            ":(exclude,glob)**/[#]notes.md"
+        );
+
+        // An escaped separator: no bracket class matches `/` under `,glob`, so
+        // this one re-encodes to a bare `/` — which also anchors the line, exactly
+        // as gitignore anchors it.
+        assert_eq!(specs("a\\/b.ts")[0], ":(exclude,glob)a/b.ts");
+
+        // A Windows-path-shaped rule is NOT a path: the backslash escapes the
+        // `f`, so the term names the literal `srcfoo.ts` and leaves `src/foo.ts`
+        // alone. Windows pathspec matching would read it the other way round, on
+        // that platform alone — which is exactly what the re-encode removes.
+        assert_eq!(specs("src\\foo.ts")[0], ":(exclude,glob)**/src[f]oo.ts");
+    }
+
+    /// The five class-special escapes (and a dangling backslash) fall back to
+    /// `?`, counted so a caller could disclose it. Over-excluding a sibling name
+    /// is the safe direction on a privacy boundary; leaking the named file is not.
+    #[test]
+    fn class_special_escapes_widen_to_a_wildcard() {
+        for (pattern, want) in [
+            ("bang\\!.txt", ":(exclude,glob)**/bang?.txt"),
+            ("br\\].txt", ":(exclude,glob)**/br?.txt"),
+            ("hat\\^.txt", ":(exclude,glob)**/hat?.txt"),
+            ("dash\\-.txt", ":(exclude,glob)**/dash?.txt"),
+            ("back\\\\.txt", ":(exclude,glob)**/back?.txt"),
+            ("dangling\\", ":(exclude,glob)**/dangling?"),
+        ] {
+            let out = pathspecs_for(&[pattern.to_string()], false);
+            assert_eq!(out.specs[0], want, "pattern {pattern:?}");
+            assert_eq!(out.widened, 1, "pattern {pattern:?}");
+        }
+        // An exact class is not a widening — including the Windows-path-shaped
+        // rule, whose `\f` is an ordinary escape however much it reads as a
+        // separator.
+        assert_eq!(pathspecs_for(&["/notes\\ ".into()], false).widened, 0);
+        assert_eq!(pathspecs_for(&["src\\foo.ts".into()], false).widened, 0);
+    }
+
     #[test]
     fn drops_blanks_comments_and_negations() {
         let out = pathspecs_for(
@@ -419,7 +550,11 @@ mod tests {
     }
 
     /// Every fixture path in the parity repo, repo-relative and sorted.
-    const FIXTURE: [&str; 15] = [
+    const FIXTURE: [&str; 18] = [
+        // `a/b.ts` beside `srcfoo.ts`/`src/foo.ts`: the pair of shapes that tell a
+        // backslash ESCAPE apart from a Windows path separator (the `\/` and
+        // `\f` rows below).
+        "a/b.ts",
         "a/b/notes.md",
         "app.log",
         "build/x.txt",
@@ -436,13 +571,15 @@ mod tests {
         "keep.txt",
         "node_modules/pkg/i.js",
         "notes.md",
+        "src/foo.ts",
         "src/node_modules/j.js",
+        "srcfoo.ts",
         "weird[1].txt",
     ];
 
     /// The measured truth table (git 2.51.1): for each AI-ignore pattern LIST,
     /// exactly which of `FIXTURE` it hides. Both engines must agree with it.
-    const PARITY: [(&[&str], &[&str]); 19] = [
+    const PARITY: [(&[&str], &[&str]); 22] = [
         (
             &["notes.md"],
             &["a/b/notes.md", "docs/notes.md", "notes.md"],
@@ -504,6 +641,20 @@ mod tests {
         // a character class and protects nothing — the `weird[1].txt` row above.
         (&["weird[[]1].txt"], &["weird[1].txt"]),
         (&["/weird[[]1].txt"], &["weird[1].txt"]),
+        // The hand-typed gitignore spelling of the same escape. Only the
+        // gitignore engine reads a backslash, so this row is what pins the
+        // pathspec side's re-encode of it.
+        (&["weird\\[1].txt"], &["weird[1].txt"]),
+        // A backslash is ALWAYS a gitignore escape, never a Windows separator:
+        // `src\foo.ts` escapes the `f` and names the literal `srcfoo.ts`, leaving
+        // `src/foo.ts` visible. This row is what keeps that uniform across
+        // engines — Windows pathspec matching would otherwise read the backslash
+        // as a separator and hide the OTHER file, on that platform alone.
+        (&["src\\foo.ts"], &["srcfoo.ts"]),
+        // The one escape that is not a bracket class on the pathspec side: no
+        // class matches a separator under `,glob`, so `\/` becomes a bare `/` —
+        // which must also anchor the line exactly as gitignore anchors it.
+        (&["a\\/b.ts"], &["a/b.ts"]),
     ];
 
     /// A `.gitignore` line the fixture repo carries but the AI-ignore lists never
@@ -600,24 +751,17 @@ mod tests {
         assert_eq!(bare, vec!["notes".to_string()]);
     }
 
-    /// The PATHSPEC engine's half of the escaped-trailing-space shape, which the
-    /// PARITY table cannot carry: git on Windows rejects a trailing-space path
-    /// outright ("Invalid path"), so it can never enter that fixture's index.
-    /// Pairs with [`escaped_trailing_space_matches_only_that_file`], which covers
-    /// the gitignore engine on every platform — together they are the parity
-    /// check for `\ `, split by platform deliberately.
+    /// Both engines on one WORKING-TREE fixture, for the escaped-trailing-space
+    /// shape the PARITY table cannot carry: git on Windows rejects a
+    /// trailing-space path outright ("Invalid path"), so it can never enter that
+    /// fixture's index. Skipped there for that reason alone — the pathspec half
+    /// itself now holds on every platform, which
+    /// [`escaped_trailing_space_excluded_by_pathspec_everywhere`] pins through the
+    /// object database instead.
     ///
     /// Skipped at RUNTIME rather than `#[cfg(unix)]`-gated so the body still
     /// compiles on Windows; a cfg-gated test first compiles on CI, where a typo
     /// costs a red run instead of a local one.
-    ///
-    /// TWO reasons it cannot run on Windows, and the second is the load-bearing
-    /// one: git there refuses to index a trailing-space path at all, AND a
-    /// backslash inside a pathspec is a separator rather than an escape, so the
-    /// `notes\ ` this anchored pattern emits becomes `notes/ ` and the pathspec
-    /// assertion below would be false there even if the fixture could be built.
-    /// The engines
-    /// genuinely diverge there for this shape — see `globLiteralPath`.
     #[tokio::test]
     async fn escaped_trailing_space_agrees_across_engines() {
         if cfg!(windows) {
@@ -679,6 +823,95 @@ mod tests {
         let want: BTreeSet<String> = ["notes ".to_string()].into_iter().collect();
         assert_eq!(by_pathspec, want, "pathspec engine");
         assert_eq!(by_gitignore, want, "gitignore engine");
+    }
+
+    /// The pathspec engine hides an escaped-trailing-space file on EVERY platform
+    /// — the regression that matters, since it is Windows where a raw `\ ` term
+    /// silently excluded nothing and handed `notes ` to a model.
+    ///
+    /// Built straight in the object database (`hash-object` → `mktree`) and
+    /// diffed tree against empty tree: no commit, no checkout and no index, which
+    /// is the only way a trailing-space path exists at all under Windows git.
+    #[tokio::test]
+    async fn escaped_trailing_space_excluded_by_pathspec_everywhere() {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-aiignore-tree-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+            vec!["config", "core.ignorecase", "false"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+
+        let git_out = |args: Vec<String>, input: Option<String>| {
+            let repo = repo.clone();
+            async move {
+                let argref: Vec<&str> = args.iter().map(String::as_str).collect();
+                // NOT trimmed: a fixture name ends in a space, and the caller
+                // below compares those names byte for byte.
+                run_git_input(Some(&repo), &argref, input.as_deref(), DEFAULT_TIMEOUT)
+                    .await
+                    .unwrap()
+                    .stdout_lossy()
+            }
+        };
+
+        let blob = git_out(
+            vec!["hash-object".into(), "-w".into(), "--stdin".into()],
+            Some("x\n".into()),
+        )
+        .await
+        .trim()
+        .to_string();
+        let files = ["notes ", "notes", "keep.txt"];
+        let rows: String = files
+            .iter()
+            .map(|p| format!("100644 blob {blob}\t{p}\n"))
+            .collect();
+        let tree = git_out(vec!["mktree".into()], Some(rows))
+            .await
+            .trim()
+            .to_string();
+        let empty = git_out(vec!["mktree".into()], Some(String::new()))
+            .await
+            .trim()
+            .to_string();
+
+        // Exactly what *Exclude from AI* writes for a file named `notes `.
+        let terms = pathspecs_for_repo(&repo, &["/notes\\ ".to_string()])
+            .await
+            .specs;
+        let mut args: Vec<String> = vec![
+            "diff".into(),
+            "--name-only".into(),
+            empty,
+            tree,
+            "--".into(),
+            ".".into(),
+        ];
+        args.extend(terms);
+        let listed: BTreeSet<String> = git_out(args, None)
+            .await
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect();
+
+        let hidden: BTreeSet<String> = files
+            .iter()
+            .map(|p| p.to_string())
+            .filter(|p| !listed.contains(p))
+            .collect();
+        assert_eq!(
+            hidden,
+            ["notes ".to_string()].into_iter().collect::<BTreeSet<_>>(),
+            "only the trailing-space file is hidden; listed = {listed:?}"
+        );
     }
 
     /// The two engines agree with each other AND with the measured table, for

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -73,25 +73,34 @@ fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
 /// Rewrites gitignore's `\<c>` escapes into the only spelling the pathspec engine
 /// reads the same way, returning the count that had to be widened.
 ///
-/// A backslash inside a pathspec argv element is normalized to `/` before
-/// matching, so an escape that gitignore honors excludes NOTHING there — on this
-/// privacy boundary that fails open (measured, git 2.51.1.windows.1:
+/// On WINDOWS a backslash inside a pathspec argv element is normalized to `/`
+/// before matching, so an escape that gitignore honors excludes NOTHING there —
+/// on this privacy boundary that fails open (measured, git 2.51.1.windows.1:
 /// `:(glob)sub\b.ts` matches `sub/b.ts`, `:(glob)sub/b\.ts` matches nothing).
-/// A one-character bracket class is exact on both engines, so `\<c>` becomes
+/// Unix honors the escape, so the raw form worked there and only there; the
+/// re-encode is what makes both platforms and both engines answer alike. A
+/// one-character bracket class is exact on both engines, so `\<c>` becomes
 /// `[<c>]`.
 ///
-/// Two characters take other routes. `/` becomes a bare `/`: no bracket class
+/// Two routes exist beside that class. `/` becomes a bare `/`: no bracket class
 /// matches a separator under `,glob`, while gitignore's `\/` does, so the class
-/// form would open the same hole it closes. (A line ending `\/` therefore ends in
-/// a real `/` and classifies as a directory, which is what gitignore's own
-/// raw-byte scan for a trailing slash decides too.) `]`, `^`, `!`, `-`, `\` — and
-/// a trailing lone backslash — have their own meaning inside a class, so they
-/// degrade to `?`, a single-char wildcard that can only over-exclude.
+/// form would open the same hole it closes. The five class-special escapes
+/// (`]`, `^`, `!`, `-`, `\`) and a dangling backslash have their own meaning
+/// inside a class, so they degrade to `?`, a single-char wildcard that can only
+/// over-exclude — [`AiIgnorePathspecs::widened`] counts those.
 ///
 /// A backslash here is ALWAYS a gitignore escape and never a Windows path
 /// separator — the lists are documented as .gitignore syntax. So a
 /// Windows-path-shaped rule matches nothing it looks like it should: `src\foo.ts`
 /// names the literal `srcfoo.ts`, uniformly on both engines.
+///
+/// One shape genuinely diverges, in the safe direction: a line ending `\/` leaves
+/// a real trailing `/` here, so [`pathspecs_for`] files it as a directory and
+/// hides its contents, while gitignore strips that slash and aborts on the
+/// dangling `foo\` residue, matching NOTHING (measured, git 2.51.1: excludes line
+/// `foo\/` hides neither `foo/x.txt` nor `foo`, where `foo/` hides `foo/x.txt`).
+/// Uncounted — `widened` means the `?` fallbacks — and unreachable from the
+/// menus, which never emit a trailing `\/`.
 fn escapes_to_classes(pattern: &str) -> (String, usize) {
     let mut out = String::with_capacity(pattern.len());
     let mut widened = 0usize;
@@ -498,6 +507,10 @@ mod tests {
         // this one re-encodes to a bare `/` — which also anchors the line, exactly
         // as gitignore anchors it.
         assert_eq!(specs("a\\/b.ts")[0], ":(exclude,glob)a/b.ts");
+        // At the END of a line that bare `/` is a directory marker, so this shape
+        // hides a directory's contents where gitignore matches nothing at all —
+        // the documented fail-closed divergence, pinned so it can't drift.
+        assert_eq!(specs("foo\\/"), [":(exclude,glob)**/foo/**"]);
 
         // A Windows-path-shaped rule is NOT a path: the backslash escapes the
         // `f`, so the term names the literal `srcfoo.ts` and leaves `src/foo.ts`
@@ -550,13 +563,17 @@ mod tests {
     }
 
     /// Every fixture path in the parity repo, repo-relative and sorted.
-    const FIXTURE: [&str; 18] = [
+    const FIXTURE: [&str; 22] = [
         // `a/b.ts` beside `srcfoo.ts`/`src/foo.ts`: the pair of shapes that tell a
         // backslash ESCAPE apart from a Windows path separator (the `\/` and
         // `\f` rows below).
         "a/b.ts",
         "a/b/notes.md",
         "app.log",
+        // Each `?`-widened escape with a sibling only the wildcard reaches, so
+        // the fail-closed asymmetry has a witness (`widened_escapes_…` below).
+        "bang!.txt",
+        "bangX.txt",
         "build/x.txt",
         "buildfile.txt",
         "deep/app.log",
@@ -568,6 +585,8 @@ mod tests {
         // real filesystem on every CI platform; the decomposable case (`café.md`)
         // is covered by the filesystem-free test below.
         "docs/日本語.md",
+        "hatX.txt",
+        "hat^.txt",
         "keep.txt",
         "node_modules/pkg/i.js",
         "notes.md",
@@ -940,6 +959,53 @@ mod tests {
             assert_eq!(
                 by_gitignore, want,
                 "gitignore engine, patterns {patterns:?}"
+            );
+        }
+    }
+
+    /// The `?`-widened escapes hold the fail-CLOSED invariant, which is the most
+    /// the PARITY table could never state: those shapes are the one place the two
+    /// engines are allowed to disagree, and the direction is the whole point.
+    ///
+    /// The gitignore engine hides exactly the escaped name; the pathspec engine
+    /// must hide AT LEAST it. Over-excluding a sibling costs a file the model
+    /// could have seen; under-excluding hands over the file the user named.
+    #[tokio::test]
+    async fn widened_escapes_over_exclude_and_never_under_exclude() {
+        let (_dir, repo) = parity_repo().await;
+        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
+
+        for (pattern, literal, only_by_wildcard) in [
+            ("bang\\!.txt", "bang!.txt", "bangX.txt"),
+            ("hat\\^.txt", "hat^.txt", "hatX.txt"),
+        ] {
+            let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
+                repo.clone(),
+                all.clone(),
+                vec![pattern.to_string()],
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+            assert_eq!(
+                by_gitignore,
+                [literal.to_string()].into_iter().collect::<BTreeSet<_>>(),
+                "gitignore engine hides exactly the escaped name, patterns {pattern:?}"
+            );
+
+            let by_pathspec = hidden_by_pathspec(&repo, &[pattern]).await;
+            assert!(
+                by_gitignore.is_subset(&by_pathspec),
+                "pathspec engine must hide at least what gitignore hides; \
+                 pattern {pattern:?} gave {by_pathspec:?}"
+            );
+            // Strictly more, here: the `?` also swallows the sibling. Asserted so
+            // the subset check above can't pass by the two sets being equal for
+            // some unrelated reason.
+            assert!(
+                by_pathspec.contains(only_by_wildcard),
+                "pattern {pattern:?} should also sweep {only_by_wildcard}"
             );
         }
     }

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -192,6 +192,14 @@ fn rewrite_for_pathspec(pattern: &str) -> (String, usize) {
 /// the class — which then has a member rewritten in place and silently changes
 /// what it accepts.
 ///
+/// The fourth turns on the FIRST `]` after `[:`, not on a `[:`…`:]` search: when
+/// that `]` is `:`-preceded it ends a class, otherwise the `[` is an ordinary
+/// member and the same `]` terminates the whole expression (measured, git 2.51.1:
+/// `a[d[:]b` and `a[d[:x]b` both hide `adb`/`a[b`, so the first `]` terminated).
+/// Over-scanning to a later `:]` is the mirror-image error — it runs past the
+/// real terminator. [`posix_class_end`] holds one deliberate divergence from that
+/// rule; see its note.
+///
 /// `[:name:]` alone: git's wildmatch has no `[=x=]` equivalence or `[.x.]`
 /// collating form (measured, git 2.51.1 — both match nothing rather than acting
 /// as a class), so treating their brackets as ordinary characters is what agrees
@@ -221,16 +229,27 @@ fn bracket_end(chars: &[char], open: usize) -> Option<usize> {
 }
 
 /// Index of the `]` ending the POSIX class `[:name:]` opening at `open`, or
-/// `None` when no `:]` follows (then the `[` is an ordinary member).
+/// `None` when this bracket is not one (then the `[` is an ordinary member).
+///
+/// Takes the FIRST `]` after `[:` and accepts a class only when that `]` is
+/// `:`-preceded, which is wildmatch's own test. Hunting for the first `:]`
+/// ANYWHERE instead over-scans past the `]` wildmatch stopped at and swallows the
+/// real class terminator — which on the widening route drops names gitignore
+/// hides (measured, git 2.51.1: `a[[:x]\-b:]c]d` hides `ax-b:]c]d`, which the
+/// `**/a?d` an over-scan produces does not).
+///
+/// The extra `close >= open + 4` is OURS, not wildmatch's: it demands a non-empty
+/// class name, where wildmatch accepts the empty `[::]` and then abandons the
+/// whole pattern (measured: excludes line `a[d[::]b` hides nothing, while
+/// rejecting `[::]` would make it the class `{d,[,:}` and hide `adb`/`a[b`). So
+/// we diverge on `[::]`-degenerates alone, and only fail-CLOSED — a pattern
+/// carrying one matches nothing at all on the gitignore side, so any term we emit
+/// is a superset of nothing.
 fn posix_class_end(chars: &[char], open: usize) -> Option<usize> {
-    let mut i = open + 2;
-    while i + 1 < chars.len() {
-        if chars[i] == ':' && chars[i + 1] == ']' {
-            return Some(i + 1);
-        }
-        i += 1;
-    }
-    None
+    // The name spans `open + 2..close - 1` (`close - 1` is the closing `:`), so
+    // `close >= open + 4` is the non-empty-name demand described above.
+    let close = (open + 2..chars.len()).find(|&i| chars[i] == ']')?;
+    (close >= open + 4 && chars[close - 1] == ':').then_some(close)
 }
 
 /// Translates gitignore-style lines into `:(exclude,glob)` pathspec terms.
@@ -671,8 +690,34 @@ mod tests {
         let out = pathspecs_for(&["a[[:digit:]\\-]d".to_string()], false);
         assert_eq!(out.specs[0], ":(exclude,glob)**/a?d");
         assert_eq!(out.widened, 1);
-        // A lone `[:` with no `:]` is an ordinary member, not a class.
+        // An inner `[:` whose first `]` is not `:`-preceded is an ordinary member,
+        // and that same `]` terminates the expression — even when a later `:]`
+        // exists. Scanning to the later `:]` would swallow the real terminator and
+        // collapse the stretch to `**/a?d`, which stops matching the
+        // `ax-b:]c]d` that gitignore hides.
         assert_eq!(specs("a[[:x]d")[0], ":(exclude,glob)**/a[[:x]d");
+        let split = pathspecs_for(&["a[[:x]\\-b:]c]d".to_string()], false);
+        assert_eq!(split.specs[0], ":(exclude,glob)**/a[[:x]?b:]c]d");
+        assert_eq!(split.widened, 1);
+
+        // `[:]` is not a class on either side (its `]` is not `:`-preceded).
+        assert_eq!(specs("a[[:]]d")[0], ":(exclude,glob)**/a[[:]]d");
+        // `[::]` is where we are deliberately STRICTER than wildmatch, which
+        // accepts the empty name and abandons the pattern. Behaviour still agrees
+        // here only because the emitted term keeps the `[::]`, so the pathspec
+        // engine abandons it too — both hide nothing (measured).
+        assert_eq!(specs("a[[::]]d")[0], ":(exclude,glob)**/a[[::]]d");
+        assert_eq!(specs("a[d[::]b")[0], ":(exclude,glob)**/a[d[::]b");
+        let kept = pathspecs_for(&["a[[::]\\-b]d".to_string()], false);
+        assert_eq!(kept.specs[0], ":(exclude,glob)**/a[[::]?b]d");
+        assert_eq!(kept.widened, 1);
+        // The one shape where the stricter guard changes BEHAVIOUR: the escape
+        // sits inside the expression we end early, so the `[::]` is widened away
+        // and the term matches names gitignore abandons entirely. Over-exclusion,
+        // never a leak.
+        let diverged = pathspecs_for(&["a[\\x[::]d".to_string()], false);
+        assert_eq!(diverged.specs[0], ":(exclude,glob)**/a?d");
+        assert_eq!(diverged.widened, 1);
 
         // Unterminated: both engines abandon the pattern and match nothing, and
         // the copied `[` keeps the pathspec side there.
@@ -1126,6 +1171,133 @@ mod tests {
             ["notes ".to_string()].into_iter().collect::<BTreeSet<_>>(),
             "only the trailing-space file is hidden; listed = {listed:?}"
         );
+    }
+
+    /// A widened bracket still hides everything the gitignore engine hides —
+    /// asserted as a DIRECTION, not as an emitted term, so a future translation
+    /// that widens differently stays covered as long as it stays fail-closed.
+    ///
+    /// `a[[:x]\-b:]c]d` is the shape that catches an over-scanning terminator
+    /// search. Its first `]` is not `:`-preceded, so wildmatch reads the inner `[`
+    /// as an ordinary member and ends the class right there; a scan that hunted
+    /// for a later `:]` instead would swallow the real terminator, collapse the
+    /// pattern to a three-character match, and quietly stop hiding the long names
+    /// gitignore hides — a leak, on the engine that guards the model boundary.
+    ///
+    /// Built in the object database because the fixture names contain `:`, which
+    /// Windows will not accept in a filename — `parity_repo` cannot carry them.
+    #[tokio::test]
+    async fn widened_bracket_never_under_excludes_the_gitignore_set() {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-aiignore-posix-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+            vec!["config", "core.ignorecase", "false"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+
+        let git_out = |args: Vec<String>, input: Option<String>| {
+            let repo = repo.clone();
+            async move {
+                let argref: Vec<&str> = args.iter().map(String::as_str).collect();
+                run_git_input(Some(&repo), &argref, input.as_deref(), DEFAULT_TIMEOUT)
+                    .await
+                    .unwrap()
+                    .stdout_lossy()
+            }
+        };
+
+        let blob = git_out(
+            vec!["hash-object".into(), "-w".into(), "--stdin".into()],
+            Some("x\n".into()),
+        )
+        .await
+        .trim()
+        .to_string();
+        // `ax-…`/`a[-…` are class members of `[[:x]`; `axQ…` differs only where
+        // gitignore has a literal `-`, so it witnesses the widening; `aZ-…` and
+        // `aXd` are the controls neither engine may hide.
+        let files = [
+            "ax-b:]c]d",
+            "a[-b:]c]d",
+            "axQb:]c]d",
+            "aZ-b:]c]d",
+            "aXd",
+        ];
+        let rows: String = files
+            .iter()
+            .map(|p| format!("100644 blob {blob}\t{p}\n"))
+            .collect();
+        let tree = git_out(vec!["mktree".into()], Some(rows))
+            .await
+            .trim()
+            .to_string();
+        let empty = git_out(vec!["mktree".into()], Some(String::new()))
+            .await
+            .trim()
+            .to_string();
+
+        let patterns = vec!["a[[:x]\\-b:]c]d".to_string()];
+        let terms = pathspecs_for_repo(&repo, &patterns).await.specs;
+        let mut args: Vec<String> = vec![
+            "diff".into(),
+            "--name-only".into(),
+            empty,
+            tree,
+            "--".into(),
+            ".".into(),
+        ];
+        args.extend(terms);
+        let listed: BTreeSet<String> = git_out(args, None)
+            .await
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect();
+        let by_pathspec: BTreeSet<String> = files
+            .iter()
+            .map(|p| p.to_string())
+            .filter(|p| !listed.contains(p))
+            .collect();
+
+        let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
+            repo.clone(),
+            files.iter().map(|p| p.to_string()).collect(),
+            patterns,
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+
+        // Fixture precondition: without this the subset check below is vacuous,
+        // and this is the exact name an over-scan drops.
+        assert!(
+            by_gitignore.contains("ax-b:]c]d"),
+            "fixture must exercise the shape; gitignore hid {by_gitignore:?}"
+        );
+        assert!(
+            by_gitignore.is_subset(&by_pathspec),
+            "pathspec must hide at least the gitignore set; \
+             gitignore {by_gitignore:?} vs pathspec {by_pathspec:?}"
+        );
+        // Strictly more, so the subset check cannot pass by the widening having
+        // silently become an exact translation of something else.
+        assert!(
+            by_pathspec.contains("axQb:]c]d"),
+            "the widened member should also sweep the witness; pathspec {by_pathspec:?}"
+        );
+        // The controls stay visible on BOTH engines — a widening, not a wildcard.
+        for control in ["aZ-b:]c]d", "aXd"] {
+            assert!(!by_pathspec.contains(control), "pathspec swept {control}");
+            assert!(!by_gitignore.contains(control), "gitignore swept {control}");
+        }
     }
 
     /// The two engines agree with each other AND with the measured table, for

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -36,10 +36,12 @@ pub struct AiIgnorePathspecs {
     /// crate's staticlib/cdylib targets make `pub` no defence against dead_code.
     #[allow(dead_code)]
     pub skipped_negations: usize,
-    /// How many backslash escapes could only be re-encoded as `?` rather than an
-    /// exact one-character class (see [`escapes_to_classes`]). Each one can
-    /// over-exclude a sibling name, never leak the escaped one. Unconsumed so
-    /// far, and `pub` is no defence against dead_code here.
+    /// How many pattern pieces this translation had to over-broaden — a
+    /// class-special escape or a backslash-carrying bracket expression becoming
+    /// `?`, or an unterminated `[` that a later emitted class closed (see
+    /// [`rewrite_for_pathspec`]). Each one can over-exclude a sibling name, never
+    /// leak the named one. Unconsumed so far, and `pub` is no defence against
+    /// dead_code here.
     #[allow(dead_code)]
     pub widened: usize,
 }
@@ -70,8 +72,8 @@ fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
     (lines, skipped_negations)
 }
 
-/// Rewrites gitignore's `\<c>` escapes into the only spelling the pathspec engine
-/// reads the same way, returning the count that had to be widened.
+/// Rewrites one gitignore pattern into the spelling the pathspec engine reads the
+/// same way, returning the count that had to be widened.
 ///
 /// On WINDOWS a backslash inside a pathspec argv element is normalized to `/`
 /// before matching, so an escape that gitignore honors excludes NOTHING there —
@@ -82,55 +84,160 @@ fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
 /// one-character bracket class is exact on both engines, so `\<c>` becomes
 /// `[<c>]`.
 ///
-/// Two routes exist beside that class. `/` becomes a bare `/`: no bracket class
-/// matches a separator under `,glob`, while gitignore's `\/` does, so the class
-/// form would open the same hole it closes. The five class-special escapes
+/// Three escapes route around that class. `/` becomes a bare `/`: no bracket
+/// class matches a separator under `,glob`, while gitignore's `\/` does, so the
+/// class form would open the same hole it closes. A NON-ASCII character also goes
+/// bare — a class matches byte-wise, so `[日]` asks for one stray byte of a
+/// three-byte character and matches nothing, while bare is exact because no
+/// non-ASCII character is a glob metacharacter. The five class-special escapes
 /// (`]`, `^`, `!`, `-`, `\`) and a dangling backslash have their own meaning
 /// inside a class, so they degrade to `?`, a single-char wildcard that can only
-/// over-exclude — [`AiIgnorePathspecs::widened`] counts those.
+/// over-exclude.
+///
+/// A bracket EXPRESSION the user wrote is git's own syntax, not ours to
+/// translate: it is copied whole, or — when it carries a backslash anywhere
+/// inside — replaced whole by a single `?`. Rewriting one member in place would
+/// silently change the class's membership (`a[b\-c]d` would become the class
+/// `{b,?,c}` and stop matching `a-d`, which gitignore hides). `?` is a strict
+/// superset of any bracket, since neither matches `/`, so the swap stays
+/// fail-closed. [`AiIgnorePathspecs::widened`] counts both `?` routes.
 ///
 /// A backslash here is ALWAYS a gitignore escape and never a Windows path
 /// separator — the lists are documented as .gitignore syntax. So a
 /// Windows-path-shaped rule matches nothing it looks like it should: `src\foo.ts`
 /// names the literal `srcfoo.ts`, uniformly on both engines.
 ///
-/// One shape genuinely diverges, in the safe direction: a line ending `\/` leaves
-/// a real trailing `/` here, so [`pathspecs_for`] files it as a directory and
-/// hides its contents, while gitignore strips that slash and aborts on the
-/// dangling `foo\` residue, matching NOTHING (measured, git 2.51.1: excludes line
-/// `foo\/` hides neither `foo/x.txt` nor `foo`, where `foo/` hides `foo/x.txt`).
-/// Uncounted — `widened` means the `?` fallbacks — and unreachable from the
-/// menus, which never emit a trailing `\/`.
-fn escapes_to_classes(pattern: &str) -> (String, usize) {
+/// Beside the widened brackets, one shape diverges in the same safe direction: a
+/// line ending `\/` leaves a real trailing `/` here, so [`pathspecs_for`] files it
+/// as a directory and hides its contents, while gitignore strips that slash and
+/// aborts on the dangling `foo\` residue, matching NOTHING (measured, git 2.51.1:
+/// excludes line `foo\/` hides neither `foo/x.txt` nor `foo`, where `foo/` hides
+/// `foo/x.txt`). Uncounted, and unreachable from the menus, which never emit a
+/// trailing `\/`.
+fn rewrite_for_pathspec(pattern: &str) -> (String, usize) {
+    let chars: Vec<char> = pattern.chars().collect();
     let mut out = String::with_capacity(pattern.len());
     let mut widened = 0usize;
-    let mut chars = pattern.chars();
-    while let Some(c) = chars.next() {
-        if c != '\\' {
-            out.push(c);
+    let mut i = 0usize;
+    // An unterminated `[` copied into `out` and not yet closed — see the arm below.
+    let mut dangling_open = false;
+    while i < chars.len() {
+        if chars[i] == '[' {
+            match bracket_end(&chars, i) {
+                Some(end) => {
+                    let expr: String = chars[i..=end].iter().collect();
+                    if expr.contains('\\') {
+                        out.push('?');
+                        widened += 1;
+                    } else {
+                        out.push_str(&expr);
+                    }
+                    i = end + 1;
+                }
+                // Unterminated. Gitignore abandons the whole pattern, matching
+                // NOTHING, and a copied `[` matches nothing too — UNLESS a later
+                // escape emits a class whose `]` closes it, which the arm below
+                // counts as the over-exclusion it is (measured, git 2.51.1:
+                // gitignore `a[b\xc` hides nothing, our `**/a[b[x]c` hides
+                // `abc`/`a[c`/`axc`).
+                None => {
+                    out.push('[');
+                    dangling_open = true;
+                    i += 1;
+                }
+            }
             continue;
         }
-        match chars.next() {
+        if chars[i] != '\\' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        match chars.get(i + 1).copied() {
             Some('/') => out.push('/'),
+            // A bracket class matches BYTE-wise, so `[日]` would ask for one
+            // stray byte of a 3-byte character and match nothing. Bare is exact
+            // instead: a non-ASCII char is never a glob metacharacter.
+            Some(e) if !e.is_ascii() => out.push(e),
             Some(e) if !matches!(e, ']' | '^' | '!' | '-' | '\\') => {
                 out.push('[');
                 out.push(e);
                 out.push(']');
+                // This `]` is the first one in `out`, so it closes the dangling
+                // `[` rather than this class — turning the run into a real class
+                // where gitignore matched nothing at all.
+                if dangling_open {
+                    widened += 1;
+                    dangling_open = false;
+                }
             }
             _ => {
                 out.push('?');
                 widened += 1;
             }
         }
+        i += if i + 1 < chars.len() { 2 } else { 1 };
     }
     (out, widened)
+}
+
+/// Index of the `]` closing the bracket expression opening at `open`, or `None`
+/// when it is unterminated.
+///
+/// Follows wildmatch's own parse, which four details make non-obvious: a leading
+/// `!` or `^` negates; a `]` in first position is a member rather than the
+/// terminator; a backslash escapes the next character; and a POSIX class
+/// `[:name:]` is consumed whole, so the `]` ending it is not the terminator
+/// either. Miss any of them and the scan stops at a false terminator, splitting
+/// the class — which then has a member rewritten in place and silently changes
+/// what it accepts.
+///
+/// `[:name:]` alone: git's wildmatch has no `[=x=]` equivalence or `[.x.]`
+/// collating form (measured, git 2.51.1 — both match nothing rather than acting
+/// as a class), so treating their brackets as ordinary characters is what agrees
+/// with it.
+fn bracket_end(chars: &[char], open: usize) -> Option<usize> {
+    let mut i = open + 1;
+    if matches!(chars.get(i).copied(), Some('!' | '^')) {
+        i += 1;
+    }
+    if matches!(chars.get(i).copied(), Some(']')) {
+        i += 1;
+    }
+    while i < chars.len() {
+        match chars[i] {
+            '\\' => i += 2,
+            '[' if matches!(chars.get(i + 1).copied(), Some(':')) => {
+                match posix_class_end(chars, i) {
+                    Some(end) => i = end + 1,
+                    None => i += 1,
+                }
+            }
+            ']' => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Index of the `]` ending the POSIX class `[:name:]` opening at `open`, or
+/// `None` when no `:]` follows (then the `[` is an ordinary member).
+fn posix_class_end(chars: &[char], open: usize) -> Option<usize> {
+    let mut i = open + 2;
+    while i + 1 < chars.len() {
+        if chars[i] == ':' && chars[i + 1] == ']' {
+            return Some(i + 1);
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Translates gitignore-style lines into `:(exclude,glob)` pathspec terms.
 ///
 /// Pure — no git call, no IO. Blanks, comments and `!` lines are dropped by the
 /// shared [`actionable_lines`]. Per surviving line: backslash escapes are
-/// re-encoded by [`escapes_to_classes`] first (the pathspec engine cannot read
+/// re-encoded by [`rewrite_for_pathspec`] first (the pathspec engine cannot read
 /// them), then a trailing `/` marks a directory, and a line is *anchored* when it
 /// starts with `/` or still contains a `/` (exactly gitignore's rule). Unanchored
 /// lines get a `**/` prefix so they match at any depth; a non-directory line also
@@ -172,7 +279,7 @@ pub fn pathspecs_for(patterns: &[String], icase: bool) -> AiIgnorePathspecs {
         // Escapes are re-encoded BEFORE anything classifies the line: `anchored`
         // reads `/`, and Windows git reads a surviving backslash as one — so a
         // raw `a\b.ts` would be filed unanchored and then matched as `a/b.ts`.
-        let (line, w) = escapes_to_classes(line);
+        let (line, w) = rewrite_for_pathspec(line);
         widened += w;
         let is_dir = line.ends_with('/');
         let core = line.strip_suffix('/').unwrap_or(line.as_str());
@@ -517,6 +624,66 @@ mod tests {
         // alone. Windows pathspec matching would read it the other way round, on
         // that platform alone — which is exactly what the re-encode removes.
         assert_eq!(specs("src\\foo.ts")[0], ":(exclude,glob)**/src[f]oo.ts");
+
+        // An escaped non-ASCII character goes BARE. A class is byte-wise, so
+        // `[日]` names one byte of a three-byte character and matches nothing.
+        assert_eq!(
+            specs("docs/\\日本語.md")[0],
+            ":(exclude,glob)docs/日本語.md"
+        );
+    }
+
+    /// A bracket expression the user wrote is git's own syntax: copied whole when
+    /// it holds no escape, and swapped whole for `?` when it does. Rewriting a
+    /// single member in place would change which characters the class accepts.
+    #[test]
+    fn user_bracket_expressions_pass_through_or_widen_whole() {
+        // Verbatim: plain class, negated (both spellings), and `]` as the first
+        // member — all parsed the same way by both engines.
+        for pattern in ["a[b-c]d", "a[!b]d", "a[^b]d", "a[]]d", "weird[[]1].txt"] {
+            let out = pathspecs_for(&[pattern.to_string()], false);
+            assert_eq!(out.specs[0], format!(":(exclude,glob)**/{pattern}"));
+            assert_eq!(out.widened, 0, "pattern {pattern:?}");
+        }
+
+        // An escape anywhere inside widens the WHOLE class: `a[b?c]d` would be
+        // the class `{b,?,c}`, which stops matching the `a-d` that gitignore hides.
+        let out = pathspecs_for(&["a[b\\-c]d".to_string()], false);
+        assert_eq!(out.specs[0], ":(exclude,glob)**/a?d");
+        assert_eq!(out.widened, 1);
+        // The scan steps over an escaped `]` rather than stopping at it, or the
+        // class would be split at a false terminator.
+        assert_eq!(
+            pathspecs_for(&["a[b\\]c]d".to_string()], false).specs[0],
+            ":(exclude,glob)**/a?d"
+        );
+
+        // A POSIX class holds a `]` that does NOT terminate the expression.
+        // Escape-free, so it survives whole.
+        for pattern in ["a[[:digit:]]d", "a[[:alpha:][:digit:]]d", "a[![:digit:]]d"] {
+            let out = pathspecs_for(&[pattern.to_string()], false);
+            assert_eq!(out.specs[0], format!(":(exclude,glob)**/{pattern}"));
+            assert_eq!(out.widened, 0, "pattern {pattern:?}");
+        }
+        // With an escape after the class, the WHOLE expression widens — stopping
+        // the scan at the class's `]` would instead rewrite one member and drop
+        // the `a-d` that gitignore hides.
+        let out = pathspecs_for(&["a[[:digit:]\\-]d".to_string()], false);
+        assert_eq!(out.specs[0], ":(exclude,glob)**/a?d");
+        assert_eq!(out.widened, 1);
+        // A lone `[:` with no `:]` is an ordinary member, not a class.
+        assert_eq!(specs("a[[:x]d")[0], ":(exclude,glob)**/a[[:x]d");
+
+        // Unterminated: both engines abandon the pattern and match nothing, and
+        // the copied `[` keeps the pathspec side there.
+        assert_eq!(specs("a[b")[0], ":(exclude,glob)**/a[b");
+        assert_eq!(specs("a[")[0], ":(exclude,glob)**/a[");
+        // …unless a later escape emits a class whose `]` closes the dangling `[`,
+        // making it a real class where gitignore matched nothing. Fail-closed, so
+        // the emission stands — but it is counted, not silent.
+        let reclosed = pathspecs_for(&["a[b\\xc".to_string()], false);
+        assert_eq!(reclosed.specs[0], ":(exclude,glob)**/a[b[x]c");
+        assert_eq!(reclosed.widened, 1);
     }
 
     /// The five class-special escapes (and a dangling backslash) fall back to
@@ -563,12 +730,23 @@ mod tests {
     }
 
     /// Every fixture path in the parity repo, repo-relative and sorted.
-    const FIXTURE: [&str; 22] = [
+    const FIXTURE: [&str; 27] = [
+        // A bracket expression's members (`a-d`/`abd`) plus a name only the
+        // widened `?` reaches (`aXd`), so a class and its widening are
+        // distinguishable.
+        "a-d",
         // `a/b.ts` beside `srcfoo.ts`/`src/foo.ts`: the pair of shapes that tell a
         // backslash ESCAPE apart from a Windows path separator (the `\/` and
         // `\f` rows below).
         "a/b.ts",
         "a/b/notes.md",
+        // A digit member for the POSIX-class rows, and a name holding a literal
+        // `[` so the unterminated-bracket rows have something they could wrongly
+        // hide (git accepts `[` in a filename on every platform).
+        "a5d",
+        "aXd",
+        "a[b",
+        "abd",
         "app.log",
         // Each `?`-widened escape with a sibling only the wildcard reaches, so
         // the fail-closed asymmetry has a witness (`widened_escapes_…` below).
@@ -598,7 +776,7 @@ mod tests {
 
     /// The measured truth table (git 2.51.1): for each AI-ignore pattern LIST,
     /// exactly which of `FIXTURE` it hides. Both engines must agree with it.
-    const PARITY: [(&[&str], &[&str]); 22] = [
+    const PARITY: [(&[&str], &[&str]); 27] = [
         (
             &["notes.md"],
             &["a/b/notes.md", "docs/notes.md", "notes.md"],
@@ -674,6 +852,23 @@ mod tests {
         // class matches a separator under `,glob`, so `\/` becomes a bare `/` —
         // which must also anchor the line exactly as gitignore anchors it.
         (&["a\\/b.ts"], &["a/b.ts"]),
+        // A bracket expression the USER wrote, carrying no escape: copied through
+        // untouched, and the two engines read it identically (a range here, so
+        // `a-d` is NOT a member — only `abd` is in this fixture).
+        (&["a[b-c]d"], &["abd"]),
+        // An escaped NON-ASCII character goes bare. As a one-character class it
+        // would ask for a single byte of a three-byte character and match nothing,
+        // while gitignore hides the file — the fail-open direction.
+        (&["docs/\\日本語.md"], &["docs/日本語.md"]),
+        // A POSIX class carries its own `]`, which the terminator scan must step
+        // over. Escape-free, so it passes through verbatim and both engines read
+        // the same class.
+        (&["a[[:digit:]]d"], &["a5d"]),
+        // An unterminated `[` is abandoned by BOTH engines — an agreement row
+        // that happens to hide nothing, which is exactly the claim worth pinning:
+        // the copied `[` must not start matching on the pathspec side.
+        (&["a["], &[]),
+        (&["a[b"], &[]),
     ];
 
     /// A `.gitignore` line the fixture repo carries but the AI-ignore lists never
@@ -975,9 +1170,16 @@ mod tests {
         let (_dir, repo) = parity_repo().await;
         let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
 
-        for (pattern, literal, only_by_wildcard) in [
-            ("bang\\!.txt", "bang!.txt", "bangX.txt"),
-            ("hat\\^.txt", "hat^.txt", "hatX.txt"),
+        for (pattern, gitignore_hides, only_by_wildcard) in [
+            ("bang\\!.txt", &["bang!.txt"][..], "bangX.txt"),
+            ("hat\\^.txt", &["hat^.txt"][..], "hatX.txt"),
+            // A bracket carrying an escape widens to `?` as a whole; gitignore
+            // reads the class literally, so `a-d` and `abd` are its members.
+            ("a[b\\-c]d", &["a-d", "abd"][..], "aXd"),
+            // The same, with a POSIX class ahead of the escape. Rewriting the
+            // escape in place would leave `a[[:digit:]?]d` — digits plus `?` —
+            // which stops hiding the `a-d` that gitignore hides.
+            ("a[[:digit:]\\-]d", &["a-d", "a5d"][..], "abd"),
         ] {
             let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
                 repo.clone(),
@@ -990,8 +1192,11 @@ mod tests {
             .collect();
             assert_eq!(
                 by_gitignore,
-                [literal.to_string()].into_iter().collect::<BTreeSet<_>>(),
-                "gitignore engine hides exactly the escaped name, patterns {pattern:?}"
+                gitignore_hides
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<BTreeSet<_>>(),
+                "gitignore engine hides exactly the named files, patterns {pattern:?}"
             );
 
             let by_pathspec = hidden_by_pathspec(&repo, &[pattern]).await;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -567,28 +567,32 @@ pub(crate) async fn git_discard_paths_core(
 
 /// Stashes only the selected files (their tracked changes plus any untracked
 /// matches), leaving the rest of the working tree in place. Creates a single
-/// stash entry; `git stash push` with a pathspec no-ops cleanly if nothing matches.
+/// stash entry; `git stash push` with a pathspec no-ops cleanly if nothing
+/// matches. `true` means an entry was actually created.
 #[tauri::command]
 pub async fn git_stash_paths(
     state: State<'_, AppState>,
     repo_path: String,
     paths: Vec<String>,
-) -> AppResult<()> {
+) -> AppResult<bool> {
     git_stash_paths_core(&state, repo_path, paths).await
 }
 
+/// `Ok(false)` when the selection matched nothing and no stash entry was
+/// created — the caller decides how to report that, since `git stash push`
+/// itself exits 0 either way.
 pub(crate) async fn git_stash_paths_core(
     state: &AppState,
     repo_path: String,
     mut paths: Vec<String>,
-) -> AppResult<()> {
+) -> AppResult<bool> {
     // An empty-string entry is not a valid pathspec (`fatal: empty string is not a
     // valid pathspec`) and would fail every git call below; drop those. Do NOT trim
     // whitespace — space-prefixed/suffixed filenames are legal and GUI paths arrive
     // verbatim from `git status`, so trimming would corrupt them.
     paths.retain(|p| !p.is_empty());
     if paths.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
 
     // A native `git stash push -- <paths>` always snapshots the WHOLE index into
@@ -667,11 +671,19 @@ pub(crate) async fn git_stash_paths_core(
     let mut stash_args = vec!["stash", "push", "--include-untracked", "--"];
     stash_args.extend(paths.iter().map(String::as_str));
 
+    // A pathspec matching nothing still exits 0, so this stdout line is the only
+    // signal that no entry was created; `run_git` pins `LC_ALL=C` to keep it stable.
+    fn created_entry(out: &crate::git::runner::GitOutput) -> bool {
+        !out.stdout_lossy()
+            .trim_start()
+            .starts_with("No local changes to save")
+    }
+
     // Fast path: no other staged file to protect, so the native pathspec stash is
     // already exact.
     if unselected_staged.is_empty() {
-        run_git(Some(&repo_path), &stash_args, DEFAULT_TIMEOUT).await?;
-        return Ok(());
+        let out = run_git(Some(&repo_path), &stash_args, DEFAULT_TIMEOUT).await?;
+        return Ok(created_entry(&out));
     }
 
     // Snapshot the full index so the unselected files' exact staged blobs can be
@@ -686,9 +698,9 @@ pub(crate) async fn git_stash_paths_core(
         .to_string();
 
     // Do the mutation, then ALWAYS restore the unselected index — even if the stash
-    // step errors, else the unselected staged files are left unstaged. `Result::and`
-    // lets the primary (mutate) error win; otherwise the restore error surfaces.
-    let mutate: AppResult<()> = async {
+    // step errors, else the unselected staged files are left unstaged. The chaining
+    // below lets the primary (mutate) error win; otherwise the restore error surfaces.
+    let mutate: AppResult<bool> = async {
         // a. Unstage the unselected staged paths (index only; worktree untouched).
         //    Chunk at 100 for the Windows argv limit (mirror git_discard_paths_core).
         for chunk in unselected_staged.chunks(100) {
@@ -699,8 +711,8 @@ pub(crate) async fn git_stash_paths_core(
         // b. Native pathspec stash of the selection — EXACTLY ONE call (chunking
         //    would create multiple stash entries). The `^2` index-commit is now
         //    clean: the index holds only the selected staged changes.
-        run_git(Some(&repo_path), &stash_args, DEFAULT_TIMEOUT).await?;
-        Ok(())
+        let out = run_git(Some(&repo_path), &stash_args, DEFAULT_TIMEOUT).await?;
+        Ok(created_entry(&out))
     }
     .await;
 
@@ -719,7 +731,7 @@ pub(crate) async fn git_stash_paths_core(
         }
     }
 
-    mutate.and(restore)
+    mutate.and_then(|created| restore.map(|()| created))
 }
 
 /// Stops tracking the files matching `pathspecs` (each a file, a folder, or a
@@ -882,12 +894,16 @@ pub struct UnignoreRule {
 /// Removes gitignore rule lines (matched by exact trimmed content) from their
 /// source files — the "remove rule" / stop-ignoring action. Matching by content
 /// (not line number) keeps it safe if the file shifted since it was read.
+///
+/// Trimming is git's own (`trim_ignore_pattern`), not `str::trim`: a blanket trim
+/// collapses `/notes\ ` and `/notes\` to the same key, so unignoring either rule
+/// would delete both lines.
 #[tauri::command]
 pub async fn git_unignore_rules(repo_path: String, rules: Vec<UnignoreRule>) -> AppResult<()> {
     let mut by_source: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
     for r in rules {
-        let pat = r.pattern.trim().to_string();
+        let pat = crate::fsops::trim_ignore_pattern(&r.pattern).to_string();
         if r.source.trim().is_empty() || pat.is_empty() {
             continue;
         }
@@ -908,8 +924,8 @@ pub async fn git_unignore_rules(repo_path: String, rules: Vec<UnignoreRule>) -> 
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             Err(e) => return Err(AppError::Io(e)),
         };
-        // Strip a leading UTF-8 BOM for processing (otherwise it rides on the
-        // first line and breaks the `trim() == pattern` match), and restore it
+        // Strip a leading UTF-8 BOM for processing (it is not whitespace, so it
+        // rides on the first line and breaks the pattern match), and restore it
         // on write. Preserve the file's existing line-ending convention — `lines()`
         // drops both \n and \r\n, so a naive `join("\n")` would silently rewrite a
         // Windows CRLF .gitignore to LF.
@@ -920,7 +936,11 @@ pub async fn git_unignore_rules(repo_path: String, rules: Vec<UnignoreRule>) -> 
         let ending = if content.contains("\r\n") { "\r\n" } else { "\n" };
         let kept: Vec<&str> = content
             .lines()
-            .filter(|l| !patterns.iter().any(|p| l.trim() == p))
+            .filter(|l| {
+                !patterns
+                    .iter()
+                    .any(|p| crate::fsops::trim_ignore_pattern(l) == p)
+            })
             .collect();
         let mut next = kept.join(ending);
         // Keep the trailing newline if the original had one, even when every
@@ -3355,6 +3375,29 @@ mod tests {
         assert_eq!(out, "\n");
     }
 
+    /// Two rules that a blanket `trim()` collapses into one key — `/notes\ `
+    /// names a file whose name ends in a space, `/notes\` one ending in a
+    /// backslash — must be removable independently. Trimming the escape away
+    /// deletes the wrong line as well as the right one.
+    #[tokio::test]
+    async fn unignore_removes_only_the_targeted_escaped_rule() {
+        let body = "/notes\\ \n/notes\\\nkeep\n";
+
+        let (dir, repo) = gitignore_dir("escaped-space", body);
+        git_unignore_rules(repo, vec![rule("/notes\\ ")]).await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(".gitignore")).unwrap(),
+            "/notes\\\nkeep\n"
+        );
+
+        let (dir2, repo2) = gitignore_dir("escaped-slash", body);
+        git_unignore_rules(repo2, vec![rule("/notes\\")]).await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir2.path().join(".gitignore")).unwrap(),
+            "/notes\\ \nkeep\n"
+        );
+    }
+
     #[tokio::test]
     async fn unignore_strips_and_restores_bom() {
         // A UTF-8 BOM ahead of the first (targeted) rule must not block the match.
@@ -4226,10 +4269,70 @@ detached
         std::fs::write(dir.path().join("a.txt"), "changed\n").unwrap();
 
         let state = AppState::default();
-        git_stash_paths_core(&state, repo.clone(), vec![])
+        let created = git_stash_paths_core(&state, repo.clone(), vec![])
             .await
             .unwrap();
 
+        assert!(!created);
         assert_eq!(stash_count(&repo).await, 0);
+    }
+
+    /// A selection that matches nothing reports `false`. `git stash push` exits 0
+    /// on that path, so without the return the MCP tool answers "stashed" for a
+    /// no-op and the agent believes work was put away.
+    #[tokio::test]
+    async fn selection_matching_nothing_reports_no_stash() {
+        let (dir, repo) = setup_repo("stash-no-match").await;
+        commit_file(&repo, dir.path(), "A", "a0\n", "add A").await;
+        // An unrelated uncommitted change, so the repo is NOT clean overall.
+        std::fs::write(dir.path().join("A"), "a1\n").unwrap();
+
+        let state = AppState::default();
+        let created = git_stash_paths_core(&state, repo.clone(), vec!["nonexistent.txt".into()])
+            .await
+            .unwrap();
+
+        assert!(!created, "nothing matched, so no stash entry was created");
+        assert_eq!(stash_count(&repo).await, 0);
+        // The unrelated change is untouched.
+        assert_eq!(
+            nlf(std::fs::read_to_string(dir.path().join("A")).unwrap()),
+            "a1\n"
+        );
+    }
+
+    /// The index-protecting slow path reports the same way: the selection matches
+    /// nothing while another file stays staged.
+    #[tokio::test]
+    async fn slow_path_selection_matching_nothing_reports_no_stash() {
+        let (dir, repo) = setup_repo("stash-no-match-slow").await;
+        commit_file(&repo, dir.path(), "A", "a0\n", "add A").await;
+        std::fs::write(dir.path().join("A"), "a1\n").unwrap();
+        git(&repo, &["add", "A"]).await;
+
+        let state = AppState::default();
+        let created = git_stash_paths_core(&state, repo.clone(), vec!["nonexistent.txt".into()])
+            .await
+            .unwrap();
+
+        assert!(!created);
+        assert_eq!(stash_count(&repo).await, 0);
+        // A survived the reset/restore round trip with its staged blob intact.
+        assert_eq!(nlf(git(&repo, &["show", ":A"]).await), "a1\n");
+    }
+
+    #[tokio::test]
+    async fn real_selection_reports_a_stash_was_created() {
+        let (dir, repo) = setup_repo("stash-reports-created").await;
+        commit_file(&repo, dir.path(), "B", "b0\n", "add B").await;
+        std::fs::write(dir.path().join("B"), "b1\n").unwrap();
+
+        let state = AppState::default();
+        let created = git_stash_paths_core(&state, repo.clone(), vec!["B".into()])
+            .await
+            .unwrap();
+
+        assert!(created);
+        assert_eq!(stash_count(&repo).await, 1);
     }
 }

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -427,13 +427,34 @@ fn patch_updater_notes(manifest: &str, notes: &str) -> AppResult<String> {
         .map_err(|e| AppError::Gh(format!("could not write {UPDATER_MANIFEST}: {e}")))
 }
 
+/// Parks the patched manifest outside the temp dir when the upload fails, under the
+/// `latest.json` BASENAME a re-upload needs (the asset takes its name from the file).
+/// Best-effort: failing here only costs the recovery hint, so it degrades to `None`
+/// rather than masking the upload error that prompted it.
+async fn save_updater_recovery_copy(src: std::path::PathBuf) -> Option<String> {
+    tokio::task::spawn_blocking(move || {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("gd-updater-recovery-{nanos}"));
+        std::fs::create_dir_all(&dir).ok()?;
+        let dest = dir.join(UPDATER_MANIFEST);
+        std::fs::copy(&src, &dest).ok()?;
+        Some(dest.to_string_lossy().into_owned())
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
 /// Re-points a release's updater manifest at `notes`, so apps updating from that
 /// release show the same body the release page does. Download → patch → re-upload
 /// with `--clobber`, which gh implements as delete-THEN-upload: the manifest is
-/// briefly absent, and a failed upload leaves it deleted rather than stale, so
-/// callers must tell the user it may need restoring. The uploaded file's BASENAME
-/// becomes the asset name (a `file#label` argument sets only the display label),
-/// so the patched copy keeps its `latest.json` name.
+/// briefly absent, and a failed upload leaves it deleted rather than stale. That
+/// makes the failure unrecoverable from the UI alone (the release no longer has the
+/// asset to re-download), so a failed upload parks the patched copy on disk and
+/// names its path in the error for a manual re-attach.
 pub async fn gh_release_sync_updater_notes(
     repo_path: &str,
     tag: &str,
@@ -464,19 +485,17 @@ pub async fn gh_release_sync_updater_notes(
     .await?;
     let path = dir.path().join(UPDATER_MANIFEST);
     let file_arg = path.to_string_lossy().to_string();
-    let (tag_owned, notes_owned) = (tag.to_string(), notes.to_string());
+    let (patch_path, notes_owned) = (path.clone(), notes.to_string());
     tokio::task::spawn_blocking(move || -> AppResult<()> {
-        let current = std::fs::read_to_string(&path).map_err(|e| {
-            AppError::Gh(format!(
-                "could not read {UPDATER_MANIFEST} for {tag_owned}: {e}"
-            ))
-        })?;
-        std::fs::write(&path, patch_updater_notes(&current, &notes_owned)?)?;
+        // Local filesystem failures stay `Io` — surfacing them as `Gh` would blame
+        // GitHub for a problem on this machine.
+        let current = std::fs::read_to_string(&patch_path).map_err(AppError::Io)?;
+        std::fs::write(&patch_path, patch_updater_notes(&current, &notes_owned)?)?;
         Ok(())
     })
     .await
     .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;
-    run_gh(
+    let upload = run_gh(
         Some(repo_path),
         &[
             "release",
@@ -489,7 +508,19 @@ pub async fn gh_release_sync_updater_notes(
         ],
         GH_NETWORK_TIMEOUT,
     )
-    .await?;
+    .await;
+    if let Err(e) = upload {
+        return Err(match save_updater_recovery_copy(path).await {
+            Some(saved) => AppError::Gh(format!(
+                "{e}\n\nThe patched {UPDATER_MANIFEST} was saved to {saved} — upload \
+                 that file to the release to restore the manifest."
+            )),
+            None => AppError::Gh(format!(
+                "{e}\n\nThe patched {UPDATER_MANIFEST} could not be saved locally, so \
+                 the release may now have no updater manifest."
+            )),
+        });
+    }
     Ok(())
 }
 

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -407,6 +407,92 @@ pub async fn gh_release_delete_asset(
     Ok(())
 }
 
+/// Tauri's updater manifest, attached to a release as an asset of this exact name.
+const UPDATER_MANIFEST: &str = "latest.json";
+
+/// Replaces the manifest's `notes` and nothing else — `version`, `pub_date` and
+/// every platform's URL + signature must survive verbatim or installed apps stop
+/// trusting the update. Absent `notes` is added. Re-serializing alphabetizes the
+/// keys (serde_json's Map is a BTreeMap without `preserve_order`), so the result
+/// isn't byte-diffable against CI's original; values are preserved and the
+/// manifest itself carries no signature over its own bytes.
+fn patch_updater_notes(manifest: &str, notes: &str) -> AppResult<String> {
+    let mut value: serde_json::Value = serde_json::from_str(manifest)
+        .map_err(|e| AppError::Gh(format!("could not parse {UPDATER_MANIFEST}: {e}")))?;
+    let obj = value.as_object_mut().ok_or_else(|| {
+        AppError::Gh(format!("{UPDATER_MANIFEST} is not a JSON object"))
+    })?;
+    obj.insert("notes".to_string(), serde_json::Value::String(notes.to_string()));
+    serde_json::to_string_pretty(&value)
+        .map_err(|e| AppError::Gh(format!("could not write {UPDATER_MANIFEST}: {e}")))
+}
+
+/// Re-points a release's updater manifest at `notes`, so apps updating from that
+/// release show the same body the release page does. Download → patch → re-upload
+/// with `--clobber`, which gh implements as delete-THEN-upload: the manifest is
+/// briefly absent, and a failed upload leaves it deleted rather than stale, so
+/// callers must tell the user it may need restoring. The uploaded file's BASENAME
+/// becomes the asset name (a `file#label` argument sets only the display label),
+/// so the patched copy keeps its `latest.json` name.
+pub async fn gh_release_sync_updater_notes(
+    repo_path: &str,
+    tag: &str,
+    notes: &str,
+) -> AppResult<()> {
+    validate_tag(tag)?;
+    let slug = crate::github::gh_origin_slug(repo_path).await?;
+    let dir = tokio::task::spawn_blocking(tempfile::tempdir)
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;
+    let dir_arg = dir.path().to_string_lossy().to_string();
+    run_gh(
+        Some(repo_path),
+        &[
+            "release",
+            "download",
+            tag,
+            "--repo",
+            &slug,
+            "--pattern",
+            UPDATER_MANIFEST,
+            "--dir",
+            &dir_arg,
+            "--clobber",
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let path = dir.path().join(UPDATER_MANIFEST);
+    let file_arg = path.to_string_lossy().to_string();
+    let (tag_owned, notes_owned) = (tag.to_string(), notes.to_string());
+    tokio::task::spawn_blocking(move || -> AppResult<()> {
+        let current = std::fs::read_to_string(&path).map_err(|e| {
+            AppError::Gh(format!(
+                "could not read {UPDATER_MANIFEST} for {tag_owned}: {e}"
+            ))
+        })?;
+        std::fs::write(&path, patch_updater_notes(&current, &notes_owned)?)?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;
+    run_gh(
+        Some(repo_path),
+        &[
+            "release",
+            "upload",
+            tag,
+            &file_arg,
+            "--repo",
+            &slug,
+            "--clobber",
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    Ok(())
+}
+
 /// Downloads one asset (by exact name, used as the glob pattern) into `dir`.
 #[tauri::command]
 pub async fn gh_release_download_asset(
@@ -440,4 +526,46 @@ pub async fn gh_release_download_asset(
     )
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = r#"{
+      "version": "0.6.0",
+      "notes": "old notes",
+      "pub_date": "2026-07-31T00:00:00Z",
+      "platforms": {
+        "windows-x86_64": { "signature": "sig-abc", "url": "https://example/app.exe" }
+      }
+    }"#;
+
+    #[test]
+    fn patch_updater_notes_replaces_only_the_notes() {
+        let out = patch_updater_notes(MANIFEST, "new notes").unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["notes"], "new notes");
+        assert_eq!(v["version"], "0.6.0");
+        assert_eq!(v["pub_date"], "2026-07-31T00:00:00Z");
+        assert_eq!(v["platforms"]["windows-x86_64"]["signature"], "sig-abc");
+        assert_eq!(
+            v["platforms"]["windows-x86_64"]["url"],
+            "https://example/app.exe"
+        );
+    }
+
+    #[test]
+    fn patch_updater_notes_adds_absent_notes() {
+        let out = patch_updater_notes(r#"{"version":"1.0.0"}"#, "fresh").unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["notes"], "fresh");
+        assert_eq!(v["version"], "1.0.0");
+    }
+
+    #[test]
+    fn patch_updater_notes_rejects_a_non_object() {
+        assert!(patch_updater_notes("[1, 2]", "x").is_err());
+        assert!(patch_updater_notes("not json", "x").is_err());
+    }
 }

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -429,19 +429,21 @@ fn patch_updater_notes(manifest: &str, notes: &str) -> AppResult<String> {
 
 /// Parks the patched manifest outside the temp dir when the upload fails, under the
 /// `latest.json` BASENAME a re-upload needs (the asset takes its name from the file).
-/// Best-effort: failing here only costs the recovery hint, so it degrades to `None`
-/// rather than masking the upload error that prompted it.
+/// The directory is created EXCLUSIVELY by `Builder::tempdir` before it's persisted —
+/// a guessable name under the shared temp dir could be pre-created as a symlink by a
+/// local attacker and redirect the copy. Best-effort: failing here only costs the
+/// recovery hint, so it degrades to `None` rather than masking the upload error that
+/// prompted it.
 async fn save_updater_recovery_copy(src: std::path::PathBuf) -> Option<String> {
     tokio::task::spawn_blocking(move || {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let dir = std::env::temp_dir().join(format!("gd-updater-recovery-{nanos}"));
-        std::fs::create_dir_all(&dir).ok()?;
-        let dest = dir.join(UPDATER_MANIFEST);
-        std::fs::copy(&src, &dest).ok()?;
-        Some(dest.to_string_lossy().into_owned())
+        let dir = tempfile::Builder::new()
+            .prefix("gd-updater-recovery-")
+            .tempdir()
+            .ok()?;
+        std::fs::copy(&src, dir.path().join(UPDATER_MANIFEST)).ok()?;
+        // Outlives this call by design — the user needs it to re-attach the asset.
+        let kept = dir.keep();
+        Some(kept.join(UPDATER_MANIFEST).to_string_lossy().into_owned())
     })
     .await
     .ok()

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -415,13 +415,26 @@ const UPDATER_MANIFEST: &str = "latest.json";
 /// trusting the update. Absent `notes` is added. Re-serializing alphabetizes the
 /// keys (serde_json's Map is a BTreeMap without `preserve_order`), so the result
 /// isn't byte-diffable against CI's original; values are preserved and the
-/// manifest itself carries no signature over its own bytes.
+/// manifest itself carries no signature over its own bytes. Rejects anything that
+/// doesn't carry the updater shape (string `version` + object `platforms`), so an
+/// unrelated asset that merely shares the name is never rewritten.
 fn patch_updater_notes(manifest: &str, notes: &str) -> AppResult<String> {
     let mut value: serde_json::Value = serde_json::from_str(manifest)
         .map_err(|e| AppError::Gh(format!("could not parse {UPDATER_MANIFEST}: {e}")))?;
     let obj = value.as_object_mut().ok_or_else(|| {
         AppError::Gh(format!("{UPDATER_MANIFEST} is not a JSON object"))
     })?;
+    // Gate the shape here, before anything uploads: the re-upload clobbers, so
+    // rewriting a same-named asset that isn't an updater manifest (a repo's own
+    // version pointer, say) would destroy it. Failing on this path deletes nothing.
+    if !obj.get("version").is_some_and(serde_json::Value::is_string)
+        || !obj.get("platforms").is_some_and(serde_json::Value::is_object)
+    {
+        return Err(AppError::Gh(format!(
+            "{UPDATER_MANIFEST} isn't a Tauri updater manifest (no version + \
+             platforms) — it was left unchanged."
+        )));
+    }
     obj.insert("notes".to_string(), serde_json::Value::String(notes.to_string()));
     serde_json::to_string_pretty(&value)
         .map_err(|e| AppError::Gh(format!("could not write {UPDATER_MANIFEST}: {e}")))
@@ -590,15 +603,32 @@ mod tests {
 
     #[test]
     fn patch_updater_notes_adds_absent_notes() {
-        let out = patch_updater_notes(r#"{"version":"1.0.0"}"#, "fresh").unwrap();
+        let out = patch_updater_notes(
+            r#"{"version":"1.0.0","platforms":{"linux-x86_64":{"signature":"s","url":"u"}}}"#,
+            "fresh",
+        )
+        .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["notes"], "fresh");
         assert_eq!(v["version"], "1.0.0");
+        assert_eq!(v["platforms"]["linux-x86_64"]["signature"], "s");
     }
 
     #[test]
     fn patch_updater_notes_rejects_a_non_object() {
         assert!(patch_updater_notes("[1, 2]", "x").is_err());
         assert!(patch_updater_notes("not json", "x").is_err());
+    }
+
+    /// A same-named asset that isn't an updater manifest must survive untouched —
+    /// the re-upload clobbers, so a false accept would destroy it.
+    #[test]
+    fn patch_updater_notes_rejects_a_foreign_same_named_asset() {
+        assert!(patch_updater_notes(r#"{"foo":1}"#, "x").is_err());
+        // Right keys, wrong types.
+        assert!(patch_updater_notes(r#"{"version":1,"platforms":{}}"#, "x").is_err());
+        assert!(
+            patch_updater_notes(r#"{"version":"1.0.0","platforms":[]}"#, "x").is_err()
+        );
     }
 }

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -431,8 +431,8 @@ fn patch_updater_notes(manifest: &str, notes: &str) -> AppResult<String> {
         || !obj.get("platforms").is_some_and(serde_json::Value::is_object)
     {
         return Err(AppError::Gh(format!(
-            "{UPDATER_MANIFEST} isn't a Tauri updater manifest (no version + \
-             platforms) — it was left unchanged."
+            "{UPDATER_MANIFEST} isn't a Tauri updater manifest (needs a string \
+             `version` and an object `platforms`) — it was left unchanged."
         )));
     }
     obj.insert("notes".to_string(), serde_json::Value::String(notes.to_string()));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -342,6 +342,7 @@ pub fn run() {
             forge::forge_release_view,
             forge::forge_release_create,
             forge::forge_release_edit,
+            forge::forge_release_sync_updater_notes,
             forge::forge_release_delete,
             forge::forge_release_upload_asset,
             forge::forge_release_delete_asset,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1510,11 +1510,20 @@ impl GitDesktopMcp {
         // Untracked names never pass through a diff, so the ignore patterns have to
         // be applied to them here — a name is disclosure too. Their hidden count
         // joins the diff's: downstream both mean "in-progress changes hidden".
-        let (untracked_paths, untracked_excluded) =
-            filter_untracked_by_ai_ignore(&self.repo, untracked_paths, &exclude)
-                .await
-                .map_err(app_err)?;
-        diff.excluded_files += untracked_excluded;
+        let filtered = filter_untracked_by_ai_ignore(&self.repo, untracked_paths, &exclude)
+            .await
+            .map_err(app_err)?;
+        let untracked_paths = filtered.paths;
+        // Held BEFORE the fold: only these may be blamed on the patterns below. An
+        // unreadable name is hidden with no pattern configured at all.
+        let tree_pattern_hidden =
+            diff.excluded_files + filtered.excluded.saturating_sub(filtered.unreadable) > 0;
+        let unreadable_note = if filtered.unreadable > 0 {
+            " Some new files were left out because their names aren't readable text."
+        } else {
+            ""
+        };
+        diff.excluded_files += filtered.excluded;
 
         // Nothing in progress → name the branch after what it has already committed.
         let (diff, untracked_paths, commit_subjects) = if diff.files.is_empty()
@@ -1525,14 +1534,20 @@ impl GitDesktopMcp {
             // deliberately takes no commit subjects — they'd describe the CURRENT
             // branch, biasing the name toward the parent branch's story.
             let Some(base) = committed_base_ref(&self.repo).await else {
-                let msg = if diff.excluded_files > 0 {
+                let msg = if tree_pattern_hidden {
                     "All in-progress changes match the AI ignore patterns — nothing to name a \
                      branch after."
+                } else if filtered.unreadable > 0 {
+                    "The only in-progress changes are new files whose names aren't readable text \
+                     — nothing to name a branch after."
                 } else {
                     "No in-progress changes, and no default branch to compare committed work \
                      against."
                 };
-                return Err(McpError::invalid_request(msg, None));
+                return Err(McpError::invalid_request(
+                    format!("{msg}{}", if tree_pattern_hidden { unreadable_note } else { "" }),
+                    None,
+                ));
             };
             let mut committed = crate::git::compare::git_branch_diff(
                 self.repo.clone(),
@@ -1547,7 +1562,8 @@ impl GitDesktopMcp {
                 // Name the side that actually hid something: claiming in-progress
                 // changes existed when the working tree was clean (or vice versa) is
                 // exactly the kind of confident-but-false reason an agent acts on.
-                let msg = match (diff.excluded_files > 0, committed.excluded_files > 0) {
+                let committed_hidden = committed.excluded_files > 0;
+                let msg = match (tree_pattern_hidden, committed_hidden) {
                     (true, true) => "All in-progress and committed changes match the AI ignore \
                                      patterns — nothing to name a branch after."
                         .to_string(),
@@ -1559,13 +1575,25 @@ impl GitDesktopMcp {
                         "All in-progress changes match the AI ignore patterns, and there are no \
                          committed changes vs {base} — nothing to name a branch after."
                     ),
-                    // Covers being ON the default branch and a fully-merged branch.
+                    // Unreadable names are the only in-progress work left to cite; below
+                    // that, being ON the default branch and a fully-merged branch.
+                    (false, false) if filtered.unreadable > 0 => format!(
+                        "The only in-progress changes are new files whose names aren't readable \
+                         text, and there are no committed changes vs {base} — nothing to name a \
+                         branch after."
+                    ),
                     (false, false) => format!(
                         "No in-progress changes, and no committed changes vs {base} — nothing to \
                          name a branch after."
                     ),
                 };
-                return Err(McpError::invalid_request(msg, None));
+                // A pattern arm cited one cause; unreadable names are a second one.
+                let suffix = if tree_pattern_hidden || committed_hidden {
+                    unreadable_note
+                } else {
+                    ""
+                };
+                return Err(McpError::invalid_request(format!("{msg}{suffix}"), None));
             }
             // Fold the working tree's hidden files into the committed diff's
             // disclosure — they're also changes the model can't see (mirrors the TS
@@ -1776,6 +1804,20 @@ async fn untracked_files(repo: &str) -> Result<Vec<String>, crate::error::AppErr
         .collect())
 }
 
+/// What the AI-ignore filter left of an untracked-name list. Mirrors the TS
+/// `filterPathsByAiIgnore` result (src/lib/ai/ignore.ts). KEEP IN SYNC.
+struct FilteredUntracked {
+    /// The names still safe to show a model.
+    paths: Vec<String>,
+    /// Every hidden name — pattern matches and unreadable ones alike, since the
+    /// disclosure counts what the model can't see, not why.
+    excluded: u32,
+    /// The subset hidden for being unreadable, which no pattern could have matched.
+    /// Broken out because a message that blames the user's patterns for these sends
+    /// them to a list that may well be empty.
+    unreadable: u32,
+}
+
 /// The untracked paths the user's AI-ignore patterns leave visible, and how many
 /// they hide. Runs on the same gitignore engine the diff side is pinned to, and
 /// filters here rather than in `untracked_files` so the names reach the engine as the
@@ -1788,16 +1830,20 @@ async fn filter_untracked_by_ai_ignore(
     repo: &str,
     paths: Vec<String>,
     exclude: &[String],
-) -> Result<(Vec<String>, u32), crate::error::AppError> {
+) -> Result<FilteredUntracked, crate::error::AppError> {
     let matched = crate::git::ai_ignore::filter_ignored(repo, &paths, exclude).await?;
     let matched: std::collections::HashSet<String> = matched.into_iter().collect();
     let total = paths.len();
+    let unreadable = paths.iter().filter(|p| p.contains('\u{FFFD}')).count() as u32;
     let kept: Vec<String> = paths
         .into_iter()
         .filter(|p| !matched.contains(p) && !p.contains('\u{FFFD}'))
         .collect();
-    let excluded = (total - kept.len()) as u32;
-    Ok((kept, excluded))
+    Ok(FilteredUntracked {
+        excluded: (total - kept.len()) as u32,
+        paths: kept,
+        unreadable,
+    })
 }
 
 #[cfg(test)]
@@ -2661,19 +2707,23 @@ mod tests {
             "secrets/customer-list.md".to_string(),
             "src/app.rs".to_string(),
         ];
-        let (visible, excluded) =
+        let filtered =
             filter_untracked_by_ai_ignore(&repo_s, untracked, &["secrets/".to_string()])
                 .await
                 .expect("filter untracked");
-        assert_eq!(visible, vec!["src/app.rs".to_string()]);
-        assert_eq!(excluded, 1);
+        assert_eq!(filtered.paths, vec!["src/app.rs".to_string()]);
+        assert_eq!(filtered.excluded, 1);
+        assert_eq!(
+            filtered.unreadable, 0,
+            "a pattern match is not an unreadable name"
+        );
 
         let recipe = assemble_branch_recipe(BranchPieces {
             diff_text: String::new(),
             diff_truncated: false,
             files: vec![],
-            untracked_paths: visible,
-            excluded_files: excluded,
+            untracked_paths: filtered.paths,
+            excluded_files: filtered.excluded,
             recent_branches: vec![],
             commit_subjects: vec![],
             repo_instructions: None,
@@ -2705,11 +2755,14 @@ mod tests {
         git(&repo_s, &["init", "-q"]).await;
 
         let paths = vec!["ok.rs".to_string(), "sec\u{FFFD}ret.md".to_string()];
-        let (visible, excluded) = filter_untracked_by_ai_ignore(&repo_s, paths, &[])
+        let filtered = filter_untracked_by_ai_ignore(&repo_s, paths, &[])
             .await
             .expect("filter untracked");
-        assert_eq!(visible, vec!["ok.rs".to_string()]);
-        assert_eq!(excluded, 1);
+        assert_eq!(filtered.paths, vec!["ok.rs".to_string()]);
+        assert_eq!(filtered.excluded, 1);
+        // Counted apart from the pattern hits, so no message can blame the (empty)
+        // pattern list for it.
+        assert_eq!(filtered.unreadable, 1);
     }
 
     /// `-z` keeps the listed names byte-exact: a name with a space stays whole, and a
@@ -2744,11 +2797,11 @@ mod tests {
         );
     }
 
-    /// `GD_SETTINGS_DIR` is process-global, so the tests that depend on the settings
-    /// store take this lock: one sets the override, the other requires it unset. Any
+    /// The store override is process-wide, so the tests that depend on the settings
+    /// store take this lock: one installs an override, the other requires none. Any
     /// future test driving `build_commit_recipe` or `build_pr_recipe` reads the store
-    /// too and must join the lock (and set the override through the guard below).
-    /// Poisoning is ignored — the guarded state is an env var, not invariant data.
+    /// too and must join the lock (and install its override through the guard below).
+    /// Poisoning is ignored — the guarded state is one override slot, not invariant data.
     static SETTINGS_STORE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn settings_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -2757,25 +2810,23 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Sets `GD_SETTINGS_DIR` for as long as it's held and restores the prior value on
-    /// drop — panics included, so a failing test can't leave the override standing for
-    /// whichever test is next through the lock.
-    struct SettingsDirOverride(Option<std::ffi::OsString>);
+    /// Points the settings reader at `dir` for as long as it's held and restores the
+    /// prior override on drop — panics included, so a failing test can't leave one
+    /// standing for whichever test is next through the lock. In-process, never process
+    /// env: `setenv` racing the other tests' env reads is unsound, not just flaky.
+    struct SettingsDirOverride(Option<std::path::PathBuf>);
 
     impl SettingsDirOverride {
         fn set(dir: &std::path::Path) -> Self {
-            let previous = std::env::var_os("GD_SETTINGS_DIR");
-            std::env::set_var("GD_SETTINGS_DIR", dir);
-            Self(previous)
+            Self(crate::app_store::swap_test_store_dir(Some(
+                dir.to_path_buf(),
+            )))
         }
     }
 
     impl Drop for SettingsDirOverride {
         fn drop(&mut self) {
-            match self.0.take() {
-                Some(previous) => std::env::set_var("GD_SETTINGS_DIR", previous),
-                None => std::env::remove_var("GD_SETTINGS_DIR"),
-            }
+            crate::app_store::swap_test_store_dir(self.0.take());
         }
     }
 
@@ -2784,18 +2835,18 @@ mod tests {
     #[test]
     fn settings_dir_override_restores_after_a_panic() {
         let _guard = settings_lock();
-        let before = std::env::var_os("GD_SETTINGS_DIR");
+        let before = crate::app_store::test_store_dir();
         let dir = std::env::temp_dir();
 
         let result = std::panic::catch_unwind(|| {
             let _override = SettingsDirOverride::set(&dir);
-            assert!(std::env::var_os("GD_SETTINGS_DIR").is_some());
+            assert!(crate::app_store::test_store_dir().is_some());
             panic!("boom");
         });
 
         assert!(result.is_err(), "the probe must actually panic");
         assert_eq!(
-            std::env::var_os("GD_SETTINGS_DIR"),
+            crate::app_store::test_store_dir(),
             before,
             "the override must not outlive the test that set it"
         );

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1778,19 +1778,24 @@ async fn untracked_files(repo: &str) -> Result<Vec<String>, crate::error::AppErr
 
 /// The untracked paths the user's AI-ignore patterns leave visible, and how many
 /// they hide. Runs on the same gitignore engine the diff side is pinned to, and
-/// filters at this call site so `untracked_files` stays raw for other callers.
+/// filters here rather than in `untracked_files` so the names reach the engine as the
+/// bytes the rules were written against, unnormalized.
+///
+/// A name carrying U+FFFD is hidden unconditionally: the path was not valid UTF-8, the
+/// lossy decode already replaced those bytes, and no rule can match what the user
+/// actually named — so it fails CLOSED (a real U+FFFD in a name is hidden too).
 async fn filter_untracked_by_ai_ignore(
     repo: &str,
     paths: Vec<String>,
     exclude: &[String],
 ) -> Result<(Vec<String>, u32), crate::error::AppError> {
-    let hidden = crate::git::ai_ignore::filter_ignored(repo, &paths, exclude).await?;
-    if hidden.is_empty() {
-        return Ok((paths, 0));
-    }
-    let hidden: std::collections::HashSet<String> = hidden.into_iter().collect();
+    let matched = crate::git::ai_ignore::filter_ignored(repo, &paths, exclude).await?;
+    let matched: std::collections::HashSet<String> = matched.into_iter().collect();
     let total = paths.len();
-    let kept: Vec<String> = paths.into_iter().filter(|p| !hidden.contains(p)).collect();
+    let kept: Vec<String> = paths
+        .into_iter()
+        .filter(|p| !matched.contains(p) && !p.contains('\u{FFFD}'))
+        .collect();
     let excluded = (total - kept.len()) as u32;
     Ok((kept, excluded))
 }
@@ -2684,6 +2689,29 @@ mod tests {
             .contains("[1 additional changed file(s) hidden by the user's AI ignore rules]"));
     }
 
+    /// A name that lost bytes to the lossy decode (invalid UTF-8 on disk — reachable on
+    /// Linux/macOS, not creatable on Windows, so it's fed in as a String here) can match
+    /// no rule the user could write, and is hidden on that basis alone: no pattern is
+    /// configured here, and it is still dropped and counted.
+    #[tokio::test]
+    async fn untracked_names_that_lost_bytes_are_hidden() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-untracked-lossy-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+
+        let paths = vec!["ok.rs".to_string(), "sec\u{FFFD}ret.md".to_string()];
+        let (visible, excluded) = filter_untracked_by_ai_ignore(&repo_s, paths, &[])
+            .await
+            .expect("filter untracked");
+        assert_eq!(visible, vec!["ok.rs".to_string()]);
+        assert_eq!(excluded, 1);
+    }
+
     /// `-z` keeps the listed names byte-exact: a name with a space stays whole, and a
     /// non-ASCII one arrives raw rather than C-quoted (`"caf\303\251.txt"`), which is
     /// what makes it comparable to the AI-ignore rules at all. The other quoted shapes
@@ -2717,7 +2745,9 @@ mod tests {
     }
 
     /// `GD_SETTINGS_DIR` is process-global, so the tests that depend on the settings
-    /// store take this lock: one sets the override, the other requires it unset.
+    /// store take this lock: one sets the override, the other requires it unset. Any
+    /// future test driving `build_commit_recipe` or `build_pr_recipe` reads the store
+    /// too and must join the lock (and set the override through the guard below).
     /// Poisoning is ignored — the guarded state is an env var, not invariant data.
     static SETTINGS_STORE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -2725,6 +2755,50 @@ mod tests {
         SETTINGS_STORE_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Sets `GD_SETTINGS_DIR` for as long as it's held and restores the prior value on
+    /// drop — panics included, so a failing test can't leave the override standing for
+    /// whichever test is next through the lock.
+    struct SettingsDirOverride(Option<std::ffi::OsString>);
+
+    impl SettingsDirOverride {
+        fn set(dir: &std::path::Path) -> Self {
+            let previous = std::env::var_os("GD_SETTINGS_DIR");
+            std::env::set_var("GD_SETTINGS_DIR", dir);
+            Self(previous)
+        }
+    }
+
+    impl Drop for SettingsDirOverride {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(previous) => std::env::set_var("GD_SETTINGS_DIR", previous),
+                None => std::env::remove_var("GD_SETTINGS_DIR"),
+            }
+        }
+    }
+
+    /// The restore is what keeps a failing store test from deciding the next one, so it
+    /// has to survive an unwind — the `boom` panic in this test's output is expected.
+    #[test]
+    fn settings_dir_override_restores_after_a_panic() {
+        let _guard = settings_lock();
+        let before = std::env::var_os("GD_SETTINGS_DIR");
+        let dir = std::env::temp_dir();
+
+        let result = std::panic::catch_unwind(|| {
+            let _override = SettingsDirOverride::set(&dir);
+            assert!(std::env::var_os("GD_SETTINGS_DIR").is_some());
+            panic!("boom");
+        });
+
+        assert!(result.is_err(), "the probe must actually panic");
+        assert_eq!(
+            std::env::var_os("GD_SETTINGS_DIR"),
+            before,
+            "the override must not outlive the test that set it"
+        );
     }
 
     /// A repo whose only in-progress changes are two untracked files, one of them
@@ -2797,12 +2871,12 @@ mod tests {
         )
         .unwrap();
 
-        std::env::set_var("GD_SETTINGS_DIR", &store_dir);
+        let _override = SettingsDirOverride::set(&store_dir);
         let mcp = GitDesktopMcp::with_options(repo_s, false, false, false, false);
-        let result = mcp.build_branch_recipe().await;
-        std::env::remove_var("GD_SETTINGS_DIR");
-
-        let err = result.expect_err("every change is ignored — nothing to name");
+        let err = mcp
+            .build_branch_recipe()
+            .await
+            .expect_err("every change is ignored — nothing to name");
         assert!(
             err.message.contains("match the AI ignore patterns"),
             "message: {}",

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1495,7 +1495,7 @@ impl GitDesktopMcp {
         let exclude = self.ai_ignore_patterns(&settings).await?;
 
         // Whole-worktree diff vs HEAD (the TS uses git_staged_diff with worktree=true).
-        let diff = crate::git::diff::git_staged_diff(
+        let mut diff = crate::git::diff::git_staged_diff(
             self.repo.clone(),
             Some(RAW_DIFF_MAX_BYTES),
             Some(exclude.clone()),
@@ -1507,6 +1507,14 @@ impl GitDesktopMcp {
         // `git diff HEAD` omits untracked files; list their paths so a branch made
         // entirely of new files can still be named (mirrors the in-app call site).
         let untracked_paths = untracked_files(&self.repo).await.map_err(app_err)?;
+        // Untracked names never pass through a diff, so the ignore patterns have to
+        // be applied to them here — a name is disclosure too. Their hidden count
+        // joins the diff's: downstream both mean "in-progress changes hidden".
+        let (untracked_paths, untracked_excluded) =
+            filter_untracked_by_ai_ignore(&self.repo, untracked_paths, &exclude)
+                .await
+                .map_err(app_err)?;
+        diff.excluded_files += untracked_excluded;
 
         // Nothing in progress → name the branch after what it has already committed.
         let (diff, untracked_paths, commit_subjects) = if diff.files.is_empty()
@@ -1748,21 +1756,43 @@ async fn committed_base_ref(repo: &str) -> Option<String> {
     None
 }
 
-/// Untracked (new) file paths, `git ls-files --others --exclude-standard`.
+/// Untracked (new) file paths, NUL-separated and raw — these names are matched
+/// against the user's AI-ignore rules, so any rewriting of them fails OPEN. Without
+/// `-z` git C-quotes a name holding a quote, backslash, or non-ASCII byte
+/// (`"caf\303\251.txt"`), and trimming would fold a trailing-space name onto a
+/// different name's spelling; either way the rule that covers it stops matching.
 async fn untracked_files(repo: &str) -> Result<Vec<String>, crate::error::AppError> {
     let out = crate::git::runner::run_git(
         Some(repo),
-        &["ls-files", "--others", "--exclude-standard"],
+        &["ls-files", "--others", "--exclude-standard", "-z"],
         crate::git::runner::DEFAULT_TIMEOUT,
     )
     .await?;
     Ok(out
         .stdout_lossy()
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
+        .split('\0')
+        .filter(|p| !p.is_empty())
         .map(str::to_string)
         .collect())
+}
+
+/// The untracked paths the user's AI-ignore patterns leave visible, and how many
+/// they hide. Runs on the same gitignore engine the diff side is pinned to, and
+/// filters at this call site so `untracked_files` stays raw for other callers.
+async fn filter_untracked_by_ai_ignore(
+    repo: &str,
+    paths: Vec<String>,
+    exclude: &[String],
+) -> Result<(Vec<String>, u32), crate::error::AppError> {
+    let hidden = crate::git::ai_ignore::filter_ignored(repo, &paths, exclude).await?;
+    if hidden.is_empty() {
+        return Ok((paths, 0));
+    }
+    let hidden: std::collections::HashSet<String> = hidden.into_iter().collect();
+    let total = paths.len();
+    let kept: Vec<String> = paths.into_iter().filter(|p| !hidden.contains(p)).collect();
+    let excluded = (total - kept.len()) as u32;
+    Ok((kept, excluded))
 }
 
 #[cfg(test)]
@@ -2606,6 +2636,177 @@ mod tests {
             branch_commit_subjects(&repo_s, &base_sha).await,
             vec!["fix: second".to_string(), "feat: first".to_string()],
             "git log order — newest first"
+        );
+    }
+
+    /// Untracked file NAMES are a disclosure of their own: an ignored one is dropped
+    /// from the recipe's file list and counted in the hidden-files note instead.
+    #[tokio::test]
+    async fn branch_untracked_paths_drop_ai_ignored_names() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-untracked-ignore-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+
+        let untracked = vec![
+            "secrets/customer-list.md".to_string(),
+            "src/app.rs".to_string(),
+        ];
+        let (visible, excluded) =
+            filter_untracked_by_ai_ignore(&repo_s, untracked, &["secrets/".to_string()])
+                .await
+                .expect("filter untracked");
+        assert_eq!(visible, vec!["src/app.rs".to_string()]);
+        assert_eq!(excluded, 1);
+
+        let recipe = assemble_branch_recipe(BranchPieces {
+            diff_text: String::new(),
+            diff_truncated: false,
+            files: vec![],
+            untracked_paths: visible,
+            excluded_files: excluded,
+            recent_branches: vec![],
+            commit_subjects: vec![],
+            repo_instructions: None,
+            global_instructions: String::new(),
+        });
+        assert!(recipe.prompt.contains("src/app.rs (new file)"));
+        assert!(
+            !recipe.prompt.contains("customer-list"),
+            "an ignored untracked name must never reach the prompt"
+        );
+        assert!(recipe
+            .prompt
+            .contains("[1 additional changed file(s) hidden by the user's AI ignore rules]"));
+    }
+
+    /// `-z` keeps the listed names byte-exact: a name with a space stays whole, and a
+    /// non-ASCII one arrives raw rather than C-quoted (`"caf\303\251.txt"`), which is
+    /// what makes it comparable to the AI-ignore rules at all. The other quoted shapes
+    /// — a trailing space, an embedded quote or backslash — can't be fixtured on
+    /// Windows, which rejects those filenames outright.
+    #[tokio::test]
+    async fn untracked_files_reads_names_verbatim() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-untracked-names-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(repo.join("sub dir")).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+
+        std::fs::write(repo.join("plain.rs"), "x\n").unwrap();
+        std::fs::write(repo.join("sub dir").join("a b.md"), "x\n").unwrap();
+        std::fs::write(repo.join("café.txt"), "x\n").unwrap();
+
+        let mut names = untracked_files(&repo_s).await.expect("list untracked");
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "café.txt".to_string(),
+                "plain.rs".to_string(),
+                "sub dir/a b.md".to_string(),
+            ]
+        );
+    }
+
+    /// `GD_SETTINGS_DIR` is process-global, so the tests that depend on the settings
+    /// store take this lock: one sets the override, the other requires it unset.
+    /// Poisoning is ignored — the guarded state is an env var, not invariant data.
+    static SETTINGS_STORE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn settings_lock() -> std::sync::MutexGuard<'static, ()> {
+        SETTINGS_STORE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// A repo whose only in-progress changes are two untracked files, one of them
+    /// covered by the repo's own `.gitdesktop/aiignore`. Returns the temp dir (kept
+    /// alive by the caller) and the repo path.
+    async fn branch_ignore_fixture() -> (tempfile::TempDir, String) {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-branch-untracked-recipe-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(repo.join(".gitdesktop")).unwrap();
+        std::fs::create_dir_all(repo.join("secrets")).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        // The ignore file is committed with the seed, so the only untracked names are
+        // the two below and the hidden count is exact.
+        std::fs::write(repo.join(".gitdesktop").join("aiignore"), "secrets/\n").unwrap();
+        std::fs::write(repo.join("seed"), "seed\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+
+        std::fs::write(repo.join("secrets").join("customer-list.md"), "x\n").unwrap();
+        std::fs::write(repo.join("new-feature.rs"), "x\n").unwrap();
+        (base_dir, repo_s)
+    }
+
+    /// The branch recipe counts ignored UNTRACKED names in its hidden-files note: the
+    /// fold has to happen before the note is assembled, or an ignored new file goes
+    /// undisclosed. Exact counts hold because no settings store is read under
+    /// `cfg(test)` (app_store's `resolve_store_dir`), so the repo's own ignore file is
+    /// the whole pattern set.
+    #[tokio::test]
+    async fn branch_recipe_counts_ignored_untracked_names() {
+        let _guard = settings_lock();
+        let (_tmp, repo_s) = branch_ignore_fixture().await;
+
+        let mcp = GitDesktopMcp::with_options(repo_s, false, false, false, false);
+        let recipe = mcp.build_branch_recipe().await.expect("assemble recipe");
+
+        assert!(recipe.prompt.contains("new-feature.rs (new file)"));
+        assert!(
+            !recipe.prompt.contains("customer-list"),
+            "an ignored untracked name must never reach the prompt"
+        );
+        assert!(
+            recipe
+                .prompt
+                .contains("[1 additional changed file(s) hidden by the user's AI ignore rules]"),
+            "exactly one hidden file, folded in before the note was assembled:\n{}",
+            recipe.prompt
+        );
+    }
+
+    /// The store IS consulted when one is resolvable — pinned through the override arm
+    /// with a pattern a user could really hold (`*` hides everything, so the recipe
+    /// must refuse and say why). The twin above owes its exactness to the arm that
+    /// keeps the developer's real store out of every test.
+    #[tokio::test]
+    async fn branch_recipe_reads_the_resolved_settings_store() {
+        let _guard = settings_lock();
+        let (tmp, repo_s) = branch_ignore_fixture().await;
+        let store_dir = tmp.path().join("store");
+        std::fs::create_dir_all(&store_dir).unwrap();
+        std::fs::write(
+            store_dir.join("settings.json"),
+            r#"{"settings":{"aiIgnorePatterns":"*"}}"#,
+        )
+        .unwrap();
+
+        std::env::set_var("GD_SETTINGS_DIR", &store_dir);
+        let mcp = GitDesktopMcp::with_options(repo_s, false, false, false, false);
+        let result = mcp.build_branch_recipe().await;
+        std::env::remove_var("GD_SETTINGS_DIR");
+
+        let err = result.expect_err("every change is ignored — nothing to name");
+        assert!(
+            err.message.contains("match the AI ignore patterns"),
+            "message: {}",
+            err.message
         );
     }
 

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -68,8 +68,9 @@ fn default_true() -> bool {
 /// `literal: false`. Getting that wrong fails loudly for stage/unstage
 /// ("did not match any files", measured exit 128) — but NOT for `stash_push`:
 /// `git stash push` with a matched-nothing pathspec no-ops at exit 0
-/// ("No local changes to save", measured), so that tool reports success on a
-/// literalized glob that stashed nothing.
+/// ("No local changes to save", measured), so `git_stash_paths_core` reports
+/// whether an entry was created and the tool answers "nothing was stashed"
+/// rather than letting the exit code speak.
 ///
 /// Used by `stage_files`, `unstage_files` and `stash_push` — not staging alone:
 /// `stash_push` sweeps the files it matches OUT of the working tree, so an
@@ -536,10 +537,18 @@ impl GitDesktopMcp {
                 ensure_not_flag(p, "path")?;
             }
             let paths = literal_pathspecs(args.paths, args.literal);
-            crate::git::ops::git_stash_paths_core(&self.state, self.repo.clone(), paths)
-                .await
-                .map_err(app_err)?;
-            ok_text("stashed selected paths")
+            let stashed = crate::git::ops::git_stash_paths_core(
+                &self.state,
+                self.repo.clone(),
+                paths,
+            )
+            .await
+            .map_err(app_err)?;
+            if stashed {
+                ok_text("stashed selected paths")
+            } else {
+                ok_text("no changes matched the given paths — nothing was stashed")
+            }
         }
     }
 

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -227,6 +227,7 @@ export function MarkdownEditor({
   rows = 7,
   disabled,
   autoFocus,
+  fill,
   textareaClassName,
   actions,
   "aria-label": ariaLabel,
@@ -240,6 +241,9 @@ export function MarkdownEditor({
   rows?: number;
   disabled?: boolean;
   autoFocus?: boolean;
+  /** Grow the input (and Preview) to the parent flex column's spare height,
+   *  instead of the default capped box. The caller owns a `min-h-0` column. */
+  fill?: boolean;
   textareaClassName?: string;
   actions?: ReactNode;
   "aria-label"?: string;
@@ -381,7 +385,12 @@ export function MarkdownEditor({
   }, [focusIntoView]);
 
   return (
-    <div className="space-y-1.5">
+    <div
+      // No `min-h-0` on the fill root: `min-height: auto` floors it at its content
+      // minimum, so a short window scrolls the parent instead of shrinking the
+      // editor past the textarea's floor and painting it over the fields below.
+      className={fill ? "flex flex-1 flex-col gap-1.5" : "space-y-1.5"}
+    >
       <div className="flex items-center gap-1">
         <Button
           type="button"
@@ -459,10 +468,19 @@ export function MarkdownEditor({
         onKeyDown={handleKeyDown}
         rows={rows}
         disabled={disabled}
-        className={cn(textareaClassName, mode === "preview" && "hidden")}
+        className={cn(
+          fill && "min-h-0 flex-1",
+          textareaClassName,
+          mode === "preview" && "hidden",
+        )}
       />
       {mode === "preview" && (
-        <div className="max-h-72 min-h-24 overflow-y-auto border border-input px-3 py-2">
+        <div
+          className={cn(
+            fill ? "min-h-24 flex-1" : "max-h-72 min-h-24",
+            "overflow-y-auto border border-input px-3 py-2",
+          )}
+        >
           {value.trim() ? (
             <Markdown>{value}</Markdown>
           ) : (

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -241,8 +241,10 @@ export function MarkdownEditor({
   rows?: number;
   disabled?: boolean;
   autoFocus?: boolean;
-  /** Grow the input (and Preview) to the parent flex column's spare height,
-   *  instead of the default capped box. The caller owns a `min-h-0` column. */
+  /** Grow the input (and Preview) to the parent flex column's spare height instead
+   *  of the default capped box. Every fill-mode box keeps a min-height floor so a
+   *  short window scrolls the parent rather than collapsing the editor; the
+   *  textarea's floor is `min-h-24`, overridable via `textareaClassName`. */
   fill?: boolean;
   textareaClassName?: string;
   actions?: ReactNode;
@@ -469,7 +471,7 @@ export function MarkdownEditor({
         rows={rows}
         disabled={disabled}
         className={cn(
-          fill && "min-h-0 flex-1",
+          fill && "min-h-24 flex-1",
           textareaClassName,
           mode === "preview" && "hidden",
         )}

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -243,8 +243,10 @@ export function MarkdownEditor({
   autoFocus?: boolean;
   /** Grow the input (and Preview) to the parent flex column's spare height instead
    *  of the default capped box. Every fill-mode box keeps a min-height floor so a
-   *  short window scrolls the parent rather than collapsing the editor; the
-   *  textarea's floor is `min-h-24`, overridable via `textareaClassName`. */
+   *  short window scrolls the parent rather than collapsing the editor. Only the
+   *  textarea's floor is caller-tunable (`min-h-24`, overridden via
+   *  `textareaClassName`); Preview's stays fixed at `min-h-24`, so a call site that
+   *  raises the textarea's floor gets a slightly shorter minimum in Preview. */
   fill?: boolean;
   textareaClassName?: string;
   actions?: ReactNode;

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1138,9 +1138,9 @@ provider differences).
 - **Create a release** from a tag: set the title and notes, mark it a **pre-release** or
   **draft**, and publish. Releases show badges (**Latest**, **Pre-release**, **Draft**).
 - **Edit a release** — revise its title and notes any time, in an editor that fills the
-  dialog. When the release carries a \`latest.json\` updater manifest, the dialog offers
-  to update the manifest's notes in the same save, so the "what's new" that installed
-  apps show on update matches the release page.
+  dialog. When a **GitHub** release carries a \`latest.json\` updater manifest, the dialog
+  offers to update the manifest's notes in the same save, so the "what's new" that
+  installed apps show on update matches the release page.
 {{ai}}- **Generate release notes with AI** — draft the notes from the commits and
   changelog between this tag and the previous one, then edit before publishing.{{/ai}}
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1137,6 +1137,10 @@ provider differences).
 - See every tag and **create a tag** (also available from a commit in History).
 - **Create a release** from a tag: set the title and notes, mark it a **pre-release** or
   **draft**, and publish. Releases show badges (**Latest**, **Pre-release**, **Draft**).
+- **Edit a release** — revise its title and notes any time, in an editor that fills the
+  dialog. When the release carries a \`latest.json\` updater manifest, the dialog offers
+  to update the manifest's notes in the same save, so the "what's new" that installed
+  apps show on update matches the release page.
 {{ai}}- **Generate release notes with AI** — draft the notes from the commits and
   changelog between this tag and the previous one, then edit before publishing.{{/ai}}
 

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -158,8 +158,9 @@ export function useGenerateBranchName(repoPath: string) {
             ? `All your in-progress changes match your AI ignore patterns, and there are no net changes vs ${fallback.base} to name a branch after.`
             : "All changes match your AI ignore patterns — nothing to name a branch after.";
         } else if (untracked.unreadable > 0) {
-          message =
-            "Nothing to name a branch after — the only new files have names that aren't readable text.";
+          message = fallback
+            ? `The only in-progress changes are new files whose names aren't readable text, and there are no net changes vs ${fallback.base} to name a branch after.`
+            : "Nothing to name a branch after — the only new files have names that aren't readable text.";
         } else if (fallback) {
           message = opts.useWorkingTree
             ? `No in-progress changes, and no net changes vs ${fallback.base} to name a branch after.`

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
-import { aiExcludePatterns } from "@/lib/ai/ignore";
+import { aiExcludePatterns, filterPathsByAiIgnore } from "@/lib/ai/ignore";
 import { buildBranchNamePrompt, extractBranchName } from "@/lib/ai/prompt";
 import {
   gitBranchDiff,
@@ -61,17 +61,6 @@ export function useGenerateBranchName(repoPath: string) {
           settings.aiIgnorePatterns,
         );
 
-        const [diff, repoInstructions] = await Promise.all([
-          opts.useWorkingTree
-            ? gitStagedDiff(repoPath, {
-                maxBytes: RAW_DIFF_MAX_BYTES,
-                exclude,
-                worktree: true,
-              })
-            : null,
-          readRepoInstructions(repoPath),
-        ]);
-
         // `git diff HEAD` omits untracked files; bring their names in so a
         // branch made of all-new files can still be named.
         const untrackedPaths = opts.useWorkingTree
@@ -80,13 +69,27 @@ export function useGenerateBranchName(repoPath: string) {
               .map((e) => e.path)
           : [];
 
-        if (diff && (diff.files.length > 0 || untrackedPaths.length > 0)) {
+        const [diff, repoInstructions, untracked] = await Promise.all([
+          opts.useWorkingTree
+            ? gitStagedDiff(repoPath, {
+                maxBytes: RAW_DIFF_MAX_BYTES,
+                exclude,
+                worktree: true,
+              })
+            : null,
+          readRepoInstructions(repoPath),
+          // Untracked names never pass through a diff, so the ignore patterns
+          // have to be applied to them here — a name is disclosure too.
+          filterPathsByAiIgnore({ repoPath, paths: untrackedPaths, exclude }),
+        ]);
+
+        if (diff && (diff.files.length > 0 || untracked.paths.length > 0)) {
           return buildBranchNamePrompt({
             diffText: diff.text,
             diffTruncated: diff.truncated,
             files: diff.files,
-            untrackedPaths,
-            excludedFiles: diff.excludedFiles,
+            untrackedPaths: untracked.paths,
+            excludedFiles: diff.excludedFiles + untracked.excluded,
             commitSubjects: opts.workingTreeSubjects,
             recentBranches: opts.recentBranches,
             repoInstructions,
@@ -117,10 +120,14 @@ export function useGenerateBranchName(repoPath: string) {
             diffTruncated: committed.truncated,
             files: committed.files,
             untrackedPaths: [],
-            // Both sides' hidden files. A file hidden in BOTH diffs counts
-            // twice — deliberately: the sum errs toward disclosing more than is
-            // hidden, never less, and there's no per-path list to dedupe on.
-            excludedFiles: committed.excludedFiles + (diff?.excludedFiles ?? 0),
+            // Both sides' hidden files, plus the working tree's hidden
+            // untracked names. A file hidden in BOTH diffs counts twice —
+            // deliberately: the sum errs toward disclosing more than is hidden,
+            // never less, and there's no per-path list to dedupe on.
+            excludedFiles:
+              committed.excludedFiles +
+              (diff?.excludedFiles ?? 0) +
+              untracked.excluded,
             commitSubjects: fallback.subjects,
             recentBranches: opts.recentBranches,
             repoInstructions,
@@ -130,7 +137,8 @@ export function useGenerateBranchName(repoPath: string) {
 
         // Nothing to name it after — say which side (if either) was emptied by
         // the ignore patterns rather than genuinely having no changes.
-        const treeHidden = diff !== null && diff.excludedFiles > 0;
+        const treeHidden =
+          diff !== null && (diff.excludedFiles > 0 || untracked.excluded > 0);
         const committedHidden =
           committed !== null && committed.excludedFiles > 0;
         let message: string;

--- a/src/features/repository/useGenerateBranchName.ts
+++ b/src/features/repository/useGenerateBranchName.ts
@@ -136,9 +136,14 @@ export function useGenerateBranchName(repoPath: string) {
         }
 
         // Nothing to name it after — say which side (if either) was emptied by
-        // the ignore patterns rather than genuinely having no changes.
+        // the ignore patterns rather than genuinely having no changes. Only the
+        // PATTERN-hidden files may be attributed to the patterns: an unreadable
+        // name is hidden with no pattern configured at all, and blaming the
+        // user's list would send them to an empty settings page.
         const treeHidden =
-          diff !== null && (diff.excludedFiles > 0 || untracked.excluded > 0);
+          diff !== null &&
+          (diff.excludedFiles > 0 ||
+            untracked.excluded - untracked.unreadable > 0);
         const committedHidden =
           committed !== null && committed.excludedFiles > 0;
         let message: string;
@@ -152,6 +157,9 @@ export function useGenerateBranchName(repoPath: string) {
           message = fallback
             ? `All your in-progress changes match your AI ignore patterns, and there are no net changes vs ${fallback.base} to name a branch after.`
             : "All changes match your AI ignore patterns — nothing to name a branch after.";
+        } else if (untracked.unreadable > 0) {
+          message =
+            "Nothing to name a branch after — the only new files have names that aren't readable text.";
         } else if (fallback) {
           message = opts.useWorkingTree
             ? `No in-progress changes, and no net changes vs ${fallback.base} to name a branch after.`
@@ -162,6 +170,12 @@ export function useGenerateBranchName(repoPath: string) {
           // Defensive: the caller disables the affordance in this state, and
           // with no working tree read there are no in-progress changes to cite.
           message = "Nothing to name this branch after.";
+        }
+        // A pattern arm cited one cause; unreadable names are a second one, and
+        // the arms below it are only reachable when there are none.
+        if (untracked.unreadable > 0 && (treeHidden || committedHidden)) {
+          message +=
+            " Some new files were also left out because their names aren't readable text.";
         }
         toast.error(message);
         return null;

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -248,9 +248,11 @@ export function CreateReleaseDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      {/* A fixed height (not a cap): release bodies routinely run thousands of
+          lines, so the notes editor claims the dialog's whole spare height. */}
+      <DialogContent className="flex h-[85vh] flex-col sm:max-w-2xl">
         <form
-          className="flex min-h-0 flex-col gap-4"
+          className="flex min-h-0 flex-1 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
             form.handleSubmit();
@@ -267,7 +269,7 @@ export function CreateReleaseDialog({
           </DialogHeader>
 
           {/* Fields scroll; header and submit footer stay pinned. */}
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label htmlFor="rel-tag">Tag</Label>
@@ -351,7 +353,7 @@ export function CreateReleaseDialog({
               )}
             </form.AppField>
 
-            <div className="space-y-1.5">
+            <div className="flex flex-1 flex-col gap-1.5">
               <div className="flex items-center justify-between gap-2">
                 <Label>Release notes</Label>
                 {existingTags.length > 0 && (
@@ -399,7 +401,9 @@ export function CreateReleaseDialog({
                 onChange={(v) => form.setFieldValue("notes", v)}
                 placeholder="What's changed… (or generate notes above)"
                 rows={8}
-                textareaClassName="max-h-72 min-h-32 resize-y font-mono"
+                fill
+                // No `resize-y`: a manual drag height fights the flex sizing.
+                textareaClassName="min-h-32 font-mono"
                 actions={
                   // GitLab's only generator is the AI one — with AI hidden the
                   // menu would hold a single disabled item, so hide it entirely.

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -400,9 +400,9 @@ export function CreateReleaseDialog({
                 value={notes}
                 onChange={(v) => form.setFieldValue("notes", v)}
                 placeholder="What's changed… (or generate notes above)"
-                rows={8}
                 fill
-                // No `resize-y`: a manual drag height fights the flex sizing.
+                // No `rows`/`resize-y` in fill mode: the explicit floor plus
+                // `flex-1` set the height, and a manual drag fights the flex sizing.
                 textareaClassName="min-h-32 font-mono"
                 actions={
                   // GitLab's only generator is the AI one — with AI hidden the

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -27,6 +27,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { presentError } from "@/lib/error-summary";
+import { UPDATER_MANIFEST_NAME } from "@/lib/git/api";
 import {
   forgeFeatureReady,
   useCheckoutCommit,
@@ -151,7 +152,7 @@ export function TagDetailView({
     // the other release writes (`canManage` also opens on a ready GitLab repo):
     // there is no GitLab arm to fall back to here.
     const canSyncUpdater =
-      canWrite && rel.assets.some((a) => a.name === "latest.json");
+      canWrite && rel.assets.some((a) => a.name === UPDATER_MANIFEST_NAME);
     // An armed sync makes Save two-phase; dismissing between the phases would fire the
     // manifest upload at a closed dialog, so the whole operation latches. A plain edit
     // (nothing armed) stays dismissible exactly as it always was.

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -141,11 +141,17 @@ export function TagDetailView({
 
   // ── Release view ───────────────────────────────────────────────────────────
   if (rel) {
-    // The updater manifest is a GitHub-only Tauri asset (`canWrite` is the same
-    // GitHub-or-pending shape the other release writes use), so the sync affordance
-    // only makes sense on a release that actually ships one.
+    // The updater manifest is a GitHub-only Tauri asset, so the sync affordance only
+    // makes sense on a release that actually ships one. Deliberately STRICTER than
+    // the other release writes (`canManage` also opens on a ready GitLab repo):
+    // there is no GitLab arm to fall back to here.
     const canSyncUpdater =
       canWrite && rel.assets.some((a) => a.name === "latest.json");
+    // Arming the sync makes Save two-phase; dismissing between the phases would fire
+    // the manifest upload at a closed dialog, so the whole operation latches. A plain
+    // edit (box off) stays dismissible exactly as it always was.
+    const savePending = editRelease.isPending || syncUpdaterNotes.isPending;
+    const saveLatched = canSyncUpdater && editSyncUpdater && savePending;
     return (
       <div className="flex h-full flex-col">
         <header className="space-y-2 border-b px-4 py-3">
@@ -360,12 +366,10 @@ export function TagDetailView({
           </div>
         </ScrollArea>
 
-        {/* Latched while the manifest uploads: dismissing mid-sync would hide a
-            partial state the user still needs to act on. */}
         <Dialog
           open={editOpen}
           onOpenChange={(o) => {
-            if (!syncUpdaterNotes.isPending) setEditOpen(o);
+            if (!saveLatched) setEditOpen(o);
           }}
         >
           {/* A fixed height (not a cap): release bodies routinely run thousands of
@@ -410,13 +414,15 @@ export function TagDetailView({
                           },
                           onError: (err) => {
                             // `--clobber` deletes before it uploads, so a failure
-                            // here can leave the asset gone, not merely stale.
-                            toast.error(
-                              "Release updated — the updater manifest may be missing.",
-                              {
-                                duration: 8000,
-                                description: `${presentError(err).summary} — save this release again with "Also update the updater manifest" on to restore it.`,
-                              },
+                            // here can leave the asset gone rather than stale — and
+                            // re-running this dialog can't recover it (the checkbox
+                            // is gated on the asset that's now missing). The backend
+                            // parks the patched file and names its path, so route
+                            // through toastError: Details carries that path.
+                            toastError(
+                              new Error(
+                                `Release updated — the updater manifest may be missing from the release. Restore it by re-uploading the saved file via Assets → Upload.\n\n${presentError(err).fullText}`,
+                              ),
                             );
                             setEditOpen(false);
                           },
@@ -447,9 +453,10 @@ export function TagDetailView({
                     value={editNotes}
                     onChange={setEditNotes}
                     placeholder="Notes…"
-                    rows={8}
                     fill
-                    // No `resize-y`: a manual drag height fights the flex sizing.
+                    // No `rows`/`resize-y` in fill mode: the explicit floor plus
+                    // `flex-1` set the height, and a manual drag fights the flex
+                    // sizing.
                     textareaClassName="min-h-24 font-mono"
                   />
                 </div>
@@ -493,8 +500,11 @@ export function TagDetailView({
                 {canSyncUpdater && (
                   <div className="flex flex-col gap-1">
                     <label className="flex cursor-pointer items-center gap-2 text-xs">
+                      {/* Frozen while saving: unchecking mid-flight would drop the
+                          latch without stopping the upload already under way. */}
                       <Checkbox
                         checked={editSyncUpdater}
+                        disabled={savePending}
                         onCheckedChange={(c) => setEditSyncUpdater(c === true)}
                       />
                       Also update the updater manifest (latest.json)
@@ -510,18 +520,13 @@ export function TagDetailView({
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={syncUpdaterNotes.isPending}
+                  disabled={saveLatched}
                   onClick={() => setEditOpen(false)}
                 >
                   Cancel
                 </Button>
-                <Button
-                  type="submit"
-                  disabled={editRelease.isPending || syncUpdaterNotes.isPending}
-                >
-                  {(editRelease.isPending || syncUpdaterNotes.isPending) && (
-                    <Spinner data-icon="inline-start" />
-                  )}
+                <Button type="submit" disabled={savePending}>
+                  {savePending && <Spinner data-icon="inline-start" />}
                   Save
                 </Button>
               </DialogFooter>

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -99,6 +99,11 @@ export function TagDetailView({
   const [editPrerelease, setEditPrerelease] = useState(false);
   const [editLatest, setEditLatest] = useState(false);
   const [editSyncUpdater, setEditSyncUpdater] = useState(true);
+  // The submitted decision, captured at submit. The live checkbox can't stand in for
+  // it: phase 1's invalidation refetches the release mid-save, and a `latest.json`
+  // that the clobber has momentarily deleted would flip the gate and drop the latch
+  // while the upload is still running.
+  const [syncArmed, setSyncArmed] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [cleanupTag, setCleanupTag] = useState(false);
   const [createReleaseOpen, setCreateReleaseOpen] = useState(false);
@@ -147,11 +152,11 @@ export function TagDetailView({
     // there is no GitLab arm to fall back to here.
     const canSyncUpdater =
       canWrite && rel.assets.some((a) => a.name === "latest.json");
-    // Arming the sync makes Save two-phase; dismissing between the phases would fire
-    // the manifest upload at a closed dialog, so the whole operation latches. A plain
-    // edit (box off) stays dismissible exactly as it always was.
+    // An armed sync makes Save two-phase; dismissing between the phases would fire the
+    // manifest upload at a closed dialog, so the whole operation latches. A plain edit
+    // (nothing armed) stays dismissible exactly as it always was.
     const savePending = editRelease.isPending || syncUpdaterNotes.isPending;
-    const saveLatched = canSyncUpdater && editSyncUpdater && savePending;
+    const saveLatched = syncArmed && savePending;
     return (
       <div className="flex h-full flex-col">
         <header className="space-y-2 border-b px-4 py-3">
@@ -199,6 +204,7 @@ export function TagDetailView({
                     setEditPrerelease(rel.isPrerelease);
                     setEditLatest(isLatest);
                     setEditSyncUpdater(true);
+                    setSyncArmed(false);
                     setEditOpen(true);
                   }}
                 >
@@ -383,6 +389,7 @@ export function TagDetailView({
                 // so there's nothing to carry into the manifest either.
                 const syncManifest =
                   canSyncUpdater && editSyncUpdater && !!editNotes.trim();
+                setSyncArmed(syncManifest);
                 editRelease.mutate(
                   {
                     tag,
@@ -398,6 +405,7 @@ export function TagDetailView({
                   {
                     onSuccess: () => {
                       if (!syncManifest) {
+                        setSyncArmed(false);
                         toast.success("Release updated");
                         setEditOpen(false);
                         return;
@@ -409,19 +417,19 @@ export function TagDetailView({
                         { tag, notes: editNotes.trim() },
                         {
                           onSuccess: () => {
+                            setSyncArmed(false);
                             toast.success("Release updated");
                             setEditOpen(false);
                           },
                           onError: (err) => {
-                            // `--clobber` deletes before it uploads, so a failure
-                            // here can leave the asset gone rather than stale — and
-                            // re-running this dialog can't recover it (the checkbox
-                            // is gated on the asset that's now missing). The backend
-                            // parks the patched file and names its path, so route
-                            // through toastError: Details carries that path.
+                            setSyncArmed(false);
+                            // Which stage failed decides what recovery is possible —
+                            // only a failed upload leaves a parked copy — so the
+                            // summary stays arm-neutral and the backend's own text
+                            // (carried into Details by toastError) names the specifics.
                             toastError(
                               new Error(
-                                `Release updated — the updater manifest may be missing from the release. Restore it by re-uploading the saved file via Assets → Upload.\n\n${presentError(err).fullText}`,
+                                `Release updated, but the updater manifest may not have been.\n\n${presentError(err).fullText}`,
                               ),
                             );
                             setEditOpen(false);
@@ -429,7 +437,12 @@ export function TagDetailView({
                         },
                       );
                     },
-                    onError,
+                    // The capture dies with the save it was taken for — phase 1
+                    // failing means no phase 2 will ever consume it.
+                    onError: (e) => {
+                      setSyncArmed(false);
+                      onError(e);
+                    },
                   },
                 );
               }}
@@ -499,9 +512,15 @@ export function TagDetailView({
                 )}
                 {canSyncUpdater && (
                   <div className="flex flex-col gap-1">
-                    <label className="flex cursor-pointer items-center gap-2 text-xs">
-                      {/* Frozen while saving: unchecking mid-flight would drop the
-                          latch without stopping the upload already under way. */}
+                    <label
+                      className={`flex items-center gap-2 text-xs ${
+                        savePending
+                          ? "cursor-not-allowed opacity-60"
+                          : "cursor-pointer"
+                      }`}
+                    >
+                      {/* Frozen while saving: toggling mid-flight would misreport the
+                          state of a save whose decision was already captured. */}
                       <Checkbox
                         checked={editSyncUpdater}
                         disabled={savePending}

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -26,6 +26,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { presentError } from "@/lib/error-summary";
 import {
   forgeFeatureReady,
   useCheckoutCommit,
@@ -38,6 +39,7 @@ import {
   usePushTag,
   useReleaseDetails,
   useReleaseList,
+  useSyncUpdaterNotes,
   useTagList,
   useUploadReleaseAsset,
 } from "@/lib/git/queries";
@@ -81,6 +83,7 @@ export function TagDetailView({
   const tagList = useTagList(repoPath);
   const releaseList = useReleaseList(repoPath, ghReady);
   const editRelease = useEditRelease(repoPath);
+  const syncUpdaterNotes = useSyncUpdaterNotes(repoPath);
   const deleteRelease = useDeleteRelease(repoPath);
   const uploadAsset = useUploadReleaseAsset(repoPath);
   const deleteAsset = useDeleteReleaseAsset(repoPath);
@@ -95,6 +98,7 @@ export function TagDetailView({
   const [editNotes, setEditNotes] = useState("");
   const [editPrerelease, setEditPrerelease] = useState(false);
   const [editLatest, setEditLatest] = useState(false);
+  const [editSyncUpdater, setEditSyncUpdater] = useState(true);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [cleanupTag, setCleanupTag] = useState(false);
   const [createReleaseOpen, setCreateReleaseOpen] = useState(false);
@@ -137,6 +141,11 @@ export function TagDetailView({
 
   // ── Release view ───────────────────────────────────────────────────────────
   if (rel) {
+    // The updater manifest is a GitHub-only Tauri asset (`canWrite` is the same
+    // GitHub-or-pending shape the other release writes use), so the sync affordance
+    // only makes sense on a release that actually ships one.
+    const canSyncUpdater =
+      canWrite && rel.assets.some((a) => a.name === "latest.json");
     return (
       <div className="flex h-full flex-col">
         <header className="space-y-2 border-b px-4 py-3">
@@ -183,6 +192,7 @@ export function TagDetailView({
                     setEditNotes(rel.body);
                     setEditPrerelease(rel.isPrerelease);
                     setEditLatest(isLatest);
+                    setEditSyncUpdater(true);
                     setEditOpen(true);
                   }}
                 >
@@ -350,12 +360,25 @@ export function TagDetailView({
           </div>
         </ScrollArea>
 
-        <Dialog open={editOpen} onOpenChange={setEditOpen}>
-          <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-lg">
+        {/* Latched while the manifest uploads: dismissing mid-sync would hide a
+            partial state the user still needs to act on. */}
+        <Dialog
+          open={editOpen}
+          onOpenChange={(o) => {
+            if (!syncUpdaterNotes.isPending) setEditOpen(o);
+          }}
+        >
+          {/* A fixed height (not a cap): release bodies routinely run thousands of
+              lines, so the notes editor claims the dialog's whole spare height. */}
+          <DialogContent className="flex h-[85vh] flex-col sm:max-w-2xl">
             <form
-              className="flex min-h-0 flex-col gap-4"
+              className="flex min-h-0 flex-1 flex-col gap-4"
               onSubmit={(e) => {
                 e.preventDefault();
+                // Empty notes leave the body untouched (the edit skips `--notes`),
+                // so there's nothing to carry into the manifest either.
+                const syncManifest =
+                  canSyncUpdater && editSyncUpdater && !!editNotes.trim();
                 editRelease.mutate(
                   {
                     tag,
@@ -370,8 +393,35 @@ export function TagDetailView({
                   },
                   {
                     onSuccess: () => {
-                      toast.success("Release updated");
-                      setEditOpen(false);
+                      if (!syncManifest) {
+                        toast.success("Release updated");
+                        setEditOpen(false);
+                        return;
+                      }
+                      // The body edit has already landed, so a manifest failure is
+                      // partial state, not a failed save: close and disclose it —
+                      // re-submitting would only repeat the edit.
+                      syncUpdaterNotes.mutate(
+                        { tag, notes: editNotes.trim() },
+                        {
+                          onSuccess: () => {
+                            toast.success("Release updated");
+                            setEditOpen(false);
+                          },
+                          onError: (err) => {
+                            // `--clobber` deletes before it uploads, so a failure
+                            // here can leave the asset gone, not merely stale.
+                            toast.error(
+                              "Release updated — the updater manifest may be missing.",
+                              {
+                                duration: 8000,
+                                description: `${presentError(err).summary} — save this release again with "Also update the updater manifest" on to restore it.`,
+                              },
+                            );
+                            setEditOpen(false);
+                          },
+                        },
+                      );
                     },
                     onError,
                   },
@@ -385,20 +435,24 @@ export function TagDetailView({
                 </DialogDescription>
               </DialogHeader>
               {/* Fields scroll; header and submit footer stay pinned. */}
-              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+              <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
                 <Input
                   value={editTitle}
                   onChange={(e) => setEditTitle(e.target.value)}
                   placeholder="Title"
                 />
-                <MarkdownEditor
-                  aria-label="Release notes"
-                  value={editNotes}
-                  onChange={setEditNotes}
-                  placeholder="Notes…"
-                  rows={8}
-                  textareaClassName="max-h-72 min-h-24 resize-y font-mono"
-                />
+                <div className="flex flex-1 flex-col">
+                  <MarkdownEditor
+                    aria-label="Release notes"
+                    value={editNotes}
+                    onChange={setEditNotes}
+                    placeholder="Notes…"
+                    rows={8}
+                    fill
+                    // No `resize-y`: a manual drag height fights the flex sizing.
+                    textareaClassName="min-h-24 font-mono"
+                  />
+                </div>
                 {/* GitLab has neither pre-release nor a per-release latest flag. */}
                 {!isGitLab && (
                   <div className="flex flex-wrap gap-x-6 gap-y-2">
@@ -436,17 +490,36 @@ export function TagDetailView({
                     </div>
                   </div>
                 )}
+                {canSyncUpdater && (
+                  <div className="flex flex-col gap-1">
+                    <label className="flex cursor-pointer items-center gap-2 text-xs">
+                      <Checkbox
+                        checked={editSyncUpdater}
+                        onCheckedChange={(c) => setEditSyncUpdater(c === true)}
+                      />
+                      Also update the updater manifest (latest.json)
+                    </label>
+                    <p className="text-muted-foreground text-[11px]">
+                      Keeps the notes installed apps see on update in sync with
+                      this edit.
+                    </p>
+                  </div>
+                )}
               </div>
               <DialogFooter>
                 <Button
                   type="button"
                   variant="outline"
+                  disabled={syncUpdaterNotes.isPending}
                   onClick={() => setEditOpen(false)}
                 >
                   Cancel
                 </Button>
-                <Button type="submit" disabled={editRelease.isPending}>
-                  {editRelease.isPending && (
+                <Button
+                  type="submit"
+                  disabled={editRelease.isPending || syncUpdaterNotes.isPending}
+                >
+                  {(editRelease.isPending || syncUpdaterNotes.isPending) && (
                     <Spinner data-icon="inline-start" />
                   )}
                   Save

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -31,23 +31,48 @@ export async function aiExcludePatterns(
   return [...repoIgnore, ...ignoreLines(aiIgnorePatterns)];
 }
 
+/** U+FFFD, what a lossy UTF-8 decode leaves where the bytes weren't valid. Built
+ *  from its code point, never written literally: the character is invisible in
+ *  source and a re-encode that mangled it would silently unguard the check below. */
+const REPLACEMENT_CHAR = String.fromCharCode(0xfffd);
+
 /**
  * The survivors of a bare path list under the user's AI-ignore patterns, plus
  * how many were hidden — for prompt inputs that carry file NAMES with no diff to
- * route through `filterDiffByAiIgnore` (untracked files). An empty `paths` or
- * `exclude` returns the input untouched, before any IPC.
+ * route through `filterDiffByAiIgnore` (untracked files).
+ *
+ * A name carrying U+FFFD is dropped whatever the patterns say: `git status` is
+ * decoded lossily, so a non-UTF-8 path arrives mangled and can match no rule the
+ * user could write — it fails CLOSED, ahead of the pattern check. `excluded`
+ * counts every hidden name (the model can't see either kind), while `unreadable`
+ * breaks out the subset no pattern could have matched — a caller explaining
+ * itself must not blame the user's patterns for those. KEEP IN SYNC with
+ * `filter_untracked_by_ai_ignore` (src-tauri/src/mcp_server/generate.rs). With
+ * nothing left to check, or no patterns, the survivors are returned before any IPC.
  */
 export async function filterPathsByAiIgnore(input: {
   repoPath: string;
   paths: string[];
   exclude: string[];
-}): Promise<{ paths: string[]; excluded: number }> {
+}): Promise<{ paths: string[]; excluded: number; unreadable: number }> {
   const { repoPath, paths, exclude } = input;
-  if (paths.length === 0 || exclude.length === 0) return { paths, excluded: 0 };
-  const hidden = new Set(await gitFilterAiIgnored(repoPath, paths, exclude));
-  if (hidden.size === 0) return { paths, excluded: 0 };
-  const kept = paths.filter((p) => !hidden.has(p));
-  return { paths: kept, excluded: paths.length - kept.length };
+  const decodable = paths.filter((p) => !p.includes(REPLACEMENT_CHAR));
+  const unreadable = paths.length - decodable.length;
+  if (decodable.length === 0 || exclude.length === 0) {
+    return { paths: decodable, excluded: unreadable, unreadable };
+  }
+  const hidden = new Set(
+    await gitFilterAiIgnored(repoPath, decodable, exclude),
+  );
+  if (hidden.size === 0) {
+    return { paths: decodable, excluded: unreadable, unreadable };
+  }
+  const kept = decodable.filter((p) => !hidden.has(p));
+  return {
+    paths: kept,
+    excluded: unreadable + (decodable.length - kept.length),
+    unreadable,
+  };
 }
 
 /**

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -32,6 +32,25 @@ export async function aiExcludePatterns(
 }
 
 /**
+ * The survivors of a bare path list under the user's AI-ignore patterns, plus
+ * how many were hidden — for prompt inputs that carry file NAMES with no diff to
+ * route through `filterDiffByAiIgnore` (untracked files). An empty `paths` or
+ * `exclude` returns the input untouched, before any IPC.
+ */
+export async function filterPathsByAiIgnore(input: {
+  repoPath: string;
+  paths: string[];
+  exclude: string[];
+}): Promise<{ paths: string[]; excluded: number }> {
+  const { repoPath, paths, exclude } = input;
+  if (paths.length === 0 || exclude.length === 0) return { paths, excluded: 0 };
+  const hidden = new Set(await gitFilterAiIgnored(repoPath, paths, exclude));
+  if (hidden.size === 0) return { paths, excluded: 0 };
+  const kept = paths.filter((p) => !hidden.has(p));
+  return { paths: kept, excluded: paths.length - kept.length };
+}
+
+/**
  * Drops every AI-ignored file from an already-resolved unified diff and its
  * changed-file list, client-side — the one recipe for both diff sources, since
  * the pathspec-exclude route (`gitBranchDiff`'s `exclude`) only exists where

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -539,6 +539,14 @@ export const forgeReleaseEdit = (
     latest,
   });
 
+/** Re-points the release's `latest.json` updater manifest at `notes`, leaving its
+ *  version, dates and platform signatures untouched. GitHub-only. */
+export const forgeReleaseSyncUpdaterNotes = (
+  repoPath: string,
+  tag: string,
+  notes: string,
+) => invoke<void>("forge_release_sync_updater_notes", { repoPath, tag, notes });
+
 /** GitHub's auto-generated release notes (suggested title + body), for preview. */
 export const ghReleaseGenerateNotes = (
   repoPath: string,
@@ -781,8 +789,10 @@ export const gitDiscardPaths = (
 export const gitStashAll = (repoPath: string) =>
   invoke<void>("git_stash_all", { repoPath });
 
+// True when a stash entry was actually created (a pathspec matching nothing
+// no-ops at exit 0); the GUI ignores it today — the MCP surface consumes it.
 export const gitStashPaths = (repoPath: string, paths: string[]) =>
-  invoke<void>("git_stash_paths", { repoPath, paths });
+  invoke<boolean>("git_stash_paths", { repoPath, paths });
 
 export const gitStashPop = (repoPath: string) =>
   invoke<void>("git_stash_pop", { repoPath });

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -539,6 +539,10 @@ export const forgeReleaseEdit = (
     latest,
   });
 
+/** The release asset Tauri's updater polls. KEEP IN SYNC with `UPDATER_MANIFEST`
+ *  in src-tauri/src/github/release.rs — the sync command matches on this name. */
+export const UPDATER_MANIFEST_NAME = "latest.json";
+
 /** Re-points the release's `latest.json` updater manifest at `notes`, leaving its
  *  version, dates and platform signatures untouched. GitHub-only. */
 export const forgeReleaseSyncUpdaterNotes = (

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -790,7 +790,8 @@ export const gitStashAll = (repoPath: string) =>
   invoke<void>("git_stash_all", { repoPath });
 
 // True when a stash entry was actually created (a pathspec matching nothing
-// no-ops at exit 0); the GUI ignores it today — the MCP surface consumes it.
+// no-ops at exit 0). No caller reads it yet; it's carried so a caller that
+// stashes a selection can tell "nothing matched" from a real stash.
 export const gitStashPaths = (repoPath: string, paths: string[]) =>
   invoke<boolean>("git_stash_paths", { repoPath, paths });
 

--- a/src/lib/git/glob.ts
+++ b/src/lib/git/glob.ts
@@ -19,9 +19,11 @@
  * unescaped trailing whitespace, so a file named `notes ` yields the pattern
  * `notes`, which hides a DIFFERENT file and leaves the named one visible
  * (measured). The escape is written in the idiomatic .gitignore spelling users
- * read in their own files; the pathspec engine cannot parse a backslash at all
- * (it is a SEPARATOR there), so Rust's `pathspecs_for` re-encodes it as `[ ]`
- * before matching rather than this emitting the class form directly.
+ * read in their own files. It reaches the pathspec engine only through Rust's
+ * `pathspecs_for`, which re-encodes it as `[ ]` first: on WINDOWS a backslash in
+ * a pathspec is a SEPARATOR rather than an escape, so the raw form matched
+ * NOTHING there while Unix honored it (measured, git 2.51.1.windows.1). The
+ * class form is what makes both platforms agree.
  *
  * The escape is defeated when the name ALREADY ends in a backslash (`notes\ `):
  * the emitted `notes\\ ` is an even backslash run, so the space reads as

--- a/src/lib/git/glob.ts
+++ b/src/lib/git/glob.ts
@@ -18,18 +18,12 @@
  * A trailing space is the one case backslash IS the answer: .gitignore strips
  * unescaped trailing whitespace, so a file named `notes ` yields the pattern
  * `notes`, which hides a DIFFERENT file and leaves the named one visible
- * (measured).
+ * (measured). The escape is written in the idiomatic .gitignore spelling users
+ * read in their own files; the pathspec engine cannot parse a backslash at all
+ * (it is a SEPARATOR there), so Rust's `pathspecs_for` re-encodes it as `[ ]`
+ * before matching rather than this emitting the class form directly.
  *
- * That escape fixes the gitignore engine ONLY, and the two AI-ignore engines
- * diverge on WINDOWS for this shape: a backslash in a pathspec is a SEPARATOR,
- * not an escape, so an emitted `notes\ ` term normalizes to `notes/ ` and
- * matches nothing (measured, git 2.51.1.windows.1: `:(glob)a\b.ts` matches
- * `a/b.ts`, while `:(glob)a/b\.ts` matches nothing). Unix honors the escape,
- * which is why the cross-engine test passes on CI. Pre-existing, not introduced
- * here — the pathspec side never matched this shape either way.
- *
- * The escape is also defeated when the name ALREADY ends in a backslash
- * (`notes\ `):
+ * The escape is defeated when the name ALREADY ends in a backslash (`notes\ `):
  * the emitted `notes\\ ` is an even backslash run, so the space reads as
  * unescaped and is stripped again. Bounded by the same limitation as above — a
  * literal backslash is inexpressible here — and impossible on Windows.

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3242,6 +3242,14 @@ export function useEditRelease(repo: string) {
   );
 }
 
+/** Syncs the release's `latest.json` updater manifest to the edited notes. Repo
+ *  mutation like the asset upload — replacing the asset changes its size/stats. */
+export function useSyncUpdaterNotes(repo: string) {
+  return useRepoMutation(repo, (args: { tag: string; notes: string }) =>
+    api.forgeReleaseSyncUpdaterNotes(repo, args.tag, args.notes),
+  );
+}
+
 /** GitHub's auto-generated release notes (for the preview-then-edit flow). */
 export function useGithubReleaseNotes(repo: string) {
   return useMutation({


### PR DESCRIPTION
Editing a GitHub release's notes left any `latest.json` updater manifest attached to it untouched, so installed apps kept showing the old "what's new" after the release page had been corrected. This adds an opt-in manifest sync to the release edit flow, and carries a batch of related fixes found alongside it: AI-ignore patterns now cover untracked file names and backslash escapes on Windows, the release notes editor fills its dialog, and MCP `stash_push` reports when it stashed nothing.

### Updater-manifest sync

- Adds `gh_release_sync_updater_notes` in `src-tauri/src/github/release.rs`: downloads the release's `latest.json`, rewrites only its `notes` via the new pure `patch_updater_notes`, and re-uploads with `--clobber`. Version, `pub_date`, platform URLs and signatures survive verbatim; unit tests cover replacement, an absent `notes` key, and non-object/non-JSON input.
- Exposes it as `forge::forge_release_sync_updater_notes` in `src-tauri/src/forge/mod.rs` (GitHub-only — GitLab and Bitbucket return an `InvalidArgument` explaining why), registered in `src-tauri/src/lib.rs`, wrapped by `forgeReleaseSyncUpdaterNotes` in `src/lib/git/api.ts` and `useSyncUpdaterNotes` in `src/lib/git/queries.ts`.
- Wires the UI in `src/features/tags/TagDetailView.tsx`: an "Also update the updater manifest (latest.json)" checkbox, defaulted on and shown only when the release actually carries a `latest.json` asset and the user `canWrite`. The dialog latches open while the manifest uploads, Cancel/Save are disabled during the sync, and a manifest failure closes with a disclosing toast (built from `presentError`) telling the user the asset may be missing, since `--clobber` deletes before it uploads.

### Release notes editor sizing

- Adds a `fill` prop to `src/components/markdown-editor.tsx` that makes the editor (and its Preview pane) claim the parent flex column's spare height instead of a capped box, with a comment recording why the fill root deliberately omits `min-h-0`.
- Switches both release dialogs to a fixed `h-[85vh]` flex column and drops `resize-y` from the textareas: `src/features/tags/CreateReleaseDialog.tsx` and the edit dialog in `src/features/tags/TagDetailView.tsx` (also widened to `sm:max-w-2xl`).

### AI-ignore matching

- Adds `rewrite_for_pathspec` in `src-tauri/src/git/ai_ignore.rs`, which re-encodes gitignore `\<c>` escapes into one-character bracket classes and scans user bracket expressions whole (POSIX character classes included) before the line is classified — on Windows a surviving backslash is a separator to the pathspec engine, so the term excluded nothing and the named file reached the model. `\/` becomes a bare `/` (no class matches a separator under `,glob`); the class-special escapes and any bracket expression carrying a backslash degrade to `?`, counted in the `AiIgnorePathspecs::widened` field so over-exclusion is the only failure direction.
- Extends the parity fixture and truth table with the rows that pin a backslash as an escape rather than a Windows separator, bracket-expression round-trips, POSIX classes, unterminated brackets, and an escaped non-ASCII name; adds `escaped_trailing_space_excluded_by_pathspec_everywhere`, which builds the fixture straight in the object database (`hash-object` → `mktree` → tree diff) so the trailing-space case can be asserted on Windows too.
- Rewrites the now-stale divergence note in `src/lib/git/glob.ts`, which documented the Windows gap this change closes.

### Untracked names in branch-name generation

- Adds `filterPathsByAiIgnore` to `src/lib/ai/ignore.ts` for prompt inputs that carry bare file names with no diff to route through `filterDiffByAiIgnore`; names whose bytes were lost to the UTF-8 decode are dropped fail-closed and counted separately, so the "matches your AI ignore patterns" copy never blames an empty pattern list.
- Applies it in `src/features/repository/useGenerateBranchName.ts` (in parallel with the diff and repo-instruction reads) and folds the hidden counts into both the working-tree and committed-fallback paths and the "nothing to name it after" messages.
- Mirrors it over MCP in `src-tauri/src/mcp_server/generate.rs`: `untracked_files` now reads `-z` NUL-separated raw names (C-quoting or trimming would break the very rules meant to match them), a new `filter_untracked_by_ai_ignore` drops the hidden ones with the same pattern-vs-unreadable split, with tests for the filter, the recipe's hidden-files note, and byte-exact name reading.
- Adds `resolve_store_dir` in `src-tauri/src/app_store.rs` — a `GD_SETTINGS_DIR` override, no store at all under `cfg!(test)`, otherwise the real app-data dir — so the new MCP tests can't be decided by the developer's own settings; a test pins all three arms including the unchanged production path, and tests install their store through an in-process `cfg(test)` override rather than mutating process env.

### Stash zero-match reporting

- `git_stash_paths` / `git_stash_paths_core` in `src-tauri/src/git/ops.rs` now return `bool`, derived from git's "No local changes to save" line, with the index-protecting slow path chaining through `and_then` so the mutate error still wins; three tests cover the fast path, slow path, and a real stash.
- `src-tauri/src/mcp_server/write_git.rs` reports "no changes matched the given paths — nothing was stashed" instead of claiming success, and `gitStashPaths` in `src/lib/git/api.ts` is retyped `invoke<boolean>`.

### Unignore exact match

- `git_unignore_rules` in `src-tauri/src/git/ops.rs` keys and compares lines with `crate::fsops::trim_ignore_pattern` instead of `str::trim`, which collapsed `/notes\ ` and `/notes\` onto the same key and deleted both; `unignore_removes_only_the_targeted_escaped_rule` covers each direction.

### Documentation

- Extends the releases paragraph in `README.md`, the Tags & releases section of `src/features/help/content.ts`, and the release capability line in `site/src/data/capabilities.ts` with release editing and the manifest sync.
- Adds six `changelog.d/` fragments: `added-updater-notes-sync`, `changed-release-notes-editor`, `fixed-ai-ignore-trailing-space-windows`, `fixed-branch-name-ai-ignore`, `fixed-stash-zero-match-report`, `fixed-unignore-exact-match`.