### PR TITLE
fix(pulls,issues): scope list placeholders to the matching lens

### DIFF
--- a/changelog.d/fixed-list-lens-placeholder.md
+++ b/changelog.d/fixed-list-lens-placeholder.md
@@ -1,3 +1,3 @@
-- On forks, switching the pull-request or issue list between origin and upstream no
-  longer briefly shows the other side's rows — or, for pull requests, their CI
-  icons — while the new list loads.
+- On forks, switching the pull-request or issue list between the fork and upstream
+  views no longer briefly shows the other side's rows — or, for pull requests, their
+  CI icons — while the new list loads.

--- a/changelog.d/fixed-list-lens-placeholder.md
+++ b/changelog.d/fixed-list-lens-placeholder.md
@@ -1,0 +1,3 @@
+- On forks, switching the pull-request or issue list between origin and upstream no
+  longer briefly shows the other side's rows — or, for pull requests, their CI
+  icons — while the new list loads.

--- a/changelog.d/fixed-pr-list-lens-placeholder.md
+++ b/changelog.d/fixed-pr-list-lens-placeholder.md
@@ -1,0 +1,3 @@
+- On forks, switching the pull-request list between origin and upstream no longer
+  briefly shows the other side's rows and CI icons while the new list loads, and CI
+  icons no longer carry over between the Open and Closed tabs.

--- a/changelog.d/fixed-pr-list-lens-placeholder.md
+++ b/changelog.d/fixed-pr-list-lens-placeholder.md
@@ -1,3 +1,0 @@
-- On forks, switching the pull-request list between origin and upstream no longer
-  briefly shows the other side's rows and CI icons while the new list loads, and CI
-  icons no longer carry over between the Open and Closed tabs.

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -67,13 +67,13 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   // resets to the first page.
   const [limit, setLimit] = useState(PAGE_SIZE);
   const prList = usePrList(repoPath, ghReady, stateFilter, limit, lens);
