### PR TITLE
feat(findings,github): add Findings tab for Dependabot alerts and repo advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
 - **GitHub Actions cockpit** — browse runs, drill into jobs and steps, re-run (all
   or failed), cancel, dispatch a workflow, and read failed-step logs — none of
   which GitHub Desktop does.
+- **Security findings, in-app** — a **Findings** tab lists a GitHub repo's open
+  **Dependabot alerts**, grouped by vulnerable package with severity and the first
+  patched version, alongside the repository's **security advisories** — each one a
+  click from its page on GitHub, and one click from turning scanning on when it's off.
 - **Explore repositories** — a full-page browser across **GitHub, GitLab & Bitbucket**:
   before you type it shows **your own repositories** (grouped by owner) and a **Popular**
   star-sorted feed (GitHub & GitLab); typing searches GitHub, all public GitLab projects,
@@ -553,6 +557,16 @@ cancel / manual dispatch, inline failed-step logs, **Debug with AI**, a current-
 CI badge in the header, and run-completion notifications.
 
 ![GitDesktop's GitHub Actions tab: a workflow run with its Lint, Unit tests, and Build jobs listed, the Build job expanded into individual steps and durations, plus Re-run all jobs and View on GitHub controls.](site/src/assets/app-actions.png)
+
+**Findings** — a tab (More ▾) for a GitHub repo's open **Dependabot alerts**,
+grouped by the vulnerable package, each with its severity, affected version range,
+first patched version, and a CVSS score when GitHub has one — plus the
+**security advisories** published
+on the repository itself. Select a row for the detail, then open it on GitHub.
+When a category isn't reporting — alerts switched off, a token that can't read
+them, or a check that didn't complete — the tab says which and why, and
+**Open security settings** goes straight to Repository settings → Security to
+turn scanning on.
 
 **Insights** — a repository-graphs tab (Ctrl/Cmd-9): commit activity, code
 frequency (additions vs. deletions), contributor churn, and a commit punch card —

--- a/changelog.d/added-findings-tab.md
+++ b/changelog.d/added-findings-tab.md
@@ -1,0 +1,4 @@
+- **Findings tab:** browse a GitHub repo's open Dependabot alerts (grouped by
+  package, with severity, affected range, and first patched version) and its
+  security advisories without leaving the app — with a direct path to turn
+  scanning on when it's off.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -279,6 +279,11 @@ export const capabilities: Capability[] = [
     group: "CI, tags & releases",
     label: "Insights graphs — commit activity, churn & more, computed locally",
   },
+  {
+    group: "CI, tags & releases",
+    label: "Findings tab — Dependabot alerts & security advisories",
+    highlight: true,
+  },
 
   // — Repository & workspace —
   {

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -32,6 +32,10 @@ pub struct Capabilities {
     pub ci: bool,
     pub webhooks: bool,
     pub approvals: bool,
+    /// Reading the platform's own vulnerability findings (Dependabot alerts +
+    /// repository security advisories). GitHub-only — GitLab's equivalent is a
+    /// paid-tier security dashboard and Bitbucket Cloud has no analogue.
+    pub security_findings: bool,
 }
 
 impl Capabilities {
@@ -53,6 +57,7 @@ impl Capabilities {
                 ci: true,
                 webhooks: true,
                 approvals: true,
+                security_findings: true,
             },
             // GitLab: MRs/issues/labels/milestones/CI/approvals, emoji "awards" as
             // reactions, but no Discussions (GitHub-only).
@@ -68,6 +73,7 @@ impl Capabilities {
                 ci: true,
                 webhooks: true,
                 approvals: true,
+                security_findings: false,
             },
             // Bitbucket Cloud: no labels, milestones, stars, reactions, or
             // discussions; PRs/CI(pipelines)/webhooks/approvals do work. Draft PRs
@@ -86,6 +92,7 @@ impl Capabilities {
                 ci: true,
                 webhooks: true,
                 approvals: true,
+                security_findings: false,
             },
         }
     }
@@ -105,6 +112,7 @@ impl Capabilities {
             ci: false,
             webhooks: false,
             approvals: false,
+            security_findings: false,
         }
     }
 }
