### PR TITLE
fix(git,pulls,mcp,stash): correct base branch, merge SHA, stash toast

### DIFF
--- a/changelog.d/fixed-default-branch-non-origin.md
+++ b/changelog.d/fixed-default-branch-non-origin.md
@@ -1,0 +1,3 @@
+- Base-branch detection now works in repositories whose remote isn't named
+  `origin` (a clone made with `git clone -o <name>`), so compare views and
+  generated branch names start from the right branch.

--- a/changelog.d/fixed-mcp-release-updater-sync.md
+++ b/changelog.d/fixed-mcp-release-updater-sync.md
@@ -1,0 +1,3 @@
+- Editing a release through the MCP server now keeps the `latest.json` updater
+  notes in sync with the release notes, matching the in-app editor, so installed
+  apps show the same "what's new" however the release was edited.

--- a/changelog.d/fixed-pr-timeline-merge-sha.md
+++ b/changelog.d/fixed-pr-timeline-merge-sha.md
@@ -1,0 +1,1 @@
+- A merged pull request's timeline now shows the commit it was merged as.

--- a/changelog.d/fixed-stash-empty-toast.md
+++ b/changelog.d/fixed-stash-empty-toast.md
@@ -1,0 +1,2 @@
+- Stashing selected files now tells you when there was nothing to stash, instead
+  of reporting a stash that was never created.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -368,6 +368,17 @@ pub(crate) async fn git_delete_remote_branch_core(
     }
 }
 
+/// The branch `refs/remotes/<remote>/HEAD` points at, or `None` when that symref
+/// is unset.
+async fn remote_head_branch(repo_path: &str, remote: &str) -> AppResult<Option<String>> {
+    crate::git::remote::read_symbolic_ref(
+        repo_path,
+        &format!("refs/remotes/{remote}/HEAD"),
+        &format!("refs/remotes/{remote}/"),
+    )
+    .await
+}
+
 /// The repository's default branch: the HEAD a remote points at — `origin` first,
 /// then every other remote in `git remote` order, so a clone made with `-o <name>`
 /// resolves too — otherwise a local "main"/"master" if one exists.
