### PR TITLE
docs(site): drop "native" from marketing and metadata copy

### DIFF
--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -37,7 +37,7 @@ const {
   ogTitle = title,
   ogDescription = description,
   ogImage = "/og-default.png",
-  ogImageAlt = "GitDesktop — a native Git client showing a pull request with CI checks and an AI code review",
+  ogImageAlt = "GitDesktop — a Git client showing a pull request with CI checks and an AI code review",
   ogType = "website",
   publishedTime,
   modifiedTime,

--- a/site/src/layouts/PostLayout.astro
+++ b/site/src/layouts/PostLayout.astro
@@ -241,7 +241,7 @@ const toc = headings.filter((h) => h.depth === 2 || h.depth === 3);
           Written while building GitDesktop.
         </h2>
         <p class="mx-auto mt-5 max-w-[48ch] leading-relaxed text-body">
-          A native Git client for GitHub, GitLab and Bitbucket — free and open
+          A desktop Git client for GitHub, GitLab and Bitbucket — free and open
           source, with AI you control or hide entirely.
         </p>
         <div class="mt-8 flex flex-wrap items-center justify-center gap-3">

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -112,7 +112,7 @@ const agentAbilities = [
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
             Pull the full diff past the prompt budget, read any file at any ref, search
             the repo, and run history — end to end read-only. Works with CLI agent
-            models (over a read-only MCP server) and with API models through a native
+            models (over a read-only MCP server) and with API models through a built-in
             tool loop that needs no workspace, so it starts instantly.
           </p>
         </div>
@@ -304,7 +304,7 @@ const agentAbilities = [
         Your model. Your keys. Your call.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
-        Free, open source, and native. Turn the AI up, or hide it entirely.
+        Free, open source, and local. Turn the AI up, or hide it entirely.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-9 flex flex-wrap items-center justify-center gap-3">
         <a href={download} class="rounded-lg bg-mint px-6 py-3 font-medium text-mint-ink transition-opacity hover:opacity-90">

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -112,7 +112,7 @@ const agentAbilities = [
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
             Pull the full diff past the prompt budget, read any file at any ref, search
             the repo, and run history — end to end read-only. Works with CLI agent
-            models (over a read-only MCP server) and with API models through a built-in
+            models (over a read-only MCP server) and with API models through a native
             tool loop that needs no workspace, so it starts instantly.
           </p>
         </div>
@@ -304,7 +304,7 @@ const agentAbilities = [
         Your model. Your keys. Your call.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
-        Free, open source, and local. Turn the AI up, or hide it entirely.
+        Free, open source, and yours. Turn the AI up, or hide it entirely.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-9 flex flex-wrap items-center justify-center gap-3">
         <a href={download} class="rounded-lg bg-mint px-6 py-3 font-medium text-mint-ink transition-opacity hover:opacity-90">

--- a/site/src/pages/bitbucket-issues-sunset.astro
+++ b/site/src/pages/bitbucket-issues-sunset.astro
@@ -164,7 +164,7 @@ const jiraPoints = [
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-5 max-w-[48ch] leading-relaxed text-body">
         Free and open source — Bitbucket pull requests, Pipelines, and linked
-        Jira issues in one native window.
+        Jira issues in one window.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-8 flex flex-wrap items-center justify-center gap-3">
         <a href={download} class="rounded-lg bg-mint px-6 py-3 font-medium text-mint-ink transition-opacity hover:opacity-90">

--- a/site/src/pages/blog/[...page].astro
+++ b/site/src/pages/blog/[...page].astro
@@ -35,9 +35,9 @@ const aiCount = page.data.filter((p) => p.data.ai).length;
   feed
   breadcrumbs={[{ name: "Blog", path: "/blog/" }]}
   title="Blog — notes from building GitDesktop"
-  description="Engineering notes from building a native Git client: merge previews, stash recovery, multi-forge parity, and AI you can switch off entirely."
+  description="Engineering notes from building a desktop Git client: merge previews, stash recovery, multi-forge parity, and AI you can switch off entirely."
   ogTitle="The GitDesktop blog"
-  ogDescription="Engineering notes from building a native Git client."
+  ogDescription="Engineering notes from building a desktop Git client."
 >
   <section class="border-b border-line">
     <div class="mx-auto max-w-6xl px-5 py-16 md:py-20">

--- a/site/src/pages/blog/tags/[tag]/[...page].astro
+++ b/site/src/pages/blog/tags/[tag]/[...page].astro
@@ -50,7 +50,7 @@ const aiCount = page.data.filter((p) => p.data.ai).length;
     { name: tag, path: tagUrl(tag) },
   ]}
   title={`${tag} — GitDesktop blog`}
-  description={`Every GitDesktop post tagged ${tag}: engineering notes from building a native Git client for GitHub, GitLab and Bitbucket.`}
+  description={`Every GitDesktop post tagged ${tag}: engineering notes from building a desktop Git client for GitHub, GitLab and Bitbucket.`}
   ogTitle={`Posts tagged ${tag}`}
   ogDescription={`Engineering notes from building GitDesktop, tagged ${tag}.`}
 >

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -69,7 +69,7 @@ const groups = GROUP_ORDER.map((group) => {
         That's a lot to keep open all day.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
-        Free, open source, and native — for GitHub, GitLab, and Bitbucket.
+        Free, open source, and local — for GitHub, GitLab, and Bitbucket.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-9 flex flex-wrap items-center justify-center gap-3">
         <a href={download} class="rounded-lg bg-mint px-6 py-3 font-medium text-mint-ink transition-opacity hover:opacity-90">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -75,7 +75,7 @@ const forges = [
   title="GitDesktop — Git client for GitHub, GitLab & Bitbucket"
   description="A free, open-source GitHub Desktop alternative that also works with GitLab and Bitbucket — staging, diffs, pull requests, CI, and issues in one window."
   ogTitle="GitDesktop — the whole Git loop, one window"
-  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues — in one fast desktop app. With AI you control, or hide entirely."
+  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues — in one fast window. With AI you control, or hide entirely."
 >
   <!-- ============================ AI-NATIVE VIEW ======================= -->
   <!-- Hero (AI) -->
@@ -198,7 +198,7 @@ const forges = [
           Everything you expect from <a href={`${base}compare/github-desktop/`} class="whitespace-nowrap text-ink underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint">GitHub Desktop</a> — staging, branches, diffs,
           history, sync — now across <span class="text-ink">GitHub, GitLab &amp;
           Bitbucket</span>, with the full pull-request loop, CI, issues, and branch
-          protection in one fast desktop app. Built to be trusted with uncommitted
+          protection in one fast window. Built to be trusted with uncommitted
           work. No AI in sight.
         </p>
         <div

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -73,9 +73,9 @@ const forges = [
 
 <SiteLayout
   title="GitDesktop — Git client for GitHub, GitLab & Bitbucket"
-  description="A free, open-source GitHub Desktop alternative that also works with GitLab and Bitbucket — staging, diffs, pull requests, CI, and issues in one native window."
-  ogTitle="GitDesktop — the whole Git loop, one native app"
-  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues — in one fast native window. With AI you control, or hide entirely."
+  description="A free, open-source GitHub Desktop alternative that also works with GitLab and Bitbucket — staging, diffs, pull requests, CI, and issues in one window."
+  ogTitle="GitDesktop — the whole Git loop, one window"
+  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues — in one fast desktop app. With AI you control, or hide entirely."
 >
   <!-- ============================ AI-NATIVE VIEW ======================= -->
   <!-- Hero (AI) -->
@@ -181,7 +181,7 @@ const forges = [
           class="mb-6 text-sm font-normal tracking-normal text-pretty text-faint"
           style="transition-delay:0ms"
         >
-          <span class="text-add" aria-hidden="true">//</span> a calm, native Git client for GitHub, GitLab &amp; Bitbucket
+          <span class="text-add" aria-hidden="true">//</span> a calm desktop Git client for GitHub, GitLab &amp; Bitbucket
         </h1>
         <h2
           data-reveal
@@ -198,7 +198,7 @@ const forges = [
           Everything you expect from <a href={`${base}compare/github-desktop/`} class="whitespace-nowrap text-ink underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint">GitHub Desktop</a> — staging, branches, diffs,
           history, sync — now across <span class="text-ink">GitHub, GitLab &amp;
           Bitbucket</span>, with the full pull-request loop, CI, issues, and branch
-          protection in one fast native window. Built to be trusted with uncommitted
+          protection in one fast desktop app. Built to be trusted with uncommitted
           work. No AI in sight.
         </p>
         <div
@@ -824,7 +824,7 @@ const forges = [
         Keep it open all day.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
-        Free, open source, and native. Fast enough to live in, careful enough to trust
+        Free, open source, and local. Fast enough to live in, careful enough to trust
         with your work — discards are recoverable and pushes use
         <code class="text-ink">--force-with-lease</code>.
       </p>

--- a/site/src/pages/integrations.astro
+++ b/site/src/pages/integrations.astro
@@ -216,7 +216,7 @@ const jiraFeatures = [
         Bring the forge you already use.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
-        Free, open source, and native. GitHub and GitLab go through their CLIs; Bitbucket
+        Free, open source, and local. GitHub and GitLab go through their CLIs; Bitbucket
         and Jira use an Atlassian token — your identity, never ours.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-9 flex flex-wrap items-center justify-center gap-3">

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -28,7 +28,7 @@ export async function GET(context: APIContext) {
   return rss({
     title: "GitDesktop",
     description:
-      "Engineering notes from building a native Git client for GitHub, GitLab and Bitbucket.",
+      "Engineering notes from building a desktop Git client for GitHub, GitLab and Bitbucket.",
     site,
     // Match the site's own URL shape so readers and analytics agree.
     trailingSlash: true,


### PR DESCRIPTION
Removes the word "native" from the marketing site's user-facing copy and metadata where it makes a toolkit claim, replacing it with plainer, more accurate phrasing ("desktop", "local", "yours") or dropping it where the sentence reads fine without it. The substitutions are context-specific rather than a blanket find-and-replace, so each claim stays true to what the app actually is. Deliberate exceptions, kept on purpose: "AI-native" (a design claim, like cloud-native), the download page's "native builds / Native installers" (the platform-installer sense), the "Native macOS menu bar" capability row (that menu bar is toolkit-native), the AI page's "native tool loop" (first-party/built-in sense, phrased identically in the README and in-app guide), and "Bitbucket's native tracker" / "GitHub- and GitLab-native" (the platform's own feature). No app code changes, so this carries no changelog fragment per the site-only convention.

### Page copy

- Swaps the closing CTA line "Free, open source, and native" for "…and local" in `site/src/pages/features.astro`, `site/src/pages/integrations.astro`, and the Keep-it-open-all-day CTA in `site/src/pages/index.astro` — and for "…and yours" in `site/src/pages/ai.astro`, where "local" would misread as local-only inference on a page that also advertises API models.
- Reworks the Just Git view in `site/src/pages/index.astro`: the hero subhead becomes "a calm desktop Git client for GitHub, GitLab & Bitbucket" and the intro paragraph now ends "…branch protection in one fast window", matching the page's "one window" motif.
- Drops "native" outright from the Bitbucket sunset CTA in `site/src/pages/bitbucket-issues-sunset.astro` ("…linked Jira issues in one window").
- Updates the blog post footer CTA in `site/src/layouts/PostLayout.astro` to "A desktop Git client for GitHub, GitLab and Bitbucket".

### Metadata, social cards, and feed

- Updates the home page `description`, `ogTitle`, and `ogDescription` in `site/src/pages/index.astro` — the OG title is now "GitDesktop — the whole Git loop, one window".
- Changes the default OG image alt text in `site/src/components/Head.astro` to "GitDesktop — a Git client showing a pull request with CI checks and an AI code review".
- Updates the blog index `description`/`ogDescription` in `site/src/pages/blog/[...page].astro` and the tag-page `description` in `site/src/pages/blog/tags/[tag]/[...page].astro` to "…building a desktop Git client…".
- Matches the RSS feed description in `site/src/pages/rss.xml.ts` to the same wording so the feed and the site agree.