### PR TITLE
docs(blog): add "the AI off switch" post

### DIFF
--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -2,76 +2,64 @@
 title: "I use AI every day. My Git client still has an off switch."
 description: "GitDesktop is AI-native. One toggle hides all of it. On agency, trust, and the Git client that's left when the AI is gone."
 pubDate: 2026-08-05
+author: theBGuy
 pillar: ai-you-own
 tags: ["ai", "workflow"]
 ---
 
 I don't keep AI out of my own workflow. I use it every day, and I build
-GitDesktop with it. And "Hide AI features" was in the plan from day one.
+GitDesktop with it. The switch that hides every AI feature in the app was
+still in the plan from day one.
 
-## They should have that option
+## Stuffed into everything
 
-Not every user wants AI, and not every user needs it. And I think there's a
-growing portion of people who just don't want to see it, because it's
-semi-controversial. I really think every app should have the ability to turn
-off AI. People don't want to use it, don't need to use it, and don't want to
-see it. They should have that agency, that option.
+People don't trust AI products. The energy use bothers them. The general
+feeling is that AI keeps being put in everyone's face when it just doesn't
+need to be.
 
-For me it comes down to simple agency. Additional features like this should
-be configurable, and I don't think it's right to force things on people when
-they're not necessary.
-
-## The whole list
-
-Why do people push back on AI in their tools? There's a lack of trust in AI
-products. There's the energy use around it. And there's a general feeling
-that it's being put in everyone's face when it just doesn't need to be.
-
-I spend time on Reddit, and the general sentiment there is that AI is being
-stuffed into everything, whether it's necessary to the product or not.
-Everyone's trying to force this AI-native flow, and not everything needs it.
+That feeling is all over Reddit: AI stuffed into everything, whether it's
+necessary to the product or not. Everyone's trying to force this AI-native
+flow, and not everything needs it.
 
 And I build an AI-native Git client.
 
 ## What the switch actually does
 
-GitDesktop's settings have a toggle under General called "Hide AI features."
-Turn it on and the AI is gone. The generate buttons leave the commit box and
-the pull request dialogs. Whole settings sections disappear. The user guide
-drops its AI chapters. The Agent tab's code never even loads.
+GitDesktop's settings have a checkbox under General: "Hide AI features."
+Turn it on and the AI is gone. The generate buttons leave the commit box
+and the pull request dialogs. Whole settings sections disappear. The user
+guide drops its AI chapters. The Agent tab's code never even loads.
 
-Underneath the toggle there's a rule: GitDesktop never calls AI on its own,
-without you explicitly invoking a feature. That's very important. The
-closest thing to an exception is automations — rules you write yourself
-that can, say, review a pull request when it opens. Those run without a
-fresh click, but only because you wrote the rule.
-
-And when you do ask, the model is your choice — your own API key, or a
-local Ollama where the calls never leave your machine. Even
-[this website](/) has the switch: a "Just Git" view that hides the AI
-features from the pitch.
+Even [this website](/) has the switch — a "Just Git" view that hides the
+AI features from the pitch.
 
 ## The Git client that's left
 
-So what's left when you turn it all off? A whole lot. This is a
-full-featured Git client, and even without the AI-native side it lets you
-do far more than any other client currently on the market. What I'd
-highlight first is not having to jump back and forth between your Git
-client and GitHub.
+So what's left when you turn it all off? A full-featured Git client,
+without the jumping back and forth to GitHub.
 