@@ -377,19 +388,19 @@ pub(crate) async fn git_delete_remote_branch_core(
 /// one) falls through to the local-name fallback.
 #[tauri::command]
 pub async fn git_default_branch(repo_path: String) -> AppResult<Option<String>> {
-    // Best-effort: an unlistable remote set just leaves no remote HEAD to consult,
-    // which the local-name fallback below already covers.
-    let mut remotes = crate::git::remote::git_remotes(repo_path.clone())
+    // Origin answers almost every repo, so probe it before paying for a remote
+    // listing — the common case stays at one git spawn.
+    if let Some(name) = remote_head_branch(&repo_path, "origin").await? {
+        return Ok(Some(name));
+    }
+    // Only now list, and sweep the OTHER remotes in `git remote` order — a clone made
+    // with `-o <name>` keeps its HEAD there. Best-effort: an unlistable remote set
+    // just leaves no remote HEAD to consult, which the fallback below already covers.
+    let remotes = crate::git::remote::git_remotes(repo_path.clone())
         .await
         .unwrap_or_default();
-    // Origin first when present (a stable sort keeps the rest in `git remote` order).
-    remotes.sort_by_key(|r| r != "origin");
-    for remote in remotes {
-        let head_ref = format!("refs/remotes/{remote}/HEAD");
-        let prefix = format!("refs/remotes/{remote}/");
-        if let Some(name) =
-            crate::git::remote::read_symbolic_ref(&repo_path, &head_ref, &prefix).await?
-        {
+    for remote in remotes.iter().filter(|r| r.as_str() != "origin") {
+        if let Some(name) = remote_head_branch(&repo_path, remote).await? {
             return Ok(Some(name));
         }
     }

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -368,20 +368,28 @@ pub(crate) async fn git_delete_remote_branch_core(
     }
 }
 
-/// The repository's default branch: origin's HEAD when known, otherwise a
-/// local "main"/"master" if one exists.
+/// The repository's default branch: the HEAD a remote points at — `origin` first,
+/// then every other remote in `git remote` order, so a clone made with `-o <name>`
+/// resolves too — otherwise a local "main"/"master" if one exists.
+///
+/// Local refs only, no network: this runs in read paths and takes no `State`, so a
+/// remote whose `refs/remotes/<remote>/HEAD` symref was never written (a hand-added
+/// one) falls through to the local-name fallback.
 #[tauri::command]
 pub async fn git_default_branch(repo_path: String) -> AppResult<Option<String>> {
-    let out = run_git_raw(
-        Some(&repo_path),
-        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-    if out.code == 0 {
-        let full = out.stdout_lossy().trim().to_string();
-        let name = full.strip_prefix("origin/").unwrap_or(&full).to_string();
-        if !name.is_empty() {
+    // Best-effort: an unlistable remote set just leaves no remote HEAD to consult,
+    // which the local-name fallback below already covers.
+    let mut remotes = crate::git::remote::git_remotes(repo_path.clone())
+        .await
+        .unwrap_or_default();
+    // Origin first when present (a stable sort keeps the rest in `git remote` order).
+    remotes.sort_by_key(|r| r != "origin");
+    for remote in remotes {
+        let head_ref = format!("refs/remotes/{remote}/HEAD");
+        let prefix = format!("refs/remotes/{remote}/");
+        if let Some(name) =
+            crate::git::remote::read_symbolic_ref(&repo_path, &head_ref, &prefix).await?
+        {
             return Ok(Some(name));
         }
     }
@@ -822,8 +830,8 @@ fn unique_suffix() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_create_branch_args, git_branches, git_create_branch_core, parse_upstream_track,
-        validate_ref_name,
+        build_create_branch_args, git_branches, git_create_branch_core, git_default_branch,
+        parse_upstream_track, validate_ref_name,
     };
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
     use crate::state::AppState;
@@ -1119,6 +1127,104 @@ mod tests {
         assert_eq!(
             solo.upstream_remote, None,
             "an untracked branch carries no upstream remote"
+        );
+    }
+
+    /// `git clone -o upstream` writes `refs/remotes/upstream/HEAD` and no origin ref
+    /// at all, so resolution has to consult whatever remotes the repo actually has.
+    /// The source branch is named `trunk` — a name the local main/master fallback
+    /// can never produce, so only the remote HEAD can satisfy this.
+    #[tokio::test]
+    async fn default_branch_resolves_a_clone_whose_remote_isnt_origin() {
+        let (_base, base) = temp_base("default-branch-upstream");
+        let src = base.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        let src_s = src.to_string_lossy().into_owned();
+        init_repo(&src_s, "r.txt").await;
+        run(&src_s, &["branch", "-m", "trunk"]).await;
+
+        let clone_s = base.join("clone").to_string_lossy().into_owned();
+        run_git(
+            None,
+            &["clone", "-q", "-o", "upstream", &src_s, &clone_s],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .expect("local clone succeeds");
+
+        assert_eq!(
+            git_default_branch(clone_s).await.expect("resolves"),
+            Some("trunk".to_string()),
+            "the only remote's HEAD answers even when it isn't named origin"
+        );
+    }
+
+    /// With several remotes, origin still wins — it is tried before the others
+    /// regardless of where `git remote` lists it.
+    #[tokio::test]
+    async fn default_branch_prefers_origin_over_other_remotes() {
+        let (_base, base) = temp_base("default-branch-origin-wins");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        init_repo(&repo_s, "r.txt").await;
+        // URLs are the repo's own path — nothing is ever fetched; the HEAD symrefs
+        // are written by hand, exactly as a clone would leave them. `canonical` sorts
+        // before `origin`, so it is the remote a naive "first listed wins" would pick.
+        for remote in ["canonical", "origin"] {
+            run(&repo_s, &["remote", "add", remote, &repo_s]).await;
+            let head = format!("refs/remotes/{remote}/{remote}-head");
+            run(&repo_s, &["update-ref", &head, "HEAD"]).await;
+            run(
+                &repo_s,
+                &[
+                    "symbolic-ref",
+                    &format!("refs/remotes/{remote}/HEAD"),
+                    &head,
+                ],
+            )
+            .await;
+        }
+        assert!(
+            run(&repo_s, &["remote"])
+                .await
+                .trim()
+                .starts_with("canonical"),
+            "fixture must list a non-origin remote first for this to discriminate"
+        );
+
+        assert_eq!(
+            git_default_branch(repo_s).await.expect("resolves"),
+            Some("origin-head".to_string()),
+            "origin's HEAD wins over another remote's"
+        );
+    }
+
+    /// No remote HEAD to read: local `main`/`master` answer, anything else is `None`.
+    /// A remote whose HEAD symref was never written (a hand-added one) must fall
+    /// through here rather than reaching for the network.
+    #[tokio::test]
+    async fn default_branch_falls_back_to_local_names() {
+        let (_base, base) = temp_base("default-branch-fallback");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        init_repo(&repo_s, "r.txt").await;
+        run(&repo_s, &["branch", "-m", "master"]).await;
+        assert_eq!(
+            git_default_branch(repo_s.clone()).await.expect("resolves"),
+            Some("master".to_string()),
+            "a remote-less repo falls back to its local master"
+        );
+
+        run(&repo_s, &["remote", "add", "upstream", &repo_s]).await;
+        run(&repo_s, &["branch", "-m", "topic"]).await;
+        assert_eq!(
+            git_default_branch(repo_s).await.expect("resolves"),
+            None,
+            "a remote with no HEAD symref and no main/master resolves to nothing"
         );
     }
 }

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -373,7 +373,7 @@ pub async fn git_remote_default_branch(
 /// Read a symbolic ref and strip `prefix` off its target, returning the tail
 /// (the branch name). `None` when the ref is unset — `git symbolic-ref` exits
 /// non-zero — or its target doesn't start with `prefix`.
-async fn read_symbolic_ref(
+pub(crate) async fn read_symbolic_ref(
     repo_path: &str,
     symref: &str,
     prefix: &str,

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2563,8 +2563,12 @@ pub async fn gh_pr_reactions(
 /// feeding the Conversation tab. The backend maps a GitHub `timelineItems`
 /// `__typename` onto a variant; an unclassifiable node is skipped, never a panic.
 /// Every `actor`/`date`/oid defaults to `""` for GitHub nulls.
+///
+/// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
+/// for the TS mirror (`src/lib/git/types.ts`): without it `Merged.commit_oid` reaches
+/// TS as `undefined` and a merged PR silently loses its merge commit.
 #[derive(Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum PrTimelineEventOut {
     /// `HeadRefForcePushedEvent` — the head branch was force-pushed.
     ForcePushed {
@@ -4885,6 +4889,28 @@ github.acme.com
         // An unrecognized/missing __typename is skipped (None), not a panic.
         assert!(node(serde_json::json!({ "__typename": "SomeOtherEvent" })).is_none());
         assert!(node(serde_json::json!({ "actor": {"login": "a"} })).is_none());
+    }
+
+    #[test]
+    fn merged_timeline_event_wire_shape_is_camel_case() {
+        // Pins the IPC contract with the TS mirror (src/lib/git/types.ts): `commit_oid`
+        // is the enum's only multi-word field, and the frontend reads it as `commitOid`.
+        let merged = serde_json::to_value(PrTimelineEventOut::Merged {
+            actor: "alice".to_string(),
+            commit_oid: Some("deadbeef".to_string()),
+            date: "2026-05-12T12:01:23Z".to_string(),
+        })
+        .expect("Merged serializes");
+        let obj = merged.as_object().expect("Merged is a JSON object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["actor", "commitOid", "date", "kind"]);
+        assert_eq!(obj["kind"], "merged");
+        assert_eq!(obj["commitOid"], "deadbeef");
+        assert!(
+            obj.get("commit_oid").is_none(),
+            "snake_case field must not ship"
+        );
     }
 
     #[test]

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1767,7 +1767,7 @@ async fn branch_commit_subjects(repo: &str, base: &str) -> Vec<String> {
 /// The ref a branch's COMMITTED work is compared against for naming: the repo's
 /// default branch, preferring the remote-tracking `origin/<default>` over the local
 /// `<default>`. `git_default_branch` returns the SHORT LOCAL name even when it
-/// derived it from `origin/HEAD`, and that local branch may be stale (skewing the
+/// derived it from a remote's HEAD, and that local branch may be stale (skewing the
 /// three-dot diff) or not exist at all — so verify both and prefer the remote.
 /// `None` = no default branch, or neither ref resolves ⇒ no fallback is possible.
 async fn committed_base_ref(repo: &str) -> Option<String> {

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -227,6 +227,11 @@ struct UpdateReleaseArgs {
     /// New prerelease state (GitHub only). Omit to keep the current state.
     #[serde(default)]
     prerelease: Option<bool>,
+    /// Whether to also point the release's `latest.json` Tauri updater manifest at
+    /// the new notes (GitHub only, and only when the release carries that asset).
+    /// Defaults to true; set false to leave the manifest alone.
+    #[serde(default)]
+    sync_updater_notes: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -382,6 +387,65 @@ struct CloseDiscussionArgs {
     /// to "RESOLVED".
     #[serde(default)]
     reason: String,
+}
+
+/// Tauri's updater manifest, attached to a release as an asset of this exact name.
+/// Mirrors `github::release`'s own constant (private to that module) and the
+/// frontend's `UPDATER_MANIFEST_NAME`.
+const UPDATER_MANIFEST: &str = "latest.json";
+
+/// Point a just-edited release's updater manifest at `notes`, mirroring the in-app
+/// editor's gate: GitHub only, and only when the release actually ships a
+/// `latest.json` asset. `None` = a gate skipped it (the common case — most repos
+/// have no manifest), `Some(Err)` = a ready-to-report sentence for the caller to
+/// disclose alongside the successful edit — each failure arm words its own, so
+/// neither asserts a manifest exists when that is exactly what went unverified.
+/// `current` is the pre-edit release read when the tool already needed one; an
+/// edit can't change the asset list.
+async fn sync_release_updater_notes(
+    repo: &str,
+    tag: &str,
+    notes: &str,
+    current: Option<&crate::github::release::ReleaseDetails>,
+) -> Option<Result<(), String>> {
+    // `detect_non_github` returning None IS the GitHub arm (forge's resilient
+    // default); GitLab/Bitbucket releases carry no Tauri updater manifest.
+    if crate::forge::detect_non_github(repo).await.is_some() {
+        return None;
+    }
+    let fetched;
+    let release = match current {
+        Some(r) => r,
+        None => {
+            match crate::forge::forge_release_view(repo.to_string(), tag.to_string()).await {
+                Ok(r) => {
+                    fetched = r;
+                    &fetched
+                }
+                // Can't tell whether a manifest is attached — report rather than
+                // let silence read as "this release has none".
+                Err(e) => {
+                    return Some(Err(format!(
+                        "The release was updated, but whether it carries a \
+                         {UPDATER_MANIFEST} updater manifest could not be checked: {e}"
+                    )))
+                }
+            }
+        }
+    };
+    if !release.assets.iter().any(|a| a.name == UPDATER_MANIFEST) {
+        return None;
+    }
+    Some(
+        crate::github::release::gh_release_sync_updater_notes(repo, tag, notes)
+            .await
+            .map_err(|e| {
+                format!(
+                    "The release was updated, but its {UPDATER_MANIFEST} updater manifest \
+                     was not: {e}"
+                )
+            }),
+    )
 }
 
 #[tool_router(router = write_forge_router, vis = "pub(crate)")]
@@ -1019,8 +1083,12 @@ impl GitDesktopMcp {
         description = "Edit a release's title and/or notes (and, on GitHub, its draft/prerelease \
                        state) by tag in the bound repository's forge (GitHub or GitLab, per its \
                        remote; Bitbucket releases aren't supported). Omitted fields keep their \
-                       current value (the current release is read first to preserve them). Requires \
-                       --allow-remote-write.",
+                       current value (the current release is read first to preserve them). When \
+                       `notes` are given and the release carries a `latest.json` Tauri updater \
+                       manifest (GitHub only), the manifest's notes are synced to match, so \
+                       installed apps show the same \"what's new\" as the release page — pass \
+                       `sync_updater_notes: false` to leave it alone. Releases without that asset \
+                       are unaffected. Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn update_release(
@@ -1028,6 +1096,15 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<UpdateReleaseArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
+        // Captured before the fallbacks below consume `args.notes`. Empty/whitespace
+        // notes leave the release body untouched (the edit skips `--notes`), so there
+        // is nothing to carry into the manifest — syncing them would blank it.
+        let notes_to_sync = args
+            .notes
+            .as_deref()
+            .map(str::trim)
+            .filter(|n| !n.is_empty())
+            .map(str::to_string);
         // forge_release_edit sends title/notes AND applies prerelease/draft explicitly
         // (gh's `--flag=<bool>` form), so an omitted flag would otherwise be forced to its
         // param default. Read the current release to preserve whatever the caller didn't
@@ -1074,7 +1151,26 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
-        json_result(&serde_json::json!({ "tag": args.tag, "action": "updated" }))
+        let mut result = serde_json::json!({ "tag": args.tag, "action": "updated" });
+        // The edit already landed, so a manifest-sync failure is a caveat on a
+        // successful result, never a tool error — and its text carries the recovery
+        // path for a clobbered manifest, so it ships verbatim.
+        if let Some(sync_notes) = notes_to_sync.filter(|_| args.sync_updater_notes != Some(false)) {
+            match sync_release_updater_notes(&self.repo, &args.tag, &sync_notes, current.as_ref())
+                .await
+            {
+                Some(Ok(())) => {
+                    result["updater_manifest"] = serde_json::Value::String(format!(
+                        "Updater manifest ({UPDATER_MANIFEST}) synced to the edited notes."
+                    ));
+                }
+                Some(Err(disclosure)) => {
+                    result["updater_manifest_error"] = serde_json::Value::String(disclosure);
+                }
+                None => {}
+            }
+        }
+        json_result(&result)
     }
 
     #[tool(
@@ -1570,6 +1666,7 @@ mod tests {
             notes: Some("n".into()),
             draft: Some(false),
             prerelease: Some(false),
+            sync_updater_notes: None,
         })));
         assert_gated!(h.create_review_thread(Parameters(CreateReviewThreadArgs {
             number: 1,

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -394,14 +394,27 @@ struct CloseDiscussionArgs {
 /// frontend's `UPDATER_MANIFEST_NAME`.
 const UPDATER_MANIFEST: &str = "latest.json";
 
+/// The notes an updater-manifest sync should carry, or `None` when it must not run.
+/// Empty/whitespace notes leave the release body untouched (the edit trims and skips
+/// `--notes`), so syncing them would blank a live manifest; `Some(false)` is the
+/// caller's opt-out. The text is TRIMMED, matching what the edit wrote to the body.
+fn updater_notes_to_sync(notes: Option<&str>, sync: Option<bool>) -> Option<String> {
+    if sync == Some(false) {
+        return None;
+    }
+    notes
+        .map(str::trim)
+        .filter(|n| !n.is_empty())
+        .map(str::to_string)
+}
+
 /// Point a just-edited release's updater manifest at `notes`, mirroring the in-app
-/// editor's gate: GitHub only, and only when the release actually ships a
-/// `latest.json` asset. `None` = a gate skipped it (the common case — most repos
-/// have no manifest), `Some(Err)` = a ready-to-report sentence for the caller to
-/// disclose alongside the successful edit — each failure arm words its own, so
-/// neither asserts a manifest exists when that is exactly what went unverified.
-/// `current` is the pre-edit release read when the tool already needed one; an
-/// edit can't change the asset list.
+/// editor's gate: GitHub only, and only when the release ships a `latest.json` asset.
+/// `None` = a gate skipped it, `Some(Err)` = a ready-to-report sentence for the caller
+/// to disclose alongside the successful edit (each failure arm words its own, so
+/// neither asserts a manifest exists when that is what went unverified). `current` is
+/// the pre-edit release read when the tool already needed one — an edit can't change
+/// the asset list.
 async fn sync_release_updater_notes(
     repo: &str,
     tag: &str,
@@ -1088,23 +1101,20 @@ impl GitDesktopMcp {
                        manifest (GitHub only), the manifest's notes are synced to match, so \
                        installed apps show the same \"what's new\" as the release page — pass \
                        `sync_updater_notes: false` to leave it alone. Releases without that asset \
-                       are unaffected. Requires --allow-remote-write.",
-        annotations(read_only_hint = false, destructive_hint = false)
+                       are unaffected. Syncing REPLACES the `latest.json` asset \
+                       (delete-then-upload), so a failed upload can leave the release without a \
+                       manifest; `updater_manifest_error` then carries the recovery details, \
+                       including the patched copy's path when one could be parked. Requires \
+                       --allow-remote-write.",
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn update_release(
         &self,
         Parameters(args): Parameters<UpdateReleaseArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_remote_write()?;
-        // Captured before the fallbacks below consume `args.notes`. Empty/whitespace
-        // notes leave the release body untouched (the edit skips `--notes`), so there
-        // is nothing to carry into the manifest — syncing them would blank it.
-        let notes_to_sync = args
-            .notes
-            .as_deref()
-            .map(str::trim)
-            .filter(|n| !n.is_empty())
-            .map(str::to_string);
+        // Decided before the fallbacks below consume `args.notes`.
+        let notes_to_sync = updater_notes_to_sync(args.notes.as_deref(), args.sync_updater_notes);
         // forge_release_edit sends title/notes AND applies prerelease/draft explicitly
         // (gh's `--flag=<bool>` form), so an omitted flag would otherwise be forced to its
         // param default. Read the current release to preserve whatever the caller didn't
@@ -1155,7 +1165,7 @@ impl GitDesktopMcp {
         // The edit already landed, so a manifest-sync failure is a caveat on a
         // successful result, never a tool error — and its text carries the recovery
         // path for a clobbered manifest, so it ships verbatim.
-        if let Some(sync_notes) = notes_to_sync.filter(|_| args.sync_updater_notes != Some(false)) {
+        if let Some(sync_notes) = notes_to_sync {
             match sync_release_updater_notes(&self.repo, &args.tag, &sync_notes, current.as_ref())
                 .await
             {
@@ -1762,5 +1772,28 @@ mod tests {
             .await
             .expect_err("expected an unknown-kind rejection");
         assert!(err.to_string().contains("kind must be"), "got: {}", err);
+    }
+
+    /// The updater-sync gate: a sync only fires for notes the edit actually wrote,
+    /// and never against the caller's opt-out. Syncing empty notes would blank a
+    /// live manifest, since the edit itself skips `--notes` for them.
+    #[test]
+    fn updater_notes_to_sync_gates_empty_notes_and_the_opt_out() {
+        assert_eq!(updater_notes_to_sync(None, None), None, "no notes, no sync");
+        assert_eq!(
+            updater_notes_to_sync(Some("   "), None),
+            None,
+            "whitespace-only notes leave the body untouched, so nothing to sync"
+        );
+        assert_eq!(
+            updater_notes_to_sync(Some("n"), Some(false)),
+            None,
+            "the caller's opt-out wins over real notes"
+        );
+        assert_eq!(
+            updater_notes_to_sync(Some(" n "), None),
+            Some("n".to_string()),
+            "the synced text is trimmed, like the text the edit wrote"
+        );
     }
 }

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -229,7 +229,8 @@ struct UpdateReleaseArgs {
     prerelease: Option<bool>,
     /// Whether to also point the release's `latest.json` Tauri updater manifest at
     /// the new notes (GitHub only, and only when the release carries that asset).
-    /// Defaults to true; set false to leave the manifest alone.
+    /// Defaults to true; set false to leave the manifest alone. Only applies when
+    /// `notes` are given — without them the manifest is left alone.
     #[serde(default)]
     sync_updater_notes: Option<bool>,
 }

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -622,12 +622,18 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     // Literal pathspecs so a `[slug]`-style path can't sweep a sibling's work
     // into the stash; `targets` stays raw for the toast below.
     stashPaths.mutate(targets.map(literalPathspec), {
-      onSuccess: () => {
-        toast.success(
-          targets.length === 1
-            ? `Stashed ${targets[0]}`
-            : `Stashed ${targets.length} files`,
-        );
+      // `matched` is false when the paths matched nothing, so no stash exists to
+      // report — the files were already gone by the time git ran.
+      onSuccess: (matched) => {
+        if (matched) {
+          toast.success(
+            targets.length === 1
+              ? `Stashed ${targets[0]}`
+              : `Stashed ${targets.length} files`,
+          );
+        } else {
+          toast.info("Nothing to stash");
+        }
         finish();
       },
       onError: (e) => {

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -623,7 +623,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     // into the stash; `targets` stays raw for the toast below.
     stashPaths.mutate(targets.map(literalPathspec), {
       // `matched` is false when the paths matched nothing, so no stash exists to
-      // report — the files were already gone by the time git ran.
+      // report — the selection no longer had changes when git ran.
       onSuccess: (matched) => {
         if (matched) {
           toast.success(

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -794,8 +794,7 @@ export const gitStashAll = (repoPath: string) =>
   invoke<void>("git_stash_all", { repoPath });
 
 // True when a stash entry was actually created (a pathspec matching nothing
-// no-ops at exit 0). No caller reads it yet; it's carried so a caller that
-// stashes a selection can tell "nothing matched" from a real stash.
+// no-ops at exit 0).
 export const gitStashPaths = (repoPath: string, paths: string[]) =>
   invoke<boolean>("git_stash_paths", { repoPath, paths });
 


### PR DESCRIPTION
Four independent user-facing bugs, each traced to a place where the code assumed something the repository or the wire format didn't guarantee: that a remote is named `origin`, that serde's `rename_all` renames fields, that the MCP release path mirrors the in-app editor, and that a stash always happened. Each fix carries a changelog fragment; no other doc surface describes these behaviors.

### Default-branch detection across remotes

- Rewrites `git_default_branch` in `src-tauri/src/git/branches.rs` to enumerate remotes via `git::remote::git_remotes` and read each `refs/remotes/<remote>/HEAD`, instead of hardcoding `refs/remotes/origin/HEAD`. A stable sort on `r != "origin"` keeps origin first and preserves `git remote` order for the rest, so a clone made with `git clone -o <name>` resolves.
- Promotes `read_symbolic_ref` in `src-tauri/src/git/remote.rs` from private to `pub(crate)` so the branch path can reuse it.
- Documents the deliberate boundary on the command's doc comment: local refs only, no network, so a hand-added remote with no HEAD symref falls through to the local `main`/`master` fallback.
- Adds three real-repo tokio tests: `default_branch_resolves_a_clone_whose_remote_isnt_origin` (uses a `trunk` source branch the local fallback could never produce), `default_branch_prefers_origin_over_other_remotes` (fixture asserts `canonical` is listed first, so the test actually discriminates), and `default_branch_falls_back_to_local_names`.

### Merged-PR timeline commit

- Adds `rename_all_fields = "camelCase"` to `PrTimelineEventOut` in `src-tauri/src/github/pr.rs`. `rename_all` on a tagged enum renames variant tags only, so `Merged.commit_oid` was reaching the TS mirror in `src/lib/git/types.ts` as `undefined` and a merged PR lost its merge commit silently.
- Pins the wire shape with `merged_timeline_event_wire_shape_is_camel_case`, asserting the exact key set (`actor`, `commitOid`, `date`, `kind`) and that no `commit_oid` key ships.

### MCP release editing ↔ updater manifest

- Adds `sync_release_updater_notes` to `src-tauri/src/mcp_server/write_forge.rs`, giving the MCP `update_release` tool the same `latest.json` sync the in-app editor performs: GitHub-only (via `forge::detect_non_github`), and only when the release actually carries the asset. It reuses the pre-edit `ReleaseDetails` the tool already fetched, falling back to `forge_release_view` otherwise.
- Guards against blanking the manifest: `notes_to_sync` is captured before the preserve-current fallbacks consume `args.notes`, and empty/whitespace notes are filtered out — those skip `--notes` on the edit, so there is nothing to carry over.
- Treats a sync failure as a caveat on a successful edit, not a tool error: results gain `updater_manifest` or `updater_manifest_error` strings, with each failure arm wording its own sentence so an unverifiable asset list is never reported as "no manifest".
- Adds the opt-out `sync_updater_notes: Option<bool>` argument to `UpdateReleaseArgs` (defaults to on), extends the tool description accordingly, and updates the gating test fixture.
- Introduces the `UPDATER_MANIFEST` constant mirroring `github::release`'s private one and the frontend's `UPDATER_MANIFEST_NAME`.

### Stash-selection toast

- `ChangesPanel.tsx` now reads the `matched` boolean from `stashPaths.mutate`'s `onSuccess` and shows `toast.info("Nothing to stash")` when a pathspec matched nothing, rather than claiming a stash that was never created.
- Trims the now-stale "no caller reads it yet" note on `gitStashPaths` in `src/lib/git/api.ts`.