### PR TITLE
feat(findings,gitlab): read SAST, secret & code quality from pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,26 @@ settings** (with repo-admin access) goes straight to Repository settings →
 Security to turn scanning on. Repository advisories have no such switch;
 they're only published on public repositories.
 
+On a **GitLab** repo the same tab reads the newest completed **pipeline**
+for your checked-out branch — falling back to the default branch, and
+saying so — and lists its **SAST**, **secret detection**, and **code
+quality** findings straight out of the pipeline's report artifacts. Those
+analyzers run on every GitLab tier, Free included; it's GitLab's own
+vulnerability report that's Ultimate-only, so this is often the only place
+you'll see findings your pipelines already produce. A provenance strip
+names the pipeline, branch, and commit the findings came from, with **View
+pipeline**; a finding's detail adds its severity, `file:line`, the scanner
+that raised it, its identifiers as links, the description, and **View file
+on GitLab** — a permalink to that line at the scanned commit. Detected
+secret *values* never leave the report: the raw extract is dropped before a
+finding reaches the app. Each section explains itself instead of looking
+clean — scanning not set up (with **Open scanning setup on GitLab**), a
+report GitLab won't serve (add the `gl-*-report.json` to that job's
+`artifacts:paths`), expired artifacts, nothing finished yet, an access
+problem, or a check that didn't complete — so an empty section only reads
+as clean once a parsed report proves it, and a partly unreadable pipeline
+says how much was lost.
+
 ### Insights
 
 A repository-graphs tab (Ctrl/Cmd-9): commit activity, code frequency

--- a/README.md
+++ b/README.md
@@ -464,7 +464,8 @@ they're only published on public repositories.
 On a **GitLab** repo the same tab reads the newest completed **pipeline**
 for your checked-out branch — falling back to the default branch, and
 saying so — and lists its **SAST**, **secret detection**, and **code
-quality** findings straight out of the pipeline's report artifacts. Those
+quality** findings straight out of the pipeline's report artifacts,
+including scans that run in triggered child pipelines. Those
 analyzers run on every GitLab tier, Free included; it's GitLab's own
 vulnerability report that's Ultimate-only, so this is often the only place
 you'll see findings your pipelines already produce. A provenance strip
@@ -475,11 +476,13 @@ on GitLab** — a permalink to that line at the scanned commit. Detected
 secret *values* never leave the report: the raw extract is dropped before a
 finding reaches the app. Each section explains itself instead of looking
 clean — scanning not set up (with **Open scanning setup on GitLab**), a
-report GitLab won't serve (add the `gl-*-report.json` to that job's
-`artifacts:paths`), expired artifacts, nothing finished yet, an access
-problem, or a check that didn't complete — so an empty section only reads
-as clean once a parsed report proves it, and a partly unreadable pipeline
-says how much was lost.
+report GitLab won't serve (add the `gl-*-report.json` to `artifacts:paths`
+in the job that produces it), expired artifacts, nothing finished yet, an
+access problem, or a check that didn't complete — so an empty section only
+reads as clean once a parsed report proves it, and a partly unreadable
+pipeline says how much was lost. When one cause covers all three — no
+pipeline to read yet, or one problem across every category — a single card
+stands in for them.
 
 ### Insights
 

--- a/changelog.d/added-findings-gitlab-arm.md
+++ b/changelog.d/added-findings-gitlab-arm.md
@@ -1,0 +1,9 @@
+- **Findings on GitLab.** The **Findings** tab now works on GitLab repositories:
+  it reads the newest completed pipeline for your branch (falling back to the
+  default branch, and saying so) and lists its **SAST**, **secret detection**, and
+  **code quality** findings — on every tier, Free included, where GitLab's own
+  vulnerability report is Ultimate-only. Each finding opens with its severity,
+  file and line, scanner, and identifiers, plus **View file on GitLab** at the
+  scanned commit; every section says why it has nothing to show — scanning not set
+  up, a report that isn't downloadable, expired artifacts, or a pipeline that
+  hasn't finished — so an empty list only reads as clean when a report proved it.

--- a/changelog.d/added-findings-gitlab-arm.md
+++ b/changelog.d/added-findings-gitlab-arm.md
@@ -1,9 +1,11 @@
 - **Findings on GitLab.** The **Findings** tab now works on GitLab repositories:
   it reads the newest completed pipeline for your branch (falling back to the
-  default branch, and saying so) and lists its **SAST**, **secret detection**, and
+  default branch, and saying so, and picking up scans that run in triggered
+  child pipelines) and lists its **SAST**, **secret detection**, and
   **code quality** findings — on every tier, Free included, where GitLab's own
   vulnerability report is Ultimate-only. Each finding opens with its severity,
   file and line, scanner, and identifiers, plus **View file on GitLab** at the
