### PR TITLE
fix(automations,git,mcp): dedupe re-reviews, fix base ref and hints

### DIFF
--- a/changelog.d/fixed-branch-name-base-remote.md
+++ b/changelog.d/fixed-branch-name-base-remote.md
@@ -1,0 +1,3 @@
+- Branch-name suggestions in repositories whose remote isn't named `origin` now
+  compare your work against that remote's branch instead of a possibly stale local
+  copy of it.

--- a/changelog.d/fixed-branch-name-base-remote.md
+++ b/changelog.d/fixed-branch-name-base-remote.md
@@ -1,3 +1,3 @@
 - Branch-name suggestions in repositories whose remote isn't named `origin` now
-  compare your work against that remote's branch instead of a possibly stale local
-  copy of it.
+  compare your work against that remote's branch instead of a possibly stale
+  local copy of it.

--- a/changelog.d/fixed-duplicate-pr-sync-review.md
+++ b/changelog.d/fixed-duplicate-pr-sync-review.md
@@ -1,0 +1,2 @@
+- Automated PR reviews no longer run twice right after a push, so a re-review
+  costs one run instead of two.

--- a/changelog.d/fixed-mcp-destructive-hints.md
+++ b/changelog.d/fixed-mcp-destructive-hints.md
@@ -1,4 +1,4 @@
 - MCP tools that can replace or discard things you didn't list — assignees and
-  reviewers, a milestone, a Jira assignee or label set, reviewer notes, a merge that
-  auto-resolves conflicts — now carry a destructive hint, so a connected agent can
-  ask first.
+  reviewers, a milestone, a Jira assignee or label set, reviewer notes, a merge
+  that auto-resolves conflicts — now carry a destructive hint, so a connected
+  agent can ask first.

--- a/changelog.d/fixed-mcp-destructive-hints.md
+++ b/changelog.d/fixed-mcp-destructive-hints.md
@@ -1,0 +1,4 @@
+- MCP tools that can replace or discard things you didn't list — assignees and
+  reviewers, a milestone, a Jira assignee or label set, reviewer notes, a merge that
+  auto-resolves conflicts — now carry a destructive hint, so a connected agent can
+  ask first.

--- a/src-tauri/src/automation_claims.rs
+++ b/src-tauri/src/automation_claims.rs
@@ -3,9 +3,9 @@
 //! Automations (AI PR reviews on pr-open / pr-sync / commit) dispatch in the frontend.
 //! Two GitDesktop instances watching the SAME repository (a main checkout and a linked
 //! worktree share a worktree-stable identity) would each decide to run and post the
-//! same PAID review: the pre-existing dedup is per-process only (an in-memory debounce
-//! map plus a tauri-store watermark whose cache is per-process, and which is written
-//! only AFTER the slow AI call). So the claim must be atomic at the OS level:
+//! same PAID review: the pre-existing dedup is per-process only (an in-memory per-PR
+//! fired-head list plus a tauri-store covered set whose cache is per-process, and which
+//! is written only AFTER the slow AI call). So the claim must be atomic at the OS level:
 //! `OpenOptions::create_new` — an atomic exclusive-create on every platform we target
 //! — on a claim file under app-data, taken at DISPATCH time. Deliberately NOT via the
 //! tauri-store plugin: that plugin's per-process cache is what we're routing around.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -368,17 +368,6 @@ pub(crate) async fn git_delete_remote_branch_core(
     }
 }
 
-/// The branch `refs/remotes/<remote>/HEAD` points at, or `None` when that symref
-/// is unset.
-async fn remote_head_branch(repo_path: &str, remote: &str) -> AppResult<Option<String>> {
-    crate::git::remote::read_symbolic_ref(
-        repo_path,
-        &format!("refs/remotes/{remote}/HEAD"),
-        &format!("refs/remotes/{remote}/"),
-    )
-    .await
-}
-
 /// The repository's default branch: the HEAD a remote points at — `origin` first,
 /// then every other remote in `git remote` order, so a clone made with `-o <name>`
 /// resolves too — otherwise a local "main"/"master" if one exists.
