### PR TITLE
fix(automations,settings,pulls): pause automations while AI is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **Privacy-first** — API keys live in the OS keychain (never in app files), local
   models keep code on your machine, AI-ignore patterns keep sensitive files out of
   context unless you opt into repo-aware review, and a single switch hides every
-  AI surface.
+  AI surface and pauses your automations.
 - **Keyboard-first** — rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (Ctrl+/), a command palette (Ctrl+K), and
   arrow-key navigation everywhere.

--- a/README.md
+++ b/README.md
@@ -576,7 +576,8 @@ enable it**, and each task can **confirm before it runs**.
 
 **Automations** — a lifecycle grid (on commit / on PR opened / on new commits to a
 reviewed PR) that runs AI review or security audit automatically, with per-action
-branch conditions, Save/Discard drafts, global defaults, and per-repo overrides.
+branch conditions, Save/Discard drafts, global defaults, and per-repo overrides
+(paused while **Hide AI** is on).
 
 **Integrations** — open in any editor or terminal (auto-detected, point at any
 executable, or set a full custom command with a `{path}` placeholder), and tunable
@@ -632,9 +633,9 @@ display can't strand it off-screen.
     multi-selection) creates and updates this file for you, adding anchored
     lines like `/src/config.ts` and `/vendor/` that mean exactly what you picked.
 - **Keys** live in the OS keychain (Windows Credential Manager, macOS Keychain,
-  libsecret). **Hide AI** (Settings → General) hides every AI surface and
-  pauses your automations while keeping your config — rules start firing again
-  when you turn AI features back on.
+  libsecret). **Hide AI** (Settings → General) hides the AI surfaces and pauses
+  your automations while keeping your config — rules start firing again when you
+  turn AI features back on.
 
 ## Updates
 

--- a/README.md
+++ b/README.md
@@ -632,8 +632,9 @@ display can't strand it off-screen.
     multi-selection) creates and updates this file for you, adding anchored
     lines like `/src/config.ts` and `/vendor/` that mean exactly what you picked.
 - **Keys** live in the OS keychain (Windows Credential Manager, macOS Keychain,
-  libsecret). **Hide AI** (Settings → General) hides every AI surface while
-  keeping your config.
+  libsecret). **Hide AI** (Settings → General) hides every AI surface and
+  pauses your automations while keeping your config — rules start firing again
+  when you turn AI features back on.
 
 ## Updates
 

--- a/changelog.d/fixed-hide-ai-pauses-automations.md
+++ b/changelog.d/fixed-hide-ai-pauses-automations.md
@@ -1,4 +1,5 @@
 - **Hide AI features** now also pauses your configured automations — while AI is
   hidden, nothing new runs or posts review comments, and Settings → General notes
   when automations you've turned on are paused. Your rules are kept and start
-  firing again the moment you show AI features.
+  firing again the moment you show AI features. The PR review panel also no longer
+  fetches your provider's model catalog until you open the model picker.

--- a/changelog.d/fixed-hide-ai-pauses-automations.md
+++ b/changelog.d/fixed-hide-ai-pauses-automations.md
@@ -1,0 +1,4 @@
+- **Hide AI features** now also pauses your configured automations — while AI is
+  hidden, nothing runs or posts review comments, and Settings → General notes when
+  automations you've turned on are paused. Your rules are kept and start firing
+  again the moment you show AI features.

--- a/changelog.d/fixed-hide-ai-pauses-automations.md
+++ b/changelog.d/fixed-hide-ai-pauses-automations.md
@@ -1,4 +1,4 @@
 - **Hide AI features** now also pauses your configured automations — while AI is
