### PR TITLE
feat(app-menu,shortcuts): add native macOS menu bar with Open Recent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,10 +123,10 @@ pnpm changelog:preview  # preview pending changelog.d/ fragments
   load the `vercel-react-best-practices` skill and apply it as you write (it doesn't
   auto-load — pull it in yourself). Vercel's 70-rule playbook: waterfalls, bundle size,
   data fetching, re-renders, memoization.
-- **macOS Edit menu** — we rely on Tauri's `Menu::default()` (it ships the Edit submenu
-  that powers undo/redo/cut/copy/paste in inputs on macOS). If you add a custom app menu,
-  derive it from `Menu::default()` or include the Edit `PredefinedMenuItem`s, or macOS
-  text editing breaks.
+- **macOS Edit menu** — the app builds its own menu bar in
+  `src-tauri/src/app_menu.rs::build_menu`. Whatever you change there, keep all seven Edit
+  `PredefinedMenuItem`s (undo, redo, separator, cut, copy, paste, select-all) or derive
+  from `Menu::default()`, or macOS text editing breaks in every input.
 - The site deploys to Cloudflare Pages at `gitdesktop.app` (`base: "/"`).
 
 ## Delegated implementation (orchestrator ⇄ subagents)

--- a/README.md
+++ b/README.md
@@ -350,6 +350,9 @@ scaffolding), publish to GitHub, and fork.
   its new home from the "no longer a git repository" notice; after you confirm the folder,
   the entry keeps its alias and badges, and its local PRs, issues, review history, and
   automations follow along.
+- **macOS menu bar** — **File** carries **New / Open / Clone Repository…** and an
+  **Open Recent** list of your last ten repos; **Settings…** sits in the GitDesktop
+  menu. Items work from any screen.
 - **GitHub repo settings** (admin) — description & topics (with AI suggestions), merge
   options and default commit messages, template & forking, **collaborators &
   invitations**, **branch rulesets** (create/edit, reversible enable/disable), **code

--- a/changelog.d/added-macos-file-menu.md
+++ b/changelog.d/added-macos-file-menu.md
@@ -1,0 +1,4 @@
+- **macOS menu bar.** The **File** menu now opens repositories the way the rest
+  of the app does — **New Repository…**, **Open Repository…**, **Clone
+  Repository…**, and an **Open Recent** submenu of your last ten repos — and
+  **Settings…** sits in the GitDesktop menu where macOS apps keep it.

