### PR TITLE
feat(findings,github): add code and secret scanning alerts to Findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   first patched version), its **code scanning** and **secret scanning** alerts, and the
   repository's **security advisories**. Select a row for its detail — for a Dependabot
   alert that adds CVSS base metrics, CWEs, labeled references, and whether the
-  dependency is direct or transitive — then open it on GitHub. A category that isn't
-  switched on says so, with a jump to the settings that enable it if you're a repo
-  admin.
+  dependency is direct or transitive — then open it on GitHub. A scanning category that
+  isn't switched on says so, with a jump to the settings that enable it if you're a
+  repo admin.
 - **Explore repositories** — a full-page browser across **GitHub, GitLab & Bitbucket**:
   before you type it shows **your own repositories** (grouped by owner) and a **Popular**
   star-sorted feed (GitHub & GitLab); typing searches GitHub, all public GitLab projects,
@@ -599,8 +599,10 @@ the detail, then open it on GitHub; a Dependabot alert's detail adds a base-metr
 table per CVSS version the advisory carries (3.x and 4.0), its CWEs, labeled reference
 links, and whether the package is a direct or transitive dependency. When a category
 isn't reporting — scanning switched off, a token that can't read it, or a check that
-didn't complete — the tab says which and why, and (with repo-admin access) **Open
-security settings** goes straight to Repository settings → Security to turn scanning on.
+didn't complete — the tab says which and why; for the three scanning categories, **Open
+security settings** (with repo-admin access) goes straight to Repository settings →
+Security to turn scanning on. Repository advisories have no such switch — they're only
+published on public repositories.
 
 **Insights** — a repository-graphs tab (Ctrl/Cmd-9): commit activity, code
 frequency (additions vs. deletions), contributor churn, and a commit punch card —

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ themselves up to date (see [Updates](#updates)). Prefer to build from source? Se
   or failed), cancel, dispatch a workflow, and read failed-step logs — none of
   which GitHub Desktop does.
 - **Security findings, in-app** — a **Findings** tab lists a GitHub repo's open
-  **Dependabot alerts**, grouped by vulnerable package with severity and the first
-  patched version, alongside the repository's **security advisories** — each one a
-  click from its page on GitHub, and one click from turning scanning on when it's off.
+  **Dependabot alerts** (grouped by vulnerable package, each row with its severity and
+  first patched version), its **code scanning** and **secret scanning** alerts, and the
+  repository's **security advisories**. Select a row for its detail — for a Dependabot
+  alert that adds CVSS base metrics, CWEs, labeled references, and whether the
+  dependency is direct or transitive — then open it on GitHub. A category that isn't
+  switched on says so, with a jump to the settings that enable it if you're a repo
+  admin.
 - **Explore repositories** — a full-page browser across **GitHub, GitLab & Bitbucket**:
   before you type it shows **your own repositories** (grouped by owner) and a **Popular**
   star-sorted feed (GitHub & GitLab); typing searches GitHub, all public GitLab projects,
@@ -588,13 +592,15 @@ CI badge in the header, and run-completion notifications.
 
 **Findings** — a tab (More ▾) for a GitHub repo's open **Dependabot alerts**,
 grouped by the vulnerable package, each with its severity, affected version range,
-first patched version, and a CVSS score when GitHub has one — plus the
-**security advisories** published
-on the repository itself. Select a row for the detail, then open it on GitHub.
-When a category isn't reporting — alerts switched off, a token that can't read
-them, or a check that didn't complete — the tab says which and why, and
-**Open security settings** goes straight to Repository settings → Security to
-turn scanning on.
+first patched version, and a CVSS score when GitHub has one — plus **code scanning**
+alerts, **secret scanning** alerts with a **validity** chip for the leaked credential,
+and the **security advisories** published on the repository itself. Select a row for
+the detail, then open it on GitHub; a Dependabot alert's detail adds a base-metric
+table per CVSS version the advisory carries (3.x and 4.0), its CWEs, labeled reference
+links, and whether the package is a direct or transitive dependency. When a category
+isn't reporting — scanning switched off, a token that can't read it, or a check that
+didn't complete — the tab says which and why, and (with repo-admin access) **Open
+security settings** goes straight to Repository settings → Security to turn scanning on.
 
 **Insights** — a repository-graphs tab (Ctrl/Cmd-9): commit activity, code
 frequency (additions vs. deletions), contributor churn, and a commit punch card —

--- a/changelog.d/added-findings-scanning-arms.md
+++ b/changelog.d/added-findings-scanning-arms.md
@@ -1,0 +1,8 @@
+- **Code scanning and secret scanning in the Findings tab.** The tab now lists a
+  GitHub repo's open code scanning alerts (grouped by rule) and secret scanning alerts
+  (grouped by kind, each with a validity chip for the leaked credential) next to its
+  Dependabot alerts and security advisories, and a Dependabot alert's detail spells out
+  a base-metric table per CVSS version the advisory carries, its CWEs, its references
+  as labeled links, and whether the vulnerable package is a direct or transitive
+  dependency. A category the repository hasn't switched on says so and, with repo-admin
+  access, offers **Open security settings** to turn it on.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -291,7 +291,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "CI, tags & releases",
-    label: "Findings tab — Dependabot alerts & security advisories",
+    label:
+      "Findings tab — Dependabot, code & secret scanning alerts, advisories",
     highlight: true,
   },
 

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -32,9 +32,10 @@ pub struct Capabilities {
     pub ci: bool,
     pub webhooks: bool,
     pub approvals: bool,
-    /// Reading the platform's own vulnerability findings (Dependabot alerts +
-    /// repository security advisories). GitHub-only — GitLab's equivalent is a
-    /// paid-tier security dashboard and Bitbucket Cloud has no analogue.
+    /// Reading the platform's own vulnerability findings (Dependabot, code
+    /// scanning and secret scanning alerts + repository security advisories).
+    /// GitHub-only — GitLab's equivalent is a paid-tier security dashboard and
+    /// Bitbucket Cloud has no analogue.
     pub security_findings: bool,
 }
 

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -646,11 +646,17 @@ fn reference_label(url: &str) -> String {
     }
 }
 