-  // Row CI icons hydrate separately from the list (so the list paints immediately)
-  // and are provider-neutral now — the backend routes GitHub/GitLab/Bitbucket — so
-  // `ghReady` alone is the correct gate. Fires whenever the remote list is ready and
-  // non-empty (the hook self-disables on an empty list).
+  // Row CI icons hydrate separately from the list, so the list paints immediately. Idle
+  // while the list serves another tab's placeholder rows: otherwise the intermediate key
+  // caches a map fetched against rows that are about to be replaced, and that cached map
+  // becomes the placeholder source for the next key.
   const prListCi = usePrListCi(
     repoPath,
-    ghReady,
+    ghReady && !prList.isPlaceholderData,
     stateFilter,
     limit,
     prList.data,
@@ -84,8 +84,8 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   // takes seconds on large GitHub repos and every active forge query joins the commit
   // mutation's awaited invalidation set, so it must be idle off this tab and off the
   // Closed tab, where no row has live mergeability to report.
-  // `!isPlaceholderData` covers the first half of a lens/tab switch: while the LIST is
-  // still serving the previous page's rows, this stays idle rather than describing a
+  // `!isPlaceholderData` covers the first half of a tab switch: while the LIST is
+  // still serving the previous tab's rows, this stays idle rather than describing a
   // page that isn't on screen. None of these gates stop a chip on their own, though —
   // a DISABLED query still renders placeholder data, so keeping the previous tab's or
   // lens's map off these rows is the hook's placeholder comparator's job.

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -67,10 +67,11 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   // resets to the first page.
   const [limit, setLimit] = useState(PAGE_SIZE);
   const prList = usePrList(repoPath, ghReady, stateFilter, limit, lens);
-  // Row CI icons hydrate separately from the list, so the list paints immediately. Idle
-  // while the list serves another tab's placeholder rows: otherwise the intermediate key
-  // caches a map fetched against rows that are about to be replaced, and that cached map
-  // becomes the placeholder source for the next key.
+  // Row CI icons hydrate separately from the list, so the list paints immediately; the
+  // backend routes GitHub/GitLab/Bitbucket, so `ghReady` is the readiness gate. Idle
+  // while the list serves placeholder rows (tab switch or Load more): otherwise the
+  // intermediate key caches a map fetched against rows that are about to be replaced,
+  // and that cached map becomes the placeholder source for the next key.
   const prListCi = usePrListCi(
     repoPath,
     ghReady && !prList.isPlaceholderData,

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -85,9 +85,9 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
   // takes seconds on large GitHub repos and every active forge query joins the commit
   // mutation's awaited invalidation set, so it must be idle off this tab and off the
   // Closed tab, where no row has live mergeability to report.
-  // `!isPlaceholderData` covers the first half of a tab switch: while the LIST is
-  // still serving the previous tab's rows, this stays idle rather than describing a
-  // page that isn't on screen. None of these gates stop a chip on their own, though —
+  // `!isPlaceholderData` covers the first half of a tab switch or Load more: while
+  // the LIST is still serving placeholder rows, this stays idle rather than describing
+  // a page that isn't on screen. None of these gates stop a chip on their own, though —
   // a DISABLED query still renders placeholder data, so keeping the previous tab's or
   // lens's map off these rows is the hook's placeholder comparator's job.
   // PR numbers repeat across states and repos, so a misplaced chip is a wrong claim.

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -88,6 +88,9 @@ export function useRepoIdentity(repo: string) {
  * number-keyed maps, briefly-wrong data). Keeps previous data only when the previous
  * query's repo segment matches, so Load-more and Open/Closed switches still skip the
  * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key here).
+ * A key that also varies on an identity axis beyond repo (lens, state) needs an inline
+ * comparator instead — matching repo alone would serve another axis's data (the PR and
+ * issue list hooks below do this).
  */
 export function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
   return <T>(
@@ -904,9 +907,10 @@ export function usePrList(
 
 /** Hydrates PR-list rows with each PR's CI rollup, keyed by number. Runs SEPARATELY from
  *  `usePrList` — a full rollup expansion inside the list query 504s on large GitHub
- *  repos. The numbers digest in the key is load-bearing: the list uses keepPreviousData,
- *  so on a tab switch this can fire against the PREVIOUS tab's rows, and keyed by
- *  state+limit alone that result would cache under the new tab's key. */
+ *  repos. The numbers digest in the key is load-bearing: the list keeps the previous
+ *  tab's rows as placeholder data, so on a tab switch this can fire against the PREVIOUS
+ *  tab's rows, and keyed by state+limit alone that result would cache under the new
+ *  tab's key. */
 export function usePrListCi(
   repo: string,
   enabled: boolean,
@@ -941,13 +945,12 @@ export function usePrListCi(
     },
     enabled: enabled && !!prs && prs.length > 0,
     staleTime: 30_000,
-    // Keeps the current icons while a "Load more" grows the list (that moves only the
-    // limit/digest segments), but ONLY within the same repo, lens AND state — the map is
-    // number-keyed too, so `usePrListMergeability`'s rationale below applies verbatim.
+    // Repo and lens must match: a fork numbers PRs independently of its parent, so a
+    // cross-lens map paints wrong icons. State stays free — the panel idles this query
+    // while the list serves another tab's rows (mirroring the mergeability gate), and
+    // open/closed sets are disjoint, so a cross-tab serve can't show another PR's status.
     placeholderData: (prev, prevQuery) =>
-      prevQuery?.queryKey?.[1] === repo &&
-      prevQuery?.queryKey?.[3] === lens &&
-      prevQuery?.queryKey?.[4] === state
+      prevQuery?.queryKey?.[1] === repo && prevQuery?.queryKey?.[3] === lens
         ? prev
         : undefined,
   });
@@ -1601,8 +1604,14 @@ export function useIssueList(
     // issuesDisabled is a permanent repo condition — retrying only delays the notice.
     retry: (failureCount, err) =>
       !(isAppError(err) && err.kind === "issuesDisabled") && failureCount < 1,
-    // Keep current rows visible while a grown "Load more" page loads.
-    placeholderData: keepPreviousDataForRepo(repo),
+    // State and limit stay free so a tab switch or "Load more" keeps the current rows
+    // instead of flashing skeletons, but lens must match: a fork numbers issues
+    // independently of its parent, so another lens's rows misdescribe the list and a
+    // click on one navigates by number to a different issue.
+    placeholderData: (prev, prevQuery) =>
+      prevQuery?.queryKey?.[1] === repo && prevQuery?.queryKey?.[3] === lens
+        ? prev
+        : undefined,
   });
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -88,9 +88,9 @@ export function useRepoIdentity(repo: string) {
  * number-keyed maps, briefly-wrong data). Keeps previous data only when the previous
  * query's repo segment matches, so Load-more and Open/Closed switches still skip the
  * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key here).
- * A key that also varies on an identity axis beyond repo (lens, state) needs an inline
- * comparator instead — matching repo alone would serve another axis's data (the PR and
- * issue list hooks below do this).
+ * A key that also varies on an identity axis beyond repo (lens, state) needs
+ * `keepPreviousDataForKeyAxes` instead — matching repo alone would serve another axis's
+ * data (the PR and issue list hooks below do this).
  */
 export function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
   return <T>(
@@ -98,6 +98,27 @@ export function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
     previousQuery: { queryKey: QueryKey } | undefined,
   ): T | undefined =>
     previousQuery?.queryKey?.[repoKeyIndex] === repo ? previousData : undefined;
