### PR TITLE
feat(blog,ci): publish future-dated posts via a daily rebuild

### DIFF
--- a/.github/workflows/site-rebuild.yml
+++ b/.github/workflows/site-rebuild.yml
@@ -21,6 +21,7 @@ permissions: {}
 jobs:
   rebuild:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Trigger Cloudflare Pages rebuild
         env:
@@ -33,5 +34,7 @@ jobs:
             echo "CLOUDFLARE_PAGES_DEPLOY_HOOK not set — skipping (site will refresh on the next site commit instead)."
             exit 0
           fi
-          curl -fsS -X POST "$HOOK" > /dev/null
+          curl -fsS --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-all-errors --retry-delay 10 \
+            -X POST "$HOOK" > /dev/null
           echo "Pages rebuild triggered for $TAG."

--- a/.github/workflows/site-scheduled-publish.yml
+++ b/.github/workflows/site-scheduled-publish.yml
@@ -1,19 +1,25 @@
 name: site-scheduled-publish
 
 # Publishes future-dated blog posts. getPosts() (site/src/lib/posts.ts) hides
-# posts whose pubDate is ahead of build time, and builds only happen on push
-# or deploy-hook fire — so this cron re-fires the production build just after
-# the UTC midnight that flips a pubDate from future to past. A no-op rebuild
-# on quiet days is the accepted cost (it also re-bakes release.ts facts).
+# posts whose pubDate is ahead of build time — outside DEV and Pages previews —
+# and builds only happen on push or deploy-hook fire, so this cron re-fires the
+# production build just after the UTC midnight that flips a pubDate from
+# future to past. A no-op rebuild on quiet days is the accepted cost (it also
+# re-bakes release.ts facts).
+#
+# GitHub disables schedules in public repos after 60 days without repository
+# activity — if scheduled posts ever stop appearing, check the workflow's
+# state in the Actions UI; workflow_dispatch is the manual recovery path.
 #
 # CLOUDFLARE_PAGES_DEPLOY_HOOK is the same Pages deploy-hook URL secret that
 # site-rebuild.yml uses. Treat it like a credential.
 
 on:
   schedule:
-    # Nominal 00:10 UTC; GitHub can delay scheduled runs by minutes or more,
-    # so pubDate precision is "that day", not "that minute".
-    - cron: "10 0 * * *"
+    # 00:37 UTC: off the top of the hour, which GitHub documents as its
+    # highest-load (most-delayed) cron window. Runs can still slip, so
+    # pubDate precision is "that day", not "that minute".
+    - cron: "37 0 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -31,9 +37,15 @@ jobs:
         run: |
           if [ -z "$HOOK" ]; then
             # Unlike site-rebuild.yml's soft skip, silence here would mean
-            # scheduled posts never publish — fail loudly.
+            # scheduled posts never publish — fail the run instead.
             echo "CLOUDFLARE_PAGES_DEPLOY_HOOK not set - scheduled posts cannot publish." >&2
             exit 1
           fi
-          curl -fsS -X POST "$HOOK" > /dev/null
+          # A green run means Cloudflare ACCEPTED the hook, not that the
+          # deploy succeeded — watching the deploy result would need a CF API
+          # credential in Actions, which this repo deliberately keeps out.
+          # Schema/render errors in a scheduled post are still caught earlier,
+          # by site.yml on its PR (the content loader validates every entry).
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 10 \
+            -X POST "$HOOK" > /dev/null
           echo "Pages rebuild triggered."

--- a/.github/workflows/site-scheduled-publish.yml
+++ b/.github/workflows/site-scheduled-publish.yml
@@ -1,0 +1,39 @@
+name: site-scheduled-publish
+
+# Publishes future-dated blog posts. getPosts() (site/src/lib/posts.ts) hides
+# posts whose pubDate is ahead of build time, and builds only happen on push
+# or deploy-hook fire — so this cron re-fires the production build just after
+# the UTC midnight that flips a pubDate from future to past. A no-op rebuild
+# on quiet days is the accepted cost (it also re-bakes release.ts facts).
+#
+# CLOUDFLARE_PAGES_DEPLOY_HOOK is the same Pages deploy-hook URL secret that
+# site-rebuild.yml uses. Treat it like a credential.
+
+on:
+  schedule:
+    # Nominal 00:10 UTC; GitHub can delay scheduled runs by minutes or more,
+    # so pubDate precision is "that day", not "that minute".
+    - cron: "10 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  rebuild:
+    # The cron would otherwise run — and red-fail on the missing secret —
+    # in forks that enable Actions.
+    if: github.repository == 'theBGuy/GitDesktop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Pages rebuild
+        env:
+          HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            # Unlike site-rebuild.yml's soft skip, silence here would mean
+            # scheduled posts never publish — fail loudly.
+            echo "CLOUDFLARE_PAGES_DEPLOY_HOOK not set - scheduled posts cannot publish." >&2
+            exit 1
+          fi
+          curl -fsS -X POST "$HOOK" > /dev/null
+          echo "Pages rebuild triggered."

