### PR TITLE
feat(pulls,github,gitlab): add stacked pull request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,8 +494,9 @@ workflow against any two branches with no remote at all).
   stacks** come straight from its API; on **GitLab**, chains of merge requests are
   **detected automatically**. On GitHub, merging is **stack-aware**: merging a stacked pull
   request merges it *and* every still-open pull request below it, bottom-up, as one
-  operation — and the merge dialog spells out that full scope before you confirm, naming
-  the pull requests it will merge, in order, whenever it has the list.
+  operation — or, when the base branch uses a **merge queue**, hands the stack to the queue
+  to land when it clears. The merge dialog spells out that full scope before you confirm,
+  naming the pull requests it will merge, in order, whenever it has the list.
 - **Record management** — open a local PR's context menu in the list to **Archive / Unarchive**
   or **Delete** it (Delete confirms; the branches are untouched), also from the command
   palette.

--- a/README.md
+++ b/README.md
@@ -494,7 +494,8 @@ workflow against any two branches with no remote at all).
   stacks** come straight from its API; on **GitLab**, chains of merge requests are
   **detected automatically**. On GitHub, merging is **stack-aware**: merging a stacked pull
   request merges it *and* every still-open pull request below it, bottom-up, as one
-  operation, and the merge dialog lists exactly which pull requests will merge.
+  operation — and the merge dialog spells out that full scope before you confirm, naming
+  the pull requests it will merge, in order, whenever it has the list.
 - **Record management** — open a local PR's context menu in the list to **Archive / Unarchive**
   or **Delete** it (Delete confirms; the branches are untouched), also from the command
   palette.

--- a/README.md
+++ b/README.md
@@ -488,6 +488,13 @@ workflow against any two branches with no remote at all).
   current step inline and a live step checklist when expanded, while finished **GitHub
   Actions** and **GitLab pipeline** jobs peek their log inline and **Bitbucket** and
   other external checks link out (name/state/URL, no fetchable logs).
+- **Stacked PRs** — a stack **position badge** (*2/3*) on stacked rows in the PR list, and a
+  **Stack** section on the PR view listing every member bottom → top, keyboard-navigable
+  (with palette commands for the next and previous PR in the stack). GitHub's **native
+  stacks** come straight from its API; on **GitLab**, chains of merge requests are
+  **detected automatically**. On GitHub, merging is **stack-aware**: merging a stacked pull
+  request merges it *and* every still-open pull request below it, bottom-up, as one
+  operation, and the merge dialog lists exactly which pull requests will merge.
 - **Record management** — open a local PR's context menu in the list to **Archive / Unarchive**
   or **Delete** it (Delete confirms; the branches are untouched), also from the command
   palette.

--- a/changelog.d/added-stacked-prs.md
+++ b/changelog.d/added-stacked-prs.md
@@ -1,0 +1,4 @@
+- **Stacked pull requests:** stack position badges in the PR list, a stack
+  navigator on the PR view (GitHub native stacks; GitLab stacked MRs detected
+  automatically), and, on GitHub, stack-aware merging that merges a stack
+  bottom-up as one operation.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -194,6 +194,11 @@ export const capabilities: Capability[] = [
     label:
       "Fork · Upstream lens — browse & work a fork's PRs and issues or the parent's",
   },
+  {
+    group: "Pull requests & review",
+    label:
+      "Stacked PRs — position badges and a stack navigator; on GitHub, merge a stack bottom-up in one go",
+  },
 
   // — Forges & trackers —
   {

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -624,6 +624,8 @@ fn from_bb_pr(p: BbPr) -> PrInfo {
             .and_then(|s| s.commit.as_ref())
             .map(|c| c.hash.clone())
             .unwrap_or_default(),
+        // Bitbucket has no stacked-PR concept.
+        stack: None,
     }
 }
 
@@ -1222,6 +1224,9 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         merge_commit_allowed: None,
         squash_merge_allowed: None,
         rebase_merge_allowed: None,
+        // Bitbucket has no stacked-PR concept.
+        stack: None,
+        stack_members: Vec::new(),
     })
 }
 

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -1224,9 +1224,10 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         merge_commit_allowed: None,
         squash_merge_allowed: None,
         rebase_merge_allowed: None,
-        // Bitbucket has no stacked-PR concept.
+        // Bitbucket has no stacked-PR concept — never stacked, never unknown.
         stack: None,
         stack_members: Vec::new(),
+        stack_unknown: false,
     })
 }
 

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -7789,6 +7789,9 @@ mod tests {
         assert!(infer_mr_stacks(&[]).is_empty());
         // A self-targeting MR can't be its own parent.
         assert!(infer_mr_stacks(&[(1, "feat-a", "feat-a")]).is_empty());
+        // A 2-cycle (each MR targets the other's source branch) has no parentless
+        // bottom, so the component yields nothing rather than looping.
+        assert!(infer_mr_stacks(&[(1, "feat-a", "feat-b"), (2, "feat-b", "feat-a")]).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -22,7 +22,8 @@ use crate::github::issue::{IssueDetails, IssueInfo, IssueReactions, Milestone, R
 use crate::github::pr::{
     ApprovalState, CommitCommentOut, DraftCommentIn, ExternalReviewItem, PrAuthor, PrCheckOut,
     PrCiStatus, PrCommitOut, PrDetails, PrFileOut, PrInfo, PrListLabel, PrPollInfo, PrRef,
-    PrThreadOut, PrTimelineEventOut, RepoLabel, ReviewSubmitOut, ReviewThreadOut,
+    PrStackInfo, PrStackMember, PrThreadOut, PrTimelineEventOut, RepoLabel, ReviewSubmitOut,
+    ReviewThreadOut,
 };
 use crate::github::release::{ReleaseAsset, ReleaseDetails, ReleaseInfo};
 use crate::state::AppState;
@@ -292,7 +293,126 @@ fn from_glab_mr(m: GlabMr) -> PrInfo {
         created_at: m.created_at,
         // GitLab queries CI by MR iid (headPipeline), never by SHA — leave it empty.
         head_sha: String::new(),
+        // GitLab has no stack object; chains are inferred over a whole open list
+        // (see `infer_mr_stacks`), which a single MR can't do.
+        stack: None,
     }
+}
+
+/// Infer stacked-MR chains from the OPEN merge requests: `(iid, source branch,
+/// target branch)` in, `iid → (stack id, 1-based position, chain size)` out.
+/// GitLab auto-detects a stack server-side when an MR targets another open MR's
+/// source branch but exposes no stack object, so we reconstruct the same relation
+/// from the list.
+///
+/// Only unambiguous LINEAR chains of two or more MRs are marked: a source branch
+/// shared by two open MRs identifies no unique parent, and an MR with two open
+/// children is a branching stack — GitHub disallows those and we mirror it by
+/// leaving the whole chain unmarked rather than guessing an order. Pure —
+/// unit-tested.
+fn infer_mr_stacks(open: &[(u64, &str, &str)]) -> HashMap<u64, (String, u32, u32)> {
+    let mut sources: HashMap<&str, Vec<u64>> = HashMap::new();
+    for (iid, head, _) in open {
+        sources.entry(*head).or_default().push(*iid);
+    }
+
+    let mut has_parent: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut children: HashMap<u64, Vec<u64>> = HashMap::new();
+    for (iid, _, base) in open {
+        // A target branch that is exactly ONE open MR's source branch is a stack
+        // link; zero means this MR sits on a plain branch, two is ambiguous.
+        let Some([parent]) = sources.get(*base).map(Vec::as_slice) else {
+            continue;
+        };
+        if *parent == *iid {
+            continue;
+        }
+        has_parent.insert(*iid);
+        children.entry(*parent).or_default().push(*iid);
+    }
+
+    let mut result = HashMap::new();
+    for (bottom, _, _) in open.iter().filter(|(iid, _, _)| !has_parent.contains(iid)) {
+        let mut chain = vec![*bottom];
+        let mut cursor = *bottom;
+        while let Some(kids) = children.get(&cursor) {
+            let [next] = kids.as_slice() else {
+                // Branching — abandon this whole chain.
+                chain.clear();
+                break;
+            };
+            // Defensive: a cycle can't reach a parentless bottom, but never loop.
+            if chain.contains(next) {
+                chain.clear();
+                break;
+            }
+            cursor = *next;
+            chain.push(cursor);
+        }
+        if chain.len() < 2 {
+            continue;
+        }
+        let id = format!("mr-{bottom}");
+        let size = chain.len() as u32;
+        for (idx, iid) in chain.into_iter().enumerate() {
+            result.insert(iid, (id.clone(), idx as u32 + 1, size));
+        }
+    }
+    result
+}
+
+/// Fill each row's `stack` from the chains inferred over the SAME list. Membership
+/// is only as complete as the list in hand — a `limit`-truncated list can hide a
+/// chain's other layers, and merged layers are gone from an open list entirely.
+fn apply_mr_stacks(prs: &mut [PrInfo]) {
+    let rows: Vec<(u64, &str, &str)> = prs
+        .iter()
+        .map(|p| {
+            (
+                p.number,
+                p.head_ref_name.as_str(),
+                p.base_ref_name.as_str(),
+            )
+        })
+        .collect();
+    let stacks = infer_mr_stacks(&rows);
+    for pr in prs.iter_mut() {
+        pr.stack = stacks.get(&pr.number).map(|(id, position, size)| PrStackInfo {
+            id: id.clone(),
+            position: *position,
+            size: *size,
+        });
+    }
+}
+
+/// One MR's chain membership plus that chain's members bottom→top, for the detail
+/// view. Reads the `stack` field `list_prs` already annotated onto its rows —
+/// inference runs once, there. `(None, [])` when the MR isn't in the list or
+/// isn't in an unambiguous chain.
+fn mr_stack_from_rows(open: &[PrInfo], number: u64) -> (Option<PrStackInfo>, Vec<PrStackMember>) {
+    let Some(stack) = open
+        .iter()
+        .find(|p| p.number == number)
+        .and_then(|p| p.stack.as_ref())
+    else {
+        return (None, Vec::new());
+    };
+    let mut members: Vec<PrStackMember> = open
+        .iter()
+        .filter_map(|p| {
+            let member = p.stack.as_ref()?;
+            (member.id == stack.id).then(|| PrStackMember {
+                number: p.number,
+                title: p.title.clone(),
+                state: p.state.to_ascii_lowercase(),
+                position: member.position,
+                head_ref_name: p.head_ref_name.clone(),
+                base_ref_name: p.base_ref_name.clone(),
+            })
+        })
+        .collect();
+    members.sort_by_key(|m| m.position);
+    (Some(stack.clone()), members)
 }
 
 /// The signed-in user's merge requests for this repo. `state` is `"open"` or
@@ -322,6 +442,12 @@ pub async fn list_prs(repo_path: &str, state: &str, limit: Option<u32>) -> AppRe
         let mrs: Vec<GlabMr> = serde_json::from_str(&out.stdout_lossy())
             .map_err(|e| AppError::Glab(format!("could not parse GitLab merge requests: {e}")))?;
         prs.extend(mrs.into_iter().map(from_glab_mr));
+    }
+    // Chains are inferred over the open set only — a closed list's rows describe
+    // merges already made. Inferred before truncation, so a `limit` narrows what's
+    // shown without distorting the chains.
+    if state == "open" {
+        apply_mr_stacks(&mut prs);
     }
     if let Some(n) = limit {
         prs.truncate(n as usize);
@@ -871,16 +997,18 @@ async fn project_label_colors(repo_path: &str, enc: &str) -> HashMap<String, Str
 pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
     let enc = encode_project(&project_path(repo_path).await?);
 
-    // Core fields + changed files in one call.
-    let out = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/merge_requests/{number}/changes"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await?;
+    // Core fields + changed files in one call, alongside the open-MR list that
+    // stack inference needs — GitLab has no per-MR stack object, so membership can
+    // only come from the whole open set. Fail-open: an empty list simply leaves
+    // this MR unstacked.
+    let changes_endpoint = format!("projects/{enc}/merge_requests/{number}/changes");
+    let changes_args = ["api", changes_endpoint.as_str()];
+    let (out, open_prs) = tokio::join!(
+        run_glab(Some(repo_path), &changes_args, GLAB_NETWORK_TIMEOUT),
+        async { list_prs(repo_path, "open", None).await.unwrap_or_default() },
+    );
+    let out = out?;
+    let (stack, stack_members) = mr_stack_from_rows(&open_prs, number);
     let mr: GlabMrChanges = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Glab(format!("could not parse GitLab merge request: {e}")))?;
 
@@ -1098,6 +1226,8 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         merge_commit_allowed: None,
         squash_merge_allowed: None,
         rebase_merge_allowed: None,
+        stack,
+        stack_members,
     })
 }
 
@@ -7452,6 +7582,90 @@ pub async fn repo_readme(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `(iid, position, size)` per MR, sorted — the readable shape of an inference.
+    fn chain_of(open: &[(u64, &str, &str)]) -> Vec<(u64, String, u32, u32)> {
+        let mut rows: Vec<(u64, String, u32, u32)> = infer_mr_stacks(open)
+            .into_iter()
+            .map(|(iid, (id, position, size))| (iid, id, position, size))
+            .collect();
+        rows.sort();
+        rows
+    }
+
+    #[test]
+    fn infer_mr_stacks_marks_a_linear_chain_bottom_first() {
+        // A (feat-a → main) ← B (feat-b → feat-a): B targets A's source branch.
+        let rows = chain_of(&[(7, "feat-a", "main"), (8, "feat-b", "feat-a")]);
+        assert_eq!(
+            rows,
+            vec![
+                (7, "mr-7".to_string(), 1, 2),
+                (8, "mr-7".to_string(), 2, 2),
+            ]
+        );
+        // Three deep, and list order must not matter.
+        let rows = chain_of(&[
+            (30, "feat-c", "feat-b"),
+            (10, "feat-a", "main"),
+            (20, "feat-b", "feat-a"),
+        ]);
+        assert_eq!(
+            rows,
+            vec![
+                (10, "mr-10".to_string(), 1, 3),
+                (20, "mr-10".to_string(), 2, 3),
+                (30, "mr-10".to_string(), 3, 3),
+            ]
+        );
+    }
+
+    #[test]
+    fn infer_mr_stacks_leaves_ambiguous_shapes_unmarked() {
+        // Branching stack: two open MRs both target feat-a. GitHub disallows the
+        // shape, so the whole chain stays unmarked rather than picking an order.
+        assert!(infer_mr_stacks(&[
+            (1, "feat-a", "main"),
+            (2, "feat-b", "feat-a"),
+            (3, "feat-c", "feat-a"),
+        ])
+        .is_empty());
+        // Two open MRs sharing a source branch identify no unique parent.
+        assert!(infer_mr_stacks(&[
+            (1, "feat-a", "main"),
+            (2, "feat-a", "release"),
+            (3, "feat-b", "feat-a"),
+        ])
+        .is_empty());
+    }
+
+    #[test]
+    fn infer_mr_stacks_finds_nothing_without_a_chain() {
+        // Independent MRs onto the trunk — a lone MR is not a stack of one.
+        assert!(infer_mr_stacks(&[(1, "feat-a", "main"), (2, "feat-b", "main")]).is_empty());
+        assert!(infer_mr_stacks(&[]).is_empty());
+        // A self-targeting MR can't be its own parent.
+        assert!(infer_mr_stacks(&[(1, "feat-a", "feat-a")]).is_empty());
+    }
+
+    #[test]
+    fn infer_mr_stacks_handles_two_independent_chains() {
+        let rows = chain_of(&[
+            (1, "a1", "main"),
+            (2, "a2", "a1"),
+            (5, "b1", "release"),
+            (6, "b2", "b1"),
+        ]);
+        assert_eq!(
+            rows,
+            vec![
+                (1, "mr-1".to_string(), 1, 2),
+                (2, "mr-1".to_string(), 2, 2),
+                (5, "mr-5".to_string(), 1, 2),
+                (6, "mr-5".to_string(), 2, 2),
+            ]
+        );
+    }
 
     #[test]
     fn gitlab_order_by_maps_each_sort() {

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -23,7 +23,7 @@ use crate::github::pr::{
     ApprovalState, CommitCommentOut, DraftCommentIn, ExternalReviewItem, PrAuthor, PrCheckOut,
     PrCiStatus, PrCommitOut, PrDetails, PrFileOut, PrInfo, PrListLabel, PrPollInfo, PrRef,
     PrStackInfo, PrStackMember, PrThreadOut, PrTimelineEventOut, RepoLabel, ReviewSubmitOut,
-    ReviewThreadOut,
+    ReviewThreadOut, STACKS_TIMEOUT,
 };
 use crate::github::release::{ReleaseAsset, ReleaseDetails, ReleaseInfo};
 use crate::state::AppState;
@@ -402,8 +402,10 @@ fn infer_mr_stacks(open: &[(u64, &str, &str)]) -> HashMap<u64, (String, u32, u32
 }
 
 /// Fill each row's `stack` from the chains inferred over the SAME list. Membership
-/// is only as complete as the list in hand — a `limit`-truncated list can hide a
-/// chain's other layers, and merged layers are gone from an open list entirely.
+/// is only as complete as the list in hand: callers pass the full open page (a
+/// truncated list would hide a chain's bottom and mis-position the rows above it),
+/// so the real limits are >100 open MRs and merged layers, which an open list has
+/// dropped entirely.
 fn apply_mr_stacks(prs: &mut [PrInfo]) {
     let rows: Vec<(u64, &str, &str)> = prs
         .iter()
@@ -471,10 +473,20 @@ pub async fn list_prs(repo_path: &str, state: &str, limit: Option<u32>) -> AppRe
             )));
         }
     };