--- a/changelog.d/changed-repo-actions-any-screen.md
+++ b/changelog.d/changed-repo-actions-any-screen.md
@@ -1,0 +1,3 @@
+- **Open, Clone and Create repository from any screen.** Their keyboard shortcuts and
+  command-palette entries stay available wherever you are in the app — Settings, the user
+  guide and Explore included.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -356,6 +356,10 @@ export const capabilities: Capability[] = [
   { group: "Repository & workspace", label: "Environment & CLI health check" },
   {
     group: "Repository & workspace",
+    label: "Native macOS menu bar — File menu with Open Recent",
+  },
+  {
+    group: "Repository & workspace",
     label: "Remembers window size & position",
   },
   {

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -4,6 +4,9 @@
 //! Our items carry no keyboard shortcuts: the app's hotkeys are rebindable in
 //! settings, while a menu shortcut is static and intercepts the chord before
 //! the webview, so it would both lie about and steal a rebound binding.
+// Off macOS only the command twin is live; the id table and its classifier stay
+// compiled (and unit-tested) on every host so the wire strings can't drift.
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
 
 use serde::Deserialize;
 
@@ -22,36 +25,59 @@ use tauri::{AppHandle, Emitter, Manager, State, Wry};
 
 /// One row of File → Open Recent. Plain shape, single-word fields: the frontend
 /// sends `{ label, path }` verbatim.
-// The fields are only read on macOS; off it the type exists solely to keep the
-// command's wire shape identical across platforms.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[derive(Deserialize)]
 pub struct RecentMenuEntry {
     pub label: String,
     pub path: String,
 }
 
-#[cfg(target_os = "macos")]
 const ID_NEW_REPO: &str = "gd-menu-new-repo";
-#[cfg(target_os = "macos")]
 const ID_OPEN_REPO: &str = "gd-menu-open-repo";
-#[cfg(target_os = "macos")]
 const ID_CLONE_REPO: &str = "gd-menu-clone-repo";
-#[cfg(target_os = "macos")]
 const ID_SETTINGS: &str = "gd-menu-settings";
 /// Recents items encode their repo path in the id, so a click needs no lookup
 /// table and can't read a stale row after a concurrent submenu rebuild.
-#[cfg(target_os = "macos")]
 const ID_RECENT_PREFIX: &str = "gd-menu-recent:";
-#[cfg(target_os = "macos")]
 const ID_RECENT_EMPTY: &str = "gd-menu-recent-empty";
+
+/// Where a menu-bar click routes.
+#[derive(Debug, PartialEq, Eq)]
+enum MenuTarget<'a> {
+    /// Open the repo at this path, carried in the item's own id.
+    OpenRecent(&'a str),
+    /// Dispatch this frontend action id.
+    Action(&'static str),
+    /// Not ours — leave it alone.
+    Ignore,
+}
+
+/// Maps a menu item id to its destination. muda has ONE global menu-event
+/// channel, so every listener sees every menu event, tray items included —
+/// anything unrecognized must classify as `Ignore` and fall through.
+fn classify_menu_id(id: &str) -> MenuTarget<'_> {
+    if let Some(path) = id.strip_prefix(ID_RECENT_PREFIX) {
+        // A bare prefix carries no path; treating it as a click would surface a
+        // validate-"" error toast.
+        if path.is_empty() {
+            return MenuTarget::Ignore;
+        }
+        return MenuTarget::OpenRecent(path);
+    }
+    match id {
+        ID_NEW_REPO => MenuTarget::Action("new-repository"),
+        ID_OPEN_REPO => MenuTarget::Action("add-local-repository"),
+        ID_CLONE_REPO => MenuTarget::Action("clone-repository"),
+        ID_SETTINGS => MenuTarget::Action("open-settings"),
+        _ => MenuTarget::Ignore,
+    }
+}
 
 /// Handle to the live Open Recent submenu so the frontend can push a fresh
 /// recents list into it. Tauri's menu types are `Send + Sync` and every menu
 /// operation hops to the main thread internally, so a command may mutate this
 /// handle directly.
 #[cfg(target_os = "macos")]
-pub struct AppMenuState(Mutex<Option<Submenu<Wry>>>);
+pub struct AppMenuState(Mutex<Submenu<Wry>>);
 
 /// Installs the application menu and routes its clicks into the frontend.
 #[cfg(target_os = "macos")]
@@ -59,15 +85,15 @@ pub fn setup_app_menu(app: &AppHandle) -> tauri::Result<()> {
     let recent = Submenu::with_items(app, "Open Recent", true, &[&empty_recent_item(app)?])?;
     let menu = build_menu(app, &recent)?;
     app.set_menu(menu)?;
-    app.manage(AppMenuState(Mutex::new(Some(recent))));
+    app.manage(AppMenuState(Mutex::new(recent)));
     app.on_menu_event(handle_menu_event);
     Ok(())
 }
 
-/// Mirrors `Menu::default`'s macOS composition, with Settings added to the app
-/// submenu and the repo actions added to File. Constructing it outright (rather
-/// than mutating the default) keeps the layout explicit; it must be re-checked
-/// against `tauri::menu::Menu::default` on a Tauri major upgrade.
+/// The macOS composition of `Menu::default` plus our additions — Settings… in
+/// the app submenu, Show All beside Hide Others, and the repo actions in File.
+/// Constructing it outright (rather than mutating the default) keeps the layout
+/// explicit; re-check it against `tauri::menu::Menu::default` on a Tauri major.
 #[cfg(target_os = "macos")]
 fn build_menu(app: &AppHandle, recent: &Submenu<Wry>) -> tauri::Result<Menu<Wry>> {
     let pkg_info = app.package_info();
@@ -93,6 +119,7 @@ fn build_menu(app: &AppHandle, recent: &Submenu<Wry>) -> tauri::Result<Menu<Wry>
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::hide(app, None)?,
             &PredefinedMenuItem::hide_others(app, None)?,
+            &PredefinedMenuItem::show_all(app, None)?,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::quit(app, None)?,
         ],
@@ -180,28 +207,18 @@ fn empty_recent_item(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
 }
 
 /// Turns a menubar click into the same frontend action the command palette and
-/// hotkeys dispatch. muda has ONE global menu-event channel — every registered
-/// listener sees EVERY menu event, tray items included — so match only our
-/// `gd-menu-` ids and fall through everything else untouched.
+/// hotkeys dispatch.
 #[cfg(target_os = "macos")]
 fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
-    let id = event.id.as_ref();
-    if let Some(path) = id.strip_prefix(ID_RECENT_PREFIX) {
-        // Close-to-tray can leave the window hidden while the menu bar stays
-        // clickable, and a dialog raised in a hidden window is invisible.
-        crate::tray::show_main_window(app);
-        let _ = app.emit("app-menu-open-recent", path);
-        return;
-    }
-    let action = match id {
-        ID_NEW_REPO => "new-repository",
-        ID_OPEN_REPO => "add-local-repository",
-        ID_CLONE_REPO => "clone-repository",
-        ID_SETTINGS => "open-settings",
-        _ => return,
+    let (name, payload) = match classify_menu_id(event.id.as_ref()) {
+        MenuTarget::OpenRecent(path) => ("app-menu-open-recent", path),
+        MenuTarget::Action(action) => ("app-menu-action", action),
+        MenuTarget::Ignore => return,
     };
+    // Close-to-tray can leave the window hidden while the menu bar stays
+    // clickable, and a dialog raised in a hidden window is invisible.
     crate::tray::show_main_window(app);
-    let _ = app.emit("app-menu-action", action);
+    let _ = app.emit(name, payload);
 }
 
 /// Rebuilds File → Open Recent from the frontend's recents list, newest first.
@@ -215,38 +232,98 @@ pub fn set_recent_repos_menu(
     fn menu_err(e: tauri::Error) -> AppError {
         AppError::Command(e.to_string())
     }
+    // Build every row BEFORE draining: a failure part-way through construction
+    // must not leave the live submenu empty, which is the state the disabled
+    // placeholder row exists to prevent.
+    let items = if entries.is_empty() {
+        vec![empty_recent_item(&app).map_err(menu_err)?]
+    } else {
+        entries
+            .into_iter()
+            .map(|entry| {
+                MenuItem::with_id(
+                    &app,
+                    format!("{ID_RECENT_PREFIX}{}", entry.path),
+                    &entry.label,
+                    true,
+                    None::<&str>,
+                )
+                .map_err(menu_err)
+            })
+            .collect::<AppResult<Vec<_>>>()?
+    };
     // A poisoned lock only means a previous rebuild panicked mid-way; the
     // submenu handle itself stays valid, so recover rather than propagate.
-    let guard = state.0.lock().unwrap_or_else(|e| e.into_inner());
-    let Some(recent) = guard.as_ref() else {
-        return Ok(());
-    };
+    let recent = state.0.lock().unwrap_or_else(|e| e.into_inner());
     // In place: this handle is the one installed in the live menu, so the rows
     // are drained and re-appended rather than the submenu being replaced.
     while recent.remove_at(0).map_err(menu_err)?.is_some() {}
-    if entries.is_empty() {
-        let item = empty_recent_item(&app).map_err(menu_err)?;
-        recent.append(&item).map_err(menu_err)?;
-        return Ok(());
-    }
-    for entry in entries {
-        let item = MenuItem::with_id(
-            &app,
-            format!("{ID_RECENT_PREFIX}{}", entry.path),
-            &entry.label,
-            true,
-            None::<&str>,
-        )
-        .map_err(menu_err)?;
-        recent.append(&item).map_err(menu_err)?;
+    for item in &items {
+        recent.append(item).map_err(menu_err)?;
     }
     Ok(())
 }
 
 /// No-op twin so the command is registered on every platform: only macOS has an
 /// app menu, but a stray call from the frontend must not error.
+// The command macro camel-cases parameter names through `heck`, which drops the
+// leading underscore — the IPC key is `entries` here exactly as on macOS.
 #[cfg(not(target_os = "macos"))]
 #[tauri::command]
 pub fn set_recent_repos_menu(_entries: Vec<RecentMenuEntry>) -> AppResult<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_menu_id, MenuTarget};
+
+    // Ids are spelled out rather than referenced through the consts: these tests
+    // pin the wire, so renaming a const must fail here instead of silently
+    // moving the contract the frontend listens on.
+
+    #[test]
+    fn recent_id_carries_its_path() {
+        assert_eq!(
+            classify_menu_id("gd-menu-recent:/Users/x/repo"),
+            MenuTarget::OpenRecent("/Users/x/repo")
+        );
+    }
+
+    #[test]
+    fn recent_id_keeps_windows_separators_and_colons() {
+        assert_eq!(
+            classify_menu_id(r"gd-menu-recent:C:\repos\gd"),
+            MenuTarget::OpenRecent(r"C:\repos\gd")
+        );
+    }
+
+    #[test]
+    fn fixed_ids_map_to_their_action_strings() {
+        for (id, action) in [
+            ("gd-menu-new-repo", "new-repository"),
+            ("gd-menu-open-repo", "add-local-repository"),
+            ("gd-menu-clone-repo", "clone-repository"),
+            ("gd-menu-settings", "open-settings"),
+        ] {
+            assert_eq!(classify_menu_id(id), MenuTarget::Action(action), "id: {id}");
+        }
+    }
+
+    #[test]
+    fn placeholder_tray_and_unknown_ids_are_ignored() {
+        // "open"/"quit" are the tray's ids: they reach this classifier because
+        // muda's menu-event channel is process-wide.
+        for id in [
+            "gd-menu-recent-empty",
+            "gd-menu-recent:",
+            "open",
+            "quit",
+            "",
+            "gd-menu-",
+            "gd-menu-unknown",
+        ] {
+            assert_eq!(classify_menu_id(id), MenuTarget::Ignore, "id: {id}");
+        }
+    }
 }

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -1,0 +1,252 @@
+//! The macOS application menu. Windows and Linux ship none on purpose — the
+//! in-window repo dropdown is the idiom there — so everything but the
+//! `set_recent_repos_menu` IPC contract is macOS-only.
+//! Our items carry no keyboard shortcuts: the app's hotkeys are rebindable in
+//! settings, while a menu shortcut is static and intercepts the chord before
+//! the webview, so it would both lie about and steal a rebound binding.
+
+use serde::Deserialize;
+
+#[cfg(target_os = "macos")]
+use crate::error::AppError;
+use crate::error::AppResult;
+#[cfg(target_os = "macos")]
+use std::sync::Mutex;
+#[cfg(target_os = "macos")]
+use tauri::menu::{
+    AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID,
+    WINDOW_SUBMENU_ID,
+};
+#[cfg(target_os = "macos")]
+use tauri::{AppHandle, Emitter, Manager, State, Wry};
+
+/// One row of File → Open Recent. Plain shape, single-word fields: the frontend
+/// sends `{ label, path }` verbatim.
+// The fields are only read on macOS; off it the type exists solely to keep the
+// command's wire shape identical across platforms.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Deserialize)]
+pub struct RecentMenuEntry {
+    pub label: String,
+    pub path: String,
+}
+
+#[cfg(target_os = "macos")]
+const ID_NEW_REPO: &str = "gd-menu-new-repo";
+#[cfg(target_os = "macos")]
+const ID_OPEN_REPO: &str = "gd-menu-open-repo";
+#[cfg(target_os = "macos")]
+const ID_CLONE_REPO: &str = "gd-menu-clone-repo";
+#[cfg(target_os = "macos")]
+const ID_SETTINGS: &str = "gd-menu-settings";
+/// Recents items encode their repo path in the id, so a click needs no lookup
+/// table and can't read a stale row after a concurrent submenu rebuild.
+#[cfg(target_os = "macos")]
+const ID_RECENT_PREFIX: &str = "gd-menu-recent:";
+#[cfg(target_os = "macos")]
+const ID_RECENT_EMPTY: &str = "gd-menu-recent-empty";
+
+/// Handle to the live Open Recent submenu so the frontend can push a fresh
+/// recents list into it. Tauri's menu types are `Send + Sync` and every menu
+/// operation hops to the main thread internally, so a command may mutate this
+/// handle directly.
+#[cfg(target_os = "macos")]
+pub struct AppMenuState(Mutex<Option<Submenu<Wry>>>);
+
+/// Installs the application menu and routes its clicks into the frontend.
+#[cfg(target_os = "macos")]
+pub fn setup_app_menu(app: &AppHandle) -> tauri::Result<()> {
+    let recent = Submenu::with_items(app, "Open Recent", true, &[&empty_recent_item(app)?])?;
+    let menu = build_menu(app, &recent)?;
+    app.set_menu(menu)?;
+    app.manage(AppMenuState(Mutex::new(Some(recent))));
+    app.on_menu_event(handle_menu_event);
+    Ok(())
+}
+
+/// Mirrors `Menu::default`'s macOS composition, with Settings added to the app
+/// submenu and the repo actions added to File. Constructing it outright (rather
+/// than mutating the default) keeps the layout explicit; it must be re-checked
+/// against `tauri::menu::Menu::default` on a Tauri major upgrade.
+#[cfg(target_os = "macos")]
+fn build_menu(app: &AppHandle, recent: &Submenu<Wry>) -> tauri::Result<Menu<Wry>> {
+    let pkg_info = app.package_info();
+    let config = app.config();
+    let about_metadata = AboutMetadata {
+        name: Some(pkg_info.name.clone()),
+        version: Some(pkg_info.version.to_string()),
+        copyright: config.bundle.copyright.clone(),
+        authors: config.bundle.publisher.clone().map(|p| vec![p]),
+        ..Default::default()
+    };
+
+    let app_submenu = Submenu::with_items(
+        app,
+        pkg_info.name.clone(),
+        true,
+        &[
+            &PredefinedMenuItem::about(app, None, Some(about_metadata))?,
+            &PredefinedMenuItem::separator(app)?,
+            &MenuItem::with_id(app, ID_SETTINGS, "Settings…", true, None::<&str>)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::services(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::hide(app, None)?,
+            &PredefinedMenuItem::hide_others(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::quit(app, None)?,
+        ],
+    )?;
+
+    let file_submenu = Submenu::with_items(
+        app,
+        "File",
+        true,
+        &[
+            &MenuItem::with_id(app, ID_NEW_REPO, "New Repository…", true, None::<&str>)?,
+            &MenuItem::with_id(app, ID_OPEN_REPO, "Open Repository…", true, None::<&str>)?,
+            &MenuItem::with_id(app, ID_CLONE_REPO, "Clone Repository…", true, None::<&str>)?,
+            recent,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+
+    // Load-bearing: macOS routes undo/redo/cut/copy/paste/select-all in text
+    // inputs through these predefined items — dropping any of them breaks
+    // typing in every field in the app.
+    let edit_submenu = Submenu::with_items(
+        app,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app, None)?,
+            &PredefinedMenuItem::redo(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None)?,
+            &PredefinedMenuItem::copy(app, None)?,
+            &PredefinedMenuItem::paste(app, None)?,
+            &PredefinedMenuItem::select_all(app, None)?,
+        ],
+    )?;
+
+    let view_submenu = Submenu::with_items(
+        app,
+        "View",
+        true,
+        &[&PredefinedMenuItem::fullscreen(app, None)?],
+    )?;
+
+    let window_submenu = Submenu::with_id_and_items(
+        app,
+        WINDOW_SUBMENU_ID,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+
+    // Empty, as in the default menu: macOS puts its own Search item here.
+    let help_submenu = Submenu::with_id_and_items(app, HELP_SUBMENU_ID, "Help", true, &[])?;
+
+    Menu::with_items(
+        app,
+        &[
+            &app_submenu,
+            &file_submenu,
+            &edit_submenu,
+            &view_submenu,
+            &window_submenu,
+            &help_submenu,
+        ],
+    )
+}
+
+/// The macOS convention for an empty recents list: one disabled row, never an
+/// empty submenu.
+#[cfg(target_os = "macos")]
+fn empty_recent_item(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
+    MenuItem::with_id(
+        app,
+        ID_RECENT_EMPTY,
+        "No Recent Repositories",
+        false,
+        None::<&str>,
+    )
+}
+
+/// Turns a menubar click into the same frontend action the command palette and
+/// hotkeys dispatch. muda has ONE global menu-event channel — every registered
+/// listener sees EVERY menu event, tray items included — so match only our
+/// `gd-menu-` ids and fall through everything else untouched.
+#[cfg(target_os = "macos")]
+fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
+    let id = event.id.as_ref();
+    if let Some(path) = id.strip_prefix(ID_RECENT_PREFIX) {
+        // Close-to-tray can leave the window hidden while the menu bar stays
+        // clickable, and a dialog raised in a hidden window is invisible.
+        crate::tray::show_main_window(app);
+        let _ = app.emit("app-menu-open-recent", path);
+        return;
+    }
+    let action = match id {
+        ID_NEW_REPO => "new-repository",
+        ID_OPEN_REPO => "add-local-repository",
+        ID_CLONE_REPO => "clone-repository",
+        ID_SETTINGS => "open-settings",
+        _ => return,
+    };
+    crate::tray::show_main_window(app);
+    let _ = app.emit("app-menu-action", action);
+}
+
+/// Rebuilds File → Open Recent from the frontend's recents list, newest first.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn set_recent_repos_menu(
+    app: AppHandle,
+    state: State<AppMenuState>,
+    entries: Vec<RecentMenuEntry>,
+) -> AppResult<()> {
+    fn menu_err(e: tauri::Error) -> AppError {
+        AppError::Command(e.to_string())
+    }
+    // A poisoned lock only means a previous rebuild panicked mid-way; the
+    // submenu handle itself stays valid, so recover rather than propagate.
+    let guard = state.0.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(recent) = guard.as_ref() else {
+        return Ok(());
+    };
+    // In place: this handle is the one installed in the live menu, so the rows
+    // are drained and re-appended rather than the submenu being replaced.
+    while recent.remove_at(0).map_err(menu_err)?.is_some() {}
+    if entries.is_empty() {
+        let item = empty_recent_item(&app).map_err(menu_err)?;
+        recent.append(&item).map_err(menu_err)?;
+        return Ok(());
+    }
+    for entry in entries {
+        let item = MenuItem::with_id(
+            &app,
+            format!("{ID_RECENT_PREFIX}{}", entry.path),
+            &entry.label,
+            true,
+            None::<&str>,
+        )
+        .map_err(menu_err)?;
+        recent.append(&item).map_err(menu_err)?;
+    }
+    Ok(())
+}
+
+/// No-op twin so the command is registered on every platform: only macOS has an
+/// app menu, but a stray call from the frontend must not error.
+#[cfg(not(target_os = "macos"))]
+#[tauri::command]
+pub fn set_recent_repos_menu(_entries: Vec<RecentMenuEntry>) -> AppResult<()> {
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod agent_sandbox;
+mod app_menu;
 mod app_store;
 mod automation_claims;
 mod dependabot;
@@ -79,6 +80,11 @@ pub fn run() {
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
                 tray::setup_tray(app.handle())?;
                 tray::init_window_title(app.handle());
+                // macOS-only: the menu bar is always present there, so it needs a
+                // real File menu. Other platforms reach the same actions through
+                // the in-window repo dropdown.
+                #[cfg(target_os = "macos")]
+                app_menu::setup_app_menu(app.handle())?;
                 // On Windows, keep the managed MCP launcher copy fresh after an
                 // update — but only if it already exists (lazy: never-used ⇒
                 // never copied). Fire-and-forget so startup never blocks on the
@@ -694,6 +700,7 @@ pub fn run() {
             agent::agent_review_cancel,
             agent::agent_session,
             tray::set_close_to_tray,
+            app_menu::set_recent_repos_menu,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,10 @@ function App() {
   useHotkeysListener();
   // The macOS menu bar routes into the same action dispatch; inert elsewhere.
   useMacAppMenu();
-  useHotkeyAction("open-settings", openSettings);
+  // Settings… is exposed in the macOS menu bar, which stays clickable on the
+  // git-missing screen — without the gate it would flip the view to a Settings
+  // screen that never renders, surfacing only after Retry.
+  useHotkeyAction("open-settings", openSettings, gitInstalled.isSuccess);
   // App owns the three repo actions outright: they must work on every screen
   // (Settings/Help/Explore mount neither the welcome list nor the repo
   // switcher), and duplicate registrations would shadow by mount order.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,15 +7,19 @@ import { ConfirmDialogHost } from "@/components/confirm-dialog-host";
 import { Spinner } from "@/components/ui/spinner";
 import { ReconnectDialog } from "@/features/accounts/ReconnectDialog";
 import { ActivityStrip } from "@/features/activity/ActivityDock";
+import { useMacAppMenu } from "@/features/app-menu/useMacAppMenu";
 import { AutomationResultDialog } from "@/features/automations/AutomationResultDialog";
 import { ExploreScreen } from "@/features/explore/ExploreScreen";
 import { HelpScreen } from "@/features/help/HelpScreen";
 import { RepositoryView } from "@/features/repository/RepositoryView";
+import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { SettingsScreen } from "@/features/settings/SettingsScreen";
 import { CommandPalette } from "@/features/shortcuts/CommandPalette";
 import { ShortcutsDialog } from "@/features/shortcuts/ShortcutsDialog";
 import { UpdateChecker } from "@/features/updates/UpdateChecker";
 import { WhatsNew } from "@/features/updates/WhatsNew";
+import { CloneRepoDialog } from "@/features/welcome/CloneRepoDialog";
+import { CreateRepoDialog } from "@/features/welcome/CreateRepoDialog";
 import { GitMissingScreen } from "@/features/welcome/GitMissingScreen";
 import { useRepoDrop } from "@/features/welcome/useRepoDrop";
 import { WelcomeScreen } from "@/features/welcome/WelcomeScreen";
@@ -49,6 +53,9 @@ function App() {
   const applyTheme = useApplyTheme();
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const pickAndOpen = usePickAndOpenRepo();
+  const [cloneOpen, setCloneOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
 
   // Show a one-time passive notice on first launch, letting users opt out.
   const noticeShown = useRef(false);
@@ -128,7 +135,25 @@ function App() {
 
   // The app-wide hotkey dispatcher plus the always-available actions.
   useHotkeysListener();
+  // The macOS menu bar routes into the same action dispatch; inert elsewhere.
+  useMacAppMenu();
   useHotkeyAction("open-settings", openSettings);
+  // App owns the three repo actions outright: they must work on every screen
+  // (Settings/Help/Explore mount neither the welcome list nor the repo
+  // switcher), and duplicate registrations would shadow by mount order.
+  // Disabled until git resolves — the dialogs render below the early returns,
+  // so a click before then would stash a stale `open` that pops later.
+  useHotkeyAction("add-local-repository", pickAndOpen, gitInstalled.isSuccess);
+  useHotkeyAction(
+    "clone-repository",
+    () => setCloneOpen(true),
+    gitInstalled.isSuccess,
+  );
+  useHotkeyAction(
+    "new-repository",
+    () => setCreateOpen(true),
+    gitInstalled.isSuccess,
+  );
   // Palette-only deep link; hidden alongside the panel when AI features are off.
   useHotkeyAction(
     "open-mcp-servers-settings",
@@ -210,6 +235,8 @@ function App() {
         <ActivityStrip />
       </div>
       <AutomationResultDialog />
+      <CloneRepoDialog open={cloneOpen} onOpenChange={setCloneOpen} />
+      <CreateRepoDialog open={createOpen} onOpenChange={setCreateOpen} />
       <ConfirmDialogHost />
       <ReconnectDialog />
       <UpdateChecker />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,15 @@ function App() {
   const [createOpen, setCreateOpen] = useState(false);
   const dialogOpen = cloneOpen || createOpen;
 
+  // The dialogs live above the view switch, so navigation no longer unmounts
+  // them (e.g. the clone dialog's "Open Settings → Accounts") — close them
+  // when the screen changes, or the new screen mounts behind the modal.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `view` is an intentional close trigger, not read directly
+  useEffect(() => {
+    setCloneOpen(false);
+    setCreateOpen(false);
+  }, [view]);
+
   // Show a one-time passive notice on first launch, letting users opt out.
   const noticeShown = useRef(false);
   // The notice lingers ~10s; read the LATEST settings at click/dismiss time (not

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ function App() {
   const pickAndOpen = usePickAndOpenRepo();
   const [cloneOpen, setCloneOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const dialogOpen = cloneOpen || createOpen;
 
   // Show a one-time passive notice on first launch, letting users opt out.
   const noticeShown = useRef(false);
@@ -140,22 +141,32 @@ function App() {
   // Settings… is exposed in the macOS menu bar, which stays clickable on the
   // git-missing screen — without the gate it would flip the view to a Settings
   // screen that never renders, surfacing only after Retry.
-  useHotkeyAction("open-settings", openSettings, gitInstalled.isSuccess);
+  useHotkeyAction(
+    "open-settings",
+    openSettings,
+    gitInstalled.isSuccess && !dialogOpen,
+  );
   // App owns the three repo actions outright: they must work on every screen
   // (Settings/Help/Explore mount neither the welcome list nor the repo
   // switcher), and duplicate registrations would shadow by mount order.
   // Disabled until git resolves — the dialogs render below the early returns,
-  // so a click before then would stash a stale `open` that pops later.
-  useHotkeyAction("add-local-repository", pickAndOpen, gitInstalled.isSuccess);
+  // so a click before then would stash a stale `open` that pops later. An open
+  // clone/create dialog suppresses all four: the native menu bar sits outside
+  // the webview's modal overlay, so a menu click there would stack a second.
+  useHotkeyAction(
+    "add-local-repository",
+    pickAndOpen,
+    gitInstalled.isSuccess && !dialogOpen,
+  );
   useHotkeyAction(
     "clone-repository",
     () => setCloneOpen(true),
-    gitInstalled.isSuccess,
+    gitInstalled.isSuccess && !dialogOpen,
   );
   useHotkeyAction(
     "new-repository",
     () => setCreateOpen(true),
-    gitInstalled.isSuccess,
+    gitInstalled.isSuccess && !dialogOpen,
   );
   // Palette-only deep link; hidden alongside the panel when AI features are off.
   useHotkeyAction(

--- a/src/features/app-menu/useMacAppMenu.ts
+++ b/src/features/app-menu/useMacAppMenu.ts
@@ -1,0 +1,106 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect, useEffectEvent } from "react";
+import { useOpenRepoByPath } from "@/features/repository/useOpenRepoByPath";
+import { isMac } from "@/lib/hotkeys/binding";
+import { dispatchAction } from "@/lib/hotkeys/hotkeys";
+import type { ActionId } from "@/lib/hotkeys/registry";
+import { type RecentRepo, repoDisplayName } from "@/lib/settings/api";
+import { useSettings } from "@/lib/settings/queries";
+import { invoke } from "@/lib/tauri/invoke";
+
+/** The actions the macOS File/app menu can trigger. Menu payloads arrive from
+ *  the native menu bar, so they're validated against this list before dispatch. */
+const MENU_ACTIONS = [
+  "new-repository",
+  "add-local-repository",
+  "clone-repository",
+  "open-settings",
+] as const satisfies readonly ActionId[];
+
+/** How many recents the Open Recent submenu shows — the macOS convention is a
+ *  short list, and the full one lives in the repo switcher. */
+const MAX_RECENT_ITEMS = 10;
+
+function isMenuAction(
+  payload: unknown,
+): payload is (typeof MENU_ACTIONS)[number] {
+  return (
+    typeof payload === "string" &&
+    (MENU_ACTIONS as readonly string[]).includes(payload)
+  );
+}
+
+/** The name of a path's parent folder; "" when the path has no parent. */
+function parentFolder(path: string): string {
+  const segments = path.split(/[/\\]+/).filter(Boolean);
+  return segments.length > 1 ? segments[segments.length - 2] : "";
+}
+
+/** Menu rows for the recents list. Repos that share a display name are ALL
+ *  suffixed with their parent folder — an unqualified twin next to a qualified
+ *  one reads as the canonical entry. */
+function toMenuEntries(repos: RecentRepo[]): { label: string; path: string }[] {
+  const names = repos.map(repoDisplayName);
+  const counts = new Map<string, number>();
+  for (const name of names) counts.set(name, (counts.get(name) ?? 0) + 1);
+  return repos.map((repo, i) => {
+    const name = names[i];
+    const parent = (counts.get(name) ?? 0) > 1 ? parentFolder(repo.path) : "";
+    return { label: parent ? `${name} — ${parent}` : name, path: repo.path };
+  });
+}
+
+/**
+ * Bridges the macOS application menu to the app: menu clicks run the same
+ * actions as the command palette and hotkeys, and the recents list is pushed
+ * into File → Open Recent whenever it changes. Mounted once, in App. Inert off
+ * macOS — no other platform builds an app menu.
+ */
+export function useMacAppMenu() {
+  const openByPath = useOpenRepoByPath();
+  const settings = useSettings();
+  const recentRepos = settings.data?.recentRepos;
+
+  const onAction = useEffectEvent((payload: unknown) => {
+    if (!isMenuAction(payload)) return;
+    // A `false` return is acceptable silence: the owning surface may not be
+    // mounted, exactly as when the action is missing from the palette.
+    dispatchAction(payload);
+  });
+
+  const onOpenRecent = useEffectEvent((payload: unknown) => {
+    if (typeof payload !== "string") return;
+    void openByPath(payload, "recent");
+  });
+
+  useEffect(() => {
+    if (!isMac) return;
+    // `listen` subscribes asynchronously, so a StrictMode double-mount can tear
+    // this effect down before the subscription exists — unlisten on arrival in
+    // that case, since cleanup has nothing to unlisten yet.
+    let cancelled = false;
+    const unlisteners: UnlistenFn[] = [];
+    const track = (pending: Promise<UnlistenFn>) => {
+      pending
+        .then((unlisten) => {
+          if (cancelled) unlisten();
+          else unlisteners.push(unlisten);
+        })
+        .catch(() => undefined);
+    };
+    track(listen("app-menu-action", (e) => onAction(e.payload)));
+    track(listen("app-menu-open-recent", (e) => onOpenRecent(e.payload)));
+    return () => {
+      cancelled = true;
+      for (const unlisten of unlisteners) unlisten();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isMac || !recentRepos) return;
+    const entries = toMenuEntries(recentRepos.slice(0, MAX_RECENT_ITEMS));
+    invoke<void>("set_recent_repos_menu", { entries }).catch(() => {
+      // Best-effort: a menu that's briefly out of date never surfaces to the user.
+    });
+  }, [recentRepos]);
+}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -65,7 +65,8 @@ A few things worth knowing up front:
 {{/ai}}
 ## Open your first repository
 
-From the welcome screen (or the repo switcher in the header):
+Use the welcome screen's buttons, the repo switcher in the header, or the command
+palette — wherever you are in the app, these actions and their shortcuts are available:
 
 - **Open repository** ({{kbd:add-local-repository}}) — point at a folder that's already
   a Git repo.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -74,6 +74,10 @@ From the welcome screen (or the repo switcher in the header):
 - **Create repository** ({{kbd:new-repository}}) — start a new repo with an optional
   README, \`.gitignore\`, and license.
 
+On macOS, the menu bar mirrors these: **File → New / Open / Clone Repository…** plus
+an **Open Recent** list of your last ten repos, with **Settings…** in the
+**GitDesktop** menu. Menu items work from any screen.
+
 ## Finding your way around
 
 Once a repo is open you land on the **Changes** tab. The header's tab rail holds the

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -7,9 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { CloneRepoDialog } from "@/features/welcome/CloneRepoDialog";
-import { CreateRepoDialog } from "@/features/welcome/CreateRepoDialog";
-import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import type { RecentRepo } from "@/lib/settings/api";
 import { useRepoAlias } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -48,8 +46,6 @@ export function RepoSwitcher() {
   // Dialogs live outside the popover: closing it unmounts its contents.
   const [aliasTarget, setAliasTarget] = useState<RecentRepo | null>(null);
   const [removeTarget, setRemoveTarget] = useState<RecentRepo | null>(null);
-  const [cloneOpen, setCloneOpen] = useState(false);
-  const [createOpen, setCreateOpen] = useState(false);
 
   useHotkeyAction("show-repositories", () => setOpen(true));
 
@@ -124,7 +120,7 @@ export function RepoSwitcher() {
                   icon={DownloadSimpleIcon}
                   onClick={() => {
                     setOpen(false);
-                    setCloneOpen(true);
+                    dispatchAction("clone-repository");
                   }}
                 >
                   Clone repository…
@@ -133,7 +129,7 @@ export function RepoSwitcher() {
                   icon={FolderPlusIcon}
                   onClick={() => {
                     setOpen(false);
-                    setCreateOpen(true);
+                    dispatchAction("new-repository");
                   }}
                 >
                   Create repository…
@@ -152,8 +148,6 @@ export function RepoSwitcher() {
         repo={removeTarget}
         onClose={() => setRemoveTarget(null)}
       />
-      <CloneRepoDialog open={cloneOpen} onOpenChange={setCloneOpen} />
-      <CreateRepoDialog open={createOpen} onOpenChange={setCreateOpen} />
     </>
   );
 }

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -51,12 +51,7 @@ export function RepoSwitcher() {
   const [cloneOpen, setCloneOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
 
-  // Open/clone/create are reachable here too, so you don't have to leave the
-  // repository view to get to another repo.
   useHotkeyAction("show-repositories", () => setOpen(true));
-  useHotkeyAction("add-local-repository", pickAndOpen);
-  useHotkeyAction("clone-repository", () => setCloneOpen(true));
-  useHotkeyAction("new-repository", () => setCreateOpen(true));
 
   const repoLabel = alias ?? repoName ?? "Repository";
 

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -13,7 +13,6 @@ import { useRepoAlias } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { RemoveRepoDialog, RepoAliasDialog } from "./RepoDialogs";
 import { RepoList } from "./RepoList";
-import { usePickAndOpenRepo } from "./useOpenRepoByPath";
 
 /** A repository action row in the switcher footer (open / clone / create). */
 function ActionRow({
@@ -41,7 +40,6 @@ export function RepoSwitcher() {
   const repoName = useUiStore((s) => s.repoName);
   const repoPath = useUiStore((s) => s.repoPath);
   const alias = useRepoAlias(repoPath);
-  const pickAndOpen = usePickAndOpenRepo();
   const [open, setOpen] = useState(false);
   // Dialogs live outside the popover: closing it unmounts its contents.
   const [aliasTarget, setAliasTarget] = useState<RecentRepo | null>(null);
@@ -111,7 +109,7 @@ export function RepoSwitcher() {
                   icon={FolderOpenIcon}
                   onClick={() => {
                     setOpen(false);
-                    pickAndOpen();
+                    dispatchAction("add-local-repository");
                   }}
                 >
                   Open repository…

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -20,8 +20,8 @@ import { toastError } from "@/lib/toast";
  * Opens a repository by path: validates it, records it in recents, and switches
  * the app to it. A path that's no longer a git repo offers a toast to **Locate…**
  * the folder's new home (moved on disk) or **Remove** the stale row.
- * Every open-by-path route lands here: the shared recents list, macOS
- * File → Open Recent, and the folder picker in {@link usePickAndOpenRepo}.
+ * Callers: the shared recents list, macOS File → Open Recent, and the folder
+ * picker in {@link usePickAndOpenRepo}.
  */
 export function useOpenRepoByPath() {
   const openRepo = useUiStore((s) => s.openRepo);

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -20,7 +20,8 @@ import { toastError } from "@/lib/toast";
  * Opens a repository by path: validates it, records it in recents, and switches
  * the app to it. A path that's no longer a git repo offers a toast to **Locate…**
  * the folder's new home (moved on disk) or **Remove** the stale row.
- * Shared by the welcome list and the in-app repo switcher.
+ * Every open-by-path route lands here: the shared recents list, macOS
+ * File → Open Recent, and the folder picker in {@link usePickAndOpenRepo}.
  */
 export function useOpenRepoByPath() {
   const openRepo = useUiStore((s) => s.openRepo);
@@ -148,8 +149,9 @@ export function useOpenWorktree() {
 
 /**
  * Prompts for a local folder, then opens it as a repository (validate, record
- * in recents, switch to it). Shared by the welcome screen and the in-app repo
- * switcher so "Open repository…" behaves identically everywhere.
+ * in recents, switch to it). App is the sole caller — it registers this as the
+ * `add-local-repository` action, and every surface offering "Open repository…"
+ * dispatches that action rather than calling here.
  */
 export function usePickAndOpenRepo() {
   const openByPath = useOpenRepoByPath();

--- a/src/features/welcome/WelcomeScreen.tsx
+++ b/src/features/welcome/WelcomeScreen.tsx
@@ -9,7 +9,6 @@ import {
 } from "@phosphor-icons/react";
 import { BrandMark } from "@/components/BrandMark";
 import { Button } from "@/components/ui/button";
-import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { useUpdateCheck } from "@/features/updates/useUpdateCheck";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { dispatchAction, useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
@@ -26,7 +25,6 @@ export function WelcomeScreen() {
   const openSettings = useUiStore((s) => s.openSettings);
   const openHelp = useUiStore((s) => s.openHelp);
   const openExplore = useUiStore((s) => s.openExplore);
-  const pickAndOpen = usePickAndOpenRepo();
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const aiEnabled = useAiEnabled();
@@ -57,7 +55,7 @@ export function WelcomeScreen() {
       label: "Open repository",
       icon: FolderOpenIcon,
       variant: "default",
-      onClick: pickAndOpen,
+      onClick: () => dispatchAction("add-local-repository"),
     },
     {
       id: "clone-repository",

--- a/src/features/welcome/WelcomeScreen.tsx
+++ b/src/features/welcome/WelcomeScreen.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { useUpdateCheck } from "@/features/updates/useUpdateCheck";
 import { formatBinding } from "@/lib/hotkeys/binding";
-import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import type { ActionId } from "@/lib/hotkeys/registry";
 import {
   useAiEnabled,
@@ -47,10 +47,6 @@ export function WelcomeScreen() {
     dismissNudge();
     openHelp();
   }
-
-  useHotkeyAction("add-local-repository", pickAndOpen);
-  useHotkeyAction("clone-repository", () => setCloneOpen(true));
-  useHotkeyAction("new-repository", () => setCreateOpen(true));
 
   // The primary entry points, surfaced as a launcher: label on the left, the
   // live keyboard shortcut on the right (honours user remaps via bindings).

--- a/src/features/welcome/WelcomeScreen.tsx
+++ b/src/features/welcome/WelcomeScreen.tsx
@@ -7,13 +7,12 @@ import {
   GitForkIcon,
   QuestionIcon,
 } from "@phosphor-icons/react";
-import { useState } from "react";
 import { BrandMark } from "@/components/BrandMark";
 import { Button } from "@/components/ui/button";
 import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { useUpdateCheck } from "@/features/updates/useUpdateCheck";
 import { formatBinding } from "@/lib/hotkeys/binding";
-import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { dispatchAction, useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import type { ActionId } from "@/lib/hotkeys/registry";
 import {
   useAiEnabled,
@@ -21,8 +20,6 @@ import {
   useSettings,
 } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
-import { CloneRepoDialog } from "./CloneRepoDialog";
-import { CreateRepoDialog } from "./CreateRepoDialog";
 import { RecentRepoList } from "./RecentRepoList";
 
 export function WelcomeScreen() {
@@ -35,8 +32,6 @@ export function WelcomeScreen() {
   const aiEnabled = useAiEnabled();
   const bindings = useEffectiveBindings();
   const updateAvailable = Boolean(useUpdateCheck().data);
-  const [cloneOpen, setCloneOpen] = useState(false);
-  const [createOpen, setCreateOpen] = useState(false);
 
   function dismissNudge() {
     if (settings.data) {
@@ -69,14 +64,14 @@ export function WelcomeScreen() {
       label: "Clone repository",
       icon: GitForkIcon,
       variant: "outline",
-      onClick: () => setCloneOpen(true),
+      onClick: () => dispatchAction("clone-repository"),
     },
     {
       id: "new-repository",
       label: "Create repository",
       icon: FolderPlusIcon,
       variant: "outline",
-      onClick: () => setCreateOpen(true),
+      onClick: () => dispatchAction("new-repository"),
     },
     {
       id: "open-explore",
@@ -192,9 +187,6 @@ export function WelcomeScreen() {
           </div>
         </div>
       </main>
-
-      <CloneRepoDialog open={cloneOpen} onOpenChange={setCloneOpen} />
-      <CreateRepoDialog open={createOpen} onOpenChange={setCreateOpen} />
     </div>
   );
 }


### PR DESCRIPTION
Gives GitDesktop a proper macOS application menu so the repo entry points are reachable from the menu bar the way Mac users expect, instead of only through the in-window welcome screen and repo switcher. **File** now carries New / Open / Clone Repository… plus an **Open Recent** submenu of the last ten repos, and **Settings…** sits in the GitDesktop menu. Windows and Linux ship no app menu on purpose — the in-window repo dropdown remains the idiom there.

### Native menu (Rust)

- Adds `src-tauri/src/app_menu.rs`, which builds the full macOS menu explicitly (mirroring `Menu::default`'s composition) with the app, File, Edit, View, Window, and Help submenus. The Edit submenu keeps every predefined item, since macOS routes undo/redo/cut/copy/paste/select-all in text inputs through them.
- Routes clicks through `handle_menu_event`, which matches only `gd-menu-` ids (muda has one global event channel shared with tray items), calls `crate::tray::show_main_window` so a hidden window can't swallow a dialog, and emits `app-menu-action` / `app-menu-open-recent`.
- Encodes each recent repo's path directly in the menu item id (`ID_RECENT_PREFIX`) so a click needs no lookup table and can't read a stale row after a concurrent rebuild.
- Exposes `set_recent_repos_menu`, which drains and re-appends rows on the live `Submenu` handle held in `AppMenuState`, recovers from a poisoned lock, and falls back to a disabled "No Recent Repositories" row when the list is empty. A no-op twin is compiled for non-macOS so the command is registered on every platform.
- Deliberately assigns no accelerators to our items: app hotkeys are rebindable in settings, and a static menu shortcut would both lie about and intercept a rebound chord.
- Wires the module and command into `src-tauri/src/lib.rs`, calling `app_menu::setup_app_menu` under `#[cfg(target_os = "macos")]` during setup.

### Frontend bridge

- Adds `src/features/app-menu/useMacAppMenu.ts`: listens for the two menu events, validates payloads against a `MENU_ACTIONS` allow-list before `dispatchAction`, opens recents via `useOpenRepoByPath`, and pushes the recents list (capped at `MAX_RECENT_ITEMS`) into the native submenu whenever it changes. Entries that share a display name are all suffixed with their parent folder so no twin reads as canonical. The listener effect guards against the StrictMode double-mount race where `listen` resolves after cleanup.
- Hoists ownership of `add-local-repository`, `clone-repository`, and `new-repository` into `src/App.tsx`, along with the `CloneRepoDialog` / `CreateRepoDialog` hosts, so the actions work from Settings, Help, and Explore — screens that mount neither the welcome list nor the repo switcher. The registrations are gated on `gitInstalled.isSuccess` because the dialogs render below the early returns.
- Removes the now-duplicate `useHotkeyAction` registrations from `src/features/repository/RepoSwitcher.tsx` and `src/features/welcome/WelcomeScreen.tsx`, which would otherwise shadow by mount order.

### Documentation

- Documents the menu bar under *Features* in `README.md` and in the "getting started" section of the in-app guide, `src/features/help/content.ts`.
- Adds the capability line to `site/src/data/capabilities.ts` and a changelog fragment at `changelog.d/added-macos-file-menu.md`.

Note for reviewers: New Window is intentionally absent — the app is single-window — and the explicit menu construction must be re-checked against `tauri::menu::Menu::default` on a Tauri major upgrade. Menu behavior still needs verification on a Mac.

Relates to #171