@@ -725,6 +733,7 @@ mod tests {
     fn github_supports_everything() {
         let c = Capabilities::for_provider(Provider::GitHub);
         assert!(c.discussions && c.labels && c.milestones && c.draft_prs && c.reactions && c.stars);
+        assert!(c.security_findings);
     }
 
     #[test]
@@ -732,12 +741,15 @@ mod tests {
         let c = Capabilities::for_provider(Provider::GitLab);
         assert!(!c.discussions);
         assert!(c.labels && c.milestones && c.stars && c.reactions && c.approvals);
+        // Dependabot alerts / repo advisories are a GitHub surface.
+        assert!(!c.security_findings);
     }
 
     #[test]
     fn bitbucket_drops_unsupported_features() {
         let c = Capabilities::for_provider(Provider::Bitbucket);
         assert!(!c.labels && !c.milestones && !c.stars && !c.reactions && !c.discussions);
+        assert!(!c.security_findings);
         // Issues are off — the native tracker sunsets 2026-08-20.
         assert!(!c.issues);
         // …but the core flow still works, and draft PRs are supported.
@@ -748,6 +760,7 @@ mod tests {
     fn none_supports_nothing() {
         let c = Capabilities::none();
         assert!(!c.pull_requests && !c.issues && !c.ci && !c.webhooks);
+        assert!(!c.security_findings);
     }
 
     #[test]

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -15,6 +15,7 @@ pub mod rulesets;
 pub mod runner;
 pub mod secrets;
 pub mod security;
+pub mod security_findings;
 
 use crate::error::{AppError, AppResult};
 

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -8,7 +8,7 @@
 //! timeout escapes as `Err`; every completed-but-failed call is classified into
 //! the envelope instead.
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::{AppError, AppResult};
@@ -168,7 +168,7 @@ struct RawVulnerability {
 #[derive(Deserialize, Default)]
 struct RawAlert {
     #[serde(default)]
-    number: i64,
+    number: Option<i64>,
     #[serde(default)]
     state: Option<String>,
     #[serde(default)]
@@ -241,7 +241,9 @@ fn alert_out(raw: RawAlert) -> DependabotAlertOut {
     let advisory = raw.security_advisory.unwrap_or_default();
     let vulnerability = raw.security_vulnerability.unwrap_or_default();
     DependabotAlertOut {
-        number: raw.number,
+        // A null/absent number degrades to 0 rather than dropping the alert; the
+        // UI's identity falls back to the list index.
+        number: raw.number.unwrap_or(0),
         state: raw.state.unwrap_or_default(),
         package_name: package.name.unwrap_or_default(),
         ecosystem: package.ecosystem.unwrap_or_default(),
@@ -405,6 +407,33 @@ fn clamp_limit(limit: Option<u32>) -> usize {
     limit.unwrap_or(100).clamp(1, 500) as usize
 }
 
+/// Whether the page walk keeps going, and if not whether findings were left behind.
+#[derive(Debug, PartialEq, Eq)]
+enum PageOutcome {
+    Stop { truncated: bool },
+    Continue,
+}
+
+/// The walk's per-page decision, given the items gathered so far and this page's
+/// size and Link header. Truncation is the safe direction: every stop we can't
+/// prove complete reports `truncated`, never a clean end of list.
+fn page_outcome(total: usize, limit: usize, page_len: usize, next: &NextPage) -> PageOutcome {
+    if total >= limit {
+        return PageOutcome::Stop {
+            truncated: total > limit || *next != NextPage::None,
+        };
+    }
+    match next {
+        NextPage::None => PageOutcome::Stop { truncated: false },
+        // A next page we can't address ends the walk as INCOMPLETE — reporting
+        // it complete would present a parse failure as "no more findings".
+        NextPage::Unreadable => PageOutcome::Stop { truncated: true },
+        // An empty page that still advertises a next link would spin the walk.
+        NextPage::Cursor(_) if page_len == 0 => PageOutcome::Stop { truncated: true },
+        NextPage::Cursor(_) => PageOutcome::Continue,
+    }
+}
+
 /// Walks a cursor-paginated list endpoint up to `limit` items. `base_path` must
 /// already carry a query string — the cursor is appended as `&after=`.
 async fn fetch_paged(repo_path: &str, base_path: &str, limit: usize) -> AppResult<Fetched> {
@@ -430,36 +459,107 @@ async fn fetch_paged(repo_path: &str, base_path: &str, limit: usize) -> AppResul
         let page_len = page.len();
         let next = parse_link_next(headers);
         items.extend(page);
-        if items.len() >= limit {
-            let truncated = items.len() > limit || next != NextPage::None;
-            items.truncate(limit);
-            return Ok(Fetched::Items { items, truncated });
-        }
-        let c = match next {
-            NextPage::None => {
-                return Ok(Fetched::Items {
-                    items,
-                    truncated: false,
-                })
+        match page_outcome(items.len(), limit, page_len, &next) {
+            PageOutcome::Stop { truncated } => {
+                items.truncate(limit);
+                return Ok(Fetched::Items { items, truncated });
             }
-            // A next page we can't address ends the walk as INCOMPLETE — reporting
-            // it complete would present a parse failure as "no more findings".
-            NextPage::Unreadable => {
-                return Ok(Fetched::Items {
-                    items,
-                    truncated: true,
-                })
-            }
-            NextPage::Cursor(c) => c,
-        };
-        // An empty page that still advertises a next link would spin the walk.
-        if page_len == 0 {
-            return Ok(Fetched::Items {
-                items,
-                truncated: true,
-            });
+            // `Continue` is only returned for an addressable cursor; anything else
+            // ends the walk as incomplete rather than as a clean list.
+            PageOutcome::Continue => match next {
+                NextPage::Cursor(c) => cursor = Some(c),
+                _ => {
+                    return Ok(Fetched::Items {
+                        items,
+                        truncated: true,
+                    })
+                }
+            },
         }
-        cursor = Some(c);
+    }
+}
+
+/// Survivors of a page's deserialization, or the size of a page nothing survived.
+enum ParsedItems<T> {
+    Items(Vec<T>),
+    AllUnreadable(usize),
+}
+
+/// Drops individually malformed items, but keeps a page that parsed away entirely
+/// distinguishable: an empty `Available` list would tell the user the repo is clean
+/// when we simply couldn't read what GitHub sent.
+fn parse_items<T: DeserializeOwned>(items: Vec<Value>) -> ParsedItems<T> {
+    let total = items.len();
+    let parsed: Vec<T> = items
+        .into_iter()
+        .filter_map(|v| serde_json::from_value::<T>(v).ok())
+        .collect();
+    if total > 0 && parsed.is_empty() {
+        ParsedItems::AllUnreadable(total)
+    } else {
+        ParsedItems::Items(parsed)
+    }
+}
+
+fn alerts_envelope(fetched: Fetched) -> DependabotAlertsOut {
+    match fetched {
+        Fetched::Unavailable {
+            availability,
+            detail,
+        } => DependabotAlertsOut {
+            availability,
+            detail,
+            alerts: Vec::new(),
+            truncated: false,
+        },
+        Fetched::Items { items, truncated } => match parse_items::<RawAlert>(items) {
+            ParsedItems::Items(raw) => DependabotAlertsOut {
+                availability: FindingAvailability::Available,
+                detail: None,
+                alerts: raw.into_iter().map(alert_out).collect(),
+                truncated,
+            },
+            ParsedItems::AllUnreadable(total) => DependabotAlertsOut {
+                availability: FindingAvailability::Indeterminate,
+                detail: Some(format!(
+                    "GitHub returned {total} {} this build couldn't read",
+                    if total == 1 { "alert" } else { "alerts" }
+                )),
+                alerts: Vec::new(),
+                truncated: false,
+            },
+        },
+    }
+}
+
+fn advisories_envelope(fetched: Fetched) -> RepoAdvisoriesOut {
+    match fetched {
+        Fetched::Unavailable {
+            availability,
+            detail,
+        } => RepoAdvisoriesOut {
+            availability,
+            detail,
+            advisories: Vec::new(),
+            truncated: false,
+        },
+        Fetched::Items { items, truncated } => match parse_items::<RawRepoAdvisory>(items) {
+            ParsedItems::Items(raw) => RepoAdvisoriesOut {
+                availability: FindingAvailability::Available,
+                detail: None,
+                advisories: raw.into_iter().map(advisory_out).collect(),
+                truncated,
+            },
+            ParsedItems::AllUnreadable(total) => RepoAdvisoriesOut {
+                availability: FindingAvailability::Indeterminate,
+                detail: Some(format!(
+                    "GitHub returned {total} {} this build couldn't read",
+                    if total == 1 { "advisory" } else { "advisories" }
+                )),
+                advisories: Vec::new(),
+                truncated: false,
+            },
+        },
     }
 }
 
@@ -473,29 +573,8 @@ pub async fn gh_dependabot_alerts(
     // on a fork with an `upstream` remote, which would list the parent's findings.
     let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let base = format!("repos/{slug}/dependabot/alerts?state=open&per_page=100");
-    Ok(
-        match fetch_paged(&repo_path, &base, clamp_limit(limit)).await? {
-            Fetched::Unavailable {
-                availability,
-                detail,
-            } => DependabotAlertsOut {
-                availability,
-                detail,
-                alerts: Vec::new(),
-                truncated: false,
-            },
-            Fetched::Items { items, truncated } => DependabotAlertsOut {
-                availability: FindingAvailability::Available,
-                detail: None,
-                alerts: items
-                    .into_iter()
-                    .filter_map(|v| serde_json::from_value::<RawAlert>(v).ok())
-                    .map(alert_out)
-                    .collect(),
-                truncated,
-            },
-        },
-    )
+    let fetched = fetch_paged(&repo_path, &base, clamp_limit(limit)).await?;
+    Ok(alerts_envelope(fetched))
 }
 
 /// Security advisories published on the repo itself (its own GHSAs).
@@ -506,29 +585,8 @@ pub async fn gh_repo_advisories(
 ) -> AppResult<RepoAdvisoriesOut> {
     let slug = crate::github::gh_origin_slug(&repo_path).await?;
     let base = format!("repos/{slug}/security-advisories?per_page=100");
-    Ok(
-        match fetch_paged(&repo_path, &base, clamp_limit(limit)).await? {
-            Fetched::Unavailable {
-                availability,
-                detail,
-            } => RepoAdvisoriesOut {
-                availability,
-                detail,
-                advisories: Vec::new(),
-                truncated: false,
-            },
-            Fetched::Items { items, truncated } => RepoAdvisoriesOut {
-                availability: FindingAvailability::Available,
-                detail: None,
-                advisories: items
-                    .into_iter()
-                    .filter_map(|v| serde_json::from_value::<RawRepoAdvisory>(v).ok())
-                    .map(advisory_out)
-                    .collect(),
-                truncated,
-            },
-        },
-    )
+    let fetched = fetch_paged(&repo_path, &base, clamp_limit(limit)).await?;
+    Ok(advisories_envelope(fetched))
 }
 
 #[cfg(test)]
@@ -902,5 +960,120 @@ mod tests {
         assert_eq!(clamp_limit(Some(0)), 1);
         assert_eq!(clamp_limit(Some(42)), 42);
         assert_eq!(clamp_limit(Some(10_000)), 500);
+    }
+
+    fn readable_alert() -> Value {
+        alert_fixture(
+            json!({ "identifier": "4.12.34" }),
+            json!({ "score": 5.3, "vector_string": "CVSS:3.1/AV:N" }),
+        )
+    }
+
+    #[test]
+    fn a_page_that_parses_away_entirely_is_indeterminate() {
+        // Every item unreadable must NOT render as "no open alerts" — that is the
+        // clean-repo lie the envelope exists to prevent.
+        let out = alerts_envelope(Fetched::Items {
+            items: vec![json!("not an object"), json!(42)],
+            truncated: false,
+        });
+        assert_eq!(out.availability, FindingAvailability::Indeterminate);
+        assert_eq!(
+            out.detail.as_deref(),
+            Some("GitHub returned 2 alerts this build couldn't read")
+        );
+        assert!(out.alerts.is_empty());
+
+        let out = advisories_envelope(Fetched::Items {
+            items: vec![json!("not an object")],
+            truncated: false,
+        });
+        assert_eq!(out.availability, FindingAvailability::Indeterminate);
+        assert_eq!(
+            out.detail.as_deref(),
+            Some("GitHub returned 1 advisory this build couldn't read")
+        );
+        assert!(out.advisories.is_empty());
+
+        // A genuinely empty page is still the real, available answer.
+        let out = alerts_envelope(Fetched::Items {
+            items: Vec::new(),
+            truncated: false,
+        });
+        assert_eq!(out.availability, FindingAvailability::Available);
+        assert_eq!(out.detail, None);
+    }
+
+    #[test]
+    fn a_partly_unreadable_page_keeps_the_survivors() {
+        let out = alerts_envelope(Fetched::Items {
+            items: vec![json!("not an object"), readable_alert()],
+            truncated: true,
+        });
+        assert_eq!(out.availability, FindingAvailability::Available);
+        assert_eq!(out.detail, None);
+        assert_eq!(out.alerts.len(), 1);
+        assert_eq!(out.alerts[0].number, 29);
+        assert!(out.truncated);
+    }
+
+    #[test]
+    fn an_alert_with_a_null_number_is_kept() {
+        // `serde(default)` covers a MISSING key, not a null — a required i64 would
+        // drop the whole alert over its identity field.
+        let mut item = readable_alert();
+        item["number"] = Value::Null;
+        let out = alerts_envelope(Fetched::Items {
+            items: vec![item],
+            truncated: false,
+        });
+        assert_eq!(out.availability, FindingAvailability::Available);
+        assert_eq!(out.alerts.len(), 1);
+        assert_eq!(out.alerts[0].number, 0);
+        assert_eq!(out.alerts[0].package_name, "hono");
+    }
+
+    #[test]
+    fn page_outcome_stops_at_the_limit() {
+        // A full window with a further page is truncated; without one it is complete.
+        assert_eq!(
+            page_outcome(5, 5, 5, &NextPage::Cursor("C".into())),
+            PageOutcome::Stop { truncated: true }
+        );
+        assert_eq!(
+            page_outcome(5, 5, 5, &NextPage::None),
+            PageOutcome::Stop { truncated: false }
+        );
+        // Overshooting the window is truncation on its own.
+        assert_eq!(
+            page_outcome(7, 5, 7, &NextPage::None),
+            PageOutcome::Stop { truncated: true }
+        );
+    }
+
+    #[test]
+    fn page_outcome_stops_short_without_claiming_completeness() {
+        // An unaddressable next page, and an empty page still advertising a cursor
+        // (which would spin the walk), both end it as incomplete.
+        assert_eq!(
+            page_outcome(2, 5, 2, &NextPage::Unreadable),
+            PageOutcome::Stop { truncated: true }
+        );
+        assert_eq!(
+            page_outcome(2, 5, 0, &NextPage::Cursor("C".into())),
+            PageOutcome::Stop { truncated: true }
+        );
+    }
+
+    #[test]
+    fn page_outcome_continues_under_the_limit_and_ends_clean() {
+        assert_eq!(
+            page_outcome(2, 5, 2, &NextPage::Cursor("C".into())),
+            PageOutcome::Continue
+        );
+        assert_eq!(
+            page_outcome(2, 5, 2, &NextPage::None),
+            PageOutcome::Stop { truncated: false }
+        );
     }
 }

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -408,19 +408,20 @@ fn clamp_limit(limit: Option<u32>) -> usize {
 }
 
 /// Whether the page walk keeps going, and if not whether findings were left behind.
+/// `Continue` carries the cursor, so only an addressable next page can resume it.
 #[derive(Debug, PartialEq, Eq)]
 enum PageOutcome {
     Stop { truncated: bool },
-    Continue,
+    Continue(String),
 }
 
 /// The walk's per-page decision, given the items gathered so far and this page's
 /// size and Link header. Truncation is the safe direction: every stop we can't
 /// prove complete reports `truncated`, never a clean end of list.
-fn page_outcome(total: usize, limit: usize, page_len: usize, next: &NextPage) -> PageOutcome {
+fn page_outcome(total: usize, limit: usize, page_len: usize, next: NextPage) -> PageOutcome {
     if total >= limit {
         return PageOutcome::Stop {
-            truncated: total > limit || *next != NextPage::None,
+            truncated: total > limit || next != NextPage::None,
         };
     }
     match next {
@@ -430,7 +431,7 @@ fn page_outcome(total: usize, limit: usize, page_len: usize, next: &NextPage) ->
         NextPage::Unreadable => PageOutcome::Stop { truncated: true },
         // An empty page that still advertises a next link would spin the walk.
         NextPage::Cursor(_) if page_len == 0 => PageOutcome::Stop { truncated: true },
-        NextPage::Cursor(_) => PageOutcome::Continue,
+        NextPage::Cursor(c) => PageOutcome::Continue(c),
     }
 }
 
@@ -459,33 +460,24 @@ async fn fetch_paged(repo_path: &str, base_path: &str, limit: usize) -> AppResul
         let page_len = page.len();
         let next = parse_link_next(headers);
         items.extend(page);
-        match page_outcome(items.len(), limit, page_len, &next) {
+        match page_outcome(items.len(), limit, page_len, next) {
             PageOutcome::Stop { truncated } => {
                 items.truncate(limit);
                 return Ok(Fetched::Items { items, truncated });
             }
-            // `Continue` is only returned for an addressable cursor; anything else
-            // ends the walk as incomplete rather than as a clean list.
-            PageOutcome::Continue => match next {
-                NextPage::Cursor(c) => cursor = Some(c),
-                _ => {
-                    return Ok(Fetched::Items {
-                        items,
-                        truncated: true,
-                    })
-                }
-            },
+            PageOutcome::Continue(c) => cursor = Some(c),
         }
     }
 }
 
-/// Survivors of a page's deserialization, or the size of a page nothing survived.
+/// Survivors of deserializing the whole fetched window, or its size when nothing
+/// survived — classification spans the walk's items, not one page.
 enum ParsedItems<T> {
     Items(Vec<T>),
     AllUnreadable(usize),
 }
 
-/// Drops individually malformed items, but keeps a page that parsed away entirely
+/// Drops individually malformed items, but keeps a window that parsed away entirely
 /// distinguishable: an empty `Available` list would tell the user the repo is clean
 /// when we simply couldn't read what GitHub sent.
 fn parse_items<T: DeserializeOwned>(items: Vec<Value>) -> ParsedItems<T> {
@@ -1037,16 +1029,16 @@ mod tests {
     fn page_outcome_stops_at_the_limit() {
         // A full window with a further page is truncated; without one it is complete.
         assert_eq!(
-            page_outcome(5, 5, 5, &NextPage::Cursor("C".into())),
+            page_outcome(5, 5, 5, NextPage::Cursor("C".into())),
             PageOutcome::Stop { truncated: true }
         );
         assert_eq!(
-            page_outcome(5, 5, 5, &NextPage::None),
+            page_outcome(5, 5, 5, NextPage::None),
             PageOutcome::Stop { truncated: false }
         );
         // Overshooting the window is truncation on its own.
         assert_eq!(
-            page_outcome(7, 5, 7, &NextPage::None),
+            page_outcome(7, 5, 7, NextPage::None),
             PageOutcome::Stop { truncated: true }
         );
     }
@@ -1056,11 +1048,11 @@ mod tests {
         // An unaddressable next page, and an empty page still advertising a cursor
         // (which would spin the walk), both end it as incomplete.
         assert_eq!(
-            page_outcome(2, 5, 2, &NextPage::Unreadable),
+            page_outcome(2, 5, 2, NextPage::Unreadable),
             PageOutcome::Stop { truncated: true }
         );
         assert_eq!(
-            page_outcome(2, 5, 0, &NextPage::Cursor("C".into())),
+            page_outcome(2, 5, 0, NextPage::Cursor("C".into())),
             PageOutcome::Stop { truncated: true }
         );
     }
@@ -1068,11 +1060,12 @@ mod tests {
     #[test]
     fn page_outcome_continues_under_the_limit_and_ends_clean() {
         assert_eq!(
-            page_outcome(2, 5, 2, &NextPage::Cursor("C".into())),
-            PageOutcome::Continue
+            page_outcome(2, 5, 2, NextPage::Cursor("C".into())),
+            // The cursor rides the outcome, so the walk can't resume on anything else.
+            PageOutcome::Continue("C".into())
         );
         assert_eq!(
-            page_outcome(2, 5, 2, &NextPage::None),
+            page_outcome(2, 5, 2, NextPage::None),
             PageOutcome::Stop { truncated: false }
         );
     }

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -1,0 +1,906 @@
+//! Read side of GitHub's security surface: the repo's open Dependabot alerts and
+//! its published security advisories, for the Findings tab.
+//!
+//! Every list rides an availability envelope. A repo with the feature off, a token
+//! without access, and an unrecognized failure are all distinct from "genuinely
+//! clean" — collapsing them into an empty list would tell the user they have no
+//! vulnerabilities when we simply couldn't look. Only a missing `gh` binary or a
+//! timeout escapes as `Err`; every completed-but-failed call is classified into
+//! the envelope instead.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+use crate::github::runner::{run_gh_raw, GH_NETWORK_TIMEOUT};
+
+/// Why a findings list may be empty. Serialized camelCase; the frontend branches
+/// on these exact strings to pick between "no findings" and an explanation.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum FindingAvailability {
+    /// The list is real — an empty one means no findings.
+    Available,
+    /// The feature is switched off for this repo.
+    NotEnabled,
+    /// The token can't read this surface (no admin / not authorized).
+    Forbidden,
+    /// The call failed in a way we can't attribute; the list is unknown, not empty.
+    Indeterminate,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependabotAlertsOut {
+    pub availability: FindingAvailability,
+    /// The server's own explanation, verbatim, when there is one.
+    pub detail: Option<String>,
+    pub alerts: Vec<DependabotAlertOut>,
+    /// More findings existed past the fetched window.
+    pub truncated: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependabotAlertOut {
+    pub number: i64,
+    pub state: String,
+    pub package_name: String,
+    pub ecosystem: String,
+    pub manifest_path: String,
+    pub scope: Option<String>,
+    /// Raw GitHub severity ("critical" | "high" | "medium" | "low"), kept as a
+    /// string so an unrecognized future value renders instead of being dropped.
+    pub severity: String,
+    pub summary: String,
+    pub description: String,
+    pub ghsa_id: String,
+    pub cve_id: Option<String>,
+    pub cvss_score: Option<f64>,
+    pub vulnerable_version_range: Option<String>,
+    /// `None` when no fix has shipped yet.
+    pub first_patched_version: Option<String>,
+    pub html_url: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepoAdvisoriesOut {
+    pub availability: FindingAvailability,
+    pub detail: Option<String>,
+    pub advisories: Vec<RepoAdvisoryOut>,
+    pub truncated: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepoAdvisoryOut {
+    pub ghsa_id: String,
+    pub cve_id: Option<String>,
+    pub summary: String,
+    pub description: Option<String>,
+    /// Nullable: a draft advisory carries no severity yet.
+    pub severity: Option<String>,
+    /// published | draft | triage | closed | withdrawn.
+    pub state: String,
+    pub html_url: String,
+    pub published_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub withdrawn_at: Option<String>,
+    pub created_at: Option<String>,
+    pub cvss_score: Option<f64>,
+    pub vulnerabilities: Vec<AdvisoryVulnerabilityOut>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdvisoryVulnerabilityOut {
+    pub package_name: String,
+    pub ecosystem: String,
+    pub vulnerable_version_range: Option<String>,
+    /// A plain version string on this endpoint (not Dependabot's object).
+    pub patched_versions: Option<String>,
+}
+
+// ── Untrusted GitHub JSON ────────────────────────────────────────────────────
+// Every field is optional so a shape change or one malformed item degrades that
+// field rather than failing the whole list.
+
+#[derive(Deserialize, Default)]
+struct RawPackage {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    ecosystem: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCvss {
+    #[serde(default)]
+    score: Option<f64>,
+    #[serde(default)]
+    vector_string: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawDependency {
+    #[serde(default)]
+    package: Option<RawPackage>,
+    #[serde(default)]
+    manifest_path: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawAlertAdvisory {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    ghsa_id: Option<String>,
+    #[serde(default)]
+    cve_id: Option<String>,
+    #[serde(default)]
+    cvss: Option<RawCvss>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawFirstPatched {
+    #[serde(default)]
+    identifier: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawVulnerability {
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    vulnerable_version_range: Option<String>,
+    /// Null as a whole object when no patched release exists.
+    #[serde(default)]
+    first_patched_version: Option<RawFirstPatched>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawAlert {
+    #[serde(default)]
+    number: i64,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    dependency: Option<RawDependency>,
+    #[serde(default)]
+    security_advisory: Option<RawAlertAdvisory>,
+    #[serde(default)]
+    security_vulnerability: Option<RawVulnerability>,
+    #[serde(default)]
+    html_url: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawAdvisoryVulnerability {
+    #[serde(default)]
+    package: Option<RawPackage>,
+    #[serde(default)]
+    vulnerable_version_range: Option<String>,
+    #[serde(default)]
+    patched_versions: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawRepoAdvisory {
+    #[serde(default)]
+    ghsa_id: Option<String>,
+    #[serde(default)]
+    cve_id: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    html_url: Option<String>,
+    #[serde(default)]
+    published_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+    #[serde(default)]
+    withdrawn_at: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    cvss: Option<RawCvss>,
+    #[serde(default)]
+    vulnerabilities: Option<Vec<RawAdvisoryVulnerability>>,
+}
+
+/// GitHub reports an absent CVSS as a score with a null vector (often `0.0`), so a
+/// null vector reads as "no score" rather than a real zero.
+fn cvss_score(cvss: Option<RawCvss>) -> Option<f64> {
+    let cvss = cvss?;
+    match cvss.vector_string.as_deref() {
+        Some(v) if !v.is_empty() => cvss.score,
+        _ => None,
+    }
+}
+
+fn alert_out(raw: RawAlert) -> DependabotAlertOut {
+    let dependency = raw.dependency.unwrap_or_default();
+    let package = dependency.package.unwrap_or_default();
+    let advisory = raw.security_advisory.unwrap_or_default();
+    let vulnerability = raw.security_vulnerability.unwrap_or_default();
+    DependabotAlertOut {
+        number: raw.number,
+        state: raw.state.unwrap_or_default(),
+        package_name: package.name.unwrap_or_default(),
+        ecosystem: package.ecosystem.unwrap_or_default(),
+        manifest_path: dependency.manifest_path.unwrap_or_default(),
+        scope: dependency.scope,
+        severity: vulnerability.severity.unwrap_or_default(),
+        summary: advisory.summary.unwrap_or_default(),
+        description: advisory.description.unwrap_or_default(),
+        ghsa_id: advisory.ghsa_id.unwrap_or_default(),
+        cve_id: advisory.cve_id,
+        cvss_score: cvss_score(advisory.cvss),
+        vulnerable_version_range: vulnerability.vulnerable_version_range,
+        first_patched_version: vulnerability
+            .first_patched_version
+            .and_then(|f| f.identifier),
+        html_url: raw.html_url.unwrap_or_default(),
+        created_at: raw.created_at.unwrap_or_default(),
+        updated_at: raw.updated_at.unwrap_or_default(),
+    }
+}
+
+fn advisory_out(raw: RawRepoAdvisory) -> RepoAdvisoryOut {
+    RepoAdvisoryOut {
+        ghsa_id: raw.ghsa_id.unwrap_or_default(),
+        cve_id: raw.cve_id,
+        summary: raw.summary.unwrap_or_default(),
+        description: raw.description,
+        severity: raw.severity,
+        state: raw.state.unwrap_or_default(),
+        html_url: raw.html_url.unwrap_or_default(),
+        published_at: raw.published_at,
+        updated_at: raw.updated_at,
+        withdrawn_at: raw.withdrawn_at,
+        created_at: raw.created_at,
+        cvss_score: cvss_score(raw.cvss),
+        vulnerabilities: raw
+            .vulnerabilities
+            .unwrap_or_default()
+            .into_iter()
+            .map(|v| {
+                let package = v.package.unwrap_or_default();
+                AdvisoryVulnerabilityOut {
+                    package_name: package.name.unwrap_or_default(),
+                    ecosystem: package.ecosystem.unwrap_or_default(),
+                    vulnerable_version_range: v.vulnerable_version_range,
+                    patched_versions: v.patched_versions,
+                }
+            })
+            .collect(),
+    }
+}
+
+// ── Transport ────────────────────────────────────────────────────────────────
+
+/// Splits `gh api -i` output into (header block, body). gh prints the status line
+/// and response headers ahead of the body on success AND failure, ended by a blank
+/// line; output with no status line is all body.
+fn split_response(out: &str) -> (&str, &str) {
+    if !out.starts_with("HTTP/") {
+        return ("", out);
+    }
+    let mut offset = 0usize;
+    for line in out.split_inclusive('\n') {
+        offset += line.len();
+        if line.trim().is_empty() {
+            return (&out[..offset], &out[offset..]);
+        }
+    }
+    (out, "")
+}
+
+/// What a response's `Link` header says about a further page.
+#[derive(Debug, PartialEq, Eq)]
+enum NextPage {
+    /// No `rel="next"` — this is the last page.
+    None,
+    /// The next page's `after` cursor.
+    Cursor(String),
+    /// A `rel="next"` exists but carries no readable cursor. Distinct from `None`
+    /// so the walk reports an unreachable page as truncation, never completeness.
+    Unreadable,
+}
+
+/// Reads the `rel="next"` Link. The cursor comes back verbatim: GitHub's is
+/// already percent-encoded and re-encoding it makes the next request 4xx.
+fn parse_link_next(headers: &str) -> NextPage {
+    for line in headers.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if !name.trim().eq_ignore_ascii_case("link") {
+            continue;
+        }
+        for part in value.split(',') {
+            let part = part.trim();
+            if !part.contains("rel=\"next\"") {
+                continue;
+            }
+            let cursor = part
+                .split_once('<')
+                .and_then(|(_, rest)| rest.split_once('>'))
+                .and_then(|(url, _)| url.split_once('?'))
+                .and_then(|(_, query)| query.split('&').find_map(|p| p.strip_prefix("after=")))
+                .filter(|c| !c.is_empty());
+            return match cursor {
+                Some(c) => NextPage::Cursor(c.to_string()),
+                None => NextPage::Unreadable,
+            };
+        }
+    }
+    NextPage::None
+}
+
+/// Maps a completed-but-failed gh call onto the envelope. Classified into `Ok`
+/// rather than `Err` so the UI can say *why* a list is empty; an unrecognized
+/// failure stays `Indeterminate` and is never presented as a clean repo.
+fn classify_failure(stdout_body: &str, stderr: &str) -> (FindingAvailability, Option<String>) {
+    let message = serde_json::from_str::<Value>(stdout_body.trim())
+        .ok()
+        .and_then(|v| {
+            v.get("message")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+                .map(str::to_string)
+        });
+    // gh appends its own guessed scope hint to stderr (it suggests `admin:repo_hook`
+    // for a disabled-alerts 403), so the server's message wins whenever it exists.
+    let detail = message.clone().or_else(|| {
+        let s = stderr.trim();
+        (!s.is_empty()).then(|| s.to_string())
+    });
+    let Some(message) = message else {
+        return (FindingAvailability::Indeterminate, detail);
+    };
+    let lower = message.to_lowercase();
+    if lower.contains("disabled") {
+        (FindingAvailability::NotEnabled, detail)
+    } else if lower.contains("not authorized") || lower.contains("forbidden") {
+        (FindingAvailability::Forbidden, detail)
+    } else {
+        (FindingAvailability::Indeterminate, detail)
+    }
+}
+
+/// Outcome of a bounded page walk: raw items, or a classified unavailability.
+enum Fetched {
+    Items {
+        items: Vec<Value>,
+        truncated: bool,
+    },
+    Unavailable {
+        availability: FindingAvailability,
+        detail: Option<String>,
+    },
+}
+
+/// The page-walk ceiling. gh's `--paginate` is unbounded, so the walk follows the
+/// Link cursor itself and stops at `limit`.
+fn clamp_limit(limit: Option<u32>) -> usize {
+    limit.unwrap_or(100).clamp(1, 500) as usize
+}
+
+/// Walks a cursor-paginated list endpoint up to `limit` items. `base_path` must
+/// already carry a query string — the cursor is appended as `&after=`.
+async fn fetch_paged(repo_path: &str, base_path: &str, limit: usize) -> AppResult<Fetched> {
+    let mut items: Vec<Value> = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let path = match &cursor {
+            Some(c) => format!("{base_path}&after={c}"),
+            None => base_path.to_string(),
+        };
+        let out = run_gh_raw(Some(repo_path), &["api", "-i", &path], GH_NETWORK_TIMEOUT).await?;
+        let raw = out.stdout_lossy();
+        let (headers, body) = split_response(&raw);
+        if out.code != 0 {
+            let (availability, detail) = classify_failure(body, &out.stderr);
+            return Ok(Fetched::Unavailable {
+                availability,
+                detail,
+            });
+        }
+        let page: Vec<Value> = serde_json::from_str(body.trim())
+            .map_err(|e| AppError::Gh(format!("could not parse security findings: {e}")))?;
+        let page_len = page.len();
+        let next = parse_link_next(headers);
+        items.extend(page);
+        if items.len() >= limit {
+            let truncated = items.len() > limit || next != NextPage::None;
+            items.truncate(limit);
+            return Ok(Fetched::Items { items, truncated });
+        }
+        let c = match next {
+            NextPage::None => {
+                return Ok(Fetched::Items {
+                    items,
+                    truncated: false,
+                })
+            }
+            // A next page we can't address ends the walk as INCOMPLETE — reporting
+            // it complete would present a parse failure as "no more findings".
+            NextPage::Unreadable => {
+                return Ok(Fetched::Items {
+                    items,
+                    truncated: true,
+                })
+            }
+            NextPage::Cursor(c) => c,
+        };
+        // An empty page that still advertises a next link would spin the walk.
+        if page_len == 0 {
+            return Ok(Fetched::Items {
+                items,
+                truncated: true,
+            });
+        }
+        cursor = Some(c);
+    }
+}
+
+/// The repo's OPEN Dependabot alerts.
+#[tauri::command]
+pub async fn gh_dependabot_alerts(
+    repo_path: String,
+    limit: Option<u32>,
+) -> AppResult<DependabotAlertsOut> {
+    // Pin the origin slug: gh's `{owner}/{repo}` placeholders resolve to the PARENT
+    // on a fork with an `upstream` remote, which would list the parent's findings.
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let base = format!("repos/{slug}/dependabot/alerts?state=open&per_page=100");
+    Ok(
+        match fetch_paged(&repo_path, &base, clamp_limit(limit)).await? {
+            Fetched::Unavailable {
+                availability,
+                detail,
+            } => DependabotAlertsOut {
+                availability,
+                detail,
+                alerts: Vec::new(),
+                truncated: false,
+            },
+            Fetched::Items { items, truncated } => DependabotAlertsOut {
+                availability: FindingAvailability::Available,
+                detail: None,
+                alerts: items
+                    .into_iter()
+                    .filter_map(|v| serde_json::from_value::<RawAlert>(v).ok())
+                    .map(alert_out)
+                    .collect(),
+                truncated,
+            },
+        },
+    )
+}
+
+/// Security advisories published on the repo itself (its own GHSAs).
+#[tauri::command]
+pub async fn gh_repo_advisories(
+    repo_path: String,
+    limit: Option<u32>,
+) -> AppResult<RepoAdvisoriesOut> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let base = format!("repos/{slug}/security-advisories?per_page=100");
+    Ok(
+        match fetch_paged(&repo_path, &base, clamp_limit(limit)).await? {
+            Fetched::Unavailable {
+                availability,
+                detail,
+            } => RepoAdvisoriesOut {
+                availability,
+                detail,
+                advisories: Vec::new(),
+                truncated: false,
+            },
+            Fetched::Items { items, truncated } => RepoAdvisoriesOut {
+                availability: FindingAvailability::Available,
+                detail: None,
+                advisories: items
+                    .into_iter()
+                    .filter_map(|v| serde_json::from_value::<RawRepoAdvisory>(v).ok())
+                    .map(advisory_out)
+                    .collect(),
+                truncated,
+            },
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const NEXT_LINK: &str = "Link: <https://api.github.com/repositories/1274107935/dependabot/alerts?state=open&per_page=1&after=Y3Vyc29yOnYyOpPPAAABn8sLIn7LP_UzMzMzMzPPAAAAAbgjUQg%3D>; rel=\"next\"\r\n";
+
+    #[test]
+    fn parse_link_next_reads_the_after_cursor() {
+        let headers = format!("HTTP/2.0 200 OK\r\nServer: github.com\r\n{NEXT_LINK}\r\n");
+        assert_eq!(
+            parse_link_next(&headers),
+            // Percent-encoding is preserved verbatim — re-encoding breaks the cursor.
+            NextPage::Cursor("Y3Vyc29yOnYyOpPPAAABn8sLIn7LP_UzMzMzMzPPAAAAAbgjUQg%3D".into())
+        );
+    }
+
+    #[test]
+    fn parse_link_next_is_none_without_a_next_rel() {
+        // No Link header at all (last page).
+        assert_eq!(
+            parse_link_next("HTTP/2.0 200 OK\r\nServer: github.com\r\n"),
+            NextPage::None
+        );
+        // A Link header carrying only prev/first.
+        let only_prev = "Link: <https://api.github.com/x?after=AAA>; rel=\"prev\", \
+                         <https://api.github.com/x?before=BBB>; rel=\"first\"\r\n";
+        assert_eq!(parse_link_next(only_prev), NextPage::None);
+    }
+
+    #[test]
+    fn parse_link_next_flags_an_unreadable_next_link() {
+        // A further page exists but can't be addressed — page-numbered instead of
+        // cursored, an empty cursor, no query at all, or mangled angle brackets.
+        // None of these may read as "last page": that hides findings.
+        for header in [
+            "Link: <https://api.github.com/x?per_page=100&page=2>; rel=\"next\"\r\n",
+            "Link: <https://api.github.com/x?after=>; rel=\"next\"\r\n",
+            "Link: <https://api.github.com/x>; rel=\"next\"\r\n",
+            "Link: https://api.github.com/x?after=AAA; rel=\"next\"\r\n",
+        ] {
+            assert_eq!(parse_link_next(header), NextPage::Unreadable, "{header}");
+        }
+    }
+
+    #[test]
+    fn parse_link_next_picks_next_out_of_multiple_rels() {
+        let headers =
+            "link: <https://api.github.com/x?per_page=100&before=PREVCUR>; rel=\"prev\", \
+                       <https://api.github.com/x?per_page=100&after=NEXTCUR>; rel=\"next\", \
+                       <https://api.github.com/x?per_page=100&after=LASTCUR>; rel=\"last\"\r\n";
+        assert_eq!(parse_link_next(headers), NextPage::Cursor("NEXTCUR".into()));
+    }
+
+    #[test]
+    fn split_response_separates_headers_from_body() {
+        let raw = "HTTP/2.0 200 OK\r\nServer: github.com\r\n\r\n[{\"number\":1}]";
+        let (headers, body) = split_response(raw);
+        assert!(headers.contains("Server: github.com"));
+        assert_eq!(body, "[{\"number\":1}]");
+        // Output with no status line is all body.
+        assert_eq!(split_response("[]"), ("", "[]"));
+    }
+
+    #[test]
+    fn classify_failure_reads_disabled_as_not_enabled() {
+        let body = r#"{"message":"Dependabot alerts are disabled for this repository.","documentation_url":"https://docs.github.com/rest","status":"403"}"#;
+        // gh's stderr appends a WRONG scope guess; the body message must win.
+        let stderr = "gh: Dependabot alerts are disabled for this repository. (HTTP 403)\ngh: This API operation needs the \"admin:repo_hook\" scope.";
+        let (availability, detail) = classify_failure(body, stderr);
+        assert_eq!(availability, FindingAvailability::NotEnabled);
+        assert_eq!(
+            detail.as_deref(),
+            Some("Dependabot alerts are disabled for this repository.")
+        );
+    }
+
+    #[test]
+    fn classify_failure_reads_not_authorized_as_forbidden() {
+        let body =
+            r#"{"message":"You are not authorized to perform this operation.","status":"403"}"#;
+        let (availability, detail) = classify_failure(
+            body,
+            "gh: You are not authorized to perform this operation. (HTTP 403)",
+        );
+        assert_eq!(availability, FindingAvailability::Forbidden);
+        assert_eq!(
+            detail.as_deref(),
+            Some("You are not authorized to perform this operation.")
+        );
+        // The literal word "Forbidden" classifies the same way.
+        let (availability, _) = classify_failure(r#"{"message":"Forbidden"}"#, "");
+        assert_eq!(availability, FindingAvailability::Forbidden);
+    }
+
+    #[test]
+    fn classify_failure_keeps_unknown_failures_indeterminate() {
+        // 404: absence of the endpoint is NOT proof the repo is clean.
+        let (availability, detail) = classify_failure(
+            r#"{"message":"Not Found","status":"404"}"#,
+            "gh: Not Found (HTTP 404)",
+        );
+        assert_eq!(availability, FindingAvailability::Indeterminate);
+        assert_eq!(detail.as_deref(), Some("Not Found"));
+        // Unparseable body → indeterminate, with gh's stderr as the only detail.
+        let (availability, detail) =
+            classify_failure("<html>502 Bad Gateway</html>", "  gh: HTTP 502  ");
+        assert_eq!(availability, FindingAvailability::Indeterminate);
+        assert_eq!(detail.as_deref(), Some("gh: HTTP 502"));
+        // Nothing to go on at all.
+        let (availability, detail) = classify_failure("", "");
+        assert_eq!(availability, FindingAvailability::Indeterminate);
+        assert_eq!(detail, None);
+    }
+
+    fn alert_fixture(first_patched: Value, cvss: Value) -> Value {
+        json!({
+            "number": 29,
+            "state": "open",
+            "dependency": {
+                "package": { "ecosystem": "npm", "name": "hono" },
+                "manifest_path": "pnpm-lock.yaml",
+                "scope": "runtime",
+                "relationship": "transitive"
+            },
+            "security_advisory": {
+                "ghsa_id": "GHSA-8j4g-w8fx-2239",
+                "cve_id": "CVE-2026-69207",
+                "summary": "Hono: ReDoS in CORS middleware",
+                "description": "### Summary\n\nThe built-in CORS middleware…",
+                "cvss": cvss
+            },
+            "security_vulnerability": {
+                "package": { "ecosystem": "npm", "name": "hono" },
+                "severity": "medium",
+                "vulnerable_version_range": "< 4.12.34",
+                "first_patched_version": first_patched
+            },
+            "html_url": "https://github.com/theBGuy/GitDesktop/security/dependabot/29",
+            "created_at": "2026-08-04T04:32:12Z",
+            "updated_at": "2026-08-04T04:32:12Z"
+        })
+    }
+
+    #[test]
+    fn alert_maps_every_field() {
+        let raw: RawAlert = serde_json::from_value(alert_fixture(
+            json!({ "identifier": "4.12.34" }),
+            json!({ "score": 5.3, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L" }),
+        ))
+        .expect("alert fixture deserializes");
+        let out = alert_out(raw);
+        assert_eq!(out.number, 29);
+        assert_eq!(out.state, "open");
+        assert_eq!(out.package_name, "hono");
+        assert_eq!(out.ecosystem, "npm");
+        assert_eq!(out.manifest_path, "pnpm-lock.yaml");
+        assert_eq!(out.scope.as_deref(), Some("runtime"));
+        assert_eq!(out.severity, "medium");
+        assert_eq!(out.summary, "Hono: ReDoS in CORS middleware");
+        assert_eq!(out.ghsa_id, "GHSA-8j4g-w8fx-2239");
+        assert_eq!(out.cve_id.as_deref(), Some("CVE-2026-69207"));
+        assert_eq!(out.cvss_score, Some(5.3));
+        assert_eq!(out.vulnerable_version_range.as_deref(), Some("< 4.12.34"));
+        assert_eq!(out.first_patched_version.as_deref(), Some("4.12.34"));
+        assert_eq!(
+            out.html_url,
+            "https://github.com/theBGuy/GitDesktop/security/dependabot/29"
+        );
+        assert_eq!(out.created_at, "2026-08-04T04:32:12Z");
+        assert_eq!(out.updated_at, "2026-08-04T04:32:12Z");
+    }
+
+    #[test]
+    fn alert_with_no_fix_reports_no_patched_version() {
+        // The whole first_patched_version OBJECT is null when nothing is patched —
+        // never a placeholder version, which would read as "a fix exists".
+        let raw: RawAlert = serde_json::from_value(alert_fixture(
+            Value::Null,
+            json!({ "score": 0.0, "vector_string": Value::Null }),
+        ))
+        .expect("alert fixture deserializes");
+        let out = alert_out(raw);
+        assert_eq!(out.first_patched_version, None);
+        assert_eq!(out.cvss_score, None);
+    }
+
+    #[test]
+    fn alert_tolerates_a_stripped_item() {
+        let raw: RawAlert =
+            serde_json::from_value(json!({ "number": 7 })).expect("sparse alert deserializes");
+        let out = alert_out(raw);
+        assert_eq!(out.number, 7);
+        assert_eq!(out.package_name, "");
+        assert_eq!(out.scope, None);
+        assert_eq!(out.cvss_score, None);
+    }
+
+    #[test]
+    fn advisory_maps_nullable_fields() {
+        let raw: RawRepoAdvisory = serde_json::from_value(json!({
+            "ghsa_id": "GHSA-pj86-cfqh-vqx6",
+            "cve_id": "CVE-2024-51999",
+            "summary": "express vulnerable to XSS",
+            "description": Value::Null,
+            "severity": Value::Null,
+            "state": "published",
+            "html_url": "https://github.com/expressjs/express/security/advisories/GHSA-pj86-cfqh-vqx6",
+            "published_at": "2025-12-01T16:24:31Z",
+            "updated_at": "2025-12-01T16:24:31Z",
+            "withdrawn_at": Value::Null,
+            "created_at": Value::Null,
+            "cvss": { "score": Value::Null, "vector_string": Value::Null },
+            "vulnerabilities": [
+                {
+                    "package": { "ecosystem": "npm", "name": "express" },
+                    "patched_versions": "4.22.0",
+                    "vulnerable_version_range": "<4.22.0",
+                    "vulnerable_functions": []
+                },
+                {
+                    "package": { "ecosystem": "npm", "name": "express" },
+                    "patched_versions": Value::Null,
+                    "vulnerable_version_range": Value::Null
+                }
+            ]
+        }))
+        .expect("advisory fixture deserializes");
+        let out = advisory_out(raw);
+        assert_eq!(out.ghsa_id, "GHSA-pj86-cfqh-vqx6");
+        assert_eq!(out.severity, None);
+        assert_eq!(out.description, None);
+        assert_eq!(out.created_at, None);
+        assert_eq!(out.withdrawn_at, None);
+        assert_eq!(out.published_at.as_deref(), Some("2025-12-01T16:24:31Z"));
+        assert_eq!(out.cvss_score, None);
+        assert_eq!(out.state, "published");
+        assert_eq!(out.vulnerabilities.len(), 2);
+        assert_eq!(out.vulnerabilities[0].package_name, "express");
+        assert_eq!(out.vulnerabilities[0].ecosystem, "npm");
+        assert_eq!(
+            out.vulnerabilities[0].patched_versions.as_deref(),
+            Some("4.22.0")
+        );
+        assert_eq!(
+            out.vulnerabilities[0].vulnerable_version_range.as_deref(),
+            Some("<4.22.0")
+        );
+        assert_eq!(out.vulnerabilities[1].patched_versions, None);
+        assert_eq!(out.vulnerabilities[1].vulnerable_version_range, None);
+    }
+
+    #[test]
+    fn availability_serializes_camel_case() {
+        for (variant, expected) in [
+            (FindingAvailability::Available, "available"),
+            (FindingAvailability::NotEnabled, "notEnabled"),
+            (FindingAvailability::Forbidden, "forbidden"),
+            (FindingAvailability::Indeterminate, "indeterminate"),
+        ] {
+            assert_eq!(serde_json::to_value(variant).unwrap(), json!(expected));
+        }
+    }
+
+    #[test]
+    fn alerts_envelope_wire_shape_is_pinned() {
+        // The TS mirror reads these exact keys; a casing drift reaches the UI as
+        // `undefined` rather than a compile error.
+        let raw: RawAlert = serde_json::from_value(alert_fixture(
+            json!({ "identifier": "4.12.34" }),
+            json!({ "score": 5.3, "vector_string": "CVSS:3.1/AV:N" }),
+        ))
+        .unwrap();
+        let envelope = DependabotAlertsOut {
+            availability: FindingAvailability::Available,
+            detail: None,
+            alerts: vec![alert_out(raw)],
+            truncated: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&envelope).unwrap(),
+            json!({
+                "availability": "available",
+                "detail": Value::Null,
+                "truncated": true,
+                "alerts": [{
+                    "number": 29,
+                    "state": "open",
+                    "packageName": "hono",
+                    "ecosystem": "npm",
+                    "manifestPath": "pnpm-lock.yaml",
+                    "scope": "runtime",
+                    "severity": "medium",
+                    "summary": "Hono: ReDoS in CORS middleware",
+                    "description": "### Summary\n\nThe built-in CORS middleware…",
+                    "ghsaId": "GHSA-8j4g-w8fx-2239",
+                    "cveId": "CVE-2026-69207",
+                    "cvssScore": 5.3,
+                    "vulnerableVersionRange": "< 4.12.34",
+                    "firstPatchedVersion": "4.12.34",
+                    "htmlUrl": "https://github.com/theBGuy/GitDesktop/security/dependabot/29",
+                    "createdAt": "2026-08-04T04:32:12Z",
+                    "updatedAt": "2026-08-04T04:32:12Z"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn advisories_envelope_wire_shape_is_pinned() {
+        let envelope = RepoAdvisoriesOut {
+            availability: FindingAvailability::NotEnabled,
+            detail: Some("Dependabot alerts are disabled for this repository.".into()),
+            advisories: vec![RepoAdvisoryOut {
+                ghsa_id: "GHSA-pj86-cfqh-vqx6".into(),
+                cve_id: None,
+                summary: "express vulnerable to XSS".into(),
+                description: None,
+                severity: Some("low".into()),
+                state: "published".into(),
+                html_url: "https://github.com/expressjs/express/security/advisories/x".into(),
+                published_at: Some("2025-12-01T16:24:31Z".into()),
+                updated_at: None,
+                withdrawn_at: None,
+                created_at: None,
+                cvss_score: Some(3.1),
+                vulnerabilities: vec![AdvisoryVulnerabilityOut {
+                    package_name: "express".into(),
+                    ecosystem: "npm".into(),
+                    vulnerable_version_range: Some("<4.22.0".into()),
+                    patched_versions: Some("4.22.0".into()),
+                }],
+            }],
+            truncated: false,
+        };
+        assert_eq!(
+            serde_json::to_value(&envelope).unwrap(),
+            json!({
+                "availability": "notEnabled",
+                "detail": "Dependabot alerts are disabled for this repository.",
+                "truncated": false,
+                "advisories": [{
+                    "ghsaId": "GHSA-pj86-cfqh-vqx6",
+                    "cveId": Value::Null,
+                    "summary": "express vulnerable to XSS",
+                    "description": Value::Null,
+                    "severity": "low",
+                    "state": "published",
+                    "htmlUrl": "https://github.com/expressjs/express/security/advisories/x",
+                    "publishedAt": "2025-12-01T16:24:31Z",
+                    "updatedAt": Value::Null,
+                    "withdrawnAt": Value::Null,
+                    "createdAt": Value::Null,
+                    "cvssScore": 3.1,
+                    "vulnerabilities": [{
+                        "packageName": "express",
+                        "ecosystem": "npm",
+                        "vulnerableVersionRange": "<4.22.0",
+                        "patchedVersions": "4.22.0"
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn limit_is_clamped_to_a_bounded_window() {
+        assert_eq!(clamp_limit(None), 100);
+        assert_eq!(clamp_limit(Some(0)), 1);
+        assert_eq!(clamp_limit(Some(42)), 42);
+        assert_eq!(clamp_limit(Some(10_000)), 500);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -556,6 +556,8 @@ pub fn run() {
             github::collaborators::gh_invitation_cancel,
             github::security::gh_security_get,
             github::security::gh_security_apply,
+            github::security_findings::gh_dependabot_alerts,
+            github::security_findings::gh_repo_advisories,
             github::lifecycle::gh_repo_set_visibility,
             github::lifecycle::gh_repo_transfer,
             github::lifecycle::gh_repo_delete,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -79,12 +79,13 @@ From the welcome screen (or the repo switcher in the header):
 Once a repo is open you land on the **Changes** tab. The header's tab rail holds the
 three primary views — **Changes**, **History**, and **Pull Requests** — and a
 **More ▾** menu holds the rest: **Compare**, {{ai}}**Agent**, {{/ai}}**Issues**,
-**Discussions**, **Actions**, **Tags**, and **Insights**. The More button shows the
-active secondary tab's name, so the rail always says where you are.
+**Code TODOs**, **Discussions**, **Actions**, **Findings**, **Tags**, **Tasks**,
+and **Insights**. The More button shows the active secondary tab's name, so the
+rail always says where you are.
 
 Switch tabs with the number keys ({{kbd:tab-changes}} through {{kbd:tab-insights}}; see
-*Keyboard & navigation*). Issues, Discussions, Actions, and Tags need \`gh\` and a GitHub
-remote{{ai}}; the **Agent** tab appears only when AI features are enabled{{/ai}}.
+*Keyboard & navigation*). Issues, Discussions, Actions, Findings, and Tags need \`gh\` and a
+GitHub remote{{ai}}; the **Agent** tab appears only when AI features are enabled{{/ai}}.
 
 > Tip: press {{kbd:command-palette}} anytime for the command palette — the fastest way
 > to find a feature when you don't know where it lives — or {{kbd:show-help}} to reopen
@@ -1842,8 +1843,9 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
 - **Tabs:** {{kbd:tab-changes}} Changes · {{kbd:tab-history}} History ·
   {{kbd:tab-compare}} Compare · {{kbd:tab-pulls}} Pull Requests · {{kbd:tab-actions}}
   Actions · {{kbd:tab-issues}} Issues · {{kbd:tab-discussions}} Discussions ·
-  {{kbd:tab-tags}} Tags · {{kbd:tab-insights}} Insights.{{ai}} The **Agent** tab is
-  palette-only by default (bind a key in Settings).{{/ai}}
+  {{kbd:tab-tags}} Tags · {{kbd:tab-insights}} Insights. The **Code TODOs**, **Findings**,
+  and **Tasks** tabs are palette-only by default{{ai}}, as is **Agent**{{/ai}} (bind a key
+  in **Settings → Keyboard**).
 - {{kbd:show-repositories}} repositories · {{kbd:show-branches}} branches ·
   {{kbd:back-to-repositories}} back to repositories · {{kbd:focus-filter}} focus the
   filter.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1264,9 +1264,9 @@ Move through the list with **↑ / ↓**; select a row for its detail, then **Vi
 GitHub** to open it there.
 
 A category that isn't reporting tells you why rather than looking empty. When Dependabot
-alerts are switched off for the repo, **Open security settings** takes you straight to
-**Repository settings → Security**, where you turn scanning on (see *Repository
-settings*). When your GitHub access can't read a category, you see what GitHub said
+alerts are switched off for the repo and you have repo-admin access, **Open security
+settings** takes you straight to **Repository settings → Security**, where you turn
+scanning on (see *Repository settings*). When your GitHub access can't read a category, you see what GitHub said
 about it; when the check couldn't complete at all, you get a **Retry**.
 
 The tab fetches when you open it — use the refresh button for the current state.`,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1245,6 +1245,32 @@ to jump to that run. You can also get an OS **notification** when a run finishes
 (**Settings → Notifications**).`,
   },
   {
+    id: "findings",
+    label: "Findings",
+    body: `# Findings
+
+The **Findings** tab (in the More ▾ menu; palette-only by default — bind a key in
+**Settings → Keyboard**) collects what GitHub's security scanning has turned up for the repo, so you
+can read it without opening the browser. It covers **GitHub** repositories; on a GitLab
+or Bitbucket repo the tab says so instead.
+
+- **Dependabot alerts** — every open alert, grouped by the vulnerable package. Each one
+  shows its **severity**, the **affected version range**, the **first patched version**,
+  and a **CVSS** score when GitHub reports one.
+- **Security advisories** — the advisories published on the repository itself.
+
+Move through the list with **↑ / ↓**; select a row for its detail, then **View on
+GitHub** to open it there.
+
+A category that isn't reporting tells you why rather than looking empty. When Dependabot
+alerts are switched off for the repo, **Open security settings** takes you straight to
+**Repository settings → Security**, where you turn scanning on (see *Repository
+settings*). When your GitHub access can't read a category, you see what GitHub said
+about it; when the check couldn't complete at all, you get a **Retry**.
+
+The tab fetches when you open it — use the refresh button for the current state.`,
+  },
+  {
     id: "bitbucket",
     label: "Bitbucket repositories",
     body: `# Bitbucket repositories

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -101,7 +101,7 @@ function eventsSummary(events: string[]): string {
   return `${labels.slice(0, 3).join(", ")} +${labels.length - 3}`;
 }
 
-type SectionId =
+export type SectionId =
   | "general"
   | "access"
   | "rules"
@@ -226,12 +226,16 @@ export function RepoSettingsDialog({
   repoPath,
   open,
   onOpenChange,
+  initialSection,
 }: {
   repoPath: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Section to land on. An initializer is enough: the dialog mounts fresh on
+   *  each open, so a later open with no request starts at "general" again. */
+  initialSection?: SectionId;
 }) {
-  const [section, setSection] = useState<SectionId>("general");
+  const [section, setSection] = useState<SectionId>(initialSection ?? "general");
   const reduceMotion = useReducedMotion();
   // The dialog is provider-aware: each provider gets the sections its API
   // supports, with the same rail + crossfade shell.

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -235,7 +235,9 @@ export function RepoSettingsDialog({
    *  each open, so a later open with no request starts at "general" again. */
   initialSection?: SectionId;
 }) {
-  const [section, setSection] = useState<SectionId>(initialSection ?? "general");
+  const [section, setSection] = useState<SectionId>(
+    initialSection ?? "general",
+  );
   const reduceMotion = useReducedMotion();
   // The dialog is provider-aware: each provider gets the sections its API
   // supports, with the same rail + crossfade shell.

--- a/src/features/repository/ForgeNotReady.tsx
+++ b/src/features/repository/ForgeNotReady.tsx
@@ -23,10 +23,10 @@ const ATLASSIAN_TOKEN_URL =
 
 /**
  * Shared "this hosted feature isn't available" empty state for the Pull
- * Requests, Issues, Discussions, and Actions tabs. Names the actual blocker and
- * pairs it with the one action that resolves it, so the tab is a path forward
- * instead of a dead end. `feature` is the noun the message reads with ("pull
- * requests", "workflow runs").
+ * Requests, Issues, Discussions, Actions, and Findings tabs. Names the actual
+ * blocker and pairs it with the one action that resolves it, so the tab is a
+ * path forward instead of a dead end. `feature` is the noun the message reads
+ * with ("pull requests", "workflow runs").
  *
  * Provider-aware, with the publish path taking precedence: when this repo has
  * no origin and ≥1 provider can publish it, the panel offers the shared

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -157,6 +157,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // everyone else.
   const settingsReady = forgeFeatureReady(gh.data, "repoSettings");
   const admin = useRepoAdmin(repoPath, settingsReady);
+  const canOpenRepoSettings = settingsReady && Boolean(admin.data?.admin);
   const editor = (settings.data?.externalEditor ?? "").trim();
   const editorName =
     (settings.data?.externalEditorName ?? "").trim() || "editor";
@@ -184,13 +185,16 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   });
 
   // A one-shot deep link raised by another surface (the Findings tab's "turn on
-  // Dependabot" card). Keyed on the request alone so re-opening the dialog can
-  // never re-fire it.
+  // Dependabot" card). Not keyed on the dialog's open state, so re-opening the
+  // dialog can never re-fire it.
   useEffect(() => {
     if (!repoSettingsRequest) return;
-    openRepoSettingsAt(repoSettingsRequest);
+    // Same admin gate as the menu item: the dialog is admin-only, so a request
+    // raised before the gate was known must not open it. Cleared either way —
+    // a refused request is dropped rather than left to fire later.
+    if (canOpenRepoSettings) openRepoSettingsAt(repoSettingsRequest);
     clearRepoSettingsRequest();
-  }, [repoSettingsRequest, clearRepoSettingsRequest]);
+  }, [repoSettingsRequest, clearRepoSettingsRequest, canOpenRepoSettings]);
 
   const onError = (e: unknown) => toastError(e);
 
@@ -240,7 +244,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction(
     "repository-settings",
     () => setRepoSettingsOpen(true),
-    settingsReady && Boolean(admin.data?.admin),
+    canOpenRepoSettings,
   );
   useHotkeyAction("branch-rules", () => setBranchRulesOpen(true));
   useHotkeyAction("git-hooks", () => setHooksOpen(true));
@@ -389,7 +393,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
           <KanbanIcon />
           {jiraLink.data ? "Change Jira project…" : "Link Jira project…"}
         </DropdownMenuItem>
-        {settingsReady && admin.data?.admin && (
+        {canOpenRepoSettings && (
           <DropdownMenuItem onClick={() => setRepoSettingsOpen(true)}>
             <GearSixIcon />
             Repository settings…

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -22,7 +22,7 @@ import {
   WarningCircleIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense, useEffect, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -46,6 +46,7 @@ import { RepoAutomationsDialog } from "@/features/automations/RepoAutomationsDia
 import { BranchRulesDialog } from "@/features/branch-rules/BranchRulesDialog";
 import { HooksDialog } from "@/features/hooks/HooksDialog";
 import { RepoJiraDialog } from "@/features/issues/RepoJiraDialog";
+import type { SectionId } from "@/features/repo-settings/RepoSettingsDialog";
 import { copyText } from "@/lib/clipboard";
 import {
   forgeRepoUrl,
@@ -104,6 +105,12 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const [automationsOpen, setAutomationsOpen] = useState(false);
   const [jiraOpen, setJiraOpen] = useState(false);
   const [repoSettingsOpen, setRepoSettingsOpen] = useState(false);
+  const [repoSettingsSection, setRepoSettingsSection] =
+    useState<SectionId | null>(null);
+  const repoSettingsRequest = useUiStore((s) => s.repoSettingsRequest);
+  const clearRepoSettingsRequest = useUiStore(
+    (s) => s.clearRepoSettingsRequest,
+  );
   const [branchRulesOpen, setBranchRulesOpen] = useState(false);
   const [hooksOpen, setHooksOpen] = useState(false);
   const [submodulesOpen, setSubmodulesOpen] = useState(false);
@@ -166,6 +173,24 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // The repo's Jira link (if any), so the menu item reads "Change…" vs "Link…"
   // and the dialog opens in edit mode.
   const jiraLink = useJiraLink(repoPath);
+
+  // A request that arrives while the dialog is already open is dropped, not
+  // queued: the section is seeded at mount, so it couldn't be applied, and
+  // deferring it would reopen the dialog the moment the user closed it.
+  const openRepoSettingsAt = useEffectEvent((section: SectionId) => {
+    if (repoSettingsOpen) return;
+    setRepoSettingsSection(section);
+    setRepoSettingsOpen(true);
+  });
+
+  // A one-shot deep link raised by another surface (the Findings tab's "turn on
+  // Dependabot" card). Keyed on the request alone so re-opening the dialog can
+  // never re-fire it.
+  useEffect(() => {
+    if (!repoSettingsRequest) return;
+    openRepoSettingsAt(repoSettingsRequest);
+    clearRepoSettingsRequest();
+  }, [repoSettingsRequest, clearRepoSettingsRequest]);
 
   const onError = (e: unknown) => toastError(e);
 
@@ -451,7 +476,13 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
           <RepoSettingsDialog
             repoPath={repoPath}
             open={repoSettingsOpen}
-            onOpenChange={setRepoSettingsOpen}
+            onOpenChange={(o) => {
+              setRepoSettingsOpen(o);
+              // Drop the deep-linked section on close so a later plain open
+              // starts at "general".
+              if (!o) setRepoSettingsSection(null);
+            }}
+            initialSection={repoSettingsSection ?? undefined}
           />
         </Suspense>
       )}

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -7,6 +7,7 @@ import {
   GitPullRequestIcon,
   ListChecksIcon,
   PlayIcon,
+  ShieldCheckIcon,
   TagIcon,
 } from "@phosphor-icons/react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -55,6 +56,8 @@ import { RunTaskPicker } from "@/features/scripts/RunTaskPicker";
 import { TaskRunConfirm } from "@/features/scripts/TaskRunConfirm";
 import { TaskRunView } from "@/features/scripts/TaskRunView";
 import { TasksPanel } from "@/features/scripts/TasksPanel";
+import { FindingDetailView } from "@/features/security-findings/FindingDetailView";
+import { FindingsPanel } from "@/features/security-findings/FindingsPanel";
 import { TagDetailView } from "@/features/tags/TagDetailView";
 import { TagsPanel } from "@/features/tags/TagsPanel";
 import {
@@ -126,6 +129,7 @@ const SECONDARY_TABS: { tab: RepoTab; label: string; ai?: boolean }[] = [
   { tab: "code-todos", label: "Code TODOs" },
   { tab: "discussions", label: "Discussions" },
   { tab: "actions", label: "Actions" },
+  { tab: "findings", label: "Findings" },
   { tab: "tags", label: "Tags" },
   { tab: "tasks", label: "Tasks" },
   { tab: "insights", label: "Insights" },
@@ -145,6 +149,7 @@ export function RepositoryView() {
   const selectedIssue = useUiStore((s) => s.selectedIssue);
   const selectedDiscussion = useUiStore((s) => s.selectedDiscussion);
   const selectedRunId = useUiStore((s) => s.selectedRunId);
+  const selectedFinding = useUiStore((s) => s.selectedFinding);
   const selectedTag = useUiStore((s) => s.selectedTag);
   const selectedTodo = useUiStore((s) => s.selectedTodo);
   const localPrCreate = useUiStore((s) => s.localPrCreate);
@@ -241,6 +246,7 @@ export function RepositoryView() {
   useHotkeyAction("tab-issues", () => changeTab("issues"));
   useHotkeyAction("tab-discussions", () => changeTab("discussions"));
   useHotkeyAction("tab-actions", () => changeTab("actions"));
+  useHotkeyAction("tab-findings", () => changeTab("findings"));
   useHotkeyAction("tab-tags", () => changeTab("tags"));
   useHotkeyAction("tab-insights", () => changeTab("insights"));
   useHotkeyAction("tab-code-todos", () => changeTab("code-todos"));
@@ -450,6 +456,12 @@ export function RepositoryView() {
           <Activity mode={mode("actions")}>
             <ActionsPanel repoPath={repoPath} active={repoTab === "actions"} />
           </Activity>
+          <Activity mode={mode("findings")}>
+            <FindingsPanel
+              repoPath={repoPath}
+              active={repoTab === "findings"}
+            />
+          </Activity>
           <Activity mode={mode("tags")}>
             <TagsPanel repoPath={repoPath} />
           </Activity>
@@ -572,6 +584,24 @@ export function RepositoryView() {
               <DiffPlaceholder
                 icon={PlayIcon}
                 message="Select a workflow run"
+              />
+            )}
+          </Activity>
+          <Activity mode={mode("findings")}>
+            {selectedFinding ? (
+              <FindingDetailView
+                key={
+                  selectedFinding.type === "alert"
+                    ? `a${selectedFinding.number}`
+                    : `g${selectedFinding.ghsaId}`
+                }
+                repoPath={repoPath}
+                active={repoTab === "findings"}
+              />
+            ) : (
+              <DiffPlaceholder
+                icon={ShieldCheckIcon}
+                message="Select a finding"
               />
             )}
           </Activity>

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -1,0 +1,247 @@
+import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { ReactNode } from "react";
+import { RelativeTime } from "@/components/relative-time";
+import { Button } from "@/components/ui/button";
+import { Markdown } from "@/components/ui/markdown";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { forgeReady, forgeSupports, useForgeStatus } from "@/lib/git/queries";
+import type {
+  DependabotAlertOut,
+  RepoAdvisoryOut,
+} from "@/lib/github/security-findings";
+import {
+  useDependabotAlerts,
+  useRepoAdvisories,
+} from "@/lib/github/security-findings";
+import { useUiStore } from "@/lib/stores/ui";
+import { SeverityChip } from "./severity";
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 wrap-break-word">{children}</dd>
+    </>
+  );
+}
+
+function DetailShell({
+  title,
+  severity,
+  htmlUrl,
+  meta,
+  children,
+}: {
+  title: string;
+  severity: string | null;
+  htmlUrl: string;
+  meta: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-b p-4">
+        <h2 className="text-sm font-semibold text-balance">{title}</h2>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <SeverityChip severity={severity} />
+          <Button
+            variant="outline"
+            size="sm"
+            className="ml-auto"
+            onClick={() => openUrl(htmlUrl)}
+          >
+            <ArrowSquareOutIcon data-icon="inline-start" />
+            View on GitHub
+          </Button>
+        </div>
+        <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+          {meta}
+        </dl>
+      </div>
+      {/* overflow-hidden: the vendored ScrollArea Root is `relative`-only, so a
+          fill-layout body would grow the pane past the viewport without it. */}
+      <ScrollArea className="min-h-0 flex-1 overflow-hidden">
+        <div className="p-4">{children}</div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
+  return (
+    <DetailShell
+      title={alert.summary}
+      severity={alert.severity}
+      htmlUrl={alert.htmlUrl}
+      meta={
+        <>
+          <Row label="Package">
+            <span className="font-mono">{alert.packageName}</span>{" "}
+            <span className="text-muted-foreground">
+              {alert.ecosystem}
+              {alert.scope ? ` · ${alert.scope}` : ""}
+            </span>
+          </Row>
+          <Row label="Manifest">
+            <span className="font-mono">{alert.manifestPath}</span>
+          </Row>
+          <Row label="GHSA">
+            <span className="font-mono">{alert.ghsaId}</span>
+          </Row>
+          {alert.cveId ? (
+            <Row label="CVE">
+              <span className="font-mono">{alert.cveId}</span>
+            </Row>
+          ) : null}
+          {alert.cvssScore !== null ? (
+            <Row label="CVSS">
+              <span className="tabular-nums">{alert.cvssScore}</span>
+            </Row>
+          ) : null}
+          <Row label="Affected">
+            {alert.vulnerableVersionRange ?? "Not stated"}
+          </Row>
+          <Row label="Patched">
+            {alert.firstPatchedVersion ?? "No patched version yet"}
+          </Row>
+          <Row label="Opened">
+            <RelativeTime date={alert.createdAt} />
+          </Row>
+        </>
+      }
+    >
+      <Markdown>{alert.description}</Markdown>
+    </DetailShell>
+  );
+}
+
+function AdvisoryDetail({ advisory }: { advisory: RepoAdvisoryOut }) {
+  return (
+    <DetailShell
+      title={advisory.summary}
+      severity={advisory.severity}
+      htmlUrl={advisory.htmlUrl}
+      meta={
+        <>
+          <Row label="GHSA">
+            <span className="font-mono">{advisory.ghsaId}</span>
+          </Row>
+          {advisory.cveId ? (
+            <Row label="CVE">
+              <span className="font-mono">{advisory.cveId}</span>
+            </Row>
+          ) : null}
+          <Row label="State">{advisory.state}</Row>
+          {advisory.cvssScore !== null ? (
+            <Row label="CVSS">
+              <span className="tabular-nums">{advisory.cvssScore}</span>
+            </Row>
+          ) : null}
+          {/* Dates that don't exist are omitted outright — a withdrawn-at of
+              "never" would read as a claim the advisory stands. */}
+          {advisory.publishedAt ? (
+            <Row label="Published">
+              <RelativeTime date={advisory.publishedAt} />
+            </Row>
+          ) : null}
+          {advisory.updatedAt ? (
+            <Row label="Updated">
+              <RelativeTime date={advisory.updatedAt} />
+            </Row>
+          ) : null}
+          {advisory.withdrawnAt ? (
+            <Row label="Withdrawn">
+              <RelativeTime date={advisory.withdrawnAt} />
+            </Row>
+          ) : null}
+        </>
+      }
+    >
+      {advisory.vulnerabilities.length > 0 && (
+        <section className="mb-4">
+          <h3 className="mb-1.5 text-xs font-semibold">Affected packages</h3>
+          <ul className="space-y-1 text-xs">
+            {advisory.vulnerabilities.map((v) => (
+              <li key={`${v.ecosystem}/${v.packageName}`}>
+                <span className="font-mono">{v.packageName}</span>{" "}
+                <span className="text-muted-foreground">{v.ecosystem}</span>
+                <span className="block text-[11px] text-muted-foreground">
+                  {v.vulnerableVersionRange ?? "Range not stated"} →{" "}
+                  {v.patchedVersions ?? "No patched version listed"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {advisory.description ? (
+        <Markdown>{advisory.description}</Markdown>
+      ) : null}
+    </DetailShell>
+  );
+}
+
+export function FindingDetailView({
+  repoPath,
+  active,
+}: {
+  repoPath: string;
+  active: boolean;
+}) {
+  const selectedFinding = useUiStore((s) => s.selectedFinding);
+  const limits = useUiStore((s) => s.findingsLimits);
+  const forge = useForgeStatus(repoPath);
+  const enabled =
+    forgeReady(forge.data) && forgeSupports(forge.data, "securityFindings");
+  // Same hooks + same store limits as the panel, so these are cache hits rather
+  // than a second fetch.
+  const alerts = useDependabotAlerts(repoPath, enabled, active, limits.alerts);
+  const advisories = useRepoAdvisories(
+    repoPath,
+    enabled,
+    active,
+    limits.advisories,
+  );
+
+  const query = selectedFinding?.type === "advisory" ? advisories : alerts;
+
+  // Gated on `enabled`: a disabled query stays `isPending` forever, so an
+  // ungated skeleton would spin here if the repo lost the capability mid-session.
+  if (enabled && query.isPending) {
+    return (
+      <div className="space-y-3 p-4">
+        <Skeleton className="h-7 w-2/3" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="p-6 text-center text-sm text-muted-foreground">
+        Couldn't load this finding.
+      </div>
+    );
+  }
+
+  if (selectedFinding?.type === "alert") {
+    const alert = alerts.data?.alerts.find(
+      (a) => a.number === selectedFinding.number,
+    );
+    if (alert) return <AlertDetail alert={alert} />;
+  } else if (selectedFinding?.type === "advisory") {
+    const advisory = advisories.data?.advisories.find(
+      (a) => a.ghsaId === selectedFinding.ghsaId,
+    );
+    if (advisory) return <AdvisoryDetail advisory={advisory} />;
+  }
+
+  return (
+    <div className="p-6 text-center text-sm text-muted-foreground">
+      This finding is no longer in the list.
+    </div>
+  );
+}

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -46,15 +46,18 @@ function DetailShell({
         <h2 className="text-sm font-semibold text-balance">{title}</h2>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <SeverityChip severity={severity} />
-          <Button
-            variant="outline"
-            size="sm"
-            className="ml-auto"
-            onClick={() => openUrl(htmlUrl)}
-          >
-            <ArrowSquareOutIcon data-icon="inline-start" />
-            View on GitHub
-          </Button>
+          {/* A tolerated malformed item can lack html_url — no link, no button. */}
+          {htmlUrl ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto"
+              onClick={() => openUrl(htmlUrl)}
+            >
+              <ArrowSquareOutIcon data-icon="inline-start" />
+              View on GitHub
+            </Button>
+          ) : null}
         </div>
         <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
           {meta}

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -1,0 +1,590 @@
+import {
+  ArrowClockwiseIcon,
+  GearSixIcon,
+  LockKeyIcon,
+  QuestionIcon,
+  ShieldCheckIcon,
+  ShieldSlashIcon,
+} from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useRef, useState } from "react";
+import { RelativeTime } from "@/components/relative-time";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { LoadMoreRow, PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
+import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
+import { forgeReady, forgeSupports, useForgeStatus } from "@/lib/git/queries";
+import type {
+  DependabotAlertOut,
+  FindingAvailability,
+  RepoAdvisoryOut,
+} from "@/lib/github/security-findings";
+import {
+  useDependabotAlerts,
+  useRepoAdvisories,
+} from "@/lib/github/security-findings";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { type SelectedFinding, useUiStore } from "@/lib/stores/ui";
+import { cn } from "@/lib/utils";
+import { SEVERITY_RANK, SeverityChip, severityLevel } from "./severity";
+
+interface AlertRow {
+  /** Unique per rendered row: the alert number, or an index fallback for a
+   *  tolerated alert whose number came through as 0 (duplicate React keys and
+   *  duplicate `data-row` values would misdirect the arrow-key focus). */
+  id: string;
+  alert: DependabotAlertOut;
+}
+
+interface AlertGroup {
+  key: string;
+  packageName: string;
+  ecosystem: string;
+  rows: AlertRow[];
+}
+
+/** Worst-first: the alerts endpoint orders by creation date, so severity order is
+ *  applied here. The sort is stable, leaving created-order as the tiebreak within
+ *  a level, and grouping preserves it — so both the groups and the rows inside
+ *  each group run worst-first. */
+function buildAlertGroups(alerts: DependabotAlertOut[]): AlertGroup[] {
+  const sorted = alerts.toSorted(
+    (a, b) =>
+      SEVERITY_RANK[severityLevel(a.severity)] -
+      SEVERITY_RANK[severityLevel(b.severity)],
+  );
+  // Keyed by name AND ecosystem: the same package name exists in several
+  // ecosystems, and merging them would mislabel the group's ecosystem.
+  const groups = new Map<string, AlertGroup>();
+  sorted.forEach((alert, i) => {
+    const key = `${alert.ecosystem}/${alert.packageName}`;
+    const row: AlertRow = {
+      id: alert.number === 0 ? `alert-i${i}` : `alert-${alert.number}`,
+      alert,
+    };
+    const bucket = groups.get(key);
+    if (bucket) bucket.rows.push(row);
+    else {
+      groups.set(key, {
+        key,
+        packageName: alert.packageName,
+        ecosystem: alert.ecosystem,
+        rows: [row],
+      });
+    }
+  });
+  return [...groups.values()];
+}
+
+/** Whether two selections point at the same finding. Degenerate identities (a
+ *  tolerated alert numbered 0, an advisory with no GHSA id) can't be told apart
+ *  by the stored selection, so the first matching row wins. */
+function sameFinding(a: SelectedFinding, b: SelectedFinding): boolean {
+  if (a.type === "alert") return b.type === "alert" && a.number === b.number;
+  return b.type === "advisory" && a.ghsaId === b.ghsaId;
+}
+
+const matchesAlert = (a: DependabotAlertOut, q: string) =>
+  !q ||
+  a.packageName.toLowerCase().includes(q) ||
+  a.summary.toLowerCase().includes(q) ||
+  a.ghsaId.toLowerCase().includes(q) ||
+  (a.cveId?.toLowerCase().includes(q) ?? false);
+
+const matchesAdvisory = (adv: RepoAdvisoryOut, q: string) =>
+  !q ||
+  adv.summary.toLowerCase().includes(q) ||
+  adv.ghsaId.toLowerCase().includes(q) ||
+  (adv.cveId?.toLowerCase().includes(q) ?? false) ||
+  adv.vulnerabilities.some((v) => v.packageName.toLowerCase().includes(q));
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <h3 className="border-b bg-muted/40 px-3 py-1.5 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+      {title}
+    </h3>
+  );
+}
+
+function RowSkeletons() {
+  return (
+    <div className="space-y-2 p-3">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+}
+
+/** A full-width, in-flow explanation of why a category has no usable data, with
+ *  the one action that resolves it. Icon + text — never tone alone. */
+function ReasonCard({
+  icon: Icon,
+  message,
+  detail,
+  action,
+}: {
+  icon: typeof ShieldSlashIcon;
+  message: string;
+  detail?: string | null;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex gap-2 border-b px-3 py-3">
+      <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <p className="text-xs text-muted-foreground">{message}</p>
+        {detail ? (
+          <p className="text-[11px] wrap-break-word text-muted-foreground/80">
+            {detail}
+          </p>
+        ) : null}
+        {action}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The card for any envelope that isn't `"available"`. `onEnable` is passed only
+ * by a category with a repo-level toggle; a category without one still reports
+ * the state the server named rather than falling through to "couldn't check".
+ * `Category` is the sentence-initial form of `category`.
+ */
+function UnavailableCard({
+  availability,
+  detail,
+  category,
+  Category,
+  onRetry,
+  onEnable,
+}: {
+  availability: Exclude<FindingAvailability, "available">;
+  detail: string | null;
+  category: string;
+  Category: string;
+  onRetry: () => void;
+  onEnable?: () => void;
+}) {
+  if (availability === "notEnabled") {
+    return onEnable ? (
+      <ReasonCard
+        icon={ShieldSlashIcon}
+        message="Dependabot alerts are off for this repository. Turn them on to see vulnerable dependencies here."
+        action={
+          <Button variant="outline" size="sm" onClick={onEnable}>
+            <GearSixIcon data-icon="inline-start" />
+            Open security settings
+          </Button>
+        }
+      />
+    ) : (
+      <ReasonCard
+        icon={ShieldSlashIcon}
+        message={`${Category} aren't enabled for this repository.`}
+        detail={detail}
+      />
+    );
+  }
+  if (availability === "forbidden") {
+    return (
+      <ReasonCard
+        icon={LockKeyIcon}
+        message={`Your GitHub sign-in can't read ${category} on this repository.`}
+        detail={detail}
+      />
+    );
+  }
+  return (
+    <ReasonCard
+      icon={QuestionIcon}
+      message={`Couldn't check ${category}.`}
+      detail={detail}
+      action={
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          <ArrowClockwiseIcon data-icon="inline-start" />
+          Retry
+        </Button>
+      }
+    />
+  );
+}
+
+function LoadFailed({
+  category,
+  onRetry,
+}: {
+  category: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-2 border-b px-3 py-3">
+      <p className="text-xs text-muted-foreground">
+        Couldn't load {category}. Retry to try again.
+      </p>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        <ArrowClockwiseIcon data-icon="inline-start" />
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+export function FindingsPanel({
+  repoPath,
+  active,
+}: {
+  repoPath: string;
+  active: boolean;
+}) {
+  const forge = useForgeStatus(repoPath);
+  // Dependabot alerts and repository advisories are GitHub-only surfaces, so the
+  // gate is the capability, not a per-provider dispatch: a GitLab/Bitbucket repo
+  // fires no query at all.
+  const ready = forgeReady(forge.data);
+  const supported = forgeSupports(forge.data, "securityFindings");
+  const enabled = ready && supported;
+
+  const limits = useUiStore((s) => s.findingsLimits);
+  const setFindingsLimits = useUiStore((s) => s.setFindingsLimits);
+  const selectedFinding = useUiStore((s) => s.selectedFinding);
+  const selectFinding = useUiStore((s) => s.selectFinding);
+  const requestRepoSettings = useUiStore((s) => s.requestRepoSettings);
+
+  const alerts = useDependabotAlerts(repoPath, enabled, active, limits.alerts);
+  const advisories = useRepoAdvisories(
+    repoPath,
+    enabled,
+    active,
+    limits.advisories,
+  );
+
+  const [filterText, setFilterText] = useState("");
+  const filterRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+
+  useHotkeyAction("focus-filter", () => filterRef.current?.focus());
+
+  const query = filterText.trim().toLowerCase();
+  const alertsOut = alerts.data;
+  const advisoriesOut = advisories.data;
+  const allAlerts = alertsOut?.alerts ?? [];
+  const allAdvisories = advisoriesOut?.advisories ?? [];
+  const alertGroups = buildAlertGroups(
+    allAlerts.filter((a) => matchesAlert(a, query)),
+  );
+  const advisoryRows = allAdvisories
+    .filter((a) => matchesAdvisory(a, query))
+    .map((advisory, i) => ({
+      // Index fallback for a tolerated advisory with no GHSA id (see AlertRow).
+      id: advisory.ghsaId ? `advisory-${advisory.ghsaId}` : `advisory-i${i}`,
+      advisory,
+    }));
+
+  const alertsShown =
+    !alerts.isError && alertsOut?.availability === "available";
+  const advisoriesShown =
+    !advisories.isError && advisoriesOut?.availability === "available";
+
+  // Flat, document-order nav list: the grouped alert rows, then the advisory
+  // rows. Group headers and the Load-more buttons are intentionally skipped.
+  const navRows: { id: string; finding: SelectedFinding }[] = [];
+  if (alertsShown) {
+    for (const group of alertGroups) {
+      for (const row of group.rows) {
+        navRows.push({
+          id: row.id,
+          finding: { type: "alert", number: row.alert.number },
+        });
+      }
+    }
+  }
+  if (advisoriesShown) {
+    for (const row of advisoryRows) {
+      navRows.push({
+        id: row.id,
+        finding: { type: "advisory", ghsaId: row.advisory.ghsaId },
+      });
+    }
+  }
+
+  // Resolved against the rendered rows (not rebuilt from the selection) so the
+  // highlight uses the same identity the nav list and `data-row` do.
+  const selectedRowId = selectedFinding
+    ? (navRows.find((r) => sameFinding(r.finding, selectedFinding))?.id ?? null)
+    : null;
+
+  const onListKeyDown = listKeyboardNav({
+    items: navRows,
+    activeIndex: navRows.findIndex((r) => r.id === selectedRowId),
+    onActivate: (row) => selectFinding(row.finding),
+    rowKey: (row) => row.id,
+  });
+
+  const refreshing = alerts.isFetching || advisories.isFetching;
+  const refreshReason = enabled
+    ? "Refresh findings"
+    : "Connect this repo to GitHub to load findings";
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-1 border-b p-2">
+        <p className="text-xs text-muted-foreground">Security findings</p>
+        <div className="ml-auto flex items-center gap-1">
+          {/* A `title` on a disabled Button never surfaces — the wrapper span is
+              what carries the explanation while the control is unusable. */}
+          <span title={refreshReason}>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              aria-label="Refresh findings"
+              disabled={!enabled || refreshing}
+              onClick={() =>
+                queryClient.invalidateQueries({
+                  queryKey: ["repo", repoPath, "findings"],
+                })
+              }
+            >
+              <ArrowClockwiseIcon
+                className={cn(refreshing && "animate-spin")}
+              />
+            </Button>
+          </span>
+        </div>
+      </div>
+      <div className="border-b p-2">
+        <Input
+          ref={filterRef}
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          placeholder="Filter by package, summary, GHSA, or CVE"
+          className="h-7"
+          autoComplete="off"
+        />
+      </div>
+
+      {/* overflow-hidden: the vendored ScrollArea Root is `relative`-only, so
+          without containment a long list leaks a window scrollbar. */}
+      <ScrollArea className="min-h-0 flex-1 overflow-hidden">
+        {forge.isPending ? (
+          <RowSkeletons />
+        ) : !ready ? (
+          <ForgeNotReady repoPath={repoPath} feature="security findings" />
+        ) : !supported ? (
+          <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+            Security findings aren't available on this repository's host.
+          </p>
+        ) : (
+          <div onKeyDown={onListKeyDown}>
+            <SectionHeader title="Dependency alerts" />
+            {alerts.isError ? (
+              <LoadFailed
+                category="dependency alerts"
+                onRetry={() => alerts.refetch()}
+              />
+            ) : !alertsOut ? (
+              <RowSkeletons />
+            ) : alertsOut.availability !== "available" ? (
+              <UnavailableCard
+                availability={alertsOut.availability}
+                detail={alertsOut.detail}
+                category="dependency alerts"
+                Category="Dependency alerts"
+                onRetry={() => alerts.refetch()}
+                onEnable={() => requestRepoSettings("security")}
+              />
+            ) : (
+              <>
+                {alertGroups.length === 0 ? (
+                  allAlerts.length > 0 ? (
+                    <p className="px-3 py-4 text-xs text-muted-foreground">
+                      No alerts match the filter.
+                    </p>
+                  ) : (
+                    <Empty className="py-8">
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <ShieldCheckIcon />
+                        </EmptyMedia>
+                        <EmptyTitle>No open Dependabot alerts</EmptyTitle>
+                      </EmptyHeader>
+                    </Empty>
+                  )
+                ) : (
+                  alertGroups.map((group) => (
+                    <div key={group.key}>
+                      <div className="flex items-baseline gap-2 px-3 py-1 text-[11px] text-muted-foreground">
+                        <span
+                          className="truncate font-mono text-foreground"
+                          title={group.packageName}
+                        >
+                          {group.packageName}
+                        </span>
+                        <span className="shrink-0">{group.ecosystem}</span>
+                        <span className="ml-auto shrink-0 tabular-nums">
+                          {group.rows.length}
+                        </span>
+                      </div>
+                      {group.rows.map(({ id, alert: a }) => (
+                        <button
+                          type="button"
+                          key={id}
+                          data-row={id}
+                          className={cn(
+                            "block w-full border-b px-3 py-2 text-left",
+                            selectedRowId === id
+                              ? "bg-accent text-accent-foreground"
+                              : "hover:bg-muted/60",
+                          )}
+                          onClick={() =>
+                            selectFinding({ type: "alert", number: a.number })
+                          }
+                        >
+                          <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                            <SeverityChip severity={a.severity} />
+                            <span className="ml-auto min-w-0 truncate">
+                              {a.firstPatchedVersion
+                                ? `fix: ${a.firstPatchedVersion}`
+                                : "no patch yet"}
+                            </span>
+                            <span className="shrink-0">
+                              <RelativeTime date={a.createdAt} />
+                            </span>
+                          </p>
+                          {/* The summary owns its own full-width line — sharing
+                              one with the chip left it cramped and truncating early. */}
+                          <p
+                            className="mt-1 truncate text-xs font-medium"
+                            title={a.summary}
+                          >
+                            {a.summary}
+                          </p>
+                        </button>
+                      ))}
+                    </div>
+                  ))
+                )}
+                {/* Outside the empty branch: filtering to zero matches must not
+                    strip the only way to reach rows past the fetched window. */}
+                {alertsOut.truncated && (
+                  <LoadMoreRow
+                    count={allAlerts.length}
+                    loading={alerts.isFetching}
+                    onLoadMore={() =>
+                      setFindingsLimits({
+                        ...limits,
+                        alerts: limits.alerts + PAGE_SIZE,
+                      })
+                    }
+                  />
+                )}
+              </>
+            )}
+
+            <SectionHeader title="Advisories" />
+            {advisories.isError ? (
+              <LoadFailed
+                category="security advisories"
+                onRetry={() => advisories.refetch()}
+              />
+            ) : !advisoriesOut ? (
+              <RowSkeletons />
+            ) : advisoriesOut.availability !== "available" ? (
+              <UnavailableCard
+                availability={advisoriesOut.availability}
+                detail={advisoriesOut.detail}
+                category="security advisories"
+                Category="Security advisories"
+                onRetry={() => advisories.refetch()}
+              />
+            ) : (
+              <>
+                {advisoryRows.length === 0 ? (
+                  allAdvisories.length > 0 ? (
+                    <p className="px-3 py-4 text-xs text-muted-foreground">
+                      No advisories match the filter.
+                    </p>
+                  ) : (
+                    <Empty className="py-8">
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <ShieldCheckIcon />
+                        </EmptyMedia>
+                        <EmptyTitle>No security advisories</EmptyTitle>
+                      </EmptyHeader>
+                    </Empty>
+                  )
+                ) : (
+                  advisoryRows.map(({ id, advisory: adv }) => {
+                    // Published is the meaningful date; fall back to updated, and
+                    // render nothing when both are absent — never invent one.
+                    const when = adv.publishedAt ?? adv.updatedAt;
+                    return (
+                      <button
+                        type="button"
+                        key={id}
+                        data-row={id}
+                        className={cn(
+                          "block w-full border-b px-3 py-2 text-left",
+                          selectedRowId === id
+                            ? "bg-accent text-accent-foreground"
+                            : "hover:bg-muted/60",
+                        )}
+                        onClick={() =>
+                          selectFinding({
+                            type: "advisory",
+                            ghsaId: adv.ghsaId,
+                          })
+                        }
+                      >
+                        <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                          <SeverityChip severity={adv.severity} />
+                          <span className="ml-auto min-w-0 truncate font-mono">
+                            {adv.ghsaId}
+                          </span>
+                          <span className="shrink-0">{adv.state}</span>
+                          {when ? (
+                            <span className="shrink-0">
+                              <RelativeTime date={when} />
+                            </span>
+                          ) : null}
+                        </p>
+                        {/* Full-width summary line, matching the alert rows. */}
+                        <p
+                          className="mt-1 truncate text-xs font-medium"
+                          title={adv.summary}
+                        >
+                          {adv.summary}
+                        </p>
+                      </button>
+                    );
+                  })
+                )}
+                {advisoriesOut.truncated && (
+                  <LoadMoreRow
+                    count={allAdvisories.length}
+                    loading={advisories.isFetching}
+                    onLoadMore={() =>
+                      setFindingsLimits({
+                        ...limits,
+                        advisories: limits.advisories + PAGE_SIZE,
+                      })
+                    }
+                  />
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -21,7 +21,13 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { LoadMoreRow, PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
-import { forgeReady, forgeSupports, useForgeStatus } from "@/lib/git/queries";
+import {
+  forgeFeatureReady,
+  forgeReady,
+  forgeSupports,
+  useForgeStatus,
+  useRepoAdmin,
+} from "@/lib/git/queries";
 import type {
   DependabotAlertOut,
   FindingAvailability,
@@ -263,6 +269,12 @@ export function FindingsPanel({
   const ready = forgeReady(forge.data);
   const supported = forgeSupports(forge.data, "securityFindings");
   const enabled = ready && supported;
+  // Mirrors RepositoryMenu's gate on the "Repository settings…" item: the deep
+  // link opens that same admin-only dialog, so offering it to a non-admin would
+  // land them on a permissions error. Same query key, so no extra fetch.
+  const settingsReady = forgeFeatureReady(forge.data, "repoSettings");
+  const admin = useRepoAdmin(repoPath, settingsReady);
+  const canOpenRepoSettings = settingsReady && Boolean(admin.data?.admin);
 
   const limits = useUiStore((s) => s.findingsLimits);
   const setFindingsLimits = useUiStore((s) => s.setFindingsLimits);
@@ -344,7 +356,9 @@ export function FindingsPanel({
   const refreshing = alerts.isFetching || advisories.isFetching;
   const refreshReason = enabled
     ? "Refresh findings"
-    : "Connect this repo to GitHub to load findings";
+    : !supported && ready
+      ? "Security findings aren't available on this repository's host."
+      : "Connect this repo to GitHub to load findings";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -411,7 +425,11 @@ export function FindingsPanel({
                 category="dependency alerts"
                 Category="Dependency alerts"
                 onRetry={() => alerts.refetch()}
-                onEnable={() => requestRepoSettings("security")}
+                onEnable={
+                  canOpenRepoSettings
+                    ? () => requestRepoSettings("security")
+                    : undefined
+                }
               />
             ) : (
               <>
@@ -489,7 +507,7 @@ export function FindingsPanel({
                 {alertsOut.truncated &&
                   (limits.alerts >= FINDINGS_LIMIT_CAP ? (
                     <p className="border-t px-3 py-3 text-xs text-muted-foreground">
-                      Showing the first {FINDINGS_LIMIT_CAP.toLocaleString()}{" "}
+                      Showing the first {allAlerts.length.toLocaleString()}{" "}
                       dependency alerts.
                     </p>
                   ) : (
@@ -592,7 +610,7 @@ export function FindingsPanel({
                 {advisoriesOut.truncated &&
                   (limits.advisories >= FINDINGS_LIMIT_CAP ? (
                     <p className="border-t px-3 py-3 text-xs text-muted-foreground">
-                      Showing the first {FINDINGS_LIMIT_CAP.toLocaleString()}{" "}
+                      Showing the first {allAdvisories.length.toLocaleString()}{" "}
                       security advisories.
                     </p>
                   ) : (

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -37,6 +37,12 @@ import { type SelectedFinding, useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import { SEVERITY_RANK, SeverityChip, severityLevel } from "./severity";
 
+/** Ceiling for a category's row limit. MUST stay in lockstep with `clamp_limit`
+ *  in src-tauri/src/github/security_findings.rs, which is the source of truth:
+ *  it clamps every fetch to 500, so growing the limit past this would re-run the
+ *  paged walk for the same 500 rows and leave "Load more" permanently offered. */
+const FINDINGS_LIMIT_CAP = 500;
+
 interface AlertRow {
   /** Unique per rendered row: the alert number, or an index fallback for a
    *  tolerated alert whose number came through as 0 (duplicate React keys and
@@ -52,16 +58,21 @@ interface AlertGroup {
   rows: AlertRow[];
 }
 
-/** Worst-first: the alerts endpoint orders by creation date, so severity order is
- *  applied here. The sort is stable, leaving created-order as the tiebreak within
- *  a level, and grouping preserves it — so both the groups and the rows inside
- *  each group run worst-first. */
+/** Worst-first, for every finding category: both endpoints order by date, so the
+ *  severity ladder is applied here instead. Callers use `toSorted` so the sort
+ *  stays stable and server date order remains the tiebreak within a level; a null
+ *  or unrecognized severity ranks with `unknown`, i.e. last. */
+const bySeverity = (
+  a: { severity: string | null },
+  b: { severity: string | null },
+) =>
+  SEVERITY_RANK[severityLevel(a.severity)] -
+  SEVERITY_RANK[severityLevel(b.severity)];
+
 function buildAlertGroups(alerts: DependabotAlertOut[]): AlertGroup[] {
-  const sorted = alerts.toSorted(
-    (a, b) =>
-      SEVERITY_RANK[severityLevel(a.severity)] -
-      SEVERITY_RANK[severityLevel(b.severity)],
-  );
+  // Grouping preserves the sorted order, so the groups AND the rows inside each
+  // group both run worst-first.
+  const sorted = alerts.toSorted(bySeverity);
   // Keyed by name AND ecosystem: the same package name exists in several
   // ecosystems, and merging them would mislabel the group's ecosystem.
   const groups = new Map<string, AlertGroup>();
@@ -283,6 +294,7 @@ export function FindingsPanel({
   );
   const advisoryRows = allAdvisories
     .filter((a) => matchesAdvisory(a, query))
+    .toSorted(bySeverity)
     .map((advisory, i) => ({
       // Index fallback for a tolerated advisory with no GHSA id (see AlertRow).
       id: advisory.ghsaId ? `advisory-${advisory.ghsaId}` : `advisory-i${i}`,
@@ -474,18 +486,27 @@ export function FindingsPanel({
                 )}
                 {/* Outside the empty branch: filtering to zero matches must not
                     strip the only way to reach rows past the fetched window. */}
-                {alertsOut.truncated && (
-                  <LoadMoreRow
-                    count={allAlerts.length}
-                    loading={alerts.isFetching}
-                    onLoadMore={() =>
-                      setFindingsLimits({
-                        ...limits,
-                        alerts: limits.alerts + PAGE_SIZE,
-                      })
-                    }
-                  />
-                )}
+                {alertsOut.truncated &&
+                  (limits.alerts >= FINDINGS_LIMIT_CAP ? (
+                    <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                      Showing the first {FINDINGS_LIMIT_CAP.toLocaleString()}{" "}
+                      dependency alerts.
+                    </p>
+                  ) : (
+                    <LoadMoreRow
+                      count={allAlerts.length}
+                      loading={alerts.isFetching}
+                      onLoadMore={() =>
+                        setFindingsLimits({
+                          ...limits,
+                          alerts: Math.min(
+                            limits.alerts + PAGE_SIZE,
+                            FINDINGS_LIMIT_CAP,
+                          ),
+                        })
+                      }
+                    />
+                  ))}
               </>
             )}
 
@@ -568,18 +589,27 @@ export function FindingsPanel({
                     );
                   })
                 )}
-                {advisoriesOut.truncated && (
-                  <LoadMoreRow
-                    count={allAdvisories.length}
-                    loading={advisories.isFetching}
-                    onLoadMore={() =>
-                      setFindingsLimits({
-                        ...limits,
-                        advisories: limits.advisories + PAGE_SIZE,
-                      })
-                    }
-                  />
-                )}
+                {advisoriesOut.truncated &&
+                  (limits.advisories >= FINDINGS_LIMIT_CAP ? (
+                    <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                      Showing the first {FINDINGS_LIMIT_CAP.toLocaleString()}{" "}
+                      security advisories.
+                    </p>
+                  ) : (
+                    <LoadMoreRow
+                      count={allAdvisories.length}
+                      loading={advisories.isFetching}
+                      onLoadMore={() =>
+                        setFindingsLimits({
+                          ...limits,
+                          advisories: Math.min(
+                            limits.advisories + PAGE_SIZE,
+                            FINDINGS_LIMIT_CAP,
+                          ),
+                        })
+                      }
+                    />
+                  ))}
               </>
             )}
           </div>

--- a/src/features/security-findings/severity.tsx
+++ b/src/features/security-findings/severity.tsx
@@ -1,0 +1,83 @@
+import {
+  CircleIcon,
+  InfoIcon,
+  WarningCircleIcon,
+  WarningIcon,
+} from "@phosphor-icons/react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+/** GitHub's advisory severity ladder, plus the bucket a missing or unrecognized
+ *  value falls into (repo advisories may carry no severity at all). */
+export type SeverityLevel = "critical" | "high" | "medium" | "low" | "unknown";
+
+/** Severity tone, via the app's semantic tokens. Critical and high share the
+ *  destructive tone and are told apart by icon weight + label, never by color. */
+export const SEVERITY_TONE: Record<SeverityLevel, string> = {
+  critical: "text-destructive",
+  high: "text-destructive",
+  medium: "text-warning",
+  low: "text-muted-foreground",
+  unknown: "text-muted-foreground",
+};
+
+/** Worst-first sort order. The alerts endpoint orders by creation date, so the
+ *  UI applies this ladder itself to float the worst findings to the top. */
+export const SEVERITY_RANK: Record<SeverityLevel, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  unknown: 4,
+};
+
+export const SEVERITY_LABEL: Record<SeverityLevel, string> = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+  unknown: "Unspecified",
+};
+
+const SEVERITY_ICON: Record<SeverityLevel, typeof WarningIcon> = {
+  critical: WarningIcon,
+  high: WarningIcon,
+  medium: WarningCircleIcon,
+  low: InfoIcon,
+  unknown: CircleIcon,
+};
+
+/** Normalize a server severity string; anything unrecognized (including null)
+ *  reads as "unknown" rather than being silently downgraded to "low". */
+export function severityLevel(severity: string | null): SeverityLevel {
+  switch (severity?.toLowerCase()) {
+    case "critical":
+      return "critical";
+    case "high":
+      return "high";
+    case "medium":
+    case "moderate":
+      return "medium";
+    case "low":
+      return "low";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * A compact severity chip — **Critical** / **High** / **Medium** / **Low** /
+ * **Unspecified**. Icon + text carry the meaning (never color alone, per the
+ * WCAG-AA rule); critical additionally fills its icon so it stays distinct from
+ * high, which shares its tone.
+ */
+export function SeverityChip({ severity }: { severity: string | null }) {
+  const level = severityLevel(severity);
+  const Icon = SEVERITY_ICON[level];
+  return (
+    <Badge variant="outline" className={cn("gap-1", SEVERITY_TONE[level])}>
+      <Icon weight={level === "critical" ? "fill" : "regular"} />
+      {SEVERITY_LABEL[level]}
+    </Badge>
+  );
+}

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -86,7 +86,7 @@ export function useRepoIdentity(repo: string) {
  * query's repo segment matches, so Load-more and Open/Closed switches still skip the
  * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key here).
  */
-function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
+export function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
   return <T>(
     previousData: T | undefined,
     previousQuery: { queryKey: QueryKey } | undefined,
@@ -2470,6 +2470,7 @@ const NO_FORGE_STATUS: ForgeStatus = {
     ci: false,
     webhooks: false,
     approvals: false,
+    securityFindings: false,
   },
   implemented: {
     pullRequests: false,

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -656,6 +656,8 @@ export interface ForgeCapabilities {
   ci: boolean;
   webhooks: boolean;
   approvals: boolean;
+  /** Dependabot alerts + repository security advisories (GitHub-only surfaces). */
+  securityFindings: boolean;
 }
 
 /** Which hosted features GitDesktop has actually *built* for a provider — a different

--- a/src/lib/github/security-findings.ts
+++ b/src/lib/github/security-findings.ts
@@ -18,7 +18,8 @@ export interface DependabotAlertsOut {
   /** The server's own explanation for a non-available envelope; null otherwise. */
   detail: string | null;
   alerts: DependabotAlertOut[];
-  /** The page filled the requested limit, so more may exist server-side. */
+  /** More findings may exist past the fetched window — the limit filled, or the
+   *  walk stopped without proving it reached the end. */
   truncated: boolean;
 }
 

--- a/src/lib/github/security-findings.ts
+++ b/src/lib/github/security-findings.ts
@@ -1,0 +1,123 @@
+import { useQuery } from "@tanstack/react-query";
+import { keepPreviousDataForRepo } from "@/lib/git/queries";
+import { invoke } from "@/lib/tauri/invoke";
+
+// ── Types (mirror the Rust structs in github/security_findings.rs) ───────────
+
+/** Why a category has (or hasn't) findings. `"available"` is the ONLY value that
+ *  lets an empty list mean "clean" — every other value names a blocker the panel
+ *  must render instead, so nothing ever defaults to reassuring. */
+export type FindingAvailability =
+  | "available"
+  | "notEnabled"
+  | "forbidden"
+  | "indeterminate";
+
+export interface DependabotAlertsOut {
+  availability: FindingAvailability;
+  /** The server's own explanation for a non-available envelope; null otherwise. */
+  detail: string | null;
+  alerts: DependabotAlertOut[];
+  /** The page filled the requested limit, so more may exist server-side. */
+  truncated: boolean;
+}
+
+export interface DependabotAlertOut {
+  number: number;
+  state: string;
+  packageName: string;
+  ecosystem: string;
+  manifestPath: string;
+  scope: string | null;
+  severity: string;
+  summary: string;
+  description: string;
+  ghsaId: string;
+  cveId: string | null;
+  cvssScore: number | null;
+  vulnerableVersionRange: string | null;
+  firstPatchedVersion: string | null;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RepoAdvisoriesOut {
+  availability: FindingAvailability;
+  detail: string | null;
+  advisories: RepoAdvisoryOut[];
+  truncated: boolean;
+}
+
+export interface RepoAdvisoryOut {
+  ghsaId: string;
+  cveId: string | null;
+  summary: string;
+  description: string | null;
+  severity: string | null;
+  state: string;
+  htmlUrl: string;
+  publishedAt: string | null;
+  updatedAt: string | null;
+  withdrawnAt: string | null;
+  createdAt: string | null;
+  cvssScore: number | null;
+  vulnerabilities: AdvisoryVulnerabilityOut[];
+}
+
+export interface AdvisoryVulnerabilityOut {
+  packageName: string;
+  ecosystem: string;
+  vulnerableVersionRange: string | null;
+  patchedVersions: string | null;
+}
+
+// ── API wrappers ─────────────────────────────────────────────────────────────
+//
+// GitHub-only: Dependabot alerts and repository security advisories have no
+// GitLab/Bitbucket analogue, so these stay `gh_*` and the panel gates on the
+// `securityFindings` capability rather than dispatching per provider.
+
+export const ghDependabotAlerts = (repoPath: string, limit: number) =>
+  invoke<DependabotAlertsOut>("gh_dependabot_alerts", { repoPath, limit });
+
+export const ghRepoAdvisories = (repoPath: string, limit: number) =>
+  invoke<RepoAdvisoriesOut>("gh_repo_advisories", { repoPath, limit });
+
+// ── Queries ──────────────────────────────────────────────────────────────────
+//
+// No refetchInterval on either: findings change on the scale of hours, so they
+// fetch on tab open and manual refresh only. `active` (the Findings tab being
+// visible) gates the fetch — <Activity> defers a hidden panel's effects but not
+// its queries. `limit` is part of the key so a Load-more is a distinct entry;
+// keepPreviousDataForRepo keeps the loaded rows painted while it refetches.
+
+export function useDependabotAlerts(
+  repo: string,
+  enabled: boolean,
+  active: boolean,
+  limit: number,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "findings", "alerts", limit] as const,
+    queryFn: () => ghDependabotAlerts(repo, limit),
+    enabled: enabled && active,
+    staleTime: 5 * 60_000,
+    placeholderData: keepPreviousDataForRepo(repo),
+  });
+}
+
+export function useRepoAdvisories(
+  repo: string,
+  enabled: boolean,
+  active: boolean,
+  limit: number,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "findings", "advisories", limit] as const,
+    queryFn: () => ghRepoAdvisories(repo, limit),
+    enabled: enabled && active,
+    staleTime: 5 * 60_000,
+    placeholderData: keepPreviousDataForRepo(repo),
+  });
+}

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -146,6 +146,13 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "tab-findings",
+    label: "Findings tab",
+    category: "Navigation",
+    // Palette-only by default: mod+1–9 are already taken by the other tabs.
+    defaultBinding: null,
+  },
+  {
     id: "tab-agent",
     label: "Agent tab",
     category: "Navigation",

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -11,6 +11,7 @@ export type RepoTab =
   | "issues"
   | "discussions"
   | "actions"
+  | "findings"
   | "tags"
   | "insights"
   | "code-todos"
@@ -64,6 +65,23 @@ export interface SelectedIssue {
   id: string;
 }
 
+/** Selected security finding: a Dependabot alert (by number) or a repository
+ *  advisory (by GHSA id) — the two categories the Findings tab lists. */
+export type SelectedFinding =
+  | { type: "alert"; number: number }
+  | { type: "advisory"; ghsaId: string };
+
+/** How many rows each Findings category has asked for. In the store (not panel
+ *  state) so the list and the detail pane build identical query keys and share
+ *  one cache entry. */
+export interface FindingsLimits {
+  alerts: number;
+  advisories: number;
+}
+
+/** One page per category — matches the shared LoadMoreRow PAGE_SIZE. */
+const DEFAULT_FINDINGS_LIMITS: FindingsLimits = { alerts: 100, advisories: 100 };
+
 export interface SelectedFile {
   path: string;
   staged: boolean;
@@ -107,6 +125,9 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   selectedDiscussion: null,
   pendingIssueDraft: null,
   selectedRunId: null,
+  selectedFinding: null,
+  findingsLimits: DEFAULT_FINDINGS_LIMITS,
+  repoSettingsRequest: null,
   selectedTag: null,
   selectedTodo: null,
   selectedFile: null,
@@ -194,6 +215,14 @@ interface UiState {
   localPrCreate: { defaultHead?: string; defaultBase?: string } | null;
   /** Selected workflow run (databaseId) on the Actions tab. */
   selectedRunId: number | null;
+  /** Selected finding on the Findings tab. */
+  selectedFinding: SelectedFinding | null;
+  /** Per-category row limits on the Findings tab; "Load more" bumps one. */
+  findingsLimits: FindingsLimits;
+  /** A one-shot request to open Repository Settings at a section, raised by
+   *  another surface (the Findings tab's "Dependabot is off" card). The menu
+   *  that owns the dialog consumes and clears it. */
+  repoSettingsRequest: "security" | null;
   /** Selected tag (by name) on the Tags tab. */
   selectedTag: { tag: string } | null;
   /** Selected TODO on the Code TODOs tab. Carries the scan's authoritative
@@ -286,6 +315,12 @@ interface UiState {
   }) => void;
   closeLocalPrCreate: () => void;
   selectRun: (id: number | null) => void;
+  selectFinding: (finding: SelectedFinding | null) => void;
+  setFindingsLimits: (limits: FindingsLimits) => void;
+  /** Ask whichever surface owns the Repository Settings dialog to open it at
+   *  `section`. Cleared by that surface as it opens (one-shot). */
+  requestRepoSettings: (section: "security") => void;
+  clearRepoSettingsRequest: () => void;
   selectTag: (tag: { tag: string } | null) => void;
   setSelectedTodo: (
     todo: {
@@ -375,6 +410,9 @@ export const useUiStore = create<UiState>()((set, get) => {
     pendingCreate: null,
     localPrCreate: null,
     selectedRunId: null,
+    selectedFinding: null,
+    findingsLimits: DEFAULT_FINDINGS_LIMITS,
+    repoSettingsRequest: null,
     selectedTag: null,
     selectedTodo: null,
     selectedFile: null,
@@ -473,6 +511,10 @@ export const useUiStore = create<UiState>()((set, get) => {
     openLocalPrCreate: (seeds) => set({ localPrCreate: seeds ?? {} }),
     closeLocalPrCreate: () => set({ localPrCreate: null }),
     selectRun: (id) => set({ selectedRunId: id }),
+    selectFinding: (finding) => set({ selectedFinding: finding }),
+    setFindingsLimits: (limits) => set({ findingsLimits: limits }),
+    requestRepoSettings: (section) => set({ repoSettingsRequest: section }),
+    clearRepoSettingsRequest: () => set({ repoSettingsRequest: null }),
     selectTag: (tag) => set({ selectedTag: tag }),
     setSelectedTodo: (todo) => set({ selectedTodo: todo }),
     selectCommit: (hash) => set({ selectedCommitHash: hash }),

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -80,7 +80,10 @@ export interface FindingsLimits {
 }
 
 /** One page per category — matches the shared LoadMoreRow PAGE_SIZE. */
-const DEFAULT_FINDINGS_LIMITS: FindingsLimits = { alerts: 100, advisories: 100 };
+const DEFAULT_FINDINGS_LIMITS: FindingsLimits = {
+  alerts: 100,
+  advisories: 100,
+};
 
 export interface SelectedFile {
   path: string;


### PR DESCRIPTION
Adds a **Findings** tab that surfaces a GitHub repository's open Dependabot alerts and its published security advisories inside the app, so a repo's vulnerability state is readable without a browser trip. Every list carries an explicit availability envelope — scanning off, token can't read it, or the check didn't complete are each reported as themselves rather than collapsing into an empty list that would falsely read as "clean".

### Backend (Rust)

- Adds `src-tauri/src/github/security_findings.rs`: the `gh_dependabot_alerts` and `gh_repo_advisories` commands, the `FindingAvailability` envelope (`available` / `notEnabled` / `forbidden` / `indeterminate`) with the server's verbatim `detail`, and camelCase output structs (`DependabotAlertOut`, `RepoAdvisoryOut`, `AdvisoryVulnerabilityOut`) plus `truncated` paging flags. Only a missing `gh` binary or a timeout escapes as `Err`; completed-but-failed calls are classified into the envelope.
- Parses GitHub's JSON through fully-optional `Raw*` structs so a shape change or one malformed item degrades a field instead of failing the whole list.
- Registers both commands in `src-tauri/src/lib.rs` and the module in `src-tauri/src/github/mod.rs`.
- Adds a `security_findings` capability to `Capabilities` in `src-tauri/src/forge/model.rs` — true for GitHub, false for GitLab/Bitbucket/none — with assertions in the existing per-provider capability tests.

### Findings UI

- Adds `src/features/security-findings/FindingsPanel.tsx`: alerts grouped by ecosystem + package name (worst-severity-first via a stable sort), advisories section, filter input, `LoadMoreRow` paging, arrow-key navigation through `listKeyboardNav`, and an `UnavailableCard` / `ReasonCard` pair that renders the blocker with its one resolving action (Retry, or **Open security settings**).
- Adds `src/features/security-findings/FindingDetailView.tsx`: a shared `DetailShell` for both finding kinds with severity chip, metadata grid (package, manifest, GHSA/CVE, CVSS, affected range, first patched version, dates), rendered description, and **View on GitHub**. Absent dates are omitted outright rather than shown as "never".
- Adds `src/features/security-findings/severity.tsx`: `severityLevel` normalization (unrecognized/null → `unknown`, never downgraded to `low`), `SEVERITY_RANK` sort ladder, and a `SeverityChip` whose meaning is carried by icon + label, not color — critical is distinguished from high by a filled icon.
- Wires the tab into `src/features/repository/RepositoryView.tsx` (secondary tabs list, both `<Activity>` panes, `DiffPlaceholder` empty state) and registers a palette-only `tab-findings` action in `src/lib/hotkeys/registry.ts` (no default chord — mod+1–9 are taken).

### State & client plumbing

- Adds `src/lib/github/security-findings.ts`: TS mirrors of the Rust structs plus `useDependabotAlerts` / `useRepoAdvisories`, keyed on `limit`, gated on the tab being `active` (since `<Activity>` defers effects but not queries), with `staleTime` and `keepPreviousDataForRepo` placeholder data.
- Extends `src/lib/stores/ui.ts` with the `findings` tab, `SelectedFinding`, `findingsLimits`, and a one-shot `repoSettingsRequest`, all included in `CROSS_REPO_RESET`.
- Exports `keepPreviousDataForRepo` from `src/lib/git/queries.ts` and adds `securityFindings` to `ForgeCapabilities` in `src/lib/git/types.ts` and the `NO_FORGE_STATUS` fallback.
- Makes `RepoSettingsDialog` accept an `initialSection` (and exports `SectionId`); `RepositoryMenu.tsx` consumes the one-shot request via `useEffectEvent`, dropping rather than queueing a request that arrives while the dialog is open, and clears the deep-linked section on close.

### Documentation

- `README.md`: a Highlights bullet and a Features entry describing the tab, the grouping, and the availability messaging.
- `site/src/data/capabilities.ts`: adds the Findings capability under "CI, tags & releases" with `highlight: true`.
- `src/features/help/content.ts`: a new **Findings** guide section covering both categories, keyboard navigation, the unavailable states, and the fetch-on-open behavior.
- `changelog.d/added-findings-tab.md`: the Keep a Changelog fragment for the release notes.