-    // GitLab pages at `per_page` (max 100); default to a full page. When a `limit` is
-    // asked, request at most that many per state and truncate the merged result to it
-    // (a "closed" filter fans out over two states, so the raw total can exceed `limit`).
-    let per_page = limit.map_or(100, |n| n.clamp(1, 100));
+    // GitLab pages at `per_page` (max 100). The OPEN set always requests a full page
+    // regardless of `limit`: stack inference reads the whole open list, and a
+    // server-side truncation would hide a chain's bottom and mis-position the rows
+    // above it. Paying for a full page on a small `limit` is therefore DELIBERATE —
+    // narrowing this fetch back down would silently corrupt the positions rather
+    // than merely returning fewer rows. A `limit` narrows the RESULT after inference
+    // instead. Closed states have no inference, so they keep the cheaper
+    // `limit`-sized page (a "closed" filter fans out over two states, so the raw
+    // total can exceed `limit`).
+    let per_page = if state == "open" {
+        100
+    } else {
+        limit.map_or(100, |n| n.clamp(1, 100))
+    };
     let mut prs = Vec::new();
     for s in states {
         let endpoint = format!("projects/{enc}/merge_requests?state={s}&per_page={per_page}");
@@ -484,8 +496,8 @@ pub async fn list_prs(repo_path: &str, state: &str, limit: Option<u32>) -> AppRe
         prs.extend(mrs.into_iter().map(from_glab_mr));
     }
     // Chains are inferred over the open set only — a closed list's rows describe
-    // merges already made. Inferred before truncation, so a `limit` narrows what's
-    // shown without distorting the chains.
+    // merges already made. Inference sees the full page (see `per_page`), so a
+    // `limit` narrows what's returned without distorting positions.
     if state == "open" {
         apply_mr_stacks(&mut prs);
     }
@@ -1045,7 +1057,15 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
     let changes_args = ["api", changes_endpoint.as_str()];
     let (out, open_prs) = tokio::join!(
         run_glab(Some(repo_path), &changes_args, GLAB_NETWORK_TIMEOUT),
-        async { list_prs(repo_path, "open", None).await.unwrap_or_default() },
+        // BOUNDED as well as concurrent: glab's own ceiling is 120s, and a stack
+        // decoration must never gate the MR view for that long. Elapsing falls back
+        // to no chain, exactly like an errored list.
+        async {
+            tokio::time::timeout(STACKS_TIMEOUT, list_prs(repo_path, "open", None))
+                .await
+                .unwrap_or_else(|_| Ok(Vec::new()))
+                .unwrap_or_default()
+        },
     );
     let out = out?;
     let (stack, stack_members) = mr_stack_from_rows(&open_prs, number);
@@ -1268,6 +1288,9 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         rebase_merge_allowed: None,
         stack,
         stack_members,
+        // Inference failing open has no disclosure consequence here: a GitLab merge
+        // never cascades, so an unknown chain can't hide a multi-MR merge.
+        stack_unknown: false,
     })
 }
 
@@ -7677,6 +7700,70 @@ mod tests {
             (3, "feat-b", "feat-a"),
         ])
         .is_empty());
