### PR TITLE
fix(branches,explore): account for forks in PR badges and Fork action

### DIFF
--- a/changelog.d/fixed-branch-pr-badge-fork-collision.md
+++ b/changelog.d/fixed-branch-pr-badge-fork-collision.md
@@ -1,0 +1,3 @@
+- Branch pull-request badges now attach only to pull requests opened from this
+  repository — a contributor's fork branch with the same name no longer claims the
+  badge on your branch.

--- a/changelog.d/fixed-branch-pr-badge-fork-collision.md
+++ b/changelog.d/fixed-branch-pr-badge-fork-collision.md
@@ -1,3 +1,4 @@
-- Branch pull-request badges now attach only to pull requests opened from this
-  repository, so a contributor's fork branch with the same name no longer claims the
-  badge on your branch.
+- A contributor's fork branch with the same name as yours no longer masquerades as
+  your own work: branch pull-request badges, the Compare tab's and Create dialog's
+  duplicate checks, Bitbucket's duplicate-create guard, and GitLab stacked-MR
+  detection all now skip fork pull requests.

--- a/changelog.d/fixed-branch-pr-badge-fork-collision.md
+++ b/changelog.d/fixed-branch-pr-badge-fork-collision.md
@@ -1,3 +1,3 @@
 - Branch pull-request badges now attach only to pull requests opened from this
   repository, so a contributor's fork branch with the same name no longer claims the
-  badge on your branch (GitHub only for now).
+  badge on your branch.

--- a/changelog.d/fixed-branch-pr-badge-fork-collision.md
+++ b/changelog.d/fixed-branch-pr-badge-fork-collision.md
@@ -1,3 +1,3 @@
 - Branch pull-request badges now attach only to pull requests opened from this
-  repository — a contributor's fork branch with the same name no longer claims the
-  badge on your branch.
+  repository, so a contributor's fork branch with the same name no longer claims the
+  badge on your branch (GitHub only for now).

--- a/changelog.d/fixed-explore-fork-own-repo.md
+++ b/changelog.d/fixed-explore-fork-own-repo.md
@@ -1,0 +1,3 @@
+- Explore no longer offers **Fork** on repositories you personally own — forks are
+  created under your account, so it could never succeed there. Organization
+  repositories remain forkable.

--- a/changelog.d/fixed-explore-fork-own-repo.md
+++ b/changelog.d/fixed-explore-fork-own-repo.md
@@ -1,3 +1,3 @@
-- Explore no longer offers **Fork** on repositories you personally own — forks are
-  created under your account, so it could never succeed there. Organization
-  repositories remain forkable.
+- **Fork** is no longer offered on repositories you personally own — in Explore and
+  in the repository menu — since a fork is always created under your own account.
+  Organization repositories remain forkable.

--- a/changelog.d/fixed-explore-fork-own-repo.md
+++ b/changelog.d/fixed-explore-fork-own-repo.md
@@ -1,3 +1,3 @@
-- **Fork** is no longer offered on repositories you personally own — in Explore and
-  in the repository menu — since a fork is always created under your own account.
-  Organization repositories remain forkable.
+- **Fork** is no longer offered on repositories you personally own — in Explore on
+  GitHub and GitLab, and in the GitHub repository menu — since a fork always lands
+  under your own account. Organization repositories remain forkable.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -606,6 +606,13 @@ fn endpoint_repo(ep: &Option<BbPrEndpoint>) -> String {
         .unwrap_or_default()
 }
 
+/// A fork PR's source repo differs from its destination; either name absent
+/// (an unfielded payload) leaves this false rather than guessing.
+fn cross_repo(source: &Option<BbPrEndpoint>, destination: &Option<BbPrEndpoint>) -> bool {
+    let (src, dst) = (endpoint_repo(source), endpoint_repo(destination));
+    !src.is_empty() && !dst.is_empty() && src != dst
+}
+
 fn branch_name(ep: &Option<BbPrEndpoint>) -> String {
     ep.as_ref()
         .and_then(|e| e.branch.as_ref())
@@ -647,12 +654,7 @@ fn from_bb_pr(p: BbPr) -> PrInfo {
         // and no stack-membership gate for a fork head to inform.
         stack: None,
         stack_unknown: false,
-        // A fork PR's source repo differs from its destination; either name absent
-        // (an unfielded payload) leaves this false rather than guessing.
-        cross_repository: {
-            let (src, dst) = (endpoint_repo(&p.source), endpoint_repo(&p.destination));
-            !src.is_empty() && !dst.is_empty() && src != dst
-        },
+        cross_repository: cross_repo(&p.source, &p.destination),
     }
 }
 
