### PR TITLE
feat(settings,sessions,plan,research): add default agent setting

### DIFF
--- a/changelog.d/added-default-agent-setting.md
+++ b/changelog.d/added-default-agent-setting.md
@@ -1,0 +1,4 @@
+- **Default agent.** Settings → AI now decides which CLI a new Session, Plan, or
+  Research run opens on: leave it on **Auto** to follow your AI provider whenever
+  it's an agent CLI, or pin Claude, Codex, GitHub Copilot, or opencode for every
+  new run.

--- a/changelog.d/added-default-agent-setting.md
+++ b/changelog.d/added-default-agent-setting.md
@@ -1,4 +1,4 @@
-- **Default agent.** Settings → AI now decides which CLI a new Session, Plan, or
-  Research run opens on: leave it on **Auto** to follow your AI provider whenever
-  it's an agent CLI, or pin Claude, Codex, GitHub Copilot, or opencode for every
-  new run.
+- **Default agent.** A new choice in Settings → AI decides which CLI a new
+  Session, Plan, or Research run opens on: leave it on **Auto** to follow your AI
+  provider whenever it's an agent CLI, or pin Claude, Codex, GitHub Copilot, or
+  opencode for every new run.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -555,6 +555,11 @@ export const capabilities: Capability[] = [
   {
     group: "AI · agents & sessions",
     ai: true,
+    label: "Default agent — new runs follow your AI provider, or pin one",
+  },
+  {
+    group: "AI · agents & sessions",
+    ai: true,
     label: "Watch the agent work step by step, with an inline diff per edit",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -555,7 +555,7 @@ export const capabilities: Capability[] = [
   {
     group: "AI · agents & sessions",
     ai: true,
-    label: "Default agent — new runs follow your AI provider, or pin one",
+    label: "Default agent — pin one, or follow a CLI-agent AI provider",
   },
   {
     group: "AI · agents & sessions",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1547,22 +1547,25 @@ distills the whole session into a plan-ready brief to hand the planner, falling 
 full session if distillation is unavailable) or **Save report** as a local Markdown
 file (written to \`.gitdesktop/research/\` for you to review and commit — never committed for
 you). It's **read-only**: it searches and reads, but never changes your code. Pick any agent —
-**Claude**, **Codex**, **GitHub Copilot**, or **opencode** — each uses its own native web search
-and fetch. (opencode's web *search* needs its Exa integration enabled — web *fetch* always works.)
+**Claude**, **Codex**, **GitHub Copilot**, or **opencode** (the picker opens on your
+**Settings → AI** default agent) — each uses its own native web search and fetch.
+(opencode's web *search* needs its Exa integration enabled — web *fetch* always works.)
 
 ## Plan a task (read-only)
 
-**Plan a task** runs a read-only agent that explores the current repo and drafts an
-**agent-ready issue** — context, approach, affected files, acceptance criteria, and a
-test plan. It can ask clarifying questions; answer them and it refines the plan in the
-same conversation. The cited file paths are validated against the repo, so the plan stays
-grounded. From a finished plan you can **file it as a GitHub or local issue**, or **hand
-it straight to an implementing session**.
+**Plan a task** runs a read-only agent (the picker opens on your **Settings → AI**
+default agent) that explores the current repo and drafts an **agent-ready issue** —
+context, approach, affected files, acceptance criteria, and a test plan. It can ask
+clarifying questions; answer them and it refines the plan in the same conversation.
+The cited file paths are validated against the repo, so the plan stays grounded. From
+a finished plan you can **file it as a GitHub or local issue**, or **hand it straight
+to an implementing session**.
 
 ## Delegate a task
 
-**Delegate** starts a write-capable session. Describe the task, pick the **agent**,
-**model**, and **reasoning effort** (Low / Medium / High / Max), and send. The agent works
+**Delegate** starts a write-capable session. Describe the task, pick the
+**agent** (it opens on your **Settings → AI** default agent), **model**, and
+**reasoning effort** (Low / Medium / High / Max), and send. The agent works
 in an **isolated git worktree** — a throwaway branch (\`gd/session/…\`) that never touches
 your working tree — and commits a **checkpoint** each turn. It works in the open: the
 conversation shows a **step-by-step transcript** of each file it reads, edits, searches,
@@ -1798,6 +1801,13 @@ Left off, security audits use the review model. The choice applies to both autom
 and the **Security audit** button on a PR; picking a model in the PR panel still overrides
 both for that one run.
 
+**Default agent.** Under **Agent sessions**, *Default agent* decides which CLI a new
+**Session**, **Plan**, or **Research** run opens on. On **Auto** those runs follow the AI
+provider above whenever it's an agent CLI (and start on Claude when it isn't) — so
+choosing Codex as your provider starts your agent runs on Codex too. Pick an agent
+explicitly to pin it whatever the provider is. Either way it's only the starting point:
+the composer's agent picker still chooses per run.
+
 **Custom & LAN servers — allowed hosts.** To reach an Ollama or OpenAI-compatible server
 that isn't \`localhost\` (a box on your network, or a self-hosted endpoint), enter its URL in
 Settings → AI and add its host to the **Allowed hosts** list — or click **Allow host** on the
@@ -1995,8 +2005,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 - **Appearance** — pick a theme: **System** (follows your OS's light/dark setting),
   **Light**, **Dark**, or **Slate** (a softer, blue-gray dark). Applies as you pick it,
   and *Cycle theme* in the command palette steps through them.
-{{ai}}- **AI** — providers, models, keys, instructions, agent-session isolation
-  (worktree / container), and the container image.
+{{ai}}- **AI** — providers, models, keys, instructions, and agent-session defaults: the
+  default agent, isolation (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.
 - **MCP servers** — register Model Context Protocol servers (secrets in your OS keychain)
   that agent sessions can opt into.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1563,14 +1563,14 @@ to an implementing session**.
 
 ## Delegate a task
 
-**Delegate** starts a write-capable session. Describe the task, pick the
-**agent** (it opens on your **Settings → AI** default agent), **model**, and
-**reasoning effort** (Low / Medium / High / Max), and send. The agent works
-in an **isolated git worktree** — a throwaway branch (\`gd/session/…\`) that never touches
-your working tree — and commits a **checkpoint** each turn. It works in the open: the
-conversation shows a **step-by-step transcript** of each file it reads, edits, searches,
-and command it runs, interleaved with its narration. **Expand any edit step** to see that
-file's diff inline, watch its **live changes** mid-turn, or read the cumulative diff under
+**Delegate** starts a write-capable session. Describe the task, pick the **agent** (it
+opens on your **Settings → AI** default agent), **model**, and **reasoning effort**
+(Low / Medium / High / Max), and send. The agent works in an **isolated git worktree**
+— a throwaway branch (\`gd/session/…\`) that never touches your working tree — and
+commits a **checkpoint** each turn. It works in the open: the conversation shows a
+**step-by-step transcript** of each file it reads, edits, searches, and command it
+runs, interleaved with its narration. **Expand any edit step** to see that file's diff
+inline, watch its **live changes** mid-turn, or read the cumulative diff under
 **Changes**.
 
 In the composer you can:

--- a/src/features/plan/PlanView.tsx
+++ b/src/features/plan/PlanView.tsx
@@ -119,10 +119,12 @@ export function PlanComposer({
   // An explicit pick; null = follow the Settings default. Derived during render
   // — no effect — so settings arriving late can't clobber a pick.
   const [agentPick, setAgentPick] = useState<AgentKind | null>(null);
-  const agent: AgentKind =
-    agentPick ?? (settings.data ? defaultAgentKind(settings.data) : "claude");
+  const agent: AgentKind = agentPick ?? defaultAgentKind(settings.data);
   const [model, setModel] = useState("");
   const [effort, setEffort] = useState("");
+  // A model picked for one agent isn't in another's list; "" = the account
+  // default. Derived, so a default-agent change drops a model it can't run.
+  const modelForAgent = MODELS[agent].includes(model) ? model : "";
 
   const planningIssue = Boolean(seed?.issueTitle || seed?.issueBody);
   const canPlan = goal.trim().length > 0 || planningIssue;
@@ -137,7 +139,7 @@ export function PlanComposer({
       originResearchId: seed?.originResearchId,
       contextPack: seed?.contextPack,
       agent,
-      model,
+      model: modelForAgent,
       effort,
     });
   };
@@ -196,7 +198,7 @@ export function PlanComposer({
               }}
             />
             <ModelPicker
-              value={model}
+              value={modelForAgent}
               onChange={setModel}
               models={MODELS[agent]}
             />

--- a/src/features/plan/PlanView.tsx
+++ b/src/features/plan/PlanView.tsx
@@ -17,12 +17,13 @@ import {
 import { AgentTranscript } from "@/features/sessions/AgentTranscript";
 import { selectSession } from "@/features/sessions/agentSelect";
 import { useSessionsStore } from "@/features/sessions/store";
-import type { AgentKind } from "@/lib/ai/agent";
+import { type AgentKind, defaultAgentKind } from "@/lib/ai/agent";
 import { formatUsd } from "@/lib/ai/cost";
 import { extractPlanQuestions } from "@/lib/ai/prompt";
 import { MODEL_SUGGESTIONS } from "@/lib/ai/providers";
 import { forgeFeatureReady, useForgeStatus } from "@/lib/git/queries";
 import { formatBinding } from "@/lib/hotkeys/binding";
+import { useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { CreateLocalIssueDialog } from "../issues/CreateLocalIssueDialog";
 import { ImplementPlanButton } from "./ImplementPlanButton";
@@ -113,8 +114,13 @@ export function PlanComposer({
   seed: PlanSeed | null;
 }) {
   const start = usePlanStore((s) => s.start);
+  const settings = useSettings();
   const [goal, setGoal] = useState(seed?.goal ?? "");
-  const [agent, setAgent] = useState<AgentKind>("claude");
+  // An explicit pick; null = follow the Settings default. Derived during render
+  // — no effect — so settings arriving late can't clobber a pick.
+  const [agentPick, setAgentPick] = useState<AgentKind | null>(null);
+  const agent: AgentKind =
+    agentPick ?? (settings.data ? defaultAgentKind(settings.data) : "claude");
   const [model, setModel] = useState("");
   const [effort, setEffort] = useState("");
 
@@ -185,7 +191,7 @@ export function PlanComposer({
             <AgentPicker
               value={agent}
               onChange={(a) => {
-                setAgent(a);
+                setAgentPick(a);
                 setModel("");
               }}
             />

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -219,17 +219,19 @@ export function ResearchComposer({
   // An explicit pick; null = follow the Settings default. Derived during render
   // — no effect — so settings arriving late can't clobber a pick.
   const [agentPick, setAgentPick] = useState<AgentKind | null>(null);
-  const agent: AgentKind =
-    agentPick ?? (settings.data ? defaultAgentKind(settings.data) : "claude");
+  const agent: AgentKind = agentPick ?? defaultAgentKind(settings.data);
   const [model, setModel] = useState("");
   const [effort, setEffort] = useState("");
+  // A model picked for one agent isn't in another's list; "" = the account
+  // default. Derived, so a default-agent change drops a model it can't run.
+  const modelForAgent = modelsForAgent(agent).includes(model) ? model : "";
 
   const canRun = topic.trim().length > 0;
   const copy = INTENT_COPY[depth];
 
   const submit = () => {
     if (!canRun) return;
-    start({ repoPath, agent, model, effort, topic, depth });
+    start({ repoPath, agent, model: modelForAgent, effort, topic, depth });
   };
 
   return (
@@ -277,7 +279,7 @@ export function ResearchComposer({
               }}
             />
             <ModelPicker
-              value={model}
+              value={modelForAgent}
               onChange={setModel}
               models={modelsForAgent(agent)}
             />

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -31,10 +31,11 @@ import {
   captureAgentSelection,
   clearAgentSelection,
 } from "@/features/sessions/agentSelect";
-import type { AgentKind } from "@/lib/ai/agent";
+import { type AgentKind, defaultAgentKind } from "@/lib/ai/agent";
 import { formatUsd } from "@/lib/ai/cost";
 import { copyText } from "@/lib/clipboard";
 import { formatBinding } from "@/lib/hotkeys/binding";
+import { useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 import {
   assembleSessionReport,
@@ -210,11 +211,16 @@ export function ResearchComposer({
   seed: ResearchSeed | null;
 }) {
   const start = useResearchStore((s) => s.start);
+  const settings = useSettings();
   const [topic, setTopic] = useState(seed?.topic ?? "");
   const [depth, setDepth] = useState<ResearchDepth>(
     seed?.depth ?? "brainstorm",
   );
-  const [agent, setAgent] = useState<AgentKind>("claude");
+  // An explicit pick; null = follow the Settings default. Derived during render
+  // — no effect — so settings arriving late can't clobber a pick.
+  const [agentPick, setAgentPick] = useState<AgentKind | null>(null);
+  const agent: AgentKind =
+    agentPick ?? (settings.data ? defaultAgentKind(settings.data) : "claude");
   const [model, setModel] = useState("");
   const [effort, setEffort] = useState("");
 
@@ -266,7 +272,7 @@ export function ResearchComposer({
             <AgentPicker
               value={agent}
               onChange={(a) => {
-                setAgent(a);
+                setAgentPick(a);
                 setModel(""); // model lists differ between agents
               }}
             />

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import type { AgentKind } from "@/lib/ai/agent";
+import { type AgentKind, defaultAgentKind } from "@/lib/ai/agent";
 import { estimateRunCost } from "@/lib/ai/cost";
 import type { ContainerStatus } from "@/lib/ai/sandbox";
 import { useContainerStatus } from "@/lib/ai/sandbox-queries";
@@ -195,12 +195,18 @@ export function SessionComposer({
   const pendingTask = useSessionsStore((s) => s.pendingTask);
   const setPendingTask = useSessionsStore((s) => s.setPendingTask);
   const sessions = useSessionsStore((s) => s.sessions);
+  // The start-agent default derives from settings, so this must resolve first.
+  const settings = useSettings();
   const [draft, setDraft] = useState("");
   const [startModel, setStartModel] = useState("");
   const [startEffort, setStartEffort] = useState("");
-  const [startAgent, setStartAgent] = useState<
-    "claude" | "codex" | "copilot" | "opencode"
-  >("claude");
+  // An explicit pick for a NEW session; null = follow the Settings default.
+  // Derived during render — no effect — so settings arriving late can't clobber
+  // a pick, and a later Settings change moves the unpicked default.
+  const [startAgentPick, setStartAgentPick] = useState<AgentKind | null>(null);
+  const startAgent: AgentKind =
+    startAgentPick ??
+    (settings.data ? defaultAgentKind(settings.data) : "claude");
   // MCP servers opted into for a NEW session. null = "use the default" (every
   // enabled registry server); a concrete array once the user picks. Frozen at
   // turn 1, so it only matters before a session exists.
@@ -305,7 +311,7 @@ export function SessionComposer({
     // onChange, so restoring an agent doesn't wipe the model restored with it.
     if (pendingTask.isolation !== undefined)
       setStartIsolation(pendingTask.isolation);
-    if (pendingTask.agent !== undefined) setStartAgent(pendingTask.agent);
+    if (pendingTask.agent !== undefined) setStartAgentPick(pendingTask.agent);
     if (pendingTask.model !== undefined) setStartModel(pendingTask.model);
     if (pendingTask.effort !== undefined) setStartEffort(pendingTask.effort);
     if (pendingTask.mode !== undefined) setMode(pendingTask.mode);
@@ -364,7 +370,6 @@ export function SessionComposer({
   // draft is a slash invocation, keyed on the repo ROOT (not the worktree) so it
   // stays cached across the session's worktree transition, and on the agent
   // (each CLI reads different dirs).
-  const settings = useSettings();
   const customCommands = settings.data?.customCommands;
   // Scope/override lookup keys for this repo (identity + raw path), so a
   // repo-scoped server or per-repo override set from a sibling worktree is
@@ -936,7 +941,7 @@ export function SessionComposer({
                 <AgentPicker
                   value={startAgent}
                   onChange={(a) => {
-                    setStartAgent(a);
+                    setStartAgentPick(a);
                     setStartModel(""); // model lists differ between agents
                     setStartMcp(null); // re-derive the new agent's default servers
                   }}

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -205,8 +205,13 @@ export function SessionComposer({
   // a pick, and a later Settings change moves the unpicked default.
   const [startAgentPick, setStartAgentPick] = useState<AgentKind | null>(null);
   const startAgent: AgentKind =
-    startAgentPick ??
-    (settings.data ? defaultAgentKind(settings.data) : "claude");
+    startAgentPick ?? defaultAgentKind(settings.data);
+  // A model picked for one agent isn't in another's list; "" = the account default.
+  // Derived, so every path that can move the agent — the picker, a stash restore,
+  // settings landing — drops a model the new agent can't run.
+  const startModelForAgent = modelsForAgent(startAgent).includes(startModel)
+    ? startModel
+    : "";
   // MCP servers opted into for a NEW session. null = "use the default" (every
   // enabled registry server); a concrete array once the user picks. Frozen at
   // turn 1, so it only matters before a session exists.
@@ -245,7 +250,7 @@ export function SessionComposer({
   const stashedRef = useRef<PendingTask | null>(null);
 
   const running = session?.running ?? false;
-  const model = session ? session.model : startModel;
+  const model = session ? session.model : startModelForAgent;
   // Agent is fixed once a session exists; while starting, it's user-selectable.
   const agent = session ? session.agent : startAgent;
   const models = modelsForAgent(agent);
@@ -564,7 +569,7 @@ export function SessionComposer({
       start(
         repoPath,
         text,
-        startModel,
+        startModelForAgent,
         startAgent,
         startEffort,
         undefined,
@@ -1033,7 +1038,11 @@ export function SessionComposer({
       <EnsembleRunDialog
         open={ensembleOpen}
         onOpenChange={setEnsembleOpen}
-        seed={{ agent: startAgent, model: startModel, effort: startEffort }}
+        seed={{
+          agent: startAgent,
+          model: startModelForAgent,
+          effort: startEffort,
+        }}
         estimate={costEstimate}
         onRun={runEnsemble}
       />

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -468,8 +468,11 @@ export function SessionComposer({
       repoPath,
       prompt: draft,
       // null = no explicit pick, so there's nothing to restore — collapse to absent.
+      // For agent that's load-bearing: the jump lands on the panel hosting Default
+      // agent, so an unpicked composer must follow a value changed there, not pin
+      // the stale derived one.
       isolation: startIsolation ?? undefined,
-      agent: startAgent,
+      agent: startAgentPick ?? undefined,
       model: startModel,
       effort: startEffort,
       mode,

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { detectAgentCli, providerKind } from "@/lib/ai/agent";
+import { type AgentKind, detectAgentCli, providerKind } from "@/lib/ai/agent";
 import {
   entryMatchesUrl,
   isHostAllowed,
@@ -299,6 +299,16 @@ const REVIEW_TIMEOUT_ITEMS: Record<ReviewTimeout, string> = {
   "30": "30 minutes",
   "45": "45 minutes",
   "60": "60 minutes",
+};
+
+/** Default-agent labels — same `items` contract as the maps above. "auto" is the
+ *  UI stand-in for an absent `defaultAgent` (follow the AI provider). */
+const DEFAULT_AGENT_ITEMS: Record<"auto" | AgentKind, string> = {
+  auto: "Auto — follow the AI provider",
+  claude: "Claude",
+  codex: "Codex",
+  copilot: "GitHub Copilot",
+  opencode: "opencode",
 };
 
 /** Ollama base-URL field — the URL the local/LAN Ollama server is reached at. */
@@ -607,6 +617,8 @@ export const AiProviderSection = withForm({
       form.store,
       (s) => s.values.reviewTimeout ?? "auto",
     );
+    // `undefined` = Auto (no explicit default; new runs follow `ai.provider`).
+    const defaultAgent = useSelector(form.store, (s) => s.values.defaultAgent);
     const agentIsolation = useSelector(
       form.store,
       (s) => s.values.agentIsolation,
@@ -1028,22 +1040,61 @@ export const AiProviderSection = withForm({
 
         <div className="space-y-3 border-t pt-4">
           <div>
-            <h3 className="text-sm font-medium">Agent session isolation</h3>
+            <h3 className="text-sm font-medium">Agent sessions</h3>
             <p className="text-xs text-muted-foreground">
-              How the write-capable agent runs your delegated tasks.
+              Defaults for delegated agent runs — Session, Plan, and Research.
             </p>
           </div>
-          <AgentSandboxField
-            value={agentIsolation}
-            onChange={(v) => form.setFieldValue("agentIsolation", v)}
-            nodeVersion={agentImageNodeVersion}
-            onNodeVersion={(v) =>
-              form.setFieldValue("agentImageNodeVersion", v)
-            }
-            providers={agentImageProviders}
-            onProviders={(v) => form.setFieldValue("agentImageProviders", v)}
-            repoPath={repoPath}
-          />
+          <div className="space-y-2">
+            <Label htmlFor="default-agent">Default agent</Label>
+            <Select
+              items={DEFAULT_AGENT_ITEMS}
+              value={defaultAgent ?? "auto"}
+              onValueChange={(v) => {
+                if (!v) return;
+                // Clear to undefined (not an "auto" sentinel) so the field is
+                // truly absent and the resolver falls through to the provider.
+                form.setFieldValue(
+                  "defaultAgent",
+                  v === "auto" ? undefined : (v as AgentKind),
+                );
+              }}
+            >
+              <SelectTrigger id="default-agent" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(
+                  Object.keys(DEFAULT_AGENT_ITEMS) as ("auto" | AgentKind)[]
+                ).map((id) => (
+                  <SelectItem key={id} value={id}>
+                    {DEFAULT_AGENT_ITEMS[id]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {defaultAgent
+                ? `New Session, Plan, and Research runs start on ${DEFAULT_AGENT_ITEMS[defaultAgent]}.`
+                : `New Session, Plan, and Research runs follow the AI provider above when it's an agent CLI — right now they start on ${DEFAULT_AGENT_ITEMS[providerKind(ai.provider) ?? "claude"]}.`}
+            </p>
+          </div>
+          <div className="space-y-2">
+            {/* Sized below the section h3 so the sandbox controls read as its
+                subordinate group, not a second section. */}
+            <h4 className="text-xs font-medium">Isolation</h4>
+            <AgentSandboxField
+              value={agentIsolation}
+              onChange={(v) => form.setFieldValue("agentIsolation", v)}
+              nodeVersion={agentImageNodeVersion}
+              onNodeVersion={(v) =>
+                form.setFieldValue("agentImageNodeVersion", v)
+              }
+              providers={agentImageProviders}
+              onProviders={(v) => form.setFieldValue("agentImageProviders", v)}
+              repoPath={repoPath}
+            />
+          </div>
         </div>
 
         <Dialog open={confirmClear} onOpenChange={setConfirmClear}>

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -1042,7 +1042,8 @@ export const AiProviderSection = withForm({
           <div>
             <h3 className="text-sm font-medium">Agent sessions</h3>
             <p className="text-xs text-muted-foreground">
-              Defaults for delegated agent runs — Session, Plan, and Research.
+              How new agent runs start — the agent that runs them, and how
+              sessions are isolated.
             </p>
           </div>
           <div className="space-y-2">

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -1,5 +1,5 @@
 import { Channel } from "@tauri-apps/api/core";
-import type { McpServer } from "@/lib/settings/api";
+import type { AppSettings, McpServer } from "@/lib/settings/api";
 import { invoke } from "@/lib/tauri/invoke";
 import type { AiProviderId } from "./types";
 
@@ -145,11 +145,11 @@ export function providerKind(provider: AiProviderId): AgentKind | null {
 
 /** The agent a NEW session, plan, or research run starts on: the explicit
  *  Settings → AI default when set, else the main AI provider when it's an
- *  agent CLI, else Claude. */
-export function defaultAgentKind(settings: {
-  defaultAgent?: AgentKind;
-  ai: { provider: AiProviderId };
-}): AgentKind {
+ *  agent CLI, else Claude — including while settings are still loading. */
+export function defaultAgentKind(
+  settings?: Pick<AppSettings, "defaultAgent" | "ai">,
+): AgentKind {
+  if (!settings) return "claude";
   return (
     settings.defaultAgent ?? providerKind(settings.ai.provider) ?? "claude"
   );

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -143,6 +143,18 @@ export function providerKind(provider: AiProviderId): AgentKind | null {
   return null;
 }
 
+/** The agent a NEW session, plan, or research run starts on: the explicit
+ *  Settings → AI default when set, else the main AI provider when it's an
+ *  agent CLI, else Claude. */
+export function defaultAgentKind(settings: {
+  defaultAgent?: AgentKind;
+  ai: { provider: AiProviderId };
+}): AgentKind {
+  return (
+    settings.defaultAgent ?? providerKind(settings.ai.provider) ?? "claude"
+  );
+}
+
 /** Resolves the CLI binary and reports version + login status for Settings. */
 export const detectAgentCli = (kind: AgentKind, path?: string) =>
   invoke<AgentInfo>("agent_detect", {

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -188,9 +188,9 @@ export interface AppSettings {
   closeToTray: boolean;
   /** Which agent CLI a new Session, Plan, or Research run starts on. Not in
    *  DEFAULT_SETTINGS — its absence is the meaningful "Auto" state: follow the
-   *  main AI provider when that's an agent CLI, else Claude. Inline union rather
-   *  than the `AgentKind` import, which would cycle (lib/ai/agent.ts imports
-   *  `McpServer` from here). */
+   *  main AI provider when that's an agent CLI, else Claude. Inline union (the
+   *  sessions store does the same) to avoid a settings↔ai import cycle, even a
+   *  type-only one. */
   defaultAgent?: "claude" | "codex" | "copilot" | "opencode";
   /** How write-capable agent sessions are isolated. "worktree" = the throwaway
    *  git worktree only (host, full-auto); "container" = also run inside an

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -186,6 +186,12 @@ export interface AppSettings {
   /** Hide the app to the system tray on window close (so background work keeps
    *  running) instead of quitting. */
   closeToTray: boolean;
+  /** Which agent CLI a new Session, Plan, or Research run starts on. Not in
+   *  DEFAULT_SETTINGS — its absence is the meaningful "Auto" state: follow the
+   *  main AI provider when that's an agent CLI, else Claude. Inline union rather
+   *  than the `AgentKind` import, which would cycle (lib/ai/agent.ts imports
+   *  `McpServer` from here). */
+  defaultAgent?: "claude" | "codex" | "copilot" | "opencode";
   /** How write-capable agent sessions are isolated. "worktree" = the throwaway
    *  git worktree only (host, full-auto); "container" = also run inside an
    *  ephemeral Docker/Podman container for kernel-enforced filesystem


### PR DESCRIPTION
Adds a **Default agent** preference to Settings → AI so new agent runs no longer always start on Claude. Users who work primarily in Codex, Copilot, or opencode can now have every new Session, Plan, or Research run open on their agent of choice — either implicitly by following the configured AI provider, or by pinning one explicitly.

### Settings

- Adds an optional `defaultAgent` field to `AppSettings` in `src/lib/settings/api.ts`. It's deliberately kept out of `DEFAULT_SETTINGS` — its absence *is* the "Auto" state — and typed as an inline union rather than importing `AgentKind` to avoid an import cycle with `lib/ai/agent.ts`.
- Adds the **Default agent** select to `src/features/settings/AiProviderSection.tsx`, backed by a new `DEFAULT_AGENT_ITEMS` map (Auto, Claude, Codex, GitHub Copilot, opencode). Choosing *Auto* writes `undefined` rather than a sentinel, so the resolver falls through to the provider.
- Explanatory helper text under the select resolves the current outcome for the user: on Auto it names the agent the provider currently implies via `providerKind(ai.provider)`.
- Restructures the surrounding block: the section heading changes from *Agent session isolation* to **Agent sessions**, and `AgentSandboxField` moves under a subordinate **Isolation** `h4` so the two defaults read as one group.

### Agent resolution

- Adds `defaultAgentKind()` to `src/lib/ai/agent.ts` — the single resolution point: explicit `defaultAgent`, else the main AI provider when it's an agent CLI, else Claude.

### Composers

- `SessionComposer.tsx`, `PlanView.tsx` (`PlanComposer`), and `ResearchView.tsx` (`ResearchComposer`) each replace their hardcoded `useState<AgentKind>("claude")` with a nullable `*Pick` state, where `null` means "follow the Settings default". The effective agent is derived during render — no effect — so late-arriving settings can't clobber an explicit pick, and a later Settings change moves the unpicked default.
- In `SessionComposer.tsx`, the restore path for `pendingTask.agent` now writes through `setStartAgentPick`, and the `useSettings()` call moves above the derived default so it resolves first.

### Documentation

- Updates `src/features/help/content.ts`: the Research, Plan, and Delegate sections now note that the agent picker opens on the Settings → AI default; a new **Default agent** paragraph is added under the AI settings section; and the Settings overview bullet is reworded from "agent-session isolation" to "agent-session defaults".
- Adds the capability line to `site/src/data/capabilities.ts` under *AI · agents & sessions* (`ai: true`, not highlighted). No new `FeatureRow` in `site/src/pages/index.astro` — this extends an existing agent-sessions story rather than warranting its own section.
- Adds the changelog fragment `changelog.d/added-default-agent-setting.md`.

Closes #184