+    }
+
+    /// Rows as `list_prs` returns them: stacks already annotated, state in GitLab's
+    /// uppercase neutral casing.
+    fn row(number: u64, head: &str, base: &str, stack: Option<(&str, u32, u32)>) -> PrInfo {
+        PrInfo {
+            number,
+            url: String::new(),
+            title: format!("MR {number}"),
+            base_ref_name: base.to_string(),
+            head_ref_name: head.to_string(),
+            is_draft: false,
+            state: "OPEN".to_string(),
+            author: None,
+            labels: Vec::new(),
+            created_at: String::new(),
+            head_sha: String::new(),
+            stack: stack.map(|(id, position, size)| PrStackInfo {
+                id: id.to_string(),
+                position,
+                size,
+            }),
+        }
+    }
+
+    #[test]
+    fn mr_stack_from_rows_filters_by_id_sorts_and_lowercases_state() {
+        // Two chains plus an unstacked MR; the chain rows are deliberately out of
+        // position order in the list.
+        let open = vec![
+            row(2, "a2", "a1", Some(("mr-1", 2, 2))),
+            row(9, "solo", "main", None),
+            row(6, "b2", "b1", Some(("mr-5", 2, 2))),
+            row(1, "a1", "main", Some(("mr-1", 1, 2))),
+            row(5, "b1", "release", Some(("mr-5", 1, 2))),
+        ];
+
+        let (stack, members) = mr_stack_from_rows(&open, 2);
+        let stack = stack.expect("MR 2 is in a chain");
+        assert_eq!((stack.id.as_str(), stack.position, stack.size), ("mr-1", 2, 2));
+        // Only the SAME chain's rows, sorted bottom→top — never the other chain's.
+        assert_eq!(
+            members.iter().map(|m| m.number).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(members[0].position, 1);
+        assert_eq!(members[0].head_ref_name, "a1");
+        assert_eq!(members[0].base_ref_name, "main");
+        assert_eq!(members[0].title, "MR 1");
+        // Provider-neutral lowercase, from GitLab's uppercase row state.
+        assert_eq!(members[0].state, "open");
+
+        // The other chain resolves independently.
+        let (stack, members) = mr_stack_from_rows(&open, 6);
+        assert_eq!(stack.expect("MR 6 is in a chain").id, "mr-5");
+        assert_eq!(
+            members.iter().map(|m| m.number).collect::<Vec<_>>(),
+            vec![5, 6]
+        );
+
+        // An unstacked MR, and one absent from the list entirely.
+        assert!(mr_stack_from_rows(&open, 9).0.is_none());
+        assert!(mr_stack_from_rows(&open, 9).1.is_empty());
+        assert!(mr_stack_from_rows(&open, 404).0.is_none());
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -305,47 +305,87 @@ fn from_glab_mr(m: GlabMr) -> PrInfo {
 /// source branch but exposes no stack object, so we reconstruct the same relation
 /// from the list.
 ///
-/// Only unambiguous LINEAR chains of two or more MRs are marked: a source branch
-/// shared by two open MRs identifies no unique parent, and an MR with two open
-/// children is a branching stack — GitHub disallows those and we mirror it by
-/// leaving the whole chain unmarked rather than guessing an order. Pure —
-/// unit-tested.
+/// Only unambiguous LINEAR chains of two or more MRs are marked, and ambiguity is
+/// judged per CONNECTED COMPONENT, not per link: a source branch shared by two
+/// open MRs identifies no unique parent, and an MR with two open children is a
+/// branching stack — GitHub disallows those, so a component containing either
+/// shape is left entirely unmarked rather than re-rooted at the break (an MR
+/// whose own base is ambiguous is not a stack bottom). Pure — unit-tested.
 fn infer_mr_stacks(open: &[(u64, &str, &str)]) -> HashMap<u64, (String, u32, u32)> {
     let mut sources: HashMap<&str, Vec<u64>> = HashMap::new();
     for (iid, head, _) in open {
         sources.entry(*head).or_default().push(*iid);
     }
 
+    // Candidate links join a component even when they're AMBIGUOUS — that's what
+    // lets one bad link poison its whole chain instead of silently splitting it.
+    let mut neighbors: HashMap<u64, Vec<u64>> = HashMap::new();
     let mut has_parent: std::collections::HashSet<u64> = std::collections::HashSet::new();
     let mut children: HashMap<u64, Vec<u64>> = HashMap::new();
+    let mut ambiguous: std::collections::HashSet<u64> = std::collections::HashSet::new();
     for (iid, _, base) in open {
-        // A target branch that is exactly ONE open MR's source branch is a stack
-        // link; zero means this MR sits on a plain branch, two is ambiguous.
-        let Some([parent]) = sources.get(*base).map(Vec::as_slice) else {
-            continue;
-        };
-        if *parent == *iid {
-            continue;
+        // The open MRs offering this target branch as their source. An MR can't be
+        // its own parent (a self-targeting MR just sits on a plain branch).
+        let candidates: Vec<u64> = sources
+            .get(*base)
+            .map(|c| c.iter().copied().filter(|p| p != iid).collect())
+            .unwrap_or_default();
+        for parent in &candidates {
+            neighbors.entry(*iid).or_default().push(*parent);
+            neighbors.entry(*parent).or_default().push(*iid);
         }
-        has_parent.insert(*iid);
-        children.entry(*parent).or_default().push(*iid);
+        match candidates.as_slice() {
+            // No open MR owns this branch — a genuine chain bottom.
+            [] => {}
+            [parent] => {
+                has_parent.insert(*iid);
+                children.entry(*parent).or_default().push(*iid);
+            }
+            _ => {
+                ambiguous.insert(*iid);
+            }
+        }
+    }
+    for (parent, kids) in &children {
+        if kids.len() > 1 {
+            ambiguous.insert(*parent);
+        }
     }
 
     let mut result = HashMap::new();
-    for (bottom, _, _) in open.iter().filter(|(iid, _, _)| !has_parent.contains(iid)) {
+    let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    // Walk components in list order so the output never depends on hash iteration.
+    for (start, _, _) in open {
+        if !seen.insert(*start) {
+            continue;
+        }
+        let mut component = vec![*start];
+        let mut queue = vec![*start];
+        while let Some(node) = queue.pop() {
+            for next in neighbors.get(&node).into_iter().flatten() {
+                if seen.insert(*next) {
+                    component.push(*next);
+                    queue.push(*next);
+                }
+            }
+        }
+        if component.iter().any(|iid| ambiguous.contains(iid)) {
+            continue;
+        }
+        // Unambiguous: every link is unique in both directions, so the component is
+        // one chain. A component whose every MR has a parent is a cycle — no bottom,
+        // nothing emitted.
+        let Some(bottom) = component.iter().find(|iid| !has_parent.contains(iid)) else {
+            continue;
+        };
         let mut chain = vec![*bottom];
         let mut cursor = *bottom;
-        while let Some(kids) = children.get(&cursor) {
-            let [next] = kids.as_slice() else {
-                // Branching — abandon this whole chain.
-                chain.clear();
+        // Bounded by the component: an unambiguous component can't join a cycle to a
+        // parentless bottom, so this is belt-and-braces against an infinite walk.
+        while chain.len() < component.len() {
+            let Some([next]) = children.get(&cursor).map(Vec::as_slice) else {
                 break;
             };
-            // Defensive: a cycle can't reach a parentless bottom, but never loop.
-            if chain.contains(next) {
-                chain.clear();
-                break;
-            }
             cursor = *next;
             chain.push(cursor);
         }
@@ -7635,6 +7675,22 @@ mod tests {
             (1, "feat-a", "main"),
             (2, "feat-a", "release"),
             (3, "feat-b", "feat-a"),
+        ])
+        .is_empty());
+    }
+
+    #[test]
+    fn infer_mr_stacks_unmarks_the_whole_component_not_just_the_bad_link() {
+        // A backport shape: !10 and !11 both source feat-a (onto main and release),
+        // !12 stacks on feat-a, !13 on !12. !12's base is an ambiguous open-MR head,
+        // so !12 is NOT a bottom — dropping only the bad link would re-root the
+        // chain there and report [12, 13] as a stack. The ambiguity poisons the
+        // whole component instead.
+        assert!(infer_mr_stacks(&[
+            (10, "feat-a", "main"),
+            (11, "feat-a", "release"),
+            (12, "feat-b", "feat-a"),
+            (13, "feat-c", "feat-b"),
         ])
         .is_empty());
     }

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1630,9 +1630,11 @@ pub async fn forge_pr_unapprove(repo_path: String, number: u64) -> AppResult<()>
 /// is GitHub-only.
 ///
 /// `cleanup_warning` on the returned [`PrMergeOutcome`](crate::github::pr::PrMergeOutcome)
-/// means the PR merged but post-merge branch cleanup failed — GitHub-only, since
-/// GitLab/Bitbucket fold branch deletion into the server-side merge. A merge FAILURE
-/// is still an `Err`.
+/// means the merge was accepted with a caveat — either the PR merged but post-merge
+/// branch cleanup failed, or (`queued`) a stacked PR went to a merge QUEUE and hasn't
+/// landed, so cleanup was skipped. Both are GitHub-only: GitLab/Bitbucket fold branch
+/// deletion into the server-side merge and have no stacked-merge queue. A merge
+/// FAILURE is still an `Err`.
 #[tauri::command]
 pub async fn forge_pr_merge(
     repo_path: String,

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -590,17 +590,26 @@ pub async fn gh_pr_comment(
     Ok(())
 }
 
-/// The outcome of a successful merge. The PR *did* merge; `cleanup_warning`
-/// carries a human-readable caveat when the post-merge remote head-branch
-/// cleanup failed (GitHub-only by construction — GitLab and Bitbucket fold
-/// deletion into the atomic merge server-side, so they never produce one). A
-/// merge *failure* is still an `Err`, never an outcome with a warning.
+/// The outcome of a successful merge — the merge was accepted; `cleanup_warning`
+/// carries a human-readable caveat about what did NOT happen afterwards. Two
+/// causes, both GitHub-only by construction (GitLab and Bitbucket fold deletion
+/// into the atomic merge server-side): the post-merge remote head-branch cleanup
+/// failed, or a stacked merge was handed to a merge QUEUE, where the PR hasn't
+/// landed yet and cleanup is deliberately skipped. A merge *failure* is still an
+/// `Err`, never an outcome with a warning.
 #[derive(Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PrMergeOutcome {
-    /// `Some(msg)` — merged fine, but head-branch cleanup failed; `msg` always
-    /// states the merge succeeded. `None` — merged and cleaned up cleanly.
+    /// `Some(msg)` — accepted, but with a caveat the user must see (cleanup failed,
+    /// or the merge is queued and the branch was left alone); `msg` always states
+    /// what did happen. `None` — merged and cleaned up cleanly.
     pub cleanup_warning: Option<String>,
+    /// The merge was handed to a merge QUEUE and has not landed yet. State, not
+    /// prose: `cleanup_warning` carries the human detail, but a programmatic caller
+    /// (the MCP merge tool, the frontend) must branch on this rather than parse a
+    /// message — and must not treat the PR as merged or its branch as deleted.
+    #[serde(default)]
+    pub queued: bool,
 }
 
 /// Merges the PR with the given strategy ("merge"/"squash"/"rebase"). With
@@ -612,8 +621,11 @@ pub struct PrMergeOutcome {
 /// (whose deletion is server-side and remote-only). We merge, then DELETE the
 /// remote ref via the API.
 ///
-/// Merge failure = `Err`. Cleanup failure after a landed merge = a
-/// `cleanup_warning` on a successful [`PrMergeOutcome`], never an error.
+/// Merge failure = `Err`. A successful [`PrMergeOutcome`] covers two non-clean
+/// endings, both carrying `cleanup_warning` and neither an error: the merge landed
+/// but branch cleanup failed, or a stacked merge was handed to a merge QUEUE and
+/// hasn't landed (`queued`), in which case cleanup is deliberately skipped —
+/// deleting the head branch would break the merge the queue still holds.
 #[tauri::command]
 pub async fn gh_pr_merge(
     repo_path: String,
@@ -638,8 +650,8 @@ pub async fn gh_pr_merge(
     // GitHub requires its asynchronous merge API there. The probe is best-effort —
     // when it can't tell, the legacy path runs and GitHub's own refusal is the
     // backstop. Merging a member also merges every unmerged layer below it.
-    if gh_pr_is_stacked(&repo_path, &slug, number).await {
-        gh_pr_merge_async(&repo_path, &slug, number, &strategy).await?;
+    let queued = if gh_pr_is_stacked(&repo_path, &slug, number).await {
+        gh_pr_merge_async(&repo_path, &slug, number, &strategy).await? == StackedMergeResult::Queued
     } else {
         run_gh(
             Some(&repo_path),
@@ -647,9 +659,18 @@ pub async fn gh_pr_merge(
             GH_NETWORK_TIMEOUT,
         )
         .await?;
-    }
-    // Merge landed: from here a cleanup failure is a warning on success, never an error.
-    let cleanup_warning = if delete_branch {
+        false
+    };
+    // Merge accepted: from here a cleanup failure is a warning on success, never an error.
+    let cleanup_warning = if queued {
+        // A queued merge has NOT landed — deleting the head branch now would break
+        // the merge the queue is still holding. Skip cleanup and disclose it.
+        Some(if delete_branch {
+            format!("Merging #{number} was queued on GitHub and will land when the queue completes. The remote branch was left in place for the queue.")
+        } else {
+            format!("Merging #{number} was queued on GitHub and will land when the queue completes.")
+        })
+    } else if delete_branch {
         gh_delete_remote_head_branch(&repo_path, number, lens.as_deref())
             .await
             .err()
@@ -657,7 +678,10 @@ pub async fn gh_pr_merge(
     } else {
         None
     };
-    Ok(PrMergeOutcome { cleanup_warning })
+    Ok(PrMergeOutcome {
+        cleanup_warning,
+        queued,
+    })
 }
 
 /// Whether the PR is a stack member — the same `pull_stack_ref` reading the detail
@@ -697,22 +721,33 @@ struct MergeAsyncDetails {
     message: Option<String>,
 }
 
-/// How a merge-async `status` ends the wait. `enqueued` is a success: a merge
-/// queue owns the merge from then on. Anything unrecognized keeps polling, so a
-/// new server state never reads as a failure.
+/// How a merge-async `status` ends the wait. `Enqueued` is NOT `Merged`: a merge
+/// queue owns the merge from then on and the PR hasn't landed, which is why the
+/// two are separate outcomes rather than one "done". Anything unrecognized keeps
+/// polling, so a new server state never reads as a failure.
 #[derive(PartialEq, Debug)]
 enum MergeAsyncOutcome {
-    Done,
+    Merged,
+    Enqueued,
     Failed,
     Pending,
 }
 
 fn classify_merge_async(status: Option<&str>) -> MergeAsyncOutcome {
     match status.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
-        Some("merged" | "enqueued") => MergeAsyncOutcome::Done,
+        Some("merged") => MergeAsyncOutcome::Merged,
+        Some("enqueued") => MergeAsyncOutcome::Enqueued,
         Some("failed") => MergeAsyncOutcome::Failed,
         _ => MergeAsyncOutcome::Pending,
     }
+}
+
+/// Where a stacked merge ended up. `Queued` means accepted but NOT landed — the
+/// caller must skip head-branch cleanup and disclose the wait.
+#[derive(PartialEq, Debug)]
+enum StackedMergeResult {
+    Merged,
+    Queued,
 }
 
 /// Polls every 2s; gives up after 90s with a "may still have landed" message
@@ -724,12 +759,16 @@ const MERGE_ASYNC_DEADLINE: std::time::Duration = std::time::Duration::from_secs
 /// verdict. `strategy` is the already-validated "merge"/"squash"/"rebase". The
 /// body is one string field, so `-f merge_method=…` suffices — no JSON on argv,
 /// which Windows `.cmd` shims reject.
+///
+/// An `enqueued` status ends the wait immediately with [`StackedMergeResult::Queued`]:
+/// a merge queue can take arbitrarily long, so polling on would false-fail at the
+/// deadline for a merge that is progressing fine.
 async fn gh_pr_merge_async(
     repo_path: &str,
     slug: &str,
     number: u64,
     strategy: &str,
-) -> AppResult<()> {
+) -> AppResult<StackedMergeResult> {
     let endpoint = format!("repos/{slug}/pulls/{number}/merge-async");
     let method_arg = format!("merge_method={strategy}");
     let out = run_gh(
@@ -756,7 +795,8 @@ async fn gh_pr_merge_async(
 
     loop {
         match classify_merge_async(current.status.as_deref()) {
-            MergeAsyncOutcome::Done => return Ok(()),
+            MergeAsyncOutcome::Merged => return Ok(StackedMergeResult::Merged),
+            MergeAsyncOutcome::Enqueued => return Ok(StackedMergeResult::Queued),
             MergeAsyncOutcome::Failed => {
                 let message = current
                     .details
@@ -1302,28 +1342,17 @@ fn stack_members_from(prs: &[GhStackPr]) -> Vec<PrStackMember> {
         .collect()
 }
 
-/// The repo's OPEN stacks as a PR-number → membership map, for the list join.
-/// Best-effort by contract: any failure (a host without the endpoint, network,
-/// unparseable body) yields an empty map and the list renders exactly as it did
-/// before stacks — stack data must never fail or block a PR list. One page only:
-/// past 100 open stacks the surplus goes unmarked rather than paginating a
-/// decoration onto the list's critical path.
-async fn gh_open_stack_memberships(
-    repo_path: &str,
-    slug: &str,
+/// Map a `GET /repos/{slug}/stacks` body onto a PR-number → membership map.
+/// Per-item tolerant: one malformed entry drops itself, not the whole join.
+///
+/// A stack counts only when `open` is explicitly `true` — the endpoint returns
+/// dissolved stacks too, and an ABSENT `open` fails CLOSED (unmarked) rather than
+/// assuming liveness. Pure — unit-tested, because that fail-closed choice would
+/// silently unmark every badge if the field were ever renamed.
+fn stack_memberships_from(
+    raw: Vec<serde_json::Value>,
 ) -> std::collections::HashMap<u64, PrStackInfo> {
     let mut map = std::collections::HashMap::new();
-    let endpoint = format!("repos/{slug}/stacks?per_page=100");
-    let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
-        return map;
-    };
-    if out.code != 0 {
-        return map;
-    }
-    let Ok(raw) = serde_json::from_str::<Vec<serde_json::Value>>(&out.stdout_lossy()) else {
-        return map;
-    };
-    // Per-item tolerance: one malformed stack drops itself, not the whole join.
     for stack in raw
         .into_iter()
         .filter_map(|v| serde_json::from_value::<GhStackEntry>(v).ok())
@@ -1351,36 +1380,93 @@ async fn gh_open_stack_memberships(
     map
 }
 
-/// This PR's stack membership plus the stack's members bottom→top, for the detail
-/// view. Best-effort at both hops: no membership (or an unreachable stacks
-/// endpoint) yields `(None, [])`, and a failed member fetch still returns the
-/// membership the PR payload itself reported.
-async fn gh_pr_stack(
+/// The repo's OPEN stacks as a PR-number → membership map, for the list join.
+/// Best-effort by contract: the list renders exactly as it did before stacks on
+/// any fail-open cause — no such endpoint (GHES), network error, unparseable
+/// body, or exceeding [`STACKS_TIMEOUT`] at the call site. One page only: past
+/// 100 open stacks the surplus goes unmarked rather than paginating a decoration.
+async fn gh_open_stack_memberships(
     repo_path: &str,
     slug: &str,
-    number: u64,
-) -> (Option<PrStackInfo>, Vec<PrStackMember>) {
-    let unstacked = (None, Vec::new());
-    let endpoint = format!("repos/{slug}/pulls/{number}");
+) -> std::collections::HashMap<u64, PrStackInfo> {
+    let empty = std::collections::HashMap::new();
+    let endpoint = format!("repos/{slug}/stacks?per_page=100");
     let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
-        return unstacked;
+        return empty;
     };
     if out.code != 0 {
-        return unstacked;
+        return empty;
     }
-    let Some((id, position, size)) = pull_stack_ref(&out.stdout_lossy()) else {
-        return unstacked;
+    let Ok(raw) = serde_json::from_str::<Vec<serde_json::Value>>(&out.stdout_lossy()) else {
+        return empty;
+    };
+    stack_memberships_from(raw)
+}
+
+/// What the detail view learned about a PR's stack. `unknown` is the tri-state
+/// the merge path depends on: the merge probe re-reads membership independently
+/// and WILL cascade a stacked merge, so a detail view that failed to probe must
+/// say "unknown", never render as confidently unstacked.
+struct PrStackProbe {
+    stack: Option<PrStackInfo>,
+    members: Vec<PrStackMember>,
+    /// The probe itself failed — membership is genuinely unknown, not absent.
+    unknown: bool,
+}
+
+impl PrStackProbe {
+    /// Probed successfully; this PR is in no stack.
+    fn unstacked() -> Self {
+        Self { stack: None, members: Vec::new(), unknown: false }
+    }
+    /// The probe failed (spawn, non-zero exit, unparseable body, or timeout).
+    fn unknown() -> Self {
+        Self { stack: None, members: Vec::new(), unknown: true }
+    }
+}
+
+/// This PR's stack membership plus the stack's members bottom→top, for the detail
+/// view. Distinguishes "probe failed" from "not stacked" (see [`PrStackProbe`]).
+/// The MEMBER fetch is best-effort within a KNOWN membership: failing it — timeout
+/// included — returns the membership the PR payload reported with an empty member
+/// list, which is incomplete, not unknown.
+///
+/// Each hop carries its OWN [`STACKS_TIMEOUT`] rather than one bound around both:
+/// a single outer bound would discard a membership hop 1 had already established
+/// just because hop 2 was still in flight, downgrading a firm "position 3 of 4"
+/// into a hedge.
+async fn gh_pr_stack(repo_path: &str, slug: &str, number: u64) -> PrStackProbe {
+    let endpoint = format!("repos/{slug}/pulls/{number}");
+    let Ok(Ok(out)) = tokio::time::timeout(
+        STACKS_TIMEOUT,
+        run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT),
+    )
+    .await
+    else {
+        return PrStackProbe::unknown();
+    };
+    if out.code != 0 {
+        return PrStackProbe::unknown();
+    }
+    let body = out.stdout_lossy();
+    // An unreadable body is a failed probe; a readable body with no `stack` is a
+    // genuine answer. Only the latter is "unstacked".
+    if serde_json::from_str::<serde_json::Value>(&body).is_err() {
+        return PrStackProbe::unknown();
+    }
+    let Some((id, position, size)) = pull_stack_ref(&body) else {
+        return PrStackProbe::unstacked();
     };
 
-    let members = gh_stack_members(repo_path, slug, id).await;
-    (
-        Some(PrStackInfo {
-            id: id.to_string(),
-            position,
-            size,
-        }),
+    // Membership is settled from here — hop 2 can only add or omit the member list.
+    let members = tokio::time::timeout(STACKS_TIMEOUT, gh_stack_members(repo_path, slug, id))
+        .await
+        .unwrap_or_default();
+    PrStackProbe {
+        stack: Some(PrStackInfo { id: id.to_string(), position, size }),
         members,
-    )
+        unknown: false,
+    }
 }
 
 /// One stack's members bottom→top. Empty on any failure — the caller treats that
@@ -1397,6 +1483,18 @@ async fn gh_stack_members(repo_path: &str, slug: &str, stack_number: u64) -> Vec
         .map(|entry| stack_members_from(&entry.pull_requests))
         .unwrap_or_default()
 }
+
+/// How long any supplementary STACK probe may take before its caller gives up and
+/// renders without it. Bounds the four DECORATION reads — GitHub list, both hops
+/// of the GitHub detail probe, and the GitLab detail's open-MR list — well inside
+/// the underlying CLI timeouts (gh 30s, glab 120s), because stack data decorates a
+/// view that must render regardless. Dropping a timed-out probe kills its child
+/// process: both runners set `kill_on_drop`.
+///
+/// Deliberately NOT applied to [`gh_pr_is_stacked`]: that read is a merge-DECISION
+/// input, not a decoration. Cutting it short would silently route a stacked PR down
+/// the legacy path, so it keeps the full `GH_TIMEOUT`.
+pub(crate) const STACKS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 const PR_LIST_FIELDS: &str =
     "number,url,title,baseRefName,headRefName,isDraft,state,author,labels,createdAt";
@@ -1448,11 +1546,17 @@ pub async fn gh_pr_list(
     // Open rows only: a closed list describes merges already made.
     let want_stacks = state == "open";
     let (out, stacks) = tokio::join!(run_gh(Some(&repo_path), &args, GH_TIMEOUT), async {
-        if want_stacks {
-            gh_open_stack_memberships(&repo_path, &slug).await
-        } else {
-            std::collections::HashMap::new()
+        if !want_stacks {
+            return std::collections::HashMap::new();
         }
+        // BOUNDED, not merely concurrent: the join removes the serial cost, the
+        // timeout removes the stall. A decoration must never hold the list.
+        tokio::time::timeout(
+            STACKS_TIMEOUT,
+            gh_open_stack_memberships(&repo_path, &slug),
+        )
+        .await
+        .unwrap_or_default()
     });
     let mut prs: Vec<PrInfo> = serde_json::from_str(&out?.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh pr list: {e}")))?;
@@ -2359,6 +2463,13 @@ pub struct PrDetails {
     /// The whole stack bottom→top (empty when unstacked). A merged layer stays a
     /// member — GitHub does not shrink a stack on merge.
     pub stack_members: Vec<PrStackMember>,
+    /// The stack probe FAILED, so `stack: None` means "unknown", not "unstacked".
+    /// Load-bearing because the merge path re-probes membership independently and
+    /// will cascade a stacked merge — a cached "not stacked" detail view would
+    /// otherwise let that happen undisclosed. GitHub only: GitLab's inference
+    /// failing open has no such consequence (each MR merges on its own, nothing
+    /// cascades), and Bitbucket has no stacks, so both report `false`.
+    pub stack_unknown: bool,
 }
 
 /// A merge/pull request's approval summary — who has approved and whether the
@@ -2454,13 +2565,19 @@ pub async fn gh_pr_view(
     // resolve to the SAME repo these PR numbers came from.
     let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let n = number.to_string();
-    // Stack membership rides alongside the view rather than after it — it's two
-    // extra REST hops that would otherwise serialize onto the detail's latency.
+    // Stack membership rides alongside the view AND is bounded — per hop, inside
+    // `gh_pr_stack`, so a slow member fetch can't discard a membership already
+    // established. Timing out hop 1 is a FAILED probe, not "unstacked".
     let view_args = ["pr", "view", &n, "--repo", &slug, "--json", PR_VIEW_FIELDS];
-    let (out, (stack, stack_members)) = tokio::join!(
+    let (out, probe) = tokio::join!(
         run_gh(Some(&repo_path), &view_args, GH_TIMEOUT),
         gh_pr_stack(&repo_path, &slug, number),
     );
+    let PrStackProbe {
+        stack,
+        members: stack_members,
+        unknown: stack_unknown,
+    } = probe;
     let out = out?;
     let raw: RawPr = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh pr view: {e}")))?;
@@ -2733,6 +2850,7 @@ pub async fn gh_pr_view(
         rebase_merge_allowed: merge_settings.rebase_merge_allowed,
         stack,
         stack_members,
+        stack_unknown,
     })
 }
 
@@ -4739,9 +4857,11 @@ mod tests {
         parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
-        pull_stack_ref, split_commit_message, stack_members_from, upstream_pulls_endpoint, GhPrFile,
+        pull_stack_ref, split_commit_message, stack_members_from, stack_memberships_from,
+        upstream_pulls_endpoint, GhPrFile,
         GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner,
         GhPrRestPull, GhPrRestReview, GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails,
+        PrMergeOutcome,
         PrInfo, PrStackInfo, PrStackMember, PrTimelineEventOut, RawLogin,
     };
     use crate::error::AppError;
@@ -4776,6 +4896,7 @@ mod tests {
     fn details_with_stack(
         stack: Option<PrStackInfo>,
         stack_members: Vec<PrStackMember>,
+        stack_unknown: bool,
     ) -> PrDetails {
         PrDetails {
             id: String::new(),
@@ -4805,6 +4926,7 @@ mod tests {
             rebase_merge_allowed: None,
             stack,
             stack_members,
+            stack_unknown,
         }
     }
 
@@ -4826,6 +4948,7 @@ mod tests {
                 head_ref_name: "feat-a".to_string(),
                 base_ref_name: "main".to_string(),
             }],
+            false,
         );
         let v = serde_json::to_value(&details).unwrap();
         assert_eq!(v["stack"]["id"], "133465");
@@ -4839,10 +4962,21 @@ mod tests {
         assert!(v.get("stack_members").is_none());
         assert!(v["stackMembers"][0].get("head_ref_name").is_none());
 
+        assert_eq!(v["stackUnknown"], false);
+        assert!(v.get("stack_unknown").is_none());
+
         // Unstacked: an explicit null plus an empty array, never a missing key.
-        let v = serde_json::to_value(details_with_stack(None, Vec::new())).unwrap();
+        let v = serde_json::to_value(details_with_stack(None, Vec::new(), false)).unwrap();
         assert!(v["stack"].is_null());
         assert_eq!(v["stackMembers"], serde_json::json!([]));
+        assert_eq!(v["stackUnknown"], false);
+
+        // Probe failed: `stack` is null exactly as for an unstacked PR, so
+        // `stackUnknown` is the ONLY signal separating the two — it must always be
+        // present, never skipped.
+        let v = serde_json::to_value(details_with_stack(None, Vec::new(), true)).unwrap();
+        assert!(v["stack"].is_null());
+        assert_eq!(v["stackUnknown"], true);
     }
 
     #[test]
@@ -4916,6 +5050,74 @@ mod tests {
         assert_eq!(members[1].base_ref_name, "feat-a");
     }
 
+    /// `queued` is STATE the MCP merge tool and the frontend branch on — a caller
+    /// must never have to parse `cleanupWarning`'s prose to learn the PR didn't land.
+    #[test]
+    fn merge_outcome_pins_queued_in_both_states() {
+        // Landed cleanly: no caveat, not queued.
+        let v = serde_json::to_value(PrMergeOutcome::default()).unwrap();
+        assert_eq!(v["queued"], false);
+        assert!(v["cleanupWarning"].is_null());
+        assert!(v.get("cleanup_warning").is_none());
+
+        // Queued: the flag carries the state, the warning only the detail text.
+        let v = serde_json::to_value(PrMergeOutcome {
+            cleanup_warning: Some("Merging #7 was queued on GitHub…".to_string()),
+            queued: true,
+        })
+        .unwrap();
+        assert_eq!(v["queued"], true);
+        assert!(v["cleanupWarning"].is_string());
+
+        // Merged but cleanup failed: a caveat WITHOUT the queued flag — the two
+        // caveat causes must stay distinguishable.
+        let v = serde_json::to_value(PrMergeOutcome {
+            cleanup_warning: Some("Merged #7, but the remote branch…".to_string()),
+            queued: false,
+        })
+        .unwrap();
+        assert_eq!(v["queued"], false);
+        assert!(v["cleanupWarning"].is_string());
+    }
+
+    /// The list join's whole payload contract. The `open`-absent arm is the one
+    /// that matters most: it fails CLOSED, so a field rename upstream unmarks every
+    /// badge rather than marking dissolved stacks as live.
+    #[test]
+    fn stack_memberships_skip_dissolved_and_open_absent_stacks() {
+        let raw: Vec<serde_json::Value> = serde_json::from_str(
+            r#"[
+              {"number":22,"open":true,"pull_requests":[{"number":21},{"number":23},{"number":25}]},
+              {"number":30,"open":false,"pull_requests":[{"number":31},{"number":32}]},
+              {"number":40,"pull_requests":[{"number":41},{"number":42}]},
+              {"number":"not-a-number","open":true,"pull_requests":[{"number":51}]},
+              {"number":60,"open":true,"pull_requests":[{"number":61},{"number":62}]}
+            ]"#,
+        )
+        .unwrap();
+        let map = stack_memberships_from(raw);
+
+        // Open stack: 1-based positions, size = member count.
+        assert_eq!(map[&21].position, 1);
+        assert_eq!(map[&23].position, 2);
+        assert_eq!(map[&25].position, 3);
+        assert_eq!(map[&21].size, 3);
+        assert_eq!(map[&21].id, "22");
+        // A dissolved stack (`open: false`) contributes nothing.
+        assert!(!map.contains_key(&31));
+        assert!(!map.contains_key(&32));
+        // `open` ABSENT is skipped too — fails closed, never assumed live.
+        assert!(!map.contains_key(&41));
+        assert!(!map.contains_key(&42));
+        // One malformed entry (`number` a string) drops itself…
+        assert!(!map.contains_key(&51));
+        // …and does NOT poison the entries after it.
+        assert_eq!(map[&61].position, 1);
+        assert_eq!(map[&62].position, 2);
+        assert_eq!(map[&62].id, "60");
+        assert_eq!(map.len(), 5);
+    }
+
     #[test]
     fn merge_async_parses_the_live_response_shapes() {
         // The PUT acknowledgement: top-level `status`, uuid nested under `details`
@@ -4944,7 +5146,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             classify_merge_async(merged.status.as_deref()),
-            MergeAsyncOutcome::Done
+            MergeAsyncOutcome::Merged
         );
 
         // Poll → failed, carrying the server's message verbatim.
@@ -4961,10 +5163,15 @@ mod tests {
             Some("Base branch was modified")
         );
 
-        // A merge queue owns an enqueued merge — success, not a wait.
+        // A merge queue owns an enqueued merge: accepted, but NOT merged — it must
+        // stay distinct from Merged so the caller skips head-branch cleanup.
         assert_eq!(
             classify_merge_async(Some("ENQUEUED")),
-            MergeAsyncOutcome::Done
+            MergeAsyncOutcome::Enqueued
+        );
+        assert_ne!(
+            classify_merge_async(Some("enqueued")),
+            MergeAsyncOutcome::Merged
         );
         // Absent or unrecognized states keep polling, never a false verdict.
         assert_eq!(classify_merge_async(None), MergeAsyncOutcome::Pending);

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -476,6 +476,33 @@ pub struct PrListLabel {
     pub name: String,
 }
 
+/// A PR's membership in a stack — GitHub's first-class stacked PRs, and the
+/// equivalent chain GitLab's arm infers from open MRs (GitLab exposes no stack
+/// object). Bitbucket has no stack concept and never fills this.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PrStackInfo {
+    /// Stack identity: GitHub's stack number as a string; GitLab synthesized
+    /// "mr-<bottom-iid>". Stable within a repo.
+    pub id: String,
+    /// 1 = bottom of the stack (merges first).
+    pub position: u32,
+    pub size: u32,
+}
+
+/// One layer of a stack as the detail view lists it, bottom→top.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PrStackMember {
+    pub number: u64,
+    pub title: String,
+    /// "open" | "merged" | "closed" — lowercase, provider-neutral.
+    pub state: String,
+    pub position: u32,
+    pub head_ref_name: String,
+    pub base_ref_name: String,
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrInfo {
@@ -501,6 +528,11 @@ pub struct PrInfo {
     /// and GitLab query by number/iid and leave this "".
     #[serde(default)]
     pub head_sha: String,
+    /// Stack membership, when the PR is in one. No provider's list payload carries
+    /// it (`gh pr list --json` has no stack field), so it defaults to `None` and is
+    /// joined in from a supplementary call — hence the serde default.
+    #[serde(default)]
+    pub stack: Option<PrStackInfo>,
 }
 
 /// Submits a review: `action` is "approve", "comment", or "request_changes".
@@ -601,12 +633,20 @@ pub async fn gh_pr_merge(
         }
     };
     let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
-    run_gh(
-        Some(&repo_path),
-        &["pr", "merge", &n, method, "--repo", &slug],
-        GH_NETWORK_TIMEOUT,
-    )
-    .await?;
+    // A stack member rejects BOTH `gh pr merge` and the plain REST merge endpoint;
+    // GitHub requires its asynchronous merge API there. The probe is best-effort —
+    // when it can't tell, the legacy path runs and GitHub's own refusal is the
+    // backstop. Merging a member also merges every unmerged layer below it.
+    if gh_pr_is_stacked(&repo_path, &slug, number).await {
+        gh_pr_merge_async(&repo_path, &slug, number, &strategy).await?;
+    } else {
+        run_gh(
+            Some(&repo_path),
+            &["pr", "merge", &n, method, "--repo", &slug],
+            GH_NETWORK_TIMEOUT,
+        )
+        .await?;
+    }
     // Merge landed: from here a cleanup failure is a warning on success, never an error.
     let cleanup_warning = if delete_branch {
         gh_delete_remote_head_branch(&repo_path, number, lens.as_deref())
@@ -617,6 +657,132 @@ pub async fn gh_pr_merge(
         None
     };
     Ok(PrMergeOutcome { cleanup_warning })
+}
+
+/// Whether the PR is a stack member, per the nullable `stack` object on its REST
+/// payload. `false` on ANY failure (network, a host without stacks, an
+/// unparseable body): the legacy merge path then runs, and GitHub rejects a
+/// stacked merge there with its own actionable error.
+async fn gh_pr_is_stacked(repo_path: &str, slug: &str, number: u64) -> bool {
+    let endpoint = format!("repos/{slug}/pulls/{number}");
+    let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
+        return false;
+    };
+    if out.code != 0 {
+        return false;
+    }
+    serde_json::from_str::<serde_json::Value>(&out.stdout_lossy())
+        .ok()
+        .and_then(|v| v.get("stack").cloned())
+        .is_some_and(|s| s.is_object())
+}
+
+/// A merge-async response — the `PUT` acknowledgement and every poll share it.
+/// The state is the TOP-LEVEL `status`, with the tracking uuid and any message
+/// nested under `details`; GitHub's published docs describe a different shape, so
+/// this mirrors the live API. Every field optional: a shape drift reads as
+/// "still pending" rather than a false verdict.
+#[derive(Deserialize, Default)]
+struct MergeAsyncStatus {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    details: Option<MergeAsyncDetails>,
+}
+
+#[derive(Deserialize, Default)]
+struct MergeAsyncDetails {
+    #[serde(default)]
+    uuid: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// How a merge-async `status` ends the wait. `enqueued` is a success: a merge
+/// queue owns the merge from then on. Anything unrecognized keeps polling, so a
+/// new server state never reads as a failure.
+#[derive(PartialEq, Debug)]
+enum MergeAsyncOutcome {
+    Done,
+    Failed,
+    Pending,
+}
+
+fn classify_merge_async(status: Option<&str>) -> MergeAsyncOutcome {
+    match status.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("merged" | "enqueued") => MergeAsyncOutcome::Done,
+        Some("failed") => MergeAsyncOutcome::Failed,
+        _ => MergeAsyncOutcome::Pending,
+    }
+}
+
+/// Polls every 2s; gives up after 90s with a "may still have landed" message
+/// rather than claiming a failure (GitHub retains the result for 24h).
+const MERGE_ASYNC_POLL: std::time::Duration = std::time::Duration::from_secs(2);
+const MERGE_ASYNC_DEADLINE: std::time::Duration = std::time::Duration::from_secs(90);
+
+/// Merges a stacked PR through GitHub's asynchronous merge API and waits for the
+/// verdict. `strategy` is the already-validated "merge"/"squash"/"rebase". The
+/// body is one string field, so `-f merge_method=…` suffices — no JSON on argv,
+/// which Windows `.cmd` shims reject.
+async fn gh_pr_merge_async(
+    repo_path: &str,
+    slug: &str,
+    number: u64,
+    strategy: &str,
+) -> AppResult<()> {
+    let endpoint = format!("repos/{slug}/pulls/{number}/merge-async");
+    let method_arg = format!("merge_method={strategy}");
+    let out = run_gh(
+        Some(repo_path),
+        &["api", "--method", "PUT", &endpoint, "-f", &method_arg],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let mut current: MergeAsyncStatus = serde_json::from_str(&out.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not parse the merge response: {e}")))?;
+    let uuid = current
+        .details
+        .as_ref()
+        .and_then(|d| d.uuid.clone())
+        .unwrap_or_default();
+    let poll_endpoint = format!("{endpoint}/{uuid}");
+    let deadline = std::time::Instant::now() + MERGE_ASYNC_DEADLINE;
+
+    loop {
+        match classify_merge_async(current.status.as_deref()) {
+            MergeAsyncOutcome::Done => return Ok(()),
+            MergeAsyncOutcome::Failed => {
+                let message = current
+                    .details
+                    .and_then(|d| d.message)
+                    .filter(|m| !m.trim().is_empty())
+                    .unwrap_or_else(|| format!("GitHub could not merge #{number}."));
+                return Err(AppError::Gh(message));
+            }
+            MergeAsyncOutcome::Pending => {}
+        }
+        // No uuid = nothing to poll. That's a shape failure, not a slow merge, and
+        // the two must not share a message.
+        if uuid.is_empty() {
+            return Err(AppError::Gh(format!(
+                "GitHub accepted the merge of #{number} but didn't return a tracking id — refresh the pull request to check whether it completed."
+            )));
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(AppError::Gh(format!(
+                "Merging #{number} is taking longer than expected. It may still complete on GitHub — refresh the pull request to check."
+            )));
+        }
+        tokio::time::sleep(MERGE_ASYNC_POLL).await;
+        // A transient poll failure must never read as a failed merge — stay pending
+        // and let the deadline (whose message is honest about the uncertainty) end it.
+        current = run_gh(Some(repo_path), &["api", &poll_endpoint], GH_NETWORK_TIMEOUT)
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<MergeAsyncStatus>(&o.stdout_lossy()).ok())
+            .unwrap_or_default();
+    }
 }
 
 /// The slice of `gh pr view` needed to delete only the remote head branch after
@@ -1041,6 +1207,185 @@ pub(crate) async fn gh_pr_set_ready(
     Ok(())
 }
 
+/// One entry of `GET /repos/{slug}/stacks` (and of `…/stacks/{number}`). Tolerant
+/// serde over the untrusted payload. Two contracts the shape doesn't show:
+/// `pull_requests` is ordered BOTTOM→TOP, and the endpoint also returns dissolved
+/// stacks (`open: false`), so callers must filter on `open`.
+#[derive(Deserialize)]
+struct GhStackEntry {
+    #[serde(default)]
+    number: Option<u64>,
+    #[serde(default)]
+    open: Option<bool>,
+    #[serde(default)]
+    pull_requests: Vec<GhStackPr>,
+}
+
+/// A stack member as the stacks endpoint embeds it (a full PR object; only the
+/// fields the stack panel needs are read).
+#[derive(Deserialize)]
+struct GhStackPr {
+    #[serde(default)]
+    number: Option<u64>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    merged_at: Option<String>,
+    #[serde(default)]
+    head: Option<GhStackRef>,
+    #[serde(default)]
+    base: Option<GhStackRef>,
+}
+
+#[derive(Deserialize)]
+struct GhStackRef {
+    #[serde(rename = "ref", default)]
+    ref_name: Option<String>,
+}
+
+/// The nullable `stack` object a REST pull payload carries: `{id, number,
+/// position, size, base}`. `number` identifies the stack for the member fetch;
+/// `position`/`size` are the server's own answer, so they're taken verbatim.
+#[derive(Deserialize)]
+struct GhPullStackRef {
+    #[serde(default)]
+    number: Option<u64>,
+    #[serde(default)]
+    position: Option<u32>,
+    #[serde(default)]
+    size: Option<u32>,
+}
+
+/// Map a stack's `pull_requests` (bottom→top) onto neutral members with 1-based
+/// positions. A merged layer stays a member and reads "merged" whatever its raw
+/// `state` says. Pure — unit-tested.
+fn stack_members_from(prs: &[GhStackPr]) -> Vec<PrStackMember> {
+    let ref_name = |r: &Option<GhStackRef>| {
+        r.as_ref()
+            .and_then(|r| r.ref_name.clone())
+            .unwrap_or_default()
+    };
+    prs.iter()
+        .enumerate()
+        .filter_map(|(idx, p)| {
+            Some(PrStackMember {
+                number: p.number?,
+                title: p.title.clone().unwrap_or_default(),
+                state: if p.merged_at.is_some() {
+                    "merged".to_string()
+                } else {
+                    p.state.clone().unwrap_or_default().to_ascii_lowercase()
+                },
+                position: idx as u32 + 1,
+                head_ref_name: ref_name(&p.head),
+                base_ref_name: ref_name(&p.base),
+            })
+        })
+        .collect()
+}
+
+/// The repo's OPEN stacks as a PR-number → membership map, for the list join.
+/// Best-effort by contract: any failure (a host without the endpoint, network,
+/// unparseable body) yields an empty map and the list renders exactly as it did
+/// before stacks — stack data must never fail or block a PR list.
+async fn gh_open_stack_memberships(
+    repo_path: &str,
+    slug: &str,
+) -> std::collections::HashMap<u64, PrStackInfo> {
+    let mut map = std::collections::HashMap::new();
+    let endpoint = format!("repos/{slug}/stacks?per_page=100");
+    let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
+        return map;
+    };
+    if out.code != 0 {
+        return map;
+    }
+    let Ok(raw) = serde_json::from_str::<Vec<serde_json::Value>>(&out.stdout_lossy()) else {
+        return map;
+    };
+    // Per-item tolerance: one malformed stack drops itself, not the whole join.
+    for stack in raw
+        .into_iter()
+        .filter_map(|v| serde_json::from_value::<GhStackEntry>(v).ok())
+    {
+        if stack.open != Some(true) {
+            continue;
+        }
+        let Some(id) = stack.number else {
+            continue;
+        };
+        let size = stack.pull_requests.len() as u32;
+        for (idx, pr) in stack.pull_requests.iter().enumerate() {
+            if let Some(number) = pr.number {
+                map.insert(
+                    number,
+                    PrStackInfo {
+                        id: id.to_string(),
+                        position: idx as u32 + 1,
+                        size,
+                    },
+                );
+            }
+        }
+    }
+    map
+}
+
+/// This PR's stack membership plus the stack's members bottom→top, for the detail
+/// view. Best-effort at both hops: no membership (or an unreachable stacks
+/// endpoint) yields `(None, [])`, and a failed member fetch still returns the
+/// membership the PR payload itself reported.
+async fn gh_pr_stack(
+    repo_path: &str,
+    slug: &str,
+    number: u64,
+) -> (Option<PrStackInfo>, Vec<PrStackMember>) {
+    let unstacked = (None, Vec::new());
+    let endpoint = format!("repos/{slug}/pulls/{number}");
+    let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
+        return unstacked;
+    };
+    if out.code != 0 {
+        return unstacked;
+    }
+    // `stack` is absent or JSON null for an unstacked PR — both read as None here.
+    let stack = serde_json::from_str::<serde_json::Value>(&out.stdout_lossy())
+        .ok()
+        .and_then(|v| v.get("stack").cloned())
+        .and_then(|s| serde_json::from_value::<GhPullStackRef>(s).ok());
+    let Some((id, position, size)) = stack.and_then(|s| Some((s.number?, s.position?, s.size?)))
+    else {
+        return unstacked;
+    };
+
+    let members = gh_stack_members(repo_path, slug, id).await;
+    (
+        Some(PrStackInfo {
+            id: id.to_string(),
+            position,
+            size,
+        }),
+        members,
+    )
+}
+
+/// One stack's members bottom→top. Empty on any failure — the caller treats that
+/// as "no member list", never an error.
+async fn gh_stack_members(repo_path: &str, slug: &str, stack_number: u64) -> Vec<PrStackMember> {
+    let endpoint = format!("repos/{slug}/stacks/{stack_number}");
+    let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
+        return Vec::new();
+    };
+    if out.code != 0 {
+        return Vec::new();
+    }
+    serde_json::from_str::<GhStackEntry>(&out.stdout_lossy())
+        .map(|entry| stack_members_from(&entry.pull_requests))
+        .unwrap_or_default()
+}
+
 const PR_LIST_FIELDS: &str =
     "number,url,title,baseRefName,headRefName,isDraft,state,author,labels,createdAt";
 
@@ -1085,9 +1430,26 @@ pub async fn gh_pr_list(
         args.push("--limit");
         args.push(&limit_str);
     }
-    let out = run_gh(Some(&repo_path), &args, GH_TIMEOUT).await?;
-    serde_json::from_str(&out.stdout_lossy())
-        .map_err(|e| AppError::Gh(format!("could not parse gh pr list: {e}")))
+    // Stack membership needs its own endpoint (`gh pr list --json` has no stack
+    // field), and it depends only on the slug — so it rides ALONGSIDE the list
+    // rather than adding a gh spawn + round-trip to the list's critical path.
+    // Open rows only: a closed list describes merges already made.
+    let want_stacks = state == "open";
+    let (out, stacks) = tokio::join!(run_gh(Some(&repo_path), &args, GH_TIMEOUT), async {
+        if want_stacks {
+            gh_open_stack_memberships(&repo_path, &slug).await
+        } else {
+            std::collections::HashMap::new()
+        }
+    });
+    let mut prs: Vec<PrInfo> = serde_json::from_str(&out?.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not parse gh pr list: {e}")))?;
+    // Strictly additive — `gh_open_stack_memberships` never errors, it just
+    // returns nothing when stacks are unavailable.
+    for pr in &mut prs {
+        pr.stack = stacks.get(&pr.number).cloned();
+    }
+    Ok(prs)
 }
 
 /// One PR's rolled-up CI signal, keyed by number — the hydration payload for the
@@ -1980,6 +2342,11 @@ pub struct PrDetails {
     pub squash_merge_allowed: Option<bool>,
     /// Whether the repository allows the rebase-merge method. See `merge_commit_allowed`.
     pub rebase_merge_allowed: Option<bool>,
+    /// This PR's stack membership; `None` when it isn't stacked.
+    pub stack: Option<PrStackInfo>,
+    /// The whole stack bottom→top (empty when unstacked). A merged layer stays a
+    /// member — GitHub does not shrink a stack on merge.
+    pub stack_members: Vec<PrStackMember>,
 }
 
 /// A merge/pull request's approval summary — who has approved and whether the
@@ -2074,20 +2441,15 @@ pub async fn gh_pr_view(
     // this fn calls (files/commits/reviews/comments) inherit the SAME lens so they
     // resolve to the SAME repo these PR numbers came from.
     let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
-    let out = run_gh(
-        Some(&repo_path),
-        &[
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            &slug,
-            "--json",
-            PR_VIEW_FIELDS,
-        ],
-        GH_TIMEOUT,
-    )
-    .await?;
+    let n = number.to_string();
+    // Stack membership rides alongside the view rather than after it — it's two
+    // extra REST hops that would otherwise serialize onto the detail's latency.
+    let view_args = ["pr", "view", &n, "--repo", &slug, "--json", PR_VIEW_FIELDS];
+    let (out, (stack, stack_members)) = tokio::join!(
+        run_gh(Some(&repo_path), &view_args, GH_TIMEOUT),
+        gh_pr_stack(&repo_path, &slug, number),
+    );
+    let out = out?;
     let raw: RawPr = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh pr view: {e}")))?;
 
@@ -2357,6 +2719,8 @@ pub async fn gh_pr_view(
         merge_commit_allowed: merge_settings.merge_commit_allowed,
         squash_merge_allowed: merge_settings.squash_merge_allowed,
         rebase_merge_allowed: merge_settings.rebase_merge_allowed,
+        stack,
+        stack_members,
     })
 }
 
@@ -4062,6 +4426,9 @@ fn rest_pull_to_pr_info(p: GhPrRestPull) -> PrInfo {
         labels: Vec::new(),
         created_at: String::new(),
         head_sha: String::new(),
+        // The duplicate probe only needs identity — stack membership is the PR
+        // list's and the detail view's job.
+        stack: None,
     }
 }
 
@@ -4355,14 +4722,15 @@ fn scrape_pr_ref(stdout: &str) -> (u64, String) {
 #[cfg(test)]
 mod tests {
     use super::{
-        external_items_from_thread_nodes, host_from_url, is_diff_too_large, map_timeline_node,
-        parse_actions_run_job, real_check_time, real_time_or_empty,
+        classify_merge_async, external_items_from_thread_nodes, host_from_url, is_diff_too_large,
+        map_timeline_node, parse_actions_run_job, real_check_time, real_time_or_empty,
         parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
-        split_commit_message, upstream_pulls_endpoint, GhPrFile, GhPrRestComment, GhPrRestCommit,
-        GhPrRestCommitGitAuthor, GhPrRestCommitInner, GhPrRestPull, GhPrRestReview,
-        PrTimelineEventOut, RawLogin,
+        split_commit_message, stack_members_from, upstream_pulls_endpoint, GhPrFile,
+        GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner,
+        GhPrRestPull, GhPrRestReview, GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails,
+        PrInfo, PrStackInfo, PrStackMember, PrTimelineEventOut, RawLogin,
     };
     use crate::error::AppError;
 
@@ -4389,6 +4757,184 @@ mod tests {
             },
             author: None,
         }
+    }
+
+    /// A `PrDetails` with everything empty but the two stack fields — the wire
+    /// shape is what these tests pin, not the payload.
+    fn details_with_stack(
+        stack: Option<PrStackInfo>,
+        stack_members: Vec<PrStackMember>,
+    ) -> PrDetails {
+        PrDetails {
+            id: String::new(),
+            number: 22,
+            title: String::new(),
+            body: String::new(),
+            author: String::new(),
+            author_avatar_url: String::new(),
+            state: String::new(),
+            is_draft: false,
+            base_ref_name: String::new(),
+            head_ref_name: String::new(),
+            additions: 0,
+            deletions: 0,
+            url: String::new(),
+            commits: Vec::new(),
+            files: Vec::new(),
+            reviews: Vec::new(),
+            comments: Vec::new(),
+            checks: Vec::new(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            reviewers: Vec::new(),
+            completed_reviewers: Vec::new(),
+            merge_commit_allowed: None,
+            squash_merge_allowed: None,
+            rebase_merge_allowed: None,
+            stack,
+            stack_members,
+        }
+    }
+
+    /// The frontend reads these keys verbatim; a serde rename slip here has
+    /// silently produced `undefined` in TS before, so the wire shape is pinned.
+    #[test]
+    fn stack_fields_serialize_camel_case() {
+        let details = details_with_stack(
+            Some(PrStackInfo {
+                id: "133465".to_string(),
+                position: 1,
+                size: 2,
+            }),
+            vec![PrStackMember {
+                number: 21,
+                title: "bottom".to_string(),
+                state: "merged".to_string(),
+                position: 1,
+                head_ref_name: "feat-a".to_string(),
+                base_ref_name: "main".to_string(),
+            }],
+        );
+        let v = serde_json::to_value(&details).unwrap();
+        assert_eq!(v["stack"]["id"], "133465");
+        assert_eq!(v["stack"]["position"], 1);
+        assert_eq!(v["stack"]["size"], 2);
+        assert_eq!(v["stackMembers"][0]["number"], 21);
+        assert_eq!(v["stackMembers"][0]["state"], "merged");
+        assert_eq!(v["stackMembers"][0]["headRefName"], "feat-a");
+        assert_eq!(v["stackMembers"][0]["baseRefName"], "main");
+        // Snake-case keys must NOT appear.
+        assert!(v.get("stack_members").is_none());
+        assert!(v["stackMembers"][0].get("head_ref_name").is_none());
+
+        // Unstacked: an explicit null plus an empty array, never a missing key.
+        let v = serde_json::to_value(details_with_stack(None, Vec::new())).unwrap();
+        assert!(v["stack"].is_null());
+        assert_eq!(v["stackMembers"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn pr_info_stack_defaults_absent_and_round_trips() {
+        // `gh pr list --json` never emits a stack field — it must default, not fail.
+        let row: PrInfo = serde_json::from_str(
+            r#"{"number":7,"url":"u","title":"t","baseRefName":"main","headRefName":"f",
+                "isDraft":false,"state":"OPEN"}"#,
+        )
+        .unwrap();
+        assert!(row.stack.is_none());
+        assert!(serde_json::to_value(&row).unwrap()["stack"].is_null());
+
+        let joined: PrInfo = serde_json::from_str(
+            r#"{"number":7,"url":"u","title":"t","baseRefName":"main","headRefName":"f",
+                "isDraft":false,"state":"OPEN","stack":{"id":"9","position":2,"size":3}}"#,
+        )
+        .unwrap();
+        let stack = joined.stack.expect("stack should round-trip");
+        assert_eq!((stack.id.as_str(), stack.position, stack.size), ("9", 2, 3));
+    }
+
+    #[test]
+    fn stack_members_map_bottom_to_top_with_merged_layers() {
+        // A stacks-endpoint entry: `pull_requests` bottom→top, and a merged layer
+        // stays a member (GitHub doesn't shrink a stack on merge).
+        let entry: GhStackEntry = serde_json::from_str(
+            r#"{"id":133465,"number":22,"open":true,"base":{"ref":"main"},
+                "pull_requests":[
+                  {"number":21,"title":"bottom","state":"closed","merged_at":"2026-08-04T00:00:00Z",
+                   "head":{"ref":"feat-a"},"base":{"ref":"main"}},
+                  {"number":23,"title":"top","state":"OPEN","merged_at":null,
+                   "head":{"ref":"feat-b"},"base":{"ref":"feat-a"}}
+                ]}"#,
+        )
+        .unwrap();
+        let members = stack_members_from(&entry.pull_requests);
+        assert_eq!(members.len(), 2);
+        assert_eq!((members[0].number, members[0].position), (21, 1));
+        // merged_at wins over the raw "closed" state.
+        assert_eq!(members[0].state, "merged");
+        assert_eq!(members[0].head_ref_name, "feat-a");
+        assert_eq!((members[1].number, members[1].position), (23, 2));
+        // Provider-neutral lowercase.
+        assert_eq!(members[1].state, "open");
+        assert_eq!(members[1].base_ref_name, "feat-a");
+    }
+
+    #[test]
+    fn merge_async_parses_the_live_response_shapes() {
+        // The PUT acknowledgement: top-level `status`, uuid nested under `details`
+        // (GitHub's published docs describe `state`/top-level uuid — the live API
+        // does not).
+        let started: MergeAsyncStatus = serde_json::from_str(
+            r#"{"status":"pending","details":{"message":"Merge request enqueued",
+                "uuid":"6a1f-…","merge_method":"merge","merge_action":"default",
+                "expected_head_sha":"deadbeef"}}"#,
+        )
+        .unwrap();
+        assert_eq!(started.status.as_deref(), Some("pending"));
+        assert_eq!(
+            started.details.and_then(|d| d.uuid).as_deref(),
+            Some("6a1f-…")
+        );
+        assert_eq!(
+            classify_merge_async(Some("pending")),
+            MergeAsyncOutcome::Pending
+        );
+
+        // Poll → merged.
+        let merged: MergeAsyncStatus = serde_json::from_str(
+            r#"{"status":"merged","details":{"message":"Merged","sha":"cafe"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            classify_merge_async(merged.status.as_deref()),
+            MergeAsyncOutcome::Done
+        );
+
+        // Poll → failed, carrying the server's message verbatim.
+        let failed: MergeAsyncStatus = serde_json::from_str(
+            r#"{"status":"failed","details":{"message":"Base branch was modified"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            classify_merge_async(failed.status.as_deref()),
+            MergeAsyncOutcome::Failed
+        );
+        assert_eq!(
+            failed.details.and_then(|d| d.message).as_deref(),
+            Some("Base branch was modified")
+        );
+
+        // A merge queue owns an enqueued merge — success, not a wait.
+        assert_eq!(
+            classify_merge_async(Some("ENQUEUED")),
+            MergeAsyncOutcome::Done
+        );
+        // Absent or unrecognized states keep polling, never a false verdict.
+        assert_eq!(classify_merge_async(None), MergeAsyncOutcome::Pending);
+        assert_eq!(
+            classify_merge_async(Some("something_new")),
+            MergeAsyncOutcome::Pending
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -4851,16 +4851,15 @@ fn scrape_pr_ref(stdout: &str) -> (u64, String) {
 mod tests {
     use super::{
         classify_merge_async, external_items_from_thread_nodes, host_from_url, is_diff_too_large,
-        map_timeline_node, parse_actions_run_job, real_check_time, real_time_or_empty,
-        parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
+        map_timeline_node, parse_actions_run_job, parse_auth_accounts, parse_pr_url_repo,
+        pull_stack_ref, real_check_time, real_time_or_empty, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
-        pull_stack_ref, split_commit_message, stack_members_from, stack_memberships_from,
-        upstream_pulls_endpoint, GhPrFile,
-        GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner,
-        GhPrRestPull, GhPrRestReview, GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails,
-        PrMergeOutcome,
-        PrInfo, PrStackInfo, PrStackMember, PrTimelineEventOut, RawLogin,
+        split_commit_message, stack_members_from, stack_memberships_from, upstream_pulls_endpoint,
+        GhPrFile, GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor,
+        GhPrRestCommitInner, GhPrRestPull, GhPrRestReview, GhStackEntry, MergeAsyncOutcome,
+        MergeAsyncStatus, PrDetails, PrInfo, PrMergeOutcome, PrStackInfo, PrStackMember,
+        PrTimelineEventOut, RawLogin,
     };
     use crate::error::AppError;
 

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -483,7 +483,8 @@ pub struct PrListLabel {
 #[serde(rename_all = "camelCase")]
 pub struct PrStackInfo {
     /// Stack identity: GitHub's stack number as a string; GitLab synthesized
-    /// "mr-<bottom-iid>". Stable within a repo.
+    /// "mr-<bottom-iid>". Stable within one inference pass — GitLab's re-roots
+    /// when the bottom MR merges and leaves the open list.
     pub id: String,
     /// 1 = bottom of the stack (merges first).
     pub position: u32,
@@ -659,10 +660,11 @@ pub async fn gh_pr_merge(
     Ok(PrMergeOutcome { cleanup_warning })
 }
 
-/// Whether the PR is a stack member, per the nullable `stack` object on its REST
-/// payload. `false` on ANY failure (network, a host without stacks, an
-/// unparseable body): the legacy merge path then runs, and GitHub rejects a
-/// stacked merge there with its own actionable error.
+/// Whether the PR is a stack member — the same `pull_stack_ref` reading the detail
+/// view uses, so the merge path can never cascade a stack the detail view didn't
+/// show. `false` on ANY failure (network, a host without stacks, an unparseable or
+/// incomplete `stack` object): the legacy merge path then runs, and GitHub rejects
+/// a stacked merge there with its own actionable error.
 async fn gh_pr_is_stacked(repo_path: &str, slug: &str, number: u64) -> bool {
     let endpoint = format!("repos/{slug}/pulls/{number}");
     let Ok(out) = run_gh_raw(Some(repo_path), &["api", &endpoint], GH_TIMEOUT).await else {
@@ -671,10 +673,7 @@ async fn gh_pr_is_stacked(repo_path: &str, slug: &str, number: u64) -> bool {
     if out.code != 0 {
         return false;
     }
-    serde_json::from_str::<serde_json::Value>(&out.stdout_lossy())
-        .ok()
-        .and_then(|v| v.get("stack").cloned())
-        .is_some_and(|s| s.is_object())
+    pull_stack_ref(&out.stdout_lossy()).is_some()
 }
 
 /// A merge-async response — the `PUT` acknowledgement and every poll share it.
@@ -739,8 +738,14 @@ async fn gh_pr_merge_async(
         GH_NETWORK_TIMEOUT,
     )
     .await?;
-    let mut current: MergeAsyncStatus = serde_json::from_str(&out.stdout_lossy())
-        .map_err(|e| AppError::Gh(format!("could not parse the merge response: {e}")))?;
+    // The PUT already succeeded, so the merge may be running — an unreadable
+    // acknowledgement is uncertainty, not a failed merge, and must read that way.
+    let mut current: MergeAsyncStatus =
+        serde_json::from_str(&out.stdout_lossy()).map_err(|_| {
+            AppError::Gh(format!(
+                "GitHub accepted the merge of #{number} but its response couldn't be read — refresh the pull request to check whether it completed."
+            ))
+        })?;
     let uuid = current
         .details
         .as_ref()
@@ -1258,6 +1263,17 @@ struct GhPullStackRef {
     size: Option<u32>,
 }
 
+/// The `stack` triple (stack number, position, size) from a REST pull payload;
+/// `None` when the PR is unstacked (the key is absent or JSON null) or the object
+/// is incomplete. The detail view and the merge path BOTH decide "is this PR
+/// stacked?" through here, so they can never disagree — a divergence would let one
+/// cascade a merge the other never disclosed. Pure — unit-tested.
+fn pull_stack_ref(body: &str) -> Option<(u64, u32, u32)> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let stack: GhPullStackRef = serde_json::from_value(value.get("stack")?.clone()).ok()?;
+    Some((stack.number?, stack.position?, stack.size?))
+}
+
 /// Map a stack's `pull_requests` (bottom→top) onto neutral members with 1-based
 /// positions. A merged layer stays a member and reads "merged" whatever its raw
 /// `state` says. Pure — unit-tested.
@@ -1289,7 +1305,9 @@ fn stack_members_from(prs: &[GhStackPr]) -> Vec<PrStackMember> {
 /// The repo's OPEN stacks as a PR-number → membership map, for the list join.
 /// Best-effort by contract: any failure (a host without the endpoint, network,
 /// unparseable body) yields an empty map and the list renders exactly as it did
-/// before stacks — stack data must never fail or block a PR list.
+/// before stacks — stack data must never fail or block a PR list. One page only:
+/// past 100 open stacks the surplus goes unmarked rather than paginating a
+/// decoration onto the list's critical path.
 async fn gh_open_stack_memberships(
     repo_path: &str,
     slug: &str,
@@ -1350,13 +1368,7 @@ async fn gh_pr_stack(
     if out.code != 0 {
         return unstacked;
     }
-    // `stack` is absent or JSON null for an unstacked PR — both read as None here.
-    let stack = serde_json::from_str::<serde_json::Value>(&out.stdout_lossy())
-        .ok()
-        .and_then(|v| v.get("stack").cloned())
-        .and_then(|s| serde_json::from_value::<GhPullStackRef>(s).ok());
-    let Some((id, position, size)) = stack.and_then(|s| Some((s.number?, s.position?, s.size?)))
-    else {
+    let Some((id, position, size)) = pull_stack_ref(&out.stdout_lossy()) else {
         return unstacked;
     };
 
@@ -4727,7 +4739,7 @@ mod tests {
         parse_auth_accounts, parse_pr_url_repo, reconstruct_pr_diff,
         reject_upstream_create_metadata, rest_comment_to_out, rest_commit_to_out,
         rest_pull_to_pr_info, rest_review_to_out, rollup_state_to_ci, scrape_pr_ref,
-        split_commit_message, stack_members_from, upstream_pulls_endpoint, GhPrFile,
+        pull_stack_ref, split_commit_message, stack_members_from, upstream_pulls_endpoint, GhPrFile,
         GhPrRestComment, GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner,
         GhPrRestPull, GhPrRestReview, GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails,
         PrInfo, PrStackInfo, PrStackMember, PrTimelineEventOut, RawLogin,
@@ -4851,6 +4863,31 @@ mod tests {
         .unwrap();
         let stack = joined.stack.expect("stack should round-trip");
         assert_eq!((stack.id.as_str(), stack.position, stack.size), ("9", 2, 3));
+    }
+
+    /// The single reading that decides stacked-or-not on BOTH the detail and the
+    /// merge path — a drift here silently changes which PRs cascade on merge.
+    #[test]
+    fn pull_stack_ref_reads_the_nullable_stack_object() {
+        // The live shape: `stack` on a plain REST pull read.
+        assert_eq!(
+            pull_stack_ref(
+                r#"{"number":22,"stack":{"id":133465,"number":22,"position":1,"size":2,
+                    "base":{"ref":"main","sha":"cafe"}}}"#
+            ),
+            Some((22, 1, 2))
+        );
+        // Unstacked, both spellings.
+        assert_eq!(pull_stack_ref(r#"{"number":22,"stack":null}"#), None);
+        assert_eq!(pull_stack_ref(r#"{"number":22}"#), None);
+        // An incomplete triple is NOT a stack — the merge path must not cascade on
+        // a membership the detail view couldn't render.
+        assert_eq!(pull_stack_ref(r#"{"stack":{"number":22,"position":1}}"#), None);
+        assert_eq!(pull_stack_ref(r#"{"stack":{"position":1,"size":2}}"#), None);
+        assert_eq!(pull_stack_ref(r#"{"stack":{}}"#), None);
+        // Garbage in, no verdict out.
+        assert_eq!(pull_stack_ref("not json"), None);
+        assert_eq!(pull_stack_ref(r#"{"stack":"yes"}"#), None);
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -608,7 +608,6 @@ pub struct PrMergeOutcome {
     /// prose: `cleanup_warning` carries the human detail, but a programmatic caller
     /// (the MCP merge tool, the frontend) must branch on this rather than parse a
     /// message — and must not treat the PR as merged or its branch as deleted.
-    #[serde(default)]
     pub queued: bool,
 }
 
@@ -1541,9 +1540,8 @@ pub async fn gh_pr_list(
         args.push(&limit_str);
     }
     // Stack membership needs its own endpoint (`gh pr list --json` has no stack
-    // field), and it depends only on the slug — so it rides ALONGSIDE the list
-    // rather than adding a gh spawn + round-trip to the list's critical path.
-    // Open rows only: a closed list describes merges already made.
+    // field) and depends only on the slug. Open rows only: a closed list describes
+    // merges already made.
     let want_stacks = state == "open";
     let (out, stacks) = tokio::join!(run_gh(Some(&repo_path), &args, GH_TIMEOUT), async {
         if !want_stacks {

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -163,9 +163,10 @@ impl GitDesktopMcp {
         description = "Get a pull request's full details (title, body, state, reviews, comments, \
                        files) by number from the repository's forge (GitHub, GitLab, or Bitbucket, \
                        per its remote). A stacked PR also carries `stack` ({id, position, size}) \
-                       and `stackMembers`, the whole stack bottom→top with each layer's state — \
-                       merged layers included, since merging one layer merges every unmerged \
-                       layer below it. For just the conversation — including file:line review \
+                       and `stackMembers`, the whole stack bottom→top with each layer's state. On \
+                       GitHub merged layers stay listed, because merging one layer also merges \
+                       every unmerged layer below it; a GitLab chain is inferred from the open \
+                       MRs and each MR merges on its own. For just the conversation — including file:line review \
                        threads — see list_pull_request_comments. Returns JSON."
     )]
     async fn get_pull_request(

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -166,7 +166,10 @@ impl GitDesktopMcp {
                        and `stackMembers`, the whole stack bottom→top with each layer's state. On \
                        GitHub merged layers stay listed, because merging one layer also merges \
                        every unmerged layer below it; a GitLab chain is inferred from the open \
-                       MRs and each MR merges on its own. For just the conversation — including file:line review \
+                       MRs and each MR merges on its own. When `stack` is null AND `stackUnknown` \
+                       is true, the stack status could NOT be checked — that is not a guarantee \
+                       the PR is unstacked, so verify on GitHub before merging it. For just the \
+                       conversation — including file:line review \
                        threads — see list_pull_request_comments. Returns JSON."
     )]
     async fn get_pull_request(

--- a/src-tauri/src/mcp_server/read_forge.rs
+++ b/src-tauri/src/mcp_server/read_forge.rs
@@ -135,8 +135,11 @@ impl GitDesktopMcp {
                        Without `limit`, returns the provider default (GitHub ~30; GitLab and \
                        Bitbucket a full page); pass `limit` to raise or lower that cap. Per-call \
                        ceiling: GitHub 1000, GitLab 100, Bitbucket 50 — a larger `limit` returns \
-                       the ceiling (no pagination). Requires the forge's authenticated \
-                       CLI/credential. Returns JSON."
+                       the ceiling (no pagination). Open rows carry a `stack` object \
+                       ({id, position, size}, position 1 = bottom and merges first) when the \
+                       PR belongs to a stack — GitHub stacks, or a chain of GitLab MRs each \
+                       targeting the next one's source branch; null otherwise. Requires the \
+                       forge's authenticated CLI/credential. Returns JSON."
     )]
     async fn list_pull_requests(
         &self,
@@ -159,7 +162,10 @@ impl GitDesktopMcp {
     #[tool(
         description = "Get a pull request's full details (title, body, state, reviews, comments, \
                        files) by number from the repository's forge (GitHub, GitLab, or Bitbucket, \
-                       per its remote). For just the conversation — including file:line review \
+                       per its remote). A stacked PR also carries `stack` ({id, position, size}) \
+                       and `stackMembers`, the whole stack bottom→top with each layer's state — \
+                       merged layers included, since merging one layer merges every unmerged \
+                       layer below it. For just the conversation — including file:line review \
                        threads — see list_pull_request_comments. Returns JSON."
     )]
     async fn get_pull_request(

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -630,8 +630,13 @@ impl GitDesktopMcp {
         description = "Merge a pull request (by number) in the bound repository's forge (GitHub, \
                        GitLab, or Bitbucket, per its remote), under the authenticated forge user. \
                        `strategy` is \"merge\" (default), \"squash\", or \"rebase\" (rebase is \
-                       GitHub-only). A merge is NOT trivially reversible. Optionally deletes the \
-                       head branch. Requires --allow-remote-write.",
+                       GitHub-only). A merge is NOT trivially reversible. On GitHub a stack merges \
+                       bottom-up: merging a stacked PR ALSO merges every still-open PR below it in \
+                       its stack, in one irreversible step — read `stack` and `stackMembers` via \
+                       get_pull_request first to see what would go with it. Optionally deletes the \
+                       head branch. The result's `action` is \"merged\", or \"queued\" when a merge \
+                       queue took the merge — queued means NOT yet merged: the head branch is left \
+                       in place and `deleted_branch` is false. Requires --allow-remote-write.",
         annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn merge_pull_request(

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -650,14 +650,17 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
+        // A QUEUED merge has not landed and its branch was deliberately left alone —
+        // an agent branching on these fields must not read it as merged/deleted.
         let mut result = serde_json::json!({
             "pull_request": args.number,
-            "action": "merged",
+            "action": if outcome.queued { "queued" } else { "merged" },
             "strategy": strategy,
-            "deleted_branch": args.delete_branch,
+            "deleted_branch": args.delete_branch && !outcome.queued,
         });
-        // The merge succeeded; a cleanup_warning means only the branch deletion failed —
-        // surface it as a caveat, not a tool error (the merge isn't reversible from here).
+        // The merge was accepted; a cleanup_warning means either the branch deletion
+        // failed or the merge is queued — a caveat, not a tool error (neither is
+        // reversible from here).
         if let Some(warning) = outcome.cleanup_warning {
             result["cleanup_warning"] = serde_json::Value::String(warning);
         }

--- a/src-tauri/src/mcp_server/write_forge.rs
+++ b/src-tauri/src/mcp_server/write_forge.rs
@@ -650,13 +650,19 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
-        // A QUEUED merge has not landed and its branch was deliberately left alone —
-        // an agent branching on these fields must not read it as merged/deleted.
+        // The branch is gone only on a clean merge: BOTH caveat causes leave it in
+        // place — a failed deletion (protected ref, lost permission) and a queued
+        // merge, whose cleanup is skipped so the queue isn't broken. Every caveat
+        // sets `cleanup_warning`, so its absence is the one honest signal. Computed
+        // BEFORE the `if let` below consumes the field.
+        let deleted_branch = args.delete_branch && outcome.cleanup_warning.is_none();
+        // A QUEUED merge has not landed — an agent branching on these fields must
+        // not read it as merged.
         let mut result = serde_json::json!({
             "pull_request": args.number,
             "action": if outcome.queued { "queued" } else { "merged" },
             "strategy": strategy,
-            "deleted_branch": args.delete_branch && !outcome.queued,
+            "deleted_branch": deleted_branch,
         });
         // The merge was accepted; a cleanup_warning means either the branch deletion
         // failed or the merge is queued — a caveat, not a tool error (neither is

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -851,6 +851,25 @@ GitLab works too**: sign \`glab\` in to your instance (from Accounts, or
 automatically. Its issues, CI pipelines, and
 releases work too (see their sections below).
 
+## Stacked pull requests
+
+When a pull request is part of a **stack** — a chain where each PR targets the one below it
+instead of the base branch — its row in the list carries a **position badge** (*2/3*), and
+the PR view gains a **Stack** section listing every member from the bottom of the stack up,
+with the one you're reading marked. Select a member — click it, or move through the section
+with **↑ / ↓** — to open that pull request. The command palette ({{kbd:command-palette}}) also
+carries **Next pull request in stack** and **Previous pull request in stack**, offered from
+the pull-request view while you have a stacked one open; both are palette commands with no
+default shortcut, so give them one in **Settings → Keyboard** if you want it on the keys.
+
+Where the stack comes from depends on the forge: on **GitHub** it's the **native
+stacked-PR API**, and on **GitLab** a chain of merge requests is **detected automatically**.
+
+On **GitHub**, merging is **stack-aware**: merging a stacked pull request merges it *and*
+every still-open pull request below it, bottom-up, as a single operation, so the stack
+lands in dependency order without you walking it by hand. The merge dialog **lists exactly
+which pull requests will merge**, in the order they'll go in, before you confirm.
+
 ## Bitbucket PRs
 
 Point the app at a **Bitbucket Cloud** repo (connect with an Atlassian API token in

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -867,8 +867,9 @@ stacked-PR API**, and on **GitLab** a chain of merge requests is **detected auto
 
 On **GitHub**, merging is **stack-aware**: merging a stacked pull request merges it *and*
 every still-open pull request below it, bottom-up, as a single operation, so the stack
-lands in dependency order without you walking it by hand. The merge dialog **lists exactly
-which pull requests will merge**, in the order they'll go in, before you confirm.
+lands in dependency order without you walking it by hand. Before you confirm, the merge
+dialog **spells out the full scope of the merge** — naming each pull request it will merge,
+in the order they'll go in, whenever it has the list.
 
 ## Bitbucket PRs
 
@@ -1775,10 +1776,10 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
 
 ## Moving around
 
-- **↑ / ↓** navigate every list — files, commits, branches, PRs, runs, sessions, and the
-  side rails (Settings, Repository settings, and this guide). **Shift + ↑ / ↓** extends a
-  selection in History. **Enter** opens the highlighted item; **Esc** closes dialogs and
-  menus.
+- **↑ / ↓** navigate every list — files, commits, branches, PRs, stack members, runs,
+  sessions, and the side rails (Settings, Repository settings, and this guide).
+  **Shift + ↑ / ↓** extends a selection in History. **Enter** opens the highlighted item;
+  **Esc** closes dialogs and menus.
 - **Tabs:** {{kbd:tab-changes}} Changes · {{kbd:tab-history}} History ·
   {{kbd:tab-compare}} Compare · {{kbd:tab-pulls}} Pull Requests · {{kbd:tab-actions}}
   Actions · {{kbd:tab-issues}} Issues · {{kbd:tab-discussions}} Discussions ·

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -859,8 +859,9 @@ the PR view gains a **Stack** section listing every member from the bottom of th
 with the one you're reading marked. Select a member — click it, or move through the section
 with **↑ / ↓** — to open that pull request. The command palette ({{kbd:command-palette}}) also
 carries **Next pull request in stack** and **Previous pull request in stack**, offered from
-the pull-request view while you have a stacked one open; both are palette commands with no
-default shortcut, so give them one in **Settings → Keyboard** if you want it on the keys.
+the pull-request view whenever there's another member in that direction; both are palette
+commands with no default shortcut, so give them one in **Settings → Keyboard** if you want
+it on the keys.
 
 Where the stack comes from depends on the forge: on **GitHub** it's the **native
 stacked-PR API**, and on **GitLab** a chain of merge requests is **detected automatically**.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -867,9 +867,11 @@ stacked-PR API**, and on **GitLab** a chain of merge requests is **detected auto
 
 On **GitHub**, merging is **stack-aware**: merging a stacked pull request merges it *and*
 every still-open pull request below it, bottom-up, as a single operation, so the stack
-lands in dependency order without you walking it by hand. Before you confirm, the merge
-dialog **spells out the full scope of the merge** — naming each pull request it will merge,
-in the order they'll go in, whenever it has the list.
+lands in dependency order without you walking it by hand — or, when the base branch uses a
+**merge queue**, is handed to the queue and lands when it clears, the head branch left in
+place for it. Before you confirm, the merge dialog **spells out the full scope of the
+merge** — naming each pull request it will merge, in the order they'll go in, whenever it
+has the list.
 
 ## Bitbucket PRs
 

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -2,6 +2,7 @@ import {
   CheckCircleIcon,
   ClockIcon,
   GitPullRequestIcon,
+  StackSimpleIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
@@ -365,7 +366,25 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
               )}
             </p>
             <p className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground">
-              #{pr.number} ·{" "}
+              #{pr.number}
+              {/* Ahead of the branch names so the row's truncation can't eat it.
+                  Text carries the meaning; the label is self-contained so the
+                  glyph reads on its own. */}
+              {pr.stack && (
+                <>
+                  {" · "}
+                  <span
+                    className="inline-flex items-center gap-1 align-middle"
+                    role="img"
+                    title={`Stack position ${pr.stack.position} of ${pr.stack.size}`}
+                    aria-label={`Stack position ${pr.stack.position} of ${pr.stack.size}`}
+                  >
+                    <StackSimpleIcon className="size-3 shrink-0 text-muted-foreground" />
+                    {pr.stack.position}/{pr.stack.size}
+                  </span>
+                </>
+              )}
+              {" · "}
               {pr.author ? `${displayLogin(pr.author.login)} · ` : ""}
               {pr.createdAt ? `${formatRelativeTime(pr.createdAt)} · ` : ""}
               {pr.headRefName} → {pr.baseRefName}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -709,7 +709,7 @@ export function RemotePrView({
           // A queued merge was accepted but hasn't landed, so announce the state
           // once — mirroring the auto-merge arm — instead of a "Merged" success
           // that the queue detail would immediately contradict.
-          if (outcome.queued ?? false) {
+          if (outcome.queued) {
             toast.success(
               outcome.cleanupWarning ?? `Merge queued for #${number}`,
             );

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -335,17 +335,18 @@ export function RemotePrView({
   const setPendingPrSection = useUiStore((s) => s.setPendingPrSection);
   const selectedPr = useUiStore((s) => s.selectedPr);
   const selectPr = useUiStore((s) => s.selectPr);
+  // Whether this view owns the current selection. Several hint/palette paths
+  // gate on it so a still-mounted lagging view (deferredPr) can't answer first.
+  const isSelectedPr =
+    selectedPr?.kind === "remote" && selectedPr.id === String(number);
   // The activity dock's "View" lands here via a pending hint; switch to the
-  // review sub-tab once, then clear it. Guarded on this being the *selected* PR
-  // so a still-mounted lagging view (deferredPr) can't swallow the hint first.
+  // review sub-tab once, then clear it.
   useEffect(() => {
-    const isSelected =
-      selectedPr?.kind === "remote" && selectedPr.id === String(number);
-    if (pendingPrSection === "review" && isSelected) {
+    if (pendingPrSection === "review" && isSelectedPr) {
       setSection("review");
       setPendingPrSection(null);
     }
-  }, [pendingPrSection, setPendingPrSection, selectedPr, number]);
+  }, [pendingPrSection, setPendingPrSection, isSelectedPr]);
   const aiEnabled = useAiEnabled();
   const rulesConfig = useEffectiveBranchRules(repoPath);
   const defaultBranch = useDefaultBranch(repoPath);
@@ -434,10 +435,7 @@ export function RemotePrView({
 
   // Palette twins of the Stack section's arrow keys: step one position up or down
   // the stack. Clamped at both ends — a stack is a dependency chain, so wrapping
-  // from the top back to the bottom would misrepresent the order. Gated on this
-  // being the *selected* PR so a still-mounted lagging view can't answer first.
-  const isSelectedPr =
-    selectedPr?.kind === "remote" && selectedPr.id === String(number);
+  // from the top back to the bottom would misrepresent the order.
   function goToStackNeighbor(delta: 1 | -1) {
     const info = details.data?.stack;
     if (!info) return;
@@ -708,12 +706,21 @@ export function RemotePrView({
       },
       {
         onSuccess: (outcome) => {
-          toast.success(`Merged #${number}`);
-          // The PR merged; a cleanupWarning means only the post-merge remote
-          // head-branch deletion failed. Surface it as a (non-error) warning so
-          // the successful merge isn't dressed up as a failure.
-          if (outcome.cleanupWarning) {
-            toast.warning(outcome.cleanupWarning, { duration: 10000 });
+          // A queued merge was accepted but hasn't landed, so announce the state
+          // once — mirroring the auto-merge arm — instead of a "Merged" success
+          // that the queue detail would immediately contradict.
+          if (outcome.queued ?? false) {
+            toast.success(
+              outcome.cleanupWarning ?? `Merge queued for #${number}`,
+            );
+          } else {
+            toast.success(`Merged #${number}`);
+            // Merged for real; a cleanupWarning here means only the post-merge
+            // remote head-branch deletion failed. Surface it as a (non-error)
+            // warning so the successful merge isn't dressed up as a failure.
+            if (outcome.cleanupWarning) {
+              toast.warning(outcome.cleanupWarning, { duration: 10000 });
+            }
           }
           setMergeOpen(false);
         },
@@ -868,16 +875,18 @@ export function RemotePrView({
   const autoMergeArmed = mergeState.data?.autoMergeEnabled ?? false;
   // What a stacked merge lands beyond the PR on screen — null when this PR is
   // unstacked or everything below it already merged, leaving today's copy right.
-  // Only a NATIVE stack cascades, and that's read off the stack's own id rather
-  // than the detected provider: forge status can be pending or failed here
-  // (canMerge deliberately stays on then), which would otherwise drop the
-  // disclosure on GitHub and invent one on GitLab.
-  const stackMerge = stackMergeDisclosure(
-    pr?.stack,
-    pr?.stackMembers,
+  // Known stacks gate on the stack's own id, not the detected provider: forge
+  // status can be pending or failed here (canMerge deliberately stays on then),
+  // which would otherwise drop the disclosure on GitHub and invent one on GitLab.
+  // `hostCascades` is the unknown arm's fallback — no stack, so no id to read.
+  const stackMerge = stackMergeDisclosure({
+    stack: pr?.stack,
+    members: pr?.stackMembers,
+    stackUnknown: pr?.stackUnknown ?? false,
     prNoun,
-    isNativeStack(pr?.stack),
-  );
+    atomic: isNativeStack(pr?.stack),
+    hostCascades: providerKey === "github",
+  });
 
   // Approval display (GitLab + Bitbucket): a quiet count shown only when there's
   // something to report — someone approved, or a GitLab Premium project requires

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -163,7 +163,11 @@ import {
   type SuggestionApply,
   threadToMarkdown,
 } from "./ReviewThreads";
-import { StackSection, stackMergeDisclosure } from "./StackSection";
+import {
+  isNativeStack,
+  StackSection,
+  stackMergeDisclosure,
+} from "./StackSection";
 import { SubmitReviewDialog } from "./SubmitReviewDialog";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
 import {
@@ -864,15 +868,15 @@ export function RemotePrView({
   const autoMergeArmed = mergeState.data?.autoMergeEnabled ?? false;
   // What a stacked merge lands beyond the PR on screen — null when this PR is
   // unstacked or everything below it already merged, leaving today's copy right.
-  // Gated on `providerKey`, not raw `provider`: forge status can be pending or
-  // failed here (canMerge deliberately stays on for GitHub then), and an
-  // unresolved host resolves to GitHub — so the scope is disclosed rather than
-  // silently dropped on the one provider that really does cascade-merge.
+  // Only a NATIVE stack cascades, and that's read off the stack's own id rather
+  // than the detected provider: forge status can be pending or failed here
+  // (canMerge deliberately stays on then), which would otherwise drop the
+  // disclosure on GitHub and invent one on GitLab.
   const stackMerge = stackMergeDisclosure(
     pr?.stack,
     pr?.stackMembers,
     prNoun,
-    providerKey === "github",
+    isNativeStack(pr?.stack),
   );
 
   // Approval display (GitLab + Bitbucket): a quiet count shown only when there's

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -163,6 +163,7 @@ import {
   type SuggestionApply,
   threadToMarkdown,
 } from "./ReviewThreads";
+import { StackSection, stackMergeDisclosure } from "./StackSection";
 import { SubmitReviewDialog } from "./SubmitReviewDialog";
 import { useGeneratePrDescription } from "./useGeneratePrDescription";
 import {
@@ -329,6 +330,7 @@ export function RemotePrView({
   const pendingPrSection = useUiStore((s) => s.pendingPrSection);
   const setPendingPrSection = useUiStore((s) => s.setPendingPrSection);
   const selectedPr = useUiStore((s) => s.selectedPr);
+  const selectPr = useUiStore((s) => s.selectPr);
   // The activity dock's "View" lands here via a pending hint; switch to the
   // review sub-tab once, then clear it. Guarded on this being the *selected* PR
   // so a still-mounted lagging view (deferredPr) can't swallow the hint first.
@@ -424,6 +426,31 @@ export function RemotePrView({
       !details.data?.isDraft &&
       details.data?.state === "OPEN" &&
       !busy,
+  );
+
+  // Palette twins of the Stack section's arrow keys: step one position up or down
+  // the stack. Clamped at both ends — a stack is a dependency chain, so wrapping
+  // from the top back to the bottom would misrepresent the order. Gated on this
+  // being the *selected* PR so a still-mounted lagging view can't answer first.
+  const isSelectedPr =
+    selectedPr?.kind === "remote" && selectedPr.id === String(number);
+  function goToStackNeighbor(delta: 1 | -1) {
+    const info = details.data?.stack;
+    if (!info) return;
+    const target = (details.data?.stackMembers ?? []).find(
+      (m) => m.position === info.position + delta,
+    );
+    if (target) selectPr({ kind: "remote", id: String(target.number) });
+  }
+  useHotkeyAction(
+    "pr-stack-next",
+    () => goToStackNeighbor(1),
+    isSelectedPr && !!details.data?.stack,
+  );
+  useHotkeyAction(
+    "pr-stack-previous",
+    () => goToStackNeighbor(-1),
+    isSelectedPr && !!details.data?.stack,
   );
 
   const [composeBody, setComposeBody] = useState("");
@@ -835,6 +862,18 @@ export function RemotePrView({
     mergeState.data?.pipelineStatus ?? "",
   );
   const autoMergeArmed = mergeState.data?.autoMergeEnabled ?? false;
+  // What a stacked merge lands beyond the PR on screen — null when this PR is
+  // unstacked or everything below it already merged, leaving today's copy right.
+  // Gated on `providerKey`, not raw `provider`: forge status can be pending or
+  // failed here (canMerge deliberately stays on for GitHub then), and an
+  // unresolved host resolves to GitHub — so the scope is disclosed rather than
+  // silently dropped on the one provider that really does cascade-merge.
+  const stackMerge = stackMergeDisclosure(
+    pr?.stack,
+    pr?.stackMembers,
+    prNoun,
+    providerKey === "github",
+  );
 
   // Approval display (GitLab + Bitbucket): a quiet count shown only when there's
   // something to report — someone approved, or a GitLab Premium project requires
@@ -1304,6 +1343,14 @@ export function RemotePrView({
             }}
           />
         )}
+        {/* Stack members, bottom-first — self-hiding for an unstacked PR, so an
+            unstacked header is unchanged. */}
+        <StackSection
+          stack={pr.stack}
+          members={pr.stackMembers}
+          currentNumber={number}
+          onSelect={(n) => selectPr({ kind: "remote", id: String(n) })}
+        />
         <ChecksRollup
           checks={pr.checks}
           repoPath={repoPath}
@@ -2257,6 +2304,8 @@ export function RemotePrView({
         pending={mergeAuto ? armAutoMerge.isPending : mergePr.isPending}
         onConfirm={confirmMerge}
         auto={mergeAuto}
+        stackNotice={stackMerge?.notice}
+        confirmLabel={stackMerge?.confirmLabel}
       />
 
       <EditTitleBodyDialog

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -434,25 +434,32 @@ export function RemotePrView({
   );
 
   // Palette twins of the Stack section's arrow keys: step one position up or down
-  // the stack. Clamped at both ends — a stack is a dependency chain, so wrapping
-  // from the top back to the bottom would misrepresent the order.
-  function goToStackNeighbor(delta: 1 | -1) {
+  // the stack. Each action is enabled only when a member actually sits at that
+  // position, so it DISABLES at the stack's ends (never wrapping — a stack is a
+  // dependency chain) and whenever the member list is missing, rather than
+  // offering a command that would silently do nothing.
+  function stackNeighbor(delta: 1 | -1) {
     const info = details.data?.stack;
-    if (!info) return;
-    const target = (details.data?.stackMembers ?? []).find(
+    if (!info) return undefined;
+    return (details.data?.stackMembers ?? []).find(
       (m) => m.position === info.position + delta,
     );
+  }
+  function goToStackNeighbor(delta: 1 | -1) {
+    // Re-resolved on activation: `enabled` is a render snapshot, while `run` reads
+    // live state through useEffectEvent.
+    const target = stackNeighbor(delta);
     if (target) selectPr({ kind: "remote", id: String(target.number) });
   }
   useHotkeyAction(
     "pr-stack-next",
     () => goToStackNeighbor(1),
-    isSelectedPr && !!details.data?.stack,
+    isSelectedPr && !!stackNeighbor(1),
   );
   useHotkeyAction(
     "pr-stack-previous",
     () => goToStackNeighbor(-1),
-    isSelectedPr && !!details.data?.stack,
+    isSelectedPr && !!stackNeighbor(-1),
   );
 
   const [composeBody, setComposeBody] = useState("");

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -332,8 +332,10 @@ export function MergePrDialog({
   /** Arms merge-when-pipeline-succeeds instead of merging now (GitLab-only) —
    *  reframes the copy + confirm button; the delete-branch checkbox rides the arm. */
   auto?: boolean;
-  /** Extra scope a stacked merge takes with it — a stacked merge is atomic and
-   *  bottom-up, so the PRs below this one merge too. Absent = unstacked. */
+  /** Extra scope this merge takes with it, shown above the options. Absent =
+   *  nothing extra to disclose: unstacked, a host whose stacked merges don't
+   *  cascade, or nothing still open below. Present is usually a cascading stack,
+   *  but can also be a hedge — that stack membership couldn't be confirmed. */
   stackNotice?: string;
   /** Overrides the confirm button's label so a stacked merge can name how many
    *  PRs it lands. Absent = the strategy label, unchanged. */

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -307,6 +307,8 @@ export function MergePrDialog({
   pending,
   onConfirm,
   auto = false,
+  stackNotice,
+  confirmLabel,
 }: {
   open: boolean;
   onClose: () => void;
@@ -330,6 +332,12 @@ export function MergePrDialog({
   /** Arms merge-when-pipeline-succeeds instead of merging now (GitLab-only) —
    *  reframes the copy + confirm button; the delete-branch checkbox rides the arm. */
   auto?: boolean;
+  /** Extra scope a stacked merge takes with it — a stacked merge is atomic and
+   *  bottom-up, so the PRs below this one merge too. Absent = unstacked. */
+  stackNotice?: string;
+  /** Overrides the confirm button's label so a stacked merge can name how many
+   *  PRs it lands. Absent = the strategy label, unchanged. */
+  confirmLabel?: string;
 }) {
   return (
     <Dialog
@@ -362,6 +370,9 @@ export function MergePrDialog({
             )}
           </DialogDescription>
         </DialogHeader>
+        {/* A stacked merge lands more than the PR on screen — say so above the
+            options, never only on the confirm button. */}
+        {stackNotice && <p className="text-xs text-warning">{stackNotice}</p>}
         {/* Deleting the head after merge is offered only when it's actually
             possible: never for the default branch (hidden — the forge refuses),
             and disabled with a reason when a branch rule blocks its deletion. */}
@@ -399,7 +410,7 @@ export function MergePrDialog({
           </Button>
           <Button disabled={pending} onClick={onConfirm}>
             {pending && <Spinner data-icon="inline-start" />}
-            {auto ? "Enable auto-merge" : strategyLabel}
+            {auto ? "Enable auto-merge" : (confirmLabel ?? strategyLabel)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/pulls/StackSection.tsx
+++ b/src/features/pulls/StackSection.tsx
@@ -8,7 +8,8 @@ import { cn } from "@/lib/utils";
  *  provider's own word at a neutral tone rather than being read as "open" — the
  *  word always carries the meaning, so color is never the only signal. */
 function memberPresentation(state: string) {
-  switch (state.toLowerCase()) {
+  const key = state.trim().toLowerCase();
+  switch (key) {
     case "merged":
       return { Icon: CheckIcon, tone: "text-merged", word: "merged" };
     case "closed":
@@ -16,10 +17,12 @@ function memberPresentation(state: string) {
     case "open":
       return { Icon: CircleIcon, tone: "text-success", word: "open" };
     default:
+      // A member can arrive with no state at all; "unknown" keeps a word beside
+      // the icon, which is the only thing carrying the status.
       return {
         Icon: CircleIcon,
         tone: "text-muted-foreground",
-        word: state.toLowerCase(),
+        word: key || "unknown",
       };
   }
 }
@@ -62,42 +65,73 @@ function numberList(members: PrStackMember[]): string {
   return `${nums.slice(0, -1).join(", ")}, and ${nums.at(-1)}`;
 }
 
-/** The merge dialog's extra-scope sentence + confirm label for a stacked PR, or
- *  null when the merge lands this PR alone. `atomic` is the whole gate: only
- *  GitHub cascade-merges a stack bottom-up, while GitLab merges one MR and
- *  retargets the next — disclosing extra scope there would describe a merge that
- *  never happens. `prNoun` carries the provider wording. */
-export function stackMergeDisclosure(
-  stack: PrStackInfo | null | undefined,
-  members: PrStackMember[] | undefined,
-  prNoun: string,
-  atomic: boolean,
-): { notice: string; confirmLabel: string } | null {
-  if (!stack || !atomic) return null;
-  const position = `This ${prNoun} is position ${stack.position} of ${stack.size} in a stack.`;
+/** The merge dialog's extra-scope sentence, plus a confirm label when the scope is
+ *  known well enough to count. Null when the merge lands this PR alone. `atomic`
+ *  gates the known-stack arms: only GitHub cascade-merges a stack bottom-up, while
+ *  GitLab merges one MR and retargets the next, so disclosing extra scope there
+ *  would describe a merge that never happens. `prNoun` carries the provider
+ *  wording. */
+export function stackMergeDisclosure({
+  stack,
+  members,
+  stackUnknown,
+  prNoun,
+  atomic,
+  hostCascades,
+}: {
+  stack: PrStackInfo | null | undefined;
+  members: PrStackMember[] | undefined;
+  /** The stack probe failed, so a null `stack` means unknown, not unstacked. */
+  stackUnknown: boolean;
+  prNoun: string;
+  /** This KNOWN stack cascades — `isNativeStack`, read off the stack's own id. */
+  atomic: boolean;
+  /** The detected host is one where stacked merges CAN cascade. Only the unknown
+   *  arm may use this: with no stack object there is no id to sniff, so host
+   *  detection is the sole signal left — every other arm prefers the id, which
+   *  survives a pending or failed forge probe. Best signal available rather than
+   *  a guarantee (an unresolved provider routes GHES here too, and GHES has no
+   *  stacks API), which is why that arm only ever hedges. */
+  hostCascades: boolean;
+}): { notice: string; confirmLabel?: string } | null {
   const tail = "the stack merges bottom-up as one operation.";
-  // No members at all above the bottom means the member fetch failed, not that
-  // nothing is below — name the scope without a count rather than fall through
-  // to copy that promises a single-PR merge.
-  if ((members ?? []).length === 0) {
-    if (stack.position <= 1) return null;
+  if (stack) {
+    if (!atomic) return null;
+    const position = `This ${prNoun} is position ${stack.position} of ${stack.size} in a stack.`;
+    // Known stack, missing member list: the members hop failed, not "nothing is
+    // below" — name the scope without a count. (The arm below covers having no
+    // stack info at all, which is a weaker claim still.)
+    if ((members ?? []).length === 0) {
+      if (stack.position <= 1) return null;
+      return {
+        notice: `${position} Merging it also merges every still-open ${prNoun} below it — ${tail}`,
+        confirmLabel: "Merge stack",
+      };
+    }
+    const below = stackMergeBelow(stack, members);
+    if (below.length === 0) return null;
     return {
-      notice: `${position} Merging it also merges every still-open ${prNoun} below it — ${tail}`,
-      confirmLabel: "Merge stack",
+      notice: `${position} Merging it also merges ${numberList(below)} below it — ${tail}`,
+      confirmLabel: `Merge ${below.length + 1} ${prNoun}s`,
     };
   }
-  const below = stackMergeBelow(stack, members);
-  if (below.length === 0) return null;
+  // No stack info at all. An unknown is NOT a stack: most such failures land on
+  // ordinary unstacked PRs, so the copy hedges and the confirm label keeps its
+  // count-free default rather than promising a stack merge that likely isn't one.
+  if (!stackUnknown || !hostCascades) return null;
   return {
-    notice: `${position} Merging it also merges ${numberList(below)} below it — ${tail}`,
-    confirmLabel: `Merge ${below.length + 1} ${prNoun}s`,
+    notice:
+      "Couldn't confirm whether this pull request is part of a stack. " +
+      "If it is, merging it also merges every still-open pull request below it " +
+      "— check on GitHub before confirming if unsure.",
   };
 }
 
 /**
  * The detail view's Stack section: the members of the open PR's stack, listed
  * bottom-first (merge order) with the one being read marked. Renders nothing at
- * all for an unstacked PR — no header, no placeholder. The data rides the
+ * all for an UNSTACKED PR — no header, no placeholder; a stacked PR whose member
+ * list is missing still gets the header and a muted note. The data rides the
  * caller's PR-details query, so this has no loading state of its own.
  */
 export function StackSection({
@@ -113,8 +147,27 @@ export function StackSection({
   currentNumber: number;
   onSelect: (number: number) => void;
 }) {
-  const rows = stack ? byPosition(members ?? []) : [];
-  if (!stack || rows.length === 0) return null;
+  if (!stack) return null;
+  const rows = byPosition(members ?? []);
+
+  // Members ride a second fetch that can fail while the stack summary succeeds
+  // (the backend emits the summary with an empty member list then) — still say
+  // the PR is stacked, rather than hiding membership over a missing list.
+  if (rows.length === 0) {
+    return (
+      <div>
+        {/* Denominator source differs per arm and must stay that way: with no
+            rows to count, the summary's own `size` is all there is; the max
+            keeps a `position` past it from reading "3 of 2". */}
+        <p className="text-xs font-medium text-muted-foreground">
+          Stack · {stack.position} of {Math.max(stack.size, stack.position)}
+        </p>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          Couldn't load the stack's members.
+        </p>
+      </div>
+    );
+  }
 
   // `listKeyboardNav` calls no hooks, so it's safe to build after the early return.
   const onKeyDown = listKeyboardNav({
@@ -127,9 +180,10 @@ export function StackSection({
   return (
     <div>
       {/* The rows are the members we actually have, so they — not the summary's
-          `size`, fetched on a separate hop — set the denominator. */}
+          `size`, fetched on a separate hop — set the denominator; the max keeps
+          a server `position` past the last row from reading "3 of 2". */}
       <p className="text-xs font-medium text-muted-foreground">
-        Stack · {stack.position} of {rows.length}
+        Stack · {stack.position} of {Math.max(rows.length, stack.position)}
       </p>
       {/* Capped like the checks rollup so a deep stack can't push the tab row
           out of the header; arrow-nav scrolls the active row into view. */}

--- a/src/features/pulls/StackSection.tsx
+++ b/src/features/pulls/StackSection.tsx
@@ -24,6 +24,16 @@ function memberPresentation(state: string) {
   }
 }
 
+/** Whether this is a forge-NATIVE stack, which merges atomically bottom-up, as
+ *  opposed to an inferred chain whose members merge one at a time. The `id` shape
+ *  is the contract, and both minting sites are the whole universe: `github/pr.rs`
+ *  stringifies the numeric stack number, `forge/gitlab.rs` synthesizes
+ *  "mr-<bottom-iid>". Provenance the payload carries itself, so a pending or
+ *  failed forge-status probe can't skew it in either direction. */
+export function isNativeStack(stack: PrStackInfo | null | undefined): boolean {
+  return stack != null && !stack.id.startsWith("mr-");
+}
+
 /** Members sorted bottom-first, the order a stack merges in. */
 function byPosition(members: PrStackMember[]): PrStackMember[] {
   return members.toSorted((a, b) => a.position - b.position);
@@ -119,7 +129,7 @@ export function StackSection({
       {/* The rows are the members we actually have, so they — not the summary's
           `size`, fetched on a separate hop — set the denominator. */}
       <p className="text-xs font-medium text-muted-foreground">
-        Stack · {stack.position} of {rows.length || stack.size}
+        Stack · {stack.position} of {rows.length}
       </p>
       {/* Capped like the checks rollup so a deep stack can't push the tab row
           out of the header; arrow-nav scrolls the active row into view. */}

--- a/src/features/pulls/StackSection.tsx
+++ b/src/features/pulls/StackSection.tsx
@@ -1,0 +1,169 @@
+import { CheckIcon, CircleIcon, XIcon } from "@phosphor-icons/react";
+import { clipTitle } from "@/lib/clip-title";
+import type { PrStackInfo, PrStackMember } from "@/lib/git/types";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { cn } from "@/lib/utils";
+
+/** Icon + word + tone for a stack member's state. An unrecognized state keeps the
+ *  provider's own word at a neutral tone rather than being read as "open" — the
+ *  word always carries the meaning, so color is never the only signal. */
+function memberPresentation(state: string) {
+  switch (state.toLowerCase()) {
+    case "merged":
+      return { Icon: CheckIcon, tone: "text-merged", word: "merged" };
+    case "closed":
+      return { Icon: XIcon, tone: "text-destructive", word: "closed" };
+    case "open":
+      return { Icon: CircleIcon, tone: "text-success", word: "open" };
+    default:
+      return {
+        Icon: CircleIcon,
+        tone: "text-muted-foreground",
+        word: state.toLowerCase(),
+      };
+  }
+}
+
+/** Members sorted bottom-first, the order a stack merges in. */
+function byPosition(members: PrStackMember[]): PrStackMember[] {
+  return members.toSorted((a, b) => a.position - b.position);
+}
+
+/**
+ * The stack members an atomic merge of `stack`'s PR would take with it:
+ * everything still open below it, bottom-first.
+ */
+function stackMergeBelow(
+  stack: PrStackInfo,
+  members: PrStackMember[] | undefined,
+): PrStackMember[] {
+  return byPosition(
+    (members ?? []).filter(
+      (m) => m.position < stack.position && m.state.toLowerCase() === "open",
+    ),
+  );
+}
+
+/** "#4", "#4 and #5", "#4, #5, and #6" — the numbers a stacked merge sweeps in. */
+function numberList(members: PrStackMember[]): string {
+  const nums = members.map((m) => `#${m.number}`);
+  if (nums.length <= 1) return nums.join("");
+  if (nums.length === 2) return `${nums[0]} and ${nums[1]}`;
+  return `${nums.slice(0, -1).join(", ")}, and ${nums.at(-1)}`;
+}
+
+/** The merge dialog's extra-scope sentence + confirm label for a stacked PR, or
+ *  null when the merge lands this PR alone. `atomic` is the whole gate: only
+ *  GitHub cascade-merges a stack bottom-up, while GitLab merges one MR and
+ *  retargets the next — disclosing extra scope there would describe a merge that
+ *  never happens. `prNoun` carries the provider wording. */
+export function stackMergeDisclosure(
+  stack: PrStackInfo | null | undefined,
+  members: PrStackMember[] | undefined,
+  prNoun: string,
+  atomic: boolean,
+): { notice: string; confirmLabel: string } | null {
+  if (!stack || !atomic) return null;
+  const position = `This ${prNoun} is position ${stack.position} of ${stack.size} in a stack.`;
+  const tail = "the stack merges bottom-up as one operation.";
+  // No members at all above the bottom means the member fetch failed, not that
+  // nothing is below — name the scope without a count rather than fall through
+  // to copy that promises a single-PR merge.
+  if ((members ?? []).length === 0) {
+    if (stack.position <= 1) return null;
+    return {
+      notice: `${position} Merging it also merges every still-open ${prNoun} below it — ${tail}`,
+      confirmLabel: "Merge stack",
+    };
+  }
+  const below = stackMergeBelow(stack, members);
+  if (below.length === 0) return null;
+  return {
+    notice: `${position} Merging it also merges ${numberList(below)} below it — ${tail}`,
+    confirmLabel: `Merge ${below.length + 1} ${prNoun}s`,
+  };
+}
+
+/**
+ * The detail view's Stack section: the members of the open PR's stack, listed
+ * bottom-first (merge order) with the one being read marked. Renders nothing at
+ * all for an unstacked PR — no header, no placeholder. The data rides the
+ * caller's PR-details query, so this has no loading state of its own.
+ */
+export function StackSection({
+  stack,
+  members,
+  currentNumber,
+  onSelect,
+}: {
+  stack: PrStackInfo | null | undefined;
+  members: PrStackMember[] | undefined;
+  /** The PR the detail view is showing — its row is highlighted and carries
+   *  `aria-current`. It stays focusable so arrow-key nav can start from it. */
+  currentNumber: number;
+  onSelect: (number: number) => void;
+}) {
+  const rows = stack ? byPosition(members ?? []) : [];
+  if (!stack || rows.length === 0) return null;
+
+  // `listKeyboardNav` calls no hooks, so it's safe to build after the early return.
+  const onKeyDown = listKeyboardNav({
+    items: rows,
+    activeIndex: rows.findIndex((m) => m.number === currentNumber),
+    onActivate: (member) => onSelect(member.number),
+    rowKey: (member) => String(member.number),
+  });
+
+  return (
+    <div>
+      {/* The rows are the members we actually have, so they — not the summary's
+          `size`, fetched on a separate hop — set the denominator. */}
+      <p className="text-xs font-medium text-muted-foreground">
+        Stack · {stack.position} of {rows.length || stack.size}
+      </p>
+      {/* Capped like the checks rollup so a deep stack can't push the tab row
+          out of the header; arrow-nav scrolls the active row into view. */}
+      <div
+        className="mt-1.5 max-h-48 overflow-y-auto border"
+        onKeyDown={onKeyDown}
+      >
+        {rows.map((member) => {
+          const { Icon, tone, word } = memberPresentation(member.state);
+          const isCurrent = member.number === currentNumber;
+          return (
+            <button
+              key={member.number}
+              type="button"
+              data-row={String(member.number)}
+              aria-current={isCurrent ? "true" : undefined}
+              onClick={() => onSelect(member.number)}
+              className={cn(
+                "flex w-full items-center gap-2 border-b px-3 py-1.5 text-left text-xs last:border-b-0",
+                isCurrent
+                  ? "bg-accent text-accent-foreground"
+                  : "cursor-pointer hover:bg-muted/60",
+              )}
+            >
+              <span className="w-4 shrink-0 text-right text-muted-foreground tabular-nums">
+                {member.position}
+              </span>
+              <span className="shrink-0 font-mono text-muted-foreground">
+                #{member.number}
+              </span>
+              <span
+                className="min-w-0 flex-1 truncate"
+                onMouseEnter={clipTitle(member.title)}
+              >
+                {member.title}
+              </span>
+              <span className={cn("flex shrink-0 items-center gap-1", tone)}>
+                <Icon className="size-3 shrink-0" weight="fill" aria-hidden />
+                {word}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2225,12 +2225,14 @@ export const ghPrMinimizeComment = (
 export const ghPrUnminimizeComment = (repoPath: string, commentId: string) =>
   invoke<void>("gh_pr_unminimize_comment", { repoPath, commentId });
 
-/** Outcome of a successful forge merge. The PR merged; `cleanupWarning` is a
- *  human-readable caveat when the post-merge remote head-branch deletion failed
- *  (GitHub-only by construction — GitLab and Bitbucket fold branch deletion into
- *  the atomic server-side merge, so they never warn). A merge *failure* rejects
- *  the invoke instead. `null` means merged and cleaned up cleanly. */
+/** Outcome of an ACCEPTED forge merge (a failure rejects the invoke instead).
+ *  `queued` means the forge took the merge but hasn't completed it — the PR is
+ *  NOT merged yet. `cleanupWarning` carries the human-readable detail either
+ *  way: on the merged path that the post-merge remote head-branch deletion
+ *  failed (GitHub-only — GitLab and Bitbucket fold deletion into their atomic
+ *  merge); on the queued path, what was queued. `null` = nothing to add. */
 export interface PrMergeOutcome {
+  queued: boolean;
   cleanupWarning: string | null;
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3994,10 +3994,10 @@ export function useMergePr(repo: string, lens: RemoteLens) {
       );
       // The remote advanced but the local repo is now stale (ahead/behind, history,
       // tracking refs). Kick off a background `git fetch --prune` so they catch up —
-      // NOT awaited, so the "Merged #N" toast fires the moment the merge resolves, and
-      // silent: the merge already succeeded, so a failure toast would misreport it
-      // (header Fetch stays the manual fallback). The mutation's own invalidation
-      // refreshes the forge-side PR state.
+      // NOT awaited, so the merge toast fires the moment the call resolves, and
+      // silent: the forge already accepted the merge (landed or queued), so a fetch
+      // failure toast would misreport it (header Fetch stays the manual fallback).
+      // The mutation's own invalidation refreshes the forge-side PR state.
       void api
         .gitFetch(repo)
         .then(() =>

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1422,6 +1422,30 @@ export interface PrRef {
  *  arms ignore it, so the frontend gates the lens UI to GitHub forks. */
 export type RemoteLens = "origin" | "upstream";
 
+/** A PR's membership in a stack — a linear chain where each PR targets the one
+ *  below it. Absent/null means unstacked; merged members stay in the stack, so
+ *  `size` never shrinks. GitHub supplies it natively, GitLab's is inferred from
+ *  how a chain of MRs targets each other, and Bitbucket never has stacks. */
+export interface PrStackInfo {
+  /** Stack identity: GitHub stack number as a string; GitLab "mr-<iid>". */
+  id: string;
+  /** 1 = bottom of the stack (merges first). */
+  position: number;
+  size: number;
+}
+
+/** One member of a stack, for the detail view's Stack section. Merging a member
+ *  atomically merges every unmerged member below it, bottom-up. */
+export interface PrStackMember {
+  number: number;
+  title: string;
+  /** "open" | "merged" | "closed" */
+  state: string;
+  position: number;
+  headRefName: string;
+  baseRefName: string;
+}
+
 export interface PrInfo {
   number: number;
   url: string;
@@ -1440,6 +1464,8 @@ export interface PrInfo {
    *  Bitbucket has no batch pipeline endpoint. "" for GitHub/GitLab (their CI
    *  fetch keys on PR number / MR iid, not the SHA). */
   headSha: string;
+  /** Stack membership, driving the row's position badge. Null/absent = unstacked. */
+  stack?: PrStackInfo | null;
 }
 
 /** A PR's rolled-up CI signal for the list-row icon. "none" = no checks. */
@@ -1678,6 +1704,10 @@ export interface PrDetails {
   /** Whether the repository allows the rebase-merge method. GitHub only; `null` =
    *  unknown — do not gate on `null`. */
   rebaseMergeAllowed: boolean | null;
+  /** Stack membership. Null/absent = unstacked (the Stack section renders nothing). */
+  stack?: PrStackInfo | null;
+  /** Every member of `stack`, bottom-first; empty when the PR is unstacked. */
+  stackMembers: PrStackMember[];
 }
 
 /** A reviewer who has submitted a verdict, as supplied by the backend (GitLab

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1711,6 +1711,11 @@ export interface PrDetails {
   stack?: PrStackInfo | null;
   /** Every member of `stack`, bottom-first; empty when the PR is unstacked. */
   stackMembers: PrStackMember[];
+  /** True when the stack probe itself FAILED, so a null `stack` above means
+   *  "unknown", not "known unstacked" — the two are not interchangeable on a
+   *  merge path that can cascade. GitHub-only this wave (only GitHub cascades);
+   *  the GitLab and Bitbucket arms always report false. */
+  stackUnknown: boolean;
 }
 
 /** A reviewer who has submitted a verdict, as supplied by the backend (GitLab

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1423,9 +1423,11 @@ export interface PrRef {
 export type RemoteLens = "origin" | "upstream";
 
 /** A PR's membership in a stack — a linear chain where each PR targets the one
- *  below it. Absent/null means unstacked; merged members stay in the stack, so
- *  `size` never shrinks. GitHub supplies it natively, GitLab's is inferred from
- *  how a chain of MRs targets each other, and Bitbucket never has stacks. */
+ *  below it. Absent/null means unstacked. Provenance differs per forge and `id`
+ *  carries it: GitHub's is native (numeric id) and keeps merged members, so
+ *  `size` never shrinks; GitLab's is inferred over OPEN MRs ("mr-<iid>" id), so
+ *  a merged layer leaves the chain and both `position` and `size` shrink — and a
+ *  two-MR chain losing one stops being marked at all. Bitbucket has no stacks. */
 export interface PrStackInfo {
   /** Stack identity: GitHub stack number as a string; GitLab "mr-<iid>". */
   id: string;
@@ -1434,8 +1436,9 @@ export interface PrStackInfo {
   size: number;
 }
 
-/** One member of a stack, for the detail view's Stack section. Merging a member
- *  atomically merges every unmerged member below it, bottom-up. */
+/** One member of a stack, for the detail view's Stack section. On GitHub merging
+ *  a member atomically merges every still-open member below it, bottom-up; GitLab
+ *  merges that MR alone and retargets the next, so nothing cascades there. */
 export interface PrStackMember {
   number: number;
   title: string;

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -692,6 +692,18 @@ export const ACTIONS = [
     category: "Pull requests",
     defaultBinding: null,
   },
+  {
+    id: "pr-stack-next",
+    label: "Next pull request in stack",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
+  {
+    id: "pr-stack-previous",
+    label: "Previous pull request in stack",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
 ] as const satisfies readonly ActionDef[];
 
 export type ActionId = (typeof ACTIONS)[number]["id"];


### PR DESCRIPTION
Adds first-class support for stacked pull requests so a chain of dependent PRs reads and merges as one unit instead of a pile of unrelated rows. The PR list gains a position badge, the PR view gains a keyboard-navigable **Stack** section, and — because GitHub rejects both `gh pr merge` and the plain REST merge endpoint for a stack member — merging on GitHub now routes through its asynchronous merge API and lands the whole stack bottom-up.

### GitHub backend

- Adds the neutral wire types `PrStackInfo` (`id` / `position` / `size`) and `PrStackMember` in `src-tauri/src/github/pr.rs`, hangs `stack` off `PrInfo` (with `#[serde(default)]`, since `gh pr list --json` has no stack field) and `stack` + `stack_members` off `PrDetails`.
- `gh_pr_list` now joins stack membership in from `GET /repos/{slug}/stacks` via `gh_open_stack_memberships`, running under `tokio::join!` alongside the list call so it doesn't lengthen the list's critical path. Open state only, and best-effort by contract: any failure yields an empty map and the list renders exactly as before.
- `gh_pr_view` fetches this PR's membership and its members in parallel through `gh_pr_stack` / `gh_stack_members`; `stack_members_from` maps the endpoint's bottom→top `pull_requests` onto 1-based positions and reports a layer with `merged_at` as `"merged"` whatever its raw state says.
- `gh_pr_merge` probes `gh_pr_is_stacked` and, for a stack member, calls the new `gh_pr_merge_async`: `PUT …/merge-async`, then polls the tracking uuid every 2s to a 90s deadline. `classify_merge_async` treats `merged`/`enqueued` as done, `failed` as an error carrying the server's message, and anything unrecognized as still pending; a transient poll failure and a missing uuid get distinct, honest messages. The non-stacked path is untouched.
- New unit tests pin the camelCase wire shape (`stack_fields_serialize_camel_case`), the `PrInfo` default/round-trip, bottom→top member mapping with merged layers, and the live merge-async response shapes.

### GitLab

- `infer_mr_stacks` in `src-tauri/src/forge/gitlab.rs` reconstructs chains from the open MR list, since GitLab exposes no stack object: an MR whose target branch is exactly one other open MR's source branch is a link. Ambiguous shapes — a shared source branch, or an MR with two open children — leave the whole chain unmarked rather than guessing an order.
- `apply_mr_stacks` annotates `list_prs` rows for the open state *before* `limit` truncation, so narrowing the list can't distort the chains; `mr_stack_from_rows` derives the detail view's members from those same rows.
- `view_pr` fetches the open MR list alongside the `/changes` call under `tokio::join!` and fails open — an empty list simply leaves the MR unstacked.
- Four tests cover linear chains (order-independent, three deep), branching/shared-source ambiguity, the no-chain and self-targeting cases, and two independent chains.
- `src-tauri/src/forge/bitbucket.rs` fills `stack: None` and an empty `stack_members`; Bitbucket has no stack concept.

### UI

- New `src/features/pulls/StackSection.tsx` renders members bottom-first with `aria-current` on the PR being read, arrow-key navigation via `listKeyboardNav`, and an icon **plus word** per state so color is never the only signal. It self-hides for an unstacked PR and caps at `max-h-48` so a deep stack can't push the tab row out of the header. It also exports `stackMergeDisclosure`, which builds the merge dialog's extra-scope sentence and confirm label.
- `RemotePrView.tsx` mounts the section, wires the two new hotkey actions to clamped stack stepping (gated on this being the selected PR), and computes `stackMerge` gated on `providerKey === "github"` — only GitHub cascade-merges, so GitLab never shows scope it wouldn't take.
- `MergePrDialog` in `RemotePrViewParts.tsx` takes optional `stackNotice` (rendered above the options, not just on the button) and `confirmLabel`, so the dialog names which PRs will merge before you confirm.
- `PullRequestsPanel.tsx` adds the `2/3` position badge with `StackSimpleIcon`, placed ahead of the branch names so row truncation can't eat it, and carrying a self-contained `aria-label`.
- `src/lib/hotkeys/registry.ts` registers `pr-stack-next` and `pr-stack-previous` under **Pull requests** with no default binding; `src/lib/git/types.ts` mirrors `PrStackInfo` / `PrStackMember` and the new `PrInfo` / `PrDetails` fields.

### MCP and documentation

- `src-tauri/src/mcp_server/read_forge.rs` documents `stack` on `list_pull_requests` rows and `stack` + `stackMembers` on `get_pull_request`, including that position 1 is the bottom and merges first.
- Adds the README *Features* bullet, a **Pull requests & review** entry in `site/src/data/capabilities.ts`, a **Stacked pull requests** section in `src/features/help/content.ts` (shortcuts as `{{kbd:…}}` tokens), and the `changelog.d/added-stacked-prs.md` fragment.