@@ -390,7 +379,7 @@ async fn remote_head_branch(repo_path: &str, remote: &str) -> AppResult<Option<S
 pub async fn git_default_branch(repo_path: String) -> AppResult<Option<String>> {
     // Origin answers almost every repo, so probe it before paying for a remote
     // listing — the common case stays at one git spawn.
-    if let Some(name) = remote_head_branch(&repo_path, "origin").await? {
+    if let Some(name) = crate::git::remote::remote_head_branch(&repo_path, "origin").await? {
         return Ok(Some(name));
     }
     // Only now list, and sweep the OTHER remotes in `git remote` order — a clone made
@@ -400,7 +389,7 @@ pub async fn git_default_branch(repo_path: String) -> AppResult<Option<String>> 
         .await
         .unwrap_or_default();
     for remote in remotes.iter().filter(|r| r.as_str() != "origin") {
-        if let Some(name) = remote_head_branch(&repo_path, remote).await? {
+        if let Some(name) = crate::git::remote::remote_head_branch(&repo_path, remote).await? {
             return Ok(Some(name));
         }
     }

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -341,11 +341,7 @@ pub async fn git_remote_default_branch(
 ) -> AppResult<String> {
     ensure_remote_exists(&repo_path, &remote).await?;
 
-    // `refs/remotes/<remote>/HEAD` → its target `refs/remotes/<remote>/<branch>`.
-    let head_ref = format!("refs/remotes/{remote}/HEAD");
-    let ref_prefix = format!("refs/remotes/{remote}/");
-
-    if let Some(branch) = read_symbolic_ref(&repo_path, &head_ref, &ref_prefix).await? {
+    if let Some(branch) = remote_head_branch(&repo_path, &remote).await? {
         return Ok(branch);
     }
 
@@ -361,7 +357,7 @@ pub async fn git_remote_default_branch(
     )
     .await?;
 
-    read_symbolic_ref(&repo_path, &head_ref, &ref_prefix)
+    remote_head_branch(&repo_path, &remote)
         .await?
         .ok_or_else(|| {
             AppError::InvalidArgument(format!(
@@ -370,10 +366,21 @@ pub async fn git_remote_default_branch(
         })
 }
 
+/// The branch `refs/remotes/<remote>/HEAD` points at, or `None` when that symref
+/// is unset (never written for a hand-added remote). Local read, no network.
+pub(crate) async fn remote_head_branch(repo_path: &str, remote: &str) -> AppResult<Option<String>> {
+    read_symbolic_ref(
+        repo_path,
+        &format!("refs/remotes/{remote}/HEAD"),
+        &format!("refs/remotes/{remote}/"),
+    )
+    .await
+}
+
 /// Read a symbolic ref and strip `prefix` off its target, returning the tail
 /// (the branch name). `None` when the ref is unset — `git symbolic-ref` exits
 /// non-zero — or its target doesn't start with `prefix`.
-pub(crate) async fn read_symbolic_ref(
+async fn read_symbolic_ref(
     repo_path: &str,
     symref: &str,
     prefix: &str,

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -468,8 +468,8 @@ async fn save_updater_recovery_copy(src: std::path::PathBuf) -> Option<String> {
 /// with `--clobber`, which gh implements as delete-THEN-upload: the manifest is
 /// briefly absent, and a failed upload leaves it deleted rather than stale. That
 /// makes the failure unrecoverable from the UI alone (the release no longer has the
-/// asset to re-download), so a failed upload parks the patched copy on disk and
-/// names its path in the error for a manual re-attach.
+/// asset to re-download), so a failed upload parks the patched copy on disk when it
+/// can, naming its path in the error for a manual re-attach.
 pub async fn gh_release_sync_updater_notes(
     repo_path: &str,
     tag: &str,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1765,11 +1765,13 @@ async fn branch_commit_subjects(repo: &str, base: &str) -> Vec<String> {
 }
 
 /// The ref a branch's COMMITTED work is compared against for naming: the repo's
-/// default branch, preferring the remote-tracking `origin/<default>` over the local
+/// default branch, preferring a remote-tracking `<remote>/<default>` over the local
 /// `<default>`. `git_default_branch` returns the SHORT LOCAL name even when it
 /// derived it from a remote's HEAD, and that local branch may be stale (skewing the
 /// three-dot diff) or not exist at all — so verify both and prefer the remote.
-/// `None` = no default branch, or neither ref resolves ⇒ no fallback is possible.
+/// Remotes are probed in `git_default_branch`'s own order: origin, then the rest as
+/// `git remote` lists them.
+/// `None` = no default branch, or no ref resolves ⇒ no fallback is possible.
 async fn committed_base_ref(repo: &str) -> Option<String> {
     let default = crate::git::branches::git_default_branch(repo.to_string())
         .await
@@ -1777,6 +1779,16 @@ async fn committed_base_ref(repo: &str) -> Option<String> {
         .flatten()?;
     if ref_exists(repo, &format!("refs/remotes/origin/{default}")).await {
         return Some(format!("origin/{default}"));
+    }
+    // Only now pay for a remote listing — origin answers almost every repo. A clone
+    // made with `-o <name>` keeps its remote-tracking refs under that name instead.
+    let remotes = crate::git::remote::git_remotes(repo.to_string())
+        .await
+        .unwrap_or_default();
+    for remote in remotes.iter().filter(|r| r.as_str() != "origin") {
+        if ref_exists(repo, &format!("refs/remotes/{remote}/{default}")).await {
+            return Some(format!("{remote}/{default}"));
+        }
     }
     if ref_exists(repo, &format!("refs/heads/{default}")).await {
         return Some(default);
@@ -2977,6 +2989,48 @@ mod tests {
             committed_base_ref(&repo_s).await,
             None,
             "no resolvable default branch ⇒ no committed-work fallback"
+        );
+    }
+
+    /// A `clone -o upstream` repo: the only remote-tracking ref lives under
+    /// `upstream/`, and the base must follow it rather than the same-named local
+    /// branch, which is exactly the copy that goes stale.
+    #[tokio::test]
+    async fn committed_base_ref_resolves_a_non_origin_remote() {
+        let base = tempfile::Builder::new()
+            .prefix("gd-basref-upstream-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        // Pin the branch name regardless of the host's init.defaultBranch.
+        git(&repo_s, &["symbolic-ref", "HEAD", "refs/heads/main"]).await;
+        std::fs::write(repo.join("a.txt"), "hello\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+
+        // No origin at all: one hand-named remote, its tracking ref, and the local
+        // branch of the same name.
+        git(
+            &repo_s,
+            &["remote", "add", "upstream", "https://example.invalid/r.git"],
+        )
+        .await;
+        git(
+            &repo_s,
+            &["update-ref", "refs/remotes/upstream/main", "HEAD"],
+        )
+        .await;
+
+        assert_eq!(
+            committed_base_ref(&repo_s).await,
+            Some("upstream/main".to_string()),
+            "a non-origin remote's tracking ref wins over the local branch"
         );
     }
 }

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -3014,8 +3014,8 @@ mod tests {
         git(&repo_s, &["add", "-A"]).await;
         git(&repo_s, &["commit", "-qm", "seed"]).await;
 
-        // No origin at all: one hand-named remote, its tracking ref, and the local
-        // branch of the same name.
+        // No origin at all: one hand-named remote, its tracking ref + HEAD symref (what a
+        // `clone -o upstream` writes), and the local branch of the same name.
         git(
             &repo_s,
             &["remote", "add", "upstream", "https://example.invalid/r.git"],
@@ -3024,6 +3024,15 @@ mod tests {
         git(
             &repo_s,
             &["update-ref", "refs/remotes/upstream/main", "HEAD"],
+        )
+        .await;
+        git(
+            &repo_s,
+            &[
+                "symbolic-ref",
+                "refs/remotes/upstream/HEAD",
+                "refs/remotes/upstream/main",
+            ],
         )
         .await;
 

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -915,6 +915,51 @@ mod tests {
         assert_eq!(per_module, 119);
     }
 
+    /// The exact set of tools a connected agent is told may destroy state. Annotations are
+    /// what a client gates its confirmation prompt on, so this list moves only when a
+    /// change INTENDS to move it — a tool that silently drops state the caller never named
+    /// (or lands a not-trivially-recoverable outcome) belongs here.
+    #[test]
+    fn destructive_tools_are_exactly_this_set() {
+        let handler = handler(false, false, false, false);
+        let mut destructive: Vec<String> = handler
+            .tool_router
+            .list_all()
+            .into_iter()
+            .filter(|t| {
+                t.annotations
+                    .as_ref()
+                    .and_then(|a| a.destructive_hint)
+                    .unwrap_or(false)
+            })
+            .map(|t| t.name.to_string())
+            .collect();
+        destructive.sort();
+        assert_eq!(
+            destructive,
+            vec![
+                "assign_jira_issue",
+                "delete_branch",
+                "delete_remote_branch",
+                "delete_tag",
+                "discard_all_changes",
+                "discard_changes",
+                "drop_stash",
+                "force_push",
+                "merge_branch",
+                "merge_pull_request",
+                "request_reviewers",
+                "reset_to_commit",
+                "set_issue_assignees",
+                "set_issue_milestone",
+                "set_pull_request_assignees",
+                "set_review_notes",
+                "update_jira_issue",
+                "update_release",
+            ]
+        );
+    }
+
     /// `ensure_key_in_project` gates a key-taking Jira tool to the linked project: the
     /// prefix (before the last `-`) must equal `link.project_key`, case-insensitively.
     /// A different project (same site) or a key with no `-` is refused, and the error

--- a/src-tauri/src/mcp_server/read_git.rs
+++ b/src-tauri/src/mcp_server/read_git.rs
@@ -278,19 +278,52 @@ impl GitDesktopMcp {
         description = "List the repository's remotes with their URLs (credentials redacted). Returns JSON."
     )]
     async fn remotes(&self) -> Result<CallToolResult, McpError> {
-        let names = crate::git::remote::git_remotes(self.repo.clone())
-            .await
-            .map_err(app_err)?;
+        // One `git remote -v` instead of a listing plus a `get-url` per remote.
+        let listing = crate::git::runner::run_git(
+            Some(&self.repo),
+            &["remote", "-v"],
+            crate::git::runner::DEFAULT_TIMEOUT,
+        )
+        .await
+        .map_err(app_err)?;
+        let listing = listing.stdout_lossy();
+        let (names, fetch_urls) = parse_remote_v(&listing);
         let mut out = Vec::with_capacity(names.len());
         for name in names {
-            let url = crate::git::remote::git_remote_url(self.repo.clone(), name.clone())
-                .await
-                .map(|u| redact_url_credentials(&u))
-                .unwrap_or_default();
+            let url = match fetch_urls.get(name) {
+                Some(url) => redact_url_credentials(url),
+                // No fetch row means `remote.<name>.url` is unset, where git's own
+                // `get-url` answers with the name itself — keep reporting that.
+                None => crate::git::remote::git_remote_url(self.repo.clone(), name.to_string())
+                    .await
+                    .map(|u| redact_url_credentials(&u))
+                    .unwrap_or_default(),
+            };
             out.push(serde_json::json!({ "name": name, "url": url }));
         }
         json_result(&out)
     }
+}
+
+/// Splits `git remote -v` output into the remote names (first seen wins, keeping git's
+/// order) and each remote's FETCH url. Names come from EVERY row because a remote with
+/// no configured URL emits one bare `name\t` row and no `(fetch)` row at all; the url
+/// comes from the `(fetch)` row alone, which is the URL `git remote get-url` reports.
+fn parse_remote_v(listing: &str) -> (Vec<&str>, std::collections::HashMap<&str, &str>) {
+    let mut names: Vec<&str> = Vec::new();
+    let mut fetch_urls: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for line in listing.lines() {
+        let Some((name, rest)) = line.split_once('\t') else {
+            continue;
+        };
+        if !names.contains(&name) {
+            names.push(name);
+        }
+        if let Some(url) = rest.strip_suffix(" (fetch)") {
+            fetch_urls.insert(name, url);
+        }
+    }
+    (names, fetch_urls)
 }
 
 /// Redacts an in-URL credential (the `user:pass@` / `token@` userinfo) from an
@@ -379,4 +412,52 @@ async fn read_file_core(
     };
 
     Ok(cap_head(raw, READ_FILE_MAX_BYTES))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A remote with no `remote.<name>.url` emits ONE bare row — name, TAB, nothing —
+    /// and no `(fetch)` row, so it must survive the parse on the name side alone. Its
+    /// absence from the url map is what routes the tool to its `get-url` arm (git
+    /// answers that with the remote's own name). Measured against git 2.51.1.windows.1.
+    #[test]
+    fn a_remote_without_a_url_keeps_its_name_and_gets_no_url() {
+        let (names, urls) = parse_remote_v("nourl\t");
+        assert_eq!(names, vec!["nourl"]);
+        assert!(urls.get("nourl").is_none());
+    }
+
+    /// A remote carrying several push URLs emits exactly one `(fetch)` row (the FIRST
+    /// url) plus one `(push)` row per url — and `git remote get-url` returns that same
+    /// first url, so taking the fetch row keeps the reported url identical to what the
+    /// per-remote `get-url` calls used to report. Measured against git 2.51.1.windows.1.
+    #[test]
+    fn a_multi_url_remote_reports_the_fetch_url_once() {
+        let (names, urls) = parse_remote_v(
+            "origin\thttps://example.com/first.git (fetch)\n\
+             origin\thttps://example.com/first.git (push)\n\
+             origin\thttps://example.com/second.git (push)",
+        );
+        assert_eq!(names, vec!["origin"]);
+        assert_eq!(
+            urls.get("origin").copied(),
+            Some("https://example.com/first.git")
+        );
+    }
+
+    /// The ordinary shape: fetch + push rows for one url, folded to a single name.
+    #[test]
+    fn a_single_url_remote_yields_one_name_and_its_url() {
+        let (names, urls) = parse_remote_v(
+            "origin\thttps://example.com/a.git (fetch)\n\
+             origin\thttps://example.com/a.git (push)",
+        );
+        assert_eq!(names, vec!["origin"]);
+        assert_eq!(
+            urls.get("origin").copied(),
+            Some("https://example.com/a.git")
+        );
+    }
 }

--- a/src-tauri/src/mcp_server/read_git.rs
+++ b/src-tauri/src/mcp_server/read_git.rs
@@ -320,7 +320,9 @@ fn parse_remote_v(listing: &str) -> (Vec<&str>, std::collections::HashMap<&str, 
             names.push(name);
         }
         if let Some(url) = rest.strip_suffix(" (fetch)") {
-            fetch_urls.insert(name, url);
+            // First-wins, like `names` above: `get-url` answers with a remote's FIRST
+            // url, so agreeing by construction survives a second fetch row.
+            fetch_urls.entry(name).or_insert(url);
         }
     }
     (names, fetch_urls)

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -6,8 +6,12 @@
 //! where a provider can't do the thing rather than failing silently.
 //!
 //! Gated on `allow_remote_write` ([`GitDesktopMcp::ensure_remote_write`]) — a SEPARATE
-//! opt-in from `--allow-write`; enabling one never grants the other. Only
-//! `merge_pull_request` is annotated destructive (a merge isn't trivially reversible).
+//! opt-in from `--allow-write`; enabling one never grants the other. A tool is annotated
+//! destructive when it can drop state the caller never named, OR when its outcome isn't
+//! trivially recoverable: the set-style tools whose payload REPLACES a whole collection
+//! or clears a field by omission (`request_reviewers`, `set_issue_assignees`,
+//! `set_pull_request_assignees`, `set_issue_milestone`) fall in the first class,
+//! `merge_pull_request` and `update_release` in the second.
 
 use std::collections::HashMap;
 
@@ -229,8 +233,8 @@ struct UpdateReleaseArgs {
     prerelease: Option<bool>,
     /// Whether to also point the release's `latest.json` Tauri updater manifest at
     /// the new notes (GitHub only, and only when the release carries that asset).
-    /// Defaults to true; set false to leave the manifest alone. Only applies when
-    /// `notes` are given — without them the manifest is left alone.
+    /// Defaults to true, and only applies when `notes` are given; set false to leave
+    /// the manifest alone.
     #[serde(default)]
     sync_updater_notes: Option<bool>,
 }
@@ -751,7 +755,7 @@ impl GitDesktopMcp {
                        desired set of logins — it REPLACES the current reviewers (an empty list \
                        clears them), it is not additive. See list_assignable_users for candidate \
                        logins. Requires --allow-remote-write.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn request_reviewers(
         &self,
@@ -878,7 +882,7 @@ impl GitDesktopMcp {
                        is the FULL desired set of logins — it REPLACES the current assignees (an \
                        empty list clears them). See list_assignable_users. Requires \
                        --allow-remote-write.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn set_issue_assignees(
         &self,
@@ -902,7 +906,7 @@ impl GitDesktopMcp {
                        `assignees` is the FULL desired set of logins — it REPLACES the current \
                        assignees (an empty list clears them). See list_assignable_users. Requires \
                        --allow-remote-write.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn set_pull_request_assignees(
         &self,
@@ -1299,7 +1303,7 @@ impl GitDesktopMcp {
                        forge (GitHub or GitLab, per its remote; Bitbucket issues aren't supported). \
                        `milestone` is the `number` of the chosen entry from list_milestones; omit \
                        it to CLEAR the milestone. Requires --allow-remote-write.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn set_issue_milestone(
         &self,

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -5,6 +5,12 @@
 //! two UNGATED reads (list_stashes, preview_merge); and DESTRUCTIVE mutations gated on
 //! [`GitDesktopMcp::ensure_destructive`], which requires BOTH flags.
 //!
+//! The `destructive_hint` annotation and that gate answer DIFFERENT questions and don't
+//! track 1:1: the hint states what a call can silently discard, the ladder is the
+//! server-side capability the operator granted. `merge_branch` is hint-destructive
+//! without being ladder-destructive — its "ours"/"theirs" strategy drops one side of
+//! every conflicting hunk, across files the caller never named.
+//!
 //! Mutations delegate to the matching `git_*_core`, which routes through `self.state`'s
 //! per-repo lock (`run_git_mutating`) so concurrent MCP calls don't fight over
 //! `.git/index.lock`. User-supplied branch/rev/path strings go through
@@ -587,7 +593,7 @@ impl GitDesktopMcp {
                        merge commit; `strategy` (\"ours\"/\"theirs\") auto-resolves conflicting \
                        hunks. Real conflicts leave the repo in a normal merge-conflict state. \
                        Requires --allow-git-write.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn merge_branch(
         &self,

--- a/src-tauri/src/mcp_server/write_jira.rs
+++ b/src-tauri/src/mcp_server/write_jira.rs
@@ -4,8 +4,10 @@
 //! LINKED project. Every tool runs the same order: `ensure_remote_write` FIRST, then
 //! [`GitDesktopMcp::jira_link`] resolves the project server-side (the single source of
 //! truth — no `site`/`projectKey` param), then the shared [`crate::forge::jira`] cores
-//! (never the `#[tauri::command]` wrappers). All annotated non-read-only and
-//! non-destructive: a Jira write is a mutation, but none is trivially irreversible.
+//! (never the `#[tauri::command]` wrappers). All annotated non-read-only; none is
+//! trivially irreversible, so only the two that drop state the caller never named are
+//! annotated destructive — `update_jira_issue` (its `labels` payload replaces the whole
+//! set) and `assign_jira_issue` (an omitted `account_id` unassigns).
 
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::CallToolResult;
@@ -251,7 +253,7 @@ impl GitDesktopMcp {
                        hint when the repo has none) and takes no site/project param (the key must \
                        belong to the linked project). Requires \
                        --allow-remote-write. Returns a confirmation as JSON.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn assign_jira_issue(
         &self,
@@ -284,7 +286,7 @@ impl GitDesktopMcp {
                        hint when the repo has none) and takes no site/project param (the key must \
                        belong to the linked project). Requires --allow-remote-write. Returns the \
                        applied changes as JSON.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn update_jira_issue(
         &self,

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -6,7 +6,9 @@
 //! or remote write ever happens here.
 //!
 //! - **Writes** (create/amend those records) are gated on `allow_write` (via
-//!   [`GitDesktopMcp::ensure_write`]) and annotated non-read-only, non-destructive.
+//!   [`GitDesktopMcp::ensure_write`]) and annotated non-read-only. Only `set_review_notes`
+//!   is annotated destructive: it replaces a branch's whole note (an empty body clears
+//!   it), and that hand-written text has no history or forge copy to recover from.
 //! - **Reads** (list/get) are UNGATED, like every other read tool — this is the user's
 //!   own local app-data, not the forge.
 
@@ -247,7 +249,7 @@ impl GitDesktopMcp {
                        Verifies `branch` exists as a local branch first. An empty (or \
                        whitespace-only) body CLEARS any existing deposit for the branch. Returns \
                        `{ branch, saved }` where `saved` is false when an empty body cleared it.",
-        annotations(read_only_hint = false, destructive_hint = false)
+        annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn set_review_notes(
         &self,

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -369,9 +369,9 @@ function LiveTaskRow({
  *
  *  Re-run just fires `task.rerun()` — it does NOT remove the row here. The row is
  *  removed inside the runner only once the replacement run actually registers, so
- *  a re-run that can't start (rule disabled since, or a claim/watermark still held
- *  by the canceled run unwinding) leaves the row in place as a retry target and
- *  toasts why. Dismiss removes the row outright. */
+ *  a re-run that can't start (rule disabled since, or a claim or already-covered
+ *  head still held by the canceled run unwinding) leaves the row in place as a
+ *  retry target and toasts why. Dismiss removes the row outright. */
 function StoppedTaskRow({
   task,
   crossRepo,

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -219,8 +219,9 @@ export function RepositoryView() {
   // OS notifications for PR/check and workflow-run events while this repo is open.
   usePrNotifications(repoPath ?? "");
   useRunNotifications(repoPath ?? "");
-  // Auto re-review open PRs (local + remote) whose head branch gets new
-  // commits — pr-sync, gated by the runner's opt-in + the heads that mode covered.
+  // Auto re-review open LOCAL PRs whose head branch gets new commits — pr-sync,
+  // gated by the runner's opt-in + the heads that mode already covered. (Remote PR
+  // heads come from usePrNotifications above and the background sync poller.)
   useWatchPrHeads(repoPath ?? "");
   // Reclaim any local-PR resolve worktrees leaked by a crash mid-resolve (runs
   // once per repo, after the local-PR list loads so active ones are spared).

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -220,7 +220,7 @@ export function RepositoryView() {
   usePrNotifications(repoPath ?? "");
   useRunNotifications(repoPath ?? "");
   // Auto re-review open PRs (local + remote) whose head branch gets new
-  // commits — pr-sync, gated by the runner's opt-in + per-mode watermark.
+  // commits — pr-sync, gated by the runner's opt-in + the heads that mode covered.
   useWatchPrHeads(repoPath ?? "");
   // Reclaim any local-PR resolve worktrees leaked by a crash mid-resolve (runs
   // once per repo, after the local-PR list loads so active ones are spared).

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -33,7 +33,11 @@ import { repoIdentity } from "@/lib/git/repo-identity";
 import type { DiffStatEntry } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
 import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
-import { getLatestReview, saveReview } from "@/lib/pulls/reviews-history";
+import {
+  getLatestReview,
+  listReviews,
+  saveReview,
+} from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { effectiveReviewAi, loadSettings } from "@/lib/settings/api";
 import { pushNotification } from "@/lib/stores/notifications";
@@ -123,7 +127,7 @@ const CLAIM_HEARTBEAT_MS = 5 * 60 * 1000;
  *  the claim age out so a second instance can recover the head. */
 const CLAIM_HEARTBEAT_MAX_BEATS = 30;
 
-/** The store key for a PR target, used to look up its review-history watermark. */
+/** The store key for a PR target, used to look up its review-history records. */
 function targetRef(event: PrAutomationEvent): string {
   return event.target.type === "remote"
     ? String(event.target.number)
@@ -219,7 +223,7 @@ export function triggerAutomations(event: AutomationEvent): void {
  *  - `matched`: rules that exist AND apply (past the `only` + branch gates). 0 = the rule
  *    genuinely no longer applies.
  *  - `attempted`: runs actually started. `matched > 0 && attempted === 0` means a claim or
- *    watermark blocked it — retryable. */
+ *    an already-covered head blocked it — retryable. */
 interface RunOutcome {
   matched: number;
   attempted: number;
@@ -268,16 +272,16 @@ async function run(
     }
     matched++;
     // pr-sync is opt-in per PR: re-review only a PR already reviewed in this mode, and
-    // only once its head advanced past the persisted review's headSha (the per-mode
-    // watermark) — so it never re-fires for a head that mode already covered.
+    // never for ANY head this mode already covered — an eventually-consistent poll can
+    // re-serve an older head after a push, so a head *change* alone isn't new work.
+    // Every retained record is checked, not just the newest: the history store prunes to
+    // MAX_PER_GROUP records per (kind, ref, mode), and that window is what absorbs an
+    // A→B→A head flap.
     if (event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
-      const prior = await getLatestReview(
-        event.repoPath,
-        event.target.type,
-        targetRef(event),
-        action,
-      );
+      const covered = (
+        await listReviews(event.repoPath, event.target.type, targetRef(event))
+      ).filter((r) => r.mode === action);
       // A CANCELLED re-review persists the dismissed head, so a cancelled head doesn't
       // re-fire after an app relaunch — only a genuinely newer head does.
       const dismissedHead = await getDismissedHead(
@@ -290,8 +294,8 @@ async function run(
       // 12-char poll head vs a full-40 seed) counts as "already reviewed" and
       // doesn't re-fire a redundant review each poll tick.
       if (
-        !prior ||
-        sameSha(prior.headSha, headSha) ||
+        covered.length === 0 ||
+        covered.some((r) => sameSha(r.headSha, headSha)) ||
         sameSha(dismissedHead ?? "", headSha)
       ) {
         continue;
@@ -416,8 +420,8 @@ async function run(
       staleKey = undefined;
     }
     // On cancel, persist the dismissed PR head so a cancelled re-review doesn't re-fire
-    // after relaunch (cancel advances no history watermark). PR events with a headSha
-    // only; best-effort. Not written on non-cancel failures, which stay retryable.
+    // after relaunch (cancel marks no head covered). PR events with a headSha only;
+    // best-effort. Not written on non-cancel failures, which stay retryable.
     const dismissOnCancel = () => {
       if (event.kind === "commit" || !event.headSha) return;
       void setDismissedHead(
@@ -470,8 +474,8 @@ async function run(
       }
       const { text, thoughts } = result;
       // Both gates throw BEFORE deliver and persistReviewHistory, so a bad run
-      // neither posts a comment nor advances the pr-sync watermark — it lands in
-      // the catch below (failure toast + inbox row with Re-run + released claim).
+      // neither posts a comment nor marks this head covered for pr-sync — it lands
+      // in the catch below (failure toast + inbox row with Re-run + released claim).
       if (!text.trim()) {
         throw new Error(
           `The AI ${label} run produced no text — nothing was posted.`,
@@ -500,7 +504,7 @@ async function run(
       });
       await deliver(event, action, body, text, notify);
       // Seed the review-history store so the next run (manual or auto) builds on these
-      // findings and this headSha becomes the pr-sync watermark. Best-effort.
+      // findings and this headSha joins the heads pr-sync treats as covered. Best-effort.
       if (event.kind === "pr-open" || event.kind === "pr-sync") {
         await persistReviewHistory(
           event,
@@ -617,8 +621,8 @@ export function rerunAutomation(
         // The rule genuinely no longer applies (disabled / conditions changed).
         toast.info(`Automated ${label} for this ${noun} is turned off.`);
       } else if (attempted === 0) {
-        // A rule applies but a held claim or sync watermark blocked it. The stopped row is
-        // kept — retry once that clears.
+        // A rule applies but a held claim or an already-covered head blocked it. The
+        // stopped row is kept — retry once that clears.
         toast.info(
           `Couldn't re-run the ${label} — another run already covers this head (still finishing or ran elsewhere). The row is kept; try again in a moment.`,
         );

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -272,11 +272,9 @@ async function run(
     }
     matched++;
     // pr-sync is opt-in per PR: re-review only a PR already reviewed in this mode, and
-    // never for ANY head this mode already covered — an eventually-consistent poll can
-    // re-serve an older head after a push, so a head *change* alone isn't new work.
-    // Every retained record is checked, not just the newest: the history store prunes to
-    // MAX_PER_GROUP records per (kind, ref, mode), and that window is what absorbs an
-    // A→B→A head flap.
+    // never for ANY head that mode covered — a poll can re-serve an older head after a
+    // push, which isn't new work. Every retained record counts, so the flap window is
+    // the history store's MAX_PER_GROUP per (kind, ref, mode).
     if (event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
       const covered = (

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -3,13 +3,10 @@ import { getDismissedHead } from "./dismissals";
 import { triggerAutomations } from "./runner";
 
 /**
- * Per-`(kind, repo, ref)` EVERY head we already fired a pr-sync event for, so each
- * head fires at most once instead of on every poll tick — watchers can call
- * `maybeFireSync` freely. Every head is kept rather than just the last one: an
- * eventually-consistent poll can serve the PREVIOUS head right after a push, and a
- * last-head-only dedup would let that stale head fire a second time. Intentionally
- * never reclaimed (the dedup must survive a repo view unmounting); bounded by the
- * real pushes per PR seen this session, and resets on restart.
+ * Per-`(kind, repo, ref)` EVERY head already fired for, `sameSha`-matched — an
+ * eventually-consistent poll can re-serve a PREVIOUS head right after a push, and that
+ * stale head must not fire again. Never reclaimed (the dedup must survive a repo view
+ * unmounting); bounded by the real pushes per PR this session, and resets on restart.
  */
 const firedHeads = new Map<string, string[]>();
 

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -3,12 +3,15 @@ import { getDismissedHead } from "./dismissals";
 import { triggerAutomations } from "./runner";
 
 /**
- * Per-`(kind, repo, ref)` last head we already fired a pr-sync event for, so a head
- * change fires at most once instead of on every poll tick — watchers can call
- * `maybeFireSync` freely. Intentionally never reclaimed: the dedup must survive a
- * repo view unmounting. One small entry per PR seen this session; resets on restart.
+ * Per-`(kind, repo, ref)` EVERY head we already fired a pr-sync event for, so each
+ * head fires at most once instead of on every poll tick — watchers can call
+ * `maybeFireSync` freely. Every head is kept rather than just the last one: an
+ * eventually-consistent poll can serve the PREVIOUS head right after a push, and a
+ * last-head-only dedup would let that stale head fire a second time. Intentionally
+ * never reclaimed (the dedup must survive a repo view unmounting); bounded by the
+ * real pushes per PR seen this session, and resets on restart.
  */
-const lastFiredHead = new Map<string, string>();
+const firedHeads = new Map<string, string[]>();
 
 /**
  * Whether two commit SHAs refer to the same commit, tolerating short-vs-full.
@@ -42,17 +45,21 @@ export interface SyncCandidate {
 }
 
 /**
- * Fires a `pr-sync` automation event when an open PR's head has advanced since
- * the last time we fired for it. Deduped by head, so an unchanged PR observed on
- * every poll never re-fires. The runner gates whether to actually review (only a
- * PR already reviewed in a mode, whose head is past that mode's watermark).
+ * Fires a `pr-sync` automation event for an open PR's head we haven't fired for
+ * this session. Deduped by head, so an unchanged PR observed on every poll never
+ * re-fires — and neither does a head the poll re-serves after moving off it. The
+ * runner gates whether to actually review (only a PR already reviewed in a mode,
+ * on a head that mode hasn't already covered).
  */
 export function maybeFireSync(c: SyncCandidate): void {
   if (!c.currentHeadSha) return;
   const key = `${c.kind}:${c.repoPath}#${c.ref}`;
-  const prior = lastFiredHead.get(key);
-  if (prior !== undefined && sameSha(prior, c.currentHeadSha)) return;
-  lastFiredHead.set(key, c.currentHeadSha);
+  const fired = firedHeads.get(key);
+  // sameSha rather than set membership: the same head arrives short from one
+  // provider and full from another, and both must count as already fired.
+  if (fired?.some((sha) => sameSha(sha, c.currentHeadSha))) return;
+  if (fired) fired.push(c.currentHeadSha);
+  else firedHeads.set(key, [c.currentHeadSha]);
   triggerAutomations({
     kind: "pr-sync",
     repoPath: c.repoPath,

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -156,8 +156,10 @@ export async function getLatestReview(
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
 }
 
-/** Every persisted review for a PR (both modes), newest first — for the
- *  "Previous reviews" disclosure. */
+/** Every persisted review for a PR (both modes), newest first. Two consumers, so
+ *  narrowing what this returns is not a UI-only change: the "Previous reviews"
+ *  disclosure, and the runner's pr-sync gate, which reads the whole retained set to
+ *  decide whether a head was already covered. */
 export async function listReviews(
   repo: string,
   kind: "remote" | "local",


### PR DESCRIPTION
Three unrelated defects fixed together: automated PR re-reviews fired twice after a push, branch-name suggestions compared against a stale local branch in non-`origin` repos, and a set of MCP tools that can silently discard state carried no destructive annotation. Each ships its own changelog fragment.

### Duplicate pr-sync re-reviews

The old dedup only remembered the *last* head fired for, and the runner only compared against the *latest* persisted review — so an eventually-consistent forge poll re-serving the previous head after a push (an A→B→A flap) was read as new work and paid for a second review.

- `src/lib/automations/sync.ts`: replaces the `lastFiredHead` single-value map with `firedHeads`, keeping every head fired for per `(kind, repo, ref)`; membership is tested with `sameSha` rather than set equality so a short SHA from one provider and a full SHA from another still match.
- `src/lib/automations/runner.ts`: swaps `getLatestReview` for `listReviews`, filtered to the mode, and skips the run when *any* retained record covers the head — the history store's `MAX_PER_GROUP` window is what absorbs the flap.
- Comment sweep replacing the "watermark" wording across `src/lib/automations/runner.ts` (rule-outcome docs, cancel/dismiss notes, `rerunAutomation` toast comment), `sync.ts` and `src/features/repository/RepositoryView.tsx`, since the mechanism is now "heads this mode already covered".

### Branch-name base ref on non-`origin` remotes

`committed_base_ref` only ever tried `origin/<default>` before falling back to the local branch — the exact copy that goes stale — so a `clone -o upstream` repo diffed against local `main`.

- `src-tauri/src/mcp_server/generate.rs`: after the `origin` probe, lists remotes and checks `refs/remotes/<remote>/<default>` in `git remote` order, mirroring `git_default_branch`'s own precedence; doc comment updated to state the new order.
- Adds `committed_base_ref_resolves_a_non_origin_remote`, a temp-dir repo with no `origin`, a hand-added `upstream` remote, and a same-named local branch, asserting `upstream/main` wins.
- `src-tauri/src/git/remote.rs`: promotes `remote_head_branch` here as `pub(crate)` and narrows `read_symbolic_ref` to private; `git_remote_default_branch` now calls the shared helper on both its pre- and post-fetch paths.
- `src-tauri/src/git/branches.rs`: drops its local duplicate of `remote_head_branch` in favor of the `git::remote` one.

### MCP `destructive_hint` annotations

Flips the hint on the tools that can drop state the caller never named, or whose outcome isn't trivially recoverable, so a connected agent can prompt first.

- `src-tauri/src/mcp_server/write_forge.rs`: `request_reviewers`, `set_issue_assignees`, `set_pull_request_assignees`, `set_issue_milestone` — all replace-a-collection / clear-by-omission tools; module doc now explains the two classes (payload-replaces-collection vs. not-trivially-recoverable, the latter covering `merge_pull_request` and `update_release`).
- `src-tauri/src/mcp_server/write_jira.rs`: `assign_jira_issue` (omitted `account_id` unassigns) and `update_jira_issue` (`labels` replaces the whole set).
- `src-tauri/src/mcp_server/write_git.rs`: `merge_branch`, whose `ours`/`theirs` strategy drops one side of every conflicting hunk; module doc records that `destructive_hint` and the `ensure_destructive` capability ladder answer different questions and don't track 1:1.
- `src-tauri/src/mcp_server/write_local.rs`: `set_review_notes`, since an empty body clears hand-written text with no history or forge copy behind it.

### `remotes` tool: one `git remote -v`

- `src-tauri/src/mcp_server/read_git.rs`: the `remotes` tool now shells out once and parses the listing via a new `parse_remote_v` helper instead of a listing plus a `get-url` per remote; names come from every row (a URL-less remote emits only a bare `name\t` row) and URLs from the `(fetch)` row, with the old `git_remote_url` path kept as the fallback arm so git's "answers with the name itself" behavior is preserved.
- Adds three unit tests covering the URL-less remote, a multi-push-URL remote (fetch row only, matching what `get-url` reports), and the ordinary fetch+push pair — measured against git 2.51.1.windows.1.

### Doc touch-up

- `src-tauri/src/github/release.rs`: softens the `gh_release_sync_updater_notes` doc comment to say a failed upload parks the patched copy on disk *when it can*.