### PR TITLE
fix(diff): stop syntax highlighting bleeding across hunk gaps in large diffs

### DIFF
--- a/changelog.d/fixed-large-diff-highlight-bleed.md
+++ b/changelog.d/fixed-large-diff-highlight-bleed.md
@@ -1,0 +1,4 @@
+- Syntax highlighting in a large file's diff no longer paints everything after a
+  hunk as one long comment or string. Each hunk is now highlighted on its own, so
+  a comment, template literal, or parameter list the hunk cuts in half can't
+  bleed color across the collapsed gaps between hunks.

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -43,6 +43,7 @@ import { DiffErrorBoundary } from "./DiffErrorBoundary";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
 import { diffLang } from "./diff-lang";
+import { installHljsGapIsolation } from "./gap-isolation";
 import { djb2 } from "./highlight-worker-shared";
 import { ImageDiff, ImagePanes, type ImageRevs, imageMime } from "./ImageDiff";
 import {
@@ -291,6 +292,11 @@ export const HIGHLIGHT_MAX_LINES = 2000;
 // by the char budgets above. SYNTAX_LINE_CAP is shared with the Shiki +
 // precomputed highlighters.
 highlighter.setMaxLineToIgnoreSyntax(SYNTAX_LINE_CAP);
+// Same singleton, gap isolation: a hunk-reconstructed buffer is tokenized per
+// contiguous non-blank run, so an unclosed construct at a hunk boundary can't
+// bleed to EOF. An explicit call, not a side-effect import, so it can't be
+// tree-shaken.
+installHljsGapIsolation();
 
 /**
  * Build a parsed `DiffFile` from unified-diff text, with syntax highlighting

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -43,8 +43,8 @@ import { DiffErrorBoundary } from "./DiffErrorBoundary";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
 import { diffLang } from "./diff-lang";
-import { installHljsGapIsolation } from "./gap-isolation";
 import { djb2 } from "./highlight-worker-shared";
+import { installHljsGapIsolation } from "./hljs-gap-isolation";
 import { ImageDiff, ImagePanes, type ImageRevs, imageMime } from "./ImageDiff";
 import {
   ensureBuiltinShikiLang,

--- a/src/features/diff/gap-isolation.ts
+++ b/src/features/diff/gap-isolation.ts
@@ -1,0 +1,131 @@
+import { type DiffAST, highlighter } from "@git-diff-view/core";
+
+/**
+ * Segment-aware tokenization for hunk-reconstructed ("holey") diff buffers,
+ * whose elided regions arrive as blank placeholder lines. Tokenizing each run
+ * of non-blank lines on its own keeps tokenizer state from crossing a gap, so a
+ * construct a hunk boundary left unclosed can't paint the rest of the buffer.
+ * Trade-off: a construct spanning a GENUINE blank line inside a holey buffer
+ * now resets there — a bounded local mis-color in place of unbounded bleed, on
+ * a path (hunk-mode highlighting) that is already best-effort.
+ */
+
+/** Buffers below this many lines are never treated as holey. */
+export const HOLEY_MIN_LINES = 50;
+/** Blank-line ratio at which a buffer is treated as hunk-reconstructed.
+ *  Measured holey buffers run ~99% blank; real source files rarely exceed ~40%. */
+export const HOLEY_MIN_BLANK_RATIO = 0.5;
+
+/**
+ * Whether `raw` looks hunk-reconstructed. Blank means exactly `""` —
+ * placeholder lines carry no whitespace, so whitespace-only lines stay real
+ * content (and a CRLF file's content lines end `"\r"`, keeping them non-blank).
+ */
+export function isHoleyBuffer(raw: string): boolean {
+  const lines = raw.split("\n");
+  if (lines.length < HOLEY_MIN_LINES) return false;
+  let blank = 0;
+  for (const line of lines) if (line === "") blank++;
+  return blank / lines.length >= HOLEY_MIN_BLANK_RATIO;
+}
+
+/** Flattened text length of an AST, without materializing the string. */
+function astTextLength(node: DiffAST | DiffAST["children"][number]): number {
+  if (node.type === "text") return node.value.length;
+  return "children" in node
+    ? node.children.reduce((sum, child) => sum + astTextLength(child), 0)
+    : 0;
+}
+
+/**
+ * Tokenize `raw` segment by segment when it looks hunk-reconstructed; a
+ * sub-threshold buffer takes the unchanged single `tokenize(raw)` path.
+ */
+export function gapIsolatedAst(
+  raw: string,
+  tokenize: (segment: string) => DiffAST,
+): DiffAST {
+  if (!isHoleyBuffer(raw)) return tokenize(raw);
+  const lines = raw.split("\n");
+  // N split elements are joined by exactly N-1 "\n" separators: one separator
+  // PRECEDES every element but the first. A run of non-blank elements keeps its
+  // internal separators inside the segment text handed to `tokenize`.
+  const children: DiffAST["children"] = [];
+  let i = 0;
+  let sepsPending = 0;
+  const emitSeps = () => {
+    if (sepsPending > 0) {
+      children.push({ type: "text", value: "\n".repeat(sepsPending) });
+      sepsPending = 0;
+    }
+  };
+  while (i < lines.length) {
+    if (lines[i] === "") {
+      if (i > 0) sepsPending++;
+      i++;
+      continue;
+    }
+    if (i > 0) sepsPending++;
+    emitSeps();
+    const start = i;
+    while (i < lines.length && lines[i] !== "") i++;
+    const segmentAst = tokenize(lines.slice(start, i).join("\n"));
+    children.push(...(segmentAst.children ?? []));
+  }
+  emitSeps();
+  const merged: DiffAST = { type: "root", children };
+  // An engine whose AST doesn't flatten back to its input (e.g. an empty-tree
+  // fallback for one segment) would drop text, so fall back to the whole-buffer
+  // pass — the wrapper is then never worse than not wrapping.
+  return astTextLength(merged) === raw.length ? merged : tokenize(raw);
+}
+
+// A registry symbol, not a module-local one: on HMR this module re-evaluates
+// with fresh state while the lowlight singleton keeps the installed wrapper, so
+// the "already patched" mark must be readable across module instances.
+const GAP_ISOLATED = Symbol.for("gd.diff.gapIsolated");
+
+function markInstalled<T extends object>(fn: T): T {
+  return Object.defineProperty(fn, GAP_ISOLATED, { value: true });
+}
+
+/**
+ * Give the highlight.js singleton gap isolation. @git-diff-view's default
+ * `initSyntax()` and the react view clone's re-tokenize both run through this
+ * one exported instance, so it is the only seam covering both. Its `getAST` is
+ * a non-writable, non-configurable property, so the wrap lands one level down
+ * on the lowlight engine — covering both of getAST's tokenize exits, a
+ * registered language via `highlight` and an unregistered one via
+ * `highlightAuto`. Idempotent, and must be called explicitly at module scope (a
+ * bare side-effect import can be dropped).
+ */
+export function installHljsGapIsolation(): void {
+  const engine = highlighter.getHighlighterEngine();
+  if (GAP_ISOLATED in engine.highlight) return;
+  const originalHighlight = engine.highlight;
+  const originalAuto = engine.highlightAuto;
+
+  const isolatedHighlight: typeof engine.highlight = (
+    language,
+    value,
+    options,
+  ) =>
+    gapIsolatedAst(value, (segment) =>
+      originalHighlight.call(engine, language, segment, options),
+    );
+
+  // Language detection stays whole-buffer, and every segment is tokenized as
+  // that one language: detecting per segment could resolve a different language
+  // for each, coloring one buffer inconsistently.
+  const isolatedAuto: typeof engine.highlightAuto = (value, options) => {
+    const whole = originalAuto.call(engine, value, options);
+    const detected = whole.data?.language;
+    if (!detected || !isHoleyBuffer(value)) return whole;
+    return gapIsolatedAst(value, (segment) =>
+      originalHighlight.call(engine, detected, segment, options),
+    );
+  };
+
+  engine.highlight = markInstalled(isolatedHighlight);
+  engine.highlightAuto = markInstalled(isolatedAuto);
+}

--- a/src/features/diff/gap-isolation.ts
+++ b/src/features/diff/gap-isolation.ts
@@ -1,3 +1,6 @@
+// Import from core, never the react entry: both re-export the same singleton,
+// but this module is reachable from the highlight worker (highlight-worker ->
+// shiki-highlighter -> here), where react would pull React into the chunk.
 import { type DiffAST, highlighter } from "@git-diff-view/core";
 
 /**
@@ -11,18 +14,18 @@ import { type DiffAST, highlighter } from "@git-diff-view/core";
  */
 
 /** Buffers below this many lines are never treated as holey. */
-export const HOLEY_MIN_LINES = 50;
+const HOLEY_MIN_LINES = 50;
 /** Blank-line ratio at which a buffer is treated as hunk-reconstructed.
- *  Measured holey buffers run ~99% blank; real source files rarely exceed ~40%. */
-export const HOLEY_MIN_BLANK_RATIO = 0.5;
+ *  Measured holey buffers run ~99% blank; no file in this repo reaches 50%
+ *  (highest among the 519 code files of >=50 lines: 15%). */
+const HOLEY_MIN_BLANK_RATIO = 0.5;
 
 /**
- * Whether `raw` looks hunk-reconstructed. Blank means exactly `""` —
+ * Whether pre-split `lines` look hunk-reconstructed. Blank means exactly `""` —
  * placeholder lines carry no whitespace, so whitespace-only lines stay real
  * content (and a CRLF file's content lines end `"\r"`, keeping them non-blank).
  */
-export function isHoleyBuffer(raw: string): boolean {
-  const lines = raw.split("\n");
+function isHoley(lines: readonly string[]): boolean {
   if (lines.length < HOLEY_MIN_LINES) return false;
   let blank = 0;
   for (const line of lines) if (line === "") blank++;
@@ -37,16 +40,13 @@ function astTextLength(node: DiffAST | DiffAST["children"][number]): number {
     : 0;
 }
 
-/**
- * Tokenize `raw` segment by segment when it looks hunk-reconstructed; a
- * sub-threshold buffer takes the unchanged single `tokenize(raw)` path.
- */
-export function gapIsolatedAst(
+/** Tokenize each run of non-blank lines separately and merge the ASTs. `lines`
+ *  must be `raw.split("\n")`. */
+function mergeSegments(
   raw: string,
+  lines: readonly string[],
   tokenize: (segment: string) => DiffAST,
 ): DiffAST {
-  if (!isHoleyBuffer(raw)) return tokenize(raw);
-  const lines = raw.split("\n");
   // N split elements are joined by exactly N-1 "\n" separators: one separator
   // PRECEDES every element but the first. A run of non-blank elements keeps its
   // internal separators inside the segment text handed to `tokenize`.
@@ -70,7 +70,9 @@ export function gapIsolatedAst(
     const start = i;
     while (i < lines.length && lines[i] !== "") i++;
     const segmentAst = tokenize(lines.slice(start, i).join("\n"));
-    children.push(...(segmentAst.children ?? []));
+    // Appended one at a time: a long contiguous run can exceed the engine's
+    // argument limit when spread into push().
+    for (const child of segmentAst.children ?? []) children.push(child);
   }
   emitSeps();
   const merged: DiffAST = { type: "root", children };
@@ -78,6 +80,18 @@ export function gapIsolatedAst(
   // fallback for one segment) would drop text, so fall back to the whole-buffer
   // pass — the wrapper is then never worse than not wrapping.
   return astTextLength(merged) === raw.length ? merged : tokenize(raw);
+}
+
+/**
+ * Tokenize `raw` segment by segment when it looks hunk-reconstructed; a
+ * sub-threshold buffer takes the unchanged single `tokenize(raw)` path.
+ */
+export function gapIsolatedAst(
+  raw: string,
+  tokenize: (segment: string) => DiffAST,
+): DiffAST {
+  const lines = raw.split("\n");
+  return isHoley(lines) ? mergeSegments(raw, lines, tokenize) : tokenize(raw);
 }
 
 // A registry symbol, not a module-local one: on HMR this module re-evaluates
@@ -96,36 +110,45 @@ function markInstalled<T extends object>(fn: T): T {
  * a non-writable, non-configurable property, so the wrap lands one level down
  * on the lowlight engine — covering both of getAST's tokenize exits, a
  * registered language via `highlight` and an unregistered one via
- * `highlightAuto`. Idempotent, and must be called explicitly at module scope (a
- * bare side-effect import can be dropped).
+ * `highlightAuto`. Fails open: if the engine ever refuses the patch, diffs
+ * render without gap isolation rather than the module throwing at import.
+ * Idempotent, and must be called explicitly at module scope (a bare
+ * side-effect import can be dropped).
  */
 export function installHljsGapIsolation(): void {
-  const engine = highlighter.getHighlighterEngine();
-  if (GAP_ISOLATED in engine.highlight) return;
-  const originalHighlight = engine.highlight;
-  const originalAuto = engine.highlightAuto;
+  try {
+    const engine = highlighter.getHighlighterEngine();
+    if (GAP_ISOLATED in engine.highlight) return;
+    const originalHighlight = engine.highlight;
+    const originalAuto = engine.highlightAuto;
 
-  const isolatedHighlight: typeof engine.highlight = (
-    language,
-    value,
-    options,
-  ) =>
-    gapIsolatedAst(value, (segment) =>
-      originalHighlight.call(engine, language, segment, options),
-    );
+    const isolatedHighlight: typeof engine.highlight = (
+      language,
+      value,
+      options,
+    ) =>
+      gapIsolatedAst(value, (segment) =>
+        originalHighlight.call(engine, language, segment, options),
+      );
 
-  // Language detection stays whole-buffer, and every segment is tokenized as
-  // that one language: detecting per segment could resolve a different language
-  // for each, coloring one buffer inconsistently.
-  const isolatedAuto: typeof engine.highlightAuto = (value, options) => {
-    const whole = originalAuto.call(engine, value, options);
-    const detected = whole.data?.language;
-    if (!detected || !isHoleyBuffer(value)) return whole;
-    return gapIsolatedAst(value, (segment) =>
-      originalHighlight.call(engine, detected, segment, options),
-    );
-  };
+    // Language detection stays whole-buffer, and every segment is tokenized as
+    // that one language: detecting per segment could resolve a different
+    // language for each, coloring one buffer inconsistently.
+    const isolatedAuto: typeof engine.highlightAuto = (value, options) => {
+      const whole = originalAuto.call(engine, value, options);
+      const detected = whole.data?.language;
+      if (!detected) return whole;
+      const lines = value.split("\n");
+      if (!isHoley(lines)) return whole;
+      const merged = mergeSegments(value, lines, (segment) =>
+        originalHighlight.call(engine, detected, segment, options),
+      );
+      return { ...merged, data: whole.data };
+    };
 
-  engine.highlight = markInstalled(isolatedHighlight);
-  engine.highlightAuto = markInstalled(isolatedAuto);
+    engine.highlight = markInstalled(isolatedHighlight);
+    engine.highlightAuto = markInstalled(isolatedAuto);
+  } catch {
+    // fail open: diffs render without gap isolation
+  }
 }

--- a/src/features/diff/gap-isolation.ts
+++ b/src/features/diff/gap-isolation.ts
@@ -1,7 +1,4 @@
-// Import from core, never the react entry: both re-export the same singleton,
-// but this module is reachable from the highlight worker (highlight-worker ->
-// shiki-highlighter -> here), where react would pull React into the chunk.
-import { type DiffAST, highlighter } from "@git-diff-view/core";
+import type { DiffAST } from "@git-diff-view/core";
 
 /**
  * Segment-aware tokenization for hunk-reconstructed ("holey") diff buffers,
@@ -11,6 +8,9 @@ import { type DiffAST, highlighter } from "@git-diff-view/core";
  * Trade-off: a construct spanning a GENUINE blank line inside a holey buffer
  * now resets there — a bounded local mis-color in place of unbounded bleed, on
  * a path (hunk-mode highlighting) that is already best-effort.
+ *
+ * Type-only imports here keep this module free of engine code: it is reachable
+ * from the highlight worker (highlight-worker -> shiki-highlighter -> here).
  */
 
 /** Buffers below this many lines are never treated as holey. */
@@ -24,8 +24,9 @@ const HOLEY_MIN_BLANK_RATIO = 0.5;
  * Whether pre-split `lines` look hunk-reconstructed. Blank means exactly `""` —
  * placeholder lines carry no whitespace, so whitespace-only lines stay real
  * content (and a CRLF file's content lines end `"\r"`, keeping them non-blank).
+ * Exported for hljs-gap-isolation, its only other consumer.
  */
-function isHoley(lines: readonly string[]): boolean {
+export function isHoley(lines: readonly string[]): boolean {
   if (lines.length < HOLEY_MIN_LINES) return false;
   let blank = 0;
   for (const line of lines) if (line === "") blank++;
@@ -40,17 +41,24 @@ function astTextLength(node: DiffAST | DiffAST["children"][number]): number {
     : 0;
 }
 
-/** Tokenize each run of non-blank lines separately and merge the ASTs. `lines`
- *  must be `raw.split("\n")`. */
-function mergeSegments(
+/**
+ * Tokenize each run of non-blank lines separately and merge the ASTs; `lines`
+ * must be `raw.split("\n")`. Null means the merge lost text and the caller
+ * should use its own whole-buffer result. The merged root inherits the first
+ * segment's `data`: every segment is tokenized as the same language, and a
+ * per-segment relevance score means nothing once the buffer is split.
+ * Exported for hljs-gap-isolation, its only other consumer.
+ */
+export function mergeSegments(
   raw: string,
   lines: readonly string[],
   tokenize: (segment: string) => DiffAST,
-): DiffAST {
+): DiffAST | null {
   // N split elements are joined by exactly N-1 "\n" separators: one separator
   // PRECEDES every element but the first. A run of non-blank elements keeps its
   // internal separators inside the segment text handed to `tokenize`.
   const children: DiffAST["children"] = [];
+  let data: DiffAST["data"];
   let i = 0;
   let sepsPending = 0;
   const emitSeps = () => {
@@ -70,16 +78,18 @@ function mergeSegments(
     const start = i;
     while (i < lines.length && lines[i] !== "") i++;
     const segmentAst = tokenize(lines.slice(start, i).join("\n"));
+    data ??= segmentAst.data;
     // Appended one at a time: a long contiguous run can exceed the engine's
     // argument limit when spread into push().
     for (const child of segmentAst.children ?? []) children.push(child);
   }
   emitSeps();
   const merged: DiffAST = { type: "root", children };
+  if (data) merged.data = data;
   // An engine whose AST doesn't flatten back to its input (e.g. an empty-tree
-  // fallback for one segment) would drop text, so fall back to the whole-buffer
-  // pass — the wrapper is then never worse than not wrapping.
-  return astTextLength(merged) === raw.length ? merged : tokenize(raw);
+  // fallback for one segment) would drop text, so the caller falls back to its
+  // whole-buffer result.
+  return astTextLength(merged) === raw.length ? merged : null;
 }
 
 /**
@@ -91,64 +101,6 @@ export function gapIsolatedAst(
   tokenize: (segment: string) => DiffAST,
 ): DiffAST {
   const lines = raw.split("\n");
-  return isHoley(lines) ? mergeSegments(raw, lines, tokenize) : tokenize(raw);
-}
-
-// A registry symbol, not a module-local one: on HMR this module re-evaluates
-// with fresh state while the lowlight singleton keeps the installed wrapper, so
-// the "already patched" mark must be readable across module instances.
-const GAP_ISOLATED = Symbol.for("gd.diff.gapIsolated");
-
-function markInstalled<T extends object>(fn: T): T {
-  return Object.defineProperty(fn, GAP_ISOLATED, { value: true });
-}
-
-/**
- * Give the highlight.js singleton gap isolation. @git-diff-view's default
- * `initSyntax()` and the react view clone's re-tokenize both run through this
- * one exported instance, so it is the only seam covering both. Its `getAST` is
- * a non-writable, non-configurable property, so the wrap lands one level down
- * on the lowlight engine — covering both of getAST's tokenize exits, a
- * registered language via `highlight` and an unregistered one via
- * `highlightAuto`. Fails open: if the engine ever refuses the patch, diffs
- * render without gap isolation rather than the module throwing at import.
- * Idempotent, and must be called explicitly at module scope (a bare
- * side-effect import can be dropped).
- */
-export function installHljsGapIsolation(): void {
-  try {
-    const engine = highlighter.getHighlighterEngine();
-    if (GAP_ISOLATED in engine.highlight) return;
-    const originalHighlight = engine.highlight;
-    const originalAuto = engine.highlightAuto;
-
-    const isolatedHighlight: typeof engine.highlight = (
-      language,
-      value,
-      options,
-    ) =>
-      gapIsolatedAst(value, (segment) =>
-        originalHighlight.call(engine, language, segment, options),
-      );
-
-    // Language detection stays whole-buffer, and every segment is tokenized as
-    // that one language: detecting per segment could resolve a different
-    // language for each, coloring one buffer inconsistently.
-    const isolatedAuto: typeof engine.highlightAuto = (value, options) => {
-      const whole = originalAuto.call(engine, value, options);
-      const detected = whole.data?.language;
-      if (!detected) return whole;
-      const lines = value.split("\n");
-      if (!isHoley(lines)) return whole;
-      const merged = mergeSegments(value, lines, (segment) =>
-        originalHighlight.call(engine, detected, segment, options),
-      );
-      return { ...merged, data: whole.data };
-    };
-
-    engine.highlight = markInstalled(isolatedHighlight);
-    engine.highlightAuto = markInstalled(isolatedAuto);
-  } catch {
-    // fail open: diffs render without gap isolation
-  }
+  if (!isHoley(lines)) return tokenize(raw);
+  return mergeSegments(raw, lines, tokenize) ?? tokenize(raw);
 }

--- a/src/features/diff/hljs-gap-isolation.ts
+++ b/src/features/diff/hljs-gap-isolation.ts
@@ -1,0 +1,63 @@
+// Import from core, never the react entry: both re-export the same singleton,
+// but react would pull React into any chunk this module reaches.
+import { highlighter } from "@git-diff-view/core";
+import { gapIsolatedAst, isHoley, mergeSegments } from "./gap-isolation";
+
+// A registry symbol, not a module-local one: on HMR this module re-evaluates
+// with fresh state while the lowlight singleton keeps the installed wrapper, so
+// the "already patched" mark must be readable across module instances.
+const GAP_ISOLATED = Symbol.for("gd.diff.gapIsolated");
+
+function markInstalled<T extends object>(fn: T): T {
+  return Object.defineProperty(fn, GAP_ISOLATED, { value: true });
+}
+
+/**
+ * Give the highlight.js singleton gap isolation. @git-diff-view's default
+ * `initSyntax()` and the react view clone's re-tokenize both run through this
+ * one exported instance, so it is the only seam covering both. Its `getAST` is
+ * a non-writable, non-configurable property, so the wrap lands one level down
+ * on the lowlight engine — covering both of getAST's tokenize exits, a
+ * registered language via `highlight` and an unregistered one via
+ * `highlightAuto`. Fails open: if the engine ever refuses the patch, diffs
+ * render without gap isolation rather than the module throwing at import.
+ * Idempotent, and must be called explicitly at module scope (a bare
+ * side-effect import can be dropped).
+ */
+export function installHljsGapIsolation(): void {
+  try {
+    const engine = highlighter.getHighlighterEngine();
+    if (GAP_ISOLATED in engine.highlight) return;
+    const originalHighlight = engine.highlight;
+    const originalAuto = engine.highlightAuto;
+
+    const isolatedHighlight: typeof engine.highlight = (
+      language,
+      value,
+      options,
+    ) =>
+      gapIsolatedAst(value, (segment) =>
+        originalHighlight.call(engine, language, segment, options),
+      );
+
+    // Language detection stays whole-buffer, and every segment is tokenized as
+    // that one language: detecting per segment could resolve a different
+    // language for each, coloring one buffer inconsistently.
+    const isolatedAuto: typeof engine.highlightAuto = (value, options) => {
+      const whole = originalAuto.call(engine, value, options);
+      const detected = whole.data?.language;
+      if (!detected) return whole;
+      const lines = value.split("\n");
+      if (!isHoley(lines)) return whole;
+      const merged = mergeSegments(value, lines, (segment) =>
+        originalHighlight.call(engine, detected, segment, options),
+      );
+      return merged ? { ...merged, data: whole.data } : whole;
+    };
+
+    engine.highlight = markInstalled(isolatedHighlight);
+    engine.highlightAuto = markInstalled(isolatedAuto);
+  } catch {
+    // fail open: diffs render without gap isolation
+  }
+}

--- a/src/features/diff/shiki-highlighter.ts
+++ b/src/features/diff/shiki-highlighter.ts
@@ -13,6 +13,7 @@ import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
 import jsonGrammar from "@shikijs/langs/json";
 import type { LanguageRegistration } from "@shikijs/types";
 import type { CustomLanguage } from "@/lib/settings/api";
+import { gapIsolatedAst } from "./gap-isolation";
 import { gdDark, gdLight } from "./shiki-theme";
 
 /**
@@ -273,7 +274,9 @@ export function shikiDiffHighlighter(
     getAST: (raw, _fileName, lang) => {
       if (!lang || !loaded.has(lang)) return EMPTY_AST;
       try {
-        return buildHast(raw, lang, isDarkOverride);
+        return gapIsolatedAst(raw, (segment) =>
+          buildHast(segment, lang, isDarkOverride),
+        );
       } catch {
         return EMPTY_AST;
       }


### PR DESCRIPTION
Large files render as a hunk-reconstructed buffer whose elided regions are blank placeholder lines, so tokenizing it in one pass lets a construct the hunk boundary left unclosed — a `/*` comment, a template literal, an open parameter list — paint every line after it as one long comment or string. This change tokenizes such buffers one contiguous run of non-blank lines at a time, so tokenizer state can't cross a gap, and applies it to both highlighting engines the diff view uses.

### Segment-aware tokenization

- Adds `src/features/diff/gap-isolation.ts` with `gapIsolatedAst(raw, tokenize)`: splits the buffer on blank lines, tokenizes each non-blank run on its own, and re-emits the `"\n"` separators as text nodes so the merged AST keeps the original line numbering.
- Gates the behavior behind `isHoleyBuffer`, which only treats a buffer as hunk-reconstructed at `HOLEY_MIN_LINES` (50) or more lines with at least `HOLEY_MIN_BLANK_RATIO` (0.5) blank lines; blank means exactly `""`, so whitespace-only lines and CRLF content lines ending in `"\r"` still count as real content. Sub-threshold buffers take the unchanged single-pass path.
- Verifies the merge via `astTextLength`, falling back to the whole-buffer `tokenize(raw)` whenever the segmented AST doesn't flatten back to the input length, so the wrapper is never worse than not wrapping.
- Documents the trade-off in the module doc comment: a construct spanning a genuine blank line inside a holey buffer now resets there — a bounded local mis-color instead of unbounded bleed, on an already best-effort path.

### highlight.js engine wrapping

- `installHljsGapIsolation()` patches the `@git-diff-view/core` `highlighter` singleton's engine. Because `getAST` is a non-writable, non-configurable property, the wrap lands on the lowlight engine's `highlight` and `highlightAuto`, covering both of `getAST`'s tokenize exits (registered vs. auto-detected language).
- The `highlightAuto` wrapper keeps language detection whole-buffer and then re-tokenizes each segment with that one detected language, so a single buffer can't end up colored as several languages.
- Installation is idempotent and HMR-safe via a `Symbol.for("gd.diff.gapIsolated")` registry mark on the wrapped functions, since the module can re-evaluate while the singleton keeps the installed wrapper.
- `src/features/diff/DiffSurface.tsx` calls `installHljsGapIsolation()` explicitly at module scope alongside `setMaxLineToIgnoreSyntax`, rather than relying on a side-effect import that could be tree-shaken.

### Shiki path

- `src/features/diff/shiki-highlighter.ts` routes its `getAST` through `gapIsolatedAst`, calling `buildHast` per segment inside the existing `try`/`catch` and loaded-language guard.

### Documentation

- Adds `changelog.d/fixed-large-diff-highlight-bleed.md` describing the fix in user terms.