### PR TITLE
fix(pulls,issues,actions,tags): gate write controls on repo access

### DIFF
--- a/changelog.d/fixed-pr-write-access-gating.md
+++ b/changelog.d/fixed-pr-write-access-gating.md
@@ -1,0 +1,6 @@
+- Write controls across pull requests, issues, CI runs and releases — merging,
+  labels, assignees, reviewers, milestones, sub-issues, pinning, locking,
+  transferring, re-running or cancelling a run, publishing and editing a
+  release — now follow your actual access to the repository: where you don't
+  have the access an action needs, it stays visible but disabled and says what
+  it requires, instead of failing when you press it.

--- a/changelog.d/fixed-pr-write-access-gating.md
+++ b/changelog.d/fixed-pr-write-access-gating.md
@@ -1,6 +1,6 @@
 - Write controls across pull requests, issues, CI runs and releases — merging,
-  labels, assignees, reviewers, milestones, sub-issues, pinning, locking,
-  transferring, re-running or cancelling a run, publishing and editing a
-  release — now follow your actual access to the repository: where you don't
-  have the access an action needs, it stays visible but disabled and says what
-  it requires, instead of failing when you press it.
+  labels, assignees, reviewers, milestones, hiding comments, pinning, locking,
+  sub-issues and dependencies, re-running or cancelling a run, publishing a release,
+  and the rest — now follow your actual access to the repository: where you don't
+  have the access an action needs, it stays visible but disabled and says what it
+  requires, instead of failing when you press it.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -3847,14 +3847,47 @@ pub async fn repo_admin(repo_path: &str) -> AppResult<bool> {
     Ok(repo_admin_matches(&page.values, &slug))
 }
 
