### PR TITLE
fix(ci,release): stop the AppImage bundling a stale libwayland-client

### DIFF
--- a/.github/actions/pin-linuxdeploy/action.yml
+++ b/.github/actions/pin-linuxdeploy/action.yml
@@ -19,6 +19,8 @@ runs:
         LINUXDEPLOY_SHA256: c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d
       run: |
         set -euo pipefail
+        # The gate is arch-agnostic (runner.os); this pin is not.
+        [ "$(uname -m)" = x86_64 ] || { echo "pin-linuxdeploy is x86_64-only"; exit 1; }
         cache_dir="$HOME/.cache/tauri"
         target="$cache_dir/linuxdeploy-x86_64.AppImage"
         mkdir -p "$cache_dir"

--- a/.github/actions/pin-linuxdeploy/action.yml
+++ b/.github/actions/pin-linuxdeploy/action.yml
@@ -1,0 +1,31 @@
+name: Pin linuxdeploy
+description: >-
+  Seed the Tauri bundler's tool cache with a pinned linuxdeploy build, so the
+  AppImage bundle excludes the runner's stale libwayland-client.
+
+# Tauri's default linuxdeploy is a July-2024 build whose baked-in excludelist
+# predates the libwayland-client.so.0 exclusion, so it bundles the runner's
+# stale copy — that shadows the host's and breaks EGL on Mesa 25+ systems.
+# tauri-bundler only downloads a tool it can't find in ~/.cache/tauri, so
+# seeding the cache with a newer release wins.
+
+runs:
+  using: composite
+  steps:
+    - name: Seed ~/.cache/tauri with pinned linuxdeploy
+      shell: bash
+      env:
+        LINUXDEPLOY_RELEASE: 1-alpha-20251107-1
+        LINUXDEPLOY_SHA256: c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d
+      run: |
+        set -euo pipefail
+        cache_dir="$HOME/.cache/tauri"
+        target="$cache_dir/linuxdeploy-x86_64.AppImage"
+        mkdir -p "$cache_dir"
+        curl -fsSL --retry 3 \
+          -o "$target" \
+          "https://github.com/linuxdeploy/linuxdeploy/releases/download/${LINUXDEPLOY_RELEASE}/linuxdeploy-x86_64.AppImage"
+        # Only valid here: the bundler patches the cached binary in place (dd
+        # zeroes 3 bytes) before running it, so this never re-verifies later.
+        echo "${LINUXDEPLOY_SHA256}  ${target}" | sha256sum -c -
+        chmod +x "$target"

--- a/.github/scripts/appimage-guard.sh
+++ b/.github/scripts/appimage-guard.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fails the build when the AppImage bundles libwayland-client: a bundled copy
+# shadows the host's and breaks EGL on Mesa 25+ systems. Run from the repo
+# root — the bundle path is relative to it.
+set -euo pipefail
+
+appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit 2>/dev/null || true)
+if [ -z "$appimage" ]; then
+  echo "No AppImage found under src-tauri/target/release/bundle/appimage"
+  exit 1
+fi
+workdir=$(mktemp -d)
+cp "$appimage" "$workdir/app.AppImage"
+chmod +x "$workdir/app.AppImage"
+# --appimage-extract avoids FUSE, which GitHub runners don't provide.
+(cd "$workdir" && ./app.AppImage --appimage-extract >/dev/null)
+# Match any soname: a bundled copy breaks EGL wherever it is placed.
+found=$(find "$workdir/squashfs-root" -name 'libwayland-client.so*' -print -quit)
+if [ -n "$found" ]; then
+  echo "FAIL: $(basename "$appimage") bundles $found"
+  exit 1
+fi
+echo "OK: $(basename "$appimage") does not bundle libwayland-client"

--- a/.github/scripts/appimage-smoke.sh
+++ b/.github/scripts/appimage-smoke.sh
@@ -46,7 +46,7 @@ timeout -k 5 30 xvfb-run -a ./squashfs-root/AppRun >/tmp/run.log 2>&1 &
 run_pid=$!
 
 sleep 20
-pgrep -f WebKitWebProcess >/dev/null || fail "web process not running at 20s"
+pgrep -f WebKitWebProcess >/dev/null || fail "no WebKitWebProcess at 20s (the app may also have exited early — see the log tail)"
 
 wait "$run_pid"
 code=$?