-/// Drops entries with no URL: a reference is only ever rendered as a link.
+/// Drops anything that isn't an http(s) link. An advisory's references are
+/// community-contributed, and this row renders as an openable link — no other
+/// scheme has a meaning here worth handing to the opener.
 fn references_out(raw: Option<Vec<RawReference>>) -> Vec<ReferenceOut> {
     raw.unwrap_or_default()
         .into_iter()
-        .filter_map(|r| r.url.filter(|u| !u.is_empty()))
+        .filter_map(|r| r.url)
+        .filter(|u| {
+            let lower = u.to_ascii_lowercase();
+            lower.starts_with("http://") || lower.starts_with("https://")
+        })
         .map(|url| ReferenceOut {
             label: reference_label(&url),
             url,
@@ -2041,7 +2047,8 @@ mod tests {
 
     #[test]
     fn advisory_detail_lists_drop_unusable_entries() {
-        // A reference with no URL can't be a link and a CWE with no id can't be named.
+        // Only http(s) survives: a reference is rendered as an openable link, and the
+        // list is community-contributed, so a mail address or a local path is not one.
         let references = references_out(Some(vec![
             RawReference {
                 url: Some("https://nvd.nist.gov/vuln/detail/CVE-1".into()),
@@ -2049,6 +2056,15 @@ mod tests {
             RawReference { url: None },
             RawReference {
                 url: Some(String::new()),
+            },
+            RawReference {
+                url: Some("mailto:security@example.com".into()),
+            },
+            RawReference {
+                url: Some("file:///C:/Windows/System32/drivers/etc/hosts".into()),
+            },
+            RawReference {
+                url: Some("not a url".into()),
             },
         ]));
         assert_eq!(references.len(), 1);

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -1,5 +1,6 @@
-//! Read side of GitHub's security surface: the repo's open Dependabot alerts and
-//! its published security advisories, for the Findings tab.
+//! Read side of GitHub's security surface for the Findings tab: the repo's open
+//! Dependabot, code scanning and secret scanning alerts, plus its published
+//! security advisories.
 //!
 //! Every list rides an availability envelope. A repo with the feature off, a token
 //! without access, and an unrecognized failure are all distinct from "genuinely
@@ -57,9 +58,112 @@ pub struct DependabotAlertOut {
     pub ghsa_id: String,
     pub cve_id: Option<String>,
     pub cvss_score: Option<f64>,
+    /// GitHub's dependency relationship ("direct" | "transitive"), verbatim so an
+    /// unrecognized value renders instead of being dropped.
+    pub relationship: Option<String>,
+    /// v3 before v4 when the advisory carries both; empty when it scores neither.
+    pub cvss: Vec<CvssOut>,
+    pub references: Vec<ReferenceOut>,
+    pub cwes: Vec<CweOut>,
     pub vulnerable_version_range: Option<String>,
     /// `None` when no fix has shipped yet.
     pub first_patched_version: Option<String>,
+    pub html_url: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CvssOut {
+    /// Read off the vector's own prefix ("3.1", "4.0"); empty when the vector
+    /// carries no recognizable one, since the slot alone can't name the revision.
+    pub version: String,
+    pub score: Option<f64>,
+    pub vector_string: String,
+    /// Decoded base metrics in canonical order; empty when the vector is foreign,
+    /// which is the view's cue to fall back to the raw string.
+    pub metrics: Vec<CvssMetricOut>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CvssMetricOut {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReferenceOut {
+    pub url: String,
+    /// Derived here: the wire carries a bare URL with no title.
+    pub label: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CweOut {
+    pub cwe_id: String,
+    pub name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodeScanningAlertsOut {
+    pub availability: FindingAvailability,
+    pub detail: Option<String>,
+    pub alerts: Vec<CodeScanningAlertOut>,
+    pub truncated: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodeScanningAlertOut {
+    pub number: i64,
+    pub state: String,
+    pub rule_id: String,
+    pub rule_name: Option<String>,
+    pub rule_description: Option<String>,
+    /// The SARIF level ("note" | "warning" | "error"), raw — it is a different
+    /// scale from `security_severity` and collapsing the two mislabels findings.
+    pub severity: Option<String>,
+    /// `rule.security_severity_level` ("low" … "critical"), raw.
+    pub security_severity: Option<String>,
+    pub tool_name: String,
+    pub tool_version: Option<String>,
+    pub path: String,
+    pub start_line: Option<i64>,
+    pub message: String,
+    /// The ref the alert was last seen on. `ref` is a Rust keyword, so the wire
+    /// key is pinned by hand.
+    #[serde(rename = "ref")]
+    pub git_ref: Option<String>,
+    pub html_url: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretScanningAlertsOut {
+    pub availability: FindingAvailability,
+    pub detail: Option<String>,
+    pub alerts: Vec<SecretScanningAlertOut>,
+    pub truncated: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretScanningAlertOut {
+    pub number: i64,
+    pub state: String,
+    pub secret_type: String,
+    pub secret_type_display_name: String,
+    /// active | inactive | unknown, raw.
+    pub validity: Option<String>,
+    pub publicly_leaked: Option<bool>,
+    pub resolution: Option<String>,
     pub html_url: String,
     pub created_at: String,
     pub updated_at: String,
@@ -116,12 +220,36 @@ struct RawPackage {
     ecosystem: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone)]
 struct RawCvss {
     #[serde(default)]
     score: Option<f64>,
     #[serde(default)]
     vector_string: Option<String>,
+}
+
+/// The per-revision scores. `cvss_v3` restates the legacy `cvss` field, which is
+/// the fallback for repos whose payload predates this object.
+#[derive(Deserialize, Default)]
+struct RawCvssSeverities {
+    #[serde(default)]
+    cvss_v3: Option<RawCvss>,
+    #[serde(default)]
+    cvss_v4: Option<RawCvss>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawReference {
+    #[serde(default)]
+    url: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCwe {
+    #[serde(default)]
+    cwe_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -132,6 +260,8 @@ struct RawDependency {
     manifest_path: Option<String>,
     #[serde(default)]
     scope: Option<String>,
+    #[serde(default)]
+    relationship: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -146,6 +276,12 @@ struct RawAlertAdvisory {
     cve_id: Option<String>,
     #[serde(default)]
     cvss: Option<RawCvss>,
+    #[serde(default)]
+    cvss_severities: Option<RawCvssSeverities>,
+    #[serde(default)]
+    references: Option<Vec<RawReference>>,
+    #[serde(default)]
+    cwes: Option<Vec<RawCwe>>,
 }
 
 #[derive(Deserialize, Default)]
@@ -225,6 +361,96 @@ struct RawRepoAdvisory {
     vulnerabilities: Option<Vec<RawAdvisoryVulnerability>>,
 }
 
+#[derive(Deserialize, Default)]
+struct RawCodeScanningRule {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    security_severity_level: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCodeScanningTool {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawInstanceMessage {
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawInstanceLocation {
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    start_line: Option<i64>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCodeScanningInstance {
+    #[serde(default, rename = "ref")]
+    git_ref: Option<String>,
+    #[serde(default)]
+    message: Option<RawInstanceMessage>,
+    #[serde(default)]
+    location: Option<RawInstanceLocation>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCodeScanningAlert {
+    #[serde(default)]
+    number: Option<i64>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    rule: Option<RawCodeScanningRule>,
+    #[serde(default)]
+    tool: Option<RawCodeScanningTool>,
+    #[serde(default)]
+    most_recent_instance: Option<RawCodeScanningInstance>,
+    #[serde(default)]
+    html_url: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawSecretScanningAlert {
+    #[serde(default)]
+    number: Option<i64>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    secret_type: Option<String>,
+    #[serde(default)]
+    secret_type_display_name: Option<String>,
+    #[serde(default)]
+    validity: Option<String>,
+    #[serde(default)]
+    publicly_leaked: Option<bool>,
+    #[serde(default)]
+    resolution: Option<String>,
+    #[serde(default)]
+    html_url: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+}
+
 /// GitHub reports an absent CVSS as a score with a null vector (often `0.0`), so a
 /// null vector reads as "no score" rather than a real zero.
 fn cvss_score(cvss: Option<RawCvss>) -> Option<f64> {
@@ -233,6 +459,216 @@ fn cvss_score(cvss: Option<RawCvss>) -> Option<f64> {
         Some(v) if !v.is_empty() => cvss.score,
         _ => None,
     }
+}
+
+/// One base metric: its key, its full label, and the letters it defines. Values
+/// outside the list pass through raw — inventing a label would misstate the score.
+type MetricSpec = (
+    &'static str,
+    &'static str,
+    &'static [(&'static str, &'static str)],
+);
+
+const NONE_LOW_HIGH: &[(&str, &str)] = &[("N", "None"), ("L", "Low"), ("H", "High")];
+const ATTACK_VECTOR: &[(&str, &str)] = &[
+    ("N", "Network"),
+    ("A", "Adjacent"),
+    ("L", "Local"),
+    ("P", "Physical"),
+];
+const LOW_HIGH: &[(&str, &str)] = &[("L", "Low"), ("H", "High")];
+
+/// CVSS v3 base metrics in the order GitHub's own table shows them.
+const CVSS_V3_BASE: &[MetricSpec] = &[
+    ("AV", "Attack vector", ATTACK_VECTOR),
+    ("AC", "Attack complexity", LOW_HIGH),
+    ("PR", "Privileges required", NONE_LOW_HIGH),
+    (
+        "UI",
+        "User interaction",
+        &[("N", "None"), ("R", "Required")],
+    ),
+    ("S", "Scope", &[("U", "Unchanged"), ("C", "Changed")]),
+    ("C", "Confidentiality", NONE_LOW_HIGH),
+    ("I", "Integrity", NONE_LOW_HIGH),
+    ("A", "Availability", NONE_LOW_HIGH),
+];
+
+/// CVSS v4 base metrics. v4 renames the impact metrics and adds attack
+/// requirements, so a v3 table applied to a v4 vector would mislabel it.
+const CVSS_V4_BASE: &[MetricSpec] = &[
+    ("AV", "Attack vector", ATTACK_VECTOR),
+    ("AC", "Attack complexity", LOW_HIGH),
+    (
+        "AT",
+        "Attack requirements",
+        &[("N", "None"), ("P", "Present")],
+    ),
+    ("PR", "Privileges required", NONE_LOW_HIGH),
+    (
+        "UI",
+        "User interaction",
+        &[("N", "None"), ("P", "Passive"), ("A", "Active")],
+    ),
+    ("VC", "Vulnerable system confidentiality", NONE_LOW_HIGH),
+    ("VI", "Vulnerable system integrity", NONE_LOW_HIGH),
+    ("VA", "Vulnerable system availability", NONE_LOW_HIGH),
+    ("SC", "Subsequent system confidentiality", NONE_LOW_HIGH),
+    ("SI", "Subsequent system integrity", NONE_LOW_HIGH),
+    ("SA", "Subsequent system availability", NONE_LOW_HIGH),
+];
+
+/// The revision a vector declares, e.g. `CVSS:3.1/…` → `3.1`. Empty for anything
+/// else, since only the vector distinguishes 3.0 from 3.1.
+fn cvss_version(vector: &str) -> String {
+    vector
+        .split('/')
+        .next()
+        .and_then(|prefix| prefix.strip_prefix("CVSS:"))
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Decodes a vector's BASE metrics only — temporal, threat and environmental
+/// tokens carry no key in the tables above and are skipped, as is a foreign
+/// prefix, which yields no metrics at all rather than v3-labelled nonsense.
+fn cvss_metrics(vector: &str) -> Vec<CvssMetricOut> {
+    let mut parts = vector.split('/');
+    let table = match parts.next() {
+        Some("CVSS:3.0" | "CVSS:3.1") => CVSS_V3_BASE,
+        Some("CVSS:4.0") => CVSS_V4_BASE,
+        _ => return Vec::new(),
+    };
+    let tokens: Vec<(&str, &str)> = parts.filter_map(|p| p.split_once(':')).collect();
+    let mut metrics = Vec::new();
+    for &(key, label, values) in table {
+        let Some(raw) = tokens
+            .iter()
+            .find(|(k, _)| *k == key)
+            .map(|&(_, v)| v)
+            .filter(|v| !v.is_empty())
+        else {
+            continue;
+        };
+        let value = values
+            .iter()
+            .find(|(letter, _)| *letter == raw)
+            .map_or(raw, |&(_, name)| name);
+        metrics.push(CvssMetricOut {
+            label: label.to_string(),
+            value: value.to_string(),
+        });
+    }
+    metrics
+}
+
+/// One scored revision, or nothing: a null/empty vector means GitHub has no score
+/// here, and its companion `score` (often `0.0`) is not a real zero.
+fn cvss_out(cvss: RawCvss) -> Option<CvssOut> {
+    let vector = cvss.vector_string.filter(|v| !v.is_empty())?;
+    Some(CvssOut {
+        version: cvss_version(&vector),
+        score: cvss.score,
+        metrics: cvss_metrics(&vector),
+        vector_string: vector,
+    })
+}
+
+/// The advisory's scores, v3 first. The legacy `cvss` field stands in for a v3
+/// entry the newer `cvss_severities` object doesn't carry.
+fn cvss_list(severities: Option<RawCvssSeverities>, legacy: Option<RawCvss>) -> Vec<CvssOut> {
+    let severities = severities.unwrap_or_default();
+    let v3_slot_is_legacy = severities.cvss_v3.is_none();
+    let mut list: Vec<CvssOut> = [severities.cvss_v3.or(legacy), severities.cvss_v4]
+        .into_iter()
+        .flatten()
+        .filter_map(cvss_out)
+        .collect();
+    // The legacy field names no revision, so on a v4-only advisory it can restate
+    // the v4 vector and list the same score twice. `cvss_severities` is the
+    // authoritative source when the two collide.
+    if list.len() == 2 && list[0].version == list[1].version {
+        list.remove(if v3_slot_is_legacy { 0 } else { 1 });
+    }
+    list
+}
+
+/// Splits a URL into its lowercased host (no `www.`, userinfo or port) and its
+/// path. `None` when there is no scheme-delimited authority to read.
+fn split_url(url: &str) -> Option<(String, &str)> {
+    let after_scheme = url.split_once("://")?.1;
+    let hierarchical = after_scheme
+        .split_at(after_scheme.find(['?', '#']).unwrap_or(after_scheme.len()))
+        .0;
+    let (authority, path) =
+        hierarchical.split_at(hierarchical.find('/').unwrap_or(hierarchical.len()));
+    let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    // Case-fold before stripping `www.`: hosts are case-insensitive, so an
+    // upper-case prefix has to fall away too.
+    let lower = host
+        .split_once(':')
+        .map_or(host, |(h, _)| h)
+        .to_ascii_lowercase();
+    let host = lower.strip_prefix("www.").unwrap_or(&lower);
+    (!host.is_empty()).then(|| (host.to_string(), path))
+}
+
+/// A short label for a bare reference URL — GitHub sends no title, and an
+/// unlabelled link is unreadable in the detail pane.
+fn reference_label(url: &str) -> String {
+    let Some((host, path)) = split_url(url) else {
+        return url.to_string();
+    };
+    if host == "nvd.nist.gov" {
+        return "NVD".to_string();
+    }
+    if host != "github.com" {
+        return host;
+    }
+    let is_ghsa = path.split('/').any(|seg| {
+        seg.as_bytes()
+            .get(..5)
+            .is_some_and(|p| p.eq_ignore_ascii_case(b"GHSA-"))
+    });
+    if path.contains("/commit/") {
+        "Commit".to_string()
+    } else if path.contains("/releases/tag/") {
+        "Release".to_string()
+    } else if path.contains("/advisories/") || is_ghsa {
+        "Advisory".to_string()
+    } else if path.contains("/pull/") {
+        "Pull request".to_string()
+    } else if path.contains("/issues/") {
+        "Issue".to_string()
+    } else {
+        host
+    }
+}
+
+/// Drops entries with no URL: a reference is only ever rendered as a link.
+fn references_out(raw: Option<Vec<RawReference>>) -> Vec<ReferenceOut> {
+    raw.unwrap_or_default()
+        .into_iter()
+        .filter_map(|r| r.url.filter(|u| !u.is_empty()))
+        .map(|url| ReferenceOut {
+            label: reference_label(&url),
+            url,
+        })
+        .collect()
+}
+
+/// Drops entries with no CWE id — the id is the row's identity and its link target.
+fn cwes_out(raw: Option<Vec<RawCwe>>) -> Vec<CweOut> {
+    raw.unwrap_or_default()
+        .into_iter()
+        .filter_map(|c| {
+            let cwe_id = c.cwe_id.filter(|id| !id.is_empty())?;
+            Some(CweOut {
+                cwe_id,
+                name: c.name.unwrap_or_default(),
+            })
+        })
+        .collect()
 }
 
 fn alert_out(raw: RawAlert) -> DependabotAlertOut {
@@ -254,7 +690,11 @@ fn alert_out(raw: RawAlert) -> DependabotAlertOut {
         description: advisory.description.unwrap_or_default(),
         ghsa_id: advisory.ghsa_id.unwrap_or_default(),
         cve_id: advisory.cve_id,
-        cvss_score: cvss_score(advisory.cvss),
+        cvss_score: cvss_score(advisory.cvss.clone()),
+        relationship: dependency.relationship,
+        cvss: cvss_list(advisory.cvss_severities, advisory.cvss),
+        references: references_out(advisory.references),
+        cwes: cwes_out(advisory.cwes),
         vulnerable_version_range: vulnerability.vulnerable_version_range,
         first_patched_version: vulnerability
             .first_patched_version
@@ -293,6 +733,46 @@ fn advisory_out(raw: RawRepoAdvisory) -> RepoAdvisoryOut {
                 }
             })
             .collect(),
+    }
+}
+
+fn code_scanning_alert_out(raw: RawCodeScanningAlert) -> CodeScanningAlertOut {
+    let rule = raw.rule.unwrap_or_default();
+    let tool = raw.tool.unwrap_or_default();
+    let instance = raw.most_recent_instance.unwrap_or_default();
+    let location = instance.location.unwrap_or_default();
+    CodeScanningAlertOut {
+        number: raw.number.unwrap_or(0),
+        state: raw.state.unwrap_or_default(),
+        rule_id: rule.id.unwrap_or_default(),
+        rule_name: rule.name,
+        rule_description: rule.description,
+        severity: rule.severity,
+        security_severity: rule.security_severity_level,
+        tool_name: tool.name.unwrap_or_default(),
+        tool_version: tool.version,
+        path: location.path.unwrap_or_default(),
+        start_line: location.start_line,
+        message: instance.message.and_then(|m| m.text).unwrap_or_default(),
+        git_ref: instance.git_ref,
+        html_url: raw.html_url.unwrap_or_default(),
+        created_at: raw.created_at.unwrap_or_default(),
+        updated_at: raw.updated_at.unwrap_or_default(),
+    }
+}
+
+fn secret_scanning_alert_out(raw: RawSecretScanningAlert) -> SecretScanningAlertOut {
+    SecretScanningAlertOut {
+        number: raw.number.unwrap_or(0),
+        state: raw.state.unwrap_or_default(),
+        secret_type: raw.secret_type.unwrap_or_default(),
+        secret_type_display_name: raw.secret_type_display_name.unwrap_or_default(),
+        validity: raw.validity,
+        publicly_leaked: raw.publicly_leaked,
+        resolution: raw.resolution,
+        html_url: raw.html_url.unwrap_or_default(),
+        created_at: raw.created_at.unwrap_or_default(),
+        updated_at: raw.updated_at.unwrap_or_default(),
     }
 }
 
@@ -380,9 +860,22 @@ fn classify_failure(stdout_body: &str, stderr: &str) -> (FindingAvailability, Op
         return (FindingAvailability::Indeterminate, detail);
     };
     let lower = message.to_lowercase();
-    if lower.contains("disabled") {
+    // Each arm words "off for this repo" differently: Dependabot says "disabled",
+    // code scanning says "not enabled", and a scanned-but-never-analyzed repo
+    // answers "no analysis found" — none of them mean the repo is clean.
+    if lower.contains("disabled")
+        || lower.contains("not enabled")
+        || lower.contains("no analysis found")
+    {
         (FindingAvailability::NotEnabled, detail)
-    } else if lower.contains("not authorized") || lower.contains("forbidden") {
+    } else if lower.contains("not authorized")
+        || lower.contains("forbidden")
+        || lower.contains("not accessible")
+        || lower.contains("must have admin")
+    {
+        // The scanning endpoints refuse an under-scoped token in their own words
+        // ("Resource not accessible by…", "You must have admin permissions to…");
+        // as Indeterminate they would offer a Retry that can never succeed.
         (FindingAvailability::Forbidden, detail)
     } else {
         (FindingAvailability::Indeterminate, detail)
@@ -398,7 +891,22 @@ enum Fetched {
     Unavailable {
         availability: FindingAvailability,
         detail: Option<String>,
+        /// The response's status code when the status line was readable; arm-level
+        /// rules need it to tell a bare 404 from a same-worded failure.
+        status: Option<u16>,
     },
+}
+
+/// The status code off gh's echoed status line (`HTTP/2.0 404 Not Found`).
+fn parse_status(headers: &str) -> Option<u16> {
+    headers
+        .lines()
+        .next()?
+        .strip_prefix("HTTP/")?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
 }
 
 /// The page-walk ceiling. gh's `--paginate` is unbounded, so the walk follows the
@@ -453,6 +961,7 @@ async fn fetch_paged(repo_path: &str, base_path: &str, limit: usize) -> AppResul
             return Ok(Fetched::Unavailable {
                 availability,
                 detail,
+                status: parse_status(headers),
             });
         }
         let page: Vec<Value> = serde_json::from_str(body.trim())
@@ -498,6 +1007,7 @@ fn alerts_envelope(fetched: Fetched) -> DependabotAlertsOut {
         Fetched::Unavailable {
             availability,
             detail,
+            ..
         } => DependabotAlertsOut {
             availability,
             detail,
@@ -524,13 +1034,31 @@ fn alerts_envelope(fetched: Fetched) -> DependabotAlertsOut {
     }
 }
 
+/// Repository advisories exist only on public repos; a private one answers the
+/// endpoint with a bare `404 Not Found`, which the generic classifier can only
+/// read as an error. Scoped to this arm — elsewhere a 404 stays indeterminate.
+fn advisories_availability(
+    availability: FindingAvailability,
+    detail: Option<&str>,
+    status: Option<u16>,
+) -> FindingAvailability {
+    if availability == FindingAvailability::Indeterminate
+        && status == Some(404)
+        && detail == Some("Not Found")
+    {
+        return FindingAvailability::NotEnabled;
+    }
+    availability
+}
+
 fn advisories_envelope(fetched: Fetched) -> RepoAdvisoriesOut {
     match fetched {
         Fetched::Unavailable {
             availability,
             detail,
+            status,
         } => RepoAdvisoriesOut {
-            availability,
+            availability: advisories_availability(availability, detail.as_deref(), status),
             detail,
             advisories: Vec::new(),
             truncated: false,
@@ -549,6 +1077,70 @@ fn advisories_envelope(fetched: Fetched) -> RepoAdvisoriesOut {
                     if total == 1 { "advisory" } else { "advisories" }
                 )),
                 advisories: Vec::new(),
+                truncated: false,
+            },
+        },
+    }
+}
+
+fn code_scanning_envelope(fetched: Fetched) -> CodeScanningAlertsOut {
+    match fetched {
+        Fetched::Unavailable {
+            availability,
+            detail,
+            ..
+        } => CodeScanningAlertsOut {
+            availability,
+            detail,
+            alerts: Vec::new(),
+            truncated: false,
+        },
+        Fetched::Items { items, truncated } => match parse_items::<RawCodeScanningAlert>(items) {
+            ParsedItems::Items(raw) => CodeScanningAlertsOut {
+                availability: FindingAvailability::Available,
+                detail: None,
+                alerts: raw.into_iter().map(code_scanning_alert_out).collect(),
+                truncated,
+            },
+            ParsedItems::AllUnreadable(total) => CodeScanningAlertsOut {
+                availability: FindingAvailability::Indeterminate,
+                detail: Some(format!(
+                    "GitHub returned {total} {} this build couldn't read",
+                    if total == 1 { "alert" } else { "alerts" }
+                )),
+                alerts: Vec::new(),
+                truncated: false,
+            },
+        },
+    }
+}
+
+fn secret_scanning_envelope(fetched: Fetched) -> SecretScanningAlertsOut {
+    match fetched {
+        Fetched::Unavailable {
+            availability,
+            detail,
+            ..
+        } => SecretScanningAlertsOut {
+            availability,
+            detail,
+            alerts: Vec::new(),
+            truncated: false,
+        },
+        Fetched::Items { items, truncated } => match parse_items::<RawSecretScanningAlert>(items) {
+            ParsedItems::Items(raw) => SecretScanningAlertsOut {
+                availability: FindingAvailability::Available,
+                detail: None,
+                alerts: raw.into_iter().map(secret_scanning_alert_out).collect(),
+                truncated,
+            },
+            ParsedItems::AllUnreadable(total) => SecretScanningAlertsOut {
+                availability: FindingAvailability::Indeterminate,
+                detail: Some(format!(
+                    "GitHub returned {total} {} this build couldn't read",
+                    if total == 1 { "alert" } else { "alerts" }
+                )),
+                alerts: Vec::new(),
                 truncated: false,
             },
         },
@@ -579,6 +1171,34 @@ pub async fn gh_repo_advisories(
     let base = format!("repos/{slug}/security-advisories?per_page=100");
     let fetched = fetch_paged(&repo_path, &base, clamp_limit(limit)).await?;
     Ok(advisories_envelope(fetched))
+}
+
+/// The repo's OPEN code scanning alerts.
+#[tauri::command]
+pub async fn gh_code_scanning_alerts(
+    repo_path: String,
+    limit: Option<u32>,
+) -> AppResult<CodeScanningAlertsOut> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let base = format!("repos/{slug}/code-scanning/alerts?state=open&per_page=100");
+    let fetched = fetch_paged(&repo_path, &base, clamp_limit(limit)).await?;
+    Ok(code_scanning_envelope(fetched))
+}
+
+/// The repo's OPEN secret scanning alerts.
+#[tauri::command]
+pub async fn gh_secret_scanning_alerts(
+    repo_path: String,
+    limit: Option<u32>,
+) -> AppResult<SecretScanningAlertsOut> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // `hide_secret` keeps the literal leaked credential out of the response, so it
+    // never reaches this process's memory or gh's logging — the app only ever needs
+    // the alert's metadata.
+    let base =
+        format!("repos/{slug}/secret-scanning/alerts?state=open&per_page=100&hide_secret=true");
+    let fetched = fetch_paged(&repo_path, &base, clamp_limit(limit)).await?;
+    Ok(secret_scanning_envelope(fetched))
 }
 
 #[cfg(test)]
@@ -879,6 +1499,15 @@ mod tests {
                     "ghsaId": "GHSA-8j4g-w8fx-2239",
                     "cveId": "CVE-2026-69207",
                     "cvssScore": 5.3,
+                    "relationship": "transitive",
+                    "cvss": [{
+                        "version": "3.1",
+                        "score": 5.3,
+                        "vectorString": "CVSS:3.1/AV:N",
+                        "metrics": [{ "label": "Attack vector", "value": "Network" }]
+                    }],
+                    "references": [],
+                    "cwes": [],
                     "vulnerableVersionRange": "< 4.12.34",
                     "firstPatchedVersion": "4.12.34",
                     "htmlUrl": "https://github.com/theBGuy/GitDesktop/security/dependabot/29",
@@ -1067,6 +1696,654 @@ mod tests {
         assert_eq!(
             page_outcome(2, 5, 2, NextPage::None),
             PageOutcome::Stop { truncated: false }
+        );
+    }
+
+    #[test]
+    fn classify_failure_reads_code_scanning_off_as_not_enabled() {
+        // Measured against a private repo with code scanning off (403). "not enabled"
+        // is code scanning's own wording — nothing in it says "disabled".
+        let (availability, detail) = classify_failure(
+            r#"{"message":"Code scanning is not enabled for this repository. Please enable code scanning in the repository settings."}"#,
+            "gh: Code scanning is not enabled for this repository. (HTTP 403)",
+        );
+        assert_eq!(availability, FindingAvailability::NotEnabled);
+        assert_eq!(
+            detail.as_deref(),
+            Some("Code scanning is not enabled for this repository. Please enable code scanning in the repository settings.")
+        );
+        // A public repo that has never run an analysis (404) is likewise "off", not clean.
+        let (availability, detail) =
+            classify_failure(r#"{"message":"no analysis found"}"#, "gh: HTTP 404");
+        assert_eq!(availability, FindingAvailability::NotEnabled);
+        assert_eq!(detail.as_deref(), Some("no analysis found"));
+    }
+
+    #[test]
+    fn classify_failure_reads_secret_scanning_off_as_not_enabled() {
+        let (availability, detail) = classify_failure(
+            r#"{"message":"Secret scanning is disabled on this repository.","status":"404"}"#,
+            "gh: Secret scanning is disabled on this repository. (HTTP 404)",
+        );
+        assert_eq!(availability, FindingAvailability::NotEnabled);
+        assert_eq!(
+            detail.as_deref(),
+            Some("Secret scanning is disabled on this repository.")
+        );
+    }
+
+    #[test]
+    fn classify_failure_reads_a_scanning_refusal_as_forbidden() {
+        // GitHub's documented refusal wordings for these endpoints (not live-measured
+        // — no under-scoped token was available to probe with). As Indeterminate they
+        // would offer the user a Retry that can never succeed.
+        for message in [
+            "Resource not accessible by personal access token",
+            "You must have admin permissions to the repository to use this endpoint.",
+        ] {
+            let body = json!({ "message": message }).to_string();
+            let (availability, detail) = classify_failure(&body, "gh: HTTP 403");
+            assert_eq!(availability, FindingAvailability::Forbidden, "{message}");
+            assert_eq!(detail.as_deref(), Some(message));
+        }
+    }
+
+    #[test]
+    fn parse_status_reads_the_status_line() {
+        assert_eq!(
+            parse_status("HTTP/2.0 404 Not Found\r\nServer: github.com\r\n"),
+            Some(404)
+        );
+        assert_eq!(parse_status("HTTP/1.1 200 OK\r\n"), Some(200));
+        // No status line (gh printed only a body) leaves the code unknown.
+        assert_eq!(parse_status(""), None);
+        assert_eq!(parse_status("Server: github.com\r\n"), None);
+    }
+
+    #[test]
+    fn advisories_read_a_bare_not_found_as_not_enabled() {
+        // Advisories exist only on public repos; a private one 404s with "Not Found",
+        // which as Indeterminate would read to the user as a failure.
+        let out = advisories_envelope(Fetched::Unavailable {
+            availability: FindingAvailability::Indeterminate,
+            detail: Some("Not Found".into()),
+            status: Some(404),
+        });
+        assert_eq!(out.availability, FindingAvailability::NotEnabled);
+        assert_eq!(out.detail.as_deref(), Some("Not Found"));
+        // The override is scoped to this arm: elsewhere a bare 404 stays unknown.
+        let out = alerts_envelope(Fetched::Unavailable {
+            availability: FindingAvailability::Indeterminate,
+            detail: Some("Not Found".into()),
+            status: Some(404),
+        });
+        assert_eq!(out.availability, FindingAvailability::Indeterminate);
+        // A different message, or an unreadable status, is not the private-repo case.
+        for (detail, status) in [
+            (Some("Bad credentials".to_string()), Some(404)),
+            (Some("Not Found".to_string()), Some(502)),
+            (Some("Not Found".to_string()), None),
+        ] {
+            let out = advisories_envelope(Fetched::Unavailable {
+                availability: FindingAvailability::Indeterminate,
+                detail,
+                status,
+            });
+            assert_eq!(out.availability, FindingAvailability::Indeterminate);
+        }
+        // A classified failure is never re-read by the override.
+        let out = advisories_envelope(Fetched::Unavailable {
+            availability: FindingAvailability::Forbidden,
+            detail: Some("Not Found".into()),
+            status: Some(404),
+        });
+        assert_eq!(out.availability, FindingAvailability::Forbidden);
+    }
+
+    fn metric_pairs(metrics: &[CvssMetricOut]) -> Vec<(&str, &str)> {
+        metrics
+            .iter()
+            .map(|m| (m.label.as_str(), m.value.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn cvss_v3_vector_decodes_to_the_base_table() {
+        let metrics = cvss_metrics("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H");
+        assert_eq!(
+            metric_pairs(&metrics),
+            vec![
+                ("Attack vector", "Network"),
+                ("Attack complexity", "High"),
+                ("Privileges required", "None"),
+                ("User interaction", "None"),
+                ("Scope", "Unchanged"),
+                ("Confidentiality", "None"),
+                ("Integrity", "None"),
+                ("Availability", "High"),
+            ]
+        );
+        // 3.0 shares the table.
+        assert_eq!(cvss_metrics("CVSS:3.0/AV:L/AC:L").len(), 2);
+    }
+
+    #[test]
+    fn cvss_v4_vector_decodes_to_its_own_base_table() {
+        let metrics =
+            cvss_metrics("CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N");
+        assert_eq!(
+            metric_pairs(&metrics),
+            vec![
+                ("Attack vector", "Network"),
+                ("Attack complexity", "Low"),
+                ("Attack requirements", "Present"),
+                ("Privileges required", "None"),
+                ("User interaction", "None"),
+                ("Vulnerable system confidentiality", "None"),
+                ("Vulnerable system integrity", "None"),
+                ("Vulnerable system availability", "High"),
+                ("Subsequent system confidentiality", "None"),
+                ("Subsequent system integrity", "None"),
+                ("Subsequent system availability", "None"),
+            ]
+        );
+    }
+
+    #[test]
+    fn cvss_metric_table_is_chosen_by_the_prefix() {
+        // v4-only keys inside a v3 vector are skipped rather than mislabelled, and
+        // v3-only keys inside a v4 vector likewise — "UI:P" means Passive only in v4.
+        let v3 = cvss_metrics("CVSS:3.1/AV:N/AT:P/VC:H/S:C/UI:R");
+        assert_eq!(
+            metric_pairs(&v3),
+            vec![
+                ("Attack vector", "Network"),
+                ("User interaction", "Required"),
+                ("Scope", "Changed"),
+            ]
+        );
+        let v4 = cvss_metrics("CVSS:4.0/AV:N/S:C/C:H/UI:P");
+        assert_eq!(
+            metric_pairs(&v4),
+            vec![
+                ("Attack vector", "Network"),
+                ("User interaction", "Passive")
+            ]
+        );
+    }
+
+    #[test]
+    fn cvss_metrics_tolerate_unknown_tokens() {
+        // Temporal/threat/environmental tokens carry no base key and drop out; an
+        // unrecognized VALUE falls back to the raw letter rather than an invented label.
+        let metrics = cvss_metrics("CVSS:3.1/AV:X/AC:L/E:P/RL:O/RC:C/MAV:N/CR:H/ZZ:Q/PR:");
+        assert_eq!(
+            metric_pairs(&metrics),
+            vec![("Attack vector", "X"), ("Attack complexity", "Low")]
+        );
+    }
+
+    #[test]
+    fn a_foreign_vector_yields_no_metrics() {
+        // The view falls back to the raw vector string; guessing a table would print
+        // v3 labels over a v2 (or future) vector's letters.
+        for vector in [
+            "",
+            "not a vector",
+            "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "CVSS:2.0/AV:N/AC:L",
+            "CVSS:5.0/AV:N",
+        ] {
+            assert!(cvss_metrics(vector).is_empty(), "{vector}");
+        }
+    }
+
+    #[test]
+    fn cvss_entries_come_from_the_vector_not_the_score() {
+        // Both revisions, v3 first, each versioned off its own prefix.
+        let list = cvss_list(
+            Some(RawCvssSeverities {
+                cvss_v3: Some(RawCvss {
+                    score: Some(7.5),
+                    vector_string: Some("CVSS:3.1/AV:N/AC:L".into()),
+                }),
+                cvss_v4: Some(RawCvss {
+                    score: Some(8.7),
+                    vector_string: Some("CVSS:4.0/AV:N/AC:L".into()),
+                }),
+            }),
+            None,
+        );
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].version, "3.1");
+        assert_eq!(list[0].score, Some(7.5));
+        assert_eq!(list[0].vector_string, "CVSS:3.1/AV:N/AC:L");
+        assert_eq!(list[1].version, "4.0");
+        assert_eq!(list[1].score, Some(8.7));
+        // A null vector means "no score here" — the 0.0 alongside it is not a real zero.
+        let list = cvss_list(
+            Some(RawCvssSeverities {
+                cvss_v3: Some(RawCvss {
+                    score: Some(0.0),
+                    vector_string: None,
+                }),
+                cvss_v4: None,
+            }),
+            None,
+        );
+        assert!(list.is_empty());
+        // The legacy `cvss` field stands in for a missing v3 entry.
+        let list = cvss_list(
+            None,
+            Some(RawCvss {
+                score: Some(5.3),
+                vector_string: Some("CVSS:3.0/AV:N".into()),
+            }),
+        );
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].version, "3.0");
+        // A vector with no CVSS prefix keeps its raw string but claims no revision.
+        let list = cvss_list(
+            None,
+            Some(RawCvss {
+                score: Some(6.8),
+                vector_string: Some("AV:N/AC:L/Au:N".into()),
+            }),
+        );
+        assert_eq!(list[0].version, "");
+        assert!(list[0].metrics.is_empty());
+        assert_eq!(list[0].vector_string, "AV:N/AC:L/Au:N");
+    }
+
+    #[test]
+    fn a_legacy_vector_never_duplicates_a_scored_revision() {
+        // The legacy `cvss` field names no revision: on a v4-only advisory it can
+        // restate the v4 vector, which must not render as two identical scores.
+        let list = cvss_list(
+            Some(RawCvssSeverities {
+                cvss_v3: None,
+                cvss_v4: Some(RawCvss {
+                    score: Some(6.9),
+                    vector_string: Some("CVSS:4.0/AV:N/AC:L".into()),
+                }),
+            }),
+            Some(RawCvss {
+                score: Some(9.9),
+                vector_string: Some("CVSS:4.0/AV:N/AC:L".into()),
+            }),
+        );
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].version, "4.0");
+        // The surviving entry is the cvss_severities one, not the legacy restatement.
+        assert_eq!(list[0].score, Some(6.9));
+        // Genuinely different revisions still both survive.
+        let list = cvss_list(
+            Some(RawCvssSeverities {
+                cvss_v3: None,
+                cvss_v4: Some(RawCvss {
+                    score: Some(6.9),
+                    vector_string: Some("CVSS:4.0/AV:N/AC:L".into()),
+                }),
+            }),
+            Some(RawCvss {
+                score: Some(5.3),
+                vector_string: Some("CVSS:3.1/AV:N/AC:L".into()),
+            }),
+        );
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].version, "3.1");
+        assert_eq!(list[1].version, "4.0");
+    }
+
+    #[test]
+    fn reference_labels_name_the_link_target() {
+        for (url, expected) in [
+            ("https://nvd.nist.gov/vuln/detail/CVE-2026-69207", "NVD"),
+            ("https://github.com/honojs/hono/commit/abc123", "Commit"),
+            (
+                "https://github.com/honojs/hono/releases/tag/v4.12.34",
+                "Release",
+            ),
+            (
+                "https://github.com/honojs/hono/security/advisories/GHSA-8j4g-w8fx-2239",
+                "Advisory",
+            ),
+            // A GHSA id anywhere in the path is an advisory even off the advisories route.
+            (
+                "https://github.com/advisories/GHSA-8j4g-w8fx-2239",
+                "Advisory",
+            ),
+            ("https://github.com/honojs/hono/pull/4212", "Pull request"),
+            ("https://github.com/honojs/hono/issues/4211", "Issue"),
+            // No recognized route: the bare host, never an empty label.
+            ("https://github.com/honojs/hono", "github.com"),
+            ("https://www.cve.org/CVERecord?id=CVE-2026-69207", "cve.org"),
+            (
+                "https://lists.debian.org:8443/msg00001.html",
+                "lists.debian.org",
+            ),
+            ("http://EXAMPLE.COM/x", "example.com"),
+            ("https://WWW.Example.com/x", "example.com"),
+            // Nothing parseable to name it by: the URL labels itself.
+            ("not a url", "not a url"),
+            ("mailto:security@example.com", "mailto:security@example.com"),
+            ("https:///no-host/path", "https:///no-host/path"),
+        ] {
+            assert_eq!(reference_label(url), expected, "{url}");
+        }
+    }
+
+    #[test]
+    fn advisory_detail_lists_drop_unusable_entries() {
+        // A reference with no URL can't be a link and a CWE with no id can't be named.
+        let references = references_out(Some(vec![
+            RawReference {
+                url: Some("https://nvd.nist.gov/vuln/detail/CVE-1".into()),
+            },
+            RawReference { url: None },
+            RawReference {
+                url: Some(String::new()),
+            },
+        ]));
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].label, "NVD");
+        let cwes = cwes_out(Some(vec![
+            RawCwe {
+                cwe_id: Some("CWE-1333".into()),
+                name: Some("Inefficient Regular Expression Complexity".into()),
+            },
+            RawCwe {
+                cwe_id: None,
+                name: Some("orphan".into()),
+            },
+        ]));
+        assert_eq!(cwes.len(), 1);
+        assert_eq!(cwes[0].cwe_id, "CWE-1333");
+        assert_eq!(cwes[0].name, "Inefficient Regular Expression Complexity");
+        assert!(references_out(None).is_empty());
+        assert!(cwes_out(None).is_empty());
+    }
+
+    fn detailed_alert_fixture() -> Value {
+        let mut alert = alert_fixture(
+            json!({ "identifier": "4.12.34" }),
+            json!({ "score": 5.3, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H" }),
+        );
+        alert["security_advisory"]["cvss_severities"] = json!({
+            "cvss_v3": {
+                "score": 5.3,
+                "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+            },
+            "cvss_v4": {
+                "score": 6.9,
+                "vector_string": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+            }
+        });
+        alert["security_advisory"]["references"] = json!([
+            { "url": "https://github.com/honojs/hono/security/advisories/GHSA-8j4g-w8fx-2239" },
+            { "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-69207" }
+        ]);
+        alert["security_advisory"]["cwes"] = json!([
+            { "cwe_id": "CWE-1333", "name": "Inefficient Regular Expression Complexity" }
+        ]);
+        alert
+    }
+
+    #[test]
+    fn alert_maps_the_detail_fields() {
+        let raw: RawAlert =
+            serde_json::from_value(detailed_alert_fixture()).expect("alert fixture deserializes");
+        let out = alert_out(raw);
+        assert_eq!(out.relationship.as_deref(), Some("transitive"));
+        // The legacy cvss field still feeds cvssScore; the new list is separate.
+        assert_eq!(out.cvss_score, Some(5.3));
+        assert_eq!(out.cvss.len(), 2);
+        assert_eq!(out.cvss[0].version, "3.1");
+        assert_eq!(out.cvss[0].metrics.len(), 8);
+        assert_eq!(out.cvss[1].version, "4.0");
+        assert_eq!(out.cvss[1].score, Some(6.9));
+        assert_eq!(out.cvss[1].metrics.len(), 11);
+        assert_eq!(out.references.len(), 2);
+        assert_eq!(out.references[0].label, "Advisory");
+        assert_eq!(out.references[1].label, "NVD");
+        assert_eq!(out.cwes.len(), 1);
+        assert_eq!(out.cwes[0].cwe_id, "CWE-1333");
+    }
+
+    #[test]
+    fn alert_detail_fields_tolerate_a_stripped_item() {
+        let raw: RawAlert =
+            serde_json::from_value(json!({ "number": 7 })).expect("sparse alert deserializes");
+        let out = alert_out(raw);
+        assert_eq!(out.relationship, None);
+        assert!(out.cvss.is_empty());
+        assert!(out.references.is_empty());
+        assert!(out.cwes.is_empty());
+    }
+
+    fn code_scanning_fixture() -> Value {
+        json!({
+            "number": 4,
+            "state": "open",
+            "rule": {
+                "id": "js/zipslip",
+                "name": "js/zipslip",
+                "description": "Arbitrary file write during zip extraction",
+                "severity": "error",
+                "security_severity_level": "high",
+                "tags": ["security"]
+            },
+            "tool": { "name": "CodeQL", "guid": Value::Null, "version": "2.4.0" },
+            "most_recent_instance": {
+                "ref": "refs/heads/main",
+                "state": "open",
+                "commit_sha": "39406e42cb832f683daa691dd652a8dc36ee8930",
+                "message": { "text": "This path depends on a user-provided value." },
+                "location": {
+                    "path": "lib/ab12-gen.js",
+                    "start_line": 917,
+                    "end_line": 917,
+                    "start_column": 7,
+                    "end_column": 18
+                },
+                "classifications": ["library"]
+            },
+            "html_url": "https://github.com/theBGuy/GitDesktop/security/code-scanning/4",
+            "created_at": "2026-08-04T12:29:18Z",
+            "updated_at": "2026-08-05T12:29:18Z"
+        })
+    }
+
+    #[test]
+    fn code_scanning_alert_maps_every_field() {
+        let raw: RawCodeScanningAlert =
+            serde_json::from_value(code_scanning_fixture()).expect("fixture deserializes");
+        let out = code_scanning_alert_out(raw);
+        assert_eq!(out.number, 4);
+        assert_eq!(out.state, "open");
+        assert_eq!(out.rule_id, "js/zipslip");
+        assert_eq!(out.rule_name.as_deref(), Some("js/zipslip"));
+        assert_eq!(
+            out.rule_description.as_deref(),
+            Some("Arbitrary file write during zip extraction")
+        );
+        // The SARIF level and the security severity are separate scales.
+        assert_eq!(out.severity.as_deref(), Some("error"));
+        assert_eq!(out.security_severity.as_deref(), Some("high"));
+        assert_eq!(out.tool_name, "CodeQL");
+        assert_eq!(out.tool_version.as_deref(), Some("2.4.0"));
+        assert_eq!(out.path, "lib/ab12-gen.js");
+        assert_eq!(out.start_line, Some(917));
+        assert_eq!(out.message, "This path depends on a user-provided value.");
+        assert_eq!(out.git_ref.as_deref(), Some("refs/heads/main"));
+        assert_eq!(
+            out.html_url,
+            "https://github.com/theBGuy/GitDesktop/security/code-scanning/4"
+        );
+        assert_eq!(out.created_at, "2026-08-04T12:29:18Z");
+        assert_eq!(out.updated_at, "2026-08-05T12:29:18Z");
+    }
+
+    #[test]
+    fn code_scanning_alert_tolerates_a_stripped_item() {
+        let raw: RawCodeScanningAlert =
+            serde_json::from_value(json!({ "number": 9 })).expect("sparse alert deserializes");
+        let out = code_scanning_alert_out(raw);
+        assert_eq!(out.number, 9);
+        assert_eq!(out.rule_id, "");
+        assert_eq!(out.message, "");
+        assert_eq!(out.path, "");
+        assert_eq!(out.start_line, None);
+        assert_eq!(out.git_ref, None);
+        assert_eq!(out.security_severity, None);
+    }
+
+    fn secret_scanning_fixture() -> Value {
+        json!({
+            "number": 2,
+            "state": "open",
+            "secret_type": "adafruit_io_key",
+            "secret_type_display_name": "Adafruit IO Key",
+            "secret": "aio_XXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            "validity": "active",
+            "publicly_leaked": true,
+            "multi_repo": false,
+            "resolution": Value::Null,
+            "html_url": "https://github.com/theBGuy/GitDesktop/security/secret-scanning/2",
+            "created_at": "2026-08-04T18:18:30Z",
+            "updated_at": "2026-08-05T18:18:30Z"
+        })
+    }
+
+    #[test]
+    fn secret_scanning_alert_maps_every_field() {
+        let raw: RawSecretScanningAlert =
+            serde_json::from_value(secret_scanning_fixture()).expect("fixture deserializes");
+        let out = secret_scanning_alert_out(raw);
+        assert_eq!(out.number, 2);
+        assert_eq!(out.state, "open");
+        assert_eq!(out.secret_type, "adafruit_io_key");
+        assert_eq!(out.secret_type_display_name, "Adafruit IO Key");
+        assert_eq!(out.validity.as_deref(), Some("active"));
+        assert_eq!(out.publicly_leaked, Some(true));
+        assert_eq!(out.resolution, None);
+        assert_eq!(
+            out.html_url,
+            "https://github.com/theBGuy/GitDesktop/security/secret-scanning/2"
+        );
+        assert_eq!(out.created_at, "2026-08-04T18:18:30Z");
+        assert_eq!(out.updated_at, "2026-08-05T18:18:30Z");
+    }
+
+    #[test]
+    fn secret_scanning_alert_tolerates_a_stripped_item() {
+        let raw: RawSecretScanningAlert =
+            serde_json::from_value(json!({ "number": 3 })).expect("sparse alert deserializes");
+        let out = secret_scanning_alert_out(raw);
+        assert_eq!(out.number, 3);
+        assert_eq!(out.secret_type, "");
+        assert_eq!(out.secret_type_display_name, "");
+        assert_eq!(out.validity, None);
+        assert_eq!(out.publicly_leaked, None);
+    }
+
+    #[test]
+    fn code_scanning_envelope_wire_shape_is_pinned() {
+        let raw: RawCodeScanningAlert = serde_json::from_value(code_scanning_fixture()).unwrap();
+        let envelope = CodeScanningAlertsOut {
+            availability: FindingAvailability::Available,
+            detail: None,
+            alerts: vec![code_scanning_alert_out(raw)],
+            truncated: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&envelope).unwrap(),
+            json!({
+                "availability": "available",
+                "detail": Value::Null,
+                "truncated": true,
+                "alerts": [{
+                    "number": 4,
+                    "state": "open",
+                    "ruleId": "js/zipslip",
+                    "ruleName": "js/zipslip",
+                    "ruleDescription": "Arbitrary file write during zip extraction",
+                    "severity": "error",
+                    "securitySeverity": "high",
+                    "toolName": "CodeQL",
+                    "toolVersion": "2.4.0",
+                    "path": "lib/ab12-gen.js",
+                    "startLine": 917,
+                    "message": "This path depends on a user-provided value.",
+                    // A Rust keyword on the wire: the key must stay literally "ref".
+                    "ref": "refs/heads/main",
+                    "htmlUrl": "https://github.com/theBGuy/GitDesktop/security/code-scanning/4",
+                    "createdAt": "2026-08-04T12:29:18Z",
+                    "updatedAt": "2026-08-05T12:29:18Z"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn secret_scanning_envelope_wire_shape_is_pinned() {
+        let raw: RawSecretScanningAlert =
+            serde_json::from_value(secret_scanning_fixture()).unwrap();
+        let envelope = SecretScanningAlertsOut {
+            availability: FindingAvailability::NotEnabled,
+            detail: Some("Secret scanning is disabled on this repository.".into()),
+            alerts: vec![secret_scanning_alert_out(raw)],
+            truncated: false,
+        };
+        // The exact shape also pins what does NOT cross: the fixture's `secret` value
+        // stays server-side — this app never carries a leaked credential to the UI.
+        assert_eq!(
+            serde_json::to_value(&envelope).unwrap(),
+            json!({
+                "availability": "notEnabled",
+                "detail": "Secret scanning is disabled on this repository.",
+                "truncated": false,
+                "alerts": [{
+                    "number": 2,
+                    "state": "open",
+                    "secretType": "adafruit_io_key",
+                    "secretTypeDisplayName": "Adafruit IO Key",
+                    "validity": "active",
+                    "publiclyLeaked": true,
+                    "resolution": Value::Null,
+                    "htmlUrl": "https://github.com/theBGuy/GitDesktop/security/secret-scanning/2",
+                    "createdAt": "2026-08-04T18:18:30Z",
+                    "updatedAt": "2026-08-05T18:18:30Z"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn new_arms_keep_the_availability_envelope() {
+        // A readable-but-empty window is the real answer; an unavailable one carries
+        // the reason instead of an empty list the user would read as "clean".
+        let out = code_scanning_envelope(Fetched::Items {
+            items: Vec::new(),
+            truncated: false,
+        });
+        assert_eq!(out.availability, FindingAvailability::Available);
+        assert!(out.alerts.is_empty());
+        let out = secret_scanning_envelope(Fetched::Unavailable {
+            availability: FindingAvailability::NotEnabled,
+            detail: Some("Secret scanning is disabled on this repository.".into()),
+            status: Some(404),
+        });
+        assert_eq!(out.availability, FindingAvailability::NotEnabled);
+        assert!(!out.truncated);
+        let out = secret_scanning_envelope(Fetched::Items {
+            items: vec![json!("not an object")],
+            truncated: false,
+        });
+        assert_eq!(out.availability, FindingAvailability::Indeterminate);
+        assert_eq!(
+            out.detail.as_deref(),
+            Some("GitHub returned 1 alert this build couldn't read")
         );
     }
 }

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -24,6 +24,9 @@ pub enum FindingAvailability {
     Available,
     /// The feature is switched off for this repo.
     NotEnabled,
+    /// No analysis has ever run: the first scan may still be in flight, or scanning
+    /// was never configured. Distinct from `NotEnabled`, which the server asserts.
+    NoResultsYet,
     /// The token can't read this surface (no admin / not authorized).
     Forbidden,
     /// The call failed in a way we can't attribute; the list is unknown, not empty.
@@ -163,7 +166,7 @@ pub struct SecretScanningAlertOut {
     /// active | inactive | unknown, raw.
     pub validity: Option<String>,
     pub publicly_leaked: Option<bool>,
-    pub resolution: Option<String>,
+    // No `resolution`: the fetch pins `state=open`, so it is always null here.
     pub html_url: String,
     pub created_at: String,
     pub updated_at: String,
@@ -441,8 +444,6 @@ struct RawSecretScanningAlert {
     validity: Option<String>,
     #[serde(default)]
     publicly_leaked: Option<bool>,
-    #[serde(default)]
-    resolution: Option<String>,
     #[serde(default)]
     html_url: Option<String>,
     #[serde(default)]
@@ -769,7 +770,6 @@ fn secret_scanning_alert_out(raw: RawSecretScanningAlert) -> SecretScanningAlert
         secret_type_display_name: raw.secret_type_display_name.unwrap_or_default(),
         validity: raw.validity,
         publicly_leaked: raw.publicly_leaked,
-        resolution: raw.resolution,
         html_url: raw.html_url.unwrap_or_default(),
         created_at: raw.created_at.unwrap_or_default(),
         updated_at: raw.updated_at.unwrap_or_default(),
@@ -860,13 +860,12 @@ fn classify_failure(stdout_body: &str, stderr: &str) -> (FindingAvailability, Op
         return (FindingAvailability::Indeterminate, detail);
     };
     let lower = message.to_lowercase();
-    // Each arm words "off for this repo" differently: Dependabot says "disabled",
-    // code scanning says "not enabled", and a scanned-but-never-analyzed repo
-    // answers "no analysis found" — none of them mean the repo is clean.
-    if lower.contains("disabled")
-        || lower.contains("not enabled")
-        || lower.contains("no analysis found")
-    {
+    // "no analysis found" is weaker than the other two: a repo mid-first-scan and a
+    // repo that never configured scanning both answer it, so it can't claim the
+    // feature is off the way an explicit "disabled"/"not enabled" body does.
+    if lower.contains("no analysis found") {
+        (FindingAvailability::NoResultsYet, detail)
+    } else if lower.contains("disabled") || lower.contains("not enabled") {
         (FindingAvailability::NotEnabled, detail)
     } else if lower.contains("not authorized")
         || lower.contains("forbidden")
@@ -1458,6 +1457,7 @@ mod tests {
         for (variant, expected) in [
             (FindingAvailability::Available, "available"),
             (FindingAvailability::NotEnabled, "notEnabled"),
+            (FindingAvailability::NoResultsYet, "noResultsYet"),
             (FindingAvailability::Forbidden, "forbidden"),
             (FindingAvailability::Indeterminate, "indeterminate"),
         ] {
@@ -1712,10 +1712,16 @@ mod tests {
             detail.as_deref(),
             Some("Code scanning is not enabled for this repository. Please enable code scanning in the repository settings.")
         );
-        // A public repo that has never run an analysis (404) is likewise "off", not clean.
+    }
+
+    #[test]
+    fn classify_failure_reads_no_analysis_as_no_results_yet() {
+        // Measured on a public repo whose scanning has never produced an analysis
+        // (404). A repo mid-first-scan answers the same, so this is NOT proof the
+        // feature is off — the two states need different copy.
         let (availability, detail) =
             classify_failure(r#"{"message":"no analysis found"}"#, "gh: HTTP 404");
-        assert_eq!(availability, FindingAvailability::NotEnabled);
+        assert_eq!(availability, FindingAvailability::NoResultsYet);
         assert_eq!(detail.as_deref(), Some("no analysis found"));
     }
 
@@ -2208,7 +2214,6 @@ mod tests {
             "validity": "active",
             "publicly_leaked": true,
             "multi_repo": false,
-            "resolution": Value::Null,
             "html_url": "https://github.com/theBGuy/GitDesktop/security/secret-scanning/2",
             "created_at": "2026-08-04T18:18:30Z",
             "updated_at": "2026-08-05T18:18:30Z"
@@ -2226,7 +2231,6 @@ mod tests {
         assert_eq!(out.secret_type_display_name, "Adafruit IO Key");
         assert_eq!(out.validity.as_deref(), Some("active"));
         assert_eq!(out.publicly_leaked, Some(true));
-        assert_eq!(out.resolution, None);
         assert_eq!(
             out.html_url,
             "https://github.com/theBGuy/GitDesktop/security/secret-scanning/2"
@@ -2310,7 +2314,6 @@ mod tests {
                     "secretTypeDisplayName": "Adafruit IO Key",
                     "validity": "active",
                     "publiclyLeaked": true,
-                    "resolution": Value::Null,
                     "htmlUrl": "https://github.com/theBGuy/GitDesktop/security/secret-scanning/2",
                     "createdAt": "2026-08-04T18:18:30Z",
                     "updatedAt": "2026-08-05T18:18:30Z"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -567,6 +567,8 @@ pub fn run() {
             github::security::gh_security_apply,
             github::security_findings::gh_dependabot_alerts,
             github::security_findings::gh_repo_advisories,
+            github::security_findings::gh_code_scanning_alerts,
+            github::security_findings::gh_secret_scanning_alerts,
             github::lifecycle::gh_repo_set_visibility,
             github::lifecycle::gh_repo_transfer,
             github::lifecycle::gh_repo_delete,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1345,9 +1345,12 @@ only reads as clean once GitHub has confirmed it's switched on. When **Dependabo
 alerts**, **code scanning**, or **secret scanning** is switched off for the repo and you
 have repo-admin access, **Open security settings** takes you straight to **Repository
 settings → Security**, where you turn that scanning on (see *Repository settings*).
-Advisories have no such switch — they're only published on public repositories, so
-their card says just that. When your GitHub access can't read a category, you see what
-GitHub said about it; when the check couldn't complete at all, you get a **Retry**.
+**Code scanning** hedges on purpose: GitHub reports nothing whether it was never set up
+or its first analysis is still running, so its card says results haven't arrived yet
+instead of guessing, and keeps the settings link for either case. Advisories have no
+such switch — they're only published on public repositories, so their card says just
+that. When your GitHub access can't read a category, you see what GitHub said about it;
+when the check couldn't complete at all, you get a **Retry**.
 
 The tab fetches when you open it — use the refresh button for the current state.`,
   },

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1326,16 +1326,28 @@ or Bitbucket repo the tab says so instead.
 - **Dependabot alerts** — every open alert, grouped by the vulnerable package. Each one
   shows its **severity**, the **affected version range**, the **first patched version**,
   and a **CVSS** score when GitHub reports one.
+- **Code scanning alerts** — the open alerts the repo's code scanning tools have
+  raised, grouped by the **rule** that fired.
+- **Secret scanning alerts** — the open alerts for credentials found committed to the
+  repository, grouped by the kind of secret, each with a **validity** chip —
+  **Active**, **Inactive**, or **Unknown** — for the leaked credential.
 - **Security advisories** — the advisories published on the repository itself.
 
 Move through the list with **↑ / ↓**; select a row for its detail, then **View on
-GitHub** to open it there.
+GitHub** to open it there. A Dependabot alert's detail goes further: whether the
+vulnerable package is a **direct** or **transitive** dependency, a **base-metric
+table** for each CVSS version the advisory carries (**3.x** and **4.0** can both be
+there), the **CWEs** GitHub classified it under, and its **references** as labeled
+links.
 
-A category that isn't reporting tells you why rather than looking empty. When Dependabot
-alerts are switched off for the repo and you have repo-admin access, **Open security
-settings** takes you straight to **Repository settings → Security**, where you turn
-scanning on (see *Repository settings*). When your GitHub access can't read a category, you see what GitHub said
-about it; when the check couldn't complete at all, you get a **Retry**.
+A category that isn't reporting tells you why rather than looking empty — a category
+only reads as clean once GitHub has confirmed it's switched on. When **Dependabot
+alerts**, **code scanning**, or **secret scanning** is switched off for the repo and you
+have repo-admin access, **Open security settings** takes you straight to **Repository
+settings → Security**, where you turn that scanning on (see *Repository settings*).
+Advisories have no such switch — they're only published on public repositories, so
+their card says just that. When your GitHub access can't read a category, you see what
+GitHub said about it; when the check couldn't complete at all, you get a **Retry**.
 
 The tab fetches when you open it — use the refresh button for the current state.`,
   },

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -593,7 +593,11 @@ export function RepositoryView() {
                 key={
                   selectedFinding.type === "alert"
                     ? `a${selectedFinding.number}`
-                    : `g${selectedFinding.ghsaId}`
+                    : selectedFinding.type === "codeScanning"
+                      ? `c${selectedFinding.number}`
+                      : selectedFinding.type === "secretScanning"
+                        ? `s${selectedFinding.number}`
+                        : `g${selectedFinding.ghsaId}`
                 }
                 repoPath={repoPath}
                 active={repoTab === "findings"}

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -164,7 +164,9 @@ function ReferencesSection({ references }: { references: ReferenceOut[] }) {
 function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
   return (
     <DetailShell
-      title={alert.summary}
+      // Falls back to the identity field, never invented prose: a doubly-degraded
+      // item with no GHSA id either keeps a blank heading rather than a lie.
+      title={alert.summary || alert.ghsaId}
       chip={<SeverityChip severity={alert.severity} />}
       htmlUrl={alert.htmlUrl}
       meta={
@@ -194,7 +196,9 @@ function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
               <span className="font-mono">{alert.cveId}</span>
             </Row>
           ) : null}
-          {alert.cvssScore !== null ? (
+          {/* Only when there's no CVSS section to carry the score — otherwise
+              this row and the first section state the same number twice. */}
+          {alert.cvssScore !== null && alert.cvss.length === 0 ? (
             <Row label="CVSS">
               <span className="tabular-nums">{alert.cvssScore}</span>
             </Row>
@@ -244,10 +248,17 @@ function capitalizeFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+/** `path:line`, or a placeholder when the path came through empty — a line
+ *  number hung off nothing reads as a location. Must stay in step with
+ *  `PathLabel` in FindingsPanel, which renders the same value in the list. */
+function locationText(path: string, line: number | null): string {
+  return path ? (line === null ? path : `${path}:${line}`) : "No file path";
+}
+
 function CodeScanningDetail({ alert }: { alert: CodeScanningAlertOut }) {
   return (
     <DetailShell
-      title={alert.ruleName ?? alert.ruleId}
+      title={alert.ruleName || alert.ruleId || "Unidentified rule"}
       chip={
         <CodeScanningChip
           securitySeverity={alert.securitySeverity}
@@ -257,9 +268,13 @@ function CodeScanningDetail({ alert }: { alert: CodeScanningAlertOut }) {
       htmlUrl={alert.htmlUrl}
       meta={
         <>
-          <Row label="Rule">
-            <span className="font-mono">{alert.ruleId}</span>
-          </Row>
+          {/* Omitted outright when the id is empty — the title already carries
+              the fallback, matching how a missing date drops its row. */}
+          {alert.ruleId ? (
+            <Row label="Rule">
+              <span className="font-mono">{alert.ruleId}</span>
+            </Row>
+          ) : null}
           {/* The SARIF level, spelled out — the chip shows it only when the rule
               carries no security severity to outrank it. */}
           {alert.severity ? (
@@ -276,9 +291,7 @@ function CodeScanningDetail({ alert }: { alert: CodeScanningAlertOut }) {
           </Row>
           <Row label="Location">
             <span className="font-mono">
-              {alert.startLine === null
-                ? alert.path
-                : `${alert.path}:${alert.startLine}`}
+              {locationText(alert.path, alert.startLine)}
             </span>
           </Row>
           {alert.ref ? (
@@ -286,7 +299,8 @@ function CodeScanningDetail({ alert }: { alert: CodeScanningAlertOut }) {
               <span className="font-mono">{alert.ref}</span>
             </Row>
           ) : null}
-          <Row label="State">{alert.state}</Row>
+          {/* No State row: the fetch pins state=open, so it could only ever
+              read "open". */}
           <Row label="Opened">
             <RelativeTime date={alert.createdAt} />
           </Row>
@@ -306,17 +320,19 @@ function CodeScanningDetail({ alert }: { alert: CodeScanningAlertOut }) {
 function SecretScanningDetail({ alert }: { alert: SecretScanningAlertOut }) {
   return (
     <DetailShell
-      title={alert.secretTypeDisplayName}
+      title={
+        alert.secretTypeDisplayName || alert.secretType || "Unknown secret type"
+      }
       chip={<ValidityChip validity={alert.validity} />}
       htmlUrl={alert.htmlUrl}
       meta={
         <>
-          <Row label="Type">{alert.secretTypeDisplayName}</Row>
+          <Row label="Type">
+            {alert.secretTypeDisplayName || alert.secretType || "Unknown"}
+          </Row>
           <Row label="Validity">{validityLabel(alert.validity)}</Row>
-          <Row label="State">{alert.state}</Row>
-          {alert.resolution ? (
-            <Row label="Resolution">{alert.resolution}</Row>
-          ) : null}
+          {/* No State row: the fetch pins state=open, so it could only ever
+              read "open". */}
           {/* Only for a confirmed public leak — a null means GitHub didn't say,
               and "No" would read as a clearance it never gave. */}
           {alert.publiclyLeaked === true ? (
@@ -340,7 +356,7 @@ function SecretScanningDetail({ alert }: { alert: SecretScanningAlertOut }) {
 function AdvisoryDetail({ advisory }: { advisory: RepoAdvisoryOut }) {
   return (
     <DetailShell
-      title={advisory.summary}
+      title={advisory.summary || advisory.ghsaId}
       chip={<SeverityChip severity={advisory.severity} />}
       htmlUrl={advisory.htmlUrl}
       meta={

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -2,21 +2,33 @@ import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { ReactNode } from "react";
 import { RelativeTime } from "@/components/relative-time";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { forgeReady, forgeSupports, useForgeStatus } from "@/lib/git/queries";
 import type {
+  CodeScanningAlertOut,
+  CvssOut,
   DependabotAlertOut,
+  ReferenceOut,
   RepoAdvisoryOut,
+  SecretScanningAlertOut,
 } from "@/lib/github/security-findings";
 import {
+  useCodeScanningAlerts,
   useDependabotAlerts,
   useRepoAdvisories,
+  useSecretScanningAlerts,
 } from "@/lib/github/security-findings";
 import { useUiStore } from "@/lib/stores/ui";
-import { SeverityChip } from "./severity";
+import {
+  CodeScanningChip,
+  SeverityChip,
+  ValidityChip,
+  validityLabel,
+} from "./severity";
 
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -29,13 +41,15 @@ function Row({ label, children }: { label: string; children: ReactNode }) {
 
 function DetailShell({
   title,
-  severity,
+  chip,
   htmlUrl,
   meta,
   children,
 }: {
   title: string;
-  severity: string | null;
+  /** The category's own status chip — severity, SARIF level, or validity; each
+   *  category names its state in its own ladder's words. */
+  chip: ReactNode;
   htmlUrl: string;
   meta: ReactNode;
   children: ReactNode;
@@ -45,7 +59,7 @@ function DetailShell({
       <div className="border-b p-4">
         <h2 className="text-sm font-semibold text-balance">{title}</h2>
         <div className="mt-2 flex flex-wrap items-center gap-2">
-          <SeverityChip severity={severity} />
+          {chip}
           {/* A tolerated malformed item can lack html_url — no link, no button. */}
           {htmlUrl ? (
             <Button
@@ -72,11 +86,86 @@ function DetailShell({
   );
 }
 
+/** GitHub reports `direct` / `transitive`; anything else is shown as it arrived,
+ *  so a value we don't know yet is never dropped or mislabeled. */
+function relationshipLabel(relationship: string): string {
+  switch (relationship.toLowerCase()) {
+    case "direct":
+      return "Direct";
+    case "transitive":
+      return "Transitive";
+    default:
+      return relationship;
+  }
+}
+
+/** One CVSS version's score and decoded metrics. An advisory can carry v3 and v4
+ *  at once, so each gets its own section rather than one collapsed "CVSS" row. */
+function CvssSection({ cvss }: { cvss: CvssOut }) {
+  return (
+    <section className="mb-4">
+      <h3 className="mb-1.5 flex items-baseline gap-2 text-xs font-semibold">
+        {/* The version is empty when the vector named none — heading it
+            "CVSS" alone beats a dangling revision number. */}
+        <span>{cvss.version ? `CVSS ${cvss.version}` : "CVSS"}</span>
+        {cvss.score !== null ? (
+          <span className="font-normal text-muted-foreground tabular-nums">
+            {cvss.score}
+          </span>
+        ) : null}
+      </h3>
+      {cvss.metrics.length > 0 ? (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+          {cvss.metrics.map((m) => (
+            <Row key={m.label} label={m.label}>
+              {m.value}
+            </Row>
+          ))}
+        </dl>
+      ) : (
+        // An unparseable vector still says something — show it raw rather than
+        // silently rendering an empty section.
+        <p className="font-mono text-[11px] wrap-break-word text-muted-foreground">
+          {cvss.vectorString}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function ReferencesSection({ references }: { references: ReferenceOut[] }) {
+  return (
+    <section className="mt-4">
+      <h3 className="mb-1.5 text-xs font-semibold">References</h3>
+      <ul>
+        {references.map((r, i) => (
+          <li key={`${r.url}-${i}`}>
+            <button
+              type="button"
+              onClick={() => openUrl(r.url)}
+              className="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-1 text-left text-xs hover:bg-muted/40"
+            >
+              <span className="shrink-0">{r.label}</span>
+              <span
+                className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground"
+                title={r.url}
+              >
+                {r.url}
+              </span>
+              <ArrowSquareOutIcon className="size-3 shrink-0 text-muted-foreground" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
 function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
   return (
     <DetailShell
       title={alert.summary}
-      severity={alert.severity}
+      chip={<SeverityChip severity={alert.severity} />}
       htmlUrl={alert.htmlUrl}
       meta={
         <>
@@ -87,6 +176,13 @@ function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
               {alert.scope ? ` · ${alert.scope}` : ""}
             </span>
           </Row>
+          {/* Next to the package: whether this is your dependency or something
+              underneath it decides who can act on it. Omitted when unstated. */}
+          {alert.relationship ? (
+            <Row label="Dependency">
+              {relationshipLabel(alert.relationship)}
+            </Row>
+          ) : null}
           <Row label="Manifest">
             <span className="font-mono">{alert.manifestPath}</span>
           </Row>
@@ -109,13 +205,134 @@ function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
           <Row label="Patched">
             {alert.firstPatchedVersion ?? "No patched version yet"}
           </Row>
+          {alert.cwes.length > 0 ? (
+            <Row label="CWE">
+              <span className="flex flex-wrap gap-1">
+                {alert.cwes.map((c) => (
+                  <Badge
+                    key={c.cweId}
+                    variant="outline"
+                    className="h-auto max-w-full py-0.5 text-left font-normal whitespace-normal"
+                  >
+                    <span className="font-mono">{c.cweId}</span> {c.name}
+                  </Badge>
+                ))}
+              </span>
+            </Row>
+          ) : null}
           <Row label="Opened">
             <RelativeTime date={alert.createdAt} />
           </Row>
         </>
       }
     >
+      {/* Index-keyed: the version can come through empty, so it isn't unique. */}
+      {alert.cvss.map((c, i) => (
+        <CvssSection key={`${c.version}-${i}`} cvss={c} />
+      ))}
       <Markdown>{alert.description}</Markdown>
+      {alert.references.length > 0 ? (
+        <ReferencesSection references={alert.references} />
+      ) : null}
+    </DetailShell>
+  );
+}
+
+/** Sentence-case a raw wire value, leaving the rest of it as it arrived so an
+ *  unrecognized level still reads instead of collapsing to "Unspecified". */
+function capitalizeFirst(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function CodeScanningDetail({ alert }: { alert: CodeScanningAlertOut }) {
+  return (
+    <DetailShell
+      title={alert.ruleName ?? alert.ruleId}
+      chip={
+        <CodeScanningChip
+          securitySeverity={alert.securitySeverity}
+          severity={alert.severity}
+        />
+      }
+      htmlUrl={alert.htmlUrl}
+      meta={
+        <>
+          <Row label="Rule">
+            <span className="font-mono">{alert.ruleId}</span>
+          </Row>
+          {/* The SARIF level, spelled out — the chip shows it only when the rule
+              carries no security severity to outrank it. */}
+          {alert.severity ? (
+            <Row label="Level">{capitalizeFirst(alert.severity)}</Row>
+          ) : null}
+          <Row label="Tool">
+            {alert.toolName}
+            {alert.toolVersion ? (
+              <span className="text-muted-foreground">
+                {" "}
+                {alert.toolVersion}
+              </span>
+            ) : null}
+          </Row>
+          <Row label="Location">
+            <span className="font-mono">
+              {alert.startLine === null
+                ? alert.path
+                : `${alert.path}:${alert.startLine}`}
+            </span>
+          </Row>
+          {alert.ref ? (
+            <Row label="Ref">
+              <span className="font-mono">{alert.ref}</span>
+            </Row>
+          ) : null}
+          <Row label="State">{alert.state}</Row>
+          <Row label="Opened">
+            <RelativeTime date={alert.createdAt} />
+          </Row>
+        </>
+      }
+    >
+      <p className="text-xs wrap-break-word">{alert.message}</p>
+      {alert.ruleDescription ? (
+        <p className="mt-3 text-xs wrap-break-word text-muted-foreground">
+          {alert.ruleDescription}
+        </p>
+      ) : null}
+    </DetailShell>
+  );
+}
+
+function SecretScanningDetail({ alert }: { alert: SecretScanningAlertOut }) {
+  return (
+    <DetailShell
+      title={alert.secretTypeDisplayName}
+      chip={<ValidityChip validity={alert.validity} />}
+      htmlUrl={alert.htmlUrl}
+      meta={
+        <>
+          <Row label="Type">{alert.secretTypeDisplayName}</Row>
+          <Row label="Validity">{validityLabel(alert.validity)}</Row>
+          <Row label="State">{alert.state}</Row>
+          {alert.resolution ? (
+            <Row label="Resolution">{alert.resolution}</Row>
+          ) : null}
+          {/* Only for a confirmed public leak — a null means GitHub didn't say,
+              and "No" would read as a clearance it never gave. */}
+          {alert.publiclyLeaked === true ? (
+            <Row label="Publicly leaked">Yes</Row>
+          ) : null}
+          <Row label="Opened">
+            <RelativeTime date={alert.createdAt} />
+          </Row>
+        </>
+      }
+    >
+      {/* The locations of a secret are a separate paginated endpoint we don't
+          fetch, so this says so instead of implying the alert has no detail. */}
+      <p className="text-xs text-muted-foreground">
+        Open this alert on GitHub to see where the secret appears and manage it.
+      </p>
     </DetailShell>
   );
 }
@@ -124,7 +341,7 @@ function AdvisoryDetail({ advisory }: { advisory: RepoAdvisoryOut }) {
   return (
     <DetailShell
       title={advisory.summary}
-      severity={advisory.severity}
+      chip={<SeverityChip severity={advisory.severity} />}
       htmlUrl={advisory.htmlUrl}
       meta={
         <>
@@ -201,6 +418,18 @@ export function FindingDetailView({
   // Same hooks + same store limits as the panel, so these are cache hits rather
   // than a second fetch.
   const alerts = useDependabotAlerts(repoPath, enabled, active, limits.alerts);
+  const codeScanning = useCodeScanningAlerts(
+    repoPath,
+    enabled,
+    active,
+    limits.codeScanning,
+  );
+  const secrets = useSecretScanningAlerts(
+    repoPath,
+    enabled,
+    active,
+    limits.secretScanning,
+  );
   const advisories = useRepoAdvisories(
     repoPath,
     enabled,
@@ -208,7 +437,16 @@ export function FindingDetailView({
     limits.advisories,
   );
 
-  const query = selectedFinding?.type === "advisory" ? advisories : alerts;
+  // Only the selected finding's own category decides the pending/error state —
+  // a sibling category failing must not blank a finding that loaded fine.
+  const query =
+    selectedFinding?.type === "advisory"
+      ? advisories
+      : selectedFinding?.type === "codeScanning"
+        ? codeScanning
+        : selectedFinding?.type === "secretScanning"
+          ? secrets
+          : alerts;
 
   // Gated on `enabled`: a disabled query stays `isPending` forever, so an
   // ungated skeleton would spin here if the repo lost the capability mid-session.
@@ -235,6 +473,16 @@ export function FindingDetailView({
       (a) => a.number === selectedFinding.number,
     );
     if (alert) return <AlertDetail alert={alert} />;
+  } else if (selectedFinding?.type === "codeScanning") {
+    const alert = codeScanning.data?.alerts.find(
+      (a) => a.number === selectedFinding.number,
+    );
+    if (alert) return <CodeScanningDetail alert={alert} />;
+  } else if (selectedFinding?.type === "secretScanning") {
+    const alert = secrets.data?.alerts.find(
+      (a) => a.number === selectedFinding.number,
+    );
+    if (alert) return <SecretScanningDetail alert={alert} />;
   } else if (selectedFinding?.type === "advisory") {
     const advisory = advisories.data?.advisories.find(
       (a) => a.ghsaId === selectedFinding.ghsaId,

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -337,6 +337,12 @@ function UnavailableCard({
       Open security settings
     </Button>
   ) : undefined;
+  const retryAction = (
+    <Button variant="outline" size="sm" onClick={onRetry}>
+      <ArrowClockwiseIcon data-icon="inline-start" />
+      Retry
+    </Button>
+  );
 
   if (availability === "notEnabled") {
     // The category's own sentence is how a non-admin learns what to ask for, so
@@ -355,17 +361,23 @@ function UnavailableCard({
   }
   if (availability === "noResultsYet") {
     // Deliberately not phrased as "turn it on": this state can't distinguish an
-    // unconfigured feature from one whose first analysis is still running, so it
-    // names both. The settings action stays — setup is the likely need.
+    // unconfigured feature from one whose first analysis is still running, so
+    // both the copy and the actions cover each — settings for setup, Retry for
+    // a run that may since have finished. Retry is the non-admin's only path.
     return (
       <ReasonCard
         icon={InfoIcon}
         message={
           noResultsYetMessage ??
-          `No ${category} have been reported for this repository yet.`
+          `No ${category} have been reported for this repository yet — the feature may not be set up, or its first run may still be going.`
         }
         detail={noResultsYetMessage ? null : detail}
-        action={enableAction}
+        action={
+          <div className="flex flex-wrap items-center gap-2">
+            {enableAction}
+            {retryAction}
+          </div>
+        }
       />
     );
   }
@@ -384,12 +396,7 @@ function UnavailableCard({
         icon={QuestionIcon}
         message={`Couldn't check ${category}.`}
         detail={detail}
-        action={
-          <Button variant="outline" size="sm" onClick={onRetry}>
-            <ArrowClockwiseIcon data-icon="inline-start" />
-            Retry
-          </Button>
-        }
+        action={retryAction}
       />
     );
   }

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -970,11 +970,21 @@ export function FindingsPanel({
                               </Badge>
                             ) : null}
                             {/* Rows in a group share a type and often a date, so
-                                the alert number is what tells them apart. */}
-                            <span className="ml-auto shrink-0 tabular-nums">
-                              #{a.number}
-                            </span>
-                            <span className="shrink-0">
+                                the alert number is what tells them apart — but a
+                                tolerated alert numbered 0 has none to show. */}
+                            {a.number === 0 ? null : (
+                              <span className="ml-auto shrink-0 tabular-nums">
+                                #{a.number}
+                              </span>
+                            )}
+                            {/* The number span normally carries `ml-auto`;
+                                without it the date takes over pushing right. */}
+                            <span
+                              className={cn(
+                                "shrink-0",
+                                a.number === 0 && "ml-auto",
+                              )}
+                            >
                               <RelativeTime date={a.createdAt} />
                             </span>
                           </p>

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowClockwiseIcon,
   GearSixIcon,
+  InfoIcon,
   LockKeyIcon,
   QuestionIcon,
   ShieldCheckIcon,
@@ -158,7 +159,9 @@ function buildCodeScanningGroups(
     else {
       groups.set(alert.ruleId, {
         key: alert.ruleId,
-        label: alert.ruleName ?? alert.ruleId,
+        // `||`, not `??`: the tolerant Raw parse degrades a missing field to an
+        // empty string, so an empty name must fall through the same as a null.
+        label: alert.ruleName || alert.ruleId || "Unidentified rule",
         rows: [row],
       });
     }
@@ -176,6 +179,13 @@ const bySecretUrgency = (
     VALIDITY_RANK[validityLevel(b.validity)] ||
   b.createdAt.localeCompare(a.createdAt);
 
+/** A secret type's display name, falling back through the tolerated-empty fields
+ *  the Raw parse can leave behind. Shared by the group header and the row title
+ *  so the two can never disagree — and grouping on it keeps two differently-typed
+ *  secrets apart when both lost their display name. */
+const secretTypeLabel = (a: SecretScanningAlertOut) =>
+  a.secretTypeDisplayName || a.secretType || "Unknown secret type";
+
 function buildSecretGroups(alerts: SecretScanningAlertOut[]): SecretGroup[] {
   const sorted = alerts.toSorted(bySecretUrgency);
   const groups = new Map<string, SecretGroup>();
@@ -184,15 +194,10 @@ function buildSecretGroups(alerts: SecretScanningAlertOut[]): SecretGroup[] {
       id: alert.number === 0 ? `secret-i${i}` : `secret-${alert.number}`,
       alert,
     };
-    const bucket = groups.get(alert.secretTypeDisplayName);
+    const label = secretTypeLabel(alert);
+    const bucket = groups.get(label);
     if (bucket) bucket.rows.push(row);
-    else {
-      groups.set(alert.secretTypeDisplayName, {
-        key: alert.secretTypeDisplayName,
-        label: alert.secretTypeDisplayName,
-        rows: [row],
-      });
-    }
+    else groups.set(label, { key: label, label, rows: [row] });
   });
   return [...groups.values()];
 }
@@ -247,7 +252,13 @@ function SectionHeader({ title }: { title: string }) {
  *  identifies the finding — survives. `dir="rtl"` moves the ellipsis to the
  *  leading edge; the `<bdi>` keeps the path itself reading left-to-right. */
 function PathLabel({ path, line }: { path: string; line: number | null }) {
-  const text = line === null ? path : `${path}:${line}`;
+  // A tolerated alert can arrive with no path at all; a line number hung off the
+  // placeholder would read as a location, so it's dropped with the path.
+  const text = path
+    ? line === null
+      ? path
+      : `${path}:${line}`
+    : "No file path";
   return (
     <span dir="rtl" className="ml-auto min-w-0 truncate font-mono" title={text}>
       <bdi>{text}</bdi>
@@ -294,12 +305,12 @@ function ReasonCard({
 }
 
 /**
- * The card for any envelope that isn't `"available"`. `notEnabledMessage` is the
- * category's own benefit-phrased sentence for the not-enabled state; `onEnable`
- * is passed on top of it only where the app can open the toggle. A category
- * without either still reports the state the server named rather than falling
- * through to "couldn't check". `Category` is the sentence-initial form of
- * `category`.
+ * The card for any envelope that isn't `"available"`. `notEnabledMessage` and
+ * `noResultsYetMessage` are the category's own copy for those two states;
+ * `onEnable` is passed on top of either only where the app can open the toggle.
+ * A category without them still reports the state the server named rather than
+ * falling through to "couldn't check". `Category` is the sentence-initial form
+ * of `category`.
  */
 function UnavailableCard({
   availability,
@@ -307,6 +318,7 @@ function UnavailableCard({
   category,
   Category,
   notEnabledMessage,
+  noResultsYetMessage,
   onRetry,
   onEnable,
 }: {
@@ -315,12 +327,20 @@ function UnavailableCard({
   category: string;
   Category: string;
   notEnabledMessage?: string;
+  noResultsYetMessage?: string;
   onRetry: () => void;
   onEnable?: () => void;
 }) {
+  const enableAction = onEnable ? (
+    <Button variant="outline" size="sm" onClick={onEnable}>
+      <GearSixIcon data-icon="inline-start" />
+      Open security settings
+    </Button>
+  ) : undefined;
+
   if (availability === "notEnabled") {
-    // The benefit sentence is how a non-admin learns what to ask for, so it
-    // shows with or without the action. It already names the cause, so the
+    // The category's own sentence is how a non-admin learns what to ask for, so
+    // it shows with or without the action. It already names the cause, so the
     // server's detail would only restate it — detail is for the generic path.
     return (
       <ReasonCard
@@ -329,14 +349,23 @@ function UnavailableCard({
           notEnabledMessage ?? `${Category} aren't enabled for this repository.`
         }
         detail={notEnabledMessage ? null : detail}
-        action={
-          onEnable ? (
-            <Button variant="outline" size="sm" onClick={onEnable}>
-              <GearSixIcon data-icon="inline-start" />
-              Open security settings
-            </Button>
-          ) : undefined
+        action={enableAction}
+      />
+    );
+  }
+  if (availability === "noResultsYet") {
+    // Deliberately not phrased as "turn it on": this state can't distinguish an
+    // unconfigured feature from one whose first analysis is still running, so it
+    // names both. The settings action stays — setup is the likely need.
+    return (
+      <ReasonCard
+        icon={InfoIcon}
+        message={
+          noResultsYetMessage ??
+          `No ${category} have been reported for this repository yet.`
         }
+        detail={noResultsYetMessage ? null : detail}
+        action={enableAction}
       />
     );
   }
@@ -349,19 +378,26 @@ function UnavailableCard({
       />
     );
   }
-  return (
-    <ReasonCard
-      icon={QuestionIcon}
-      message={`Couldn't check ${category}.`}
-      detail={detail}
-      action={
-        <Button variant="outline" size="sm" onClick={onRetry}>
-          <ArrowClockwiseIcon data-icon="inline-start" />
-          Retry
-        </Button>
-      }
-    />
-  );
+  if (availability === "indeterminate") {
+    return (
+      <ReasonCard
+        icon={QuestionIcon}
+        message={`Couldn't check ${category}.`}
+        detail={detail}
+        action={
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <ArrowClockwiseIcon data-icon="inline-start" />
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+  // Every state is branched above, so this is unreachable — and the assignment
+  // is the point: a new FindingAvailability variant fails to compile here
+  // instead of silently rendering the "couldn't check" card.
+  const _exhaustive: never = availability;
+  return _exhaustive;
 }
 
 function LoadFailed({
@@ -635,9 +671,9 @@ export function FindingsPanel({
                       <div className="flex items-baseline gap-2 px-3 py-1 text-[11px] text-muted-foreground">
                         <span
                           className="truncate font-mono text-foreground"
-                          title={group.packageName}
+                          title={group.packageName || "Unknown package"}
                         >
-                          {group.packageName}
+                          {group.packageName || "Unknown package"}
                         </span>
                         <span className="shrink-0">{group.ecosystem}</span>
                         <span className="ml-auto shrink-0 tabular-nums">
@@ -723,7 +759,8 @@ export function FindingsPanel({
                 detail={codeScanningOut.detail}
                 category="code scanning alerts"
                 Category="Code scanning alerts"
-                notEnabledMessage="Code scanning isn't producing results for this repository yet. Turn it on to see alerts here."
+                notEnabledMessage="Code scanning is off for this repository. Turn it on to see alerts here."
+                noResultsYetMessage="Code scanning hasn't reported results for this repository yet — it may still need setting up, or its first analysis may still be running."
                 onRetry={() => codeScanning.refetch()}
                 onEnable={
                   canOpenRepoSettings
@@ -763,14 +800,16 @@ export function FindingsPanel({
                         >
                           {group.label}
                         </span>
-                        {group.label === group.key ? null : (
+                        {/* The raw id, alongside a named rule. Suppressed when
+                            the id is itself empty — the label already covers it. */}
+                        {group.key && group.label !== group.key ? (
                           <span
                             className="min-w-0 shrink truncate font-mono"
                             title={group.key}
                           >
                             {group.key}
                           </span>
-                        )}
+                        ) : null}
                         <span className="ml-auto shrink-0 tabular-nums">
                           {group.rows.length}
                         </span>
@@ -935,9 +974,9 @@ export function FindingsPanel({
                           {/* Full-width type line, matching the alert rows. */}
                           <p
                             className="mt-1 truncate text-xs font-medium"
-                            title={a.secretTypeDisplayName}
+                            title={secretTypeLabel(a)}
                           >
-                            {a.secretTypeDisplayName}
+                            {secretTypeLabel(a)}
                           </p>
                         </button>
                       ))}
@@ -1027,10 +1066,18 @@ export function FindingsPanel({
                       >
                         <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
                           <SeverityChip severity={adv.severity} />
-                          <span className="ml-auto min-w-0 truncate font-mono">
-                            {adv.ghsaId}
+                          {adv.ghsaId ? (
+                            <span className="ml-auto min-w-0 truncate font-mono">
+                              {adv.ghsaId}
+                            </span>
+                          ) : null}
+                          {/* The GHSA span normally carries `ml-auto`; without
+                              it the state takes over pushing the row right. */}
+                          <span
+                            className={cn("shrink-0", !adv.ghsaId && "ml-auto")}
+                          >
+                            {adv.state}
                           </span>
-                          <span className="shrink-0">{adv.state}</span>
                           {when ? (
                             <span className="shrink-0">
                               <RelativeTime date={when} />

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useRef, useState } from "react";
 import { RelativeTime } from "@/components/relative-time";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -29,19 +30,32 @@ import {
   useRepoAdmin,
 } from "@/lib/git/queries";
 import type {
+  CodeScanningAlertOut,
   DependabotAlertOut,
   FindingAvailability,
   RepoAdvisoryOut,
+  SecretScanningAlertOut,
 } from "@/lib/github/security-findings";
 import {
+  useCodeScanningAlerts,
   useDependabotAlerts,
   useRepoAdvisories,
+  useSecretScanningAlerts,
 } from "@/lib/github/security-findings";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { type SelectedFinding, useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
-import { SEVERITY_RANK, SeverityChip, severityLevel } from "./severity";
+import {
+  CodeScanningChip,
+  codeScanningRank,
+  SEVERITY_RANK,
+  SeverityChip,
+  severityLevel,
+  VALIDITY_RANK,
+  ValidityChip,
+  validityLevel,
+} from "./severity";
 
 /** Ceiling for a category's row limit. MUST stay in lockstep with `clamp_limit`
  *  in src-tauri/src/github/security_findings.rs, which is the source of truth:
@@ -62,6 +76,29 @@ interface AlertGroup {
   packageName: string;
   ecosystem: string;
   rows: AlertRow[];
+}
+
+interface CodeScanningRow {
+  id: string;
+  alert: CodeScanningAlertOut;
+}
+
+interface CodeScanningGroup {
+  key: string;
+  /** The rule's human name where it has one, else the raw id — never blank. */
+  label: string;
+  rows: CodeScanningRow[];
+}
+
+interface SecretRow {
+  id: string;
+  alert: SecretScanningAlertOut;
+}
+
+interface SecretGroup {
+  key: string;
+  label: string;
+  rows: SecretRow[];
 }
 
 /** Worst-first, for every finding category: both endpoints order by date, so the
@@ -102,12 +139,73 @@ function buildAlertGroups(alerts: DependabotAlertOut[]): AlertGroup[] {
   return [...groups.values()];
 }
 
+function buildCodeScanningGroups(
+  alerts: CodeScanningAlertOut[],
+): CodeScanningGroup[] {
+  // Sort first, group after: the groups AND the rows inside each group both run
+  // worst-first, and the server's date order stays the tiebreak within a rung.
+  const sorted = alerts.toSorted(
+    (a, b) => codeScanningRank(a) - codeScanningRank(b),
+  );
+  const groups = new Map<string, CodeScanningGroup>();
+  sorted.forEach((alert, i) => {
+    const row: CodeScanningRow = {
+      id: alert.number === 0 ? `cs-i${i}` : `cs-${alert.number}`,
+      alert,
+    };
+    const bucket = groups.get(alert.ruleId);
+    if (bucket) bucket.rows.push(row);
+    else {
+      groups.set(alert.ruleId, {
+        key: alert.ruleId,
+        label: alert.ruleName ?? alert.ruleId,
+        rows: [row],
+      });
+    }
+  });
+  return [...groups.values()];
+}
+
+/** Urgency order for leaked secrets: a credential that still works first, then
+ *  newest. `createdAt` is ISO-8601, so a string compare is a date compare. */
+const bySecretUrgency = (
+  a: SecretScanningAlertOut,
+  b: SecretScanningAlertOut,
+) =>
+  VALIDITY_RANK[validityLevel(a.validity)] -
+    VALIDITY_RANK[validityLevel(b.validity)] ||
+  b.createdAt.localeCompare(a.createdAt);
+
+function buildSecretGroups(alerts: SecretScanningAlertOut[]): SecretGroup[] {
+  const sorted = alerts.toSorted(bySecretUrgency);
+  const groups = new Map<string, SecretGroup>();
+  sorted.forEach((alert, i) => {
+    const row: SecretRow = {
+      id: alert.number === 0 ? `secret-i${i}` : `secret-${alert.number}`,
+      alert,
+    };
+    const bucket = groups.get(alert.secretTypeDisplayName);
+    if (bucket) bucket.rows.push(row);
+    else {
+      groups.set(alert.secretTypeDisplayName, {
+        key: alert.secretTypeDisplayName,
+        label: alert.secretTypeDisplayName,
+        rows: [row],
+      });
+    }
+  });
+  return [...groups.values()];
+}
+
 /** Whether two selections point at the same finding. Degenerate identities (a
  *  tolerated alert numbered 0, an advisory with no GHSA id) can't be told apart
  *  by the stored selection, so the first matching row wins. */
 function sameFinding(a: SelectedFinding, b: SelectedFinding): boolean {
-  if (a.type === "alert") return b.type === "alert" && a.number === b.number;
-  return b.type === "advisory" && a.ghsaId === b.ghsaId;
+  if (a.type === "advisory")
+    return b.type === "advisory" && a.ghsaId === b.ghsaId;
+  // The three numbered categories keep separate number sequences, so the type
+  // tag has to match too — alert #4 is not code scanning alert #4.
+  return b.type !== "advisory" && b.type === a.type && b.number === a.number;
 }
 
 const matchesAlert = (a: DependabotAlertOut, q: string) =>
@@ -116,6 +214,19 @@ const matchesAlert = (a: DependabotAlertOut, q: string) =>
   a.summary.toLowerCase().includes(q) ||
   a.ghsaId.toLowerCase().includes(q) ||
   (a.cveId?.toLowerCase().includes(q) ?? false);
+
+const matchesCodeScanning = (a: CodeScanningAlertOut, q: string) =>
+  !q ||
+  a.ruleId.toLowerCase().includes(q) ||
+  (a.ruleName?.toLowerCase().includes(q) ?? false) ||
+  a.message.toLowerCase().includes(q) ||
+  a.path.toLowerCase().includes(q) ||
+  a.toolName.toLowerCase().includes(q);
+
+const matchesSecret = (a: SecretScanningAlertOut, q: string) =>
+  !q ||
+  a.secretType.toLowerCase().includes(q) ||
+  a.secretTypeDisplayName.toLowerCase().includes(q);
 
 const matchesAdvisory = (adv: RepoAdvisoryOut, q: string) =>
   !q ||
@@ -129,6 +240,18 @@ function SectionHeader({ title }: { title: string }) {
     <h3 className="border-b bg-muted/40 px-3 py-1.5 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
       {title}
     </h3>
+  );
+}
+
+/** `path:line`, truncated from the *start* so the filename — the part that
+ *  identifies the finding — survives. `dir="rtl"` moves the ellipsis to the
+ *  leading edge; the `<bdi>` keeps the path itself reading left-to-right. */
+function PathLabel({ path, line }: { path: string; line: number | null }) {
+  const text = line === null ? path : `${path}:${line}`;
+  return (
+    <span dir="rtl" className="ml-auto min-w-0 truncate font-mono" title={text}>
+      <bdi>{text}</bdi>
+    </span>
   );
 }
 
@@ -171,16 +294,19 @@ function ReasonCard({
 }
 
 /**
- * The card for any envelope that isn't `"available"`. `onEnable` is passed only
- * by a category with a repo-level toggle; a category without one still reports
- * the state the server named rather than falling through to "couldn't check".
- * `Category` is the sentence-initial form of `category`.
+ * The card for any envelope that isn't `"available"`. `notEnabledMessage` is the
+ * category's own benefit-phrased sentence for the not-enabled state; `onEnable`
+ * is passed on top of it only where the app can open the toggle. A category
+ * without either still reports the state the server named rather than falling
+ * through to "couldn't check". `Category` is the sentence-initial form of
+ * `category`.
  */
 function UnavailableCard({
   availability,
   detail,
   category,
   Category,
+  notEnabledMessage,
   onRetry,
   onEnable,
 }: {
@@ -188,26 +314,29 @@ function UnavailableCard({
   detail: string | null;
   category: string;
   Category: string;
+  notEnabledMessage?: string;
   onRetry: () => void;
   onEnable?: () => void;
 }) {
   if (availability === "notEnabled") {
-    return onEnable ? (
+    // The benefit sentence is how a non-admin learns what to ask for, so it
+    // shows with or without the action. It already names the cause, so the
+    // server's detail would only restate it — detail is for the generic path.
+    return (
       <ReasonCard
         icon={ShieldSlashIcon}
-        message="Dependabot alerts are off for this repository. Turn them on to see vulnerable dependencies here."
-        action={
-          <Button variant="outline" size="sm" onClick={onEnable}>
-            <GearSixIcon data-icon="inline-start" />
-            Open security settings
-          </Button>
+        message={
+          notEnabledMessage ?? `${Category} aren't enabled for this repository.`
         }
-      />
-    ) : (
-      <ReasonCard
-        icon={ShieldSlashIcon}
-        message={`${Category} aren't enabled for this repository.`}
-        detail={detail}
+        detail={notEnabledMessage ? null : detail}
+        action={
+          onEnable ? (
+            <Button variant="outline" size="sm" onClick={onEnable}>
+              <GearSixIcon data-icon="inline-start" />
+              Open security settings
+            </Button>
+          ) : undefined
+        }
       />
     );
   }
@@ -263,9 +392,10 @@ export function FindingsPanel({
   active: boolean;
 }) {
   const forge = useForgeStatus(repoPath);
-  // Dependabot alerts and repository advisories are GitHub-only surfaces, so the
-  // gate is the capability, not a per-provider dispatch: a GitLab/Bitbucket repo
-  // fires no query at all.
+  // All four categories — Dependabot alerts, code scanning, secret scanning and
+  // repository advisories — are GitHub-only surfaces, so the gate is the
+  // capability, not a per-provider dispatch: a GitLab/Bitbucket repo fires no
+  // query at all.
   const ready = forgeReady(forge.data);
   const supported = forgeSupports(forge.data, "securityFindings");
   const enabled = ready && supported;
@@ -283,6 +413,18 @@ export function FindingsPanel({
   const requestRepoSettings = useUiStore((s) => s.requestRepoSettings);
 
   const alerts = useDependabotAlerts(repoPath, enabled, active, limits.alerts);
+  const codeScanning = useCodeScanningAlerts(
+    repoPath,
+    enabled,
+    active,
+    limits.codeScanning,
+  );
+  const secrets = useSecretScanningAlerts(
+    repoPath,
+    enabled,
+    active,
+    limits.secretScanning,
+  );
   const advisories = useRepoAdvisories(
     repoPath,
     enabled,
@@ -298,11 +440,21 @@ export function FindingsPanel({
 
   const query = filterText.trim().toLowerCase();
   const alertsOut = alerts.data;
+  const codeScanningOut = codeScanning.data;
+  const secretsOut = secrets.data;
   const advisoriesOut = advisories.data;
   const allAlerts = alertsOut?.alerts ?? [];
+  const allCodeScanning = codeScanningOut?.alerts ?? [];
+  const allSecrets = secretsOut?.alerts ?? [];
   const allAdvisories = advisoriesOut?.advisories ?? [];
   const alertGroups = buildAlertGroups(
     allAlerts.filter((a) => matchesAlert(a, query)),
+  );
+  const codeScanningGroups = buildCodeScanningGroups(
+    allCodeScanning.filter((a) => matchesCodeScanning(a, query)),
+  );
+  const secretGroups = buildSecretGroups(
+    allSecrets.filter((a) => matchesSecret(a, query)),
   );
   const advisoryRows = allAdvisories
     .filter((a) => matchesAdvisory(a, query))
@@ -315,11 +467,15 @@ export function FindingsPanel({
 
   const alertsShown =
     !alerts.isError && alertsOut?.availability === "available";
+  const codeScanningShown =
+    !codeScanning.isError && codeScanningOut?.availability === "available";
+  const secretsShown =
+    !secrets.isError && secretsOut?.availability === "available";
   const advisoriesShown =
     !advisories.isError && advisoriesOut?.availability === "available";
 
-  // Flat, document-order nav list: the grouped alert rows, then the advisory
-  // rows. Group headers and the Load-more buttons are intentionally skipped.
+  // Flat, document-order nav list: the grouped rows of each section in the order
+  // the sections render. Group headers and the Load-more buttons are skipped.
   const navRows: { id: string; finding: SelectedFinding }[] = [];
   if (alertsShown) {
     for (const group of alertGroups) {
@@ -327,6 +483,26 @@ export function FindingsPanel({
         navRows.push({
           id: row.id,
           finding: { type: "alert", number: row.alert.number },
+        });
+      }
+    }
+  }
+  if (codeScanningShown) {
+    for (const group of codeScanningGroups) {
+      for (const row of group.rows) {
+        navRows.push({
+          id: row.id,
+          finding: { type: "codeScanning", number: row.alert.number },
+        });
+      }
+    }
+  }
+  if (secretsShown) {
+    for (const group of secretGroups) {
+      for (const row of group.rows) {
+        navRows.push({
+          id: row.id,
+          finding: { type: "secretScanning", number: row.alert.number },
         });
       }
     }
@@ -353,7 +529,11 @@ export function FindingsPanel({
     rowKey: (row) => row.id,
   });
 
-  const refreshing = alerts.isFetching || advisories.isFetching;
+  const refreshing =
+    alerts.isFetching ||
+    codeScanning.isFetching ||
+    secrets.isFetching ||
+    advisories.isFetching;
   const refreshReason = enabled
     ? "Refresh findings"
     : !supported && ready
@@ -391,7 +571,7 @@ export function FindingsPanel({
           ref={filterRef}
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          placeholder="Filter by package, summary, GHSA, or CVE"
+          placeholder="Filter by package, rule, secret type, summary, GHSA, or CVE"
           className="h-7"
           autoComplete="off"
         />
@@ -424,6 +604,7 @@ export function FindingsPanel({
                 detail={alertsOut.detail}
                 category="dependency alerts"
                 Category="Dependency alerts"
+                notEnabledMessage="Dependabot alerts are off for this repository. Turn them on to see vulnerable dependencies here."
                 onRetry={() => alerts.refetch()}
                 onEnable={
                   canOpenRepoSettings
@@ -528,6 +709,265 @@ export function FindingsPanel({
               </>
             )}
 
+            <SectionHeader title="Code scanning" />
+            {codeScanning.isError ? (
+              <LoadFailed
+                category="code scanning alerts"
+                onRetry={() => codeScanning.refetch()}
+              />
+            ) : !codeScanningOut ? (
+              <RowSkeletons />
+            ) : codeScanningOut.availability !== "available" ? (
+              <UnavailableCard
+                availability={codeScanningOut.availability}
+                detail={codeScanningOut.detail}
+                category="code scanning alerts"
+                Category="Code scanning alerts"
+                notEnabledMessage="Code scanning isn't producing results for this repository yet. Turn it on to see alerts here."
+                onRetry={() => codeScanning.refetch()}
+                onEnable={
+                  canOpenRepoSettings
+                    ? () => requestRepoSettings("security")
+                    : undefined
+                }
+              />
+            ) : (
+              <>
+                {codeScanningGroups.length === 0 ? (
+                  allCodeScanning.length > 0 ? (
+                    <p className="px-3 py-4 text-xs text-muted-foreground">
+                      No code scanning alerts match the filter.
+                    </p>
+                  ) : (
+                    <Empty className="py-8">
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <ShieldCheckIcon />
+                        </EmptyMedia>
+                        <EmptyTitle>No open code scanning alerts</EmptyTitle>
+                      </EmptyHeader>
+                    </Empty>
+                  )
+                ) : (
+                  codeScanningGroups.map((group) => (
+                    <div key={group.key}>
+                      <div className="flex items-baseline gap-2 px-3 py-1 text-[11px] text-muted-foreground">
+                        <span
+                          className={cn(
+                            "truncate text-foreground",
+                            // A rule with no name falls back to its id, which
+                            // reads as an identifier, so it gets the mono face.
+                            group.label === group.key && "font-mono",
+                          )}
+                          title={group.label}
+                        >
+                          {group.label}
+                        </span>
+                        {group.label === group.key ? null : (
+                          <span
+                            className="min-w-0 shrink truncate font-mono"
+                            title={group.key}
+                          >
+                            {group.key}
+                          </span>
+                        )}
+                        <span className="ml-auto shrink-0 tabular-nums">
+                          {group.rows.length}
+                        </span>
+                      </div>
+                      {group.rows.map(({ id, alert: a }) => (
+                        <button
+                          type="button"
+                          key={id}
+                          data-row={id}
+                          className={cn(
+                            "block w-full border-b px-3 py-2 text-left",
+                            selectedRowId === id
+                              ? "bg-accent text-accent-foreground"
+                              : "hover:bg-muted/60",
+                          )}
+                          onClick={() =>
+                            selectFinding({
+                              type: "codeScanning",
+                              number: a.number,
+                            })
+                          }
+                        >
+                          <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                            <CodeScanningChip
+                              securitySeverity={a.securitySeverity}
+                              severity={a.severity}
+                            />
+                            <PathLabel path={a.path} line={a.startLine} />
+                            <span className="shrink-0">
+                              <RelativeTime date={a.createdAt} />
+                            </span>
+                          </p>
+                          {/* Full-width message line, matching the alert rows. */}
+                          <p
+                            className="mt-1 truncate text-xs font-medium"
+                            title={a.message}
+                          >
+                            {a.message}
+                          </p>
+                        </button>
+                      ))}
+                    </div>
+                  ))
+                )}
+                {codeScanningOut.truncated &&
+                  (limits.codeScanning >= FINDINGS_LIMIT_CAP ? (
+                    <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                      Showing the first{" "}
+                      {allCodeScanning.length.toLocaleString()} code scanning
+                      alerts.
+                    </p>
+                  ) : (
+                    <LoadMoreRow
+                      count={allCodeScanning.length}
+                      loading={codeScanning.isFetching}
+                      onLoadMore={() =>
+                        setFindingsLimits({
+                          ...limits,
+                          codeScanning: Math.min(
+                            limits.codeScanning + PAGE_SIZE,
+                            FINDINGS_LIMIT_CAP,
+                          ),
+                        })
+                      }
+                    />
+                  ))}
+              </>
+            )}
+
+            <SectionHeader title="Secret scanning" />
+            {secrets.isError ? (
+              <LoadFailed
+                category="secret scanning alerts"
+                onRetry={() => secrets.refetch()}
+              />
+            ) : !secretsOut ? (
+              <RowSkeletons />
+            ) : secretsOut.availability !== "available" ? (
+              <UnavailableCard
+                availability={secretsOut.availability}
+                detail={secretsOut.detail}
+                category="secret scanning alerts"
+                Category="Secret scanning alerts"
+                notEnabledMessage="Secret scanning is off for this repository. Turn it on to catch leaked credentials."
+                onRetry={() => secrets.refetch()}
+                onEnable={
+                  canOpenRepoSettings
+                    ? () => requestRepoSettings("security")
+                    : undefined
+                }
+              />
+            ) : (
+              <>
+                {secretGroups.length === 0 ? (
+                  allSecrets.length > 0 ? (
+                    <p className="px-3 py-4 text-xs text-muted-foreground">
+                      No secret scanning alerts match the filter.
+                    </p>
+                  ) : (
+                    <Empty className="py-8">
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <ShieldCheckIcon />
+                        </EmptyMedia>
+                        <EmptyTitle>No open secret scanning alerts</EmptyTitle>
+                      </EmptyHeader>
+                    </Empty>
+                  )
+                ) : (
+                  secretGroups.map((group) => (
+                    <div key={group.key}>
+                      <div className="flex items-baseline gap-2 px-3 py-1 text-[11px] text-muted-foreground">
+                        <span
+                          className="truncate text-foreground"
+                          title={group.label}
+                        >
+                          {group.label}
+                        </span>
+                        <span className="ml-auto shrink-0 tabular-nums">
+                          {group.rows.length}
+                        </span>
+                      </div>
+                      {group.rows.map(({ id, alert: a }) => (
+                        <button
+                          type="button"
+                          key={id}
+                          data-row={id}
+                          className={cn(
+                            "block w-full border-b px-3 py-2 text-left",
+                            selectedRowId === id
+                              ? "bg-accent text-accent-foreground"
+                              : "hover:bg-muted/60",
+                          )}
+                          onClick={() =>
+                            selectFinding({
+                              type: "secretScanning",
+                              number: a.number,
+                            })
+                          }
+                        >
+                          <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                            <ValidityChip validity={a.validity} />
+                            {/* Only ever rendered for a confirmed public leak —
+                                a null `publiclyLeaked` means GitHub didn't say. */}
+                            {a.publiclyLeaked === true ? (
+                              <Badge
+                                variant="outline"
+                                className="text-destructive"
+                              >
+                                Publicly leaked
+                              </Badge>
+                            ) : null}
+                            {/* Rows in a group share a type and often a date, so
+                                the alert number is what tells them apart. */}
+                            <span className="ml-auto shrink-0 tabular-nums">
+                              #{a.number}
+                            </span>
+                            <span className="shrink-0">
+                              <RelativeTime date={a.createdAt} />
+                            </span>
+                          </p>
+                          {/* Full-width type line, matching the alert rows. */}
+                          <p
+                            className="mt-1 truncate text-xs font-medium"
+                            title={a.secretTypeDisplayName}
+                          >
+                            {a.secretTypeDisplayName}
+                          </p>
+                        </button>
+                      ))}
+                    </div>
+                  ))
+                )}
+                {secretsOut.truncated &&
+                  (limits.secretScanning >= FINDINGS_LIMIT_CAP ? (
+                    <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                      Showing the first {allSecrets.length.toLocaleString()}{" "}
+                      secret scanning alerts.
+                    </p>
+                  ) : (
+                    <LoadMoreRow
+                      count={allSecrets.length}
+                      loading={secrets.isFetching}
+                      onLoadMore={() =>
+                        setFindingsLimits({
+                          ...limits,
+                          secretScanning: Math.min(
+                            limits.secretScanning + PAGE_SIZE,
+                            FINDINGS_LIMIT_CAP,
+                          ),
+                        })
+                      }
+                    />
+                  ))}
+              </>
+            )}
+
             <SectionHeader title="Advisories" />
             {advisories.isError ? (
               <LoadFailed
@@ -542,6 +982,7 @@ export function FindingsPanel({
                 detail={advisoriesOut.detail}
                 category="security advisories"
                 Category="Security advisories"
+                notEnabledMessage="Repository advisories are only published on public repositories."
                 onRetry={() => advisories.refetch()}
               />
             ) : (

--- a/src/features/security-findings/severity.tsx
+++ b/src/features/security-findings/severity.tsx
@@ -1,6 +1,7 @@
 import {
   CircleIcon,
   InfoIcon,
+  QuestionIcon,
   WarningCircleIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
@@ -78,6 +79,141 @@ export function SeverityChip({ severity }: { severity: string | null }) {
     <Badge variant="outline" className={cn("gap-1", SEVERITY_TONE[level])}>
       <Icon weight={level === "critical" ? "fill" : "regular"} />
       {SEVERITY_LABEL[level]}
+    </Badge>
+  );
+}
+
+// ── Code scanning ────────────────────────────────────────────────────────────
+
+/** A code scanning alert's SARIF level. A ladder of its own: an `error` is the
+ *  analysis tool's confidence, not an advisory severity, so it is never relabeled
+ *  "Critical" or "High" — only *ranked* alongside them. */
+export type SarifLevel = "error" | "warning" | "note" | "unknown";
+
+const SARIF_LABEL: Record<SarifLevel, string> = {
+  error: "Error",
+  warning: "Warning",
+  note: "Note",
+  unknown: "Unspecified",
+};
+
+/** The severity rung a SARIF level shares for ordering and visual weight. Sort
+ *  and tone only — `SARIF_LABEL` is what names the level to the user. */
+const SARIF_AS_SEVERITY: Record<SarifLevel, SeverityLevel> = {
+  error: "high",
+  warning: "medium",
+  note: "low",
+  unknown: "unknown",
+};
+
+export function sarifLevel(level: string | null): SarifLevel {
+  switch (level?.toLowerCase()) {
+    case "error":
+      return "error";
+    case "warning":
+      return "warning";
+    case "note":
+      return "note";
+    default:
+      return "unknown";
+  }
+}
+
+/** Fields of a code scanning alert that decide its chip and its rank. */
+interface CodeScanningLevels {
+  securitySeverity: string | null;
+  severity: string | null;
+}
+
+/** Worst-first rank for a code scanning alert: its security severity when the
+ *  rule carries one, else its SARIF level on the shared ladder. Presence of
+ *  `securitySeverity` is the switch, matching `CodeScanningChip`. */
+export function codeScanningRank(a: CodeScanningLevels): number {
+  return SEVERITY_RANK[
+    a.securitySeverity
+      ? severityLevel(a.securitySeverity)
+      : SARIF_AS_SEVERITY[sarifLevel(a.severity)]
+  ];
+}
+
+/**
+ * The chip for a code scanning alert. A rule with a security severity gets the
+ * ordinary severity chip; anything else is labeled with its SARIF level in that
+ * ladder's own words, so nothing is promoted to a severity GitHub never assigned.
+ */
+export function CodeScanningChip({
+  securitySeverity,
+  severity,
+}: CodeScanningLevels) {
+  if (securitySeverity) return <SeverityChip severity={securitySeverity} />;
+  const level = sarifLevel(severity);
+  const rung = SARIF_AS_SEVERITY[level];
+  const Icon = SEVERITY_ICON[rung];
+  return (
+    <Badge variant="outline" className={cn("gap-1", SEVERITY_TONE[rung])}>
+      <Icon />
+      {SARIF_LABEL[level]}
+    </Badge>
+  );
+}
+
+// ── Secret scanning ──────────────────────────────────────────────────────────
+
+/** Whether a leaked secret still works. GitHub only checks providers it has a
+ *  validator for, so "unknown" is the honest reading of a missing validity —
+ *  never "inactive". */
+export type ValidityLevel = "active" | "inactive" | "unknown";
+
+const VALIDITY_LABEL: Record<ValidityLevel, string> = {
+  active: "Active",
+  inactive: "Inactive",
+  unknown: "Unknown",
+};
+
+/** A still-working credential is the emergency, so it takes the destructive
+ *  tone; the label carries the meaning on its own for the color-blind path. */
+const VALIDITY_TONE: Record<ValidityLevel, string> = {
+  active: "text-destructive",
+  inactive: "text-muted-foreground",
+  unknown: "text-foreground",
+};
+
+/** Active secrets float to the top of the list. */
+export const VALIDITY_RANK: Record<ValidityLevel, number> = {
+  active: 0,
+  unknown: 1,
+  inactive: 2,
+};
+
+const VALIDITY_ICON: Record<ValidityLevel, typeof WarningIcon> = {
+  active: WarningIcon,
+  inactive: CircleIcon,
+  unknown: QuestionIcon,
+};
+
+export function validityLevel(validity: string | null): ValidityLevel {
+  switch (validity?.toLowerCase()) {
+    case "active":
+      return "active";
+    case "inactive":
+      return "inactive";
+    default:
+      return "unknown";
+  }
+}
+
+/** The user-facing name for a validity, normalized exactly as the chip does. */
+export const validityLabel = (validity: string | null): string =>
+  VALIDITY_LABEL[validityLevel(validity)];
+
+/** A secret's validity chip — **Active** / **Inactive** / **Unknown**. */
+export function ValidityChip({ validity }: { validity: string | null }) {
+  const level = validityLevel(validity);
+  const Icon = VALIDITY_ICON[level];
+  return (
+    <Badge variant="outline" className={cn("gap-1", VALIDITY_TONE[level])}>
+      <Icon weight={level === "active" ? "fill" : "regular"} />
+      {VALIDITY_LABEL[level]}
     </Badge>
   );
 }

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -656,7 +656,8 @@ export interface ForgeCapabilities {
   ci: boolean;
   webhooks: boolean;
   approvals: boolean;
-  /** Dependabot alerts + repository security advisories (GitHub-only surfaces). */
+  /** Dependabot, code scanning and secret scanning alerts + repository security
+   *  advisories (GitHub-only surfaces). */
   securityFindings: boolean;
 }
 

--- a/src/lib/github/security-findings.ts
+++ b/src/lib/github/security-findings.ts
@@ -41,6 +41,89 @@ export interface DependabotAlertOut {
   htmlUrl: string;
   createdAt: string;
   updatedAt: string;
+  /** `"direct"` / `"transitive"` when GitHub states it; null when it doesn't —
+   *  the two read very differently to someone deciding whether to act. */
+  relationship: string | null;
+  /** Every CVSS version the advisory carries (v3 and v4 coexist). */
+  cvss: CvssOut[];
+  references: ReferenceOut[];
+  cwes: CweOut[];
+}
+
+export interface CvssOut {
+  version: string;
+  score: number | null;
+  vectorString: string;
+  /** The vector decoded into human labels; empty when the vector couldn't be
+   *  parsed, in which case the raw `vectorString` is all there is to show. */
+  metrics: CvssMetricOut[];
+}
+
+export interface CvssMetricOut {
+  label: string;
+  value: string;
+}
+
+export interface ReferenceOut {
+  url: string;
+  label: string;
+}
+
+export interface CweOut {
+  cweId: string;
+  name: string;
+}
+
+export interface CodeScanningAlertsOut {
+  availability: FindingAvailability;
+  detail: string | null;
+  alerts: CodeScanningAlertOut[];
+  truncated: boolean;
+}
+
+export interface CodeScanningAlertOut {
+  number: number;
+  state: string;
+  ruleId: string;
+  ruleName: string | null;
+  ruleDescription: string | null;
+  /** The SARIF level — `note` / `warning` / `error`. A different ladder from the
+   *  advisory severities, so it is labeled in its own words, never mapped onto
+   *  Critical/High. */
+  severity: string | null;
+  /** The security severity (critical/high/medium/low) when the rule carries one. */
+  securitySeverity: string | null;
+  toolName: string;
+  toolVersion: string | null;
+  path: string;
+  startLine: number | null;
+  message: string;
+  ref: string | null;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SecretScanningAlertsOut {
+  availability: FindingAvailability;
+  detail: string | null;
+  alerts: SecretScanningAlertOut[];
+  truncated: boolean;
+}
+
+export interface SecretScanningAlertOut {
+  number: number;
+  state: string;
+  secretType: string;
+  secretTypeDisplayName: string;
+  /** `active` / `inactive` / `unknown` — GitHub only validates secrets for
+   *  providers it has a checker for, so null means "never checked". */
+  validity: string | null;
+  publiclyLeaked: boolean | null;
+  resolution: string | null;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface RepoAdvisoriesOut {
@@ -75,15 +158,25 @@ export interface AdvisoryVulnerabilityOut {
 
 // ── API wrappers ─────────────────────────────────────────────────────────────
 //
-// GitHub-only: Dependabot alerts and repository security advisories have no
-// GitLab/Bitbucket analogue, so these stay `gh_*` and the panel gates on the
-// `securityFindings` capability rather than dispatching per provider.
+// GitHub-only: every findings category here (Dependabot, code scanning, secret
+// scanning, repository advisories) has no GitLab/Bitbucket analogue, so these
+// stay `gh_*` and the panel gates on the `securityFindings` capability rather
+// than dispatching per provider.
 
 export const ghDependabotAlerts = (repoPath: string, limit: number) =>
   invoke<DependabotAlertsOut>("gh_dependabot_alerts", { repoPath, limit });
 
 export const ghRepoAdvisories = (repoPath: string, limit: number) =>
   invoke<RepoAdvisoriesOut>("gh_repo_advisories", { repoPath, limit });
+
+export const ghCodeScanningAlerts = (repoPath: string, limit: number) =>
+  invoke<CodeScanningAlertsOut>("gh_code_scanning_alerts", { repoPath, limit });
+
+export const ghSecretScanningAlerts = (repoPath: string, limit: number) =>
+  invoke<SecretScanningAlertsOut>("gh_secret_scanning_alerts", {
+    repoPath,
+    limit,
+  });
 
 // ── Queries ──────────────────────────────────────────────────────────────────
 //
@@ -117,6 +210,36 @@ export function useRepoAdvisories(
   return useQuery({
     queryKey: ["repo", repo, "findings", "advisories", limit] as const,
     queryFn: () => ghRepoAdvisories(repo, limit),
+    enabled: enabled && active,
+    staleTime: 5 * 60_000,
+    placeholderData: keepPreviousDataForRepo(repo),
+  });
+}
+
+export function useCodeScanningAlerts(
+  repo: string,
+  enabled: boolean,
+  active: boolean,
+  limit: number,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "findings", "codeScanning", limit] as const,
+    queryFn: () => ghCodeScanningAlerts(repo, limit),
+    enabled: enabled && active,
+    staleTime: 5 * 60_000,
+    placeholderData: keepPreviousDataForRepo(repo),
+  });
+}
+
+export function useSecretScanningAlerts(
+  repo: string,
+  enabled: boolean,
+  active: boolean,
+  limit: number,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "findings", "secretScanning", limit] as const,
+    queryFn: () => ghSecretScanningAlerts(repo, limit),
     enabled: enabled && active,
     staleTime: 5 * 60_000,
     placeholderData: keepPreviousDataForRepo(repo),

--- a/src/lib/github/security-findings.ts
+++ b/src/lib/github/security-findings.ts
@@ -10,6 +10,10 @@ import { invoke } from "@/lib/tauri/invoke";
 export type FindingAvailability =
   | "available"
   | "notEnabled"
+  /** The server answered, but nothing has been reported yet — the feature may be
+   *  unconfigured or its first run may still be going. Distinct from
+   *  `notEnabled`, which the wire proves; this state can't tell the two apart. */
+  | "noResultsYet"
   | "forbidden"
   | "indeterminate";
 
@@ -120,7 +124,6 @@ export interface SecretScanningAlertOut {
    *  providers it has a checker for, so null means "never checked". */
   validity: string | null;
   publiclyLeaked: boolean | null;
-  resolution: string | null;
   htmlUrl: string;
   createdAt: string;
   updatedAt: string;

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -65,10 +65,13 @@ export interface SelectedIssue {
   id: string;
 }
 
-/** Selected security finding: a Dependabot alert (by number) or a repository
- *  advisory (by GHSA id) — the two categories the Findings tab lists. */
+/** Selected security finding, one variant per category the Findings tab lists.
+ *  Alert / code-scanning / secret-scanning numbers are per-category sequences, so
+ *  the `type` tag is what keeps two same-numbered findings distinct. */
 export type SelectedFinding =
   | { type: "alert"; number: number }
+  | { type: "codeScanning"; number: number }
+  | { type: "secretScanning"; number: number }
   | { type: "advisory"; ghsaId: string };
 
 /** How many rows each Findings category has asked for. In the store (not panel
@@ -76,12 +79,16 @@ export type SelectedFinding =
  *  one cache entry. */
 export interface FindingsLimits {
   alerts: number;
+  codeScanning: number;
+  secretScanning: number;
   advisories: number;
 }
 
 /** One page per category — matches the shared LoadMoreRow PAGE_SIZE. */
 const DEFAULT_FINDINGS_LIMITS: FindingsLimits = {
   alerts: 100,
+  codeScanning: 100,
+  secretScanning: 100,
   advisories: 100,
 };
 


### PR DESCRIPTION
Extends the Findings tab beyond Dependabot alerts and repository advisories so a GitHub repo's full security surface is readable in-app: open **code scanning** alerts (grouped by rule) and **secret scanning** alerts (grouped by secret kind, with a validity chip), plus a much richer Dependabot detail view. Each new category rides the same availability envelope as the existing ones, so a repo that hasn't switched scanning on says so rather than looking clean.

### Backend (Rust)

- Adds `gh_code_scanning_alerts` and `gh_secret_scanning_alerts` commands in `src-tauri/src/github/security_findings.rs`, with `CodeScanningAlertsOut` / `CodeScanningAlertOut` and `SecretScanningAlertsOut` / `SecretScanningAlertOut` payloads carrying the SARIF `severity` and `rule.security_severity_level` separately (they are different ladders), tool name/version, path and start line, and — for secrets — `validity`, `publiclyLeaked` and `resolution`. Both are registered in `src-tauri/src/lib.rs`.
- Enriches `DependabotAlertOut` with `relationship` (direct/transitive), a `cvss: Vec<CvssOut>` list so an advisory carrying both v3 and v4 keeps each revision's score and decoded base metrics, `references` (URL + derived label), and `cwes`. New `RawCvssSeverities`, `RawReference` and `RawCwe` deserializers back these, with the legacy `cvss` field kept as the fallback for older payloads.
- The wire key for a code scanning alert's ref is pinned by hand (`#[serde(rename = "ref")]`) since `ref` is a Rust keyword; unrecognized enum-ish values (`relationship`, `validity`, SARIF level) are carried verbatim so nothing is dropped or mislabeled.
- Updates the `security_findings` capability doc in `src-tauri/src/forge/model.rs` to name all four categories.

### Frontend

- `src/features/security-findings/FindingsPanel.tsx` gains code scanning and secret scanning sections: `buildCodeScanningGroups` groups by rule (worst-first via `codeScanningRank`, server date order as tiebreak), `buildSecretGroups` groups by display name and sorts by `bySecretUrgency` (active credentials first, then newest), and `matchesCodeScanning` / `matchesSecret` extend the filter. `sameFinding` now compares the `type` tag too, since the three numbered categories keep independent number sequences.
- `src/features/security-findings/severity.tsx` adds the SARIF ladder (`sarifLevel`, `SARIF_LABEL`, `SARIF_AS_SEVERITY`, `CodeScanningChip`) — a rule with a security severity gets the ordinary severity chip, everything else is labeled in SARIF's own words — and the secret validity ladder (`validityLevel`, `validityLabel`, `VALIDITY_RANK`, `ValidityChip`), where a missing validity reads as *Unknown*, never *Inactive*. Each chip pairs an icon and a text label, so no state is conveyed by color alone.
- `src/features/security-findings/FindingDetailView.tsx` renders the new detail arms: `CvssSection` per CVSS version (falling back to the raw vector string when it can't be decoded), `ReferencesSection` with labeled external links, the CWE list, and a `Dependency` row via `relationshipLabel`. `DetailShell` now takes a generic `chip` node instead of a `severity` string so each category supplies its own status chip.
- `src/lib/github/security-findings.ts` adds the matching TypeScript types (`CodeScanningAlertOut`, `SecretScanningAlertOut`, `CvssOut`, `CvssMetricOut`, `ReferenceOut`, `CweOut`), the `ghCodeScanningAlerts` / `ghSecretScanningAlerts` wrappers, and `useCodeScanningAlerts` / `useSecretScanningAlerts` hooks keyed per repo/category/limit with the same 5-minute stale time and repo-scoped placeholder data.
- `src/lib/stores/ui.ts` widens `SelectedFinding` with `codeScanning` and `secretScanning` variants and adds their per-category row limits to `FindingsLimits` / `DEFAULT_FINDINGS_LIMITS`; `src/features/repository/RepositoryView.tsx` extends the detail-view remount key to prefix by category so numbers can't collide.
- `src/lib/git/types.ts` updates the `securityFindings` capability doc to match the Rust side.

### Documentation

- `README.md` — rewrites both the Highlights bullet and the Findings section to cover the two new categories, the secret validity chip, the richer Dependabot detail, and the repo-admin condition on **Open security settings**.
- `src/features/help/content.ts` — extends the Findings guide section with the code scanning and secret scanning list items, the added Dependabot detail, and a note that advisories have no scanning switch to offer.
- `site/src/data/capabilities.ts` — updates the Findings capability label to name all the categories.
- `changelog.d/added-findings-scanning-arms.md` — new `added` fragment describing the shipped behavior.