-/// A repo's slug only, for the admin probe's slug match.
+/// Whether the signed-in viewer can push to this repo — the write twin of
+/// [`repo_admin`], asking the same endpoint for `role=contributor` (Bitbucket's
+/// write tier). The listing answering without the repo is an affirmative "no
+/// write"; a credential/HTTP failure errors instead, so the caller can tell the
+/// two apart.
+pub async fn repo_write_access(repo_path: &str) -> AppResult<crate::forge::ForgeRepoWriteAccess> {
+    let (ws, slug) = workspace_slug(repo_path).await?;
+    if slug.contains('"') {
+        return Err(AppError::Bitbucket(format!(
+            "unexpected characters in repository slug: {slug}"
+        )));
+    }
+    let creds = http::load_credentials().await?;
+    // Lowercase the BBQL value — the server-side `slug="…"` filter is
+    // case-sensitive, so a mixed-case clone URL would match 0 rows.
+    let query = format!(r#"slug="{}""#, slug.to_ascii_lowercase());
+    let path = format!(
+        "repositories/{}?role=contributor&q={}&pagelen=100",
+        encode_query_value(&ws),
+        encode_query_value(&query),
+    );
+    let page: BbPage<BbRepoSlug> = http::bb_get_json(&creds, &path, "repositories").await?;
+    let listed = repo_admin_matches(&page.values, &slug);
+    Ok(crate::forge::ForgeRepoWriteAccess {
+        can_push: Some(listed),
+        // Bitbucket has no triage tier — issue/PR metadata rides on write.
+        can_triage: Some(listed),
+        role: listed.then(|| "contributor".to_string()),
+        repo: Some(format!("{ws}/{slug}")),
+        unknown_reason: None,
+    })
+}
+
+/// A repo's slug only, for the role-scoped probes' slug match.
 #[derive(Deserialize)]
 struct BbRepoSlug {
     #[serde(default)]
     slug: String,
 }
 
-/// Whether the admin-scoped repo list contains this slug (case-insensitive). Pure
+/// Whether a role-scoped repo list contains this slug (case-insensitive). Pure
 /// (testable): the `q=slug="…"` filter is server-side, but we confirm the match
 /// defensively rather than trusting a non-empty list.
 fn repo_admin_matches(repos: &[BbRepoSlug], slug: &str) -> bool {

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -6057,10 +6057,47 @@ struct GlabProjectPermissions {
     permissions: Option<GlabPermissions>,
 }
 
-/// Whether the signed-in viewer can manage this project's settings
-/// (Maintainer+) and whether they hold the Owner-only lifecycle powers.
-pub async fn repo_admin(repo_path: &str) -> AppResult<(bool, bool)> {
-    let enc = encode_project(&project_path(repo_path).await?);
+/// The viewer's effective access level, plus why the membership fallback
+/// couldn't answer when it failed. An unanswered fallback makes `level` a FLOOR
+/// (the fallback only ever raises it), never a denial.
+struct EffectiveAccess {
+    level: u8,
+    ambiguous: Option<String>,
+}
+
+/// The viewer's access level from the effective-membership endpoint:
+/// `Ok(Some(level))` when it answered, `Ok(None)` on a 404 (GitLab saying the
+/// viewer is genuinely not a member), `Err(reason)` when it couldn't answer.
+async fn membership_access_level(repo_path: &str, enc: &str) -> Result<Option<u8>, String> {
+    let user = current_user(repo_path)
+        .await
+        .map_err(|e| format!("could not identify the signed-in GitLab user: {e}"))?;
+    let endpoint = format!("projects/{enc}/members/all/{}", user.id);
+    let out = run_glab_raw(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT)
+        .await
+        .map_err(|e| format!("could not read GitLab project membership: {e}"))?;
+    if out.code != 0 {
+        let stdout = out.stdout_lossy();
+        if glab_output_is_404(&out.stderr, &stdout) {
+            return Ok(None);
+        }
+        let msg = out.stderr.trim();
+        return Err(if msg.is_empty() {
+            format!("glab exited with code {} reading project membership", out.code)
+        } else {
+            msg.to_string()
+        });
+    }
+    serde_json::from_str::<GlabAccessLevel>(&out.stdout_lossy())
+        .map(|m| Some(m.access_level))
+        .map_err(|e| format!("could not parse GitLab project membership: {e}"))
+}
+
+/// The viewer's effective access level on the project (0 when they have none) —
+/// the shared resolution behind the admin and write-access probes. `enc` is the
+/// already-encoded project id, so a caller that needs the raw path doesn't
+/// resolve it twice.
+async fn effective_access_level(repo_path: &str, enc: &str) -> AppResult<EffectiveAccess> {
     let out = run_glab(
         Some(repo_path),
         &["api", &format!("projects/{enc}")],
@@ -6081,19 +6118,63 @@ pub async fn repo_admin(repo_path: &str) -> AppResult<(bool, bool)> {
     // access inherited from an ancestor group or an invited group reads as
     // null/null. Before concluding the viewer can't manage, ask the
     // effective-membership endpoint (a 404 there = genuinely not a member).
+    let mut ambiguous = None;
     if level < 40 {
-        if let Ok(user) = current_user(repo_path).await {
-            let endpoint = format!("projects/{enc}/members/all/{}", user.id);
-            if let Ok(out) =
-                run_glab(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT).await
-            {
-                if let Ok(m) = serde_json::from_str::<GlabAccessLevel>(&out.stdout_lossy()) {
-                    level = level.max(m.access_level);
-                }
-            }
+        match membership_access_level(repo_path, enc).await {
+            Ok(Some(inherited)) => level = level.max(inherited),
+            Ok(None) => {}
+            Err(reason) => ambiguous = Some(reason),
         }
     }
+    Ok(EffectiveAccess { level, ambiguous })
+}
+
+/// Whether the signed-in viewer can manage this project's settings
+/// (Maintainer+) and whether they hold the Owner-only lifecycle powers. An
+/// unanswered membership fallback reads as "not a member" here, as it always has.
+pub async fn repo_admin(repo_path: &str) -> AppResult<(bool, bool)> {
+    let enc = encode_project(&project_path(repo_path).await?);
+    let level = effective_access_level(repo_path, &enc).await?.level;
     Ok((level >= 40, level >= 50))
+}
+
+/// A GitLab access level → `(can push, can triage, role label)`. Pure. Developer
+/// (30) is the first level that can push and Reporter (20) the first that manages
+/// issue/MR metadata; levels the app doesn't name (0 = none, 5 = minimal access,
+/// any future tier) carry no label.
+fn write_access_from_level(level: u8) -> (bool, bool, Option<String>) {
+    let role = match level {
+        50 => Some("owner"),
+        40 => Some("maintainer"),
+        30 => Some("developer"),
+        20 => Some("reporter"),
+        10 => Some("guest"),
+        _ => None,
+    };
+    (level >= 30, level >= 20, role.map(str::to_string))
+}
+
+/// Whether the signed-in viewer can push to this project — the write twin of
+/// [`repo_admin`]. A resolved level is an affirmative answer even at 0 (the
+/// endpoints replied), and a failed project read propagates as an error rather
+/// than a guessed `false`.
+///
+/// An unanswered membership fallback leaves the level a FLOOR, so a threshold it
+/// already clears stays affirmative while the ones it doesn't become unknown.
+/// The tier label survives only alongside a granted push, and even then the
+/// floor can understate it — nothing gates on the label.
+pub async fn repo_write_access(repo_path: &str) -> AppResult<crate::forge::ForgeRepoWriteAccess> {
+    let path = project_path(repo_path).await?;
+    let access = effective_access_level(repo_path, &encode_project(&path)).await?;
+    let (can_push, can_triage, role) = write_access_from_level(access.level);
+    let resolved = access.ambiguous.is_none();
+    Ok(crate::forge::ForgeRepoWriteAccess {
+        can_push: (can_push || resolved).then_some(can_push),
+        can_triage: (can_triage || resolved).then_some(can_triage),
+        role: if can_push || resolved { role } else { None },
+        repo: Some(path),
+        unknown_reason: if can_push { None } else { access.ambiguous },
+    })
 }
 
 /// The GitLab project settings the app manages, as the frontend consumes them.
@@ -9807,5 +9888,33 @@ mod tests {
         // Cross-side lookups miss (new_path on the old side, etc.).
         assert!(gl_file_diff(&changes, "new_name.rs", "old").is_none());
         assert!(gl_file_diff(&changes, "absent.rs", "new").is_none());
+    }
+
+    #[test]
+    fn write_access_from_level_maps_push_triage_and_role() {
+        let role = |level| write_access_from_level(level).2;
+        assert_eq!(write_access_from_level(50), (true, true, Some("owner".into())));
+        assert_eq!(
+            write_access_from_level(40),
+            (true, true, Some("maintainer".into()))
+        );
+        assert_eq!(
+            write_access_from_level(30),
+            (true, true, Some("developer".into()))
+        );
+        // Reporter can't push but DOES manage issue/MR metadata.
+        assert_eq!(
+            write_access_from_level(20),
+            (false, true, Some("reporter".into()))
+        );
+        assert_eq!(
+            write_access_from_level(10),
+            (false, false, Some("guest".into()))
+        );
+        // No membership resolved at all is an affirmative "no" on both axes.
+        assert_eq!(write_access_from_level(0), (false, false, None));
+        // Levels the app doesn't name (5 = minimal access) stay unlabeled.
+        assert_eq!(role(5), None);
+        assert_eq!(role(35), None);
     }
 }

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -6154,26 +6154,35 @@ fn write_access_from_level(level: u8) -> (bool, bool, Option<String>) {
     (level >= 30, level >= 20, role.map(str::to_string))
 }
 
-/// Whether the signed-in viewer can push to this project — the write twin of
-/// [`repo_admin`]. A resolved level is an affirmative answer even at 0 (the
-/// endpoints replied), and a failed project read propagates as an error rather
-/// than a guessed `false`.
+/// The write-access answer a resolved level implies. Pure; `repo` is left `None`
+/// because the caller resolves that identity asynchronously.
 ///
 /// An unanswered membership fallback leaves the level a FLOOR, so a threshold it
 /// already clears stays affirmative while the ones it doesn't become unknown.
 /// The tier label survives only alongside a granted push, and even then the
 /// floor can understate it — nothing gates on the label.
-pub async fn repo_write_access(repo_path: &str) -> AppResult<crate::forge::ForgeRepoWriteAccess> {
-    let path = project_path(repo_path).await?;
-    let access = effective_access_level(repo_path, &encode_project(&path)).await?;
-    let (can_push, can_triage, role) = write_access_from_level(access.level);
-    let resolved = access.ambiguous.is_none();
-    Ok(crate::forge::ForgeRepoWriteAccess {
+fn write_access_fields(level: u8, ambiguous: Option<String>) -> crate::forge::ForgeRepoWriteAccess {
+    let (can_push, can_triage, role) = write_access_from_level(level);
+    let resolved = ambiguous.is_none();
+    crate::forge::ForgeRepoWriteAccess {
         can_push: (can_push || resolved).then_some(can_push),
         can_triage: (can_triage || resolved).then_some(can_triage),
         role: if can_push || resolved { role } else { None },
+        repo: None,
+        unknown_reason: if can_push { None } else { ambiguous },
+    }
+}
+
+/// Whether the signed-in viewer can push to this project — the write twin of
+/// [`repo_admin`]. A resolved level is an affirmative answer even at 0 (the
+/// endpoints replied), and a failed project read propagates as an error rather
+/// than a guessed `false`.
+pub async fn repo_write_access(repo_path: &str) -> AppResult<crate::forge::ForgeRepoWriteAccess> {
+    let path = project_path(repo_path).await?;
+    let access = effective_access_level(repo_path, &encode_project(&path)).await?;
+    Ok(crate::forge::ForgeRepoWriteAccess {
         repo: Some(path),
-        unknown_reason: if can_push { None } else { access.ambiguous },
+        ..write_access_fields(access.level, access.ambiguous)
     })
 }
 
@@ -9916,5 +9925,37 @@ mod tests {
         // Levels the app doesn't name (5 = minimal access) stay unlabeled.
         assert_eq!(role(5), None);
         assert_eq!(role(35), None);
+    }
+
+    #[test]
+    fn write_access_fields_treat_an_unanswered_fallback_as_a_floor() {
+        let fields = |level, ambiguous: Option<&str>| {
+            let a = write_access_fields(level, ambiguous.map(str::to_string));
+            (a.can_push, a.can_triage, a.role, a.repo, a.unknown_reason)
+        };
+        // Developer already clears both bars, so an unanswered fallback is moot.
+        assert_eq!(
+            fields(30, Some("502 Bad Gateway")),
+            (Some(true), Some(true), Some("developer".into()), None, None)
+        );
+        // Reporter clears triage but not push: only the unmet axis — and the
+        // label, which the floor can understate — goes unknown, with the reason.
+        assert_eq!(
+            fields(20, Some("502 Bad Gateway")),
+            (
+                None,
+                Some(true),
+                None,
+                None,
+                Some("502 Bad Gateway".into())
+            )
+        );
+        // Nothing resolved and no answer from the fallback: both axes unknown.
+        assert_eq!(
+            fields(0, Some("502 Bad Gateway")),
+            (None, None, None, None, Some("502 Bad Gateway".into()))
+        );
+        // An answered fallback (404 = not a member) is an affirmative "no".
+        assert_eq!(fields(0, None), (Some(false), Some(false), None, None, None));
     }
 }

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -2663,8 +2663,12 @@ pub struct ForgeRepoWriteAccess {
     /// None = unknown (failed/ambiguous probe) — the frontend fails OPEN on None.
     pub can_push: Option<bool>,
     /// Whether the viewer can manage issue/PR metadata (labels, assignees,
-    /// milestones, pin, lock) — GitHub's triage tier and above; a tier BELOW push.
+    /// milestones, review requests, hide-comments) — GitHub's triage tier and
+    /// above; a tier BELOW push.
     pub can_triage: Option<bool>,
+    /// The provider's tier label ("admin"/"maintain"/"write"/"triage"/"read" on
+    /// GitHub, "owner"/"maintainer"/"developer"/… on GitLab). Diagnostic only —
+    /// the two boolean axes do the gating; nothing on the frontend reads this.
     pub role: Option<String>,
     /// The probed repo identity ("owner/repo" / project path / "ws/slug") for UI copy.
     pub repo: Option<String>,

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -2655,6 +2655,43 @@ pub async fn forge_repo_admin(repo_path: String) -> AppResult<ForgeRepoAdmin> {
     }
 }
 
+/// The viewer's push permission on a repo, as the frontend consumes it.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForgeRepoWriteAccess {
+    /// Some(true/false) only when the provider AFFIRMATIVELY answered;
+    /// None = unknown (failed/ambiguous probe) — the frontend fails OPEN on None.
+    pub can_push: Option<bool>,
+    /// Whether the viewer can manage issue/PR metadata (labels, assignees,
+    /// milestones, pin, lock) — GitHub's triage tier and above; a tier BELOW push.
+    pub can_triage: Option<bool>,
+    pub role: Option<String>,
+    /// The probed repo identity ("owner/repo" / project path / "ws/slug") for UI copy.
+    pub repo: Option<String>,
+    pub unknown_reason: Option<String>,
+}
+
+/// Whether the signed-in viewer can PUSH to this repo — the viewer-PERMISSION
+/// probe, distinct from the provider-capability flags (what this app implements
+/// for a forge) and from the admin probe (who may manage settings). A `None`
+/// `can_push` means the probe couldn't answer: callers keep write controls
+/// ENABLED rather than hiding them on a guess.
+///
+/// `lens` is honored on the GitHub arm ONLY — a fork PR targets the PARENT repo,
+/// so the parent's permission is what gates its controls. The GitLab and
+/// Bitbucket surfaces in this app are origin-pinned (see `forge_pr_list`).
+#[tauri::command]
+pub async fn forge_repo_write_access(
+    repo_path: String,
+    lens: Option<String>,
+) -> AppResult<ForgeRepoWriteAccess> {
+    match detect_non_github(&repo_path).await {
+        Some((Provider::GitLab, _)) => gitlab::repo_write_access(&repo_path).await,
+        Some((Provider::Bitbucket, _)) => bitbucket::repo_write_access(&repo_path).await,
+        _ => crate::github::repo_settings::gh_repo_write_access(repo_path, lens).await,
+    }
+}
+
 /// The GitLab project-settings read. GitLab-only — its settings model (feature
 /// access levels, one merge-method enum, a squash option) doesn't map onto
 /// GitHub's `RepoSettings`, so each provider keeps its own shaped surface
@@ -3824,5 +3861,48 @@ mod tests {
         assert!(capped.len() <= README_CAP);
         assert_eq!(capped.len(), pad_len);
         assert!(capped.chars().all(|c| c == 'a'));
+    }
+
+    /// The frontend keys off these exact names, and an unknown probe must travel
+    /// as a JSON `null` (not an omitted field) so it reads as "fails open".
+    #[test]
+    fn write_access_serializes_camel_case_wire_keys() {
+        let known = serde_json::to_value(ForgeRepoWriteAccess {
+            can_push: Some(false),
+            can_triage: Some(true),
+            role: Some("triage".into()),
+            repo: Some("o/r".into()),
+            unknown_reason: None,
+        })
+        .unwrap();
+        assert_eq!(
+            known,
+            serde_json::json!({
+                "canPush": false,
+                "canTriage": true,
+                "role": "triage",
+                "repo": "o/r",
+                "unknownReason": null,
+            })
+        );
+
+        let unknown = serde_json::to_value(ForgeRepoWriteAccess {
+            can_push: None,
+            can_triage: None,
+            role: None,
+            repo: Some("o/r".into()),
+            unknown_reason: Some("HTTP 404".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            unknown,
+            serde_json::json!({
+                "canPush": null,
+                "canTriage": null,
+                "role": null,
+                "repo": "o/r",
+                "unknownReason": "HTTP 404",
+            })
+        );
     }
 }

--- a/src-tauri/src/github/repo_settings.rs
+++ b/src-tauri/src/github/repo_settings.rs
@@ -850,7 +850,24 @@ pub async fn gh_repo_settings_update(
 
 #[cfg(test)]
 mod tests {
-    use super::write_access_from_repo_json;
+    use super::{gh_failure_reason, write_access_from_repo_json, GhOutput};
+
+    #[test]
+    fn gh_failure_reason_names_the_failure_even_when_gh_is_silent() {
+        let noisy = GhOutput {
+            stdout: Vec::new(),
+            stderr: "\n  \ngh: Not Found (HTTP 404)\nsecond line\n".into(),
+            code: 1,
+        };
+        assert_eq!(gh_failure_reason(&noisy), "gh: Not Found (HTTP 404)");
+        // Empty stderr still names the failure rather than reading as silence.
+        let silent = GhOutput {
+            stdout: Vec::new(),
+            stderr: String::new(),
+            code: 4,
+        };
+        assert_eq!(gh_failure_reason(&silent), "gh exited with status 4");
+    }
 
     #[test]
     fn write_access_reads_the_permissions_block() {

--- a/src-tauri/src/github/repo_settings.rs
+++ b/src-tauri/src/github/repo_settings.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 
 use crate::error::{AppError, AppResult};
 use crate::github::runner::{
-    run_gh, run_gh_input, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT,
+    run_gh, run_gh_input, run_gh_raw, GhOutput, GH_NETWORK_TIMEOUT, GH_TIMEOUT,
 };
 
 /// Whether the signed-in user is an admin on this repo — gates the repo-settings /
@@ -30,6 +30,119 @@ pub async fn gh_repo_admin(repo_path: String) -> AppResult<bool> {
         return Ok(false);
     }
     Ok(out.stdout_lossy().trim() == "true")
+}
+
+/// The viewer's permission bits on `GET repos/{slug}`. Every flag is optional:
+/// GitHub omits the whole block for an unauthenticated read and has added tiers
+/// (triage/maintain) over time, so an absent flag must read as "didn't say"
+/// rather than "false".
+#[derive(Deserialize)]
+struct GhRepoPermissions {
+    #[serde(default)]
+    admin: Option<bool>,
+    #[serde(default)]
+    maintain: Option<bool>,
+    #[serde(default)]
+    push: Option<bool>,
+    #[serde(default)]
+    triage: Option<bool>,
+    #[serde(default)]
+    pull: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct GhRepoPermissionsJson {
+    #[serde(default)]
+    permissions: Option<GhRepoPermissions>,
+}
+
+/// The highest role the permission bits name, `None` when none is set. Ordered
+/// most- to least-privileged: GitHub sets every tier at or below the viewer's.
+fn role_from_permissions(p: &GhRepoPermissions) -> Option<String> {
+    [
+        (p.admin, "admin"),
+        (p.maintain, "maintain"),
+        (p.push, "write"),
+        (p.triage, "triage"),
+        (p.pull, "read"),
+    ]
+    .into_iter()
+    .find(|(flag, _)| *flag == Some(true))
+    .map(|(_, role)| role.to_string())
+}
+
+/// `(can_push, can_triage, role)`, the shape both the probe and its tests read.
+type WriteAccessBits = (Option<bool>, Option<bool>, Option<String>);
+
+/// The permission bits from a `GET repos/{slug}` body. Pure. `Err` carries the
+/// unknown-reason: unparseable JSON or a missing `permissions` block means the
+/// probe couldn't answer, which must never collapse into "cannot push".
+///
+/// Triage falls back to the push bit — a response predating the triage tier still
+/// says a pusher can manage metadata; both absent stays unknown.
+fn write_access_from_repo_json(repo_json: &str) -> Result<WriteAccessBits, String> {
+    let parsed: GhRepoPermissionsJson = serde_json::from_str(repo_json)
+        .map_err(|e| format!("could not read the repository's permissions: {e}"))?;
+    let perms = parsed
+        .permissions
+        .ok_or_else(|| "the repository response carried no permissions".to_string())?;
+    Ok((
+        perms.push,
+        perms.triage.or(perms.push),
+        role_from_permissions(&perms),
+    ))
+}
+
+/// A one-line reason for a failed `gh` call — its first non-empty stderr line,
+/// or the exit status when gh said nothing. It reaches the UI, so keep it short.
+fn gh_failure_reason(out: &GhOutput) -> String {
+    out.stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("gh exited with status {}", out.code))
+}
+
+/// Whether the signed-in viewer can push to this repo — the viewer-permission
+/// probe behind `forge_repo_write_access`'s GitHub arm.
+///
+/// Resolved through the LENS, not origin: a fork PR targets the parent repo, and
+/// the parent's permission is what gates that PR's controls. Every failure mode
+/// (gh error, unparseable body, no `permissions` block) answers `can_push: None`
+/// with a reason — `Some(false)` is reserved for GitHub affirmatively saying the
+/// viewer can't push, so a broken probe never hides a control the user can use.
+pub async fn gh_repo_write_access(
+    repo_path: String,
+    lens: Option<String>,
+) -> AppResult<crate::forge::ForgeRepoWriteAccess> {
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
+    let out = run_gh_raw(
+        Some(&repo_path),
+        &["api", &format!("repos/{slug}")],
+        GH_TIMEOUT,
+    )
+    .await?;
+    let unknown = |reason: String| crate::forge::ForgeRepoWriteAccess {
+        can_push: None,
+        can_triage: None,
+        role: None,
+        repo: Some(slug.clone()),
+        unknown_reason: Some(reason),
+    };
+    if out.code != 0 {
+        return Ok(unknown(gh_failure_reason(&out)));
+    }
+    match write_access_from_repo_json(&out.stdout_lossy()) {
+        Ok((can_push, can_triage, role)) => Ok(crate::forge::ForgeRepoWriteAccess {
+            can_push,
+            can_triage,
+            role,
+            repo: Some(slug),
+            unknown_reason: None,
+        }),
+        Err(reason) => Ok(unknown(reason)),
+    }
 }
 
 /// The `parent` block `gh repo view --json parent` returns for a fork — the
@@ -733,4 +846,71 @@ pub async fn gh_repo_settings_update(
         settings.topics = t.names;
     }
     Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_access_from_repo_json;
+
+    #[test]
+    fn write_access_reads_the_permissions_block() {
+        // GitHub sets every tier at or below the viewer's, so the role is the
+        // highest set flag.
+        assert_eq!(
+            write_access_from_repo_json(
+                r#"{"permissions":{"admin":false,"maintain":true,"push":true,"triage":true,"pull":true}}"#
+            ),
+            Ok((Some(true), Some(true), Some("maintain".into()))),
+        );
+        assert_eq!(
+            write_access_from_repo_json(
+                r#"{"permissions":{"admin":true,"maintain":true,"push":true,"triage":true,"pull":true}}"#
+            ),
+            Ok((Some(true), Some(true), Some("admin".into()))),
+        );
+        // A read-only viewer: an AFFIRMATIVE denial, distinct from unknown.
+        assert_eq!(
+            write_access_from_repo_json(
+                r#"{"permissions":{"admin":false,"maintain":false,"push":false,"triage":false,"pull":true}}"#
+            ),
+            Ok((Some(false), Some(false), Some("read".into()))),
+        );
+        // A triager can't push but DOES manage metadata — the axis that keeps
+        // labels/assignees enabled for a real collaborator.
+        assert_eq!(
+            write_access_from_repo_json(
+                r#"{"permissions":{"admin":false,"maintain":false,"push":false,"triage":true,"pull":true}}"#
+            ),
+            Ok((Some(false), Some(true), Some("triage".into()))),
+        );
+        // Tiers the response omits don't invent a role, and no flag set at all
+        // leaves the role unlabeled while `push` still answers. A response with
+        // no `triage` key borrows the push bit.
+        assert_eq!(
+            write_access_from_repo_json(r#"{"permissions":{"push":true,"pull":true}}"#),
+            Ok((Some(true), Some(true), Some("write".into()))),
+        );
+        assert_eq!(
+            write_access_from_repo_json(
+                r#"{"permissions":{"admin":false,"push":false,"pull":false}}"#
+            ),
+            Ok((Some(false), Some(false), None)),
+        );
+    }
+
+    #[test]
+    fn write_access_reports_unknown_rather_than_denying() {
+        // No `permissions` block (unauthenticated read) — the probe can't answer.
+        let no_block = write_access_from_repo_json(r#"{"full_name":"o/r"}"#).unwrap_err();
+        assert!(no_block.contains("permissions"), "{no_block}");
+        // `permissions` present but without `push` or `triage`: the role can still
+        // be read, yet both axes stay unknown rather than defaulting to false.
+        assert_eq!(
+            write_access_from_repo_json(r#"{"permissions":{"pull":true}}"#),
+            Ok((None, None, Some("read".into()))),
+        );
+        // A null block and unparseable output are both unknown, never `false`.
+        assert!(write_access_from_repo_json(r#"{"permissions":null}"#).is_err());
+        assert!(write_access_from_repo_json("gh: not found (HTTP 404)").is_err());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -366,6 +366,7 @@ pub fn run() {
             forge::forge_issue_transfer,
             forge::forge_issue_delete,
             forge::forge_repo_admin,
+            forge::forge_repo_write_access,
             forge::forge_gl_repo_settings,
             forge::forge_gl_repo_settings_update,
             forge::forge_gl_members,

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -18,6 +18,8 @@ import {
   forgeFeatureReady,
   useForgeStatus,
   useRepoStatus,
+  useRepoWriteAccess,
+  writeAccessReason,
 } from "@/lib/git/queries";
 import { useWorkflowRuns } from "@/lib/github/actions";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
@@ -48,6 +50,17 @@ export function ActionsPanel({
   const isPipelines = provider === "gitlab" || provider === "bitbucket";
   const canWrite = provider !== "gitlab" && provider !== "bitbucket";
   const canDispatch = canWrite || forgeFeatureReady(forge.data, "ciDispatch");
+  // Starting a run is a repo write: an explicitly read-only viewer keeps the
+  // control (with the reason) rather than losing it. CI is repo-wide, so the
+  // probe takes no lens; an Activity-hidden tab still renders, so it also gates
+  // on `active` to keep a background tab from fetching.
+  const writeAccess = useRepoWriteAccess(
+    repoPath,
+    undefined,
+    active && !!provider,
+  );
+  const writeReason = writeAccessReason(writeAccess.data);
+  const writeBlocked = writeAccess.data?.canPush === false;
   const runNoun = isPipelines ? "pipeline" : "workflow";
   const status = useRepoStatus(repoPath);
   const currentBranch = status.data?.branch.name ?? null;
@@ -104,22 +117,32 @@ export function ActionsPanel({
         </Button>
         <div className="ml-auto flex items-center gap-1">
           {canDispatch && (
-            <Button
-              variant="ghost"
-              size="xs"
-              disabled={!ghReady}
+            // A natively-disabled Button swallows `title`, so the hint rides the
+            // wrapping span (house idiom) — it covers the enabled case too.
+            <span
               title={
-                ghReady
+                writeReason ??
+                (ghReady
                   ? `Run a ${runNoun}`
                   : isGitLab
                     ? "Sign in with the GitLab CLI (glab) to run pipelines"
-                    : "Sign in with GitHub CLI to run workflows"
+                    : "Sign in with GitHub CLI to run workflows")
               }
-              onClick={() => setRunOpen(true)}
+              className={cn(
+                "inline-flex",
+                writeBlocked && "cursor-not-allowed",
+              )}
             >
-              <PlayIcon data-icon="inline-start" />
-              Run {runNoun}…
-            </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={!ghReady || writeBlocked}
+                onClick={() => setRunOpen(true)}
+              >
+                <PlayIcon data-icon="inline-start" />
+                Run {runNoun}…
+              </Button>
+            </span>
           )}
           <Button
             variant="outline"
@@ -204,14 +227,23 @@ export function ActionsPanel({
               </EmptyHeader>
               {canDispatch && (
                 <EmptyContent>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setRunOpen(true)}
+                  <span
+                    title={writeReason}
+                    className={cn(
+                      "inline-flex",
+                      writeBlocked && "cursor-not-allowed",
+                    )}
                   >
-                    <PlayIcon data-icon="inline-start" />
-                    Run {runNoun}…
-                  </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={writeBlocked}
+                      onClick={() => setRunOpen(true)}
+                    >
+                      <PlayIcon data-icon="inline-start" />
+                      Run {runNoun}…
+                    </Button>
+                  </span>
                 </EmptyContent>
               )}
             </Empty>

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -15,7 +15,12 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { forgeFeatureReady, useForgeStatus } from "@/lib/git/queries";
+import {
+  forgeFeatureReady,
+  useForgeStatus,
+  useRepoWriteAccess,
+  writeAccessReason,
+} from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
 import type { RunJob } from "@/lib/github/actions";
 import {
@@ -301,6 +306,16 @@ export function RunDetailView({
   // alone gates — never `canWrite || …`. With the gate GitHub never matches the
   // manual-job shape anyway.
   const canPlay = forgeFeatureReady(forge.data, "ciJobPlay");
+  // Re-run and cancel are repo writes: an explicitly read-only viewer keeps the
+  // buttons (disabled, with the reason). CI is repo-wide — no lens.
+  const writeAccess = useRepoWriteAccess(repoPath, undefined, tabActive && !!provider);
+  const writeReason = writeAccessReason(writeAccess.data);
+  const writeBlocked = writeAccess.data?.canPush === false;
+  // Shared by every disabled-with-reason wrapper below (a natively-disabled
+  // Button swallows `title`, so it rides the span).
+  const blockedSpanClass = writeBlocked
+    ? "inline-flex cursor-not-allowed"
+    : "inline-flex";
   const remoteLabel = providerLabel(provider);
   // GitLab pipelines and Bitbucket steps carry no per-job step list; only GitHub
   // jobs do — so the steps placeholder is suppressed for both.
@@ -409,69 +424,88 @@ export function RunDetailView({
         <div className="mt-3 flex flex-wrap items-center gap-2">
           {active || gitlabBlocked
             ? canCancel && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={cancel.isPending}
-                  onClick={doCancel}
-                >
-                  {cancel.isPending ? (
-                    <Spinner data-icon="inline-start" />
-                  ) : (
-                    <ProhibitIcon data-icon="inline-start" />
-                  )}
-                  Cancel run
-                </Button>
+                <span title={writeReason} className={blockedSpanClass}>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={cancel.isPending || writeBlocked}
+                    onClick={doCancel}
+                  >
+                    {cancel.isPending ? (
+                      <Spinner data-icon="inline-start" />
+                    ) : (
+                      <ProhibitIcon data-icon="inline-start" />
+                    )}
+                    Cancel run
+                  </Button>
+                </span>
               )
             : provider === "gitlab"
               ? canRerun &&
                 retryable && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={rerun.isPending}
-                    title="Restart this pipeline's failed and canceled jobs"
-                    onClick={() => doRerun(true)}
+                  <span
+                    title={
+                      writeReason ??
+                      "Restart this pipeline's failed and canceled jobs"
+                    }
+                    className={blockedSpanClass}
                   >
-                    <ArrowClockwiseIcon data-icon="inline-start" />
-                    Retry pipeline
-                  </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={rerun.isPending || writeBlocked}
+                      onClick={() => doRerun(true)}
+                    >
+                      <ArrowClockwiseIcon data-icon="inline-start" />
+                      Retry pipeline
+                    </Button>
+                  </span>
                 )
               : provider === "bitbucket"
                 ? canRerun &&
                   bitbucketRerunnable && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={rerun.isPending}
-                      title="Trigger this pipeline's branch again"
-                      onClick={() => doRerun(true)}
+                    <span
+                      title={
+                        writeReason ?? "Trigger this pipeline's branch again"
+                      }
+                      className={blockedSpanClass}
                     >
-                      <ArrowClockwiseIcon data-icon="inline-start" />
-                      Rerun pipeline
-                    </Button>
-                  )
-                : canWrite && (
-                    <>
                       <Button
                         variant="outline"
                         size="sm"
-                        disabled={rerun.isPending}
-                        onClick={() => doRerun(false)}
+                        disabled={rerun.isPending || writeBlocked}
+                        onClick={() => doRerun(true)}
                       >
                         <ArrowClockwiseIcon data-icon="inline-start" />
-                        Re-run all jobs
+                        Rerun pipeline
                       </Button>
-                      {failed && (
+                    </span>
+                  )
+                : canWrite && (
+                    <>
+                      <span title={writeReason} className={blockedSpanClass}>
                         <Button
                           variant="outline"
                           size="sm"
-                          disabled={rerun.isPending}
-                          onClick={() => doRerun(true)}
+                          disabled={rerun.isPending || writeBlocked}
+                          onClick={() => doRerun(false)}
                         >
                           <ArrowClockwiseIcon data-icon="inline-start" />
-                          Re-run failed jobs
+                          Re-run all jobs
                         </Button>
+                      </span>
+                      {failed && (
+                        <span title={writeReason} className={blockedSpanClass}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={rerun.isPending || writeBlocked}
+                            onClick={() => doRerun(true)}
+                          >
+                            <ArrowClockwiseIcon data-icon="inline-start" />
+                            Re-run failed jobs
+                          </Button>
+                        </span>
                       )}
                     </>
                   )}

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -69,6 +69,7 @@ function JobRow({
   onDebug,
   onPlay,
   playing = false,
+  playDisabledReason,
 }: {
   repoPath: string;
   job: RunJob;
@@ -81,6 +82,9 @@ function JobRow({
   onPlay?: () => void;
   /** Whether the play mutation is in flight for THIS job. */
   playing?: boolean;
+  /** Set when the viewer may not push: the play button stays visible but
+   *  disabled, with this text as its hint. */
+  playDisabledReason?: string;
 }) {
   // Failed and in-progress jobs are the interesting ones — open them by default.
   const [open, setOpen] = useState(
@@ -134,21 +138,32 @@ function JobRow({
           )}
         </button>
         {onPlay && (
-          <Button
-            variant="ghost"
-            size="xs"
-            className="mr-2 shrink-0 text-muted-foreground"
-            disabled={playing}
-            aria-label={`Run job ${job.name}`}
-            onClick={onPlay}
+          // A natively disabled button swallows `title`, so the reason rides a
+          // wrapping span.
+          <span
+            title={playDisabledReason}
+            className={
+              playDisabledReason
+                ? "inline-flex cursor-not-allowed"
+                : "inline-flex"
+            }
           >
-            {playing ? (
-              <Spinner data-icon="inline-start" />
-            ) : (
-              <PlayIcon data-icon="inline-start" />
-            )}
-            Run job
-          </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="mr-2 shrink-0 text-muted-foreground"
+              disabled={playing || !!playDisabledReason}
+              aria-label={`Run job ${job.name}`}
+              onClick={onPlay}
+            >
+              {playing ? (
+                <Spinner data-icon="inline-start" />
+              ) : (
+                <PlayIcon data-icon="inline-start" />
+              )}
+              Run job
+            </Button>
+          </span>
         )}
         {onDebug && (
           <Button
@@ -308,7 +323,11 @@ export function RunDetailView({
   const canPlay = forgeFeatureReady(forge.data, "ciJobPlay");
   // Re-run and cancel are repo writes: an explicitly read-only viewer keeps the
   // buttons (disabled, with the reason). CI is repo-wide — no lens.
-  const writeAccess = useRepoWriteAccess(repoPath, undefined, tabActive && !!provider);
+  const writeAccess = useRepoWriteAccess(
+    repoPath,
+    undefined,
+    tabActive && !!provider,
+  );
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
   // Shared by every disabled-with-reason wrapper below (a natively-disabled
@@ -351,9 +370,11 @@ export function RunDetailView({
           toast.success(
             provider === "gitlab"
               ? "Retrying pipeline"
-              : failedOnly
-                ? "Re-running failed jobs"
-                : "Re-running workflow",
+              : provider === "bitbucket"
+                ? "Triggering a new pipeline"
+                : failedOnly
+                  ? "Re-running failed jobs"
+                  : "Re-running workflow",
           ),
         onError: toastError,
       },
@@ -563,6 +584,7 @@ export function RunDetailView({
                       : undefined
                   }
                   playing={playJob.isPending && playJob.variables === job.id}
+                  playDisabledReason={writeReason}
                 />
               ))}
             </div>

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -23,6 +23,7 @@ export function LabelsPopover({
   labelableId,
   labels,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -34,6 +35,9 @@ export function LabelsPopover({
   labels: RepoLabel[];
   /** The origin|upstream lens the parent PR/issue surface resolved. */
   lens: RemoteLens;
+  /** Set when the viewer may not write to the repo: the trigger stays visible
+   *  but disabled and this text explains why. Absent = editable as before. */
+  disabledReason?: string;
 }) {
   const repoLabels = useRepoLabels(repoPath, enabled, lens);
   const editLabels = useEditPrLabels(repoPath, lens);
@@ -87,18 +91,29 @@ export function LabelsPopover({
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      {/* Trigger first, so it never shifts as chips come and go. */}
+      {/* Trigger first, so it never shifts as chips come and go. A natively
+          disabled button swallows `title`, so the reason rides a wrapping span. */}
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <Popover.Trigger
-          render={<Button variant="ghost" size="xs" aria-label="Edit labels" />}
+        <span
+          title={disabledReason}
+          className={
+            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+          }
         >
-          {editLabels.isPending ? (
-            <Spinner data-icon="inline-start" />
-          ) : (
-            <TagIcon data-icon="inline-start" />
-          )}
-          Labels
-        </Popover.Trigger>
+          <Popover.Trigger
+            disabled={!!disabledReason}
+            render={
+              <Button variant="ghost" size="xs" aria-label="Edit labels" />
+            }
+          >
+            {editLabels.isPending ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <TagIcon data-icon="inline-start" />
+            )}
+            Labels
+          </Popover.Trigger>
+        </span>
         <Popover.Portal>
           <Popover.Positioner
             align="start"

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -35,8 +35,9 @@ export function LabelsPopover({
   labels: RepoLabel[];
   /** The origin|upstream lens the parent PR/issue surface resolved. */
   lens: RemoteLens;
-  /** Set when the viewer may not write to the repo: the trigger stays visible
-   *  but disabled and this text explains why. Absent = editable as before. */
+  /** Set when the viewer lacks the access this picker's action needs — callers
+   *  pass the reason for the matching axis. The trigger stays visible but
+   *  disabled and this text explains why. Absent = editable as before. */
   disabledReason?: string;
 }) {
   const repoLabels = useRepoLabels(repoPath, enabled, lens);

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -97,6 +97,7 @@ export function Thread({
   onToggleReaction,
   renderBody,
   copyMarkdown,
+  writeDisabledReason,
 }: {
   thread: PrThreadOut;
   onQuote?: () => void;
@@ -117,6 +118,10 @@ export function Thread({
   onHide?: (classifier: MinimizeReason) => void;
   /** Unhide a previously hidden comment. */
   onUnhide?: () => void;
+  /** Set when the viewer may not write to the repo: the hide/unhide items stay
+   *  visible but disabled, with this text appended to their label (a disabled
+   *  item drops pointer events, so a tooltip would never show). */
+  writeDisabledReason?: string;
   /** Current reactions on this comment (only used when onToggleReaction set). */
   reactions?: Reaction[];
   /** Present to enable the reaction bar; toggles the viewer's reaction. */
@@ -126,6 +131,7 @@ export function Thread({
   const [draft, setDraft] = useState("");
   const [expanded, setExpanded] = useState(false);
   const minimized = thread.isMinimized;
+  const writeSuffix = writeDisabledReason ? ` — ${writeDisabledReason}` : "";
   return (
     <div className="group space-y-1">
       <p className="flex items-center gap-2 text-xs">
@@ -197,11 +203,24 @@ export function Thread({
                   </DropdownMenuItem>
                 )}
                 {onUnhide && minimized && (
-                  <DropdownMenuItem onClick={onUnhide}>Unhide</DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!!writeDisabledReason}
+                    onClick={onUnhide}
+                  >
+                    Unhide{writeSuffix}
+                  </DropdownMenuItem>
                 )}
                 {onHide && !minimized && (
                   <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>Hide…</DropdownMenuSubTrigger>
+                    {/* The vendored sub-trigger carries no disabled styling of
+                        its own (unlike menu items), so the dim rides a
+                        call-site class. */}
+                    <DropdownMenuSubTrigger
+                      disabled={!!writeDisabledReason}
+                      className="data-disabled:opacity-50"
+                    >
+                      Hide…{writeSuffix}
+                    </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
                       {HIDE_REASONS.map(([label, classifier]) => (
                         <DropdownMenuItem

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -97,7 +97,7 @@ export function Thread({
   onToggleReaction,
   renderBody,
   copyMarkdown,
-  writeDisabledReason,
+  disabledReason,
 }: {
   thread: PrThreadOut;
   onQuote?: () => void;
@@ -118,10 +118,11 @@ export function Thread({
   onHide?: (classifier: MinimizeReason) => void;
   /** Unhide a previously hidden comment. */
   onUnhide?: () => void;
-  /** Set when the viewer may not write to the repo: the hide/unhide items stay
-   *  visible but disabled, with this text appended to their label (a disabled
-   *  item drops pointer events, so a tooltip would never show). */
-  writeDisabledReason?: string;
+  /** Set when the viewer may not hide comments — a TRIAGE-tier action, so
+   *  callers feed this from the triage axis rather than push. The hide/unhide
+   *  items stay visible but disabled, with this text appended to their label (a
+   *  disabled item drops pointer events, so a tooltip would never show). */
+  disabledReason?: string;
   /** Current reactions on this comment (only used when onToggleReaction set). */
   reactions?: Reaction[];
   /** Present to enable the reaction bar; toggles the viewer's reaction. */
@@ -131,7 +132,7 @@ export function Thread({
   const [draft, setDraft] = useState("");
   const [expanded, setExpanded] = useState(false);
   const minimized = thread.isMinimized;
-  const writeSuffix = writeDisabledReason ? ` — ${writeDisabledReason}` : "";
+  const disabledSuffix = disabledReason ? ` — ${disabledReason}` : "";
   return (
     <div className="group space-y-1">
       <p className="flex items-center gap-2 text-xs">
@@ -204,10 +205,10 @@ export function Thread({
                 )}
                 {onUnhide && minimized && (
                   <DropdownMenuItem
-                    disabled={!!writeDisabledReason}
+                    disabled={!!disabledReason}
                     onClick={onUnhide}
                   >
-                    Unhide{writeSuffix}
+                    Unhide{disabledSuffix}
                   </DropdownMenuItem>
                 )}
                 {onHide && !minimized && (
@@ -216,10 +217,10 @@ export function Thread({
                         its own (unlike menu items), so the dim rides a
                         call-site class. */}
                     <DropdownMenuSubTrigger
-                      disabled={!!writeDisabledReason}
+                      disabled={!!disabledReason}
                       className="data-disabled:opacity-50"
                     >
-                      Hide…{writeSuffix}
+                      Hide…{disabledSuffix}
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
                       {HIDE_REASONS.map(([label, classifier]) => (

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -655,6 +655,12 @@ instead of a dead end.) When a token is within a week of expiring, a quiet **dis
 notice** at the top of this tab (and the Issues tab) reminds you to reconnect before it
 lapses.
 
+What you can *do* here follows your access on the repository: when you lack the access an
+action needs — push access to **merge**, a lighter tier (GitHub's triage, GitLab's
+Reporter) for **labels**, **assignees**, and **reviewers** — the control stays where it
+is, disabled, and says what it requires
+instead of failing when you press it.
+
 ## Fork · Upstream lens
 
 When the repo is a **GitHub fork** — an \`origin\` you pushed to plus an \`upstream\`

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -657,9 +657,8 @@ lapses.
 
 What you can *do* here follows your access on the repository: when you lack the access an
 action needs — push access to **merge**, a lighter tier (GitHub's triage, GitLab's
-Reporter) for **labels**, **assignees**, and **reviewers** — the control stays where it
-is, disabled, and says what it requires
-instead of failing when you press it.
+Reporter) for **labels**, **assignees**, and **reviewers** — the control stays where it is,
+disabled, and says what it requires instead of failing when you press it.
 
 ## Fork · Upstream lens
 
@@ -1119,6 +1118,11 @@ add labels, **close / reopen**, **lock**, and **transfer** an issue to another r
 - **Dependencies** — link issues as blocked-by / blocking.
 - **Development** — see linked PRs and branches, and **create a branch** wired to the
   issue.
+
+As on the Pull Requests tab, these follow your access on the repository: an action you
+don't have the access for — a lighter tier for labels, assignees and milestones, push
+access for pinning, transferring or creating a branch — stays visible but disabled and
+says what it needs.
 
 ## Fork · Upstream lens
 

--- a/src/features/issues/IssueDevelopment.tsx
+++ b/src/features/issues/IssueDevelopment.tsx
@@ -78,6 +78,7 @@ export function IssueDevelopment({
   issueTitle,
   issueUrl,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   number: number;
@@ -86,6 +87,11 @@ export function IssueDevelopment({
   issueUrl: string;
   /** The origin|upstream lens the parent issue view resolved. */
   lens: RemoteLens;
+  /** Set when the viewer may not push: creating a linked branch is a remote
+   *  branch write, so that item disables and appends this text to its label (a
+   *  disabled menu item drops pointer events, so a tooltip never shows).
+   *  Callers pass the compact write-axis reason; the link-out stays live. */
+  disabledReason?: string;
 }) {
   const dev = useIssueDevelopment(repoPath, number, lens);
   const createBranch = useCreateLinkedBranch(repoPath, lens);
@@ -139,12 +145,14 @@ export function IssueDevelopment({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="min-w-56">
             <DropdownMenuItem
+              disabled={!!disabledReason}
               onClick={() => {
                 setBranchName(defaultBranchName(number, issueTitle));
                 setBranchOpen(true);
               }}
             >
               Create a branch…
+              {disabledReason ? ` — ${disabledReason}` : ""}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => openUrl(issueUrl)}>
               <ArrowSquareOutIcon />

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -78,8 +78,9 @@ export function AssigneesPopover({
   commitOnClose?: boolean;
   /** The origin|upstream lens the parent surface resolved. */
   lens: RemoteLens;
-  /** Set when the viewer may not write to the repo: the trigger stays visible
-   *  but disabled and this text explains why. Absent = editable as before. */
+  /** Set when the viewer lacks the access this picker's action needs — callers
+   *  pass the reason for the matching axis. The trigger stays visible but
+   *  disabled and this text explains why. Absent = editable as before. */
   disabledReason?: string;
 }) {
   const users = useAssignableUsers(repoPath, enabled, lens);
@@ -214,8 +215,9 @@ export function MilestoneMenu({
   onChange: (milestone: number | null, title: string | null) => void;
   /** The origin|upstream lens the parent surface resolved. */
   lens: RemoteLens;
-  /** Set when the viewer may not write to the repo: the trigger stays visible
-   *  but disabled and this text explains why. Absent = editable as before. */
+  /** Set when the viewer lacks the access this picker's action needs — callers
+   *  pass the reason for the matching axis. The trigger stays visible but
+   *  disabled and this text explains why. Absent = editable as before. */
   disabledReason?: string;
 }) {
   const milestones = useMilestones(repoPath, enabled, lens);
@@ -288,6 +290,7 @@ export function IssueTypeMenu({
   value,
   onChange,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -295,6 +298,10 @@ export function IssueTypeMenu({
   onChange: (type: IssueType | null) => void;
   /** The origin|upstream lens the parent surface resolved. */
   lens: RemoteLens;
+  /** Set when the viewer lacks the access this picker's action needs — callers
+   *  pass the reason for the matching axis. The trigger stays visible but
+   *  disabled and this text explains why. Absent = editable as before. */
+  disabledReason?: string;
 }) {
   const types = useIssueTypes(repoPath, enabled, lens);
   const list = types.data ?? [];
@@ -304,19 +311,29 @@ export function IssueTypeMenu({
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button variant="ghost" size="xs" aria-label="Set issue type" />
+        {/* A natively disabled button swallows `title`, so the reason rides a
+            wrapping span. */}
+        <span
+          title={disabledReason}
+          className={
+            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
           }
         >
-          {value ? (
-            <TypeDot color={value.color} data-icon="inline-start" />
-          ) : (
-            <ShapesIcon data-icon="inline-start" />
-          )}
-          {value?.name ?? "Type"}
-          <CaretDownIcon data-icon="inline-end" />
-        </DropdownMenuTrigger>
+          <DropdownMenuTrigger
+            disabled={!!disabledReason}
+            render={
+              <Button variant="ghost" size="xs" aria-label="Set issue type" />
+            }
+          >
+            {value ? (
+              <TypeDot color={value.color} data-icon="inline-start" />
+            ) : (
+              <ShapesIcon data-icon="inline-start" />
+            )}
+            {value?.name ?? "Type"}
+            <CaretDownIcon data-icon="inline-end" />
+          </DropdownMenuTrigger>
+        </span>
         <DropdownMenuContent align="start" className="min-w-52">
           <DropdownMenuItem
             onClick={() => onChange(null)}

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -69,6 +69,7 @@ export function AssigneesPopover({
   onChange,
   commitOnClose = false,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -77,6 +78,9 @@ export function AssigneesPopover({
   commitOnClose?: boolean;
   /** The origin|upstream lens the parent surface resolved. */
   lens: RemoteLens;
+  /** Set when the viewer may not write to the repo: the trigger stays visible
+   *  but disabled and this text explains why. Absent = editable as before. */
+  disabledReason?: string;
 }) {
   const users = useAssignableUsers(repoPath, enabled, lens);
   const ghHost = useForgeGhHost(repoPath);
@@ -129,14 +133,24 @@ export function AssigneesPopover({
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <Popover.Trigger
-          render={
-            <Button variant="ghost" size="xs" aria-label="Edit assignees" />
+        {/* A natively disabled button swallows `title`, so the reason rides a
+            wrapping span. */}
+        <span
+          title={disabledReason}
+          className={
+            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
           }
         >
-          <UserPlusIcon data-icon="inline-start" />
-          Assignees
-        </Popover.Trigger>
+          <Popover.Trigger
+            disabled={!!disabledReason}
+            render={
+              <Button variant="ghost" size="xs" aria-label="Edit assignees" />
+            }
+          >
+            <UserPlusIcon data-icon="inline-start" />
+            Assignees
+          </Popover.Trigger>
+        </span>
         <Popover.Portal>
           <Popover.Positioner
             align="start"
@@ -191,6 +205,7 @@ export function MilestoneMenu({
   valueLabel,
   onChange,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -199,6 +214,9 @@ export function MilestoneMenu({
   onChange: (milestone: number | null, title: string | null) => void;
   /** The origin|upstream lens the parent surface resolved. */
   lens: RemoteLens;
+  /** Set when the viewer may not write to the repo: the trigger stays visible
+   *  but disabled and this text explains why. Absent = editable as before. */
+  disabledReason?: string;
 }) {
   const milestones = useMilestones(repoPath, enabled, lens);
   const list = milestones.data ?? [];
@@ -211,15 +229,25 @@ export function MilestoneMenu({
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button variant="ghost" size="xs" aria-label="Set milestone" />
+        {/* A natively disabled button swallows `title`, so the reason rides a
+            wrapping span. */}
+        <span
+          title={disabledReason}
+          className={
+            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
           }
         >
-          <FlagIcon data-icon="inline-start" />
-          {display}
-          <CaretDownIcon data-icon="inline-end" />
-        </DropdownMenuTrigger>
+          <DropdownMenuTrigger
+            disabled={!!disabledReason}
+            render={
+              <Button variant="ghost" size="xs" aria-label="Set milestone" />
+            }
+          >
+            <FlagIcon data-icon="inline-start" />
+            {display}
+            <CaretDownIcon data-icon="inline-end" />
+          </DropdownMenuTrigger>
+        </span>
         <DropdownMenuContent align="start" className="min-w-52">
           <DropdownMenuItem
             onClick={() => onChange(null, null)}

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -99,7 +99,7 @@ export function RelatedRow({
           className={cn(
             "text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             // Full opacity only for the in-flight spinner — a permission-blocked
-            // remove keeps the vendored disabled dim and hover-reveal.
+            // remove keeps the vendored disabled dim.
             pending && "disabled:opacity-100",
           )}
           onClick={onRemove}

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -57,11 +57,15 @@ export function RelatedRow({
   onOpen,
   onRemove,
   pending,
+  removeDisabledReason,
 }: {
   issue: RelatedIssue;
   onOpen: (n: number) => void;
   onRemove: () => void;
   pending?: boolean;
+  /** Set when the viewer may not write to the repo: the remove button stays
+   *  visible but disabled, with this text as its hint. */
+  removeDisabledReason?: string;
 }) {
   return (
     <div className="group flex items-center gap-1.5 text-xs">
@@ -75,16 +79,27 @@ export function RelatedRow({
         <span className="text-muted-foreground">#{issue.number}</span>{" "}
         {issue.title}
       </button>
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        aria-label={`Remove #${issue.number}`}
-        disabled={pending}
-        className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 disabled:opacity-100"
-        onClick={onRemove}
+      {/* A natively disabled button swallows `title`, so the reason rides a
+          wrapping span. */}
+      <span
+        title={removeDisabledReason}
+        className={
+          removeDisabledReason
+            ? "inline-flex cursor-not-allowed"
+            : "inline-flex"
+        }
       >
-        {pending ? <Spinner /> : <XIcon />}
-      </Button>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Remove #${issue.number}`}
+          disabled={pending || !!removeDisabledReason}
+          className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 disabled:opacity-100"
+          onClick={onRemove}
+        >
+          {pending ? <Spinner /> : <XIcon />}
+        </Button>
+      </span>
     </div>
   );
 }
@@ -184,12 +199,17 @@ export function IssueSubIssues({
   issueId,
   number,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   issueId: string;
   number: number;
   /** The origin|upstream lens the parent issue view resolved. */
   lens: RemoteLens;
+  /** Set when the viewer may not write to the repo: the add + remove
+   *  affordances stay visible but disabled, with this text as their hint. The
+   *  parent breadcrumb and the checklist itself are reads and stay live. */
+  disabledReason?: string;
 }) {
   const relations = useIssueRelations(repoPath, number, lens);
   const addSub = useAddSubIssue(repoPath, lens);
@@ -252,19 +272,32 @@ export function IssueSubIssues({
           <span className="flex-1" />
           {mode === null && (
             <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    aria-label="Add a sub-issue"
-                  />
+              {/* A natively disabled button swallows `title`, so the reason
+                  rides a wrapping span. Every item in this menu is a write, so
+                  the gate sits on the trigger rather than on each item. */}
+              <span
+                title={disabledReason}
+                className={
+                  disabledReason
+                    ? "inline-flex cursor-not-allowed"
+                    : "inline-flex"
                 }
               >
-                <PlusIcon data-icon="inline-start" />
-                Add sub-issue
-                <CaretDownIcon data-icon="inline-end" />
-              </DropdownMenuTrigger>
+                <DropdownMenuTrigger
+                  disabled={!!disabledReason}
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      aria-label="Add a sub-issue"
+                    />
+                  }
+                >
+                  <PlusIcon data-icon="inline-start" />
+                  Add sub-issue
+                  <CaretDownIcon data-icon="inline-end" />
+                </DropdownMenuTrigger>
+              </span>
               <DropdownMenuContent align="end" className="min-w-52">
                 <DropdownMenuItem onClick={() => setCreateOpen(true)}>
                   Create new sub-issue…
@@ -295,6 +328,7 @@ export function IssueSubIssues({
               removeSub.mutate({ parentId: issueId, subId: s.id }, { onError })
             }
             pending={removeSub.isPending && removeSub.variables?.subId === s.id}
+            removeDisabledReason={disabledReason}
           />
         ))}
 

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -39,6 +39,7 @@ import type {
 } from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 import { CreateIssueDialog } from "./CreateIssueDialog";
 
 /** Open/closed glyph for a related issue, so state isn't conveyed by text alone. */
@@ -95,7 +96,12 @@ export function RelatedRow({
           size="icon-xs"
           aria-label={`Remove #${issue.number}`}
           disabled={pending || !!removeDisabledReason}
-          className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 disabled:opacity-100"
+          className={cn(
+            "text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+            // Full opacity only for the in-flight spinner — a permission-blocked
+            // remove keeps the vendored disabled dim and hover-reveal.
+            pending && "disabled:opacity-100",
+          )}
           onClick={onRemove}
         >
           {pending ? <Spinner /> : <XIcon />}

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -63,8 +63,9 @@ export function RelatedRow({
   onOpen: (n: number) => void;
   onRemove: () => void;
   pending?: boolean;
-  /** Set when the viewer may not write to the repo: the remove button stays
-   *  visible but disabled, with this text as its hint. */
+  /** Set when the viewer lacks the access this row's remove needs — callers pass
+   *  the reason for the matching axis (sub-issues are write, dependency and
+   *  related-issue links are triage). The button stays visible but disabled. */
   removeDisabledReason?: string;
 }) {
   return (
@@ -112,12 +113,16 @@ function RelationList({
   onOpen,
   onRemove,
   isRemoving,
+  removeDisabledReason,
 }: {
   label: string;
   items: RelatedIssue[];
   onOpen: (n: number) => void;
   onRemove: (target: number) => void;
   isRemoving: (target: number) => boolean;
+  /** Set when the viewer may not edit dependencies: each row's remove stays
+   *  visible but disabled, with this text as its hint. */
+  removeDisabledReason?: string;
 }) {
   return (
     <div className="space-y-1">
@@ -129,6 +134,7 @@ function RelationList({
           onOpen={onOpen}
           onRemove={() => onRemove(it.number)}
           pending={isRemoving(it.number)}
+          removeDisabledReason={removeDisabledReason}
         />
       ))}
     </div>
@@ -375,11 +381,15 @@ export function IssueRelationships({
   repoPath,
   number,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   number: number;
   /** The origin|upstream lens the parent issue view resolved. */
   lens: RemoteLens;
+  /** Set when the viewer lacks the access dependency edits need: Add and the
+   *  per-row removes disable, with this text as their hint. The lists stay live. */
+  disabledReason?: string;
 }) {
   const dependencies = useIssueDependencies(repoPath, number, lens);
   const setDep = useSetIssueDependency(repoPath, lens);
@@ -412,19 +422,32 @@ export function IssueRelationships({
         <span className="flex-1" />
         {addRelation === null && (
           <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  aria-label="Add a relationship"
-                />
+            {/* A natively disabled button swallows `title`, so the reason rides
+                a wrapping span. Every item in this menu is a write, so the gate
+                sits on the trigger rather than on each item. */}
+            <span
+              title={disabledReason}
+              className={
+                disabledReason
+                  ? "inline-flex cursor-not-allowed"
+                  : "inline-flex"
               }
             >
-              <PlusIcon data-icon="inline-start" />
-              Add
-              <CaretDownIcon data-icon="inline-end" />
-            </DropdownMenuTrigger>
+              <DropdownMenuTrigger
+                disabled={!!disabledReason}
+                render={
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    aria-label="Add a relationship"
+                  />
+                }
+              >
+                <PlusIcon data-icon="inline-start" />
+                Add
+                <CaretDownIcon data-icon="inline-end" />
+              </DropdownMenuTrigger>
+            </span>
             <DropdownMenuContent align="end" className="min-w-44">
               <DropdownMenuItem onClick={() => setAddRelation("blocked_by")}>
                 Blocked by…
@@ -454,6 +477,7 @@ export function IssueRelationships({
             setDep.variables.relation === "blocked_by" &&
             setDep.variables.target === t
           }
+          removeDisabledReason={disabledReason}
         />
       )}
       {blocking.length > 0 && (
@@ -473,6 +497,7 @@ export function IssueRelationships({
             setDep.variables.relation === "blocking" &&
             setDep.variables.target === t
           }
+          removeDisabledReason={disabledReason}
         />
       )}
       {depsLoaded &&

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -127,19 +127,22 @@ export function RemoteIssueView({
   const lens = useRepoLens(repoPath);
   // The viewer's permission on the lens repo — a PERMISSION axis the per-action
   // flags below don't cover, so it never hides a control: it only disables one,
-  // and only on an explicit denial. Triage is its own tier: labels, assignees,
-  // milestones, pin and lock come with it WITHOUT push, so they read
-  // `canTriage` and gating them on push would strip a triager's controls.
+  // and only on an explicit denial. Triage is its own, LOWER tier: labels,
+  // assignees, milestones, hide-comments and the other issue-metadata rows come
+  // with it without push, so those read `canTriage`; pin, transfer, delete and
+  // branch creation are write-tier. Each blocked flag derives from its reason so
+  // the two can never disagree.
   const writeAccess = useRepoWriteAccess(repoPath, lens, !!provider);
   const writeReason = writeAccessReason(writeAccess.data);
-  const writeBlocked = writeAccess.data?.canPush === false;
   const triageReason = triageAccessReason(writeAccess.data);
-  const triageBlocked = writeAccess.data?.canTriage === false;
+  const writeBlocked = !!writeReason;
+  const triageBlocked = !!triageReason;
   // A disabled menu item drops pointer events, so its explanation goes in the
   // label; each suffix is empty whenever its axis allows the action.
-  const itemReason = writeBlocked ? WRITE_ACCESS_ITEM_REASON : undefined;
-  const itemSuffix = itemReason ? ` — ${itemReason}` : "";
-  const triageSuffix = triageBlocked ? ` — ${TRIAGE_ACCESS_ITEM_REASON}` : "";
+  const triageItemReason = triageReason ? TRIAGE_ACCESS_ITEM_REASON : undefined;
+  const writeItemReason = writeReason ? WRITE_ACCESS_ITEM_REASON : undefined;
+  const itemSuffix = writeItemReason ? ` — ${writeItemReason}` : "";
+  const triageSuffix = triageItemReason ? ` — ${triageItemReason}` : "";
   // GitLab WRITES land per-action. Each shared control is
   // `canWrite || forgeFeatureReady(...)` so GitHub keeps its controls while a
   // forge-status query is pending/failed (canWrite default-true) AND a ready GitLab
@@ -161,6 +164,10 @@ export function RemoteIssueView({
   // pin stays GitHub-only via `canWrite`. GitLab locks without a reason and
   // "moves" instead of transferring — labels/submenus branch on the provider.
   const isGitLab = provider === "gitlab";
+  // Locking is write-tier on GitHub but only Reporter (triage) on GitLab, so
+  // the lock arms take their axis from the provider.
+  const lockBlocked = isGitLab ? triageBlocked : writeBlocked;
+  const lockSuffix = isGitLab ? triageSuffix : itemSuffix;
   const canLock = canWrite || forgeFeatureReady(forge.data, "issueLock");
   const canTransfer =
     canWrite || forgeFeatureReady(forge.data, "issueTransfer");
@@ -449,7 +456,7 @@ export function RemoteIssueView({
               <DropdownMenuContent align="end" className="min-w-52">
                 {canWrite && (
                   <DropdownMenuItem
-                    disabled={triageBlocked}
+                    disabled={writeBlocked}
                     onClick={() =>
                       pinIssue.mutate(
                         { number, pinned: !issue.isPinned },
@@ -464,13 +471,13 @@ export function RemoteIssueView({
                     }
                   >
                     {issue.isPinned ? "Unpin issue" : "Pin issue"}
-                    {triageSuffix}
+                    {itemSuffix}
                   </DropdownMenuItem>
                 )}
                 {canLock &&
                   (issue.locked ? (
                     <DropdownMenuItem
-                      disabled={triageBlocked}
+                      disabled={lockBlocked}
                       onClick={() =>
                         unlockIssue.mutate(number, {
                           onSuccess: () =>
@@ -479,12 +486,12 @@ export function RemoteIssueView({
                         })
                       }
                     >
-                      Unlock conversation{triageSuffix}
+                      Unlock conversation{lockSuffix}
                     </DropdownMenuItem>
                   ) : isGitLab ? (
                     // GitLab locks without a reason — a plain item, no submenu.
                     <DropdownMenuItem
-                      disabled={triageBlocked}
+                      disabled={lockBlocked}
                       onClick={() =>
                         lockIssue.mutate(
                           { number, reason: null },
@@ -496,7 +503,7 @@ export function RemoteIssueView({
                         )
                       }
                     >
-                      Lock conversation{triageSuffix}
+                      Lock conversation{lockSuffix}
                     </DropdownMenuItem>
                   ) : (
                     <DropdownMenuSub>
@@ -504,10 +511,10 @@ export function RemoteIssueView({
                           of its own (unlike menu items), so the dim rides a
                           call-site class. */}
                       <DropdownMenuSubTrigger
-                        disabled={triageBlocked}
+                        disabled={writeBlocked}
                         className="data-disabled:opacity-50"
                       >
-                        Lock conversation…{triageSuffix}
+                        Lock conversation…{itemSuffix}
                       </DropdownMenuSubTrigger>
                       <DropdownMenuSubContent>
                         {LOCK_REASONS.map(([label, reason]) => (
@@ -698,7 +705,7 @@ export function RemoteIssueView({
                       ? () => unhideComment(c.id)
                       : undefined
                   }
-                  writeDisabledReason={itemReason}
+                  disabledReason={triageItemReason}
                   reactions={
                     canReact ? reactions.data?.comments[c.id] : undefined
                   }
@@ -847,6 +854,7 @@ export function RemoteIssueView({
           remoteLabel={remoteLabel}
           lens={lens}
           pickerDisabledReason={triageReason}
+          writeItemReason={writeItemReason}
         />
       </div>
 

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -45,6 +45,8 @@ import { presentError } from "@/lib/error-summary";
 import type { LockReason, MinimizeReason } from "@/lib/git/api";
 import {
   forgeFeatureReady,
+  TRIAGE_ACCESS_ITEM_REASON,
+  triageAccessReason,
   useCloseIssue,
   useCommentIssue,
   useDeleteIssue,
@@ -60,10 +62,13 @@ import {
   useMinimizeComment,
   usePinIssue,
   useReopenIssue,
+  useRepoWriteAccess,
   useToggleReaction,
   useTransferIssue,
   useUnlockIssue,
   useUnminimizeComment,
+  WRITE_ACCESS_ITEM_REASON,
+  writeAccessReason,
 } from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
@@ -120,6 +125,21 @@ export function RemoteIssueView({
   // The single lens-resolution point for this surface (package B2): every issue
   // read/write below targets the fork (origin) or its parent (upstream).
   const lens = useRepoLens(repoPath);
+  // The viewer's permission on the lens repo — a PERMISSION axis the per-action
+  // flags below don't cover, so it never hides a control: it only disables one,
+  // and only on an explicit denial. Triage is its own tier: labels, assignees,
+  // milestones, pin and lock come with it WITHOUT push, so they read
+  // `canTriage` and gating them on push would strip a triager's controls.
+  const writeAccess = useRepoWriteAccess(repoPath, lens, !!provider);
+  const writeReason = writeAccessReason(writeAccess.data);
+  const writeBlocked = writeAccess.data?.canPush === false;
+  const triageReason = triageAccessReason(writeAccess.data);
+  const triageBlocked = writeAccess.data?.canTriage === false;
+  // A disabled menu item drops pointer events, so its explanation goes in the
+  // label; each suffix is empty whenever its axis allows the action.
+  const itemReason = writeBlocked ? WRITE_ACCESS_ITEM_REASON : undefined;
+  const itemSuffix = itemReason ? ` — ${itemReason}` : "";
+  const triageSuffix = triageBlocked ? ` — ${TRIAGE_ACCESS_ITEM_REASON}` : "";
   // GitLab WRITES land per-action. Each shared control is
   // `canWrite || forgeFeatureReady(...)` so GitHub keeps its controls while a
   // forge-status query is pending/failed (canWrite default-true) AND a ready GitLab
@@ -429,6 +449,7 @@ export function RemoteIssueView({
               <DropdownMenuContent align="end" className="min-w-52">
                 {canWrite && (
                   <DropdownMenuItem
+                    disabled={triageBlocked}
                     onClick={() =>
                       pinIssue.mutate(
                         { number, pinned: !issue.isPinned },
@@ -443,11 +464,13 @@ export function RemoteIssueView({
                     }
                   >
                     {issue.isPinned ? "Unpin issue" : "Pin issue"}
+                    {triageSuffix}
                   </DropdownMenuItem>
                 )}
                 {canLock &&
                   (issue.locked ? (
                     <DropdownMenuItem
+                      disabled={triageBlocked}
                       onClick={() =>
                         unlockIssue.mutate(number, {
                           onSuccess: () =>
@@ -456,11 +479,12 @@ export function RemoteIssueView({
                         })
                       }
                     >
-                      Unlock conversation
+                      Unlock conversation{triageSuffix}
                     </DropdownMenuItem>
                   ) : isGitLab ? (
                     // GitLab locks without a reason — a plain item, no submenu.
                     <DropdownMenuItem
+                      disabled={triageBlocked}
                       onClick={() =>
                         lockIssue.mutate(
                           { number, reason: null },
@@ -472,12 +496,18 @@ export function RemoteIssueView({
                         )
                       }
                     >
-                      Lock conversation
+                      Lock conversation{triageSuffix}
                     </DropdownMenuItem>
                   ) : (
                     <DropdownMenuSub>
-                      <DropdownMenuSubTrigger>
-                        Lock conversation…
+                      {/* The vendored sub-trigger carries no disabled styling
+                          of its own (unlike menu items), so the dim rides a
+                          call-site class. */}
+                      <DropdownMenuSubTrigger
+                        disabled={triageBlocked}
+                        className="data-disabled:opacity-50"
+                      >
+                        Lock conversation…{triageSuffix}
                       </DropdownMenuSubTrigger>
                       <DropdownMenuSubContent>
                         {LOCK_REASONS.map(([label, reason]) => (
@@ -508,20 +538,23 @@ export function RemoteIssueView({
                 )}
                 {canTransfer && (
                   <DropdownMenuItem
+                    disabled={writeBlocked}
                     onClick={() => {
                       setTransferDest("");
                       setTransferOpen(true);
                     }}
                   >
                     {isGitLab ? "Move issue…" : "Transfer issue…"}
+                    {itemSuffix}
                   </DropdownMenuItem>
                 )}
                 {canDelete && (
                   <DropdownMenuItem
                     variant="destructive"
+                    disabled={writeBlocked}
                     onClick={() => setDeleteOpen(true)}
                   >
-                    Delete issue…
+                    Delete issue…{itemSuffix}
                   </DropdownMenuItem>
                 )}
               </DropdownMenuContent>
@@ -637,6 +670,7 @@ export function RemoteIssueView({
                   issueId={issue.id}
                   number={number}
                   lens={lens}
+                  disabledReason={writeReason}
                 />
               )}
               {comments.map((c) => (
@@ -664,6 +698,7 @@ export function RemoteIssueView({
                       ? () => unhideComment(c.id)
                       : undefined
                   }
+                  writeDisabledReason={itemReason}
                   reactions={
                     canReact ? reactions.data?.comments[c.id] : undefined
                   }
@@ -811,6 +846,7 @@ export function RemoteIssueView({
           canLinkIssues={canLinkIssues}
           remoteLabel={remoteLabel}
           lens={lens}
+          pickerDisabledReason={triageReason}
         />
       </div>
 

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -71,6 +71,7 @@ export function IssueSidebar({
   canLinkIssues,
   remoteLabel,
   lens,
+  pickerDisabledReason,
 }: {
   repoPath: string;
   number: number;
@@ -88,6 +89,10 @@ export function IssueSidebar({
   remoteLabel: string;
   /** The origin|upstream lens the parent issue view resolved. */
   lens: RemoteLens;
+  /** Set when the viewer lacks the tier these pickers need (TRIAGE, not push):
+   *  they stay visible but disabled, with this text explaining why. Absent =
+   *  editable as before. */
+  pickerDisabledReason?: string;
 }) {
   const setAssignees = useSetIssueAssignees(repoPath, lens);
   const setMilestone = useSetIssueMilestone(repoPath, lens);
@@ -127,6 +132,7 @@ export function IssueSidebar({
             labelableId={issue.id}
             labels={issue.labels}
             lens={lens}
+            disabledReason={pickerDisabledReason}
           />
         )}
         {canEditAssignees && (
@@ -136,6 +142,7 @@ export function IssueSidebar({
             value={issue.assignees}
             commitOnClose
             lens={lens}
+            disabledReason={pickerDisabledReason}
             onChange={(next) =>
               setAssignees.mutate({ number, assignees: next }, { onError })
             }
@@ -148,6 +155,7 @@ export function IssueSidebar({
             value={issue.milestone?.number ?? null}
             valueLabel={issue.milestone?.title}
             lens={lens}
+            disabledReason={pickerDisabledReason}
             onChange={(m, title) =>
               setMilestone.mutate({ number, milestone: m, title }, { onError })
             }
@@ -231,6 +239,7 @@ export function IssueSidebar({
         value={issue.assignees}
         commitOnClose
         lens={lens}
+        disabledReason={pickerDisabledReason}
         onChange={(next) =>
           setAssignees.mutate({ number, assignees: next }, { onError })
         }
@@ -243,6 +252,7 @@ export function IssueSidebar({
         labelableId={issue.id}
         labels={issue.labels}
         lens={lens}
+        disabledReason={pickerDisabledReason}
       />
       <MilestoneMenu
         repoPath={repoPath}
@@ -250,6 +260,7 @@ export function IssueSidebar({
         value={issue.milestone?.number ?? null}
         valueLabel={issue.milestone?.title}
         lens={lens}
+        disabledReason={pickerDisabledReason}
         onChange={(m, title) =>
           setMilestone.mutate({ number, milestone: m, title }, { onError })
         }

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -370,7 +370,9 @@ export function DueDateRow({
           // button swallows `title`, while the Label stays live either way.
           <span
             title={disabledReason}
-            className={blocked ? "inline-flex cursor-not-allowed" : undefined}
+            className={
+              blocked ? "inline-flex cursor-not-allowed" : "inline-flex"
+            }
           >
             <Button
               type="button"
@@ -439,7 +441,7 @@ function ConfidentialRow({
         <span
           title={disabledReason}
           className={
-            disabledReason ? "inline-flex cursor-not-allowed" : undefined
+            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
           }
         >
           <Switch

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -72,6 +72,7 @@ export function IssueSidebar({
   remoteLabel,
   lens,
   pickerDisabledReason,
+  writeItemReason,
 }: {
   repoPath: string;
   number: number;
@@ -93,6 +94,9 @@ export function IssueSidebar({
    *  they stay visible but disabled, with this text explaining why. Absent =
    *  editable as before. */
   pickerDisabledReason?: string;
+  /** The compact WRITE-axis reason for the rail's one push-tier affordance
+   *  (Development → create a linked branch), which triage doesn't cover. */
+  writeItemReason?: string;
 }) {
   const setAssignees = useSetIssueAssignees(repoPath, lens);
   const setMilestone = useSetIssueMilestone(repoPath, lens);
@@ -175,6 +179,7 @@ export function IssueSidebar({
             value={issue.dueDate}
             open={issue.state === "OPEN"}
             pending={setDueDate.isPending}
+            disabledReason={pickerDisabledReason}
             onChange={(dueDate) =>
               setDueDate.mutate({ number, dueDate }, { onError })
             }
@@ -184,6 +189,7 @@ export function IssueSidebar({
           <ConfidentialRow
             value={issue.confidential}
             pending={setConfidential.isPending}
+            disabledReason={pickerDisabledReason}
             onChange={(confidential) =>
               setConfidential.mutate({ number, confidential }, { onError })
             }
@@ -194,6 +200,7 @@ export function IssueSidebar({
             repoPath={repoPath}
             number={number}
             editable={issue.state === "OPEN"}
+            disabledReason={pickerDisabledReason}
           />
         )}
         {canLinkIssues && (
@@ -202,6 +209,7 @@ export function IssueSidebar({
             number={number}
             editable={issue.state === "OPEN"}
             lens={lens}
+            disabledReason={pickerDisabledReason}
           />
         )}
         <div className="space-y-1.5">
@@ -226,6 +234,7 @@ export function IssueSidebar({
         enabled
         value={issue.issueType}
         lens={lens}
+        disabledReason={pickerDisabledReason}
         onChange={(type) =>
           setType.mutate(
             { number, typeName: type?.name ?? null, type },
@@ -276,7 +285,12 @@ export function IssueSidebar({
           Manage on GitHub
         </button>
       </div>
-      <IssueRelationships repoPath={repoPath} number={number} lens={lens} />
+      <IssueRelationships
+        repoPath={repoPath}
+        number={number}
+        lens={lens}
+        disabledReason={pickerDisabledReason}
+      />
       <IssueDevelopment
         repoPath={repoPath}
         number={number}
@@ -284,6 +298,7 @@ export function IssueSidebar({
         issueTitle={issue.title}
         issueUrl={issue.url}
         lens={lens}
+        disabledReason={writeItemReason}
       />
       <div className="space-y-1.5">
         <p className="text-xs font-medium text-muted-foreground">
@@ -327,6 +342,7 @@ export function DueDateRow({
   open,
   pending,
   onChange,
+  disabledReason,
 }: {
   /** "YYYY-MM-DD" or null. */
   value: string | null;
@@ -334,8 +350,12 @@ export function DueDateRow({
   open: boolean;
   pending: boolean;
   onChange: (date: string | null) => void;
+  /** Set when the viewer lacks the tier this row needs: the input and Clear stay
+   *  visible but disabled, with this text as their hint. */
+  disabledReason?: string;
 }) {
   const pastDue = open && value !== null && isPastDue(value);
+  const blocked = !!disabledReason;
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between gap-2">
@@ -346,34 +366,47 @@ export function DueDateRow({
           Due date
         </Label>
         {value !== null && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            className="text-muted-foreground"
-            disabled={pending}
-            onClick={() => onChange(null)}
+          // The hint sits on the controls, not the row: a disabled input or
+          // button swallows `title`, while the Label stays live either way.
+          <span
+            title={disabledReason}
+            className={blocked ? "inline-flex cursor-not-allowed" : undefined}
           >
-            Clear
-          </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              disabled={pending || blocked}
+              onClick={() => onChange(null)}
+            >
+              Clear
+            </Button>
+          </span>
         )}
       </div>
       {/* Uncontrolled while focused (key remounts on external change) so the
           segment editing never fights a controlled re-render; blur commits. */}
-      <Input
-        key={value ?? ""}
-        id="issue-due-date"
-        type="date"
-        defaultValue={value ?? ""}
-        className="h-7"
-        onBlur={(e) => {
-          const next = e.target.value;
-          if (next && next !== value) onChange(next);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
-        }}
-      />
+      <span
+        title={disabledReason}
+        className={blocked ? "block cursor-not-allowed" : "block"}
+      >
+        <Input
+          key={value ?? ""}
+          id="issue-due-date"
+          type="date"
+          defaultValue={value ?? ""}
+          className="h-7"
+          disabled={blocked}
+          onBlur={(e) => {
+            const next = e.target.value;
+            if (next && next !== value) onChange(next);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+          }}
+        />
+      </span>
       {pastDue && <p className="text-[11px] text-destructive">Past due</p>}
     </div>
   );
@@ -384,10 +417,14 @@ function ConfidentialRow({
   value,
   pending,
   onChange,
+  disabledReason,
 }: {
   value: boolean;
   pending: boolean;
   onChange: (confidential: boolean) => void;
+  /** Set when the viewer lacks the tier this row needs: the switch stays visible
+   *  but disabled, with this text as its hint. */
+  disabledReason?: string;
 }) {
   return (
     <div className="space-y-1.5">
@@ -398,12 +435,20 @@ function ConfidentialRow({
         >
           Confidential
         </Label>
-        <Switch
-          id="issue-confidential"
-          checked={value}
-          disabled={pending}
-          onCheckedChange={onChange}
-        />
+        {/* A disabled switch swallows `title`, so the hint rides its wrapper. */}
+        <span
+          title={disabledReason}
+          className={
+            disabledReason ? "inline-flex cursor-not-allowed" : undefined
+          }
+        >
+          <Switch
+            id="issue-confidential"
+            checked={value}
+            disabled={pending || !!disabledReason}
+            onCheckedChange={onChange}
+          />
+        </span>
       </div>
       {value && (
         <p className="text-[11px] text-muted-foreground">
@@ -429,6 +474,7 @@ export function TimeTrackingControls({
   onSetEstimate,
   onAddSpent,
   idPrefix,
+  disabledReason,
 }: {
   stats: GitLabTimeStats | undefined;
   editable: boolean;
@@ -439,6 +485,10 @@ export function TimeTrackingControls({
   onAddSpent: (duration: string | null) => void;
   /** Disambiguates the input ids when two instances mount (issue rail + MR). */
   idPrefix: string;
+  /** Set when the viewer lacks the tier the edits need: the inputs and their
+   *  Clear/Reset buttons disable, with this text as the group's hint. The
+   *  summary above them is a read and stays live. */
+  disabledReason?: string;
 }) {
   const estimate = stats?.timeEstimate ?? 0;
   const spent = stats?.totalTimeSpent ?? 0;
@@ -489,7 +539,15 @@ export function TimeTrackingControls({
         <p className="text-[11px] text-muted-foreground">No time tracked.</p>
       )}
       {editable && (
-        <div className="space-y-1.5 pt-0.5">
+        // Group-level hint: the disabled inputs and buttons inside swallow
+        // `title`, so the wrapper is the hover target.
+        <div
+          className={cn(
+            "space-y-1.5 pt-0.5",
+            disabledReason && "cursor-not-allowed",
+          )}
+          title={disabledReason}
+        >
           <div className="flex items-center gap-1.5">
             <Input
               id={`${idPrefix}-time-estimate`}
@@ -498,7 +556,7 @@ export function TimeTrackingControls({
               className="h-7"
               placeholder="Estimate (e.g. 3h)"
               aria-label="Set time estimate"
-              disabled={pending}
+              disabled={pending || !!disabledReason}
               onBlur={(e) => {
                 const next = e.target.value.trim();
                 if (next && next !== humanEstimate) onSetEstimate(next);
@@ -513,7 +571,7 @@ export function TimeTrackingControls({
                 variant="ghost"
                 size="xs"
                 className="shrink-0 text-muted-foreground"
-                disabled={pending}
+                disabled={pending || !!disabledReason}
                 onClick={() => onSetEstimate(null)}
               >
                 Clear
@@ -526,7 +584,7 @@ export function TimeTrackingControls({
               className="h-7"
               placeholder="Add spent (e.g. 45m, -15m)"
               aria-label="Add spent time"
-              disabled={pending}
+              disabled={pending || !!disabledReason}
               onKeyDown={(e) => {
                 if (e.key !== "Enter") return;
                 const el = e.currentTarget;
@@ -543,7 +601,7 @@ export function TimeTrackingControls({
                 variant="ghost"
                 size="xs"
                 className="shrink-0 text-muted-foreground"
-                disabled={pending}
+                disabled={pending || !!disabledReason}
                 onClick={() => onAddSpent(null)}
               >
                 Reset
@@ -571,10 +629,14 @@ function IssueTimeTrackingSection({
   repoPath,
   number,
   editable,
+  disabledReason,
 }: {
   repoPath: string;
   number: number;
   editable: boolean;
+  /** Set when the viewer lacks the tier the editing controls need — the summary
+   *  is a read and stays live. */
+  disabledReason?: string;
 }) {
   const stats = useGlIssueTimeStats(repoPath, number);
   const setEstimate = useSetIssueTimeEstimate(repoPath);
@@ -591,6 +653,7 @@ function IssueTimeTrackingSection({
           stats={stats.data}
           editable={editable}
           pending={setEstimate.isPending || addSpent.isPending}
+          disabledReason={disabledReason}
           idPrefix="issue"
           onSetEstimate={(duration) =>
             setEstimate.mutate({ number, duration }, { onError })
@@ -612,12 +675,16 @@ function IssueLinksSection({
   number,
   editable,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   number: number;
   editable: boolean;
   /** The parent issue's lens (GitLab-only section, so always "origin"). */
   lens: RemoteLens;
+  /** Set when the viewer lacks the tier link edits need: Add and the per-row
+   *  removes disable, with this text as their hint. The list stays live. */
+  disabledReason?: string;
 }) {
   const links = useGlIssueLinks(repoPath, number);
   const linkIssue = useLinkIssue(repoPath);
@@ -641,16 +708,26 @@ function IssueLinksSection({
         </span>
         <span className="flex-1" />
         {editable && !adding && (
-          <Button
-            variant="ghost"
-            size="xs"
-            aria-label="Link a related issue"
-            onClick={() => setAdding(true)}
+          // A natively disabled button swallows `title`, so the reason rides a
+          // wrapping span.
+          <span
+            title={disabledReason}
+            className={
+              disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+            }
           >
-            <PlusIcon data-icon="inline-start" />
-            Add
-            <CaretDownIcon data-icon="inline-end" />
-          </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              aria-label="Link a related issue"
+              disabled={!!disabledReason}
+              onClick={() => setAdding(true)}
+            >
+              <PlusIcon data-icon="inline-start" />
+              Add
+              <CaretDownIcon data-icon="inline-end" />
+            </Button>
+          </span>
         )}
       </div>
 
@@ -659,6 +736,7 @@ function IssueLinksSection({
           key={l.linkId}
           issue={toRelated(l)}
           onOpen={open}
+          removeDisabledReason={disabledReason}
           onRemove={() =>
             unlinkIssue.mutate({ number, linkId: l.linkId }, { onError })
           }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -91,6 +91,7 @@ import {
   forgeFeatureReady,
   PIPELINE_IN_FLIGHT,
   prDiffOptions,
+  triageAccessReason,
   useAbortRemotePrResolve,
   useApplySuggestion,
   useApprovePr,
@@ -122,6 +123,7 @@ import {
   usePrTimeline,
   useReopenPr,
   useRepoStatus,
+  useRepoWriteAccess,
   useRequestChangesPr,
   useSetPrAssignees,
   useSetPrDraft,
@@ -135,6 +137,8 @@ import {
   useUnapprovePr,
   useUnminimizeComment,
   useUnrequestChangesPr,
+  WRITE_ACCESS_ITEM_REASON,
+  writeAccessReason,
 } from "@/lib/git/queries";
 import {
   detectStackOffer,
@@ -282,10 +286,26 @@ export function RemotePrView({
   // targets the fork (origin) or its parent (upstream) — "origin" everywhere but a
   // GitHub fork whose lens is set upstream.
   const lens = useRepoLens(repoPath);
+  // The viewer's push permission on the lens repo — the axis the per-action
+  // forge flags don't cover. Only fetched once a provider is known; an
+  // unanswered probe leaves every control exactly as it is.
+  const writeAccess = useRepoWriteAccess(
+    repoPath,
+    lens,
+    !!forge.data?.provider,
+  );
+  const writeReason = writeAccessReason(writeAccess.data);
+  // Labels, assignees and reviewers are granted at TRIAGE tier, below push —
+  // gating them on the write axis would strip controls a triager holds.
+  const triageReason = triageAccessReason(writeAccess.data);
+  // Menu items can't show a tooltip once disabled — they carry the compact
+  // reason in their label instead.
+  const itemReason = writeReason ? WRITE_ACCESS_ITEM_REASON : undefined;
   // Per-action write-capability flags from forge status + provider (gating
   // convention: usePrCapabilities).
   const {
     canWrite,
+    writeBlocked,
     canComment,
     canChangeState,
     canEdit,
@@ -308,7 +328,7 @@ export function RemotePrView({
     canCommentCommits,
     canCreateThread,
     canSubmitReview,
-  } = usePrCapabilities(forge.data, provider);
+  } = usePrCapabilities(forge.data, provider, writeAccess.data);
   const details = usePrDetails(repoPath, number, lens);
   const prDiff = usePrDiff(repoPath, number, lens);
   const setAssignees = useSetPrAssignees(repoPath, lens);
@@ -1650,6 +1670,7 @@ export function RemotePrView({
             labelableId={pr.id}
             labels={pr.labels}
             lens={lens}
+            disabledReason={triageReason}
           />
         ) : (
           pr.labels.length > 0 && (
@@ -1669,6 +1690,7 @@ export function RemotePrView({
             value={pr.assignees}
             commitOnClose
             lens={lens}
+            disabledReason={triageReason}
             onChange={(next) =>
               setAssignees.mutate(
                 { number, assignees: next },
@@ -1703,6 +1725,7 @@ export function RemotePrView({
               enabled
               value={humanReviewers}
               lens={lens}
+              disabledReason={triageReason}
               onChange={(next) =>
                 setReviewers.mutate(
                   { number, reviewers: next },
@@ -2174,6 +2197,7 @@ export function RemotePrView({
                               ? () => unhideComment(c.id)
                               : undefined
                           }
+                          writeDisabledReason={itemReason}
                           reactions={
                             canReact
                               ? reactions.data?.comments[c.id]
@@ -2596,19 +2620,28 @@ export function RemotePrView({
                 <ClockCountdownIcon className="size-3.5 shrink-0" />
                 Auto-merge enabled
               </span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={busy}
-                onClick={() =>
-                  cancelAutoMerge.mutate(number, {
-                    onSuccess: () => toast.success("Auto-merge canceled"),
-                    onError,
-                  })
+              <span
+                title={writeReason}
+                className={
+                  writeBlocked
+                    ? "inline-flex cursor-not-allowed"
+                    : "inline-flex"
                 }
               >
-                Cancel auto-merge
-              </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={busy || writeBlocked}
+                  onClick={() =>
+                    cancelAutoMerge.mutate(number, {
+                      onSuccess: () => toast.success("Auto-merge canceled"),
+                      onError,
+                    })
+                  }
+                >
+                  Cancel auto-merge
+                </Button>
+              </span>
             </div>
           )}
           <span className="flex-1" />
@@ -2635,19 +2668,24 @@ export function RemotePrView({
                 render={
                   <span
                     title={
-                      pr.isDraft
+                      // Permission outranks the availability hints: a viewer who
+                      // can't push can't act on any of them.
+                      writeReason ??
+                      (pr.isDraft
                         ? `Mark the ${prNoun} ready before merging`
                         : mergeGuardMissing
                           ? "Reload to merge — couldn't load the head commit to guard the merge"
                           : allMergeMethodsBlocked
                             ? "No merge method is enabled by both this repository's settings and its branch rules"
-                            : `Merge this ${prNoun}`
+                            : `Merge this ${prNoun}`)
                     }
+                    className={writeBlocked ? "cursor-not-allowed" : undefined}
                   >
                     <Button
                       size="sm"
                       disabled={
                         busy ||
+                        writeBlocked ||
                         pr.isDraft ||
                         mergeGuardMissing ||
                         allMergeMethodsBlocked

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -91,6 +91,7 @@ import {
   forgeFeatureReady,
   PIPELINE_IN_FLIGHT,
   prDiffOptions,
+  TRIAGE_ACCESS_ITEM_REASON,
   triageAccessReason,
   useAbortRemotePrResolve,
   useApplySuggestion,
@@ -137,7 +138,6 @@ import {
   useUnapprovePr,
   useUnminimizeComment,
   useUnrequestChangesPr,
-  WRITE_ACCESS_ITEM_REASON,
   writeAccessReason,
 } from "@/lib/git/queries";
 import {
@@ -295,12 +295,12 @@ export function RemotePrView({
     !!forge.data?.provider,
   );
   const writeReason = writeAccessReason(writeAccess.data);
-  // Labels, assignees and reviewers are granted at TRIAGE tier, below push —
-  // gating them on the write axis would strip controls a triager holds.
+  // Labels, assignees, reviewers and hiding comments are granted at TRIAGE tier,
+  // below push — gating them on the write axis would strip a triager's controls.
   const triageReason = triageAccessReason(writeAccess.data);
   // Menu items can't show a tooltip once disabled — they carry the compact
   // reason in their label instead.
-  const itemReason = writeReason ? WRITE_ACCESS_ITEM_REASON : undefined;
+  const triageItemReason = triageReason ? TRIAGE_ACCESS_ITEM_REASON : undefined;
   // Per-action write-capability flags from forge status + provider (gating
   // convention: usePrCapabilities).
   const {
@@ -1781,7 +1781,12 @@ export function RemotePrView({
         {/* GitLab-only time-tracking summary; a popover with estimate/add-spent
             while the MR is open, static once closed. */}
         {canTrackTime && (
-          <MrTimeTracking repoPath={repoPath} number={number} open={isOpen} />
+          <MrTimeTracking
+            repoPath={repoPath}
+            number={number}
+            open={isOpen}
+            disabledReason={triageReason}
+          />
         )}
         {/* Bitbucket-only PR-tasks chip — quiet until there are unresolved tasks;
             jumps to the Tasks section. Same usePrTasks query as the section. */}
@@ -2197,7 +2202,7 @@ export function RemotePrView({
                               ? () => unhideComment(c.id)
                               : undefined
                           }
-                          writeDisabledReason={itemReason}
+                          disabledReason={triageItemReason}
                           reactions={
                             canReact
                               ? reactions.data?.comments[c.id]

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -432,11 +432,16 @@ export function MrTimeTracking({
   repoPath,
   number,
   open,
+  disabledReason,
 }: {
   repoPath: string;
   number: number;
   /** Whether the MR is open — only then are the editing controls offered. */
   open: boolean;
+  /** Set when the viewer lacks the access these edits need: the estimate and
+   *  spent controls disable, with this text as their hint. The summary is a
+   *  read and stays live. */
+  disabledReason?: string;
 }) {
   const stats = useGlMrTimeStats(repoPath, number);
   const setEstimate = useSetMrTimeEstimate(repoPath);
@@ -501,6 +506,7 @@ export function MrTimeTracking({
             stats={data}
             editable
             pending={setEstimate.isPending || addSpent.isPending}
+            disabledReason={disabledReason}
             idPrefix="mr"
             onSetEstimate={(duration) =>
               setEstimate.mutate({ number, duration }, { onError })

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -46,6 +46,7 @@ export function ReviewersPopover({
   value,
   onChange,
   lens,
+  disabledReason,
 }: {
   repoPath: string;
   number: number | null;
@@ -54,6 +55,9 @@ export function ReviewersPopover({
   onChange: (next: ForgeUserRef[]) => void;
   /** The origin|upstream lens the parent surface resolved (create dialog: "origin"). */
   lens: RemoteLens;
+  /** Set when the viewer may not write to the repo: the trigger stays visible
+   *  but disabled and this text explains why. Absent = editable as before. */
+  disabledReason?: string;
 }) {
   const candidates = useReviewerCandidates(repoPath, number, enabled, lens);
   // GitHub reviewer ids are logins (avatars served at `<host>/<login>.png`), so the
@@ -101,14 +105,24 @@ export function ReviewersPopover({
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <Popover.Trigger
-          render={
-            <Button variant="ghost" size="xs" aria-label="Edit reviewers" />
+        {/* A natively disabled button swallows `title`, so the reason rides a
+            wrapping span. */}
+        <span
+          title={disabledReason}
+          className={
+            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
           }
         >
-          <UserCheckIcon data-icon="inline-start" />
-          Reviewers
-        </Popover.Trigger>
+          <Popover.Trigger
+            disabled={!!disabledReason}
+            render={
+              <Button variant="ghost" size="xs" aria-label="Edit reviewers" />
+            }
+          >
+            <UserCheckIcon data-icon="inline-start" />
+            Reviewers
+          </Popover.Trigger>
+        </span>
         <Popover.Portal>
           <Popover.Positioner
             align="start"

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -55,8 +55,9 @@ export function ReviewersPopover({
   onChange: (next: ForgeUserRef[]) => void;
   /** The origin|upstream lens the parent surface resolved (create dialog: "origin"). */
   lens: RemoteLens;
-  /** Set when the viewer may not write to the repo: the trigger stays visible
-   *  but disabled and this text explains why. Absent = editable as before. */
+  /** Set when the viewer lacks the access this picker's action needs — callers
+   *  pass the reason for the matching axis. The trigger stays visible but
+   *  disabled and this text explains why. Absent = editable as before. */
   disabledReason?: string;
 }) {
   const candidates = useReviewerCandidates(repoPath, number, enabled, lens);

--- a/src/features/pulls/usePrCapabilities.ts
+++ b/src/features/pulls/usePrCapabilities.ts
@@ -21,13 +21,13 @@ import type {
  *   duplicate a GitHub control that lives elsewhere.
  *
  * Axes, never conflated: every `can*` flag above is AVAILABILITY (is this action
- * wired for this provider?) and decides what RENDERS. `writeBlocked` and
- * `triageBlocked` are PERMISSION and decide only what is ENABLED — consumers
- * disable-with-reason and never hide on permission. Triage is its own tier
- * (labels, assignees, milestones, pin, lock are granted there without push), so
- * a triage control keys on the triage axis — this flag or `triageAccessReason` —
- * never the write axis. Absent or
- * unanswered probe data leaves both false (fail open).
+ * wired for this provider?) and decides what RENDERS. `writeBlocked` is
+ * PERMISSION and decides only what is ENABLED — consumers disable-with-reason
+ * and never hide on permission. Triage is a SEPARATE, lower tier granting
+ * labels, assignees, milestones, review requests and hiding comments without
+ * push, so a triage control keys on `triageAccessReason`, never on
+ * `writeBlocked`. Absent or unanswered probe data leaves `writeBlocked` false
+ * (fail open).
  */
 export function usePrCapabilities(
   forgeData: ForgeStatus | undefined,
@@ -101,12 +101,10 @@ export function usePrCapabilities(
   // Only an explicit denial blocks: null/undefined (probe pending, failed, or
   // unable to answer) must behave exactly as before.
   const writeBlocked = writeAccess?.canPush === false;
-  const triageBlocked = writeAccess?.canTriage === false;
 
   return {
     canWrite,
     writeBlocked,
-    triageBlocked,
     canComment,
     canChangeState,
     canEdit,

--- a/src/features/pulls/usePrCapabilities.ts
+++ b/src/features/pulls/usePrCapabilities.ts
@@ -1,5 +1,9 @@
 import { forgeFeatureReady } from "@/lib/git/queries";
-import type { ForgeProvider, ForgeStatus } from "@/lib/git/types";
+import type {
+  ForgeProvider,
+  ForgeRepoWriteAccess,
+  ForgeStatus,
+} from "@/lib/git/types";
 
 /**
  * Per-action write-capability flags for a remote PR/MR, derived from the repo's
@@ -15,10 +19,20 @@ import type { ForgeProvider, ForgeStatus } from "@/lib/git/types";
  * - A provider-ONLY control (no GitHub analogue here, e.g. GitLab auto-merge,
  *   Bitbucket tasks) gates on the forge feature ALONE — `canWrite || …` would
  *   duplicate a GitHub control that lives elsewhere.
+ *
+ * Axes, never conflated: every `can*` flag above is AVAILABILITY (is this action
+ * wired for this provider?) and decides what RENDERS. `writeBlocked` and
+ * `triageBlocked` are PERMISSION and decide only what is ENABLED — consumers
+ * disable-with-reason and never hide on permission. Triage is its own tier
+ * (labels, assignees, milestones, pin, lock are granted there without push), so
+ * a triage control keys on the triage axis — this flag or `triageAccessReason` —
+ * never the write axis. Absent or
+ * unanswered probe data leaves both false (fail open).
  */
 export function usePrCapabilities(
   forgeData: ForgeStatus | undefined,
   provider: ForgeProvider | null | undefined,
+  writeAccess?: ForgeRepoWriteAccess,
 ) {
   const canWrite = provider !== "gitlab" && provider !== "bitbucket";
   const canComment = canWrite || forgeFeatureReady(forgeData, "mrComment");
@@ -84,9 +98,15 @@ export function usePrCapabilities(
   // providers.
   const canSubmitReview =
     canWrite || forgeFeatureReady(forgeData, "mrReviewSubmit");
+  // Only an explicit denial blocks: null/undefined (probe pending, failed, or
+  // unable to answer) must behave exactly as before.
+  const writeBlocked = writeAccess?.canPush === false;
+  const triageBlocked = writeAccess?.canTriage === false;
 
   return {
     canWrite,
+    writeBlocked,
+    triageBlocked,
     canComment,
     canChangeState,
     canEdit,

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -40,9 +40,11 @@ import {
   usePushTag,
   useReleaseDetails,
   useReleaseList,
+  useRepoWriteAccess,
   useSyncUpdaterNotes,
   useTagList,
   useUploadReleaseAsset,
+  writeAccessReason,
 } from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
@@ -78,6 +80,16 @@ export function TagDetailView({
   const canWrite = provider !== "gitlab" && provider !== "bitbucket";
   const canManage = canWrite || forgeFeatureReady(gh.data, "releaseEdit");
   const canCreate = canWrite || forgeFeatureReady(gh.data, "releaseCreate");
+  // Publishing a release is a repo write: an explicitly read-only viewer keeps
+  // the buttons (disabled, with the reason). Releases are repo-wide — no lens.
+  const writeAccess = useRepoWriteAccess(repoPath, undefined, !!provider);
+  const writeReason = writeAccessReason(writeAccess.data);
+  const writeBlocked = writeAccess.data?.canPush === false;
+  // A natively-disabled Button swallows `title`, so every hint below rides a
+  // wrapping span (house idiom).
+  const blockedSpanClass = writeBlocked
+    ? "inline-flex cursor-not-allowed"
+    : "inline-flex";
   const remoteLabel = providerLabel(provider);
   // Ask the provider for a release only when connected; otherwise it's just a tag.
   const release = useReleaseDetails(repoPath, ghReady ? tag : null);
@@ -168,59 +180,67 @@ export function TagDetailView({
             {canManage && (
               <>
                 {rel.isDraft && (
+                  <span title={writeReason} className={blockedSpanClass}>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      disabled={editRelease.isPending || writeBlocked}
+                      onClick={() =>
+                        editRelease.mutate(
+                          {
+                            tag,
+                            title: "",
+                            notes: "",
+                            prerelease: rel.isPrerelease,
+                            draft: false,
+                            // Omit --latest so GitHub applies its default (a newly
+                            // published stable release becomes Latest, like the web UI).
+                            // A draft's isLatest is structurally false — sending it here
+                            // was the bug that stripped Latest on publish.
+                            latest: undefined,
+                          },
+                          {
+                            onSuccess: () => toast.success("Published"),
+                            onError,
+                          },
+                        )
+                      }
+                    >
+                      Publish
+                    </Button>
+                  </span>
+                )}
+                <span title={writeReason} className={blockedSpanClass}>
                   <Button
                     variant="outline"
                     size="xs"
-                    disabled={editRelease.isPending}
-                    onClick={() =>
-                      editRelease.mutate(
-                        {
-                          tag,
-                          title: "",
-                          notes: "",
-                          prerelease: rel.isPrerelease,
-                          draft: false,
-                          // Omit --latest so GitHub applies its default (a newly
-                          // published stable release becomes Latest, like the web UI).
-                          // A draft's isLatest is structurally false — sending it here
-                          // was the bug that stripped Latest on publish.
-                          latest: undefined,
-                        },
-                        {
-                          onSuccess: () => toast.success("Published"),
-                          onError,
-                        },
-                      )
-                    }
+                    disabled={writeBlocked}
+                    onClick={() => {
+                      setEditTitle(rel.name);
+                      setEditNotes(rel.body);
+                      setEditPrerelease(rel.isPrerelease);
+                      setEditLatest(isLatest);
+                      setEditSyncUpdater(true);
+                      setSyncArmed(false);
+                      setEditOpen(true);
+                    }}
                   >
-                    Publish
+                    Edit
                   </Button>
-                )}
-                <Button
-                  variant="outline"
-                  size="xs"
-                  onClick={() => {
-                    setEditTitle(rel.name);
-                    setEditNotes(rel.body);
-                    setEditPrerelease(rel.isPrerelease);
-                    setEditLatest(isLatest);
-                    setEditSyncUpdater(true);
-                    setSyncArmed(false);
-                    setEditOpen(true);
-                  }}
-                >
-                  Edit
-                </Button>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  onClick={() => {
-                    setCleanupTag(false);
-                    setDeleteOpen(true);
-                  }}
-                >
-                  Delete
-                </Button>
+                </span>
+                <span title={writeReason} className={blockedSpanClass}>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    disabled={writeBlocked}
+                    onClick={() => {
+                      setCleanupTag(false);
+                      setDeleteOpen(true);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </span>
               </>
             )}
             {rel.url && (
@@ -266,19 +286,21 @@ export function TagDetailView({
                 <span className="flex-1" />
                 {/* GitHub attaches a binary; GitLab uploads + links the file. */}
                 {canManage && (
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    disabled={uploadAsset.isPending}
-                    onClick={onUpload}
-                  >
-                    {uploadAsset.isPending ? (
-                      <Spinner data-icon="inline-start" />
-                    ) : (
-                      <UploadSimpleIcon data-icon="inline-start" />
-                    )}
-                    Upload
-                  </Button>
+                  <span title={writeReason} className={blockedSpanClass}>
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      disabled={uploadAsset.isPending || writeBlocked}
+                      onClick={onUpload}
+                    >
+                      {uploadAsset.isPending ? (
+                        <Spinner data-icon="inline-start" />
+                      ) : (
+                        <UploadSimpleIcon data-icon="inline-start" />
+                      )}
+                      Upload
+                    </Button>
+                  </span>
                 )}
               </div>
               {rel.assets.length === 0 ? (
@@ -310,23 +332,27 @@ export function TagDetailView({
                         >
                           <DownloadSimpleIcon />
                         </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          aria-label={`Delete ${a.name}`}
-                          className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                          onClick={() =>
-                            deleteAsset.mutate(
-                              { tag, assetName: a.name },
-                              {
-                                onSuccess: () => toast.success("Asset deleted"),
-                                onError,
-                              },
-                            )
-                          }
-                        >
-                          <TrashIcon />
-                        </Button>
+                        <span title={writeReason} className={blockedSpanClass}>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label={`Delete ${a.name}`}
+                            disabled={writeBlocked}
+                            className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                            onClick={() =>
+                              deleteAsset.mutate(
+                                { tag, assetName: a.name },
+                                {
+                                  onSuccess: () =>
+                                    toast.success("Asset deleted"),
+                                  onError,
+                                },
+                              )
+                            }
+                          >
+                            <TrashIcon />
+                          </Button>
+                        </span>
                       </>
                     ) : (
                       // GitLab asset links carry no size/download count — open the
@@ -345,24 +371,30 @@ export function TagDetailView({
                           </Button>
                         )}
                         {canManage && (
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            aria-label={`Delete ${a.name}`}
-                            className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                            onClick={() =>
-                              deleteAsset.mutate(
-                                { tag, assetName: a.name },
-                                {
-                                  onSuccess: () =>
-                                    toast.success("Asset deleted"),
-                                  onError,
-                                },
-                              )
-                            }
+                          <span
+                            title={writeReason}
+                            className={blockedSpanClass}
                           >
-                            <TrashIcon />
-                          </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              aria-label={`Delete ${a.name}`}
+                              disabled={writeBlocked}
+                              className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                              onClick={() =>
+                                deleteAsset.mutate(
+                                  { tag, assetName: a.name },
+                                  {
+                                    onSuccess: () =>
+                                      toast.success("Asset deleted"),
+                                    onError,
+                                  },
+                                )
+                              }
+                            >
+                              <TrashIcon />
+                            </Button>
+                          </span>
                         )}
                       </>
                     )}
@@ -614,13 +646,16 @@ export function TagDetailView({
           <h2 className="font-mono text-sm font-medium">{tag}</h2>
           <span className="flex-1" />
           {ghReady && canCreate && (
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => setCreateReleaseOpen(true)}
-            >
-              Create release
-            </Button>
+            <span title={writeReason} className={blockedSpanClass}>
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={writeBlocked}
+                onClick={() => setCreateReleaseOpen(true)}
+              >
+                Create release
+              </Button>
+            </span>
           )}
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -47,6 +47,7 @@ import type {
   ForgeProviderFeatures,
   ForgeRepoAdmin,
   ForgeRepoList,
+  ForgeRepoWriteAccess,
   ForgeSearchList,
   ForgeStatus,
   ForgeUserRef,
@@ -2497,6 +2498,12 @@ export const forgeRepoSetStar = (repoPath: string, starred: boolean) =>
  *  Owner-only lifecycle actions). Gates the settings UI. */
 export const forgeRepoAdmin = (repoPath: string) =>
   invoke<ForgeRepoAdmin>("forge_repo_admin", { repoPath });
+
+/** Whether the signed-in user can PUSH to the repo behind the lens — the
+ *  permission axis the per-action forge flags don't cover (they answer "is this
+ *  wired for this provider?"). Nulls mean the probe couldn't answer: fail open. */
+export const forgeRepoWriteAccess = (repoPath: string, lens?: RemoteLens) =>
+  invoke<ForgeRepoWriteAccess>("forge_repo_write_access", { repoPath, lens });
 
 /** The GitLab project-settings read (GitLab repos only — GitHub stays on
  *  `ghRepoSettingsGet`; the models are provider-shaped). */

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4686,8 +4686,10 @@ export function writeAccessReason(
 }
 
 /** The disabled-reason for TRIAGE-gated controls (labels, assignees,
- *  milestones, pin, lock) — a lower tier than push, so it must be read off its
- *  own axis or a triager loses controls they hold. Same fail-open rule. */
+ *  milestones, review requests, hiding comments) — a lower tier than push, so it
+ *  must be read off its own axis or a triager loses controls they hold. Pin is
+ *  write-tier; locking is write-tier on GitHub but Reporter (triage) on GitLab.
+ *  Same fail-open rule. */
 export function triageAccessReason(
   access: ForgeRepoWriteAccess | undefined,
 ): string | undefined {

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -30,6 +30,7 @@ import type {
   ForgeCapabilities,
   ForgeImplemented,
   ForgeProvider,
+  ForgeRepoWriteAccess,
   ForgeSearchList,
   ForgeStatus,
   ForgeUserRef,
@@ -4649,6 +4650,49 @@ export function useRepoAdmin(repo: string, enabled: boolean) {
     staleTime: 5 * 60_000,
     retry: false,
   });
+}
+
+/** The viewer's push permission on the repo behind `lens` — the PERMISSION axis
+ *  the per-action forge flags don't answer. `retry: false` keeps a failed probe
+ *  from a retry storm; consumers fail open on anything but `canPush === false`. */
+export function useRepoWriteAccess(
+  repo: string,
+  lens: RemoteLens | undefined,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "write-access", lens ?? "origin"] as const,
+    queryFn: () => api.forgeRepoWriteAccess(repo, lens),
+    enabled,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
+/** The compact reasons appended to a disabled MENU ITEM's label: a disabled item
+ *  drops pointer events, so a `title` never surfaces there and the explanation
+ *  has to live in the label. Headline buttons use the reason helpers below. */
+export const WRITE_ACCESS_ITEM_REASON = "requires write access";
+export const TRIAGE_ACCESS_ITEM_REASON = "requires triage access";
+
+/** The disabled-reason string for PUSH-gated controls, or undefined while the
+ *  probe hasn't positively denied access (pending / errored / unknown all read
+ *  as "allowed" so a probe outage never strips controls). */
+export function writeAccessReason(
+  access: ForgeRepoWriteAccess | undefined,
+): string | undefined {
+  if (access?.canPush !== false) return undefined;
+  return `Requires write access to ${access.repo ?? "this repository"}`;
+}
+
+/** The disabled-reason for TRIAGE-gated controls (labels, assignees,
+ *  milestones, pin, lock) — a lower tier than push, so it must be read off its
+ *  own axis or a triager loses controls they hold. Same fail-open rule. */
+export function triageAccessReason(
+  access: ForgeRepoWriteAccess | undefined,
+): string | undefined {
+  if (access?.canTriage !== false) return undefined;
+  return `Requires triage access to ${access.repo ?? "this repository"}`;
 }
 
 /** The active gh token's OAuth scopes — for "this needs gh auth refresh -s X"

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -853,13 +853,16 @@ export interface ForgeRepoAdmin {
   owner: boolean;
 }
 
-/** Viewer write-permission on the repo behind the lens. null everywhere = the
- *  probe couldn't answer — consumers must FAIL OPEN (leave controls enabled). */
+/** Viewer write-permission on the repo behind the lens. A null `canPush` /
+ *  `canTriage` means the probe couldn't answer that axis (`repo` and
+ *  `unknownReason` may still be set) — consumers must FAIL OPEN on null
+ *  (leave controls enabled). */
 export interface ForgeRepoWriteAccess {
   canPush: boolean | null;
-  /** Triage tier and above, which grants labels / assignees / milestones / pin /
-   *  lock WITHOUT push (GitHub triage; GitLab Reporter) — a separate axis, not
-   *  implied by `canPush`. */
+  /** Triage tier and above, which grants labels, assignees, milestones, review
+   *  requests and hiding comments WITHOUT push (GitHub triage; GitLab Reporter)
+   *  — a separate axis, not implied by `canPush`. Pin is write-tier; locking is
+   *  write-tier on GitHub but Reporter (triage) on GitLab. */
   canTriage: boolean | null;
   role: string | null;
   /** The probed repo identity ("owner/repo") for UI copy. */

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -853,6 +853,20 @@ export interface ForgeRepoAdmin {
   owner: boolean;
 }
 
+/** Viewer write-permission on the repo behind the lens. null everywhere = the
+ *  probe couldn't answer — consumers must FAIL OPEN (leave controls enabled). */
+export interface ForgeRepoWriteAccess {
+  canPush: boolean | null;
+  /** Triage tier and above, which grants labels / assignees / milestones / pin /
+   *  lock WITHOUT push (GitHub triage; GitLab Reporter) — a separate axis, not
+   *  implied by `canPush`. */
+  canTriage: boolean | null;
+  role: string | null;
+  /** The probed repo identity ("owner/repo") for UI copy. */
+  repo: string | null;
+  unknownReason: string | null;
+}
+
 /** GitLab project settings — its own shape rather than a lossy mapping onto
  *  {@link RepoSettings}: features are ACCESS LEVELS (enabled / private /
  *  disabled), the merge style is one enum, squash is a four-way option. */


### PR DESCRIPTION
Read-only viewers previously saw every write control fully enabled and only discovered they lacked permission when the action failed against the forge. This adds a viewer-permission probe (`forge_repo_write_access`) across GitHub, GitLab and Bitbucket, and wires it into the PR, issue, CI and release surfaces so controls the viewer can't use stay visible but disabled with a reason. The probe fails **open**: anything other than an affirmative denial leaves controls exactly as they were, so a broken or pending probe never strips an action the user actually has.

### Backend probe

- Adds the `forge_repo_write_access` command and the `ForgeRepoWriteAccess` wire shape in `src-tauri/src/forge/mod.rs` — `canPush`, `canTriage`, `role`, `repo` and `unknownReason`, where `None`/`null` means "the probe couldn't answer". Registered in `src-tauri/src/lib.rs`.
- GitHub arm in `src-tauri/src/github/repo_settings.rs`: `gh_repo_write_access` reads the `permissions` block from `GET repos/{slug}` resolved through the **lens** (a fork PR targets the parent, so the parent's permission gates it). `write_access_from_repo_json` is pure and treats unparseable JSON or a missing `permissions` block as unknown rather than "cannot push"; `role_from_permissions` picks the highest set tier and `gh_failure_reason` renders a one-line stderr reason for the UI.
- GitLab arm in `src-tauri/src/forge/gitlab.rs`: factors the existing `repo_admin` resolution into a shared `effective_access_level` / `membership_access_level` pair that records *why* the membership fallback failed. `repo_write_access` maps levels through `write_access_from_level` (Developer 30 = push, Reporter 20 = triage) and treats an unanswered fallback as a **floor** — thresholds already cleared stay affirmative, the rest become unknown.
- Bitbucket arm in `src-tauri/src/forge/bitbucket.rs`: `repo_write_access` asks the same endpoint as `repo_admin` for `role=contributor`, lowercasing the slug for the case-sensitive BBQL filter; Bitbucket has no triage tier, so triage rides on write.
- Tests: `write_access_serializes_camel_case_wire_keys` in `forge/mod.rs` pins the camelCase keys and asserts unknowns travel as JSON `null` rather than omitted fields; `repo_settings.rs` gains unit tests for the permission-block reader.

### Frontend plumbing

- `src/lib/git/types.ts` adds the `ForgeRepoWriteAccess` interface, `src/lib/git/api.ts` the `forgeRepoWriteAccess` invoke wrapper.
- `src/lib/git/queries.ts` adds `useRepoWriteAccess` (lens-keyed, 5-minute `staleTime`, `retry: false`) plus the shared copy helpers `writeAccessReason` / `triageAccessReason` and the compact `WRITE_ACCESS_ITEM_REASON` / `TRIAGE_ACCESS_ITEM_REASON` constants used in menu-item labels.
- `src/features/pulls/usePrCapabilities.ts` takes the probe data and returns `writeBlocked` / `triageBlocked`, with the doc comment spelling out the two axes: the existing `can*` flags are **availability** and decide what renders; the new flags are **permission** and decide only what is enabled.

### Gated surfaces

- `src/features/pulls/RemotePrView.tsx`: merge, cancel auto-merge and the comment hide/unhide menu gate on push; labels, assignees and reviewers gate on the lower triage tier. Permission text outranks the existing availability hints on the merge button.
- `src/features/issues/RemoteIssueView.tsx` and `RemoteIssueViewParts.tsx`: pin, lock/unlock and the sidebar pickers gate on triage; transfer/move and delete gate on push, with the reason appended to each disabled menu item's label.
- `src/features/issues/IssueRelations.tsx`, `IssueMetaPickers.tsx`, `src/features/conversations/LabelsPopover.tsx`, `ReviewersPopover.tsx` and `Thread.tsx` take an optional `disabledReason` / `writeDisabledReason` prop — absent means editable exactly as before.
- `src/features/actions/ActionsPanel.tsx` and `RunDetailView.tsx`: run dispatch, re-run and cancel gate on push (CI is repo-wide, so no lens), and the probe stays disabled while the tab is inactive so a background `<Activity>` subtree doesn't fetch.
- `src/features/tags/TagDetailView.tsx`: publish, edit and delete on a release gate on push.
- Throughout, hints ride a wrapping `<span title>` because a natively disabled button swallows `title`; disabled menu items carry the reason in their label instead, and `DropdownMenuSubTrigger` gets a call-site `data-disabled:opacity-50` since the vendored primitive ships no disabled styling.

### Docs

- `src/features/help/content.ts` explains in the pull-requests guide section that available actions follow the viewer's repository access, naming the push/triage split.
- Adds `changelog.d/fixed-pr-write-access-gating.md`.