### PR TITLE
fix(ai,pulls,automations): stop passing AI errors off as results

### DIFF
--- a/changelog.d/fixed-ai-error-publish.md
+++ b/changelog.d/fixed-ai-error-publish.md
@@ -1,5 +1,6 @@
 - A failed AI run no longer passes its error text off as a result: an outage or a
   usage limit that interrupts a review never gets posted to your PR, and one that
   interrupts a generation never lands in the commit-message or other drafts.
-  Failures now appear in **Activity & notifications** with the reason and a
-  one-click re-run, and posting a review that stopped part-way asks first.
+  Failed reviews land in **Activity & notifications** with the reason (automated
+  ones with a one-click re-run), and posting a review that stopped part-way asks
+  first.

--- a/changelog.d/fixed-ai-error-publish.md
+++ b/changelog.d/fixed-ai-error-publish.md
@@ -1,0 +1,5 @@
+- A failed AI run no longer passes its error text off as a result: an outage or a
+  usage limit that interrupts a review never gets posted to your PR, and one that
+  interrupts a generation never lands in the commit-message or other drafts.
+  Failures now appear in **Activity & notifications** with the reason and a
+  one-click re-run, and posting a review that stopped part-way asks first.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -137,10 +137,9 @@ pub struct AgentInfo {
 /// Streaming events sent to the frontend over the review channel.
 ///
 /// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
-/// for the TS mirror (`src/lib/ai/agent.ts`): without it `Done.is_error` arrived as
-/// `undefined` and every failure reported through `Done` (claude, copilot) read as a
-/// success, publishing provider error text as review content — the `Error` variant's
-/// single-word field was unaffected. `review_event_wire_shape_is_camel_case` pins it.
+/// for the TS mirror (`src/lib/ai/agent.ts`): without it a multi-word field like
+/// `Done.is_error` reaches TS as `undefined`, silently — a failure reported through
+/// `Done` then reads as a success. `review_event_wire_shape_is_camel_case` pins it.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum ReviewEvent {
@@ -1208,9 +1207,9 @@ fn parse_codex_line(
 
 /// Parses one line of Copilot CLI `--output-format json` (JSONL). Streams
 /// `message_delta.deltaContent` as narration, keeps the latest
-/// `assistant.message.content` as the final text, emits `Done` at `result`
-/// (a `session.error` or a non-zero `exitCode` fails the run).
-/// Setup/MCP/skills/reasoning events ignored.
+/// `assistant.message.content` as the final text, emits `Done` at `result` — a
+/// `session.error` (whose message becomes the failure reason) or a non-zero
+/// `exitCode` fails the run. Setup/MCP/skills/reasoning events ignored.
 ///
 /// A `\n\n` is lazily PREPENDED to the first non-empty delta after a completed
 /// message, so the delta buffer still ENDS WITH `Done.text` (frontend invariant).
@@ -1220,7 +1219,7 @@ fn parse_copilot_line(
     last_message: &mut String,
     emitted_text: &mut bool,
     pending_sep: &mut bool,
-    saw_error: &mut bool,
+    error_message: &mut Option<String>,
 ) -> Option<ReviewEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -1280,26 +1279,33 @@ fn parse_copilot_line(
             })
         }
         "session.error" => {
-            let msg = v
-                .get("data")
-                .and_then(|d| d.get("message"))
-                .and_then(|m| m.as_str())
-                .unwrap_or("Copilot reported an error.");
-            if last_message.is_empty() {
-                *last_message = msg.to_string();
-            }
-            // Latch: the CLI still exits 0 after a session error, which would ship the
-            // error message as a successful answer. A later genuine recovery now fails
-            // the run too — acceptable for a CLI whose only verdict is the exit code.
-            *saw_error = true;
+            // The CLI still exits 0 after a session error, so this message is the only
+            // failure reason there is — keep it whole, whatever prose already streamed.
+            // A later genuine recovery now fails the run too; acceptable for a CLI whose
+            // only other verdict is the exit code.
+            *error_message = Some(
+                v.get("data")
+                    .and_then(|d| d.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("Copilot reported an error.")
+                    .to_string(),
+            );
             None // surfaced at the terminal `result`
         }
         "result" => {
             *saw_terminal = true;
-            let is_error =
-                *saw_error || v.get("exitCode").and_then(|c| c.as_i64()).unwrap_or(0) != 0;
+            // An errored `Done` carries the REASON, not the prose (which stays in the
+            // delta stream): the buffer-ends-with-`Done.text` peel runs only on a
+            // successful settle — both frontend consumers reject on `is_error` first.
+            let (text, is_error) = match error_message.take() {
+                Some(msg) => (msg, true),
+                None => (
+                    std::mem::take(last_message),
+                    v.get("exitCode").and_then(|c| c.as_i64()).unwrap_or(0) != 0,
+                ),
+            };
             Some(ReviewEvent::Done {
-                text: std::mem::take(last_message),
+                text,
                 is_error,
                 cost_usd: None,
             })
@@ -1557,12 +1563,16 @@ fn parse_claude_line(
     }
 }
 
+/// Longest body the error-shape net will judge. Three copies must agree: this one,
+/// `ERROR_SHAPE_MAX_CHARS` (automations runner) and `MAX_ERROR_TEXT` (terminal-error).
+const ERROR_TEXT_MAX_CHARS: usize = 300;
+
 /// Whether a Claude terminal `result` line reports a FAILED run.
 ///
 /// The CLI exits 0 and reports `subtype: "success"` even on an API error, and
 /// some versions ship usage-limit / API-error text as the `result` with
-/// `is_error: false` — so the flag alone once shipped an error message as a real
-/// PR review comment. Structural signals first, then a narrow text net.
+/// `is_error: false` — the flag alone cannot be trusted. Structural signals
+/// first, then a narrow text net.
 fn claude_result_is_error(v: &serde_json::Value, text: &str, synthetic_error: Option<&str>) -> bool {
     if v.get("is_error").and_then(|b| b.as_bool()).unwrap_or(false) {
         return true;
@@ -1581,12 +1591,11 @@ fn claude_result_is_error(v: &serde_json::Value, text: &str, synthetic_error: Op
     if synthetic_error.is_some_and(|s| s == trimmed) {
         return true;
     }
-    // Best-effort net behind the structural signals above, for limit messages that
-    // arrive with none of them (2026-07-29 incident: an "API Error: 500" body was
-    // posted as a review). Deliberately narrow — a real review that merely mentions
-    // limits is multi-paragraph and far longer.
+    // Best-effort net behind the structural signals above, for limit / API-error
+    // bodies that arrive with none of them. Deliberately narrow — a real review
+    // that merely mentions limits is multi-paragraph and far longer.
     !trimmed.is_empty()
-        && trimmed.chars().count() <= 300
+        && trimmed.chars().count() <= ERROR_TEXT_MAX_CHARS
         && !has_blank_line(trimmed)
         && (trimmed.starts_with("API Error")
             || trimmed.starts_with("Claude AI usage limit reached")
@@ -1736,9 +1745,10 @@ async fn stream_agent(
     let mut emitted_text = false;
     let mut pending_sep = false;
     // claude: text of a synthetic API-error message, matched against the terminal
-    // `result`. copilot: a `session.error` was seen (its exit code lies).
+    // `result`. copilot: a `session.error`'s message — the run's failure reason,
+    // since its exit code lies.
     let mut claude_synthetic_error: Option<String> = None;
-    let mut copilot_saw_error = false;
+    let mut copilot_error: Option<String> = None;
     let mut cancelled = false;
     let mut timed_out = false;
 
@@ -1778,7 +1788,7 @@ async fn stream_agent(
                                 &mut last_message,
                                 &mut emitted_text,
                                 &mut pending_sep,
-                                &mut copilot_saw_error,
+                                &mut copilot_error,
                             ),
                             AgentKind::Opencode => parse_opencode_line(
                                 &l,
@@ -2805,7 +2815,8 @@ mod tests {
     fn copilot_lazy_separator_between_assistant_messages() {
         // Deltas across two assistant messages get exactly one `\n\n` between them.
         let (mut term, mut msg) = (false, String::new());
-        let (mut emitted, mut pending, mut err) = (false, false, false);
+        let (mut emitted, mut pending) = (false, false);
+        let mut err: Option<String> = None;
         let d1 = r#"{"type":"assistant.message_delta","data":{"deltaContent":"First."}}"#;
         let m1 = r#"{"type":"assistant.message","data":{"content":"First."}}"#;
         let d2 = r#"{"type":"assistant.message_delta","data":{"deltaContent":"Second."}}"#;
@@ -2829,7 +2840,8 @@ mod tests {
     fn copilot_first_delta_has_no_separator() {
         // The very first delta of a run must not be prefixed (nothing emitted before).
         let (mut term, mut msg) = (false, String::new());
-        let (mut emitted, mut pending, mut err) = (false, false, false);
+        let (mut emitted, mut pending) = (false, false);
+        let mut err: Option<String> = None;
         let d = r#"{"type":"assistant.message_delta","data":{"deltaContent":"Hello."}}"#;
         let ev =
             parse_copilot_line(d, &mut term, &mut msg, &mut emitted, &mut pending, &mut err)
@@ -2844,10 +2856,11 @@ mod tests {
 
     #[test]
     fn copilot_session_error_fails_the_run_despite_exit_zero() {
-        // The CLI exits 0 after a session error, which once shipped the error text as
-        // a successful answer; the latch makes the terminal `result` report failure.
+        // The CLI exits 0 after a session error, so exit code alone would report the
+        // error text as a successful answer; the stash makes `result` report failure.
         let (mut term, mut msg) = (false, String::new());
-        let (mut emitted, mut pending, mut err) = (false, false, false);
+        let (mut emitted, mut pending) = (false, false);
+        let mut err: Option<String> = None;
         assert!(
             parse_copilot_line(
                 CP_SESSION_ERROR,
@@ -2859,7 +2872,7 @@ mod tests {
             )
             .is_none()
         );
-        assert!(err);
+        assert_eq!(err.as_deref(), Some("API rate limit exceeded for this session."));
         let ev = parse_copilot_line(
             CP_RESULT_OK,
             &mut term,
@@ -2881,9 +2894,47 @@ mod tests {
     }
 
     #[test]
+    fn copilot_session_error_after_prose_reports_the_reason_not_the_prose() {
+        // Prose already streamed when the session errors: `Done.text` must still be the
+        // REASON — the frontend refuses run output as an error message, and the prose
+        // survives in the delta stream regardless.
+        let (mut term, mut msg) = (false, String::new());
+        let (mut emitted, mut pending) = (false, false);
+        let mut err: Option<String> = None;
+        let prose = r#"{"type":"assistant.message","data":{"content":"Here is my review of the retry path."}}"#;
+        parse_copilot_line(prose, &mut term, &mut msg, &mut emitted, &mut pending, &mut err);
+        assert_eq!(msg, "Here is my review of the retry path.");
+        parse_copilot_line(
+            CP_SESSION_ERROR,
+            &mut term,
+            &mut msg,
+            &mut emitted,
+            &mut pending,
+            &mut err,
+        );
+        let ev = parse_copilot_line(
+            CP_RESULT_OK,
+            &mut term,
+            &mut msg,
+            &mut emitted,
+            &mut pending,
+            &mut err,
+        )
+        .unwrap();
+        match ev {
+            ReviewEvent::Done { text, is_error, .. } => {
+                assert!(is_error);
+                assert_eq!(text, "API rate limit exceeded for this session.");
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn copilot_clean_run_stays_successful() {
         let (mut term, mut msg) = (false, String::new());
-        let (mut emitted, mut pending, mut err) = (false, false, false);
+        let (mut emitted, mut pending) = (false, false);
+        let mut err: Option<String> = None;
         let m = r#"{"type":"assistant.message","data":{"content":"All good."}}"#;
         parse_copilot_line(m, &mut term, &mut msg, &mut emitted, &mut pending, &mut err);
         let ev = parse_copilot_line(

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -138,8 +138,9 @@ pub struct AgentInfo {
 ///
 /// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
 /// for the TS mirror (`src/lib/ai/agent.ts`): without it `Done.is_error` arrived as
-/// `undefined` and every failed run read as a success, publishing provider error
-/// text as review content. `review_event_wire_shape_is_camel_case` pins the shape.
+/// `undefined` and every failure reported through `Done` (claude, copilot) read as a
+/// success, publishing provider error text as review content — the `Error` variant's
+/// single-word field was unaffected. `review_event_wire_shape_is_camel_case` pins it.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum ReviewEvent {
@@ -1593,8 +1594,10 @@ fn claude_result_is_error(v: &serde_json::Value, text: &str, synthetic_error: Op
 }
 
 /// Whether `text` contains a paragraph break — two newlines separated only by
-/// blanks, so CRLF bodies count. Mirrors `/\n[ \t\r]*\n/` in the runner-side twin
-/// (`src/lib/automations/runner.ts`); the two nets must stay semantically aligned.
+/// blanks, so CRLF bodies count. Mirrors `/\n[ \t\r]*\n/` in the TS twins
+/// (`looksLikeProviderError` in `src/lib/automations/runner.ts`,
+/// `terminalErrorMessage` in `src/lib/ai/cli-client.ts`); all three predicates
+/// must stay semantically aligned.
 fn has_blank_line(text: &str) -> bool {
     text.match_indices('\n').any(|(i, _)| {
         text[i + 1..]

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -157,7 +157,11 @@ pub enum ReviewEvent {
         tool: String,
         target: Option<String>,
     },
-    /// Terminal success: the full final review text plus run metadata.
+    /// Terminal event, success or failure: on success `text` is the full final
+    /// answer; on `is_error` it carries what the CLI reported at termination — an
+    /// error message when the CLI gave one (copilot `session.error`, claude API /
+    /// limit text), possibly run output on cap-style stops, which is why consumers
+    /// surface it as the reason only when error-shaped (`terminalErrorMessage`).
     Done {
         text: String,
         is_error: bool,
@@ -1605,8 +1609,8 @@ fn claude_result_is_error(v: &serde_json::Value, text: &str, synthetic_error: Op
 /// Whether `text` contains a paragraph break — two newlines separated only by
 /// blanks, so CRLF bodies count. Mirrors `/\n[ \t\r]*\n/` in the TS twins
 /// (`looksLikeProviderError` in `src/lib/automations/runner.ts`,
-/// `terminalErrorMessage` in `src/lib/ai/cli-client.ts`); all three predicates
-/// must stay semantically aligned.
+/// `terminalErrorMessage` in `src/lib/ai/terminal-error.ts`); all three
+/// predicates must stay semantically aligned.
 fn has_blank_line(text: &str) -> bool {
     text.match_indices('\n').any(|(i, _)| {
         text[i + 1..]

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1216,7 +1216,8 @@ fn parse_codex_line(
 /// `exitCode` fails the run. Setup/MCP/skills/reasoning events ignored.
 ///
 /// A `\n\n` is lazily PREPENDED to the first non-empty delta after a completed
-/// message, so the delta buffer still ENDS WITH `Done.text` (frontend invariant).
+/// message, so the delta buffer still ENDS WITH `Done.text` (frontend invariant —
+/// success path only; an errored `Done` carries the failure reason instead).
 fn parse_copilot_line(
     line: &str,
     saw_terminal: &mut bool,

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -135,8 +135,13 @@ pub struct AgentInfo {
 }
 
 /// Streaming events sent to the frontend over the review channel.
+///
+/// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
+/// for the TS mirror (`src/lib/ai/agent.ts`): without it `Done.is_error` arrived as
+/// `undefined` and every failed run read as a success, publishing provider error
+/// text as review content. `review_event_wire_shape_is_camel_case` pins the shape.
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum ReviewEvent {
     /// A chunk of assistant text to append to the rendered review.
     Delta { text: String },
@@ -1203,7 +1208,8 @@ fn parse_codex_line(
 /// Parses one line of Copilot CLI `--output-format json` (JSONL). Streams
 /// `message_delta.deltaContent` as narration, keeps the latest
 /// `assistant.message.content` as the final text, emits `Done` at `result`
-/// (its `exitCode` decides success). Setup/MCP/skills/reasoning events ignored.
+/// (a `session.error` or a non-zero `exitCode` fails the run).
+/// Setup/MCP/skills/reasoning events ignored.
 ///
 /// A `\n\n` is lazily PREPENDED to the first non-empty delta after a completed
 /// message, so the delta buffer still ENDS WITH `Done.text` (frontend invariant).
@@ -1213,6 +1219,7 @@ fn parse_copilot_line(
     last_message: &mut String,
     emitted_text: &mut bool,
     pending_sep: &mut bool,
+    saw_error: &mut bool,
 ) -> Option<ReviewEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -1280,11 +1287,16 @@ fn parse_copilot_line(
             if last_message.is_empty() {
                 *last_message = msg.to_string();
             }
-            None // the terminal `result` carries the exit code; surface there
+            // Latch: the CLI still exits 0 after a session error, which would ship the
+            // error message as a successful answer. A later genuine recovery now fails
+            // the run too — acceptable for a CLI whose only verdict is the exit code.
+            *saw_error = true;
+            None // surfaced at the terminal `result`
         }
         "result" => {
             *saw_terminal = true;
-            let is_error = v.get("exitCode").and_then(|c| c.as_i64()).unwrap_or(0) != 0;
+            let is_error =
+                *saw_error || v.get("exitCode").and_then(|c| c.as_i64()).unwrap_or(0) != 0;
             Some(ReviewEvent::Done {
                 text: std::mem::take(last_message),
                 is_error,
@@ -1409,12 +1421,17 @@ fn parse_opencode_line(
 /// completed TEXT block, so the delta buffer still ENDS WITH `Done.text` (the
 /// raw `result`, never separator-prefixed) — the frontend's suffix-strip relies
 /// on that.
+///
+/// `synthetic_error` carries the text of a synthetic API-error assistant message
+/// forward to the terminal line; see `claude_result_is_error` for why the CLI's
+/// own `is_error` flag can't be trusted alone.
 fn parse_claude_line(
     line: &str,
     saw_result: &mut bool,
     tool_inputs: &mut std::collections::HashMap<i64, (String, String)>,
     emitted_text: &mut bool,
     pending_sep: &mut bool,
+    synthetic_error: &mut Option<String>,
 ) -> Option<ReviewEvent> {
     let line = line.trim();
     if line.is_empty() {
@@ -1496,20 +1513,94 @@ fn parse_claude_line(
                 _ => None,
             }
         }
+        // A synthetic API-error message (no stream_event deltas back it, so nothing
+        // was streamed): stash its text — the terminal line repeats it as `result`.
+        "assistant" => {
+            let msg = v.get("message")?;
+            let synthetic = v
+                .get("is_api_error_message")
+                .and_then(|b| b.as_bool())
+                .unwrap_or(false)
+                || msg.get("model").and_then(|m| m.as_str()) == Some("<synthetic>");
+            if synthetic {
+                let text: String = msg
+                    .get("content")
+                    .and_then(|c| c.as_array())
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if !text.trim().is_empty() {
+                    *synthetic_error = Some(text.trim().to_string());
+                }
+            }
+            None
+        }
         "result" => {
             *saw_result = true;
+            let text = v
+                .get("result")
+                .and_then(|s| s.as_str())
+                .unwrap_or_default()
+                .to_string();
             Some(ReviewEvent::Done {
-                text: v
-                    .get("result")
-                    .and_then(|s| s.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                is_error: v.get("is_error").and_then(|b| b.as_bool()).unwrap_or(false),
+                is_error: claude_result_is_error(&v, &text, synthetic_error.as_deref()),
+                text,
                 cost_usd: v.get("total_cost_usd").and_then(|c| c.as_f64()),
             })
         }
         _ => None,
     }
+}
+
+/// Whether a Claude terminal `result` line reports a FAILED run.
+///
+/// The CLI exits 0 and reports `subtype: "success"` even on an API error, and
+/// some versions ship usage-limit / API-error text as the `result` with
+/// `is_error: false` — so the flag alone once shipped an error message as a real
+/// PR review comment. Structural signals first, then a narrow text net.
+fn claude_result_is_error(v: &serde_json::Value, text: &str, synthetic_error: Option<&str>) -> bool {
+    if v.get("is_error").and_then(|b| b.as_bool()).unwrap_or(false) {
+        return true;
+    }
+    if v.get("api_error_status").is_some_and(|s| !s.is_null()) {
+        return true;
+    }
+    // Absent on older CLIs — only a PRESENT, non-"completed" reason is a signal.
+    if v.get("terminal_reason")
+        .and_then(|r| r.as_str())
+        .is_some_and(|r| r != "completed")
+    {
+        return true;
+    }
+    let trimmed = text.trim();
+    if synthetic_error.is_some_and(|s| s == trimmed) {
+        return true;
+    }
+    // Best-effort net behind the structural signals above, for limit messages that
+    // arrive with none of them (2026-07-29 incident: an "API Error: 500" body was
+    // posted as a review). Deliberately narrow — a real review that merely mentions
+    // limits is multi-paragraph and far longer.
+    !trimmed.is_empty()
+        && trimmed.chars().count() <= 300
+        && !has_blank_line(trimmed)
+        && (trimmed.starts_with("API Error")
+            || trimmed.starts_with("Claude AI usage limit reached")
+            || (trimmed.contains("limit reached") && trimmed.contains("resets")))
+}
+
+/// Whether `text` contains a paragraph break — two newlines separated only by
+/// blanks, so CRLF bodies count. Mirrors `/\n[ \t\r]*\n/` in the runner-side twin
+/// (`src/lib/automations/runner.ts`); the two nets must stay semantically aligned.
+fn has_blank_line(text: &str) -> bool {
+    text.match_indices('\n').any(|(i, _)| {
+        text[i + 1..]
+            .trim_start_matches([' ', '\t', '\r'])
+            .starts_with('\n')
+    })
 }
 
 /// Kills the entire process tree of a host-mode agent child on cancel/timeout.
@@ -1641,6 +1732,10 @@ async fn stream_agent(
     // claude/copilot: lazy `\n\n` between successive text blocks/messages.
     let mut emitted_text = false;
     let mut pending_sep = false;
+    // claude: text of a synthetic API-error message, matched against the terminal
+    // `result`. copilot: a `session.error` was seen (its exit code lies).
+    let mut claude_synthetic_error: Option<String> = None;
+    let mut copilot_saw_error = false;
     let mut cancelled = false;
     let mut timed_out = false;
 
@@ -1669,6 +1764,7 @@ async fn stream_agent(
                                 &mut claude_tool_inputs,
                                 &mut emitted_text,
                                 &mut pending_sep,
+                                &mut claude_synthetic_error,
                             ),
                             AgentKind::Codex => {
                                 parse_codex_line(&l, &mut saw_result, &mut last_message)
@@ -1679,6 +1775,7 @@ async fn stream_agent(
                                 &mut last_message,
                                 &mut emitted_text,
                                 &mut pending_sep,
+                                &mut copilot_saw_error,
                             ),
                             AgentKind::Opencode => parse_opencode_line(
                                 &l,
@@ -2438,14 +2535,25 @@ mod tests {
         let mut saw = false;
         let mut acc = std::collections::HashMap::new();
         let (mut emitted, mut pending) = (false, false);
+        let mut syn = None;
         let start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"Read","input":{}}}}"#;
         let d1 = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"file_pa"}}}"#;
         let d2 = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"th\":\"src/x.ts\"}"}}}"#;
         let stop = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":1}}"#;
-        assert!(parse_claude_line(start, &mut saw, &mut acc, &mut emitted, &mut pending).is_none());
-        assert!(parse_claude_line(d1, &mut saw, &mut acc, &mut emitted, &mut pending).is_none());
-        assert!(parse_claude_line(d2, &mut saw, &mut acc, &mut emitted, &mut pending).is_none());
-        let ev = parse_claude_line(stop, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+        assert!(
+            parse_claude_line(start, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn)
+                .is_none()
+        );
+        assert!(
+            parse_claude_line(d1, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn)
+                .is_none()
+        );
+        assert!(
+            parse_claude_line(d2, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn)
+                .is_none()
+        );
+        let ev = parse_claude_line(stop, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn)
+            .unwrap();
         match ev {
             ReviewEvent::Tool { tool, target } => {
                 assert_eq!(tool, "read");
@@ -2467,6 +2575,7 @@ mod tests {
         let mut saw = false;
         let mut acc = std::collections::HashMap::new();
         let (mut emitted, mut pending) = (false, false);
+        let mut syn = None;
         let mut buffer = String::new();
 
         // Text block 1: "Looking at the code." then its stop.
@@ -2485,7 +2594,9 @@ mod tests {
             (t1a, Some("Looking at ")),
             (t1b, Some("the code.")),
         ] {
-            let ev = parse_claude_line(line, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+            let ev =
+                parse_claude_line(line, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn)
+                    .unwrap();
             match ev {
                 ReviewEvent::Delta { text } => {
                     assert_eq!(text, expect.unwrap());
@@ -2495,14 +2606,15 @@ mod tests {
             }
         }
         // Block-1 stop arms the separator; the tool block's stop leaves it armed.
-        parse_claude_line(stop1, &mut saw, &mut acc, &mut emitted, &mut pending);
+        parse_claude_line(stop1, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn);
         assert!(pending, "a text block's stop arms the separator");
-        parse_claude_line(tstart, &mut saw, &mut acc, &mut emitted, &mut pending);
-        parse_claude_line(tstop, &mut saw, &mut acc, &mut emitted, &mut pending);
+        parse_claude_line(tstart, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn);
+        parse_claude_line(tstop, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn);
         assert!(pending, "a tool block's stop leaves the pending separator intact");
 
         // Block-2's first delta is prefixed `\n\n`.
-        let ev = parse_claude_line(t2, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+        let ev =
+            parse_claude_line(t2, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn).unwrap();
         match ev {
             ReviewEvent::Delta { text } => {
                 assert_eq!(text, "\n\nThe fix is X.");
@@ -2510,9 +2622,11 @@ mod tests {
             }
             other => panic!("expected Delta, got {other:?}"),
         }
-        parse_claude_line(stop2, &mut saw, &mut acc, &mut emitted, &mut pending);
+        parse_claude_line(stop2, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn);
 
-        let done = parse_claude_line(result, &mut saw, &mut acc, &mut emitted, &mut pending).unwrap();
+        let done =
+            parse_claude_line(result, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn)
+                .unwrap();
         match done {
             ReviewEvent::Done { text, .. } => {
                 assert_eq!(text, "The fix is X.", "Done.text is the raw result, no separator");
@@ -2525,21 +2639,185 @@ mod tests {
         }
     }
 
+    // Real Claude CLI terminal lines (probed 2026-08-01, v2.1.220, with the app's
+    // flags), abridged to the fields the parser reads plus a few real neighbours.
+    const CL_SUCCESS: &str = r#"{"is_error":false,"stop_reason":"end_turn","terminal_reason":"completed","subtype":"success","api_error_status":null,"result":"OK","type":"result","total_cost_usd":0.036494}"#;
+    const CL_API_ERROR: &str = r#"{"is_error":true,"terminal_reason":"api_error","subtype":"success","api_error_status":404,"result":"There's an issue with the selected model (bogus-model-xyz). It may not exist or you may not have access to it.","type":"result","total_cost_usd":0}"#;
+    const CL_SYNTHETIC: &str = r#"{"type":"assistant","message":{"model":"<synthetic>","role":"assistant","content":[{"type":"text","text":"There's an issue with the selected model (bogus-model-xyz). It may not exist or you may not have access to it."}]},"error":"model_not_found","is_api_error_message":true}"#;
+
+    /// Feeds fixture lines through one parser state and returns the terminal `Done`.
+    fn claude_done(lines: &[&str]) -> (String, bool) {
+        let mut saw = false;
+        let mut acc = std::collections::HashMap::new();
+        let (mut emitted, mut pending) = (false, false);
+        let mut syn = None;
+        let mut last = None;
+        for line in lines {
+            last = parse_claude_line(line, &mut saw, &mut acc, &mut emitted, &mut pending, &mut syn);
+        }
+        assert!(saw, "the fixture must end with a terminal result");
+        match last.expect("the terminal result emits Done") {
+            ReviewEvent::Done { text, is_error, .. } => (text, is_error),
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_probed_success_line_is_not_an_error() {
+        let (text, is_error) = claude_done(&[CL_SUCCESS]);
+        assert_eq!(text, "OK");
+        assert!(!is_error);
+    }
+
+    #[test]
+    fn claude_probed_api_error_line_is_an_error() {
+        let (text, is_error) = claude_done(&[CL_API_ERROR]);
+        assert!(is_error);
+        assert!(text.starts_with("There's an issue with the selected model"));
+    }
+
+    #[test]
+    fn review_event_wire_shape_is_camel_case() {
+        // Pins the IPC contract with the TS mirror (src/lib/ai/agent.ts): the fields
+        // the frontend reads by name must be exactly these, in camelCase.
+        let done = serde_json::to_value(ReviewEvent::Done {
+            text: "body".to_string(),
+            is_error: true,
+            cost_usd: Some(0.5),
+        })
+        .expect("Done serializes");
+        let obj = done.as_object().expect("Done is a JSON object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["costUsd", "isError", "kind", "text"]);
+        assert_eq!(obj["kind"], "done");
+        assert_eq!(obj["isError"], true);
+        assert_eq!(obj["costUsd"], 0.5);
+        assert!(obj.get("is_error").is_none(), "snake_case field must not ship");
+        assert!(obj.get("cost_usd").is_none(), "snake_case field must not ship");
+
+        // Variant tags are camelCase too (single-word ones are casing-identical).
+        let err = serde_json::to_value(ReviewEvent::Error {
+            message: "boom".to_string(),
+        })
+        .expect("Error serializes");
+        assert_eq!(err["kind"], "error");
+        let native = serde_json::to_value(ReviewEvent::NativeSession {
+            id: "ses_1".to_string(),
+        })
+        .expect("NativeSession serializes");
+        assert_eq!(native["kind"], "nativeSession");
+        assert_eq!(native["id"], "ses_1");
+    }
+
+    #[test]
+    fn claude_is_error_flag_alone_is_decisive() {
+        // The flag pinned in ISOLATION: no api_error_status, no terminal_reason, and
+        // result text no other signal can catch.
+        let line = r#"{"type":"result","subtype":"success","is_error":true,"result":"The run stopped early."}"#;
+        let (text, is_error) = claude_done(&[line]);
+        assert!(is_error);
+        assert_eq!(text, "The run stopped early.");
+    }
+
+    #[test]
+    fn claude_structural_signals_outrank_is_error_false() {
+        // Both shapes claim success in `is_error`; the structural fields say otherwise.
+        let status = r#"{"type":"result","subtype":"success","is_error":false,"api_error_status":529,"result":"Overloaded"}"#;
+        assert!(claude_done(&[status]).1, "api_error_status is decisive");
+        let reason = r#"{"type":"result","subtype":"success","is_error":false,"terminal_reason":"api_error","result":"Something went wrong."}"#;
+        assert!(claude_done(&[reason]).1, "a non-completed terminal_reason is decisive");
+    }
+
+    #[test]
+    fn claude_result_echoing_a_synthetic_error_is_an_error() {
+        // The live-bug shape: an API failure reported with no structural signal at all,
+        // caught only because the synthetic assistant message repeated the same text.
+        let result = r#"{"type":"result","subtype":"success","is_error":false,"result":"There's an issue with the selected model (bogus-model-xyz). It may not exist or you may not have access to it."}"#;
+        assert!(claude_done(&[CL_SYNTHETIC, result]).1);
+        // Without the synthetic message ahead of it, that same line has no signal.
+        assert!(!claude_done(&[result]).1);
+        // The `<synthetic>` model is the fallback when the flag is absent.
+        let by_model = r#"{"type":"assistant","message":{"model":"<synthetic>","role":"assistant","content":[{"type":"text","text":"There's an issue with the selected model (bogus-model-xyz). It may not exist or you may not have access to it."}]}}"#;
+        assert!(claude_done(&[by_model, result]).1);
+    }
+
+    #[test]
+    fn claude_limit_messages_are_caught_without_structural_signals() {
+        let usage = r#"{"type":"result","subtype":"success","is_error":false,"result":"Claude AI usage limit reached|1753980000"}"#;
+        assert!(claude_done(&[usage]).1);
+        let session = r#"{"type":"result","subtype":"success","is_error":false,"result":"5-hour limit reached ∙ resets 3am"}"#;
+        assert!(claude_done(&[session]).1);
+    }
+
+    #[test]
+    fn claude_a_real_review_mentioning_limits_stays_successful() {
+        // The net must never fire on a genuine review body: it is multi-paragraph and
+        // far past the length bound even though it says "limit reached" mid-prose.
+        let review = r#"{"type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","result":"Review of the retry path.\n\nIt swallows the 429 response, so a caller that hits the rate limit reached state never learns why the request failed. That matters here because the surrounding code assumes a thrown error, and the silent None flows into the cache as if it were a successful empty result, which later reads cannot tell apart from real data.\n\nSuggest surfacing the status instead.","total_cost_usd":0.02}"#;
+        let (text, is_error) = claude_done(&[review]);
+        assert!(text.chars().count() > 300, "fixture must exceed the net's bound");
+        assert!(!is_error);
+    }
+
+    #[test]
+    fn claude_long_single_paragraph_clears_the_net_on_length_alone() {
+        // The length bound pinned in ISOLATION: this body matches a net pattern and has
+        // no paragraph break, so only its size keeps a real long answer out of the net.
+        let body = format!(
+            "API Error handling is the subject of this answer, {}",
+            "which runs on in a single paragraph without a blank line anywhere. ".repeat(5)
+        );
+        assert!(body.chars().count() > 300, "fixture must exceed the bound");
+        let line = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "result": body,
+        })
+        .to_string();
+        assert!(!claude_done(&[&line]).1);
+    }
+
+    #[test]
+    fn claude_crlf_paragraph_break_clears_the_net() {
+        // CRLF bodies are multi-paragraph too — the blank-line check must see
+        // `\r\n\r\n`, matching the runner-side twin's /\n[ \t\r]*\n/.
+        let line = r#"{"type":"result","subtype":"success","is_error":false,"result":"API Error: 500 while fetching the diff.\r\n\r\nRetried once, then the review completed."}"#;
+        let (text, is_error) = claude_done(&[line]);
+        assert!(text.chars().count() <= 300, "length must not be what clears it");
+        assert!(!is_error);
+    }
+
+    #[test]
+    fn claude_absent_terminal_reason_stays_successful() {
+        // Back-compat: older CLIs emit neither `terminal_reason` nor `api_error_status`.
+        let old = r#"{"type":"result","subtype":"success","is_error":false,"result":"OK"}"#;
+        let (text, is_error) = claude_done(&[old]);
+        assert_eq!(text, "OK");
+        assert!(!is_error);
+    }
+
     #[test]
     fn copilot_lazy_separator_between_assistant_messages() {
         // Deltas across two assistant messages get exactly one `\n\n` between them.
         let (mut term, mut msg) = (false, String::new());
-        let (mut emitted, mut pending) = (false, false);
+        let (mut emitted, mut pending, mut err) = (false, false, false);
         let d1 = r#"{"type":"assistant.message_delta","data":{"deltaContent":"First."}}"#;
         let m1 = r#"{"type":"assistant.message","data":{"content":"First."}}"#;
         let d2 = r#"{"type":"assistant.message_delta","data":{"deltaContent":"Second."}}"#;
 
-        let ev = parse_copilot_line(d1, &mut term, &mut msg, &mut emitted, &mut pending).unwrap();
+        let ev = parse_copilot_line(d1, &mut term, &mut msg, &mut emitted, &mut pending, &mut err)
+            .unwrap();
         assert!(matches!(ev, ReviewEvent::Delta { text } if text == "First."));
         // A completed message arms the separator; the next delta is prefixed once.
-        assert!(parse_copilot_line(m1, &mut term, &mut msg, &mut emitted, &mut pending).is_none());
+        assert!(
+            parse_copilot_line(m1, &mut term, &mut msg, &mut emitted, &mut pending, &mut err)
+                .is_none()
+        );
         assert!(pending);
-        let ev = parse_copilot_line(d2, &mut term, &mut msg, &mut emitted, &mut pending).unwrap();
+        let ev = parse_copilot_line(d2, &mut term, &mut msg, &mut emitted, &mut pending, &mut err)
+            .unwrap();
         assert!(matches!(ev, ReviewEvent::Delta { text } if text == "\n\nSecond."));
         assert!(!pending, "the separator is consumed by the first following delta");
     }
@@ -2548,11 +2826,79 @@ mod tests {
     fn copilot_first_delta_has_no_separator() {
         // The very first delta of a run must not be prefixed (nothing emitted before).
         let (mut term, mut msg) = (false, String::new());
-        let (mut emitted, mut pending) = (false, false);
+        let (mut emitted, mut pending, mut err) = (false, false, false);
         let d = r#"{"type":"assistant.message_delta","data":{"deltaContent":"Hello."}}"#;
-        let ev = parse_copilot_line(d, &mut term, &mut msg, &mut emitted, &mut pending).unwrap();
+        let ev =
+            parse_copilot_line(d, &mut term, &mut msg, &mut emitted, &mut pending, &mut err)
+                .unwrap();
         assert!(matches!(ev, ReviewEvent::Delta { text } if text == "Hello."));
         assert!(emitted);
+    }
+
+    // Real Copilot CLI `--output-format json` terminal lines.
+    const CP_SESSION_ERROR: &str = r#"{"type":"session.error","data":{"message":"API rate limit exceeded for this session."}}"#;
+    const CP_RESULT_OK: &str = r#"{"type":"result","exitCode":0}"#;
+
+    #[test]
+    fn copilot_session_error_fails_the_run_despite_exit_zero() {
+        // The CLI exits 0 after a session error, which once shipped the error text as
+        // a successful answer; the latch makes the terminal `result` report failure.
+        let (mut term, mut msg) = (false, String::new());
+        let (mut emitted, mut pending, mut err) = (false, false, false);
+        assert!(
+            parse_copilot_line(
+                CP_SESSION_ERROR,
+                &mut term,
+                &mut msg,
+                &mut emitted,
+                &mut pending,
+                &mut err
+            )
+            .is_none()
+        );
+        assert!(err);
+        let ev = parse_copilot_line(
+            CP_RESULT_OK,
+            &mut term,
+            &mut msg,
+            &mut emitted,
+            &mut pending,
+            &mut err,
+        )
+        .unwrap();
+        match ev {
+            ReviewEvent::Done { text, is_error, .. } => {
+                assert!(is_error, "a session.error fails the run whatever the exit code");
+                // The error message is the failure reason the frontend shows.
+                assert_eq!(text, "API rate limit exceeded for this session.");
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+        assert!(term);
+    }
+
+    #[test]
+    fn copilot_clean_run_stays_successful() {
+        let (mut term, mut msg) = (false, String::new());
+        let (mut emitted, mut pending, mut err) = (false, false, false);
+        let m = r#"{"type":"assistant.message","data":{"content":"All good."}}"#;
+        parse_copilot_line(m, &mut term, &mut msg, &mut emitted, &mut pending, &mut err);
+        let ev = parse_copilot_line(
+            CP_RESULT_OK,
+            &mut term,
+            &mut msg,
+            &mut emitted,
+            &mut pending,
+            &mut err,
+        )
+        .unwrap();
+        match ev {
+            ReviewEvent::Done { text, is_error, .. } => {
+                assert!(!is_error);
+                assert_eq!(text, "All good.");
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -274,8 +274,11 @@ export const usePlanStore = create<PlanState>((set, get) => {
               status: "",
             });
           } else if (ev.kind === "done") {
-            // The terminal event carries the authoritative full text; prefer it.
-            if (ev.text.length > finalText.length) finalText = ev.text;
+            // The terminal event carries the authoritative full text; prefer it —
+            // except on an errored Done, whose text is the failure reason and must
+            // not fold into the transcript (visible on the superseded path).
+            if (!ev.isError && ev.text.length > finalText.length)
+              finalText = ev.text;
             if (ev.costUsd != null) patch(id, { costUsd: ev.costUsd });
             // Whole-message agents (codex) stream no deltas — fold the final text
             // in so the transcript shows it after its tool steps.

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -289,8 +289,10 @@ export const usePlanStore = create<PlanState>((set, get) => {
               // restart superseded) — a killed process may emit one on the way out.
               if (!superseded())
                 patch(id, {
+                  // The terminal event's OWN text — never the delta accumulation,
+                  // whose narration could pass the error-shape net as the "reason".
                   error: terminalErrorMessage(
-                    finalText,
+                    ev.text,
                     "The planner reported an error.",
                   ),
                 });

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -16,6 +16,7 @@ import {
   extractPlanDraft,
   validatePlanPaths,
 } from "@/lib/ai/prompt";
+import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { gitListTracked, readRepoInstructions } from "@/lib/git/api";
 import { notify } from "@/lib/notify";
 import { loadSettings } from "@/lib/settings/api";
@@ -288,7 +289,10 @@ export const usePlanStore = create<PlanState>((set, get) => {
               // restart superseded) — a killed process may emit one on the way out.
               if (!superseded())
                 patch(id, {
-                  error: finalText || "The planner reported an error.",
+                  error: terminalErrorMessage(
+                    finalText,
+                    "The planner reported an error.",
+                  ),
                 });
             }
           } else if (ev.kind === "error") {

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/lib/pulls/queries";
 import type { PersistedReview } from "@/lib/pulls/reviews-history";
 import { useSecretPreview, useSettings } from "@/lib/settings/queries";
+import { useConfirm } from "@/lib/stores/confirm";
 import {
   type ReviewContext,
   type ReviewTarget,
@@ -273,6 +274,20 @@ export function PrReviewPanel({
 
   async function post() {
     if (!onPost || !text.trim() || posting) return;
+    // A failed OR cancelled run keeps whatever streamed before it stopped, and that
+    // partial text stays postable — publishing an unfinished review is consequential,
+    // so confirm first, naming which way the run ended.
+    if (phase === "error" || phase === "cancelled") {
+      const ok = await useConfirm.getState().ask({
+        title: "Post partial review?",
+        body:
+          phase === "cancelled"
+            ? "This run was cancelled before it finished, so the text may be incomplete. Post it as a comment anyway?"
+            : "This run failed before completing, so the text may be incomplete. Post it as a comment anyway?",
+        confirmLabel: "Post anyway",
+      });
+      if (!ok) return;
+    }
     const label = mode === "security" ? "security audit" : "review";
     const body = buildAiCommentBody({
       kind: label,

--- a/src/features/repository/ConflictResolveView.tsx
+++ b/src/features/repository/ConflictResolveView.tsx
@@ -121,8 +121,8 @@ export function ConflictResolveView({
     const completed = await run(reviewAi, { system, prompt, repoPath });
     if (gen !== genRef.current) return;
     // A failed or cancelled run leaves a partial (or provider-error) buffer behind;
-    // proposing a "resolution" from it would corrupt the file. The hook toasted the
-    // error already — just let the user retry.
+    // proposing a "resolution" from it would corrupt the file. The hook already
+    // toasted a failure (cancels stay silent by design) — just let the user retry.
     if (!completed) {
       setPhase("idle");
       return;

--- a/src/features/repository/ConflictResolveView.tsx
+++ b/src/features/repository/ConflictResolveView.tsx
@@ -118,8 +118,15 @@ export function ConflictResolveView({
       globalInstructions: settings.data?.globalInstructions ?? "",
     });
     setPhase("streaming");
-    await run(reviewAi, { system, prompt, repoPath });
+    const completed = await run(reviewAi, { system, prompt, repoPath });
     if (gen !== genRef.current) return;
+    // A failed or cancelled run leaves a partial (or provider-error) buffer behind;
+    // proposing a "resolution" from it would corrupt the file. The hook toasted the
+    // error already — just let the user retry.
+    if (!completed) {
+      setPhase("idle");
+      return;
+    }
 
     const merged = extractResolvedContent(textRef.current);
     if (!merged.trim()) {

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -369,8 +369,10 @@ export const useResearchStore = create<ResearchState>((set, get) => {
               // restart superseded) — a killed process may emit one on the way out.
               if (!superseded())
                 patch(id, {
+                  // The terminal event's OWN text — never the delta accumulation,
+                  // whose narration could pass the error-shape net as the "reason".
                   error: terminalErrorMessage(
-                    finalText,
+                    ev.text,
                     "The research agent reported an error.",
                   ),
                 });

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -18,6 +18,7 @@ import {
   buildResearchPrompt,
   extractResearchReport,
 } from "@/lib/ai/prompt";
+import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { readRepoInstructions } from "@/lib/git/api";
 import { notify } from "@/lib/notify";
 import { loadSettings } from "@/lib/settings/api";
@@ -368,7 +369,10 @@ export const useResearchStore = create<ResearchState>((set, get) => {
               // restart superseded) — a killed process may emit one on the way out.
               if (!superseded())
                 patch(id, {
-                  error: finalText || "The research agent reported an error.",
+                  error: terminalErrorMessage(
+                    finalText,
+                    "The research agent reported an error.",
+                  ),
                 });
             }
           } else if (ev.kind === "error") {

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -354,7 +354,11 @@ export const useResearchStore = create<ResearchState>((set, get) => {
               status: "",
             });
           } else if (ev.kind === "done") {
-            if (ev.text.length > finalText.length) finalText = ev.text;
+            // Prefer the terminal event's authoritative full text — except on an
+            // errored Done, whose text is the failure reason and must not fold
+            // into the transcript (visible on the superseded path).
+            if (!ev.isError && ev.text.length > finalText.length)
+              finalText = ev.text;
             if (ev.costUsd != null) patch(id, { costUsd: ev.costUsd });
             // Whole-message agents (e.g. Codex) stream no deltas — fold the final
             // text in so the transcript shows it after its tool steps (uniform with

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -427,8 +427,9 @@ async function runTurn(
             // Codex delivers its whole message in the done event, not as `delta`s, so adopt
             // `ev.text` when nothing was streamed — otherwise the turn shows blank. Added as
             // a text segment too so the transcript shows it after its tool steps; streaming
-            // agents already have both.
-            ...(ev.text && !last.narration
+            // agents already have both. Never on an errored Done, whose text is the failure
+            // REASON — adopting it would render the reason as the agent's own message.
+            ...(ev.text && !last.narration && !ev.isError
               ? {
                   narration: ev.text,
                   segments: appendTranscriptText(last.segments ?? [], ev.text),

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -8,6 +8,7 @@ import {
   type TranscriptSegment,
 } from "@/lib/ai/agent";
 import { cleanupContainerSandbox, stopTestContainer } from "@/lib/ai/sandbox";
+import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import {
   commitWorktreeAll,
@@ -436,8 +437,10 @@ async function runTurn(
             ...(ev.isError
               ? {
                   status: "error",
-                  error:
-                    last.narration || ev.text || "The agent reported an error.",
+                  error: terminalErrorMessage(
+                    ev.text,
+                    "The agent reported an error.",
+                  ),
                 }
               : {}),
           });

--- a/src/lib/ai/cli-client.ts
+++ b/src/lib/ai/cli-client.ts
@@ -25,8 +25,8 @@ const MAX_ERROR_TEXT = 300;
 /**
  * The message for an errored terminal event. Short single-paragraph terminal text on an
  * errored run is the CLI's own error message (probe-verified); anything longer or
- * multi-paragraph is run output, which must never be presented as the failure reason —
- * a run failed by its terminal reason alone carries the truncated body there.
+ * multi-paragraph is run output — e.g. a run failed by its terminal reason alone
+ * carries its truncated body there — and must never be presented as the reason.
  */
 export function terminalErrorMessage(text: string): string {
   const trimmed = text.trim();

--- a/src/lib/ai/cli-client.ts
+++ b/src/lib/ai/cli-client.ts
@@ -18,6 +18,28 @@ const LOGIN_COMMAND = {
   opencode: "opencode auth login",
 } as const;
 
+/** Longest terminal text we will accept as an error reason — mirrors the
+ *  runner-side error-shape tripwire's ceiling. */
+const MAX_ERROR_TEXT = 300;
+
+/**
+ * The message for an errored terminal event. Short single-paragraph terminal text on an
+ * errored run is the CLI's own error message (probe-verified); anything longer or
+ * multi-paragraph is run output, which must never be presented as the failure reason —
+ * a run failed by its terminal reason alone carries the truncated body there.
+ */
+export function terminalErrorMessage(text: string): string {
+  const trimmed = text.trim();
+  if (
+    !trimmed ||
+    trimmed.length > MAX_ERROR_TEXT ||
+    /\n[ \t\r]*\n/.test(trimmed)
+  ) {
+    return "The run ended with an error.";
+  }
+  return trimmed;
+}
+
 /**
  * Builds an {@link AiClient} backed by a locally-installed agent CLI
  * (claude/codex/copilot/opencode), adapting the Tier-1 (non-repo-aware, zero-tools)
@@ -136,7 +158,8 @@ export function createCliClient(settings: AiSettings): AiClient {
             // An errored run throws BEFORE the tail is yielded, matching the
             // `error`-kind branch — a failed run never paints its final text
             // into the caller's draft field.
-            if (event.isError) throw new Error("The run ended with an error.");
+            if (event.isError)
+              throw new Error(terminalErrorMessage(event.text));
             // The terminal event carries the authoritative full text. A coalescing
             // CLI (Codex emits NO deltas — only this final text) has emitted nothing
             // yet, so yield the untold tail; streaming CLIs already emitted it all.

--- a/src/lib/ai/cli-client.ts
+++ b/src/lib/ai/cli-client.ts
@@ -7,6 +7,7 @@ import {
   runAgentReview,
 } from "./agent";
 import { PROVIDER_LABELS } from "./providers";
+import { terminalErrorMessage } from "./terminal-error";
 import type { AiClient, AiSettings, AiStreamRequest } from "./types";
 
 /** The `<CLI> login` command each agent uses to authenticate — mirrors the
@@ -17,28 +18,6 @@ const LOGIN_COMMAND = {
   copilot: "copilot login",
   opencode: "opencode auth login",
 } as const;
-
-/** Longest terminal text we will accept as an error reason — mirrors the
- *  runner-side error-shape tripwire's ceiling. */
-const MAX_ERROR_TEXT = 300;
-
-/**
- * The message for an errored terminal event. Short single-paragraph terminal text on an
- * errored run is the CLI's own error message (probe-verified); anything longer or
- * multi-paragraph is run output — e.g. a run failed by its terminal reason alone
- * carries its truncated body there — and must never be presented as the reason.
- */
-export function terminalErrorMessage(text: string): string {
-  const trimmed = text.trim();
-  if (
-    !trimmed ||
-    trimmed.length > MAX_ERROR_TEXT ||
-    /\n[ \t\r]*\n/.test(trimmed)
-  ) {
-    return "The run ended with an error.";
-  }
-  return trimmed;
-}
 
 /**
  * Builds an {@link AiClient} backed by a locally-installed agent CLI

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -90,8 +90,39 @@ export async function createAiClient(
         abortSignal: req.abortSignal,
         ...(providerOptions ? { providerOptions } : {}),
       });
-      for await (const chunk of result.textStream) {
-        yield chunk;
+      // `textStream` forwards ONLY text deltas and routes an in-stream provider
+      // error to the default `onError` (console.error), so a failed run ends
+      // cleanly and reads as a short success. `fullStream` lets it throw instead.
+      try {
+        for await (const part of result.fullStream) {
+          switch (part.type) {
+            case "text-delta":
+              yield part.text;
+              break;
+            case "error":
+              throw new Error(errorMessage(part.error));
+            case "abort":
+              throw new DOMException(
+                "The generation was cancelled.",
+                "AbortError",
+              );
+            // Remaining parts carry no text; this call passes no tools, so no
+            // tool part can arrive.
+            default:
+              break;
+          }
+        }
+      } catch (e) {
+        // An abort surfaces either as the part above or as a thrown AbortError
+        // mid-await; both must keep the AbortError name, which consumers gate
+        // cancellation on (a cancel is "no result", never a partial buffer).
+        if (
+          req.abortSignal?.aborted ||
+          (e instanceof DOMException && e.name === "AbortError")
+        ) {
+          throw new DOMException("The generation was cancelled.", "AbortError");
+        }
+        throw new Error(errorMessage(e));
       }
     },
     async testConnection() {

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -106,8 +106,9 @@ export async function createAiClient(
                 "The generation was cancelled.",
                 "AbortError",
               );
-            // Remaining parts carry no text; this call passes no tools, so no
-            // tool part can arrive.
+            // Non-answer parts (reasoning deltas included) are dropped on purpose —
+            // only answer text belongs in a draft; no tools are passed, so no tool
+            // part can arrive.
             default:
               break;
           }

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -8,6 +8,7 @@ import {
 import { toastError } from "@/lib/toast";
 import type { AgentToolKind } from "./agent";
 import { cancelAgentReview, providerKind, runAgentReview } from "./agent";
+import { terminalErrorMessage } from "./cli-client";
 import { createAiClient, runAgenticStream } from "./client";
 import { isCliProvider } from "./providers";
 import type { AiSettings } from "./types";
@@ -140,8 +141,9 @@ export async function runCliStream({
             settled = true;
             onCost?.(event.costUsd);
             // An errored run keeps whatever streamed — partial text plus the error, no strip.
+            // Its terminal text is the CLI's error message, not review content: surface it.
             if (event.isError) {
-              reject(new Error("The run ended with an error."));
+              reject(new Error(terminalErrorMessage(event.text)));
               return;
             }
             // The terminal event's text IS the agent's final answer. The delta buffer
@@ -308,7 +310,9 @@ export interface RunStreamArgs {
 /**
  * Generic streaming-AI hook: routes a system+prompt to an HTTP provider (Vercel
  * AI SDK) or a CLI agent subprocess, accumulating the response into `text`.
- * `repoPath` is only used by CLI providers.
+ * `repoPath` is only used by CLI providers. `run` resolves true only for a run that
+ * completed without error and without a cancel, so a caller that consumes `text`
+ * afterwards can tell a real result from a failed/cancelled partial.
  */
 export function useAiTextStream() {
   const [generating, setGenerating] = useState(false);
@@ -335,47 +339,54 @@ export function useAiTextStream() {
     setStatus("");
   }, []);
 
-  const run = useCallback(async (ai: AiSettings, args: RunStreamArgs) => {
-    const gen = ++runGenRef.current;
-    const isCurrent = () => gen === runGenRef.current;
-    // A superseded run must not touch the shared state the newer run now owns.
-    const putText = (t: string) => {
-      if (isCurrent()) setText(t);
-    };
-    const putStatus = (s: string) => {
-      if (isCurrent()) setStatus(s);
-    };
-    cancelledRef.current = false;
-    setGenerating(true);
-    setText("");
-    setStatus("");
-    try {
-      await streamAi({
-        ai,
-        system: args.system,
-        prompt: args.prompt,
-        repoPath: args.repoPath,
-        setText: putText,
-        setStatus: putStatus,
-        onCliId: (id) => {
-          if (isCurrent()) cliIdRef.current = id;
-        },
-        onAbort: (a) => {
-          if (isCurrent()) abortRef.current = a;
-        },
-      });
-    } catch (e) {
-      if (!cancelledRef.current && isCurrent()) toastError(e);
-    } finally {
-      // Only the latest run settles the shared state.
-      if (isCurrent()) {
-        setGenerating(false);
-        setStatus("");
-        abortRef.current = null;
-        cliIdRef.current = null;
+  const run = useCallback(
+    async (ai: AiSettings, args: RunStreamArgs): Promise<boolean> => {
+      const gen = ++runGenRef.current;
+      const isCurrent = () => gen === runGenRef.current;
+      // A superseded run must not touch the shared state the newer run now owns.
+      const putText = (t: string) => {
+        if (isCurrent()) setText(t);
+      };
+      const putStatus = (s: string) => {
+        if (isCurrent()) setStatus(s);
+      };
+      cancelledRef.current = false;
+      setGenerating(true);
+      setText("");
+      setStatus("");
+      try {
+        await streamAi({
+          ai,
+          system: args.system,
+          prompt: args.prompt,
+          repoPath: args.repoPath,
+          setText: putText,
+          setStatus: putStatus,
+          onCliId: (id) => {
+            if (isCurrent()) cliIdRef.current = id;
+          },
+          onAbort: (a) => {
+            if (isCurrent()) abortRef.current = a;
+          },
+        });
+        // A cancel can also settle cleanly (a killed CLI run returns with no
+        // terminal event), so success is "no throw AND not cancelled".
+        return !cancelledRef.current;
+      } catch (e) {
+        if (!cancelledRef.current && isCurrent()) toastError(e);
+        return false;
+      } finally {
+        // Only the latest run settles the shared state.
+        if (isCurrent()) {
+          setGenerating(false);
+          setStatus("");
+          abortRef.current = null;
+          cliIdRef.current = null;
+        }
       }
-    }
-  }, []);
+    },
+    [],
+  );
 
   return { run, cancel, reset, generating, text, status };
 }

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -8,9 +8,9 @@ import {
 import { toastError } from "@/lib/toast";
 import type { AgentToolKind } from "./agent";
 import { cancelAgentReview, providerKind, runAgentReview } from "./agent";
-import { terminalErrorMessage } from "./cli-client";
 import { createAiClient, runAgenticStream } from "./client";
 import { isCliProvider } from "./providers";
+import { terminalErrorMessage } from "./terminal-error";
 import type { AiSettings } from "./types";
 
 export interface CliStreamOpts {
@@ -370,9 +370,10 @@ export function useAiTextStream() {
             if (isCurrent()) abortRef.current = a;
           },
         });
-        // A cancel can also settle cleanly (a killed CLI run returns with no
-        // terminal event), so success is "no throw AND not cancelled".
-        return !cancelledRef.current;
+        // A cancel can also settle cleanly (a killed CLI run returns with no terminal
+        // event), so success is "no throw AND not cancelled" — and a superseded run
+        // must report failure rather than read the newer run's reset cancel flag.
+        return isCurrent() && !cancelledRef.current;
       } catch (e) {
         if (!cancelledRef.current && isCurrent()) toastError(e);
         return false;

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -141,7 +141,8 @@ export async function runCliStream({
             settled = true;
             onCost?.(event.costUsd);
             // An errored run keeps whatever streamed — partial text plus the error, no strip.
-            // Its terminal text is the CLI's error message, not review content: surface it.
+            // Surface the terminal text as the reason only when it's error-shaped
+            // (terminalErrorMessage refuses run output, e.g. a body ended by session.error).
             if (event.isError) {
               reject(new Error(terminalErrorMessage(event.text)));
               return;

--- a/src/lib/ai/terminal-error.ts
+++ b/src/lib/ai/terminal-error.ts
@@ -1,0 +1,30 @@
+/** Longest terminal text we will accept as an error reason — mirrors the
+ *  runner-side error-shape tripwire's ceiling. */
+const MAX_ERROR_TEXT = 300;
+
+/**
+ * The message for an errored terminal event, or `fallback` (the calling surface's own
+ * generic copy) when the text isn't error-shaped. Short single-paragraph terminal text
+ * on an errored run is the CLI's own error message (probe-verified); anything longer or
+ * multi-paragraph is run output — a run failed by its terminal reason alone carries the
+ * truncated body there, and presenting that as the reason is the bug this exists to stop.
+ * Error-shape twins to keep aligned: `claude_result_is_error` / `has_blank_line`
+ * (agent.rs) and `looksLikeProviderError` (automations/runner.ts).
+ *
+ * Deliberately a leaf module — the session stores and the streaming core import it, so it
+ * must never pull in `cli-client` (which `client.ts` loads lazily) or any other ai/ module.
+ */
+export function terminalErrorMessage(
+  text: string,
+  fallback = "The run ended with an error.",
+): string {
+  const trimmed = text.trim();
+  if (
+    !trimmed ||
+    trimmed.length > MAX_ERROR_TEXT ||
+    /\n[ \t\r]*\n/.test(trimmed)
+  ) {
+    return fallback;
+  }
+  return trimmed;
+}

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -18,6 +18,7 @@ import { buildReviewPrompt } from "@/lib/ai/prompt";
 import { isCliProvider, isLocalProvider } from "@/lib/ai/providers";
 import { reviewTimeoutSecs } from "@/lib/ai/review-timeout";
 import { runCliStream } from "@/lib/ai/stream";
+import { safeSlice } from "@/lib/ai/truncate";
 import type { AiSettings, PromptProvider, ReviewMode } from "@/lib/ai/types";
 import {
   forgePrComment,
@@ -131,6 +132,28 @@ function targetRef(event: PrAutomationEvent): string {
 
 function modeLabel(mode: ReviewMode): "security audit" | "review" {
   return mode === "security" ? "security audit" : "review";
+}
+
+/** Longest whole body {@link looksLikeProviderError} will judge, and how much of it
+ *  the thrown message quotes back. */
+const ERROR_SHAPE_MAX_CHARS = 300;
+const ERROR_SHAPE_CLIP_CHARS = 200;
+
+/**
+ * Last-resort net for a CLI/provider that reports a failure as a successful review —
+ * an outage once posted "API Error: 500 …" as a real automated PR comment (2026-07-29).
+ * Scoped to a SHORT, single-paragraph WHOLE body, so a genuine review that merely quotes
+ * an error can't trip it; the parser-side twin guards agent.rs's claude result branch.
+ */
+function looksLikeProviderError(text: string): boolean {
+  const body = text.trim();
+  if (body.length > ERROR_SHAPE_MAX_CHARS) return false;
+  if (/\n[ \t\r]*\n/.test(body)) return false;
+  return (
+    body.startsWith("API Error") ||
+    body.startsWith("Claude AI usage limit reached") ||
+    (body.includes("limit reached") && body.includes("resets"))
+  );
 }
 
 /**
@@ -444,6 +467,26 @@ async function run(
         continue;
       }
       const { text, thoughts } = result;
+      // Both gates throw BEFORE deliver and persistReviewHistory, so a bad run
+      // neither posts a comment nor advances the pr-sync watermark — it lands in
+      // the catch below (failure toast + inbox row with Re-run + released claim).
+      if (!text.trim()) {
+        throw new Error(
+          `The AI ${label} run produced no text — nothing was posted.`,
+        );
+      }
+      if (looksLikeProviderError(text)) {
+        const body = text.trim();
+        // Ellipsis only when the quote was actually cut, so a short error reads as the
+        // complete message it is.
+        const quoted =
+          body.length > ERROR_SHAPE_CLIP_CHARS
+            ? `${safeSlice(body, ERROR_SHAPE_CLIP_CHARS)}…`
+            : body;
+        throw new Error(
+          `The AI ${label} run returned an error message instead of a review: "${quoted}" — nothing was posted.`,
+        );
+      }
       // The delivered comment body carries the final review text ONLY — the
       // agentic narration is persisted to history for later inspection, never
       // posted (buildAiCommentBody + deliver both take `text`).

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -143,8 +143,9 @@ const ERROR_SHAPE_CLIP_CHARS = 200;
  * Last-resort net for a CLI/provider that reports a failure as a successful review —
  * this is the unattended path, so an error body that slips through gets posted to a
  * real PR. Scoped to a SHORT, single-paragraph WHOLE body, so a genuine review that
- * merely quotes an error can't trip it; the parser-side twin guards agent.rs's claude
- * result branch.
+ * merely quotes an error can't trip it. Twins that must stay aligned: agent.rs's
+ * `claude_result_is_error`/`has_blank_line` (parser side) and `terminalErrorMessage`
+ * in `src/lib/ai/terminal-error.ts` (the inverse accept-gate).
  */
 function looksLikeProviderError(text: string): boolean {
   const body = text.trim();

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -141,9 +141,10 @@ const ERROR_SHAPE_CLIP_CHARS = 200;
 
 /**
  * Last-resort net for a CLI/provider that reports a failure as a successful review —
- * an outage once posted "API Error: 500 …" as a real automated PR comment (2026-07-29).
- * Scoped to a SHORT, single-paragraph WHOLE body, so a genuine review that merely quotes
- * an error can't trip it; the parser-side twin guards agent.rs's claude result branch.
+ * this is the unattended path, so an error body that slips through gets posted to a
+ * real PR. Scoped to a SHORT, single-paragraph WHOLE body, so a genuine review that
+ * merely quotes an error can't trip it; the parser-side twin guards agent.rs's claude
+ * result branch.
  */
 function looksLikeProviderError(text: string): boolean {
   const body = text.trim();

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -719,6 +719,13 @@ export async function startReview(
       },
     });
     if (control.cancelled) return;
+    // The stream's final text, read from the store so it covers the CLI and HTTP paths
+    // alike; a cancelled run returned above, so this is never a mid-stream fragment.
+    const finalText = useReviewStore.getState().texts[key] ?? "";
+    // A run that settled with nothing failed, however the provider reported it — throw
+    // so it rides the catch below (error phase + inbox row) rather than settling "done"
+    // and announcing a review that isn't there.
+    if (!finalText.trim()) throw new Error("The review run produced no text.");
     // A run WITH tools closes its own coverage gap, so only a non-agentic run that
     // saw a truncated diff drives the panel's upgrade nudge.
     patch({
@@ -728,10 +735,8 @@ export async function startReview(
       endedAt: Date.now(),
     });
     void notifyReviewDone(title, mode, true, target);
-    // Persist the finished review so the NEXT run can use it as soft context. The final
-    // text is read from the store (covers CLI and HTTP paths); a cancelled run returns
-    // above, so no mid-stream fragment is stored. Best-effort.
-    const finalText = useReviewStore.getState().texts[key] ?? "";
+    // Persist the finished review so the NEXT run can use it as soft context.
+    // Best-effort.
     // The agentic run's narration, peeled off at settle — persisted as display-only
     // metadata (omitted when empty; the next run's soft context reads `text` alone).
     const thoughts = useReviewStore.getState().entries[key]?.thoughts;


### PR DESCRIPTION
A failed AI run could reach the user as a successful result: the CLI parsers trusted signals that lie (Claude exits 0 with `is_error: false` on API errors, Copilot exits 0 after a `session.error`), the HTTP path swallowed in-stream provider errors via `textStream`'s default `onError`, and the IPC layer dropped `is_error` entirely because `serde`'s `rename_all` doesn't rename fields. The result was error text posted as a real automated PR review (an "API Error: 500" body, 2026-07-29) and provider errors landing in commit-message and conflict-resolution drafts. This change makes failure detection trustworthy at every layer and adds last-resort nets where a provider gives no honest signal at all.

### IPC wire shape (root cause)

- Adds `rename_all_fields = "camelCase"` to `ReviewEvent` in `src-tauri/src/agent.rs` — without it `Done.is_error` arrived at the TS mirror (`src/lib/ai/agent.ts`) as `undefined`, so every failed run read as a success.
- Pins the contract with `review_event_wire_shape_is_camel_case`, asserting the exact key set (`costUsd`, `isError`, `kind`, `text`), the camelCase variant tags, and that no snake_case field ships.

### Claude CLI parsing

- Adds `claude_result_is_error` in `agent.rs`, which ranks structural signals — `is_error`, a non-null `api_error_status`, a present-but-not-`"completed"` `terminal_reason` — ahead of a narrow text net for limit/`API Error` bodies that arrive with no signal at all. The net is bounded to short, single-paragraph bodies so a genuine review that mentions rate limits can't trip it.
- Threads a `synthetic_error` state through `parse_claude_line`: a synthetic API-error assistant message (`is_api_error_message`, or `model: "<synthetic>"`) is stashed and matched against the terminal `result` text, which is the only signal in the live-bug shape.
- Adds `has_blank_line`, a CRLF-tolerant paragraph-break check that mirrors `/\n[ \t\r]*\n/` in the runner-side twin.
- Adds fixture-backed tests from a real CLI probe (v2.1.220) covering success, API error, the `is_error` flag in isolation, structural signals outranking `is_error: false`, synthetic-echo detection, limit messages, back-compat with an absent `terminal_reason`, and two negative controls (a long real review, a long single-paragraph body, a CRLF multi-paragraph body).

### Copilot CLI parsing

- Latches `session.error` in `parse_copilot_line` via a new `saw_error` flag and ORs it into `Done.is_error` at the terminal `result`, since the CLI exits 0 after a session error. The trade-off (a later genuine recovery also fails the run) is stated at the call site.
- Adds `copilot_session_error_fails_the_run_despite_exit_zero` and `copilot_clean_run_stays_successful`.

### HTTP provider path

- Switches `src/lib/ai/client.ts` from `result.textStream` to `result.fullStream`, throwing on an `error` part and mapping `abort` to a `DOMException`/`AbortError`, so an in-stream provider error no longer ends the run cleanly and reads as a short success.
- Preserves the `AbortError` name across both the part-based and thrown-mid-await abort shapes, which consumers gate cancellation on.

### Failure surfacing and consumers

- Adds `terminalErrorMessage` in `src/lib/ai/cli-client.ts` (bounded to 300 chars and single-paragraph) so a real CLI error message is shown as the reason instead of the generic "The run ended with an error."; used by both `cli-client.ts` and `runCliStream` in `src/lib/ai/stream.ts`.
- Changes `useAiTextStream`'s `run` in `src/lib/ai/stream.ts` to return `Promise<boolean>` — true only when the run neither threw nor was cancelled — so callers can distinguish a real result from a partial buffer.
- Uses that signal in `src/features/repository/ConflictResolveView.tsx`: a failed or cancelled run resets to `idle` instead of proposing a "resolution" built from a partial or error buffer.
- Adds a confirmation in `src/features/pulls/PrReviewPanel.tsx` before posting when `phase` is `error` or `cancelled`, with copy naming which way the run ended.
- Throws in `startReview` (`src/lib/stores/reviews.ts`) when the settled run produced no text, so it rides the existing catch into the error phase and inbox row rather than announcing a review that isn't there.

### Automation runner

- Adds an empty-text gate and `looksLikeProviderError` in `src/lib/automations/runner.ts`, both throwing *before* `deliver` and `persistReviewHistory` so a bad run neither posts a comment nor advances the pr-sync watermark, and instead lands in the failure toast + inbox row with Re-run.
- Quotes the offending body in the thrown message using `safeSlice`, appending an ellipsis only when the quote was actually cut.

### Docs

- Adds `changelog.d/fixed-ai-error-publish.md` describing the user-visible effect: failed runs no longer post to PRs or land in drafts, failures appear in Activity & notifications with a re-run, and posting a partial review asks first.