--- a/.github/workflows/site-scheduled-publish.yml
+++ b/.github/workflows/site-scheduled-publish.yml
@@ -30,6 +30,7 @@ jobs:
     # in forks that enable Actions.
     if: github.repository == 'theBGuy/GitDesktop'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Trigger Cloudflare Pages rebuild
         env:
@@ -46,6 +47,7 @@ jobs:
           # credential in Actions, which this repo deliberately keeps out.
           # Schema/render errors in a scheduled post are still caught earlier,
           # by site.yml on its PR (the content loader validates every entry).
-          curl -fsS --retry 3 --retry-all-errors --retry-delay 10 \
+          curl -fsS --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-all-errors --retry-delay 10 \
             -X POST "$HOOK" > /dev/null
           echo "Pages rebuild triggered."

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -51,6 +51,18 @@ jobs:
       - name: Build the marketing site
         run: pnpm --filter site build
 
+      # A second build with unpublished posts (drafts + future-dated) visible,
+      # so a scheduled post's own route renders BEFORE its publication day —
+      # the cron publish is unattended, and this is the only pre-merge render
+      # of that page (getStaticPaths filters it from the plain build).
+      # Overwrites site/dist, which is safe while nothing after this uploads
+      # or deploys it; if an artifact step is ever added, run this variant
+      # first or give it its own --outDir.
+      - name: Build with unpublished posts
+        env:
+          PUBLIC_SHOW_DRAFTS: "true"
+        run: pnpm --filter site build
+
       # Check-only (biome ci never writes); `pnpm lint` locally is --write.
       # Verified green against git's LF blobs — a Windows checkout reports CRLF
       # format diffs on untouched files, but CI checks out LF.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,12 +83,14 @@ back-catalogue in the same change rather than grandfathering it.
   author's own writing, never from patterns shared by previously generated posts
   (two generated texts agreeing is one drafting process sampled twice, not
   evidence of a house style).
-- **Scheduling.** A future `pubDate` keeps a post out of production builds — it
-  behaves like a draft (visible in DEV and Pages previews) until the daily
-  `site-scheduled-publish` cron rebuilds the site shortly after 00:00 UTC.
-  Use a **bare date**: it means midnight UTC (still the prior evening in US
-  time zones), and because the cron builds once per day, a time component
-  never targets an hour — it only delays publication to the NEXT day's run.
+Blog mechanics (not copy) — **scheduling**: a future `pubDate` keeps a post
+out of production builds — it behaves like a draft (visible in DEV and Pages
+previews) until the daily `site-scheduled-publish` cron (00:37 UTC nominal;
+GitHub can delay runs, so precision is the day, not the hour) rebuilds the
+site. Use a **bare date** — midnight UTC, still the prior evening in US time
+zones. A time component doesn't schedule an hour: the post appears on the
+first daily build after its timestamp, so anything later than ~00:37 UTC
+waits for the next day.
 
 ## Everyday commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,10 @@ back-catalogue in the same change rather than grandfathering it.
   evidence of a house style).
 - **Scheduling.** A future `pubDate` keeps a post out of production builds — it
   behaves like a draft (visible in DEV and Pages previews) until the daily
-  `site-scheduled-publish` cron rebuilds the site after 00:00 UTC on its date.
-  A bare date means midnight UTC — 8pm ET the evening before; add a time
-  component (`2026-08-05T13:00:00Z`) to target a later hour.
+  `site-scheduled-publish` cron rebuilds the site shortly after 00:00 UTC.
+  Use a **bare date**: it means midnight UTC (still the prior evening in US
+  time zones), and because the cron builds once per day, a time component
+  never targets an hour — it only delays publication to the NEXT day's run.
 
 ## Everyday commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,14 +83,16 @@ back-catalogue in the same change rather than grandfathering it.
   author's own writing, never from patterns shared by previously generated posts
   (two generated texts agreeing is one drafting process sampled twice, not
   evidence of a house style).
+
 Blog mechanics (not copy) — **scheduling**: a future `pubDate` keeps a post
 out of production builds — it behaves like a draft (visible in DEV and Pages
 previews) until the daily `site-scheduled-publish` cron (00:37 UTC nominal;
 GitHub can delay runs, so precision is the day, not the hour) rebuilds the
 site. Use a **bare date** — midnight UTC, still the prior evening in US time
 zones. A time component doesn't schedule an hour: the post appears on the
