### PR TITLE
ci(workflows,release): align CI with master's required status checks

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -167,7 +167,10 @@ warrants; non-AI features in both site views) → in-app guide
 `src/features/help/content.ts` → a `changelog.d/<added|changed|fixed>-<slug>.md`
 fragment (its body is the finished Keep-a-Changelog bullet). **Never hand-edit
 `## [Unreleased]` in `CHANGELOG.md`** — it's *generated* from the fragments at
-release time; one file per change keeps parallel branches conflict-free.
+release time; one file per change keeps parallel branches conflict-free. The
+`fragment` check is **required** on master and keys on paths — any `src/` or
+`src-tauri/` change needs a fragment, the `no-changelog` label, or
+`skip-changelog` in the PR title.
 
 **In a delegated package the spec's `Docs-sync:` field is authoritative:**
 apply exactly what it lists (those files are thereby in scope); "orchestrator

--- a/.gitdesktop/instructions.md
+++ b/.gitdesktop/instructions.md
@@ -57,7 +57,9 @@ gap per file.
 4. **Changelog fragment** — `changelog.d/<added|changed|fixed>-<slug>.md`, whose
    body is the finished Keep a Changelog bullet, written for humans. Never edit
    `## [Unreleased]` in `CHANGELOG.md` directly; fragments are assembled there at
