### PR TITLE
feat(ai,git): unify AI-ignore on git's ignore engine and honor `!` lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,10 +640,11 @@ display can't strand it off-screen.
 - **AI ignore patterns** (keep files out of AI context; they still commit
   normally), in `.gitignore` syntax: `secrets.env` hides that file at any depth,
   `/secrets.env` only the copy at the repo root, `node_modules` or `vendor/` a
-  folder wherever it sits, and `docs/*.log` just that folder's logs. `!`
-  re-include lines aren't supported. A model that reads your repository itself
-  isn't limited by them — that's what the PR panel's **Agentic review** toggle
-  turns on.
+  folder wherever it sits, and `docs/*.log` just that folder's logs. A `!` line
+  puts back something a broader pattern hid, and your global patterns are
+  applied last, so a repo's committed file can never re-expose what you excluded
+  yourself. A model that reads your repository itself isn't limited by them —
+  that's what the PR panel's **Agentic review** toggle turns on.
   - **Global** — Settings → Excluded files (one pattern per line).
   - **Per-repo** — `.gitdesktop/aiignore` in the repo. A changed file's
     context menu → **Exclude from AI** (file, folder, or file type — or a

--- a/README.md
+++ b/README.md
@@ -641,8 +641,10 @@ display can't strand it off-screen.
   normally), in `.gitignore` syntax: `secrets.env` hides that file at any depth,
   `/secrets.env` only the copy at the repo root, `node_modules` or `vendor/` a
   folder wherever it sits, and `docs/*.log` just that folder's logs. A `!` line
-  puts back something a broader pattern hid, and your global patterns are
-  applied last, so a repo's committed file can never re-expose what you excluded
+  puts back something a broader pattern hid — to spare a file inside an excluded
+  folder, exclude the folder's *contents* (`vendor/*`, not `vendor/`), since git
+  never re-includes below an excluded directory. Your global patterns are applied
+  last, so a repo's committed file can never re-expose what you excluded
   yourself. A model that reads your repository itself isn't limited by them —
   that's what the PR panel's **Agentic review** toggle turns on.
   - **Global** — Settings → Excluded files (one pattern per line).

--- a/changelog.d/added-ai-unignore.md
+++ b/changelog.d/added-ai-unignore.md
@@ -1,3 +1,3 @@
 - AI ignore lists now honor `!` un-ignore lines with full gitignore semantics —
-  and your global patterns always outrank a repo's `.gitdesktop/aiignore`, so a
-  committed rule can never re-expose a file you excluded globally.
+  and a repo's committed `.gitdesktop/aiignore` can never re-expose a file your
+  global patterns exclude.

--- a/changelog.d/added-ai-unignore.md
+++ b/changelog.d/added-ai-unignore.md
@@ -1,0 +1,3 @@
+- AI ignore lists now honor `!` un-ignore lines with full gitignore semantics —
+  and your global patterns always outrank a repo's `.gitdesktop/aiignore`, so a
+  committed rule can never re-expose a file you excluded globally.

--- a/changelog.d/changed-ai-ignore-single-engine.md
+++ b/changelog.d/changed-ai-ignore-single-engine.md
@@ -1,0 +1,3 @@
+- AI ignore patterns now filter staged and branch diffs through Git's own ignore
+  engine, matching .gitignore semantics exactly — and a renamed file is hidden
+  entirely when either its old or new name matches.

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -17,6 +17,11 @@
 //! valid UTF-8 — fall back to a deliberately wider glob
 //! ([`widened_glob_for_name`]), which over-hides rather than leaks.
 //!
+//! `!` un-ignore lines are honored with git's own semantics, which makes list
+//! ORDER significant (last match wins) and carries git's documented limitation
+//! with it: a file cannot be re-included once one of its parent directories is
+//! excluded. Callers concatenate repo-then-global so the user's own list wins.
+//!
 //! This is a privacy boundary: a pattern that fails to match is a file that
 //! reaches a third-party model.
 
@@ -32,29 +37,28 @@ use crate::git::diff::{parse_numstat_z, parse_numstat_z_rows};
 use crate::git::runner::{run_git, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT};
 use crate::git::types::DiffStatEntry;
 
-/// The lines of an AI-ignore list the matcher acts on: trimmed, with blanks,
-/// `#` comments and `!` un-ignore lines dropped. Returns them with the number of
-/// `!` lines dropped.
+/// The lines of an AI-ignore list the matcher acts on — trimmed, with blanks and
+/// `#` comments dropped — plus whether any of them is a POSITIVE (non-`!`) line.
 ///
-/// `!` is dropped rather than honored because a diff is filtered by EXCLUSION —
-/// a pathspec has no un-exclude — so an un-ignore git's matcher honored would
-/// hide a file on the name pass and hand it to a model on the content pass. Of
-/// the two uniform behaviors, refusing an un-ignore withholds more.
-fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
+/// Order is preserved and load-bearing: gitignore is last-match-wins, so a `!`
+/// un-ignore only re-includes what an EARLIER line hid, and the caller's
+/// concatenation order decides precedence.
+///
+/// The flag exists because a list of nothing but `!` lines can never hide
+/// anything — a negation alone causes no ignoring — so callers short-circuit on
+/// it rather than spawning git to be told nothing matched.
+fn actionable_lines(patterns: &[String]) -> (Vec<&str>, bool) {
     let mut lines: Vec<&str> = Vec::new();
-    let mut skipped_negations = 0usize;
+    let mut has_positive = false;
     for raw in patterns {
         let line = crate::fsops::trim_ignore_pattern(raw);
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        if line.starts_with('!') {
-            skipped_negations += 1;
-            continue;
-        }
+        has_positive |= !line.starts_with('!');
         lines.push(line);
     }
-    (lines, skipped_negations)
+    (lines, has_positive)
 }
 
 /// The repo's effective `core.ignorecase`. Unset (or unreadable) means `false`,
