### PR TITLE
fix(history,compare,issues,diff): stop detail panes serving stale data

### DIFF
--- a/changelog.d/fixed-detail-pane-stale-transitions.md
+++ b/changelog.d/fixed-detail-pane-stale-transitions.md
@@ -1,0 +1,4 @@
+- Copying a commit's SHA right after selecting it now always copies the commit you
+  selected, detail views visibly indicate when they are still loading the next item
+  instead of silently showing the previous one, and a diff can no longer render
+  under another file's header.

--- a/changelog.d/fixed-detail-pane-stale-transitions.md
+++ b/changelog.d/fixed-detail-pane-stale-transitions.md
@@ -1,4 +1,5 @@
 - Copying a commit's SHA right after selecting it now always copies the commit you
-  selected, detail views visibly indicate when they are still loading the next item
-  instead of silently showing the previous one, and a diff can no longer render
-  under another file's header.
+  selected, the Jira button opens the issue you selected rather than the one still
+  on screen, detail views visibly indicate when they are still loading the next
+  item instead of silently showing the previous one, and a diff can no longer
+  render under another file's header.

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -831,6 +831,45 @@ mod tests {
         assert_eq!(noop.text, all.text);
     }
 
+    /// The diff pane discards a rendered body whose `file_path` doesn't match the
+    /// path it asked for (that mismatch is how it detects a stale placeholder), so
+    /// the echo must stay verbatim — including a `[slug]`-style name, which only
+    /// survives because the pathspec is quoted literally.
+    #[tokio::test]
+    async fn branch_file_diff_echoes_the_requested_path() {
+        let (_base, repo) = seed_repo("branchfilediff-echo").await;
+        let root = std::path::Path::new(&repo);
+
+        std::fs::create_dir_all(root.join("[slug]")).unwrap();
+        std::fs::write(root.join("plain.txt"), "one\n").unwrap();
+        std::fs::write(root.join("[slug]").join("a.txt"), "one\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        let base_sha = run(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        std::fs::write(root.join("plain.txt"), "one\ntwo\n").unwrap();
+        std::fs::write(root.join("[slug]").join("a.txt"), "one\ntwo\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "work"]).await;
+
+        for path in ["plain.txt", "[slug]/a.txt"] {
+            let diff = git_branch_file_diff(
+                repo.clone(),
+                base_sha.clone(),
+                "HEAD".into(),
+                path.to_string(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(diff.file_path, path);
+            assert!(
+                diff.text.contains("+two"),
+                "no hunk for {path}: {}",
+                diff.text
+            );
+        }
+    }
+
     /// AI-ignore patterns are gitignore-style, so a bare NAME matches at any
     /// depth (not just the repo root), a bare DIRECTORY name hides that
     /// directory's contents wherever it sits, and a leading `/` anchors to the

--- a/src-tauri/src/git/history.rs
+++ b/src-tauri/src/git/history.rs
@@ -504,6 +504,45 @@ mod tests {
         }
     }
 
+    /// The diff pane discards a rendered body whose `file_path` doesn't match the
+    /// path it asked for (that mismatch is how it detects a stale placeholder), so
+    /// the echo must stay verbatim — including a `[slug]`-style name, which only
+    /// survives because the pathspec is quoted literally.
+    #[tokio::test]
+    async fn commit_file_diff_echoes_the_requested_path() {
+        let (_dir, repo) = temp_repo("file-diff-echo");
+        git(&repo, &["init"]).await;
+        git(&repo, &["config", "user.email", "t@t"]).await;
+        git(&repo, &["config", "user.name", "t"]).await;
+        let root = Path::new(&repo);
+        std::fs::create_dir_all(root.join("[slug]")).unwrap();
+        std::fs::write(root.join("plain.txt"), "one\n").unwrap();
+        std::fs::write(root.join("[slug]").join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "."]).await;
+        git(&repo, &["commit", "-m", "seed"]).await;
+        std::fs::write(root.join("plain.txt"), "one\ntwo\n").unwrap();
+        std::fs::write(root.join("[slug]").join("a.txt"), "one\ntwo\n").unwrap();
+        git(&repo, &["commit", "-am", "change both"]).await;
+        let hash = run_git(Some(&repo), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        for path in ["plain.txt", "[slug]/a.txt"] {
+            let diff = git_commit_file_diff(repo.clone(), hash.clone(), path.to_string())
+                .await
+                .unwrap();
+            assert_eq!(diff.file_path, path);
+            assert!(
+                diff.text.contains("+two"),
+                "no hunk for {path}: {}",
+                diff.text
+            );
+        }
+    }
+
     #[tokio::test]
     async fn blame_dash_prefixed_rev_rejected() {
         let (_dir, repo, _first, _second) = two_commit_repo("dash-rev").await;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -4378,6 +4378,37 @@ mod tests {
 
     }
 
+    /// The diff pane discards a rendered body whose `file_path` doesn't match the
+    /// path it asked for (that mismatch is how it detects a stale placeholder), so
+    /// the echo must stay verbatim — including a `[slug]`-style name, which only
+    /// survives because the pathspec is quoted literally.
+    #[tokio::test]
+    async fn stash_file_diff_echoes_the_requested_path() {
+        let (dir, repo) = setup_repo("stash-file-diff-echo").await;
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("[slug]")).unwrap();
+        std::fs::write(root.join("plain.txt"), "one\n").unwrap();
+        std::fs::write(root.join("[slug]").join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "."]).await;
+        git(&repo, &["commit", "-m", "seed"]).await;
+
+        std::fs::write(root.join("plain.txt"), "one\ntwo\n").unwrap();
+        std::fs::write(root.join("[slug]").join("a.txt"), "one\ntwo\n").unwrap();
+        git(&repo, &["stash", "push", "-m", "echo test"]).await;
+
+        for path in ["plain.txt", "[slug]/a.txt"] {
+            let diff = git_stash_file_diff(repo.clone(), 0, path.to_string())
+                .await
+                .unwrap();
+            assert_eq!(diff.file_path, path);
+            assert!(
+                diff.text.contains("+two"),
+                "no hunk for {path}: {}",
+                diff.text
+            );
+        }
+    }
+
     #[test]
     fn parse_worktree_branches_reads_path_and_branch_and_detached() {
         // Main worktree on a branch, a linked worktree on another branch, and a

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -8,6 +8,9 @@ import { useBranchDiffFiles, useBranchFileDiff } from "@/lib/git/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { cn } from "@/lib/utils";
 
+const PLACEHOLDER_FADE =
+  "transition-opacity duration-150 motion-reduce:transition-none";
+
 /**
  * The net change `compare` introduces relative to `base` (the three-dot diff,
  * what a PR would show): a changed-file list plus the selected file's diff.
@@ -40,7 +43,16 @@ export function BranchDiffView({
   // Diff off a deferred path so rapidly arrowing the file list only fetches +
   // renders the landed-on file; the highlight stays on effectivePath.
   const deferredPath = useDeferredValue(effectivePath);
-  const diff = useBranchFileDiff(repoPath, base, compare, deferredPath);
+  // Gated on a settled file list: the path comes FROM that list, so while it's a
+  // placeholder the path belongs to the previous comparison. Fetching anyway
+  // succeeds with an empty diff and flashes "No changes to show".
+  const diff = useBranchFileDiff(
+    repoPath,
+    base,
+    compare,
+    deferredPath,
+    !files.isPlaceholderData,
+  );
 
   if (files.isPending) {
     return (
@@ -63,6 +75,9 @@ export function BranchDiffView({
 
   const totalAdded = files.data.reduce((sum, f) => sum + f.added, 0);
   const totalDeleted = files.data.reduce((sum, f) => sum + f.deleted, 0);
+  // The counts, totals and file list belong to the PREVIOUS comparison until the
+  // selected one lands; fade them. The branch names are props — always current.
+  const staleDim = files.isPlaceholderData && "opacity-80";
 
   // Arrow keys walk the file list, mirroring the app's other lists.
   const onFilesKeyDown = listKeyboardNav({
@@ -81,14 +96,20 @@ export function BranchDiffView({
           <span className="font-mono">{base}</span>
         </span>
         <span className="flex-1" />
-        <span className="text-muted-foreground">
+        <span
+          className={cn("text-muted-foreground", PLACEHOLDER_FADE, staleDim)}
+        >
           {files.data.length} file{files.data.length === 1 ? "" : "s"}
         </span>
-        <span className="text-success">+{totalAdded}</span>
-        <span className="text-destructive">-{totalDeleted}</span>
+        <span className={cn("text-success", PLACEHOLDER_FADE, staleDim)}>
+          +{totalAdded}
+        </span>
+        <span className={cn("text-destructive", PLACEHOLDER_FADE, staleDim)}>
+          -{totalDeleted}
+        </span>
       </header>
 
-      <div className="flex min-h-0 flex-1">
+      <div className={cn("flex min-h-0 flex-1", PLACEHOLDER_FADE, staleDim)}>
         <aside
           className="flex w-72 shrink-0 flex-col border-r"
           role="listbox"

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -6,10 +6,7 @@ import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
 import { FileRowActions } from "@/features/history/FileRowActions";
 import { useBranchDiffFiles, useBranchFileDiff } from "@/lib/git/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
-import { cn } from "@/lib/utils";
-
-const PLACEHOLDER_FADE =
-  "transition-opacity duration-150 motion-reduce:transition-none";
+import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
 
 /**
  * The net change `compare` introduces relative to `base` (the three-dot diff,
@@ -43,18 +40,24 @@ export function BranchDiffView({
   // Diff off a deferred path so rapidly arrowing the file list only fetches +
   // renders the landed-on file; the highlight stays on effectivePath.
   const deferredPath = useDeferredValue(effectivePath);
-  // Gated on a settled file list: the path comes FROM that list, so while it's a
-  // placeholder the path belongs to the previous comparison. Fetching anyway
-  // succeeds with an empty diff and flashes "No changes to show".
+  // Fetch only once the path is one this comparison actually changed. The path
+  // comes FROM the file list, so it belongs to the previous comparison both while
+  // that list is a placeholder AND for the deferred frame after it settles — and a
+  // fetch there "succeeds" with an empty diff, flashing "No changes to show".
+  const diffEnabled =
+    !files.isPlaceholderData &&
+    (files.data?.some((f) => f.path === deferredPath) ?? false);
   const diff = useBranchFileDiff(
     repoPath,
     base,
     compare,
     deferredPath,
-    !files.isPlaceholderData,
+    diffEnabled,
   );
 
-  if (files.isPending) {
+  // A placeholder list is the PREVIOUS comparison's, so an empty one says nothing
+  // about this pair — hold the skeleton rather than claim "no changes" below.
+  if (files.isPending || (files.isPlaceholderData && files.data.length === 0)) {
     return (
       <div className="space-y-3 p-4">
         <Skeleton className="h-5 w-2/3" />
@@ -78,6 +81,10 @@ export function BranchDiffView({
   // The counts, totals and file list belong to the PREVIOUS comparison until the
   // selected one lands; fade them. The branch names are props — always current.
   const staleDim = files.isPlaceholderData && "opacity-80";
+  // The diff pane serves the previous file's diff for longer than the rest (its
+  // query stays on placeholder data through the gated window above), so it fades
+  // on its own state. Never nested inside another dim — 0.8² reads as disabled.
+  const diffDim = (staleDim || diff.isPlaceholderData) && "opacity-80";
 
   // Arrow keys walk the file list, mirroring the app's other lists.
   const onFilesKeyDown = listKeyboardNav({
@@ -89,7 +96,7 @@ export function BranchDiffView({
   });
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
       <header className="flex items-center gap-2 border-b px-4 py-3 text-xs">
         <span className="font-medium">
           <span className="font-mono">{compare}</span> vs{" "}
@@ -109,9 +116,13 @@ export function BranchDiffView({
         </span>
       </header>
 
-      <div className={cn("flex min-h-0 flex-1", PLACEHOLDER_FADE, staleDim)}>
+      <div className="flex min-h-0 flex-1">
         <aside
-          className="flex w-72 shrink-0 flex-col border-r"
+          className={cn(
+            "flex w-72 shrink-0 flex-col border-r",
+            PLACEHOLDER_FADE,
+            staleDim,
+          )}
           role="listbox"
           aria-label="Changed files"
         >
@@ -155,7 +166,7 @@ export function BranchDiffView({
             </FileRowActions>
           </ScrollArea>
         </aside>
-        <main className="min-w-0 flex-1">
+        <main className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}>
           {deferredPath ? (
             <DiffSurface
               filePath={deferredPath}

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -166,7 +166,10 @@ export function BranchDiffView({
             </FileRowActions>
           </ScrollArea>
         </aside>
-        <main className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}>
+        <main
+          aria-busy={Boolean(diffDim)}
+          className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}
+        >
           {deferredPath ? (
             <DiffSurface
               filePath={deferredPath}

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -1183,6 +1183,10 @@ export function DiffContent({
   // and a layout shift on the way to the real content — render nothing until
   // it's ready.
   if (isPending) return null;
+  // Every backend diff command echoes the requested path back verbatim, so a
+  // mismatch means `data` is a stale placeholder from the previously selected
+  // file's key. Re-scope this if the backend ever normalizes the path it returns.
+  if (data && data.filePath !== filePath) return null;
   if (isError || !data) {
     return <DiffPlaceholder message="Could not load diff for this file" />;
   }

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -45,12 +45,9 @@ import { providerLabel } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
-import { cn } from "@/lib/utils";
+import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
 import { FileRowActions } from "./FileRowActions";
 import { useAmendWithConfirm } from "./useAmendCommit";
-
-const PLACEHOLDER_FADE =
-  "transition-opacity duration-150 motion-reduce:transition-none";
 
 export function CommitDetailView({
   repoPath,
@@ -82,15 +79,14 @@ export function CommitDetailView({
   // large IPC payload otherwise deserializes on the main thread and stalls
   // input). The file-list highlight still uses effectivePath, so it stays live.
   const deferredPath = useDeferredValue(effectivePath);
-  // Gated on a settled file list: the path comes FROM that list, so while it's a
-  // placeholder the path is the previous commit's. Fetching anyway succeeds — with
-  // an empty diff for a file this commit never touched — and flashes "No changes".
-  const diff = useCommitFileDiff(
-    repoPath,
-    hash,
-    deferredPath,
-    !files.isPlaceholderData,
-  );
+  // Fetch only once the path is one this commit actually changed. The path comes
+  // FROM the file list, so it's the previous commit's both while that list is a
+  // placeholder AND for the deferred frame after it settles — and a fetch there
+  // "succeeds" with an empty diff, flashing "No changes to show".
+  const diffEnabled =
+    !files.isPlaceholderData &&
+    (files.data?.some((f) => f.path === deferredPath) ?? false);
+  const diff = useCommitFileDiff(repoPath, hash, deferredPath, diffEnabled);
 
   // Commit-comment surface — mirrors the PR Commits drill-in (PrCommitDetail),
   // but lights up ONLY when the repo has a ready forge, the provider supports
@@ -209,6 +205,11 @@ export function CommitDetailView({
   // current. The ⋯ actions act on the `hash` prop, so they stay solid.
   const staleDim =
     (details.isPlaceholderData || files.isPlaceholderData) && "opacity-80";
+  // The diff pane keeps serving the previous file's diff for longer than the rest
+  // (its query stays on placeholder data through the gated window above), so it
+  // fades on its own state. Never nested inside another dim — 0.8² reads as
+  // disabled.
+  const diffDim = (staleDim || diff.isPlaceholderData) && "opacity-80";
 
   // Identity comes from the `hash` PROP, never `commit.hash`: while the next
   // commit's details load, `details.data` is still the previous commit's
@@ -245,7 +246,7 @@ export function CommitDetailView({
   });
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
       <header className="space-y-1 border-b px-4 py-3">
         <h2 className={cn("text-sm font-medium", PLACEHOLDER_FADE, staleDim)}>
           {commit.subject}
@@ -262,26 +263,25 @@ export function CommitDetailView({
           </p>
         )}
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <CommitAuthorAvatar
-            name={commit.author}
-            email={commit.authorEmail}
-            className={cn(PLACEHOLDER_FADE, staleDim)}
-          />
-          <span className={cn(PLACEHOLDER_FADE, staleDim)}>
-            {commit.author}
-          </span>
-          <span className={cn(PLACEHOLDER_FADE, staleDim)}>•</span>
-          <span className={cn(PLACEHOLDER_FADE, staleDim)}>
-            {formatRelativeTime(commit.date)}
-          </span>
-          <span className={cn(PLACEHOLDER_FADE, staleDim)}>•</span>
-          <button
-            type="button"
+          <span
             className={cn(
-              "inline-flex items-center gap-1 font-mono hover:text-foreground",
+              "flex items-center gap-2",
               PLACEHOLDER_FADE,
               staleDim,
             )}
+          >
+            <CommitAuthorAvatar
+              name={commit.author}
+              email={commit.authorEmail}
+            />
+            <span>{commit.author}</span>
+            <span>•</span>
+            <span>{formatRelativeTime(commit.date)}</span>
+            <span>•</span>
+          </span>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 font-mono hover:text-foreground"
             onClick={copyHash}
             title="Copy full hash"
           >
@@ -289,11 +289,15 @@ export function CommitDetailView({
             <CopyIcon className="size-3" />
           </button>
           <span className="flex-1" />
-          <span className={cn("text-success", PLACEHOLDER_FADE, staleDim)}>
-            +{totalAdded}
-          </span>
-          <span className={cn("text-destructive", PLACEHOLDER_FADE, staleDim)}>
-            -{totalDeleted}
+          <span
+            className={cn(
+              "flex items-center gap-2",
+              PLACEHOLDER_FADE,
+              staleDim,
+            )}
+          >
+            <span className="text-success">+{totalAdded}</span>
+            <span className="text-destructive">-{totalDeleted}</span>
           </span>
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -363,8 +367,14 @@ export function CommitDetailView({
         )}
       </header>
 
-      <div className={cn("flex min-h-0 flex-1", PLACEHOLDER_FADE, staleDim)}>
-        <aside className="flex w-72 shrink-0 flex-col border-r">
+      <div className="flex min-h-0 flex-1">
+        <aside
+          className={cn(
+            "flex w-72 shrink-0 flex-col border-r",
+            PLACEHOLDER_FADE,
+            staleDim,
+          )}
+        >
           <p className="border-b px-3 py-1.5 text-xs text-muted-foreground">
             {files.data.length} changed file{files.data.length === 1 ? "" : "s"}
           </p>
@@ -409,7 +419,7 @@ export function CommitDetailView({
             </FileRowActions>
           </ScrollArea>
         </aside>
-        <main className="min-w-0 flex-1">
+        <main className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}>
           {deferredPath ? (
             <DiffSurface
               filePath={deferredPath}

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -419,7 +419,10 @@ export function CommitDetailView({
             </FileRowActions>
           </ScrollArea>
         </aside>
-        <main className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}>
+        <main
+          aria-busy={Boolean(diffDim)}
+          className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}
+        >
           {deferredPath ? (
             <DiffSurface
               filePath={deferredPath}

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -49,6 +49,9 @@ import { cn } from "@/lib/utils";
 import { FileRowActions } from "./FileRowActions";
 import { useAmendWithConfirm } from "./useAmendCommit";
 
+const PLACEHOLDER_FADE =
+  "transition-opacity duration-150 motion-reduce:transition-none";
+
 export function CommitDetailView({
   repoPath,
   hash,
@@ -79,7 +82,15 @@ export function CommitDetailView({
   // large IPC payload otherwise deserializes on the main thread and stalls
   // input). The file-list highlight still uses effectivePath, so it stays live.
   const deferredPath = useDeferredValue(effectivePath);
-  const diff = useCommitFileDiff(repoPath, hash, deferredPath);
+  // Gated on a settled file list: the path comes FROM that list, so while it's a
+  // placeholder the path is the previous commit's. Fetching anyway succeeds — with
+  // an empty diff for a file this commit never touched — and flashes "No changes".
+  const diff = useCommitFileDiff(
+    repoPath,
+    hash,
+    deferredPath,
+    !files.isPlaceholderData,
+  );
 
   // Commit-comment surface — mirrors the PR Commits drill-in (PrCommitDetail),
   // but lights up ONLY when the repo has a ready forge, the provider supports
@@ -193,10 +204,18 @@ export function CommitDetailView({
   const commit = details.data;
   const totalAdded = files.data.reduce((sum, f) => sum + f.added, 0);
   const totalDeleted = files.data.reduce((sum, f) => sum + f.deleted, 0);
+  // Everything derived from these two queries is the PREVIOUS commit's until the
+  // selected one lands; fade it so the pane never passes stale content off as
+  // current. The ⋯ actions act on the `hash` prop, so they stay solid.
+  const staleDim =
+    (details.isPlaceholderData || files.isPlaceholderData) && "opacity-80";
 
+  // Identity comes from the `hash` PROP, never `commit.hash`: while the next
+  // commit's details load, `details.data` is still the previous commit's
+  // placeholder — copying from it would hand over the wrong SHA.
   async function copyHash() {
     try {
-      await navigator.clipboard.writeText(commit.hash);
+      await navigator.clipboard.writeText(hash);
       toast.success("Commit hash copied");
     } catch {
       toast.error("Could not copy to clipboard");
@@ -228,30 +247,54 @@ export function CommitDetailView({
   return (
     <div className="flex h-full flex-col">
       <header className="space-y-1 border-b px-4 py-3">
-        <h2 className="text-sm font-medium">{commit.subject}</h2>
+        <h2 className={cn("text-sm font-medium", PLACEHOLDER_FADE, staleDim)}>
+          {commit.subject}
+        </h2>
         {commit.body && (
-          <p className="max-h-24 overflow-y-auto text-xs whitespace-pre-wrap text-muted-foreground">
+          <p
+            className={cn(
+              "max-h-24 overflow-y-auto text-xs whitespace-pre-wrap text-muted-foreground",
+              PLACEHOLDER_FADE,
+              staleDim,
+            )}
+          >
             {commit.body}
           </p>
         )}
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <CommitAuthorAvatar name={commit.author} email={commit.authorEmail} />
-          <span>{commit.author}</span>
-          <span>•</span>
-          <span>{formatRelativeTime(commit.date)}</span>
-          <span>•</span>
+          <CommitAuthorAvatar
+            name={commit.author}
+            email={commit.authorEmail}
+            className={cn(PLACEHOLDER_FADE, staleDim)}
+          />
+          <span className={cn(PLACEHOLDER_FADE, staleDim)}>
+            {commit.author}
+          </span>
+          <span className={cn(PLACEHOLDER_FADE, staleDim)}>•</span>
+          <span className={cn(PLACEHOLDER_FADE, staleDim)}>
+            {formatRelativeTime(commit.date)}
+          </span>
+          <span className={cn(PLACEHOLDER_FADE, staleDim)}>•</span>
           <button
             type="button"
-            className="inline-flex items-center gap-1 font-mono hover:text-foreground"
+            className={cn(
+              "inline-flex items-center gap-1 font-mono hover:text-foreground",
+              PLACEHOLDER_FADE,
+              staleDim,
+            )}
             onClick={copyHash}
             title="Copy full hash"
           >
-            {commit.hash.slice(0, 7)}
+            {hash.slice(0, 7)}
             <CopyIcon className="size-3" />
           </button>
           <span className="flex-1" />
-          <span className="text-success">+{totalAdded}</span>
-          <span className="text-destructive">-{totalDeleted}</span>
+          <span className={cn("text-success", PLACEHOLDER_FADE, staleDim)}>
+            +{totalAdded}
+          </span>
+          <span className={cn("text-destructive", PLACEHOLDER_FADE, staleDim)}>
+            -{totalDeleted}
+          </span>
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -300,24 +343,27 @@ export function CommitDetailView({
                 Cherry-pick commit
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => copyText(commit.hash, "SHA copied")}
-              >
+              <DropdownMenuItem onClick={() => copyText(hash, "SHA copied")}>
                 Copy SHA
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        <JiraRefRow
-          repoPath={repoPath}
-          sources={[
-            { label: "commit subject", text: commit.subject },
-            { label: "commit message body", text: commit.body },
-          ]}
-        />
+        {/* Absent rather than faded while the details are a placeholder: these
+            are CLICKABLE links mined from the message text, and a dimmed one
+            still navigates to the previous commit's issue. */}
+        {!details.isPlaceholderData && (
+          <JiraRefRow
+            repoPath={repoPath}
+            sources={[
+              { label: "commit subject", text: commit.subject },
+              { label: "commit message body", text: commit.body },
+            ]}
+          />
+        )}
       </header>
 
-      <div className="flex min-h-0 flex-1">
+      <div className={cn("flex min-h-0 flex-1", PLACEHOLDER_FADE, staleDim)}>
         <aside className="flex w-72 shrink-0 flex-col border-r">
           <p className="border-b px-3 py-1.5 text-xs text-muted-foreground">
             {files.data.length} changed file{files.data.length === 1 ? "" : "s"}

--- a/src/features/issues/JiraIssueSidebar.tsx
+++ b/src/features/issues/JiraIssueSidebar.tsx
@@ -5,6 +5,7 @@ import type { JiraLink } from "@/lib/jira/store";
 import { formatStoryPoints, type JiraIssueDetails } from "@/lib/jira/types";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 import {
   IssueTypeMeta,
   JiraAssigneePicker,
@@ -39,6 +40,7 @@ export function JiraIssueSidebar({
   canDeleteOwnWorklogs,
   canEditAllWorklogs,
   canDeleteAllWorklogs,
+  className,
 }: {
   repoPath: string;
   issueKey: string;
@@ -54,12 +56,20 @@ export function JiraIssueSidebar({
   canDeleteOwnWorklogs: boolean;
   canEditAllWorklogs: boolean;
   canDeleteAllWorklogs: boolean;
+  /** Merged into the rail's own classes — the caller owns the placeholder fade,
+   *  since it holds the query whose data these rows render. */
+  className?: string;
 }) {
   const setDueDate = useJiraSetDueDate(repoPath, link);
   const selectIssue = useUiStore((s) => s.selectIssue);
 
   return (
-    <aside className="w-64 shrink-0 space-y-4 overflow-y-auto border-l p-4">
+    <aside
+      className={cn(
+        "w-64 shrink-0 space-y-4 overflow-y-auto border-l p-4",
+        className,
+      )}
+    >
       {/* Type + priority. Type is a muted glyph + name; priority is editable
           when permitted, else the muted value (omitted when neither present). */}
       {(issue.issueTypeName ||

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1579,6 +1579,11 @@ export function JiraIssueView({
   const isDone = issue.statusCategory === "done";
   const busy =
     comment.isPending || transition.isPending || transitionTo.isPending;
+  // Rebuild Jira's canonical browse path from the current `issueKey`: `issue.url`
+  // belongs to the LOADED issue, which is the previous one during a placeholder.
+  const browseUrl = link.data
+    ? `https://${link.data.siteHost}/browse/${issueKey}`
+    : issue.url;
 
   function submitComment() {
     const body = composeBody.trim();
@@ -1623,7 +1628,11 @@ export function JiraIssueView({
             {issue.summary}
           </h2>
           <span className="flex-1" />
+          {/* Absent while a placeholder is served: the verb comes from the
+              LOADED issue's status, so a click during that window would fire the
+              wrong transition against the issue you actually selected. */}
           {canTransition &&
+            !details.isPlaceholderData &&
             (isDone ? (
               <Button
                 variant="outline"
@@ -1651,7 +1660,7 @@ export function JiraIssueView({
             variant="outline"
             size="xs"
             className="cursor-pointer"
-            onClick={() => openUrl(issue.url)}
+            onClick={() => openUrl(browseUrl)}
             title="Open this issue in Jira"
           >
             <ArrowSquareOutIcon data-icon="inline-start" />
@@ -1688,7 +1697,12 @@ export function JiraIssueView({
               Root is `relative`-only) so a long issue can't leak a window
               scrollbar. */}
           <ScrollArea className="min-h-0 flex-1 overflow-hidden">
-            <div className="space-y-4 p-4">
+            <div
+              className={cn(
+                "space-y-4 p-4 transition-opacity duration-150 motion-reduce:transition-none",
+                details.isPlaceholderData && "opacity-80",
+              )}
+            >
               <div className="border-b pb-3">
                 {issue.descriptionMd.trim() ? (
                   <Markdown>{issue.descriptionMd}</Markdown>

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -84,7 +84,7 @@ import {
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
-import { cn } from "@/lib/utils";
+import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
 
 /** Platform-correct submit hint (Cmd+Enter on macOS, Ctrl+Enter else) — never a
  *  literal modifier (house platform-mod-key rule). */
@@ -1584,6 +1584,7 @@ export function JiraIssueView({
   const browseUrl = link.data
     ? `https://${link.data.siteHost}/browse/${issueKey}`
     : issue.url;
+  const staleDim = details.isPlaceholderData && "opacity-80";
 
   function submitComment() {
     const body = composeBody.trim();
@@ -1618,12 +1619,21 @@ export function JiraIssueView({
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
       <header className="space-y-2 border-b px-4 py-3">
         <div className="flex items-start gap-2">
-          <h2 className="min-w-0 text-sm font-medium">
+          {/* The key is the PROP (always the issue you selected); the summary is
+              fetched, so it fades rather than disappearing — hiding it would
+              collapse the header's height mid-transition. */}
+          <h2
+            className={cn(
+              "min-w-0 text-sm font-medium",
+              PLACEHOLDER_FADE,
+              staleDim,
+            )}
+          >
             <span className="font-mono font-normal text-muted-foreground">
-              {issue.key}
+              {issueKey}
             </span>{" "}
             {issue.summary}
           </h2>
@@ -1697,12 +1707,7 @@ export function JiraIssueView({
               Root is `relative`-only) so a long issue can't leak a window
               scrollbar. */}
           <ScrollArea className="min-h-0 flex-1 overflow-hidden">
-            <div
-              className={cn(
-                "space-y-4 p-4 transition-opacity duration-150 motion-reduce:transition-none",
-                details.isPlaceholderData && "opacity-80",
-              )}
-            >
+            <div className={cn("space-y-4 p-4", PLACEHOLDER_FADE, staleDim)}>
               <div className="border-b pb-3">
                 {issue.descriptionMd.trim() ? (
                   <Markdown>{issue.descriptionMd}</Markdown>
@@ -1791,6 +1796,7 @@ export function JiraIssueView({
         </div>
 
         <JiraIssueSidebar
+          className={cn(PLACEHOLDER_FADE, staleDim)}
           repoPath={repoPath}
           issueKey={issueKey}
           // `?? null`: render read-only during the link-pending window; the

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1680,7 +1680,13 @@ export function JiraIssueView({
         {/* Status stays in the header as a chip/dropdown next to the title
             (like the PR view's state pill); the rest of the metadata lives in
             the right-hand rail below. */}
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-2 text-xs text-muted-foreground",
+            PLACEHOLDER_FADE,
+            staleDim,
+          )}
+        >
           {canTransition && link.data ? (
             <StatusMenu
               repoPath={repoPath}

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -87,7 +87,8 @@ export function useRepoIdentity(repo: string) {
  * plain keepPreviousData would keep the previous repo's rows on screen (and, for
  * number-keyed maps, briefly-wrong data). Keeps previous data only when the previous
  * query's repo segment matches, so Load-more and Open/Closed switches still skip the
- * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key here).
+ * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key in this
+ * file and in jira/queries.ts).
  * A key that also varies on an identity axis beyond repo (lens, state) needs
  * `keepPreviousDataForKeyAxes` instead (the PR and issue list hooks below do):
  * matching repo alone would serve another axis's data.
@@ -468,14 +469,18 @@ export function useCommitFiles(repo: string, hash: string | null) {
   });
 }
 
+/** `enabled` lets a caller hold the fetch off while its `file` argument is still
+ *  derived from placeholder data — see the call sites for why an eager fetch there
+ *  succeeds with a misleading empty diff. */
 export function useCommitFileDiff(
   repo: string,
   hash: string | null,
   file: string | null,
+  enabled = true,
 ) {
   return useQuery({
     ...commitFileDiffOptions(repo, hash ?? "", file ?? ""),
-    enabled: hash !== null && file !== null,
+    enabled: enabled && hash !== null && file !== null,
     placeholderData: keepPreviousDataForRepo(repo),
   });
 }
@@ -819,11 +824,14 @@ export function useBranchDiffFiles(
   });
 }
 
+/** `enabled`: same caller gate as `useCommitFileDiff` — hold the fetch off while
+ *  `file` still comes from a placeholder file list. */
 export function useBranchFileDiff(
   repo: string,
   base: string | null,
   compare: string | null,
   file: string | null,
+  enabled = true,
 ) {
   return useQuery({
     queryKey: repoKeys.branchFileDiff(
@@ -835,7 +843,11 @@ export function useBranchFileDiff(
     queryFn: () =>
       api.gitBranchFileDiff(repo, base ?? "", compare ?? "", file ?? ""),
     enabled:
-      base !== null && compare !== null && base !== compare && file !== null,
+      enabled &&
+      base !== null &&
+      compare !== null &&
+      base !== compare &&
+      file !== null,
     placeholderData: keepPreviousDataForRepo(repo),
   });
 }
@@ -974,8 +986,8 @@ export function usePrListCi(
 
 /** Hydrates PR-list rows with each PR's mergeability, keyed by number — the rows' conflict
  *  chip. Runs separately from `usePrList`, and its numbers digest in the key is
- *  load-bearing for the same reason as `usePrListCi`'s: it keeps a map built from one
- *  page's rows from caching under another page's key. `prs` never
+ *  load-bearing: the digest pins the key to the row set the map describes, so an
+ *  intermediate result can never cache under the next page's key. `prs` never
  *  reaches the backend (it re-queries the page from the filters): it is here only to
  *  form that digest and to keep the read off an empty page. */
 export function usePrListMergeability(

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -87,8 +87,8 @@ export function useRepoIdentity(repo: string) {
  * plain keepPreviousData would keep the previous repo's rows on screen (and, for
  * number-keyed maps, briefly-wrong data). Keeps previous data only when the previous
  * query's repo segment matches, so Load-more and Open/Closed switches still skip the
- * skeleton. `repoKeyIndex` is where the repo sits in the key (1 for every key in this
- * file and in jira/queries.ts).
+ * skeleton. `repoKeyIndex` is where the repo sits in the key (index 1 for every key
+ * passed to it).
  * A key that also varies on an identity axis beyond repo (lens, state) needs
  * `keepPreviousDataForKeyAxes` instead (the PR and issue list hooks below do):
  * matching repo alone would serve another axis's data.

--- a/src/lib/jira/queries.ts
+++ b/src/lib/jira/queries.ts
@@ -1,10 +1,10 @@
 import {
   keepPreviousData,
-  type QueryKey,
   useMutation,
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { keepPreviousDataForRepo } from "@/lib/git/queries";
 import type { ForgeUserRef } from "@/lib/git/types";
 import {
   jiraAccount,
@@ -49,20 +49,6 @@ import type {
 } from "./types";
 
 const jiraLinkKey = (repo: string) => ["jira-link", repo] as const;
-
-/**
- * `keepPreviousData` scoped to a single repo (the Jira twin of git/queries.ts's, kept local
- * so this module doesn't depend on it). Panels stay mounted across repo switches, so plain
- * keepPreviousData would flash the previous repo's Jira issue — keep previous data only
- * when the previous query was for the SAME repo (repo at query-key index 1).
- */
-function keepPreviousDataForRepo(repo: string, repoKeyIndex = 1) {
-  return <T>(
-    previousData: T | undefined,
-    previousQuery: { queryKey: QueryKey } | undefined,
-  ): T | undefined =>
-    previousQuery?.queryKey?.[repoKeyIndex] === repo ? previousData : undefined;
-}
 
 /** This repo's Jira link (or `null` when unlinked). */
 export function useJiraLink(repo: string) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** Carried UNCONDITIONALLY by any element whose opacity tracks a query's
+ *  placeholder state, so the fade plays both ways; the conditional dim class
+ *  rides alongside it. */
+export const PLACEHOLDER_FADE =
+  "transition-opacity duration-150 motion-reduce:transition-none";


### PR DESCRIPTION
Detail panes keep the previous selection's data on screen while the next one loads (react-query `placeholderData`), with no visual difference from settled content — so a copy action could hand over the previous commit's SHA, a diff could render under another file's header, and a Jira transition could fire against the issue you just navigated away from. This change makes identity-bearing controls read from props instead of placeholder query data, hides interactive elements that would act on the wrong item, and dims the rest so a pane never passes stale content off as current.

### Commit detail (`src/features/history/CommitDetailView.tsx`)

- `copyHash` and the ⋯ menu's *Copy SHA* item now write the `hash` **prop** rather than `commit.hash`, and the header's short SHA renders `hash.slice(0, 7)` — while the next commit's details load, `details.data` is still the previous commit's placeholder.
- Adds a `staleDim` (`opacity-80`) + `PLACEHOLDER_FADE` treatment applied to the subject, body, author avatar/name, relative time, hash button, `+/-` totals and the file-list/diff region whenever `details.isPlaceholderData || files.isPlaceholderData`.
- `JiraRefRow` is omitted outright during a placeholder instead of dimmed, since a faded link still navigates to the previous commit's issue.
- `useCommitFileDiff` is now gated on `!files.isPlaceholderData`, so the diff isn't fetched with a path that belongs to the previous commit's file list (which succeeds with an empty diff and flashes "No changes").

### Branch compare (`src/features/compare/BranchDiffView.tsx`)

- `useBranchFileDiff` gets the same settled-file-list gate, for the same reason: the selected path comes from that list.
- Header file count and `+/-` totals plus the file list/diff region fade via `staleDim` while the file list is placeholder data; the branch names stay solid since they come from props.

### Diff surface (`src/features/diff/DiffSurface.tsx`)

- `DiffContent` renders nothing when `data.filePath !== filePath`, catching a placeholder left over from the previously selected file's query key — backends echo the requested path back verbatim, so a mismatch is unambiguous.

### Jira issue view (`src/features/issues/JiraIssueView.tsx`)

- Adds `browseUrl`, rebuilt from the current `issueKey` and `link.data.siteHost`, and uses it for the *Open in Jira* button in place of `issue.url` (which belongs to the loaded issue).
- The status-transition buttons are hidden while `details.isPlaceholderData`, since their verb derives from the loaded issue's status.
- The scrolling issue body fades with the same opacity transition during a placeholder.

### Query layer

- `useCommitFileDiff` and `useBranchFileDiff` in `src/lib/git/queries.ts` take an optional `enabled` parameter (defaulting to `true`) that is ANDed with their existing null/equality guards, documented as the caller-side gate for placeholder-derived arguments.
- `src/lib/jira/queries.ts` drops its local copy of `keepPreviousDataForRepo` and imports the shared helper from `@/lib/git/queries`, removing the now-unused `QueryKey` import.
- Comment fixes in `src/lib/git/queries.ts`: the `repoKeyIndex` note now covers `jira/queries.ts` as well, and `usePrListMergeability`'s digest rationale is restated in terms of pinning the key to the row set the map describes.

### Changelog

- Adds `changelog.d/fixed-detail-pane-stale-transitions.md` describing the corrected SHA copy, the visible loading state, and the diff/header mismatch. No README, marketing-site or in-app guide updates — the fix corrects existing behavior without changing any documented capability.