-   release time.
+   release time. The `fragment` check is required on master and keys on paths:
+   any `src/` or `src-tauri/` change needs a fragment, the `no-changelog` label,
+   or `skip-changelog` in the PR title.
 
 When a change alters **existing** behavior, grep all four surfaces for the old
 wording rather than updating the spots you remember — stale copies of the same

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ the codebase but authored the solution manually." Write "None." if no AI was use
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(pulls): ...`).
 - [ ] `pnpm lint` passes (Biome).
 - [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes (if Rust was touched).
-- [ ] Added a `changelog.d/` fragment for any user-facing change (`<added|changed|fixed>-<slug>.md`, human-written — see [`changelog.d/README.md`](../changelog.d/README.md)).
+- [ ] Added a `changelog.d/` fragment for any user-facing change (`<added|changed|fixed>-<slug>.md`, human-written — see [`changelog.d/README.md`](../changelog.d/README.md)). Required check: `src/` or `src-tauri/` changes need one, else the `no-changelog` label or `skip-changelog` in the title.
 - [ ] New UI supports keyboard navigation and meets WCAG AA; destructive paths confirm clearly.
 - [ ] No secrets, tokens, or private paths are committed.
 - [ ] Any AI assistance used is disclosed above (or "None.").

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,8 +2,8 @@ name: changelog
 
 # Requires a changelog.d/ fragment when a PR changes code. "fragment" is a
 # required status check on master (repo ruleset), so this gate blocks the merge.
-# Escape hatches unchanged: the `no-changelog` label (a job-level `if:` skip
-# still reports success to a required check), or `skip-changelog` in the title.
+# Escape hatches: the `no-changelog` label (exempts only the fragment
+# requirement — the format check always runs), or `skip-changelog` in the title.
 
 on:
   pull_request:
@@ -23,7 +23,6 @@ permissions:
 jobs:
   fragment:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -34,7 +33,10 @@ jobs:
       # over it at release time. Uses only node built-ins, no install needed.
       - name: Validate changelog.d fragment format
         run: node scripts/changelog-draft.mjs --check
+      # Step-level on purpose: hoisting this to the job would skip the format
+      # check above, letting a malformed fragment merge under the label.
       - name: Require a changelog.d/ fragment for code changes
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
         shell: bash
         env:
           BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -46,7 +46,12 @@ jobs:
           changed=$(git diff --name-only "$BASE...$HEAD")
           printf '%s\n' "$changed"
           if grep -qE '^(src|src-tauri)/' <<< "$changed"; then
-            if grep -E '^changelog\.d/' <<< "$changed" | grep -qiE '^changelog\.d/(added|changed|fixed)-[^/]+\.md$'; then
+            # A deleted fragment must not satisfy the gate: presence scans an
+            # exclude-deletions view; the src detection above stays unfiltered.
+            present=$(git diff --name-only --diff-filter=d "$BASE...$HEAD")
+            # Directory match stays case-sensitive; only the basename folds
+            # (mirrors FRAGMENT_RE's /i scope + readdirSync's top-level scan).
+            if grep -E '^changelog\.d/' <<< "$present" | grep -qiE '^changelog\.d/(added|changed|fixed)-[^/]+\.md$'; then
               echo "Changelog fragment present — thanks!"
             elif grep -qiF 'skip-changelog' <<< "$TITLE"; then
               echo "'skip-changelog' in the PR title — fragment not required."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -43,10 +43,10 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          changed=$(git diff --name-only "$BASE" "$HEAD")
+          changed=$(git diff --name-only "$BASE...$HEAD")
           printf '%s\n' "$changed"
           if grep -qE '^(src|src-tauri)/' <<< "$changed"; then
-            if grep -qE '^changelog\.d/.+\.md$' <<< "$changed"; then
+            if grep -E '^changelog\.d/' <<< "$changed" | grep -qiE '^changelog\.d/(added|changed|fixed)-[^/]+\.md$'; then
               echo "Changelog fragment present — thanks!"
             elif grep -qiF 'skip-changelog' <<< "$TITLE"; then
               echo "'skip-changelog' in the PR title — fragment not required."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,14 +2,20 @@ name: changelog
 
 # Requires a changelog.d/ fragment when a PR changes code. "fragment" is a
 # required status check on master (repo ruleset), so this gate blocks the merge.
-# Escape hatches unchanged: label the PR `no-changelog` (a job-level `if:` skip
-# still reports success to a required check), or put `skip-changelog` in the title.
+# Escape hatches unchanged: the `no-changelog` label (a job-level `if:` skip
+# still reports success to a required check), or `skip-changelog` in the title.
 
 on:
   pull_request:
-    # labeled/unlabeled: toggling no-changelog must re-run this check now that
-    # it is required (the default PR event types miss label changes).
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    # labeled/unlabeled/edited: no-changelog toggles and skip-changelog title
+    # edits must re-run this now-required check; default types cover neither.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+# One in-flight run per ref; label and title events can fire several runs at
+# one SHA, and only the newest should decide a required check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,12 +1,15 @@
 name: changelog
 
-# Reminds contributors to add a changelog.d/ fragment when they change code.
-# This is opt-in: it's only enforced if you make the "fragment" check a required
-# status in branch protection. Escape hatches: label the PR `no-changelog`, or put
-# `skip-changelog` in the PR title.
+# Requires a changelog.d/ fragment when a PR changes code. "fragment" is a
+# required status check on master (repo ruleset), so this gate blocks the merge.
+# Escape hatches unchanged: label the PR `no-changelog` (a job-level `if:` skip
+# still reports success to a required check), or put `skip-changelog` in the title.
 
 on:
   pull_request:
+    # labeled/unlabeled: toggling no-changelog must re-run this check now that
+    # it is required (the default PR event types miss label changes).
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,8 +5,8 @@ name: frontend
 # workflow leaves it stuck "Expected" forever (GitHub required-checks docs).
 # The path-filtered push:master run is the backstop re-validating the true
 # merged tree, since a PR green against a stale base merges stale-green (the
-# push run only detects; the PR run gates). No other workflow builds the root
-# toolchain — the rest cover src-tauri/**, site/, and changelog fragments.
+# push run only detects; the PR run gates). No other PR workflow builds the
+# root toolchain — the rest cover src-tauri/**, site/, and changelog fragments.
 
 on:
   pull_request:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,10 +3,10 @@ name: frontend
 # Builds + typechecks the root frontend on EVERY PR — no paths filter, because
 # `build` is a required status check on master's ruleset and a paths-skipped
 # workflow leaves it stuck "Expected" forever (GitHub required-checks docs).
-# The path-filtered push:master run is the backstop that re-validates the true
-# merged tree: a PR green against a stale base merges stale-green. Filters are
-# harmless there (the push run detects; only the PR run gates). Nothing else
-# covers the root toolchain — rust-tests.yml is src-tauri/**, Pages builds site/.
+# The path-filtered push:master run is the backstop re-validating the true
+# merged tree, since a PR green against a stale base merges stale-green (the
+# push run only detects; the PR run gates). No other workflow builds the root
+# toolchain — the rest cover src-tauri/**, site/, and changelog fragments.
 
 on:
   pull_request:
@@ -23,6 +23,7 @@ on:
       - "vite.config.ts"
       - "tsconfig*.json"
       - "biome.json"
+      - ".gitignore" # live biome input (vcs.useIgnoreFile)
       - ".github/workflows/frontend.yml"
 
 # One in-flight run per ref; a superseded push cancels the stale run instead of

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,14 +1,18 @@
 name: frontend
 
-# Builds + typechecks the root frontend on PRs that touch it. This is the gate
-# that turns toolchain breakage red BEFORE merge — e.g. dependabot's vite 8->7
-# workspace-convergence downgrade (PRs #59/#62) previously merged all-green:
-# rust-tests.yml only covers src-tauri/**, changelog.yml only checks fragments,
-# and Cloudflare Pages builds site/ on its own lockfile, so nothing exercised
-# the root vite/plugin-react/rolldown toolchain on pull_request.
+# Builds + typechecks the root frontend on EVERY PR — no paths filter, because
+# `build` is a required status check on master's ruleset and a paths-skipped
+# workflow leaves it stuck "Expected" forever (GitHub required-checks docs).
+# The path-filtered push:master run is the backstop that re-validates the true
+# merged tree: a PR green against a stale base merges stale-green. Filters are
+# harmless there (the push run detects; only the PR run gates). Nothing else
+# covers the root toolchain — rust-tests.yml is src-tauri/**, Pages builds site/.
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
     paths:
       - "package.json"
       - "pnpm-lock.yaml"
@@ -20,6 +24,12 @@ on:
       - "tsconfig*.json"
       - "biome.json"
       - ".github/workflows/frontend.yml"
+
+# One in-flight run per ref; a superseded push cancels the stale run instead of
+# stacking a second one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   build:
+    # Distinct display name: master's ruleset requires the context "build"
+    # (frontend.yml); same-named check runs would make site's build gate it too.
+    name: site build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ don't wait to be asked:**
    record. **Never edit `## [Unreleased]` in `CHANGELOG.md` directly** — fragments
    are assembled there at release time, and one file per change keeps parallel
    branches conflict-free. Preview with `pnpm changelog:preview`; conventions live