+}
+
+/**
+ * `keepPreviousData` scoped to a repo PLUS extra key segments: previous data is reused
+ * only when every listed `[index, value]` axis matches as well. The indices are
+ * positional, so each call site's axes list must stay in sync with its key literal —
+ * this helper dedupes that coupling, it does not remove it.
+ */
+export function keepPreviousDataForKeyAxes(
+  repo: string,
+  axes: ReadonlyArray<readonly [index: number, value: unknown]>,
+  repoKeyIndex = 1,
+) {
+  return <T>(
+    previousData: T | undefined,
+    previousQuery: { queryKey: QueryKey } | undefined,
+  ): T | undefined => {
+    const key = previousQuery?.queryKey;
+    if (!key || key[repoKeyIndex] !== repo) return undefined;
+    return axes.every(([i, v]) => key[i] === v) ? previousData : undefined;
+  };
 }
 
 export const repoKeys = {
@@ -898,19 +919,17 @@ export function usePrList(
     // instead of flashing skeletons, but lens must match: a fork numbers PRs
     // independently of its parent, so another lens's rows misdescribe the list and a
     // click on one navigates by number to a different PR.
-    placeholderData: (prev, prevQuery) =>
-      prevQuery?.queryKey?.[1] === repo && prevQuery?.queryKey?.[3] === lens
-        ? prev
-        : undefined,
+    placeholderData: keepPreviousDataForKeyAxes(repo, [[3, lens]]),
   });
 }
 
 /** Hydrates PR-list rows with each PR's CI rollup, keyed by number. Runs SEPARATELY from
  *  `usePrList` — a full rollup expansion inside the list query 504s on large GitHub
- *  repos. The numbers digest in the key is load-bearing: the list keeps the previous
- *  tab's rows as placeholder data, so on a tab switch this can fire against the PREVIOUS
- *  tab's rows, and keyed by state+limit alone that result would cache under the new
- *  tab's key. */
+ *  repos. CALLER CONTRACT: idle this hook while the list serves placeholder rows
+ *  (`enabled: … && !list.isPlaceholderData`) — the comparator below leaves `state` free,
+ *  so an ungated intermediate fetch would build a map from the outgoing rows and cache it
+ *  under the incoming key. The numbers digest in the key is the remaining defense: it
+ *  keeps such a result from ever caching under another page's key. */
 export function usePrListCi(
   repo: string,
   enabled: boolean,
@@ -947,12 +966,9 @@ export function usePrListCi(
     staleTime: 30_000,
     // Repo and lens must match: a fork numbers PRs independently of its parent, so a
     // cross-lens map paints wrong icons. State stays free — the panel idles this query
-    // while the list serves another tab's rows (mirroring the mergeability gate), and
+    // while the list serves placeholder rows (mirroring the mergeability gate), and
     // open/closed sets are disjoint, so a cross-tab serve can't show another PR's status.
-    placeholderData: (prev, prevQuery) =>
-      prevQuery?.queryKey?.[1] === repo && prevQuery?.queryKey?.[3] === lens
-        ? prev
-        : undefined,
+    placeholderData: keepPreviousDataForKeyAxes(repo, [[3, lens]]),
   });
 }
 
@@ -996,12 +1012,10 @@ export function usePrListMergeability(
     // on any keyed query with no data yet — so matching on repo alone (what the shared
     // `keepPreviousDataForRepo` does) would paint the open tab's map onto closed rows,
     // and origin's onto upstream's, since numbers collide across both axes.
-    placeholderData: (prev, prevQuery) =>
-      prevQuery?.queryKey?.[1] === repo &&
-      prevQuery?.queryKey?.[3] === lens &&
-      prevQuery?.queryKey?.[4] === state
-        ? prev
-        : undefined,
+    placeholderData: keepPreviousDataForKeyAxes(repo, [
+      [3, lens],
+      [4, state],
+    ]),
   });
 }
 