@@ -1258,12 +1260,7 @@ pub async fn view_pr(repo_path: &str, number: u64) -> AppResult<PrDetails> {
         // Bitbucket Cloud's PR payload carries no mergeability field, and its only
         // pre-check needs a write scope — so "unknown", never a guess.
         mergeability: PrMergeability::unavailable(),
-        // A fork PR's source repo differs from its destination; either name absent
-        // (an unfielded payload) leaves this false rather than guessing.
-        cross_repository: {
-            let (src, dst) = (endpoint_repo(&pr.source), endpoint_repo(&pr.destination));
-            !src.is_empty() && !dst.is_empty() && src != dst
-        },
+        cross_repository: cross_repo(&pr.source, &pr.destination),
         // GitHub's "allow edits by maintainers" has no Bitbucket equivalent —
         // unknown, not denied.
         maintainer_can_modify: None,
@@ -2752,10 +2749,12 @@ fn build_create_body(
 /// Find an existing OPEN PR from `head` into `base`. Pure (testable). `prs_for_branch`
 /// already constrains source + OPEN but NOT the destination, so filter on
 /// `base_ref_name == base` to catch only a genuine same-source→same-dest duplicate.
+/// A fork PR is never YOUR duplicate — its source branch lives in another repository,
+/// so a contributor's same-named branch must not block your create.
 fn duplicate_pr_number(open_prs: &[PrInfo], base: &str) -> Option<u64> {
     open_prs
         .iter()
-        .find(|p| p.base_ref_name == base)
+        .find(|p| p.base_ref_name == base && !p.cross_repository)
         .map(|p| p.number)
 }
 
@@ -5348,10 +5347,28 @@ mod tests {
         assert_eq!(endpoint_repo(&absent.source), "");
         assert_eq!(endpoint_repo(&absent.destination), "");
 
+        // One-sided absence is what the emptiness guards exist for: a bare `src != dst`
+        // would read the missing destination as a different repo and invent a fork.
+        let one_sided: BbPr = serde_json::from_str(
+            r#"{"id":7,"state":"OPEN",
+                "source":{"branch":{"name":"feat"},"repository":{"full_name":"me/app"}},
+                "destination":{"branch":{"name":"main"}}}"#,
+        )
+        .unwrap();
+        assert_eq!(endpoint_repo(&one_sided.source), "me/app");
+        assert_eq!(endpoint_repo(&one_sided.destination), "");
+
+        // Both arms share `cross_repo`, so covering it covers the detail arm too.
+        assert!(cross_repo(&fork.source, &fork.destination));
+        assert!(!cross_repo(&same.source, &same.destination));
+        assert!(!cross_repo(&absent.source, &absent.destination));
+        assert!(!cross_repo(&one_sided.source, &one_sided.destination));
+
         // The list arm reads the same names off the same (unfielded) list payload.
         assert!(from_bb_pr(fork).cross_repository);
         assert!(!from_bb_pr(same).cross_repository);
         assert!(!from_bb_pr(absent).cross_repository);
+        assert!(!from_bb_pr(one_sided).cross_repository);
     }
 
     #[test]
@@ -6422,6 +6439,14 @@ mod tests {
         assert_eq!(duplicate_pr_number(&list, "main"), Some(7));
         // Empty list → no duplicate.
         assert_eq!(duplicate_pr_number(&[], "main"), None);
+
+        // A contributor's fork PR shares the source AND destination branch names but
+        // is not yours — it must never block your own create.
+        let from_fork = pr(r#"{"id":11,"title":"z","state":"OPEN",
+            "source":{"branch":{"name":"feature/x"},"repository":{"full_name":"them/app"}},
+            "destination":{"branch":{"name":"main"},"repository":{"full_name":"us/app"}}}"#);
+        assert!(from_fork.cross_repository);
+        assert_eq!(duplicate_pr_number(&[from_fork], "main"), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -647,7 +647,12 @@ fn from_bb_pr(p: BbPr) -> PrInfo {
         // and no stack-membership gate for a fork head to inform.
         stack: None,
         stack_unknown: false,
-        cross_repository: false,
+        // A fork PR's source repo differs from its destination; either name absent
+        // (an unfielded payload) leaves this false rather than guessing.
+        cross_repository: {
+            let (src, dst) = (endpoint_repo(&p.source), endpoint_repo(&p.destination));
+            !src.is_empty() && !dst.is_empty() && src != dst
+        },
     }
 }
 
@@ -5342,6 +5347,11 @@ mod tests {
         .unwrap();
         assert_eq!(endpoint_repo(&absent.source), "");
         assert_eq!(endpoint_repo(&absent.destination), "");
+
+        // The list arm reads the same names off the same (unfielded) list payload.
+        assert!(from_bb_pr(fork).cross_repository);
+        assert!(!from_bb_pr(same).cross_repository);
+        assert!(!from_bb_pr(absent).cross_repository);
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -419,10 +419,13 @@ fn infer_mr_stacks(open: &[(u64, &str, &str)]) -> HashMap<u64, (String, u32, u32
 /// is only as complete as the list in hand: callers pass the full open page (a
 /// truncated list would hide a chain's bottom and mis-position the rows above it),
 /// so the real limits are >100 open MRs and merged layers, which an open list has
-/// dropped entirely.
+/// dropped entirely. Cross-repository rows sit out the inference entirely: their
+/// source branch lives in another project, so its name says nothing about a chain
+/// in this one.
 fn apply_mr_stacks(prs: &mut [PrInfo]) {
     let rows: Vec<(u64, &str, &str)> = prs
         .iter()
+        .filter(|p| !p.cross_repository)
         .map(|p| {
             (
                 p.number,
@@ -8021,6 +8024,34 @@ mod tests {
             stack_unknown: false,
             cross_repository: false,
         }
+    }
+
+    /// The same row from a FORK: its source branch name is a coincidence, not a link.
+    fn fork_row(number: u64, head: &str, base: &str) -> PrInfo {
+        PrInfo {
+            cross_repository: true,
+            ..row(number, head, base, None)
+        }
+    }
+
+    #[test]
+    fn apply_mr_stacks_ignores_fork_rows() {
+        // A fork MR whose source branch happens to be named `feat-a` — the same name
+        // the real chain's bottom uses. Counted, it would make `feat-a` an ambiguous
+        // parent and poison the whole chain.
+        let mut prs = vec![
+            fork_row(99, "feat-a", "main"),
+            row(7, "feat-a", "main", None),
+            row(8, "feat-b", "feat-a", None),
+        ];
+        apply_mr_stacks(&mut prs);
+        // The fork row is never a member…
+        assert!(prs[0].stack.is_none());
+        // …and the real chain still marks, bottom→top.
+        let bottom = prs[1].stack.as_ref().expect("MR 7 is the chain bottom");
+        let top = prs[2].stack.as_ref().expect("MR 8 is the chain top");
+        assert_eq!((bottom.id.as_str(), bottom.position, bottom.size), ("mr-7", 1, 2));
+        assert_eq!((top.id.as_str(), top.position, top.size), ("mr-7", 2, 2));
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -273,6 +273,12 @@ struct GlabMr {
     labels: Vec<String>,
     #[serde(default)]
     created_at: String,
+    /// The head/target projects. Differing ids mean a fork MR; `None` on either
+    /// side leaves `cross_repository` false rather than guessing.
+    #[serde(default)]
+    source_project_id: Option<u64>,
+    #[serde(default)]
+    target_project_id: Option<u64>,
 }
 
 fn from_glab_mr(m: GlabMr) -> PrInfo {
@@ -298,9 +304,12 @@ fn from_glab_mr(m: GlabMr) -> PrInfo {
         // over rows already in hand — it has no probe to fail, so never unknown.
         stack: None,
         stack_unknown: false,
-        // The fork marker gates GITHUB stack membership; `glab mr list` carries no
-        // equivalent here, so it stays false rather than guessing.
-        cross_repository: false,
+        // A fork MR lives in a different project; either id missing leaves this
+        // false rather than guessing a fork the resolve flow would then refuse.
+        cross_repository: match (m.source_project_id, m.target_project_id) {
+            (Some(src), Some(tgt)) => src != tgt,
+            _ => false,
+        },
     }
 }
 
@@ -8672,6 +8681,29 @@ mod tests {
         assert_eq!(p.labels.len(), 2);
         // Opened-time maps through (CI status is a separate follow-up fetch).
         assert_eq!(p.created_at, "2026-07-01T10:00:00Z");
+        // The fixture carries no project ids at all — absent must read as same-repo.
+        assert!(!p.cross_repository);
+    }
+
+    /// A fork MR's source project differs from its target; either id absent (an
+    /// older cached shape) must read as same-repo, never as a fork.
+    #[test]
+    fn cross_repository_compares_mr_project_ids() {
+        let mr = |ids: &str| -> PrInfo {
+            let json = format!(
+                r#"{{"iid":7,"web_url":"","title":"t","target_branch":"main",
+                     "source_branch":"feat","state":"opened"{ids}}}"#
+            );
+            from_glab_mr(serde_json::from_str(&json).unwrap())
+        };
+        // Differing projects → a fork MR.
+        assert!(mr(r#","source_project_id":42,"target_project_id":7"#).cross_repository);
+        // Same project → a plain branch MR.
+        assert!(!mr(r#","source_project_id":7,"target_project_id":7"#).cross_repository);
+        // Either side missing or null → false rather than a guess.
+        assert!(!mr(r#","target_project_id":7"#).cross_repository);
+        assert!(!mr(r#","source_project_id":42"#).cross_repository);
+        assert!(!mr(r#","source_project_id":null,"target_project_id":7"#).cross_repository);
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -543,8 +543,11 @@ pub struct PrInfo {
     pub stack_unknown: bool,
     /// The head branch lives in a FORK, so this PR can never be a stack member
     /// (GitHub stacks are same-repo only) and its head name may collide with a
-    /// same-repo branch. Populated by the GitHub list arm alone (gh's
-    /// `isCrossRepository`, hence the alias); other providers leave it false.
+    /// same-repo branch. Every provider's list arm populates it — GitHub from gh's
+    /// `isCrossRepository` (hence the alias), GitLab from differing project ids,
+    /// Bitbucket from differing endpoint repo names. Absent = same-repo — except on
+    /// the upstream-lens REST arm (`rest_pull_to_pr_info`), which serves fork→parent
+    /// rows and reports false unconditionally; consumers there must not trust it.
     #[serde(default, alias = "isCrossRepository")]
     pub cross_repository: bool,
 }
@@ -5358,6 +5361,12 @@ fn upstream_pulls_endpoint(parent_slug: &str, fork_owner: &str, head: &str) -> S
     format!("repos/{parent_slug}/pulls?head={owner}:{head}&state=open")
 }
 
+/// The projection for the branch duplicate probe. `isCrossRepository` is load-bearing:
+/// `gh pr list --head <branch>` matches a FORK PR by bare head name, so without the
+/// marker a contributor's same-named branch reads as your own open PR.
+const PRS_FOR_BRANCH_FIELDS: &str =
+    "number,url,title,baseRefName,headRefName,isDraft,state,isCrossRepository";
+
 /// Open PRs whose head is `head` (at most one per base) — lets the UI offer "View
 /// pull request" instead of "Create".
 ///
@@ -5407,7 +5416,7 @@ pub async fn gh_prs_for_branch(
             "--state",
             "open",
             "--json",
-            "number,url,title,baseRefName,headRefName,isDraft,state",
+            PRS_FOR_BRANCH_FIELDS,
         ],
         GH_TIMEOUT,
     )
@@ -5643,7 +5652,8 @@ mod tests {
         rest_comment_to_out, rest_commit_to_out, rest_pull_to_pr_info, rest_review_to_out,
         rollup_state_to_ci, scrape_pr_ref, split_commit_message, stack_members_from,
         map_gh_mergeability, stack_memberships_from, stack_write_args, stack_write_outcome_from,
-        PR_LIST_FIELDS, PR_VIEW_FIELDS, upstream_pulls_endpoint, GhPrFile, GhPrRestComment,
+        PR_LIST_FIELDS, PR_VIEW_FIELDS, PRS_FOR_BRANCH_FIELDS, upstream_pulls_endpoint, GhPrFile,
+        GhPrRestComment,
         GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner, GhPrRestPull, GhPrRestReview,
         GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails, PrInfo, PrMergeOutcome,
         GhMergeabilityRow, PrMergeability, PrStackInfo, PrStackMember, PrTimelineEventOut,
@@ -6209,6 +6219,22 @@ mod tests {
         assert!(
             fields.iter().all(|f| f.trim() == *f && !f.is_empty()),
             "got: {PR_LIST_FIELDS}"
+        );
+    }
+
+    /// The branch duplicate probe needs the marker just as much: `gh pr list --head`
+    /// matches a fork PR by bare head name, so a missing field would silently let a
+    /// contributor's same-named branch pose as your own open PR.
+    #[test]
+    fn prs_for_branch_fields_request_the_fork_marker() {
+        let fields: Vec<&str> = PRS_FOR_BRANCH_FIELDS.split(',').collect();
+        assert!(
+            fields.contains(&"isCrossRepository"),
+            "got: {PRS_FOR_BRANCH_FIELDS}"
+        );
+        assert!(
+            fields.iter().all(|f| f.trim() == *f && !f.is_empty()),
+            "got: {PRS_FOR_BRANCH_FIELDS}"
         );
     }
 

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -105,8 +105,10 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
   const behind = comparison.data?.behind ?? [];
   const canPr = forgeFeatureReady(gh.data, "mrCreate");
   // An open PR from the current branch into the compared branch already exists.
+  // The probe is origin-pinned (above), so a cross-repository row heads from
+  // someone else's fork and must not flip Create into View.
   const existingPr = (branchPrs.data ?? []).find(
-    (p) => p.baseRefName === compareBranch,
+    (p) => p.baseRefName === compareBranch && !p.crossRepository,
   );
 
   useHotkeyAction(

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -18,7 +18,6 @@ import { Markdown } from "@/components/ui/markdown";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import {
-  useForgeRepos,
   useForkRepoByName,
   useRepoReadme,
   useRepoStarred,
@@ -37,17 +36,22 @@ import type { ExploreCloneTarget } from "./ExploreCloneDialog";
 import { compactNumber } from "./explore-utils";
 
 /** The Explore detail pane: the selected repo's header, actions (clone / fork /
- *  star / view), and its lazily-fetched README. `features` gates fork/star; a
- *  selected repo drives the star + README queries. */
+ *  star / view), and its lazily-fetched README. `features` gates fork/star, and
+ *  `viewer` (the screen's own-repos query) additionally gates fork; a selected
+ *  repo drives the star + README queries. */
 export function ExploreDetail({
   provider,
   repo,
   features,
+  viewer,
   onClone,
 }: {
   provider: ForgeProvider;
   repo: ForgeSearchRepo | null;
   features: ForgeProviderFeatures | undefined;
+  /** The signed-in user's login; null while resolving, and may be "" when the
+   *  provider's viewer probe fails (both fall back to the capability-only gate). */
+  viewer: string | null;
   onClone: (target: ExploreCloneTarget) => void;
 }) {
   if (!repo) {
@@ -70,6 +74,7 @@ export function ExploreDetail({
       provider={provider}
       repo={repo}
       features={features}
+      viewer={viewer}
       onClone={onClone}
     />
   );
@@ -79,23 +84,24 @@ function ExploreDetailBody({
   provider,
   repo,
   features,
+  viewer,
   onClone,
 }: {
   provider: ForgeProvider;
   repo: ForgeSearchRepo;
   features: ForgeProviderFeatures | undefined;
+  viewer: string | null;
   onClone: (target: ExploreCloneTarget) => void;
 }) {
   const label = providerLabel(provider);
   // Forking always creates the copy under your own account, so a repo you own
   // personally is never a valid target — hidden, not disabled, since there's
   // nothing actionable to explain. Personal ownership, not write access: org
-  // repos stay forkable; an unresolved viewer falls back to the capability gate.
-  const ownRepos = useForgeRepos(provider, true);
-  const viewer = ownRepos.data?.viewer ?? null;
+  // repos stay forkable; an unknown viewer (null, or the "" non-GitHub backends
+  // emit) falls back to the capability gate.
   const canFork =
     (features?.implemented.repoForkByName ?? false) &&
-    !(viewer !== null && repo.owner === viewer);
+    !(viewer && repo.owner === viewer);
   const canStar = features?.implemented.repoStar ?? false;
   const canReadme = features?.implemented.repoReadme ?? false;
 

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -18,6 +18,7 @@ import { Markdown } from "@/components/ui/markdown";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import {
+  useForgeRepos,
   useForkRepoByName,
   useRepoReadme,
   useRepoStarred,
@@ -86,7 +87,15 @@ function ExploreDetailBody({
   onClone: (target: ExploreCloneTarget) => void;
 }) {
   const label = providerLabel(provider);
-  const canFork = features?.implemented.repoForkByName ?? false;
+  // Forking always creates the copy under your own account, so a repo you own
+  // personally is never a valid target — hidden, not disabled, since there's
+  // nothing actionable to explain. Personal ownership, not write access: org
+  // repos stay forkable; an unresolved viewer falls back to the capability gate.
+  const ownRepos = useForgeRepos(provider, true);
+  const viewer = ownRepos.data?.viewer ?? null;
+  const canFork =
+    (features?.implemented.repoForkByName ?? false) &&
+    !(viewer !== null && repo.owner === viewer);
   const canStar = features?.implemented.repoStar ?? false;
   const canReadme = features?.implemented.repoReadme ?? false;
 

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -98,7 +98,9 @@ function ExploreDetailBody({
   // personally is never a valid target — hidden, not disabled, since there's
   // nothing actionable to explain. Personal ownership, not write access: org
   // repos stay forkable; an unknown viewer (null, or the "" non-GitHub backends
-  // emit) falls back to the capability gate.
+  // emit) falls back to the capability gate. On Bitbucket the compare is inert in
+  // practice — `owner` is a workspace slug, `viewer` a username — which is why the
+  // guide scopes this behavior to GitHub and GitLab.
   const canFork =
     (features?.implemented.repoForkByName ?? false) &&
     !(viewer && repo.owner === viewer);

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -87,6 +87,12 @@ export function ExploreScreen() {
   const showingYours = !searching && effectiveZeroMode === "yours";
 
   const features = useForgeProviderFeatures(provider);
+  // One observer for the signed-in user's repos, shared by the Yours list and the
+  // detail pane's own-repo Fork gate. Hoisted because a per-selection hook would
+  // refetch once the 5-minute staleTime lapsed — and on Bitbucket that read walks
+  // every workspace.
+  const ownRepos = useForgeRepos(provider, true);
+  const viewer = ownRepos.data?.viewer ?? null;
 
   // Esc closes Explore. Guarded so Base UI popups (which mark the event consumed)
   // get first claim; an effect event reads the latest closeExplore.
@@ -221,6 +227,7 @@ export function ExploreScreen() {
           {showingYours ? (
             <YoursResults
               provider={provider}
+              repos={ownRepos}
               selected={selected}
               onSelect={setSelected}
               onRowsChange={setFlatRepos}
@@ -244,6 +251,7 @@ export function ExploreScreen() {
               provider={provider}
               repo={selected}
               features={features.data}
+              viewer={viewer}
               onClone={setCloneTarget}
             />
           </div>
@@ -260,21 +268,22 @@ export function ExploreScreen() {
   );
 }
 
-/** The "Your repositories" zero-state list — reuses the clone browser's own-repos
- *  hook, mapped into the shared result-row shape and owner-grouped. */
+/** The "Your repositories" zero-state list — renders the screen's own-repos query
+ *  (the clone browser's hook), mapped into the shared result-row shape and
+ *  owner-grouped. */
 function YoursResults({
   provider,
+  repos,
   selected,
   onSelect,
   onRowsChange,
 }: {
   provider: ForgeProvider;
+  repos: ReturnType<typeof useForgeRepos>;
   selected: ForgeSearchRepo | null;
   onSelect: (repo: ForgeSearchRepo | null) => void;
   onRowsChange: (repos: ForgeSearchRepo[]) => void;
 }) {
-  const repos = useForgeRepos(provider, true);
-
   const rows = useMemo<ExploreRow[]>(() => {
     const data = repos.data;
     if (!data) return [];

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -127,6 +127,8 @@ Click the **⋮** menu next to the repo name for repo-wide actions:
 - On the host: **Star** the repository, **create an issue**, or **Fork** it (on GitLab
   and Bitbucket, forking opens the web fork page). Bitbucket has no stars and its
   issue tracker is retired, so those two actions don't appear for Bitbucket repos.
+  **Fork** doesn't appear on a GitHub repository you own personally — a fork always
+  lands under your own account (organization repositories stay forkable).
 - **Insights** (analytics), **manage files**, **submodules**, the **remote URL**,
   **branch rules**, **git hooks**, {{ai}}**automations**, {{/ai}}**repository settings**,
   an **alias**, copy the repo path, copy the branch name, copy the HEAD SHA, and
@@ -186,7 +188,8 @@ From here:
 - **Clone** — pick a folder to clone into; GitDesktop opens the repo once it finishes.
 - **Fork** — create a fork under your account (on **GitHub, GitLab, and Bitbucket**). The
   fork is created in the background, and then you're offered to **clone** it. It doesn't
-  appear on repositories you own personally — a fork always lands under your own account.
+  appear on repositories you own personally (GitHub and GitLab) — a fork always lands
+  under your own account.
 - **Star / Unstar** — on **GitHub and GitLab** only. Bitbucket has no stars, so this action
   doesn't appear on Bitbucket results.
 - **View on GitHub / GitLab / Bitbucket** — open the repository on its host in your browser.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -185,7 +185,8 @@ From here:
 
 - **Clone** — pick a folder to clone into; GitDesktop opens the repo once it finishes.
 - **Fork** — create a fork under your account (on **GitHub, GitLab, and Bitbucket**). The
-  fork is created in the background, and then you're offered to **clone** it.
+  fork is created in the background, and then you're offered to **clone** it. It doesn't
+  appear on repositories you own personally — a fork always lands under your own account.
 - **Star / Unstar** — on **GitHub and GitLab** only. Bitbucket has no stars, so this action
   doesn't appear on Bitbucket results.
 - **View on GitHub / GitLab / Bitbucket** — open the repository on its host in your browser.

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -494,9 +494,17 @@ export function CreatePrDialog({
 
   // Duplicate probe: an open PR from this head against the chosen target already
   // exists. Probe with the target's lens ("upstream" composes owner:branch
-  // Rust-side; pass the BARE head), matching ComparePanel's baseRefName match.
+  // Rust-side; pass the BARE head). The origin path skips cross-repository rows for
+  // the same reason ComparePanel does — an origin-pinned probe can only reach them
+  // via a contributor's same-named fork branch. The upstream lens keeps them,
+  // because there your own fork→parent duplicate IS cross-repository; that arm
+  // reports the flag false for every row today, so the qualifier guards the future.
   const branchPrs = usePrsForBranch(repoPath, head || null, open, createLens);
-  const existingPr = (branchPrs.data ?? []).find((p) => p.baseRefName === base);
+  const existingPr = (branchPrs.data ?? []).find(
+    (p) =>
+      p.baseRefName === base &&
+      (createLens === "upstream" || !p.crossRepository),
+  );
 
   // Linked-issue chip cluster — extraction seeding, AI union, candidate ranking and
   // the chip mutations live in the shared hook. Gated on a usable tracker AND the

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -344,9 +344,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     };
     // Remote PRs first, so they win ties against a local PR of equal state.
     for (const pr of [...(openPrs.data ?? []), ...(closedPrs.data ?? [])]) {
-      // A fork PR's head lives in the contributor's repository, so it must never
-      // badge a same-named local branch. Both lists are pinned to the origin lens
-      // above, so every cross-repo PR here heads from someone else's fork.
+      // A cross-repository PR's head lives in a contributor's fork, so it must not
+      // badge a same-named local branch. Safe as a blanket skip only because both
+      // lists above are origin-pinned; only GitHub's list arm populates the flag
+      // (GitLab/Bitbucket lists leave it false — their behavior is unchanged). A
+      // deliberately checked-out fork-PR head loses its badge too: accepted
+      // over-hide, since by name alone the two cases are indistinguishable.
       if (pr.crossRepository) continue;
       const state: PrState =
         pr.isDraft && pr.state === "OPEN"

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -346,10 +346,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     for (const pr of [...(openPrs.data ?? []), ...(closedPrs.data ?? [])]) {
       // A cross-repository PR's head lives in a contributor's fork, so it must not
       // badge a same-named local branch. Safe as a blanket skip only because both
-      // lists above are origin-pinned; only GitHub's list arm populates the flag
-      // (GitLab/Bitbucket lists leave it false — their behavior is unchanged). A
-      // deliberately checked-out fork-PR head loses its badge too: accepted
-      // over-hide, since by name alone the two cases are indistinguishable.
+      // lists above are origin-pinned. A deliberately checked-out fork-PR head
+      // loses its badge too: accepted over-hide, since by name alone the two
+      // cases are indistinguishable.
       if (pr.crossRepository) continue;
       const state: PrState =
         pr.isDraft && pr.state === "OPEN"

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -344,6 +344,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     };
     // Remote PRs first, so they win ties against a local PR of equal state.
     for (const pr of [...(openPrs.data ?? []), ...(closedPrs.data ?? [])]) {
+      // A fork PR's head lives in the contributor's repository, so it must never
+      // badge a same-named local branch. Both lists are pinned to the origin lens
+      // above, so every cross-repo PR here heads from someone else's fork.
+      if (pr.crossRepository) continue;
       const state: PrState =
         pr.isDraft && pr.state === "OPEN"
           ? "draft"

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -156,6 +156,8 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
     !!gh.data?.repo &&
     !!gh.data?.login &&
     gh.data.repo.split("/")[0] === gh.data.login;
+  // One predicate for the menu item and its palette twin, so the two can't drift.
+  const canForkHere = canGh && (isGitLab || isBitbucket || !ownRepo);
   const starStatus = useRepoStarStatus(repoPath, canStar);
   const setStar = useSetRepoStar(repoPath);
   const starred = starStatus.data ?? false;
@@ -227,11 +229,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction("view-on-github", () => openWeb(), canGh);
   // create-issue is the in-app dialog (registered in RepositoryView + IssuesPanel);
   // the "Create issue on {host}" menu item below still opens the web page.
-  useHotkeyAction(
-    "fork-repository",
-    forkAction,
-    canGh && (isGitLab || isBitbucket || !ownRepo),
-  );
+  useHotkeyAction("fork-repository", forkAction, canForkHere);
   useHotkeyAction("open-in-terminal", () =>
     openInTerminal(
       repoPath,
@@ -341,20 +339,21 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
                 Create issue on {remoteLabel}
               </DropdownMenuItem>
             )}
-            {isGitLab || isBitbucket ? (
-              // The fork dialog's flow (fork + rewire remotes + set-default) is
-              // GitHub-only; GitLab/Bitbucket fork from their web page instead of
-              // hiding the affordance.
-              <DropdownMenuItem onClick={forkAction}>
-                <GitForkIcon />
-                Fork on {remoteLabel}…
-              </DropdownMenuItem>
-            ) : ownRepo ? null : (
-              <DropdownMenuItem onClick={() => setForkOpen(true)}>
-                <GitForkIcon />
-                Fork repository…
-              </DropdownMenuItem>
-            )}
+            {canForkHere &&
+              (isGitLab || isBitbucket ? (
+                // The fork dialog's flow (fork + rewire remotes + set-default) is
+                // GitHub-only; GitLab/Bitbucket fork from their web page instead of
+                // hiding the affordance.
+                <DropdownMenuItem onClick={forkAction}>
+                  <GitForkIcon />
+                  Fork on {remoteLabel}…
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={() => setForkOpen(true)}>
+                  <GitForkIcon />
+                  Fork repository…
+                </DropdownMenuItem>
+              ))}
             <DropdownMenuSeparator />
           </>
         )}

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -149,6 +149,13 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const remoteLabel = providerLabel(provider);
   const canStar = canGh && forgeSupports(gh.data, "stars");
   const canCreateHostIssue = canGh && forgeSupports(gh.data, "issues");
+  // The in-app fork dialog always creates the fork under your own account, so a
+  // repo you own personally is never a valid target (org repos stay forkable).
+  // The GitLab/Bitbucket web arms offer a namespace choice, so they stay put.
+  const ownRepo =
+    !!gh.data?.repo &&
+    !!gh.data?.login &&
+    gh.data.repo.split("/")[0] === gh.data.login;
   const starStatus = useRepoStarStatus(repoPath, canStar);
   const setStar = useSetRepoStar(repoPath);
   const starred = starStatus.data ?? false;
@@ -220,7 +227,11 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction("view-on-github", () => openWeb(), canGh);
   // create-issue is the in-app dialog (registered in RepositoryView + IssuesPanel);
   // the "Create issue on {host}" menu item below still opens the web page.
-  useHotkeyAction("fork-repository", forkAction, canGh);
+  useHotkeyAction(
+    "fork-repository",
+    forkAction,
+    canGh && (isGitLab || isBitbucket || !ownRepo),
+  );
   useHotkeyAction("open-in-terminal", () =>
     openInTerminal(
       repoPath,
@@ -338,7 +349,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
                 <GitForkIcon />
                 Fork on {remoteLabel}…
               </DropdownMenuItem>
-            ) : (
+            ) : ownRepo ? null : (
               <DropdownMenuItem onClick={() => setForkOpen(true)}>
                 <GitForkIcon />
                 Fork repository…

--- a/src/lib/pulls/audit.ts
+++ b/src/lib/pulls/audit.ts
@@ -76,7 +76,7 @@ export function usePrAuditByBranch(
     // Remote PRs first, so they win ties against a local PR of equal state.
     for (const pr of [...(openPrs.data ?? []), ...(closedPrs.data ?? [])]) {
       // Fork PRs never attach by name — same guard and rationale as
-      // BranchSwitcher's prByBranch (origin-pinned lists; GitHub-only flag).
+      // BranchSwitcher's prByBranch (origin-pinned lists).
       if (pr.crossRepository) continue;
       const state: PrAuditState =
         pr.isDraft && pr.state === "OPEN"

--- a/src/lib/pulls/audit.ts
+++ b/src/lib/pulls/audit.ts
@@ -75,6 +75,9 @@ export function usePrAuditByBranch(
     };
     // Remote PRs first, so they win ties against a local PR of equal state.
     for (const pr of [...(openPrs.data ?? []), ...(closedPrs.data ?? [])]) {
+      // Fork PRs never attach by name — same guard and rationale as
+      // BranchSwitcher's prByBranch (origin-pinned lists; GitHub-only flag).
+      if (pr.crossRepository) continue;
       const state: PrAuditState =
         pr.isDraft && pr.state === "OPEN"
           ? "draft"


### PR DESCRIPTION
Two fork-related UI defects let the app attribute someone else's fork to your repository: branch pull-request badges matched fork PRs by branch name alone, and Explore offered **Fork** on repositories you personally own — an action that can never succeed, since a fork is always created under your own account.

### Branch PR badges

- Skips cross-repository pull requests when mapping PRs onto branches in `src/features/repository/BranchSwitcher.tsx`, so a contributor's fork branch with the same name no longer claims the badge on your local branch. Both the open and closed PR lists are already pinned to the origin lens, so every `crossRepository` PR reaching that loop heads from someone else's fork.

### Explore Fork action

- Gates `canFork` in `src/features/explore/ExploreDetail.tsx` on personal ownership: `useForgeRepos` supplies the viewer, and the action is hidden when `repo.owner` matches it. Ownership, not write access — organization repos stay forkable, and an unresolved viewer falls back to the existing `features.implemented.repoForkByName` capability check.
- The action is hidden rather than disabled, since there is nothing actionable to explain to the user.

### Changelog

- Adds `changelog.d/fixed-branch-pr-badge-fork-collision.md` and `changelog.d/fixed-explore-fork-own-repo.md`, both phrased as user-facing behavior rather than the underlying defect.