--- a/.github/scripts/appimage-smoke.sh
+++ b/.github/scripts/appimage-smoke.sh
@@ -2,9 +2,10 @@
 # Runtime smoke test for the Linux AppImage, run inside a modern-Mesa container
 # (fedora:44) against $APPIMAGE. The full gtk3 closure is required: linuxdeploy
 # excludes those libs from the bundle, so without them the app dies on a missing
-# host lib (e.g. libfribidi) long before EGL is reached. Both pass criteria are
-# required — an early crash exits well before the timeout, while an EGL failure
-# aborts only the web process and leaves the shell alive until the timeout.
+# host lib (e.g. libfribidi) long before EGL is reached. Three criteria, each
+# catching what the others miss: alive at the timeout (early crash), a live
+# WebKitWebProcess at 20s and no EGL-failure line (an EGL abort kills only the
+# web process, leaving the shell alive and sometimes silent).
 set -u
 
 : "${APPIMAGE:?APPIMAGE must point at the AppImage to test}"
@@ -28,11 +29,11 @@ cd /tmp || exit 1
   exit 1
 }
 
-export XDG_RUNTIME_DIR=/tmp/xdg && mkdir -p /tmp/xdg && chmod 700 /tmp/xdg
-export HOME=/tmp/home && mkdir -p /tmp/home
-
-timeout -k 5 30 xvfb-run -a ./squashfs-root/AppRun >/tmp/run.log 2>&1
-code=$?
+export XDG_RUNTIME_DIR=/tmp/xdg
+mkdir -p /tmp/xdg
+chmod 700 /tmp/xdg
+export HOME=/tmp/home
+mkdir -p /tmp/home
 
 fail() {
   echo "SMOKE FAILED: $1"
@@ -41,13 +42,22 @@ fail() {
   exit 1
 }
 
+timeout -k 5 30 xvfb-run -a ./squashfs-root/AppRun >/tmp/run.log 2>&1 &
+run_pid=$!
+
+sleep 20
+pgrep -f WebKitWebProcess >/dev/null || fail "web process not running at 20s"
+
+wait "$run_pid"
+code=$?
+
 # 124 = timeout fired; 137 = the -k KILL backstop fired on a TERM-blocking app.
 # Both mean the app was still alive at 30s.
 if [ "$code" -ne 124 ] && [ "$code" -ne 137 ]; then
   fail "app exited with code $code before the 30s timeout (expected 124 or 137)"
 fi
-if grep -q "Could not create default EGL display" /tmp/run.log; then
+if grep -Eqi 'Could not create default EGL display|EGL_BAD_PARAMETER|Failed to create EGL display' /tmp/run.log; then
   fail "EGL initialization error in the log"
 fi
 
-echo "SMOKE OK: app stayed alive for 30s with no EGL error"
+echo "SMOKE OK: alive at the 30s timeout, web process running at 20s, no EGL failure"

--- a/.github/scripts/appimage-smoke.sh
+++ b/.github/scripts/appimage-smoke.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Runtime smoke test for the Linux AppImage, run inside a modern-Mesa container
+# (fedora:44) against $APPIMAGE. The full gtk3 closure is required: linuxdeploy
+# excludes those libs from the bundle, so without them the app dies on a missing
+# host lib (e.g. libfribidi) long before EGL is reached. Both pass criteria are
+# required — an early crash exits well before the timeout, while an EGL failure
+# aborts only the web process and leaves the shell alive until the timeout.
+set -u
+
+: "${APPIMAGE:?APPIMAGE must point at the AppImage to test}"
+
+dnf -y -q install mesa-dri-drivers mesa-libEGL mesa-libGL libglvnd-egl libglvnd-glx \
+  gtk3 xorg-x11-server-Xvfb dbus-daemon procps-ng >/tmp/dnf.log 2>&1 || {
+  echo "DNF INSTALL FAILED"
+  tail -n 40 /tmp/dnf.log || true
+  exit 1
+}
+
+cp "$APPIMAGE" /tmp/gd.AppImage || {
+  echo "COPY FAILED: cannot read $APPIMAGE (check the container mount)"
+  exit 1
+}
+chmod +x /tmp/gd.AppImage || exit 1
+cd /tmp || exit 1
+./gd.AppImage --appimage-extract >/tmp/extract.log 2>&1 || {
+  echo "EXTRACT FAILED"
+  tail -n 40 /tmp/extract.log || true
+  exit 1
+}
+
+export XDG_RUNTIME_DIR=/tmp/xdg && mkdir -p /tmp/xdg && chmod 700 /tmp/xdg
+export HOME=/tmp/home && mkdir -p /tmp/home
+
+timeout -k 5 30 xvfb-run -a ./squashfs-root/AppRun >/tmp/run.log 2>&1
+code=$?
+
+fail() {
+  echo "SMOKE FAILED: $1"
+  echo "--- last 40 log lines ---"
+  tail -n 40 /tmp/run.log || true
+  exit 1
+}
+
+# 124 = timeout fired; 137 = the -k KILL backstop fired on a TERM-blocking app.
+# Both mean the app was still alive at 30s.
+if [ "$code" -ne 124 ] && [ "$code" -ne 137 ]; then
+  fail "app exited with code $code before the 30s timeout (expected 124 or 137)"
+fi
+if grep -q "Could not create default EGL display" /tmp/run.log; then
+  fail "EGL initialization error in the log"
+fi
+
+echo "SMOKE OK: app stayed alive for 30s with no EGL error"

--- a/.github/workflows/appimage-check.yml
+++ b/.github/workflows/appimage-check.yml
@@ -1,0 +1,112 @@
+name: appimage-check
+
+# Builds an unsigned AppImage the way release.yml does, then proves it actually
+# runs on a modern-Mesa distro. Dispatch it by hand when touching the Linux
+# bundling path; the PR trigger is paths-limited to that path's own files, so
+# it never becomes a required check on unrelated work.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/appimage-check.yml"
+      - ".github/workflows/release.yml"
+      - ".github/actions/pin-linuxdeploy/**"
+      - ".github/scripts/appimage-smoke.sh"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  appimage:
+    # Mirrors release.yml's Linux leg environment — if that runner ever
+    # migrates, this one moves with it or the check stops proving anything.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: Install Node
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            build-essential \
+            libssl-dev \
+            file
+
+      - name: Pin newer linuxdeploy for AppImage bundling
+        uses: ./.github/actions/pin-linuxdeploy
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      # createUpdaterArtifacts in tauri.conf.json would demand the signing key;
+      # the inline override drops it without affecting the bundle's contents.
+      - name: Build unsigned AppImage
+        run: pnpm tauri build --bundles appimage --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      # A bundled libwayland-client.so.0 shadows the host's and breaks EGL on
+      # Mesa 25+ systems. Kept identical to release.yml's guard step.
+      - name: Guard against a bundled libwayland-client
+        shell: bash
+        run: |
+          set -euo pipefail
+          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
+          if [ -z "$appimage" ]; then
+            echo "No AppImage found under src-tauri/target/release/bundle/appimage"
+            exit 1
+          fi
+          workdir=$(mktemp -d)
+          cp "$appimage" "$workdir/app.AppImage"
+          chmod +x "$workdir/app.AppImage"
+          # --appimage-extract avoids FUSE, which GitHub runners don't provide.
+          (cd "$workdir" && ./app.AppImage --appimage-extract >/dev/null)
+          # Match any soname: a bundled copy breaks EGL wherever it is placed.
+          found=$(find "$workdir/squashfs-root" -name 'libwayland-client.so*' -print -quit)
+          if [ -n "$found" ]; then
+            echo "FAIL: $(basename "$appimage") bundles $found"
+            exit 1
+          fi
+          echo "OK: $(basename "$appimage") does not bundle libwayland-client"
+
+      - name: Run the AppImage on modern Mesa
+        shell: bash
+        run: |
+          set -euo pipefail
+          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -e APPIMAGE="/work/$appimage" \
+            fedora:44 bash /work/.github/scripts/appimage-smoke.sh
+
+      - name: Upload the AppImage
+        uses: actions/upload-artifact@v7
+        with:
+          name: appimage-unsigned
+          path: src-tauri/target/release/bundle/appimage/*.AppImage
+          if-no-files-found: error

--- a/.github/workflows/appimage-check.yml
+++ b/.github/workflows/appimage-check.yml
@@ -12,7 +12,11 @@ on:
       - ".github/workflows/appimage-check.yml"
       - ".github/workflows/release.yml"
       - ".github/actions/pin-linuxdeploy/**"
+      - ".github/scripts/appimage-guard.sh"
       - ".github/scripts/appimage-smoke.sh"
+      # A Tauri CLI or bundle-config change can silently no-op the pin.
+      - "src-tauri/tauri.conf.json"
+      - "package.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,8 +27,8 @@ permissions:
 
 jobs:
   appimage:
-    # Mirrors release.yml's Linux leg environment — if that runner ever
-    # migrates, this one moves with it or the check stops proving anything.
+    # Paired with release.yml's Linux leg by convention only — nothing enforces
+    # it, so a runner bump there must be mirrored here or this proves nothing.
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
@@ -70,38 +74,18 @@ jobs:
       - name: Build unsigned AppImage
         run: pnpm tauri build --bundles appimage --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
-      # A bundled libwayland-client.so.0 shadows the host's and breaks EGL on
-      # Mesa 25+ systems. Kept identical to release.yml's guard step.
       - name: Guard against a bundled libwayland-client
         shell: bash
-        run: |
-          set -euo pipefail
-          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
-          if [ -z "$appimage" ]; then
-            echo "No AppImage found under src-tauri/target/release/bundle/appimage"
-            exit 1
-          fi
-          workdir=$(mktemp -d)
-          cp "$appimage" "$workdir/app.AppImage"
-          chmod +x "$workdir/app.AppImage"
-          # --appimage-extract avoids FUSE, which GitHub runners don't provide.
-          (cd "$workdir" && ./app.AppImage --appimage-extract >/dev/null)
-          # Match any soname: a bundled copy breaks EGL wherever it is placed.
-          found=$(find "$workdir/squashfs-root" -name 'libwayland-client.so*' -print -quit)
-          if [ -n "$found" ]; then
-            echo "FAIL: $(basename "$appimage") bundles $found"
-            exit 1
-          fi
-          echo "OK: $(basename "$appimage") does not bundle libwayland-client"
+        run: bash .github/scripts/appimage-guard.sh
 
       - name: Run the AppImage on modern Mesa
         shell: bash
         run: |
           set -euo pipefail
-          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
+          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit 2>/dev/null || true)
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/work" \
-            -e APPIMAGE="/work/$appimage" \
+            -e APPIMAGE="/work/${appimage:?no AppImage found}" \
             fedora:44 bash /work/.github/scripts/appimage-smoke.sh
 
       - name: Upload the AppImage
@@ -110,3 +94,4 @@ jobs:
           name: appimage-unsigned
           path: src-tauri/target/release/bundle/appimage/*.AppImage
           if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             file
 
       - name: Pin newer linuxdeploy for AppImage bundling
-        if: matrix.platform == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         uses: ./.github/actions/pin-linuxdeploy
 
       - name: Install frontend dependencies
@@ -132,28 +132,9 @@ jobs:
           # uploadUpdaterJson defaults to true → generates & attaches latest.json.
           updaterJsonPreferNsis: true
 
-      # A bundled libwayland-client.so.0 shadows the host's and breaks EGL on
-      # Mesa 25+ systems. This runs after the asset upload, but the release
-      # stays a draft until every leg is green, so a red guard blocks publishing.
+      # Runs after the asset upload, but the release stays a draft until every
+      # leg is green, so a red guard still blocks publishing.
       - name: Guard against a bundled libwayland-client
-        if: matrix.platform == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         shell: bash
-        run: |
-          set -euo pipefail
-          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
-          if [ -z "$appimage" ]; then
-            echo "No AppImage found under src-tauri/target/release/bundle/appimage"
-            exit 1
-          fi
-          workdir=$(mktemp -d)
-          cp "$appimage" "$workdir/app.AppImage"
-          chmod +x "$workdir/app.AppImage"
-          # --appimage-extract avoids FUSE, which GitHub runners don't provide.
-          (cd "$workdir" && ./app.AppImage --appimage-extract >/dev/null)
-          # Match any soname: a bundled copy breaks EGL wherever it is placed.
-          found=$(find "$workdir/squashfs-root" -name 'libwayland-client.so*' -print -quit)
-          if [ -n "$found" ]; then
-            echo "FAIL: $(basename "$appimage") bundles $found"
-            exit 1
-          fi
-          echo "OK: $(basename "$appimage") does not bundle libwayland-client"
+        run: bash .github/scripts/appimage-guard.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,10 @@ jobs:
             libssl-dev \
             file
 
+      - name: Pin newer linuxdeploy for AppImage bundling
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: ./.github/actions/pin-linuxdeploy
+
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
@@ -127,3 +131,29 @@ jobs:
           args: ${{ matrix.args }}
           # uploadUpdaterJson defaults to true → generates & attaches latest.json.
           updaterJsonPreferNsis: true
+
+      # A bundled libwayland-client.so.0 shadows the host's and breaks EGL on
+      # Mesa 25+ systems. This runs after the asset upload, but the release
+      # stays a draft until every leg is green, so a red guard blocks publishing.
+      - name: Guard against a bundled libwayland-client
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          set -euo pipefail
+          appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
+          if [ -z "$appimage" ]; then
+            echo "No AppImage found under src-tauri/target/release/bundle/appimage"
+            exit 1
+          fi
+          workdir=$(mktemp -d)
+          cp "$appimage" "$workdir/app.AppImage"
+          chmod +x "$workdir/app.AppImage"
+          # --appimage-extract avoids FUSE, which GitHub runners don't provide.
+          (cd "$workdir" && ./app.AppImage --appimage-extract >/dev/null)
+          # Match any soname: a bundled copy breaks EGL wherever it is placed.
+          found=$(find "$workdir/squashfs-root" -name 'libwayland-client.so*' -print -quit)
+          if [ -n "$found" ]; then
+            echo "FAIL: $(basename "$appimage") bundles $found"
+            exit 1
+          fi
+          echo "OK: $(basename "$appimage") does not bundle libwayland-client"

--- a/changelog.d/fixed-appimage-modern-linux.md
+++ b/changelog.d/fixed-appimage-modern-linux.md
@@ -1,0 +1,4 @@
+- The Linux AppImage now starts on current distributions (Fedora 42+, Arch, and
+  other systems with recent Mesa graphics drivers) instead of aborting with an
+  EGL error or showing an empty window — it no longer bundles an outdated
+  Wayland library that conflicted with the host's graphics drivers.


### PR DESCRIPTION
The Linux AppImage shipped a copy of `libwayland-client.so.0` taken from the Ubuntu 22.04 release runner. That stale library shadows the host's own, so EGL display initialization fails on systems with recent Mesa (Fedora 42+, Arch) and the app aborts or shows an empty window. The root cause is Tauri's default linuxdeploy — a July-2024 build whose baked-in excludelist predates the `libwayland-client.so.0` exclusion — so this pins a newer linuxdeploy for the bundle step and adds guards so the regression can't ship again.

### The fix

- Adds `.github/actions/pin-linuxdeploy/action.yml`, a composite action that seeds `~/.cache/tauri` with a pinned `linuxdeploy-x86_64.AppImage` (`1-alpha-20251107-1`), verified against a SHA-256 checksum. `tauri-bundler` only downloads a tool it can't already find in that cache, so the newer build wins and its excludelist keeps the Wayland library out.
- Wires that action into the Linux leg of `.github/workflows/release.yml` (`if: matrix.platform == 'ubuntu-22.04'`), ahead of the frontend install and bundle steps.

### Release-time guard

- Adds a post-build "Guard against a bundled libwayland-client" step to `release.yml` that extracts the built AppImage with `--appimage-extract` (avoiding FUSE, which GitHub runners don't provide) and fails if any `libwayland-client.so*` is found anywhere in `squashfs-root`. It runs after asset upload, but the release stays a draft until all legs are green, so a red guard blocks publishing.

### Runtime verification

- Adds `.github/workflows/appimage-check.yml`, which reproduces the release Linux leg on `ubuntu-22.04`, builds an unsigned AppImage (overriding `createUpdaterArtifacts` so no signing key is needed), runs the same bundling guard, executes the runtime smoke test, and uploads the artifact. It is `workflow_dispatch` plus a `pull_request` trigger scoped to the Linux bundling path's own files, so it never gates unrelated work.
- Adds `.github/scripts/appimage-smoke.sh`, which runs the AppImage under `xvfb-run` inside a `fedora:44` container with modern Mesa. It installs the full gtk3 closure (linuxdeploy excludes those libs from the bundle), then requires both that the process survives the 30s timeout (exit 124 or 137) and that `Could not create default EGL display` never appears in the log — an early crash and an EGL abort fail in different ways, so both checks are needed.

### Changelog

- Adds `changelog.d/fixed-appimage-modern-linux.md` describing the user-visible outcome: the AppImage now starts on current distributions instead of failing with an EGL error or an empty window.

Relates to #169