### PR TITLE
docs(help,site): document stash-and-reapply settings and merge outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,8 +385,9 @@ branch**, labeled with the default's name — plus a PR badge.
 - **Local branch-protection rules** — naming, merge methods, require-PR, force-push;
   shareable via a committed file or importable from GitHub.
 - **Advanced merge tooling** ⭐ — predicts the result in memory before you commit
-  (fast-forward / clean / which files will conflict), with `--no-ff` and a clearly
-  cautioned auto-resolve strategy (`-X ours/theirs`) — which GitHub Desktop doesn't offer.
+  (fast-forward / already up to date / clean / which files will conflict), with
+  `--no-ff` and a clearly cautioned auto-resolve strategy (`-X ours/theirs`) — which
+  GitHub Desktop doesn't offer.
   (This is the *local* prediction; a remote PR's conflict state comes from the forge
   itself, and falls back to this prediction only where the forge publishes none.)
 - **Change base** ⭐ — rebase a branch onto a different base when it was branched off the
@@ -414,11 +415,11 @@ commit that hasn't been pushed yet.
   restart, it surfaces a calm recovery notice naming what was interrupted and the exact
   branch + commit it started from (browsable any time via the *Operation history*
   command).
-- **Worktree manager** — create, switch between, promote a worktree's branch into your
-  main checkout, and remove linked worktrees, so you can work on several branches in
-  parallel folders without stashing — with one-click jumps to the main workspace right
-  from the branch switcher, where each worktree row also carries a context menu with
-  the management actions it supports.
+- **Worktree manager** — create, switch between, rename, lock, promote a worktree's
+  branch into your main checkout, and remove linked worktrees, so you can work on
+  several branches in parallel folders without stashing — with one-click jumps to the
+  main workspace right from the branch switcher, where each worktree row also carries
+  a context menu with the management actions it supports.
 - **Push or publish a branch without switching to it** — from the branch switcher's
   context menu, push a branch that's ahead of the remote it tracks (its own remote,
   not just `origin`) or publish an unpushed one (choosing the remote when there's more

--- a/changelog.d/fixed-guide-stash-merge-docs.md
+++ b/changelog.d/fixed-guide-stash-merge-docs.md
@@ -1,0 +1,2 @@
+- The in-app guide now covers the automatic stash-and-reapply settings under
+  Settings → General and the Merge preview's *already up to date* outcome.

--- a/changelog.d/fixed-guide-stash-merge-docs.md
+++ b/changelog.d/fixed-guide-stash-merge-docs.md
@@ -1,2 +1,2 @@
-- The in-app guide now covers the automatic stash-and-reapply settings under
-  Settings → General and the Merge preview's *already up to date* outcome.
+- The in-app guide now lists both stash-and-reapply toggles in its Settings section and
+  adds *already up to date* to the Merge dialog's previewed outcomes.

--- a/changelog.d/fixed-guide-stash-merge-docs.md
+++ b/changelog.d/fixed-guide-stash-merge-docs.md
@@ -1,2 +1,2 @@
-- The in-app guide now lists both stash-and-reapply toggles in its Settings section and
-  adds *already up to date* to the Merge dialog's previewed outcomes.
+- The in-app guide now names both stash-and-reapply toggles under **Settings → General**
+  and documents the Merge dialog's *already up to date* preview outcome.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -329,7 +329,7 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
-    label: "Worktree manager — create, switch, promote & remove",
+    label: "Worktree manager — create, switch, rename, lock, promote & remove",
     highlight: true,
   },
   { group: "Repository & workspace", label: "Submodule status & update" },

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -121,7 +121,7 @@ export const capabilities: Capability[] = [
   {
     group: "Rewrite & recovery",
     label:
-      "Merge preview — fast-forward / clean / which files conflict, before you merge",
+      "Merge preview — fast-forward / already up to date / clean / which files conflict, before you merge",
     highlight: true,
   },
   {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -655,7 +655,8 @@ const forges = [
     </p>
     <p class="text-muted">
       Merging shows an advanced tooling panel that predicts the result in memory —
-      fast-forward, clean, or which files will conflict — before you commit to it.
+      fast-forward, already up to date, clean, or which files will conflict — before
+      you commit to it.
     </p>
   </FeatureRow>
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1953,13 +1953,16 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 - **General** — hide AI features (which also pauses your automations until you show them
   again — your rules are kept), keep running in the **system tray** on close (so
   background work continues; launching the app again while it's running —
-  tray-hidden or not — focuses the existing window), **create pull requests as drafts**
-  by default (off by default — pre-checks the Create-PR dialog's draft box, still
-  overridable per PR; pairs with *Review draft PRs when created* so a draft's automated
-  first review waits until it's marked ready), **automatically stash and reapply on pull
-  and branch updates** (an operation git would refuse over uncommitted changes recovers
-  on its own, no prompt), **reapply stashed changes after switching branches** (*Stash
-  and switch* puts your changes back once the switch lands), and privacy options.
+  tray-hidden or not — focuses the existing window), **automatically stash and reapply
+  on pull and branch updates** (an operation git would refuse over uncommitted changes
+  recovers on its own, no prompt), **reapply stashed changes after switching branches**
+  (*Stash and switch* puts your changes back once the switch lands), **create pull
+  requests as drafts** by default (off by default — pre-checks the Create-PR dialog's
+  draft box, still overridable per PR; pairs with *Review draft PRs when created* so a
+  draft's automated first review waits until it's marked ready), and privacy options.
+- **Appearance** — pick a theme: **System** (follows your OS's light/dark setting),
+  **Light**, **Dark**, or **Slate** (a softer, blue-gray dark). Applies as you pick it,
+  and *Cycle theme* in the command palette steps through them.
 {{ai}}- **AI** — providers, models, keys, instructions, agent-session isolation
   (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -469,8 +469,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   yet — click one to check it out (creating a local tracking branch), or {{secondaryclick}} to
   **Delete on _origin_…**, a server-side delete that removes the branch from the remote for
   everyone (protected names are blocked, and it can't be undone from the app).
-- The **Merge** dialog previews the result before you commit to it — *fast-forward*, *clean
-  merge*, or *which files will conflict* — worked out in memory without touching your files.
+- The **Merge** dialog previews the result before you commit to it — *fast-forward*, *already
+  up to date*, *clean merge*, or *which files will conflict* — worked out in memory without
+  touching your files.
   Two options sit alongside: **Always create a merge commit** (no fast-forward), and an **On
   conflict** strategy — *Stop and let me resolve* (default), or *Prefer current* / *Prefer
   incoming* to auto-resolve conflicting changes in one branch's favor (the other side's
@@ -1955,7 +1956,10 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   tray-hidden or not — focuses the existing window), **create pull requests as drafts**
   by default (off by default — pre-checks the Create-PR dialog's draft box, still
   overridable per PR; pairs with *Review draft PRs when created* so a draft's automated
-  first review waits until it's marked ready), and privacy options.
+  first review waits until it's marked ready), **automatically stash and reapply on pull
+  and branch updates** (an operation git would refuse over uncommitted changes recovers
+  on its own, no prompt), **reapply stashed changes after switching branches** (*Stash
+  and switch* puts your changes back once the switch lands), and privacy options.
 {{ai}}- **AI** — providers, models, keys, instructions, agent-session isolation
   (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1953,13 +1953,15 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 - **General** — hide AI features (which also pauses your automations until you show them
   again — your rules are kept), keep running in the **system tray** on close (so
   background work continues; launching the app again while it's running —
-  tray-hidden or not — focuses the existing window), **automatically stash and reapply
-  on pull and branch updates** (an operation git would refuse over uncommitted changes
-  recovers on its own, no prompt), **reapply stashed changes after switching branches**
-  (*Stash and switch* puts your changes back once the switch lands), **create pull
-  requests as drafts** by default (off by default — pre-checks the Create-PR dialog's
-  draft box, still overridable per PR; pairs with *Review draft PRs when created* so a
-  draft's automated first review waits until it's marked ready), and privacy options.
+  tray-hidden or not — focuses the existing window), **automatically fetch from your
+  remotes** (a background fetch on an interval you pick — it never pulls, merges, or
+  changes your files), **automatically stash and reapply on pull and branch updates**
+  (an operation git would refuse over uncommitted changes recovers on its own, no
+  prompt), **reapply stashed changes after switching branches** (*Stash and switch*
+  puts your changes back once the switch lands), **create pull requests as drafts** by
+  default (off by default — pre-checks the Create-PR dialog's draft box, still
+  overridable per PR; pairs with *Review draft PRs when created* so a draft's automated
+  first review waits until it's marked ready), and privacy options.
 - **Appearance** — pick a theme: **System** (follows your OS's light/dark setting),
   **Light**, **Dark**, or **Slate** (a softer, blue-gray dark). Applies as you pick it,
   and *Cycle theme* in the command palette steps through them.


### PR DESCRIPTION
Brings three documentation surfaces back in line with shipped behavior: the in-app guide never mentioned the automatic stash-and-reapply settings or the Merge preview's *already up to date* result, and the site capability catalog still described an older, smaller worktree manager. No app behavior changes.

### In-app guide (`src/features/help/content.ts`)

- Extends the Settings → General bullet to cover **automatically stash and reapply on pull and branch updates** (recovers an operation git would refuse over uncommitted changes, no prompt) and **reapply stashed changes after switching branches** (*Stash and switch* restores the changes once the switch lands).
- Adds *already up to date* to the Merge dialog's list of previewed outcomes, alongside *fast-forward*, *clean merge*, and the conflicting-files case.

### Marketing site (`site/src/data/capabilities.ts`)

- Updates the "Worktree manager" capability label to include **rename** and **lock** next to create, switch, promote, and remove.

### Changelog

- Adds `changelog.d/fixed-guide-stash-merge-docs.md` recording the guide coverage of the stash-and-reapply settings and the *already up to date* merge outcome.

Relates to #150