### PR TITLE
fix(automations,pulls): re-read review state from disk before gating

### DIFF
--- a/changelog.d/fixed-duplicate-review-cross-instance.md
+++ b/changelog.d/fixed-duplicate-review-cross-instance.md
@@ -1,0 +1,4 @@
+- AI review automations no longer double-run a pull request that was already
+  reviewed when a second GitDesktop window or instance — or a restarted dev
+  session — watches the same repository: automation decisions now read the
+  review history on disk instead of a stale in-memory copy.

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -31,6 +31,19 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+// Re-read the store from disk, tolerating a store file that doesn't exist yet:
+// `load()` tolerates a missing file but `reload()` rejects with a raw io error
+// until the first `save()` creates it. Falls back to the in-memory state on ANY
+// failure. Mirrors the same guard in reviews-history.ts.
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing file — the next save() creates it.
+  }
+}
+
 // Reads merge in any records still under a legacy checkout-path key (folded onto
 // the identity key by the next write via `keyFor`).
 async function readMerged(repo: string): Promise<DismissalMap> {
@@ -53,13 +66,18 @@ async function keyFor(repo: string): Promise<string> {
   );
 }
 
-/** The head SHA last dismissed for a PR + mode, or undefined if none. */
+/** The head SHA last dismissed for a PR + mode, or undefined if none. `fresh`
+ *  reloads from disk first — the automation gates must read this watermark as
+ *  fresh as the claim they pair with (see reviews-history.ts's `read`), since the
+ *  plugin-store's per-process cache is otherwise loaded once at launch. */
 export async function getDismissedHead(
   repo: string,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
+  opts?: { fresh?: boolean },
 ): Promise<string | undefined> {
+  if (opts?.fresh) await reloadRaw();
   const all = await readMerged(repo);
   return all[cellKey(kind, ref, mode)];
 }
