### PR TITLE
fix(agent,git,terminal): strip AppImage paths from spawned tool env

### DIFF
--- a/.github/scripts/appimage-guard.sh
+++ b/.github/scripts/appimage-guard.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Fails the build when the AppImage bundles libwayland-client: a bundled copy
-# shadows the host's and breaks EGL on Mesa 25+ systems. Run from the repo
-# root — the bundle path is relative to it.
+# Fails the build when the AppImage bundles libwayland-client (a bundled copy
+# shadows the host's and breaks EGL on Mesa 25+ systems), or when a startup hook
+# exports a $APPDIR-derived variable the app doesn't strip from spawned children.
+# Run from the repo root — the bundle path is relative to it.
 set -euo pipefail
 
 appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit 2>/dev/null || true)
@@ -21,3 +22,34 @@ if [ -n "$found" ]; then
   exit 1
 fi
 echo "OK: $(basename "$appimage") does not bundle libwayland-client"
+
+# Every variable a startup hook points into the bundle must also be stripped from
+# the environment of the tools we spawn. Twin of `APPDIR_PATHLIST_VARS` +
+# `APPDIR_SCALAR_VARS` in src-tauri/src/agent.rs — extend both together.
+# Hook SCRIPTS only: AppRun.wrapped is a binary that sets LD_LIBRARY_PATH
+# programmatically, so there is no export text there to parse.
+allowed=" LD_LIBRARY_PATH PATH XDG_DATA_DIRS GTK_PATH"
+allowed="$allowed GST_PLUGIN_SYSTEM_PATH GST_PLUGIN_SYSTEM_PATH_1_0"
+allowed="$allowed GSETTINGS_SCHEMA_DIR GTK_EXE_PREFIX GTK_DATA_PREFIX"
+allowed="$allowed GTK_IM_MODULE_FILE GDK_PIXBUF_MODULE_FILE GIO_EXTRA_MODULES"
+allowed="$allowed APPDIR " # the hook's own re-export
+hooks=0
+unknown=""
+for hook in "$workdir"/squashfs-root/apprun-hooks/*.sh; do
+  [ -e "$hook" ] || continue
+  hooks=$((hooks + 1))
+  exported=$(grep -E '^[[:space:]]*export[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=.*\$\{?APPDIR' "$hook" \
+    | sed -E 's/^[[:space:]]*export[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)=.*/\1/' || true)
+  for name in $exported; do
+    case "$allowed" in
+      *" $name "*) ;;
+      *) unknown="$unknown $name" ;;
+    esac
+  done
+done
+if [ -n "$unknown" ]; then
+  echo "FAIL: hook exports \$APPDIR-derived var(s) the app does not strip:$unknown"
+  echo "      add them to APPDIR_PATHLIST_VARS / APPDIR_SCALAR_VARS in src-tauri/src/agent.rs"
+  exit 1
+fi
+echo "OK: every \$APPDIR-derived export in $hooks startup hook(s) is stripped from child processes"

--- a/.github/scripts/appimage-guard.sh
+++ b/.github/scripts/appimage-guard.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Fails the build when the AppImage bundles libwayland-client (a bundled copy
-# shadows the host's and breaks EGL on Mesa 25+ systems), or when a startup hook
-# exports a $APPDIR-derived variable the app doesn't strip from spawned children.
-# Run from the repo root — the bundle path is relative to it.
+# shadows the host's and breaks EGL on Mesa 25+ systems), or when a startup
+# script exports a $APPDIR-derived variable the app doesn't strip from spawned
+# children. Run from the repo root — the bundle path is relative to it.
 set -euo pipefail
 
 appimage=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit 2>/dev/null || true)
@@ -23,22 +23,25 @@ if [ -n "$found" ]; then
 fi
 echo "OK: $(basename "$appimage") does not bundle libwayland-client"
 
-# Every variable a startup hook points into the bundle must also be stripped from
-# the environment of the tools we spawn. Twin of `APPDIR_PATHLIST_VARS` +
+# Every variable a startup script points into the bundle must also be stripped
+# from the environment of the tools we spawn. Twin of `APPDIR_PATHLIST_VARS` +
 # `APPDIR_SCALAR_VARS` in src-tauri/src/agent.rs — extend both together.
-# Hook SCRIPTS only: AppRun.wrapped is a binary that sets LD_LIBRARY_PATH
-# programmatically, so there is no export text there to parse.
+# Scans the generated AppRun wrapper and the hooks it sources; AppRun.wrapped is
+# skipped as a binary that sets LD_LIBRARY_PATH programmatically.
+# Shape limit: only single-line `export NAME=…` is matched — `NAME=…; export
+# NAME` and `declare -x` are out of scope (linuxdeploy emits single-line exports).
 allowed=" LD_LIBRARY_PATH PATH XDG_DATA_DIRS GTK_PATH"
 allowed="$allowed GST_PLUGIN_SYSTEM_PATH GST_PLUGIN_SYSTEM_PATH_1_0"
 allowed="$allowed GSETTINGS_SCHEMA_DIR GTK_EXE_PREFIX GTK_DATA_PREFIX"
 allowed="$allowed GTK_IM_MODULE_FILE GDK_PIXBUF_MODULE_FILE GIO_EXTRA_MODULES"
 allowed="$allowed APPDIR " # the hook's own re-export