-  hidden, nothing runs or posts review comments, and Settings → General notes when
-  automations you've turned on are paused. Your rules are kept and start firing
-  again the moment you show AI features.
+  hidden, nothing new runs or posts review comments, and Settings → General notes
+  when automations you've turned on are paused. Your rules are kept and start
+  firing again the moment you show AI features.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1650,9 +1650,9 @@ notes**, and **repository descriptions**.
   file, its folder, or its file type — or a multi-selection) appends to
   \`.gitdesktop/aiignore\`, creating it if needed — an anchored line (\`/src/config.ts\`,
   \`/vendor/\`) for exactly the file or folder you picked.
-- **Hide AI** (Settings → General) removes every AI surface from the app and pauses your
-  automations — nothing runs or posts while it's on. Your configuration and rules are
-  kept, and automations start again when you turn AI features back on.
+- **Hide AI** (Settings → General) hides the AI surfaces and pauses your automations —
+  nothing new runs or posts while it's on. Your configuration and rules are kept, and
+  automations start again when you turn AI features back on.
 
 ## Automations
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1650,8 +1650,9 @@ notes**, and **repository descriptions**.
   file, its folder, or its file type — or a multi-selection) appends to
   \`.gitdesktop/aiignore\`, creating it if needed — an anchored line (\`/src/config.ts\`,
   \`/vendor/\`) for exactly the file or folder you picked.
-- **Hide AI** (Settings → General) removes every AI surface from the app while keeping
-  your configuration.
+- **Hide AI** (Settings → General) removes every AI surface from the app and pauses your
+  automations — nothing runs or posts while it's on. Your configuration and rules are
+  kept, and automations start again when you turn AI features back on.
 
 ## Automations
 
@@ -1797,7 +1798,8 @@ there's an equivalent.`,
 
 Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 