-   in `changelog.d/README.md`.
+   in `changelog.d/README.md`. CI keys on paths: the required `fragment` check
+   fires on any `src/` or `src-tauri/` change; one that needs no fragment takes
+   the `no-changelog` label or `skip-changelog` in the PR title.
 
 When a change alters **existing** behavior, grep README / site / help for the old
 wording (e.g. the feature's old phrase) rather than updating spots from memory — stale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,10 @@ humans** — a clear sentence about what changed for the user, not a copy of you
 commit subject. One file per change means parallel branches never conflict on the
 changelog; see [`changelog.d/README.md`](changelog.d/README.md) for the format.
 
-CI enforces this: `fragment` is a required status check on `master`, so a PR that
-touches `src/` or `src-tauri/` without adding a fragment can't merge. If a change
-genuinely doesn't need one, label the PR `no-changelog` or put `skip-changelog`
-in the title.
+CI keys on paths, not user impact: `fragment` is a required status check on
+`master`, so a PR that touches `src/` or `src-tauri/` without adding a fragment
+can't merge. If a change genuinely doesn't need one, label the PR `no-changelog`
+or put `skip-changelog` in the title.
 
 Don't edit `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md) directly — the
 fragments are assembled there at release time. Preview the pending changelog with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,11 @@ humans** — a clear sentence about what changed for the user, not a copy of you
 commit subject. One file per change means parallel branches never conflict on the
 changelog; see [`changelog.d/README.md`](changelog.d/README.md) for the format.
 
+CI enforces this: `fragment` is a required status check on `master`, so a PR that
+touches `src/` or `src-tauri/` without adding a fragment can't merge. If a change
+genuinely doesn't need one, label the PR `no-changelog` or put `skip-changelog`
+in the title.
+
 Don't edit `## [Unreleased]` in [CHANGELOG.md](CHANGELOG.md) directly — the
 fragments are assembled there at release time. Preview the pending changelog with
 `pnpm changelog:preview`; `pnpm changelog` still drafts starting-point bullets
@@ -175,7 +180,9 @@ the utmost care.
 2. Keep PRs small and focused; one logical change per PR is easiest to review.
 3. Link the issue it addresses (`Closes #123`).
 4. Run `pnpm lint` and, if you touched Rust, `cargo test --manifest-path src-tauri/Cargo.toml`.
-5. Add a `changelog.d/` fragment if the change is user-facing (see the Changelog section).
+5. Add a `changelog.d/` fragment if the change is user-facing — the required
+   `fragment` check blocks merge on `src/` or `src-tauri/` changes without one
+   (see the Changelog section for the escape hatches).
 6. Fill out the PR template — including screenshots or a short screen recording
    for UI changes.
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -12,6 +12,11 @@ the updater's "what's new" both come from it), so marketing-site work — blog
 posts, comparison pages, anything under `site/` — gets **no fragment**, however
 user-facing it is on the web.
 
+CI enforces this with the `fragment` required check on `master`. It fires on any
+`src/` or `src-tauri/` change regardless of user impact, so a change that
+genuinely needs no fragment — an internal refactor, say — takes the
+`no-changelog` label or `skip-changelog` in the PR title.
+
 ## Format
 
 Create a file named **`<category>-<slug>.md`**, where:

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -12,10 +12,10 @@ the updater's "what's new" both come from it), so marketing-site work — blog
 posts, comparison pages, anything under `site/` — gets **no fragment**, however
 user-facing it is on the web.
 
-CI enforces this with the `fragment` required check on `master`. It fires on any
-`src/` or `src-tauri/` change regardless of user impact, so a change that
-genuinely needs no fragment — an internal refactor, say — takes the
-`no-changelog` label or `skip-changelog` in the PR title.
+CI keys on paths, not user impact: the `fragment` required check on `master`
+fires on any `src/` or `src-tauri/` change, so a change that genuinely needs no
+fragment — an internal refactor, say — takes the `no-changelog` label or
+`skip-changelog` in the PR title.
 
 ## Format
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -534,7 +534,7 @@ async function main() {
       );
       say(
         dim(
-          `   To undo the release commit entirely (restores the fragments): git reset --hard HEAD~1 && git tag -d ${tag}`,
+          `  To undo the release commit entirely (restores the fragments): git reset --hard HEAD~1 && git tag -d ${tag}`,
         ),
       );
       rl.close();

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -532,6 +532,11 @@ async function main() {
           "  (Rejected for protected-branch/rules instead? The account lost master's ruleset bypass — rebasing won't help.)",
         ),
       );
