### PR TITLE
feat(site,changelog): add an on-site changelog page

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -15,6 +15,8 @@ on:
   pull_request:
     paths:
       - "site/**"
+      # /changelog/ renders it at build time, so a changelog edit is a site change.
+      - "CHANGELOG.md"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "biome.json"

--- a/site/src/layouts/SiteLayout.astro
+++ b/site/src/layouts/SiteLayout.astro
@@ -279,7 +279,7 @@ const toggleScript = `
           <a href={`${base}features/`} class="transition-colors hover:text-ink">Features</a>
           <a href={`${base}blog/`} class="transition-colors hover:text-ink">Blog</a>
           <a href={repo} class="transition-colors hover:text-ink">GitHub</a>
-          <a href={`${repo}/releases`} class="transition-colors hover:text-ink">Releases</a>
+          <a href={`${base}changelog/`} class="transition-colors hover:text-ink">Changelog</a>
           <a href={`${base}privacy/`} class="transition-colors hover:text-ink">Privacy</a>
           <a href={`${base}terms/`} class="transition-colors hover:text-ink">Terms</a>
         </div>

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -1,0 +1,154 @@
+// ?raw so Vite inlines the file at transform time: a node:fs read would
+// resolve import.meta.url against the bundled prerender chunk, not this file.
+import raw from "../../../CHANGELOG.md?raw";
+
+// Build-time parse of the repo-root CHANGELOG.md into per-release sections.
+// The grammar is the project's own fragment contract (changelog.d/README.md):
+// `## [x.y.z] - date` sections, `### Added|Changed|Fixed` groups, `- ` bullets
+// wrapped with 2-space continuations, inline bold/italic/code/links only.
+// Parsing is fail-open — an unrecognized line renders as plain prose instead of
+// throwing, because a throw here would take down the production Pages build on
+// a release-day push that never runs the PR site gate.
+
+export interface ReleaseCategory {
+  name: string;
+  /** Rendered HTML, one entry per bullet. */
+  bullets: string[];
+}
+
+export interface Release {
+  version: string;
+  /** ISO date from the section heading (yyyy-mm-dd). */
+  date: string;
+  /** GitHub compare view from the Keep a Changelog link refs, when it is one. */
+  compareUrl?: string;
+  releaseUrl: string;
+  /** Rendered HTML paragraphs of pre-category prose (0.1.0's preface). */
+  intro: string[];
+  categories: ReleaseCategory[];
+}
+
+const REPO = "https://github.com/theBGuy/GitDesktop";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderText(seg: string): string {
+  let html = escapeHtml(seg);
+  html = html.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+    '<a href="$2">$1</a>',
+  );
+  html = html.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+  return html;
+}
+
+function renderSpans(seg: string): string {
+  return seg
+    .split(/(`[^`]+`)/)
+    .map((s) =>
+      s.startsWith("`") && s.endsWith("`") && s.length > 2
+        ? `<code>${escapeHtml(s.slice(1, -1))}</code>`
+        : renderText(s),
+    )
+    .join("");
+}
+
+// Bold first, then code inside it: bullets like "**`gh` required.**" nest a
+// code span within the bold pair, so splitting on code first would break the
+// pair apart. The file has no literal `**` inside code spans to confuse this.
+function renderInline(md: string): string {
+  return md
+    .split(/(\*\*.+?\*\*)/)
+    .map((s) =>
+      s.startsWith("**") && s.endsWith("**") && s.length > 4
+        ? `<strong>${renderSpans(s.slice(2, -2))}</strong>`
+        : renderSpans(s),
+    )
+    .join("");
+}
+
+export function getChangelog(): Release[] {
+  const lines = raw.split(/\r?\n/);
+
+  const refs = new Map<string, string>();
+  for (const line of lines) {
+    const m = line.match(/^\[([^\]]+)\]:\s+(\S+)\s*$/);
+    if (m) refs.set(m[1], m[2]);
+  }
+
+  const releases: Release[] = [];
+  let release: Release | null = null;
+  let category: ReleaseCategory | null = null;
+  let bullet: string | null = null;
+  let para: string | null = null;
+
+  const flush = () => {
+    if (bullet !== null && category)
+      category.bullets.push(renderInline(bullet));
+    if (para !== null && release) release.intro.push(renderInline(para));
+    bullet = null;
+    para = null;
+  };
+
+  for (const line of lines) {
+    const h2 = line.match(/^## \[([^\]]+)\](?: - (\d{4}-\d{2}-\d{2}))?/);
+    if (h2) {
+      flush();
+      category = null;
+      // Unreleased is empty on master between releases (fragments assemble
+      // into it only at release time) and unshipped either way — skip it.
+      if (!h2[2]) {
+        release = null;
+        continue;
+      }
+      const ref = refs.get(h2[1]);
+      release = {
+        version: h2[1],
+        date: h2[2],
+        compareUrl: ref?.includes("/compare/") ? ref : undefined,
+        releaseUrl: `${REPO}/releases/tag/v${h2[1]}`,
+        intro: [],
+        categories: [],
+      };
+      releases.push(release);
+      continue;
+    }
+    if (!release) continue;
+
+    const h3 = line.match(/^### (.+)$/);
+    if (h3) {
+      flush();
+      category = { name: h3[1].trim(), bullets: [] };
+      release.categories.push(category);
+      continue;
+    }
+    if (/^\[[^\]]+\]:/.test(line)) continue;
+    if (line.startsWith("- ")) {
+      flush();
+      if (!category) {
+        category = { name: "", bullets: [] };
+        release.categories.push(category);
+      }
+      bullet = line.slice(2);
+      continue;
+    }
+    if (line.trim() === "") {
+      flush();
+      continue;
+    }
+    if (/^\s/.test(line) && bullet !== null) {
+      bullet += ` ${line.trim()}`;
+      continue;
+    }
+    para = para === null ? line.trim() : `${para} ${line.trim()}`;
+  }
+  flush();
+
+  return releases;
+}

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -2,15 +2,14 @@
 // resolve import.meta.url against the bundled prerender chunk, not this file.
 import raw from "../../../CHANGELOG.md?raw";
 
-// Build-time parse of the repo-root CHANGELOG.md into per-release sections.
-// The grammar is the project's own fragment contract (changelog.d/README.md):
-// `## [x.y.z] - date` sections, `### Added|Changed|Fixed` groups, `- ` bullets
-// wrapped with 2-space continuations, inline bold/italic/code and http(s)
-// links; any other [label](target) collapses to its bare label (the historical
-// relative links point into the gitignored docs/ tree, dead on every surface).
-// Parsing is fail-open — an unrecognized line renders as plain prose instead of
-// throwing, because a throw here would take down the production Pages build on
-// a release-day push that never runs the PR site gate.
+// Build-time parse of the repo-root CHANGELOG.md, per the fragment contract
+// (changelog.d/README.md): `## [x.y.z] - date`, `### ` categories, `- `
+// bullets with 2-space continuations (blank lines don't close a bullet);
+// inline bold/italic/code + http(s)
+// links, any other [label](target) collapsed to its label (the relative
+// links target the gitignored docs/ tree). Fail-open — unknown lines render
+// as prose, never throw: a throw would kill the production Pages build on a
+// release-day push, which no PR site gate fronts.
 
 export interface ReleaseCategory {
   name: string;
@@ -92,12 +91,18 @@ export function getChangelog(): Release[] {
   let bullet: string | null = null;
   let para: string | null = null;
 
+  const flushPara = () => {
+    if (para !== null && release) release.intro.push(renderInline(para));
+    para = null;
+  };
+  // A blank line closes only a paragraph: the fragment validator accepts blank
+  // lines inside a bullet body, so an indented continuation may follow one and
+  // must rejoin its still-open bullet.
   const flush = () => {
     if (bullet !== null && category)
       category.bullets.push(renderInline(bullet));
-    if (para !== null && release) release.intro.push(renderInline(para));
     bullet = null;
-    para = null;
+    flushPara();
   };
 
   for (const line of lines) {
@@ -145,7 +150,7 @@ export function getChangelog(): Release[] {
       continue;
     }
     if (line.trim() === "") {
-      flush();
+      flushPara();
       continue;
     }
     if (/^\s/.test(line) && bullet !== null) {

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -5,7 +5,9 @@ import raw from "../../../CHANGELOG.md?raw";
 // Build-time parse of the repo-root CHANGELOG.md into per-release sections.
 // The grammar is the project's own fragment contract (changelog.d/README.md):
 // `## [x.y.z] - date` sections, `### Added|Changed|Fixed` groups, `- ` bullets
-// wrapped with 2-space continuations, inline bold/italic/code/links only.
+// wrapped with 2-space continuations, inline bold/italic/code and http(s)
+// links; any other [label](target) collapses to its bare label (the historical
+// relative links point into the gitignored docs/ tree, dead on every surface).
 // Parsing is fail-open — an unrecognized line renders as plain prose instead of
 // throwing, because a throw here would take down the production Pages build on
 // a release-day push that never runs the PR site gate.
@@ -44,6 +46,8 @@ function renderText(seg: string): string {
     /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
     '<a href="$2">$1</a>',
   );
+  // Runs after the http pass, so only non-http link syntax remains to collapse.
+  html = html.replace(/\[([^\]]+)\]\([^)\s]*\)/g, "$1");
   html = html.replace(/\*([^*]+)\*/g, "<em>$1</em>");
   return html;
 }
@@ -101,8 +105,10 @@ export function getChangelog(): Release[] {
     if (h2) {
       flush();
       category = null;
-      // Unreleased is empty on master between releases (fragments assemble
-      // into it only at release time) and unshipped either way — skip it.
+      // Any heading without a recognized date is skipped. Unreleased (empty on
+      // master between releases, unshipped either way) is the standing case; a
+      // malformed hand-edited date drops its section rather than mis-attaching
+      // its bullets to the previous release.
       if (!h2[2]) {
         release = null;
         continue;

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -2,14 +2,12 @@
 // resolve import.meta.url against the bundled prerender chunk, not this file.
 import raw from "../../../CHANGELOG.md?raw";
 
-// Build-time parse of the repo-root CHANGELOG.md, per the fragment contract
-// (changelog.d/README.md): `## [x.y.z] - date`, `### ` categories, `- `
-// bullets with 2-space continuations (blank lines don't close a bullet);
-// inline bold/italic/code + http(s)
-// links, any other [label](target) collapsed to its label (the relative
-// links target the gitignored docs/ tree). Fail-open — unknown lines render
-// as prose, never throw: a throw would kill the production Pages build on a
-// release-day push, which no PR site gate fronts.
+// Build-time parse of the repo-root CHANGELOG.md (grammar = the fragment
+// contract in changelog.d/README.md). Three non-obvious contracts: an
+// indented continuation after a blank line rejoins its still-open bullet;
+// non-http [label](target) links collapse to their label (the relative ones
+// point into the gitignored docs/ tree); and parsing is fail-open — never
+// throw, because a release-day direct push has no PR site gate in front of it.
 
 export interface ReleaseCategory {
   name: string;
@@ -91,13 +89,13 @@ export function getChangelog(): Release[] {
   let bullet: string | null = null;
   let para: string | null = null;
 
+  // A blank line closes only a paragraph: the fragment validator accepts blank
+  // lines inside a bullet body, so an indented continuation may follow one and
+  // must rejoin its still-open bullet.
   const flushPara = () => {
     if (para !== null && release) release.intro.push(renderInline(para));
     para = null;
   };
-  // A blank line closes only a paragraph: the fragment validator accepts blank
-  // lines inside a bullet body, so an indented continuation may follow one and
-  // must rejoin its still-open bullet.
   const flush = () => {
     if (bullet !== null && category)
       category.bullets.push(renderInline(bullet));

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,11 +1,10 @@
 ---
-// The full CHANGELOG.md, rendered on-site: one anchored section per release
-// with the same Added/Changed/Fixed groups that ship in the app's updater
-// notes. Freshness rides the existing pipeline — site-rebuild.yml pings the
-// Pages deploy hook on every release publish, so this page re-bakes on
-// release day.
+// Renders the repo-root CHANGELOG.md at build time — the same notes the
+// in-app updater ships. Fresh on release day with no extra machinery:
+// site-rebuild.yml pings the Pages deploy hook on every release publish.
 import SiteLayout from "../layouts/SiteLayout.astro";
 import { getChangelog } from "../lib/changelog";
+import { formatReleaseDate } from "../lib/release";
 
 const base = import.meta.env.BASE_URL;
 
@@ -16,13 +15,7 @@ const latest = releases.at(0);
 const oldest = releases.at(-1);
 
 const utc = (iso: string) => new Date(`${iso}T00:00:00Z`);
-const fmtLong = (iso: string) =>
-  utc(iso).toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  });
+const fmtLong = (iso: string) => formatReleaseDate(utc(iso));
 const fmtShort = (iso: string) =>
   utc(iso).toLocaleDateString("en-US", {
     month: "short",
@@ -91,7 +84,10 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
     <div
       class="mx-auto max-w-6xl px-5 py-12 md:py-16 lg:grid lg:grid-cols-[200px_minmax(0,1fr)] lg:items-start lg:gap-14"
     >
-      <nav aria-label="Jump to a release" class="sticky top-20 hidden lg:block">
+      <nav
+        aria-label="Jump to a release"
+        class="sticky top-20 hidden max-h-[calc(100vh-6rem)] overflow-y-auto overscroll-contain lg:block"
+      >
         <ol class="space-y-0.5 border-l border-line pl-4 text-sm">
           {
             releases.map((r) => (
@@ -172,14 +168,16 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
 
               {r.categories.map((c) => (
                 <section class="mt-8">
-                  <h3 class="flex items-baseline gap-2 text-base font-semibold text-ink">
-                    {glyphs[c.name] && (
-                      <span class="text-mint" aria-hidden="true">
-                        {glyphs[c.name]}
-                      </span>
-                    )}
-                    {c.name}
-                  </h3>
+                  {c.name && (
+                    <h3 class="flex items-baseline gap-2 text-base font-semibold text-ink">
+                      {glyphs[c.name] && (
+                        <span class="text-mint" aria-hidden="true">
+                          {glyphs[c.name]}
+                        </span>
+                      )}
+                      {c.name}
+                    </h3>
+                  )}
                   <ul class="notes mt-4 space-y-3 pl-5">
                     {c.bullets.map((b) => (
                       <li set:html={b} />
@@ -224,53 +222,3 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
     })();
   </script>
 </SiteLayout>
-
-{/* Rendered via set:html, so Astro's scoped styles can't reach the content —
-    global, namespaced under .release/.notes. */}
-<style is:global>
-  .notes {
-    list-style: disc;
-  }
-  .notes li {
-    max-width: 76ch;
-    line-height: 1.75;
-    color: var(--color-body);
-  }
-  .notes li::marker {
-    color: var(--color-faint);
-  }
-  .release strong {
-    color: var(--color-ink);
-    font-weight: 600;
-  }
-  .release em {
-    font-style: italic;
-  }
-  .release code {
-    background: var(--color-surface-2);
-    padding: 0.12em 0.38em;
-    border-radius: 4px;
-    font-size: 0.88em;
-    color: var(--color-ink);
-  }
-  /* .intro too, but never bare `.release a`: this block is unlayered global
-     CSS, so it would outrank the header links' utility classes. */
-  .notes a,
-  .release .intro a {
-    color: var(--color-mint);
-    text-decoration: underline;
-    text-decoration-color: oklch(0.82 0.12 178 / 0.45);
-    text-decoration-thickness: 1px;
-    text-underline-offset: 3px;
-  }
-  .notes a:hover,
-  .notes a:focus-visible,
-  .release .intro a:hover,
-  .release .intro a:focus-visible {
-    text-decoration-color: var(--color-mint);
-  }
-  [data-nav-version][aria-current="location"] {
-    color: var(--color-ink);
-    font-weight: 500;
-  }
-</style>

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,0 +1,263 @@
+---
+// The full CHANGELOG.md, rendered on-site: one anchored section per release
+// with the same Added/Changed/Fixed groups that ship in the app's updater
+// notes. Freshness rides the existing pipeline — site-rebuild.yml pings the
+// Pages deploy hook on every release publish, so this page re-bakes with the
+// release facts the same way download.astro's version does.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import { getChangelog } from "../lib/changelog";
+
+const base = import.meta.env.BASE_URL;
+
+const releases = getChangelog();
+const latest = releases[0];
+const oldest = releases[releases.length - 1];
+
+const utc = (iso: string) => new Date(`${iso}T00:00:00Z`);
+const fmtLong = (iso: string) =>
+  utc(iso).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+const fmtShort = (iso: string) =>
+  utc(iso).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+const sinceMonth = utc(oldest.date).toLocaleDateString("en-US", {
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+// Word + glyph together (never a glyph alone): the glyph is decoration in the
+// site's diff idiom, the category name carries the meaning.
+const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" };
+---
+
+<SiteLayout
+  title="GitDesktop changelog — every release, in plain language"
+  description={`What's new in GitDesktop ${latest.version} (${fmtLong(latest.date)}) — and every feature, change, and fix in the releases before it, written for humans.`}
+  ogTitle="GitDesktop changelog"
+  ogDescription={`Every GitDesktop release since ${sinceMonth}, in plain language — the same notes the in-app updater shows.`}
+  breadcrumbs={[{ name: "Changelog", path: "/changelog/" }]}
+>
+  <section class="border-b border-line">
+    <div class="mx-auto max-w-6xl px-5 py-16 md:py-20">
+      <p data-reveal class="text-sm text-faint">
+        <span class="text-add" aria-hidden="true">//</span> changelog
+      </p>
+      <h1
+        data-reveal
+        style="transition-delay:60ms"
+        class="mt-5 max-w-[24ch] text-[clamp(1.9rem,4.5vw,3rem)] font-semibold tracking-tight"
+      >
+        Every release, in plain language.
+      </h1>
+      <p
+        data-reveal
+        style="transition-delay:120ms"
+        class="mt-6 max-w-[62ch] text-base leading-relaxed text-body sm:text-lg"
+      >
+        GitDesktop ships small and often. This is the full record since
+        {sinceMonth} — every feature, change, and fix, written for humans rather
+        than pasted from commit subjects. They're the same notes the in-app
+        updater shows with each new version.
+      </p>
+      <p data-reveal style="transition-delay:180ms" class="mt-5 text-sm text-muted">
+        Latest:
+        <a href={`#v${latest.version}`} class="text-mint underline-offset-4 hover:underline"
+          >v{latest.version}</a
+        > · {fmtLong(latest.date)} · installers on the
+        <a href={`${base}download/`} class="text-mint underline-offset-4 hover:underline"
+          >download page</a
+        >
+      </p>
+    </div>
+  </section>
+
+  <section>
+    <div
+      class="mx-auto max-w-6xl px-5 py-12 md:py-16 lg:grid lg:grid-cols-[200px_minmax(0,1fr)] lg:items-start lg:gap-14"
+    >
+      <nav aria-label="Jump to a release" class="sticky top-20 hidden lg:block">
+        <ol class="space-y-0.5 border-l border-line pl-4 text-sm">
+          {
+            releases.map((r) => (
+              <li>
+                <a
+                  href={`#v${r.version}`}
+                  data-nav-version={r.version}
+                  class="flex items-baseline gap-2 rounded py-1 text-muted transition-colors hover:text-ink"
+                >
+                  <span>v{r.version}</span>
+                  <span class="text-xs text-faint">{fmtShort(r.date)}</span>
+                </a>
+              </li>
+            ))
+          }
+        </ol>
+      </nav>
+
+      <div class="min-w-0">
+        <details class="mb-10 rounded-lg border border-line-2 bg-surface px-4 py-3 lg:hidden">
+          <summary class="cursor-pointer text-sm text-muted">Jump to a release</summary>
+          <ol class="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm sm:grid-cols-3">
+            {
+              releases.map((r) => (
+                <li>
+                  <a
+                    href={`#v${r.version}`}
+                    class="flex items-baseline gap-2 py-0.5 text-muted transition-colors hover:text-ink"
+                  >
+                    <span>v{r.version}</span>
+                    <span class="text-xs text-faint">{fmtShort(r.date)}</span>
+                  </a>
+                </li>
+              ))
+            }
+          </ol>
+        </details>
+
+        {
+          releases.map((r, i) => (
+            <article
+              id={`v${r.version}`}
+              class:list={["release scroll-mt-20", i > 0 && "mt-14 border-t border-line pt-12"]}
+            >
+              <header class="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+                <h2 class="text-2xl font-semibold tracking-tight">
+                  <a href={`#v${r.version}`} class="text-ink transition-colors hover:text-mint">
+                    v{r.version}
+                  </a>
+                </h2>
+                {i === 0 && (
+                  <span class="rounded-full border border-mint/40 bg-mint/10 px-2.5 py-0.5 text-xs font-medium text-mint">
+                    Latest
+                  </span>
+                )}
+                <span class="text-sm text-muted">{fmtLong(r.date)}</span>
+                <span class="flex items-baseline gap-4 text-sm">
+                  <a
+                    href={r.releaseUrl}
+                    class="text-muted underline decoration-line-2 underline-offset-4 transition-colors hover:text-ink"
+                  >
+                    release
+                  </a>
+                  {r.compareUrl && (
+                    <a
+                      href={r.compareUrl}
+                      class="text-muted underline decoration-line-2 underline-offset-4 transition-colors hover:text-ink"
+                    >
+                      full diff
+                    </a>
+                  )}
+                </span>
+              </header>
+
+              {r.intro.map((p) => (
+                <p class="mt-5 max-w-[72ch] leading-relaxed text-body" set:html={p} />
+              ))}
+
+              {r.categories.map((c) => (
+                <section class="mt-8">
+                  <h3 class="flex items-baseline gap-2 text-base font-semibold text-ink">
+                    {glyphs[c.name] && (
+                      <span class="text-mint" aria-hidden="true">
+                        {glyphs[c.name]}
+                      </span>
+                    )}
+                    {c.name}
+                  </h3>
+                  <ul class="notes mt-4 space-y-3 pl-5">
+                    {c.bullets.map((b) => (
+                      <li set:html={b} />
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </article>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <script is:inline slot="scripts">
+    // Scrollspy for the desktop release rail — pure enhancement; without JS the
+    // rail is a plain list of working anchor links.
+    (function () {
+      var links = document.querySelectorAll("[data-nav-version]");
+      if (!links.length || !("IntersectionObserver" in window)) return;
+      var byVersion = {};
+      links.forEach(function (l) {
+        byVersion[l.getAttribute("data-nav-version")] = l;
+      });
+      var current = null;
+      var io = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (e) {
+            if (!e.isIntersecting) return;
+            var link = byVersion[e.target.id.slice(1)];
+            if (!link || link === current) return;
+            if (current) current.removeAttribute("aria-current");
+            current = link;
+            current.setAttribute("aria-current", "location");
+          });
+        },
+        { rootMargin: "-10% 0px -70% 0px" },
+      );
+      document.querySelectorAll("article.release[id]").forEach(function (a) {
+        io.observe(a);
+      });
+    })();
+  </script>
+</SiteLayout>
+
+{/* Rendered via set:html, so Astro's scoped styles can't reach the content —
+    global, namespaced under .release/.notes. */}
+<style is:global>
+  .notes {
+    list-style: disc;
+  }
+  .notes li {
+    max-width: 76ch;
+    line-height: 1.75;
+    color: var(--color-body);
+  }
+  .notes li::marker {
+    color: var(--color-faint);
+  }
+  .release strong {
+    color: var(--color-ink);
+    font-weight: 600;
+  }
+  .release em {
+    font-style: italic;
+  }
+  .release code {
+    background: var(--color-surface-2);
+    padding: 0.12em 0.38em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--color-ink);
+  }
+  .notes a {
+    color: var(--color-mint);
+    text-decoration: underline;
+    text-decoration-color: oklch(0.82 0.12 178 / 0.45);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+  .notes a:hover,
+  .notes a:focus-visible {
+    text-decoration-color: var(--color-mint);
+  }
+  [data-nav-version][aria-current="location"] {
+    color: var(--color-ink);
+    font-weight: 500;
+  }
+</style>

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -2,16 +2,18 @@
 // The full CHANGELOG.md, rendered on-site: one anchored section per release
 // with the same Added/Changed/Fixed groups that ship in the app's updater
 // notes. Freshness rides the existing pipeline — site-rebuild.yml pings the
-// Pages deploy hook on every release publish, so this page re-bakes with the
-// release facts the same way download.astro's version does.
+// Pages deploy hook on every release publish, so this page re-bakes on
+// release day.
 import SiteLayout from "../layouts/SiteLayout.astro";
 import { getChangelog } from "../lib/changelog";
 
 const base = import.meta.env.BASE_URL;
 
 const releases = getChangelog();
-const latest = releases[0];
-const oldest = releases[releases.length - 1];
+// .at() + guards below keep the parser's fail-open promise at page level: a
+// changelog whose headings all stop parsing must not crash the Pages build.
+const latest = releases.at(0);
+const oldest = releases.at(-1);
 
 const utc = (iso: string) => new Date(`${iso}T00:00:00Z`);
 const fmtLong = (iso: string) =>
@@ -27,11 +29,12 @@ const fmtShort = (iso: string) =>
     year: "numeric",
     timeZone: "UTC",
   });
-const sinceMonth = utc(oldest.date).toLocaleDateString("en-US", {
-  month: "long",
-  year: "numeric",
-  timeZone: "UTC",
-});
+const sincePhrase = oldest
+  ? ` since ${utc(oldest.date).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" })}`
+  : "";
+const description = latest
+  ? `What's new in GitDesktop ${latest.version} (${fmtLong(latest.date)}) — and every feature, change, and fix in the releases before it, written for humans.`
+  : "Every GitDesktop release, in plain language — the same notes the in-app updater shows.";
 
 // Word + glyph together (never a glyph alone): the glyph is decoration in the
 // site's diff idiom, the category name carries the meaning.
@@ -40,9 +43,9 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
 
 <SiteLayout
   title="GitDesktop changelog — every release, in plain language"
-  description={`What's new in GitDesktop ${latest.version} (${fmtLong(latest.date)}) — and every feature, change, and fix in the releases before it, written for humans.`}
+  description={description}
   ogTitle="GitDesktop changelog"
-  ogDescription={`Every GitDesktop release since ${sinceMonth}, in plain language — the same notes the in-app updater shows.`}
+  ogDescription={`Every GitDesktop release${sincePhrase}, in plain language — the same notes the in-app updater shows.`}
   breadcrumbs={[{ name: "Changelog", path: "/changelog/" }]}
 >
   <section class="border-b border-line">
@@ -62,20 +65,25 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
         style="transition-delay:120ms"
         class="mt-6 max-w-[62ch] text-base leading-relaxed text-body sm:text-lg"
       >
-        GitDesktop ships small and often. This is the full record since
-        {sinceMonth} — every feature, change, and fix, written for humans rather
-        than pasted from commit subjects. They're the same notes the in-app
-        updater shows with each new version.
+        GitDesktop ships small and often. This is the full record{sincePhrase} —
+        every feature, change, and fix, written for humans rather than pasted
+        from commit subjects. They're the same notes the in-app updater shows
+        with each new version.
       </p>
-      <p data-reveal style="transition-delay:180ms" class="mt-5 text-sm text-muted">
-        Latest:
-        <a href={`#v${latest.version}`} class="text-mint underline-offset-4 hover:underline"
-          >v{latest.version}</a
-        > · {fmtLong(latest.date)} · installers on the
-        <a href={`${base}download/`} class="text-mint underline-offset-4 hover:underline"
-          >download page</a
-        >
-      </p>
+      {
+        latest && (
+          <p data-reveal style="transition-delay:180ms" class="mt-5 text-sm text-muted">
+            Latest:
+            <a href={`#v${latest.version}`} class="text-mint underline-offset-4 hover:underline">
+              v{latest.version}
+            </a>{" "}
+            · {fmtLong(latest.date)} · installers on the
+            <a href={`${base}download/`} class="text-mint underline-offset-4 hover:underline">
+              download page
+            </a>
+          </p>
+        )
+      }
     </div>
   </section>
 
@@ -159,7 +167,7 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
               </header>
 
               {r.intro.map((p) => (
-                <p class="mt-5 max-w-[72ch] leading-relaxed text-body" set:html={p} />
+                <p class="intro mt-5 max-w-[72ch] leading-relaxed text-body" set:html={p} />
               ))}
 
               {r.categories.map((c) => (
@@ -245,7 +253,10 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
     font-size: 0.88em;
     color: var(--color-ink);
   }
-  .notes a {
+  /* .intro too, but never bare `.release a`: this block is unlayered global
+     CSS, so it would outrank the header links' utility classes. */
+  .notes a,
+  .release .intro a {
     color: var(--color-mint);
     text-decoration: underline;
     text-decoration-color: oklch(0.82 0.12 178 / 0.45);
@@ -253,7 +264,9 @@ const glyphs: Record<string, string> = { Added: "+", Changed: "~", Fixed: "✓" 
     text-underline-offset: 3px;
   }
   .notes a:hover,
-  .notes a:focus-visible {
+  .notes a:focus-visible,
+  .release .intro a:hover,
+  .release .intro a:focus-visible {
     text-decoration-color: var(--color-mint);
   }
   [data-nav-version][aria-current="location"] {

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -8,6 +8,7 @@ import {
   getLatestRelease,
 } from "../lib/release";
 
+const base = import.meta.env.BASE_URL;
 const repo = "https://github.com/theBGuy/GitDesktop";
 const releases = `${repo}/releases`;
 
@@ -199,8 +200,10 @@ const softwareLd = JSON.stringify({
           }
         </ul>
         <p class="mt-5 text-sm text-muted">
-          Latest builds, checksums, and release notes live on
-          <a href={releases} class="text-mint underline-offset-4 hover:underline">GitHub Releases</a>.
+          Latest builds and checksums live on
+          <a href={releases} class="text-mint underline-offset-4 hover:underline">GitHub Releases</a>;
+          what changed in each version is on the
+          <a href={`${base}changelog/`} class="text-mint underline-offset-4 hover:underline">changelog</a>.
         </p>
       </div>
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -496,7 +496,9 @@ kbd {
 /* Underlined, not mint-only: .legal underlines on :hover alone, which is
    meaning by color alone. Survivable across two legal pages, not at blog link
    density. */
-.prose a {
+.prose a,
+.release .notes a,
+.release .intro a {
   color: var(--color-mint);
   text-decoration: underline;
   text-decoration-color: oklch(0.82 0.12 178 / 0.45);
@@ -504,15 +506,21 @@ kbd {
   text-underline-offset: 3px;
 }
 .prose a:hover,
-.prose a:focus-visible {
+.prose a:focus-visible,
+.release .notes a:hover,
+.release .notes a:focus-visible,
+.release .intro a:hover,
+.release .intro a:focus-visible {
   text-decoration-color: var(--color-mint);
 }
 
-.prose strong {
+.prose strong,
+.release strong {
   color: var(--color-ink);
   font-weight: 600;
 }
-.prose em {
+.prose em,
+.release em {
   font-style: italic;
 }
 
@@ -530,7 +538,8 @@ kbd {
 .prose li + li {
   margin-top: 0.4rem;
 }
-.prose li::marker {
+.prose li::marker,
+.release .notes li::marker {
   color: var(--color-faint);
 }
 
@@ -541,12 +550,30 @@ kbd {
   max-width: var(--measure);
 }
 
-.prose :not(pre) > code {
+.prose :not(pre) > code,
+.release code {
   background: var(--color-surface-2);
   padding: 0.12em 0.38em;
   border-radius: 4px;
   font-size: 0.88em;
   color: var(--color-ink);
+}
+
+/* Changelog page (/changelog/): .release/.notes markup is the set:html output
+   of lib/changelog.ts, sharing .prose's link/strong/em/code/marker rules
+   above. Never a bare `.release a` — these rules are unlayered, so it would
+   outrank the article-header links' utility classes. */
+.release .notes {
+  list-style: disc;
+}
+.release .notes li {
+  max-width: 76ch;
+  line-height: 1.75;
+  color: var(--color-body);
+}
+[data-nav-version][aria-current="location"] {
+  color: var(--color-ink);
+  font-weight: 500;
 }
 
 /* html sets `overflow-x: clip`, which — unlike hidden — creates NO scroll

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -562,7 +562,9 @@ kbd {
 /* Changelog page (/changelog/): .release/.notes markup is the set:html output
    of lib/changelog.ts, sharing .prose's link/strong/em/code/marker rules
    above. Never a bare `.release a` — these rules are unlayered, so it would
-   outrank the article-header links' utility classes. */
+   outrank the article-header links' utility classes; that same unlayered
+   position is what lets the scrollspy rule below beat the rail link's
+   `text-muted`. */
 .release .notes {
   list-style: disc;
 }


### PR DESCRIPTION
Adds a `/changelog/` page to the marketing site that renders the repo-root `CHANGELOG.md` at build time, so visitors can read what changed in each version without leaving for GitHub Releases. The page shows the same Added/Changed/Fixed notes the in-app updater surfaces, and re-bakes on every release publish via the existing Pages deploy hook.

### Changelog parsing

- Adds `site/src/lib/changelog.ts`, which imports `CHANGELOG.md` with Vite's `?raw` (a `node:fs` read would resolve `import.meta.url` against the bundled prerender chunk) and parses it into `Release` / `ReleaseCategory` shapes.
- Follows the project's own fragment grammar from `changelog.d/README.md`: `## [x.y.z] - date` sections, `### Added|Changed|Fixed` groups, `- ` bullets with 2-space continuations, plus pre-category prose captured as `intro`.
- Parsing is fail-open — unrecognized lines render as plain prose rather than throwing, so a release-day push can't take down the production Pages build.
- Renders inline Markdown through `renderInline` → `renderSpans` → `renderText`, escaping HTML first and handling bold before code spans so bullets like `` **`gh` required.** `` nest correctly.
- Resolves `compareUrl` from the Keep a Changelog link refs when the ref is a compare view, derives `releaseUrl` from the version tag, and skips the `Unreleased` section (empty on master, unshipped either way).

### Changelog page

- Adds `site/src/pages/changelog.astro`: a hero with the latest version and date, then one anchored `article` per release with `Latest` badge, formatted date, and `release` / `full diff` links.
- Provides a sticky desktop release rail plus a `<details>` jump list on mobile, both linking to the `#v<version>` anchors.
- Adds an `IntersectionObserver` scrollspy that sets `aria-current="location"` on the active rail link — pure enhancement; without JS the rail stays a plain list of working anchors.
- Pairs each category glyph (`+`, `~`, `✓`) with its word and marks the glyph `aria-hidden`, so meaning never rides on the symbol alone.
- Ships a namespaced `is:global` style block under `.release` / `.notes`, since `set:html` content is out of reach of Astro's scoped styles.
- All dates are formatted in UTC via an explicit `T00:00:00Z` construction and `timeZone: "UTC"`, keeping the rendered day stable regardless of build host.

### Navigation

- Swaps the footer's *Releases* link for *Changelog* in `site/src/layouts/SiteLayout.astro`.
- Reworks the closing note in `site/src/pages/download.astro` so builds and checksums point at GitHub Releases while "what changed" points at the new changelog page.