-You can open, view, and completely manage [pull requests](/#pull-requests)
-from your local Git client. The same thing applies for issues and
-discussions. Go further and you can handle your tags and releases, or your
-[repository insights](/integrations/). And further still:
-[local branch protection](/features/) — the kind of branch rules GitHub
-doesn't offer on a private repository unless you're on a paid plan. Here
-they work offline, on any repository.
+You can open, view, and completely manage
+[pull requests](/#pull-requests) from your local client — issues and
+discussions the same way. You can cut tags and publish releases. You can
+check [repository insights](/integrations/) without opening a browser. And
+you can protect branches locally: the kind of [branch rules](/features/)
+GitHub doesn't offer on a private repository unless you're on a paid plan.
+In GitDesktop they work offline, on any repository.
 
-It still stays true to the name, **the whole loop, one window**: your whole
-development workflow, all within one application.
+[**The whole loop, one window**](/blog/the-whole-loop-one-window/) was
+never about the AI.
+
+## When you leave it on
+
+The switch isn't the only boundary. GitDesktop never calls AI on its own —
+nothing runs unless you invoke it. The only thing that runs unattended is
+an automation: a rule you wrote yourself, maybe to review each pull
+request when it opens. Even then, nothing happens that you didn't set up.
+
+When you do use the AI, the model is your choice: your own API key, or a
+local Ollama where the calls never leave your machine.
 
 ## Not everything needs it
 
-I don't keep AI out of my own workflow. But that's my workflow. Not
-everything needs it, and not everyone wants it. They should have that
-agency, that option. So it's one checkbox, first thing under General.
+I don't keep AI out of my own workflow. But that's my workflow, not yours.
+Everyone should have that agency, that option.

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -1,0 +1,77 @@
+---
+title: "I use AI every day. My Git client still has an off switch."
+description: "GitDesktop is AI-native. One toggle hides all of it. On agency, trust, and the Git client that's left when the AI is gone."
+pubDate: 2026-08-05
+pillar: ai-you-own
+tags: ["ai", "workflow"]
+---
+
+I don't keep AI out of my own workflow. I use it every day, and I build
+GitDesktop with it. And "Hide AI features" was in the plan from day one.
+
+## They should have that option
+
+Not every user wants AI, and not every user needs it. And I think there's a
+growing portion of people who just don't want to see it, because it's
+semi-controversial. I really think every app should have the ability to turn
+off AI. People don't want to use it, don't need to use it, and don't want to
+see it. They should have that agency, that option.
+
+For me it comes down to simple agency. Additional features like this should
+be configurable, and I don't think it's right to force things on people when
+they're not necessary.
+
+## The whole list
+
+Why do people push back on AI in their tools? There's a lack of trust in AI
+products. There's the energy use around it. And there's a general feeling
+that it's being put in everyone's face when it just doesn't need to be.
+
+I spend time on Reddit, and the general sentiment there is that AI is being
+stuffed into everything, whether it's necessary to the product or not.
+Everyone's trying to force this AI-native flow, and not everything needs it.
+
+And I build an AI-native Git client.
+
+## What the switch actually does
+
+GitDesktop's settings have a toggle under General called "Hide AI features."
+Turn it on and the AI is gone. The generate buttons leave the commit box and
+the pull request dialogs. Whole settings sections disappear. The user guide
+drops its AI chapters. The Agent tab's code never even loads.
+
+Underneath the toggle there's a rule: GitDesktop never calls AI on its own,
+without you explicitly invoking a feature. That's very important. The
+closest thing to an exception is automations — rules you write yourself
+that can, say, review a pull request when it opens. Those run without a
+fresh click, but only because you wrote the rule.
+
+And when you do ask, the model is your choice — your own API key, or a
+local Ollama where the calls never leave your machine. Even
+[this website](/) has the switch: a "Just Git" view that hides the AI
+features from the pitch.
+
+## The Git client that's left
+
+So what's left when you turn it all off? A whole lot. This is a
+full-featured Git client, and even without the AI-native side it lets you
+do far more than any other client currently on the market. What I'd
+highlight first is not having to jump back and forth between your Git
+client and GitHub.
+
+You can open, view, and completely manage [pull requests](/#pull-requests)
+from your local Git client. The same thing applies for issues and
+discussions. Go further and you can handle your tags and releases, or your
+[repository insights](/integrations/). And further still:
+[local branch protection](/features/) — the kind of branch rules GitHub
+doesn't offer on a private repository unless you're on a paid plan. Here
+they work offline, on any repository.
+
+It still stays true to the name, **the whole loop, one window**: your whole
+development workflow, all within one application.
+
+## Not everything needs it
+
+I don't keep AI out of my own workflow. But that's my workflow. Not
+everything needs it, and not everyone wants it. They should have that
+agency, that option. So it's one checkbox, first thing under General.

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -22,15 +22,15 @@ Because I don't think software should decide how people work.
 ## AI isn't the product
 
 It's easy to look at developer tools right now and feel like every
-application has become an AI application. Sometimes that's useful.
-Sometimes it's just another button you have to ignore.
+application has become an AI application. Sometimes that's useful. Other
+times it's another button you have to ignore.
 
 I didn't want GitDesktop to end up as an assistant with a Git client
 somewhere underneath it. I wanted a Git client first. The goal was
 [the whole loop, one window](/blog/the-whole-loop-one-window/) long
 before the first AI feature existed.
 
-## The switch isn't cosmetic
+## What the switch actually does
 
 Turn on "Hide AI features" (one checkbox under General) and GitDesktop
 doesn't gray out a few buttons. The generate actions disappear from the
@@ -43,7 +43,7 @@ What's left is simply GitDesktop.
 
 You can manage [pull requests](/#pull-requests), issues, discussions,
 releases, worktrees, interactive rebases, repository insights, and
-[local branch rules](/features/) without opening a browser.
+[local branch protection](/features/) without opening a browser.
 
 The workflow is still complete.
 
@@ -51,10 +51,9 @@ Only the optional layer disappears.
 
 ## Agency matters
 
-I think AI is genuinely useful. I also think people should decide when
-it belongs in their workflow. So GitDesktop never calls a model on its
-own. The only thing that runs automatically is a rule you created
-yourself.
+I think AI is genuinely useful. I also think people should decide when it
+belongs in their workflow. So GitDesktop never calls a model on its own. The
+only thing that runs automatically is an automation you turned on yourself.
 
 When you do use it, you choose where the requests go. Bring your own API
 key. Run Ollama locally, so the calls never leave your machine. Or don't
@@ -74,5 +73,4 @@ That's my workflow.
 
 It doesn't have to be yours.
 
-One of the design goals behind GitDesktop is that it never assumes
-otherwise.
+One of the design goals behind GitDesktop is that it never assumes otherwise.

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -7,21 +7,23 @@ pillar: ai-you-own
 tags: ["ai", "workflow"]
 ---
 
-I use AI constantly. It writes commit messages I would have typed myself.
-It drafts pull request descriptions. It reviews my code before I open a
-pull request — sometimes it catches something I missed, sometimes it just
-saves me five minutes. GitDesktop has all of those features. It also has
-a setting called "Hide AI features."
+I use AI constantly. It helps write commit messages, draft pull request
+descriptions, and review code before I open a PR. Sometimes it catches
+something I missed. Sometimes it just saves me five minutes.
 
-Why build AI into a Git client and then make it disappear? Because I
-don't think software should decide how people work.
+GitDesktop has all of those features.
+
+It also has a setting called **Hide AI features**.
+
+Why build AI into a Git client and then make it disappear?
+
+Because I don't think software should decide how people work.
 
 ## AI isn't the product
 
 It's easy to look at developer tools right now and feel like every
 application has become an AI application. Sometimes that's useful.
-Sometimes it's just another button you have to ignore. Everyone's trying
-to force this AI-native flow, and not everything needs it.
+Sometimes it's just another button you have to ignore.
 
 I didn't want GitDesktop to end up as an assistant with a Git client
 somewhere underneath it. I wanted a Git client first. The goal was
@@ -37,27 +39,28 @@ removed. The user guide drops its AI chapters. The Agent tab's code never
 even loads. Even [this website](/) has the switch: a "Just Git" view that
 hides the AI features from the pitch.
 
-What's left is simply GitDesktop. You can open, view, and completely
-manage [pull requests](/#pull-requests) from your local client — issues
-and discussions the same way. You can cut tags, publish releases, manage
-your worktrees, edit your unpushed history, and check your
-[repository insights](/integrations/) without opening a browser. You can
-recover lost work from the operation history, and protect branches
-locally with the kind of [branch rules](/features/) GitHub doesn't offer
-on a private repository unless you're on a paid plan. The workflow stays
-complete. Only the optional layer disappears.
+What's left is simply GitDesktop.
+
+You can manage [pull requests](/#pull-requests), issues, discussions,
+releases, worktrees, interactive rebases, repository insights, and
+[local branch rules](/features/) without opening a browser.
+
+The workflow is still complete.
+
+Only the optional layer disappears.
 
 ## Agency matters
 
-I think AI is genuinely useful — I use it every day. I also think people should
-decide when it belongs in their workflow. So GitDesktop never calls a
-model on its own. Nothing happens unless you ask for it; the one
-exception is an automation you wrote yourself, and even that only runs
-the rule you gave it.
+I think AI is genuinely useful — I use it every day. I also think people
+should decide when it belongs in their workflow. So GitDesktop never
+calls a model on its own. Nothing happens unless you ask for it. The only
+thing that runs automatically is a rule you created yourself.
 
 When you do use it, you choose where the requests go. Bring your own API
 key. Run Ollama locally, so the calls never leave your machine. Or don't
 use AI at all. The software shouldn't make that decision for you.
+
+Optional means optional.
 
 ## Software you can trust
 
@@ -66,5 +69,11 @@ tools will do. When you disable a feature, it should actually disappear.
 When you don't want AI in your workflow, your Git client shouldn't keep
 reminding you that it exists.
 
-I use AI every day. But that's my workflow. One of the design goals
-behind GitDesktop is that you never have to make it yours.
+I use AI every day.
+
+That's my workflow.
+
+It doesn't have to be yours.
+
+One of the design goals behind GitDesktop is that it never assumes
+otherwise.

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -27,7 +27,7 @@ Sometimes it's just another button you have to ignore.
 
 I didn't want GitDesktop to end up as an assistant with a Git client
 somewhere underneath it. I wanted a Git client first. The goal was
-[**the whole loop, one window**](/blog/the-whole-loop-one-window/) long
+[the whole loop, one window](/blog/the-whole-loop-one-window/) long
 before the first AI feature existed.
 
 ## The switch isn't cosmetic
@@ -51,10 +51,10 @@ Only the optional layer disappears.
 
 ## Agency matters
 
-I think AI is genuinely useful — I use it every day. I also think people
-should decide when it belongs in their workflow. So GitDesktop never
-calls a model on its own. Nothing happens unless you ask for it. The only
-thing that runs automatically is a rule you created yourself.
+I think AI is genuinely useful. I also think people should decide when
+it belongs in their workflow. So GitDesktop never calls a model on its
+own. The only thing that runs automatically is a rule you created
+yourself.
 
 When you do use it, you choose where the requests go. Bring your own API
 key. Run Ollama locally, so the calls never leave your machine. Or don't
@@ -64,10 +64,9 @@ Optional means optional.
 
 ## Software you can trust
 
-Trust isn't only about security or privacy. It's about knowing what your
-tools will do. When you disable a feature, it should actually disappear.
-When you don't want AI in your workflow, your Git client shouldn't keep
-reminding you that it exists.
+Trust is knowing what your tools will do. When you hide a feature, it
+should actually disappear. When you don't want AI in your workflow, your
+Git client shouldn't keep reminding you that it exists.
 
 I use AI every day.
 

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -7,59 +7,64 @@ pillar: ai-you-own
 tags: ["ai", "workflow"]
 ---
 
-I don't keep AI out of my own workflow. I use it every day, and I build
-GitDesktop with it. The switch that hides every AI feature in the app was
-still in the plan from day one.
+I use AI constantly. It writes commit messages I would have typed myself.
+It drafts pull request descriptions. It reviews my code before I open a
+pull request — sometimes it catches something I missed, sometimes it just
+saves me five minutes. GitDesktop has all of those features. It also has
+a setting called "Hide AI features."
 
-## Stuffed into everything
+Why build AI into a Git client and then make it disappear? Because I
+don't think software should decide how people work.
 
-People don't trust AI products. The energy use bothers them. The general
-feeling is that AI keeps being put in everyone's face when it just doesn't
-need to be.
+## AI isn't the product
 
-That feeling is all over Reddit: AI stuffed into everything, whether it's
-necessary to the product or not. Everyone's trying to force this AI-native
-flow, and not everything needs it.
+It's easy to look at developer tools right now and feel like every
+application has become an AI application. Sometimes that's useful.
+Sometimes it's just another button you have to ignore. Everyone's trying
+to force this AI-native flow, and not everything needs it.
 
-And I build an AI-native Git client.
+I didn't want GitDesktop to end up as an assistant with a Git client
+somewhere underneath it. I wanted a Git client first. The goal was
+[**the whole loop, one window**](/blog/the-whole-loop-one-window/) long
+before the first AI feature existed.
 
-## What the switch actually does
+## The switch isn't cosmetic
 
-GitDesktop's settings have a checkbox under General: "Hide AI features."
-Turn it on and the AI is gone. The generate buttons leave the commit box
-and the pull request dialogs. Whole settings sections disappear. The user
-guide drops its AI chapters. The Agent tab's code never even loads.
+Turn on "Hide AI features" (one checkbox under General) and GitDesktop
+doesn't gray out a few buttons. The generate actions disappear from the
+commit box and the pull request dialogs. Whole settings sections are
+removed. The user guide drops its AI chapters. The Agent tab's code never
+even loads. Even [this website](/) has the switch: a "Just Git" view that
+hides the AI features from the pitch.
 
-Even [this website](/) has the switch — a "Just Git" view that hides the
-AI features from the pitch.
+What's left is simply GitDesktop. You can open, view, and completely
+manage [pull requests](/#pull-requests) from your local client — issues
+and discussions the same way. You can cut tags, publish releases, manage
+your worktrees, edit your unpushed history, and check your
+[repository insights](/integrations/) without opening a browser. You can
+recover lost work from the operation history, and protect branches
+locally with the kind of [branch rules](/features/) GitHub doesn't offer
+on a private repository unless you're on a paid plan. The workflow stays
+complete. Only the optional layer disappears.
 
-## The Git client that's left
+## Agency matters
 
-So what's left when you turn it all off? A full-featured Git client,
-without the jumping back and forth to GitHub.
+I think AI is genuinely useful — I use it every day. I also think people should
+decide when it belongs in their workflow. So GitDesktop never calls a
+model on its own. Nothing happens unless you ask for it; the one
+exception is an automation you wrote yourself, and even that only runs
+the rule you gave it.
 
-You can open, view, and completely manage
-[pull requests](/#pull-requests) from your local client — issues and
-discussions the same way. You can cut tags and publish releases. You can
-check [repository insights](/integrations/) without opening a browser. And
-you can protect branches locally: the kind of [branch rules](/features/)
-GitHub doesn't offer on a private repository unless you're on a paid plan.
-In GitDesktop they work offline, on any repository.
+When you do use it, you choose where the requests go. Bring your own API
+key. Run Ollama locally, so the calls never leave your machine. Or don't
+use AI at all. The software shouldn't make that decision for you.
 
-[**The whole loop, one window**](/blog/the-whole-loop-one-window/) was
-never about the AI.
+## Software you can trust
 
-## When you leave it on
+Trust isn't only about security or privacy. It's about knowing what your
+tools will do. When you disable a feature, it should actually disappear.
+When you don't want AI in your workflow, your Git client shouldn't keep
+reminding you that it exists.
 
-The switch isn't the only boundary. GitDesktop never calls AI on its own —
-nothing runs unless you invoke it. The only thing that runs unattended is
-an automation: a rule you wrote yourself, maybe to review each pull
-request when it opens. Even then, nothing happens that you didn't set up.
-
-When you do use the AI, the model is your choice: your own API key, or a
-local Ollama where the calls never leave your machine.
-
-## Not everything needs it
-
-I don't keep AI out of my own workflow. But that's my workflow, not yours.
-Everyone should have that agency, that option.
+I use AI every day. But that's my workflow. One of the design goals
+behind GitDesktop is that you never have to make it yours.


### PR DESCRIPTION
Adds a new marketing-site blog post arguing GitDesktop's AI features are optional by design, framed around the app's **Hide AI features** setting. The post sits in the `ai-you-own` pillar and gives the "Just Git" story a piece of long-form copy to point at.

- Adds `site/src/content/blog/the-ai-off-switch.md`, a 79-line post under the `theBGuy` byline (`pubDate: 2026-08-05`, `pillar: ai-you-own`, tags `ai` / `workflow`) titled "I use AI every day. My Git client still has an off switch."
- Walks through what the toggle actually removes — generate actions in the commit box and PR dialogs, whole settings sections, the guide's AI chapters, and the Agent tab's code never loading — plus the site's own "Just Git" view.
- Cross-links to existing site surfaces: `/blog/the-whole-loop-one-window/`, `/#pull-requests`, `/features/`, and the home page, so the post routes readers into the non-AI capability catalog.
- Closes on the agency argument (no model calls without an explicit ask, BYO API key, local Ollama), consistent with the series' fresh-closer convention.

Site-only change: no `src/` or `src-tauri/` code is touched, so per the repo's docs policy this carries no changelog fragment.