### PR TITLE
style(site): reduce em-dash density across site copy

### DIFF
--- a/site/src/lib/brand.ts
+++ b/site/src/lib/brand.ts
@@ -8,6 +8,6 @@
 export const canonicalSentence =
   "GitDesktop is a free, open-source (Apache-2.0) desktop Git client for " +
   "Windows, macOS, and Linux, built with Tauri 2 and React 19 by theBGuy. " +
-  "It works with GitHub, GitLab, and Bitbucket — staging, diffs, branches, " +
+  "It works with GitHub, GitLab, and Bitbucket: staging, diffs, branches, " +
   "history, and the full pull-request loop with code review, CI, and issues " +
-  "— with optional AI you can hide entirely.";
+  "— plus optional AI you can hide entirely.";

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -216,8 +216,8 @@ const agentAbilities = [
           <McpConfig />
         </figure>
         <p class="mt-4 text-sm text-muted">
-          Writes are an escalating opt-in ladder, each tier a separate flag, off by
-          default:
+          Writes are an escalating opt-in ladder: each tier a separate flag, off by
+          default.
         </p>
         <ul class="ladder mt-3">
           <li data-default>
@@ -271,8 +271,9 @@ const agentAbilities = [
         <div class="min-w-0">
           <h3 class="text-sm text-ink">Custom instructions</h3>
           <p class="mt-2 text-sm leading-relaxed text-muted">
-            Global, or per-repo via <code class="text-ink">.gitdesktop/instructions.md</code>.
-            Both are included in every generation and every AI review.
+            Global instructions steer every generation and every AI review; a per-repo
+            <code class="text-ink">.gitdesktop/instructions.md</code> takes precedence
+            where both apply.
           </p>
         </div>
         <div class="min-w-0">

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -53,7 +53,7 @@ const agentAbilities = [
         AI you actually control.
       </h1>
       <p data-reveal style="transition-delay:120ms" class="mt-6 max-w-[62ch] text-base leading-relaxed text-body sm:text-lg">
-        Every AI surface is optional, editable, and attributable — and it runs on
+        Every AI surface is optional, editable, and attributable. It runs on
         <span class="text-ink">your own model</span>: a cloud API, a local Ollama, or a
         keyless CLI you already pay for. Keys live in your OS keychain, never in app
         files, and a single switch hides all of it. It assists the workflow; it never
@@ -68,7 +68,7 @@ const agentAbilities = [
       <div data-reveal class="min-w-0">
         <h2 class="text-2xl tracking-[-0.02em] sm:text-3xl">It writes; you edit.</h2>
         <p class="mt-6 max-w-[46ch] leading-relaxed text-body">
-          One click reads your staged diff and drafts the message — streaming into the
+          One click reads your staged diff and drafts the message, streaming into the
           same field you'd type in, always editable.
         </p>
       </div>
@@ -101,8 +101,8 @@ const agentAbilities = [
         <div class="rule-mint mb-6 w-16"></div>
         <h2 class="text-2xl tracking-[-0.02em] sm:text-3xl">A reviewer that reads the code.</h2>
         <p class="mt-6 leading-relaxed text-body">
-          Run a general review or a security audit on any pull request — local or on
-          GitHub, GitLab, or Bitbucket. It reads the changed files, flags real issues
+          Run a general review or a security audit on any pull request, whether local
+          or on GitHub, GitLab, or Bitbucket. It reads the changed files, flags real issues
           with a severity, and cites the exact lines. The result stays on your machine
           unless you post it.
         </p>
@@ -128,15 +128,15 @@ const agentAbilities = [
         <div class="min-w-0">
           <h3 class="text-ink">Clearly machine-authored.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
-            A branded header/footer and a robot avatar — and with a GitLab access token,
-            posted as the real project bot rather than your own account.
+            A branded header/footer and a robot avatar. With a GitLab access token, it
+            posts as the real project bot rather than your own account.
           </p>
         </div>
         <div class="min-w-0">
           <h3 class="text-ink">On a schedule, if you want.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
             Automations run a review or security audit on commit, on PR open, or on new
-            commits to a reviewed PR — scoped by branch. And Debug-with-AI turns a failed
+            commits to a reviewed PR, scoped by branch. And Debug-with-AI turns a failed
             CI job's logs into a root cause and fix.
           </p>
         </div>
@@ -161,8 +161,8 @@ const agentAbilities = [
       <div data-reveal class="max-w-2xl">
         <h2 class="text-2xl tracking-[-0.02em] sm:text-3xl">Hand off whole tasks.</h2>
         <p class="mt-6 leading-relaxed text-body">
-          Beyond generation, GitDesktop drives full coding agents — the CLI you already
-          have, no extra subscription — and keeps every run inspectable and reversible.
+          Beyond generation, GitDesktop drives full coding agents (the CLI you already
+          have, no extra subscription) and keeps every run inspectable and reversible.
         </p>
       </div>
       <ul data-reveal style="transition-delay:80ms" class="mt-10 grid gap-x-12 gap-y-3.5 md:grid-cols-2">
@@ -197,15 +197,15 @@ const agentAbilities = [
         <h2 class="text-2xl tracking-[-0.02em] sm:text-3xl">GitDesktop as an MCP server.</h2>
         <p class="mt-6 max-w-[52ch] leading-relaxed text-body">
           The reverse direction: expose this repo's read-only git &amp; forge tools to any
-          external MCP client — Claude Desktop, Cursor, Claude Code. Settings shows a
+          external MCP client, like Claude Desktop, Cursor, or Claude Code. Settings shows a
           ready-to-paste snippet, writes it into the repo's
           <code class="text-ink">.mcp.json</code>, or installs it globally, with an
           Add-to-PATH launcher so the bare <code class="text-ink">gitdesktop-mcp</code>
           command resolves anywhere.
         </p>
         <p class="mt-4 max-w-[52ch] leading-relaxed text-muted">
-          It also hands a connected agent GitDesktop's own generation recipes — the fully
-          assembled commit-message, PR-description, and branch-name prompts — as tools and
+          It also hands a connected agent GitDesktop's own generation recipes (the fully
+          assembled commit-message, PR-description, and branch-name prompts) as tools and
           as MCP prompts. And you can bring your own MCP servers into a session, or browse
           the official registry to add new ones.
         </p>
@@ -216,7 +216,7 @@ const agentAbilities = [
           <McpConfig />
         </figure>
         <p class="mt-4 text-sm text-muted">
-          Writes are an escalating opt-in ladder — each tier a separate flag, off by
+          Writes are an escalating opt-in ladder, each tier a separate flag, off by
           default:
         </p>
         <ul class="ladder mt-3">
@@ -253,7 +253,7 @@ const agentAbilities = [
         <p class="mt-6 leading-relaxed text-body">
           Separate models for generation and review, in a searchable live picker. Point
           Ollama or an OpenAI-compatible endpoint at a box on your LAN, not just
-          localhost — non-built-in hosts are enforced against an allow-list before every
+          localhost. Non-built-in hosts are enforced against an allow-list before every
           request.
         </p>
       </div>
@@ -271,8 +271,8 @@ const agentAbilities = [
         <div class="min-w-0">
           <h3 class="text-sm text-ink">Custom instructions</h3>
           <p class="mt-2 text-sm leading-relaxed text-muted">
-            Global, or per-repo via <code class="text-ink">.gitdesktop/instructions.md</code>
-            — included in every generation and every AI review.
+            Global, or per-repo via <code class="text-ink">.gitdesktop/instructions.md</code>.
+            Both are included in every generation and every AI review.
           </p>
         </div>
         <div class="min-w-0">

--- a/site/src/pages/ai.astro
+++ b/site/src/pages/ai.astro
@@ -101,10 +101,10 @@ const agentAbilities = [
         <div class="rule-mint mb-6 w-16"></div>
         <h2 class="text-2xl tracking-[-0.02em] sm:text-3xl">A reviewer that reads the code.</h2>
         <p class="mt-6 leading-relaxed text-body">
-          Run a general review or a security audit on any pull request, whether local
-          or on GitHub, GitLab, or Bitbucket. It reads the changed files, flags real issues
-          with a severity, and cites the exact lines. The result stays on your machine
-          unless you post it.
+          Run a general review or a security audit on any pull request, whether
+          local or on GitHub, GitLab, or Bitbucket. It reads the changed files,
+          flags real issues with a severity, and cites the exact lines. The result
+          stays on your machine unless you post it.
         </p>
       </div>
       <div data-reveal style="transition-delay:80ms" class="mt-10 grid gap-x-12 gap-y-8 sm:grid-cols-2">
@@ -128,8 +128,8 @@ const agentAbilities = [
         <div class="min-w-0">
           <h3 class="text-ink">Clearly machine-authored.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
-            A branded header/footer and a robot avatar. With a GitLab access token, it
-            posts as the real project bot rather than your own account.
+            A branded header/footer and a robot avatar. With a GitLab access token,
+            the review posts as the real project bot rather than your own account.
           </p>
         </div>
         <div class="min-w-0">

--- a/site/src/pages/bitbucket-issues-sunset.astro
+++ b/site/src/pages/bitbucket-issues-sunset.astro
@@ -36,7 +36,7 @@ const options = [
 
 const jiraPoints = [
   "Link a Jira Cloud site and project to any repository, and its Issues tab gains a Jira section: browse, filter, and read status, priority, assignee, description, and comments",
-  "Create, comment, assign, set due dates, change priority, and close or reopen along the project's own workflow, every action gated on your Jira permissions",
+  "Create, comment, assign, set due dates, change priority, and close or reopen along the project's own workflow, with every action gated on your Jira permissions",
   "Issue keys in your branch names, commit messages, and PR titles are spotted and linked straight back to the issue",
   "A local issue can be promoted to Jira when the work goes public",
 ];

--- a/site/src/pages/bitbucket-issues-sunset.astro
+++ b/site/src/pages/bitbucket-issues-sunset.astro
@@ -20,7 +20,7 @@ const options = [
   {
     label: "Export the data",
     detail:
-      "Issues can be exported from Bitbucket as a zip archive — a snapshot you keep, not a live tracker. Do this before the removal date even if you migrate; it's the only raw copy you'll have.",
+      "Issues can be exported from Bitbucket as a zip archive. That's a snapshot you keep, not a live tracker. Do this before the removal date even if you migrate; it's the only raw copy you'll have.",
   },
   {
     label: "Migrate to Jira",
@@ -30,13 +30,13 @@ const options = [
   {
     label: "Keep a tracker next to your code",
     detail:
-      "If the browser round-trip is what you're trying to avoid, put the tracker inside your Git client — the section below is the honest pitch for that.",
+      "If the browser round-trip is what you're trying to avoid, put the tracker inside your Git client. The section below is the honest pitch for that.",
   },
 ];
 
 const jiraPoints = [
-  "Link a Jira Cloud site and project to any repository, and its Issues tab gains a Jira section — browse, filter, and read status, priority, assignee, description, and comments",
-  "Create, comment, assign, set due dates, change priority, and close or reopen along the project's own workflow — every action gated on your Jira permissions",
+  "Link a Jira Cloud site and project to any repository, and its Issues tab gains a Jira section: browse, filter, and read status, priority, assignee, description, and comments",
+  "Create, comment, assign, set due dates, change priority, and close or reopen along the project's own workflow, every action gated on your Jira permissions",
   "Issue keys in your branch names, commit messages, and PR titles are spotted and linked straight back to the issue",
   "A local issue can be promoted to Jira when the work goes public",
 ];
@@ -113,8 +113,8 @@ const jiraPoints = [
             A tracker inside your Git client
           </h2>
           <p class="mt-6 max-w-[52ch] leading-relaxed text-body">
-            GitDesktop is a desktop Git client for GitHub, GitLab, and Bitbucket
-            — and for Bitbucket repositories, its issue story is a linked
+            GitDesktop is a desktop Git client for GitHub, GitLab, and Bitbucket.
+            For Bitbucket repositories, its issue story is a linked
             <span class="text-ink">Jira Cloud</span> project, so the migration
             Atlassian is pushing you toward doesn't have to mean living in a
             browser tab.
@@ -163,7 +163,7 @@ const jiraPoints = [
         Migrating anyway? Bring the client too.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-5 max-w-[48ch] leading-relaxed text-body">
-        Free and open source — Bitbucket pull requests, Pipelines, and linked
+        Free and open source: Bitbucket pull requests, Pipelines, and linked
         Jira issues in one window.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-8 flex flex-wrap items-center justify-center gap-3">

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -234,19 +234,19 @@ const groups: Group[] = [
 const faqs = [
   {
     q: "Is GitDesktop a GitHub Desktop alternative?",
-    a: "Yes. GitDesktop is a free, open-source (Apache-2.0) GitHub Desktop alternative for Windows, macOS, and Linux. GitDesktop covers the same daily loop — staging, branches, history, diffs, sync — and adds the parts GitHub Desktop hands to the browser: reading, reviewing, and merging pull requests, browsing CI runs, and working issues, across GitHub, GitLab, and Bitbucket.",
+    a: "Yes. GitDesktop is a free, open-source (Apache-2.0) GitHub Desktop alternative for Windows, macOS, and Linux. GitDesktop covers the same daily loop (staging, branches, history, diffs, sync) and adds the parts GitHub Desktop hands to the browser: reading, reviewing, and merging pull requests, browsing CI runs, and working issues, across GitHub, GitLab, and Bitbucket.",
   },
   {
     q: "Does GitHub Desktop work with GitLab or Bitbucket?",
-    a: "No. GitHub Desktop can push and pull any git remote, but its hosted features — pull requests, checks, sign-in — are GitHub-only. GitDesktop runs the same pull-request, CI, and issue panels against GitHub, GitLab, and Bitbucket, each on its own authenticated identity.",
+    a: "No. GitHub Desktop can push and pull any git remote, but its hosted features (pull requests, checks, sign-in) are GitHub-only. GitDesktop runs the same pull-request, CI, and issue panels against GitHub, GitLab, and Bitbucket, each on its own authenticated identity.",
   },
   {
     q: "Do you need GitHub Copilot for AI features?",
-    a: "In GitHub Desktop, yes — its commit messages and conflict resolution are Copilot-powered and require Copilot access, even when bringing your own key. In GitDesktop, no — AI runs on your own Anthropic, OpenAI, or OpenRouter key, a local Ollama model, or a keyless CLI agent, and one setting hides every AI surface entirely.",
+    a: "In GitHub Desktop, yes: its commit messages and conflict resolution are Copilot-powered and require Copilot access, even when bringing your own key. In GitDesktop, no. AI runs on your own Anthropic, OpenAI, or OpenRouter key, a local Ollama model, or a keyless CLI agent, and one setting hides every AI surface entirely.",
   },
   {
     q: "What about the GitHub Copilot app?",
-    a: "The GitHub Copilot app is GitHub's second desktop product: an agent-orchestration shell with no manual Git surface — no staging, branching, or diffs you drive yourself, and GitHub-only. GitDesktop does both jobs in one window: a full manual Git client and agent delegation, on any of the three forges.",
+    a: "The GitHub Copilot app is GitHub's second desktop product: an agent-orchestration shell with no manual Git surface (no staging, branching, or diffs you drive yourself), and GitHub-only. GitDesktop does both jobs in one window: a full manual Git client and agent delegation, on any of the three forges.",
   },
 ];
 ---
@@ -276,8 +276,8 @@ const faqs = [
       >
         GitDesktop is a free, open-source GitHub Desktop alternative that keeps
         the same approachable daily loop and adds what GitHub Desktop sends to
-        the browser: the full pull-request loop, CI, and issues — across
-        <span class="text-ink">GitHub, GitLab, and Bitbucket</span> — with AI
+        the browser: the full pull-request loop, CI, and issues, across
+        <span class="text-ink">GitHub, GitLab, and Bitbucket</span>, with AI
         that runs on your own models, or switches off entirely.
       </p>
       <p data-reveal style="transition-delay:180ms" class="mt-5 max-w-[66ch] text-sm text-muted">
@@ -303,7 +303,7 @@ const faqs = [
             <span class="text-ink">Zero prerequisites.</span> GitHub Desktop bundles
             its own Git and signs in with a browser OAuth flow. GitDesktop needs
             system Git, plus <code class="text-ink">gh</code> or
-            <code class="text-ink">glab</code> for forge features — sign-in is
+            <code class="text-ink">glab</code> for forge features. Sign-in is
             guided from inside the app, but it's still a real first-run step.
           </span>
         </li>
@@ -342,7 +342,7 @@ const faqs = [
         Feature by feature
       </h2>
       <p data-reveal class="mt-5 max-w-[66ch] leading-relaxed text-body">
-        Both clients cover the fundamentals — clone, stage by file, hunk, or
+        Both clients cover the fundamentals: clone, stage by file, hunk, or
         line, commit, branch, stash, sync, and resolve conflicts. The table
         keeps to where they diverge.
       </p>
@@ -416,7 +416,7 @@ const faqs = [
         Try the whole loop.
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-5 max-w-[48ch] leading-relaxed text-body">
-        Free and open source. Keep GitHub Desktop installed — nothing here needs
+        Free and open source. Keep GitHub Desktop installed; nothing here needs
         an account, a migration, or a goodbye.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-8 flex flex-wrap items-center justify-center gap-3">

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -242,19 +242,19 @@ const groups: Group[] = [
 const faqs = [
   {
     q: "Is GitDesktop a good Sourcetree alternative?",
-    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for — staging by file, hunk, or line, interactive rebase, stashes, submodule status — and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs (with GitHub and GitLab step logs in-app), and issues, across GitHub, GitLab, and Bitbucket — Bitbucket issues through a linked Jira project. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those — the table above is honest about it.",
+    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for (staging by file, hunk, or line, interactive rebase, stashes, submodule status) and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs (with GitHub and GitLab step logs in-app), and issues, across GitHub, GitLab, and Bitbucket. On Bitbucket, issues go through a linked Jira project. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those. The table above is honest about it.",
   },
   {
     q: "Is there a Sourcetree for Linux?",
-    a: "No. Atlassian ships Sourcetree for Windows and macOS only, and community answers as recent as April 2026 say Linux isn't on the roadmap. GitDesktop ships Windows, macOS, and Linux builds — including an AppImage and a Homebrew cask.",
+    a: "No. Atlassian ships Sourcetree for Windows and macOS only, and community answers as recent as April 2026 say Linux isn't on the roadmap. GitDesktop ships Windows, macOS, and Linux builds, including an AppImage and a Homebrew cask.",
   },
   {
     q: "Do you need an Atlassian account to use Sourcetree?",
-    a: "Yes — Atlassian's own install documentation says an Atlassian account is required to use Sourcetree, regardless of which forge your code lives on. GitDesktop has no vendor account at all: you sign in only to the forges you actually use (GitHub via gh, GitLab via glab, Bitbucket with an API token), and none of it is needed for local-only work.",
+    a: "Yes. Atlassian's own install documentation says an Atlassian account is required to use Sourcetree, regardless of which forge your code lives on. GitDesktop has no vendor account at all: you sign in only to the forges you actually use (GitHub via gh, GitLab via glab, Bitbucket with an API token), and none of it is needed for local-only work.",
   },
   {
     q: "Is Sourcetree still maintained?",
-    a: "Yes, in a steady-patch sense: both apps shipped point releases through mid-2026 (Windows 3.4.31 in June, Mac 4.2.19 in July). But the two platforms run on separate codebases with a long-standing feature gap between them, community threads note it's absent from Atlassian's public product roadmap, and the big asks — worktree support requested since 2015, in-app pull requests since 2017 — remain open. It's stable, not evolving.",
+    a: "Yes, in a steady-patch sense: both apps shipped point releases through mid-2026 (Windows 3.4.31 in June, Mac 4.2.19 in July). But the two platforms run on separate codebases with a long-standing feature gap between them, community threads note it's absent from Atlassian's public product roadmap, and the big asks (worktree support requested since 2015, in-app pull requests since 2017) remain open. It's stable, not evolving.",
   },
 ];
 ---
@@ -284,15 +284,15 @@ const faqs = [
       >
         GitDesktop is a free, open-source Sourcetree alternative that runs on
         <span class="text-ink">Linux as well as Windows and macOS</span>, needs
-        no vendor account, and keeps the pull-request loop — create, review,
-        merge, CI — in the app instead of the browser, across
+        no vendor account, and keeps the pull-request loop (create, review,
+        merge, CI) in the app instead of the browser, across
         <span class="text-ink">GitHub, GitLab, and Bitbucket</span>, with
         issues in-app too (via a linked Jira project on Bitbucket). AI is
         optional: your own models, or hidden entirely.
       </p>
       <p data-reveal style="transition-delay:180ms" class="mt-5 max-w-[66ch] text-sm text-muted">
         Verified against Sourcetree for Windows {ST_WIN_VERSION} and Sourcetree
-        for Mac {ST_MAC_VERSION} — two separate apps on separate release lines —
+        for Mac {ST_MAC_VERSION} (two separate apps on separate release lines)
         on {VERIFIED_ON}. Something stale?
         <a href={`${repo}/issues`} class="text-mint underline-offset-4 hover:underline"
           >Open an issue</a
@@ -315,7 +315,7 @@ const faqs = [
             bundles its own Git (system Git optional). GitDesktop needs system
             Git, plus <code class="text-ink">gh</code> or
             <code class="text-ink">glab</code> for GitHub and GitLab features
-            (Bitbucket needs only an API token) — sign-in is guided from inside
+            (Bitbucket needs only an API token). Sign-in is guided from inside
             the app, but it's still a real first-run step.
           </span>
         </li>
@@ -324,7 +324,7 @@ const faqs = [
           <span>
             <span class="text-ink">Mercurial.</span> Sourcetree is the rare
             mainstream client still shipping Mercurial support, on both
-            platforms, with Hg-flow to match. GitDesktop is Git-only — if your
+            platforms, with Hg-flow to match. GitDesktop is Git-only; if your
             repos are hg, Sourcetree remains the tool.
           </span>
         </li>
@@ -332,7 +332,7 @@ const faqs = [
           <span class="mt-px select-none text-add" aria-hidden="true">+</span>
           <span>
             <span class="text-ink">Git-flow, one menu item.</span> Initialize a
-            repo and the whole branch ceremony — feature, release, hotfix — is
+            repo and the whole branch ceremony (feature, release, hotfix) is
             driven from the UI. GitDesktop has no git-flow support.
           </span>
         </li>
@@ -374,7 +374,7 @@ const faqs = [
         Feature by feature
       </h2>
       <p data-reveal class="mt-5 max-w-[66ch] leading-relaxed text-body">
-        Both clients cover the fundamentals — clone, stage by file, hunk, or
+        Both clients cover the fundamentals: clone, stage by file, hunk, or
         line, commit, branch, stash, sync, and resolve conflicts. The table
         keeps to where they diverge. Where Sourcetree's two apps differ from
         each other, the row says so.
@@ -383,8 +383,8 @@ const faqs = [
       <CompareTable competitor="Sourcetree" groups={groups} />
 
       <p class="mt-6 max-w-[66ch] text-sm leading-relaxed text-muted">
-        Every Sourcetree cell traces to a primary Atlassian source — release
-        notes, support documentation, or its public issue tracker — checked on
+        Every Sourcetree cell traces to a primary Atlassian source (release
+        notes, support documentation, or its public issue tracker), checked on
         the date above. Rows where both clients are simply fine were left out
         on purpose. Also compared:
         <a
@@ -404,10 +404,10 @@ const faqs = [
         </h2>
         <p data-reveal class="mt-5 leading-relaxed text-body">
           Sourcetree's "Create Pull Request" opens a browser tab, and reading,
-          reviewing, or merging one was never added — Atlassian's own answer,
-          given in 2018 and never revisited since: "we don't currently support
-          listing or viewing PRs in Sourcetree." In GitDesktop the whole loop
-          lives next to your staging and history.
+          reviewing, or merging one was never added. Atlassian's own answer has
+          stood since 2018: "we don't currently support listing or viewing PRs
+          in Sourcetree." In GitDesktop the whole loop lives next to your
+          staging and history.
         </p>
       </div>
       <figure data-reveal style="transition-delay:120ms" class="window mt-10">
@@ -453,7 +453,7 @@ const faqs = [
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-5 max-w-[48ch] leading-relaxed text-body">
         Free, open source, and no account to create. Keep Sourcetree right
-        where it is — open one repo in GitDesktop and see which window you
+        where it is. Open one repo in GitDesktop and see which window you
         keep.
       </p>
       <div data-reveal style="transition-delay:140ms" class="mt-8 flex flex-wrap items-center justify-center gap-3">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -277,13 +277,13 @@ const forges = [
         <p class="mt-6 max-w-[60ch] leading-relaxed text-body">
           One click reads your staged diff and drafts the commit message in your
           conventions; the PR dialog gives its title and description the same
-          treatment. It streams into the same fields
+          treatment. Generation streams into the same fields
           you'd type in, so it's always editable and never blocks the manual path.
           Generating a PR description can also propose which of your open issues it
           <span class="text-ink">Closes</span> or relates to, chosen from a grounded
           shortlist so it never invents an issue number. On a Bitbucket repo with a
           linked Jira project, it can propose linked-Jira tickets to mention instead,
-          drawn from the same grounded shortlist.
+          drawn from an equally grounded shortlist of the linked project's tickets.
         </p>
         <p class="mt-4 max-w-[60ch] leading-relaxed text-muted">
           Bring your own model: Anthropic, OpenAI, Google AI Studio, any
@@ -467,8 +467,8 @@ const forges = [
           status, type, priority, assignee, description and comments, plus agile
           fields like story points, sprint, and a clickable epic when the project uses
           them. Create, comment, assign, set a due date, change priority, edit
-          labels, and close or reopen along the project's own workflow, every action
-          gated on your Jira permissions.
+          labels, and close or reopen along the project's own workflow, with every
+          action gated on your Jira permissions.
         </p>
         <p class="mt-4 max-w-[56ch] leading-relaxed text-muted">
           Especially handy for Bitbucket, whose native tracker Atlassian retires on
@@ -720,7 +720,7 @@ const forges = [
         </h2>
         <p class="mt-6 max-w-[56ch] leading-relaxed text-body">
           The reverse direction: run GitDesktop <span class="text-ink">as an MCP
-          server</span> and any external client (Claude Desktop, Cursor, Claude Code)
+          server</span>, and any external client (Claude Desktop, Cursor, Claude Code)
           can understand a repo through read-only git, PR &amp; CI tools, across GitHub,
           GitLab, and Bitbucket. Settings writes the config into your repo's
           <code class="text-ink">.mcp.json</code> or installs it globally.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -73,9 +73,9 @@ const forges = [
 
 <SiteLayout
   title="GitDesktop — Git client for GitHub, GitLab & Bitbucket"
-  description="A free, open-source GitHub Desktop alternative that also works with GitLab and Bitbucket — staging, diffs, pull requests, CI, and issues in one window."
+  description="A free, open-source GitHub Desktop alternative that also works with GitLab and Bitbucket: staging, diffs, pull requests, CI, and issues in one window."
   ogTitle="GitDesktop — the whole Git loop, one window"
-  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues — in one fast window. With AI you control, or hide entirely."
+  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues, in one fast window. With AI you control, or hide entirely."
 >
   <!-- ============================ AI-NATIVE VIEW ======================= -->
   <!-- Hero (AI) -->
@@ -109,8 +109,8 @@ const forges = [
           Everything <a href={`${base}compare/github-desktop/`} class="whitespace-nowrap text-ink underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint">GitHub Desktop</a> does (staging, branches, diffs, history,
           sync), now across <span class="text-ink">GitHub, GitLab &amp; Bitbucket</span>,
           with the full pull-request loop, CI, and issues in one window. Then AI that
-          reads your diff for commits, PR descriptions, and code review — and takes on
-          whole delegated tasks — on your own models, or hidden entirely.
+          drafts commits and PR descriptions from your diff, reviews code, and takes
+          on whole delegated tasks — on your own models, or hidden entirely.
         </p>
         <div
           data-reveal
@@ -195,8 +195,8 @@ const forges = [
           style="transition-delay:120ms"
           class="mt-7 max-w-[58ch] text-base leading-relaxed text-body sm:text-lg"
         >
-          Everything you expect from <a href={`${base}compare/github-desktop/`} class="whitespace-nowrap text-ink underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint">GitHub Desktop</a> — staging, branches, diffs,
-          history, sync — now across <span class="text-ink">GitHub, GitLab &amp;
+          Everything you expect from <a href={`${base}compare/github-desktop/`} class="whitespace-nowrap text-ink underline decoration-line-2 underline-offset-4 transition-colors hover:decoration-mint">GitHub Desktop</a> (staging, branches, diffs,
+          history, sync), now across <span class="text-ink">GitHub, GitLab &amp;
           Bitbucket</span>, with the full pull-request loop, CI, issues, and branch
           protection in one fast window. Built to be trusted with uncommitted
           work. No AI in sight.
@@ -275,13 +275,15 @@ const forges = [
           It writes the commit.<br class="hidden sm:block" /> You keep the keys.
         </h2>
         <p class="mt-6 max-w-[60ch] leading-relaxed text-body">
-          One click reads your staged diff and drafts the commit message — and the PR
-          title and description — in your conventions. It streams into the same fields
+          One click reads your staged diff and drafts the commit message in your
+          conventions; the PR dialog gives its title and description the same
+          treatment. It streams into the same fields
           you'd type in, so it's always editable and never blocks the manual path.
           Generating a PR description can also propose which of your open issues it
           <span class="text-ink">Closes</span> or relates to, chosen from a grounded
-          shortlist so it never invents an issue number — or, on a Bitbucket repo with a
-          linked Jira project, which linked-Jira tickets to mention.
+          shortlist so it never invents an issue number. On a Bitbucket repo with a
+          linked Jira project, it can propose linked-Jira tickets to mention instead,
+          drawn from the same grounded shortlist.
         </p>
         <p class="mt-4 max-w-[60ch] leading-relaxed text-muted">
           Bring your own model: Anthropic, OpenAI, Google AI Studio, any
@@ -308,7 +310,7 @@ const forges = [
         </h2>
         <p class="mt-6 max-w-[56ch] leading-relaxed text-body">
           Delegate a coding task to a <span class="text-ink">Claude, Codex, Copilot,
-          or opencode</span> agent — it works in an isolated worktree, so your own
+          or opencode</span> agent. It works in an isolated worktree, so your own
           checkout is never touched. Follow every file it reads and edits, expand any
           edit to its diff inline, then keep it as a branch, open a local PR from it,
           or discard it.
@@ -371,10 +373,10 @@ const forges = [
           A reviewer that actually reads the code.
         </h2>
         <p class="mt-6 leading-relaxed text-body">
-          Run a general review or a security audit on any pull request — local or on
-          GitHub, GitLab, or Bitbucket. It reads the changed files, flags real issues
+          Run a general review or a security audit on any pull request, whether local
+          or on GitHub, GitLab, or Bitbucket. It reads the changed files, flags real issues
           with a severity, and cites the exact lines. The result stays on your machine
-          unless you choose to post it — and it keeps running while you move between
+          unless you choose to post it. The review keeps running while you move between
           PRs, or even after you close the window, then pings you when it's done.
         </p>
         <p class="mt-4 leading-relaxed text-muted">
@@ -409,7 +411,7 @@ const forges = [
         <p class="mt-6 leading-relaxed text-body">
           One calm client for all three. GitDesktop routes every pull-request and CI
           action through a forge abstraction, so the same panels work whether your
-          remote points at GitHub, GitLab, or Bitbucket — each on its own authenticated
+          remote points at GitHub, GitLab, or Bitbucket, each on its own authenticated
           identity, none borrowing another's. Sign in and reconnect to GitHub and GitLab
           without leaving the app; GitDesktop spots an expired session, badges the
           account, and warns before a token lapses.
@@ -440,7 +442,7 @@ const forges = [
       </p>
       <p data-reveal class="mt-8 max-w-[62ch] text-sm leading-relaxed text-muted">
         GitHub &amp; GitLab go through their CLIs (<code class="text-ink">gh</code>,
-        <code class="text-ink">glab</code>) — including GitHub Enterprise and
+        <code class="text-ink">glab</code>), including GitHub Enterprise and
         self-managed GitLab; Bitbucket Cloud uses an Atlassian API token. A few things
         differ by platform, and we say so where they do.
       </p>
@@ -462,16 +464,16 @@ const forges = [
         <p class="mt-6 max-w-[56ch] leading-relaxed text-body">
           Link a <span class="text-ink">Jira Cloud</span> project to any repository and
           the Issues tab gains a Jira section: browse and filter your issues, read
-          status, type, priority, assignee, description and comments — plus agile
+          status, type, priority, assignee, description and comments, plus agile
           fields like story points, sprint, and a clickable epic when the project uses
           them. Create, comment, assign, set a due date, change priority, edit
-          labels, and close or reopen along the project's own workflow — every action
+          labels, and close or reopen along the project's own workflow, every action
           gated on your Jira permissions.
         </p>
         <p class="mt-4 max-w-[56ch] leading-relaxed text-muted">
           Especially handy for Bitbucket, whose native tracker Atlassian retires on
-          August 20, 2026 —
-          <a href={`${base}bitbucket-issues-sunset/`} class="text-mint underline-offset-4 hover:underline">what that means for your repos →</a>
+          August 20, 2026.
+          <a href={`${base}bitbucket-issues-sunset/`} class="text-mint underline-offset-4 hover:underline">What that means for your repos →</a>
         </p>
         <p class="mt-6 text-sm">
           <a href={`${base}integrations/`} class="text-mint underline-offset-4 hover:underline">More on Jira &amp; forges →</a>
@@ -504,7 +506,7 @@ const forges = [
   <!-- Local PRs (shared) -->
   <FeatureRow
     id="pull-requests"
-    title="Pull requests. Without the browser — or the cloud."
+    title="Pull requests. Without the browser. Or the cloud."
     image={appPrDialog}
     alt="The New local pull request dialog: merge one branch into another and review it locally"
     side="right"
@@ -515,11 +517,11 @@ const forges = [
       Open pull requests on GitHub, GitLab, and Bitbucket, or private
       <span class="text-ink">local PRs</span> that never leave your machine: propose a
       merge, review the diff, and merge with a <code class="text-ink">--no-ff</code>
-      commit — on a repo that isn't on any forge at all.
+      commit, even on a repo that isn't on any forge at all.
     </p>
     <p class="text-muted">
       A local-PR merge pre-shows whether it will conflict, and if it does you resolve
-      it in an isolated worktree that never touches your branch — then Finish or Abort.
+      it in an isolated worktree that never touches your branch, then Finish or Abort.
       Promote a local PR to a real GitHub PR, comments and all, in one click.
     </p>
   </FeatureRow>
@@ -534,7 +536,7 @@ const forges = [
     surface={true}
   >
     <p>
-      GitHub&nbsp;Actions, in the app — browse runs for the current branch, drill into
+      GitHub&nbsp;Actions, in the app: browse runs for the current branch, drill into
       jobs and steps, dispatch a workflow, and re-run or cancel. A PR's checks collapse
       into a pass/fail/pending/skipped rollup that shows a running check's current step
       live and peeks a failing job's log inline.
@@ -600,7 +602,7 @@ const forges = [
         <div data-reveal class="min-w-0">
           <h3 class="text-xl text-ink">Stage exactly what you mean.</h3>
           <p class="mt-4 max-w-[52ch] leading-relaxed text-body">
-            Stage — or discard — by file, by hunk, or by dragging across individual
+            Stage or discard by file, by hunk, or by dragging across individual
             lines, even within a brand-new file, to split a messy working tree into
             clean, reviewable commits, with partial patches applied via git's own
             <code class="text-ink">--cached</code>.
@@ -632,7 +634,7 @@ const forges = [
           <h3 class="text-xl text-ink">Read the whole story.</h3>
           <p class="mt-4 max-w-[52ch] leading-relaxed text-body">
             Browse history, search every commit, and blame any line back to the change
-            that introduced it — then cherry-pick, squash, reorder, or stash, without
+            that introduced it, then cherry-pick, squash, reorder, or stash, without
             leaving the keyboard.
           </p>
         </div>
@@ -650,12 +652,12 @@ const forges = [
     surface={true}
   >
     <p>
-      Compare any branch against another — ahead/behind counts, a three-dot diff, the
+      Compare any branch against another: ahead/behind counts, a three-dot diff, the
       full list of changed files, and every commit that isn't on the base yet.
     </p>
     <p class="text-muted">
-      Merging shows an advanced tooling panel that predicts the result in memory —
-      fast-forward, already up to date, clean, or which files will conflict — before
+      Merging shows an advanced tooling panel that predicts the result in memory
+      (fast-forward, already up to date, clean, or which files will conflict) before
       you commit to it.
     </p>
   </FeatureRow>
@@ -690,7 +692,7 @@ const forges = [
         <div class="min-w-0">
           <h3 class="text-ink">An operation journal.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
-            Risky compound ops — merges, cherry-picks, rebases, history edits — are
+            Risky compound ops (merges, cherry-picks, rebases, history edits) are
             recorded, so an interrupted one surfaces a calm recovery notice with the
             exact state it started from.
           </p>
@@ -718,13 +720,13 @@ const forges = [
         </h2>
         <p class="mt-6 max-w-[56ch] leading-relaxed text-body">
           The reverse direction: run GitDesktop <span class="text-ink">as an MCP
-          server</span> and any external client — Claude Desktop, Cursor, Claude Code —
+          server</span> and any external client (Claude Desktop, Cursor, Claude Code)
           can understand a repo through read-only git, PR &amp; CI tools, across GitHub,
           GitLab, and Bitbucket. Settings writes the config into your repo's
           <code class="text-ink">.mcp.json</code> or installs it globally.
         </p>
         <p class="mt-4 max-w-[56ch] leading-relaxed text-muted">
-          Writes are an escalating opt-in ladder — each tier a separate flag, off by
+          Writes are an escalating opt-in ladder: each tier a separate flag, off by
           default, so read-only stays the default.
         </p>
         <p class="mt-6 text-sm">
@@ -776,7 +778,7 @@ const forges = [
       attach the cross-platform binaries.
     </p>
     <p class="text-muted">
-      Lightweight tags for a quick checkpoint; full releases when you ship — push, edit,
+      Lightweight tags for a quick checkpoint; full releases when you ship. Push, edit,
       delete, or download any asset, in the app.
     </p>
   </FeatureRow>
@@ -825,7 +827,7 @@ const forges = [
       </h2>
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
         Free, open source, and local. Fast enough to live in, careful enough to trust
-        with your work — discards are recoverable and pushes use
+        with your work: discards are recoverable and pushes use
         <code class="text-ink">--force-with-lease</code>.
       </p>
       <div

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -75,7 +75,7 @@ const forges = [
   title="GitDesktop — Git client for GitHub, GitLab & Bitbucket"
   description="A free, open-source GitHub Desktop alternative that also works with GitLab and Bitbucket: staging, diffs, pull requests, CI, and issues in one window."
   ogTitle="GitDesktop — the whole Git loop, one window"
-  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues, in one fast window. With AI you control, or hide entirely."
+  ogDescription="GitHub Desktop fundamentals across GitHub, GitLab & Bitbucket, plus the full pull-request loop, code review, CI, and issues in one fast window. With AI you control, or hide entirely."
 >
   <!-- ============================ AI-NATIVE VIEW ======================= -->
   <!-- Hero (AI) -->

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -277,8 +277,8 @@ const forges = [
         <p class="mt-6 max-w-[60ch] leading-relaxed text-body">
           One click reads your staged diff and drafts the commit message in your
           conventions; the PR dialog gives its title and description the same
-          treatment. Generation streams into the same fields
-          you'd type in, so it's always editable and never blocks the manual path.
+          treatment. Generation streams into the same fields you'd type in, so
+          it's always editable and never blocks the manual path.
           Generating a PR description can also propose which of your open issues it
           <span class="text-ink">Closes</span> or relates to, chosen from a grounded
           shortlist so it never invents an issue number. On a Bitbucket repo with a
@@ -373,11 +373,12 @@ const forges = [
           A reviewer that actually reads the code.
         </h2>
         <p class="mt-6 leading-relaxed text-body">
-          Run a general review or a security audit on any pull request, whether local
-          or on GitHub, GitLab, or Bitbucket. It reads the changed files, flags real issues
-          with a severity, and cites the exact lines. The result stays on your machine
-          unless you choose to post it. The review keeps running while you move between
-          PRs, or even after you close the window, then pings you when it's done.
+          Run a general review or a security audit on any pull request, whether
+          local or on GitHub, GitLab, or Bitbucket. It reads the changed files,
+          flags real issues with a severity, and cites the exact lines. The result
+          stays on your machine unless you choose to post it. The review keeps
+          running while you move between PRs, or even after you close the window,
+          then pings you when it's done.
         </p>
         <p class="mt-4 leading-relaxed text-muted">
           Turn on <span class="text-ink">Agentic review</span> and the reviewer pulls

--- a/site/src/pages/integrations.astro
+++ b/site/src/pages/integrations.astro
@@ -31,9 +31,9 @@ const forges = [
     forge: "gitlab",
     name: "GitLab",
     via: "via the GitLab CLI (glab)",
-    lead: "gitlab.com or self-managed — GitDesktop recognizes any host glab is signed in to. Browse and clone your projects, then read and act on merge requests, issues, pipelines, and releases in the same panels.",
+    lead: "gitlab.com or self-managed: GitDesktop recognizes any host glab is signed in to. Browse and clone your projects, then read and act on merge requests, issues, pipelines, and releases in the same panels.",
     features: [
-      "Merge requests — comment (edit/delete your own), close/reopen, edit title & description, react, edit labels & assignees, approve/unapprove, request changes, and merge (merge/squash) — including auto-merge when the pipeline succeeds",
+      "Merge requests — comment (edit/delete your own), close/reopen, edit title & description, react, edit labels & assignees, approve/unapprove, request changes, and merge (merge/squash), including auto-merge when the pipeline succeeds",
       "Issues — create, comment, close/reopen, labels, assignees, milestone, due date, confidential, time tracking (estimate + spent), and linked related issues; lock, move, or delete",
       "Pipelines — retry / cancel / run with CI/CD variables, and play a manual job",
       "Releases — publish, edit, delete, with asset uploads; star a project and publish a local repo to GitLab",
@@ -55,7 +55,7 @@ const forges = [
       "Pipelines — rerun, trigger (pick a custom pipeline, with variables), and stop; publish a local repo to Bitbucket",
       "Repo settings — General, default reviewers, branch restrictions, pipeline variables & schedules, deployment environments, webhooks, and a Danger zone",
     ],
-    note: "Build statuses link out (name, state, URL — no fetchable logs). Reopening a declined PR isn't available (a Bitbucket platform limit), and Bitbucket has no native issue tracker — link a Jira project instead (below).",
+    note: "Build statuses link out with name, state, and URL; logs aren't fetchable. Reopening a declined PR isn't available (a Bitbucket platform limit), and Bitbucket has no native issue tracker. Link a Jira project instead (below).",
     image: appBitbucket,
     alt: "A Bitbucket pull request in GitDesktop: a Tasks checklist, an approval, review comments, and the merge action",
   },
@@ -63,10 +63,10 @@ const forges = [
 
 const jiraFeatures = [
   "Browse and filter issues (open / closed / all), and read status, type, priority, assignee, labels, a Markdown description, and comments",
-  "Agile fields when the project uses them — story points, sprint, a clickable epic / parent, components, and fix versions — discovered automatically per site",
+  "Agile fields when the project uses them (story points, sprint, a clickable epic / parent, components, and fix versions), discovered automatically per site",
   "Create, comment in Markdown, assign, set a due date, change priority, edit labels, and close/reopen along the project's own workflow",
   "Time tracking, when the project has it on — log work with Jira's duration grammar (2d 4h 30m), set the original and remaining estimates, and edit or delete your own worklog entries",
-  "Edit or delete your own comments — and every action is gated on your Jira permissions, so what you can't do simply doesn't appear",
+  "Edit or delete your own comments, with every action gated on your Jira permissions, so what you can't do simply doesn't appear",
   "Issue keys in your branch, commits, and PR titles are linked back to the Issues tab; a local issue can be promoted to Jira",
 ];
 ---
@@ -74,7 +74,7 @@ const jiraFeatures = [
 <SiteLayout
   active="integrations"
   title="Integrations — GitHub, GitLab, Bitbucket & Jira | GitDesktop"
-  description="GitDesktop works with GitHub, GitLab, and Bitbucket — the full PR loop, CI, issues, and releases — plus linked Jira Cloud issues, each on its own identity."
+  description="GitDesktop works with GitHub, GitLab, and Bitbucket: the full PR loop, CI, issues, and releases, plus linked Jira Cloud issues, each on its own identity."
   breadcrumbs={[{ name: "Integrations", path: "/integrations/" }]}
   ogTitle="GitDesktop integrations — GitHub, GitLab, Bitbucket & Jira"
   ogDescription="One calm client across GitHub, GitLab, and Bitbucket, with linked Jira Cloud issues. The full loop for each, with the honest per-platform differences."
@@ -90,7 +90,7 @@ const jiraFeatures = [
         GitDesktop routes every pull-request and CI action through a forge
         abstraction, so the same panels work whether your remote points at
         <span class="text-ink">GitHub</span>, <span class="text-ink">GitLab</span>, or
-        <span class="text-ink">Bitbucket</span> — each on its own authenticated identity,
+        <span class="text-ink">Bitbucket</span>, each on its own authenticated identity,
         none borrowing another's. Issues are GitHub- and GitLab-native; on Bitbucket, link
         a <span class="text-ink">Jira Cloud</span> project for the tracker layer instead.
       </p>
@@ -134,7 +134,7 @@ const jiraFeatures = [
               ))}
             </ul>
             <p class="mt-6 border-t border-line pt-5 text-sm leading-relaxed text-muted">
-              <span class="text-ink">Good to know — </span>{f.note}
+              <span class="text-ink">Good to know: </span>{f.note}
             </p>
           </div>
           </div>
@@ -165,14 +165,14 @@ const jiraFeatures = [
         </div>
         <p class="mt-2 text-sm text-faint">with an Atlassian API token</p>
         <p class="mt-6 max-w-[46ch] leading-relaxed text-body">
-          Link a Jira Cloud site and project to any repository — from the repo menu or
-          the command palette — and its Issues tab gains a Jira section. Connect with an
+          Link a Jira Cloud site and project to any repository (from the repo menu or
+          the command palette) and its Issues tab gains a Jira section. Connect with an
           Atlassian API token, or reuse an existing Bitbucket credential.
         </p>
         <p class="mt-4 max-w-[46ch] text-sm leading-relaxed text-muted">
           Especially handy for Bitbucket, whose native tracker Atlassian retires on
-          August 20, 2026 —
-          <a href={`${base}bitbucket-issues-sunset/`} class="text-mint underline-offset-4 hover:underline">what that means for your repos →</a>
+          August 20, 2026.
+          <a href={`${base}bitbucket-issues-sunset/`} class="text-mint underline-offset-4 hover:underline">What that means for your repos →</a>
         </p>
       </div>
       <div data-reveal style="transition-delay:80ms" class="min-w-0">
@@ -187,7 +187,7 @@ const jiraFeatures = [
           }
         </ul>
         <p data-view="ai" class="mt-6 border-t border-line pt-5 text-sm leading-relaxed text-muted">
-          <span class="text-ink">And for agents — </span>a connected MCP client gets
+          <span class="text-ink">And for agents: </span>a connected MCP client gets
           <code class="text-ink">jira_*</code> tools to list and read the linked project,
           and (behind the remote-write opt-in) comment, create, assign, log work, and
           update issues, including their estimates.

--- a/site/src/pages/privacy.md
+++ b/site/src/pages/privacy.md
@@ -37,7 +37,7 @@ When usage analytics is enabled (see Your choices and rights), we collect:
   (used for coarse, country-level context and abuse prevention) and the app
   version.
 
-When **session recording** is enabled (off by default — opt-in), we additionally
+When **session recording** is enabled (off by default, opt-in), we additionally
 collect a recording of your interactions in which **all text is masked** and the
 diff viewer, file content, blame view, AI review output, and text editors are
 **fully blocked** (recorded as blank regions). Recordings are designed so they
@@ -63,13 +63,13 @@ region under a Data Processing Agreement.
 Some features connect directly to services you choose. These receive data under
 their own privacy policies, not ours:
 
-- **GitHub.** All GitHub features — pull requests, issues, Actions, releases, and
-  so on — run through the GitHub CLI (`gh`) using your own GitHub authentication;
+- **GitHub.** All GitHub features (pull requests, issues, Actions, releases, and
+  so on) run through the GitHub CLI (`gh`) using your own GitHub authentication;
   the corresponding API requests, and your IP address, reach GitHub. Update
   checks and downloads are fetched from GitHub Releases.
 - **AI providers (only if you enable AI features).** When you use an AI feature,
-  GitDesktop sends the context needed for that action — for example a diff or an
-  issue's text — to the AI provider you have configured (such as Anthropic,
+  GitDesktop sends the context needed for that action, for example a diff or an
+  issue's text, to the AI provider you have configured (such as Anthropic,
   OpenAI, or OpenRouter). With a local **Ollama** model or the local **Claude
   Code / Codex CLI** agents, this stays on your machine. We never receive or
   store this content; it is governed by your chosen provider's terms.
@@ -87,7 +87,7 @@ advertising or cross-site tracking.
      2026-07-25: zero references to static.cloudflareinsights.com in the
      served apex HTML, browser UA included. -->
 
-- **Traffic measurement.** The site uses **Cloudflare Web Analytics** —
+- **Traffic measurement.** The site uses **Cloudflare Web Analytics**:
   cookie-free, aggregate measurement (page views and referrers, derived at
   Cloudflare's edge), with no client-side state and no cross-site profiles.
   It is processed by Cloudflare under
@@ -97,10 +97,10 @@ advertising or cross-site tracking.
   pages.
 - **Release lookups.** The homepage and download page ask GitHub's public API
   for the latest release, from your browser, so the version badge and download
-  buttons stay current — that request (and your IP) goes to GitHub, and the
+  buttons stay current; that request (and your IP) goes to GitHub, and the
   installers themselves download from GitHub Releases.
 
-Fonts and every other asset are served from gitdesktop.app itself — there are no
+Fonts and every other asset are served from gitdesktop.app itself; there are no
 other third-party scripts or embeds.
 
 ## Retention

--- a/site/src/pages/terms.md
+++ b/site/src/pages/terms.md
@@ -16,7 +16,7 @@ not legal advice.
 ## The software license
 
 GitDesktop is open-source software licensed under the **Apache License 2.0**.
-That license — not this page — governs your rights to use, copy, modify, and
+That license, not this page, governs your rights to use, copy, modify, and
 distribute the software, and it controls in any conflict with these terms. A copy
 ships with the app and is in the [project repository](https://github.com/theBGuy/GitDesktop).
 
@@ -30,7 +30,7 @@ against your repositories, so **keep backups of important work.**
 ## Limitation of liability
 
 To the fullest extent permitted by law, the authors and contributors are **not
-liable** for any damages — including lost data, lost commits, or lost profits —
+liable** for any damages (including lost data, lost commits, or lost profits)
 arising from your use of GitDesktop, even if advised of the possibility.
 
 ## Third-party services


### PR DESCRIPTION
The marketing and legal pages leaned hard on paired em-dash interrupters, which reads as an AI tell in prose shipped under the project's own byline. This sweep recasts those interrupters as colons, semicolons, parentheses, or separate sentences across the whole site. It is editorial only: no claims, capabilities, layout, or component structure change, and since nothing under `src/` or `src-tauri/` is touched, no changelog fragment applies. A few em-dashes are kept deliberately where the contrast is the point (for example `— on your own models, or hidden entirely` in `index.astro` and the closing clause of `canonicalSentence`).

### Home page
- Rewrites the AI hero paragraph in `site/src/pages/index.astro` so the commit/PR/review claims read as a list rather than a dashed aside, and parenthesizes `(staging, branches, diffs, history, sync)` in the Just Git hero.
- Splits the commit-generation paragraph into distinct claims: the commit message in your conventions, the PR dialog getting "the same treatment", and the grounded Jira shortlist as its own sentence.
- Recasts the AI review, agent-delegation, forge-abstraction, Jira, operation-journal, and MCP sections, plus the `FeatureRow` bodies for local PRs, CI, branch compare, and releases, and the closing CTA.
- Retitles the local-PR `FeatureRow` to `Pull requests. Without the browser. Or the cloud.` and sentence-cases the Bitbucket-sunset link to `What that means for your repos →` now that it follows a full stop.
- Updates the page `description` and `ogDescription` passed to `SiteLayout`.

### AI page
- Reworks the hero, commit-drafting, and reviewer paragraphs in `site/src/pages/ai.astro`, including "whether local or on GitHub, GitLab, or Bitbucket".
- Recasts the bot-attribution and automations cards, the coding-agents lead, the MCP-server section (external clients, generation recipes, and the write-ladder intro), the LAN/models paragraph, and the custom-instructions card.

### Comparison pages
- Rewrites all four FAQ answers in `site/src/pages/compare/github-desktop.astro` (these feed the FAQ entries), plus the hero, the "Zero prerequisites" bullet, the "Feature by feature" lead, and the closing CTA.
- Rewrites all four FAQ answers in `site/src/pages/compare/sourcetree.astro`, splitting the long Sourcetree-alternative answer into separate sentences for the Bitbucket/Jira and Mercurial caveats.
- Recasts the sourcetree hero and the `ST_WIN_VERSION`/`ST_MAC_VERSION` verification note, the prerequisites/Mercurial/git-flow bullets, the source-provenance footnote under `CompareTable`, the pull-request section (the 2018 Atlassian quote now stands as its own sentence), and the closing CTA.

### Integrations and Bitbucket sunset
- Updates the GitLab `lead` and merge-request feature string, the Bitbucket `note` (build statuses/logs and the tracker caveat), and two `jiraFeatures` entries in `site/src/pages/integrations.astro`, along with the page `description`, the forge-abstraction intro, and the Jira linking paragraph.
- Changes the inline labels there from dashed to colon form: `Good to know: ` and `And for agents: `.
- Recasts the `options` details, `jiraPoints`, the "tracker inside your Git client" paragraph, and the CTA in `site/src/pages/bitbucket-issues-sunset.astro`.

### Legal pages and shared copy
- Rewrites the session-recording, GitHub, AI-provider, Cloudflare Web Analytics, release-lookup, and font-hosting passages in `site/src/pages/privacy.md`.
- Rewrites the Apache-2.0 and limitation-of-liability paragraphs in `site/src/pages/terms.md`.
- Reworks `canonicalSentence` in `site/src/lib/brand.ts`, the shared one-sentence description reused across page metadata.