### PR TITLE
fix(ai,settings): surface provider reasons in AI connection tests

### DIFF
--- a/changelog.d/changed-gemini-model-suggestions.md
+++ b/changelog.d/changed-gemini-model-suggestions.md
@@ -1,0 +1,4 @@
+- **Google AI Studio suggests models a free key can actually run.** The suggested
+  Gemini list is now Flash-tier only; Pro models reject a free AI Studio key
+  outright, so they were a dead end for most new setups. Paid keys still reach
+  every model through the live catalog.

--- a/changelog.d/changed-gemini-model-suggestions.md
+++ b/changelog.d/changed-gemini-model-suggestions.md
@@ -1,4 +1,4 @@
 - **Google AI Studio suggests models a free key can actually run.** The suggested
-  Gemini list is now Flash-tier only; Pro models reject a free AI Studio key
-  outright, so they were a dead end for most new setups. Paid keys still reach
-  every model through the live catalog.
+  Gemini list is now Flash-tier only — Pro models reject a free AI Studio key
+  outright, so they were a dead end for most new setups. Pro is still one pick
+  away in the live model list.

--- a/changelog.d/fixed-ai-connection-test-feedback.md
+++ b/changelog.d/fixed-ai-connection-test-feedback.md
@@ -1,4 +1,6 @@
-- **AI connection tests explain themselves.** A failed **Test connection** now shows
-  the provider's own reason (e.g. "Invalid Auth key." or a quota message) instead of a
-  bare "Bad Request", and the result clears when you save or remove a key, so a setup
-  you just fixed no longer looks broken.
+- **AI failures explain themselves.** A failed **Test connection**, generation, or AI
+  review now shows the provider's own reason (e.g. "Invalid Auth key.", a quota
+  message, or Ollama's "model not found") instead of a bare "Bad Request", and the
+  connection-test result clears whenever what it tested changes — key saved or
+  removed, provider or model switched, allowed hosts edited — so a setup you just
+  fixed no longer looks broken.

--- a/changelog.d/fixed-ai-connection-test-feedback.md
+++ b/changelog.d/fixed-ai-connection-test-feedback.md
@@ -1,5 +1,4 @@
 - **AI connection tests explain themselves.** A failed **Test connection** now shows
-  the provider's own reason (e.g. "Invalid Auth key.") instead of a bare "Bad
-  Request", the result clears when you save or remove a key so a fixed setup no
-  longer looks broken, and a pasted key with stray whitespace is trimmed before
-  testing — matching what Save stores.
+  the provider's own reason (e.g. "Invalid Auth key." or a quota message) instead of a
+  bare "Bad Request", and the result clears when you save or remove a key, so a setup
+  you just fixed no longer looks broken.

