### PR TITLE
fix(diff): highlight staging diffs with Shiki grammars and workers

### DIFF
--- a/changelog.d/fixed-staging-diff-shiki-highlight.md
+++ b/changelog.d/fixed-staging-diff-shiki-highlight.md
@@ -1,0 +1,4 @@
+- Staged and unstaged diffs now get the same VSCode-fidelity syntax highlighting
+  as every other diff surface for TSX, JSX, Rust, Astro, Svelte, and other
+  TextMate-highlighted languages — including very large diffs, which now
+  highlight off the UI thread.

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -463,10 +463,11 @@ export function useFileContent(
  * and off-thread worker ASTs for an over-budget Shiki-routed diff. Shared by
  * both {@link createDiffFile} call sites so they apply the same routing rules.
  *
- * Contract: callers must list BOTH returned `grammarState` and `workerAsts` in
- * their {@link createDiffFile} memo's deps — createDiffFile reads the loaded
- * grammar via module state (isShikiLang), not a passed value, so only their
- * identity change forces the rebuild that picks it up.
+ * Contract: callers must list both returned `grammarState` and `workerAsts` in
+ * their {@link createDiffFile} memo's deps. `workerAsts` is passed into
+ * createDiffFile and is an ordinary dep; `grammarState` is read only via module
+ * state (isShikiLang), so listing it explicitly is what forces the rebuild that
+ * picks the loaded grammar up.
  */
 export function useShikiRouting({
   filePath,

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -462,6 +462,11 @@ export function useFileContent(
  * holding the paint until that settles, triggering the rebuild that picks it up,
  * and off-thread worker ASTs for an over-budget Shiki-routed diff. Shared by
  * both {@link createDiffFile} call sites so they apply the same routing rules.
+ *
+ * Contract: callers must list BOTH returned `grammarState` and `workerAsts` in
+ * their {@link createDiffFile} memo's deps — createDiffFile reads the loaded
+ * grammar via module state (isShikiLang), not a passed value, so only their
+ * identity change forces the rebuild that picks it up.
  */
 export function useShikiRouting({
   filePath,
@@ -697,9 +702,7 @@ function RenderedDiff({
     customLanguages,
   });
 
-  // grammarState + workerAsts are deliberate rebuild TRIGGERS: createDiffFile
-  // reads the loaded grammar via module state (isShikiLang), not a passed value,
-  // so only their identity change forces the rebuild that picks it up.
+  // grammarState + workerAsts: rebuild-trigger deps — see useShikiRouting's contract.
   // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -457,6 +457,127 @@ export function useFileContent(
   );
 }
 
+/**
+ * Shiki routing for one diff: lazily loading the built-in grammar it needs,
+ * holding the paint until that settles, triggering the rebuild that picks it up,
+ * and off-thread worker ASTs for an over-budget Shiki-routed diff. Shared by
+ * both {@link createDiffFile} call sites so the two surfaces route identically.
+ */
+export function useShikiRouting({
+  filePath,
+  text,
+  content,
+  contentPending,
+  blocked = false,
+  syntaxMap,
+  customLanguages,
+}: {
+  /** Deferred path of the file whose diff is being built. */
+  filePath: string;
+  /** The exact text that will be handed to createDiffFile (already capped/shortened). */
+  text: string;
+  /** Whole-file old/new content (content mode), or null. */
+  content: { old: string; new: string } | null;
+  /** Content-mode reads still settling — worker requests must wait on this. */
+  contentPending: boolean;
+  /** Surface is showing a placeholder, not a diff (mega-line block). */
+  blocked?: boolean;
+  syntaxMap?: Record<string, string>;
+  customLanguages?: CustomLanguage[];
+}): {
+  holdForGrammar: boolean;
+  grammarState: Record<string, "ready" | "failed">;
+  workerAsts: WorkerAsts | null;
+} {
+  const isDark = useIsDark();
+
+  // Built-in Shiki grammars load lazily (off the startup bundle). Hold the paint
+  // until the load settles rather than rebuild on arrival (highlight pop-in).
+  // Track "ready" OR "failed" so a failed import still releases the gate — a
+  // missing grammar must fall back to hljs/plain, never deadlock the pane.
+  const [grammarState, setGrammarState] = useState<
+    Record<string, "ready" | "failed">
+  >({});
+  const lang = useMemo(
+    () => diffLang(filePath, syntaxMap),
+    [filePath, syntaxMap],
+  );
+  useEffect(() => {
+    if (
+      !lang ||
+      // A blocked mega file shows a placeholder, not a diff — don't fetch a
+      // grammar it will never render.
+      blocked ||
+      !isBuiltinShikiLang(lang) ||
+      isShikiLang(lang) ||
+      grammarState[lang] !== undefined ||
+      // Over the Shiki budget (a builtin-Shiki lang is Shiki-routed, so that's
+      // the budget that applies) the main thread never tokenizes this file —
+      // the worker loads its own grammar copy. Loading here too would waste the
+      // fetch AND flip grammarState, rebuilding the interim hljs paint to plain.
+      overHighlightBudget(text.length, true)
+    )
+      return;
+    let cancelled = false;
+    ensureBuiltinShikiLang(lang).then((ok) => {
+      if (!cancelled)
+        setGrammarState((s) => ({ ...s, [lang]: ok ? "ready" : "failed" }));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [lang, grammarState, text.length, blocked]);
+
+  // A built-in Shiki grammar this diff needs is still loading (never seen a
+  // "ready"/"failed" result for it): hold the paint. `isShikiLang(lang)` already
+  // true means it loaded (this or an earlier diff), so it isn't pending.
+  const grammarPending =
+    !!lang &&
+    isBuiltinShikiLang(lang) &&
+    !isShikiLang(lang) &&
+    !grammarState[lang];
+
+  // Off-thread highlighting, Shiki-only: an over-budget Shiki-routed file would
+  // otherwise get the view clone's hljs pass — the engine those languages are
+  // routed OFF on purpose. An over-budget hljs file sends NO request (the clone
+  // already highlights it correctly, ≤15K lines). A builtin Shiki lang whose
+  // grammar the main thread hasn't loaded also routes here — the worker loads
+  // its own copy. A custom `tmGrammar` routes directly: its registration happens
+  // lazily inside createDiffFile with no rebuild trigger, and the grammar (unlike
+  // module state) is available on the first render.
+  const tmGrammar = useMemo(
+    () =>
+      lang
+        ? (customLanguages?.find((c) => c.id === lang)?.tmGrammar ?? null)
+        : null,
+    [lang, customLanguages],
+  );
+  const useShikiWorker =
+    !!lang &&
+    (isShikiLang(lang) || isBuiltinShikiLang(lang) || tmGrammar != null);
+  const overBudget = !!lang && overHighlightBudget(text.length, useShikiWorker);
+  const workerAsts = useWorkerHighlight({
+    // Shiki-routed + over budget only. Don't request while whole-file reads are
+    // still settling — the worker input would be built on interim text and
+    // superseded. (Over budget we never hold the paint on grammarPending, so it
+    // isn't gated on here.)
+    enabled: overBudget && useShikiWorker && !contentPending,
+    filePath,
+    text,
+    lang: lang ?? null,
+    isDark,
+    content,
+    tmGrammar,
+  });
+
+  // Over budget the main thread never Shiki-tokenizes, so holding the paint for
+  // a grammar only the worker needs would just delay the interim paint. Under
+  // budget, hold — so the lazy-grammar rebuild still lands in one paint.
+  const holdForGrammar = grammarPending && !overBudget;
+
+  return { holdForGrammar, grammarState, workerAsts };
+}
+
 /** The per-side line -> render() maps the vendored DiffView consumes. */
 type AnchorExtendData = Record<string, { data: { render: () => ReactNode } }>;
 
@@ -566,90 +687,15 @@ function RenderedDiff({
   const activeRepo = useUiStore((s) => s.repoPath);
   const { syntaxMap, customLanguages } = useEffectiveSyntax(activeRepo);
 
-  // Built-in Shiki grammars load lazily (off the startup bundle). Hold the paint
-  // until the load settles rather than rebuild on arrival (highlight pop-in).
-  // Track "ready" OR "failed" so a failed import still releases the gate — a
-  // missing grammar must fall back to hljs/plain, never deadlock the pane.
-  const [grammarState, setGrammarState] = useState<
-    Record<string, "ready" | "failed">
-  >({});
-  const lang = useMemo(
-    () => diffLang(deferredPath, syntaxMap),
-    [deferredPath, syntaxMap],
-  );
-  useEffect(() => {
-    if (
-      !lang ||
-      // A blocked mega file shows a placeholder, not a diff — don't fetch a
-      // grammar it will never render.
-      blocked ||
-      !isBuiltinShikiLang(lang) ||
-      isShikiLang(lang) ||
-      grammarState[lang] !== undefined ||
-      // Over the Shiki budget (a builtin-Shiki lang is Shiki-routed, so that's
-      // the budget that applies) the main thread never tokenizes this file —
-      // the worker loads its own grammar copy. Loading here too would waste the
-      // fetch AND flip grammarState, rebuilding the interim hljs paint to plain.
-      overHighlightBudget(shown.length, true)
-    )
-      return;
-    let cancelled = false;
-    ensureBuiltinShikiLang(lang).then((ok) => {
-      if (!cancelled)
-        setGrammarState((s) => ({ ...s, [lang]: ok ? "ready" : "failed" }));
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [lang, grammarState, shown.length, blocked]);
-
-  // A built-in Shiki grammar this diff needs is still loading (never seen a
-  // "ready"/"failed" result for it): hold the paint. `isShikiLang(lang)` already
-  // true means it loaded (this or an earlier diff), so it isn't pending.
-  const grammarPending =
-    !!lang &&
-    isBuiltinShikiLang(lang) &&
-    !isShikiLang(lang) &&
-    !grammarState[lang];
-
-  // Off-thread highlighting, Shiki-only: an over-budget Shiki-routed file would
-  // otherwise get the view clone's hljs pass — the engine those languages are
-  // routed OFF on purpose. An over-budget hljs file sends NO request (the clone
-  // already highlights it correctly, ≤15K lines). A builtin Shiki lang whose
-  // grammar the main thread hasn't loaded also routes here — the worker loads
-  // its own copy. A custom `tmGrammar` routes directly: its registration happens
-  // lazily inside createDiffFile with no rebuild trigger, and the grammar (unlike
-  // module state) is available on the first render.
-  const tmGrammar = useMemo(
-    () =>
-      lang
-        ? (customLanguages?.find((c) => c.id === lang)?.tmGrammar ?? null)
-        : null,
-    [lang, customLanguages],
-  );
-  const useShikiWorker =
-    !!lang &&
-    (isShikiLang(lang) || isBuiltinShikiLang(lang) || tmGrammar != null);
-  const overBudget =
-    !!lang && overHighlightBudget(shown.length, useShikiWorker);
-  const workerAsts = useWorkerHighlight({
-    // Shiki-routed + over budget only. Don't request while whole-file reads are
-    // still settling — the worker input would be built on interim text and
-    // superseded. (Over budget we never hold the paint on grammarPending, so it
-    // isn't gated on here.)
-    enabled: overBudget && useShikiWorker && !contentPending,
+  const { holdForGrammar, grammarState, workerAsts } = useShikiRouting({
     filePath: deferredPath,
     text: shown,
-    lang: lang ?? null,
-    isDark,
     content: content ?? null,
-    tmGrammar,
+    contentPending,
+    blocked,
+    syntaxMap,
+    customLanguages,
   });
-
-  // Over budget the main thread never Shiki-tokenizes, so holding the paint for
-  // a grammar only the worker needs would just delay the interim paint. Under
-  // budget, hold — so the lazy-grammar rebuild still lands in one paint.
-  const holdForGrammar = grammarPending && !overBudget;
 
   // grammarState + workerAsts are deliberate rebuild TRIGGERS: createDiffFile
   // reads the loaded grammar via module state (isShikiLang), not a passed value,

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -327,10 +327,10 @@ export function createDiffFile(
     const tmLang =
       lang && customLanguages?.find((c) => c.id === lang && c.tmGrammar);
     if (tmLang) ensureShikiGrammars([tmLang]);
-    // Built-in Shiki grammars load lazily (RenderedDiff kicks that off), so this
-    // synchronous build can only route to Shiki once the grammar is already
+    // Built-in Shiki grammars load lazily (useShikiRouting kicks that off), so
+    // this synchronous build can only route to Shiki once the grammar is already
     // loaded. Until then a built-in Shiki language falls back to highlight.js /
-    // plain; RenderedDiff rebuilds the diff when the grammar finishes loading.
+    // plain; useShikiRouting's grammarState triggers the rebuild that picks it up.
     const useShiki = lang ? isShikiLang(lang) : false;
     const data = {
       oldFile: {
@@ -461,7 +461,7 @@ export function useFileContent(
  * Shiki routing for one diff: lazily loading the built-in grammar it needs,
  * holding the paint until that settles, triggering the rebuild that picks it up,
  * and off-thread worker ASTs for an over-budget Shiki-routed diff. Shared by
- * both {@link createDiffFile} call sites so the two surfaces route identically.
+ * both {@link createDiffFile} call sites so they apply the same routing rules.
  */
 export function useShikiRouting({
   filePath,

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -128,9 +128,9 @@ export function DiffViewer({ repoPath }: { repoPath: string }) {
 /**
  * The working-tree variant of the diff pane: hunks render as cards with
  * whole-hunk stage/unstage/discard, plus drag-to-select for staging a subset of
- * lines. Untracked, binary, truncated, and generated/minified (one enormous
- * line) diffs fall back to the plain whole-file surface (which is what shows
- * the generated/minified placeholder).
+ * lines. Binary, truncated, and generated/minified (one enormous line) diffs
+ * fall back to the plain whole-file surface (which is what shows the
+ * generated/minified placeholder); untracked text files stage here like any other.
  */
 function WorkingTreeDiff({
   repoPath,

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -60,6 +60,7 @@ import {
   DiffSurface,
   HIGHLIGHT_MAX_LINES,
   useFileContent,
+  useShikiRouting,
 } from "./DiffSurface";
 import { ImagePanes } from "./ImageDiff";
 
@@ -609,8 +610,7 @@ function StagingDiffView({
   // Whole-file highlight context + expand. The staging view renders every hunk
   // regardless, so content mode may engage for big diffs too — bounded by the
   // file highlight budget, not the read-only surface's render cap. `pending`
-  // holds the paint so the diff is built once in its final layout. (No lazy
-  // built-in Shiki grammar gating on this path — known gap.)
+  // holds the paint so the diff is built once in its final layout.
   const { content, pending: contentPending } = useFileContent(
     repoPath,
     deferredPath,
@@ -621,20 +621,35 @@ function StagingDiffView({
     longestLine > DIFF_MAX_LINE_CHARS ? undefined : contentRevs,
     HIGHLIGHT_MAX_LINES,
   );
+  // `blocked` is omitted: a mega-line file never reaches this view —
+  // WorkingTreeDiff routes it to the whole-file DiffSurface fallback first.
+  const { holdForGrammar, grammarState, workerAsts } = useShikiRouting({
+    filePath: deferredPath,
+    text: displayText,
+    content: content ?? null,
+    contentPending,
+    syntaxMap,
+    customLanguages,
+  });
   // The whole-file diff (every hunk) — never capped, so all hunks stay stageable.
   // Built from the shortened DISPLAY text; the original text still backs every
   // stage/unstage/discard patch (see WorkingTreeDiff). Null while content reads
   // are pending: don't build an intermediate diff the arriving reads would
   // immediately restructure.
+  // grammarState + workerAsts are deliberate rebuild TRIGGERS: createDiffFile
+  // reads the loaded grammar via module state (isShikiLang), not a passed value,
+  // so only their identity change forces the rebuild that picks it up.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>
-      contentPending
+      contentPending || holdForGrammar
         ? null
         : createDiffFile(
             deferredPath,
             displayText,
             { syntaxMap, customLanguages },
             content ?? undefined,
+            workerAsts ?? undefined,
           ),
     [
       deferredPath,
@@ -643,6 +658,9 @@ function StagingDiffView({
       customLanguages,
       content,
       contentPending,
+      holdForGrammar,
+      grammarState,
+      workerAsts,
     ],
   );
 
@@ -729,12 +747,13 @@ function StagingDiffView({
     };
   }, [diffFile, hunks]);
 
-  // Whole-file reads still settling: render nothing rather than build a hunk-only
-  // diff we'd immediately restructure (the single-paint fix). Must precede the
-  // empty-state placeholder so loading never reads as "No changes to show". The
-  // effects above guard on `!diffFile`, so they no-op while pending and re-bind on
-  // the single build.
-  if (contentPending) return null;
+  // Whole-file reads still settling, or a lazy built-in Shiki grammar still
+  // loading: render nothing rather than build a diff we'd immediately restructure
+  // or re-highlight (the single-paint gate). Must precede the empty-state
+  // placeholder so loading never reads as "No changes to show". The effects above
+  // guard on `!diffFile`, so they no-op while pending and re-bind on the single
+  // build.
+  if (contentPending || holdForGrammar) return null;
   if (!diffFile) return <DiffPlaceholder message="No changes to show" />;
   // A line-1 hunk has no `@@` row to host its buttons — synthetic header instead.
   const firstNeedsHeader =

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -636,9 +636,7 @@ function StagingDiffView({
   // stage/unstage/discard patch (see WorkingTreeDiff). Null while content reads
   // are pending: don't build an intermediate diff the arriving reads would
   // immediately restructure.
-  // grammarState + workerAsts are deliberate rebuild TRIGGERS: createDiffFile
-  // reads the loaded grammar via module state (isShikiLang), not a passed value,
-  // so only their identity change forces the rebuild that picks it up.
+  // grammarState + workerAsts: rebuild-trigger deps — see useShikiRouting's contract.
   // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>

--- a/src/features/diff/HighlightedCode.tsx
+++ b/src/features/diff/HighlightedCode.tsx
@@ -6,9 +6,8 @@ import { diffLang } from "./diff-lang";
 /**
  * A read-only, syntax-highlighted view of a whole file's text. Highlights the
  * full content in one pass (so multi-line strings/comments keep their context,
- * unlike per-line highlighting) via highlight.js — the same engine the diff pane
- * falls back to for most languages, so a file here matches its diff. Falls back
- * to plain, still-readable text for languages highlight.js doesn't recognize.
+ * unlike per-line highlighting) via highlight.js. Falls back to plain,
+ * still-readable text for languages highlight.js doesn't recognize.
  */
 export function HighlightedCode({
   path,


### PR DESCRIPTION
The staging (working-tree) diff view never gated on lazily-loaded built-in Shiki grammars and never received worker-produced ASTs, so staged/unstaged diffs for TSX, JSX, Rust, Astro, Svelte and other TextMate-highlighted languages fell back to hljs or plain text while every other diff surface rendered them at full fidelity. This extracts the read-only surface's Shiki routing into a shared hook and wires the staging view through it, closing the known gap called out in the old comment.

### Shared routing hook

- Adds `useShikiRouting` in `src/features/diff/DiffSurface.tsx`, exported so both `createDiffFile` call sites route identically. It owns the lazy built-in grammar load (`ensureBuiltinShikiLang` with `"ready"`/`"failed"` tracking so a failed import still releases the gate), the `holdForGrammar` single-paint gate, the custom `tmGrammar` lookup, and the over-budget `useWorkerHighlight` request.
- Removes the same logic from `RenderedDiff`, which now consumes `holdForGrammar`, `grammarState`, and `workerAsts` from the hook — behavior-preserving, with `shown`/`deferredPath` passed in as `text`/`filePath` and `blocked` forwarded for the mega-line placeholder case.

### Staging view

- `StagingDiffView` in `src/features/diff/DiffViewer.tsx` now calls `useShikiRouting` and passes `workerAsts` into `createDiffFile`, so over-budget Shiki-routed staging diffs tokenize off the UI thread instead of falling back to the view clone's hljs pass.
- Extends the `diffFile` memo to hold on `holdForGrammar` and to take `grammarState`/`workerAsts` as deliberate rebuild triggers (with the `useExhaustiveDependencies` biome-ignore explaining that the grammar is read via module state), and extends the early `return null` gate to cover a pending grammar so the diff is built once in its final highlighted layout.
- `blocked` is intentionally omitted here — a mega-line file is routed to the whole-file `DiffSurface` fallback by `WorkingTreeDiff` before reaching this view; the reasoning is captured inline.
- Drops the now-stale "known gap" note from the `useFileContent` comment.

### Changelog

- Adds `changelog.d/fixed-staging-diff-shiki-highlight.md` describing the restored highlighting parity and off-thread highlighting for very large diffs.