-  scanned commit; every section says why it has nothing to show — scanning not set
-  up, a report that isn't downloadable, expired artifacts, or a pipeline that
-  hasn't finished — so an empty list only reads as clean when a report proved it.
+  scanned commit; every section says why it has nothing to show — scanning not
+  set up, a report that isn't downloadable, expired artifacts, or a pipeline
+  that hasn't finished — so an empty list only reads as clean when a report
+  proved it.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -292,7 +292,7 @@ export const capabilities: Capability[] = [
   {
     group: "CI, tags & releases",
     label:
-      "Findings tab — Dependabot, code & secret scanning alerts, advisories",
+      "Findings tab — GitHub Dependabot/scanning alerts & advisories; GitLab SAST, secrets & code quality",
     highlight: true,
   },
 

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -205,7 +205,7 @@ fn gitlab_credential_entries(host: &str, glab_path: &str) -> Vec<String> {
 
 /// URL-encode a project's full path for use as a `glab api` project id. Only `/`
 /// needs escaping for the paths GitLab allows (letters/digits/`_`/`-`/`.`).
-fn encode_project(path: &str) -> String {
+pub(crate) fn encode_project(path: &str) -> String {
     path.replace('/', "%2F")
 }
 
@@ -216,7 +216,7 @@ fn encode_project(path: &str) -> String {
 use crate::forge::encode_query_value;
 
 /// The project's full path (`group/name`) from the repo's origin remote.
-async fn project_path(repo_path: &str) -> AppResult<String> {
+pub(crate) async fn project_path(repo_path: &str) -> AppResult<String> {
     let url =
         crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await?;
     crate::forge::remote_path(&url).ok_or_else(|| {
@@ -7861,7 +7861,7 @@ pub async fn starred(owner: &str, name: &str) -> AppResult<bool> {
 /// rate-limit failure that must be surfaced. glab prints the HTTP status to stderr
 /// (`404 Not Found`); some builds echo the JSON body (`{"message":"404 ... Not
 /// Found"}`) too, so scan both. Pure, so it's unit-testable.
-fn glab_output_is_404(stderr: &str, stdout: &str) -> bool {
+pub(crate) fn glab_output_is_404(stderr: &str, stdout: &str) -> bool {
     let hay = format!("{stderr}\n{stdout}").to_ascii_lowercase();
     hay.contains("404") || hay.contains("not found")
 }

--- a/src-tauri/src/forge/gitlab_findings.rs
+++ b/src-tauri/src/forge/gitlab_findings.rs
@@ -875,15 +875,15 @@ async fn fetch_json<T: serde::de::DeserializeOwned>(
     }
 }
 
-/// Recent pipelines for one ref. The `pipelines/latest?ref=` endpoint is BANNED
-/// here: it answers a ref with no pipelines with a bare `{"message":"403
-/// Forbidden"}` (measured 2026-08-11, gitlab.com), which would read as a
-/// permissions problem; the list endpoint answers `[]` honestly.
 /// The pipeline window. Wide enough to survive an auto-cancel storm: interrupted
 /// pushes fill the newest entries with `canceled` pipelines, and a window that
 /// holds only those would report "nothing has finished" for a branch that has.
 const PIPELINE_WINDOW: u32 = 50;
 
+/// Recent pipelines for one ref. The `pipelines/latest?ref=` endpoint is BANNED
+/// here: it answers a ref with no pipelines with a bare `{"message":"403
+/// Forbidden"}` (measured 2026-08-11, gitlab.com), which would read as a
+/// permissions problem; the list endpoint answers `[]` honestly.
 async fn fetch_pipelines(
     repo_path: &str,
     enc: &str,
@@ -897,7 +897,7 @@ async fn fetch_pipelines(
 }
 
 /// GitLab caps a list page at 100.
-const JOBS_PER_PAGE: usize = 100;
+const LIST_PER_PAGE: usize = 100;
 /// The list walk's ceiling, for jobs and bridges alike. Either can run past one
 /// page — a fan-out pipeline's jobs, a many-way `trigger:` matrix's bridges — but
 /// both can also run to thousands, so three pages covers every realistic pipeline
@@ -911,7 +911,7 @@ const MAX_BRIDGES: usize = 3;
 /// Whether the walk continues: a short page is the last one, and the ceiling
 /// stops a full page from paging forever.
 fn has_more_list_pages(page: u32, page_len: usize) -> bool {
-    page < MAX_LIST_PAGES && page_len == JOBS_PER_PAGE
+    page < MAX_LIST_PAGES && page_len == LIST_PER_PAGE
 }
 
 /// Walks a 100-per-page list endpoint to the ceiling. `base` must already carry a
@@ -946,19 +946,18 @@ async fn fetch_paged<T: serde::de::DeserializeOwned>(
 
 /// Every job of a pipeline, up to the walk's ceiling.
 async fn fetch_jobs(repo_path: &str, enc: &str, pipeline_id: u64) -> AppResult<Listed<RawJob>> {
-    let base = format!("projects/{enc}/pipelines/{pipeline_id}/jobs?per_page={JOBS_PER_PAGE}");
+    let base = format!("projects/{enc}/pipelines/{pipeline_id}/jobs?per_page={LIST_PER_PAGE}");
     fetch_paged(repo_path, &base, "pipeline jobs").await
 }
 
-/// A pipeline's `trigger:` jobs. Measured 2026-08-11: the endpoint answers `[]`
-/// on a pipeline with no bridges, so the child walk costs nothing on the common
-/// single-pipeline layout.
+/// A pipeline's `trigger:` jobs. Measured 2026-08-11: a pipeline with no bridges
+/// answers `[]` rather than 404, so the absence of children needs no special case.
 async fn fetch_bridges(
     repo_path: &str,
     enc: &str,
     pipeline_id: u64,
 ) -> AppResult<Listed<RawBridge>> {
-    let base = format!("projects/{enc}/pipelines/{pipeline_id}/bridges?per_page={JOBS_PER_PAGE}");
+    let base = format!("projects/{enc}/pipelines/{pipeline_id}/bridges?per_page={LIST_PER_PAGE}");
     fetch_paged(repo_path, &base, "pipeline bridges").await
 }
 
@@ -984,9 +983,9 @@ fn downstream_pipeline_ids(bridges: &[RawBridge], project_id: Option<u64>) -> Ve
         .collect()
 }
 
-/// Whether a child-pipeline walk could still add anything: any category the
-/// parent's own jobs don't already answer. On the common single-pipeline layout
-/// every category is answered, so the bridges call never happens.
+/// Whether a child-pipeline walk could still add anything: true when the parent's
+/// own jobs leave any category unanswered, which is the only case a child's jobs
+/// could change.
 fn needs_child_jobs(jobs: &[RawJob]) -> bool {
     [
         SAST_FILE_TYPE,
@@ -1157,11 +1156,10 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
         }
     };
     // A monorepo that scans in a child pipeline publishes its reports on the
-    // CHILD's jobs, which the parent's jobs endpoint never lists — but only a
-    // category the parent leaves unanswered can gain anything, so the common
-    // single-pipeline layout never pays for the extra calls. Failures here are
-    // swallowed on purpose: a bridges hiccup must not turn a good read into an
-    // error when the parent's own jobs already answered.
+    // CHILD's jobs, which the parent's jobs endpoint never lists. Gated on a
+    // category the parent left unanswered, since that is the only case a child
+    // could change. Failures here are swallowed on purpose: a bridges hiccup must
+    // not turn an otherwise-good read into an error.
     if needs_child_jobs(&jobs) {
         if let Ok(Listed::Items(bridges)) = fetch_bridges(repo_path, &enc, pipeline_id).await {
             for child_id in downstream_pipeline_ids(&bridges, project_id) {
@@ -1845,12 +1843,12 @@ mod tests {
 
     #[test]
     fn the_list_walk_stops_on_a_short_page_or_the_ceiling() {
-        assert!(has_more_list_pages(1, JOBS_PER_PAGE));
-        assert!(has_more_list_pages(2, JOBS_PER_PAGE));
+        assert!(has_more_list_pages(1, LIST_PER_PAGE));
+        assert!(has_more_list_pages(2, LIST_PER_PAGE));
         // The ceiling stops a full page from paging forever.
-        assert!(!has_more_list_pages(MAX_LIST_PAGES, JOBS_PER_PAGE));
+        assert!(!has_more_list_pages(MAX_LIST_PAGES, LIST_PER_PAGE));
         // A short page is the last one.
-        assert!(!has_more_list_pages(1, JOBS_PER_PAGE - 1));
+        assert!(!has_more_list_pages(1, LIST_PER_PAGE - 1));
         assert!(!has_more_list_pages(1, 0));
     }
 

--- a/src-tauri/src/forge/gitlab_findings.rs
+++ b/src-tauri/src/forge/gitlab_findings.rs
@@ -79,6 +79,10 @@ pub struct GlFindingsOut {
     /// The default branch's pipelines were read instead of the requested ref's.
     pub used_fallback: bool,
     pub fallback_ref: Option<String>,
+    /// The default branch's NAME — the ref the fallback consults, stated whether
+    /// or not it was used; `fallback_ref` answers that separate question. `None`
+    /// only when the project lookup itself failed.
+    pub default_ref: Option<String>,
     pub project_web_url: Option<String>,
     pub sast: GlSecureCategoryOut,
     pub secret_detection: GlSecureCategoryOut,
@@ -795,6 +799,7 @@ struct RefContext {
     requested_ref: String,
     used_fallback: bool,
     fallback_ref: Option<String>,
+    default_ref: Option<String>,
     project_web_url: Option<String>,
 }
 
@@ -819,6 +824,7 @@ fn uniform_out(
         requested_ref: refs.requested_ref,
         used_fallback: refs.used_fallback,
         fallback_ref: refs.fallback_ref,
+        default_ref: refs.default_ref,
         project_web_url: refs.project_web_url,
         sast: secure(),
         secret_detection: secure(),
@@ -1048,6 +1054,7 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
         requested_ref,
         used_fallback: false,
         fallback_ref: None,
+        default_ref: None,
         project_web_url: None,
     };
 
@@ -1079,6 +1086,9 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
     };
     let default_branch = project.default_branch.unwrap_or_default();
     let project_id = project.id;
+    // Recorded BEFORE any fallback attempt, so every later exit — including the
+    // one where neither ref has a pipeline — can name the branch that was checked.
+    refs.default_ref = (!default_branch.is_empty()).then(|| default_branch.clone());
     refs.project_web_url = project
         .web_url
         .map(|u| u.trim_end_matches('/').to_string())
@@ -1181,6 +1191,7 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
         requested_ref: refs.requested_ref,
         used_fallback: refs.used_fallback,
         fallback_ref: refs.fallback_ref,
+        default_ref: refs.default_ref,
         project_web_url: refs.project_web_url,
         sast: secure_envelope(sast, cap),
         secret_detection: secure_envelope(secrets, cap),
@@ -1338,6 +1349,7 @@ mod tests {
             requested_ref: "feature".into(),
             used_fallback: true,
             fallback_ref: Some("main".into()),
+            default_ref: Some("main".into()),
             project_web_url: Some("https://gitlab.com/g/r".into()),
             sast: secure_envelope(bodies(&[SAST_REPORT]), 100),
             secret_detection: GlSecureCategoryOut {
@@ -1353,6 +1365,7 @@ mod tests {
         assert_eq!(value["requestedRef"], json!("feature"));
         assert_eq!(value["usedFallback"], json!(true));
         assert_eq!(value["fallbackRef"], json!("main"));
+        assert_eq!(value["defaultRef"], json!("main"));
         assert_eq!(value["projectWebUrl"], json!("https://gitlab.com/g/r"));
         // `ref` and `type` are hand-pinned around the Rust keywords.
         assert_eq!(value["pipeline"]["ref"], json!("main"));
@@ -1388,6 +1401,51 @@ mod tests {
         assert_eq!(cq["path"], json!("src/app.py"));
         assert_eq!(cq["line"], json!(17));
         assert_eq!(value["codeQuality"]["truncated"], json!(true));
+    }
+
+    #[test]
+    fn the_no_pipelines_exit_still_names_the_default_branch() {
+        // Neither the checked-out ref nor the default branch had a pipeline, so
+        // nothing was USED — but the card has to say both refs were checked, and
+        // fallback_ref can't carry that (it means "a default pipeline supplied
+        // these findings").
+        let out = uniform_out(
+            GlPipelineState::None,
+            None,
+            RefContext {
+                requested_ref: "feature".into(),
+                used_fallback: false,
+                fallback_ref: None,
+                default_ref: Some("main".into()),
+                project_web_url: Some("https://gitlab.com/g/r".into()),
+            },
+            GlFindingAvailability::NotConfigured,
+            None,
+        );
+        let value = serde_json::to_value(&out).expect("envelope serializes");
+        assert_eq!(value["pipelineState"], json!("none"));
+        assert_eq!(value["requestedRef"], json!("feature"));
+        assert_eq!(value["defaultRef"], json!("main"));
+        assert_eq!(value["fallbackRef"], json!(null));
+        assert_eq!(value["usedFallback"], json!(false));
+        // Only a failed project lookup leaves the default branch unknown.
+        let unavailable = uniform_out(
+            GlPipelineState::Unavailable,
+            None,
+            RefContext {
+                requested_ref: "feature".into(),
+                used_fallback: false,
+                fallback_ref: None,
+                default_ref: None,
+                project_web_url: None,
+            },
+            GlFindingAvailability::Forbidden,
+            Some("403 Forbidden".into()),
+        );
+        assert_eq!(
+            serde_json::to_value(&unavailable).expect("envelope serializes")["defaultRef"],
+            json!(null)
+        );
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab_findings.rs
+++ b/src-tauri/src/forge/gitlab_findings.rs
@@ -1,0 +1,1760 @@
+//! GitLab's Findings arm: SAST, secret detection and code quality read out of a
+//! pipeline's CI report artifacts.
+//!
+//! GitLab paywalls the rendered vulnerability report behind Ultimate, but the
+//! analyzers write plain JSON artifacts that every tier can download, so this
+//! reads those. Each category rides an availability envelope: scanning never
+//! configured, an expired artifact, a report the API won't serve, and an
+//! unrecognized failure are all distinct from "genuinely clean" — an empty list
+//! only renders as clean when a parsed report says so. Only a missing `glab`
+//! binary or a timeout escapes as `Err`; every completed-but-failed call is
+//! classified into the envelope instead.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::AppResult;
+use crate::forge::encode_query_value;
+use crate::forge::gitlab::{encode_project, glab_output_is_404, project_path};
+use crate::forge::glab::{run_glab_raw, GlabOutput, GLAB_NETWORK_TIMEOUT};
+
+/// A report bigger than this is refused rather than parsed — the artifact is
+/// attacker-influenceable in size and the whole body is held in memory.
+const MAX_REPORT_BYTES: usize = 16 * 1024 * 1024;
+
+/// GitLab's `file_type` for each report we read, as the jobs payload spells them.
+const SAST_FILE_TYPE: &str = "sast";
+const SECRET_DETECTION_FILE_TYPE: &str = "secret_detection";
+const CODE_QUALITY_FILE_TYPE: &str = "codequality";
+
+// ── Wire shape ───────────────────────────────────────────────────────────────
+
+/// Why a category's list may be empty. Serialized camelCase; the frontend
+/// branches on these exact strings to pick between "no findings" and a reason.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum GlFindingAvailability {
+    /// The list is real — an empty one means no findings.
+    Available,
+    /// The pipeline runs no job publishing this report.
+    NotConfigured,
+    /// The job declares the report but GitLab won't serve the file.
+    ReportNotReadable,
+    /// The job's artifacts have passed their expiry.
+    Expired,
+    /// The pipeline hasn't finished, so no artifact exists yet.
+    AnalysisPending,
+    /// The token can't read this project's pipelines or artifacts.
+    Forbidden,
+    /// The call failed in a way we can't attribute; the list is unknown, not empty.
+    Indeterminate,
+}
+
+/// Which pipeline (if any) the findings were read from.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum GlPipelineState {
+    /// A completed pipeline was found; `pipeline` describes it.
+    Found,
+    /// Neither the checked-out ref nor the default branch has any pipeline.
+    None,
+    /// Pipelines exist but none has finished, so no artifacts exist yet.
+    RunningOnly,
+    /// The project or pipeline lookup itself failed.
+    Unavailable,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlFindingsOut {
+    pub pipeline_state: GlPipelineState,
+    /// `Some` only when `pipeline_state` is `Found`.
+    pub pipeline: Option<GlPipelineRefOut>,
+    /// The ref we looked for — the checkout branch, or `"HEAD"` when detached.
+    pub requested_ref: String,
+    /// The default branch's pipelines were read instead of the requested ref's.
+    pub used_fallback: bool,
+    pub fallback_ref: Option<String>,
+    pub project_web_url: Option<String>,
+    pub sast: GlSecureCategoryOut,
+    pub secret_detection: GlSecureCategoryOut,
+    pub code_quality: GlCodeQualityCategoryOut,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlPipelineRefOut {
+    pub id: u64,
+    pub iid: u64,
+    pub status: String,
+    pub sha: String,
+    /// `ref` is a Rust keyword, so the wire key is pinned by hand.
+    #[serde(rename = "ref")]
+    pub git_ref: String,
+    pub web_url: String,
+    pub created_at: String,
+    /// The pipelines LIST payload carries no finish time (measured, gitlab.com
+    /// 2026-08-11), so this is `None` unless the host sends one.
+    pub finished_at: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlSecureCategoryOut {
+    pub availability: GlFindingAvailability,
+    /// Why the list is unavailable — or, alongside `Available`, how much of the
+    /// pipeline's output was unreadable; the frontend renders that as a muted
+    /// notice over a list that is short rather than wrong.
+    pub detail: Option<String>,
+    pub findings: Vec<GlSecureFindingOut>,
+    /// More findings existed than the cap kept.
+    pub truncated: bool,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlCodeQualityCategoryOut {
+    pub availability: GlFindingAvailability,
+    /// Same contract as [`GlSecureCategoryOut::detail`] — non-null is possible
+    /// alongside `Available`.
+    pub detail: Option<String>,
+    pub findings: Vec<GlCodeQualityFindingOut>,
+    pub truncated: bool,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlSecureFindingOut {
+    pub id: String,
+    pub name: String,
+    /// GitLab's capitalized ladder ("Critical" … "Unknown"), raw so an
+    /// unrecognized future value renders instead of being dropped.
+    pub severity: String,
+    pub description: String,
+    pub file: String,
+    pub start_line: Option<u64>,
+    pub end_line: Option<u64>,
+    pub scanner_name: String,
+    pub identifiers: Vec<GlIdentifierOut>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlIdentifierOut {
+    /// `type` is a Rust keyword, so the wire key is pinned by hand.
+    #[serde(rename = "type")]
+    pub identifier_type: String,
+    pub name: String,
+    pub value: String,
+    pub url: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GlCodeQualityFindingOut {
+    pub fingerprint: String,
+    pub check_name: String,
+    /// CodeClimate's lowercase ladder ("blocker" … "info"), raw.
+    pub severity: String,
+    pub description: String,
+    pub path: String,
+    pub line: Option<u64>,
+}
+
+// ── Untrusted GitLab JSON ────────────────────────────────────────────────────
+// Every field is optional so a shape change or one malformed item degrades that
+// field rather than failing the whole list.
+
+#[derive(Deserialize, Default)]
+struct RawProject {
+    #[serde(default)]
+    default_branch: Option<String>,
+    #[serde(default)]
+    web_url: Option<String>,
+}
+
+#[derive(Deserialize, Default, Clone, Debug)]
+struct RawPipeline {
+    #[serde(default)]
+    id: Option<u64>,
+    #[serde(default)]
+    iid: Option<u64>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    sha: Option<String>,
+    #[serde(default, rename = "ref")]
+    git_ref: Option<String>,
+    #[serde(default)]
+    web_url: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    finished_at: Option<String>,
+}
+
+#[derive(Deserialize, Default, Clone, Debug)]
+struct RawJobArtifact {
+    #[serde(default)]
+    file_type: Option<String>,
+    #[serde(default)]
+    filename: Option<String>,
+}
+
+#[derive(Deserialize, Default, Clone, Debug)]
+struct RawJob {
+    #[serde(default)]
+    id: Option<u64>,
+    /// Null while artifacts are kept forever; a past instant is what separates an
+    /// expired report from one the API simply won't serve.
+    #[serde(default)]
+    artifacts_expire_at: Option<String>,
+    #[serde(default)]
+    artifacts: Option<Vec<RawJobArtifact>>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawScanner {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawSecureLocation {
+    #[serde(default)]
+    file: Option<String>,
+    #[serde(default)]
+    start_line: Option<u64>,
+    #[serde(default)]
+    end_line: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawIdentifier {
+    #[serde(default, rename = "type")]
+    identifier_type: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+/// One vulnerability from a secure report (schema 15.2.x). Two fields are
+/// deliberately NOT declared: `raw_source_code_extract` carries the literal
+/// leaked secret, and leaving it undeclared keeps it out of this process's
+/// serialization entirely; `cve` on a secret-detection finding is a
+/// `path:hash:rule` fingerprint composite, not a CVE (both measured 2026-08-11).
+#[derive(Deserialize, Default)]
+struct RawVulnerability {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    scanner: Option<RawScanner>,
+    #[serde(default)]
+    location: Option<RawSecureLocation>,
+    #[serde(default)]
+    identifiers: Option<Vec<RawIdentifier>>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawSecureReport {
+    #[serde(default)]
+    vulnerabilities: Option<Vec<Value>>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCqLines {
+    #[serde(default)]
+    begin: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCqPosition {
+    #[serde(default)]
+    line: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCqPositions {
+    #[serde(default)]
+    begin: Option<RawCqPosition>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCqLocation {
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    lines: Option<RawCqLines>,
+    #[serde(default)]
+    positions: Option<RawCqPositions>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawCqIssue {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    check_name: Option<String>,
+    #[serde(default)]
+    fingerprint: Option<String>,
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    location: Option<RawCqLocation>,
+}
+
+// ── Mapping ──────────────────────────────────────────────────────────────────
+
+fn secure_finding_out(raw: RawVulnerability) -> GlSecureFindingOut {
+    let location = raw.location.unwrap_or_default();
+    GlSecureFindingOut {
+        id: raw.id.unwrap_or_default(),
+        name: raw.name.unwrap_or_default(),
+        severity: raw.severity.unwrap_or_default(),
+        description: raw.description.unwrap_or_default(),
+        file: location.file.unwrap_or_default(),
+        start_line: location.start_line,
+        end_line: location.end_line,
+        scanner_name: raw.scanner.unwrap_or_default().name.unwrap_or_default(),
+        identifiers: raw
+            .identifiers
+            .unwrap_or_default()
+            .into_iter()
+            .map(|i| GlIdentifierOut {
+                identifier_type: i.identifier_type.unwrap_or_default(),
+                name: i.name.unwrap_or_default(),
+                value: i.value.unwrap_or_default(),
+                url: i.url,
+            })
+            .collect(),
+    }
+}
+
+fn code_quality_finding_out(raw: RawCqIssue) -> GlCodeQualityFindingOut {
+    let location = raw.location.unwrap_or_default();
+    // CodeClimate allows either shape for a line; whichever is present wins.
+    let line = location.lines.and_then(|l| l.begin).or_else(|| {
+        location
+            .positions
+            .and_then(|p| p.begin)
+            .and_then(|b| b.line)
+    });
+    GlCodeQualityFindingOut {
+        fingerprint: raw.fingerprint.unwrap_or_default(),
+        check_name: raw.check_name.unwrap_or_default(),
+        severity: raw.severity.unwrap_or_default(),
+        description: raw.description.unwrap_or_default(),
+        path: location.path.unwrap_or_default(),
+        line,
+    }
+}
+
+fn pipeline_ref_out(raw: RawPipeline) -> GlPipelineRefOut {
+    GlPipelineRefOut {
+        id: raw.id.unwrap_or(0),
+        iid: raw.iid.unwrap_or(0),
+        status: raw.status.unwrap_or_default(),
+        sha: raw.sha.unwrap_or_default(),
+        git_ref: raw.git_ref.unwrap_or_default(),
+        web_url: raw.web_url.unwrap_or_default(),
+        created_at: raw.created_at.unwrap_or_default(),
+        finished_at: raw.finished_at,
+    }
+}
+
+// ── Classification ───────────────────────────────────────────────────────────
+
+/// GitLab's error bodies are a few hundred bytes; anything larger on a failed
+/// call is an echoed report, not an error envelope. Bounding the read keeps
+/// classification off a multi-megabyte body.
+const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
+
+/// The server's own `message`, when the body is one — it beats glab's stderr,
+/// which restates the status without the explanation.
+fn server_message(stdout: &str) -> Option<String> {
+    if stdout.len() > MAX_ERROR_BODY_BYTES {
+        return None;
+    }
+    serde_json::from_str::<Value>(stdout.trim())
+        .ok()
+        .and_then(|v| {
+            v.get("message")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+                .map(str::to_string)
+        })
+}
+
+/// Maps a completed-but-failed glab call onto the envelope. Classified into `Ok`
+/// so the UI can say *why* a list is empty; anything unrecognized stays
+/// `Indeterminate` and is never presented as a clean project.
+fn classify_call_failure(stdout: &str, stderr: &str) -> (GlFindingAvailability, Option<String>) {
+    let message = server_message(stdout);
+    let stderr = stderr.trim();
+    let detail = message
+        .clone()
+        .or_else(|| (!stderr.is_empty()).then(|| stderr.to_string()));
+    // Only the server's own message and glab's stderr may classify: a report body
+    // can carry "forbidden" in a rule description, and GitLab Free answers a
+    // paywalled read with a bare `403 Forbidden` and no explanation anyway, so the
+    // client supplies the context the server withholds.
+    let hay = format!("{}\n{stderr}", message.as_deref().unwrap_or_default()).to_ascii_lowercase();
+    if hay.contains("403") || hay.contains("forbidden") {
+        (GlFindingAvailability::Forbidden, detail)
+    } else {
+        (GlFindingAvailability::Indeterminate, detail)
+    }
+}
+
+/// Whether a job's artifacts are past their expiry. An absent or unparseable
+/// timestamp reads as "not expired" — guessing expiry would mislabel a report
+/// GitLab is simply refusing to serve.
+fn artifacts_expired(expire_at: Option<&str>, now: DateTime<Utc>) -> bool {
+    expire_at
+        .and_then(|s| DateTime::parse_from_rfc3339(s.trim()).ok())
+        .is_some_and(|t| t.with_timezone(&Utc) <= now)
+}
+
+/// A downloaded report's bytes, or why they're unusable.
+fn artifact_outcome(
+    out: GlabOutput,
+    expire_at: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, (GlFindingAvailability, Option<String>)> {
+    if out.code == 0 {
+        if out.stdout.len() > MAX_REPORT_BYTES {
+            return Err((
+                GlFindingAvailability::Indeterminate,
+                Some("the report was too large to read".to_string()),
+            ));
+        }
+        return Ok(out.stdout);
+    }
+    let stdout = out.stdout_lossy();
+    if glab_output_is_404(&out.stderr, &stdout) {
+        return Err(if artifacts_expired(expire_at, now) {
+            (
+                GlFindingAvailability::Expired,
+                expire_at.map(|e| format!("the job's artifacts expired on {e}")),
+            )
+        } else {
+            // MEASURED: a report declared only under `artifacts:reports` lists its
+            // file_type in the job metadata yet 404s on download — the project has
+            // to expose it via `artifacts:paths` for the API to serve the file.
+            (
+                GlFindingAvailability::ReportNotReadable,
+                Some("the job lists this report but GitLab returned 404 for the file".to_string()),
+            )
+        });
+    }
+    Err(classify_call_failure(&stdout, &out.stderr))
+}
+
+// ── Selection ────────────────────────────────────────────────────────────────
+
+/// Only a finished pipeline can have artifacts; `canceled`/`skipped` produce none
+/// and `running` hasn't yet.
+fn is_completed(status: &str) -> bool {
+    status == "success" || status == "failed"
+}
+
+/// The newest completed pipeline. GitLab's pipelines list is newest-first, so the
+/// first completed entry is the newest one.
+fn pick_pipeline(list: Vec<RawPipeline>) -> Option<RawPipeline> {
+    list.into_iter()
+        .find(|p| is_completed(p.status.as_deref().unwrap_or_default()))
+}
+
+/// One downloadable report artifact of a job.
+#[derive(Debug, PartialEq, Eq)]
+struct ArtifactRef {
+    job_id: u64,
+    filename: String,
+    expire_at: Option<String>,
+}
+
+/// Every job publishing `file_type`. A category with no candidate job isn't
+/// configured — that is a different answer from "no findings".
+fn candidates(jobs: &[RawJob], file_type: &str) -> Vec<ArtifactRef> {
+    let mut out = Vec::new();
+    for job in jobs {
+        let Some(job_id) = job.id else { continue };
+        for artifact in job.artifacts.iter().flatten() {
+            if artifact.file_type.as_deref() != Some(file_type) {
+                continue;
+            }
+            let Some(filename) = artifact.filename.clone().filter(|f| !f.is_empty()) else {
+                continue;
+            };
+            out.push(ArtifactRef {
+                job_id,
+                filename,
+                expire_at: job.artifacts_expire_at.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// Severity ladder for the secure reports; an unrecognized value ranks lowest so
+/// it can't displace a real Critical from a truncated list.
+fn secure_severity_rank(severity: &str) -> u8 {
+    match severity.to_ascii_lowercase().as_str() {
+        "critical" => 5,
+        "high" => 4,
+        "medium" => 3,
+        "low" => 2,
+        "info" => 1,
+        _ => 0,
+    }
+}
+
+/// CodeClimate's own ladder, which puts `blocker` above `critical`.
+fn code_quality_severity_rank(severity: &str) -> u8 {
+    match severity.to_ascii_lowercase().as_str() {
+        "blocker" => 5,
+        "critical" => 4,
+        "major" => 3,
+        "minor" => 2,
+        "info" => 1,
+        _ => 0,
+    }
+}
+
+/// The per-category cap.
+fn clamp_limit(limit: Option<u32>) -> usize {
+    limit.unwrap_or(100).clamp(1, 500) as usize
+}
+
+// ── Envelopes ────────────────────────────────────────────────────────────────
+
+/// A category's raw material: the report bodies we could download, plus why the
+/// first undownloadable one failed and how many reports never arrived.
+#[derive(Default)]
+struct CategoryFetch {
+    had_candidates: bool,
+    bodies: Vec<Vec<u8>>,
+    failure: Option<(GlFindingAvailability, Option<String>)>,
+    /// Reports that failed to download. Counted so a category that still has one
+    /// good report reports the loss instead of looking complete.
+    lost_reports: usize,
+}
+
+/// Survivors of parsing a category's report bodies, alongside what didn't parse —
+/// a window that parsed away entirely must not read as a clean project.
+struct Tally<T> {
+    items: Vec<T>,
+    total: usize,
+    readable_bodies: usize,
+    /// Findings known lost: items that failed to deserialize, plus one per body
+    /// that wasn't a readable report at all.
+    dropped: usize,
+}
+
+/// Deserializes each report body's item array, dropping individually malformed
+/// items but counting them.
+fn tally<T, F, R>(bodies: &[Vec<u8>], items_of: F, map: R) -> Tally<T>
+where
+    F: Fn(&[u8]) -> Option<Vec<Value>>,
+    R: Fn(Value) -> Option<T>,
+{
+    let mut out = Tally {
+        items: Vec::new(),
+        total: 0,
+        readable_bodies: 0,
+        dropped: 0,
+    };
+    for body in bodies {
+        let Some(values) = items_of(body) else {
+            // An unreadable body hides an unknown number of findings; one keeps
+            // the loss visible without inventing a census.
+            out.dropped += 1;
+            continue;
+        };
+        let count = values.len();
+        out.readable_bodies += 1;
+        out.total += count;
+        let before = out.items.len();
+        out.items.extend(values.into_iter().filter_map(&map));
+        out.dropped += count - (out.items.len() - before);
+    }
+    out
+}
+
+/// The `vulnerabilities` KEY is what makes a body a report: an analyzer that
+/// failed internally can emit `{}`, and reading that as zero findings would issue
+/// a clean bill of health nothing proved.
+fn secure_report_items(body: &[u8]) -> Option<Vec<Value>> {
+    serde_json::from_slice::<RawSecureReport>(body)
+        .ok()
+        .and_then(|r| r.vulnerabilities)
+}
+
+fn code_quality_report_items(body: &[u8]) -> Option<Vec<Value>> {
+    serde_json::from_slice::<Vec<Value>>(body).ok()
+}
+
+/// The detail for a window that parsed away entirely.
+fn unreadable_detail(total: usize) -> Option<String> {
+    Some(if total == 0 {
+        "GitLab returned a report this build couldn't read".to_string()
+    } else {
+        format!(
+            "GitLab returned {total} {} this build couldn't read",
+            if total == 1 { "finding" } else { "findings" }
+        )
+    })
+}
+
+/// The muted notice that rides an otherwise-`Available` category: part of the
+/// pipeline's output was unreadable, so the list is short rather than wrong.
+fn partial_loss_detail(dropped: usize) -> Option<String> {
+    (dropped > 0).then(|| {
+        format!(
+            "{dropped} {} in this pipeline's reports couldn't be read",
+            if dropped == 1 { "finding" } else { "findings" }
+        )
+    })
+}
+
+/// A secure finding's identity. GitLab's `id` is a content hash, but a stripped
+/// or hand-rolled report can omit it — keying on an empty string would collapse
+/// every id-less finding into one, so those key on where the finding is instead.
+#[derive(PartialEq, Eq, Hash)]
+enum SecureKey {
+    Id(String),
+    Location(String, String, Option<u64>),
+}
+
+fn secure_key(finding: &GlSecureFindingOut) -> SecureKey {
+    if finding.id.is_empty() {
+        SecureKey::Location(
+            finding.name.clone(),
+            finding.file.clone(),
+            finding.start_line,
+        )
+    } else {
+        SecureKey::Id(finding.id.clone())
+    }
+}
+
+/// The availability a category's downloads settle on before any parsing, or
+/// `None` when there are bodies to read.
+fn fetch_availability(fetch: &CategoryFetch) -> Option<(GlFindingAvailability, Option<String>)> {
+    if !fetch.had_candidates {
+        return Some((GlFindingAvailability::NotConfigured, None));
+    }
+    if fetch.bodies.is_empty() {
+        // One candidate job is the norm, so the first failure is the whole story.
+        return Some(
+            fetch
+                .failure
+                .clone()
+                .unwrap_or((GlFindingAvailability::Indeterminate, None)),
+        );
+    }
+    None
+}
+
+fn secure_envelope(fetch: CategoryFetch, limit: usize) -> GlSecureCategoryOut {
+    if let Some((availability, detail)) = fetch_availability(&fetch) {
+        return GlSecureCategoryOut {
+            availability,
+            detail,
+            findings: Vec::new(),
+            truncated: false,
+        };
+    }
+    let tallied = tally(&fetch.bodies, secure_report_items, |v| {
+        serde_json::from_value::<RawVulnerability>(v)
+            .ok()
+            .map(secure_finding_out)
+    });
+    if tallied.readable_bodies == 0 || (tallied.total > 0 && tallied.items.is_empty()) {
+        return GlSecureCategoryOut {
+            availability: GlFindingAvailability::Indeterminate,
+            detail: unreadable_detail(tallied.total),
+            findings: Vec::new(),
+            truncated: false,
+        };
+    }
+    let mut findings = tallied.items;
+    let mut seen = HashSet::new();
+    findings.retain(|f| seen.insert(secure_key(f)));
+    // Sort BEFORE the cap so truncation drops the least severe, not the last read.
+    findings.sort_by_key(|f| std::cmp::Reverse(secure_severity_rank(&f.severity)));
+    let truncated = findings.len() > limit;
+    findings.truncate(limit);
+    GlSecureCategoryOut {
+        availability: GlFindingAvailability::Available,
+        detail: partial_loss_detail(tallied.dropped + fetch.lost_reports),
+        findings,
+        truncated,
+    }
+}
+
+fn code_quality_envelope(fetch: CategoryFetch, limit: usize) -> GlCodeQualityCategoryOut {
+    if let Some((availability, detail)) = fetch_availability(&fetch) {
+        return GlCodeQualityCategoryOut {
+            availability,
+            detail,
+            findings: Vec::new(),
+            truncated: false,
+        };
+    }
+    let tallied = tally(&fetch.bodies, code_quality_report_items, |v| {
+        serde_json::from_value::<RawCqIssue>(v)
+            .ok()
+            .map(code_quality_finding_out)
+    });
+    if tallied.readable_bodies == 0 || (tallied.total > 0 && tallied.items.is_empty()) {
+        return GlCodeQualityCategoryOut {
+            availability: GlFindingAvailability::Indeterminate,
+            detail: unreadable_detail(tallied.total),
+            findings: Vec::new(),
+            truncated: false,
+        };
+    }
+    let mut findings = tallied.items;
+    // A fingerprint alone repeats across checks and files, so identity is the
+    // fingerprint plus the check that raised it and where it landed. The
+    // frontend's composite row id mirrors this tuple.
+    let mut seen = HashSet::new();
+    findings.retain(|f| {
+        seen.insert((
+            f.fingerprint.clone(),
+            f.check_name.clone(),
+            f.path.clone(),
+            f.line,
+        ))
+    });
+    findings.sort_by_key(|f| std::cmp::Reverse(code_quality_severity_rank(&f.severity)));
+    let truncated = findings.len() > limit;
+    findings.truncate(limit);
+    GlCodeQualityCategoryOut {
+        availability: GlFindingAvailability::Available,
+        detail: partial_loss_detail(tallied.dropped + fetch.lost_reports),
+        findings,
+        truncated,
+    }
+}
+
+/// What every early exit needs to report about which ref it looked at.
+struct RefContext {
+    requested_ref: String,
+    used_fallback: bool,
+    fallback_ref: Option<String>,
+    project_web_url: Option<String>,
+}
+
+/// Every category carrying the same classified outcome — the shape of every exit
+/// taken before per-category reports are read.
+fn uniform_out(
+    state: GlPipelineState,
+    pipeline: Option<GlPipelineRefOut>,
+    refs: RefContext,
+    availability: GlFindingAvailability,
+    detail: Option<String>,
+) -> GlFindingsOut {
+    let secure = || GlSecureCategoryOut {
+        availability,
+        detail: detail.clone(),
+        findings: Vec::new(),
+        truncated: false,
+    };
+    GlFindingsOut {
+        pipeline_state: state,
+        pipeline,
+        requested_ref: refs.requested_ref,
+        used_fallback: refs.used_fallback,
+        fallback_ref: refs.fallback_ref,
+        project_web_url: refs.project_web_url,
+        sast: secure(),
+        secret_detection: secure(),
+        code_quality: GlCodeQualityCategoryOut {
+            availability,
+            detail,
+            findings: Vec::new(),
+            truncated: false,
+        },
+    }
+}
+
+// ── Transport ────────────────────────────────────────────────────────────────
+
+/// A list endpoint's items, or a classified unavailability.
+enum Listed<T> {
+    Items(Vec<T>),
+    Unavailable(GlFindingAvailability, Option<String>),
+}
+
+/// The checked-out branch, or `"HEAD"` when detached (or unreadable) — read with
+/// the same `rev-parse --abbrev-ref HEAD` shape as the rest of the app.
+async fn current_branch(repo_path: &str) -> String {
+    crate::git::runner::run_git_raw(
+        Some(repo_path),
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+        crate::git::runner::DEFAULT_TIMEOUT,
+    )
+    .await
+    .ok()
+    .filter(|o| o.code == 0)
+    .map(|o| o.stdout_lossy().trim().to_string())
+    .filter(|b| !b.is_empty())
+    .unwrap_or_else(|| "HEAD".to_string())
+}
+
+async fn fetch_json<T: serde::de::DeserializeOwned>(
+    repo_path: &str,
+    endpoint: &str,
+    what: &str,
+) -> AppResult<Listed<T>> {
+    let out = run_glab_raw(Some(repo_path), &["api", endpoint], GLAB_NETWORK_TIMEOUT).await?;
+    let stdout = out.stdout_lossy();
+    if out.code != 0 {
+        let (availability, detail) = classify_call_failure(&stdout, &out.stderr);
+        return Ok(Listed::Unavailable(availability, detail));
+    }
+    match serde_json::from_str::<Vec<T>>(stdout.trim()) {
+        Ok(items) => Ok(Listed::Items(items)),
+        Err(e) => Ok(Listed::Unavailable(
+            GlFindingAvailability::Indeterminate,
+            Some(format!("could not read GitLab's {what}: {e}")),
+        )),
+    }
+}
+
+/// Recent pipelines for one ref. The `pipelines/latest?ref=` endpoint is BANNED
+/// here: it answers a ref with no pipelines with a bare `{"message":"403
+/// Forbidden"}` (measured 2026-08-11, gitlab.com), which would read as a
+/// permissions problem; the list endpoint answers `[]` honestly.
+/// The pipeline window. Wide enough to survive an auto-cancel storm: interrupted
+/// pushes fill the newest entries with `canceled` pipelines, and a window that
+/// holds only those would report "nothing has finished" for a branch that has.
+const PIPELINE_WINDOW: u32 = 50;
+
+async fn fetch_pipelines(
+    repo_path: &str,
+    enc: &str,
+    git_ref: &str,
+) -> AppResult<Listed<RawPipeline>> {
+    let endpoint = format!(
+        "projects/{enc}/pipelines?ref={}&per_page={PIPELINE_WINDOW}",
+        encode_query_value(git_ref)
+    );
+    fetch_json(repo_path, &endpoint, "pipelines").await
+}
+
+/// GitLab caps a jobs page at 100.
+const JOBS_PER_PAGE: usize = 100;
+/// The jobs walk's ceiling. A fan-out pipeline can push the report job off page
+/// one, but a matrix build can also run thousands of jobs — three pages covers
+/// every realistic pipeline without an unbounded walk on a pathological one.
+const MAX_JOB_PAGES: u32 = 3;
+
+/// Whether the walk continues: a short page is the last one, and the ceiling
+/// stops a full page from paging forever.
+fn has_more_job_pages(page: u32, page_len: usize) -> bool {
+    page < MAX_JOB_PAGES && page_len == JOBS_PER_PAGE
+}
+
+/// Every job of a pipeline, up to the walk's ceiling.
+async fn fetch_jobs(repo_path: &str, enc: &str, pipeline_id: u64) -> AppResult<Listed<RawJob>> {
+    let mut all: Vec<RawJob> = Vec::new();
+    for page in 1..=MAX_JOB_PAGES {
+        let endpoint = format!(
+            "projects/{enc}/pipelines/{pipeline_id}/jobs?per_page={JOBS_PER_PAGE}&page={page}"
+        );
+        match fetch_json::<RawJob>(repo_path, &endpoint, "pipeline jobs").await? {
+            Listed::Items(items) => {
+                let page_len = items.len();
+                all.extend(items);
+                if !has_more_job_pages(page, page_len) {
+                    break;
+                }
+            }
+            // A later page failing must not erase the jobs already read; only a
+            // failure with nothing in hand leaves the category unclassified.
+            Listed::Unavailable(availability, detail) => {
+                if all.is_empty() {
+                    return Ok(Listed::Unavailable(availability, detail));
+                }
+                break;
+            }
+        }
+    }
+    Ok(Listed::Items(all))
+}
+
+/// The artifact download endpoint. The filename is third-party data off the job
+/// metadata, so it is percent-encoded rather than interpolated.
+fn artifact_endpoint(enc: &str, job_id: u64, filename: &str) -> String {
+    format!(
+        "projects/{enc}/jobs/{job_id}/artifacts/{}",
+        encode_query_value(filename)
+    )
+}
+
+/// Every candidate report of one category, downloaded. A transport failure is
+/// contained here: escaping as `Err` would take the pipeline provenance and both
+/// sibling categories down with one slow download.
+async fn fetch_category(
+    repo_path: &str,
+    enc: &str,
+    jobs: &[RawJob],
+    file_type: &str,
+    now: DateTime<Utc>,
+) -> CategoryFetch {
+    let refs = candidates(jobs, file_type);
+    let mut fetch = CategoryFetch {
+        had_candidates: !refs.is_empty(),
+        ..CategoryFetch::default()
+    };
+    for artifact in refs {
+        let endpoint = artifact_endpoint(enc, artifact.job_id, &artifact.filename);
+        let outcome =
+            match run_glab_raw(Some(repo_path), &["api", &endpoint], GLAB_NETWORK_TIMEOUT).await {
+                Ok(out) => artifact_outcome(out, artifact.expire_at.as_deref(), now),
+                Err(e) => Err((GlFindingAvailability::Indeterminate, Some(e.to_string()))),
+            };
+        match outcome {
+            Ok(body) => fetch.bodies.push(body),
+            Err(failure) => {
+                fetch.lost_reports += 1;
+                fetch.failure.get_or_insert(failure);
+            }
+        }
+    }
+    fetch
+}
+
+/// The security and quality findings of the newest completed pipeline on the
+/// checked-out branch, falling back to the default branch when that ref has none.
+pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult<GlFindingsOut> {
+    let cap = clamp_limit(limit);
+    let enc = encode_project(&project_path(repo_path).await?);
+    let requested_ref = current_branch(repo_path).await;
+    let mut refs = RefContext {
+        requested_ref,
+        used_fallback: false,
+        fallback_ref: None,
+        project_web_url: None,
+    };
+
+    let out = run_glab_raw(
+        Some(repo_path),
+        &["api", &format!("projects/{enc}")],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let stdout = out.stdout_lossy();
+    if out.code != 0 {
+        let (availability, detail) = classify_call_failure(&stdout, &out.stderr);
+        return Ok(uniform_out(
+            GlPipelineState::Unavailable,
+            None,
+            refs,
+            availability,
+            detail,
+        ));
+    }
+    let Ok(project) = serde_json::from_str::<RawProject>(stdout.trim()) else {
+        return Ok(uniform_out(
+            GlPipelineState::Unavailable,
+            None,
+            refs,
+            GlFindingAvailability::Indeterminate,
+            Some("could not read GitLab's project response".to_string()),
+        ));
+    };
+    let default_branch = project.default_branch.unwrap_or_default();
+    refs.project_web_url = project
+        .web_url
+        .map(|u| u.trim_end_matches('/').to_string())
+        .filter(|u| !u.is_empty());
+
+    // A detached HEAD names no ref GitLab can filter on, so it goes straight to
+    // the default branch.
+    let detached = refs.requested_ref == "HEAD";
+    let mut pipelines: Vec<RawPipeline> = Vec::new();
+    if !detached {
+        match fetch_pipelines(repo_path, &enc, &refs.requested_ref).await? {
+            Listed::Items(items) => pipelines = items,
+            Listed::Unavailable(availability, detail) => {
+                return Ok(uniform_out(
+                    GlPipelineState::Unavailable,
+                    None,
+                    refs,
+                    availability,
+                    detail,
+                ))
+            }
+        }
+    }
+    if pipelines.is_empty() && !default_branch.is_empty() && default_branch != refs.requested_ref {
+        match fetch_pipelines(repo_path, &enc, &default_branch).await? {
+            Listed::Items(items) => {
+                if !items.is_empty() {
+                    refs.used_fallback = true;
+                    refs.fallback_ref = Some(default_branch);
+                    pipelines = items;
+                }
+            }
+            Listed::Unavailable(availability, detail) => {
+                return Ok(uniform_out(
+                    GlPipelineState::Unavailable,
+                    None,
+                    refs,
+                    availability,
+                    detail,
+                ))
+            }
+        }
+    }
+    if pipelines.is_empty() {
+        return Ok(uniform_out(
+            GlPipelineState::None,
+            None,
+            refs,
+            GlFindingAvailability::NotConfigured,
+            None,
+        ));
+    }
+    let Some(chosen) = pick_pipeline(pipelines) else {
+        return Ok(uniform_out(
+            GlPipelineState::RunningOnly,
+            None,
+            refs,
+            GlFindingAvailability::AnalysisPending,
+            None,
+        ));
+    };
+    let pipeline_id = chosen.id.unwrap_or(0);
+    let pipeline = pipeline_ref_out(chosen);
+
+    let jobs = match fetch_jobs(repo_path, &enc, pipeline_id).await? {
+        Listed::Items(items) => items,
+        Listed::Unavailable(availability, detail) => {
+            return Ok(uniform_out(
+                GlPipelineState::Found,
+                Some(pipeline),
+                refs,
+                availability,
+                detail,
+            ))
+        }
+    };
+
+    let now = Utc::now();
+    let sast = fetch_category(repo_path, &enc, &jobs, SAST_FILE_TYPE, now).await;
+    let secrets = fetch_category(repo_path, &enc, &jobs, SECRET_DETECTION_FILE_TYPE, now).await;
+    let quality = fetch_category(repo_path, &enc, &jobs, CODE_QUALITY_FILE_TYPE, now).await;
+
+    Ok(GlFindingsOut {
+        pipeline_state: GlPipelineState::Found,
+        pipeline: Some(pipeline),
+        requested_ref: refs.requested_ref,
+        used_fallback: refs.used_fallback,
+        fallback_ref: refs.fallback_ref,
+        project_web_url: refs.project_web_url,
+        sast: secure_envelope(sast, cap),
+        secret_detection: secure_envelope(secrets, cap),
+        code_quality: code_quality_envelope(quality, cap),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Trimmed from a real gitlab.com SAST artifact (schema 15.2.2).
+    const SAST_REPORT: &str = r#"{
+      "version": "15.2.2",
+      "vulnerabilities": [
+        {
+          "id": "26f562dd73ffc7044509b75c97c82528bf01abd0023dc728c4ad417caad55339",
+          "category": "sast",
+          "name": "Improper neutralization of directives in dynamically evaluated code",
+          "description": "The application was found calling the `eval` function.",
+          "cve": "semgrep_id:bandit.B307:21:21",
+          "severity": "High",
+          "scanner": { "id": "semgrep", "name": "Semgrep" },
+          "location": { "file": "src/app.py", "start_line": 21 },
+          "identifiers": [
+            { "type": "semgrep_id", "name": "bandit.B307", "value": "bandit.B307",
+              "url": "https://semgrep.dev/r/gitlab.bandit.B307" },
+            { "type": "cwe", "name": "CWE-95", "value": "95",
+              "url": "https://cwe.mitre.org/data/definitions/95.html" }
+          ]
+        },
+        {
+          "id": "8b46a585c8bc6d909ca9ca99209f42fcd6c11e89c026ab2f7c872ce5e77f68c3",
+          "category": "sast",
+          "name": "Use of a broken or risky cryptographic algorithm",
+          "description": "The application was found using an insecure digest algorithm.",
+          "cve": "semgrep_id:bandit.B303-1:26:26",
+          "severity": "Medium",
+          "scanner": { "id": "semgrep", "name": "Semgrep" },
+          "location": { "file": "src/app.py", "start_line": 26 },
+          "identifiers": [
+            { "type": "cwe", "name": "CWE-327", "value": "327",
+              "url": "https://cwe.mitre.org/data/definitions/327.html" }
+          ]
+        }
+      ],
+      "scan": { "type": "sast", "status": "success" }
+    }"#;
+
+    /// Trimmed from a real gitlab.com secret-detection artifact (schema 15.2.4).
+    /// The credentials in it are fixtures — they are what the strip test asserts on.
+    const SECRET_REPORT: &str = r#"{
+      "version": "15.2.4",
+      "vulnerabilities": [
+        {
+          "id": "ab833bb20d198f25e85ffcd6c46cb1c489c21b6e67ab423fae27d4f587281ff3",
+          "category": "secret_detection",
+          "name": "RSA private key",
+          "description": "An RSA private key was identified.",
+          "cve": "config/deploy-config.py:8bcac7908eb95041:RSA private key",
+          "severity": "Critical",
+          "confidence": "Unknown",
+          "raw_source_code_extract": "-----BEGIN RSA PRIVATE KEY-----",
+          "scanner": { "id": "gitleaks", "name": "Gitleaks" },
+          "location": { "file": "config/deploy-config.py", "start_line": 9 },
+          "identifiers": [
+            { "type": "gitleaks_rule_id", "name": "Gitleaks rule ID RSA private key",
+              "value": "RSA private key" }
+          ]
+        },
+        {
+          "id": "b3519db96df50f6c2176378a4b422d453585e1dc6192f20a02ef9258b594f7d8",
+          "category": "secret_detection",
+          "name": "GitLab personal access token",
+          "description": "A GitLab personal access token was identified.",
+          "cve": "config/deploy-config.py:ac641ef297c9dba8:gitlab_personal_access_token",
+          "severity": "Critical",
+          "confidence": "Unknown",
+          "raw_source_code_extract": "FAKE-EXTRACT-SENTINEL-000",
+          "scanner": { "id": "gitleaks", "name": "Gitleaks" },
+          "location": { "file": "config/deploy-config.py", "start_line": 7 },
+          "identifiers": [
+            { "type": "gitleaks_rule_id", "name": "Gitleaks rule ID gitlab_personal_access_token",
+              "value": "gitlab_personal_access_token" }
+          ]
+        }
+      ],
+      "scan": { "type": "secret_detection", "status": "success" }
+    }"#;
+
+    /// A real gitlab.com codequality artifact, plus one `positions`-shaped item —
+    /// CodeClimate allows either line shape.
+    const CQ_REPORT: &str = r#"[
+      { "description": "Function runQuery has a cognitive complexity of 12.",
+        "check_name": "cognitive-complexity", "fingerprint": "cq-fixture-0001",
+        "severity": "major", "location": { "path": "src/server.js", "lines": { "begin": 6 } } },
+      { "description": "Similar blocks of code found in 2 locations.",
+        "check_name": "duplicate-code", "fingerprint": "cq-fixture-0002",
+        "severity": "minor", "location": { "path": "src/app.py", "lines": { "begin": 9 } } },
+      { "description": "Avoid deeply nested control flow statements.",
+        "check_name": "nested-control-flow", "fingerprint": "cq-fixture-0003",
+        "severity": "critical", "location": { "path": "src/app.py", "lines": { "begin": 17 } } },
+      { "description": "TODO found: remove debug logging before release.",
+        "check_name": "fixme", "fingerprint": "cq-fixture-0004",
+        "severity": "info",
+        "location": { "path": "src/server.js", "positions": { "begin": { "line": 13 } } } }
+    ]"#;
+
+    fn bodies(reports: &[&str]) -> CategoryFetch {
+        CategoryFetch {
+            had_candidates: true,
+            bodies: reports.iter().map(|r| r.as_bytes().to_vec()).collect(),
+            failure: None,
+            lost_reports: 0,
+        }
+    }
+
+    fn ok_output(stdout: &[u8]) -> GlabOutput {
+        GlabOutput {
+            stdout: stdout.to_vec(),
+            stderr: String::new(),
+            code: 0,
+        }
+    }
+
+    fn failed_output(stdout: &str, stderr: &str) -> GlabOutput {
+        GlabOutput {
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.to_string(),
+            code: 1,
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-11T18:00:00Z")
+            .expect("fixed clock parses")
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn wire_shape_is_pinned() {
+        let out = GlFindingsOut {
+            pipeline_state: GlPipelineState::Found,
+            pipeline: Some(GlPipelineRefOut {
+                id: 2751382498,
+                iid: 57,
+                status: "success".into(),
+                sha: "eb1e0a68".into(),
+                git_ref: "main".into(),
+                web_url: "https://gitlab.com/g/r/-/pipelines/2751382498".into(),
+                created_at: "2026-08-11T17:11:33.295Z".into(),
+                finished_at: None,
+            }),
+            requested_ref: "feature".into(),
+            used_fallback: true,
+            fallback_ref: Some("main".into()),
+            project_web_url: Some("https://gitlab.com/g/r".into()),
+            sast: secure_envelope(bodies(&[SAST_REPORT]), 100),
+            secret_detection: GlSecureCategoryOut {
+                availability: GlFindingAvailability::Expired,
+                detail: Some("the job's artifacts expired on 2026-08-01T00:00:00Z".into()),
+                findings: Vec::new(),
+                truncated: false,
+            },
+            code_quality: code_quality_envelope(bodies(&[CQ_REPORT]), 1),
+        };
+        let value = serde_json::to_value(&out).expect("envelope serializes");
+        assert_eq!(value["pipelineState"], json!("found"));
+        assert_eq!(value["requestedRef"], json!("feature"));
+        assert_eq!(value["usedFallback"], json!(true));
+        assert_eq!(value["fallbackRef"], json!("main"));
+        assert_eq!(value["projectWebUrl"], json!("https://gitlab.com/g/r"));
+        // `ref` and `type` are hand-pinned around the Rust keywords.
+        assert_eq!(value["pipeline"]["ref"], json!("main"));
+        assert_eq!(value["pipeline"]["iid"], json!(57));
+        assert_eq!(
+            value["pipeline"]["webUrl"],
+            json!("https://gitlab.com/g/r/-/pipelines/2751382498")
+        );
+        assert_eq!(
+            value["pipeline"]["createdAt"],
+            json!("2026-08-11T17:11:33.295Z")
+        );
+        assert_eq!(value["pipeline"]["finishedAt"], json!(null));
+        assert_eq!(value["sast"]["availability"], json!("available"));
+        assert_eq!(value["sast"]["truncated"], json!(false));
+        let finding = &value["sast"]["findings"][0];
+        assert_eq!(finding["severity"], json!("High"));
+        assert_eq!(finding["file"], json!("src/app.py"));
+        assert_eq!(finding["startLine"], json!(21));
+        assert_eq!(finding["endLine"], json!(null));
+        assert_eq!(finding["scannerName"], json!("Semgrep"));
+        assert_eq!(finding["identifiers"][0]["type"], json!("semgrep_id"));
+        assert_eq!(finding["identifiers"][0]["value"], json!("bandit.B307"));
+        assert_eq!(
+            finding["identifiers"][0]["url"],
+            json!("https://semgrep.dev/r/gitlab.bandit.B307")
+        );
+        assert_eq!(value["secretDetection"]["availability"], json!("expired"));
+        let cq = &value["codeQuality"]["findings"][0];
+        assert_eq!(cq["checkName"], json!("nested-control-flow"));
+        assert_eq!(cq["fingerprint"], json!("cq-fixture-0003"));
+        assert_eq!(cq["severity"], json!("critical"));
+        assert_eq!(cq["path"], json!("src/app.py"));
+        assert_eq!(cq["line"], json!(17));
+        assert_eq!(value["codeQuality"]["truncated"], json!(true));
+    }
+
+    #[test]
+    fn availability_and_state_wire_strings_are_pinned() {
+        for (variant, wire) in [
+            (GlFindingAvailability::Available, "available"),
+            (GlFindingAvailability::NotConfigured, "notConfigured"),
+            (
+                GlFindingAvailability::ReportNotReadable,
+                "reportNotReadable",
+            ),
+            (GlFindingAvailability::Expired, "expired"),
+            (GlFindingAvailability::AnalysisPending, "analysisPending"),
+            (GlFindingAvailability::Forbidden, "forbidden"),
+            (GlFindingAvailability::Indeterminate, "indeterminate"),
+        ] {
+            assert_eq!(serde_json::to_value(variant).unwrap(), json!(wire));
+        }
+        for (variant, wire) in [
+            (GlPipelineState::Found, "found"),
+            (GlPipelineState::None, "none"),
+            (GlPipelineState::RunningOnly, "runningOnly"),
+            (GlPipelineState::Unavailable, "unavailable"),
+        ] {
+            assert_eq!(serde_json::to_value(variant).unwrap(), json!(wire));
+        }
+    }
+
+    #[test]
+    fn the_leaked_secret_never_reaches_the_wire() {
+        // The input really does carry the extract — otherwise this passes vacuously.
+        // (Sentinel value, not a token shape: GitHub push protection blocks anything
+        // matching a real credential pattern, even a fake.)
+        assert!(SECRET_REPORT.contains("FAKE-EXTRACT-SENTINEL-000"));
+        assert!(SECRET_REPORT.contains("BEGIN RSA PRIVATE KEY"));
+        let envelope = secure_envelope(bodies(&[SECRET_REPORT]), 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::Available);
+        assert_eq!(envelope.findings.len(), 2);
+        let json = serde_json::to_string(&envelope).expect("envelope serializes");
+        // `raw_source_code_extract` is undeclared, so the extract can't survive the
+        // round trip; `cve` on secret detection is a fingerprint composite, not a CVE.
+        assert!(!json.contains("FAKE-EXTRACT-SENTINEL-000"), "{json}");
+        assert!(!json.contains("BEGIN RSA PRIVATE KEY"), "{json}");
+        assert!(!json.contains("rawSourceCodeExtract"), "{json}");
+        assert!(
+            !json.contains("deploy-config.py:ac641ef297c9dba8"),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn sast_report_maps_every_field() {
+        let envelope = secure_envelope(bodies(&[SAST_REPORT]), 100);
+        let first = &envelope.findings[0];
+        assert_eq!(
+            first.id,
+            "26f562dd73ffc7044509b75c97c82528bf01abd0023dc728c4ad417caad55339"
+        );
+        assert_eq!(
+            first.name,
+            "Improper neutralization of directives in dynamically evaluated code"
+        );
+        assert_eq!(first.severity, "High");
+        assert_eq!(first.file, "src/app.py");
+        assert_eq!(first.start_line, Some(21));
+        assert_eq!(first.end_line, None);
+        assert_eq!(first.scanner_name, "Semgrep");
+        assert_eq!(first.identifiers.len(), 2);
+        assert_eq!(first.identifiers[1].identifier_type, "cwe");
+        assert_eq!(first.identifiers[1].value, "95");
+        assert!(first.description.starts_with("The application was found"));
+    }
+
+    #[test]
+    fn code_quality_reads_either_line_shape() {
+        let envelope = code_quality_envelope(bodies(&[CQ_REPORT]), 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::Available);
+        let by_check = |name: &str| {
+            envelope
+                .findings
+                .iter()
+                .find(|f| f.check_name == name)
+                .expect("check present")
+                .line
+        };
+        assert_eq!(by_check("cognitive-complexity"), Some(6)); // location.lines.begin
+        assert_eq!(by_check("fixme"), Some(13)); // location.positions.begin.line
+    }
+
+    #[test]
+    fn a_sparse_finding_degrades_field_by_field() {
+        let report = r#"{"vulnerabilities":[{"id":"only-an-id"}]}"#;
+        let envelope = secure_envelope(bodies(&[report]), 100);
+        let first = &envelope.findings[0];
+        assert_eq!(first.id, "only-an-id");
+        assert_eq!(first.severity, "");
+        assert_eq!(first.file, "");
+        assert_eq!(first.start_line, None);
+        assert!(first.identifiers.is_empty());
+    }
+
+    #[test]
+    fn a_bare_403_reads_as_forbidden() {
+        // GitLab Free sends no explanation at all with a paywalled/unauthorized read.
+        let out = failed_output(r#"{"message":"403 Forbidden"}"#, "glab: HTTP 403");
+        let Err((availability, detail)) = artifact_outcome(out, None, now()) else {
+            panic!("a 403 is not a readable report");
+        };
+        assert_eq!(availability, GlFindingAvailability::Forbidden);
+        assert_eq!(detail.as_deref(), Some("403 Forbidden"));
+        // The same classifier runs on the project/pipelines calls.
+        let (availability, _) = classify_call_failure("", "glab: HTTP 403 Forbidden");
+        assert_eq!(availability, GlFindingAvailability::Forbidden);
+    }
+
+    #[test]
+    fn an_expired_artifact_is_told_from_one_the_api_wont_serve() {
+        // Measured 404 shape: glab prints `404 page not found` and `glab: HTTP 404`.
+        let expired = artifact_outcome(
+            failed_output("404 page not found", "glab: HTTP 404"),
+            Some("2026-08-01T12:00:00Z"),
+            now(),
+        );
+        assert_eq!(
+            expired.unwrap_err().0,
+            GlFindingAvailability::Expired,
+            "a past artifacts_expire_at explains the 404"
+        );
+        // No expiry (artifacts kept) → the report is declared but unserved.
+        let not_readable = artifact_outcome(
+            failed_output("404 page not found", "glab: HTTP 404"),
+            None,
+            now(),
+        );
+        assert_eq!(
+            not_readable.unwrap_err().0,
+            GlFindingAvailability::ReportNotReadable
+        );
+        // An expiry still in the future can't explain it either.
+        let future = artifact_outcome(
+            failed_output("404 page not found", "glab: HTTP 404"),
+            Some("2026-09-10T17:11:43.795Z"),
+            now(),
+        );
+        assert_eq!(
+            future.unwrap_err().0,
+            GlFindingAvailability::ReportNotReadable
+        );
+    }
+
+    #[test]
+    fn an_oversized_report_is_refused_rather_than_parsed() {
+        let outcome = artifact_outcome(ok_output(&vec![b'x'; MAX_REPORT_BYTES + 1]), None, now());
+        let (availability, detail) = outcome.unwrap_err();
+        assert_eq!(availability, GlFindingAvailability::Indeterminate);
+        assert_eq!(detail.as_deref(), Some("the report was too large to read"));
+    }
+
+    #[test]
+    fn a_category_with_no_candidate_job_is_not_configured() {
+        let jobs: Vec<RawJob> = serde_json::from_value(json!([
+            { "id": 1, "artifacts": [{ "file_type": "trace", "filename": "job.log" }] },
+            { "id": 2, "artifacts": [
+                { "file_type": "archive", "filename": "artifacts.zip" },
+                { "file_type": "codequality", "filename": "gl-code-quality-report.json" }
+            ], "artifacts_expire_at": "2026-09-10T17:11:43.795Z" }
+        ]))
+        .expect("jobs deserialize");
+        assert!(candidates(&jobs, SAST_FILE_TYPE).is_empty());
+        assert_eq!(
+            candidates(&jobs, CODE_QUALITY_FILE_TYPE),
+            vec![ArtifactRef {
+                job_id: 2,
+                filename: "gl-code-quality-report.json".into(),
+                expire_at: Some("2026-09-10T17:11:43.795Z".into()),
+            }]
+        );
+        let envelope = secure_envelope(CategoryFetch::default(), 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::NotConfigured);
+        assert!(envelope.findings.is_empty());
+        assert_eq!(envelope.detail, None);
+    }
+
+    #[test]
+    fn a_parsed_empty_report_is_the_clean_state() {
+        let envelope = secure_envelope(
+            bodies(&[r#"{"version":"15.2.2","vulnerabilities":[]}"#]),
+            100,
+        );
+        assert_eq!(envelope.availability, GlFindingAvailability::Available);
+        assert!(envelope.findings.is_empty());
+        assert!(!envelope.truncated);
+        let cq = code_quality_envelope(bodies(&["[]"]), 100);
+        assert_eq!(cq.availability, GlFindingAvailability::Available);
+        assert!(cq.findings.is_empty());
+    }
+
+    #[test]
+    fn a_window_that_parsed_away_is_indeterminate_with_its_count() {
+        // Items of the wrong TYPE (severity as a number, identifiers as a string)
+        // survive the report parse but not their own — an empty Available list here
+        // would claim the project is clean.
+        let report =
+            r#"{"vulnerabilities":[{"id":"a","severity":7},{"id":"b","identifiers":"nope"}]}"#;
+        let envelope = secure_envelope(bodies(&[report]), 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::Indeterminate);
+        assert_eq!(
+            envelope.detail.as_deref(),
+            Some("GitLab returned 2 findings this build couldn't read")
+        );
+        // A body that isn't a report at all is unreadable, not clean — and with no
+        // item count to report, it says so without a number.
+        let garbage = code_quality_envelope(bodies(&["<html>502</html>"]), 100);
+        assert_eq!(garbage.availability, GlFindingAvailability::Indeterminate);
+        assert_eq!(
+            garbage.detail.as_deref(),
+            Some("GitLab returned a report this build couldn't read")
+        );
+    }
+
+    #[test]
+    fn a_report_without_a_vulnerabilities_key_is_never_clean() {
+        // An analyzer that failed internally can emit a body with no findings KEY;
+        // reading that as zero findings would render "No SAST findings".
+        for body in [
+            r#"{"version":"15.2.2"}"#,
+            "{}",
+            r#"{"scan":{"status":"failure"}}"#,
+        ] {
+            let envelope = secure_envelope(bodies(&[body]), 100);
+            assert_eq!(
+                envelope.availability,
+                GlFindingAvailability::Indeterminate,
+                "{body}"
+            );
+            assert_eq!(
+                envelope.detail.as_deref(),
+                Some("GitLab returned a report this build couldn't read")
+            );
+        }
+        // The key present and empty IS the clean state.
+        assert_eq!(
+            secure_envelope(bodies(&[r#"{"vulnerabilities":[]}"#]), 100).availability,
+            GlFindingAvailability::Available
+        );
+    }
+
+    #[test]
+    fn id_less_findings_are_not_deduped_into_one() {
+        // A report with no `id` must not collapse on the empty string.
+        let report = r#"{"vulnerabilities":[
+          { "name": "Hardcoded password", "severity": "High",
+            "location": { "file": "a.py", "start_line": 3 } },
+          { "name": "Hardcoded password", "severity": "High",
+            "location": { "file": "b.py", "start_line": 3 } },
+          { "name": "Hardcoded password", "severity": "High",
+            "location": { "file": "c.py", "start_line": 3 } }
+        ]}"#;
+        let envelope = secure_envelope(bodies(&[report]), 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::Available);
+        assert_eq!(envelope.findings.len(), 3);
+        // The same id-less finding at the same place still dedupes.
+        assert_eq!(
+            secure_envelope(bodies(&[report, report]), 100)
+                .findings
+                .len(),
+            3
+        );
+    }
+
+    #[test]
+    fn a_partly_unreadable_category_says_how_much_it_lost() {
+        // One good report + one body that isn't a report: the list is short, not
+        // wrong, so it stays Available and carries the loss as a notice.
+        let fetch = bodies(&[SAST_REPORT, "<html>502 Bad Gateway</html>"]);
+        let envelope = secure_envelope(fetch, 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::Available);
+        assert_eq!(envelope.findings.len(), 2);
+        assert_eq!(
+            envelope.detail.as_deref(),
+            Some("1 finding in this pipeline's reports couldn't be read")
+        );
+        // Per-ITEM losses count the same way, and pluralize.
+        let partial = r#"{"vulnerabilities":[
+          { "id": "good", "severity": "Low" },
+          { "id": "bad", "severity": 7 },
+          { "id": "worse", "identifiers": "nope" }
+        ]}"#;
+        let envelope = secure_envelope(bodies(&[partial]), 100);
+        assert_eq!(envelope.availability, GlFindingAvailability::Available);
+        assert_eq!(envelope.findings.len(), 1);
+        assert_eq!(
+            envelope.detail.as_deref(),
+            Some("2 findings in this pipeline's reports couldn't be read")
+        );
+        // A report that failed to DOWNLOAD counts too, next to one that parsed.
+        let mut mixed = bodies(&[CQ_REPORT]);
+        mixed.lost_reports = 1;
+        let cq = code_quality_envelope(mixed, 100);
+        assert_eq!(cq.availability, GlFindingAvailability::Available);
+        assert_eq!(cq.findings.len(), 4);
+        assert_eq!(
+            cq.detail.as_deref(),
+            Some("1 finding in this pipeline's reports couldn't be read")
+        );
+        // Nothing lost → no notice.
+        assert_eq!(secure_envelope(bodies(&[SAST_REPORT]), 100).detail, None);
+    }
+
+    #[test]
+    fn code_quality_identity_includes_the_check() {
+        // One fingerprint, two checks, same line: two findings, not one.
+        let report = r#"[
+          { "fingerprint": "f", "check_name": "duplicate-code", "severity": "minor",
+            "location": { "path": "a.js", "lines": { "begin": 1 } } },
+          { "fingerprint": "f", "check_name": "cognitive-complexity", "severity": "minor",
+            "location": { "path": "a.js", "lines": { "begin": 1 } } }
+        ]"#;
+        assert_eq!(
+            code_quality_envelope(bodies(&[report]), 100).findings.len(),
+            2
+        );
+    }
+
+    #[test]
+    fn a_large_body_cannot_classify_the_failure() {
+        // A report echoed on a failed call can carry "forbidden" in rule prose; only
+        // the server's message and glab's stderr may classify.
+        let mut prose = String::from("Improper access control: the resource is forbidden. ");
+        while prose.len() <= MAX_ERROR_BODY_BYTES {
+            prose.push_str("padding padding padding padding padding padding ");
+        }
+        let (availability, detail) = classify_call_failure(&prose, "glab: HTTP 500");
+        assert_eq!(availability, GlFindingAvailability::Indeterminate);
+        assert_eq!(detail.as_deref(), Some("glab: HTTP 500"));
+        // Small, but not an error envelope: still no message to classify on.
+        let (availability, _) =
+            classify_call_failure(r#"[{"description":"forbidden pattern"}]"#, "glab: HTTP 500");
+        assert_eq!(availability, GlFindingAvailability::Indeterminate);
+    }
+
+    #[test]
+    fn the_artifact_filename_is_encoded() {
+        // The plain case is pinned byte for byte — encoding must not disturb it.
+        assert_eq!(
+            artifact_endpoint("g%2Fr", 15838385685, "gl-sast-report.json"),
+            "projects/g%2Fr/jobs/15838385685/artifacts/gl-sast-report.json"
+        );
+        // The filename comes off job metadata, so it can't be interpolated raw.
+        assert_eq!(
+            artifact_endpoint("g%2Fr", 1, "../../secrets?x=1"),
+            "projects/g%2Fr/jobs/1/artifacts/..%2F..%2Fsecrets%3Fx%3D1"
+        );
+    }
+
+    #[test]
+    fn the_jobs_walk_stops_on_a_short_page_or_the_ceiling() {
+        assert!(has_more_job_pages(1, JOBS_PER_PAGE));
+        assert!(has_more_job_pages(2, JOBS_PER_PAGE));
+        // The ceiling stops a full page from paging forever.
+        assert!(!has_more_job_pages(MAX_JOB_PAGES, JOBS_PER_PAGE));
+        // A short page is the last one.
+        assert!(!has_more_job_pages(1, JOBS_PER_PAGE - 1));
+        assert!(!has_more_job_pages(1, 0));
+    }
+
+    #[test]
+    fn a_download_failure_carries_its_classification_into_the_envelope() {
+        let fetch = CategoryFetch {
+            had_candidates: true,
+            bodies: Vec::new(),
+            failure: Some((
+                GlFindingAvailability::ReportNotReadable,
+                Some("the job lists this report but GitLab returned 404 for the file".into()),
+            )),
+            lost_reports: 1,
+        };
+        let envelope = secure_envelope(fetch, 100);
+        assert_eq!(
+            envelope.availability,
+            GlFindingAvailability::ReportNotReadable
+        );
+        assert!(envelope.detail.is_some());
+        assert!(envelope.findings.is_empty());
+    }
+
+    #[test]
+    fn the_newest_completed_pipeline_wins_over_a_running_one() {
+        let list: Vec<RawPipeline> = serde_json::from_value(json!([
+            { "id": 3, "iid": 59, "status": "running", "ref": "main" },
+            { "id": 2, "iid": 58, "status": "failed", "ref": "main", "sha": "beef" },
+            { "id": 1, "iid": 57, "status": "success", "ref": "main" }
+        ]))
+        .expect("pipelines deserialize");
+        let chosen = pick_pipeline(list).expect("a completed pipeline exists");
+        assert_eq!(chosen.id, Some(2));
+        let out = pipeline_ref_out(chosen);
+        assert_eq!(out.status, "failed");
+        assert_eq!(out.git_ref, "main");
+        assert_eq!(out.sha, "beef");
+        // The list payload carries no finish time (measured) — never invented.
+        assert_eq!(out.finished_at, None);
+    }
+
+    #[test]
+    fn a_pipeline_list_with_nothing_finished_has_no_pick() {
+        let list: Vec<RawPipeline> = serde_json::from_value(json!([
+            { "id": 3, "status": "running" },
+            { "id": 2, "status": "pending" },
+            // Canceled and skipped pipelines publish no artifacts either.
+            { "id": 1, "status": "canceled" }
+        ]))
+        .expect("pipelines deserialize");
+        assert!(pick_pipeline(list).is_none());
+        assert!(pick_pipeline(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn the_same_finding_across_two_jobs_is_listed_once() {
+        // Two SAST jobs (e.g. two analyzers) both publishing the same vulnerability.
+        let envelope = secure_envelope(bodies(&[SAST_REPORT, SAST_REPORT]), 100);
+        assert_eq!(envelope.findings.len(), 2);
+        let cq = code_quality_envelope(bodies(&[CQ_REPORT, CQ_REPORT]), 100);
+        assert_eq!(cq.findings.len(), 4);
+        // Same fingerprint at a different location is a different finding.
+        let moved = r#"[
+          { "fingerprint": "f", "check_name": "c", "severity": "minor",
+            "location": { "path": "a.js", "lines": { "begin": 1 } } },
+          { "fingerprint": "f", "check_name": "c", "severity": "minor",
+            "location": { "path": "b.js", "lines": { "begin": 1 } } }
+        ]"#;
+        assert_eq!(
+            code_quality_envelope(bodies(&[moved]), 100).findings.len(),
+            2
+        );
+    }
+
+    #[test]
+    fn truncation_keeps_the_worst_findings() {
+        let report = r#"{"vulnerabilities":[
+          { "id": "1", "severity": "Low" },
+          { "id": "2", "severity": "unknown" },
+          { "id": "3", "severity": "CRITICAL" },
+          { "id": "4", "severity": "Medium" }
+        ]}"#;
+        let envelope = secure_envelope(bodies(&[report]), 2);
+        assert!(envelope.truncated);
+        let kept: Vec<&str> = envelope.findings.iter().map(|f| f.id.as_str()).collect();
+        // Case-insensitive ladder, sorted before the cap.
+        assert_eq!(kept, vec!["3", "4"]);
+        // Blocker outranks critical on the CodeClimate ladder.
+        let cq = code_quality_envelope(
+            bodies(&[r#"[
+              { "fingerprint": "a", "severity": "critical" },
+              { "fingerprint": "b", "severity": "BLOCKER" },
+              { "fingerprint": "c", "severity": "info" }
+            ]"#]),
+            1,
+        );
+        assert!(cq.truncated);
+        assert_eq!(cq.findings[0].fingerprint, "b");
+        // Nothing dropped → not truncated.
+        assert!(!secure_envelope(bodies(&[report]), 4).truncated);
+    }
+
+    #[test]
+    fn the_cap_is_clamped() {
+        assert_eq!(clamp_limit(None), 100);
+        assert_eq!(clamp_limit(Some(0)), 1);
+        assert_eq!(clamp_limit(Some(25)), 25);
+        assert_eq!(clamp_limit(Some(10_000)), 500);
+    }
+
+    #[test]
+    fn artifact_expiry_needs_a_parseable_past_instant() {
+        assert!(artifacts_expired(Some("2026-08-01T12:00:00Z"), now()));
+        assert!(!artifacts_expired(Some("2026-09-10T17:11:43.795Z"), now()));
+        assert!(!artifacts_expired(None, now()));
+        assert!(!artifacts_expired(Some(""), now()));
+        assert!(!artifacts_expired(Some("last Tuesday"), now()));
+    }
+}

--- a/src-tauri/src/forge/gitlab_findings.rs
+++ b/src-tauri/src/forge/gitlab_findings.rs
@@ -81,7 +81,7 @@ pub struct GlFindingsOut {
     pub fallback_ref: Option<String>,
     /// The default branch's NAME — the ref the fallback consults, stated whether
     /// or not it was used; `fallback_ref` answers that separate question. `None`
-    /// only when the project lookup itself failed.
+    /// when the project lookup failed, or the project has no default branch yet.
     pub default_ref: Option<String>,
     pub project_web_url: Option<String>,
     pub sast: GlSecureCategoryOut,
@@ -1428,7 +1428,8 @@ mod tests {
         assert_eq!(value["defaultRef"], json!("main"));
         assert_eq!(value["fallbackRef"], json!(null));
         assert_eq!(value["usedFallback"], json!(false));
-        // Only a failed project lookup leaves the default branch unknown.
+        // A failed project lookup — or a project with no default branch yet —
+        // leaves the default branch unknown.
         let unavailable = uniform_out(
             GlPipelineState::Unavailable,
             None,

--- a/src-tauri/src/forge/gitlab_findings.rs
+++ b/src-tauri/src/forge/gitlab_findings.rs
@@ -21,8 +21,9 @@ use crate::forge::encode_query_value;
 use crate::forge::gitlab::{encode_project, glab_output_is_404, project_path};
 use crate::forge::glab::{run_glab_raw, GlabOutput, GLAB_NETWORK_TIMEOUT};
 
-/// A report bigger than this is refused rather than parsed — the artifact is
-/// attacker-influenceable in size and the whole body is held in memory.
+/// A report bigger than this is refused rather than parsed. `run_glab_raw` has
+/// already buffered the whole artifact by the time we look, so the cap bounds the
+/// PARSE — serde over an attacker-influenceable body — not the bytes held.
 const MAX_REPORT_BYTES: usize = 16 * 1024 * 1024;
 
 /// GitLab's `file_type` for each report we read, as the jobs payload spells them.
@@ -170,6 +171,10 @@ pub struct GlCodeQualityFindingOut {
 
 #[derive(Deserialize, Default)]
 struct RawProject {
+    /// The numeric project id, which is what a bridge's downstream pipeline
+    /// identifies its own project by.
+    #[serde(default)]
+    id: Option<u64>,
     #[serde(default)]
     default_branch: Option<String>,
     #[serde(default)]
@@ -214,6 +219,25 @@ struct RawJob {
     artifacts_expire_at: Option<String>,
     #[serde(default)]
     artifacts: Option<Vec<RawJobArtifact>>,
+}
+
+#[derive(Deserialize, Default, Clone, Debug)]
+struct RawDownstreamPipeline {
+    #[serde(default)]
+    id: Option<u64>,
+    /// Pipeline ids are instance-global, so this is what tells a parent-child
+    /// pipeline apart from a multi-project (`trigger: project:`) one.
+    #[serde(default)]
+    project_id: Option<u64>,
+}
+
+/// A `trigger:` job. Its work runs in a downstream pipeline whose jobs the
+/// parent's own jobs endpoint never lists.
+#[derive(Deserialize, Default, Clone, Debug)]
+struct RawBridge {
+    /// Null until the bridge triggers, and when creating the child failed.
+    #[serde(default)]
+    downstream_pipeline: Option<RawDownstreamPipeline>,
 }
 
 #[derive(Deserialize, Default)]
@@ -559,8 +583,10 @@ struct Tally<T> {
     items: Vec<T>,
     total: usize,
     readable_bodies: usize,
-    /// Findings known lost: items that failed to deserialize, plus one per body
-    /// that wasn't a readable report at all.
+    /// Bodies that arrived but weren't readable reports. Counted in REPORTS: how
+    /// many findings each hid is exactly what couldn't be read.
+    unreadable_bodies: usize,
+    /// Individual findings that failed to deserialize out of a readable report.
     dropped: usize,
 }
 
@@ -575,13 +601,12 @@ where
         items: Vec::new(),
         total: 0,
         readable_bodies: 0,
+        unreadable_bodies: 0,
         dropped: 0,
     };
     for body in bodies {
         let Some(values) = items_of(body) else {
-            // An unreadable body hides an unknown number of findings; one keeps
-            // the loss visible without inventing a census.
-            out.dropped += 1;
+            out.unreadable_bodies += 1;
             continue;
         };
         let count = values.len();
@@ -621,13 +646,20 @@ fn unreadable_detail(total: usize) -> Option<String> {
 
 /// The muted notice that rides an otherwise-`Available` category: part of the
 /// pipeline's output was unreadable, so the list is short rather than wrong.
-fn partial_loss_detail(dropped: usize) -> Option<String> {
-    (dropped > 0).then(|| {
-        format!(
-            "{dropped} {} in this pipeline's reports couldn't be read",
-            if dropped == 1 { "finding" } else { "findings" }
-        )
+/// Reports and findings stay separate units — a lost report hides an unknown
+/// number of findings, so folding it into a finding count would understate it.
+fn partial_loss_detail(lost_reports: usize, dropped_findings: usize) -> Option<String> {
+    let parts: Vec<String> = [
+        (lost_reports, "report", "reports"),
+        (dropped_findings, "finding", "findings"),
+    ]
+    .into_iter()
+    .filter(|(count, _, _)| *count > 0)
+    .map(|(count, singular, plural)| {
+        format!("{count} {}", if count == 1 { singular } else { plural })
     })
+    .collect();
+    (!parts.is_empty()).then(|| format!("{} couldn't be read", parts.join(" and ")))
 }
 
 /// A secure finding's identity. GitLab's `id` is a content hash, but a stripped
@@ -700,7 +732,10 @@ fn secure_envelope(fetch: CategoryFetch, limit: usize) -> GlSecureCategoryOut {
     findings.truncate(limit);
     GlSecureCategoryOut {
         availability: GlFindingAvailability::Available,
-        detail: partial_loss_detail(tallied.dropped + fetch.lost_reports),
+        detail: partial_loss_detail(
+            fetch.lost_reports + tallied.unreadable_bodies,
+            tallied.dropped,
+        ),
         findings,
         truncated,
     }
@@ -746,7 +781,10 @@ fn code_quality_envelope(fetch: CategoryFetch, limit: usize) -> GlCodeQualityCat
     findings.truncate(limit);
     GlCodeQualityCategoryOut {
         availability: GlFindingAvailability::Available,
-        detail: partial_loss_detail(tallied.dropped + fetch.lost_reports),
+        detail: partial_loss_detail(
+            fetch.lost_reports + tallied.unreadable_bodies,
+            tallied.dropped,
+        ),
         findings,
         truncated,
     }
@@ -858,35 +896,42 @@ async fn fetch_pipelines(
     fetch_json(repo_path, &endpoint, "pipelines").await
 }
 
-/// GitLab caps a jobs page at 100.
+/// GitLab caps a list page at 100.
 const JOBS_PER_PAGE: usize = 100;
-/// The jobs walk's ceiling. A fan-out pipeline can push the report job off page
-/// one, but a matrix build can also run thousands of jobs — three pages covers
-/// every realistic pipeline without an unbounded walk on a pathological one.
-const MAX_JOB_PAGES: u32 = 3;
+/// The list walk's ceiling, for jobs and bridges alike. Either can run past one
+/// page — a fan-out pipeline's jobs, a many-way `trigger:` matrix's bridges — but
+/// both can also run to thousands, so three pages covers every realistic pipeline
+/// without an unbounded walk on a pathological one.
+const MAX_LIST_PAGES: u32 = 3;
+/// How many downstream (child) pipelines a parent's bridges may contribute. The
+/// walk is ONE level deep: a grandchild would need its own bridges walk, and each
+/// child costs a serial page walk at up to 120 s per call.
+const MAX_BRIDGES: usize = 3;
 
 /// Whether the walk continues: a short page is the last one, and the ceiling
 /// stops a full page from paging forever.
-fn has_more_job_pages(page: u32, page_len: usize) -> bool {
-    page < MAX_JOB_PAGES && page_len == JOBS_PER_PAGE
+fn has_more_list_pages(page: u32, page_len: usize) -> bool {
+    page < MAX_LIST_PAGES && page_len == JOBS_PER_PAGE
 }
 
-/// Every job of a pipeline, up to the walk's ceiling.
-async fn fetch_jobs(repo_path: &str, enc: &str, pipeline_id: u64) -> AppResult<Listed<RawJob>> {
-    let mut all: Vec<RawJob> = Vec::new();
-    for page in 1..=MAX_JOB_PAGES {
-        let endpoint = format!(
-            "projects/{enc}/pipelines/{pipeline_id}/jobs?per_page={JOBS_PER_PAGE}&page={page}"
-        );
-        match fetch_json::<RawJob>(repo_path, &endpoint, "pipeline jobs").await? {
+/// Walks a 100-per-page list endpoint to the ceiling. `base` must already carry a
+/// query string — the page number is appended as `&page=`.
+async fn fetch_paged<T: serde::de::DeserializeOwned>(
+    repo_path: &str,
+    base: &str,
+    what: &str,
+) -> AppResult<Listed<T>> {
+    let mut all: Vec<T> = Vec::new();
+    for page in 1..=MAX_LIST_PAGES {
+        match fetch_json::<T>(repo_path, &format!("{base}&page={page}"), what).await? {
             Listed::Items(items) => {
                 let page_len = items.len();
                 all.extend(items);
-                if !has_more_job_pages(page, page_len) {
+                if !has_more_list_pages(page, page_len) {
                     break;
                 }
             }
-            // A later page failing must not erase the jobs already read; only a
+            // A later page failing must not erase what was already read; only a
             // failure with nothing in hand leaves the category unclassified.
             Listed::Unavailable(availability, detail) => {
                 if all.is_empty() {
@@ -897,6 +942,59 @@ async fn fetch_jobs(repo_path: &str, enc: &str, pipeline_id: u64) -> AppResult<L
         }
     }
     Ok(Listed::Items(all))
+}
+
+/// Every job of a pipeline, up to the walk's ceiling.
+async fn fetch_jobs(repo_path: &str, enc: &str, pipeline_id: u64) -> AppResult<Listed<RawJob>> {
+    let base = format!("projects/{enc}/pipelines/{pipeline_id}/jobs?per_page={JOBS_PER_PAGE}");
+    fetch_paged(repo_path, &base, "pipeline jobs").await
+}
+
+/// A pipeline's `trigger:` jobs. Measured 2026-08-11: the endpoint answers `[]`
+/// on a pipeline with no bridges, so the child walk costs nothing on the common
+/// single-pipeline layout.
+async fn fetch_bridges(
+    repo_path: &str,
+    enc: &str,
+    pipeline_id: u64,
+) -> AppResult<Listed<RawBridge>> {
+    let base = format!("projects/{enc}/pipelines/{pipeline_id}/bridges?per_page={JOBS_PER_PAGE}");
+    fetch_paged(repo_path, &base, "pipeline bridges").await
+}
+
+/// The child pipelines a bridge set points at, in order, deduped and capped.
+/// SAME-PROJECT children only: the endpoint lists multi-project (`trigger:
+/// project:`) bridges too, and a foreign pipeline id is another project's data —
+/// never walked, and never allowed to consume the bridge budget. A bridge with no
+/// `downstream_pipeline` never triggered, and an unstated project can't be proven
+/// local, so both contribute nothing.
+fn downstream_pipeline_ids(bridges: &[RawBridge], project_id: Option<u64>) -> Vec<u64> {
+    let Some(project_id) = project_id else {
+        return Vec::new();
+    };
+    let mut seen = HashSet::new();
+    bridges
+        .iter()
+        .filter_map(|b| {
+            let downstream = b.downstream_pipeline.as_ref()?;
+            (downstream.project_id? == project_id).then_some(downstream.id?)
+        })
+        .filter(|id| seen.insert(*id))
+        .take(MAX_BRIDGES)
+        .collect()
+}
+
+/// Whether a child-pipeline walk could still add anything: any category the
+/// parent's own jobs don't already answer. On the common single-pipeline layout
+/// every category is answered, so the bridges call never happens.
+fn needs_child_jobs(jobs: &[RawJob]) -> bool {
+    [
+        SAST_FILE_TYPE,
+        SECRET_DETECTION_FILE_TYPE,
+        CODE_QUALITY_FILE_TYPE,
+    ]
+    .iter()
+    .any(|file_type| candidates(jobs, file_type).is_empty())
 }
 
 /// The artifact download endpoint. The filename is third-party data off the job
@@ -981,6 +1079,7 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
         ));
     };
     let default_branch = project.default_branch.unwrap_or_default();
+    let project_id = project.id;
     refs.project_web_url = project
         .web_url
         .map(|u| u.trim_end_matches('/').to_string())
@@ -1045,7 +1144,7 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
     let pipeline_id = chosen.id.unwrap_or(0);
     let pipeline = pipeline_ref_out(chosen);
 
-    let jobs = match fetch_jobs(repo_path, &enc, pipeline_id).await? {
+    let mut jobs = match fetch_jobs(repo_path, &enc, pipeline_id).await? {
         Listed::Items(items) => items,
         Listed::Unavailable(availability, detail) => {
             return Ok(uniform_out(
@@ -1057,6 +1156,21 @@ pub async fn pipeline_findings(repo_path: &str, limit: Option<u32>) -> AppResult
             ))
         }
     };
+    // A monorepo that scans in a child pipeline publishes its reports on the
+    // CHILD's jobs, which the parent's jobs endpoint never lists — but only a
+    // category the parent leaves unanswered can gain anything, so the common
+    // single-pipeline layout never pays for the extra calls. Failures here are
+    // swallowed on purpose: a bridges hiccup must not turn a good read into an
+    // error when the parent's own jobs already answered.
+    if needs_child_jobs(&jobs) {
+        if let Ok(Listed::Items(bridges)) = fetch_bridges(repo_path, &enc, pipeline_id).await {
+            for child_id in downstream_pipeline_ids(&bridges, project_id) {
+                if let Ok(Listed::Items(child_jobs)) = fetch_jobs(repo_path, &enc, child_id).await {
+                    jobs.extend(child_jobs);
+                }
+            }
+        }
+    }
 
     let now = Utc::now();
     let sast = fetch_category(repo_path, &enc, &jobs, SAST_FILE_TYPE, now).await;
@@ -1554,11 +1668,12 @@ mod tests {
         let envelope = secure_envelope(fetch, 100);
         assert_eq!(envelope.availability, GlFindingAvailability::Available);
         assert_eq!(envelope.findings.len(), 2);
+        // A body that wasn't a readable report is a lost REPORT, not one finding.
         assert_eq!(
             envelope.detail.as_deref(),
-            Some("1 finding in this pipeline's reports couldn't be read")
+            Some("1 report couldn't be read")
         );
-        // Per-ITEM losses count the same way, and pluralize.
+        // Per-ITEM losses count in findings, and pluralize.
         let partial = r#"{"vulnerabilities":[
           { "id": "good", "severity": "Low" },
           { "id": "bad", "severity": 7 },
@@ -1569,17 +1684,22 @@ mod tests {
         assert_eq!(envelope.findings.len(), 1);
         assert_eq!(
             envelope.detail.as_deref(),
-            Some("2 findings in this pipeline's reports couldn't be read")
+            Some("2 findings couldn't be read")
         );
-        // A report that failed to DOWNLOAD counts too, next to one that parsed.
+        // A report that failed to DOWNLOAD counts in reports, next to one that
+        // parsed — never folded into the finding count, whose size it can't know.
         let mut mixed = bodies(&[CQ_REPORT]);
         mixed.lost_reports = 1;
         let cq = code_quality_envelope(mixed, 100);
         assert_eq!(cq.availability, GlFindingAvailability::Available);
         assert_eq!(cq.findings.len(), 4);
+        assert_eq!(cq.detail.as_deref(), Some("1 report couldn't be read"));
+        // Both kinds at once keep their own units.
+        let mut both = bodies(&[partial, "<html>502</html>"]);
+        both.lost_reports = 1;
         assert_eq!(
-            cq.detail.as_deref(),
-            Some("1 finding in this pipeline's reports couldn't be read")
+            secure_envelope(both, 100).detail.as_deref(),
+            Some("2 reports and 2 findings couldn't be read")
         );
         // Nothing lost → no notice.
         assert_eq!(secure_envelope(bodies(&[SAST_REPORT]), 100).detail, None);
@@ -1632,14 +1752,106 @@ mod tests {
     }
 
     #[test]
-    fn the_jobs_walk_stops_on_a_short_page_or_the_ceiling() {
-        assert!(has_more_job_pages(1, JOBS_PER_PAGE));
-        assert!(has_more_job_pages(2, JOBS_PER_PAGE));
+    fn child_pipeline_jobs_join_the_candidate_pool() {
+        // The parent runs only a build; the scanning happens in a child pipeline,
+        // so reading the parent alone would report "not configured".
+        let parent: Vec<RawJob> = serde_json::from_value(json!([
+            { "id": 1, "artifacts": [{ "file_type": "trace", "filename": "job.log" }] }
+        ]))
+        .expect("parent jobs deserialize");
+        let child: Vec<RawJob> = serde_json::from_value(json!([
+            { "id": 90, "artifacts": [
+                { "file_type": "sast", "filename": "gl-sast-report.json" }
+            ], "artifacts_expire_at": "2026-09-10T17:11:43.795Z" }
+        ]))
+        .expect("child jobs deserialize");
+        assert!(candidates(&parent, SAST_FILE_TYPE).is_empty());
+        let mut merged = parent;
+        merged.extend(child);
+        assert_eq!(
+            candidates(&merged, SAST_FILE_TYPE),
+            vec![ArtifactRef {
+                job_id: 90,
+                filename: "gl-sast-report.json".into(),
+                expire_at: Some("2026-09-10T17:11:43.795Z".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn the_child_walk_only_runs_when_a_category_is_unanswered() {
+        let all_three: Vec<RawJob> = serde_json::from_value(json!([
+            { "id": 1, "artifacts": [
+                { "file_type": "sast", "filename": "gl-sast-report.json" },
+                { "file_type": "secret_detection", "filename": "gl-secret-detection-report.json" },
+                { "file_type": "codequality", "filename": "gl-code-quality-report.json" }
+            ] }
+        ]))
+        .expect("jobs deserialize");
+        // Every category answered by the parent — the bridges call is pure cost.
+        assert!(!needs_child_jobs(&all_three));
+        // One category short still qualifies: the child may publish the rest.
+        let two_of_three: Vec<RawJob> = serde_json::from_value(json!([
+            { "id": 1, "artifacts": [
+                { "file_type": "sast", "filename": "gl-sast-report.json" },
+                { "file_type": "codequality", "filename": "gl-code-quality-report.json" }
+            ] }
+        ]))
+        .expect("jobs deserialize");
+        assert!(needs_child_jobs(&two_of_three));
+        // A parent that scans nothing is the monorepo case this exists for.
+        assert!(needs_child_jobs(&[]));
+    }
+
+    #[test]
+    fn only_same_project_child_pipelines_are_walked() {
+        // Field shape measured 2026-08-11 against a real parent-child pipeline.
+        const PARENT: u64 = 83906586;
+        let bridges: Vec<RawBridge> = serde_json::from_value(json!([
+            // Never triggered, or the child failed to create — both send null.
+            { "name": "trigger-web", "downstream_pipeline": null },
+            { "name": "child-scans", "downstream_pipeline": {
+                "id": 2752106301_u64, "project_id": PARENT, "ref": "main",
+                "status": "success", "source": "parent_pipeline" } },
+            // A multi-project `trigger: project:` bridge — another project's data.
+            { "name": "trigger-other-repo", "downstream_pipeline": {
+                "id": 2752106999_u64, "project_id": 12345678, "source": "pipeline" } },
+            // Neither of these can be proven local or addressed.
+            { "name": "trigger-docs", "downstream_pipeline": {} },
+            { "name": "trigger-idless", "downstream_pipeline": { "project_id": PARENT } },
+            // The same child listed twice is walked once.
+            { "name": "child-scans-again", "downstream_pipeline": {
+                "id": 2752106301_u64, "project_id": PARENT } }
+        ]))
+        .expect("bridges deserialize");
+        assert_eq!(
+            downstream_pipeline_ids(&bridges, Some(PARENT)),
+            vec![2752106301]
+        );
+        // No bridges at all is the common case and contributes nothing.
+        assert!(downstream_pipeline_ids(&[], Some(PARENT)).is_empty());
+        // An unknown parent project can't prove any child local.
+        assert!(downstream_pipeline_ids(&bridges, None).is_empty());
+        // The cap bounds the serial child walks, and foreign ids never eat it.
+        let many: Vec<RawBridge> = serde_json::from_value(json!((1..=10)
+            .map(|i| json!({ "downstream_pipeline": { "id": i, "project_id": PARENT } }))
+            .collect::<Vec<_>>()))
+        .expect("bridges deserialize");
+        assert_eq!(
+            downstream_pipeline_ids(&many, Some(PARENT)).len(),
+            MAX_BRIDGES
+        );
+    }
+
+    #[test]
+    fn the_list_walk_stops_on_a_short_page_or_the_ceiling() {
+        assert!(has_more_list_pages(1, JOBS_PER_PAGE));
+        assert!(has_more_list_pages(2, JOBS_PER_PAGE));
         // The ceiling stops a full page from paging forever.
-        assert!(!has_more_job_pages(MAX_JOB_PAGES, JOBS_PER_PAGE));
+        assert!(!has_more_list_pages(MAX_LIST_PAGES, JOBS_PER_PAGE));
         // A short page is the last one.
-        assert!(!has_more_job_pages(1, JOBS_PER_PAGE - 1));
-        assert!(!has_more_job_pages(1, 0));
+        assert!(!has_more_list_pages(1, JOBS_PER_PAGE - 1));
+        assert!(!has_more_list_pages(1, 0));
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -10,6 +10,7 @@
 pub mod bitbucket;
 pub mod github;
 pub mod gitlab;
+mod gitlab_findings;
 pub mod glab;
 pub mod http;
 pub mod jira;
@@ -3000,6 +3001,20 @@ pub async fn forge_gl_mr_cancel_auto_merge(repo_path: String, number: u64) -> Ap
 #[tauri::command]
 pub async fn forge_gl_remove_fork_relationship(repo_path: String) -> AppResult<()> {
     gl_only!(repo_path, gitlab::remove_fork_relationship(&repo_path))
+}
+
+/// The Findings tab's GitLab arm: security and quality reports read out of the
+/// newest completed pipeline's job artifacts. GitLab-only — GitHub's findings come
+/// from its own alert APIs (`github::security_findings`), not from CI artifacts.
+#[tauri::command]
+pub async fn forge_gl_pipeline_findings(
+    repo_path: String,
+    limit: Option<u32>,
+) -> AppResult<gitlab_findings::GlFindingsOut> {
+    gl_only!(
+        repo_path,
+        gitlab_findings::pipeline_findings(&repo_path, limit)
+    )
 }
 
 /// Play (start) a manual CI job. GitLab-only — GitHub Actions has no per-job

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -10,7 +10,7 @@
 pub mod bitbucket;
 pub mod github;
 pub mod gitlab;
-mod gitlab_findings;
+pub mod gitlab_findings;
 pub mod glab;
 pub mod http;
 pub mod jira;

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -32,10 +32,12 @@ pub struct Capabilities {
     pub ci: bool,
     pub webhooks: bool,
     pub approvals: bool,
-    /// Reading the platform's own vulnerability findings (Dependabot, code
-    /// scanning and secret scanning alerts + repository security advisories).
-    /// GitHub-only — GitLab's equivalent is a paid-tier security dashboard and
-    /// Bitbucket Cloud has no analogue.
+    /// Reading the repo's vulnerability findings — from each platform's own
+    /// source: GitHub's alert APIs (Dependabot, code scanning, secret scanning +
+    /// repository advisories), and on GitLab the SAST / secret-detection /
+    /// code-quality report artifacts a CI pipeline publishes (readable on every
+    /// tier, unlike GitLab's own Ultimate-gated dashboard). Bitbucket Cloud has
+    /// no analogue.
     pub security_findings: bool,
 }
 
@@ -74,7 +76,7 @@ impl Capabilities {
                 ci: true,
                 webhooks: true,
                 approvals: true,
-                security_findings: false,
+                security_findings: true,
             },
             // Bitbucket Cloud: no labels, milestones, stars, reactions, or
             // discussions; PRs/CI(pipelines)/webhooks/approvals do work. Draft PRs
@@ -742,8 +744,8 @@ mod tests {
         let c = Capabilities::for_provider(Provider::GitLab);
         assert!(!c.discussions);
         assert!(c.labels && c.milestones && c.stars && c.reactions && c.approvals);
-        // Dependabot alerts / repo advisories are a GitHub surface.
-        assert!(!c.security_findings);
+        // Findings come from the pipeline's report artifacts, not an alert API.
+        assert!(c.security_findings);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -399,6 +399,7 @@ pub fn run() {
             forge::forge_gl_mr_cancel_auto_merge,
             forge::forge_gl_remove_fork_relationship,
             forge::forge_gl_ci_play_job,
+            forge::forge_gl_pipeline_findings,
             forge::forge_gl_issue_time_stats,
             forge::forge_gl_mr_time_stats,
             forge::forge_gl_issue_set_time_estimate,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -90,8 +90,9 @@ and **Insights**. The More button shows the active secondary tab's name, so the
 rail always says where you are.
 
 Switch tabs with the number keys ({{kbd:tab-changes}} through {{kbd:tab-insights}}; see
-*Keyboard & navigation*). Issues, Discussions, Actions, Findings, and Tags need \`gh\` and a
-GitHub remote{{ai}}; the **Agent** tab appears only when AI features are enabled{{/ai}}.
+*Keyboard & navigation*). Issues, Discussions, Actions, and Tags need \`gh\` and a
+GitHub remote; **Findings** works on a GitHub remote with \`gh\` or a GitLab one with
+\`glab\`{{ai}}; the **Agent** tab appears only when AI features are enabled{{/ai}}.
 
 > Tip: press {{kbd:command-palette}} anytime for the command palette — the fastest way
 > to find a feature when you don't know where it lives — or {{kbd:show-help}} to reopen
@@ -1337,9 +1338,11 @@ to jump to that run. You can also get an OS **notification** when a run finishes
     body: `# Findings
 
 The **Findings** tab (in the More ▾ menu; palette-only by default — bind a key in
-**Settings → Keyboard**) collects what GitHub's security scanning has turned up for the repo, so you
-can read it without opening the browser. It covers **GitHub** repositories; on a GitLab
-or Bitbucket repo the tab says so instead.
+**Settings → Keyboard**) collects what your repository's security scanning has turned up, so you
+can read it without opening the browser. It covers **GitHub** and **GitLab**
+repositories; on a Bitbucket repo the tab says so instead.
+
+## On a GitHub repository
 
 - **Dependabot alerts** — every open alert, grouped by the vulnerable package. Each one
   shows its **severity**, the **affected version range**, the **first patched version**,
@@ -1369,6 +1372,44 @@ instead of guessing, and keeps the settings link for either case. Advisories hav
 such switch — they're only published on public repositories, so their card says just
 that. When your GitHub access can't read a category, you see what GitHub said about it;
 when the check couldn't complete at all, you get a **Retry**.
+
+## On a GitLab repository
+
+GitLab keeps findings in a **pipeline's report artifacts** rather than in a
+repository-wide alert list, so the tab reads the newest **completed pipeline** for your
+checked-out branch — falling back to the **default branch** when your branch has no
+pipelines yet, and saying so — and splits it into **SAST**, **Secret detection**, and
+**Code quality**. A line above the list names the pipeline, branch, and commit the
+findings came from, with **View pipeline** to open it on GitLab.
+
+Those analyzers run on **every GitLab tier**, Free included; it's GitLab's own
+vulnerability report that's Ultimate-only, so this is often the only place you'll see
+findings your pipelines already produce.
+
+Move through the list with **↑ / ↓** and select a row for its detail: its **severity**,
+the **file and line**, the **scanner** that raised it, its **identifiers** (CVE, CWE,
+rule keys) as links where the report gives one, and the description. **View file on
+GitLab** opens that line in the file at the exact commit the pipeline scanned. Detected
+secret *values* never leave the report — the raw extract is dropped before a finding
+reaches the app.
+
+Each section explains itself rather than looking clean; when there's no pipeline to
+read at all, one card stands in for all three:
+
+- **Scanning isn't set up** — the project's CI has run no scanning, or this pipeline
+  published no report of that kind. **Open scanning setup on GitLab** goes to the
+  project's Security configuration page.
+- **The report isn't downloadable** — the job lists it but GitLab returns a 404 for the
+  file; add the \`gl-*-report.json\` to that job's \`artifacts:paths\` to expose it.
+- **The artifacts expired** — findings come back with the next pipeline run.
+- **Nothing has finished yet** — the branch has pipelines but none has completed, or
+  that job is still running in this one.
+- **Your GitLab sign-in can't read** the project's pipelines or job artifacts.
+- **The check didn't complete** — you get a **Retry**.
+
+An empty section only reads as clean once a report was actually parsed, and when part
+of a pipeline's output couldn't be read, a quiet line above the rows says so — a short
+list is never passed off as a whole one.
 
 The tab fetches when you open it — use the refresh button for the current state.`,
   },

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1399,9 +1399,9 @@ Each section explains itself rather than looking clean; when one cause covers al
 three — no pipeline to read yet, or one problem across every category — a single card
 stands in for them:
 
-- **Scanning isn't set up** — the project's CI has run no scanning, or this pipeline
-  published no report of that kind. **Open scanning setup on GitLab** goes to the
-  project's Security configuration page.
+- **Scanning isn't set up** — no pipeline was found on your branch or the default
+  branch, or the pipeline published no report of that kind. **Open scanning setup on
+  GitLab** goes to the project's Security configuration page.
 - **The report isn't downloadable** — the job lists it but GitLab returns a 404 for the
   file; add the \`gl-*-report.json\` to that job's \`artifacts:paths\` to expose it.
 - **The artifacts expired** — findings come back with the next pipeline run.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1379,8 +1379,10 @@ GitLab keeps findings in a **pipeline's report artifacts** rather than in a
 repository-wide alert list, so the tab reads the newest **completed pipeline** for your
 checked-out branch — falling back to the **default branch** when your branch has no
 pipelines yet, and saying so — and splits it into **SAST**, **Secret detection**, and
-**Code quality**. A line above the list names the pipeline, branch, and commit the
-findings came from, with **View pipeline** to open it on GitLab.
+**Code quality**. Scans that run in **triggered child pipelines** are picked up too, so
+a parent that only orchestrates still reports what its children found. A line above the
+list names the pipeline, branch, and commit the findings came from, with **View
+pipeline** to open it on GitLab.
 
 Those analyzers run on **every GitLab tier**, Free included; it's GitLab's own
 vulnerability report that's Ultimate-only, so this is often the only place you'll see
@@ -1393,8 +1395,9 @@ GitLab** opens that line in the file at the exact commit the pipeline scanned. D
 secret *values* never leave the report — the raw extract is dropped before a finding
 reaches the app.
 
-Each section explains itself rather than looking clean; when there's no pipeline to
-read at all, one card stands in for all three:
+Each section explains itself rather than looking clean; when one cause covers all
+three — no pipeline to read yet, or one problem across every category — a single card
+stands in for them:
 
 - **Scanning isn't set up** — the project's CI has run no scanning, or this pipeline
   published no report of that kind. **Open scanning setup on GitLab** goes to the
@@ -1402,8 +1405,7 @@ read at all, one card stands in for all three:
 - **The report isn't downloadable** — the job lists it but GitLab returns a 404 for the
   file; add the \`gl-*-report.json\` to that job's \`artifacts:paths\` to expose it.
 - **The artifacts expired** — findings come back with the next pipeline run.
-- **Nothing has finished yet** — the branch has pipelines but none has completed, or
-  that job is still running in this one.
+- **Nothing has finished yet** — the branch has pipelines but none has completed.
 - **Your GitLab sign-in can't read** the project's pipelines or job artifacts.
 - **The check didn't complete** — you get a **Retry**.
 

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -597,7 +597,9 @@ export function RepositoryView() {
                       ? `c${selectedFinding.number}`
                       : selectedFinding.type === "secretScanning"
                         ? `s${selectedFinding.number}`
-                        : `g${selectedFinding.ghsaId}`
+                        : selectedFinding.type === "glFinding"
+                          ? `gl:${selectedFinding.category}:${selectedFinding.id}`
+                          : `g${selectedFinding.ghsaId}`
                 }
                 repoPath={repoPath}
                 active={repoTab === "findings"}

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -22,9 +22,19 @@ import {
   useRepoAdvisories,
   useSecretScanningAlerts,
 } from "@/lib/github/security-findings";
+import type {
+  GlCodeQualityFindingOut,
+  GlFindingsOut,
+  GlSecureFindingOut,
+} from "@/lib/gitlab/security-findings";
+import {
+  codeQualityFindingId,
+  useGitLabFindings,
+} from "@/lib/gitlab/security-findings";
 import { useUiStore } from "@/lib/stores/ui";
 import {
   CodeScanningChip,
+  CqChip,
   SeverityChip,
   ValidityChip,
   validityLabel,
@@ -43,6 +53,7 @@ function DetailShell({
   title,
   chip,
   htmlUrl,
+  linkLabel = "View on GitHub",
   meta,
   children,
 }: {
@@ -51,6 +62,8 @@ function DetailShell({
    *  category names its state in its own ladder's words. */
   chip: ReactNode;
   htmlUrl: string;
+  /** What the link-out opens, when it isn't the finding's page on GitHub. */
+  linkLabel?: string;
   meta: ReactNode;
   children: ReactNode;
 }) {
@@ -69,7 +82,7 @@ function DetailShell({
               onClick={() => openUrl(htmlUrl)}
             >
               <ArrowSquareOutIcon data-icon="inline-start" />
-              View on GitHub
+              {linkLabel}
             </Button>
           ) : null}
         </div>
@@ -419,6 +432,151 @@ function AdvisoryDetail({ advisory }: { advisory: RepoAdvisoryOut }) {
   );
 }
 
+/** The URL only when it's one the system browser should open. Identifier links
+ *  come from third-party report files, where a `file://` or `javascript:` value
+ *  has no meaning here. */
+function httpUrl(url: string | null): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? url
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A permalink to the finding's line at the pipeline's commit, or `""` when any
+ *  piece is missing. GitLab's own vulnerability pages are an Ultimate feature and
+ *  404 for exactly the Free-tier projects this reads reports for, so the blob
+ *  view is the only link that resolves. */
+function glBlobUrl(
+  data: GlFindingsOut,
+  path: string,
+  line: number | null,
+): string {
+  if (!data.projectWebUrl || !data.pipeline || !path) return "";
+  // Each segment encoded, `/` separators kept, so an odd path can't rewrite the
+  // URL it lands in.
+  const encoded = path.split("/").map(encodeURIComponent).join("/");
+  const anchor = line === null ? "" : `#L${line}`;
+  return `${data.projectWebUrl}/-/blob/${data.pipeline.sha}/${encoded}${anchor}`;
+}
+
+/** The pipeline these findings were read from, one click from the detail. */
+function GlPipelineRow({ data }: { data: GlFindingsOut }) {
+  const pipeline = data.pipeline;
+  if (!pipeline?.webUrl) return null;
+  return (
+    <Row label="Pipeline">
+      <button
+        type="button"
+        onClick={() => openUrl(pipeline.webUrl)}
+        className="inline-flex cursor-pointer items-center gap-1 hover:underline"
+      >
+        #{pipeline.iid}
+        <ArrowSquareOutIcon className="size-3" />
+      </button>
+    </Row>
+  );
+}
+
+function GlSecureDetail({
+  finding,
+  data,
+  fallbackTitle,
+}: {
+  finding: GlSecureFindingOut;
+  data: GlFindingsOut;
+  /** The category's own name for a finding whose report gave none. */
+  fallbackTitle: string;
+}) {
+  return (
+    <DetailShell
+      title={finding.name || fallbackTitle}
+      chip={<SeverityChip severity={finding.severity} />}
+      htmlUrl={glBlobUrl(data, finding.file, finding.startLine)}
+      linkLabel="View file on GitLab"
+      meta={
+        <>
+          <Row label="File">
+            <span className="font-mono">
+              {locationText(finding.file, finding.startLine)}
+            </span>
+          </Row>
+          {finding.scannerName ? (
+            <Row label="Scanner">{finding.scannerName}</Row>
+          ) : null}
+          {finding.identifiers.length > 0 ? (
+            <Row label="Identifiers">
+              <span className="flex flex-wrap gap-1">
+                {finding.identifiers.map((identifier, i) => {
+                  const label =
+                    identifier.name || identifier.value || identifier.type;
+                  const url = httpUrl(identifier.url);
+                  const key = `${identifier.type}-${identifier.value}-${i}`;
+                  return url ? (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => openUrl(url)}
+                      className="inline-flex cursor-pointer items-center gap-1 rounded border px-1.5 py-0.5 hover:bg-muted/40"
+                    >
+                      {label}
+                      <ArrowSquareOutIcon className="size-3 text-muted-foreground" />
+                    </button>
+                  ) : (
+                    <Badge key={key} variant="outline" className="font-normal">
+                      {label}
+                    </Badge>
+                  );
+                })}
+              </span>
+            </Row>
+          ) : null}
+          <GlPipelineRow data={data} />
+        </>
+      }
+    >
+      {/* Scanner descriptions carry fenced code and links, so they render as
+          markdown rather than as preformatted text. */}
+      {finding.description ? <Markdown>{finding.description}</Markdown> : null}
+    </DetailShell>
+  );
+}
+
+function GlQualityDetail({
+  finding,
+  data,
+}: {
+  finding: GlCodeQualityFindingOut;
+  data: GlFindingsOut;
+}) {
+  return (
+    <DetailShell
+      title={finding.checkName || "Unidentified check"}
+      chip={<CqChip severity={finding.severity} />}
+      htmlUrl={glBlobUrl(data, finding.path, finding.line)}
+      linkLabel="View file on GitLab"
+      meta={
+        <>
+          {/* No Severity row — the chip above already names it in the
+              CodeClimate ladder's own words. */}
+          <Row label="Path">
+            <span className="font-mono">
+              {locationText(finding.path, finding.line)}
+            </span>
+          </Row>
+          <GlPipelineRow data={data} />
+        </>
+      }
+    >
+      {finding.description ? <Markdown>{finding.description}</Markdown> : null}
+    </DetailShell>
+  );
+}
+
 export function FindingDetailView({
   repoPath,
   active,
@@ -431,38 +589,49 @@ export function FindingDetailView({
   const forge = useForgeStatus(repoPath);
   const enabled =
     forgeReady(forge.data) && forgeSupports(forge.data, "securityFindings");
-  // Same hooks + same store limits as the panel, so these are cache hits rather
-  // than a second fetch.
-  const alerts = useDependabotAlerts(repoPath, enabled, active, limits.alerts);
+  // Same hooks, same provider gate and same store limits as the panel, so these
+  // are cache hits rather than a second fetch — and the other provider's
+  // commands are never invoked.
+  const provider = forge.data?.provider;
+  const onGitHub = enabled && provider === "github";
+  const alerts = useDependabotAlerts(repoPath, onGitHub, active, limits.alerts);
   const codeScanning = useCodeScanningAlerts(
     repoPath,
-    enabled,
+    onGitHub,
     active,
     limits.codeScanning,
   );
   const secrets = useSecretScanningAlerts(
     repoPath,
-    enabled,
+    onGitHub,
     active,
     limits.secretScanning,
   );
   const advisories = useRepoAdvisories(
     repoPath,
-    enabled,
+    onGitHub,
     active,
     limits.advisories,
+  );
+  const gl = useGitLabFindings(
+    repoPath,
+    enabled && provider === "gitlab",
+    active,
+    limits.gitlab,
   );
 
   // Only the selected finding's own category decides the pending/error state —
   // a sibling category failing must not blank a finding that loaded fine.
   const query =
-    selectedFinding?.type === "advisory"
-      ? advisories
-      : selectedFinding?.type === "codeScanning"
-        ? codeScanning
-        : selectedFinding?.type === "secretScanning"
-          ? secrets
-          : alerts;
+    selectedFinding?.type === "glFinding"
+      ? gl
+      : selectedFinding?.type === "advisory"
+        ? advisories
+        : selectedFinding?.type === "codeScanning"
+          ? codeScanning
+          : selectedFinding?.type === "secretScanning"
+            ? secrets
+            : alerts;
 
   // Gated on `enabled`: a disabled query stays `isPending` forever, so an
   // ungated skeleton would spin here if the repo lost the capability mid-session.
@@ -504,6 +673,32 @@ export function FindingDetailView({
       (a) => a.ghsaId === selectedFinding.ghsaId,
     );
     if (advisory) return <AdvisoryDetail advisory={advisory} />;
+  } else if (selectedFinding?.type === "glFinding" && gl.data) {
+    const data = gl.data;
+    if (selectedFinding.category === "codeQuality") {
+      const finding = data.codeQuality.findings.find(
+        (f) => codeQualityFindingId(f) === selectedFinding.id,
+      );
+      if (finding) return <GlQualityDetail finding={finding} data={data} />;
+    } else {
+      const category =
+        selectedFinding.category === "sast" ? data.sast : data.secretDetection;
+      const finding = category.findings.find(
+        (f) => f.id === selectedFinding.id,
+      );
+      if (finding)
+        return (
+          <GlSecureDetail
+            finding={finding}
+            data={data}
+            fallbackTitle={
+              selectedFinding.category === "sast"
+                ? "Unidentified rule"
+                : "Unknown secret type"
+            }
+          />
+        );
+    }
   }
 
   return (

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -29,6 +29,7 @@ import type {
 } from "@/lib/gitlab/security-findings";
 import {
   codeQualityFindingId,
+  secureFindingId,
   useGitLabFindings,
 } from "@/lib/gitlab/security-findings";
 import { useUiStore } from "@/lib/stores/ui";
@@ -684,7 +685,7 @@ export function FindingDetailView({
       const category =
         selectedFinding.category === "sast" ? data.sast : data.secretDetection;
       const finding = category.findings.find(
-        (f) => f.id === selectedFinding.id,
+        (f) => secureFindingId(f) === selectedFinding.id,
       );
       if (finding)
         return (

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -1,13 +1,17 @@
 import {
   ArrowClockwiseIcon,
+  ArrowSquareOutIcon,
+  ClockIcon,
   GearSixIcon,
   InfoIcon,
   LockKeyIcon,
   QuestionIcon,
   ShieldCheckIcon,
   ShieldSlashIcon,
+  WarningCircleIcon,
 } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useRef, useState } from "react";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
@@ -30,6 +34,7 @@ import {
   useForgeStatus,
   useRepoAdmin,
 } from "@/lib/git/queries";
+import { providerLabel } from "@/lib/git/types";
 import type {
   CodeScanningAlertOut,
   DependabotAlertOut,
@@ -43,13 +48,26 @@ import {
   useRepoAdvisories,
   useSecretScanningAlerts,
 } from "@/lib/github/security-findings";
+import type {
+  GlCodeQualityFindingOut,
+  GlFindingAvailability,
+  GlFindingsOut,
+  GlPipelineState,
+  GlSecureFindingOut,
+} from "@/lib/gitlab/security-findings";
+import {
+  codeQualityFindingId,
+  useGitLabFindings,
+} from "@/lib/gitlab/security-findings";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { type SelectedFinding, useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import {
   CodeScanningChip,
+  CqChip,
   codeScanningRank,
+  cqRank,
   SEVERITY_RANK,
   SeverityChip,
   severityLevel,
@@ -59,9 +77,10 @@ import {
 } from "./severity";
 
 /** Ceiling for a category's row limit. MUST stay in lockstep with `clamp_limit`
- *  in src-tauri/src/github/security_findings.rs, which is the source of truth:
- *  it clamps every fetch to 500, so growing the limit past this would re-run the
- *  paged walk for the same 500 rows and leave "Load more" permanently offered. */
+ *  in BOTH src-tauri/src/github/security_findings.rs and
+ *  src-tauri/src/forge/gitlab_findings.rs, which are the source of truth: they
+ *  clamp every fetch to 500, so growing the limit past this would re-read the
+ *  same 500 rows and leave "Load more" permanently offered. */
 const FINDINGS_LIMIT_CAP = 500;
 
 interface AlertRow {
@@ -202,15 +221,99 @@ function buildSecretGroups(alerts: SecretScanningAlertOut[]): SecretGroup[] {
   return [...groups.values()];
 }
 
+// ── GitLab pipeline findings ─────────────────────────────────────────────────
+
+interface GlSecureRow {
+  /** Unique per rendered row: the report's own finding id, or an index fallback
+   *  when it came through empty (duplicate `data-row` values misdirect focus). */
+  id: string;
+  finding: GlSecureFindingOut;
+}
+
+interface GlSecureGroup {
+  key: string;
+  label: string;
+  rows: GlSecureRow[];
+}
+
+interface GlQualityRow {
+  id: string;
+  finding: GlCodeQualityFindingOut;
+}
+
+interface GlQualityGroup {
+  key: string;
+  label: string;
+  rows: GlQualityRow[];
+}
+
+/** SAST and secret-detection findings, grouped by rule/secret type. Sort first,
+ *  group after: the groups AND the rows inside each group both run worst-first,
+ *  and the report's own order stays the tiebreak within a rung. */
+function buildGlSecureGroups(
+  findings: GlSecureFindingOut[],
+  prefix: "gl-sast" | "gl-secret",
+  fallbackLabel: string,
+): GlSecureGroup[] {
+  const sorted = findings.toSorted(
+    (a, b) =>
+      SEVERITY_RANK[severityLevel(a.severity)] -
+      SEVERITY_RANK[severityLevel(b.severity)],
+  );
+  const groups = new Map<string, GlSecureGroup>();
+  sorted.forEach((finding, i) => {
+    // `||`, not `??`: the tolerant parse degrades a missing field to an empty
+    // string, so an empty name must fall through the same as a null.
+    const label = finding.name || fallbackLabel;
+    const row: GlSecureRow = {
+      id: finding.id ? `${prefix}-${finding.id}` : `${prefix}-i${i}`,
+      finding,
+    };
+    const bucket = groups.get(label);
+    if (bucket) bucket.rows.push(row);
+    else groups.set(label, { key: label, label, rows: [row] });
+  });
+  return [...groups.values()];
+}
+
+function buildGlQualityGroups(
+  findings: GlCodeQualityFindingOut[],
+): GlQualityGroup[] {
+  const sorted = findings.toSorted(
+    (a, b) => cqRank(a.severity) - cqRank(b.severity),
+  );
+  const groups = new Map<string, GlQualityGroup>();
+  for (const finding of sorted) {
+    const label = finding.checkName || "Unidentified check";
+    const row: GlQualityRow = {
+      id: `gl-cq-${codeQualityFindingId(finding)}`,
+      finding,
+    };
+    const bucket = groups.get(label);
+    if (bucket) bucket.rows.push(row);
+    else groups.set(label, { key: label, label, rows: [row] });
+  }
+  return [...groups.values()];
+}
+
 /** Whether two selections point at the same finding. Degenerate identities (a
  *  tolerated alert numbered 0, an advisory with no GHSA id) can't be told apart
  *  by the stored selection, so the first matching row wins. */
 function sameFinding(a: SelectedFinding, b: SelectedFinding): boolean {
   if (a.type === "advisory")
     return b.type === "advisory" && a.ghsaId === b.ghsaId;
+  // GitLab ids are unique only within their category — a secret and a SAST
+  // finding can share one — so the category is part of the comparison.
+  if (a.type === "glFinding")
+    return b.type === "glFinding" && b.category === a.category && b.id === a.id;
   // The three numbered categories keep separate number sequences, so the type
   // tag has to match too — alert #4 is not code scanning alert #4.
-  return b.type !== "advisory" && b.type === a.type && b.number === a.number;
+  return (
+    b.type !== "advisory" &&
+    b.type !== "glFinding" &&
+    b.type === a.type &&
+    b.number === a.number
+  );
 }
 
 const matchesAlert = (a: DependabotAlertOut, q: string) =>
@@ -239,6 +342,23 @@ const matchesAdvisory = (adv: RepoAdvisoryOut, q: string) =>
   adv.ghsaId.toLowerCase().includes(q) ||
   (adv.cveId?.toLowerCase().includes(q) ?? false) ||
   adv.vulnerabilities.some((v) => v.packageName.toLowerCase().includes(q));
+
+/** Identifier *values* (CVE ids, CWE numbers, rule keys) are what a user pastes
+ *  in — the identifier's own display name repeats the finding name. */
+const matchesGlSecure = (f: GlSecureFindingOut, q: string) =>
+  !q ||
+  f.name.toLowerCase().includes(q) ||
+  f.file.toLowerCase().includes(q) ||
+  f.severity.toLowerCase().includes(q) ||
+  f.scannerName.toLowerCase().includes(q) ||
+  f.identifiers.some((i) => i.value.toLowerCase().includes(q));
+
+const matchesGlQuality = (f: GlCodeQualityFindingOut, q: string) =>
+  !q ||
+  f.checkName.toLowerCase().includes(q) ||
+  f.path.toLowerCase().includes(q) ||
+  f.description.toLowerCase().includes(q) ||
+  f.severity.toLowerCase().includes(q);
 
 function SectionHeader({ title }: { title: string }) {
   return (
@@ -427,6 +547,372 @@ function LoadFailed({
   );
 }
 
+/** The project's scanning setup page, or null when the project URL is unknown —
+ *  derived in one place so the panel-level card and the per-category cards can't
+ *  drift apart on the path. */
+const glScanningSetupUrl = (data: GlFindingsOut): string | null =>
+  data.projectWebUrl ? `${data.projectWebUrl}/-/security/configuration` : null;
+
+/** A partial-read disclosure on a category that IS available: some report bodies
+ *  or items failed to parse, so the rows below are incomplete. Quiet by design —
+ *  the data is usable, just not whole. */
+function GlPartialDetail({ detail }: { detail: string | null }) {
+  if (!detail) return null;
+  return (
+    <p className="px-3 py-2 text-[11px] text-muted-foreground">{detail}</p>
+  );
+}
+
+/**
+ * Which pipeline these findings came from. GitLab's reports are artifacts of one
+ * commit's pipeline, not a repository-wide alert store, so the strip is what
+ * keeps the list honest about how current it is. In normal layout flow (never
+ * floating) so it can never cover a row.
+ */
+function PipelineProvenance({ data }: { data: GlFindingsOut }) {
+  const pipeline = data.pipeline;
+  if (!pipeline) return null;
+  // The finish time is what dates the findings; a still-listed pipeline that
+  // never finished falls back to when it started rather than showing nothing.
+  const when = pipeline.finishedAt ?? pipeline.createdAt;
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground">
+      {data.usedFallback ? (
+        <p className="w-full">
+          No pipelines on {data.requestedRef} yet — showing{" "}
+          {data.fallbackRef || "the default branch"}.
+        </p>
+      ) : null}
+      <p className="min-w-0 flex-1 truncate">
+        From pipeline #{pipeline.iid} ·{" "}
+        <span className="font-mono">{pipeline.ref}</span> @{" "}
+        <span className="font-mono">{pipeline.sha.slice(0, 8)}</span> ·{" "}
+        <RelativeTime date={when} />
+      </p>
+      {pipeline.webUrl ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => openUrl(pipeline.webUrl)}
+        >
+          <ArrowSquareOutIcon data-icon="inline-start" />
+          View pipeline
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The one panel-level card for a repo with no pipeline to read reports from —
+ * all three categories share the state, so three identical cards would only
+ * repeat it. `state` is passed separately from `data` so the exhaustiveness net
+ * below has a union without `"found"` to close over.
+ */
+function GlNoPipelineCard({
+  state,
+  data,
+  onRetry,
+}: {
+  state: Exclude<GlPipelineState, "found">;
+  data: GlFindingsOut;
+  onRetry: () => void;
+}) {
+  const retryAction = (
+    <Button variant="outline" size="sm" onClick={onRetry}>
+      <ArrowClockwiseIcon data-icon="inline-start" />
+      Retry
+    </Button>
+  );
+  const setupUrl = glScanningSetupUrl(data);
+
+  if (state === "none") {
+    return (
+      <ReasonCard
+        icon={ShieldSlashIcon}
+        message="Scanning hasn't run in this project's CI yet. Add SAST, secret detection, or code quality jobs to see findings here."
+        action={
+          <div className="flex flex-wrap items-center gap-2">
+            {setupUrl ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => openUrl(setupUrl)}
+              >
+                <GearSixIcon data-icon="inline-start" />
+                Open scanning setup on GitLab
+              </Button>
+            ) : null}
+            {retryAction}
+          </div>
+        }
+      />
+    );
+  }
+  if (state === "runningOnly") {
+    const ref = data.usedFallback
+      ? data.fallbackRef || data.requestedRef
+      : data.requestedRef;
+    return (
+      <ReasonCard
+        icon={ClockIcon}
+        // Canceled, skipped, manual and pending pipelines all land here, so this
+        // promises no finish — only that a completed one would be read.
+        message={`No pipeline on ${ref} has finished yet — findings will appear once one completes.`}
+        action={retryAction}
+      />
+    );
+  }
+  if (state === "unavailable") {
+    // Every category carries the same classified state here, so the SAST
+    // envelope speaks for the panel.
+    if (data.sast.availability === "forbidden") {
+      return (
+        <ReasonCard
+          icon={LockKeyIcon}
+          message="Your GitLab sign-in can't read this project's pipelines."
+          detail={data.sast.detail}
+        />
+      );
+    }
+    return (
+      <ReasonCard
+        icon={QuestionIcon}
+        message="Couldn't check findings for this repository."
+        detail={data.sast.detail}
+        action={retryAction}
+      />
+    );
+  }
+  // A new GlPipelineState fails to compile here instead of silently rendering
+  // nothing at all.
+  const _exhaustive: never = state;
+  return _exhaustive;
+}
+
+/**
+ * The card for a category whose envelope isn't `"available"`, on a pipeline we
+ * did find. `category` is the lowercase mid-sentence form, `Category` the
+ * sentence-initial one; `onSetup` is passed only where the project's web URL is
+ * known, so the setup link can't be a dead end.
+ */
+function GlUnavailableCard({
+  availability,
+  detail,
+  category,
+  Category,
+  onRetry,
+  onSetup,
+}: {
+  availability: Exclude<GlFindingAvailability, "available">;
+  detail: string | null;
+  category: string;
+  Category: string;
+  onRetry: () => void;
+  onSetup?: () => void;
+}) {
+  const retryAction = (
+    <Button variant="outline" size="sm" onClick={onRetry}>
+      <ArrowClockwiseIcon data-icon="inline-start" />
+      Retry
+    </Button>
+  );
+
+  if (availability === "notConfigured") {
+    return (
+      <ReasonCard
+        icon={ShieldSlashIcon}
+        // Hedged deliberately: an analyzer job that ran and FAILED publishes no
+        // artifacts either, and the wire can't tell that from never-configured.
+        message={`This pipeline didn't publish a ${category} report — most likely scanning isn't set up yet.`}
+        action={
+          <div className="flex flex-wrap items-center gap-2">
+            {onSetup ? (
+              <Button variant="outline" size="sm" onClick={onSetup}>
+                <GearSixIcon data-icon="inline-start" />
+                Open scanning setup on GitLab
+              </Button>
+            ) : null}
+            {retryAction}
+          </div>
+        }
+      />
+    );
+  }
+  if (availability === "reportNotReadable") {
+    return (
+      <ReasonCard
+        icon={WarningCircleIcon}
+        message={`This pipeline produced a ${category} report GitDesktop can't download. Add the gl-*-report.json file to artifacts:paths in that job to expose it.`}
+        detail={detail}
+        action={retryAction}
+      />
+    );
+  }
+  if (availability === "expired") {
+    return (
+      <ReasonCard
+        icon={ClockIcon}
+        message="The reports from this pipeline have expired. Findings will return on the next pipeline run."
+        detail={detail}
+        action={retryAction}
+      />
+    );
+  }
+  if (availability === "analysisPending") {
+    return (
+      <ReasonCard
+        icon={InfoIcon}
+        message={`${Category} is still running in this pipeline.`}
+        action={retryAction}
+      />
+    );
+  }
+  if (availability === "forbidden") {
+    return (
+      <ReasonCard
+        icon={LockKeyIcon}
+        message="Your GitLab sign-in can't read this project's job artifacts."
+        detail={detail}
+      />
+    );
+  }
+  if (availability === "indeterminate") {
+    return (
+      <ReasonCard
+        icon={QuestionIcon}
+        message={`Couldn't check ${category}.`}
+        detail={detail}
+        action={retryAction}
+      />
+    );
+  }
+  // A new GlFindingAvailability variant fails to compile here instead of
+  // silently rendering the "couldn't check" card.
+  const _exhaustive: never = availability;
+  return _exhaustive;
+}
+
+/** The grouped rows of SAST or secret detection. The group header carries the
+ *  rule/secret name, so each row leads with where it was found. */
+function GlSecureRows({
+  groups,
+  category,
+  selectedRowId,
+  onSelect,
+}: {
+  groups: GlSecureGroup[];
+  category: "sast" | "secretDetection";
+  selectedRowId: string | null;
+  onSelect: (finding: SelectedFinding) => void;
+}) {
+  return (
+    <>
+      {groups.map((group) => (
+        <div key={group.key}>
+          <div className="flex items-baseline gap-2 px-3 py-1 text-[11px] text-muted-foreground">
+            <span className="truncate text-foreground" title={group.label}>
+              {group.label}
+            </span>
+            <span className="ml-auto shrink-0 tabular-nums">
+              {group.rows.length}
+            </span>
+          </div>
+          {group.rows.map(({ id, finding: f }) => (
+            <button
+              type="button"
+              key={id}
+              data-row={id}
+              className={cn(
+                "block w-full border-b px-3 py-2 text-left",
+                selectedRowId === id
+                  ? "bg-accent text-accent-foreground"
+                  : "hover:bg-muted/60",
+              )}
+              onClick={() =>
+                onSelect({ type: "glFinding", category, id: f.id })
+              }
+            >
+              <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <SeverityChip severity={f.severity} />
+                <PathLabel path={f.file} line={f.startLine} />
+              </p>
+              {f.scannerName ? (
+                <p
+                  className="mt-1 truncate text-[11px] text-muted-foreground"
+                  title={f.scannerName}
+                >
+                  {f.scannerName}
+                </p>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function GlQualityRows({
+  groups,
+  selectedRowId,
+  onSelect,
+}: {
+  groups: GlQualityGroup[];
+  selectedRowId: string | null;
+  onSelect: (finding: SelectedFinding) => void;
+}) {
+  return (
+    <>
+      {groups.map((group) => (
+        <div key={group.key}>
+          <div className="flex items-baseline gap-2 px-3 py-1 text-[11px] text-muted-foreground">
+            <span className="truncate text-foreground" title={group.label}>
+              {group.label}
+            </span>
+            <span className="ml-auto shrink-0 tabular-nums">
+              {group.rows.length}
+            </span>
+          </div>
+          {group.rows.map(({ id, finding: f }) => (
+            <button
+              type="button"
+              key={id}
+              data-row={id}
+              className={cn(
+                "block w-full border-b px-3 py-2 text-left",
+                selectedRowId === id
+                  ? "bg-accent text-accent-foreground"
+                  : "hover:bg-muted/60",
+              )}
+              onClick={() =>
+                onSelect({
+                  type: "glFinding",
+                  category: "codeQuality",
+                  id: codeQualityFindingId(f),
+                })
+              }
+            >
+              <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <CqChip severity={f.severity} />
+                <PathLabel path={f.path} line={f.line} />
+              </p>
+              {f.description ? (
+                <p
+                  className="mt-1 truncate text-xs font-medium"
+                  title={f.description}
+                >
+                  {f.description}
+                </p>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}
+
 export function FindingsPanel({
   repoPath,
   active,
@@ -435,10 +921,11 @@ export function FindingsPanel({
   active: boolean;
 }) {
   const forge = useForgeStatus(repoPath);
-  // All four categories — Dependabot alerts, code scanning, secret scanning and
-  // repository advisories — are GitHub-only surfaces, so the gate is the
-  // capability, not a per-provider dispatch: a GitLab/Bitbucket repo fires no
-  // query at all.
+  // Two different findings models behind one capability: GitHub's four
+  // repository-wide alert stores, and GitLab's per-pipeline report artifacts.
+  // The capability gates whether the tab has anything at all; the provider picks
+  // which set of queries runs, so the other provider's fire not at all.
+  const provider = forge.data?.provider;
   const ready = forgeReady(forge.data);
   const supported = forgeSupports(forge.data, "securityFindings");
   const enabled = ready && supported;
@@ -455,24 +942,31 @@ export function FindingsPanel({
   const selectFinding = useUiStore((s) => s.selectFinding);
   const requestRepoSettings = useUiStore((s) => s.requestRepoSettings);
 
-  const alerts = useDependabotAlerts(repoPath, enabled, active, limits.alerts);
+  const onGitHub = enabled && provider === "github";
+  const alerts = useDependabotAlerts(repoPath, onGitHub, active, limits.alerts);
   const codeScanning = useCodeScanningAlerts(
     repoPath,
-    enabled,
+    onGitHub,
     active,
     limits.codeScanning,
   );
   const secrets = useSecretScanningAlerts(
     repoPath,
-    enabled,
+    onGitHub,
     active,
     limits.secretScanning,
   );
   const advisories = useRepoAdvisories(
     repoPath,
-    enabled,
+    onGitHub,
     active,
     limits.advisories,
+  );
+  const gl = useGitLabFindings(
+    repoPath,
+    enabled && provider === "gitlab",
+    active,
+    limits.gitlab,
   );
 
   const [filterText, setFilterText] = useState("");
@@ -508,6 +1002,25 @@ export function FindingsPanel({
       advisory,
     }));
 
+  const glOut = gl.data;
+  const glSetupUrl = glOut ? glScanningSetupUrl(glOut) : null;
+  const allGlSast = glOut?.sast.findings ?? [];
+  const allGlSecrets = glOut?.secretDetection.findings ?? [];
+  const allGlQuality = glOut?.codeQuality.findings ?? [];
+  const glSastGroups = buildGlSecureGroups(
+    allGlSast.filter((f) => matchesGlSecure(f, query)),
+    "gl-sast",
+    "Unidentified rule",
+  );
+  const glSecretGroups = buildGlSecureGroups(
+    allGlSecrets.filter((f) => matchesGlSecure(f, query)),
+    "gl-secret",
+    "Unknown secret type",
+  );
+  const glQualityGroups = buildGlQualityGroups(
+    allGlQuality.filter((f) => matchesGlQuality(f, query)),
+  );
+
   const alertsShown =
     !alerts.isError && alertsOut?.availability === "available";
   const codeScanningShown =
@@ -516,6 +1029,14 @@ export function FindingsPanel({
     !secrets.isError && secretsOut?.availability === "available";
   const advisoriesShown =
     !advisories.isError && advisoriesOut?.availability === "available";
+  // Every GitLab category hangs off one pipeline, so a state other than "found"
+  // hides all three at once.
+  const glFound = !gl.isError && glOut?.pipelineState === "found";
+  const glSastShown = glFound && glOut?.sast.availability === "available";
+  const glSecretsShown =
+    glFound && glOut?.secretDetection.availability === "available";
+  const glQualityShown =
+    glFound && glOut?.codeQuality.availability === "available";
 
   // Flat, document-order nav list: the grouped rows of each section in the order
   // the sections render. Group headers and the Load-more buttons are skipped.
@@ -558,6 +1079,44 @@ export function FindingsPanel({
       });
     }
   }
+  if (glSastShown) {
+    for (const group of glSastGroups) {
+      for (const row of group.rows) {
+        navRows.push({
+          id: row.id,
+          finding: { type: "glFinding", category: "sast", id: row.finding.id },
+        });
+      }
+    }
+  }
+  if (glSecretsShown) {
+    for (const group of glSecretGroups) {
+      for (const row of group.rows) {
+        navRows.push({
+          id: row.id,
+          finding: {
+            type: "glFinding",
+            category: "secretDetection",
+            id: row.finding.id,
+          },
+        });
+      }
+    }
+  }
+  if (glQualityShown) {
+    for (const group of glQualityGroups) {
+      for (const row of group.rows) {
+        navRows.push({
+          id: row.id,
+          finding: {
+            type: "glFinding",
+            category: "codeQuality",
+            id: codeQualityFindingId(row.finding),
+          },
+        });
+      }
+    }
+  }
 
   // Resolved against the rendered rows (not rebuilt from the selection) so the
   // highlight uses the same identity the nav list and `data-row` do.
@@ -576,12 +1135,18 @@ export function FindingsPanel({
     alerts.isFetching ||
     codeScanning.isFetching ||
     secrets.isFetching ||
-    advisories.isFetching;
+    advisories.isFetching ||
+    gl.isFetching;
   const refreshReason = enabled
     ? "Refresh findings"
     : !supported && ready
       ? "Security findings aren't available on this repository's host."
-      : "Connect this repo to GitHub to load findings";
+      : // Names the host the remote actually points at; a repo with no
+        // recognized remote gets the neutral wording rather than a guess
+        // (`providerLabel` alone would name GitHub for an unknown provider).
+        provider
+        ? `Connect this repo to ${providerLabel(provider)} to load findings`
+        : "Connect this repo to a supported host to load findings";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -614,7 +1179,11 @@ export function FindingsPanel({
           ref={filterRef}
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          placeholder="Filter by package, rule, secret type, summary, GHSA, or CVE"
+          placeholder={
+            provider === "gitlab"
+              ? "Filter by rule, secret type, check, file, or severity"
+              : "Filter by package, rule, secret type, summary, GHSA, or CVE"
+          }
           className="h-7"
           autoComplete="off"
         />
@@ -631,6 +1200,209 @@ export function FindingsPanel({
           <p className="px-3 py-6 text-center text-xs text-muted-foreground">
             Security findings aren't available on this repository's host.
           </p>
+        ) : provider === "gitlab" ? (
+          gl.isError ? (
+            <LoadFailed category="findings" onRetry={() => gl.refetch()} />
+          ) : !glOut ? (
+            <RowSkeletons />
+          ) : glOut.pipelineState !== "found" ? (
+            <GlNoPipelineCard
+              state={glOut.pipelineState}
+              data={glOut}
+              onRetry={() => gl.refetch()}
+            />
+          ) : (
+            <div onKeyDown={onListKeyDown}>
+              <PipelineProvenance data={glOut} />
+
+              <SectionHeader title="SAST" />
+              {glOut.sast.availability !== "available" ? (
+                <GlUnavailableCard
+                  availability={glOut.sast.availability}
+                  detail={glOut.sast.detail}
+                  category="SAST"
+                  Category="SAST"
+                  onRetry={() => gl.refetch()}
+                  onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
+                />
+              ) : (
+                <>
+                  <GlPartialDetail detail={glOut.sast.detail} />
+                  {glSastGroups.length === 0 ? (
+                    allGlSast.length > 0 ? (
+                      <p className="px-3 py-4 text-xs text-muted-foreground">
+                        No SAST findings match the filter.
+                      </p>
+                    ) : (
+                      <Empty className="py-8">
+                        <EmptyHeader>
+                          <EmptyMedia variant="icon">
+                            <ShieldCheckIcon />
+                          </EmptyMedia>
+                          <EmptyTitle>
+                            No SAST findings in this pipeline
+                          </EmptyTitle>
+                        </EmptyHeader>
+                      </Empty>
+                    )
+                  ) : (
+                    <GlSecureRows
+                      groups={glSastGroups}
+                      category="sast"
+                      selectedRowId={selectedRowId}
+                      onSelect={selectFinding}
+                    />
+                  )}
+                  {/* Outside the empty branch: filtering to zero matches must
+                      not strip the only way to reach rows past the window. */}
+                  {glOut.sast.truncated &&
+                    (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
+                      <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                        Showing the first {allGlSast.length.toLocaleString()}{" "}
+                        SAST findings.
+                      </p>
+                    ) : (
+                      <LoadMoreRow
+                        count={allGlSast.length}
+                        loading={gl.isFetching}
+                        onLoadMore={() =>
+                          setFindingsLimits({
+                            ...limits,
+                            gitlab: Math.min(
+                              limits.gitlab + PAGE_SIZE,
+                              FINDINGS_LIMIT_CAP,
+                            ),
+                          })
+                        }
+                      />
+                    ))}
+                </>
+              )}
+
+              <SectionHeader title="Secret detection" />
+              {glOut.secretDetection.availability !== "available" ? (
+                <GlUnavailableCard
+                  availability={glOut.secretDetection.availability}
+                  detail={glOut.secretDetection.detail}
+                  category="secret detection"
+                  Category="Secret detection"
+                  onRetry={() => gl.refetch()}
+                  onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
+                />
+              ) : (
+                <>
+                  <GlPartialDetail detail={glOut.secretDetection.detail} />
+                  {glSecretGroups.length === 0 ? (
+                    allGlSecrets.length > 0 ? (
+                      <p className="px-3 py-4 text-xs text-muted-foreground">
+                        No secret findings match the filter.
+                      </p>
+                    ) : (
+                      <Empty className="py-8">
+                        <EmptyHeader>
+                          <EmptyMedia variant="icon">
+                            <ShieldCheckIcon />
+                          </EmptyMedia>
+                          <EmptyTitle>
+                            No secrets detected in this pipeline
+                          </EmptyTitle>
+                        </EmptyHeader>
+                      </Empty>
+                    )
+                  ) : (
+                    <GlSecureRows
+                      groups={glSecretGroups}
+                      category="secretDetection"
+                      selectedRowId={selectedRowId}
+                      onSelect={selectFinding}
+                    />
+                  )}
+                  {glOut.secretDetection.truncated &&
+                    (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
+                      <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                        Showing the first {allGlSecrets.length.toLocaleString()}{" "}
+                        secret findings.
+                      </p>
+                    ) : (
+                      <LoadMoreRow
+                        count={allGlSecrets.length}
+                        loading={gl.isFetching}
+                        onLoadMore={() =>
+                          setFindingsLimits({
+                            ...limits,
+                            gitlab: Math.min(
+                              limits.gitlab + PAGE_SIZE,
+                              FINDINGS_LIMIT_CAP,
+                            ),
+                          })
+                        }
+                      />
+                    ))}
+                </>
+              )}
+
+              <SectionHeader title="Code quality" />
+              {glOut.codeQuality.availability !== "available" ? (
+                <GlUnavailableCard
+                  availability={glOut.codeQuality.availability}
+                  detail={glOut.codeQuality.detail}
+                  category="code quality"
+                  Category="Code quality"
+                  onRetry={() => gl.refetch()}
+                  onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
+                />
+              ) : (
+                <>
+                  <GlPartialDetail detail={glOut.codeQuality.detail} />
+                  {glQualityGroups.length === 0 ? (
+                    allGlQuality.length > 0 ? (
+                      <p className="px-3 py-4 text-xs text-muted-foreground">
+                        No code quality findings match the filter.
+                      </p>
+                    ) : (
+                      <Empty className="py-8">
+                        <EmptyHeader>
+                          <EmptyMedia variant="icon">
+                            <ShieldCheckIcon />
+                          </EmptyMedia>
+                          <EmptyTitle>
+                            No code quality findings in this pipeline
+                          </EmptyTitle>
+                        </EmptyHeader>
+                      </Empty>
+                    )
+                  ) : (
+                    <GlQualityRows
+                      groups={glQualityGroups}
+                      selectedRowId={selectedRowId}
+                      onSelect={selectFinding}
+                    />
+                  )}
+                  {glOut.codeQuality.truncated &&
+                    (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
+                      <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                        Showing the first {allGlQuality.length.toLocaleString()}{" "}
+                        code quality findings.
+                      </p>
+                    ) : (
+                      <LoadMoreRow
+                        count={allGlQuality.length}
+                        loading={gl.isFetching}
+                        onLoadMore={() =>
+                          setFindingsLimits({
+                            ...limits,
+                            gitlab: Math.min(
+                              limits.gitlab + PAGE_SIZE,
+                              FINDINGS_LIMIT_CAP,
+                            ),
+                          })
+                        }
+                      />
+                    ))}
+                </>
+              )}
+            </div>
+          )
         ) : (
           <div onKeyDown={onListKeyDown}>
             <SectionHeader title="Dependency alerts" />

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -562,16 +562,21 @@ function LoadFailed({
  *  claim a result *for* it; sentences name the ref actually listed instead. */
 const isUnnamedRef = (ref: string): boolean => ref === "HEAD";
 
-/** The refs whose pipelines were actually listed, for copy that would otherwise
- *  claim something project-wide: the sentinel contributes nothing (never queried
- *  under a name), and a branch that IS the default is named once, not twice.
- *  Null when neither ref can be named. */
+/** The refs that were looked at, for copy that would otherwise claim something
+ *  project-wide. Built from `requestedRef` + `defaultRef` — NOT `fallbackRef`,
+ *  which is set only when a default-branch pipeline was actually used and so can
+ *  never name the second ref in the state this serves. The sentinel contributes
+ *  nothing (never queried under a name) and a branch that IS the default is named
+ *  once; null when neither can be named. */
 function checkedRefs(data: GlFindingsOut): string | null {
-  const requested = isUnnamedRef(data.requestedRef) ? null : data.requestedRef;
-  const fallback = data.fallbackRef;
-  if (requested && fallback && requested !== fallback)
-    return `${requested} or ${fallback}`;
-  return requested || fallback;
+  const names = [
+    isUnnamedRef(data.requestedRef) ? null : data.requestedRef,
+    data.defaultRef && data.defaultRef !== data.requestedRef
+      ? data.defaultRef
+      : null,
+  ].filter((name): name is string => name !== null);
+  if (names.length === 2) return `${names[0]} or ${names[1]}`;
+  return names[0] ?? null;
 }
 
 /** The project's scanning setup page, or null when the project URL is unknown —

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -57,6 +57,7 @@ import type {
 } from "@/lib/gitlab/security-findings";
 import {
   codeQualityFindingId,
+  secureFindingId,
   useGitLabFindings,
 } from "@/lib/gitlab/security-findings";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
@@ -224,8 +225,8 @@ function buildSecretGroups(alerts: SecretScanningAlertOut[]): SecretGroup[] {
 // ── GitLab pipeline findings ─────────────────────────────────────────────────
 
 interface GlSecureRow {
-  /** Unique per rendered row: the report's own finding id, or an index fallback
-   *  when it came through empty (duplicate `data-row` values misdirect focus). */
+  /** The rendered row's DOM id, built from the same `secureFindingId` the stored
+   *  selection uses — the two must agree or a click highlights another row. */
   id: string;
   finding: GlSecureFindingOut;
 }
@@ -261,18 +262,18 @@ function buildGlSecureGroups(
       SEVERITY_RANK[severityLevel(b.severity)],
   );
   const groups = new Map<string, GlSecureGroup>();
-  sorted.forEach((finding, i) => {
+  for (const finding of sorted) {
     // `||`, not `??`: the tolerant parse degrades a missing field to an empty
     // string, so an empty name must fall through the same as a null.
     const label = finding.name || fallbackLabel;
     const row: GlSecureRow = {
-      id: finding.id ? `${prefix}-${finding.id}` : `${prefix}-i${i}`,
+      id: `${prefix}-${secureFindingId(finding)}`,
       finding,
     };
     const bucket = groups.get(label);
     if (bucket) bucket.rows.push(row);
     else groups.set(label, { key: label, label, rows: [row] });
-  });
+  }
   return [...groups.values()];
 }
 
@@ -296,9 +297,12 @@ function buildGlQualityGroups(
   return [...groups.values()];
 }
 
-/** Whether two selections point at the same finding. Degenerate identities (a
- *  tolerated alert numbered 0, an advisory with no GHSA id) can't be told apart
- *  by the stored selection, so the first matching row wins. */
+/** Whether two selections point at the same finding. The GitLab arms carry a
+ *  derived composite (`secureFindingId` / `codeQualityFindingId`) precisely so an
+ *  id-less finding is still distinguishable. The GitHub arms keep first-match-wins
+ *  for their degenerate identities (an alert numbered 0, an advisory with no GHSA
+ *  id) — a recorded deferral, not an oversight: the server always sends those, so
+ *  only a tolerated parse degradation can blank one. */
 function sameFinding(a: SelectedFinding, b: SelectedFinding): boolean {
   if (a.type === "advisory")
     return b.type === "advisory" && a.ghsaId === b.ghsaId;
@@ -348,6 +352,7 @@ const matchesAdvisory = (adv: RepoAdvisoryOut, q: string) =>
 const matchesGlSecure = (f: GlSecureFindingOut, q: string) =>
   !q ||
   f.name.toLowerCase().includes(q) ||
+  f.description.toLowerCase().includes(q) ||
   f.file.toLowerCase().includes(q) ||
   f.severity.toLowerCase().includes(q) ||
   f.scannerName.toLowerCase().includes(q) ||
@@ -547,6 +552,12 @@ function LoadFailed({
   );
 }
 
+/** `"HEAD"` is the wire's sentinel for a ref we cannot name: a detached checkout,
+ *  and equally a branch read that failed or came back empty — the backend degrades
+ *  both to it and never queries pipelines under that name. No copy may therefore
+ *  claim a result *for* it; sentences name the ref actually listed instead. */
+const isUnnamedRef = (ref: string): boolean => ref === "HEAD";
+
 /** The project's scanning setup page, or null when the project URL is unknown —
  *  derived in one place so the panel-level card and the per-category cards can't
  *  drift apart on the path. */
@@ -575,17 +586,29 @@ function PipelineProvenance({ data }: { data: GlFindingsOut }) {
   // The finish time is what dates the findings; a still-listed pipeline that
   // never finished falls back to when it started rather than showing nothing.
   const when = pipeline.finishedAt ?? pipeline.createdAt;
+  // A failed pipeline still publishes artifacts and is deliberately accepted as
+  // a source, so its status is surfaced — otherwise a failed run reads as a
+  // healthy one above cards blaming setup. Success is the quiet default.
+  const degraded = pipeline.status !== "success";
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground">
       {data.usedFallback ? (
         <p className="w-full">
-          No pipelines on {data.requestedRef} yet — showing{" "}
-          {data.fallbackRef || "the default branch"}.
+          {isUnnamedRef(data.requestedRef)
+            ? `Detached checkout — showing ${data.fallbackRef || "the default branch"}.`
+            : `No pipelines on ${data.requestedRef} yet — showing ${data.fallbackRef || "the default branch"}.`}
         </p>
       ) : null}
       <p className="min-w-0 flex-1 truncate">
-        From pipeline #{pipeline.iid} ·{" "}
-        <span className="font-mono">{pipeline.ref}</span> @{" "}
+        From pipeline #{pipeline.iid}
+        {degraded && pipeline.status ? (
+          // Icon + the status word: the state is never carried by tone alone.
+          <span className="ml-1 inline-flex items-center gap-1 text-warning">
+            <WarningCircleIcon className="size-3" aria-hidden />
+            {pipeline.status}
+          </span>
+        ) : null}{" "}
+        · <span className="font-mono">{pipeline.ref}</span> @{" "}
         <span className="font-mono">{pipeline.sha.slice(0, 8)}</span> ·{" "}
         <RelativeTime date={when} />
       </p>
@@ -650,15 +673,22 @@ function GlNoPipelineCard({
     );
   }
   if (state === "runningOnly") {
-    const ref = data.usedFallback
-      ? data.fallbackRef || data.requestedRef
-      : data.requestedRef;
+    // Name only a ref whose pipelines were actually listed: on the "HEAD"
+    // sentinel that is the fallback branch, never the checkout itself.
+    const listed =
+      data.usedFallback || isUnnamedRef(data.requestedRef)
+        ? data.fallbackRef
+        : data.requestedRef;
     return (
       <ReasonCard
         icon={ClockIcon}
         // Canceled, skipped, manual and pending pipelines all land here, so this
         // promises no finish — only that a completed one would be read.
-        message={`No pipeline on ${ref} has finished yet — findings will appear once one completes.`}
+        message={
+          listed
+            ? `No pipeline on ${listed} has finished yet — findings will appear once one completes.`
+            : "No pipeline has finished yet — findings will appear once one completes."
+        }
         action={retryAction}
       />
     );
@@ -743,7 +773,9 @@ function GlUnavailableCard({
     return (
       <ReasonCard
         icon={WarningCircleIcon}
-        message={`This pipeline produced a ${category} report GitDesktop can't download. Add the gl-*-report.json file to artifacts:paths in that job to expose it.`}
+        // "the job that produces it" reads correctly whether this card speaks for
+        // one category or, hoisted, for all three (up to three jobs).
+        message={`This pipeline produced a ${category} report GitDesktop can't download. Add the gl-*-report.json file to artifacts:paths in the job that produces it.`}
         detail={detail}
         action={retryAction}
       />
@@ -793,6 +825,36 @@ function GlUnavailableCard({
   return _exhaustive;
 }
 
+/** The empty state for an available category with no rows. A wholly-clean report
+ *  and one whose items partly failed to parse must never read the same, so the
+ *  reassuring shield is reserved for the case where nothing was lost. The lossy
+ *  wording claims only what was read: one analyzer's report can parse clean while
+ *  a sibling's is lost, so "nothing readable" would deny a read that happened. */
+function GlSectionEmpty({
+  category,
+  cleanTitle,
+  detail,
+}: {
+  category: string;
+  cleanTitle: string;
+  detail: string | null;
+}) {
+  return (
+    <Empty className="py-8">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          {detail ? <InfoIcon /> : <ShieldCheckIcon />}
+        </EmptyMedia>
+        <EmptyTitle>
+          {detail
+            ? `No ${category} findings in the reports that could be read.`
+            : cleanTitle}
+        </EmptyTitle>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+
 /** The grouped rows of SAST or secret detection. The group header carries the
  *  rule/secret name, so each row leads with where it was found. */
 function GlSecureRows({
@@ -830,7 +892,11 @@ function GlSecureRows({
                   : "hover:bg-muted/60",
               )}
               onClick={() =>
-                onSelect({ type: "glFinding", category, id: f.id })
+                onSelect({
+                  type: "glFinding",
+                  category,
+                  id: secureFindingId(f),
+                })
               }
             >
               <p className="flex items-center gap-2 text-[11px] text-muted-foreground">
@@ -1029,6 +1095,14 @@ export function FindingsPanel({
     !secrets.isError && secretsOut?.availability === "available";
   const advisoriesShown =
     !advisories.isError && advisoriesOut?.availability === "available";
+  // Equal availability AND equal detail across all three — what a pipeline-wide
+  // cause (a jobs-fetch failure, a pipeline with no scanning jobs) produces.
+  const glUniformState =
+    !!glOut &&
+    glOut.sast.availability === glOut.secretDetection.availability &&
+    glOut.sast.availability === glOut.codeQuality.availability &&
+    glOut.sast.detail === glOut.secretDetection.detail &&
+    glOut.sast.detail === glOut.codeQuality.detail;
   // Every GitLab category hangs off one pipeline, so a state other than "found"
   // hides all three at once.
   const glFound = !gl.isError && glOut?.pipelineState === "found";
@@ -1084,7 +1158,11 @@ export function FindingsPanel({
       for (const row of group.rows) {
         navRows.push({
           id: row.id,
-          finding: { type: "glFinding", category: "sast", id: row.finding.id },
+          finding: {
+            type: "glFinding",
+            category: "sast",
+            id: secureFindingId(row.finding),
+          },
         });
       }
     }
@@ -1097,7 +1175,7 @@ export function FindingsPanel({
           finding: {
             type: "glFinding",
             category: "secretDetection",
-            id: row.finding.id,
+            id: secureFindingId(row.finding),
           },
         });
       }
@@ -1181,7 +1259,7 @@ export function FindingsPanel({
           onChange={(e) => setFilterText(e.target.value)}
           placeholder={
             provider === "gitlab"
-              ? "Filter by rule, secret type, check, file, or severity"
+              ? "Filter by rule, secret type, check, file, severity, or description"
               : "Filter by package, rule, secret type, summary, GHSA, or CVE"
           }
           className="h-7"
@@ -1214,191 +1292,198 @@ export function FindingsPanel({
           ) : (
             <div onKeyDown={onListKeyDown}>
               <PipelineProvenance data={glOut} />
-
-              <SectionHeader title="SAST" />
-              {glOut.sast.availability !== "available" ? (
+              {glUniformState && glOut.sast.availability !== "available" ? (
+                /* One cause, one card — and no section headers, since naming
+                   three empty sections would only restate it. */
                 <GlUnavailableCard
                   availability={glOut.sast.availability}
                   detail={glOut.sast.detail}
-                  category="SAST"
-                  Category="SAST"
+                  category="findings"
+                  Category="Scanning"
                   onRetry={() => gl.refetch()}
                   onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
                 />
               ) : (
                 <>
-                  <GlPartialDetail detail={glOut.sast.detail} />
-                  {glSastGroups.length === 0 ? (
-                    allGlSast.length > 0 ? (
-                      <p className="px-3 py-4 text-xs text-muted-foreground">
-                        No SAST findings match the filter.
-                      </p>
-                    ) : (
-                      <Empty className="py-8">
-                        <EmptyHeader>
-                          <EmptyMedia variant="icon">
-                            <ShieldCheckIcon />
-                          </EmptyMedia>
-                          <EmptyTitle>
-                            No SAST findings in this pipeline
-                          </EmptyTitle>
-                        </EmptyHeader>
-                      </Empty>
-                    )
-                  ) : (
-                    <GlSecureRows
-                      groups={glSastGroups}
-                      category="sast"
-                      selectedRowId={selectedRowId}
-                      onSelect={selectFinding}
+                  <SectionHeader title="SAST" />
+                  {glOut.sast.availability !== "available" ? (
+                    <GlUnavailableCard
+                      availability={glOut.sast.availability}
+                      detail={glOut.sast.detail}
+                      category="SAST"
+                      Category="SAST"
+                      onRetry={() => gl.refetch()}
+                      onSetup={
+                        glSetupUrl ? () => openUrl(glSetupUrl) : undefined
+                      }
                     />
+                  ) : (
+                    <>
+                      <GlPartialDetail detail={glOut.sast.detail} />
+                      {glSastGroups.length === 0 ? (
+                        allGlSast.length > 0 ? (
+                          <p className="px-3 py-4 text-xs text-muted-foreground">
+                            No SAST findings match the filter.
+                          </p>
+                        ) : (
+                          <GlSectionEmpty
+                            category="SAST"
+                            cleanTitle="No SAST findings in this pipeline"
+                            detail={glOut.sast.detail}
+                          />
+                        )
+                      ) : (
+                        <GlSecureRows
+                          groups={glSastGroups}
+                          category="sast"
+                          selectedRowId={selectedRowId}
+                          onSelect={selectFinding}
+                        />
+                      )}
+                      {/* Outside the empty branch: filtering to zero matches must
+                          not strip the only way to reach rows past the window. */}
+                      {glOut.sast.truncated &&
+                        (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
+                          <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                            Showing the first{" "}
+                            {allGlSast.length.toLocaleString()} SAST findings.
+                          </p>
+                        ) : (
+                          <LoadMoreRow
+                            count={allGlSast.length}
+                            loading={gl.isFetching}
+                            onLoadMore={() =>
+                              setFindingsLimits({
+                                ...limits,
+                                gitlab: Math.min(
+                                  limits.gitlab + PAGE_SIZE,
+                                  FINDINGS_LIMIT_CAP,
+                                ),
+                              })
+                            }
+                          />
+                        ))}
+                    </>
                   )}
-                  {/* Outside the empty branch: filtering to zero matches must
-                      not strip the only way to reach rows past the window. */}
-                  {glOut.sast.truncated &&
-                    (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
-                      <p className="border-t px-3 py-3 text-xs text-muted-foreground">
-                        Showing the first {allGlSast.length.toLocaleString()}{" "}
-                        SAST findings.
-                      </p>
-                    ) : (
-                      <LoadMoreRow
-                        count={allGlSast.length}
-                        loading={gl.isFetching}
-                        onLoadMore={() =>
-                          setFindingsLimits({
-                            ...limits,
-                            gitlab: Math.min(
-                              limits.gitlab + PAGE_SIZE,
-                              FINDINGS_LIMIT_CAP,
-                            ),
-                          })
-                        }
-                      />
-                    ))}
-                </>
-              )}
 
-              <SectionHeader title="Secret detection" />
-              {glOut.secretDetection.availability !== "available" ? (
-                <GlUnavailableCard
-                  availability={glOut.secretDetection.availability}
-                  detail={glOut.secretDetection.detail}
-                  category="secret detection"
-                  Category="Secret detection"
-                  onRetry={() => gl.refetch()}
-                  onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
-                />
-              ) : (
-                <>
-                  <GlPartialDetail detail={glOut.secretDetection.detail} />
-                  {glSecretGroups.length === 0 ? (
-                    allGlSecrets.length > 0 ? (
-                      <p className="px-3 py-4 text-xs text-muted-foreground">
-                        No secret findings match the filter.
-                      </p>
-                    ) : (
-                      <Empty className="py-8">
-                        <EmptyHeader>
-                          <EmptyMedia variant="icon">
-                            <ShieldCheckIcon />
-                          </EmptyMedia>
-                          <EmptyTitle>
-                            No secrets detected in this pipeline
-                          </EmptyTitle>
-                        </EmptyHeader>
-                      </Empty>
-                    )
-                  ) : (
-                    <GlSecureRows
-                      groups={glSecretGroups}
-                      category="secretDetection"
-                      selectedRowId={selectedRowId}
-                      onSelect={selectFinding}
+                  <SectionHeader title="Secret detection" />
+                  {glOut.secretDetection.availability !== "available" ? (
+                    <GlUnavailableCard
+                      availability={glOut.secretDetection.availability}
+                      detail={glOut.secretDetection.detail}
+                      category="secret detection"
+                      Category="Secret detection"
+                      onRetry={() => gl.refetch()}
+                      onSetup={
+                        glSetupUrl ? () => openUrl(glSetupUrl) : undefined
+                      }
                     />
+                  ) : (
+                    <>
+                      <GlPartialDetail detail={glOut.secretDetection.detail} />
+                      {glSecretGroups.length === 0 ? (
+                        allGlSecrets.length > 0 ? (
+                          <p className="px-3 py-4 text-xs text-muted-foreground">
+                            No secret findings match the filter.
+                          </p>
+                        ) : (
+                          <GlSectionEmpty
+                            category="secret detection"
+                            cleanTitle="No secrets detected in this pipeline"
+                            detail={glOut.secretDetection.detail}
+                          />
+                        )
+                      ) : (
+                        <GlSecureRows
+                          groups={glSecretGroups}
+                          category="secretDetection"
+                          selectedRowId={selectedRowId}
+                          onSelect={selectFinding}
+                        />
+                      )}
+                      {glOut.secretDetection.truncated &&
+                        (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
+                          <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                            Showing the first{" "}
+                            {allGlSecrets.length.toLocaleString()} secret
+                            findings.
+                          </p>
+                        ) : (
+                          <LoadMoreRow
+                            count={allGlSecrets.length}
+                            loading={gl.isFetching}
+                            onLoadMore={() =>
+                              setFindingsLimits({
+                                ...limits,
+                                gitlab: Math.min(
+                                  limits.gitlab + PAGE_SIZE,
+                                  FINDINGS_LIMIT_CAP,
+                                ),
+                              })
+                            }
+                          />
+                        ))}
+                    </>
                   )}
-                  {glOut.secretDetection.truncated &&
-                    (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
-                      <p className="border-t px-3 py-3 text-xs text-muted-foreground">
-                        Showing the first {allGlSecrets.length.toLocaleString()}{" "}
-                        secret findings.
-                      </p>
-                    ) : (
-                      <LoadMoreRow
-                        count={allGlSecrets.length}
-                        loading={gl.isFetching}
-                        onLoadMore={() =>
-                          setFindingsLimits({
-                            ...limits,
-                            gitlab: Math.min(
-                              limits.gitlab + PAGE_SIZE,
-                              FINDINGS_LIMIT_CAP,
-                            ),
-                          })
-                        }
-                      />
-                    ))}
-                </>
-              )}
 
-              <SectionHeader title="Code quality" />
-              {glOut.codeQuality.availability !== "available" ? (
-                <GlUnavailableCard
-                  availability={glOut.codeQuality.availability}
-                  detail={glOut.codeQuality.detail}
-                  category="code quality"
-                  Category="Code quality"
-                  onRetry={() => gl.refetch()}
-                  onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
-                />
-              ) : (
-                <>
-                  <GlPartialDetail detail={glOut.codeQuality.detail} />
-                  {glQualityGroups.length === 0 ? (
-                    allGlQuality.length > 0 ? (
-                      <p className="px-3 py-4 text-xs text-muted-foreground">
-                        No code quality findings match the filter.
-                      </p>
-                    ) : (
-                      <Empty className="py-8">
-                        <EmptyHeader>
-                          <EmptyMedia variant="icon">
-                            <ShieldCheckIcon />
-                          </EmptyMedia>
-                          <EmptyTitle>
-                            No code quality findings in this pipeline
-                          </EmptyTitle>
-                        </EmptyHeader>
-                      </Empty>
-                    )
-                  ) : (
-                    <GlQualityRows
-                      groups={glQualityGroups}
-                      selectedRowId={selectedRowId}
-                      onSelect={selectFinding}
+                  <SectionHeader title="Code quality" />
+                  {glOut.codeQuality.availability !== "available" ? (
+                    <GlUnavailableCard
+                      availability={glOut.codeQuality.availability}
+                      detail={glOut.codeQuality.detail}
+                      category="code quality"
+                      Category="Code quality"
+                      onRetry={() => gl.refetch()}
+                      onSetup={
+                        glSetupUrl ? () => openUrl(glSetupUrl) : undefined
+                      }
                     />
+                  ) : (
+                    <>
+                      <GlPartialDetail detail={glOut.codeQuality.detail} />
+                      {glQualityGroups.length === 0 ? (
+                        allGlQuality.length > 0 ? (
+                          <p className="px-3 py-4 text-xs text-muted-foreground">
+                            No code quality findings match the filter.
+                          </p>
+                        ) : (
+                          <GlSectionEmpty
+                            category="code quality"
+                            cleanTitle="No code quality findings in this pipeline"
+                            detail={glOut.codeQuality.detail}
+                          />
+                        )
+                      ) : (
+                        <GlQualityRows
+                          groups={glQualityGroups}
+                          selectedRowId={selectedRowId}
+                          onSelect={selectFinding}
+                        />
+                      )}
+                      {glOut.codeQuality.truncated &&
+                        (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
+                          <p className="border-t px-3 py-3 text-xs text-muted-foreground">
+                            Showing the first{" "}
+                            {allGlQuality.length.toLocaleString()} code quality
+                            findings.
+                          </p>
+                        ) : (
+                          <LoadMoreRow
+                            count={allGlQuality.length}
+                            loading={gl.isFetching}
+                            onLoadMore={() =>
+                              setFindingsLimits({
+                                ...limits,
+                                gitlab: Math.min(
+                                  limits.gitlab + PAGE_SIZE,
+                                  FINDINGS_LIMIT_CAP,
+                                ),
+                              })
+                            }
+                          />
+                        ))}
+                    </>
                   )}
-                  {glOut.codeQuality.truncated &&
-                    (limits.gitlab >= FINDINGS_LIMIT_CAP ? (
-                      <p className="border-t px-3 py-3 text-xs text-muted-foreground">
-                        Showing the first {allGlQuality.length.toLocaleString()}{" "}
-                        code quality findings.
-                      </p>
-                    ) : (
-                      <LoadMoreRow
-                        count={allGlQuality.length}
-                        loading={gl.isFetching}
-                        onLoadMore={() =>
-                          setFindingsLimits({
-                            ...limits,
-                            gitlab: Math.min(
-                              limits.gitlab + PAGE_SIZE,
-                              FINDINGS_LIMIT_CAP,
-                            ),
-                          })
-                        }
-                      />
-                    ))}
                 </>
               )}
             </div>

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -347,8 +347,9 @@ const matchesAdvisory = (adv: RepoAdvisoryOut, q: string) =>
   (adv.cveId?.toLowerCase().includes(q) ?? false) ||
   adv.vulnerabilities.some((v) => v.packageName.toLowerCase().includes(q));
 
-/** Identifier *values* (CVE ids, CWE numbers, rule keys) are what a user pastes
- *  in — the identifier's own display name repeats the finding name. */
+/** Identifiers match on BOTH name and value: reports spell a CWE as name
+ *  `CWE-79` with value `79`, so searching values alone would miss what the detail
+ *  pane actually shows — and the placeholder cues identifiers. */
 const matchesGlSecure = (f: GlSecureFindingOut, q: string) =>
   !q ||
   f.name.toLowerCase().includes(q) ||
@@ -356,7 +357,10 @@ const matchesGlSecure = (f: GlSecureFindingOut, q: string) =>
   f.file.toLowerCase().includes(q) ||
   f.severity.toLowerCase().includes(q) ||
   f.scannerName.toLowerCase().includes(q) ||
-  f.identifiers.some((i) => i.value.toLowerCase().includes(q));
+  f.identifiers.some(
+    (i) =>
+      i.name.toLowerCase().includes(q) || i.value.toLowerCase().includes(q),
+  );
 
 const matchesGlQuality = (f: GlCodeQualityFindingOut, q: string) =>
   !q ||
@@ -558,6 +562,18 @@ function LoadFailed({
  *  claim a result *for* it; sentences name the ref actually listed instead. */
 const isUnnamedRef = (ref: string): boolean => ref === "HEAD";
 
+/** The refs whose pipelines were actually listed, for copy that would otherwise
+ *  claim something project-wide: the sentinel contributes nothing (never queried
+ *  under a name), and a branch that IS the default is named once, not twice.
+ *  Null when neither ref can be named. */
+function checkedRefs(data: GlFindingsOut): string | null {
+  const requested = isUnnamedRef(data.requestedRef) ? null : data.requestedRef;
+  const fallback = data.fallbackRef;
+  if (requested && fallback && requested !== fallback)
+    return `${requested} or ${fallback}`;
+  return requested || fallback;
+}
+
 /** The project's scanning setup page, or null when the project URL is unknown —
  *  derived in one place so the panel-level card and the per-category cards can't
  *  drift apart on the path. */
@@ -595,7 +611,7 @@ function PipelineProvenance({ data }: { data: GlFindingsOut }) {
       {data.usedFallback ? (
         <p className="w-full">
           {isUnnamedRef(data.requestedRef)
-            ? `Detached checkout — showing ${data.fallbackRef || "the default branch"}.`
+            ? `No named branch checked out — showing ${data.fallbackRef || "the default branch"}.`
             : `No pipelines on ${data.requestedRef} yet — showing ${data.fallbackRef || "the default branch"}.`}
         </p>
       ) : null}
@@ -650,10 +666,14 @@ function GlNoPipelineCard({
   const setupUrl = glScanningSetupUrl(data);
 
   if (state === "none") {
+    // Only two refs were queried, so the sentence names them rather than
+    // clearing the whole project: pipelines can live on refs we never asked for
+    // (merge-request refs, tags, other branches).
+    const refs = checkedRefs(data);
     return (
       <ReasonCard
         icon={ShieldSlashIcon}
-        message="Scanning hasn't run in this project's CI yet. Add SAST, secret detection, or code quality jobs to see findings here."
+        message={`${refs ? `No pipelines found on ${refs}.` : "No pipelines found."} Add SAST, secret detection, or code quality jobs to see findings here.`}
         action={
           <div className="flex flex-wrap items-center gap-2">
             {setupUrl ? (
@@ -731,6 +751,7 @@ function GlUnavailableCard({
   detail,
   category,
   Category,
+  notConfiguredMessage,
   onRetry,
   onSetup,
 }: {
@@ -738,6 +759,9 @@ function GlUnavailableCard({
   detail: string | null;
   category: string;
   Category: string;
+  /** Replaces the per-category sentence where the shared template reads badly —
+   *  the hoisted card speaks for all three at once. */
+  notConfiguredMessage?: string;
   onRetry: () => void;
   onSetup?: () => void;
 }) {
@@ -754,7 +778,10 @@ function GlUnavailableCard({
         icon={ShieldSlashIcon}
         // Hedged deliberately: an analyzer job that ran and FAILED publishes no
         // artifacts either, and the wire can't tell that from never-configured.
-        message={`This pipeline didn't publish a ${category} report — most likely scanning isn't set up yet.`}
+        message={
+          notConfiguredMessage ??
+          `This pipeline didn't publish a ${category} report — most likely scanning isn't set up yet.`
+        }
         action={
           <div className="flex flex-wrap items-center gap-2">
             {onSetup ? (
@@ -1259,7 +1286,7 @@ export function FindingsPanel({
           onChange={(e) => setFilterText(e.target.value)}
           placeholder={
             provider === "gitlab"
-              ? "Filter by rule, secret type, check, file, severity, or description"
+              ? "Filter by rule, secret type, check, file, severity, description, or identifier"
               : "Filter by package, rule, secret type, summary, GHSA, or CVE"
           }
           className="h-7"
@@ -1300,6 +1327,7 @@ export function FindingsPanel({
                   detail={glOut.sast.detail}
                   category="findings"
                   Category="Scanning"
+                  notConfiguredMessage="This pipeline didn't publish any scanning reports — most likely scanning isn't set up yet."
                   onRetry={() => gl.refetch()}
                   onSetup={glSetupUrl ? () => openUrl(glSetupUrl) : undefined}
                 />

--- a/src/features/security-findings/severity.tsx
+++ b/src/features/security-findings/severity.tsx
@@ -8,17 +8,26 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
-/** GitHub's advisory severity ladder, plus the bucket a missing or unrecognized
- *  value falls into (repo advisories may carry no severity at all). */
-export type SeverityLevel = "critical" | "high" | "medium" | "low" | "unknown";
+/** GitHub's advisory severity ladder plus GitLab's `Info` rung, and the bucket a
+ *  missing or unrecognized value falls into (repo advisories may carry no
+ *  severity at all). No GitHub surface reports `info`. */
+export type SeverityLevel =
+  | "critical"
+  | "high"
+  | "medium"
+  | "low"
+  | "info"
+  | "unknown";
 
 /** Severity tone, via the app's semantic tokens. Critical and high share the
- *  destructive tone and are told apart by icon weight + label, never by color. */
+ *  destructive tone and are told apart by icon weight + label, never by color;
+ *  everything at or below `low` is muted so the ladder never inverts. */
 export const SEVERITY_TONE: Record<SeverityLevel, string> = {
   critical: "text-destructive",
   high: "text-destructive",
   medium: "text-warning",
   low: "text-muted-foreground",
+  info: "text-muted-foreground",
   unknown: "text-muted-foreground",
 };
 
@@ -29,7 +38,8 @@ export const SEVERITY_RANK: Record<SeverityLevel, number> = {
   high: 1,
   medium: 2,
   low: 3,
-  unknown: 4,
+  info: 4,
+  unknown: 5,
 };
 
 export const SEVERITY_LABEL: Record<SeverityLevel, string> = {
@@ -37,6 +47,7 @@ export const SEVERITY_LABEL: Record<SeverityLevel, string> = {
   high: "High",
   medium: "Medium",
   low: "Low",
+  info: "Info",
   unknown: "Unspecified",
 };
 
@@ -45,6 +56,7 @@ const SEVERITY_ICON: Record<SeverityLevel, typeof WarningIcon> = {
   high: WarningIcon,
   medium: WarningCircleIcon,
   low: InfoIcon,
+  info: InfoIcon,
   unknown: CircleIcon,
 };
 
@@ -61,6 +73,8 @@ export function severityLevel(severity: string | null): SeverityLevel {
       return "medium";
     case "low":
       return "low";
+    case "info":
+      return "info";
     default:
       return "unknown";
   }
@@ -214,6 +228,74 @@ export function ValidityChip({ validity }: { validity: string | null }) {
     <Badge variant="outline" className={cn("gap-1", VALIDITY_TONE[level])}>
       <Icon weight={level === "active" ? "fill" : "regular"} />
       {VALIDITY_LABEL[level]}
+    </Badge>
+  );
+}
+
+// ── Code quality ─────────────────────────────────────────────────────────────
+
+/** A CodeClimate report's severity. Its own ladder, like SARIF: a `blocker` is a
+ *  maintainability call by a linter, not a security severity, so it is never
+ *  relabeled "Critical" — only *ranked* alongside them. */
+export type CqLevel =
+  | "blocker"
+  | "critical"
+  | "major"
+  | "minor"
+  | "info"
+  | "unknown";
+
+const CQ_LABEL: Record<CqLevel, string> = {
+  blocker: "Blocker",
+  critical: "Critical",
+  major: "Major",
+  minor: "Minor",
+  info: "Info",
+  unknown: "Unspecified",
+};
+
+/** The severity rung a CodeClimate level shares for ordering and visual weight.
+ *  Sort and tone only — `CQ_LABEL` is what names the level to the user. */
+const CQ_AS_SEVERITY: Record<CqLevel, SeverityLevel> = {
+  blocker: "critical",
+  critical: "high",
+  major: "medium",
+  minor: "low",
+  info: "info",
+  unknown: "unknown",
+};
+
+export function cqLevel(severity: string | null): CqLevel {
+  switch (severity?.toLowerCase()) {
+    case "blocker":
+      return "blocker";
+    case "critical":
+      return "critical";
+    case "major":
+      return "major";
+    case "minor":
+      return "minor";
+    case "info":
+      return "info";
+    default:
+      return "unknown";
+  }
+}
+
+/** Worst-first rank for a code quality finding, on the shared severity ladder. */
+export const cqRank = (severity: string | null): number =>
+  SEVERITY_RANK[CQ_AS_SEVERITY[cqLevel(severity)]];
+
+/** The chip for a code quality finding, labeled in CodeClimate's own words so
+ *  nothing is promoted to a severity the report never assigned. */
+export function CqChip({ severity }: { severity: string | null }) {
+  const level = cqLevel(severity);
+  const rung = CQ_AS_SEVERITY[level];
+  const Icon = SEVERITY_ICON[rung];
+  return (
+    <Badge variant="outline" className={cn("gap-1", SEVERITY_TONE[rung])}>
+      <Icon weight={rung === "critical" ? "fill" : "regular"} />
+      {CQ_LABEL[level]}
     </Badge>
   );
 }

--- a/src/features/security-findings/severity.tsx
+++ b/src/features/security-findings/severity.tsx
@@ -1,5 +1,6 @@
 import {
   CircleIcon,
+  DotOutlineIcon,
   InfoIcon,
   QuestionIcon,
   WarningCircleIcon,
@@ -51,12 +52,14 @@ export const SEVERITY_LABEL: Record<SeverityLevel, string> = {
   unknown: "Unspecified",
 };
 
+/** One glyph per rung: `info` sits below `low`, so it takes the lightest mark
+ *  rather than repeating low's — adjacent rungs must not differ by label alone. */
 const SEVERITY_ICON: Record<SeverityLevel, typeof WarningIcon> = {
   critical: WarningIcon,
   high: WarningIcon,
   medium: WarningCircleIcon,
   low: InfoIcon,
-  info: InfoIcon,
+  info: DotOutlineIcon,
   unknown: CircleIcon,
 };
 
@@ -82,9 +85,9 @@ export function severityLevel(severity: string | null): SeverityLevel {
 
 /**
  * A compact severity chip — **Critical** / **High** / **Medium** / **Low** /
- * **Unspecified**. Icon + text carry the meaning (never color alone, per the
- * WCAG-AA rule); critical additionally fills its icon so it stays distinct from
- * high, which shares its tone.
+ * **Info** / **Unspecified**. Icon + text carry the meaning (never color alone,
+ * per the WCAG-AA rule); critical additionally fills its icon so it stays
+ * distinct from high, which shares its tone.
  */
 export function SeverityChip({ severity }: { severity: string | null }) {
   const level = severityLevel(severity);

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -656,8 +656,10 @@ export interface ForgeCapabilities {
   ci: boolean;
   webhooks: boolean;
   approvals: boolean;
-  /** Dependabot, code scanning and secret scanning alerts + repository security
-   *  advisories (GitHub-only surfaces). */
+  /** The Findings tab. Each provider reads what it actually has: GitHub the
+   *  platform alert APIs (Dependabot, code scanning, secret scanning, repository
+   *  advisories); GitLab the SAST, secret detection and code quality report
+   *  artifacts of a pipeline. Bitbucket has no analogue. */
   securityFindings: boolean;
 }
 

--- a/src/lib/github/security-findings.ts
+++ b/src/lib/github/security-findings.ts
@@ -161,10 +161,11 @@ export interface AdvisoryVulnerabilityOut {
 
 // ── API wrappers ─────────────────────────────────────────────────────────────
 //
-// GitHub-only: every findings category here (Dependabot, code scanning, secret
-// scanning, repository advisories) has no GitLab/Bitbucket analogue, so these
-// stay `gh_*` and the panel gates on the `securityFindings` capability rather
-// than dispatching per provider.
+// The four GitHub categories (Dependabot, code scanning, secret scanning,
+// repository advisories) are platform alert stores with no direct analogue
+// elsewhere, so they keep their `gh_*` commands. The panel picks a query set by
+// provider on top of the `securityFindings` capability: GitLab reads pipeline
+// report artifacts via `forge_gl_pipeline_findings` instead of these.
 
 export const ghDependabotAlerts = (repoPath: string, limit: number) =>
   invoke<DependabotAlertsOut>("gh_dependabot_alerts", { repoPath, limit });

--- a/src/lib/gitlab/security-findings.ts
+++ b/src/lib/gitlab/security-findings.ts
@@ -104,12 +104,24 @@ export interface GlCodeQualityFindingOut {
   line: number | null;
 }
 
+/** Stable identity for a SAST or secret-detection finding. Reports may omit the
+ *  id entirely, and every id-less finding would otherwise share the empty string
+ *  as its identity — so the location stands in, mirroring the fields of Rust's
+ *  `SecureKey::Location` (the backend's dedup key). The join is not injective the
+ *  way that tuple is: report-controlled text containing the separator can still
+ *  collide, degrading to the documented first-match-wins rather than to a mix-up
+ *  of unrelated findings. */
+export const secureFindingId = (f: GlSecureFindingOut): string =>
+  f.id || `${f.name}:${f.file}:${f.startLine ?? ""}`;
+
 /** Stable identity for a code quality finding, mirroring the Rust side's
  *  composite. A fingerprint repeats across files for the same offending
  *  construct — and can be missing entirely — so the check name, path and line all
  *  join the key; without the check name, two different checks at one path:line
- *  collapse into each other. The panel and the detail pane must derive it
- *  identically or a selected row resolves to the wrong finding. */
+ *  collapse into each other. Same caveat as `secureFindingId`: the join is not
+ *  injective the way the Rust tuple is, and a separator-bearing collision degrades
+ *  to first-match-wins. The panel and the detail pane must derive it identically
+ *  or a selected row resolves to the wrong finding. */
 export const codeQualityFindingId = (f: GlCodeQualityFindingOut): string =>
   `${f.fingerprint}:${f.checkName}:${f.path}:${f.line ?? ""}`;
 

--- a/src/lib/gitlab/security-findings.ts
+++ b/src/lib/gitlab/security-findings.ts
@@ -38,6 +38,11 @@ export interface GlFindingsOut {
   usedFallback: boolean;
   /** The default branch name when `usedFallback`; null otherwise. */
   fallbackRef: string | null;
+  /** The project's default branch name, set on every exit where the project fetch
+   *  answered — including when no pipelines were found at all. Distinct from
+   *  `fallbackRef`, which means a default-branch pipeline was actually used: this
+   *  one says which ref was *looked at*, not which one supplied findings. */
+  defaultRef: string | null;
   /** e.g. `https://gitlab.com/group/name`, no trailing slash; null when unknown. */
   projectWebUrl: string | null;
   sast: GlSecureCategoryOut;

--- a/src/lib/gitlab/security-findings.ts
+++ b/src/lib/gitlab/security-findings.ts
@@ -38,10 +38,11 @@ export interface GlFindingsOut {
   usedFallback: boolean;
   /** The default branch name when `usedFallback`; null otherwise. */
   fallbackRef: string | null;
-  /** The project's default branch name, set on every exit where the project fetch
-   *  answered — including when no pipelines were found at all. Distinct from
-   *  `fallbackRef`, which means a default-branch pipeline was actually used: this
-   *  one says which ref was *looked at*, not which one supplied findings. */
+  /** The project's default branch name, set whenever the project fetch answered
+   *  and the project has a default branch — including when no pipelines were
+   *  found at all. Distinct from `fallbackRef`, which means a default-branch
+   *  pipeline was actually used: this one says which ref was *looked at*, not
+   *  which one supplied findings. */
   defaultRef: string | null;
   /** e.g. `https://gitlab.com/group/name`, no trailing slash; null when unknown. */
   projectWebUrl: string | null;

--- a/src/lib/gitlab/security-findings.ts
+++ b/src/lib/gitlab/security-findings.ts
@@ -1,0 +1,145 @@
+import { useQuery } from "@tanstack/react-query";
+import { keepPreviousDataForRepo } from "@/lib/git/queries";
+import { invoke } from "@/lib/tauri/invoke";
+
+// ── Types (mirror the Rust structs behind `forge_gl_pipeline_findings`) ──────
+
+/** Whether a pipeline was found to read reports from. Only `"found"` carries a
+ *  `pipeline`; the other three name why there is nothing to read, so an empty
+ *  findings list never defaults to "clean". */
+export type GlPipelineState = "found" | "none" | "runningOnly" | "unavailable";
+
+/** Why a category has (or hasn't) findings. `"available"` is the ONLY value that
+ *  lets an empty list mean "clean" — every other value names a blocker the panel
+ *  must render instead. */
+export type GlFindingAvailability =
+  | "available"
+  /** The pipeline ran, but with no job of this kind. */
+  | "notConfigured"
+  /** The job ran, but its report isn't in the job's `artifacts:paths`. */
+  | "reportNotReadable"
+  /** The pipeline's artifacts have aged out of GitLab's retention. */
+  | "expired"
+  /** The job for this category hasn't finished in this pipeline yet. */
+  | "analysisPending"
+  | "forbidden"
+  | "indeterminate";
+
+/** Findings read from ONE pipeline's report artifacts — commit-scoped, unlike
+ *  GitHub's repository-wide alert stores. The panel's provenance strip is what
+ *  makes that visible, so `pipeline` travels with the categories. */
+export interface GlFindingsOut {
+  pipelineState: GlPipelineState;
+  /** Non-null iff `pipelineState === "found"`. */
+  pipeline: GlPipelineRefOut | null;
+  /** The checkout branch we looked for pipelines on ("HEAD" when detached). */
+  requestedRef: string;
+  /** The pipelines came from the default branch instead of `requestedRef`. */
+  usedFallback: boolean;
+  /** The default branch name when `usedFallback`; null otherwise. */
+  fallbackRef: string | null;
+  /** e.g. `https://gitlab.com/group/name`, no trailing slash; null when unknown. */
+  projectWebUrl: string | null;
+  sast: GlSecureCategoryOut;
+  secretDetection: GlSecureCategoryOut;
+  codeQuality: GlCodeQualityCategoryOut;
+}
+
+export interface GlPipelineRefOut {
+  id: number;
+  iid: number;
+  status: string;
+  sha: string;
+  ref: string;
+  webUrl: string;
+  createdAt: string;
+  finishedAt: string | null;
+}
+
+export interface GlSecureCategoryOut {
+  availability: GlFindingAvailability;
+  /** The server's own explanation for a non-available envelope; null otherwise. */
+  detail: string | null;
+  findings: GlSecureFindingOut[];
+  /** More findings exist in the report than the limit asked for. */
+  truncated: boolean;
+}
+
+export interface GlCodeQualityCategoryOut {
+  availability: GlFindingAvailability;
+  detail: string | null;
+  findings: GlCodeQualityFindingOut[];
+  truncated: boolean;
+}
+
+export interface GlSecureFindingOut {
+  id: string;
+  name: string;
+  /** Raw and capitalized as the report spells it — `"Critical"`…`"Unknown"`, and
+   *  `""` when the report omitted it. */
+  severity: string;
+  description: string;
+  file: string;
+  startLine: number | null;
+  endLine: number | null;
+  scannerName: string;
+  identifiers: GlIdentifierOut[];
+}
+
+export interface GlIdentifierOut {
+  type: string;
+  name: string;
+  value: string;
+  url: string | null;
+}
+
+export interface GlCodeQualityFindingOut {
+  fingerprint: string;
+  checkName: string;
+  /** Raw and lowercase as CodeClimate spells it — `"blocker"`…`"info"`, and `""`
+   *  when the report omitted it. A ladder of its own, never a security severity. */
+  severity: string;
+  description: string;
+  path: string;
+  line: number | null;
+}
+
+/** Stable identity for a code quality finding, mirroring the Rust side's
+ *  composite. A fingerprint repeats across files for the same offending
+ *  construct — and can be missing entirely — so the check name, path and line all
+ *  join the key; without the check name, two different checks at one path:line
+ *  collapse into each other. The panel and the detail pane must derive it
+ *  identically or a selected row resolves to the wrong finding. */
+export const codeQualityFindingId = (f: GlCodeQualityFindingOut): string =>
+  `${f.fingerprint}:${f.checkName}:${f.path}:${f.line ?? ""}`;
+
+// ── API wrappers ─────────────────────────────────────────────────────────────
+
+export const glPipelineFindings = (repoPath: string, limit: number) =>
+  invoke<GlFindingsOut>("forge_gl_pipeline_findings", { repoPath, limit });
+
+// ── Queries ──────────────────────────────────────────────────────────────────
+
+/**
+ * One query for all three GitLab categories: they come from a single pipeline's
+ * artifacts, so splitting them would re-resolve that pipeline three times. No
+ * refetchInterval — findings change per pipeline, so this fetches on tab open and
+ * manual refresh only. `active` (the Findings tab being visible) gates the fetch;
+ * <Activity> defers a hidden panel's effects but not its queries. `limit` is part
+ * of the key so a Load-more is a distinct entry; keepPreviousDataForRepo keeps the
+ * loaded rows painted while it refetches.
+ */
+export function useGitLabFindings(
+  repo: string,
+  enabled: boolean,
+  active: boolean,
+  limit: number,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "findings", "gitlab", limit] as const,
+    queryFn: () => glPipelineFindings(repo, limit),
+    enabled: enabled && active,
+    staleTime: 5 * 60_000,
+    placeholderData: keepPreviousDataForRepo(repo),
+  });
+}

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -73,9 +73,10 @@ export type SelectedFinding =
   | { type: "codeScanning"; number: number }
   | { type: "secretScanning"; number: number }
   | { type: "advisory"; ghsaId: string }
-  /** GitLab pipeline-report findings. `id` is the secure finding's own id, or —
-   *  for code quality — `codeQualityFindingId` (a fingerprint can repeat or be
-   *  missing, so the check name, path and line join the identity). */
+  /** GitLab pipeline-report findings. `id` is always a *derived* identity —
+   *  `secureFindingId` for SAST/secrets, `codeQualityFindingId` for code
+   *  quality — because a report can omit the id or fingerprint outright, and
+   *  every finding missing one would otherwise share the empty string. */
   | {
       type: "glFinding";
       category: "sast" | "secretDetection" | "codeQuality";

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -72,7 +72,15 @@ export type SelectedFinding =
   | { type: "alert"; number: number }
   | { type: "codeScanning"; number: number }
   | { type: "secretScanning"; number: number }
-  | { type: "advisory"; ghsaId: string };
+  | { type: "advisory"; ghsaId: string }
+  /** GitLab pipeline-report findings. `id` is the secure finding's own id, or —
+   *  for code quality — `codeQualityFindingId` (a fingerprint can repeat or be
+   *  missing, so the check name, path and line join the identity). */
+  | {
+      type: "glFinding";
+      category: "sast" | "secretDetection" | "codeQuality";
+      id: string;
+    };
 
 /** How many rows each Findings category has asked for. In the store (not panel
  *  state) so the list and the detail pane build identical query keys and share
@@ -82,6 +90,8 @@ export interface FindingsLimits {
   codeScanning: number;
   secretScanning: number;
   advisories: number;
+  /** Shared by GitLab's three categories — they come from one pipeline query. */
+  gitlab: number;
 }
 
 /** One page per category — matches the shared LoadMoreRow PAGE_SIZE. */
@@ -90,6 +100,7 @@ const DEFAULT_FINDINGS_LIMITS: FindingsLimits = {
   codeScanning: 100,
   secretScanning: 100,
   advisories: 100,
+  gitlab: 100,
 };
 
 export interface SelectedFile {


### PR DESCRIPTION
Extends the **Findings** tab to GitLab repositories. GitLab paywalls its rendered vulnerability report behind Ultimate, but the analyzers write plain JSON report artifacts that every tier can download — so this reads the newest completed pipeline's `gl-*-report.json` artifacts directly, making it often the only place a Free-tier user sees findings their pipelines already produce.

### Backend — pipeline report reader

- Adds `src-tauri/src/forge/gitlab_findings.rs`: resolves the newest completed pipeline for the checked-out ref (falling back to the default branch), then reads the `sast`, `secret_detection` and `codequality` job artifacts. Every category rides an availability envelope (`GlFindingAvailability`: `Available`, `NotConfigured`, `ReportNotReadable`, `Expired`, `AnalysisPending`, `Forbidden`, `Indeterminate`) alongside `GlPipelineState`, so an empty list only renders as clean when a report was actually parsed. Only a missing `glab` binary or a timeout escapes as `Err`.
- Caps each artifact at `MAX_REPORT_BYTES` (16 MiB) since the body is attacker-influenceable and held in memory, and drops the raw secret extract before a finding leaves the module.
- Exposes `forge_gl_pipeline_findings` in `src-tauri/src/forge/mod.rs` (guarded by `gl_only!`) and registers it in `src-tauri/src/lib.rs`.
- Promotes `encode_project`, `project_path` and `glab_output_is_404` to `pub(crate)` in `src-tauri/src/forge/gitlab.rs` for reuse by the new module.
- Flips `Capabilities::security_findings` to `true` for GitLab in `src-tauri/src/forge/model.rs`, rewrites the field's doc to describe both platforms' sources, and updates the provider assertion accordingly.

### Frontend — panel, detail & severity

- Adds `src/lib/gitlab/security-findings.ts`: TS mirrors of the Rust wire shape, the `glPipelineFindings` invoke wrapper, and `useGitLabFindings` — one query for all three categories (they share a pipeline resolution), gated on the tab being `active`, with `limit` in the key and `keepPreviousDataForRepo`. Also exports `codeQualityFindingId`, the composite identity the panel and detail pane must derive identically.
- Extends `src/features/security-findings/FindingsPanel.tsx` with the GitLab sections: `buildGlSecureGroups` / `buildGlQualityGroups` sort worst-first before grouping, `sameFinding` gains a category-aware `glFinding` branch, and each availability value gets its own explanatory card (scanning not set up, report not downloadable, expired artifacts, nothing finished, forbidden, retry).
- Extends `src/features/security-findings/FindingDetailView.tsx` with `GlSecureDetail` and `GlQualityDetail`: severity chip, `file:line`, scanner, identifiers as links, the source pipeline row, and a **View file on GitLab** permalink built by `glBlobUrl` at the scanned commit. `DetailShell` takes a `linkLabel` prop, and `httpUrl` restricts identifier links from third-party reports to `http:`/`https:`.
- Adds an `info` rung to the ladder in `src/features/security-findings/severity.tsx` (tone, rank, label, icon) plus a separate CodeClimate ladder — `CqLevel`, `cqLevel`, `cqRank`, `CqChip` — which ranks and tones alongside security severities but keeps CodeClimate's own words, so a linter `blocker` is never relabeled "Critical".
- Adds the `glFinding` variant (`category` + `id`) to `SelectedFinding` and a shared `gitlab` entry to `FindingsLimits` in `src/lib/stores/ui.ts`, with the matching detail key in `src/features/repository/RepositoryView.tsx`.

### Documentation

- `README.md`: new paragraph under the Findings section covering the pipeline source, the tier situation, the provenance strip, the blob permalink, secret-value redaction and the per-section explanations.
- `src/features/help/content.ts`: splits the Findings guide into "On a GitHub repository" and "On a GitLab repository", documents each empty-state reason, and corrects the repo-view tab list — Findings now needs `gh` **or** `glab`, unlike Issues/Discussions/Actions/Tags.
- `site/src/data/capabilities.ts`: broadens the Findings capability label to name both platforms' sources.
- `changelog.d/added-findings-gitlab-arm.md`: Added fragment for the release notes.