### PR TITLE
feat(site,compare): add a GitDesktop vs Sourcetree comparison page

### DIFF
--- a/site/src/components/CompareTable.astro
+++ b/site/src/components/CompareTable.astro
@@ -1,11 +1,11 @@
 ---
 // The /compare/ pages' shared table: one competitor column vs GitDesktop,
-// grouped rows from lib/compare's Group<Row>.
-import { type Group, type Row, stateClass, stateText } from "../lib/compare";
+// grouped rows from lib/compare's Group.
+import { type Group, stateClass, stateText } from "../lib/compare";
 
 interface Props {
   competitor: string;
-  groups: Group<Row>[];
+  groups: Group[];
 }
 const { competitor, groups } = Astro.props;
 ---

--- a/site/src/components/CompareTable.astro
+++ b/site/src/components/CompareTable.astro
@@ -1,0 +1,65 @@
+---
+// The /compare/ pages' shared table: one competitor column vs GitDesktop,
+// grouped rows from lib/compare's Group<Row>.
+import { type Group, type Row, stateClass, stateText } from "../lib/compare";
+
+interface Props {
+  competitor: string;
+  groups: Group<Row>[];
+}
+const { competitor, groups } = Astro.props;
+---
+
+{/* tabindex: a keyboard user must be able to scroll the min-width table;
+    a focusable scroll region needs the role + name for AT. */}
+<div
+  data-reveal
+  style="transition-delay:80ms"
+  class="mt-10 overflow-x-auto"
+  tabindex="0"
+  role="region"
+  aria-label="Feature comparison table"
+>
+  <table class="w-full min-w-[640px] border-collapse text-[15px]">
+    <thead>
+      <tr class="border-b border-line-2 text-left">
+        <th scope="col" class="py-3 pr-6 font-normal text-faint">Capability</th>
+        <th scope="col" class="w-[26%] py-3 pr-6 font-medium text-ink">{competitor}</th>
+        <th scope="col" class="w-[30%] py-3 font-medium text-ink">GitDesktop</th>
+      </tr>
+    </thead>
+    {
+      groups.map((group) => (
+        <tbody>
+          <tr>
+            <th
+              scope="rowgroup"
+              colspan="3"
+              class="pb-2 pt-8 text-left text-sm font-normal text-faint"
+            >
+              <span class="text-add" aria-hidden="true">
+                //
+              </span>{" "}
+              {group.title}
+            </th>
+          </tr>
+          {group.rows.map((row) => (
+            <tr class="border-b border-line align-top">
+              <th scope="row" class="py-3.5 pr-6 text-left font-normal text-body">
+                {row.label}
+              </th>
+              <td class="py-3.5 pr-6">
+                <span class={stateClass[row.them.state]}>{stateText[row.them.state]}</span>
+                {row.them.note && <span class="text-sm text-muted"> — {row.them.note}</span>}
+              </td>
+              <td class="py-3.5">
+                <span class={stateClass[row.gd.state]}>{stateText[row.gd.state]}</span>
+                {row.gd.note && <span class="text-sm text-muted"> — {row.gd.note}</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      ))
+    }
+  </table>
+</div>

--- a/site/src/lib/compare.ts
+++ b/site/src/lib/compare.ts
@@ -1,0 +1,27 @@
+// Shared row machinery for the /compare/ pages. Row states render as WORDS
+// ("Yes" / "Partial" / "No"), never color or glyph alone (WCAG); the class
+// only shades emphasis on top of the word.
+
+export type State = "yes" | "partial" | "no";
+
+export interface Cell {
+  state: State;
+  note?: string;
+}
+
+export interface Group<R> {
+  title: string;
+  rows: R[];
+}
+
+export const stateText: Record<State, string> = {
+  yes: "Yes",
+  partial: "Partial",
+  no: "No",
+};
+
+export const stateClass: Record<State, string> = {
+  yes: "text-ink",
+  partial: "text-muted",
+  no: "text-faint",
+};

--- a/site/src/lib/compare.ts
+++ b/site/src/lib/compare.ts
@@ -9,6 +9,13 @@ export interface Cell {
   note?: string;
 }
 
+export interface Row {
+  label: string;
+  /** The competitor's cell. */
+  them: Cell;
+  gd: Cell;
+}
+
 export interface Group<R> {
   title: string;
   rows: R[];

--- a/site/src/lib/compare.ts
+++ b/site/src/lib/compare.ts
@@ -16,9 +16,9 @@ export interface Row {
   gd: Cell;
 }
 
-export interface Group<R> {
+export interface Group {
   title: string;
-  rows: R[];
+  rows: Row[];
 }
 
 export const stateText: Record<State, string> = {

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -8,12 +8,11 @@
 // The verified-on stamp is rendered on the page; when a row changes upstream,
 // update the stamp in the same edit. A stale comparison is worse than none —
 // it's the first thing an HN thread checks.
-//
 import { Image } from "astro:assets";
 import appGithubPr from "../../assets/app-github-pr.png";
 import CompareTable from "../../components/CompareTable.astro";
 import SiteLayout from "../../layouts/SiteLayout.astro";
-import { type Group, type Row } from "../../lib/compare";
+import type { Group } from "../../lib/compare";
 
 const base = import.meta.env.BASE_URL;
 const repo = "https://github.com/theBGuy/GitDesktop";
@@ -26,7 +25,7 @@ const GHD_VERSION = "3.6.3";
 // load-bearing parity rows). The full matrix behind this runs ~130 rows; both
 // clients cover the fundamentals, which the intro says in prose instead of
 // padding the table.
-const groups: Group<Row>[] = [
+const groups: Group[] = [
   {
     title: "Where you can use it",
     rows: [

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -13,6 +13,12 @@
 import { Image } from "astro:assets";
 import appGithubPr from "../../assets/app-github-pr.png";
 import SiteLayout from "../../layouts/SiteLayout.astro";
+import {
+  type Cell,
+  type Group,
+  stateClass,
+  stateText,
+} from "../../lib/compare";
 
 const base = import.meta.env.BASE_URL;
 const repo = "https://github.com/theBGuy/GitDesktop";
@@ -21,26 +27,17 @@ const download = `${base}download/`;
 const VERIFIED_ON = "July 25, 2026";
 const GHD_VERSION = "3.6.3";
 
-type State = "yes" | "partial" | "no";
-interface Cell {
-  state: State;
-  note?: string;
-}
 interface Row {
   label: string;
   ghd: Cell;
   gd: Cell;
-}
-interface Group {
-  title: string;
-  rows: Row[];
 }
 
 // Distilled to the rows where the two clients genuinely diverge (plus a few
 // load-bearing parity rows). The full matrix behind this runs ~130 rows; both
 // clients cover the fundamentals, which the intro says in prose instead of
 // padding the table.
-const groups: Group[] = [
+const groups: Group<Row>[] = [
   {
     title: "Where you can use it",
     rows: [
@@ -242,19 +239,6 @@ const groups: Group[] = [
     ],
   },
 ];
-
-// Rendering the state as text keeps meaning off color alone (WCAG) and off
-// glyphs alone (screen readers).
-const stateText: Record<State, string> = {
-  yes: "Yes",
-  partial: "Partial",
-  no: "No",
-};
-const stateClass: Record<State, string> = {
-  yes: "text-ink",
-  partial: "text-muted",
-  no: "text-faint",
-};
 
 const faqs = [
   {

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -9,16 +9,11 @@
 // update the stamp in the same edit. A stale comparison is worse than none —
 // it's the first thing an HN thread checks.
 //
-// Row states are WORDS ("Yes" / "Partial" / "No"), never color or glyph alone.
 import { Image } from "astro:assets";
 import appGithubPr from "../../assets/app-github-pr.png";
+import CompareTable from "../../components/CompareTable.astro";
 import SiteLayout from "../../layouts/SiteLayout.astro";
-import {
-  type Cell,
-  type Group,
-  stateClass,
-  stateText,
-} from "../../lib/compare";
+import { type Group, type Row } from "../../lib/compare";
 
 const base = import.meta.env.BASE_URL;
 const repo = "https://github.com/theBGuy/GitDesktop";
@@ -26,12 +21,6 @@ const download = `${base}download/`;
 
 const VERIFIED_ON = "July 25, 2026";
 const GHD_VERSION = "3.6.3";
-
-interface Row {
-  label: string;
-  ghd: Cell;
-  gd: Cell;
-}
 
 // Distilled to the rows where the two clients genuinely diverge (plus a few
 // load-bearing parity rows). The full matrix behind this runs ~130 rows; both
@@ -43,7 +32,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Forges with full PR / CI / issue support",
-        ghd: { state: "partial", note: "GitHub only" },
+        them: { state: "partial", note: "GitHub only" },
         gd: {
           state: "yes",
           note: "GitHub, GitLab & Bitbucket — Bitbucket issues via linked Jira",
@@ -51,17 +40,17 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Linux",
-        ghd: { state: "no", note: "macOS & Windows" },
+        them: { state: "no", note: "macOS & Windows" },
         gd: { state: "yes", note: "Windows, macOS & Linux" },
       },
       {
         label: "GitHub Enterprise",
-        ghd: { state: "yes" },
+        them: { state: "yes" },
         gd: { state: "yes", note: "via gh, per-host accounts" },
       },
       {
         label: "Jira",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes", note: "linked Jira Cloud project per repo" },
       },
     ],
@@ -71,7 +60,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Read & review a PR in-app",
-        ghd: {
+        them: {
           state: "partial",
           note: "checks view; hands off to the browser",
         },
@@ -82,17 +71,17 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Merge a PR in-app",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes", note: "merge / squash / rebase" },
       },
       {
         label: "Edit title, labels, reviewers",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes" },
       },
       {
         label: "Local PRs with no remote at all",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "review & merge offline, promote to GitHub later",
@@ -105,22 +94,22 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "PR checks rollup",
-        ghd: { state: "yes" },
+        them: { state: "yes" },
         gd: { state: "yes", note: "with a failing job's log peeked inline" },
       },
       {
         label: "Browse all workflow runs",
-        ghd: { state: "no", note: "PR-scoped checks only" },
+        them: { state: "no", note: "PR-scoped checks only" },
         gd: { state: "yes", note: "dedicated Actions tab" },
       },
       {
         label: "Dispatch, cancel, re-run workflows",
-        ghd: { state: "partial", note: "re-run only" },
+        them: { state: "partial", note: "re-run only" },
         gd: { state: "yes" },
       },
       {
         label: "Failed-step logs in-app",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes" },
       },
     ],
@@ -130,12 +119,12 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Issues",
-        ghd: { state: "no", note: "opens github.com" },
+        them: { state: "no", note: "opens github.com" },
         gd: { state: "yes", note: "GitHub & GitLab in-app; local issues too" },
       },
       {
         label: "GitHub Discussions",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes" },
       },
     ],
@@ -145,12 +134,12 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "File history & blame",
-        ghd: { state: "no", note: "opens github.com" },
+        them: { state: "no", note: "opens github.com" },
         gd: { state: "yes", note: "rename-following history, per-line blame" },
       },
       {
         label: "Interactive rebase",
-        ghd: { state: "partial", note: "squash & reorder only" },
+        them: { state: "partial", note: "squash & reorder only" },
         gd: {
           state: "yes",
           note: "pick / reword / squash / fixup / edit / drop",
@@ -158,7 +147,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Predict a merge before running it",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "fast-forward / clean / conflicts, previewed in memory",
@@ -166,12 +155,12 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Recover dropped stashes",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes", note: "a git fsck scan finds and restores them" },
       },
       {
         label: "Force push",
-        ghd: { state: "partial", note: "plain force push" },
+        them: { state: "partial", note: "plain force push" },
         gd: {
           state: "yes",
           note: "--force-with-lease only, behind divergence detection",
@@ -179,7 +168,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Git hooks management",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "view / edit / disable, templates, husky & pre-commit aware",
@@ -187,7 +176,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Linked worktrees",
-        ghd: { state: "yes", note: "since 3.6" },
+        them: { state: "yes", note: "since 3.6" },
         gd: { state: "yes", note: "plus worktree-aware branch switching" },
       },
     ],
@@ -197,7 +186,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "AI without a Copilot relationship",
-        ghd: {
+        them: {
           state: "no",
           note: "Copilot access required (Copilot Free qualifies)",
         },
@@ -208,7 +197,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "AI code review & security audit",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "dedicated review model, postable as a PR comment",
@@ -216,12 +205,12 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Keep files out of AI context",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes", note: "gitignore-style AI-ignore patterns" },
       },
       {
         label: "Hide every AI surface",
-        ghd: { state: "no" },
+        them: { state: "no" },
         gd: { state: "yes", note: "one setting, nothing left behind" },
       },
     ],
@@ -231,12 +220,12 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Price",
-        ghd: { state: "yes", note: "free" },
+        them: { state: "yes", note: "free" },
         gd: { state: "yes", note: "free" },
       },
       {
         label: "Open source",
-        ghd: { state: "yes", note: "MIT" },
+        them: { state: "yes", note: "MIT" },
         gd: { state: "yes", note: "Apache-2.0" },
       },
     ],
@@ -359,56 +348,7 @@ const faqs = [
         keeps to where they diverge.
       </p>
 
-      {/* tabindex: a keyboard user must be able to scroll the min-width table;
-          a focusable scroll region needs the role + name for AT. */}
-      <div
-        data-reveal
-        style="transition-delay:80ms"
-        class="mt-10 overflow-x-auto"
-        tabindex="0"
-        role="region"
-        aria-label="Feature comparison table"
-      >
-        <table class="w-full min-w-[640px] border-collapse text-[15px]">
-          <thead>
-            <tr class="border-b border-line-2 text-left">
-              <th scope="col" class="py-3 pr-6 font-normal text-faint">Capability</th>
-              <th scope="col" class="w-[26%] py-3 pr-6 font-medium text-ink">GitHub Desktop</th>
-              <th scope="col" class="w-[30%] py-3 font-medium text-ink">GitDesktop</th>
-            </tr>
-          </thead>
-          {
-            groups.map((group) => (
-              <tbody>
-                <tr>
-                  <th
-                    scope="rowgroup"
-                    colspan="3"
-                    class="pb-2 pt-8 text-left text-sm font-normal text-faint"
-                  >
-                    <span class="text-add" aria-hidden="true">//</span> {group.title}
-                  </th>
-                </tr>
-                {group.rows.map((row) => (
-                  <tr class="border-b border-line align-top">
-                    <th scope="row" class="py-3.5 pr-6 text-left font-normal text-body">
-                      {row.label}
-                    </th>
-                    <td class="py-3.5 pr-6">
-                      <span class={stateClass[row.ghd.state]}>{stateText[row.ghd.state]}</span>
-                      {row.ghd.note && <span class="text-sm text-muted"> — {row.ghd.note}</span>}
-                    </td>
-                    <td class="py-3.5">
-                      <span class={stateClass[row.gd.state]}>{stateText[row.gd.state]}</span>
-                      {row.gd.note && <span class="text-sm text-muted"> — {row.gd.note}</span>}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            ))
-          }
-        </table>
-      </div>
+      <CompareTable competitor="GitHub Desktop" groups={groups} />
 
       <p class="mt-6 max-w-[66ch] text-sm leading-relaxed text-muted">
         Distilled from a ~130-row working matrix, re-checked against GitHub

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -44,7 +44,10 @@ const groups: Group<Row>[] = [
       {
         label: "Forges with full PR / CI / issue support",
         ghd: { state: "partial", note: "GitHub only" },
-        gd: { state: "yes", note: "GitHub, GitLab & Bitbucket" },
+        gd: {
+          state: "yes",
+          note: "GitHub, GitLab & Bitbucket — Bitbucket issues via linked Jira",
+        },
       },
       {
         label: "Linux",
@@ -269,7 +272,7 @@ const faqs = [
 >
   <section class="border-b border-line">
     <div class="mx-auto max-w-6xl px-5 py-16 md:py-20">
-      <p data-reveal class="text-sm text-faint"><span class="text-add">//</span> compare</p>
+      <p data-reveal class="text-sm text-faint"><span class="text-add" aria-hidden="true">//</span> compare</p>
       <h1
         data-reveal
         style="transition-delay:60ms"
@@ -356,7 +359,16 @@ const faqs = [
         keeps to where they diverge.
       </p>
 
-      <div data-reveal style="transition-delay:80ms" class="mt-10 overflow-x-auto">
+      {/* tabindex: a keyboard user must be able to scroll the min-width table;
+          a focusable scroll region needs the role + name for AT. */}
+      <div
+        data-reveal
+        style="transition-delay:80ms"
+        class="mt-10 overflow-x-auto"
+        tabindex="0"
+        role="region"
+        aria-label="Feature comparison table"
+      >
         <table class="w-full min-w-[640px] border-collapse text-[15px]">
           <thead>
             <tr class="border-b border-line-2 text-left">
@@ -401,7 +413,12 @@ const faqs = [
       <p class="mt-6 max-w-[66ch] text-sm leading-relaxed text-muted">
         Distilled from a ~130-row working matrix, re-checked against GitHub
         Desktop's release notes and changelog. Rows where both clients are
-        simply fine were left out on purpose.
+        simply fine were left out on purpose. Also compared:
+        <a
+          href={`${base}compare/sourcetree/`}
+          class="text-mint underline-offset-4 hover:underline"
+          >GitDesktop vs Sourcetree</a
+        >.
       </p>
     </div>
   </section>

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -9,13 +9,9 @@
 // in the same edit — a stale comparison is worse than none.
 import { Image } from "astro:assets";
 import appGithubPr from "../../assets/app-github-pr.png";
+import CompareTable from "../../components/CompareTable.astro";
 import SiteLayout from "../../layouts/SiteLayout.astro";
-import {
-  type Cell,
-  type Group,
-  stateClass,
-  stateText,
-} from "../../lib/compare";
+import { type Group, type Row } from "../../lib/compare";
 
 const base = import.meta.env.BASE_URL;
 const repo = "https://github.com/theBGuy/GitDesktop";
@@ -25,24 +21,18 @@ const VERIFIED_ON = "August 11, 2026";
 const ST_WIN_VERSION = "3.4.31";
 const ST_MAC_VERSION = "4.2.19";
 
-interface Row {
-  label: string;
-  st: Cell;
-  gd: Cell;
-}
-
 const groups: Group<Row>[] = [
   {
     title: "Where you can use it",
     rows: [
       {
         label: "Linux",
-        st: { state: "no", note: "Windows & macOS only" },
+        them: { state: "no", note: "Windows & macOS only" },
         gd: { state: "yes", note: "Windows, macOS & Linux" },
       },
       {
         label: "Works without a vendor account",
-        st: {
+        them: {
           state: "no",
           note: "an Atlassian account is required to use the app",
         },
@@ -50,7 +40,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Forges with full PR / CI / issue support",
-        st: { state: "no", note: "accounts add sign-in and clone lists" },
+        them: { state: "no", note: "accounts add sign-in and clone lists" },
         gd: {
           state: "yes",
           note: "GitHub, GitLab & Bitbucket — Bitbucket issues via linked Jira",
@@ -58,7 +48,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Jira",
-        st: {
+        them: {
           state: "partial",
           note: "issue-key links in commit messages open the browser",
         },
@@ -66,7 +56,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Mercurial",
-        st: { state: "yes", note: "still shipping, both platforms" },
+        them: { state: "yes", note: "still shipping, both platforms" },
         gd: { state: "no", note: "Git only" },
       },
     ],
@@ -76,7 +66,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Create a PR",
-        st: {
+        them: {
           state: "partial",
           note: "opens the forge's form in your browser",
         },
@@ -87,7 +77,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Read & review a PR in-app",
-        st: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "conversation, files, checks, approve / request changes",
@@ -95,12 +85,15 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Merge a PR in-app",
-        st: { state: "no" },
-        gd: { state: "yes", note: "merge / squash / rebase" },
+        them: { state: "no" },
+        gd: {
+          state: "yes",
+          note: "merge & squash on all three; rebase (GitHub), fast-forward (Bitbucket)",
+        },
       },
       {
         label: "Resolve a PR's conflicts in-app",
-        st: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "in a hidden worktree; your checkout untouched",
@@ -108,7 +101,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Local PRs with no remote at all",
-        st: { state: "no" },
+        them: { state: "no" },
         gd: {
           state: "yes",
           note: "review & merge offline, promote to GitHub or GitLab later",
@@ -121,7 +114,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "CI status in-app",
-        st: {
+        them: {
           state: "partial",
           note: "Bitbucket Pipelines per-commit status — macOS only",
         },
@@ -132,7 +125,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Issues",
-        st: { state: "no", note: "commit-message links open the browser" },
+        them: { state: "no", note: "commit-message links open the browser" },
         gd: { state: "yes", note: "GitHub & GitLab in-app; local issues too" },
       },
     ],
@@ -142,12 +135,12 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Stage by file, hunk, or line",
-        st: { state: "yes" },
+        them: { state: "yes" },
         gd: { state: "yes", note: "plus drag-to-stage line selection" },
       },
       {
         label: "Interactive rebase",
-        st: { state: "yes", note: "squash, reword, edit, reorder, delete" },
+        them: { state: "yes", note: "squash, reword, edit, reorder, delete" },
         gd: {
           state: "yes",
           note: "pick / reword / squash / fixup / edit / drop",
@@ -155,12 +148,12 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Git-flow",
-        st: { state: "yes", note: "built in" },
+        them: { state: "yes", note: "built in" },
         gd: { state: "no" },
       },
       {
         label: "Run your own scripts",
-        st: {
+        them: {
           state: "yes",
           note: "custom actions on the toolbar & context menu",
         },
@@ -171,7 +164,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Linked worktrees",
-        st: {
+        them: {
           state: "no",
           note: "no worktree UI — open one as a separate repo",
         },
@@ -182,7 +175,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Submodules",
-        st: {
+        them: {
           state: "yes",
           note: "add from the menu, manage from the sidebar",
         },
@@ -190,12 +183,12 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Git LFS",
-        st: { state: "yes", note: "initialize & track from the menu" },
+        them: { state: "yes", note: "initialize & track from the menu" },
         gd: { state: "no", note: "system git-lfs works; no dedicated UI" },
       },
       {
         label: "Predict a merge before running it",
-        st: { state: "no", note: "conflicts surface after the merge runs" },
+        them: { state: "no", note: "conflicts surface after the merge runs" },
         gd: {
           state: "yes",
           note: "fast-forward / clean / conflicts, previewed in memory",
@@ -203,7 +196,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Recover dropped stashes",
-        st: {
+        them: {
           state: "no",
           note: "the community answer is git fsck in a terminal",
         },
@@ -216,7 +209,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "AI assistance",
-        st: { state: "no", note: "none shipped; requests open since 2023" },
+        them: { state: "no", note: "none shipped; requests open since 2023" },
         gd: {
           state: "yes",
           note: "commit messages, PR descriptions, review, delegated tasks — your own models",
@@ -224,7 +217,7 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Works with AI fully out of the way",
-        st: { state: "yes", note: "there is none" },
+        them: { state: "yes", note: "there is none" },
         gd: { state: "yes", note: "one setting hides every AI surface" },
       },
     ],
@@ -234,12 +227,12 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Price",
-        st: { state: "yes", note: "free, commercial use included" },
+        them: { state: "yes", note: "free, commercial use included" },
         gd: { state: "yes", note: "free" },
       },
       {
         label: "Open source",
-        st: { state: "no", note: "proprietary EULA" },
+        them: { state: "no", note: "proprietary EULA" },
         gd: { state: "yes", note: "Apache-2.0" },
       },
     ],
@@ -318,6 +311,16 @@ const faqs = [
         <li class="flex items-start gap-2.5 leading-relaxed text-body">
           <span class="mt-px select-none text-add" aria-hidden="true">+</span>
           <span>
+            <span class="text-ink">Nothing else to install.</span> Sourcetree
+            bundles its own Git (system Git optional). GitDesktop needs system
+            Git, plus <code class="text-ink">gh</code> or
+            <code class="text-ink">glab</code> for forge features — sign-in is
+            guided from inside the app, but it's still a real first-run step.
+          </span>
+        </li>
+        <li class="flex items-start gap-2.5 leading-relaxed text-body">
+          <span class="mt-px select-none text-add" aria-hidden="true">+</span>
+          <span>
             <span class="text-ink">Mercurial.</span> Sourcetree is the rare
             mainstream client still shipping Mercurial support, on both
             platforms, with Hg-flow to match. GitDesktop is Git-only — if your
@@ -376,56 +379,7 @@ const faqs = [
         each other, the row says so.
       </p>
 
-      {/* tabindex: a keyboard user must be able to scroll the min-width table;
-          a focusable scroll region needs the role + name for AT. */}
-      <div
-        data-reveal
-        style="transition-delay:80ms"
-        class="mt-10 overflow-x-auto"
-        tabindex="0"
-        role="region"
-        aria-label="Feature comparison table"
-      >
-        <table class="w-full min-w-[640px] border-collapse text-[15px]">
-          <thead>
-            <tr class="border-b border-line-2 text-left">
-              <th scope="col" class="py-3 pr-6 font-normal text-faint">Capability</th>
-              <th scope="col" class="w-[26%] py-3 pr-6 font-medium text-ink">Sourcetree</th>
-              <th scope="col" class="w-[30%] py-3 font-medium text-ink">GitDesktop</th>
-            </tr>
-          </thead>
-          {
-            groups.map((group) => (
-              <tbody>
-                <tr>
-                  <th
-                    scope="rowgroup"
-                    colspan="3"
-                    class="pb-2 pt-8 text-left text-sm font-normal text-faint"
-                  >
-                    <span class="text-add" aria-hidden="true">//</span> {group.title}
-                  </th>
-                </tr>
-                {group.rows.map((row) => (
-                  <tr class="border-b border-line align-top">
-                    <th scope="row" class="py-3.5 pr-6 text-left font-normal text-body">
-                      {row.label}
-                    </th>
-                    <td class="py-3.5 pr-6">
-                      <span class={stateClass[row.st.state]}>{stateText[row.st.state]}</span>
-                      {row.st.note && <span class="text-sm text-muted"> — {row.st.note}</span>}
-                    </td>
-                    <td class="py-3.5">
-                      <span class={stateClass[row.gd.state]}>{stateText[row.gd.state]}</span>
-                      {row.gd.note && <span class="text-sm text-muted"> — {row.gd.note}</span>}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            ))
-          }
-        </table>
-      </div>
+      <CompareTable competitor="Sourcetree" groups={groups} />
 
       <p class="mt-6 max-w-[66ch] text-sm leading-relaxed text-muted">
         Every Sourcetree cell traces to a primary Atlassian source — release

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -37,7 +37,7 @@ const groups: Group<Row>[] = [
     rows: [
       {
         label: "Linux",
-        st: { state: "no", note: "Windows & macOS; no Linux plans" },
+        st: { state: "no", note: "Windows & macOS only" },
         gd: { state: "yes", note: "Windows, macOS & Linux" },
       },
       {
@@ -51,7 +51,10 @@ const groups: Group<Row>[] = [
       {
         label: "Forges with full PR / CI / issue support",
         st: { state: "no", note: "accounts add sign-in and clone lists" },
-        gd: { state: "yes", note: "GitHub, GitLab & Bitbucket" },
+        gd: {
+          state: "yes",
+          note: "GitHub, GitLab & Bitbucket — Bitbucket issues via linked Jira",
+        },
       },
       {
         label: "Jira",
@@ -108,7 +111,7 @@ const groups: Group<Row>[] = [
         st: { state: "no" },
         gd: {
           state: "yes",
-          note: "review & merge offline, promote to a forge later",
+          note: "review & merge offline, promote to GitHub or GitLab later",
         },
       },
     ],
@@ -170,7 +173,7 @@ const groups: Group<Row>[] = [
         label: "Linked worktrees",
         st: {
           state: "no",
-          note: "requested since 2015, never added",
+          note: "no worktree UI — open one as a separate repo",
         },
         gd: {
           state: "yes",
@@ -179,7 +182,10 @@ const groups: Group<Row>[] = [
       },
       {
         label: "Submodules",
-        st: { state: "yes", note: "add & manage from the sidebar" },
+        st: {
+          state: "yes",
+          note: "add from the menu, manage from the sidebar",
+        },
         gd: { state: "partial", note: "status & update" },
       },
       {
@@ -243,7 +249,7 @@ const groups: Group<Row>[] = [
 const faqs = [
   {
     q: "Is GitDesktop a good Sourcetree alternative?",
-    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for — staging by file, hunk, or line, interactive rebase, stashes, submodule status — and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs with logs, and issues, across GitHub, GitLab, and Bitbucket. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those — the table above is honest about it.",
+    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for — staging by file, hunk, or line, interactive rebase, stashes, submodule status — and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs (with GitHub and GitLab step logs in-app), and issues, across GitHub, GitLab, and Bitbucket — Bitbucket issues through a linked Jira project. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those — the table above is honest about it.",
   },
   {
     q: "Is there a Sourcetree for Linux?",
@@ -255,7 +261,7 @@ const faqs = [
   },
   {
     q: "Is Sourcetree still maintained?",
-    a: "Yes, in a steady-patch sense: both apps shipped point releases through mid-2026 (Windows 3.4.31 in June, Mac 4.2.19 in July). But the two platforms run on separate codebases with a long-standing feature gap between them, Sourcetree doesn't appear on Atlassian's public product roadmap, and the big asks — worktree support requested since 2015, in-app pull requests since 2017 — remain open. It's stable, not evolving.",
+    a: "Yes, in a steady-patch sense: both apps shipped point releases through mid-2026 (Windows 3.4.31 in June, Mac 4.2.19 in July). But the two platforms run on separate codebases with a long-standing feature gap between them, community threads note it's absent from Atlassian's public product roadmap, and the big asks — worktree support requested since 2015, in-app pull requests since 2017 — remain open. It's stable, not evolving.",
   },
 ];
 ---
@@ -286,8 +292,9 @@ const faqs = [
         GitDesktop is a free, open-source Sourcetree alternative that runs on
         <span class="text-ink">Linux as well as Windows and macOS</span>, needs
         no vendor account, and keeps the pull-request loop — create, review,
-        merge, CI, issues — in the app instead of the browser, across
-        <span class="text-ink">GitHub, GitLab, and Bitbucket</span>. AI is
+        merge, CI — in the app instead of the browser, across
+        <span class="text-ink">GitHub, GitLab, and Bitbucket</span>, with
+        issues in-app too (via a linked Jira project on Bitbucket). AI is
         optional: your own models, or hidden entirely.
       </p>
       <p data-reveal style="transition-delay:180ms" class="mt-5 text-sm text-muted">
@@ -328,10 +335,10 @@ const faqs = [
         <li class="flex items-start gap-2.5 leading-relaxed text-body">
           <span class="mt-px select-none text-add" aria-hidden="true">+</span>
           <span>
-            <span class="text-ink">Scripts on the commit context menu.</span>
-            Custom actions bind your scripts to the toolbar and to right-click
-            on a commit. GitDesktop's Tasks tab runs saved and inline scripts
-            in a terminal, but doesn't attach them to commits.
+            <span class="text-ink">Scripts bound into the UI.</span>
+            Custom actions put your scripts on the toolbar and context menus.
+            GitDesktop's Tasks tab runs saved and inline scripts in a
+            terminal, without menu binding.
           </span>
         </li>
         <li class="flex items-start gap-2.5 leading-relaxed text-body">
@@ -348,10 +355,9 @@ const faqs = [
           <span class="mt-px select-none text-add" aria-hidden="true">+</span>
           <span>
             <span class="text-ink">More than a decade of ubiquity.</span> It's
-            been the default answer to "which free Git GUI" since the early
-            2010s. Teams have muscle memory and years of community answers built
-            around it, and free-for-commercial-use has always been part of the
-            deal.
+            been a default answer to "which free Git GUI" for a long time.
+            Teams have muscle memory and years of community answers built
+            around it, and it's free for commercial use.
           </span>
         </li>
       </ul>
@@ -370,7 +376,16 @@ const faqs = [
         each other, the row says so.
       </p>
 
-      <div data-reveal style="transition-delay:80ms" class="mt-10 overflow-x-auto">
+      {/* tabindex: a keyboard user must be able to scroll the min-width table;
+          a focusable scroll region needs the role + name for AT. */}
+      <div
+        data-reveal
+        style="transition-delay:80ms"
+        class="mt-10 overflow-x-auto"
+        tabindex="0"
+        role="region"
+        aria-label="Feature comparison table"
+      >
         <table class="w-full min-w-[640px] border-collapse text-[15px]">
           <thead>
             <tr class="border-b border-line-2 text-left">
@@ -416,7 +431,12 @@ const faqs = [
         Every Sourcetree cell traces to a primary Atlassian source — release
         notes, support documentation, or its public issue tracker — checked on
         the date above. Rows where both clients are simply fine were left out
-        on purpose.
+        on purpose. Also compared:
+        <a
+          href={`${base}compare/github-desktop/`}
+          class="text-mint underline-offset-4 hover:underline"
+          >GitDesktop vs GitHub Desktop</a
+        >.
       </p>
     </div>
   </section>
@@ -429,9 +449,10 @@ const faqs = [
         </h2>
         <p data-reveal class="mt-5 leading-relaxed text-body">
           Sourcetree's "Create Pull Request" opens a browser tab, and reading,
-          reviewing, or merging one was never added — Atlassian's own answer:
-          "we don't currently support listing or viewing PRs in Sourcetree." In
-          GitDesktop the whole loop lives next to your staging and history.
+          reviewing, or merging one was never added — Atlassian's own answer,
+          given in 2018 and never revisited since: "we don't currently support
+          listing or viewing PRs in Sourcetree." In GitDesktop the whole loop
+          lives next to your staging and history.
         </p>
       </div>
       <figure data-reveal style="transition-delay:120ms" class="window mt-10">

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -1,0 +1,493 @@
+---
+// GitDesktop vs Sourcetree — "sourcetree alternative" is high-intent search,
+// and Sourcetree ships Windows+macOS only, so every Linux searcher is
+// winnable. Windows and Mac Sourcetree are SEPARATE apps on separate release
+// lines; rows say which platform a fact applies to when they differ.
+// Re-grounded 2026-08-11 against Windows 3.4.31 (2026-06-09) and Mac 4.2.19
+// (2026-07-30) via primary Atlassian sources (release notes, support KBs,
+// jira.atlassian.com tickets). When a row changes upstream, update the stamp
+// in the same edit — a stale comparison is worse than none.
+import { Image } from "astro:assets";
+import appGithubPr from "../../assets/app-github-pr.png";
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import {
+  type Cell,
+  type Group,
+  stateClass,
+  stateText,
+} from "../../lib/compare";
+
+const base = import.meta.env.BASE_URL;
+const repo = "https://github.com/theBGuy/GitDesktop";
+const download = `${base}download/`;
+
+const VERIFIED_ON = "August 11, 2026";
+const ST_WIN_VERSION = "3.4.31";
+const ST_MAC_VERSION = "4.2.19";
+
+interface Row {
+  label: string;
+  st: Cell;
+  gd: Cell;
+}
+
+const groups: Group<Row>[] = [
+  {
+    title: "Where you can use it",
+    rows: [
+      {
+        label: "Linux",
+        st: { state: "no", note: "Windows & macOS; no Linux plans" },
+        gd: { state: "yes", note: "Windows, macOS & Linux" },
+      },
+      {
+        label: "Works without a vendor account",
+        st: {
+          state: "no",
+          note: "an Atlassian account is required to use the app",
+        },
+        gd: { state: "yes", note: "sign in only to the forges you use" },
+      },
+      {
+        label: "Forges with full PR / CI / issue support",
+        st: { state: "no", note: "accounts add sign-in and clone lists" },
+        gd: { state: "yes", note: "GitHub, GitLab & Bitbucket" },
+      },
+      {
+        label: "Jira",
+        st: {
+          state: "partial",
+          note: "issue-key links in commit messages open the browser",
+        },
+        gd: { state: "yes", note: "linked Jira Cloud project per repo" },
+      },
+      {
+        label: "Mercurial",
+        st: { state: "yes", note: "still shipping, both platforms" },
+        gd: { state: "no", note: "Git only" },
+      },
+    ],
+  },
+  {
+    title: "Pull requests",
+    rows: [
+      {
+        label: "Create a PR",
+        st: {
+          state: "partial",
+          note: "opens the forge's form in your browser",
+        },
+        gd: {
+          state: "yes",
+          note: "in-app: reviewers, labels, linked issues, drafts",
+        },
+      },
+      {
+        label: "Read & review a PR in-app",
+        st: { state: "no" },
+        gd: {
+          state: "yes",
+          note: "conversation, files, checks, approve / request changes",
+        },
+      },
+      {
+        label: "Merge a PR in-app",
+        st: { state: "no" },
+        gd: { state: "yes", note: "merge / squash / rebase" },
+      },
+      {
+        label: "Resolve a PR's conflicts in-app",
+        st: { state: "no" },
+        gd: {
+          state: "yes",
+          note: "in a hidden worktree; your checkout untouched",
+        },
+      },
+      {
+        label: "Local PRs with no remote at all",
+        st: { state: "no" },
+        gd: {
+          state: "yes",
+          note: "review & merge offline, promote to a forge later",
+        },
+      },
+    ],
+  },
+  {
+    title: "CI & issues",
+    rows: [
+      {
+        label: "CI status in-app",
+        st: {
+          state: "partial",
+          note: "Bitbucket Pipelines per-commit status — macOS only",
+        },
+        gd: {
+          state: "yes",
+          note: "all three forges; GitHub & GitLab failed-step logs in-app",
+        },
+      },
+      {
+        label: "Issues",
+        st: { state: "no", note: "commit-message links open the browser" },
+        gd: { state: "yes", note: "GitHub & GitLab in-app; local issues too" },
+      },
+    ],
+  },
+  {
+    title: "Daily Git work",
+    rows: [
+      {
+        label: "Stage by file, hunk, or line",
+        st: { state: "yes" },
+        gd: { state: "yes", note: "plus drag-to-stage line selection" },
+      },
+      {
+        label: "Interactive rebase",
+        st: { state: "yes", note: "squash, reword, edit, reorder, delete" },
+        gd: {
+          state: "yes",
+          note: "pick / reword / squash / fixup / edit / drop",
+        },
+      },
+      {
+        label: "Git-flow",
+        st: { state: "yes", note: "built in" },
+        gd: { state: "no" },
+      },
+      {
+        label: "Run your own scripts",
+        st: {
+          state: "yes",
+          note: "custom actions on the toolbar & context menu",
+        },
+        gd: {
+          state: "yes",
+          note: "a Tasks tab: saved or inline scripts, run in an interactive terminal",
+        },
+      },
+      {
+        label: "Linked worktrees",
+        st: {
+          state: "no",
+          note: "requested since 2015, never added",
+        },
+        gd: {
+          state: "yes",
+          note: "create, switch, rename, lock, promote & remove",
+        },
+      },
+      {
+        label: "Submodules",
+        st: { state: "yes", note: "add & manage from the sidebar" },
+        gd: { state: "partial", note: "status & update" },
+      },
+      {
+        label: "Git LFS",
+        st: { state: "yes", note: "initialize & track from the menu" },
+        gd: { state: "no", note: "system git-lfs works; no dedicated UI" },
+      },
+      {
+        label: "Predict a merge before running it",
+        st: { state: "no", note: "conflicts surface after the merge runs" },
+        gd: {
+          state: "yes",
+          note: "fast-forward / clean / conflicts, previewed in memory",
+        },
+      },
+      {
+        label: "Recover dropped stashes",
+        st: {
+          state: "no",
+          note: "the community answer is git fsck in a terminal",
+        },
+        gd: { state: "yes", note: "a git fsck scan finds and restores them" },
+      },
+    ],
+  },
+  {
+    title: "AI — take it or leave it",
+    rows: [
+      {
+        label: "AI assistance",
+        st: { state: "no", note: "none shipped; requests open since 2023" },
+        gd: {
+          state: "yes",
+          note: "commit messages, PR descriptions, review, delegated tasks — your own models",
+        },
+      },
+      {
+        label: "Works with AI fully out of the way",
+        st: { state: "yes", note: "there is none" },
+        gd: { state: "yes", note: "one setting hides every AI surface" },
+      },
+    ],
+  },
+  {
+    title: "Cost & code",
+    rows: [
+      {
+        label: "Price",
+        st: { state: "yes", note: "free, commercial use included" },
+        gd: { state: "yes", note: "free" },
+      },
+      {
+        label: "Open source",
+        st: { state: "no", note: "proprietary EULA" },
+        gd: { state: "yes", note: "Apache-2.0" },
+      },
+    ],
+  },
+];
+
+const faqs = [
+  {
+    q: "Is GitDesktop a good Sourcetree alternative?",
+    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for — staging by file, hunk, or line, interactive rebase, stashes, submodule status — and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs with logs, and issues, across GitHub, GitLab, and Bitbucket. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those — the table above is honest about it.",
+  },
+  {
+    q: "Is there a Sourcetree for Linux?",
+    a: "No. Atlassian ships Sourcetree for Windows and macOS only, and community answers as recent as April 2026 say Linux isn't on the roadmap. GitDesktop ships Windows, macOS, and Linux builds — including an AppImage and a Homebrew cask.",
+  },
+  {
+    q: "Do you need an Atlassian account to use Sourcetree?",
+    a: "Yes — Atlassian's own install documentation says an Atlassian account is required to use Sourcetree, regardless of which forge your code lives on. GitDesktop has no vendor account at all: you sign in only to the forges you actually use (GitHub via gh, GitLab via glab, Bitbucket with an API token), and none of it is needed for local-only work.",
+  },
+  {
+    q: "Is Sourcetree still maintained?",
+    a: "Yes, in a steady-patch sense: both apps shipped point releases through mid-2026 (Windows 3.4.31 in June, Mac 4.2.19 in July). But the two platforms run on separate codebases with a long-standing feature gap between them, Sourcetree doesn't appear on Atlassian's public product roadmap, and the big asks — worktree support requested since 2015, in-app pull requests since 2017 — remain open. It's stable, not evolving.",
+  },
+];
+---
+
+<SiteLayout
+  title="GitDesktop vs Sourcetree — an honest comparison"
+  description="GitDesktop vs Sourcetree, verified August 2026: Linux support, the in-app PR loop, CI, issues, optional AI, and no vendor account — plus what Sourcetree still does better."
+  ogTitle="GitDesktop vs Sourcetree"
+  ogDescription="Linux support, the in-app PR loop, CI, issues, optional AI, and no vendor account — an honest, dated comparison."
+  breadcrumbs={[{ name: "GitDesktop vs Sourcetree", path: "/compare/sourcetree/" }]}
+>
+  <section class="border-b border-line">
+    <div class="mx-auto max-w-6xl px-5 py-16 md:py-20">
+      <p data-reveal class="text-sm text-faint"><span class="text-add" aria-hidden="true">//</span> compare</p>
+      <h1
+        data-reveal
+        style="transition-delay:60ms"
+        class="mt-5 max-w-[24ch] text-[clamp(1.9rem,4.5vw,3rem)] font-semibold tracking-tight"
+      >
+        GitDesktop vs Sourcetree
+      </h1>
+      {/* Answer-first: the paragraph a search snippet or answer engine lifts. */}
+      <p
+        data-reveal
+        style="transition-delay:120ms"
+        class="mt-6 max-w-[62ch] text-base leading-relaxed text-body sm:text-lg"
+      >
+        GitDesktop is a free, open-source Sourcetree alternative that runs on
+        <span class="text-ink">Linux as well as Windows and macOS</span>, needs
+        no vendor account, and keeps the pull-request loop — create, review,
+        merge, CI, issues — in the app instead of the browser, across
+        <span class="text-ink">GitHub, GitLab, and Bitbucket</span>. AI is
+        optional: your own models, or hidden entirely.
+      </p>
+      <p data-reveal style="transition-delay:180ms" class="mt-5 text-sm text-muted">
+        Verified against Sourcetree for Windows {ST_WIN_VERSION} and Sourcetree
+        for Mac {ST_MAC_VERSION} — two separate apps on separate release lines —
+        on {VERIFIED_ON}. Something stale?
+        <a href={`${repo}/issues`} class="text-mint underline-offset-4 hover:underline"
+          >Open an issue</a
+        >.
+      </p>
+    </div>
+  </section>
+
+  <!-- Fairness first: the honest column is what makes the table credible. -->
+  <section class="border-b border-line">
+    <div class="mx-auto max-w-6xl px-5 py-14 md:py-16">
+      <h2 data-reveal class="text-balance text-2xl tracking-[-0.02em] sm:text-3xl">
+        Where Sourcetree still wins
+      </h2>
+      <ul data-reveal style="transition-delay:80ms" class="mt-8 max-w-[70ch] space-y-4">
+        <li class="flex items-start gap-2.5 leading-relaxed text-body">
+          <span class="mt-px select-none text-add" aria-hidden="true">+</span>
+          <span>
+            <span class="text-ink">Mercurial.</span> Sourcetree is the rare
+            mainstream client still shipping Mercurial support, on both
+            platforms, with Hg-flow to match. GitDesktop is Git-only — if your
+            repos are hg, Sourcetree remains the tool.
+          </span>
+        </li>
+        <li class="flex items-start gap-2.5 leading-relaxed text-body">
+          <span class="mt-px select-none text-add" aria-hidden="true">+</span>
+          <span>
+            <span class="text-ink">Git-flow, one menu item.</span> Initialize a
+            repo and the whole branch ceremony — feature, release, hotfix — is
+            driven from the UI. GitDesktop has no git-flow support.
+          </span>
+        </li>
+        <li class="flex items-start gap-2.5 leading-relaxed text-body">
+          <span class="mt-px select-none text-add" aria-hidden="true">+</span>
+          <span>
+            <span class="text-ink">Scripts on the commit context menu.</span>
+            Custom actions bind your scripts to the toolbar and to right-click
+            on a commit. GitDesktop's Tasks tab runs saved and inline scripts
+            in a terminal, but doesn't attach them to commits.
+          </span>
+        </li>
+        <li class="flex items-start gap-2.5 leading-relaxed text-body">
+          <span class="mt-px select-none text-add" aria-hidden="true">+</span>
+          <span>
+            <span class="text-ink">Git LFS and submodule tooling.</span>
+            Initialize and track LFS from the menu; add and manage submodules
+            from the sidebar. GitDesktop relies on system
+            <code class="text-ink">git-lfs</code> with no dedicated UI, and its
+            submodule support stops at status and update.
+          </span>
+        </li>
+        <li class="flex items-start gap-2.5 leading-relaxed text-body">
+          <span class="mt-px select-none text-add" aria-hidden="true">+</span>
+          <span>
+            <span class="text-ink">More than a decade of ubiquity.</span> It's
+            been the default answer to "which free Git GUI" since the early
+            2010s. Teams have muscle memory and years of community answers built
+            around it, and free-for-commercial-use has always been part of the
+            deal.
+          </span>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="border-b border-line bg-surface/30">
+    <div class="mx-auto max-w-6xl px-5 py-14 md:py-16">
+      <h2 data-reveal class="text-balance text-2xl tracking-[-0.02em] sm:text-3xl">
+        Feature by feature
+      </h2>
+      <p data-reveal class="mt-5 max-w-[66ch] leading-relaxed text-body">
+        Both clients cover the fundamentals — clone, stage by file, hunk, or
+        line, commit, branch, stash, sync, and resolve conflicts. The table
+        keeps to where they diverge. Where Sourcetree's two apps differ from
+        each other, the row says so.
+      </p>
+
+      <div data-reveal style="transition-delay:80ms" class="mt-10 overflow-x-auto">
+        <table class="w-full min-w-[640px] border-collapse text-[15px]">
+          <thead>
+            <tr class="border-b border-line-2 text-left">
+              <th scope="col" class="py-3 pr-6 font-normal text-faint">Capability</th>
+              <th scope="col" class="w-[26%] py-3 pr-6 font-medium text-ink">Sourcetree</th>
+              <th scope="col" class="w-[30%] py-3 font-medium text-ink">GitDesktop</th>
+            </tr>
+          </thead>
+          {
+            groups.map((group) => (
+              <tbody>
+                <tr>
+                  <th
+                    scope="rowgroup"
+                    colspan="3"
+                    class="pb-2 pt-8 text-left text-sm font-normal text-faint"
+                  >
+                    <span class="text-add" aria-hidden="true">//</span> {group.title}
+                  </th>
+                </tr>
+                {group.rows.map((row) => (
+                  <tr class="border-b border-line align-top">
+                    <th scope="row" class="py-3.5 pr-6 text-left font-normal text-body">
+                      {row.label}
+                    </th>
+                    <td class="py-3.5 pr-6">
+                      <span class={stateClass[row.st.state]}>{stateText[row.st.state]}</span>
+                      {row.st.note && <span class="text-sm text-muted"> — {row.st.note}</span>}
+                    </td>
+                    <td class="py-3.5">
+                      <span class={stateClass[row.gd.state]}>{stateText[row.gd.state]}</span>
+                      {row.gd.note && <span class="text-sm text-muted"> — {row.gd.note}</span>}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            ))
+          }
+        </table>
+      </div>
+
+      <p class="mt-6 max-w-[66ch] text-sm leading-relaxed text-muted">
+        Every Sourcetree cell traces to a primary Atlassian source — release
+        notes, support documentation, or its public issue tracker — checked on
+        the date above. Rows where both clients are simply fine were left out
+        on purpose.
+      </p>
+    </div>
+  </section>
+
+  <section class="border-b border-line">
+    <div class="mx-auto max-w-6xl px-5 py-16 md:py-20">
+      <div class="max-w-2xl">
+        <h2 data-reveal class="text-balance text-2xl tracking-[-0.02em] sm:text-3xl">
+          The part Sourcetree hands to the browser
+        </h2>
+        <p data-reveal class="mt-5 leading-relaxed text-body">
+          Sourcetree's "Create Pull Request" opens a browser tab, and reading,
+          reviewing, or merging one was never added — Atlassian's own answer:
+          "we don't currently support listing or viewing PRs in Sourcetree." In
+          GitDesktop the whole loop lives next to your staging and history.
+        </p>
+      </div>
+      <figure data-reveal style="transition-delay:120ms" class="window mt-10">
+        <Image
+          src={appGithubPr}
+          alt="A pull request in GitDesktop: CI checks with per-job status, an automated review, and the merge action — the loop Sourcetree sends to the browser"
+          widths={[720, 1080, 1440]}
+          sizes="(min-width: 1024px) 1100px, 94vw"
+          format="webp"
+          quality={82}
+          loading="lazy"
+        />
+      </figure>
+    </div>
+  </section>
+
+  <!-- Visible Q&A — extraction-shaped HTML on purpose (no FAQPage JSON-LD:
+       Google removed FAQ rich results sitewide in May 2026; retrieval reads
+       the visible text). -->
+  <section class="border-b border-line bg-surface/30">
+    <div class="mx-auto max-w-6xl px-5 py-14 md:py-16">
+      <h2 data-reveal class="text-balance text-2xl tracking-[-0.02em] sm:text-3xl">
+        Common questions
+      </h2>
+      <div data-reveal style="transition-delay:80ms" class="mt-8 grid gap-x-12 gap-y-10 lg:grid-cols-2">
+        {
+          faqs.map((f) => (
+            <div class="min-w-0">
+              <h3 class="text-lg text-ink">{f.q}</h3>
+              <p class="mt-3 max-w-[58ch] text-[15px] leading-relaxed text-body">{f.a}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section class="relative overflow-hidden">
+    <div class="grid-bg pointer-events-none absolute inset-0 opacity-60"></div>
+    <div class="relative mx-auto max-w-6xl px-5 py-16 text-center md:py-20">
+      <h2 data-reveal class="text-balance text-2xl tracking-tight sm:text-3xl">
+        Try the whole loop.
+      </h2>
+      <p data-reveal style="transition-delay:80ms" class="mx-auto mt-5 max-w-[48ch] leading-relaxed text-body">
+        Free, open source, and no account to create. Keep Sourcetree right
+        where it is — open one repo in GitDesktop and see which window you
+        keep.
+      </p>
+      <div data-reveal style="transition-delay:140ms" class="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <a href={download} class="rounded-lg bg-mint px-6 py-3 font-medium text-mint-ink transition-opacity hover:opacity-90">
+          Download GitDesktop
+        </a>
+        <a href={`${base}features/`} class="rounded-lg border border-line-2 px-6 py-3 font-medium text-ink transition-colors hover:bg-surface">
+          See every feature
+        </a>
+      </div>
+    </div>
+  </section>
+</SiteLayout>

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -11,7 +11,7 @@ import { Image } from "astro:assets";
 import appGithubPr from "../../assets/app-github-pr.png";
 import CompareTable from "../../components/CompareTable.astro";
 import SiteLayout from "../../layouts/SiteLayout.astro";
-import { type Group, type Row } from "../../lib/compare";
+import type { Group } from "../../lib/compare";
 
 const base = import.meta.env.BASE_URL;
 const repo = "https://github.com/theBGuy/GitDesktop";
@@ -21,7 +21,7 @@ const VERIFIED_ON = "August 11, 2026";
 const ST_WIN_VERSION = "3.4.31";
 const ST_MAC_VERSION = "4.2.19";
 
-const groups: Group<Row>[] = [
+const groups: Group[] = [
   {
     title: "Where you can use it",
     rows: [
@@ -314,8 +314,9 @@ const faqs = [
             <span class="text-ink">Nothing else to install.</span> Sourcetree
             bundles its own Git (system Git optional). GitDesktop needs system
             Git, plus <code class="text-ink">gh</code> or
-            <code class="text-ink">glab</code> for forge features — sign-in is
-            guided from inside the app, but it's still a real first-run step.
+            <code class="text-ink">glab</code> for GitHub and GitLab features
+            (Bitbucket needs only an API token) — sign-in is guided from inside
+            the app, but it's still a real first-run step.
           </span>
         </li>
         <li class="flex items-start gap-2.5 leading-relaxed text-body">


### PR DESCRIPTION
Adds a second `/compare/` landing page targeting "sourcetree alternative" search intent, and extracts the shared comparison-table machinery so both pages render states identically. Sourcetree ships Windows and macOS only, so the page leans on Linux support, the in-app PR loop, and no-vendor-account setup as the differentiators — while keeping an explicit "where Sourcetree still wins" section for credibility.

### New comparison page

- Adds `site/src/pages/compare/sourcetree.astro`: an answer-first hero, a "Where Sourcetree still wins" section (Mercurial, git-flow, commit context-menu scripts, LFS/submodule tooling, ubiquity), a grouped feature table, a PR-loop screenshot reusing `app-github-pr.png`, four visible Q&A entries, and a download CTA.
- Feature table is grouped into "Where you can use it", "Pull requests", "CI & issues", "Daily Git work", "AI — take it or leave it", and "Cost & code", with per-cell notes; rows call out where Sourcetree's Windows and Mac apps diverge (e.g. Bitbucket Pipelines status being macOS-only).
- Records provenance in the page: `VERIFIED_ON`, `ST_WIN_VERSION` (3.4.31) and `ST_MAC_VERSION` (4.2.19) constants surfaced in the hero copy, plus a note under the table that every Sourcetree cell traces to a primary Atlassian source.
- Header comment documents the two-separate-apps constraint and the rule to re-stamp `VERIFIED_ON` in the same edit as any upstream-driven row change.
- Deliberately omits FAQPage JSON-LD (commented inline), keeping the Q&A as plain extraction-shaped HTML.

### Shared compare machinery

- Adds `site/src/lib/compare.ts` with `State`, `Cell`, generic `Group<R>`, and the `stateText` / `stateClass` maps, so row states always render as the words "Yes" / "Partial" / "No" and color only shades emphasis on top of the word (WCAG, and readable to screen readers).
- Updates `site/src/pages/compare/github-desktop.astro` to import those types and maps instead of declaring its own, keeping only its page-local `Row` interface and typing its data as `Group<Row>[]`. No rendered output changes on that page.