@@ -76,6 +94,9 @@ export async function setDismissedHead(
   const key = await keyFor(repo);
   const all = (await store.get<DismissalMap>(key)) ?? {};
   await store.set(key, { ...all, [cellKey(kind, ref, mode)]: headSha });
+  // Flush now rather than on autoSave's ~100ms debounce: the gates reload from
+  // disk, so a fresh read inside that window would discard this dismissal.
+  await store.save();
 }
 
 /**
@@ -96,4 +117,7 @@ export async function clearDismissedHead(
   const all = (await store.get<DismissalMap>(key)) ?? {};
   delete all[cellKey(kind, ref, mode)];
   await store.set(key, all);
+  // Same flush as setDismissedHead: an unsaved clear would be undone by the next
+  // fresh gate read, re-blocking the re-run this call exists to unblock.
+  await store.save();
 }

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -31,10 +31,24 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+// Serialize every read-modify-write AND every fresh read on this store through one
+// in-process queue: a reload replaces the whole in-memory map from disk, so one
+// landing between a writer's `set` and its flush would persist the pre-write state
+// and silently drop the dismissal. Mirrors automations/store.ts and
+// reviews-history.ts. In-process only; cross-window races remain out of scope.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
 // Re-read the store from disk, tolerating a store file that doesn't exist yet:
 // `load()` tolerates a missing file but `reload()` rejects with a raw io error
 // until the first `save()` creates it. Falls back to the in-memory state on ANY
-// failure. Mirrors the same guard in reviews-history.ts.
+// failure. Mirrors the same guard in reviews-history.ts. Call inside the serialized
+// queue so it can't land between a set and its flush.
 async function reloadRaw(): Promise<void> {
   const store = await getStore();
   try {
@@ -66,20 +80,45 @@ async function keyFor(repo: string): Promise<string> {
   );
 }
 
-/** The head SHA last dismissed for a PR + mode, or undefined if none. `fresh`
- *  reloads from disk first — the automation gates must read this watermark as
- *  fresh as the claim they pair with (see reviews-history.ts's `read`), since the
- *  plugin-store's per-process cache is otherwise loaded once at launch. */
-export async function getDismissedHead(
+/** Reads the merged map, optionally re-reading the store from disk first. `fresh`
+ *  is what the automation gates need: the plugin-store's per-process cache is
+ *  otherwise loaded once at launch, so a gate would decide on state predating
+ *  another instance's dismissal. Reload and read run inside the queue, ordered with
+ *  any in-flight write. */
+async function readDismissals(
+  repo: string,
+  opts?: { fresh?: boolean },
+): Promise<DismissalMap> {
+  if (!opts?.fresh) return readMerged(repo);
+  return serialize(async () => {
+    await reloadRaw();
+    return readMerged(repo);
+  });
+}
+
+const isReviewMode = (v: string): v is ReviewMode =>
+  v === "general" || v === "security";
+
+/** Every mode's dismissed head for ONE PR, in a single read. The automation gates
+ *  check both modes per event, and each `fresh` read reloads (and queues behind any
+ *  write) — so they take the whole PR's cells at once instead of once per mode.
+ *  `fresh` re-reads the store from disk first — see {@link readDismissals}. */
+export async function getDismissedHeadMap(
   repo: string,
   kind: "remote" | "local",
   ref: string,
-  mode: ReviewMode,
   opts?: { fresh?: boolean },
-): Promise<string | undefined> {
-  if (opts?.fresh) await reloadRaw();
-  const all = await readMerged(repo);
-  return all[cellKey(kind, ref, mode)];
+): Promise<Partial<Record<ReviewMode, string>>> {
+  const all = await readDismissals(repo, opts);
+  const prefix = `${kind}#${ref}#`;
+  const byMode: Partial<Record<ReviewMode, string>> = {};
+  for (const [cell, headSha] of Object.entries(all)) {
+    if (!cell.startsWith(prefix)) continue;
+    // Suffix comes from the store, so it's untrusted — keep only real modes.
+    const mode = cell.slice(prefix.length);
+    if (isReviewMode(mode)) byMode[mode] = headSha;
+  }
+  return byMode;
 }
 
 /** Records the head SHA dismissed for a PR + mode (overwriting any prior). */
@@ -90,13 +129,18 @@ export async function setDismissedHead(
   mode: ReviewMode,
   headSha: string,
 ): Promise<void> {
-  const store = await getStore();
-  const key = await keyFor(repo);
-  const all = (await store.get<DismissalMap>(key)) ?? {};
-  await store.set(key, { ...all, [cellKey(kind, ref, mode)]: headSha });
-  // Flush now rather than on autoSave's ~100ms debounce: the gates reload from
-  // disk, so a fresh read inside that window would discard this dismissal.
-  await store.save();
+  return serialize(async () => {
+    const store = await getStore();
+    // Reload before the read-modify-write: this rewrites the whole per-repo map, so
+    // basing it on a launch-time cache would drop another instance's cells.
+    await reloadRaw();
+    const key = await keyFor(repo);
+    const all = (await store.get<DismissalMap>(key)) ?? {};
+    await store.set(key, { ...all, [cellKey(kind, ref, mode)]: headSha });
+    // Flush past autoSave's ~100ms debounce so the next queued reload reads this
+    // write back instead of a pre-write snapshot.
+    await store.save();
+  });
 }
 
 /**
@@ -112,12 +156,16 @@ export async function clearDismissedHead(
   ref: string,
   mode: ReviewMode,
 ): Promise<void> {
-  const store = await getStore();
-  const key = await keyFor(repo);
-  const all = (await store.get<DismissalMap>(key)) ?? {};
-  delete all[cellKey(kind, ref, mode)];
-  await store.set(key, all);
-  // Same flush as setDismissedHead: an unsaved clear would be undone by the next
-  // fresh gate read, re-blocking the re-run this call exists to unblock.
-  await store.save();
+  return serialize(async () => {
+    const store = await getStore();
+    // Same reload-first rationale as setDismissedHead.
+    await reloadRaw();
+    const key = await keyFor(repo);
+    const all = (await store.get<DismissalMap>(key)) ?? {};
+    delete all[cellKey(kind, ref, mode)];
+    await store.set(key, all);
+    // Flush for the same reason: an unflushed clear would be undone by the next
+    // queued reload, re-blocking the re-run this call exists to unblock.
+    await store.save();
+  });
 }

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -2,6 +2,7 @@ import { load, type Store } from "@tauri-apps/plugin-store";
 import type { ReviewMode } from "@/lib/ai/types";
 import { identityKeyFor, repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
+import { ALL_ACTION_IDS } from "./types";
 
 /**
  * Persistent "dismissed head" watermarks for pr-sync automations. Cancelling an
@@ -96,8 +97,10 @@ async function readDismissals(
   });
 }
 
+// Derived from the action registry rather than another copy of the literal pair, so a
+// new mode can't be silently dropped here (`ActionId` IS `ReviewMode`).
 const isReviewMode = (v: string): v is ReviewMode =>
-  v === "general" || v === "security";
+  (ALL_ACTION_IDS as readonly string[]).includes(v);
 
 /** Every mode's dismissed head for ONE PR, in a single read. The automation gates
  *  check both modes per event, and each `fresh` read reloads (and queues behind any
@@ -114,9 +117,11 @@ export async function getDismissedHeadMap(
   const byMode: Partial<Record<ReviewMode, string>> = {};
   for (const [cell, headSha] of Object.entries(all)) {
     if (!cell.startsWith(prefix)) continue;
-    // Suffix comes from the store, so it's untrusted — keep only real modes.
+    // Cell and value both come from the store, so both are untrusted — keep only real
+    // modes, and only string heads (a hand-edited value would throw inside sameSha).
     const mode = cell.slice(prefix.length);
-    if (isReviewMode(mode)) byMode[mode] = headSha;
+    if (isReviewMode(mode) && typeof headSha === "string")
+      byMode[mode] = headSha;
   }
   return byMode;
 }

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -258,14 +258,11 @@ async function run(
 
   const settings = await loadSettings();
   const notify = settings.notifications.automations;
-  // The gate stores, read once and shared by an event's per-action gate checks, then
-  // dropped after any action that actually RAN (see the loop's `finally`): a review takes
-  // minutes, and in that window another window can cancel — releasing the claim and
-  // flushing a dismissal — so a later action must re-read rather than decide on a
-  // pre-loop snapshot. `fresh` reloads from disk and queues behind any writer, and
-  // pr-reviews.json carries every review's full markdown, so the sharing is what keeps a
-  // two-mode event from paying for both twice. Taken LAZILY: an event whose actions are
-  // all filtered out reads nothing, and commit events never reach the gates below.
+  // The gate stores, read once and shared by an event's per-action gate checks: `fresh`
+  // reloads from disk and queues behind any writer, and pr-reviews.json carries every
+  // review's full markdown, so sharing is what keeps a two-mode event from paying twice.
+  // Taken LAZILY — an event whose actions are all filtered out reads nothing, and commit
+  // events never reach the gates below.
   let gateSnapshot: {
     reviews: PersistedReview[];
     dismissed: Partial<Record<ReviewMode, string>>;
@@ -273,20 +270,21 @@ async function run(
   // Memoizes the resolved object rather than the promise — the action loop is sequential,
   // so two calls can never be in flight across these awaits.
   const gateState = async (prEvent: PrAutomationEvent) => {
-    gateSnapshot ??= {
-      reviews: await listReviews(
-        prEvent.repoPath,
-        prEvent.target.type,
-        targetRef(prEvent),
-        { fresh: true },
-      ),
-      dismissed: await getDismissedHeadMap(
-        prEvent.repoPath,
-        prEvent.target.type,
-        targetRef(prEvent),
-        { fresh: true },
-      ),
-    };
+    if (!gateSnapshot) {
+      // Separate stores with independent queues, so neither read waits on the other.
+      const [reviews, dismissed] = await Promise.all([
+        listReviews(prEvent.repoPath, prEvent.target.type, targetRef(prEvent), {
+          fresh: true,
+        }),
+        getDismissedHeadMap(
+          prEvent.repoPath,
+          prEvent.target.type,
+          targetRef(prEvent),
+          { fresh: true },
+        ),
+      ]);
+      gateSnapshot = { reviews, dismissed };
+    }
     return gateSnapshot;
   };
   for (const { action, conditions } of actions) {

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -277,8 +277,12 @@ async function run(
     // the history store's MAX_PER_GROUP per (kind, ref, mode).
     if (event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
+      // `fresh` on both gate reads: they're the post-delivery authority, so they must
+      // see another instance's just-written record, not this process's launch-time cache.
       const covered = (
-        await listReviews(event.repoPath, event.target.type, targetRef(event))
+        await listReviews(event.repoPath, event.target.type, targetRef(event), {
+          fresh: true,
+        })
       ).filter((r) => r.mode === action);
       // A CANCELLED re-review persists the dismissed head, so a cancelled head doesn't
       // re-fire after an app relaunch — only a genuinely newer head does.
@@ -287,6 +291,7 @@ async function run(
         event.target.type,
         targetRef(event),
         action,
+        { fresh: true },
       );
       // sameSha (not `===`) so a short-vs-full sha for the SAME head (Bitbucket's
       // 12-char poll head vs a full-40 seed) counts as "already reviewed" and
@@ -304,11 +309,13 @@ async function run(
     // a head this mode already dismissed. Mirror of the pr-sync gate, inverted — pr-sync
     // requires a prior review, pr-open requires its absence.
     if (event.kind === "pr-open") {
+      // `fresh` for the same reason as the pr-sync gate above.
       const prior = await getLatestReview(
         event.repoPath,
         event.target.type,
         targetRef(event),
         action,
+        { fresh: true },
       );
       if (prior) continue;
       const dismissedHead = await getDismissedHead(
@@ -316,6 +323,7 @@ async function run(
         event.target.type,
         targetRef(event),
         action,
+        { fresh: true },
       );
       if (event.headSha && sameSha(dismissedHead ?? "", event.headSha)) {
         continue;

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -258,26 +258,37 @@ async function run(
 
   const settings = await loadSettings();
   const notify = settings.notifications.automations;
-  // ONE fresh read of each gate store per event, not one per action: `fresh` reloads
-  // from disk and queues behind any writer, and pr-reviews.json carries every review's
-  // full markdown. The gates below derive per action from these snapshots — they're the
-  // post-delivery authority, so they must see another instance's just-written record
-  // rather than this process's launch-time cache. Commit events have no PR to gate on.
-  const gateReviews: PersistedReview[] =
-    event.kind === "commit"
-      ? []
-      : await listReviews(event.repoPath, event.target.type, targetRef(event), {
-          fresh: true,
-        });
-  const gateDismissed: Partial<Record<ReviewMode, string>> =
-    event.kind === "commit"
-      ? {}
-      : await getDismissedHeadMap(
-          event.repoPath,
-          event.target.type,
-          targetRef(event),
-          { fresh: true },
-        );
+  // The gate stores, read once and shared by an event's per-action gate checks, then
+  // dropped after any action that actually RAN (see the loop's `finally`): a review takes
+  // minutes, and in that window another window can cancel — releasing the claim and
+  // flushing a dismissal — so a later action must re-read rather than decide on a
+  // pre-loop snapshot. `fresh` reloads from disk and queues behind any writer, and
+  // pr-reviews.json carries every review's full markdown, so the sharing is what keeps a
+  // two-mode event from paying for both twice. Taken LAZILY: an event whose actions are
+  // all filtered out reads nothing, and commit events never reach the gates below.
+  let gateSnapshot: {
+    reviews: PersistedReview[];
+    dismissed: Partial<Record<ReviewMode, string>>;
+  } | null = null;
+  // Memoizes the resolved object rather than the promise — the action loop is sequential,
+  // so two calls can never be in flight across these awaits.
+  const gateState = async (prEvent: PrAutomationEvent) => {
+    gateSnapshot ??= {
+      reviews: await listReviews(
+        prEvent.repoPath,
+        prEvent.target.type,
+        targetRef(prEvent),
+        { fresh: true },
+      ),
+      dismissed: await getDismissedHeadMap(
+        prEvent.repoPath,
+        prEvent.target.type,
+        targetRef(prEvent),
+        { fresh: true },
+      ),
+    };
+    return gateSnapshot;
+  };
   for (const { action, conditions } of actions) {
     if (only && action !== only) continue;
     if (
@@ -297,10 +308,11 @@ async function run(
     // the history store's MAX_PER_GROUP per (kind, ref, mode).
     if (event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
-      const covered = gateReviews.filter((r) => r.mode === action);
+      const { reviews, dismissed } = await gateState(event);
+      const covered = reviews.filter((r) => r.mode === action);
       // A CANCELLED re-review persists the dismissed head, so a cancelled head doesn't
       // re-fire after an app relaunch — only a genuinely newer head does.
-      const dismissedHead = gateDismissed[action];
+      const dismissedHead = dismissed[action];
       // sameSha (not `===`) so a short-vs-full sha for the SAME head (Bitbucket's
       // 12-char poll head vs a full-40 seed) counts as "already reviewed" and
       // doesn't re-fire a redundant review each poll tick.
@@ -317,11 +329,12 @@ async function run(
     // a head this mode already dismissed. Mirror of the pr-sync gate, inverted — pr-sync
     // requires a prior review, pr-open requires its absence.
     if (event.kind === "pr-open") {
-      // The hoisted list is newest-first, so this mode's first entry IS its latest
-      // review — the same record `getLatestReview` would return.
-      const prior = gateReviews.find((r) => r.mode === action);
+      const { reviews, dismissed } = await gateState(event);
+      // The list is newest-first, so this mode's first entry IS its latest review — the
+      // same record `getLatestReview` would return.
+      const prior = reviews.find((r) => r.mode === action);
       if (prior) continue;
-      const dismissedHead = gateDismissed[action];
+      const dismissedHead = dismissed[action];
       if (event.headSha && sameSha(dismissedHead ?? "", event.headSha)) {
         continue;
       }
@@ -583,6 +596,10 @@ async function run(
       // Every terminal path lands here — including both `continue`s and the delivered
       // success path, which keeps its claim but must stop heartbeating it.
       stopHeartbeat();
+      // This try is entered only past every gate, so reaching it means the action RAN:
+      // drop the shared snapshot so the next action re-reads what happened meanwhile
+      // (a delivery, or a cancel in another window flushing a dismissal).
+      gateSnapshot = null;
     }
   }
   return { matched, attempted };

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -34,8 +34,8 @@ import type { DiffStatEntry } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
 import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import {
-  getLatestReview,
   listReviews,
+  type PersistedReview,
   saveReview,
 } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
@@ -49,7 +49,7 @@ import {
 import { errorMessage, invoke } from "@/lib/tauri/invoke";
 import {
   clearDismissedHead,
-  getDismissedHead,
+  getDismissedHeadMap,
   setDismissedHead,
 } from "./dismissals";
 import { useAutomationResults } from "./results";
@@ -258,6 +258,26 @@ async function run(
 
   const settings = await loadSettings();
   const notify = settings.notifications.automations;
+  // ONE fresh read of each gate store per event, not one per action: `fresh` reloads
+  // from disk and queues behind any writer, and pr-reviews.json carries every review's
+  // full markdown. The gates below derive per action from these snapshots — they're the
+  // post-delivery authority, so they must see another instance's just-written record
+  // rather than this process's launch-time cache. Commit events have no PR to gate on.
+  const gateReviews: PersistedReview[] =
+    event.kind === "commit"
+      ? []
+      : await listReviews(event.repoPath, event.target.type, targetRef(event), {
+          fresh: true,
+        });
+  const gateDismissed: Partial<Record<ReviewMode, string>> =
+    event.kind === "commit"
+      ? {}
+      : await getDismissedHeadMap(
+          event.repoPath,
+          event.target.type,
+          targetRef(event),
+          { fresh: true },
+        );
   for (const { action, conditions } of actions) {
     if (only && action !== only) continue;
     if (
@@ -277,22 +297,10 @@ async function run(
     // the history store's MAX_PER_GROUP per (kind, ref, mode).
     if (event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
-      // `fresh` on both gate reads: they're the post-delivery authority, so they must
-      // see another instance's just-written record, not this process's launch-time cache.
-      const covered = (
-        await listReviews(event.repoPath, event.target.type, targetRef(event), {
-          fresh: true,
-        })
-      ).filter((r) => r.mode === action);
+      const covered = gateReviews.filter((r) => r.mode === action);
       // A CANCELLED re-review persists the dismissed head, so a cancelled head doesn't
       // re-fire after an app relaunch — only a genuinely newer head does.
-      const dismissedHead = await getDismissedHead(
-        event.repoPath,
-        event.target.type,
-        targetRef(event),
-        action,
-        { fresh: true },
-      );
+      const dismissedHead = gateDismissed[action];
       // sameSha (not `===`) so a short-vs-full sha for the SAME head (Bitbucket's
       // 12-char poll head vs a full-40 seed) counts as "already reviewed" and
       // doesn't re-fire a redundant review each poll tick.
@@ -309,22 +317,11 @@ async function run(
     // a head this mode already dismissed. Mirror of the pr-sync gate, inverted — pr-sync
     // requires a prior review, pr-open requires its absence.
     if (event.kind === "pr-open") {
-      // `fresh` for the same reason as the pr-sync gate above.
-      const prior = await getLatestReview(
-        event.repoPath,
-        event.target.type,
-        targetRef(event),
-        action,
-        { fresh: true },
-      );
+      // The hoisted list is newest-first, so this mode's first entry IS its latest
+      // review — the same record `getLatestReview` would return.
+      const prior = gateReviews.find((r) => r.mode === action);
       if (prior) continue;
-      const dismissedHead = await getDismissedHead(
-        event.repoPath,
-        event.target.type,
-        targetRef(event),
-        action,
-        { fresh: true },
-      );
+      const dismissedHead = gateDismissed[action];
       if (event.headSha && sameSha(dismissedHead ?? "", event.headSha)) {
         continue;
       }

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -1,5 +1,5 @@
-import { getLatestReview } from "@/lib/pulls/reviews-history";
-import { getDismissedHead } from "./dismissals";
+import { listReviews } from "@/lib/pulls/reviews-history";
+import { getDismissedHeadMap } from "./dismissals";
 import { triggerAutomations } from "./runner";
 
 /**
@@ -187,16 +187,18 @@ export async function prOpenEligible(
 ): Promise<boolean> {
   try {
     const modes = ["general", "security"] as const;
+    // One fresh read of each store for the whole PR instead of one per mode: `fresh`
+    // reloads from disk and queues behind any writer. This is a gate, so it must see
+    // another instance's just-written record, not this process's launch-time cache.
+    const reviews = await listReviews(repoPath, "remote", ref, { fresh: true });
+    const dismissedByMode = await getDismissedHeadMap(repoPath, "remote", ref, {
+      fresh: true,
+    });
     for (const mode of modes) {
-      // `fresh` on both: this is a gate, so it must see another instance's
-      // just-written record rather than this process's launch-time store cache.
-      const prior = await getLatestReview(repoPath, "remote", ref, mode, {
-        fresh: true,
-      });
+      // Newest-first, so this mode's first entry is the latest review for it.
+      const prior = reviews.find((r) => r.mode === mode);
       if (prior) continue; // this mode already reviewed — no need on its account
-      const dismissed = await getDismissedHead(repoPath, "remote", ref, mode, {
-        fresh: true,
-      });
+      const dismissed = dismissedByMode[mode];
       // A dismissed head matching the current head means this mode was deliberately
       // skipped for this head — it doesn't need a review either.
       if (dismissed && sameSha(dismissed, currentHeadSha)) continue;

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -1,6 +1,7 @@
 import { listReviews } from "@/lib/pulls/reviews-history";
 import { getDismissedHeadMap } from "./dismissals";
 import { triggerAutomations } from "./runner";
+import { ALL_ACTION_IDS } from "./types";
 
 /**
  * Per-`(kind, repo, ref)` EVERY head already fired for, `sameSha`-matched — an
@@ -186,15 +187,15 @@ export async function prOpenEligible(
   currentHeadSha: string,
 ): Promise<boolean> {
   try {
-    const modes = ["general", "security"] as const;
-    // One fresh read of each store for the whole PR instead of one per mode: `fresh`
-    // reloads from disk and queues behind any writer. This is a gate, so it must see
-    // another instance's just-written record, not this process's launch-time cache.
-    const reviews = await listReviews(repoPath, "remote", ref, { fresh: true });
-    const dismissedByMode = await getDismissedHeadMap(repoPath, "remote", ref, {
-      fresh: true,
-    });
-    for (const mode of modes) {
+    // One fresh read of each store for the whole PR instead of one per mode, and the two
+    // concurrently — separate stores, independent queues. `fresh` reloads from disk and
+    // queues behind any writer: this is a gate, so it must see another instance's
+    // just-written record, not this process's launch-time cache.
+    const [reviews, dismissedByMode] = await Promise.all([
+      listReviews(repoPath, "remote", ref, { fresh: true }),
+      getDismissedHeadMap(repoPath, "remote", ref, { fresh: true }),
+    ]);
+    for (const mode of ALL_ACTION_IDS) {
       // Newest-first, so this mode's first entry is the latest review for it.
       const prior = reviews.find((r) => r.mode === mode);
       if (prior) continue; // this mode already reviewed — no need on its account

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -188,9 +188,15 @@ export async function prOpenEligible(
   try {
     const modes = ["general", "security"] as const;
     for (const mode of modes) {
-      const prior = await getLatestReview(repoPath, "remote", ref, mode);
+      // `fresh` on both: this is a gate, so it must see another instance's
+      // just-written record rather than this process's launch-time store cache.
+      const prior = await getLatestReview(repoPath, "remote", ref, mode, {
+        fresh: true,
+      });
       if (prior) continue; // this mode already reviewed — no need on its account
-      const dismissed = await getDismissedHead(repoPath, "remote", ref, mode);
+      const dismissed = await getDismissedHead(repoPath, "remote", ref, mode, {
+        fresh: true,
+      });
       // A dismissed head matching the current head means this mode was deliberately
       // skipped for this head — it doesn't need a review either.
       if (dismissed && sameSha(dismissed, currentHeadSha)) continue;

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -160,7 +160,8 @@ async function read(
   });
 }
 
-/** The most recent review for a specific PR + mode, or undefined if none. */
+/** The most recent review for a specific PR + mode, or undefined if none. `fresh`
+ *  re-reads the store from disk first — see {@link read}. */
 export async function getLatestReview(
   repo: string,
   kind: "remote" | "local",
@@ -177,7 +178,8 @@ export async function getLatestReview(
 /** Every persisted review for a PR (both modes), newest first. Two consumers, so
  *  narrowing what this returns is not a UI-only change: the "Previous reviews"
  *  disclosure, and the runner's pr-sync gate, which reads the whole retained set to
- *  decide whether a head was already covered. */
+ *  decide whether a head was already covered. `fresh` re-reads the store from disk
+ *  first — see {@link read}. */
 export async function listReviews(
   repo: string,
   kind: "remote" | "local",

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -143,14 +143,32 @@ function prune(records: PersistedReview[]): PersistedReview[] {
   return kept;
 }
 
+/** Reads the merged records, optionally re-reading the store from disk first.
+ *  `fresh` is what the automation gates need: the automation claim is an OS-atomic
+ *  lock covering CONCURRENT runs only — after delivery THIS store's record is the
+ *  authority, and the plugin-store's per-process cache is otherwise launch-time, so
+ *  a second instance would gate on "never reviewed" and re-review. Runs inside the
+ *  serialize queue so the reload is ordered with in-flight mutations. */
+async function read(
+  repo: string,
+  opts?: { fresh?: boolean },
+): Promise<PersistedReview[]> {
+  if (!opts?.fresh) return readMerged(repo);
+  return serialize(async () => {
+    await reloadRaw();
+    return readMerged(repo);
+  });
+}
+
 /** The most recent review for a specific PR + mode, or undefined if none. */
 export async function getLatestReview(
   repo: string,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
+  opts?: { fresh?: boolean },
 ): Promise<PersistedReview | undefined> {
-  const all = await readMerged(repo);
+  const all = await read(repo, opts);
   return all
     .filter((r) => r.kind === kind && r.ref === ref && r.mode === mode)
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
@@ -164,8 +182,9 @@ export async function listReviews(
   repo: string,
   kind: "remote" | "local",
   ref: string,
+  opts?: { fresh?: boolean },
 ): Promise<PersistedReview[]> {
-  const all = await readMerged(repo);
+  const all = await read(repo, opts);
   return all
     .filter((r) => r.kind === kind && r.ref === ref)
     .sort((a, b) => b.finishedAt - a.finishedAt);


### PR DESCRIPTION
AI review automations gate on persisted review history and dismissal watermarks, but the Tauri plugin-store caches its contents per process and only loads at launch. A second GitDesktop window/instance — or a restarted dev session — therefore gated against a launch-time snapshot, concluded "never reviewed", and re-ran a review another instance had already delivered. This adds an opt-in `fresh` read that reloads the store from disk at the gates, and flushes dismissal writes immediately so a fresh read can't race past them.

### Persistence layer

- Adds a `read(repo, opts)` helper in `src/lib/pulls/reviews-history.ts` that reloads the store from disk before merging records when `fresh` is set, running the reload inside the existing `serialize` queue so it's ordered against in-flight mutations. `getLatestReview` and `listReviews` both take the new `opts?: { fresh?: boolean }` and route through it.
- Adds `reloadRaw()` to `src/lib/automations/dismissals.ts`, guarding the case where `reload()` rejects with a raw io error on a store file that doesn't exist yet (unlike `load()`), and falling back to in-memory state on any failure — mirroring the guard already in `reviews-history.ts`. `getDismissedHead` gains the same `fresh` option.
- Makes `setDismissedHead` and `clearDismissedHead` in `dismissals.ts` `await store.save()` instead of relying on autoSave's ~100ms debounce; without the explicit flush, a fresh gate read inside that window would discard a just-written dismissal (or undo a clear, re-blocking the re-run it was meant to unblock).
- Default behavior is unchanged for existing callers — `fresh` is opt-in, so non-gate readers keep the cached path.

### Automation gates

- `src/lib/automations/runner.ts` passes `{ fresh: true }` to the `pr-sync` gate's `listReviews` and `getDismissedHead` calls, and to the `pr-open` gate's `getLatestReview` and `getDismissedHead` calls, so both post-delivery authorities see another instance's just-written record.
- `src/lib/automations/sync.ts` does the same in `prOpenEligible`, for both the prior-review check and the dismissed-head check across the `general` and `security` modes.

### Changelog

- Adds `changelog.d/fixed-duplicate-review-cross-instance.md` describing the fix for users. No README, marketing-site, or in-app guide changes: this corrects existing behavior without altering any documented surface or claim.