@@ -123,14 +127,13 @@ async fn neutral_repo() -> AppResult<PathBuf> {
 /// exist in the working tree or the index — which is what lets callers ask about
 /// a remote PR's changed-file list, or about one conflicted path without
 /// depending on how the index happens to hold it. The pattern lines go into a
-/// temp excludes file, so semantics are gitignore's own — but only the lines
-/// [`actionable_lines`] keeps, so a `!` un-ignore is dropped here even though
-/// git would honor it natively (see that function).
+/// temp excludes file IN ORDER, so semantics are gitignore's own, `!` un-ignore
+/// lines and their last-match-wins precedence included.
 ///
 /// `paths` are repo-relative, forward-slashed. Empty `paths`, or an `exclude`
-/// with no actionable line in it, short-circuits to `[]` without spawning git;
-/// so does "nothing matched" (check-ignore's exit code 1, which is not an
-/// error).
+/// carrying no positive line (see [`actionable_lines`]), short-circuits to `[]`
+/// without spawning git; so does "nothing matched" (check-ignore's exit code 1,
+/// which is not an error).
 ///
 /// Matching runs in [`neutral_repo`] rather than the user's repo, so their AI
 /// patterns are the only rules in play — but `repo_path` still decides case
@@ -156,8 +159,8 @@ pub async fn filter_ignored(
     paths: &[String],
     exclude: &[String],
 ) -> AppResult<Vec<String>> {
-    let (lines, _) = actionable_lines(exclude);
-    if paths.is_empty() || lines.is_empty() {
+    let (lines, has_positive) = actionable_lines(exclude);
+    if paths.is_empty() || !has_positive {
         return Ok(Vec::new());
     }
     let icase = repo_ignorecase(repo_path).await;
@@ -264,10 +267,11 @@ pub struct FilteredDiff {
     pub excluded_files: u32,
 }
 
-/// Whether an AI-ignore list holds anything the matcher would act on — the flag
-/// a caller needs to keep its unfiltered command shape when it does not.
+/// Whether an AI-ignore list can hide anything — the flag a caller needs to keep
+/// its unfiltered command shape when it cannot. A list of nothing but `!` lines
+/// is inert (a negation causes no ignoring), so it takes the unfiltered path.
 pub fn has_actionable_lines(patterns: &[String]) -> bool {
-    !actionable_lines(patterns).0.is_empty()
+    actionable_lines(patterns).1
 }
 
 /// Whether a name is inexpressible as a `,literal` exclude term and needs
@@ -464,11 +468,19 @@ mod tests {
             "  *.log  ".to_string(),
             "/".to_string(),
         ];
-        let (lines, skipped) = actionable_lines(&patterns);
-        // A bare `/` survives this filter: git's own matcher decides what it
-        // means, exactly as it does for every other surviving line.
-        assert_eq!(lines, ["*.log", "/"]);
-        assert_eq!(skipped, 1);
+        let (lines, has_positive) = actionable_lines(&patterns);
+        // Negations are KEPT, in place: order is what gives them meaning. A bare
+        // `/` survives too — git's own matcher decides what it means, exactly as
+        // it does for every other surviving line.
+        assert_eq!(lines, ["!docs/notes.md", "*.log", "/"]);
+        assert!(has_positive);
+
+        // Nothing but negations (and droppables) can never hide anything.
+        let inert = ["!a".to_string(), "  ".to_string(), "# c".to_string()];
+        let (lines, has_positive) = actionable_lines(&inert);
+        assert_eq!(lines, ["!a"]);
+        assert!(!has_positive);
+        assert!(!has_actionable_lines(&inert));
     }
 
     /// The widened term keeps every glob metacharacter literal, collapses each
@@ -547,7 +559,7 @@ mod tests {
     /// The measured truth table (git 2.51.1): for each AI-ignore pattern LIST,
     /// exactly which of `FIXTURE` it hides. The diff commands and
     /// `git_filter_ai_ignored` must both agree with it.
-    const PARITY: [(&[&str], &[&str]); 27] = [
+    const PARITY: [(&[&str], &[&str]); 31] = [
         (
             &["notes.md"],
             &["a/b/notes.md", "docs/notes.md", "notes.md"],
@@ -584,19 +596,39 @@ mod tests {
         // A bracket is a character class in gitignore, so this PATTERN never
         // matches the literal name — however concrete the name looks.
         (&["weird[1].txt"], &[]),
-        // `!` un-ignore lines are unsupported and dropped before git sees them: a
-        // lone negation hides nothing, and a negation after a matching pattern
-        // re-includes nothing. Git's matcher would honor the second case, but a
-        // diff filtered by exclusion has no un-exclude to mirror it with.
+        // A LONE `!` line hides nothing: a negation only ever re-includes what an
+        // earlier line hid, so it can never cause ignoring by itself.
         (&["!docs/notes.md"], &[]),
+        // …but after a matching pattern it re-includes, with git's own
+        // last-match-wins precedence.
         (
             &["*.md", "!docs/notes.md"],
+            &["a/b/notes.md", "docs/日本語.md", "notes.md"],
+        ),
+        // Reversed, the negation is DEAD — the later positive line matches last.
+        (
+            &["!docs/notes.md", "*.md"],
             &[
                 "a/b/notes.md",
                 "docs/notes.md",
                 "docs/日本語.md",
                 "notes.md",
             ],
+        ),
+        // Git's documented limitation, pinned so it is never mistaken for a bug:
+        // a file cannot be re-included once a parent DIRECTORY is excluded, so
+        // this hides exactly what a bare `build/` hides.
+        (
+            &["build/", "!build/x.txt"],
+            &["build/x.txt", "docs/build/y.txt"],
+        ),
+        // The repo-then-global concatenation in miniature: whichever list is
+        // appended LAST decides, which is why callers put the user's global
+        // patterns after the repo's committed file.
+        (&["notes.md", "!notes.md"], &[]),
+        (
+            &["!notes.md", "notes.md"],
+            &["a/b/notes.md", "docs/notes.md", "notes.md"],
         ),
         // Blanks and comments are dropped everywhere too.
         (&["  ", "# a comment", "docs/*.log"], &["docs/a.log"]),
@@ -1073,41 +1105,81 @@ mod tests {
         );
     }
 
-    /// A `!` un-ignore line is unsupported: adding one changes NOTHING. Git's own
-    /// matcher would re-include the negated path, and a diff filtered by
-    /// exclusion has no un-exclude to mirror that with.
+    /// A `!` un-ignore line really re-includes the file, all the way through the
+    /// REAL command: the re-included path is back in the diff TEXT, not merely
+    /// back in the file list. Every AI surface reads the same engine, so the one
+    /// `git_filter_ai_ignored` assertion carries the conflict-gate and
+    /// remote-PR paths with it.
     #[tokio::test]
-    async fn negation_lines_change_nothing_on_either_engine() {
+    async fn a_negation_re_includes_the_file_end_to_end() {
         let (_dir, repo) = parity_repo().await;
         let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
-        let plain = vec!["*.md".to_string()];
-        let negated = vec!["*.md".to_string(), "!docs/notes.md".to_string()];
 
-        let (kept, skipped) = actionable_lines(&negated);
-        assert_eq!(skipped, 1);
-        assert_eq!(kept, actionable_lines(&plain).0);
+        let out = git_staged_diff(
+            repo.clone(),
+            None,
+            Some(vec!["*.md".to_string(), "!docs/notes.md".to_string()]),
+            None,
+        )
+        .await
+        .unwrap();
 
-        let (with_negation, _) = hidden_by_command(&repo, &["*.md", "!docs/notes.md"]).await;
-        let (without, _) = hidden_by_command(&repo, &["*.md"]).await;
-        assert_eq!(
-            with_negation, without,
-            "the `!` line did not re-include anything"
+        let listed: BTreeSet<&str> = out.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(
+            listed.contains("docs/notes.md"),
+            "the un-ignored file is back in the file list: {listed:?}"
         );
         assert!(
-            with_negation.contains("docs/notes.md"),
-            "the negated path stays hidden"
+            out.text.contains("+++ b/docs/notes.md"),
+            "…and back in the diff TEXT, which is what reaches the model"
         );
+        for still_hidden in ["notes.md", "a/b/notes.md", "docs/日本語.md"] {
+            assert!(
+                !listed.contains(still_hidden),
+                "{still_hidden} stays hidden"
+            );
+            assert!(
+                !out.text.contains(&format!("+++ b/{still_hidden}")),
+                "{still_hidden} stays out of the diff text"
+            );
+        }
+        assert_eq!(out.excluded_files, 3, "the three unnegated `*.md` files");
 
-        let with = git_filter_ai_ignored(repo.clone(), all.clone(), negated)
+        // The shared engine, so every other AI surface inherits the same verdict.
+        let by_gitignore = git_filter_ai_ignored(
+            repo,
+            all,
+            vec!["*.md".to_string(), "!docs/notes.md".to_string()],
+        )
+        .await
+        .unwrap();
+        assert!(!by_gitignore.contains(&"docs/notes.md".to_string()));
+        assert!(by_gitignore.contains(&"notes.md".to_string()));
+    }
+
+    /// A list of nothing but `!` lines is inert — it cannot hide anything — so it
+    /// takes the unfiltered fast path rather than spawning the two-pass flow.
+    #[tokio::test]
+    async fn only_negations_behaves_as_no_filter() {
+        let (_dir, repo) = parity_repo().await;
+
+        let unfiltered = git_staged_diff(repo.clone(), None, None, None)
             .await
             .unwrap();
-        let without = git_filter_ai_ignored(repo.clone(), all, plain)
-            .await
-            .unwrap();
-        assert_eq!(with, without);
+        let negations_only = git_staged_diff(
+            repo.clone(),
+            None,
+            Some(vec!["!notes.md".to_string(), "!docs/a.log".to_string()]),
+            None,
+        )
+        .await
+        .unwrap();
 
-        // An exclude list of nothing BUT droppable lines matches nothing at all,
-        // and never spawns git.
+        assert_eq!(negations_only.files.len(), unfiltered.files.len());
+        assert_eq!(negations_only.excluded_files, 0);
+        assert_eq!(negations_only.text, unfiltered.text);
+
+        // Same on the path-list engine: no positive line, nothing hidden.
         let only_droppable = git_filter_ai_ignored(
             repo,
             vec!["docs/notes.md".to_string()],

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -33,7 +33,7 @@ use tempfile::TempPath;
 use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
-use crate::git::diff::{parse_numstat_z, parse_numstat_z_rows};
+use crate::git::diff::{parse_numstat_z, parse_numstat_z_rows, DiffStatRow};
 use crate::git::runner::{run_git, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT};
 use crate::git::types::DiffStatEntry;
 
@@ -260,8 +260,10 @@ const MAX_ATTEMPTS: u32 = 3;
 /// Byte ceiling on the content pass's whole argv. The exclude list grows with
 /// the hidden-file count and Windows caps a command line at 32,767 UTF-16 units,
 /// so a large enough change fails the spawn outright (os error 206). Past this
-/// the diff is withheld whole: over-hiding costs the model context, spawning
-/// without the terms would hand it every ignored file.
+/// the call ERRORS: spawning without the terms would hand the model every
+/// ignored file, and returning an empty diff is indistinguishable from
+/// "everything was ignored" — advice the caller would repeat to the user while
+/// survivors sat unshown.
 const TERM_BUDGET: usize = 16_000;
 
 /// A `git diff` filtered by the user's AI-ignore list. `text` is untruncated —
@@ -276,7 +278,7 @@ pub struct FilteredDiff {
 /// Whether an AI-ignore list can hide anything — the flag a caller needs to keep
 /// its unfiltered command shape when it cannot. A list of nothing but `!` lines
 /// is inert (a negation causes no ignoring), so it takes the unfiltered path.
-pub fn has_actionable_lines(patterns: &[String]) -> bool {
+pub fn has_positive_pattern(patterns: &[String]) -> bool {
     actionable_lines(patterns).1
 }
 
@@ -334,17 +336,23 @@ fn widened_glob_for_name(path: &str) -> String {
 /// diff excluding the concrete names it hid. A rename is hidden whole when either
 /// side matches, and an unreadable name is hidden unconditionally.
 ///
-/// `repo_path` must be the repository ROOT: diff prints root-relative names
-/// while pathspecs resolve against the cwd, so a subdirectory would void every
-/// term. The positive pathspec alongside the excludes must likewise be exactly
-/// `.`: git's `common_prefix_len()` skips exclude items, then advances each
-/// negative pattern by the prefix it computed, so any directory component
-/// silently voids them (measured, git 2.51.1).
+/// Once there is anything to filter, every spawn runs at the working-tree
+/// TOPLEVEL, resolved here rather than trusted from `repo_path`: below the
+/// toplevel the exclude terms would match nothing and the positive `.` would
+/// truncate the diff, so a subdirectory binding has to be resolved before any
+/// pathspec is built. The positive pathspec must likewise be exactly `.`: git's
+/// `common_prefix_len()` skips exclude items, then advances each negative pattern
+/// by the prefix it computed, so any directory component silently voids them
+/// (measured, git 2.51.1).
 ///
 /// `recheck` re-reads the names after the content pass and retries on a mismatch,
 /// for callers whose diff reads mutable state (index, working tree) — a file
 /// appearing between the passes would otherwise enter the diff unchecked.
 /// Callers over immutable trees pin their refs instead and pass `false`.
+///
+/// Errors when the exclude terms would exceed [`TERM_BUDGET`]: an empty result
+/// there would read to every caller as "everything was ignored" while survivors
+/// went unshown, so the failure is explicit rather than silent.
 pub async fn filtered_diff(
     repo_path: &str,
     content_args: &[&str],
@@ -352,7 +360,12 @@ pub async fn filtered_diff(
     exclude: &[String],
     recheck: bool,
 ) -> AppResult<FilteredDiff> {
-    if !has_actionable_lines(exclude) {
+    // No toplevel resolution here: there are no exclude terms for a subdirectory
+    // cwd to void, and `git diff` is cwd-independent anyway (measured, git 2.51.1:
+    // `--cached --numstat` returns the same root-relative rows from a
+    // subdirectory). So these spawns stay byte-identical to the unfiltered
+    // command, and the common case pays nothing.
+    if !has_positive_pattern(exclude) {
         let (content, stat) = tokio::try_join!(
             run_git(Some(repo_path), content_args, DEFAULT_TIMEOUT),
             run_git(Some(repo_path), numstat_args, DEFAULT_TIMEOUT)
@@ -363,6 +376,13 @@ pub async fn filtered_diff(
             excluded_files: 0,
         });
     }
+
+    // Pin every spawn below to the working-tree toplevel. PATHSPEC elements
+    // resolve against the cwd, so below the toplevel the exclude terms match
+    // nothing and the positive `.` truncates the diff — shipping an excluded file
+    // while reporting it hidden.
+    let toplevel = crate::git::runner::worktree_toplevel(repo_path).await?;
+    let repo_path = toplevel.as_str();
 
     for _ in 0..MAX_ATTEMPTS {
         let stat = run_git(Some(repo_path), numstat_args, DEFAULT_TIMEOUT).await?;
@@ -380,7 +400,6 @@ pub async fn filtered_diff(
             .into_iter()
             .collect();
 
-        let total_rows = rows.len() as u32;
         let mut terms: Vec<String> = Vec::new();
         let mut files: Vec<DiffStatEntry> = Vec::new();
         let mut excluded_files = 0u32;
@@ -417,14 +436,13 @@ pub async fn filtered_diff(
         let mut args: Vec<&str> = content_args.to_vec();
         args.extend(["--", "."]);
         args.extend(terms.iter().map(String::as_str));
-        // Over budget the survivors go too: they can only be shipped by a spawn
-        // that would either fail outright or have to drop terms (see TERM_BUDGET).
+        // Over budget this cannot be answered safely OR honestly — see TERM_BUDGET.
         if args.iter().map(|a| a.len()).sum::<usize>() > TERM_BUDGET {
-            return Ok(FilteredDiff {
-                text: String::new(),
-                files: Vec::new(),
-                excluded_files: total_rows,
-            });
+            return Err(AppError::Command(
+                "too many AI-ignored changed files to filter this diff safely \
+                 — narrow the diff or the AI ignore patterns"
+                    .into(),
+            ));
         }
         let content = run_git(Some(repo_path), &args, DEFAULT_TIMEOUT).await?;
 
@@ -447,7 +465,7 @@ pub async fn filtered_diff(
 
 /// Every path a numstat pass named, both rename sides included, in a
 /// comparable order.
-fn sorted_names(rows: &[crate::git::diff::DiffStatRow]) -> Vec<String> {
+fn sorted_names(rows: &[DiffStatRow]) -> Vec<String> {
     let mut names: Vec<String> = rows
         .iter()
         .flat_map(|row| row.names.iter().cloned())
@@ -486,7 +504,7 @@ mod tests {
         let (lines, has_positive) = actionable_lines(&inert);
         assert_eq!(lines, ["!a"]);
         assert!(!has_positive);
-        assert!(!has_actionable_lines(&inert));
+        assert!(!has_positive_pattern(&inert));
 
         // An embedded newline would reach the excludes file as TWO lines — the
         // second an effective negation — while classifying by its first
@@ -496,14 +514,14 @@ mod tests {
         let (lines, has_positive) = actionable_lines(&smuggled);
         assert!(lines.is_empty(), "{lines:?}");
         assert!(!has_positive);
-        assert!(!has_actionable_lines(&smuggled));
+        assert!(!has_positive_pattern(&smuggled));
         // A bare CR is dropped on the same grounds.
         assert!(actionable_lines(&["a\rb".to_string()]).0.is_empty());
         // …but a TRAILING newline is just line noise: it trims away and the
         // pattern still counts.
         let trailing = ["*.env\n".to_string()];
         assert_eq!(actionable_lines(&trailing).0, ["*.env"]);
-        assert!(has_actionable_lines(&trailing));
+        assert!(has_positive_pattern(&trailing));
     }
 
     /// The widened term keeps every glob metacharacter literal, collapses each
@@ -1229,6 +1247,66 @@ mod tests {
         assert!(only_droppable.is_empty());
     }
 
+    /// What a `\` in a NAME needs from a pattern, per platform — the two lines
+    /// `aiExcludePatternLinesForPath` emits for such a path.
+    ///
+    /// The platforms disagree about what that byte IS while matching. Unix keeps
+    /// it an ordinary byte, so the ESCAPED pattern matches it exactly. Windows
+    /// normalizes the name's `\` to a separator before matching, so no backslash
+    /// spelling can reach it and only the `/`-separated twin does. Path STRINGS,
+    /// so no filesystem is involved and the fixture exists on both.
+    ///
+    /// The raw single-backslash pattern is asserted everywhere because it is the
+    /// bug this pins: gitignore reads it as an escape, so it hides a DIFFERENT
+    /// file and leaves the named one visible.
+    #[tokio::test]
+    async fn a_backslash_in_a_name_needs_the_platforms_own_spelling() {
+        let (_dir, repo) = parity_repo().await;
+        let paths = vec!["weird\\name.env".to_string(), "weirdname.env".to_string()];
+        let hits = |pattern: &str| {
+            let repo = repo.clone();
+            let paths = paths.clone();
+            let pattern = pattern.to_string();
+            async move {
+                git_filter_ai_ignored(repo, paths, vec![pattern])
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // The bug: `\n` is an escaped `n`, so this names `weirdname.env`.
+        let raw = hits("/weird\\name.env").await;
+        assert_eq!(
+            raw,
+            vec!["weirdname.env".to_string()],
+            "a raw backslash escapes the next character on every platform"
+        );
+
+        let escaped = hits("/weird\\\\name.env").await;
+        let separated = hits("/weird/name.env").await;
+        if cfg!(windows) {
+            assert_eq!(
+                separated,
+                vec!["weird\\name.env".to_string()],
+                "the name's `\\` normalizes to a separator here"
+            );
+            assert!(
+                !escaped.contains(&"weird\\name.env".to_string()),
+                "…so no backslash spelling reaches it: {escaped:?}"
+            );
+        } else {
+            assert_eq!(
+                escaped,
+                vec!["weird\\name.env".to_string()],
+                "the `\\` is an ordinary byte here, matched exactly by the escape"
+            );
+            assert!(
+                !separated.contains(&"weird\\name.env".to_string()),
+                "…and the `/` twin names a nested path instead: {separated:?}"
+            );
+        }
+    }
+
     /// A renamed file is hidden WHOLE when either side matches. Excluding only
     /// the new name leaves a `D <old name>` row, which names the very file the
     /// user withheld; excluding only the old name leaves the new content.
@@ -1399,6 +1477,90 @@ mod tests {
         );
     }
 
+    /// A `repo_path` BELOW the toplevel still filters correctly, because the
+    /// flow resolves the toplevel itself.
+    ///
+    /// Left at a subdirectory cwd, `--numstat` still prints root-relative names
+    /// — so the verdicts and `excluded_files` look right — while the exclude
+    /// terms resolve against that cwd and match nothing, and the positive `.`
+    /// scopes the diff to the subdirectory. The excluded file's content would
+    /// ship while reported hidden, and everything outside the subdirectory would
+    /// vanish. The MCP server takes `--repo` verbatim, so this cwd is reachable.
+    #[tokio::test]
+    async fn a_subdirectory_repo_path_still_filters_from_the_toplevel() {
+        let (_dir, repo) = seed_repo("subdir").await;
+        let root = Path::new(&repo);
+        std::fs::create_dir_all(root.join("services").join("api")).unwrap();
+        std::fs::write(
+            root.join("services").join("api").join(".env"),
+            "TOKEN=SECRET_MARKER\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("services").join("api").join("app.js"),
+            "// APP_MARKER\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("root.txt"), "ROOT_MARKER\n").unwrap();
+        run_git(Some(&repo), &["add", "-A", "-f"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        let subdir = root
+            .join("services")
+            .join("api")
+            .to_string_lossy()
+            .into_owned();
+        for (label, path) in [("subdirectory", &subdir), ("toplevel", &repo)] {
+            let out = git_staged_diff(path.clone(), None, Some(vec!["*.env".to_string()]), None)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                out.files
+                    .iter()
+                    .map(|f| f.path.as_str())
+                    .collect::<Vec<_>>(),
+                ["root.txt", "services/api/app.js"],
+                "{label}: file list"
+            );
+            assert_eq!(out.excluded_files, 1, "{label}: disclosure");
+            assert!(
+                !out.text.contains("SECRET_MARKER"),
+                "{label}: the excluded file's CONTENT must not ship"
+            );
+            assert!(
+                out.text.contains("ROOT_MARKER"),
+                "{label}: the diff must not be scoped to the subdirectory"
+            );
+            assert!(out.text.contains("APP_MARKER"), "{label}: survivor kept");
+        }
+
+        // …and with NO patterns at all: both paths cover the same tree. The
+        // unfiltered path takes no toplevel resolution at all, so this passes
+        // either way — `git diff` is cwd-independent. It is the uniformity
+        // insurance, guarding the SCOPE property (a future `--relative`, or a
+        // pathspec added to this path, would break it), not the resolution.
+        for (label, path) in [("subdirectory", &subdir), ("toplevel", &repo)] {
+            let out = git_staged_diff(path.clone(), None, None, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                out.files
+                    .iter()
+                    .map(|f| f.path.as_str())
+                    .collect::<Vec<_>>(),
+                ["root.txt", "services/api/.env", "services/api/app.js"],
+                "{label}: unfiltered scope"
+            );
+            assert_eq!(out.excluded_files, 0);
+            assert!(
+                out.text.contains("ROOT_MARKER"),
+                "{label}: the whole tree, not just the subdirectory"
+            );
+        }
+    }
+
     /// Every changed file hidden ⇒ no content pass runs at all. A `git diff`
     /// carrying no pathspec is the FULL diff, so this short-circuit is what stops
     /// an all-ignored change from coming back unfiltered.
@@ -1480,44 +1642,79 @@ mod tests {
         );
     }
 
-    /// Past `TERM_BUDGET` the diff is withheld WHOLE — survivors included —
-    /// because the only alternatives are a spawn that fails outright on Windows
-    /// or one with terms dropped, which ships the very files that matched.
+    /// Past `TERM_BUDGET` the call ERRORS rather than returning an empty diff:
+    /// empty is indistinguishable from "everything was ignored", which every
+    /// generation surface repeats to the user as advice — while survivors sit
+    /// unshown. The just-under case runs alongside it so the cliff cannot move
+    /// silently in either direction.
+    ///
+    /// Sizes are argv bytes: each term is `:(exclude,literal)` (19) plus a
+    /// ~73-char path, so ~94 each on top of ~100 bytes of fixed args.
     #[tokio::test]
-    async fn a_term_list_over_budget_withholds_the_whole_diff() {
+    async fn a_term_list_over_budget_errors_instead_of_leaking_or_lying() {
         let (_dir, repo) = seed_repo("budget").await;
         let blob = seed_blob(&repo).await;
-
-        // 400 long ignored names: ~94 bytes of term each, far past the budget.
         let pad = "a".repeat(60);
-        let mut inner = String::new();
-        for i in 0..400 {
-            inner.push_str(&format!("100644 blob {blob}\tf{i}_{pad}.env\n"));
-        }
-        let vendor = mktree_raw(&repo, inner.as_bytes());
-        let top = format!(
-            "040000 tree {vendor}\tvendor\n\
-             100644 blob {blob}\ta.txt\n\
-             100644 blob {blob}\tkeep.txt\n"
-        );
-        let (base, head) = commit_tree_pair(&repo, top.as_bytes()).await;
 
-        // Fixture precondition: the two survivors really are in the range.
+        // Builds a tree of `count` long ignored names under `vendor/`, plus two
+        // short survivors outside it.
+        let tree_of = |count: usize| {
+            let blob = blob.clone();
+            let pad = pad.clone();
+            let repo = repo.clone();
+            async move {
+                let mut inner = String::new();
+                for i in 0..count {
+                    inner.push_str(&format!("100644 blob {blob}\tf{i}_{pad}.env\n"));
+                }
+                let vendor = mktree_raw(&repo, inner.as_bytes());
+                let top = format!(
+                    "040000 tree {vendor}\tvendor\n\
+                     100644 blob {blob}\ta.txt\n\
+                     100644 blob {blob}\tkeep.txt\n"
+                );
+                commit_tree_pair(&repo, top.as_bytes()).await
+            }
+        };
+
+        // ~400 × 94 ≈ 37,600 bytes of terms — far past the 16,000 budget.
+        let (base, head) = tree_of(400).await;
         let all = git_branch_diff(repo.clone(), base.clone(), head.clone(), None, None)
             .await
             .unwrap();
-        assert_eq!(all.files.len(), 402);
-        assert_eq!(all.excluded_files, 0);
+        assert_eq!(all.files.len(), 402, "fixture precondition");
 
+        let err = git_branch_diff(
+            repo.clone(),
+            base,
+            head,
+            None,
+            Some(vec!["vendor/".to_string()]),
+        )
+        .await
+        .expect_err("over budget must not return a diff at all");
+        assert!(
+            err.to_string()
+                .contains("too many AI-ignored changed files"),
+            "{err}"
+        );
+
+        // ~150 × 94 ≈ 14,100 bytes — just under, so the content pass runs and
+        // the survivors come back filtered in the ordinary way.
+        let (base, head) = tree_of(150).await;
         let filtered = git_branch_diff(repo, base, head, None, Some(vec!["vendor/".to_string()]))
             .await
-            .unwrap();
-        assert!(filtered.text.is_empty(), "{}", filtered.text);
-        assert!(filtered.files.is_empty(), "{:?}", filtered.files);
+            .expect("under budget filters normally");
         assert_eq!(
-            filtered.excluded_files, 402,
-            "the disclosure counts survivors too — they are withheld as well"
+            filtered
+                .files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            ["a.txt", "keep.txt"]
         );
+        assert_eq!(filtered.excluded_files, 150);
+        assert!(!filtered.text.contains("vendor/"), "{}", filtered.text);
     }
 
     /// A multi-line rev expansion is a hard error on the pinned path, rather than

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -55,6 +55,12 @@ fn actionable_lines(patterns: &[String]) -> (Vec<&str>, bool) {
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
+        // An embedded newline would smuggle EXTRA pattern lines into the excludes
+        // file past this per-line classification — the smuggled tail could be a
+        // negation while the entry classifies by its first character as positive.
+        if line.contains('\n') || line.contains('\r') {
+            continue;
+        }
         has_positive |= !line.starts_with('!');
         lines.push(line);
     }
@@ -460,7 +466,7 @@ mod tests {
     use std::path::Path;
 
     #[test]
-    fn drops_blanks_comments_and_negations() {
+    fn keeps_negations_in_order_drops_blanks_and_comments() {
         let patterns = [
             "  ".to_string(),
             "# a comment".to_string(),
@@ -481,6 +487,23 @@ mod tests {
         assert_eq!(lines, ["!a"]);
         assert!(!has_positive);
         assert!(!has_actionable_lines(&inert));
+
+        // An embedded newline would reach the excludes file as TWO lines — the
+        // second an effective negation — while classifying by its first
+        // character as positive. `git_filter_ai_ignored` takes this list
+        // straight from the renderer, so the entry is dropped whole.
+        let smuggled = ["*.env\n!secrets.env".to_string()];
+        let (lines, has_positive) = actionable_lines(&smuggled);
+        assert!(lines.is_empty(), "{lines:?}");
+        assert!(!has_positive);
+        assert!(!has_actionable_lines(&smuggled));
+        // A bare CR is dropped on the same grounds.
+        assert!(actionable_lines(&["a\rb".to_string()]).0.is_empty());
+        // …but a TRAILING newline is just line noise: it trims away and the
+        // pattern still counts.
+        let trailing = ["*.env\n".to_string()];
+        assert_eq!(actionable_lines(&trailing).0, ["*.env"]);
+        assert!(has_actionable_lines(&trailing));
     }
 
     /// The widened term keeps every glob metacharacter literal, collapses each
@@ -513,7 +536,11 @@ mod tests {
     }
 
     /// Every fixture path in the parity repo, repo-relative and sorted.
-    const FIXTURE: [&str; 27] = [
+    const FIXTURE: [&str; 28] = [
+        // A name starting with the negation marker, so an escaped `\!` pattern
+        // has something real to hide. `!` is a legal filename character on every
+        // platform we ship.
+        "!important.txt",
         // A bracket expression's members (`a-d`/`abd`) plus `aXd`, which is not
         // one — so a class that quietly widened would be visible.
         "a-d",
@@ -530,8 +557,9 @@ mod tests {
         "a[b",
         "abd",
         "app.log",
-        // An escaped metacharacter beside the sibling a wildcard would also
-        // sweep, so an over-broad match has a witness.
+        // Negative controls: a `!` and a `^` mid-name, each beside an `X` twin.
+        // Nothing in PARITY may hide these — they are what an over-broad match
+        // (a stray wildcard, a mis-parsed class) would sweep up first.
         "bang!.txt",
         "bangX.txt",
         "build/x.txt",
@@ -559,7 +587,7 @@ mod tests {
     /// The measured truth table (git 2.51.1): for each AI-ignore pattern LIST,
     /// exactly which of `FIXTURE` it hides. The diff commands and
     /// `git_filter_ai_ignored` must both agree with it.
-    const PARITY: [(&[&str], &[&str]); 31] = [
+    const PARITY: [(&[&str], &[&str]); 34] = [
         (
             &["notes.md"],
             &["a/b/notes.md", "docs/notes.md", "notes.md"],
@@ -655,6 +683,10 @@ mod tests {
         // A bracket expression the USER wrote is git's own syntax, read as a range
         // here — so `a-d` is NOT a member, only `abd` is in this fixture.
         (&["a[b-c]d"], &["abd"]),
+        // A backslash escape INSIDE a class: `\-` makes the `-` a member rather
+        // than a range, so the class is {b,-,c} and `a-d` joins `abd`. `aXd` is
+        // the control that must stay visible either way.
+        (&["a[b\\-c]d"], &["a-d", "abd"]),
         // An escaped NON-ASCII character is simply that character to the matcher,
         // multi-byte encoding and all.
         (&["docs/\\日本語.md"], &["docs/日本語.md"]),
@@ -665,6 +697,13 @@ mod tests {
         // nothing at all — including the `a[b` that is a real fixture name.
         (&["a["], &[]),
         (&["a[b"], &[]),
+        // `\!` ESCAPES the marker: this is a POSITIVE pattern naming a file whose
+        // name starts with `!`, and the bare form is a negation that hides
+        // nothing. The pair pins the classification `has_positive` keys on — read
+        // it as a negation and a list of only this line takes the unfiltered fast
+        // path, shipping the whole diff.
+        (&["\\!important.txt"], &["!important.txt"]),
+        (&["!important.txt"], &[]),
     ];
 
     /// A `.gitignore` line the fixture repo carries but the AI-ignore lists never

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -1,21 +1,26 @@
 //! The one AI-ignore matcher.
 //!
 //! The app documents its AI-ignore lists (`.gitdesktop/aiignore` + the global
-//! settings list) as "gitignore-style", so matching has to BE gitignore. This
-//! module owns the two ways we evaluate those patterns, and a test pins them to
-//! the same truth table so they cannot drift:
+//! settings list) as "gitignore-style", so matching has to BE gitignore: every
+//! verdict comes from git's own engine via [`filter_ignored`]
+//! (`check-ignore --no-index --stdin`) in a neutral repo, which matches
+//! arbitrary path STRINGS and so needs nothing to exist in the index or the
+//! working tree.
 //!
-//! * [`pathspecs_for`] — pure translation to `:(exclude,glob)` pathspec terms,
-//!   for the call sites that filter a whole git command's output
-//!   (`git_staged_diff`, `git_branch_diff`).
-//! * [`filter_ignored`] / [`git_filter_ai_ignored`] — git's real gitignore
-//!   engine (`check-ignore --no-index --stdin`), for deciding a list of paths
-//!   that need not exist in the working tree or index (a remote PR's changed
-//!   files, or one conflicted path).
+//! Filtering a whole diff therefore runs in two passes ([`filtered_diff`]): name
+//! the changed files with `--numstat -z`, ask this engine which of those names
+//! are ignored, then re-run the content diff with one `:(exclude,literal)<name>`
+//! term per hidden name. `git diff` has no `--pathspec-from-file`, so the
+//! exclude direction is the only one available; a `,literal` term of a name git
+//! itself printed is exact, which leaves no pattern translation to drift. The
+//! two names that spelling cannot carry — one holding a `\`, or one that was not
+//! valid UTF-8 — fall back to a deliberately wider glob
+//! ([`widened_glob_for_name`]), which over-hides rather than leaks.
 //!
 //! This is a privacy boundary: a pattern that fails to match is a file that
 //! reaches a third-party model.
 
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -23,38 +28,18 @@ use tempfile::TempPath;
 use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
+use crate::git::diff::{parse_numstat_z, parse_numstat_z_rows};
 use crate::git::runner::{run_git, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT};
+use crate::git::types::DiffStatEntry;
 
-/// The pathspec translation of one AI-ignore list.
-pub struct AiIgnorePathspecs {
-    /// `:(exclude,glob)…` terms, ready to append after a caller's own positive
-    /// pathspec. Empty when nothing translatable was supplied.
-    pub specs: Vec<String>,
-    /// How many `!` un-ignore lines were dropped — by BOTH engines, not just
-    /// this one (see [`actionable_lines`]); callers may surface the count as
-    /// "un-ignore lines aren't supported". No consumer discloses it yet, and the
-    /// crate's staticlib/cdylib targets make `pub` no defence against dead_code.
-    #[allow(dead_code)]
-    pub skipped_negations: usize,
-    /// How many pattern pieces this translation had to over-broaden — a
-    /// class-special escape or a backslash-carrying bracket expression becoming
-    /// `?`, or an unterminated `[` that a later emitted class closed (see
-    /// [`rewrite_for_pathspec`]). Each one can over-exclude a sibling name, never
-    /// leak the named one. Unconsumed so far, and `pub` is no defence against
-    /// dead_code here.
-    #[allow(dead_code)]
-    pub widened: usize,
-}
-
-/// The lines of an AI-ignore list that either engine acts on: trimmed, with
-/// blanks, `#` comments and `!` un-ignore lines dropped. Returns them with the
-/// number of `!` lines dropped.
+/// The lines of an AI-ignore list the matcher acts on: trimmed, with blanks,
+/// `#` comments and `!` un-ignore lines dropped. Returns them with the number of
+/// `!` lines dropped.
 ///
-/// One definition, deliberately shared: both engines must decide every list
-/// identically, and `!` can only be made uniform by dropping it — a pathspec has
-/// no un-exclude, so honoring negations on the gitignore side alone would hide a
-/// file on one generation path and hand it to a model on another. Of the two
-/// uniform behaviors, refusing an un-ignore withholds more.
+/// `!` is dropped rather than honored because a diff is filtered by EXCLUSION —
+/// a pathspec has no un-exclude — so an un-ignore git's matcher honored would
+/// hide a file on the name pass and hand it to a model on the content pass. Of
+/// the two uniform behaviors, refusing an un-ignore withholds more.
 fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
     let mut lines: Vec<&str> = Vec::new();
     let mut skipped_negations = 0usize;
@@ -72,266 +57,16 @@ fn actionable_lines(patterns: &[String]) -> (Vec<&str>, usize) {
     (lines, skipped_negations)
 }
 
-/// Rewrites one gitignore pattern into the spelling the pathspec engine reads the
-/// same way, returning the count that had to be widened.
-///
-/// On WINDOWS a backslash inside a pathspec argv element is normalized to `/`
-/// before matching, so an escape that gitignore honors excludes NOTHING there —
-/// on this privacy boundary that fails open (measured, git 2.51.1.windows.1:
-/// `:(glob)sub\b.ts` matches `sub/b.ts`, `:(glob)sub/b\.ts` matches nothing).
-/// Unix honors the escape, so the raw form worked there and only there; the
-/// re-encode is what makes both platforms and both engines answer alike. A
-/// one-character bracket class is exact on both engines, so `\<c>` becomes
-/// `[<c>]`.
-///
-/// Three escapes route around that class. `/` becomes a bare `/`: no bracket
-/// class matches a separator under `,glob`, while gitignore's `\/` does, so the
-/// class form would open the same hole it closes. A NON-ASCII character also goes
-/// bare — a class matches byte-wise, so `[日]` asks for one stray byte of a
-/// three-byte character and matches nothing, while bare is exact because no
-/// non-ASCII character is a glob metacharacter. The five class-special escapes
-/// (`]`, `^`, `!`, `-`, `\`) and a dangling backslash have their own meaning
-/// inside a class, so they degrade to `?`, a single-char wildcard that can only
-/// over-exclude.
-///
-/// A bracket EXPRESSION the user wrote is git's own syntax, not ours to
-/// translate: it is copied whole, or — when it carries a backslash anywhere
-/// inside — replaced whole by a single `?`. Rewriting one member in place would
-/// silently change the class's membership (`a[b\-c]d` would become the class
-/// `{b,?,c}` and stop matching `a-d`, which gitignore hides). `?` is a strict
-/// superset of any bracket, since neither matches `/`, so the swap stays
-/// fail-closed. [`AiIgnorePathspecs::widened`] counts both `?` routes.
-///
-/// A backslash here is ALWAYS a gitignore escape and never a Windows path
-/// separator — the lists are documented as .gitignore syntax. So a
-/// Windows-path-shaped rule matches nothing it looks like it should: `src\foo.ts`
-/// names the literal `srcfoo.ts`, uniformly on both engines.
-///
-/// Beside the widened brackets, one shape diverges in the same safe direction: a
-/// line ending `\/` leaves a real trailing `/` here, so [`pathspecs_for`] files it
-/// as a directory and hides its contents, while gitignore strips that slash and
-/// aborts on the dangling `foo\` residue, matching NOTHING (measured, git 2.51.1:
-/// excludes line `foo\/` hides neither `foo/x.txt` nor `foo`, where `foo/` hides
-/// `foo/x.txt`). Uncounted, and unreachable from the menus, which never emit a
-/// trailing `\/`.
-fn rewrite_for_pathspec(pattern: &str) -> (String, usize) {
-    let chars: Vec<char> = pattern.chars().collect();
-    let mut out = String::with_capacity(pattern.len());
-    let mut widened = 0usize;
-    let mut i = 0usize;
-    // An unterminated `[` copied into `out` and not yet closed — see the arm below.
-    let mut dangling_open = false;
-    while i < chars.len() {
-        if chars[i] == '[' {
-            match bracket_end(&chars, i) {
-                Some(end) => {
-                    let expr: String = chars[i..=end].iter().collect();
-                    if expr.contains('\\') {
-                        out.push('?');
-                        widened += 1;
-                    } else {
-                        out.push_str(&expr);
-                    }
-                    i = end + 1;
-                }
-                // Unterminated. Gitignore abandons the whole pattern, matching
-                // NOTHING, and a copied `[` matches nothing too — UNLESS a later
-                // escape emits a class whose `]` closes it, which the arm below
-                // counts as the over-exclusion it is (measured, git 2.51.1:
-                // gitignore `a[b\xc` hides nothing, our `**/a[b[x]c` hides
-                // `abc`/`a[c`/`axc`).
-                None => {
-                    out.push('[');
-                    dangling_open = true;
-                    i += 1;
-                }
-            }
-            continue;
-        }
-        if chars[i] != '\\' {
-            out.push(chars[i]);
-            i += 1;
-            continue;
-        }
-        match chars.get(i + 1).copied() {
-            Some('/') => out.push('/'),
-            // A bracket class matches BYTE-wise, so `[日]` would ask for one
-            // stray byte of a 3-byte character and match nothing. Bare is exact
-            // instead: a non-ASCII char is never a glob metacharacter.
-            Some(e) if !e.is_ascii() => out.push(e),
-            Some(e) if !matches!(e, ']' | '^' | '!' | '-' | '\\') => {
-                out.push('[');
-                out.push(e);
-                out.push(']');
-                // This `]` is the first one in `out`, so it closes the dangling
-                // `[` rather than this class — turning the run into a real class
-                // where gitignore matched nothing at all.
-                if dangling_open {
-                    widened += 1;
-                    dangling_open = false;
-                }
-            }
-            _ => {
-                out.push('?');
-                widened += 1;
-            }
-        }
-        i += if i + 1 < chars.len() { 2 } else { 1 };
-    }
-    (out, widened)
-}
-
-/// Index of the `]` closing the bracket expression opening at `open`, or `None`
-/// when it is unterminated.
-///
-/// Follows wildmatch's own parse, which four details make non-obvious: a leading
-/// `!` or `^` negates; a `]` in first position is a member rather than the
-/// terminator; a backslash escapes the next character; and a POSIX class
-/// `[:name:]` is consumed whole, so the `]` ending it is not the terminator
-/// either. Miss any of them and the scan stops at a false terminator, splitting
-/// the class — which then has a member rewritten in place and silently changes
-/// what it accepts.
-///
-/// The fourth turns on the FIRST `]` after `[:`, not on a `[:`…`:]` search: when
-/// that `]` is `:`-preceded it ends a class, otherwise the `[` is an ordinary
-/// member and the same `]` terminates the whole expression (measured, git 2.51.1:
-/// `a[d[:]b` and `a[d[:x]b` both hide `adb`/`a[b`, so the first `]` terminated).
-/// Over-scanning to a later `:]` is the mirror-image error — it runs past the
-/// real terminator. [`posix_class_end`] holds one deliberate divergence from that
-/// rule; see its note.
-///
-/// `[:name:]` alone: git's wildmatch has no `[=x=]` equivalence or `[.x.]`
-/// collating form (measured, git 2.51.1 — both match nothing rather than acting
-/// as a class), so treating their brackets as ordinary characters is what agrees
-/// with it.
-fn bracket_end(chars: &[char], open: usize) -> Option<usize> {
-    let mut i = open + 1;
-    if matches!(chars.get(i).copied(), Some('!' | '^')) {
-        i += 1;
-    }
-    if matches!(chars.get(i).copied(), Some(']')) {
-        i += 1;
-    }
-    while i < chars.len() {
-        match chars[i] {
-            '\\' => i += 2,
-            '[' if matches!(chars.get(i + 1).copied(), Some(':')) => {
-                match posix_class_end(chars, i) {
-                    Some(end) => i = end + 1,
-                    None => i += 1,
-                }
-            }
-            ']' => return Some(i),
-            _ => i += 1,
-        }
-    }
-    None
-}
-
-/// Index of the `]` ending the POSIX class `[:name:]` opening at `open`, or
-/// `None` when this bracket is not one (then the `[` is an ordinary member).
-///
-/// Takes the FIRST `]` after `[:` and accepts a class only when that `]` is
-/// `:`-preceded, which is wildmatch's own test. Hunting for the first `:]`
-/// ANYWHERE instead over-scans past the `]` wildmatch stopped at and swallows the
-/// real class terminator — which on the widening route drops names gitignore
-/// hides (measured, git 2.51.1: `a[[:x]\-b:]c]d` hides `ax-b:]c]d`, which the
-/// `**/a?d` an over-scan produces does not).
-///
-/// The extra `close >= open + 4` is OURS, not wildmatch's: it demands a non-empty
-/// class name, where wildmatch accepts the empty `[::]` and then abandons the
-/// whole pattern (measured: excludes line `a[d[::]b` hides nothing, while
-/// rejecting `[::]` would make it the class `{d,[,:}` and hide `adb`/`a[b`). So
-/// we diverge on `[::]`-degenerates alone, and only fail-CLOSED — a pattern
-/// carrying one matches nothing at all on the gitignore side, so any term we emit
-/// is a superset of nothing.
-fn posix_class_end(chars: &[char], open: usize) -> Option<usize> {
-    // The name spans `open + 2..close - 1` (`close - 1` is the closing `:`), so
-    // `close >= open + 4` is the non-empty-name demand described above.
-    let close = (open + 2..chars.len()).find(|&i| chars[i] == ']')?;
-    (close >= open + 4 && chars[close - 1] == ':').then_some(close)
-}
-
-/// Translates gitignore-style lines into `:(exclude,glob)` pathspec terms.
-///
-/// Pure — no git call, no IO. Blanks, comments and `!` lines are dropped by the
-/// shared [`actionable_lines`]. Per surviving line: backslash escapes are
-/// re-encoded by [`rewrite_for_pathspec`] first (the pathspec engine cannot read
-/// them), then a trailing `/` marks a directory, and a line is *anchored* when it
-/// starts with `/` or still contains a `/` (exactly gitignore's rule). Unanchored
-/// lines get a `**/` prefix so they match at any depth; a non-directory line also
-/// emits a `<pattern>/**` term, which is what makes a bare `node_modules` hide
-/// the directory's contents and matches nothing extra for a real file.
-///
-/// Every term carries `,glob` magic, and that is load-bearing twice over: it
-/// makes a leading `**/` match at depth zero (so a bare name hits the repo root
-/// too), and it stops `*` from crossing `/` (so `docs/*.log` does not
-/// over-match `docs/sub/b.log`). Never `,literal` — gitignore reads `[1]` as a
-/// character class, so we must too.
-///
-/// `icase` comes from the repo's `core.ignorecase` (see [`repo_ignorecase`]) and
-/// adds `,icase`. It is required for parity, not a nicety: pathspec matching is
-/// case-SENSITIVE whatever `core.ignorecase` says, while real gitignore folds
-/// case when it is set — so on the case-insensitive filesystems Windows and
-/// macOS default to, a `Secrets.env` pattern would hide `secrets.env` from the
-/// gitignore engine and leak it through every pathspec caller (measured, git
-/// 2.51.1).
-///
-/// ⚠ The caller's own positive pathspec must NOT carry a directory component —
-/// `.` is the shape that works. Git's `common_prefix_len()` skips exclude items
-/// when computing the leading prefix it strips, then `match_pathspec_item()`
-/// advances each *negative* pattern by that many bytes: with a positive
-/// pathspec of `docs/file.txt`, `**/file.txt` is compared as `ile.txt` and
-/// silently matches nothing (measured, git 2.51.1). Ask about a single path via
-/// [`filter_ignored`] instead.
-pub fn pathspecs_for(patterns: &[String], icase: bool) -> AiIgnorePathspecs {
-    let (lines, skipped_negations) = actionable_lines(patterns);
-    let magic = if icase {
-        "exclude,glob,icase"
-    } else {
-        "exclude,glob"
-    };
-    let mut specs: Vec<String> = Vec::new();
-    let mut widened = 0usize;
-
-    for line in lines {
-        // Escapes are re-encoded BEFORE anything classifies the line: `anchored`
-        // reads `/`, and Windows git reads a surviving backslash as one — so a
-        // raw `a\b.ts` would be filed unanchored and then matched as `a/b.ts`.
-        let (line, w) = rewrite_for_pathspec(line);
-        widened += w;
-        let is_dir = line.ends_with('/');
-        let core = line.strip_suffix('/').unwrap_or(line.as_str());
-        let anchored = core.starts_with('/') || core.contains('/');
-        let core = core.strip_prefix('/').unwrap_or(core);
-        if core.is_empty() {
-            continue;
-        }
-        let prefix = if anchored { "" } else { "**/" };
-        if !is_dir {
-            specs.push(format!(":({magic}){prefix}{core}"));
-        }
-        specs.push(format!(":({magic}){prefix}{core}/**"));
-    }
-
-    AiIgnorePathspecs {
-        specs,
-        skipped_negations,
-        widened,
-    }
-}
-
 /// The repo's effective `core.ignorecase`. Unset (or unreadable) means `false`,
 /// which is git's own default; `git init` sets it true on a case-insensitive
-/// filesystem. Both engines must be driven from THIS one value so they fold case
-/// alike — and from the user's repo, never from wherever a temp dir happens to
-/// live.
+/// filesystem. Case folding must come from the USER'S repo, never from wherever
+/// the neutral temp repo happens to live.
 ///
 /// `--type=bool` is required, not tidiness: git accepts `1`, `yes`, `on` and a
 /// valueless key as true, and the raw value is whatever the user wrote. Reading
 /// it raw computes false for those, which then FORCES `-c core.ignorecase=false`
-/// onto `check-ignore` — so a `Secrets.env` pattern stops hiding `secrets.env` on
-/// both engines at once (measured, git 2.51.1).
+/// onto `check-ignore` — so a `Secrets.env` pattern stops hiding `secrets.env`
+/// (measured, git 2.51.1).
 async fn repo_ignorecase(repo_path: &str) -> bool {
     run_git_raw(
         Some(repo_path),
@@ -343,27 +78,16 @@ async fn repo_ignorecase(repo_path: &str) -> bool {
     .unwrap_or(false)
 }
 
-/// [`pathspecs_for`] with the repo's own case sensitivity applied — what the
-/// diff call sites should use, so they never have to know about `core.ignorecase`.
-pub async fn pathspecs_for_repo(repo_path: &str, patterns: &[String]) -> AiIgnorePathspecs {
-    // Only worth a spawn when there is something to translate.
-    if actionable_lines(patterns).0.is_empty() {
-        return pathspecs_for(patterns, false);
-    }
-    pathspecs_for(patterns, repo_ignorecase(repo_path).await)
-}
-
 /// An empty throwaway repo, created once per process, that [`filter_ignored`]
 /// runs `check-ignore` inside.
 ///
 /// The AI-ignore patterns must be the ONLY rules in play: running in the user's
 /// repo would add that repo's `.gitignore` files, which both over-reports (a
 /// committed-but-gitignored lockfile declared AI-ignored, with no bypass in the
-/// conflict UI) and breaks the invariant that this engine and `pathspecs_for`
-/// decide alike. An empty work tree leaves `core.excludesFile` as the only
-/// active source. Reused across calls because `is_ai_ignored` runs per
-/// conflicted file; only a successful init is cached (`get_or_try_init` leaves
-/// the cell empty on error).
+/// conflict UI) and reports paths no AI pattern named. An empty work tree leaves
+/// `core.excludesFile` as the only active source. Reused across calls because
+/// `is_ai_ignored` runs per conflicted file; only a successful init is cached
+/// (`get_or_try_init` leaves the cell empty on error).
 ///
 /// `TempDir` rather than a pid-derived name: in a shared `/tmp` a guessable path
 /// lets a local attacker pre-create `.git/info/exclude` holding `!secrets.env`,
@@ -399,10 +123,9 @@ async fn neutral_repo() -> AppResult<PathBuf> {
 /// exist in the working tree or the index — which is what lets callers ask about
 /// a remote PR's changed-file list, or about one conflicted path without
 /// depending on how the index happens to hold it. The pattern lines go into a
-/// temp excludes file, so semantics are gitignore's own rather than our pathspec
-/// translation of them — but only the lines [`actionable_lines`] keeps, so a `!`
-/// un-ignore is dropped here exactly as it is on the pathspec side. Git would
-/// honor it natively; letting it would split the two engines on the same list.
+/// temp excludes file, so semantics are gitignore's own — but only the lines
+/// [`actionable_lines`] keeps, so a `!` un-ignore is dropped here even though
+/// git would honor it natively (see that function).
 ///
 /// `paths` are repo-relative, forward-slashed. Empty `paths`, or an `exclude`
 /// with no actionable line in it, short-circuits to `[]` without spawning git;
@@ -413,7 +136,7 @@ async fn neutral_repo() -> AppResult<PathBuf> {
 /// patterns are the only rules in play — but `repo_path` still decides case
 /// folding: `core.ignorecase` is read from it and forced onto the invocation, so
 /// the answer follows the user's repo instead of whatever filesystem the temp
-/// dir happens to sit on, and agrees with [`pathspecs_for`].
+/// dir happens to sit on.
 ///
 /// `-z` is load-bearing, not cosmetic: without it git C-dequotes an input path
 /// that happens to be quoted and C-quotes non-ASCII output, either of which
@@ -508,7 +231,7 @@ pub async fn filter_ignored(
 /// [`filter_ignored`] as a command: which of `paths` the user's AI-ignore
 /// patterns hide. The frontend uses it for path lists it holds itself (a remote
 /// PR's changed files), where there is no git command whose output we could
-/// filter with pathspecs.
+/// filter.
 #[tauri::command]
 pub async fn git_filter_ai_ignored(
     repo_path: String,
@@ -518,267 +241,269 @@ pub async fn git_filter_ai_ignored(
     filter_ignored(&repo_path, &paths, &exclude).await
 }
 
+/// U+FFFD — what a non-UTF-8 byte in a filename becomes on the way in.
+const REPLACEMENT: char = '\u{FFFD}';
+
+/// How many times [`filtered_diff`] re-runs its two passes when the tree moved
+/// underneath them.
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Byte ceiling on the content pass's whole argv. The exclude list grows with
+/// the hidden-file count and Windows caps a command line at 32,767 UTF-16 units,
+/// so a large enough change fails the spawn outright (os error 206). Past this
+/// the diff is withheld whole: over-hiding costs the model context, spawning
+/// without the terms would hand it every ignored file.
+const TERM_BUDGET: usize = 16_000;
+
+/// A `git diff` filtered by the user's AI-ignore list. `text` is untruncated —
+/// each caller applies its own budget and boundary rule.
+pub struct FilteredDiff {
+    pub text: String,
+    pub files: Vec<DiffStatEntry>,
+    /// Changed files (rename pairs count once) the patterns hid.
+    pub excluded_files: u32,
+}
+
+/// Whether an AI-ignore list holds anything the matcher would act on — the flag
+/// a caller needs to keep its unfiltered command shape when it does not.
+pub fn has_actionable_lines(patterns: &[String]) -> bool {
+    !actionable_lines(patterns).0.is_empty()
+}
+
+/// Whether a name is inexpressible as a `,literal` exclude term and needs
+/// [`widened_glob_for_name`] instead — see that function for both causes.
+fn needs_widened_term(name: &str) -> bool {
+    name.contains(REPLACEMENT) || name.contains('\\')
+}
+
+/// An exclude term for a name `,literal` cannot express, deliberately WIDER than
+/// the name itself. Two causes, both fail-OPEN without this:
+///
+/// A non-UTF-8 byte arrives only as U+FFFD, so a literal term would compare the
+/// lossy string against the real bytes and match nothing; each RUN of U+FFFD
+/// becomes one `*`, which cannot cross `/` because no lossy byte is one.
+/// A literal `\` is normalized to a separator by Windows git even under
+/// `,literal`, so that term matches nothing there while the content ships; `?`
+/// in its place excludes the file on Windows and, since glob `?` matches a
+/// literal `\` on Unix, spells the same term on both (measured, git 2.51.1).
+///
+/// Either way the term can sweep a sibling name — the safe direction — but never
+/// misses the file it stands for.
+fn widened_glob_for_name(path: &str) -> String {
+    let mut out = String::with_capacity(path.len() + 8);
+    let mut in_run = false;
+    for c in path.chars() {
+        if c == REPLACEMENT {
+            if !in_run {
+                out.push('*');
+                in_run = true;
+            }
+            continue;
+        }
+        in_run = false;
+        match c {
+            '\\' => out.push('?'),
+            // `[`, `*` and `?` are glob metacharacters; a one-character class is
+            // the spelling that keeps them literal.
+            '[' | '*' | '?' => {
+                out.push('[');
+                out.push(c);
+                out.push(']');
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// The `git diff` described by `content_args` with every AI-ignored file removed.
+///
+/// Two passes, because git's gitignore engine takes path STRINGS while `git diff`
+/// takes pathspecs and has no `--pathspec-from-file`: name the changed files with
+/// `numstat_args`, get verdicts from [`filter_ignored`], then re-run the content
+/// diff excluding the concrete names it hid. A rename is hidden whole when either
+/// side matches, and an unreadable name is hidden unconditionally.
+///
+/// `repo_path` must be the repository ROOT: diff prints root-relative names
+/// while pathspecs resolve against the cwd, so a subdirectory would void every
+/// term. The positive pathspec alongside the excludes must likewise be exactly
+/// `.`: git's `common_prefix_len()` skips exclude items, then advances each
+/// negative pattern by the prefix it computed, so any directory component
+/// silently voids them (measured, git 2.51.1).
+///
+/// `recheck` re-reads the names after the content pass and retries on a mismatch,
+/// for callers whose diff reads mutable state (index, working tree) — a file
+/// appearing between the passes would otherwise enter the diff unchecked.
+/// Callers over immutable trees pin their refs instead and pass `false`.
+pub async fn filtered_diff(
+    repo_path: &str,
+    content_args: &[&str],
+    numstat_args: &[&str],
+    exclude: &[String],
+    recheck: bool,
+) -> AppResult<FilteredDiff> {
+    if !has_actionable_lines(exclude) {
+        let (content, stat) = tokio::try_join!(
+            run_git(Some(repo_path), content_args, DEFAULT_TIMEOUT),
+            run_git(Some(repo_path), numstat_args, DEFAULT_TIMEOUT)
+        )?;
+        return Ok(FilteredDiff {
+            text: content.stdout_lossy(),
+            files: parse_numstat_z(&stat.stdout_lossy()),
+            excluded_files: 0,
+        });
+    }
+
+    for _ in 0..MAX_ATTEMPTS {
+        let stat = run_git(Some(repo_path), numstat_args, DEFAULT_TIMEOUT).await?;
+        let rows = parse_numstat_z_rows(&stat.stdout_lossy());
+        let before = recheck.then(|| sorted_names(&rows));
+
+        // Only names we can vouch for byte-for-byte are worth asking about.
+        let readable: Vec<String> = rows
+            .iter()
+            .filter(|row| !row.names.iter().any(|n| n.contains(REPLACEMENT)))
+            .flat_map(|row| row.names.iter().cloned())
+            .collect();
+        let ignored: HashSet<String> = filter_ignored(repo_path, &readable, exclude)
+            .await?
+            .into_iter()
+            .collect();
+
+        let total_rows = rows.len() as u32;
+        let mut terms: Vec<String> = Vec::new();
+        let mut files: Vec<DiffStatEntry> = Vec::new();
+        let mut excluded_files = 0u32;
+        for row in rows {
+            let hidden = row
+                .names
+                .iter()
+                .any(|n| n.contains(REPLACEMENT) || ignored.contains(n));
+            if !hidden {
+                files.push(row.entry);
+                continue;
+            }
+            excluded_files += 1;
+            for name in row.names {
+                terms.push(if needs_widened_term(&name) {
+                    format!(":(exclude,glob){}", widened_glob_for_name(&name))
+                } else {
+                    format!(":(exclude,literal){name}")
+                });
+            }
+        }
+
+        // Nothing survives ⇒ no content pass at all: a `git diff` carrying no
+        // pathspec is the FULL diff, which is the leak this branch exists to
+        // prevent. Nothing was read, so nothing needs re-checking either.
+        if files.is_empty() {
+            return Ok(FilteredDiff {
+                text: String::new(),
+                files,
+                excluded_files,
+            });
+        }
+
+        let mut args: Vec<&str> = content_args.to_vec();
+        args.extend(["--", "."]);
+        args.extend(terms.iter().map(String::as_str));
+        // Over budget the survivors go too: they can only be shipped by a spawn
+        // that would either fail outright or have to drop terms (see TERM_BUDGET).
+        if args.iter().map(|a| a.len()).sum::<usize>() > TERM_BUDGET {
+            return Ok(FilteredDiff {
+                text: String::new(),
+                files: Vec::new(),
+                excluded_files: total_rows,
+            });
+        }
+        let content = run_git(Some(repo_path), &args, DEFAULT_TIMEOUT).await?;
+
+        if let Some(before) = before {
+            let stat = run_git(Some(repo_path), numstat_args, DEFAULT_TIMEOUT).await?;
+            if sorted_names(&parse_numstat_z_rows(&stat.stdout_lossy())) != before {
+                continue;
+            }
+        }
+        return Ok(FilteredDiff {
+            text: content.stdout_lossy(),
+            files,
+            excluded_files,
+        });
+    }
+    Err(AppError::Command(
+        "the repository changed while computing the AI-filtered diff; try again".into(),
+    ))
+}
+
+/// Every path a numstat pass named, both rename sides included, in a
+/// comparable order.
+fn sorted_names(rows: &[crate::git::diff::DiffStatRow]) -> Vec<String> {
+    let mut names: Vec<String> = rows
+        .iter()
+        .flat_map(|row| row.names.iter().cloned())
+        .collect();
+    names.sort();
+    names
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git::compare::git_branch_diff;
+    use crate::git::diff::git_staged_diff;
     use crate::git::runner::{run_git, run_git_input};
     use std::collections::BTreeSet;
     use std::path::Path;
 
-    fn specs_icase(pattern: &str) -> Vec<String> {
-        pathspecs_for(&[pattern.to_string()], true).specs
-    }
-
-    fn specs(pattern: &str) -> Vec<String> {
-        pathspecs_for(&[pattern.to_string()], false).specs
-    }
-
-    #[test]
-    fn emits_the_measured_terms_per_pattern() {
-        // A bare name matches at any depth (both the file and, harmlessly, its
-        // "contents"); a leading slash anchors it to the repo root.
-        assert_eq!(
-            specs("notes.md"),
-            [
-                ":(exclude,glob)**/notes.md",
-                ":(exclude,glob)**/notes.md/**"
-            ]
-        );
-        assert_eq!(
-            specs("/notes.md"),
-            [":(exclude,glob)notes.md", ":(exclude,glob)notes.md/**"]
-        );
-        // A trailing slash is a directory: one term, contents only.
-        assert_eq!(specs("build/"), [":(exclude,glob)**/build/**"]);
-        assert_eq!(specs("docs/build/"), [":(exclude,glob)docs/build/**"]);
-        // A bare directory NAME needs the second term to hide its contents.
-        assert_eq!(
-            specs("node_modules"),
-            [
-                ":(exclude,glob)**/node_modules",
-                ":(exclude,glob)**/node_modules/**"
-            ]
-        );
-        assert_eq!(
-            specs("build"),
-            [":(exclude,glob)**/build", ":(exclude,glob)**/build/**"]
-        );
-        // An embedded `/` anchors without a leading slash.
-        assert_eq!(
-            specs("docs/*.log"),
-            [":(exclude,glob)docs/*.log", ":(exclude,glob)docs/*.log/**"]
-        );
-        assert_eq!(
-            specs("docs/notes.md"),
-            [
-                ":(exclude,glob)docs/notes.md",
-                ":(exclude,glob)docs/notes.md/**"
-            ]
-        );
-        assert_eq!(
-            specs("*.log"),
-            [":(exclude,glob)**/*.log", ":(exclude,glob)**/*.log/**"]
-        );
-        assert_eq!(
-            specs("*.md"),
-            [":(exclude,glob)**/*.md", ":(exclude,glob)**/*.md/**"]
-        );
-        // Brackets pass through untouched — git reads them as a character class
-        // on both sides, so neither engine matches the literal name.
-        assert_eq!(
-            specs("weird[1].txt"),
-            [
-                ":(exclude,glob)**/weird[1].txt",
-                ":(exclude,glob)**/weird[1].txt/**"
-            ]
-        );
-        assert!(specs("!docs/notes.md").is_empty());
-    }
-
-    /// Backslash escapes come out as one-character classes, the only spelling
-    /// both engines read alike — a surviving backslash is a separator to Windows
-    /// git, so the term would exclude nothing and the file would reach a model.
-    #[test]
-    fn escapes_become_one_character_classes() {
-        assert_eq!(
-            specs("/notes\\ "),
-            [":(exclude,glob)notes[ ]", ":(exclude,glob)notes[ ]/**"]
-        );
-        assert_eq!(
-            specs("weird\\[1].txt"),
-            [
-                ":(exclude,glob)**/weird[[]1].txt",
-                ":(exclude,glob)**/weird[[]1].txt/**"
-            ]
-        );
-        assert_eq!(
-            specs("star\\*.txt"),
-            [
-                ":(exclude,glob)**/star[*].txt",
-                ":(exclude,glob)**/star[*].txt/**"
-            ]
-        );
-        assert_eq!(
-            specs("q\\?.txt"),
-            [":(exclude,glob)**/q[?].txt", ":(exclude,glob)**/q[?].txt/**"]
-        );
-        // `\#` and a hand-typed `\!` are how gitignore names a file whose name
-        // starts with a comment/negation marker; only the second needs widening.
-        assert_eq!(
-            specs("\\#notes.md")[0],
-            ":(exclude,glob)**/[#]notes.md"
-        );
-
-        // An escaped separator: no bracket class matches `/` under `,glob`, so
-        // this one re-encodes to a bare `/` — which also anchors the line, exactly
-        // as gitignore anchors it.
-        assert_eq!(specs("a\\/b.ts")[0], ":(exclude,glob)a/b.ts");
-        // At the END of a line that bare `/` is a directory marker, so this shape
-        // hides a directory's contents where gitignore matches nothing at all —
-        // the documented fail-closed divergence, pinned so it can't drift.
-        assert_eq!(specs("foo\\/"), [":(exclude,glob)**/foo/**"]);
-
-        // A Windows-path-shaped rule is NOT a path: the backslash escapes the
-        // `f`, so the term names the literal `srcfoo.ts` and leaves `src/foo.ts`
-        // alone. Windows pathspec matching would read it the other way round, on
-        // that platform alone — which is exactly what the re-encode removes.
-        assert_eq!(specs("src\\foo.ts")[0], ":(exclude,glob)**/src[f]oo.ts");
-
-        // An escaped non-ASCII character goes BARE. A class is byte-wise, so
-        // `[日]` names one byte of a three-byte character and matches nothing.
-        assert_eq!(
-            specs("docs/\\日本語.md")[0],
-            ":(exclude,glob)docs/日本語.md"
-        );
-    }
-
-    /// A bracket expression the user wrote is git's own syntax: copied whole when
-    /// it holds no escape, and swapped whole for `?` when it does. Rewriting a
-    /// single member in place would change which characters the class accepts.
-    #[test]
-    fn user_bracket_expressions_pass_through_or_widen_whole() {
-        // Verbatim: plain class, negated (both spellings), and `]` as the first
-        // member — all parsed the same way by both engines.
-        for pattern in ["a[b-c]d", "a[!b]d", "a[^b]d", "a[]]d", "weird[[]1].txt"] {
-            let out = pathspecs_for(&[pattern.to_string()], false);
-            assert_eq!(out.specs[0], format!(":(exclude,glob)**/{pattern}"));
-            assert_eq!(out.widened, 0, "pattern {pattern:?}");
-        }
-
-        // An escape anywhere inside widens the WHOLE class: `a[b?c]d` would be
-        // the class `{b,?,c}`, which stops matching the `a-d` that gitignore hides.
-        let out = pathspecs_for(&["a[b\\-c]d".to_string()], false);
-        assert_eq!(out.specs[0], ":(exclude,glob)**/a?d");
-        assert_eq!(out.widened, 1);
-        // The scan steps over an escaped `]` rather than stopping at it, or the
-        // class would be split at a false terminator.
-        assert_eq!(
-            pathspecs_for(&["a[b\\]c]d".to_string()], false).specs[0],
-            ":(exclude,glob)**/a?d"
-        );
-
-        // A POSIX class holds a `]` that does NOT terminate the expression.
-        // Escape-free, so it survives whole.
-        for pattern in ["a[[:digit:]]d", "a[[:alpha:][:digit:]]d", "a[![:digit:]]d"] {
-            let out = pathspecs_for(&[pattern.to_string()], false);
-            assert_eq!(out.specs[0], format!(":(exclude,glob)**/{pattern}"));
-            assert_eq!(out.widened, 0, "pattern {pattern:?}");
-        }
-        // With an escape after the class, the WHOLE expression widens — stopping
-        // the scan at the class's `]` would instead rewrite one member and drop
-        // the `a-d` that gitignore hides.
-        let out = pathspecs_for(&["a[[:digit:]\\-]d".to_string()], false);
-        assert_eq!(out.specs[0], ":(exclude,glob)**/a?d");
-        assert_eq!(out.widened, 1);
-        // An inner `[:` whose first `]` is not `:`-preceded is an ordinary member,
-        // and that same `]` terminates the expression — even when a later `:]`
-        // exists. Scanning to the later `:]` would swallow the real terminator and
-        // collapse the stretch to `**/a?d`, which stops matching the
-        // `ax-b:]c]d` that gitignore hides.
-        assert_eq!(specs("a[[:x]d")[0], ":(exclude,glob)**/a[[:x]d");
-        let split = pathspecs_for(&["a[[:x]\\-b:]c]d".to_string()], false);
-        assert_eq!(split.specs[0], ":(exclude,glob)**/a[[:x]?b:]c]d");
-        assert_eq!(split.widened, 1);
-
-        // `[:]` is not a class on either side (its `]` is not `:`-preceded).
-        assert_eq!(specs("a[[:]]d")[0], ":(exclude,glob)**/a[[:]]d");
-        // `[::]` is where we are deliberately STRICTER than wildmatch, which
-        // accepts the empty name and abandons the pattern. Behaviour still agrees
-        // here only because the emitted term keeps the `[::]`, so the pathspec
-        // engine abandons it too — both hide nothing (measured).
-        assert_eq!(specs("a[[::]]d")[0], ":(exclude,glob)**/a[[::]]d");
-        assert_eq!(specs("a[d[::]b")[0], ":(exclude,glob)**/a[d[::]b");
-        let kept = pathspecs_for(&["a[[::]\\-b]d".to_string()], false);
-        assert_eq!(kept.specs[0], ":(exclude,glob)**/a[[::]?b]d");
-        assert_eq!(kept.widened, 1);
-        // The one shape where the stricter guard changes BEHAVIOUR: the escape
-        // sits inside the expression we end early, so the `[::]` is widened away
-        // and the term matches names gitignore abandons entirely. Over-exclusion,
-        // never a leak.
-        let diverged = pathspecs_for(&["a[\\x[::]d".to_string()], false);
-        assert_eq!(diverged.specs[0], ":(exclude,glob)**/a?d");
-        assert_eq!(diverged.widened, 1);
-
-        // Unterminated: both engines abandon the pattern and match nothing, and
-        // the copied `[` keeps the pathspec side there.
-        assert_eq!(specs("a[b")[0], ":(exclude,glob)**/a[b");
-        assert_eq!(specs("a[")[0], ":(exclude,glob)**/a[");
-        // …unless a later escape emits a class whose `]` closes the dangling `[`,
-        // making it a real class where gitignore matched nothing. Fail-closed, so
-        // the emission stands — but it is counted, not silent.
-        let reclosed = pathspecs_for(&["a[b\\xc".to_string()], false);
-        assert_eq!(reclosed.specs[0], ":(exclude,glob)**/a[b[x]c");
-        assert_eq!(reclosed.widened, 1);
-    }
-
-    /// The five class-special escapes (and a dangling backslash) fall back to
-    /// `?`, counted so a caller could disclose it. Over-excluding a sibling name
-    /// is the safe direction on a privacy boundary; leaking the named file is not.
-    #[test]
-    fn class_special_escapes_widen_to_a_wildcard() {
-        for (pattern, want) in [
-            ("bang\\!.txt", ":(exclude,glob)**/bang?.txt"),
-            ("br\\].txt", ":(exclude,glob)**/br?.txt"),
-            ("hat\\^.txt", ":(exclude,glob)**/hat?.txt"),
-            ("dash\\-.txt", ":(exclude,glob)**/dash?.txt"),
-            ("back\\\\.txt", ":(exclude,glob)**/back?.txt"),
-            ("dangling\\", ":(exclude,glob)**/dangling?"),
-        ] {
-            let out = pathspecs_for(&[pattern.to_string()], false);
-            assert_eq!(out.specs[0], want, "pattern {pattern:?}");
-            assert_eq!(out.widened, 1, "pattern {pattern:?}");
-        }
-        // An exact class is not a widening — including the Windows-path-shaped
-        // rule, whose `\f` is an ordinary escape however much it reads as a
-        // separator.
-        assert_eq!(pathspecs_for(&["/notes\\ ".into()], false).widened, 0);
-        assert_eq!(pathspecs_for(&["src\\foo.ts".into()], false).widened, 0);
-    }
-
     #[test]
     fn drops_blanks_comments_and_negations() {
-        let out = pathspecs_for(
-            &[
-                "  ".to_string(),
-                "# a comment".to_string(),
-                "!docs/notes.md".to_string(),
-                "  *.log  ".to_string(),
-                "/".to_string(),
-            ],
-            false,
+        let patterns = [
+            "  ".to_string(),
+            "# a comment".to_string(),
+            "!docs/notes.md".to_string(),
+            "  *.log  ".to_string(),
+            "/".to_string(),
+        ];
+        let (lines, skipped) = actionable_lines(&patterns);
+        // A bare `/` survives this filter: git's own matcher decides what it
+        // means, exactly as it does for every other surviving line.
+        assert_eq!(lines, ["*.log", "/"]);
+        assert_eq!(skipped, 1);
+    }
+
+    /// The widened term keeps every glob metacharacter literal, collapses each
+    /// RUN of unreadable bytes into a single `*`, and swaps a `\` for `?`.
+    #[test]
+    fn widened_glob_escapes_metacharacters_and_widens_the_inexpressible() {
+        assert_eq!(
+            widened_glob_for_name("we?rd\u{FFFD}\u{FFFD}[1].txt"),
+            "we[?]rd*[[]1].txt"
         );
         assert_eq!(
-            out.specs,
-            [":(exclude,glob)**/*.log", ":(exclude,glob)**/*.log/**"]
+            widened_glob_for_name("docs/caf\u{FFFD}.env"),
+            "docs/caf*.env"
         );
-        assert_eq!(out.skipped_negations, 1);
+        assert_eq!(widened_glob_for_name("a\\b.env"), "a?b.env");
+        // All three causes at once.
+        assert_eq!(
+            widened_glob_for_name("a\\b\u{FFFD}\u{FFFD}c[1]*.env"),
+            "a?b*c[[]1][*].env"
+        );
+        assert_eq!(widened_glob_for_name("st*ar.txt"), "st[*]ar.txt");
+        // Nothing inexpressible, nothing special: unchanged.
+        assert_eq!(widened_glob_for_name("src/a.rs"), "src/a.rs");
+
+        // Only these two shapes route away from the exact `,literal` spelling.
+        assert!(needs_widened_term("a\\b.env"));
+        assert!(needs_widened_term("caf\u{FFFD}.env"));
+        assert!(!needs_widened_term("weird[1].txt"));
+        assert!(!needs_widened_term("notes "));
     }
 
     /// Every fixture path in the parity repo, repo-relative and sorted.
     const FIXTURE: [&str; 27] = [
-        // A bracket expression's members (`a-d`/`abd`) plus a name only the
-        // widened `?` reaches (`aXd`), so a class and its widening are
-        // distinguishable.
+        // A bracket expression's members (`a-d`/`abd`) plus `aXd`, which is not
+        // one — so a class that quietly widened would be visible.
         "a-d",
         // `a/b.ts` beside `srcfoo.ts`/`src/foo.ts`: the pair of shapes that tell a
         // backslash ESCAPE apart from a Windows path separator (the `\/` and
@@ -793,8 +518,8 @@ mod tests {
         "a[b",
         "abd",
         "app.log",
-        // Each `?`-widened escape with a sibling only the wildcard reaches, so
-        // the fail-closed asymmetry has a witness (`widened_escapes_…` below).
+        // An escaped metacharacter beside the sibling a wildcard would also
+        // sweep, so an over-broad match has a witness.
         "bang!.txt",
         "bangX.txt",
         "build/x.txt",
@@ -820,7 +545,8 @@ mod tests {
     ];
 
     /// The measured truth table (git 2.51.1): for each AI-ignore pattern LIST,
-    /// exactly which of `FIXTURE` it hides. Both engines must agree with it.
+    /// exactly which of `FIXTURE` it hides. The diff commands and
+    /// `git_filter_ai_ignored` must both agree with it.
     const PARITY: [(&[&str], &[&str]); 27] = [
         (
             &["notes.md"],
@@ -855,13 +581,13 @@ mod tests {
         (&["docs/notes.md"], &["docs/notes.md"]),
         (&["docs/*.log"], &["docs/a.log"]),
         (&["docs/build/"], &["docs/build/y.txt"]),
-        // A bracket is a character class in gitignore, so it never matches the
-        // literal name — `,literal` pathspec magic would silently diverge here.
+        // A bracket is a character class in gitignore, so this PATTERN never
+        // matches the literal name — however concrete the name looks.
         (&["weird[1].txt"], &[]),
-        // `!` un-ignore lines are unsupported and dropped by BOTH engines: a lone
-        // negation hides nothing, and a negation after a matching pattern
-        // re-includes nothing. Git's own engine would honor the second case, so
-        // this row is what holds the two engines together on negations.
+        // `!` un-ignore lines are unsupported and dropped before git sees them: a
+        // lone negation hides nothing, and a negation after a matching pattern
+        // re-includes nothing. Git's matcher would honor the second case, but a
+        // diff filtered by exclusion has no un-exclude to mirror it with.
         (&["!docs/notes.md"], &[]),
         (
             &["*.md", "!docs/notes.md"],
@@ -875,43 +601,36 @@ mod tests {
         // Blanks and comments are dropped everywhere too.
         (&["  ", "# a comment", "docs/*.log"], &["docs/a.log"]),
         // Case: the fixture pins `core.ignorecase=false`, so a case-differing
-        // pattern matches nothing — on BOTH engines. `case_folding_follows_the_repo`
-        // covers the `true` half, which is the platform default on Windows/macOS.
+        // pattern matches nothing. `case_folding_follows_the_repo` covers the
+        // `true` half, which is the platform default on Windows/macOS.
         (&["NOTES.MD"], &[]),
         // A concrete path carrying glob metacharacters, escaped the way the UI's
         // *Exclude from AI* actions emit it: `[` wrapped as `[[]`. Unescaped it is
         // a character class and protects nothing — the `weird[1].txt` row above.
         (&["weird[[]1].txt"], &["weird[1].txt"]),
         (&["/weird[[]1].txt"], &["weird[1].txt"]),
-        // The hand-typed gitignore spelling of the same escape. Only the
-        // gitignore engine reads a backslash, so this row is what pins the
-        // pathspec side's re-encode of it.
+        // The hand-typed gitignore spelling of the same escape, read natively by
+        // git's matcher.
         (&["weird\\[1].txt"], &["weird[1].txt"]),
-        // A backslash is ALWAYS a gitignore escape, never a Windows separator:
-        // `src\foo.ts` escapes the `f` and names the literal `srcfoo.ts`, leaving
-        // `src/foo.ts` visible. This row is what keeps that uniform across
-        // engines — Windows pathspec matching would otherwise read the backslash
-        // as a separator and hide the OTHER file, on that platform alone.
+        // A backslash in a PATTERN is ALWAYS a gitignore escape, never a Windows
+        // separator: `src\foo.ts` escapes the `f` and names the literal
+        // `srcfoo.ts`, leaving `src/foo.ts` visible — uniformly on every platform,
+        // since one matcher decides it.
         (&["src\\foo.ts"], &["srcfoo.ts"]),
-        // The one escape that is not a bracket class on the pathspec side: no
-        // class matches a separator under `,glob`, so `\/` becomes a bare `/` —
-        // which must also anchor the line exactly as gitignore anchors it.
+        // An escaped separator is still a separator to the matcher, so it anchors
+        // the line the same way a bare `/` would.
         (&["a\\/b.ts"], &["a/b.ts"]),
-        // A bracket expression the USER wrote, carrying no escape: copied through
-        // untouched, and the two engines read it identically (a range here, so
-        // `a-d` is NOT a member — only `abd` is in this fixture).
+        // A bracket expression the USER wrote is git's own syntax, read as a range
+        // here — so `a-d` is NOT a member, only `abd` is in this fixture.
         (&["a[b-c]d"], &["abd"]),
-        // An escaped NON-ASCII character goes bare. As a one-character class it
-        // would ask for a single byte of a three-byte character and match nothing,
-        // while gitignore hides the file — the fail-open direction.
+        // An escaped NON-ASCII character is simply that character to the matcher,
+        // multi-byte encoding and all.
         (&["docs/\\日本語.md"], &["docs/日本語.md"]),
-        // A POSIX class carries its own `]`, which the terminator scan must step
-        // over. Escape-free, so it passes through verbatim and both engines read
-        // the same class.
+        // A POSIX class carries its own `]`, which does not terminate the
+        // enclosing expression.
         (&["a[[:digit:]]d"], &["a5d"]),
-        // An unterminated `[` is abandoned by BOTH engines — an agreement row
-        // that happens to hide nothing, which is exactly the claim worth pinning:
-        // the copied `[` must not start matching on the pathspec side.
+        // An unterminated `[` makes git abandon the whole pattern, so these hide
+        // nothing at all — including the `a[b` that is a real fixture name.
         (&["a["], &[]),
         (&["a[b"], &[]),
     ];
@@ -957,32 +676,47 @@ mod tests {
         (dir, repo)
     }
 
-    /// What the pathspec terms hide: `FIXTURE` minus what `ls-files` still lists.
-    /// Goes through `pathspecs_for_repo`, so case folding is resolved from the
-    /// repo exactly as the real diff call sites do it.
-    async fn hidden_by_pathspec(repo: &str, patterns: &[&str]) -> BTreeSet<String> {
+    /// What the real staged-diff command hides: `FIXTURE` minus the paths it
+    /// still lists, plus the count it disclosed. `parity_repo` has no commits, so
+    /// `git diff --cached` compares the index against the empty tree and every
+    /// fixture file shows up as an addition. Sets are FIXTURE-relative because the
+    /// index also holds a `.gitignore` no PARITY pattern names.
+    ///
+    /// The DIFF TEXT is checked against the file list here rather than in each
+    /// caller: the file list comes from the name pass, so a term constructor that
+    /// excluded nothing would leave every "hidden" file's content in `text` while
+    /// every list-based assertion still passed. Paths come off the `+++ b/` lines
+    /// (the runner forces `core.quotePath=false` and the fixture is ASCII).
+    async fn hidden_by_command(repo: &str, patterns: &[&str]) -> (BTreeSet<String>, u32) {
         let owned: Vec<String> = patterns.iter().map(|p| p.to_string()).collect();
-        let terms = pathspecs_for_repo(repo, &owned).await.specs;
-        let mut args: Vec<String> = vec!["ls-files".into()];
-        if !terms.is_empty() {
-            args.push("--".into());
-            args.push(".".into());
-            args.extend(terms);
-        }
-        let argref: Vec<&str> = args.iter().map(String::as_str).collect();
-        let listed: BTreeSet<String> = run_git(Some(repo), &argref, DEFAULT_TIMEOUT)
+        let out = git_staged_diff(repo.to_string(), None, Some(owned), None)
             .await
-            .unwrap()
-            .stdout_lossy()
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty())
-            .collect();
-        FIXTURE
+            .unwrap();
+        let listed: BTreeSet<&str> = out.files.iter().map(|f| f.path.as_str()).collect();
+        let hidden: BTreeSet<String> = FIXTURE
             .iter()
+            .filter(|p| !listed.contains(*p))
             .map(|p| p.to_string())
-            .filter(|p| !listed.contains(p))
-            .collect()
+            .collect();
+
+        let in_text: BTreeSet<String> = out
+            .text
+            .lines()
+            .filter_map(|l| l.strip_prefix("+++ b/"))
+            .map(str::to_string)
+            .collect();
+        let mut want_text: BTreeSet<String> = FIXTURE
+            .iter()
+            .filter(|p| !hidden.contains(**p))
+            .map(|p| p.to_string())
+            .collect();
+        want_text.insert(".gitignore".to_string());
+        assert_eq!(
+            in_text, want_text,
+            "diff text must carry exactly the surviving files, patterns {patterns:?}"
+        );
+
+        (hidden, out.excluded_files)
     }
 
     /// A trailing space survives into the match, which only a backslash escape
@@ -990,9 +724,9 @@ mod tests {
     /// named `notes ` would otherwise hide `notes` instead — the wrong file, and
     /// the named one left visible.
     ///
-    /// Gitignore engine only, deliberately: this engine takes arbitrary path
-    /// STRINGS, while the pathspec half matches against the index, and git on
-    /// Windows refuses to index a trailing-space path at all ("Invalid path").
+    /// Driven straight through `filter_ignored`, which takes arbitrary path
+    /// STRINGS: git on Windows refuses to index a trailing-space path at all
+    /// ("Invalid path"), so `parity_repo` cannot carry this fixture.
     #[tokio::test]
     async fn escaped_trailing_space_matches_only_that_file() {
         let (_dir, repo) = parity_repo().await;
@@ -1008,440 +742,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(bare, vec!["notes".to_string()]);
-    }
-
-    /// Both engines on one WORKING-TREE fixture, for the escaped-trailing-space
-    /// shape the PARITY table cannot carry: git on Windows rejects a
-    /// trailing-space path outright ("Invalid path"), so it can never enter that
-    /// fixture's index. Skipped there for that reason alone — the pathspec half
-    /// itself now holds on every platform, which
-    /// [`escaped_trailing_space_excluded_by_pathspec_everywhere`] pins through the
-    /// object database instead.
-    ///
-    /// Skipped at RUNTIME rather than `#[cfg(unix)]`-gated so the body still
-    /// compiles on Windows; a cfg-gated test first compiles on CI, where a typo
-    /// costs a red run instead of a local one.
-    #[tokio::test]
-    async fn escaped_trailing_space_agrees_across_engines() {
-        if cfg!(windows) {
-            return;
-        }
-        let dir = tempfile::Builder::new()
-            .prefix("gd-aiignore-space-")
-            .tempdir()
-            .expect("create temp dir");
-        let repo = dir.path().to_string_lossy().into_owned();
-        for args in [
-            vec!["init", "-q"],
-            vec!["config", "user.email", "t@t.local"],
-            vec!["config", "user.name", "T"],
-            vec!["config", "core.ignorecase", "false"],
-        ] {
-            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
-        }
-        let files = ["notes ", "notes"];
-        for rel in files {
-            std::fs::write(Path::new(&repo).join(rel), "x\n").unwrap();
-        }
-        run_git(Some(&repo), &["add", "-A", "-f"], DEFAULT_TIMEOUT)
-            .await
-            .unwrap();
-
-        // Exactly what *Exclude from AI* now writes for a file named `notes `.
-        let patterns = vec!["/notes\\ ".to_string()];
-
-        let terms = pathspecs_for_repo(&repo, &patterns).await.specs;
-        let mut args: Vec<String> = vec!["ls-files".into(), "--".into(), ".".into()];
-        args.extend(terms);
-        let argref: Vec<&str> = args.iter().map(String::as_str).collect();
-        // NOT trimmed: the whole point is a name whose last character is a space.
-        let listed: BTreeSet<String> = run_git(Some(&repo), &argref, DEFAULT_TIMEOUT)
-            .await
-            .unwrap()
-            .stdout_lossy()
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(str::to_string)
-            .collect();
-        let by_pathspec: BTreeSet<String> = files
-            .iter()
-            .map(|p| p.to_string())
-            .filter(|p| !listed.contains(p))
-            .collect();
-
-        let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
-            repo.clone(),
-            files.iter().map(|p| p.to_string()).collect(),
-            patterns,
-        )
-        .await
-        .unwrap()
-        .into_iter()
-        .collect();
-
-        let want: BTreeSet<String> = ["notes ".to_string()].into_iter().collect();
-        assert_eq!(by_pathspec, want, "pathspec engine");
-        assert_eq!(by_gitignore, want, "gitignore engine");
-    }
-
-    /// The pathspec engine hides an escaped-trailing-space file on EVERY platform
-    /// — the regression that matters, since it is Windows where a raw `\ ` term
-    /// silently excluded nothing and handed `notes ` to a model.
-    ///
-    /// Built straight in the object database (`hash-object` → `mktree`) and
-    /// diffed tree against empty tree: no commit, no checkout and no index, which
-    /// is the only way a trailing-space path exists at all under Windows git.
-    #[tokio::test]
-    async fn escaped_trailing_space_excluded_by_pathspec_everywhere() {
-        let dir = tempfile::Builder::new()
-            .prefix("gd-aiignore-tree-")
-            .tempdir()
-            .expect("create temp dir");
-        let repo = dir.path().to_string_lossy().into_owned();
-        for args in [
-            vec!["init", "-q"],
-            vec!["config", "user.email", "t@t.local"],
-            vec!["config", "user.name", "T"],
-            vec!["config", "core.ignorecase", "false"],
-        ] {
-            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
-        }
-
-        let git_out = |args: Vec<String>, input: Option<String>| {
-            let repo = repo.clone();
-            async move {
-                let argref: Vec<&str> = args.iter().map(String::as_str).collect();
-                // NOT trimmed: a fixture name ends in a space, and the caller
-                // below compares those names byte for byte.
-                run_git_input(Some(&repo), &argref, input.as_deref(), DEFAULT_TIMEOUT)
-                    .await
-                    .unwrap()
-                    .stdout_lossy()
-            }
-        };
-
-        let blob = git_out(
-            vec!["hash-object".into(), "-w".into(), "--stdin".into()],
-            Some("x\n".into()),
-        )
-        .await
-        .trim()
-        .to_string();
-        let files = ["notes ", "notes", "keep.txt"];
-        let rows: String = files
-            .iter()
-            .map(|p| format!("100644 blob {blob}\t{p}\n"))
-            .collect();
-        let tree = git_out(vec!["mktree".into()], Some(rows))
-            .await
-            .trim()
-            .to_string();
-        let empty = git_out(vec!["mktree".into()], Some(String::new()))
-            .await
-            .trim()
-            .to_string();
-
-        // Exactly what *Exclude from AI* writes for a file named `notes `.
-        let terms = pathspecs_for_repo(&repo, &["/notes\\ ".to_string()])
-            .await
-            .specs;
-        let mut args: Vec<String> = vec![
-            "diff".into(),
-            "--name-only".into(),
-            empty,
-            tree,
-            "--".into(),
-            ".".into(),
-        ];
-        args.extend(terms);
-        let listed: BTreeSet<String> = git_out(args, None)
-            .await
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(str::to_string)
-            .collect();
-
-        let hidden: BTreeSet<String> = files
-            .iter()
-            .map(|p| p.to_string())
-            .filter(|p| !listed.contains(p))
-            .collect();
-        assert_eq!(
-            hidden,
-            ["notes ".to_string()].into_iter().collect::<BTreeSet<_>>(),
-            "only the trailing-space file is hidden; listed = {listed:?}"
-        );
-    }
-
-    /// A widened bracket still hides everything the gitignore engine hides —
-    /// asserted as a DIRECTION, not as an emitted term, so a future translation
-    /// that widens differently stays covered as long as it stays fail-closed.
-    ///
-    /// `a[[:x]\-b:]c]d` is the shape that catches an over-scanning terminator
-    /// search. Its first `]` is not `:`-preceded, so wildmatch reads the inner `[`
-    /// as an ordinary member and ends the class right there; a scan that hunted
-    /// for a later `:]` instead would swallow the real terminator, collapse the
-    /// pattern to a three-character match, and quietly stop hiding the long names
-    /// gitignore hides — a leak, on the engine that guards the model boundary.
-    ///
-    /// Built in the object database because the fixture names contain `:`, which
-    /// Windows will not accept in a filename — `parity_repo` cannot carry them.
-    #[tokio::test]
-    async fn widened_bracket_never_under_excludes_the_gitignore_set() {
-        let dir = tempfile::Builder::new()
-            .prefix("gd-aiignore-posix-")
-            .tempdir()
-            .expect("create temp dir");
-        let repo = dir.path().to_string_lossy().into_owned();
-        for args in [
-            vec!["init", "-q"],
-            vec!["config", "user.email", "t@t.local"],
-            vec!["config", "user.name", "T"],
-            vec!["config", "core.ignorecase", "false"],
-        ] {
-            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
-        }
-
-        let git_out = |args: Vec<String>, input: Option<String>| {
-            let repo = repo.clone();
-            async move {
-                let argref: Vec<&str> = args.iter().map(String::as_str).collect();
-                run_git_input(Some(&repo), &argref, input.as_deref(), DEFAULT_TIMEOUT)
-                    .await
-                    .unwrap()
-                    .stdout_lossy()
-            }
-        };
-
-        let blob = git_out(
-            vec!["hash-object".into(), "-w".into(), "--stdin".into()],
-            Some("x\n".into()),
-        )
-        .await
-        .trim()
-        .to_string();
-        // `ax-…`/`a[-…` are class members of `[[:x]`; `axQ…` differs only where
-        // gitignore has a literal `-`, so it witnesses the widening; `aZ-…` and
-        // `aXd` are the controls neither engine may hide.
-        let files = [
-            "ax-b:]c]d",
-            "a[-b:]c]d",
-            "axQb:]c]d",
-            "aZ-b:]c]d",
-            "aXd",
-        ];
-        let rows: String = files
-            .iter()
-            .map(|p| format!("100644 blob {blob}\t{p}\n"))
-            .collect();
-        let tree = git_out(vec!["mktree".into()], Some(rows))
-            .await
-            .trim()
-            .to_string();
-        let empty = git_out(vec!["mktree".into()], Some(String::new()))
-            .await
-            .trim()
-            .to_string();
-
-        let patterns = vec!["a[[:x]\\-b:]c]d".to_string()];
-        let terms = pathspecs_for_repo(&repo, &patterns).await.specs;
-        let mut args: Vec<String> = vec![
-            "diff".into(),
-            "--name-only".into(),
-            empty,
-            tree,
-            "--".into(),
-            ".".into(),
-        ];
-        args.extend(terms);
-        let listed: BTreeSet<String> = git_out(args, None)
-            .await
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(str::to_string)
-            .collect();
-        let by_pathspec: BTreeSet<String> = files
-            .iter()
-            .map(|p| p.to_string())
-            .filter(|p| !listed.contains(p))
-            .collect();
-
-        let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
-            repo.clone(),
-            files.iter().map(|p| p.to_string()).collect(),
-            patterns,
-        )
-        .await
-        .unwrap()
-        .into_iter()
-        .collect();
-
-        // Fixture precondition: without this the subset check below is vacuous,
-        // and this is the exact name an over-scan drops.
-        assert!(
-            by_gitignore.contains("ax-b:]c]d"),
-            "fixture must exercise the shape; gitignore hid {by_gitignore:?}"
-        );
-        assert!(
-            by_gitignore.is_subset(&by_pathspec),
-            "pathspec must hide at least the gitignore set; \
-             gitignore {by_gitignore:?} vs pathspec {by_pathspec:?}"
-        );
-        // Strictly more, so the subset check cannot pass by the widening having
-        // silently become an exact translation of something else.
-        assert!(
-            by_pathspec.contains("axQb:]c]d"),
-            "the widened member should also sweep the witness; pathspec {by_pathspec:?}"
-        );
-        // The controls stay visible on BOTH engines — a widening, not a wildcard.
-        for control in ["aZ-b:]c]d", "aXd"] {
-            assert!(!by_pathspec.contains(control), "pathspec swept {control}");
-            assert!(!by_gitignore.contains(control), "gitignore swept {control}");
-        }
-    }
-
-    /// The two engines agree with each other AND with the measured table, for
-    /// every pattern shape the UI can produce. This is the test that stops the
-    /// pathspec translation drifting away from real gitignore.
-    #[tokio::test]
-    async fn both_engines_match_the_measured_table() {
-        let (_dir, repo) = parity_repo().await;
-        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
-
-        for (patterns, expected) in PARITY {
-            let want: BTreeSet<String> = expected.iter().map(|p| p.to_string()).collect();
-
-            let by_pathspec = hidden_by_pathspec(&repo, patterns).await;
-            assert_eq!(by_pathspec, want, "pathspec engine, patterns {patterns:?}");
-
-            let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
-                repo.clone(),
-                all.clone(),
-                patterns.iter().map(|p| p.to_string()).collect(),
-            )
-            .await
-            .unwrap()
-            .into_iter()
-            .collect();
-            assert_eq!(
-                by_gitignore, want,
-                "gitignore engine, patterns {patterns:?}"
-            );
-        }
-    }
-
-    /// The `?`-widened escapes hold the fail-CLOSED invariant, which is the most
-    /// the PARITY table could never state: those shapes are the one place the two
-    /// engines are allowed to disagree, and the direction is the whole point.
-    ///
-    /// The gitignore engine hides exactly the escaped name; the pathspec engine
-    /// must hide AT LEAST it. Over-excluding a sibling costs a file the model
-    /// could have seen; under-excluding hands over the file the user named.
-    #[tokio::test]
-    async fn widened_escapes_over_exclude_and_never_under_exclude() {
-        let (_dir, repo) = parity_repo().await;
-        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
-
-        for (pattern, gitignore_hides, only_by_wildcard) in [
-            ("bang\\!.txt", &["bang!.txt"][..], "bangX.txt"),
-            ("hat\\^.txt", &["hat^.txt"][..], "hatX.txt"),
-            // A bracket carrying an escape widens to `?` as a whole; gitignore
-            // reads the class literally, so `a-d` and `abd` are its members.
-            ("a[b\\-c]d", &["a-d", "abd"][..], "aXd"),
-            // The same, with a POSIX class ahead of the escape. Rewriting the
-            // escape in place would leave `a[[:digit:]?]d` — digits plus `?` —
-            // which stops hiding the `a-d` that gitignore hides.
-            ("a[[:digit:]\\-]d", &["a-d", "a5d"][..], "abd"),
-        ] {
-            let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
-                repo.clone(),
-                all.clone(),
-                vec![pattern.to_string()],
-            )
-            .await
-            .unwrap()
-            .into_iter()
-            .collect();
-            assert_eq!(
-                by_gitignore,
-                gitignore_hides
-                    .iter()
-                    .map(|p| p.to_string())
-                    .collect::<BTreeSet<_>>(),
-                "gitignore engine hides exactly the named files, patterns {pattern:?}"
-            );
-
-            let by_pathspec = hidden_by_pathspec(&repo, &[pattern]).await;
-            assert!(
-                by_gitignore.is_subset(&by_pathspec),
-                "pathspec engine must hide at least what gitignore hides; \
-                 pattern {pattern:?} gave {by_pathspec:?}"
-            );
-            // Strictly more, here: the `?` also swallows the sibling. Asserted so
-            // the subset check above can't pass by the two sets being equal for
-            // some unrelated reason.
-            assert!(
-                by_pathspec.contains(only_by_wildcard),
-                "pattern {pattern:?} should also sweep {only_by_wildcard}"
-            );
-        }
-    }
-
-    /// Case folding follows the USER'S REPO, identically on both engines.
-    ///
-    /// The failure this pins is asymmetric and silent: pathspec matching is
-    /// case-sensitive whatever `core.ignorecase` says, while real gitignore folds
-    /// when it is set — the default on Windows and macOS. Without `,icase` a
-    /// `NOTES.MD` pattern would hide `notes.md` from the conflict gate and the
-    /// remote-PR filter while every diff path still shipped it to the model.
-    #[tokio::test]
-    async fn case_folding_follows_the_repo() {
-        let (_dir, repo) = parity_repo().await;
-        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
-        let pattern = vec!["NOTES.MD".to_string()];
-        let want_folded: BTreeSet<String> = ["a/b/notes.md", "docs/notes.md", "notes.md"]
-            .iter()
-            .map(|p| p.to_string())
-            .collect();
-
-        // The fixture pins ignorecase=false: a case-differing pattern matches
-        // nothing, on either engine.
-        assert!(hidden_by_pathspec(&repo, &["NOTES.MD"]).await.is_empty());
-        assert!(
-            git_filter_ai_ignored(repo.clone(), all.clone(), pattern.clone())
-                .await
-                .unwrap()
-                .is_empty()
-        );
-        assert_eq!(specs("NOTES.MD")[0], ":(exclude,glob)**/NOTES.MD");
-
-        // Flip the REPO's setting; both engines must follow it, and each other.
-        // Written as `1`, NOT `true`: git accepts `1`/`yes`/`on`/a valueless key
-        // as true, so a raw string compare reads this repo as case-SENSITIVE and
-        // forces that onto both engines — agreeing with each other and wrong.
-        run_git(
-            Some(&repo),
-            &["config", "core.ignorecase", "1"],
-            DEFAULT_TIMEOUT,
-        )
-        .await
-        .unwrap();
-        // Behavior first: an emitted-magic assertion ahead of it would mask which
-        // half actually broke.
-        let by_pathspec = hidden_by_pathspec(&repo, &["NOTES.MD"]).await;
-        assert_eq!(by_pathspec, want_folded, "pathspec engine folds case");
-
-        let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(repo, all, pattern)
-            .await
-            .unwrap()
-            .into_iter()
-            .collect();
-        assert_eq!(by_gitignore, want_folded, "gitignore engine folds case");
-        assert_eq!(by_pathspec, by_gitignore, "and the two agree");
-        assert_eq!(
-            specs_icase("NOTES.MD")[0],
-            ":(exclude,glob,icase)**/NOTES.MD"
-        );
     }
 
     /// A returned path is byte-identical to the one that went in, whatever
@@ -1491,49 +791,6 @@ mod tests {
         );
     }
 
-    /// The repo's OWN `.gitignore` is not an AI-ignore list. Matching runs in an
-    /// empty neutral repo, so `keep.txt` — gitignored by the fixture, named by no
-    /// AI pattern — stays visible to both engines. Running check-ignore inside
-    /// the user's repo instead reports it, which would both silently
-    /// over-withhold and split the two engines apart.
-    #[tokio::test]
-    async fn repo_gitignore_never_counts_as_an_ai_pattern() {
-        let (_dir, repo) = parity_repo().await;
-        // Sanity: git really does ignore it there, so the negative below has teeth.
-        let native = run_git(
-            Some(&repo),
-            &["check-ignore", "--no-index", "--", REPO_GITIGNORE_ONLY],
-            DEFAULT_TIMEOUT,
-        )
-        .await
-        .unwrap();
-        assert_eq!(
-            native.stdout_lossy().trim(),
-            REPO_GITIGNORE_ONLY,
-            "fixture precondition: the repo's .gitignore covers this path"
-        );
-
-        let ai_patterns = vec!["notes.md".to_string()];
-        let by_gitignore = git_filter_ai_ignored(
-            repo.clone(),
-            vec![REPO_GITIGNORE_ONLY.to_string(), "notes.md".to_string()],
-            ai_patterns.clone(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(
-            by_gitignore,
-            vec!["notes.md".to_string()],
-            "only the AI pattern matched — the repo's .gitignore did not leak in"
-        );
-
-        let by_pathspec = hidden_by_pathspec(&repo, &["notes.md"]).await;
-        assert!(
-            !by_pathspec.contains(REPO_GITIGNORE_ONLY),
-            "the pathspec engine agrees the gitignored path is not AI-ignored"
-        );
-    }
-
     /// `git_filter_ai_ignored` matches paths that exist nowhere in the repo (the
     /// remote-PR case), returns `[]` rather than erroring when nothing matches,
     /// and short-circuits on empty input.
@@ -1567,10 +824,258 @@ mod tests {
             .is_empty());
     }
 
-    /// A `!` un-ignore line is unsupported: adding one changes NOTHING on either
-    /// engine. Git's own matcher would re-include the negated path, so without
-    /// the shared drop the same list would hide a file on the pathspec paths and
-    /// hand it to a model on this one.
+    /// A fresh repo with an identity and pinned case sensitivity, for the
+    /// commit-based fixtures below.
+    async fn seed_repo(tag: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-aiignore-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+            vec!["config", "core.ignorecase", "false"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        (dir, repo)
+    }
+
+    /// An escaped-trailing-space file is hidden from a real branch diff on EVERY
+    /// platform — the regression that matters, since it is Windows where a raw
+    /// `\ ` term silently excluded nothing and handed `notes ` to a model.
+    ///
+    /// Built straight in the object database (`hash-object` → `mktree` →
+    /// `commit-tree`): git on Windows refuses to index a trailing-space path at
+    /// all ("Invalid path"), so no checkout can carry this fixture.
+    #[tokio::test]
+    async fn escaped_trailing_space_excluded_from_a_branch_diff_everywhere() {
+        let (_dir, repo) = seed_repo("tree").await;
+
+        let git_out = |args: Vec<String>, input: Option<String>| {
+            let repo = repo.clone();
+            async move {
+                let argref: Vec<&str> = args.iter().map(String::as_str).collect();
+                // NOT trimmed beyond the surrounding newline: a fixture name ends
+                // in a space, and the assertions below compare names byte for byte.
+                run_git_input(Some(&repo), &argref, input.as_deref(), DEFAULT_TIMEOUT)
+                    .await
+                    .unwrap()
+                    .stdout_lossy()
+            }
+        };
+
+        let blob = git_out(
+            vec!["hash-object".into(), "-w".into(), "--stdin".into()],
+            Some("x\n".into()),
+        )
+        .await
+        .trim()
+        .to_string();
+        let files = ["notes ", "notes", "keep.txt"];
+        let rows: String = files
+            .iter()
+            .map(|p| format!("100644 blob {blob}\t{p}\n"))
+            .collect();
+        let tree = git_out(vec!["mktree".into()], Some(rows))
+            .await
+            .trim()
+            .to_string();
+        let empty_tree = git_out(vec!["mktree".into()], Some(String::new()))
+            .await
+            .trim()
+            .to_string();
+        // The empty-tree commit is the merge base, so the three-dot diff below is
+        // the whole tree.
+        let base = git_out(
+            vec![
+                "commit-tree".into(),
+                empty_tree,
+                "-m".into(),
+                "empty".into(),
+            ],
+            None,
+        )
+        .await
+        .trim()
+        .to_string();
+        let head = git_out(
+            vec![
+                "commit-tree".into(),
+                tree,
+                "-p".into(),
+                base.clone(),
+                "-m".into(),
+                "full".into(),
+            ],
+            None,
+        )
+        .await
+        .trim()
+        .to_string();
+
+        // Exactly what *Exclude from AI* writes for a file named `notes `.
+        let out = git_branch_diff(repo, base, head, None, Some(vec!["/notes\\ ".to_string()]))
+            .await
+            .unwrap();
+
+        let listed: BTreeSet<&str> = out.files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            listed,
+            ["keep.txt", "notes"].into_iter().collect::<BTreeSet<_>>(),
+            "only the trailing-space file is hidden"
+        );
+        assert_eq!(out.excluded_files, 1);
+        // Compared as HEADER lines, not by substring: `diff --git a/notes b/notes`
+        // itself contains the string "notes ".
+        let headers: BTreeSet<&str> = out
+            .text
+            .lines()
+            .filter(|l| l.starts_with("diff --git "))
+            .collect();
+        assert_eq!(
+            headers,
+            [
+                "diff --git a/keep.txt b/keep.txt",
+                "diff --git a/notes b/notes"
+            ]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+            "diff text: {}",
+            out.text
+        );
+    }
+
+    /// The staged-diff command agrees with the measured table AND with
+    /// `git_filter_ai_ignored`, for every pattern shape the UI can produce — the
+    /// test that keeps the diff paths on real gitignore semantics.
+    #[tokio::test]
+    async fn staged_diff_matches_the_measured_table() {
+        let (_dir, repo) = parity_repo().await;
+        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
+
+        for (patterns, expected) in PARITY {
+            let want: BTreeSet<String> = expected.iter().map(|p| p.to_string()).collect();
+
+            let (hidden, excluded) = hidden_by_command(&repo, patterns).await;
+            assert_eq!(hidden, want, "staged diff, patterns {patterns:?}");
+            assert_eq!(
+                excluded as usize,
+                want.len(),
+                "disclosed count, patterns {patterns:?}"
+            );
+
+            let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(
+                repo.clone(),
+                all.clone(),
+                patterns.iter().map(|p| p.to_string()).collect(),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+            assert_eq!(
+                by_gitignore, want,
+                "gitignore engine, patterns {patterns:?}"
+            );
+        }
+    }
+
+    /// Case folding follows the USER'S REPO. Pathspec matching is case-SENSITIVE
+    /// whatever `core.ignorecase` says, so every verdict has to come from the
+    /// gitignore engine driven by the repo's own setting — `true` is the default
+    /// on Windows and macOS, where a `NOTES.MD` pattern must hide `notes.md`.
+    #[tokio::test]
+    async fn case_folding_follows_the_repo() {
+        let (_dir, repo) = parity_repo().await;
+        let all: Vec<String> = FIXTURE.iter().map(|p| p.to_string()).collect();
+        let pattern = vec!["NOTES.MD".to_string()];
+        let want_folded: BTreeSet<String> = ["a/b/notes.md", "docs/notes.md", "notes.md"]
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        // The fixture pins ignorecase=false: a case-differing pattern matches
+        // nothing.
+        let (hidden, excluded) = hidden_by_command(&repo, &["NOTES.MD"]).await;
+        assert!(hidden.is_empty());
+        assert_eq!(excluded, 0);
+        assert!(
+            git_filter_ai_ignored(repo.clone(), all.clone(), pattern.clone())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // Flip the REPO's setting; the command must follow it. Written as `1`,
+        // NOT `true`: git accepts `1`/`yes`/`on`/a valueless key as true, so a raw
+        // string compare would read this repo as case-SENSITIVE and force that on.
+        run_git(
+            Some(&repo),
+            &["config", "core.ignorecase", "1"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        let (hidden, excluded) = hidden_by_command(&repo, &["NOTES.MD"]).await;
+        assert_eq!(hidden, want_folded, "the staged diff folds case");
+        assert_eq!(excluded as usize, want_folded.len());
+
+        let by_gitignore: BTreeSet<String> = git_filter_ai_ignored(repo, all, pattern)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(by_gitignore, want_folded, "gitignore engine folds case");
+    }
+
+    /// The repo's OWN `.gitignore` is not an AI-ignore list. Matching runs in an
+    /// empty neutral repo, so `keep.txt` — gitignored by the fixture, named by no
+    /// AI pattern — stays visible. Running check-ignore inside the user's repo
+    /// instead reports it, silently over-withholding.
+    #[tokio::test]
+    async fn repo_gitignore_never_counts_as_an_ai_pattern() {
+        let (_dir, repo) = parity_repo().await;
+        // Sanity: git really does ignore it there, so the negative below has teeth.
+        let native = run_git(
+            Some(&repo),
+            &["check-ignore", "--no-index", "--", REPO_GITIGNORE_ONLY],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            native.stdout_lossy().trim(),
+            REPO_GITIGNORE_ONLY,
+            "fixture precondition: the repo's .gitignore covers this path"
+        );
+
+        let ai_patterns = vec!["notes.md".to_string()];
+        let by_gitignore = git_filter_ai_ignored(
+            repo.clone(),
+            vec![REPO_GITIGNORE_ONLY.to_string(), "notes.md".to_string()],
+            ai_patterns,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            by_gitignore,
+            vec!["notes.md".to_string()],
+            "only the AI pattern matched — the repo's .gitignore did not leak in"
+        );
+
+        let (hidden, _) = hidden_by_command(&repo, &["notes.md"]).await;
+        assert!(
+            !hidden.contains(REPO_GITIGNORE_ONLY),
+            "the staged diff agrees the gitignored path is not AI-ignored"
+        );
+    }
+
+    /// A `!` un-ignore line is unsupported: adding one changes NOTHING. Git's own
+    /// matcher would re-include the negated path, and a diff filtered by
+    /// exclusion has no un-exclude to mirror that with.
     #[tokio::test]
     async fn negation_lines_change_nothing_on_either_engine() {
         let (_dir, repo) = parity_repo().await;
@@ -1578,9 +1083,20 @@ mod tests {
         let plain = vec!["*.md".to_string()];
         let negated = vec!["*.md".to_string(), "!docs/notes.md".to_string()];
 
-        let translated = pathspecs_for(&negated, false);
-        assert_eq!(translated.skipped_negations, 1);
-        assert_eq!(translated.specs, pathspecs_for(&plain, false).specs);
+        let (kept, skipped) = actionable_lines(&negated);
+        assert_eq!(skipped, 1);
+        assert_eq!(kept, actionable_lines(&plain).0);
+
+        let (with_negation, _) = hidden_by_command(&repo, &["*.md", "!docs/notes.md"]).await;
+        let (without, _) = hidden_by_command(&repo, &["*.md"]).await;
+        assert_eq!(
+            with_negation, without,
+            "the `!` line did not re-include anything"
+        );
+        assert!(
+            with_negation.contains("docs/notes.md"),
+            "the negated path stays hidden"
+        );
 
         let with = git_filter_ai_ignored(repo.clone(), all.clone(), negated)
             .await
@@ -1588,11 +1104,7 @@ mod tests {
         let without = git_filter_ai_ignored(repo.clone(), all, plain)
             .await
             .unwrap();
-        assert_eq!(with, without, "the `!` line did not re-include anything");
-        assert!(
-            with.contains(&"docs/notes.md".to_string()),
-            "the negated path stays hidden"
-        );
+        assert_eq!(with, without);
 
         // An exclude list of nothing BUT droppable lines matches nothing at all,
         // and never spawns git.
@@ -1604,5 +1116,326 @@ mod tests {
         .await
         .unwrap();
         assert!(only_droppable.is_empty());
+    }
+
+    /// A renamed file is hidden WHOLE when either side matches. Excluding only
+    /// the new name leaves a `D <old name>` row, which names the very file the
+    /// user withheld; excluding only the old name leaves the new content.
+    #[tokio::test]
+    async fn a_rename_is_hidden_when_either_side_matches() {
+        let (_dir, repo) = seed_repo("rename").await;
+        let root = Path::new(&repo);
+        std::fs::write(root.join("secrets.env"), "TOKEN=abc123\nKEY=def456\n").unwrap();
+        std::fs::write(root.join("keep.txt"), "keep\n").unwrap();
+        for args in [
+            vec!["add", "-A", "-f"],
+            vec!["commit", "-qm", "first"],
+            vec!["mv", "secrets.env", "renamed.txt"],
+            vec!["commit", "-qam", "rename"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        let first = run_git(Some(&repo), &["rev-parse", "HEAD~1"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        // Fixture precondition: git reports ONE rename row, not an add + delete.
+        let all = git_branch_diff(repo.clone(), first.clone(), "HEAD".into(), None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            all.files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            ["renamed.txt"]
+        );
+
+        let filtered = git_branch_diff(
+            repo,
+            first,
+            "HEAD".into(),
+            None,
+            Some(vec!["*.env".to_string()]),
+        )
+        .await
+        .unwrap();
+        assert!(filtered.files.is_empty(), "{:?}", filtered.files);
+        assert_eq!(filtered.excluded_files, 1);
+        assert!(!filtered.text.contains("secrets.env"), "{}", filtered.text);
+        assert!(!filtered.text.contains("renamed.txt"), "{}", filtered.text);
+    }
+
+    /// `git mktree` fed RAW bytes, for a fixture whose name is not valid UTF-8 —
+    /// the `run_git` helpers are `&str`-typed and cannot express one.
+    fn mktree_raw(repo: &str, input: &[u8]) -> String {
+        use std::io::Write as _;
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("git")
+            .arg("mktree")
+            .current_dir(repo)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn git mktree");
+        child
+            .stdin
+            .take()
+            .expect("stdin was piped")
+            .write_all(input)
+            .expect("write tree rows");
+        let out = child.wait_with_output().expect("git mktree");
+        assert!(
+            out.status.success(),
+            "git mktree failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Commits raw `mktree` rows as the child of an empty-tree commit, returning
+    /// `(base, head)`. The empty commit is the merge base, so a three-dot diff
+    /// over the pair is the whole tree — and nothing ever reaches the index,
+    /// which is the only way these fixture names exist under Windows git.
+    async fn commit_tree_pair(repo: &str, rows: &[u8]) -> (String, String) {
+        let tree = mktree_raw(repo, rows);
+        let empty_tree = mktree_raw(repo, b"");
+        let base = run_git(
+            Some(repo),
+            &["commit-tree", &empty_tree, "-m", "empty"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+        let head = run_git(
+            Some(repo),
+            &["commit-tree", &tree, "-p", &base, "-m", "full"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+        (base, head)
+    }
+
+    /// A blob of `x\n`, for the object-DB fixtures.
+    async fn seed_blob(repo: &str) -> String {
+        run_git_input(
+            Some(repo),
+            &["hash-object", "-w", "--stdin"],
+            Some("x\n"),
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap()
+        .stdout_lossy()
+        .trim()
+        .to_string()
+    }
+
+    /// A name that is not valid UTF-8 reaches us only as a lossy string, so its
+    /// check-ignore verdict cannot be trusted in the leak direction: the row is
+    /// hidden unconditionally, through a widened glob rather than an exact term.
+    #[tokio::test]
+    async fn an_unreadable_name_is_hidden_unconditionally() {
+        let (_dir, repo) = seed_repo("lossy").await;
+        let blob = seed_blob(&repo).await;
+
+        // A lone `0xE9` is not valid UTF-8, so this name comes back as
+        // `caf\u{FFFD}.env` — a string no `,literal` term can match.
+        let mut rows: Vec<u8> = format!("100644 blob {blob}\t").into_bytes();
+        rows.extend_from_slice(b"caf\xE9.env\n");
+        rows.extend_from_slice(format!("100644 blob {blob}\tkeep.txt\n").as_bytes());
+        let (base, head) = commit_tree_pair(&repo, &rows).await;
+
+        let filtered = git_branch_diff(
+            repo.clone(),
+            base.clone(),
+            head.clone(),
+            None,
+            Some(vec!["*.env".to_string()]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            filtered
+                .files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            ["keep.txt"]
+        );
+        assert_eq!(filtered.excluded_files, 1);
+        assert!(!filtered.text.contains("caf"), "{}", filtered.text);
+
+        // Control: unfiltered, the lossy row is present under its lossy name.
+        let all = git_branch_diff(repo, base, head, None, None).await.unwrap();
+        assert_eq!(
+            all.files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            ["caf\u{FFFD}.env", "keep.txt"]
+        );
+    }
+
+    /// Every changed file hidden ⇒ no content pass runs at all. A `git diff`
+    /// carrying no pathspec is the FULL diff, so this short-circuit is what stops
+    /// an all-ignored change from coming back unfiltered.
+    #[tokio::test]
+    async fn everything_hidden_returns_an_empty_diff() {
+        let (_dir, repo) = seed_repo("allhidden").await;
+        let root = Path::new(&repo);
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::write(root.join("a.txt"), "a\n").unwrap();
+        std::fs::write(root.join("b.rs"), "b\n").unwrap();
+        std::fs::write(root.join("docs").join("c.md"), "c\n").unwrap();
+        run_git(Some(&repo), &["add", "-A", "-f"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        let all = git_staged_diff(repo.clone(), None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(all.files.len(), 3);
+
+        let hidden = git_staged_diff(repo, None, Some(vec!["*".to_string()]), None)
+            .await
+            .unwrap();
+        assert!(hidden.text.is_empty(), "{}", hidden.text);
+        assert!(hidden.files.is_empty());
+        assert!(!hidden.truncated);
+        assert_eq!(hidden.excluded_files, 3);
+    }
+
+    /// A `\` in a name is inexpressible as a `,literal` term: Windows git
+    /// normalizes it to a separator even under literal magic, so the term
+    /// excludes NOTHING while the file list still reports the file hidden — the
+    /// content leaks. The widened `?` form excludes it on both platforms
+    /// (measured, git 2.51.1.windows.1).
+    ///
+    /// Runs on EVERY platform deliberately: Windows is the one the leak exists on.
+    #[tokio::test]
+    async fn a_backslash_name_is_excluded_by_the_widened_term() {
+        let (_dir, repo) = seed_repo("backslash").await;
+        let blob = seed_blob(&repo).await;
+
+        // Byte 0x5C is ordinary UTF-8, so unlike the lossy fixture this name
+        // round-trips exactly — only its TERM encoding has to widen.
+        let mut rows: Vec<u8> = format!("100644 blob {blob}\t").into_bytes();
+        rows.extend_from_slice(b"weird\\name.env\n");
+        rows.extend_from_slice(format!("100644 blob {blob}\tkeep.txt\n").as_bytes());
+        let (base, head) = commit_tree_pair(&repo, &rows).await;
+
+        let filtered = git_branch_diff(
+            repo.clone(),
+            base.clone(),
+            head.clone(),
+            None,
+            Some(vec!["*.env".to_string()]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            filtered
+                .files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            ["keep.txt"]
+        );
+        assert_eq!(filtered.excluded_files, 1);
+        // "weird" rather than the whole name: `--name-only`-style diff headers
+        // C-quote a backslash whatever `core.quotePath` says.
+        assert!(!filtered.text.contains("weird"), "{}", filtered.text);
+
+        // Control: unfiltered, the row is present under its raw name.
+        let all = git_branch_diff(repo, base, head, None, None).await.unwrap();
+        assert_eq!(
+            all.files
+                .iter()
+                .map(|f| f.path.as_str())
+                .collect::<Vec<_>>(),
+            ["keep.txt", "weird\\name.env"]
+        );
+    }
+
+    /// Past `TERM_BUDGET` the diff is withheld WHOLE — survivors included —
+    /// because the only alternatives are a spawn that fails outright on Windows
+    /// or one with terms dropped, which ships the very files that matched.
+    #[tokio::test]
+    async fn a_term_list_over_budget_withholds_the_whole_diff() {
+        let (_dir, repo) = seed_repo("budget").await;
+        let blob = seed_blob(&repo).await;
+
+        // 400 long ignored names: ~94 bytes of term each, far past the budget.
+        let pad = "a".repeat(60);
+        let mut inner = String::new();
+        for i in 0..400 {
+            inner.push_str(&format!("100644 blob {blob}\tf{i}_{pad}.env\n"));
+        }
+        let vendor = mktree_raw(&repo, inner.as_bytes());
+        let top = format!(
+            "040000 tree {vendor}\tvendor\n\
+             100644 blob {blob}\ta.txt\n\
+             100644 blob {blob}\tkeep.txt\n"
+        );
+        let (base, head) = commit_tree_pair(&repo, top.as_bytes()).await;
+
+        // Fixture precondition: the two survivors really are in the range.
+        let all = git_branch_diff(repo.clone(), base.clone(), head.clone(), None, None)
+            .await
+            .unwrap();
+        assert_eq!(all.files.len(), 402);
+        assert_eq!(all.excluded_files, 0);
+
+        let filtered = git_branch_diff(repo, base, head, None, Some(vec!["vendor/".to_string()]))
+            .await
+            .unwrap();
+        assert!(filtered.text.is_empty(), "{}", filtered.text);
+        assert!(filtered.files.is_empty(), "{:?}", filtered.files);
+        assert_eq!(
+            filtered.excluded_files, 402,
+            "the disclosure counts survivors too — they are withheld as well"
+        );
+    }
+
+    /// A multi-line rev expansion is a hard error on the pinned path, rather than
+    /// an argument whose extra output line silently misaligns the two SHAs.
+    /// Only the filtered path resolves refs, so the unfiltered one is untouched.
+    #[tokio::test]
+    async fn a_multi_line_rev_is_rejected_when_patterns_are_actionable() {
+        let (_dir, repo) = seed_repo("revpin").await;
+        let root = Path::new(&repo);
+        std::fs::write(root.join("a.txt"), "a\n").unwrap();
+        for args in [vec!["add", "-A"], vec!["commit", "-qm", "one"]] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        std::fs::write(root.join("b.txt"), "b\n").unwrap();
+        for args in [vec!["add", "-A"], vec!["commit", "-qm", "two"]] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+
+        let out = git_branch_diff(
+            repo,
+            "HEAD^!".into(),
+            "HEAD".into(),
+            None,
+            Some(vec!["*.env".to_string()]),
+        )
+        .await;
+        assert!(
+            out.is_err(),
+            "a two-line rev expansion must not resolve to a pinned range"
+        );
     }
 }

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -145,7 +145,7 @@ pub async fn git_branch_diff(
     validate_ref(&compare)?;
     let exclude = exclude.unwrap_or_default();
 
-    let range = if crate::git::ai_ignore::has_actionable_lines(&exclude) {
+    let range = if crate::git::ai_ignore::has_positive_pattern(&exclude) {
         pinned_range(&repo_path, &base, &compare).await?
     } else {
         format!("{base}...{compare}")

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -92,11 +92,47 @@ pub async fn git_branch_diff_files(
     Ok(parse_numstat_z(&out.stdout_lossy()))
 }
 
+/// Both refs resolved to SHAs in ONE spawn, so every call of the AI-ignore
+/// filter's two-pass flow reads the same trees. Trees are immutable once named,
+/// which is why the branch path pins refs where the staged path re-reads instead.
+///
+/// `^{commit}` peels an annotated tag to its commit, and turns a multi-line rev
+/// expansion (`HEAD^!`, `HEAD^@`) into a git error rather than an argument whose
+/// line count silently misaligns with the two SHAs expected below.
+async fn pinned_range(repo_path: &str, base: &str, compare: &str) -> AppResult<String> {
+    let base_rev = format!("{base}^{{commit}}");
+    let compare_rev = format!("{compare}^{{commit}}");
+    let out = run_git(
+        Some(repo_path),
+        &["rev-parse", &base_rev, &compare_rev],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    let text = out.stdout_lossy();
+    let shas: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let [base_sha, compare_sha] = shas[..] else {
+        return Err(AppError::InvalidArgument(format!(
+            "could not resolve {base} and {compare}"
+        )));
+    };
+    let is_sha = |s: &str| s.chars().all(|c| c.is_ascii_hexdigit());
+    if !is_sha(base_sha) || !is_sha(compare_sha) {
+        return Err(AppError::InvalidArgument(format!(
+            "could not resolve {base} and {compare}"
+        )));
+    }
+    Ok(format!("{base_sha}...{compare_sha}"))
+}
+
 /// The full combined `base...compare` diff text plus its file summary, for
 /// feeding AI PR description generation. `exclude` mirrors `git_staged_diff`:
-/// AI-ignore patterns become pathspec excludes and `excluded_files` reports how
-/// many changed files they hid. Truncation deliberately differs — char boundary
-/// at a 1 MB default, not file boundary at the AI budget.
+/// AI-ignore patterns hide changed files and `excluded_files` reports how many.
+/// Truncation deliberately differs — char boundary at a 1 MB default, not file
+/// boundary at the AI budget.
 #[tauri::command]
 pub async fn git_branch_diff(
     repo_path: String,
@@ -107,54 +143,32 @@ pub async fn git_branch_diff(
 ) -> AppResult<StagedDiff> {
     validate_ref(&base)?;
     validate_ref(&compare)?;
-    let range = format!("{base}...{compare}");
+    let exclude = exclude.unwrap_or_default();
 
-    // AI-ignore patterns → pathspec excludes (`git::ai_ignore` owns the
-    // translation). ":(exclude)" needs an inclusive pathspec alongside it,
-    // hence the leading ".".
-    let pathspec =
-        crate::git::ai_ignore::pathspecs_for_repo(&repo_path, &exclude.unwrap_or_default())
-            .await
-            .specs;
-
-    let mut diff_args: Vec<&str> = vec!["diff", "--no-color", &range];
-    let mut stat_args: Vec<&str> = vec!["diff", "--numstat", "-z", &range];
-    if !pathspec.is_empty() {
-        for args in [&mut diff_args, &mut stat_args] {
-            args.push("--");
-            args.push(".");
-            args.extend(pathspec.iter().map(String::as_str));
-        }
-    }
-
-    let (text_out, files_out) = tokio::try_join!(
-        run_git(Some(&repo_path), &diff_args, DEFAULT_TIMEOUT),
-        run_git(Some(&repo_path), &stat_args, DEFAULT_TIMEOUT)
-    )?;
-    let (text, truncated) =
-        truncate_at_char_boundary(text_out.stdout_lossy(), max_bytes.unwrap_or(1_000_000));
-    let files = parse_numstat_z(&files_out.stdout_lossy());
-
-    // Tell the caller how many changed files the excludes hid, so the AI
-    // prompt can mention that the diff is not the whole story.
-    let excluded_files = if pathspec.is_empty() {
-        0
+    let range = if crate::git::ai_ignore::has_actionable_lines(&exclude) {
+        pinned_range(&repo_path, &base, &compare).await?
     } else {
-        let all = run_git(
-            Some(&repo_path),
-            &["diff", "--numstat", "-z", &range],
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
-        let total = parse_numstat_z(&all.stdout_lossy()).len();
-        total.saturating_sub(files.len()) as u32
+        format!("{base}...{compare}")
     };
+
+    // `recheck: false` — the range is pinned to immutable trees above.
+    let filtered = crate::git::ai_ignore::filtered_diff(
+        &repo_path,
+        &["diff", "--no-color", &range],
+        &["diff", "--numstat", "-z", &range],
+        &exclude,
+        false,
+    )
+    .await?;
+
+    let (text, truncated) =
+        truncate_at_char_boundary(filtered.text, max_bytes.unwrap_or(1_000_000));
 
     Ok(StagedDiff {
         text,
         truncated,
-        files,
-        excluded_files,
+        files: filtered.files,
+        excluded_files: filtered.excluded_files,
     })
 }
 

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -412,53 +412,24 @@ pub async fn git_staged_diff(
         "--cached"
     };
 
-    // AI-ignore patterns → pathspec excludes (`git::ai_ignore` owns the
-    // translation). ":(exclude)" needs an inclusive pathspec alongside it,
-    // hence the leading ".".
-    let pathspec =
-        crate::git::ai_ignore::pathspecs_for_repo(&repo_path, &exclude.unwrap_or_default())
-            .await
-            .specs;
+    // `recheck: true` — this diff reads the index and working tree, which a
+    // concurrent edit can change between the name pass and the content pass.
+    let filtered = crate::git::ai_ignore::filtered_diff(
+        &repo_path,
+        &["diff", base, "--no-color"],
+        &["diff", base, "--numstat", "-z"],
+        &exclude.unwrap_or_default(),
+        true,
+    )
+    .await?;
 
-    let mut diff_args: Vec<&str> = vec!["diff", base, "--no-color"];
-    let mut stat_args: Vec<&str> = vec!["diff", base, "--numstat", "-z"];
-    if !pathspec.is_empty() {
-        for args in [&mut diff_args, &mut stat_args] {
-            args.push("--");
-            args.push(".");
-            args.extend(pathspec.iter().map(String::as_str));
-        }
-    }
-
-    let (diff_out, stat_out) = tokio::try_join!(
-        run_git(Some(&repo_path), &diff_args, DEFAULT_TIMEOUT),
-        run_git(Some(&repo_path), &stat_args, DEFAULT_TIMEOUT)
-    )?;
-
-    let files = parse_numstat_z(&stat_out.stdout_lossy());
-
-    // Tell the caller how many changed files the excludes hid, so the AI
-    // prompt can mention that the diff is not the whole story.
-    let excluded_files = if pathspec.is_empty() {
-        0
-    } else {
-        let all = run_git(
-            Some(&repo_path),
-            &["diff", base, "--numstat", "-z"],
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
-        let total = parse_numstat_z(&all.stdout_lossy()).len();
-        total.saturating_sub(files.len()) as u32
-    };
-
-    let (text, truncated) = truncate_at_file_boundary(diff_out.stdout_lossy(), max_bytes);
+    let (text, truncated) = truncate_at_file_boundary(filtered.text, max_bytes);
 
     Ok(StagedDiff {
         text,
         truncated,
-        files,
-        excluded_files,
+        files: filtered.files,
+        excluded_files: filtered.excluded_files,
     })
 }
 
@@ -505,13 +476,32 @@ fn truncate_at_file_boundary(text: String, max: usize) -> (String, bool) {
     (text[..kept_end].trim_end().to_string(), true)
 }
 
+/// One `--numstat -z` row together with EVERY path it names — one for a regular
+/// change, both sides for a rename.
+///
+/// The AI-ignore filter needs the old side too: excluding only one side of a
+/// rename leaves the other side's half of the change (an `A` or `D` row) in the
+/// diff, so a match on either name has to hide the pair.
+pub(crate) struct DiffStatRow {
+    pub entry: DiffStatEntry,
+    pub names: Vec<String>,
+}
+
 /// Parses `git diff --numstat -z` output.
 /// Regular entry: `added\tdeleted\tpath\0`.
 /// Rename entry:  `added\tdeleted\t\0oldpath\0newpath\0`.
 /// Binary files report `-` for both counts.
 pub fn parse_numstat_z(text: &str) -> Vec<DiffStatEntry> {
-    let mut entries = Vec::new();
-    let mut tokens = text.split('\0').peekable();
+    parse_numstat_z_rows(text)
+        .into_iter()
+        .map(|row| row.entry)
+        .collect()
+}
+
+/// [`parse_numstat_z`] keeping both sides of a rename (see [`DiffStatRow`]).
+pub(crate) fn parse_numstat_z_rows(text: &str) -> Vec<DiffStatRow> {
+    let mut rows = Vec::new();
+    let mut tokens = text.split('\0');
     while let Some(token) = tokens.next() {
         if token.is_empty() {
             continue;
@@ -525,24 +515,34 @@ pub fn parse_numstat_z(text: &str) -> Vec<DiffStatEntry> {
         let is_binary = added == "-";
         let added = added.parse().unwrap_or(0);
         let deleted = deleted.parse().unwrap_or(0);
-        let path = if path.is_empty() {
-            // rename: skip old path, take new path
-            tokens.next();
+        let (path, names) = if path.is_empty() {
+            // rename: old path, then new path — the entry reports the new one.
+            let old = tokens.next().unwrap_or("");
             match tokens.next() {
-                Some(new_path) if !new_path.is_empty() => new_path.to_string(),
+                Some(new_path) if !new_path.is_empty() => (
+                    new_path.to_string(),
+                    [old, new_path]
+                        .iter()
+                        .filter(|n| !n.is_empty())
+                        .map(|n| n.to_string())
+                        .collect(),
+                ),
                 _ => continue,
             }
         } else {
-            path.to_string()
+            (path.to_string(), vec![path.to_string()])
         };
-        entries.push(DiffStatEntry {
-            path,
-            added,
-            deleted,
-            is_binary,
+        rows.push(DiffStatRow {
+            entry: DiffStatEntry {
+                path,
+                added,
+                deleted,
+                is_binary,
+            },
+            names,
         });
     }
-    entries
+    rows
 }
 
 #[cfg(test)]

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -166,6 +166,31 @@ pub async fn run_git_input(
     Ok(out)
 }
 
+/// The working tree's toplevel for `repo_path`, which may be any directory
+/// inside it.
+///
+/// Anything that reads repo-relative NAMES out of git, or hands git pathspecs
+/// meant to match them, has to bind to this rather than to the path it was
+/// given: git prints and resolves both relative to the cwd, so a subdirectory
+/// silently re-scopes the answer while still looking well-formed. The MCP server
+/// takes `--repo` verbatim, so that subdirectory is reachable.
+pub(crate) async fn worktree_toplevel(repo_path: &str) -> AppResult<String> {
+    let out = run_git(
+        Some(repo_path),
+        &["rev-parse", "--show-toplevel"],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    let stdout = out.stdout_lossy();
+    // Line endings ONLY: a trailing space can be part of the directory name, and
+    // `trim()` would strip it into a path that does not exist.
+    let toplevel = stdout.trim_end_matches(['\r', '\n']).to_string();
+    if toplevel.is_empty() {
+        return Err(AppError::NotARepo(repo_path.to_string()));
+    }
+    Ok(toplevel)
+}
+
 /// Runs a mutating git command under the per-repo lock, retrying once on
 /// index.lock contention caused by external tools (editors, other clients).
 pub async fn run_git_mutating(

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -36,10 +36,21 @@ pub async fn read_repo_ai_ignore(repo_path: String) -> AppResult<Vec<String>> {
 
 /// Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore`, creating the
 /// `.gitdesktop` directory and the file (seeded with a `#` header comment) if
-/// absent. Mirrors `append_to_gitignore`: trim, de-dupe in batch, skip lines
-/// already present. Lines are stored verbatim, gitignore-style — a leading `/`
-/// is preserved and anchors the pattern to the repo root. Returns how many
-/// patterns were appended (0 when all were empty or already present).
+/// absent. Lines are stored verbatim, gitignore-style — a leading `/` is
+/// preserved and anchors the pattern to the repo root. Returns how many patterns
+/// were appended (0 when all were empty or already EFFECTIVE).
+///
+/// Two properties are load-bearing now that `!` un-ignore lines are honored
+/// last-match-wins (see [`crate::git::ai_ignore`]):
+///
+/// Dedup compares only against the lines AFTER the file's last `!`, because a
+/// pattern sitting before a later negation is present but NOT in effect —
+/// counting it as a duplicate would return 0 and let the UI report a file
+/// excluded while it still reaches the model. An unrelated later `!` at worst
+/// re-appends a line the file already had, which changes no verdict.
+///
+/// New lines go at the END, which is what lets a fresh *Exclude from AI* outrank
+/// an earlier hand-written negation of the same path.
 #[tauri::command]
 pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> AppResult<usize> {
     const HEADER: &str =
@@ -66,13 +77,19 @@ pub async fn append_repo_ai_ignore(repo_path: String, patterns: Vec<String>) -> 
         Err(e) => return Err(AppError::Io(e)),
     };
 
-    // Drop anything already in the file (scoped so the borrow ends before we
-    // mutate `content`).
+    // Drop anything already EFFECTIVE in the file — only the lines after its last
+    // `!`, since an earlier one is overridden by that negation (see the doc
+    // above). Scoped so the borrow ends before we mutate `content`.
     let to_add: Vec<String> = {
-        let existing: HashSet<&str> = content
+        let trimmed: Vec<&str> = content
             .lines()
             .map(crate::fsops::trim_ignore_pattern)
             .collect();
+        let after_last_negation = trimmed
+            .iter()
+            .rposition(|l| l.starts_with('!'))
+            .map_or(0, |i| i + 1);
+        let existing: HashSet<&str> = trimmed[after_last_negation..].iter().copied().collect();
         wanted
             .into_iter()
             .filter(|p| !existing.contains(p.as_str()))
@@ -586,5 +603,49 @@ mod tests {
         assert_eq!(added_dupe, 0);
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(before, after);
+    }
+
+    /// Dedup is "already EFFECTIVE", not "present anywhere": a pattern sitting
+    /// before a later `!` is overridden, so *Exclude from AI* must re-append it
+    /// at the end rather than report success while the file still reaches a model.
+    #[tokio::test]
+    async fn append_ai_ignore_re_adds_a_pattern_a_later_negation_overrides() {
+        let (_tmp, dir) = ai_ignore_test_repo();
+        let repo = dir.to_string_lossy().into_owned();
+        let path = dir.join(".gitdesktop").join("aiignore");
+        std::fs::create_dir_all(dir.join(".gitdesktop")).unwrap();
+
+        // The line is present but DEAD — a hand-written negation follows it.
+        std::fs::write(&path, "/secrets.env\n!secrets.env\n").unwrap();
+        let added = append_repo_ai_ignore(repo.clone(), vec!["/secrets.env".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(
+            added, 1,
+            "the overridden pattern is re-asserted, not skipped"
+        );
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            text.trim_end().ends_with("/secrets.env"),
+            "…and lands LAST, which is what makes it win: {text:?}"
+        );
+
+        // No negation in play → unchanged behavior, still a duplicate.
+        std::fs::write(&path, "/secrets.env\n").unwrap();
+        let added = append_repo_ai_ignore(repo.clone(), vec!["/secrets.env".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(added, 0);
+
+        // An UNRELATED later negation re-appends a line the file already had.
+        // Harmless duplication is the fail-closed direction here.
+        std::fs::write(&path, "/secrets.env\n!other.txt\n").unwrap();
+        let added = append_repo_ai_ignore(repo, vec!["/secrets.env".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(
+            added, 1,
+            "a duplicate is accepted rather than risk a stale skip"
+        );
     }
 }

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1135,17 +1135,40 @@ impl GitDesktopMcp {
     /// un-ignore lines are honored last-match-wins, and `.gitdesktop/aiignore` is
     /// committed content anyone with push access can write. Reversed, a committed
     /// `!` could re-expose a file the user excluded globally.
+    ///
+    /// The repo file is read from the working-tree TOPLEVEL, not `self.repo` as
+    /// given: `read_repo_ai_ignore` joins `.gitdesktop/aiignore` under whatever
+    /// path it gets, and a `--repo` bound to a subdirectory finds no file there —
+    /// whose NotFound arm is an empty list, silently dropping the team's whole
+    /// committed rule set while the global patterns still apply.
     async fn ai_ignore_patterns(
         &self,
         settings: &crate::app_store::AiGenSettings,
     ) -> Result<Vec<String>, McpError> {
-        let repo_ignore = crate::instructions::read_repo_ai_ignore(self.repo.clone())
+        let toplevel = crate::git::runner::worktree_toplevel(&self.repo)
+            .await
+            .map_err(app_err)?;
+        let repo_ignore = crate::instructions::read_repo_ai_ignore(toplevel)
             .await
             .map_err(app_err)?;
         Ok(repo_ignore
             .into_iter()
             .chain(settings.ai_ignore_patterns.iter().cloned())
             .collect())
+    }
+
+    /// The bound repo's committed `.gitdesktop/instructions.md`, read from the
+    /// working-tree TOPLEVEL for the same reason as
+    /// [`Self::ai_ignore_patterns`]: the reader joins a fixed relative path onto
+    /// whatever it is given and answers NotFound with `None`, so a `--repo` bound
+    /// to a subdirectory drops the repo's instructions without a word.
+    async fn repo_instructions(&self) -> Result<Option<String>, McpError> {
+        let toplevel = crate::git::runner::worktree_toplevel(&self.repo)
+            .await
+            .map_err(app_err)?;
+        crate::instructions::read_repo_instructions(toplevel)
+            .await
+            .map_err(app_err)
     }
 
     /// Gather + assemble the commit-message recipe (STAGED changes). Errors with
@@ -1176,9 +1199,7 @@ impl GitDesktopMcp {
         let commits = crate::git::commit::git_recent_commits(self.repo.clone(), 10)
             .await
             .map_err(app_err)?;
-        let repo_instructions = crate::instructions::read_repo_instructions(self.repo.clone())
-            .await
-            .map_err(app_err)?;
+        let repo_instructions = self.repo_instructions().await?;
 
         Ok(assemble_commit_recipe(CommitPieces {
             diff_text: staged.text,
@@ -1291,9 +1312,7 @@ impl GitDesktopMcp {
             Vec::new()
         };
 
-        let repo_instructions = crate::instructions::read_repo_instructions(self.repo.clone())
-            .await
-            .map_err(app_err)?;
+        let repo_instructions = self.repo_instructions().await?;
 
         Ok(assemble_pr_recipe(PrPieces {
             diff_text: diff.text,
@@ -1622,9 +1641,7 @@ impl GitDesktopMcp {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
-        let repo_instructions = crate::instructions::read_repo_instructions(self.repo.clone())
-            .await
-            .map_err(app_err)?;
+        let repo_instructions = self.repo_instructions().await?;
 
         Ok(assemble_branch_recipe(BranchPieces {
             diff_text: diff.text,
@@ -1806,9 +1823,16 @@ async fn committed_base_ref(repo: &str) -> Option<String> {
 /// `-z` git C-quotes a name holding a quote, backslash, or non-ASCII byte
 /// (`"caf\303\251.txt"`), and trimming would fold a trailing-space name onto a
 /// different name's spelling; either way the rule that covers it stops matching.
+///
+/// Listed from the working-tree TOPLEVEL rather than `repo` as given: `ls-files`
+/// prints names relative to its cwd and lists only that subtree, so a `--repo`
+/// pointing below the root would both hand the engine names an anchored rule
+/// cannot match — leaking the NAME — and silently drop every untracked file
+/// outside that subdirectory.
 async fn untracked_files(repo: &str) -> Result<Vec<String>, crate::error::AppError> {
+    let toplevel = crate::git::runner::worktree_toplevel(repo).await?;
     let out = crate::git::runner::run_git(
-        Some(repo),
+        Some(&toplevel),
         &["ls-files", "--others", "--exclude-standard", "-z"],
         crate::git::runner::DEFAULT_TIMEOUT,
     )
@@ -2812,6 +2836,196 @@ mod tests {
                 "sub dir/a b.md".to_string(),
             ]
         );
+    }
+
+    /// A `--repo` BELOW the working-tree root still lists the whole tree, with
+    /// ROOT-relative names — so the user's anchored rules match and nothing
+    /// outside the subdirectory silently disappears.
+    ///
+    /// Listed from the subdir instead, `ls-files` would print `secret.env` rather
+    /// than `services/api/secret.env`: an anchored `/services/api/secret.env` rule
+    /// stops matching and the NAME reaches the model, while `root-untracked.txt`
+    /// vanishes from the recipe entirely.
+    #[tokio::test]
+    async fn untracked_files_lists_from_the_toplevel_for_a_subdir_repo() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-untracked-subdir-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(repo.join("services").join("api")).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+
+        std::fs::write(
+            repo.join("services").join("api").join("secret.env"),
+            "TOKEN=x\n",
+        )
+        .unwrap();
+        std::fs::write(repo.join("root-untracked.txt"), "x\n").unwrap();
+
+        let subdir = repo
+            .join("services")
+            .join("api")
+            .to_string_lossy()
+            .into_owned();
+        let mut names = untracked_files(&subdir).await.expect("list untracked");
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "root-untracked.txt".to_string(),
+                "services/api/secret.env".to_string(),
+            ],
+            "names are root-relative and the whole tree is listed"
+        );
+
+        // …which is what lets the user's anchored rule actually hide it.
+        let filtered = filter_untracked_by_ai_ignore(
+            &subdir,
+            names,
+            &["/services/api/secret.env".to_string()],
+        )
+        .await
+        .expect("filter untracked");
+        assert_eq!(filtered.paths, vec!["root-untracked.txt".to_string()]);
+        assert_eq!(filtered.excluded, 1);
+        assert_eq!(filtered.unreadable, 0);
+    }
+
+    /// The repo's COMMITTED aiignore is found from the toplevel, so a `--repo`
+    /// bound to a subdirectory still honors the team's rules.
+    ///
+    /// `read_repo_ai_ignore` joins `.gitdesktop/aiignore` under the path it is
+    /// given, and its NotFound arm returns an empty list — so from a subdirectory
+    /// the whole committed rule set silently vanished while the global patterns
+    /// kept working, which is what made the gap quiet. Driven through the real
+    /// `ai_ignore_patterns` → `filtered_diff` composition the recipes use.
+    #[tokio::test]
+    async fn repo_aiignore_is_read_from_the_toplevel_for_a_subdir_repo() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-subdir-aiignore-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(repo.join("services").join("api")).unwrap();
+        std::fs::create_dir_all(repo.join(".gitdesktop")).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+
+        // The TEAM's rule, COMMITTED at the repo root so it is not itself part of
+        // the staged diff under test.
+        std::fs::write(repo.join(".gitdesktop").join("aiignore"), "*.env\n").unwrap();
+        git(&repo_s, &["add", "-A", "-f"]).await;
+        git(&repo_s, &["commit", "-qm", "add team aiignore"]).await;
+
+        std::fs::write(
+            repo.join("services").join("api").join("x.env"),
+            "TOKEN=SECRET_MARKER\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo.join("services").join("api").join("app.js"),
+            "// APP_MARKER\n",
+        )
+        .unwrap();
+        git(&repo_s, &["add", "-A", "-f"]).await;
+
+        let subdir = repo
+            .join("services")
+            .join("api")
+            .to_string_lossy()
+            .into_owned();
+        // No global patterns: the repo file is the ONLY source, so a dropped read
+        // shows up as a leak rather than being masked.
+        let settings = crate::app_store::AiGenSettings::default();
+
+        for (label, path) in [("subdirectory", &subdir), ("toplevel", &repo_s)] {
+            let mcp = crate::mcp_server::GitDesktopMcp::with_options(
+                path.clone(),
+                false,
+                false,
+                false,
+                false,
+            );
+            let exclude = mcp
+                .ai_ignore_patterns(&settings)
+                .await
+                .expect("assemble exclude list");
+            assert_eq!(exclude, vec!["*.env".to_string()], "{label}: exclude list");
+
+            let filtered = crate::git::ai_ignore::filtered_diff(
+                path,
+                &["diff", "--cached", "--no-color"],
+                &["diff", "--cached", "--numstat", "-z"],
+                &exclude,
+                true,
+            )
+            .await
+            .expect("filtered diff");
+            assert_eq!(
+                filtered
+                    .files
+                    .iter()
+                    .map(|f| f.path.as_str())
+                    .collect::<Vec<_>>(),
+                ["services/api/app.js"],
+                "{label}: file list"
+            );
+            assert_eq!(filtered.excluded_files, 1, "{label}: disclosure");
+            assert!(
+                !filtered.text.contains("SECRET_MARKER"),
+                "{label}: the committed rule must keep this content out"
+            );
+            assert!(filtered.text.contains("APP_MARKER"), "{label}: survivor");
+        }
+    }
+
+    /// The repo's committed instructions are found from the toplevel, so a
+    /// `--repo` bound to a subdirectory still steers every recipe with them.
+    ///
+    /// Same quiet shape as the aiignore read: a fixed relative join plus a
+    /// NotFound arm that answers `None`, so from a subdirectory the repo's rules
+    /// simply stopped applying. Asserted at `repo_instructions`, the one seam all
+    /// three recipes now share, rather than through a full prompt render.
+    #[tokio::test]
+    async fn repo_instructions_are_read_from_the_toplevel_for_a_subdir_repo() {
+        let base_dir = tempfile::Builder::new()
+            .prefix("gd-subdir-instructions-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base_dir.path().join("repo");
+        std::fs::create_dir_all(repo.join("services").join("api")).unwrap();
+        std::fs::create_dir_all(repo.join(".gitdesktop")).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        git(&repo_s, &["init", "-q"]).await;
+        std::fs::write(
+            repo.join(".gitdesktop").join("instructions.md"),
+            "Always mention the ticket id.\n",
+        )
+        .unwrap();
+
+        let subdir = repo
+            .join("services")
+            .join("api")
+            .to_string_lossy()
+            .into_owned();
+        for (label, path) in [("subdirectory", &subdir), ("toplevel", &repo_s)] {
+            let mcp = crate::mcp_server::GitDesktopMcp::with_options(
+                path.clone(),
+                false,
+                false,
+                false,
+                false,
+            );
+            assert_eq!(
+                mcp.repo_instructions().await.expect("read instructions"),
+                Some("Always mention the ticket id.".to_string()),
+                "{label}: the repo's committed instructions"
+            );
+        }
     }
 
     /// The store override is process-wide, so the tests that depend on the settings

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1145,9 +1145,7 @@ impl GitDesktopMcp {
         &self,
         settings: &crate::app_store::AiGenSettings,
     ) -> Result<Vec<String>, McpError> {
-        let toplevel = crate::git::runner::worktree_toplevel(&self.repo)
-            .await
-            .map_err(app_err)?;
+        let toplevel = self.toplevel().await.map_err(app_err)?.to_string();
         let repo_ignore = crate::instructions::read_repo_ai_ignore(toplevel)
             .await
             .map_err(app_err)?;
@@ -1163,12 +1161,37 @@ impl GitDesktopMcp {
     /// whatever it is given and answers NotFound with `None`, so a `--repo` bound
     /// to a subdirectory drops the repo's instructions without a word.
     async fn repo_instructions(&self) -> Result<Option<String>, McpError> {
-        let toplevel = crate::git::runner::worktree_toplevel(&self.repo)
-            .await
-            .map_err(app_err)?;
+        let toplevel = self.toplevel().await.map_err(app_err)?.to_string();
         crate::instructions::read_repo_instructions(toplevel)
             .await
             .map_err(app_err)
+    }
+
+    /// Untracked (new) file paths, NUL-separated and raw — these names are matched
+    /// against the user's AI-ignore rules, so any rewriting of them fails OPEN. Without
+    /// `-z` git C-quotes a name holding a quote, backslash, or non-ASCII byte
+    /// (`"cafÃ©.txt"`), and trimming would fold a trailing-space name onto a
+    /// different name's spelling; either way the rule that covers it stops matching.
+    ///
+    /// Listed from the working-tree TOPLEVEL rather than `self.repo` as given:
+    /// `ls-files` prints names relative to its cwd and lists only that subtree, so a
+    /// `--repo` pointing below the root would both hand the engine names an anchored
+    /// rule cannot match — leaking the NAME — and silently drop every untracked file
+    /// outside that subdirectory.
+    async fn untracked_files(&self) -> Result<Vec<String>, crate::error::AppError> {
+        let toplevel = self.toplevel().await?;
+        let out = crate::git::runner::run_git(
+            Some(toplevel),
+            &["ls-files", "--others", "--exclude-standard", "-z"],
+            crate::git::runner::DEFAULT_TIMEOUT,
+        )
+        .await?;
+        Ok(out
+            .stdout_lossy()
+            .split('\0')
+            .filter(|p| !p.is_empty())
+            .map(str::to_string)
+            .collect())
     }
 
     /// Gather + assemble the commit-message recipe (STAGED changes). Errors with
@@ -1530,7 +1553,7 @@ impl GitDesktopMcp {
 
         // `git diff HEAD` omits untracked files; list their paths so a branch made
         // entirely of new files can still be named (mirrors the in-app call site).
-        let untracked_paths = untracked_files(&self.repo).await.map_err(app_err)?;
+        let untracked_paths = self.untracked_files().await.map_err(app_err)?;
         // Untracked names never pass through a diff, so the ignore patterns have to
         // be applied to them here — a name is disclosure too. Their hidden count
         // joins the diff's: downstream both mean "in-progress changes hidden".
@@ -1816,33 +1839,6 @@ async fn committed_base_ref(repo: &str) -> Option<String> {
         return Some(default);
     }
     None
-}
-
-/// Untracked (new) file paths, NUL-separated and raw — these names are matched
-/// against the user's AI-ignore rules, so any rewriting of them fails OPEN. Without
-/// `-z` git C-quotes a name holding a quote, backslash, or non-ASCII byte
-/// (`"caf\303\251.txt"`), and trimming would fold a trailing-space name onto a
-/// different name's spelling; either way the rule that covers it stops matching.
-///
-/// Listed from the working-tree TOPLEVEL rather than `repo` as given: `ls-files`
-/// prints names relative to its cwd and lists only that subtree, so a `--repo`
-/// pointing below the root would both hand the engine names an anchored rule
-/// cannot match — leaking the NAME — and silently drop every untracked file
-/// outside that subdirectory.
-async fn untracked_files(repo: &str) -> Result<Vec<String>, crate::error::AppError> {
-    let toplevel = crate::git::runner::worktree_toplevel(repo).await?;
-    let out = crate::git::runner::run_git(
-        Some(&toplevel),
-        &["ls-files", "--others", "--exclude-standard", "-z"],
-        crate::git::runner::DEFAULT_TIMEOUT,
-    )
-    .await?;
-    Ok(out
-        .stdout_lossy()
-        .split('\0')
-        .filter(|p| !p.is_empty())
-        .map(str::to_string)
-        .collect())
 }
 
 /// What the AI-ignore filter left of an untracked-name list. Mirrors the TS
@@ -2826,7 +2822,14 @@ mod tests {
         std::fs::write(repo.join("sub dir").join("a b.md"), "x\n").unwrap();
         std::fs::write(repo.join("café.txt"), "x\n").unwrap();
 
-        let mut names = untracked_files(&repo_s).await.expect("list untracked");
+        let mcp = crate::mcp_server::GitDesktopMcp::with_options(
+            repo_s.clone(),
+            false,
+            false,
+            false,
+            false,
+        );
+        let mut names = mcp.untracked_files().await.expect("list untracked");
         names.sort();
         assert_eq!(
             names,
@@ -2869,7 +2872,14 @@ mod tests {
             .join("api")
             .to_string_lossy()
             .into_owned();
-        let mut names = untracked_files(&subdir).await.expect("list untracked");
+        let mcp = crate::mcp_server::GitDesktopMcp::with_options(
+            subdir.clone(),
+            false,
+            false,
+            false,
+            false,
+        );
+        let mut names = mcp.untracked_files().await.expect("list untracked");
         names.sort();
         assert_eq!(
             names,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1170,7 +1170,7 @@ impl GitDesktopMcp {
     /// Untracked (new) file paths, NUL-separated and raw — these names are matched
     /// against the user's AI-ignore rules, so any rewriting of them fails OPEN. Without
     /// `-z` git C-quotes a name holding a quote, backslash, or non-ASCII byte
-    /// (`"cafÃ©.txt"`), and trimming would fold a trailing-space name onto a
+    /// (`"caf\303\251.txt"`), and trimming would fold a trailing-space name onto a
     /// different name's spelling; either way the rule that covers it stops matching.
     ///
     /// Listed from the working-tree TOPLEVEL rather than `self.repo` as given:

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1128,8 +1128,13 @@ impl GitDesktopMcp {
 impl GitDesktopMcp {
     /// The user's AI-ignore patterns for the bound repo: the repo's own ignore
     /// file first, then the global setting's patterns — the merge every recipe
-    /// passes to the git layer as pathspec excludes. Takes the caller's already-read
-    /// `settings`, so one recipe call reads the settings store exactly once.
+    /// passes to the git layer. Takes the caller's already-read `settings`, so
+    /// one recipe call reads the settings store exactly once.
+    ///
+    /// Repo-first/global-LAST is a security invariant, not a preference: `!`
+    /// un-ignore lines are honored last-match-wins, and `.gitdesktop/aiignore` is
+    /// committed content anyone with push access can write. Reversed, a committed
+    /// `!` could re-expose a file the user excluded globally.
     async fn ai_ignore_patterns(
         &self,
         settings: &crate::app_store::AiGenSettings,

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -95,6 +95,13 @@ pub struct GitDesktopMcp {
     /// ops (`run_git_mutating` takes `&AppState`). Built with `AppState::default()` (no
     /// Tauri runtime needed); `Arc` so it survives the per-request clones.
     state: Arc<crate::state::AppState>,
+    /// The working tree's toplevel for [`Self::repo`], resolved on first use (see
+    /// [`Self::toplevel`]). `repo` is fixed for the process lifetime, which is what
+    /// makes caching it sound; `Arc` so the resolution survives the per-request
+    /// clones instead of re-running for each. `git::ai_ignore::filtered_diff`
+    /// resolves separately and deliberately — it serves non-MCP callers too, and
+    /// only spawns when there are patterns to apply.
+    toplevel: Arc<tokio::sync::OnceCell<String>>,
     // Read by the `#[tool_handler]`-generated `list_tools`/`call_tool`; the
     // dead-code lint misses that (it only sees the derived `Clone` touch it).
     #[allow(dead_code)]
@@ -224,6 +231,7 @@ impl GitDesktopMcp {
             allow_destructive,
             consolidated: Arc::new(AtomicBool::new(false)),
             state: Arc::new(crate::state::AppState::default()),
+            toplevel: Arc::new(tokio::sync::OnceCell::new()),
             // `ToolRouter` implements `Add`, so the domain modules stay independent — a
             // module gaining tools never touches this expression.
             tool_router: Self::read_git_router()
@@ -238,6 +246,21 @@ impl GitDesktopMcp {
             // contributes any, so there's no `+` chain here.
             prompt_router: Self::generate_prompt_router(),
         }
+    }
+
+    /// The bound repo's working-tree TOPLEVEL, resolved once per process.
+    ///
+    /// `--repo` is taken verbatim and may name any directory inside the tree, but
+    /// anything that reads repo-relative names out of git — or joins a fixed
+    /// relative path onto it — has to use the root or it answers about the
+    /// subdirectory instead, quietly. Cached because `repo` never changes after
+    /// construction; only a successful resolution is stored, so a repo that
+    /// becomes readable later is still picked up.
+    pub(super) async fn toplevel(&self) -> crate::error::AppResult<&str> {
+        self.toplevel
+            .get_or_try_init(|| crate::git::runner::worktree_toplevel(&self.repo))
+            .await
+            .map(String::as_str)
     }
 
     /// Gate for the app-data write tools (local PRs AND local issues): an actionable

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1697,7 +1697,9 @@ notes**, and **repository descriptions**.
   *Pull requests*). They're \`.gitignore\` patterns: \`secrets.env\` hides
   that file at any depth, \`/secrets.env\` only the copy at the repo root, \`node_modules\`
   or \`vendor/\` a folder wherever it sits, and \`docs/*.log\` just that folder's logs.
-  \`!\` re-include lines aren't supported. No
+  A \`!\` line puts back something a broader pattern hid, and your global patterns are
+  applied last, so a repo's committed file can never re-expose what you excluded
+  yourself. No
   need to hand-edit the file: {{secondaryclick}} a changed file → *Exclude from AI* (the
   file, its folder, or its file type — or a multi-selection) appends to
   \`.gitdesktop/aiignore\`, creating it if needed — an anchored line (\`/src/config.ts\`,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1694,14 +1694,15 @@ notes**, and **repository descriptions**.
   of the AI's context while still committing them normally — global in Settings, or
   per-repo via \`.gitdesktop/aiignore\`. A model that reads your repository itself isn't
   limited by them — that's what **Agentic review** on a pull request turns on (see
-  *Pull requests*). They're \`.gitignore\` patterns: \`secrets.env\` hides
-  that file at any depth, \`/secrets.env\` only the copy at the repo root, \`node_modules\`
-  or \`vendor/\` a folder wherever it sits, and \`docs/*.log\` just that folder's logs.
-  A \`!\` line puts back something a broader pattern hid, and your global patterns are
-  applied last, so a repo's committed file can never re-expose what you excluded
-  yourself. No
-  need to hand-edit the file: {{secondaryclick}} a changed file → *Exclude from AI* (the
-  file, its folder, or its file type — or a multi-selection) appends to
+  *Pull requests*). They're \`.gitignore\` patterns: \`secrets.env\` hides that file at
+  any depth, \`/secrets.env\` only the copy at the repo root, \`node_modules\` or
+  \`vendor/\` a folder wherever it sits, and \`docs/*.log\` just that folder's logs. A
+  \`!\` line puts back something a broader pattern hid — to spare a file inside an
+  excluded folder, exclude the folder's *contents* (\`vendor/*\`, not \`vendor/\`), since
+  git never re-includes below an excluded directory. Your global patterns are applied
+  last, so a repo's committed file can never re-expose what you excluded yourself.
+  No need to hand-edit the file: {{secondaryclick}} a changed file → *Exclude from AI*
+  (the file, its folder, or its file type — or a multi-selection) appends to
   \`.gitdesktop/aiignore\`, creating it if needed — an anchored line (\`/src/config.ts\`,
   \`/vendor/\`) for exactly the file or folder you picked.
 - **Hide AI** (Settings → General) hides the AI surfaces and pauses your automations —

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -11,7 +11,11 @@ import {
   openWithProgram,
   revealInExplorer,
 } from "@/lib/git/api";
-import { globLiteralPath, literalPathspec } from "@/lib/git/glob";
+import {
+  aiExcludePatternLinesForPath,
+  globLiteralPath,
+  literalPathspec,
+} from "@/lib/git/glob";
 import type { FileEntry } from "@/lib/git/types";
 import { isWindows } from "@/lib/hotkeys/binding";
 import {
@@ -52,8 +56,10 @@ export interface ChangesMenuActions {
   /** `pathspec` reaches `git rm --cached` as given, so a concrete path must
    *  arrive through `literalPathspec` or it removes its glob-siblings too. */
   untrack: (pathspec: string, ignorePattern: string, label: string) => void;
-  /** `pattern` is an AI-ignore line — glob-escape a concrete path. */
-  aiExclude: (pattern: string, label: string) => void;
+  /** AI-ignore LINES for a concrete path — build them with
+   *  `aiExcludePatternLinesForPath`, which glob-escapes and adds the
+   *  `/`-separated twin a `\`-holding path needs to be hidden on Windows. */
+  aiExclude: (patterns: string[], label: string) => void;
   aiExcludeSelected: () => void;
 }
 
@@ -288,7 +294,7 @@ export function ChangesContextMenuItems({
           <ContextMenuItem
             onClick={() =>
               actions.aiExclude(
-                `/${globLiteralPath(entry.path)}`,
+                aiExcludePatternLinesForPath(entry.path),
                 `/${entry.path}`,
               )
             }
@@ -306,7 +312,9 @@ export function ChangesContextMenuItems({
                     key={folder}
                     onClick={() =>
                       actions.aiExclude(
-                        `/${globLiteralPath(folder)}/`,
+                        aiExcludePatternLinesForPath(folder).map(
+                          (line) => `${line}/`,
+                        ),
                         `/${folder}/`,
                       )
                     }
@@ -320,7 +328,7 @@ export function ChangesContextMenuItems({
           {extensionPattern && (
             <ContextMenuItem
               onClick={() =>
-                actions.aiExclude(extensionPattern, `*.${extension}`)
+                actions.aiExclude([extensionPattern], `*.${extension}`)
               }
             >
               Exclude all .{extension} files from AI (add to

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -20,7 +20,11 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BlameDialog } from "@/features/history/BlameDialog";
 import { FileHistoryDialog } from "@/features/history/FileHistoryDialog";
-import { globLiteralPath, literalPathspec } from "@/lib/git/glob";
+import {
+  aiExcludePatternLinesForPath,
+  globLiteralPath,
+  literalPathspec,
+} from "@/lib/git/glob";
 import {
   useAppendRepoAiIgnore,
   useAppendToGitignore,
@@ -68,10 +72,14 @@ function unstagePaths(entry: FileEntry): string[] {
 }
 
 /**
- * Toast copy for a bulk ignore / AI-exclude of `total` selected entries, where
- * `added` came back from the Rust command as the count actually appended
- * (already-present ones are skipped). Reports the honest end state: nothing new
- * when everything was already covered, a partial when some were skipped.
+ * Toast copy for a bulk ignore / AI-exclude, where `total` is the number of
+ * LINES written and `added` came back from the Rust command as the count
+ * actually appended — skipping lines already present (.gitignore) or already in
+ * EFFECT (.gitdesktop/aiignore, where a later `!` un-ignore revives a line).
+ * Lines, not selected entries: on the AI path a `\`-holding path emits a second
+ * `/`-separated line, so the total can exceed the selection. Reports the honest
+ * end state: nothing new when everything was already covered, a partial when
+ * some were skipped.
  */
 function ignoreToast(added: number, total: number, file: string): string {
   const entries = (n: number) => `entr${n === 1 ? "y" : "ies"}`;
@@ -425,8 +433,8 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
       onError,
     });
   }
-  function aiExcludeOne(pattern: string, label: string) {
-    appendAiIgnore.mutate([pattern], {
+  function aiExcludeOne(patterns: string[], label: string) {
+    appendAiIgnore.mutate(patterns, {
       onSuccess: (added) =>
         toast.success(
           added === 0
@@ -522,10 +530,18 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
 
   // Bulk AI-exclude: add a `/path` line per selected file — the leading slash
   // anchors each pattern to THIS file rather than every file with that name.
-  // The Rust side de-dupes and skips lines already present.
+  // A path holding `\` contributes a second line, so the count below is LINES,
+  // which is what the toast names. The Rust side skips lines already in EFFECT.
   function aiExcludeSelected() {
     if (selectionCount === 0) return;
-    const patterns = selectedEntries.map((e) => `/${globLiteralPath(e.path)}`);
+    // Deduped: a literal `weird\name.env` and a real `weird/name.env` both emit
+    // the `/`-separated line, and the duplicate would read as a false partial
+    // ("Added 2 of 3") once the Rust side collapses it.
+    const patterns = [
+      ...new Set(
+        selectedEntries.flatMap((e) => aiExcludePatternLinesForPath(e.path)),
+      ),
+    ];
     appendAiIgnore.mutate(patterns, {
       onSuccess: (added) => {
         toast.success(

--- a/src/features/settings/InstructionsSection.tsx
+++ b/src/features/settings/InstructionsSection.tsx
@@ -46,11 +46,15 @@ export const InstructionsSection = withForm({
             <code className="rounded bg-muted px-1 py-0.5">vendor/</code> a
             folder wherever it sits. A leading{" "}
             <code className="rounded bg-muted px-1 py-0.5">!</code> puts back
-            something a broader pattern hid, and these patterns are applied after
-            a repository's own file, so a repo can never re-expose what you
-            excluded here. Matching files stay staged and committed as usual, but
-            their diffs are left out of what the AI sees, so noisy folders don't
-            dominate the message.
+            something a broader pattern hid — to spare a file inside an excluded
+            folder, exclude the folder's contents (
+            <code className="rounded bg-muted px-1 py-0.5">vendor/*</code>, not{" "}
+            <code className="rounded bg-muted px-1 py-0.5">vendor/</code>),
+            since git never re-includes below an excluded directory. These
+            patterns are applied after a repository's own file, so a repo can
+            never re-expose what you excluded here. Matching files stay staged
+            and committed as usual, but their diffs are left out of what the AI
+            sees, so noisy folders don't dominate the message.
           </p>
         </div>
         <p className="text-xs text-muted-foreground">

--- a/src/features/settings/InstructionsSection.tsx
+++ b/src/features/settings/InstructionsSection.tsx
@@ -44,11 +44,13 @@ export const InstructionsSection = withForm({
             <code className="rounded bg-muted px-1 py-0.5">/secrets.env</code>{" "}
             only the copy at the repo root, and{" "}
             <code className="rounded bg-muted px-1 py-0.5">vendor/</code> a
-            folder wherever it sits.{" "}
-            <code className="rounded bg-muted px-1 py-0.5">!</code> re-include
-            lines aren't supported. Matching files stay staged and committed as
-            usual, but their diffs are left out of what the AI sees, so noisy
-            folders don't dominate the message.
+            folder wherever it sits. A leading{" "}
+            <code className="rounded bg-muted px-1 py-0.5">!</code> puts back
+            something a broader pattern hid, and these patterns are applied after
+            a repository's own file, so a repo can never re-expose what you
+            excluded here. Matching files stay staged and committed as usual, but
+            their diffs are left out of what the AI sees, so noisy folders don't
+            dominate the message.
           </p>
         </div>
         <p className="text-xs text-muted-foreground">

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -78,7 +78,7 @@ export async function filterPathsByAiIgnore(input: {
 /**
  * Drops every AI-ignored file from an already-resolved unified diff and its
  * changed-file list, client-side — the one recipe for both diff sources, since
- * the pathspec-exclude route (`gitBranchDiff`'s `exclude`) only exists where
+ * the server-side route (`gitBranchDiff`'s `exclude`) only exists where
  * GitDesktop runs the diff itself and a forge-supplied PR diff arrives whole.
  *
  * Candidates are the UNION of the diff's own section keys and the file list,

--- a/src/lib/ai/ignore.ts
+++ b/src/lib/ai/ignore.ts
@@ -15,6 +15,11 @@ function ignoreLines(patterns: string): string[] {
  * `.gitdesktop/aiignore` entries first, then the global setting's lines
  * (`aiIgnorePatterns`, raw and newline-joined).
  *
+ * That order is a security invariant, not a preference: `!` un-ignore lines are
+ * honored last-match-wins, and the repo file is committed content anyone with
+ * push access can write. Global LAST means a committed `!` can never re-expose a
+ * file the user excluded globally.
+ *
  * Rejects when the repo file can't be read — except under
  * `tolerateRepoReadError`, which the conflict-resolve surface passes so an
  * unreadable repo file can't abort a resolution the global patterns alone can

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -3055,10 +3055,10 @@ export const appendRepoAiIgnore = (repoPath: string, patterns: string[]) =>
   invoke<number>("append_repo_ai_ignore", { repoPath, patterns });
 
 /** Which of `paths` the user's AI-ignore patterns hide, decided by git's own
- *  gitignore engine — the same matcher the diff-side pathspec translation is
- *  pinned to. For path lists the frontend holds itself (a remote PR's changed
- *  files): the paths need not exist in the working tree or index. Returns `[]`
- *  when nothing matches, or when either list is empty. */
+ *  gitignore engine — the same matcher the diff commands filter through. For
+ *  path lists the frontend holds itself (a remote PR's changed files): the paths
+ *  need not exist in the working tree or index. Returns `[]` when nothing
+ *  matches, or when either list is empty. */
 export const gitFilterAiIgnored = (
   repoPath: string,
   paths: string[],

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -3049,8 +3049,9 @@ export const readRepoAiIgnore = (repoPath: string) =>
   invoke<string[]>("read_repo_ai_ignore", { repoPath });
 
 /** Appends AI-ignore patterns to `<repo>/.gitdesktop/aiignore` (created if
- *  absent), returning the number of patterns actually appended (already-present
- *  ones are skipped). */
+ *  absent), returning the number actually appended. Skipped only when already
+ *  EFFECTIVE — a pattern sitting before a later `!` un-ignore line is re-added
+ *  at the end, where last-match-wins puts it back in force. */
 export const appendRepoAiIgnore = (repoPath: string, patterns: string[]) =>
   invoke<number>("append_repo_ai_ignore", { repoPath, patterns });
 

--- a/src/lib/git/conflict.ts
+++ b/src/lib/git/conflict.ts
@@ -17,7 +17,7 @@ export interface ConflictSides {
 /** Reads a conflicted file's base/ours/theirs blobs + the marked working file,
  *  plus whether it's AI-ignored. `exclude` is the combined (repo + global)
  *  AI-ignore pattern list, decided by git's own gitignore engine — the same
- *  truth table a test pins the diff-side pathspec translation to. */
+ *  matcher, and the same pinned truth table, as the diff commands. */
 export const conflictSides = (
   repoPath: string,
   path: string,

--- a/src/lib/git/glob.ts
+++ b/src/lib/git/glob.ts
@@ -11,26 +11,57 @@
  * `[`, `*` and `?` are metacharacters, so a raw path holding one matches the
  * wrong files: `app/[slug]/page.tsx` reads as a character class. Wrapping each
  * as a one-character class (`[` → `[[]`) makes it literal to git's matcher
- * (measured, git 2.51.1). `]` outside a class is already literal; a literal
- * backslash is inexpressible as a gitignore pattern and is left alone
- * (impossible on Windows).
+ * (measured, git 2.51.1). `]` outside a class is already literal.
  *
- * A trailing space is the one case backslash IS the answer: .gitignore strips
+ * A `\` is DOUBLED, because raw it is a gitignore escape that eats the next
+ * character: `weird\name.env` names `weirdname.env` — a different file hidden
+ * while the one the user picked stays visible (the `src\foo.ts` row of Rust's
+ * PARITY table pins exactly that, and nothing more).
+ *
+ * Doubling fixes the PARSE everywhere — `\\` is a literal backslash to git on
+ * every platform — but not the MATCH, which diverges on the name side: Windows
+ * normalizes a name's `\` to a separator before comparing, so no backslash
+ * spelling reaches such a file there. That is why a second, `/`-separated line
+ * is required and NOT redundant; see [`aiExcludePatternLinesForPath`].
+ *
+ * A trailing space is the other case backslash is the answer: .gitignore strips
  * unescaped trailing whitespace, so a file named `notes ` yields the pattern
  * `notes`, which hides a DIFFERENT file and leaves the named one visible
  * (measured). The escape is written in the idiomatic .gitignore spelling users
  * read in their own files, and `check-ignore` — the one engine every AI-ignore
  * verdict comes from — reads it natively on every platform.
  *
- * The escape is defeated when the name ALREADY ends in a backslash (`notes\ `):
- * the emitted `notes\\ ` is an even backslash run, so the space reads as
- * unescaped and is stripped again. Bounded by the same limitation as above — a
- * literal backslash is inexpressible here — and impossible on Windows.
+ * Order is load-bearing: doubling runs FIRST, so the escape the trailing-space
+ * arm adds is not doubled in turn, and a name already ending in `\` yields an
+ * ODD run (`notes\` + space → `notes\\\ `) that both `trimIgnorePattern` and
+ * Rust's `trim_ignore_pattern` read as a kept space.
  */
 export function globLiteralPath(path: string): string {
   return path
+    .replace(/\\/g, "\\\\")
     .replace(/[[*?]/g, (c) => `[${c}]`)
     .replace(/ +$/, (spaces) => spaces.replaceAll(" ", "\\ "));
+}
+
+/**
+ * The AI-ignore line(s) that hide one concrete path, anchored to the repo root.
+ *
+ * Usually one line. A path containing `\` gets a second, `/`-separated twin,
+ * because the two platforms disagree about what that byte IS during matching:
+ * Windows normalizes the NAME's `\` to a separator, so there only
+ * `weird/name.env` reaches it and no backslash spelling can. Unix keeps it an
+ * ordinary byte, where the escaped form matches exactly and the `/` twin is a
+ * real path pattern that would also hide a genuine `weird/name.env` subtree.
+ * So the pair can over-hide on either platform — the safe direction on a
+ * privacy boundary — and never misses the named file. AI-ignore files are
+ * committed and shared, so one line set has to serve both.
+ */
+export function aiExcludePatternLinesForPath(path: string): string[] {
+  const lines = [`/${globLiteralPath(path)}`];
+  if (path.includes("\\")) {
+    lines.push(`/${globLiteralPath(path.replaceAll("\\", "/"))}`);
+  }
+  return lines;
 }
 
 /**

--- a/src/lib/git/glob.ts
+++ b/src/lib/git/glob.ts
@@ -10,20 +10,17 @@
  *
  * `[`, `*` and `?` are metacharacters, so a raw path holding one matches the
  * wrong files: `app/[slug]/page.tsx` reads as a character class. Wrapping each
- * as a one-character class (`[` → `[[]`) is the only form BOTH engines honor —
- * pathspec ignores the backslash escapes .gitignore accepts (measured, git
- * 2.51.1). `]` outside a class is already literal; a literal backslash is
- * inexpressible on either engine and is left alone (impossible on Windows).
+ * as a one-character class (`[` → `[[]`) makes it literal to git's matcher
+ * (measured, git 2.51.1). `]` outside a class is already literal; a literal
+ * backslash is inexpressible as a gitignore pattern and is left alone
+ * (impossible on Windows).
  *
  * A trailing space is the one case backslash IS the answer: .gitignore strips
  * unescaped trailing whitespace, so a file named `notes ` yields the pattern
  * `notes`, which hides a DIFFERENT file and leaves the named one visible
  * (measured). The escape is written in the idiomatic .gitignore spelling users
- * read in their own files. It reaches the pathspec engine only through Rust's
- * `pathspecs_for`, which re-encodes it as `[ ]` first: on WINDOWS a backslash in
- * a pathspec is a SEPARATOR rather than an escape, so the raw form matched
- * NOTHING there while Unix honored it (measured, git 2.51.1.windows.1). The
- * class form is what makes both platforms agree.
+ * read in their own files, and `check-ignore` — the one engine every AI-ignore
+ * verdict comes from — reads it natively on every platform.
  *
  * The escape is defeated when the name ALREADY ends in a backslash (`notes\ `):
  * the emitted `notes\\ ` is an even backslash run, so the space reads as


### PR DESCRIPTION
AI-ignore lists are documented as gitignore-style, but the diff commands never used git's ignore engine — they ran a hand-written translation of each pattern into `:(exclude,glob)` pathspec terms, a second matcher that could drift from the real one on a privacy boundary (a pattern that fails to match is a file that reaches a third-party model). This deletes the translation layer so every AI-ignore verdict comes from `git check-ignore`, which in turn makes `!` un-ignore lines expressible with git's own last-match-wins semantics and makes repo-then-global concatenation a security invariant rather than a preference.

### Matching engine

- Rewrites `src-tauri/src/git/ai_ignore.rs` around a single engine: the `AiIgnorePathspecs` struct, `pathspecs_for`/`pathspecs_for_repo` and the pattern-rewriting helpers are gone, and every verdict now goes through `filter_ignored` (`check-ignore --no-index --stdin` in a neutral repo, so paths need not exist in the index or working tree).
- Adds `filtered_diff`, a two-pass flow for filtering a whole diff: name the changed files with `--numstat -z`, ask the engine which names are ignored, then re-run the content diff with one `:(exclude,literal)<name>` term per hidden name — exact, because it excludes a name git itself printed. Names that spelling cannot carry (holding a `\`, or not valid UTF-8) fall back to `widened_glob_for_name`, which over-hides rather than leaks.
- Reworks `actionable_lines` to keep `!` lines and report whether the list has any positive line, plus a `has_actionable_lines` short-circuit — a list of only negations can never hide anything, so git is not spawned for it. Order is now load-bearing and preserved.

### Diff commands

- `git_staged_diff` in `src-tauri/src/git/diff.rs` delegates to `filtered_diff` with `recheck: true`, since the index and working tree can change between the name pass and the content pass.
- Adds `DiffStatRow` and `parse_numstat_z_rows` in `src-tauri/src/git/diff.rs`, retaining both sides of a rename; `parse_numstat_z` is now derived from it. A match on either the old or new name hides the pair, so excluding one side can no longer strand the other side's `A`/`D` row in the diff.
- `git_branch_diff` in `src-tauri/src/git/compare.rs` delegates with `recheck: false` after the new `pinned_range` helper resolves both refs to SHAs in one `rev-parse` — `^{commit}` peels annotated tags and turns multi-line rev expansions (`HEAD^!`, `HEAD^@`) into an error, and the results are hex-validated — so both passes read the same immutable trees.

### Precedence invariant

- Documents repo-first/global-last as a security invariant in `ai_ignore_patterns` (`src-tauri/src/mcp_server/generate.rs`) and `src/lib/ai/ignore.ts`: `.gitdesktop/aiignore` is committed content anyone with push access can write, so global patterns must be applied last or a committed `!` could re-expose a file the user excluded globally.

### Documentation and copy

- Replaces the "`!` re-include lines aren't supported" claim everywhere it lived — `README.md`, the AI-ignore guide section in `src/features/help/content.ts`, and the Excluded files copy in `src/features/settings/InstructionsSection.tsx` — with the new behavior plus the global-last guarantee.
- Adds changelog fragments `changelog.d/added-ai-unignore.md` (`!` support and precedence) and `changelog.d/changed-ai-ignore-single-engine.md` (diffs filtered through git's engine, renames hidden on either name).
- Refreshes now-stale comments that referenced the pathspec route in `src/lib/git/api.ts`, `src/lib/git/conflict.ts` and `src/lib/git/glob.ts` — including dropping the Windows pathspec-backslash caveat, since `check-ignore` reads the trailing-space escape natively on every platform.