-hooks=0
+scripts=0
 unknown=""
-for hook in "$workdir"/squashfs-root/apprun-hooks/*.sh; do
-  [ -e "$hook" ] || continue
-  hooks=$((hooks + 1))
-  exported=$(grep -E '^[[:space:]]*export[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=.*\$\{?APPDIR' "$hook" \
+for script in "$workdir"/squashfs-root/AppRun "$workdir"/squashfs-root/apprun-hooks/*.sh; do
+  [ -f "$script" ] || continue
+  scripts=$((scripts + 1))
+  # -I so a binary AppRun yields no matches instead of "Binary file matches".
+  exported=$(grep -IE '^[[:space:]]*export[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=.*\$\{?APPDIR' "$script" \
     | sed -E 's/^[[:space:]]*export[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)=.*/\1/' || true)
   for name in $exported; do
     case "$allowed" in
@@ -48,8 +51,8 @@ for hook in "$workdir"/squashfs-root/apprun-hooks/*.sh; do
   done
 done
 if [ -n "$unknown" ]; then
-  echo "FAIL: hook exports \$APPDIR-derived var(s) the app does not strip:$unknown"
+  echo "FAIL: startup script exports \$APPDIR-derived var(s) the app does not strip:$unknown"
   echo "      add them to APPDIR_PATHLIST_VARS / APPDIR_SCALAR_VARS in src-tauri/src/agent.rs"
   exit 1
 fi
-echo "OK: every \$APPDIR-derived export in $hooks startup hook(s) is stripped from child processes"
+echo "OK: every \$APPDIR-derived export in $scripts startup script(s) is stripped from child processes"

--- a/.github/workflows/appimage-check.yml
+++ b/.github/workflows/appimage-check.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build unsigned AppImage
         run: pnpm tauri build --bundles appimage --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
-      - name: Guard against a bundled libwayland-client
+      - name: Guard the AppImage bundle and its startup env
         shell: bash
         run: bash .github/scripts/appimage-guard.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
 
       # Runs after the asset upload, but the release stays a draft until every
       # leg is green, so a red guard still blocks publishing.
-      - name: Guard against a bundled libwayland-client
+      - name: Guard the AppImage bundle and its startup env
         if: runner.os == 'Linux'
         shell: bash
         run: bash .github/scripts/appimage-guard.sh

--- a/changelog.d/fixed-appimage-spawned-tools.md
+++ b/changelog.d/fixed-appimage-spawned-tools.md
@@ -1,0 +1,4 @@
+- Git and other external tools launched from the Linux AppImage (including
+  commands run in the built-in terminal) no longer inherit the bundle's
+  library paths — fixing fetches and pushes failing with a
+  `git-remote-https: symbol lookup error` on newer distributions.

--- a/changelog.d/fixed-appimage-spawned-tools.md
+++ b/changelog.d/fixed-appimage-spawned-tools.md
@@ -1,4 +1,4 @@
-- Git and other external tools launched from the Linux AppImage (including
-  commands run in the built-in terminal) no longer inherit the bundle's
-  library paths — fixing fetches and pushes failing with a
-  `git-remote-https: symbol lookup error` on newer distributions.
+- Git, the GitHub/GitLab CLIs, agent tools, and commands run in the built-in
+  terminal no longer inherit the AppImage bundle's library paths — fixing
+  fetches and pushes failing with a `git-remote-https: symbol lookup error`
+  on newer Linux distributions.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -201,7 +201,9 @@ impl EventSink for Channel<ReviewEvent> {
 // to the lists but overwrites the scalars; upstream's adds GI_TYPELIB_PATH.
 
 /// `PATH`-style lists the bundle prepends itself to; `$APPDIR` entries are
-/// dropped and the variable is unset when nothing survives.
+/// dropped and the variable is unset when nothing survives — except `PATH`,
+/// which is replaced with a minimal host PATH.
+/// Twin of the `export` allowlist in `.github/scripts/appimage-guard.sh`.
 const APPDIR_PATHLIST_VARS: &[&str] = &[
     "LD_LIBRARY_PATH",
     "PATH",
@@ -215,6 +217,7 @@ const APPDIR_PATHLIST_VARS: &[&str] = &[
 /// `$APPDIR`. Deliberately left alone: `GDK_BACKEND` and `GTK_THEME` (set by the
 /// hook but not `$APPDIR`-derived, and a child may legitimately want them), and
 /// `LD_PRELOAD` (the AppImage never sets it, so any value is the user's).
+/// Twin of the `export` allowlist in `.github/scripts/appimage-guard.sh`.
 const APPDIR_SCALAR_VARS: &[&str] = &[
     "GSETTINGS_SCHEMA_DIR",
     "GTK_EXE_PREFIX",
@@ -223,6 +226,9 @@ const APPDIR_SCALAR_VARS: &[&str] = &[
     "GDK_PIXBUF_MODULE_FILE",
     "GIO_EXTRA_MODULES",
 ];
+
+/// Where a child's `PATH` lands when every entry it inherited was bundle-derived.
+const FALLBACK_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 
 /// Whether `entry` is `appdir` itself or a path beneath it. Matches on a path
 /// boundary so a sibling mount (`/tmp/.mount_gdX`) isn't stripped by a prefix.
@@ -273,11 +279,11 @@ fn compute_child_env_overrides(
         if !dropped {
             continue;
         }
-        // A child always needs a PATH, so an all-bundle PATH is emptied rather
-        // than unset (AppRun prepends to the host PATH, so host entries remain
-        // in practice).
+        // A child always needs a PATH, and an EMPTY element means "the current
+        // directory" to POSIX exec — so an all-bundle PATH falls back to a
+        // minimal host PATH rather than being unset or left empty.
         let kept = if *name == "PATH" {
-            Some(kept.unwrap_or_default())
+            Some(kept.unwrap_or_else(|| FALLBACK_PATH.to_string()))
         } else {
             kept
         };
@@ -293,7 +299,7 @@ fn compute_child_env_overrides(
 
 /// The process-wide override plan, computed once from the live environment.
 /// Empty (so every applier is a no-op) unless we're running from an AppImage.
-pub(crate) fn child_env_overrides() -> &'static [(&'static str, Option<String>)] {
+fn child_env_overrides() -> &'static [(&'static str, Option<String>)] {
     // AppImage is Linux-only, and `APPDIR` alone gates it: an extracted run
     // (`--appimage-extract`, the no-FUSE path) sets `APPDIR` but never `APPIMAGE`.
     if !cfg!(all(unix, not(target_os = "macos"))) {
@@ -1812,9 +1818,9 @@ fn kill_process_tree(child: &mut tokio::process::Child) {
     {
         // Negative PID targets the process group (pgid == pid for a group
         // leader), so `kill -KILL` reaches every descendant.
-        let _ = std::process::Command::new("kill")
-            .args(["-KILL", &format!("-{pid}")])
-            .spawn();
+        let mut cmd = std::process::Command::new("kill");
+        sanitize_child_env(&mut cmd);
+        let _ = cmd.args(["-KILL", &format!("-{pid}")]).spawn();
     }
 
     // Belt-and-braces: the tree-kill can race the child exiting, and this is
@@ -2629,7 +2635,7 @@ mod child_env_tests {
     }
 
     /// Expected result when nothing `$APPDIR`-derived was there to drop.
-    fn untouched(list: &str) -> (Option<String>, bool) {
+    fn no_strip(list: &str) -> (Option<String>, bool) {
         (Some(list.to_string()), false)
     }
 
@@ -2637,7 +2643,7 @@ mod child_env_tests {
     fn a_list_without_bundle_entries_is_untouched() {
         assert_eq!(
             strip_appdir_pathlist("/usr/bin:/bin", APPDIR),
-            untouched("/usr/bin:/bin")
+            no_strip("/usr/bin:/bin")
         );
     }
 
@@ -2684,17 +2690,17 @@ mod child_env_tests {
         // and nothing was dropped, so no override is warranted either.
         assert_eq!(
             strip_appdir_pathlist("/tmp/.mount_gdAbcX/lib:/usr/lib", APPDIR),
-            untouched("/tmp/.mount_gdAbcX/lib:/usr/lib")
+            no_strip("/tmp/.mount_gdAbcX/lib:/usr/lib")
         );
     }
 
     #[test]
-    fn a_host_only_list_keeps_its_empty_segments_and_emits_no_override() {
-        // Empty segments are dropped only as a side effect of a real strip; with
-        // nothing bundle-derived to remove, the child inherits the value verbatim.
+    fn a_host_only_list_collapses_empty_segments_but_emits_no_override() {
+        // The helper always collapses empty segments; the child keeps its original
+        // value only because a host-only list produces no override at all.
         assert_eq!(
             strip_appdir_pathlist("/usr/local/bin::/usr/bin", APPDIR),
-            untouched("/usr/local/bin:/usr/bin")
+            no_strip("/usr/local/bin:/usr/bin")
         );
         assert!(compute_child_env_overrides(
             APPDIR,
@@ -2704,7 +2710,7 @@ mod child_env_tests {
     }
 
     #[test]
-    fn degenerate_segments_are_dropped_and_an_empty_value_unsets() {
+    fn empty_segments_collapse_and_a_list_with_no_survivors_unsets() {
         assert_eq!(
             strip_appdir_pathlist(":/tmp/.mount_gdAbc/bin::/usr/bin:", APPDIR),
             stripped_to("/usr/bin")
@@ -2712,7 +2718,7 @@ mod child_env_tests {
         assert_eq!(strip_appdir_pathlist("", APPDIR), (None, false));
         assert_eq!(strip_appdir_pathlist("::", APPDIR), (None, false));
         // An empty appdir strips nothing (the plan never asks for one).
-        assert_eq!(strip_appdir_pathlist("/usr/bin", ""), untouched("/usr/bin"));
+        assert_eq!(strip_appdir_pathlist("/usr/bin", ""), no_strip("/usr/bin"));
     }
 
     #[test]
@@ -2795,9 +2801,29 @@ mod child_env_tests {
             APPDIR,
             lookup(&[("PATH", "/tmp/.mount_gdAbc/usr/bin:/tmp/.mount_gdAbc/bin")]),
         );
-        assert_eq!(plan, vec![("PATH", Some(String::new()))]);
+        assert_eq!(
+            plan,
+            vec![("PATH", Some("/usr/local/bin:/usr/bin:/bin".to_string()))]
+        );
         // An already-empty PATH is left alone rather than re-set to itself.
         assert!(compute_child_env_overrides(APPDIR, lookup(&[("PATH", "")])).is_empty());
+    }
+
+    #[test]
+    fn portable_pty_env_remove_drops_an_inherited_var() {
+        // The PTY applier only subtracts, so `CommandBuilder` must snapshot the
+        // parent environment into its own map — an `env_remove` that only cleared
+        // caller overrides would leave the bundle paths in place for the terminal.
+        let mut cmd = portable_pty::CommandBuilder::new("x");
+        assert!(
+            cmd.get_env("PATH").is_some(),
+            "portable-pty must snapshot the parent environment"
+        );
+        cmd.env_remove("PATH");
+        assert!(
+            cmd.get_env("PATH").is_none(),
+            "portable-pty must drop inherited vars, not just caller overrides"
+        );
     }
 }
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -191,6 +191,167 @@ impl EventSink for Channel<ReviewEvent> {
     }
 }
 
+// --- child environment -----------------------------------------------------
+//
+// Inside the Linux AppImage, AppRun and its GTK hook point loader/toolkit vars
+// into the bundle, so any spawned HOST binary loads the bundle's Ubuntu 22.04
+// libraries and dies. Subtract per child only: never clear (SSH_AUTH_SOCK
+// inherits), never touch our own env (WebKit helpers, the dlopen'd tray). The
+// list/scalar split tracks Tauri's linuxdeploy-plugin-gtk fork, which appends
+// to the lists but overwrites the scalars; upstream's adds GI_TYPELIB_PATH.
+
+/// `PATH`-style lists the bundle prepends itself to; `$APPDIR` entries are
+/// dropped and the variable is unset when nothing survives.
+const APPDIR_PATHLIST_VARS: &[&str] = &[
+    "LD_LIBRARY_PATH",
+    "PATH",
+    "XDG_DATA_DIRS",
+    "GTK_PATH",
+    "GST_PLUGIN_SYSTEM_PATH",
+    "GST_PLUGIN_SYSTEM_PATH_1_0",
+];
+
+/// Single-path variables the bundle owns outright — unset when they point into
+/// `$APPDIR`. Deliberately left alone: `GDK_BACKEND` and `GTK_THEME` (set by the
+/// hook but not `$APPDIR`-derived, and a child may legitimately want them), and
+/// `LD_PRELOAD` (the AppImage never sets it, so any value is the user's).
+const APPDIR_SCALAR_VARS: &[&str] = &[
+    "GSETTINGS_SCHEMA_DIR",
+    "GTK_EXE_PREFIX",
+    "GTK_DATA_PREFIX",
+    "GTK_IM_MODULE_FILE",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GIO_EXTRA_MODULES",
+];
+
+/// Whether `entry` is `appdir` itself or a path beneath it. Matches on a path
+/// boundary so a sibling mount (`/tmp/.mount_gdX`) isn't stripped by a prefix.
+fn is_under_appdir(entry: &str, appdir: &str) -> bool {
+    if appdir.is_empty() {
+        return false;
+    }
+    entry == appdir
+        || (entry.len() > appdir.len()
+            && entry.starts_with(appdir)
+            && entry.as_bytes()[appdir.len()] == b'/')
+}
+
+/// Drops `$APPDIR` entries (and empty ones) from a `:`-separated list. Returns
+/// the survivors — `None` meaning "unset the variable" — plus whether any
+/// `$APPDIR` entry was actually dropped, which is what makes an override
+/// warranted: a host-only list must be left exactly as the child inherited it.
+fn strip_appdir_pathlist(value: &str, appdir: &str) -> (Option<String>, bool) {
+    let appdir = appdir.trim_end_matches('/');
+    let mut dropped = false;
+    let kept: Vec<&str> = value
+        .split(':')
+        .filter(|entry| {
+            if is_under_appdir(entry, appdir) {
+                dropped = true;
+                return false;
+            }
+            !entry.is_empty()
+        })
+        .collect();
+    ((!kept.is_empty()).then(|| kept.join(":")), dropped)
+}
+
+/// Builds the override plan from an `appdir` and an environment lookup; `Some`
+/// sets the variable on the child, `None` removes it. Pure so the rules are
+/// testable off-Linux.
+fn compute_child_env_overrides(
+    appdir: &str,
+    var: impl Fn(&str) -> Option<String>,
+) -> Vec<(&'static str, Option<String>)> {
+    if appdir.is_empty() {
+        return Vec::new();
+    }
+    let mut plan = Vec::new();
+    for name in APPDIR_PATHLIST_VARS {
+        let Some(value) = var(name) else { continue };
+        let (kept, dropped) = strip_appdir_pathlist(&value, appdir);
+        if !dropped {
+            continue;
+        }
+        // A child always needs a PATH, so an all-bundle PATH is emptied rather
+        // than unset (AppRun prepends to the host PATH, so host entries remain
+        // in practice).
+        let kept = if *name == "PATH" {
+            Some(kept.unwrap_or_default())
+        } else {
+            kept
+        };
+        plan.push((*name, kept));
+    }
+    for name in APPDIR_SCALAR_VARS {
+        if var(name).is_some_and(|value| is_under_appdir(&value, appdir.trim_end_matches('/'))) {
+            plan.push((*name, None));
+        }
+    }
+    plan
+}
+
+/// The process-wide override plan, computed once from the live environment.
+/// Empty (so every applier is a no-op) unless we're running from an AppImage.
+pub(crate) fn child_env_overrides() -> &'static [(&'static str, Option<String>)] {
+    // AppImage is Linux-only, and `APPDIR` alone gates it: an extracted run
+    // (`--appimage-extract`, the no-FUSE path) sets `APPDIR` but never `APPIMAGE`.
+    if !cfg!(all(unix, not(target_os = "macos"))) {
+        return &[];
+    }
+    static PLAN: std::sync::OnceLock<Vec<(&'static str, Option<String>)>> =
+        std::sync::OnceLock::new();
+    PLAN.get_or_init(|| {
+        let appdir = std::env::var("APPDIR").unwrap_or_default();
+        compute_child_env_overrides(&appdir, |key| std::env::var(key).ok())
+    })
+}
+
+/// Env sink for [`sanitize_child_env`], implemented for every command builder the
+/// app spawns through (std, tokio, portable-pty).
+pub(crate) trait ChildEnv {
+    fn set_var(&mut self, key: &str, value: &str);
+    fn unset_var(&mut self, key: &str);
+}
+
+impl ChildEnv for Command {
+    fn set_var(&mut self, key: &str, value: &str) {
+        self.env(key, value);
+    }
+    fn unset_var(&mut self, key: &str) {
+        self.env_remove(key);
+    }
+}
+
+impl ChildEnv for std::process::Command {
+    fn set_var(&mut self, key: &str, value: &str) {
+        self.env(key, value);
+    }
+    fn unset_var(&mut self, key: &str) {
+        self.env_remove(key);
+    }
+}
+
+impl ChildEnv for portable_pty::CommandBuilder {
+    fn set_var(&mut self, key: &str, value: &str) {
+        self.env(key, value);
+    }
+    fn unset_var(&mut self, key: &str) {
+        self.env_remove(key);
+    }
+}
+
+/// Removes the AppImage bundle's paths from a child's environment. Call it FIRST,
+/// before a site's own `.env()` calls, so explicitly-set variables always win.
+pub(crate) fn sanitize_child_env<C: ChildEnv>(cmd: &mut C) {
+    for (name, value) in child_env_overrides() {
+        match value {
+            Some(v) => cmd.set_var(name, v),
+            None => cmd.unset_var(name),
+        }
+    }
+}
+
 // --- binary resolution -----------------------------------------------------
 //
 // A GUI app does not reliably inherit the user's shell PATH, and npm-installed
@@ -421,6 +582,7 @@ async fn resolve_via_login_shell(names: &[&str]) -> Option<PathBuf> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
     for name in names {
         let mut cmd = Command::new(&shell);
+        sanitize_child_env(&mut cmd);
         // -l sources the profile; -i sources the rc files, where zsh/bash users
         // commonly set PATH (nvm, `brew shellenv`, …). stdin is closed so the
         // shell runs the one command and exits rather than waiting for input.
@@ -486,6 +648,7 @@ pub(crate) async fn run_capture(
     timeout: Duration,
 ) -> AppResult<(i32, String)> {
     let mut cmd = Command::new(program);
+    sanitize_child_env(&mut cmd);
     cmd.args(args)
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")
@@ -1690,6 +1853,7 @@ async fn stream_agent(
     on_event: &dyn EventSink,
 ) -> AppResult<()> {
     let mut cmd = Command::new(binary);
+    sanitize_child_env(&mut cmd);
     cmd.args(args)
         .current_dir(cwd)
         .env("NO_COLOR", "1")
@@ -2441,6 +2605,200 @@ pub async fn agent_session(
         &on_event,
     )
     .await
+}
+
+#[cfg(test)]
+mod child_env_tests {
+    use super::*;
+
+    const APPDIR: &str = "/tmp/.mount_gdAbc";
+
+    /// Look up a var from a fixture table, so these run identically on every OS.
+    fn lookup(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| (*v).to_string())
+        }
+    }
+
+    /// Expected `strip_appdir_pathlist` result when `list` survived a real strip.
+    fn stripped_to(list: &str) -> (Option<String>, bool) {
+        (Some(list.to_string()), true)
+    }
+
+    /// Expected result when nothing `$APPDIR`-derived was there to drop.
+    fn untouched(list: &str) -> (Option<String>, bool) {
+        (Some(list.to_string()), false)
+    }
+
+    #[test]
+    fn a_list_without_bundle_entries_is_untouched() {
+        assert_eq!(
+            strip_appdir_pathlist("/usr/bin:/bin", APPDIR),
+            untouched("/usr/bin:/bin")
+        );
+    }
+
+    #[test]
+    fn an_all_bundle_list_strips_to_nothing() {
+        assert_eq!(
+            strip_appdir_pathlist(
+                "/tmp/.mount_gdAbc/usr/lib:/tmp/.mount_gdAbc:/tmp/.mount_gdAbc/usr/lib/x86_64-linux-gnu",
+                APPDIR
+            ),
+            (None, true)
+        );
+    }
+
+    #[test]
+    fn bundle_entries_are_dropped_in_place_and_host_order_survives() {
+        assert_eq!(
+            strip_appdir_pathlist(
+                "/tmp/.mount_gdAbc/usr/bin:/usr/local/bin:/tmp/.mount_gdAbc/usr/lib:/usr/bin",
+                APPDIR
+            ),
+            stripped_to("/usr/local/bin:/usr/bin")
+        );
+    }
+
+    #[test]
+    fn a_trailing_slash_on_appdir_is_equivalent() {
+        let value = "/tmp/.mount_gdAbc/usr/lib:/usr/lib";
+        assert_eq!(
+            strip_appdir_pathlist(value, "/tmp/.mount_gdAbc/"),
+            strip_appdir_pathlist(value, APPDIR),
+            "a trailing slash must not change the outcome"
+        );
+        // The bare directory itself matches with or without the trailing slash.
+        assert_eq!(
+            strip_appdir_pathlist("/tmp/.mount_gdAbc", "/tmp/.mount_gdAbc//"),
+            (None, true)
+        );
+    }
+
+    #[test]
+    fn a_prefix_that_is_not_a_path_boundary_survives() {
+        // A sibling mount whose name merely starts with ours must not be stripped —
+        // and nothing was dropped, so no override is warranted either.
+        assert_eq!(
+            strip_appdir_pathlist("/tmp/.mount_gdAbcX/lib:/usr/lib", APPDIR),
+            untouched("/tmp/.mount_gdAbcX/lib:/usr/lib")
+        );
+    }
+
+    #[test]
+    fn a_host_only_list_keeps_its_empty_segments_and_emits_no_override() {
+        // Empty segments are dropped only as a side effect of a real strip; with
+        // nothing bundle-derived to remove, the child inherits the value verbatim.
+        assert_eq!(
+            strip_appdir_pathlist("/usr/local/bin::/usr/bin", APPDIR),
+            untouched("/usr/local/bin:/usr/bin")
+        );
+        assert!(compute_child_env_overrides(
+            APPDIR,
+            lookup(&[("PATH", "/usr/local/bin::/usr/bin")])
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn degenerate_segments_are_dropped_and_an_empty_value_unsets() {
+        assert_eq!(
+            strip_appdir_pathlist(":/tmp/.mount_gdAbc/bin::/usr/bin:", APPDIR),
+            stripped_to("/usr/bin")
+        );
+        assert_eq!(strip_appdir_pathlist("", APPDIR), (None, false));
+        assert_eq!(strip_appdir_pathlist("::", APPDIR), (None, false));
+        // An empty appdir strips nothing (the plan never asks for one).
+        assert_eq!(strip_appdir_pathlist("/usr/bin", ""), untouched("/usr/bin"));
+    }
+
+    #[test]
+    fn vars_outside_the_two_tables_never_enter_the_plan() {
+        // GDK_BACKEND/GTK_THEME aren't `$APPDIR`-derived and LD_PRELOAD is the
+        // user's, so even bundle-looking values must come through untouched.
+        let plan = compute_child_env_overrides(
+            APPDIR,
+            lookup(&[
+                ("GDK_BACKEND", "/tmp/.mount_gdAbc/wayland"),
+                ("GTK_THEME", "/tmp/.mount_gdAbc/Adwaita"),
+                ("LD_PRELOAD", "/tmp/.mount_gdAbc/usr/lib/libfoo.so"),
+            ]),
+        );
+        assert!(plan.is_empty(), "unexpected overrides: {plan:?}");
+    }
+
+    #[test]
+    fn a_scalar_equal_to_appdir_is_unset_and_respects_the_path_boundary() {
+        let expected = vec![("GTK_DATA_PREFIX", None)];
+        assert_eq!(
+            compute_child_env_overrides(
+                APPDIR,
+                lookup(&[("GTK_DATA_PREFIX", "/tmp/.mount_gdAbc")])
+            ),
+            expected
+        );
+        // Same directory, appdir spelled with a trailing slash.
+        assert_eq!(
+            compute_child_env_overrides(
+                "/tmp/.mount_gdAbc/",
+                lookup(&[("GTK_DATA_PREFIX", "/tmp/.mount_gdAbc")])
+            ),
+            expected
+        );
+        // A sibling directory sharing the prefix belongs to the host — leave it.
+        assert!(compute_child_env_overrides(
+            APPDIR,
+            lookup(&[("GTK_DATA_PREFIX", "/tmp/.mount_gdAbcX")])
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn no_appdir_means_no_overrides_at_all() {
+        assert!(
+            compute_child_env_overrides("", lookup(&[("PATH", "/tmp/.mount_gdAbc/usr/bin")]))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn the_plan_rewrites_lists_removes_bundle_scalars_and_skips_clean_vars() {
+        let plan = compute_child_env_overrides(
+            APPDIR,
+            lookup(&[
+                ("LD_LIBRARY_PATH", "/tmp/.mount_gdAbc/usr/lib"),
+                ("PATH", "/tmp/.mount_gdAbc/usr/bin:/usr/bin"),
+                ("XDG_DATA_DIRS", "/usr/share"),
+                (
+                    "GDK_PIXBUF_MODULE_FILE",
+                    "/tmp/.mount_gdAbc/usr/lib/loaders.cache",
+                ),
+                ("GTK_IM_MODULE_FILE", "/etc/gtk/immodules.cache"),
+            ]),
+        );
+        assert_eq!(
+            plan,
+            vec![
+                ("LD_LIBRARY_PATH", None),
+                ("PATH", Some("/usr/bin".to_string())),
+                ("GDK_PIXBUF_MODULE_FILE", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn path_is_never_unset_even_when_every_entry_is_bundle_derived() {
+        let plan = compute_child_env_overrides(
+            APPDIR,
+            lookup(&[("PATH", "/tmp/.mount_gdAbc/usr/bin:/tmp/.mount_gdAbc/bin")]),
+        );
+        assert_eq!(plan, vec![("PATH", Some(String::new()))]);
+        // An already-empty PATH is left alone rather than re-set to itself.
+        assert!(compute_child_env_overrides(APPDIR, lookup(&[("PATH", "")])).is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -364,6 +364,7 @@ pub async fn agent_container_prepare(
 /// and a tail of the build log on failure. Callers own their temp context dir.
 async fn run_build(bin: &Path, build_args: &[String]) -> AppResult<()> {
     let mut cmd = Command::new(bin);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(build_args)
         .env("NO_COLOR", "1")
         .stdin(Stdio::null())
@@ -1056,11 +1057,9 @@ fn launch_container_shell(bin: &str, args: &[String], tip: &str) -> AppResult<()
     }
     let cmd = format!("echo '{tip}'; {line}; echo; echo '(container exited)'; exec bash");
     for term in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"] {
-        if Command::new(term)
-            .args(["-e", "bash", "-c", &cmd])
-            .spawn()
-            .is_ok()
-        {
+        let mut term_cmd = Command::new(term);
+        crate::agent::sanitize_child_env(&mut term_cmd);
+        if term_cmd.args(["-e", "bash", "-c", &cmd]).spawn().is_ok() {
             return Ok(());
         }
     }

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -66,6 +66,7 @@ pub async fn run_glab_raw(
 ) -> AppResult<GlabOutput> {
     let glab = glab_bin().await?;
     let mut cmd = Command::new(&glab);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);
@@ -266,6 +267,7 @@ pub async fn run_glab_ex(
 ) -> AppResult<GlabOutput> {
     let glab = glab_bin().await?;
     let mut cmd = Command::new(&glab);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -940,6 +940,7 @@ async fn run_reconnect_child(
     on_event: &Channel<ReconnectEvent>,
 ) -> AppResult<()> {
     let mut cmd = Command::new(binary);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args.iter().map(String::as_str));
     // Non-interactive + quiet. Deliberately no GH_PROMPT_DISABLED — stdin-null
     // suffices and that env var's effect on the web flow is unvalidated.

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -419,6 +419,7 @@ async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
     }
 
     let mut cmd = Command::new(&resolved);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(rest);
     // Always root at the repository directory: harmless when `{path}` is used
     // explicitly, and the only cwd signal for launchers that inherit it
@@ -559,12 +560,16 @@ fn launch_terminal_unix(kind: &str, program: &str, path: &str) -> AppResult<()> 
             None
         };
         if let Some(bin) = chosen {
-            if Command::new(&bin).current_dir(path).spawn().is_ok() {
+            let mut cmd = Command::new(&bin);
+            crate::agent::sanitize_child_env(&mut cmd);
+            if cmd.current_dir(path).spawn().is_ok() {
                 return Ok(());
             }
         }
         for term in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"] {
-            if Command::new(term).current_dir(path).spawn().is_ok() {
+            let mut cmd = Command::new(term);
+            crate::agent::sanitize_child_env(&mut cmd);
+            if cmd.current_dir(path).spawn().is_ok() {
                 return Ok(());
             }
         }
@@ -1054,6 +1059,7 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
         c
     } else {
         let mut c = std::process::Command::new(&program);
+        crate::agent::sanitize_child_env(&mut c);
         c.arg(&path);
         c
     };

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -72,6 +72,8 @@ pub async fn run_git_raw_input(
 ) -> AppResult<GitOutput> {
     let git = git_bin().await?;
     let mut cmd = Command::new(&git);
+    // Also covers the credential helpers git spawns in turn.
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(["-c", "core.quotePath=false", "-c", "color.ui=false"]);
     cmd.args(args);
     if let Some(repo) = repo_path {

--- a/src-tauri/src/github/runner.rs
+++ b/src-tauri/src/github/runner.rs
@@ -55,6 +55,7 @@ pub async fn run_gh_raw(
 ) -> AppResult<GhOutput> {
     let gh = gh_bin().await?;
     let mut cmd = Command::new(&gh);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);
@@ -121,6 +122,7 @@ pub async fn run_gh_input(
 
     let gh = gh_bin().await?;
     let mut cmd = Command::new(&gh);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -203,6 +203,7 @@ pub async fn git_run_hook_manager(
         }
     };
     let mut cmd = tokio::process::Command::new(&manager);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args)
         .current_dir(&repo_path)
         .stdin(std::process::Stdio::null());

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -669,6 +669,7 @@ async fn run_client_cli(bin: &str, args: &[&str]) -> AppResult<(String, String, 
     })?;
 
     let mut cmd = Command::new(&program);
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.args(args)
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -464,8 +464,10 @@ pub async fn pty_open(
         tree_kill,
     } = build_command(&opts, &id).await?;
     // portable-pty's CommandBuilder already inherits the parent environment, so we
-    // only advertise a capable terminal here (re-copying every var is redundant and
-    // can introduce odd-cased duplicate Windows vars).
+    // only subtract (the AppImage bundle's paths, which would poison host tools run
+    // in the terminal) and advertise a capable terminal — re-copying every var is
+    // redundant and can introduce odd-cased duplicate Windows vars.
+    crate::agent::sanitize_child_env(&mut cmd);
     cmd.env("TERM", "xterm-256color");
 
     let pty_system = native_pty_system();


### PR DESCRIPTION
Inside the Linux AppImage, AppRun and its GTK hook point the loader and toolkit variables at the bundle, so every host binary we spawn (git, gh, glab, the terminal's shell) loads the bundle's Ubuntu 22.04 libraries instead of the system's — most visibly as `git-remote-https: symbol lookup error` on fetch/push against newer distributions. This adds a single subtractive sanitizer that removes the bundle's paths from each child's environment at spawn time, and applies it at every process-spawn site in the backend.

### Environment sanitizer (`src-tauri/src/agent.rs`)

- Adds `compute_child_env_overrides` plus the `APPDIR_PATHLIST_VARS` / `APPDIR_SCALAR_VARS` tables: `PATH`-style lists (`LD_LIBRARY_PATH`, `PATH`, `XDG_DATA_DIRS`, `GTK_PATH`, the two `GST_PLUGIN_SYSTEM_PATH` spellings) have their `$APPDIR` entries dropped in place and are unset when nothing survives; single-path vars (`GSETTINGS_SCHEMA_DIR`, `GTK_EXE_PREFIX`, `GTK_DATA_PREFIX`, `GTK_IM_MODULE_FILE`, `GDK_PIXBUF_MODULE_FILE`, `GIO_EXTRA_MODULES`) are unset only when they point into the bundle.
- `strip_appdir_pathlist` / `is_under_appdir` match on a path boundary (and normalize a trailing slash) so a sibling mount sharing our prefix isn't stripped, and an override is emitted only when a bundle entry was actually dropped — a host-only list is inherited verbatim. `PATH` is emptied rather than unset so a child always has one.
- The plan is computed once by `child_env_overrides()` behind a `OnceLock`, gated on Linux and on a non-empty `APPDIR` (which also covers `--appimage-extract` runs, where `APPIMAGE` is absent); off-AppImage it is empty and every applier is a no-op. Comments record the deliberate exclusions — `GDK_BACKEND`, `GTK_THEME` and `LD_PRELOAD` are left alone — and that the environment is never cleared wholesale, so things like `SSH_AUTH_SOCK` still inherit.
- Introduces the `ChildEnv` trait with `sanitize_child_env`, implemented for `tokio::process::Command`, `std::process::Command` and `portable_pty::CommandBuilder`, so one helper covers every builder the app spawns through. It is called before each site's own `.env()` calls so explicit settings win.

### Spawn sites

- Git and forge CLIs: `git/runner.rs` (`run_git_raw_input`, which also covers the credential helpers git spawns in turn), `github/runner.rs` (`run_gh_raw`, `run_gh_input`), `forge/glab.rs` (`run_glab_raw`, `run_glab_ex`) and `forge/session.rs` (`run_reconnect_child`).
- Terminal and external launchers: `pty.rs` (`pty_open`, with its comment updated to describe the subtract-then-advertise-`TERM` approach) and `fsops.rs` (`launch_custom_command`, both fallback loops in `launch_terminal_unix`, and `open_with_program`).
- Agent and tooling paths: `agent.rs` (`resolve_via_login_shell`, `run_capture`, `stream_agent`), `agent_sandbox.rs` (`run_build`, plus `launch_container_shell`, whose chained builder is unfolded into a local `term_cmd`), `hooks.rs` (`git_run_hook_manager`) and `mcp.rs` (`run_client_cli`).

### Tests and changelog

- Adds a `child_env_tests` module in `src-tauri/src/agent.rs` covering the rules off-Linux via a fixture lookup: untouched host lists, all-bundle lists collapsing to unset, in-place removal preserving host order, trailing-slash equivalence, the prefix-vs-boundary case, degenerate/empty segments, the never-unset `PATH` behavior, scalars equal to `$APPDIR`, the excluded variables, and the empty-`APPDIR` no-op.
- Adds `changelog.d/fixed-appimage-spawned-tools.md` describing the fix in user terms.

Relates to #174