-first daily build after its timestamp, so anything later than ~00:37 UTC
-waits for the next day.
+first production build after its timestamp — the daily cron, or any earlier
+push/release rebuild — so a timestamp past ~00:37 UTC waits for the next
+daily run unless an unrelated rebuild lands sooner.
 
 ## Everyday commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,11 @@ back-catalogue in the same change rather than grandfathering it.
   author's own writing, never from patterns shared by previously generated posts
   (two generated texts agreeing is one drafting process sampled twice, not
   evidence of a house style).
+- **Scheduling.** A future `pubDate` keeps a post out of production builds — it
+  behaves like a draft (visible in DEV and Pages previews) until the daily
+  `site-scheduled-publish` cron rebuilds the site after 00:00 UTC on its date.
+  A bare date means midnight UTC — 8pm ET the evening before; add a time
+  component (`2026-08-05T13:00:00Z`) to target a later hour.
 
 ## Everyday commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,10 @@ that call on purpose.
 Writing a **blog post**? Post copy follows the anti-AI-tell rules in
 [CLAUDE.md](CLAUDE.md#blog-post-copy--anti-ai-tell-rules-sitesrccontentblog) —
 phrasing, wrap band, and voice; spelling and personal voice follow the post's
-byline author.
+byline author. To schedule a post, give it a future `pubDate` (bare date =
+midnight UTC): it stays out of production builds — while remaining visible in
+dev and Pages previews — until the daily `site-scheduled-publish` cron
+rebuilds the site shortly after 00:00 UTC on its date.
 
 ### UI changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,10 +141,12 @@ that call on purpose.
 Writing a **blog post**? Post copy follows the anti-AI-tell rules in
 [CLAUDE.md](CLAUDE.md#blog-post-copy--anti-ai-tell-rules-sitesrccontentblog) —
 phrasing, wrap band, and voice; spelling and personal voice follow the post's
-byline author. To schedule a post, give it a future `pubDate` (bare date =
-midnight UTC): it stays out of production builds — while remaining visible in
-dev and Pages previews — until the daily `site-scheduled-publish` cron
-rebuilds the site shortly after 00:00 UTC on its date.
+byline author. To schedule a post, give it a future `pubDate` — prefer a bare
+date (midnight UTC): the post stays out of production builds, while remaining
+visible in dev and Pages previews, until the daily `site-scheduled-publish`
+cron (00:37 UTC nominal; precision is the day, not the hour) rebuilds the
+site. A time component doesn't pick an hour — the post appears on the first
+daily build after its timestamp.
 
 ### UI changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,8 @@ date (midnight UTC): the post stays out of production builds, while remaining
 visible in dev and Pages previews, until the daily `site-scheduled-publish`
 cron (00:37 UTC nominal; precision is the day, not the hour) rebuilds the
 site. A time component doesn't pick an hour — the post appears on the first
-daily build after its timestamp.
+production build after its timestamp, whether that's the daily cron or an
+earlier push/release rebuild.
 
 ### UI changes
 

--- a/site/src/lib/posts.ts
+++ b/site/src/lib/posts.ts
@@ -7,8 +7,15 @@ export type Post = CollectionEntry<"blog">;
 // and a draft would be invisible on the very branch deploy you want to read it
 // on. PUBLIC_SHOW_DRAFTS is set only in the Pages "Preview" environment.
 // Both branches are literal `import.meta.env` reads, so they DCE cleanly.
-const showDrafts =
+const showUnpublished =
   import.meta.env.DEV || import.meta.env.PUBLIC_SHOW_DRAFTS === "true";
+
+// One cutoff for the entire build so every surface agrees on which posts
+// exist. A future pubDate behaves exactly like `draft: true` until the
+// site-scheduled-publish cron re-fires the production build after the UTC
+// midnight that flips it — a date gate alone publishes nothing, because
+// builds only happen on push or deploy-hook fire.
+const buildTime = Date.now();
 
 /**
  * The ONLY way to read posts. Every route, the feed, the tag pages and
@@ -18,7 +25,8 @@ const showDrafts =
 export async function getPosts(): Promise<Post[]> {
   const posts = await getCollection(
     "blog",
-    ({ data }) => showDrafts || !data.draft,
+    ({ data }) =>
+      showUnpublished || (!data.draft && data.pubDate.valueOf() <= buildTime),
   );
   return posts.sort(
     (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),

--- a/site/src/lib/posts.ts
+++ b/site/src/lib/posts.ts
@@ -2,10 +2,11 @@ import { type CollectionEntry, getCollection } from "astro:content";
 
 export type Post = CollectionEntry<"blog">;
 
-// The textbook `import.meta.env.PROD` gate breaks draft PREVIEWS: Cloudflare
-// Pages preview deployments also run `astro build`, so PROD is true there too
-// and a draft would be invisible on the very branch deploy you want to read it
-// on. PUBLIC_SHOW_DRAFTS is set only in the Pages "Preview" environment.
+// The textbook `import.meta.env.PROD` gate breaks unpublished-post PREVIEWS:
+// Cloudflare Pages preview deployments also run `astro build`, so PROD is true
+// there too and an unpublished post (draft or future-dated) would be invisible
+// on the very branch deploy you want to proof it on. PUBLIC_SHOW_DRAFTS is set
+// only in the Pages "Preview" environment.
 // Both branches are literal `import.meta.env` reads, so they DCE cleanly.
 const showUnpublished =
   import.meta.env.DEV || import.meta.env.PUBLIC_SHOW_DRAFTS === "true";
@@ -19,8 +20,9 @@ const buildTime = Date.now();
 
 /**
  * The ONLY way to read posts. Every route, the feed, the tag pages and
- * prev/next must go through this — a draft leaking into /rss.xml because one
- * caller reached for `getCollection("blog")` directly is the classic blog bug.
+ * prev/next must go through this — an unpublished post (draft or future-dated)
+ * leaking into /rss.xml because one caller reached for `getCollection("blog")`
+ * directly is the classic blog bug.
  */
 export async function getPosts(): Promise<Post[]> {
   const posts = await getCollection(

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -28,8 +28,9 @@ const download = `${base}download/`;
 
 // Resolved from the collection rather than hardcoded, so renaming the post
 // fails the build here instead of silently 404ing the hero link in both views.
-// Asymmetry worth knowing: getPosts() hides drafts outside DEV/PUBLIC_SHOW_DRAFTS,
-// so marking this post `draft` would pass a Pages preview and fail production.
+// Asymmetry worth knowing: getPosts() hides drafts and future-dated posts
+// outside DEV/PUBLIC_SHOW_DRAFTS, so marking this post `draft` (or dating it
+// ahead) would pass a Pages preview and fail production.
 const founderEssay = (await getPosts()).find(
   (p) => p.id === "the-whole-loop-one-window",
 );


### PR DESCRIPTION
Lets a blog post be scheduled by giving it a future `pubDate` instead of hand-timing a merge. Posts dated ahead of build time now behave exactly like drafts in production, and a daily cron re-fires the Cloudflare Pages build just after the UTC midnight that flips a date from future to past — which is what actually makes the post appear, since builds otherwise only happen on push or deploy-hook fire.

### Site build

- `site/src/lib/posts.ts` now filters on the pubDate as well as `draft`: the collection predicate keeps a post only when `!data.draft && data.pubDate.valueOf() <= buildTime`, with `buildTime` captured once per build so every route, feed and tag page agrees on the same cutoff.
- Renames `showDrafts` to `showUnpublished` in the same file, since the DEV / `PUBLIC_SHOW_DRAFTS` escape hatch now covers future-dated posts too — they stay visible in DEV and Pages previews.
- Updates the hero-link comment in `site/src/pages/index.astro` to note the new asymmetry: dating the founder essay ahead (not just marking it `draft`) would pass a Pages preview and fail the production build.

### Scheduling workflow

- Adds `.github/workflows/site-scheduled-publish.yml`, a `37 0 * * *` cron (off GitHub's congested top-of-hour window) plus `workflow_dispatch`, POSTing to the existing `CLOUDFLARE_PAGES_DEPLOY_HOOK` secret with `permissions: {}` and transient-failure retries.
- Guards the job with `if: github.repository == 'theBGuy/GitDesktop'` so forks that enable Actions don't red-fail on the missing secret, and fails the run when the hook is unset — unlike `site-rebuild.yml`'s soft skip, silence here would mean scheduled posts never publish. A green run means Cloudflare accepted the hook (deploy-result observation would need a CF API credential in Actions, deliberately kept out); schema/render errors in a scheduled post are still caught by `site.yml` on its own PR.
- Workflow comments record that GitHub can delay scheduled runs (pubDate precision is "that day", not "that minute"), that public-repo schedules auto-disable after 60 idle days (`workflow_dispatch` is the recovery path), and that a no-op rebuild on quiet days is the accepted cost.

### Documentation

- Adds a **Scheduling** bullet to the blog section of `CLAUDE.md` and a matching note to `CONTRIBUTING.md`'s blog-post paragraph: use a bare date (midnight UTC — still the prior evening in US time zones); because the site builds once per day, a time component never targets an hour, it only delays publication to the next day's run.

Site-only change, so no changelog fragment — per the repo's docs rules, the site and guide updates are its record.