--- a/changelog.d/fixed-ai-connection-test-feedback.md
+++ b/changelog.d/fixed-ai-connection-test-feedback.md
@@ -1,0 +1,5 @@
+- **AI connection tests explain themselves.** A failed **Test connection** now shows
+  the provider's own reason (e.g. "Invalid Auth key.") instead of a bare "Bad
+  Request", the result clears when you save or remove a key so a fixed setup no
+  longer looks broken, and a pasted key with stray whitespace is trimmed before
+  testing — matching what Save stores.

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -666,6 +666,9 @@ export const AiProviderSection = withForm({
         try {
           await setSecret(provider, value.key.trim());
           keyForm.reset({ key: "" });
+          // The old result described the old key; leaving it up makes a fixed
+          // problem look unfixed (only a provider/model change cleared it).
+          setTestResult(null);
           queryClient.invalidateQueries({
             queryKey: settingsKeys.secret(provider),
           });
@@ -699,6 +702,7 @@ export const AiProviderSection = withForm({
           queryKey: settingsKeys.secret(provider),
         });
         setConfirmClear(false);
+        setTestResult(null);
         toast.success("Key removed");
       } catch (e) {
         toastError(e);
@@ -710,10 +714,12 @@ export const AiProviderSection = withForm({
       setTestResult(null);
       try {
         // Use a typed-but-unsaved key and the unsaved allow list, so you can
-        // test a just-added host/key before saving the settings draft.
+        // test a just-added host/key before saving the settings draft. Trimmed to
+        // match what Save stores, so a pasted key with stray whitespace doesn't
+        // fail the test and then work once saved.
         const client = await createAiClient(
           ai,
-          keyForm.getFieldValue("key"),
+          keyForm.getFieldValue("key").trim(),
           allowedHosts,
         );
         const result = await client.testConnection();

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -656,10 +656,19 @@ export const AiProviderSection = withForm({
     const [testResult, setTestResult] = useState<{
       ok: boolean;
       message?: string;
+      /** The draft signature this verdict was produced under (see testConfig). */
+      config: string;
     } | null>(null);
+    /** Signature over every DRAFT input testConnection reads. The verdict renders
+     *  only while the current signature still matches the one it was produced
+     *  under, so any route that changes the draft — including the footer's Discard,
+     *  which form.reset()s while this section stays mounted, and allow-list writes
+     *  from other sections — retires it without needing to know to clear it. A
+     *  key-order difference could only hide a verdict early, never keep a stale one. */
+    const testConfig = JSON.stringify({ ai, allowedHosts });
     /** Generation for the in-flight connection test. Bumping it makes a running
-     *  test discard its own outcome: the key or provider it was testing is gone,
-     *  so its verdict would re-pin a result describing a setup you just changed. */
+     *  test discard its own outcome — used for saved-key changes, which the draft
+     *  signature can't see (keys live in the keychain, not the form). */
     const testRun = useRef(0);
 
     function discardTestResult() {
@@ -691,7 +700,6 @@ export const AiProviderSection = withForm({
     });
 
     function setAi(next: AiSettings) {
-      discardTestResult();
       form.setFieldValue("ai", next);
     }
 
@@ -701,9 +709,6 @@ export const AiProviderSection = withForm({
       const host = normalizeHost(url);
       if (host && !allowedHosts.includes(host)) {
         form.setFieldValue("aiAllowedHosts", [...allowedHosts, host]);
-        // The draft allow list is an input to the test (testConnection hands it to
-        // guardedFetch), so a blocked-host verdict describes a setup this just changed.
-        discardTestResult();
       }
     }
 
@@ -723,6 +728,9 @@ export const AiProviderSection = withForm({
 
     async function testConnection() {
       const run = ++testRun.current;
+      // Captured before the first await: the verdict must carry the signature it
+      // was produced under, not whatever the draft holds when it resolves.
+      const config = testConfig;
       setTesting(true);
       setTestResult(null);
       try {
@@ -736,11 +744,13 @@ export const AiProviderSection = withForm({
         const result = await client.testConnection();
         if (run !== testRun.current) return;
         setTestResult(
-          result.ok ? { ok: true } : { ok: false, message: result.message },
+          result.ok
+            ? { ok: true, config }
+            : { ok: false, message: result.message, config },
         );
       } catch (e) {
         if (run !== testRun.current) return;
-        setTestResult({ ok: false, message: errorMessage(e) });
+        setTestResult({ ok: false, message: errorMessage(e), config });
       } finally {
         // Always released: the button is disabled while testing, so no newer run
         // can own this flag — a superseded run still has to hand it back.
@@ -871,12 +881,12 @@ export const AiProviderSection = withForm({
             {testing && <Spinner data-icon="inline-start" />}
             Test connection
           </Button>
-          {testResult?.ok && (
+          {testResult?.ok && testResult.config === testConfig && (
             <span className="flex items-center gap-1 text-xs text-success">
               <CheckCircleIcon className="size-4" /> Connected
             </span>
           )}
-          {testResult && !testResult.ok && (
+          {testResult && !testResult.ok && testResult.config === testConfig && (
             <span className="flex min-w-0 items-center gap-1 text-xs text-destructive">
               <XCircleIcon className="size-4 shrink-0" />
               <span className="line-clamp-2">{testResult.message}</span>
@@ -1060,10 +1070,7 @@ export const AiProviderSection = withForm({
           <AllowedHostsField
             hosts={allowedHosts}
             activeUrls={activeProviderUrls}
-            onChange={(next) => {
-              form.setFieldValue("aiAllowedHosts", next);
-              discardTestResult();
-            }}
+            onChange={(next) => form.setFieldValue("aiAllowedHosts", next)}
           />
         )}
 

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -657,6 +657,15 @@ export const AiProviderSection = withForm({
       ok: boolean;
       message?: string;
     } | null>(null);
+    /** Generation for the in-flight connection test. Bumping it makes a running
+     *  test discard its own outcome: the key or provider it was testing is gone,
+     *  so its verdict would re-pin a result describing a setup you just changed. */
+    const testRun = useRef(0);
+
+    function discardTestResult() {
+      testRun.current += 1;
+      setTestResult(null);
+    }
 
     // Keys save immediately to the OS keychain (they're not part of the
     // settings draft), so they get their own little form.
@@ -666,9 +675,9 @@ export const AiProviderSection = withForm({
         try {
           await setSecret(provider, value.key.trim());
           keyForm.reset({ key: "" });
-          // The old result described the old key; leaving it up makes a fixed
-          // problem look unfixed (only a provider/model change cleared it).
-          setTestResult(null);
+          // The old result described the old key, so leaving it up makes a fixed
+          // setup look broken.
+          discardTestResult();
           queryClient.invalidateQueries({
             queryKey: settingsKeys.secret(provider),
           });
@@ -682,7 +691,7 @@ export const AiProviderSection = withForm({
     });
 
     function setAi(next: AiSettings) {
-      setTestResult(null);
+      discardTestResult();
       form.setFieldValue("ai", next);
     }
 
@@ -702,7 +711,7 @@ export const AiProviderSection = withForm({
           queryKey: settingsKeys.secret(provider),
         });
         setConfirmClear(false);
-        setTestResult(null);
+        discardTestResult();
         toast.success("Key removed");
       } catch (e) {
         toastError(e);
@@ -710,25 +719,28 @@ export const AiProviderSection = withForm({
     }
 
     async function testConnection() {
+      const run = ++testRun.current;
       setTesting(true);
       setTestResult(null);
       try {
         // Use a typed-but-unsaved key and the unsaved allow list, so you can
-        // test a just-added host/key before saving the settings draft. Trimmed to
-        // match what Save stores, so a pasted key with stray whitespace doesn't
-        // fail the test and then work once saved.
+        // test a just-added host/key before saving the settings draft.
         const client = await createAiClient(
           ai,
-          keyForm.getFieldValue("key").trim(),
+          keyForm.getFieldValue("key"),
           allowedHosts,
         );
         const result = await client.testConnection();
+        if (run !== testRun.current) return;
         setTestResult(
           result.ok ? { ok: true } : { ok: false, message: result.message },
         );
       } catch (e) {
+        if (run !== testRun.current) return;
         setTestResult({ ok: false, message: errorMessage(e) });
       } finally {
+        // Always released: the button is disabled while testing, so no newer run
+        // can own this flag — a superseded run still has to hand it back.
         setTesting(false);
       }
     }

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -701,6 +701,9 @@ export const AiProviderSection = withForm({
       const host = normalizeHost(url);
       if (host && !allowedHosts.includes(host)) {
         form.setFieldValue("aiAllowedHosts", [...allowedHosts, host]);
+        // The draft allow list is an input to the test (testConnection hands it to
+        // guardedFetch), so a blocked-host verdict describes a setup this just changed.
+        discardTestResult();
       }
     }
 
@@ -1057,7 +1060,10 @@ export const AiProviderSection = withForm({
           <AllowedHostsField
             hosts={allowedHosts}
             activeUrls={activeProviderUrls}
-            onChange={(next) => form.setFieldValue("aiAllowedHosts", next)}
+            onChange={(next) => {
+              form.setFieldValue("aiAllowedHosts", next);
+              discardTestResult();
+            }}
           />
         )}
 

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -21,38 +21,47 @@ export class MissingApiKeyError extends Error {
 
 /**
  * The provider's own explanation for a failed call, falling back to the generic
- * message. When a provider's error body doesn't match the SDK's expected schema the
- * SDK sets `APICallError.message` to the bare HTTP reason phrase and leaves the cause
- * unread in `responseBody` — Google's body is array-wrapped, so a rejected key reads
- * as "Bad Request" rather than "Invalid Auth key.". Two unwraps are load-bearing:
- * retries replace the error with a `RetryError` whose body lives on `lastError`, and
- * in-stream error parts arrive as the provider's already-parsed payload rather than
- * an Error (so `String(e)` would render "[object Object]").
+ * message. Three constraints shape it: a body the SDK's error schema can't parse
+ * leaves `APICallError.message` as the bare HTTP reason phrase with the cause unread
+ * in `responseBody` (Google's is array-wrapped, so a rejected key reads "Bad Request"
+ * rather than "Invalid Auth key."); a retry moves that body onto `RetryError.lastError`,
+ * and `isRetryable` covers 429/5xx — the quota case; and an in-stream error part is the
+ * provider's already-parsed payload rather than an Error.
  */
+/** The human-readable reason out of a provider error payload, whether it nests under
+ *  `error` (OpenAI, Google) or sits bare on `message`, wrapped in an array (Google) or
+ *  not. One reader for both call sites below: the parsed response body and the raw
+ *  in-stream payload carry the same shapes, so they must accept the same set. */
+function errorTextOf(value: unknown): string | null {
+  const entry = (Array.isArray(value) ? value[0] : value) as {
+    error?: { message?: unknown };
+    message?: unknown;
+  } | null;
+  const message = entry?.error?.message ?? entry?.message;
+  return typeof message === "string" && message.trim() ? message : null;
+}
+
 function providerErrorMessage(e: unknown): string {
   const unwrapped = ((e as { lastError?: unknown } | null)?.lastError ?? e) as {
     responseBody?: unknown;
-    message?: unknown;
   } | null;
   const body = unwrapped?.responseBody;
   if (typeof body === "string" && body.trim()) {
     try {
-      const parsed: unknown = JSON.parse(body);
-      const entry = Array.isArray(parsed) ? parsed[0] : parsed;
-      const message = (entry as { error?: { message?: unknown } } | null)?.error
-        ?.message;
-      if (typeof message === "string" && message.trim()) return message;
+      const fromBody = errorTextOf(JSON.parse(body));
+      if (fromBody) return fromBody;
     } catch {
       // Not JSON — the generic message is the best we have.
     }
   }
-  if (
-    !(unwrapped instanceof Error) &&
-    typeof unwrapped?.message === "string" &&
-    unwrapped.message.trim()
-  ) {
-    return unwrapped.message;
+  // An Error's own `message` is what the generic fallback already returns; only a raw
+  // payload object needs reading here.
+  if (!(unwrapped instanceof Error)) {
+    const fromPayload = errorTextOf(unwrapped);
+    if (fromPayload) return fromPayload;
   }
+  // Deliberately the wrapper, not `unwrapped`: a retry's message embeds the last
+  // error's text and adds the attempt count, which is worth keeping.
   return errorMessage(e);
 }
 

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -21,15 +21,20 @@ export class MissingApiKeyError extends Error {
 
 /**
  * The provider's own explanation for a failed call, falling back to the generic
- * message. The AI SDK's `APICallError.message` is only the HTTP reason phrase
- * ("Bad Request"), while the cause sits unread in `responseBody` — Google answers
- * a rejected key with 400 + "Invalid Auth key.", so the bare phrase reads like a
- * malformed request instead of an auth problem. Google wraps the payload in an
- * array, OpenAI-compatible servers use a bare object; accept either, and keep the
- * generic message for a non-JSON body.
+ * message. When a provider's error body doesn't match the SDK's expected schema the
+ * SDK sets `APICallError.message` to the bare HTTP reason phrase and leaves the cause
+ * unread in `responseBody` — Google's body is array-wrapped, so a rejected key reads
+ * as "Bad Request" rather than "Invalid Auth key.". Two unwraps are load-bearing:
+ * retries replace the error with a `RetryError` whose body lives on `lastError`, and
+ * in-stream error parts arrive as the provider's already-parsed payload rather than
+ * an Error (so `String(e)` would render "[object Object]").
  */
 function providerErrorMessage(e: unknown): string {
-  const body = (e as { responseBody?: unknown } | null)?.responseBody;
+  const unwrapped = ((e as { lastError?: unknown } | null)?.lastError ?? e) as {
+    responseBody?: unknown;
+    message?: unknown;
+  } | null;
+  const body = unwrapped?.responseBody;
   if (typeof body === "string" && body.trim()) {
     try {
       const parsed: unknown = JSON.parse(body);
@@ -40,6 +45,13 @@ function providerErrorMessage(e: unknown): string {
     } catch {
       // Not JSON — the generic message is the best we have.
     }
+  }
+  if (
+    !(unwrapped instanceof Error) &&
+    typeof unwrapped?.message === "string" &&
+    unwrapped.message.trim()
+  ) {
+    return unwrapped.message;
   }
   return errorMessage(e);
 }
@@ -264,7 +276,7 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
         : {}),
     });
   } catch (e) {
-    throw new Error(annotateToolError(errorMessage(e)));
+    throw new Error(annotateToolError(providerErrorMessage(e)));
   }
 
   let buffer = "";
@@ -327,7 +339,7 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
           break;
         }
         case "error": {
-          throw new Error(annotateToolError(errorMessage(part.error)));
+          throw new Error(annotateToolError(providerErrorMessage(part.error)));
         }
         case "abort": {
           // `type: 'abort'` is real in the installed ai@6 TextStreamPart union; an
@@ -341,7 +353,7 @@ export async function runAgenticStream(opts: AgenticStreamOpts): Promise<void> {
     }
   } catch (e) {
     if (opts.abortSignal.aborted) return; // clean cancellation — not an error
-    throw new Error(annotateToolError(errorMessage(e)));
+    throw new Error(annotateToolError(providerErrorMessage(e)));
   }
 
   // A clean finish that produced no prose (all steps spent on tool calls, or ended on

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -19,6 +19,22 @@ export class MissingApiKeyError extends Error {
   }
 }
 
+/** The human-readable reason out of a provider error payload, whether it nests under
+ *  `error` as an object (OpenAI, Google), sits bare on `message`, or is a plain string
+ *  under `error` (Ollama's native `/api`), array-wrapped (Google) or not. One reader
+ *  for both call sites below: the parsed response body and the raw in-stream payload
+ *  carry the same shapes, so they must accept the same set. */
+function errorTextOf(value: unknown): string | null {
+  const entry = (Array.isArray(value) ? value[0] : value) as {
+    error?: { message?: unknown } | string;
+    message?: unknown;
+  } | null;
+  const nested = entry?.error;
+  const message =
+    typeof nested === "string" ? nested : (nested?.message ?? entry?.message);
+  return typeof message === "string" && message.trim() ? message : null;
+}
+
 /**
  * The provider's own explanation for a failed call, falling back to the generic
  * message. Three constraints shape it: a body the SDK's error schema can't parse
@@ -28,19 +44,6 @@ export class MissingApiKeyError extends Error {
  * and `isRetryable` covers 429/5xx — the quota case; and an in-stream error part is the
  * provider's already-parsed payload rather than an Error.
  */
-/** The human-readable reason out of a provider error payload, whether it nests under
- *  `error` (OpenAI, Google) or sits bare on `message`, wrapped in an array (Google) or
- *  not. One reader for both call sites below: the parsed response body and the raw
- *  in-stream payload carry the same shapes, so they must accept the same set. */
-function errorTextOf(value: unknown): string | null {
-  const entry = (Array.isArray(value) ? value[0] : value) as {
-    error?: { message?: unknown };
-    message?: unknown;
-  } | null;
-  const message = entry?.error?.message ?? entry?.message;
-  return typeof message === "string" && message.trim() ? message : null;
-}
-
 function providerErrorMessage(e: unknown): string {
   const unwrapped = ((e as { lastError?: unknown } | null)?.lastError ?? e) as {
     responseBody?: unknown;

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -20,6 +20,31 @@ export class MissingApiKeyError extends Error {
 }
 
 /**
+ * The provider's own explanation for a failed call, falling back to the generic
+ * message. The AI SDK's `APICallError.message` is only the HTTP reason phrase
+ * ("Bad Request"), while the cause sits unread in `responseBody` — Google answers
+ * a rejected key with 400 + "Invalid Auth key.", so the bare phrase reads like a
+ * malformed request instead of an auth problem. Google wraps the payload in an
+ * array, OpenAI-compatible servers use a bare object; accept either, and keep the
+ * generic message for a non-JSON body.
+ */
+function providerErrorMessage(e: unknown): string {
+  const body = (e as { responseBody?: unknown } | null)?.responseBody;
+  if (typeof body === "string" && body.trim()) {
+    try {
+      const parsed: unknown = JSON.parse(body);
+      const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+      const message = (entry as { error?: { message?: unknown } } | null)?.error
+        ?.message;
+      if (typeof message === "string" && message.trim()) return message;
+    } catch {
+      // Not JSON — the generic message is the best we have.
+    }
+  }
+  return errorMessage(e);
+}
+
+/**
  * Resolves `settings` to a ready model: reads the saved API key (or an unsaved
  * override), throwing {@link MissingApiKeyError} when a key-requiring provider has
  * none, then builds the guarded-fetch model. Shared by {@link createAiClient} and
@@ -100,7 +125,7 @@ export async function createAiClient(
               yield part.text;
               break;
             case "error":
-              throw new Error(errorMessage(part.error));
+              throw new Error(providerErrorMessage(part.error));
             case "abort":
               throw new DOMException(
                 "The generation was cancelled.",
@@ -123,7 +148,7 @@ export async function createAiClient(
         ) {
           throw new DOMException("The generation was cancelled.", "AbortError");
         }
-        throw new Error(errorMessage(e));
+        throw new Error(providerErrorMessage(e));
       }
     },
     async testConnection() {
@@ -139,7 +164,7 @@ export async function createAiClient(
               message: "Model returned an empty response.",
             } as const);
       } catch (e) {
-        return { ok: false, message: errorMessage(e) } as const;
+        return { ok: false, message: providerErrorMessage(e) } as const;
       }
     },
   };

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -26,11 +26,14 @@ export const GOOGLE_AI_STUDIO_KEYS_URL = "https://aistudio.google.com/apikey";
 
 /** Suggested Gemini ids. The head is what `defaultModelForProvider("google")`
  *  stamps on a provider switch, so it must be a currently-served model — Google
- *  retires ids fast (the 1.5 line and 2.0 Flash are already shut down). */
+ *  retires ids fast (the 1.5 line and 2.0 Flash are already shut down). Flash
+ *  tiers only: Pro models answer a free AI Studio key with 429 `limit: 0`, so
+ *  suggesting one hands most new users a model they cannot call. Paid keys reach
+ *  Pro through the live catalog, which lists everything the key can use. */
 const GEMINI_MODELS = [
   "gemini-3.6-flash",
   "gemini-3.5-flash",
-  "gemini-2.5-pro",
+  "gemini-3.5-flash-lite",
 ];
 
 /** Presets for the `openai-compatible` provider — each is an OpenAI-compatible

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -25,11 +25,10 @@ export const GOOGLE_AI_STUDIO_BASE_URL =
 export const GOOGLE_AI_STUDIO_KEYS_URL = "https://aistudio.google.com/apikey";
 
 /** Suggested Gemini ids. The head is what `defaultModelForProvider("google")`
- *  stamps on a provider switch, so it must be a currently-served model — Google
- *  retires ids fast (the 1.5 line and 2.0 Flash are already shut down). Flash
- *  tiers only: Pro models answer a free AI Studio key with 429 `limit: 0`, so
- *  suggesting one hands most new users a model they cannot call. Paid keys reach
- *  Pro through the live catalog, which lists everything the key can use. */
+ *  stamps on a provider switch, so it must be currently served — Google retires
+ *  ids fast (the 1.5 line and 2.0 Flash are shut down). Flash tiers only: Pro
+ *  answers a FREE AI Studio key with 429 `limit: 0`. The live catalog still
+ *  offers Pro — it lists what a key can SEE, not what its tier can CALL. */
 const GEMINI_MODELS = [
   "gemini-3.6-flash",
   "gemini-3.5-flash",


### PR DESCRIPTION
A failed **Test connection** in Settings → AI showed only the HTTP reason phrase ("Bad Request"), which reads like a malformed request even when the real cause was a rejected key. This surfaces the provider's own explanation, clears stale test results when the key changes, and stops suggesting Gemini models a free AI Studio key can't call.

### AI client error reporting

- Adds `providerErrorMessage()` in `src/lib/ai/client.ts`, which parses the unread `responseBody` on the SDK's `APICallError` and returns `error.message` from it — handling Google's array-wrapped payload and the bare object OpenAI-compatible servers return, and falling back to the generic `errorMessage(e)` for a non-JSON body.
- Routes all three failure paths through it: the `"error"` stream part, the streaming catch block, and `testConnection()`'s result message.

### Settings → AI panel

- Clears `testResult` after saving a key and after removing one in `src/features/settings/AiProviderSection.tsx`, so a result describing the old key no longer makes a fixed setup look broken (previously only a provider/model change cleared it).
- Trims the unsaved key before building the client in the test handler, matching what Save stores so a pasted key with stray whitespace doesn't fail the test and then work once saved.

### Gemini model suggestions

- Replaces `gemini-2.5-pro` with `gemini-3.5-flash-lite` in `GEMINI_MODELS` (`src/lib/ai/providers.ts`), making the suggested list Flash-tier only; the doc comment records that Pro answers a free AI Studio key with 429 `limit: 0`, while paid keys still reach Pro through the live catalog.

### Changelog

- Adds `changelog.d/fixed-ai-connection-test-feedback.md` and `changelog.d/changed-gemini-model-suggestions.md` covering the two user-facing changes.