-- **General** — hide AI features, keep running in the **system tray** on close (so
+- **General** — hide AI features (which also pauses your automations until you show them
+  again — your rules are kept), keep running in the **system tray** on close (so
   background work continues; launching the app again while it's running —
   tray-hidden or not — focuses the existing window), **create pull requests as drafts**
   by default (off by default — pre-checks the Create-PR dialog's draft box, still

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -194,6 +194,10 @@ export function PrReviewPanel({
     enabled: Boolean(cliKind),
     staleTime: 60_000,
   });
+  // Viewing a PR expresses no model-config intent, so the provider catalog is
+  // fetched only once the user reaches the picker — sticky, so the list stays put
+  // for the rest of the panel's life.
+  const [modelsWanted, setModelsWanted] = useState(false);
   const available = useAvailableModels(
     reviewAi ?? {
       provider,
@@ -202,6 +206,8 @@ export function PrReviewPanel({
       openaiCompatibleBaseUrl: "",
     },
     Boolean(keyPreview.data),
+    undefined,
+    { enabled: modelsWanted },
   );
   const models = available.data?.models ?? [];
 
@@ -307,7 +313,14 @@ export function PrReviewPanel({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="space-y-2 border-b p-3">
-        <div className="grid grid-cols-2 gap-2">
+        {/* DOM capture, not Base UI event props. Pointer-down is load-bearing:
+            WebKit doesn't focus buttons on click, and the Select moves focus into
+            a portalled popup outside this container. */}
+        <div
+          className="grid grid-cols-2 gap-2"
+          onFocusCapture={() => setModelsWanted(true)}
+          onPointerDownCapture={() => setModelsWanted(true)}
+        >
           <Select
             value={provider}
             onValueChange={(v) => {
@@ -351,7 +364,13 @@ export function PrReviewPanel({
               }
             />
             <ComboboxContent>
-              <ComboboxEmpty>Uses the typed id as-is</ComboboxEmpty>
+              {/* `isFetching`, never `isPending` — a catalog that was never
+                  requested must not read as loading. */}
+              <ComboboxEmpty>
+                {available.isFetching
+                  ? "Loading models…"
+                  : "Uses the typed id as-is"}
+              </ComboboxEmpty>
               <ComboboxList>
                 {(item: string) => (
                   <ComboboxItem key={item} value={item}>

--- a/src/features/pulls/useWatchPrHeads.ts
+++ b/src/features/pulls/useWatchPrHeads.ts
@@ -12,6 +12,7 @@ import { useAiEnabled } from "@/lib/settings/queries";
  * remote PRs, `usePrNotifications` watches the GitHub head OID, which also covers
  * heads that aren't local — forks / pushed elsewhere.) `maybeFireSync` debounces
  * by head; the runner gates whether to actually re-review. Mount once per repo.
+ * Both the poll and the dispatch are paused while AI features are hidden.
  */
 export function useWatchPrHeads(repoPath: string) {
   // This poll exists only to feed automations, which pause with AI hidden — so it

--- a/src/features/pulls/useWatchPrHeads.ts
+++ b/src/features/pulls/useWatchPrHeads.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from "react";
 import { maybeFireSync } from "@/lib/automations/sync";
 import { gitBranchTips } from "@/lib/git/api";
 import { useLocalPrs } from "@/lib/pulls/queries";
+import { useAiEnabled } from "@/lib/settings/queries";
 
 /**
  * Watches each OPEN LOCAL PR's head branch for new commits and fires a `pr-sync`
@@ -13,6 +14,9 @@ import { useLocalPrs } from "@/lib/pulls/queries";
  * by head; the runner gates whether to actually re-review. Mount once per repo.
  */
 export function useWatchPrHeads(repoPath: string) {
+  // This poll exists only to feed automations, which pause with AI hidden — so it
+  // stops entirely, and cached tips can't dispatch after the flip.
+  const aiEnabled = useAiEnabled();
   const prs = useLocalPrs(repoPath);
   const openPrs = useMemo(
     () => (prs.data ?? []).filter((p) => p.status === "open"),
@@ -26,12 +30,13 @@ export function useWatchPrHeads(repoPath: string) {
   const tips = useQuery({
     queryKey: ["branch-tips", repoPath, headBranches],
     queryFn: () => gitBranchTips(repoPath, headBranches),
-    enabled: Boolean(repoPath) && headBranches.length > 0,
+    enabled: Boolean(repoPath) && headBranches.length > 0 && aiEnabled,
     refetchInterval: 10_000,
     refetchIntervalInBackground: false,
   });
 
   useEffect(() => {
+    if (!aiEnabled) return;
     const data = tips.data;
     if (!data) return;
     for (const pr of openPrs) {
@@ -49,5 +54,5 @@ export function useWatchPrHeads(repoPath: string) {
         commitSubjects: [],
       });
     }
-  }, [tips.data, openPrs, repoPath]);
+  }, [tips.data, openPrs, repoPath, aiEnabled]);
 }

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -68,7 +68,7 @@ import { providerLabel } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink } from "@/lib/jira/queries";
 import type { RecentRepo } from "@/lib/settings/api";
-import { useSettings } from "@/lib/settings/queries";
+import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { RemoteUrlDialog } from "./RemoteUrlDialog";
@@ -95,6 +95,9 @@ const RepoSettingsDialog = lazy(() =>
 export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const gh = useForgeStatus(repoPath);
   const settings = useSettings();
+  // Automations are paused while AI features are hidden, so every way into the
+  // per-repo grid goes with them — an editable rule that can't run misleads.
+  const aiEnabled = useAiEnabled();
   const repoName = useUiStore((s) => s.repoName);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
   const fork = useForkRepo(repoPath);
@@ -207,7 +210,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   );
   useHotkeyAction("repository-statistics", () => setRepoTab("insights"));
   useHotkeyAction("manage-files", () => setFilesOpen(true));
-  useHotkeyAction("automations", () => setAutomationsOpen(true));
+  useHotkeyAction("automations", () => setAutomationsOpen(true), aiEnabled);
   useHotkeyAction("link-jira-project", () => setJiraOpen(true));
   useHotkeyAction(
     "repository-settings",
@@ -351,10 +354,12 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
           <FilesIcon />
           Manage files…
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setAutomationsOpen(true)}>
-          <LightningIcon />
-          Automations…
-        </DropdownMenuItem>
+        {aiEnabled && (
+          <DropdownMenuItem onClick={() => setAutomationsOpen(true)}>
+            <LightningIcon />
+            Automations…
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onClick={() => setJiraOpen(true)}>
           <KanbanIcon />
           {jiraLink.data ? "Change Jira project…" : "Link Jira project…"}

--- a/src/features/repository/usePrNotifications.ts
+++ b/src/features/repository/usePrNotifications.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/git/queries";
 import type { PrPollInfo } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
-import { useSettings } from "@/lib/settings/queries";
+import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import {
   type NotificationTone,
   pushNotification,
@@ -30,6 +30,9 @@ export function usePrNotifications(repoPath: string) {
   const settings = useSettings();
   const gh = useForgeStatus(repoPath);
   const automations = useAutomations();
+  // Hiding AI features pauses automations, so the automation arms below go inert —
+  // but the poll itself keeps running for the non-AI notifications it also drives.
+  const aiEnabled = useAiEnabled();
   const prefs = settings.data?.notifications;
   const anyNotif = Boolean(
     prefs && (prefs.prChecks !== "off" || prefs.prActivity || prefs.prReviews),
@@ -64,7 +67,7 @@ export function usePrNotifications(repoPath: string) {
   const enabled =
     repoPath !== "" &&
     forgeFeatureReady(gh.data, "pullRequests") &&
-    (anyNotif || hasPrSync || hasPrOpen);
+    (anyNotif || ((hasPrSync || hasPrOpen) && aiEnabled));
 
   const poll = useQuery({
     queryKey: ["repo", repoPath, "pr-poll"] as const,
@@ -96,7 +99,7 @@ export function usePrNotifications(repoPath: string) {
     // head branch isn't local (forks / pushed elsewhere). Gated on hasPrSync so
     // notification-only users get no fan-out. The poll payload has no body/commit
     // subjects — the PR diff is the source of truth.
-    if (hasPrSync) {
+    if (hasPrSync && aiEnabled) {
       for (const pr of snapshot.values()) {
         if (pr.state === "OPEN" && pr.headSha) {
           maybeFireSync({
@@ -118,7 +121,7 @@ export function usePrNotifications(repoPath: string) {
     // from the same open+headSha snapshot plus author/createdAt/isDraft.
     // `maybeCatchUpMissedOpen` owns the recency/ownership/draft/already-reviewed
     // gating and fires at most one per tick.
-    if (hasPrOpen) {
+    if (hasPrOpen && aiEnabled) {
       const candidates = [...snapshot.values()]
         .filter((pr) => pr.state === "OPEN" && pr.headSha)
         .map((pr) => ({

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -59,8 +59,8 @@ export const GeneralSection = withForm({
             >
               <WarningIcon className="size-4 shrink-0" />
               <span>
-                Automations you've turned on won't run while AI features are
-                hidden — they start again when you turn this off.
+                You have automations turned on — they won't run while AI
+                features are hidden.
               </span>
             </p>
           )}

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -48,7 +48,7 @@ export const GeneralSection = withForm({
           </form.AppField>
           <p className="text-xs text-muted-foreground">
             Hides the AI commit-message and pull-request helpers, the AI review
-            panel, and the AI and Automations settings sections, and pauses your
+            panel, and the AI-related settings sections, and pauses your
             automations. Your provider, API keys, and rules are kept —
             automations run again once you turn AI features back on.
           </p>
@@ -76,9 +76,9 @@ export const GeneralSection = withForm({
           </form.AppField>
           <p className="text-xs text-muted-foreground">
             Closing the window hides GitDesktop to the system tray instead of
-            quitting, so background work like AI reviews keeps running. Reopen
-            from the tray icon, or use its Quit menu to exit. Turn this off to
-            make closing quit the app.
+            quitting, so background work keeps running. Reopen from the tray
+            icon, or use its Quit menu to exit. Turn this off to make closing
+            quit the app.
           </p>
         </div>
         <div className="space-y-1.5">

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -1,8 +1,11 @@
+import { WarningIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PRIVACY_POLICY_URL, resetAnalyticsId } from "@/lib/analytics";
+import { useAutomations } from "@/lib/automations/queries";
+import { anyAutomationEnabled } from "@/lib/automations/types";
 import { withForm } from "@/lib/form";
 import { settingsFormOpts } from "./settings-form";
 
@@ -18,6 +21,13 @@ export const GeneralSection = withForm({
   ...settingsFormOpts,
   render: function GeneralSectionRender({ form }) {
     const autoFetchOn = useSelector(form.store, (s) => s.values.autoFetch);
+    // Keyed off the DRAFT value so the consequence shows before Save commits it, and
+    // stands as the standing explanation once hiding AI is saved on.
+    const hideAiOn = useSelector(form.store, (s) => s.values.hideAi);
+    const automations = useAutomations();
+    const automationsPaused =
+      hideAiOn &&
+      Boolean(automations.data && anyAutomationEnabled(automations.data));
     return (
       <section className="space-y-4">
         <div>
@@ -38,9 +48,22 @@ export const GeneralSection = withForm({
           </form.AppField>
           <p className="text-xs text-muted-foreground">
             Hides the AI commit-message and pull-request helpers, the AI review
-            panel, and the AI and Automations settings sections. Your configured
-            provider and API keys are kept — they're just not shown.
+            panel, and the AI and Automations settings sections, and pauses your
+            automations. Your provider, API keys, and rules are kept —
+            automations run again once you turn AI features back on.
           </p>
+          {automationsPaused && (
+            <p
+              role="status"
+              className="flex items-start gap-1.5 text-xs text-warning"
+            >
+              <WarningIcon className="size-4 shrink-0" />
+              <span>
+                Automations you've turned on won't run while AI features are
+                hidden — they start again when you turn this off.
+              </span>
+            </p>
+          )}
         </div>
         <div className="space-y-1.5">
           <form.AppField name="closeToTray">

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -113,12 +113,14 @@ async function fetchProviderModels(
 
 /**
  * Live model list for the current provider, falling back to the static
- * suggestions when there's no key or the request fails.
+ * suggestions when there's no key or the request fails. `opts.enabled` lets a
+ * caller defer the provider request until the user shows intent to pick a model.
  */
 export function useAvailableModels(
   settings: AiSettings,
   keySaved: boolean,
   allowedHosts?: readonly string[],
+  opts?: { enabled?: boolean },
 ) {
   return useQuery({
     queryKey: [
@@ -140,6 +142,7 @@ export function useAvailableModels(
       }
       return { models: fallbackModels(settings), live: false };
     },
+    enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -240,6 +240,10 @@ async function run(
   only?: ReviewMode,
   replacesKey?: string,
 ): Promise<RunOutcome> {
+  // Hiding AI features PAUSES automations: while `hideAi` is set no rule may fire,
+  // post, toast, or notify. Rules are kept and resume when AI is shown again.
+  const settings = await loadSettings();
+  if (settings.hideAi) return { matched: 0, attempted: 0 };
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   const actions = effectiveActions(config, repo, event.kind);
@@ -256,7 +260,6 @@ async function run(
   const head = event.kind === "commit" ? undefined : event.head;
   const base = event.kind === "commit" ? undefined : event.base;
 
-  const settings = await loadSettings();
   const notify = settings.notifications.automations;
   // The gate stores, read once and shared by an event's per-action gate checks: `fresh`
   // reloads from disk and queues behind any writer, and pr-reviews.json carries every
@@ -622,6 +625,12 @@ export function rerunAutomation(
   const noun = event.kind === "commit" ? "commit" : "pull request";
   void (async () => {
     try {
+      // The dismissal clear below mutates BEFORE run()'s own pause gate, so a paused
+      // re-run has to stop here — clearing nothing and running nothing.
+      if ((await loadSettings()).hideAi) {
+        toast.info("Automations are paused while AI features are hidden.");
+        return;
+      }
       // Best-effort ONLY here: a cleared-dismissal failure must not block the
       // re-run (it just means the pr-sync gate might skip; we then toast retryable).
       if (event.kind !== "commit") {

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -617,7 +617,8 @@ async function run(
  * cancelled run wrote one, and the pr-sync `sameSha(dismissedHead, headSha)` gate would
  * otherwise make the re-run a silent no-op. The run then flows through the normal pipeline
  * scoped to `only`. If the rule was disabled since, nothing matches and we toast rather
- * than leave a dead button.
+ * than leave a dead button. While AI features are hidden it stops before the clear —
+ * a paused re-run must not consume the watermark.
  */
 export function rerunAutomation(
   event: AutomationEvent,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -221,7 +221,7 @@ export function triggerAutomations(event: AutomationEvent): void {
 
 /** What a {@link run} pass did, so a re-run can tell outcomes apart:
  *  - `matched`: rules that exist AND apply (past the `only` + branch gates). 0 = the rule
- *    genuinely no longer applies.
+ *    no longer applies, or automations are paused (Hide AI).
  *  - `attempted`: runs actually started. `matched > 0 && attempted === 0` means a claim or
  *    an already-covered head blocked it — retryable. */
 interface RunOutcome {
@@ -230,18 +230,21 @@ interface RunOutcome {
 }
 
 /**
- * Runs the automation rules matching `event`. `only` scopes a re-run to a single mode.
- * `replacesKey` is the stopped row a re-run replaces — removed the instant its replacement
- * registers, so the stopped row survives whenever nothing registers. Returns a
- * {@link RunOutcome} so a re-run can tell "rule gone" from "blocked" from "started".
+ * Runs the automation rules matching `event`, unless AI features are hidden — that
+ * pauses automations, so it returns immediately with a zero outcome. `only` scopes a
+ * re-run to a single mode. `replacesKey` is the stopped row a re-run replaces — removed
+ * the instant its replacement registers, so the stopped row survives whenever nothing
+ * registers. Returns a {@link RunOutcome} so a re-run can tell "rule gone" from
+ * "blocked" from "started".
  */
 async function run(
   event: AutomationEvent,
   only?: ReviewMode,
   replacesKey?: string,
 ): Promise<RunOutcome> {
-  // Hiding AI features PAUSES automations: while `hideAi` is set no rule may fire,
-  // post, toast, or notify. Rules are kept and resume when AI is shown again.
+  // Hiding AI features PAUSES automations: no NEW run starts while `hideAi` is set
+  // (an in-flight run still completes and delivers — deliberate). Rules are kept and
+  // resume when AI is shown again.
   const settings = await loadSettings();
   if (settings.hideAi) return { matched: 0, attempted: 0 };
   const config = await loadAutomations();

--- a/src/lib/automations/types.ts
+++ b/src/lib/automations/types.ts
@@ -133,6 +133,29 @@ export function effectiveActions(
 }
 
 /**
+ * Whether the user has ANY automation turned on anywhere — the question behind the
+ * Settings → General note that hiding AI features pauses them. A repo override can
+ * enable a cell the global config leaves off, so overrides count on their own.
+ */
+export function anyAutomationEnabled(config: AutomationsConfigV2): boolean {
+  // Each `?? {}` fallback is annotated: an unannotated one widens `Object.values`
+  // to `any[]`, which would silently accept a misspelled `.enabled`.
+  const globalOn = Object.values(config.lifecycles).some((lifecycle) => {
+    const actions: LifecycleConfig["actions"] = lifecycle?.actions ?? {};
+    return Object.values(actions).some((a) => a?.enabled === true);
+  });
+  if (globalOn) return true;
+  return Object.values(config.repos).some((repo) => {
+    const lifecycles: RepoOverride["lifecycles"] = repo?.lifecycles ?? {};
+    return Object.values(lifecycles).some((overrides) => {
+      const cells: Partial<Record<ActionId, RepoActionOverride>> =
+        overrides ?? {};
+      return Object.values(cells).some((o) => o?.enabled === true);
+    });
+  });
+}
+
+/**
  * Whether an event's branch(es) satisfy an action's branch conditions. An action
  * runs iff `enabled` (checked by the caller) AND (`include` empty OR ≥1 include
  * glob matches) AND no `exclude` glob matches. Commit events test `event.branch`;

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -49,6 +49,9 @@ export function useBackgroundPrSync(): void {
     retry: false,
     queryFn: async () => {
       const settings = await loadSettings();
+      // Hiding AI features pauses automations, so a paused tick makes no forge call.
+      // Settings are read per tick, so flipping it takes effect on the next one.
+      if (settings.hideAi) return { polled: 0 };
       // No recents → nothing to watch; skip the config read and the loop.
       if (settings.recentRepos.length === 0) return { polled: 0 };
       const config = await loadAutomations();

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -176,8 +176,9 @@ export interface AppSettings {
    *  security audits alike). Absent — settings written before this shipped — reads as
    *  `"auto"`, the backend's tier defaults. */
   reviewTimeout?: ReviewTimeout;
-  /** Hide every AI surface (commit/PR helpers, review panel, AI settings) and pause
-   *  automations — no new automated run starts while set (an in-flight run finishes).
+  /** Hide every AI surface — commit/PR helpers, review panel, and the AI-related
+   *  settings sections (AI, Slash commands, MCP servers, Automations) — and pause
+   *  automations: no new automated run starts while set (an in-flight run finishes).
    *  Provider config, API keys, and rules are kept. */
   hideAi: boolean;
   /** OS notifications (sent only while the window is unfocused). */

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -176,13 +176,14 @@ export interface AppSettings {
    *  security audits alike). Absent — settings written before this shipped — reads as
    *  `"auto"`, the backend's tier defaults. */
   reviewTimeout?: ReviewTimeout;
-  /** Hide every AI surface (commit/PR helpers, review panel, AI settings).
-   *  Provider config and API keys are kept, just not shown. */
+  /** Hide every AI surface (commit/PR helpers, review panel, AI settings) and pause
+   *  automations — no new automated run starts while set (an in-flight run finishes).
+   *  Provider config, API keys, and rules are kept. */
   hideAi: boolean;
   /** OS notifications (sent only while the window is unfocused). */
   notifications: NotificationSettings;
-  /** Hide the app to the system tray on window close (so background work like
-   *  AI reviews keeps running) instead of quitting. */
+  /** Hide the app to the system tray on window close (so background work keeps
+   *  running) instead of quitting. */
   closeToTray: boolean;
   /** How write-capable agent sessions are isolated. "worktree" = the throwaway
    *  git worktree only (host, full-auto); "container" = also run inside an


### PR DESCRIPTION
**Hide AI features** hid every AI surface but left configured automations running in the background — rules kept firing, posting review comments, and polling forges even though the user had turned the whole AI side of the app off. This change makes *Hide AI* a real pause switch: nothing runs or posts while it's on, rules are kept, and everything resumes the moment AI features are shown again.

### Automation gating

- Adds the pause gate at the top of `run()` in `src/lib/automations/runner.ts` — a `loadSettings()` read moved ahead of the config load returns early on `hideAi`, so no rule fires, posts, toasts, or notifies.
- Guards `rerunAutomation()` in the same file separately: the dismissal-clearing step mutates state *before* `run()`'s gate, so a paused manual re-run stops early and toasts "Automations are paused while AI features are hidden."
- Short-circuits the background poll in `src/lib/automations/useBackgroundPrSync.ts` before any forge call; settings are read per tick, so flipping the toggle takes effect on the next one.
- Stops the head-branch poll in `src/features/pulls/useWatchPrHeads.ts` — `useAiEnabled()` now gates both the query's `enabled` and the dispatch effect, so cached tips can't fire a `pr-sync` after the flip.
- Narrows the automation arms of `src/features/repository/usePrNotifications.ts`: `hasPrSync` / `hasPrOpen` now require `aiEnabled` in the `enabled` predicate and at both `maybeFireSync` / `maybeCatchUpMissedOpen` call sites, while the poll itself keeps running for the non-AI notifications it also drives.

### Settings disclosure

- Adds a `role="status"` warning note to `src/features/settings/GeneralSection.tsx`, shown when hiding AI is on and any automation is enabled, and rewrites the section's description to say automations are paused and rules are kept.
- Keys the note off the *draft* `hideAi` form value so the consequence appears before Save commits it.
- Adds `anyAutomationEnabled()` to `src/lib/automations/types.ts` — checks global lifecycle actions and per-repo overrides independently, since an override can enable a cell the global config leaves off.

### PR review panel model fetch

- Defers the provider catalog request in `src/features/pulls/PrReviewPanel.tsx` behind a sticky `modelsWanted` flag set by `onFocusCapture` / `onPointerDownCapture` on the picker row, so merely viewing a PR no longer triggers a provider call.
- Threads an `opts.enabled` parameter through `useAvailableModels` in `src/lib/ai/models.ts` to support that deferral.
- Shows "Loading models…" in `ComboboxEmpty` based on `isFetching` (not `isPending`), so a never-requested catalog doesn't read as loading.

### Documentation

- Updates the **Hide AI** bullet in `README.md` and both the AI and Settings → General sections of `src/features/help/content.ts` to describe the pause behavior.
- Adds `changelog.d/fixed-hide-ai-pauses-automations.md`.