@@ -1608,10 +1622,7 @@ export function useIssueList(
     // instead of flashing skeletons, but lens must match: a fork numbers issues
     // independently of its parent, so another lens's rows misdescribe the list and a
     // click on one navigates by number to a different issue.
-    placeholderData: (prev, prevQuery) =>
-      prevQuery?.queryKey?.[1] === repo && prevQuery?.queryKey?.[3] === lens
-        ? prev
-        : undefined,
+    placeholderData: keepPreviousDataForKeyAxes(repo, [[3, lens]]),
   });
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -89,8 +89,8 @@ export function useRepoIdentity(repo: string) {
  * query's repo segment matches, so Load-more and Open/Closed switches still skip the
  * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key here).
  * A key that also varies on an identity axis beyond repo (lens, state) needs
- * `keepPreviousDataForKeyAxes` instead — matching repo alone would serve another axis's
- * data (the PR and issue list hooks below do this).
+ * `keepPreviousDataForKeyAxes` instead (the PR and issue list hooks below do):
+ * matching repo alone would serve another axis's data.
  */
 export function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
   return <T>(
@@ -974,7 +974,8 @@ export function usePrListCi(
 
 /** Hydrates PR-list rows with each PR's mergeability, keyed by number — the rows' conflict
  *  chip. Runs separately from `usePrList`, and its numbers digest in the key is
- *  load-bearing, for exactly the reasons documented on `usePrListCi` above. `prs` never
+ *  load-bearing for the same reason as `usePrListCi`'s: it keeps a map built from one
+ *  page's rows from caching under another page's key. `prs` never
  *  reaches the backend (it re-queries the page from the filters): it is here only to
  *  form that digest and to keep the read off an empty page. */
 export function usePrListMergeability(

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -891,9 +891,14 @@ export function usePrList(
     queryFn: () => api.forgePrList(repo, state, limit, lens),
     enabled,
     staleTime: 30_000,
-    // Growing the limit ("Load more") keeps the current rows visible instead of
-    // flashing skeletons while the larger page loads.
-    placeholderData: keepPreviousDataForRepo(repo),
+    // State and limit stay free so a tab switch or "Load more" keeps the current rows
+    // instead of flashing skeletons, but lens must match: a fork numbers PRs
+    // independently of its parent, so another lens's rows misdescribe the list and a
+    // click on one navigates by number to a different PR.
+    placeholderData: (prev, prevQuery) =>
+      prevQuery?.queryKey?.[1] === repo && prevQuery?.queryKey?.[3] === lens
+        ? prev
+        : undefined,
   });
 }
 
@@ -936,8 +941,15 @@ export function usePrListCi(
     },
     enabled: enabled && !!prs && prs.length > 0,
     staleTime: 30_000,
-    // Keep the current icons while a "Load more" grows the list, matching usePrList.
-    placeholderData: keepPreviousDataForRepo(repo),
+    // Keeps the current icons while a "Load more" grows the list (that moves only the
+    // limit/digest segments), but ONLY within the same repo, lens AND state — the map is
+    // number-keyed too, so `usePrListMergeability`'s rationale below applies verbatim.
+    placeholderData: (prev, prevQuery) =>
+      prevQuery?.queryKey?.[1] === repo &&
+      prevQuery?.queryKey?.[3] === lens &&
+      prevQuery?.queryKey?.[4] === state
+        ? prev
+        : undefined,
   });
 }
 


### PR DESCRIPTION
Placeholder data in the pull-request and issue lists was keyed only by repo, so switching a fork's list between the origin and upstream lens briefly rendered the previous query's rows and CI icons. Because a fork numbers its PRs and issues independently of its parent, those carried-over rows misdescribe the incoming list — and clicking one navigates by number, opening a different item than the row displayed. This scopes the placeholder predicates to the axes they can safely describe, and idles the CI hydrator across transitional rows.

- Replaces `keepPreviousDataForRepo(repo)` in `usePrList` and `useIssueList` (`src/lib/git/queries.ts`) with an inline predicate that reuses previous data only when the previous query key matches on both repo (`queryKey[1]`) and lens (`queryKey[3]`), leaving `state` and `limit` free so tab switches and "Load more" still skip the skeleton.
- Applies the same repo+lens predicate to `usePrListCi`, and gates that hook's `enabled` on `!prList.isPlaceholderData` in `PullRequestsPanel` (mirroring the existing mergeability gate) so a tab switch can no longer cache a CI map fetched against the outgoing tab's rows under the incoming key. A `state` term in the comparator was tried and rejected — it blanks correct icons during the transition while a two-hop path bypasses it; details in the context comment, item 3.
- Updates the shared helper's doc to warn that keys varying on identity axes beyond repo need an inline comparator, and rewrites the adjacent hook comments to state the fork-numbering constraint that motivates the lens pinning.
- Adds the changelog fragment `changelog.d/fixed-list-lens-placeholder.md` describing the user-visible fix.