+      say(
+        dim(
+          `   To undo the release commit entirely (restores the fragments): git reset --hard HEAD~1 && git tag -d ${tag}`,
+        ),
+      );
       rl.close();
       process.exit(1);
     }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -512,6 +512,8 @@ async function main() {
   } else {
     // One atomic push — both refs land or neither does. We push the tag
     // explicitly: it is lightweight, so --follow-tags would silently skip it.
+    // Rides the ruleset's Repository-admin always-bypass (build + fragment are
+    // required checks); losing that bypass rejects this push, tag included.
     const push = spawnSync(
       "git",
       ["push", "--atomic", "origin", "master", tag],

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -527,6 +527,11 @@ async function main() {
       say(
         `  git pull --rebase origin master && git tag -f ${tag} && git push --atomic origin master ${tag}`,
       );
+      say(
+        dim(
+          "  (Rejected for protected-branch/rules instead? The account lost master's ruleset bypass — rebasing won't help.)",
+        ),
+      );
       rl.close();
       process.exit(1);
     }


### PR DESCRIPTION
Master's ruleset now requires the `build` and `fragment` status checks, which changes what the workflows have to guarantee: a required context must actually report on every PR, and no other workflow may report under the same name. This aligns the three workflows with that contract and records the admin-bypass the release push depends on.

### Frontend build gate (`.github/workflows/frontend.yml`)
- Removes the `paths` filter from the `pull_request` trigger so `build` runs on every PR — a paths-skipped run never reports, leaving the required check stuck at "Expected" forever.
- Adds a `push` trigger on `master` and keeps the path filter there, as the backstop that re-validates the real merged tree (a PR green against a stale base can otherwise merge stale-green); filtering is harmless on that side since only the PR run gates.
- Adds a `concurrency` group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so a superseded push cancels the stale run rather than stacking.
- Rewrites the header comment to state the new rationale, keeping the note that nothing else exercises the root toolchain (`rust-tests.yml` is `src-tauri/**`, Cloudflare Pages builds `site/`).

### Changelog fragment gate (`.github/workflows/changelog.yml`)
- Adds `labeled` / `unlabeled` to the `pull_request` event `types` (alongside `opened`, `synchronize`, `reopened`) so toggling the `no-changelog` label re-runs the now-blocking check — the default event types miss label changes.
- Updates the header comment: the gate is no longer opt-in, and both escape hatches still work (the job-level `if:` skip reports success to a required check, and `skip-changelog` in the PR title).

### Check-name collision (`.github/workflows/site.yml`)
- Gives the `build` job the display name `site build`, so the site workflow no longer reports under the required `build` context and inadvertently gate master alongside `frontend.yml`.

### Release script (`scripts/release.mjs`)
- Comments the atomic `git push --atomic origin master <tag>` to record that it rides the ruleset's Repository-admin always-bypass now that `build` and `fragment` are required; losing that bypass rejects the push, tag included.