### PR TITLE
fix(git,gitlab): harden push refspecs and keep glab secrets off argv

### DIFF
--- a/changelog.d/fixed-gitlab-secret-stdin.md
+++ b/changelog.d/fixed-gitlab-secret-stdin.md
@@ -1,0 +1,3 @@
+- GitLab CI/CD variable values — including variables passed when running a
+  pipeline manually — and webhook secret tokens now reach glab over stdin instead
+  of the command line, keeping them out of the system process table.

--- a/changelog.d/fixed-push-refspec-validation.md
+++ b/changelog.d/fixed-push-refspec-validation.md
@@ -1,0 +1,3 @@
+- Pushes GitDesktop makes on your behalf (PR/MR creation, repository publish, tag
+  push) now validate the branch or tag name up front and only ever touch that
+  exact ref on the remote.

--- a/changelog.d/fixed-push-refspec-validation.md
+++ b/changelog.d/fixed-push-refspec-validation.md
@@ -1,3 +1,4 @@
 - Pushes GitDesktop makes on your behalf (PR/MR creation, repository publish, tag
   push) now validate the branch or tag name up front and only ever touch that
-  exact ref on the remote.
+  exact ref on the remote, and the same tag rules guard creating, editing, and
+  deleting releases on GitHub and GitLab.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -2907,9 +2907,10 @@ pub async fn create_pr(
     reviewers: &[String],
 ) -> AppResult<PrRef> {
     for b in [base, head] {
-        if b.is_empty() || b.starts_with('-') {
-            return Err(AppError::InvalidArgument(format!("invalid branch: {b}")));
-        }
+        // The shared ref validator (empty / leading `-` / refspec metacharacters);
+        // remapped so this surface keeps its own wording.
+        crate::git::branches::validate_ref_name(b)
+            .map_err(|_| AppError::InvalidArgument(format!("invalid branch: {b}")))?;
     }
     let title = title.trim();
     if title.is_empty() {
@@ -2930,8 +2931,9 @@ pub async fn create_pr(
     // the same `credential_config_for_remote` funnel every other network op uses; an
     // unconfigured user (or an SSH origin) gets no entries — fail-open.
     let cred = crate::forge::credential_config_for_remote(repo_path, "origin").await?;
+    let spec = crate::git::remote::publish_refspec(head);
     let push_args =
-        crate::git::remote::with_credentials(&cred, &["push", "-u", "origin", head]);
+        crate::git::remote::with_credentials(&cred, &["push", "-u", "origin", &spec]);
     let push_refs: Vec<&str> = push_args.iter().map(String::as_str).collect();
     crate::git::runner::run_git_mutating(
         state,
@@ -4947,6 +4949,10 @@ pub async fn publish_repo(
             "check out a branch before publishing (detached HEAD)".into(),
         ));
     }
+    // The branch rides the publish push's refspec — validate it here, still
+    // before the create POST.
+    crate::git::branches::validate_ref_name(&branch)
+        .map_err(|_| AppError::InvalidArgument(format!("invalid branch name: {branch}")))?;
 
     // Origin must not already exist (an externally-added origin would strand an
     // orphaned repo when the post-create `remote add` fails).
@@ -5009,10 +5015,11 @@ pub async fn publish_repo(
         return Err(AppError::Bitbucket(format!("{created_hint}adding the 'origin' remote failed: {e}")));
     }
 
+    let spec = crate::git::remote::publish_refspec(&branch);
     if let Err(e) = crate::git::runner::run_git_mutating(
         state,
         repo_path,
-        &["-c", "credential.interactive=false", "push", "-u", "origin", &branch],
+        &["-c", "credential.interactive=false", "push", "-u", "origin", &spec],
         crate::git::runner::NETWORK_TIMEOUT,
     )
     .await

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -4951,8 +4951,7 @@ pub async fn publish_repo(
     }
     // The branch rides the publish push's refspec — validate it here, still
     // before the create POST.
-    crate::git::branches::validate_ref_name(&branch)
-        .map_err(|_| AppError::InvalidArgument(format!("invalid branch name: {branch}")))?;
+    crate::git::branches::validate_ref_name(&branch)?;
 
     // Origin must not already exist (an externally-added origin would strand an
     // orphaned repo when the post-create `remote add` fails).

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -215,6 +215,23 @@ pub(crate) fn encode_project(path: &str) -> String {
 /// the Bitbucket provider, hence it lives in the parent `forge` module.
 use crate::forge::encode_query_value;
 
+/// `glab api` args that send a JSON body over stdin — the form every request
+/// carrying a secret uses, so the value never reaches argv. glab forwards an
+/// `--input` body raw without a content type, and GitLab 415s on that, so the
+/// header is ours to set.
+fn json_body_args<'a>(method: &'a str, endpoint: &'a str) -> [&'a str; 8] {
+    [
+        "api",
+        "--method",
+        method,
+        endpoint,
+        "--input",
+        "-",
+        "--header",
+        "Content-Type: application/json",
+    ]
+}
+
 /// The project's full path (`group/name`) from the repo's origin remote.
 pub(crate) async fn project_path(repo_path: &str) -> AppResult<String> {
     let url =
@@ -1848,16 +1865,7 @@ pub async fn commit_comment_create(
             let payload = serde_json::json!({ "body": body, "position": position });
             run_glab_ex(
                 Some(repo_path),
-                &[
-                    "api",
-                    "--method",
-                    "POST",
-                    &endpoint,
-                    "--input",
-                    "-",
-                    "--header",
-                    "Content-Type: application/json",
-                ],
+                &json_body_args("POST", &endpoint),
                 Some(&payload.to_string()),
                 &[],
                 GLAB_NETWORK_TIMEOUT,
@@ -4145,16 +4153,7 @@ pub async fn thread_create(
     let endpoint = format!("projects/{enc}/merge_requests/{number}/discussions");
     run_glab_ex(
         Some(repo_path),
-        &[
-            "api",
-            "--method",
-            "POST",
-            &endpoint,
-            "--input",
-            "-",
-            "--header",
-            "Content-Type: application/json",
-        ],
+        &json_body_args("POST", &endpoint),
         Some(&payload.to_string()),
         &[],
         GLAB_NETWORK_TIMEOUT,
@@ -4249,16 +4248,7 @@ pub async fn review_submit(
         let payload = serde_json::json!({ "note": c.body, "position": position });
         if let Err(e) = run_glab_ex(
             Some(repo_path),
-            &[
-                "api",
-                "--method",
-                "POST",
-                &draft_endpoint,
-                "--input",
-                "-",
-                "--header",
-                "Content-Type: application/json",
-            ],
+            &json_body_args("POST", &draft_endpoint),
             Some(&payload.to_string()),
             &[],
             GLAB_NETWORK_TIMEOUT,
@@ -4917,6 +4907,10 @@ pub async fn publish_repo(
             "check out a branch before publishing (detached HEAD)".into(),
         ));
     }
+    // The branch rides the publish push's refspec — validate it here, still
+    // before the create.
+    crate::git::branches::validate_ref_name(&branch)
+        .map_err(|_| AppError::InvalidArgument(format!("invalid branch name: {branch}")))?;
     // An origin remote may have appeared since the UI's (cached) no-origin
     // check — adding one externally then publishing would otherwise strand an
     // orphaned project when the post-create `remote add` fails.
@@ -4994,7 +4988,8 @@ pub async fn publish_repo(
         push_args.push("-c");
         push_args.push(entry);
     }
-    push_args.extend(["push", "-u", "origin", &branch]);
+    let spec = crate::git::remote::publish_refspec(&branch);
+    push_args.extend(["push", "-u", "origin", &spec]);
     crate::git::runner::run_git_mutating(
         state,
         repo_path,
@@ -5101,9 +5096,10 @@ pub async fn create_mr(
     assignees: &[String],
 ) -> AppResult<PrRef> {
     for b in [base, head] {
-        if b.is_empty() || b.starts_with('-') {
-            return Err(AppError::InvalidArgument(format!("invalid branch: {b}")));
-        }
+        // The shared ref validator (empty / leading `-` / refspec metacharacters);
+        // remapped so this surface keeps its own wording.
+        crate::git::branches::validate_ref_name(b)
+            .map_err(|_| AppError::InvalidArgument(format!("invalid branch: {b}")))?;
     }
     let title = title.trim();
     if title.is_empty() {
@@ -5127,7 +5123,8 @@ pub async fn create_mr(
         push_args.push("-c");
         push_args.push(entry);
     }
-    push_args.extend(["push", "-u", "origin", head]);
+    let spec = crate::git::remote::publish_refspec(head);
+    push_args.extend(["push", "-u", "origin", &spec]);
     crate::git::runner::run_git_mutating(
         state,
         repo_path,
@@ -5647,29 +5644,17 @@ pub async fn play_job(repo_path: &str, job_id: u64) -> AppResult<()> {
     Ok(())
 }
 
-/// A CI/CD variable key must be a valid env-var name. The `key:value` token
-/// `glab ci run --variables-env` takes splits on the FIRST colon, so anything
-/// beyond `[A-Za-z_][A-Za-z0-9_]*` (a colon especially) would corrupt the value.
+/// A CI/CD variable key must be a valid env-var name — it becomes an
+/// environment variable in the pipeline's jobs: `[A-Za-z_][A-Za-z0-9_]*`.
 fn valid_variable_key(k: &str) -> bool {
     !k.is_empty()
         && !k.starts_with(|c: char| c.is_ascii_digit())
         && k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// One `--variables` token: glab reads the flag's value through a CSV reader
-/// (pflag StringSlice), so a bare comma in a VALUE would split it into bogus
-/// extra `key:value` entries — silently corrupting the variables. A fully
-/// CSV-quoted field (embedded quotes doubled) passes commas and quotes through
-/// intact (validated live: `"REGIONS:a,b"` → one variable `a,b`).
-fn variable_token(key: &str, value: &str) -> String {
-    format!("\"{key}:{}\"", value.replace('"', "\"\""))
-}
-
 /// Manually run a new pipeline on a ref — GitLab's analogue of a workflow
-/// dispatch. `variables` become CI/CD env variables via `glab ci run`'s
-/// `--variables key:value` tokens, CSV-quoted (see [`variable_token`]) — the
-/// REST `variables[]` array form doesn't survive glab's `-f` field encoding, so
-/// the purpose-built subcommand is the safe path.
+/// dispatch. `variables` POST as the REST `variables[]` array over stdin, so a
+/// value a user typed never reaches argv (nor any flag-encoding rules).
 pub async fn run_pipeline(
     repo_path: &str,
     git_ref: &str,
@@ -5678,18 +5663,26 @@ pub async fn run_pipeline(
     if git_ref.is_empty() || git_ref.starts_with('-') {
         return Err(AppError::InvalidArgument(format!("invalid ref: {git_ref}")));
     }
-    let mut args: Vec<String> = vec!["ci".into(), "run".into(), "-b".into(), git_ref.into()];
+    let mut vars = Vec::with_capacity(variables.len());
     for (k, v) in variables {
         if !valid_variable_key(k) {
             return Err(AppError::InvalidArgument(format!(
                 "invalid variable name: {k} (letters, digits and _ only)"
             )));
         }
-        args.push("--variables".into());
-        args.push(variable_token(k, v));
+        vars.push(serde_json::json!({ "key": k, "value": v }));
     }
-    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    run_glab(Some(repo_path), &arg_refs, GLAB_NETWORK_TIMEOUT).await?;
+    let enc = encode_project(&project_path(repo_path).await?);
+    let endpoint = format!("projects/{enc}/pipeline");
+    let body = serde_json::json!({ "ref": git_ref, "variables": vars });
+    run_glab_ex(
+        Some(repo_path),
+        &json_body_args("POST", &endpoint),
+        Some(&body.to_string()),
+        &[],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -5855,6 +5848,7 @@ pub async fn view_release(repo_path: &str, tag: &str) -> AppResult<ReleaseDetail
     if tag.is_empty() {
         return Err(AppError::InvalidArgument("a tag is required".into()));
     }
+    crate::git::ops::validate_tag_name(tag)?;
     let enc = encode_project(&project_path(repo_path).await?);
     // The tag is a single path segment — percent-encode it so a `/` in a tag like
     // `release/1.0` (or any query-significant byte) can't break the endpoint path.
@@ -5881,9 +5875,7 @@ pub async fn create_release(
     notes: &str,
     target: &str,
 ) -> AppResult<String> {
-    if tag.is_empty() || tag.starts_with('-') {
-        return Err(AppError::InvalidArgument(format!("invalid tag: {tag}")));
-    }
+    crate::git::ops::validate_tag_name(tag)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let endpoint = format!("projects/{enc}/releases");
     let mut args: Vec<String> = vec![
@@ -5920,6 +5912,7 @@ pub async fn edit_release(repo_path: &str, tag: &str, title: &str, notes: &str) 
     if tag.is_empty() {
         return Err(AppError::InvalidArgument("a tag is required".into()));
     }
+    crate::git::ops::validate_tag_name(tag)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let enc_tag = encode_query_value(tag);
     let endpoint = format!("projects/{enc}/releases/{enc_tag}");
@@ -5946,6 +5939,7 @@ pub async fn delete_release(repo_path: &str, tag: &str, cleanup_tag: bool) -> Ap
     if tag.is_empty() {
         return Err(AppError::InvalidArgument("a tag is required".into()));
     }
+    crate::git::ops::validate_tag_name(tag)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let enc_tag = encode_query_value(tag);
     let endpoint = format!("projects/{enc}/releases/{enc_tag}");
@@ -5973,9 +5967,7 @@ pub async fn delete_release(repo_path: &str, tag: &str, cleanup_tag: bool) -> Ap
 /// (`file#name#type`), so a `#`-bearing path can't be passed unambiguously — reject
 /// it rather than upload under a mangled name.
 pub async fn upload_release_asset(repo_path: &str, tag: &str, file_path: &str) -> AppResult<()> {
-    if tag.is_empty() || tag.starts_with('-') {
-        return Err(AppError::InvalidArgument(format!("invalid tag: {tag}")));
-    }
+    crate::git::ops::validate_tag_name(tag)?;
     if file_path.is_empty() || file_path.starts_with('-') {
         return Err(AppError::InvalidArgument("a file is required".into()));
     }
@@ -6007,6 +5999,7 @@ pub async fn delete_release_asset(repo_path: &str, tag: &str, asset_name: &str) 
     if tag.is_empty() {
         return Err(AppError::InvalidArgument("a tag is required".into()));
     }
+    crate::git::ops::validate_tag_name(tag)?;
     if asset_name.is_empty() {
         return Err(AppError::InvalidArgument(
             "an asset name is required".into(),
@@ -6785,9 +6778,11 @@ pub struct GitLabHookInput {
     pub events: Vec<String>,
 }
 
-/// The `-f` args shared by hook create/update: url + SSL + every known event
-/// flag set explicitly true/false (so unchecking sticks on update).
-fn hook_args(input: &GitLabHookInput) -> AppResult<Vec<String>> {
+/// The JSON body shared by hook create/update: url + SSL + every known event
+/// flag set explicitly true/false (so unchecking sticks on update). It rides
+/// stdin, so the secret token never reaches argv — an omitted `token` key
+/// leaves the stored secret untouched.
+fn hook_body(input: &GitLabHookInput) -> AppResult<serde_json::Value> {
     let url = input.url.trim();
     if !(url.starts_with("https://") || url.starts_with("http://")) {
         return Err(AppError::InvalidArgument(
@@ -6806,32 +6801,35 @@ fn hook_args(input: &GitLabHookInput) -> AppResult<Vec<String>> {
             "select at least one event".into(),
         ));
     }
-    let mut args = vec![format!("url={url}")];
+    let mut body = serde_json::Map::new();
+    body.insert("url".to_string(), url.into());
     for e in HOOK_EVENTS {
-        args.push(format!("{e}={}", input.events.iter().any(|x| x == e)));
+        body.insert(e.to_string(), input.events.iter().any(|x| x == e).into());
     }
-    args.push(format!(
-        "enable_ssl_verification={}",
-        input.enable_ssl_verification
-    ));
+    body.insert(
+        "enable_ssl_verification".to_string(),
+        input.enable_ssl_verification.into(),
+    );
     if let Some(token) = input.token.as_deref() {
         if !token.is_empty() {
-            args.push(format!("token={token}"));
+            body.insert("token".to_string(), token.into());
         }
     }
-    Ok(args)
+    Ok(serde_json::Value::Object(body))
 }
 
 pub async fn create_hook(repo_path: &str, input: GitLabHookInput) -> AppResult<()> {
-    let fields = hook_args(&input)?;
+    let body = hook_body(&input)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let endpoint = format!("projects/{enc}/hooks");
-    let mut args: Vec<&str> = vec!["api", "--method", "POST", &endpoint];
-    for f in &fields {
-        args.push("-f");
-        args.push(f);
-    }
-    run_glab(Some(repo_path), &args, GLAB_NETWORK_TIMEOUT).await?;
+    run_glab_ex(
+        Some(repo_path),
+        &json_body_args("POST", &endpoint),
+        Some(&body.to_string()),
+        &[],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -6839,15 +6837,17 @@ pub async fn update_hook(repo_path: &str, hook_id: &str, input: GitLabHookInput)
     let hook_id: u64 = hook_id
         .parse()
         .map_err(|_| AppError::InvalidArgument("invalid webhook id".into()))?;
-    let fields = hook_args(&input)?;
+    let body = hook_body(&input)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let endpoint = format!("projects/{enc}/hooks/{hook_id}");
-    let mut args: Vec<&str> = vec!["api", "--method", "PUT", &endpoint];
-    for f in &fields {
-        args.push("-f");
-        args.push(f);
-    }
-    run_glab(Some(repo_path), &args, GLAB_NETWORK_TIMEOUT).await?;
+    run_glab_ex(
+        Some(repo_path),
+        &json_body_args("PUT", &endpoint),
+        Some(&body.to_string()),
+        &[],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -7079,6 +7079,22 @@ fn scope_filter(scope: &str) -> String {
     )
 }
 
+/// The create/update body. `key` rides the body only on create — an update
+/// addresses its key in the endpoint, and resending it there reads as a rename.
+fn variable_body(
+    create: bool,
+    key: &str,
+    value: &str,
+    protected: bool,
+    masked: bool,
+) -> serde_json::Value {
+    if create {
+        serde_json::json!({ "key": key, "value": value, "protected": protected, "masked": masked })
+    } else {
+        serde_json::json!({ "value": value, "protected": protected, "masked": masked })
+    }
+}
+
 /// Create (`create: true`) or update a variable. Split endpoints on GitLab —
 /// POST 400s on an existing key, PUT 404s on a missing one — and the form
 /// knows which it's doing. Updates address the exact `scope` (a key can exist
@@ -7102,29 +7118,28 @@ pub async fn set_variable(
             format!("projects/{enc}/variables/{key}{}", scope_filter(scope)),
         )
     };
-    let key_arg = format!("key={key}");
-    let value_arg = format!("value={value}");
-    let protected_arg = format!("protected={protected}");
-    let masked_arg = format!("masked={masked}");
-    let mut args = vec!["api", "--method", method, &endpoint, "-f", &value_arg];
-    if create {
-        args.push("-f");
-        args.push(&key_arg);
-    }
-    args.push("-f");
-    args.push(&protected_arg);
-    args.push("-f");
-    args.push(&masked_arg);
-    run_glab(Some(repo_path), &args, GLAB_NETWORK_TIMEOUT)
-        .await
-        .map_err(|e| match e {
-            // GitLab enforces maskability server-side (length ≥ 8, one line,
-            // Base64-ish alphabet) with a curt 400 — spell it out.
-            AppError::Glab(msg) if masked && msg.contains("masked") => AppError::Glab(
-                "GitLab can't mask this value — masked values need at least 8 characters on a single line, without most special characters".into(),
-            ),
-            other => other,
-        })?;
+    // The value rides stdin, never argv: a masked variable readable in the
+    // process table isn't masked at all.
+    let body = variable_body(create, key, value, protected, masked);
+    run_glab_ex(
+        Some(repo_path),
+        &json_body_args(method, &endpoint),
+        Some(&body.to_string()),
+        &[],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await
+    .map_err(|e| match e {
+        // GitLab enforces maskability server-side (length ≥ 8, one line, Base64-ish
+        // alphabet) with a curt 400 — spell it out. Measured wordings: current
+        // GitLab says `value:[is invalid]`; older wordings said "masked".
+        AppError::Glab(msg)
+            if masked && (msg.contains("masked") || msg.contains("value:[is invalid")) =>
+        AppError::Glab(
+            "GitLab can't mask this value — masked values need at least 8 characters on a single line, without most special characters".into(),
+        ),
+        other => other,
+    })?;
     Ok(())
 }
 
@@ -7943,6 +7958,59 @@ mod tests {
         let retarget = edit_mr_args("projects/9/merge_requests/7", "T", "D", Some("main"));
         assert_eq!(retarget[..plain.len()], plain[..]);
         assert_eq!(retarget[plain.len()..], ["-f", "target_branch=main"]);
+    }
+
+    /// The hook body carries the secret token only when the form supplied one:
+    /// an absent/empty token must leave the key out entirely, or the request
+    /// would clear GitLab's stored secret (it never returns it to re-send).
+    /// Event flags are real JSON booleans; `-f` is `--raw-field`, so the old
+    /// form sent the strings "true"/"false" — GitLab accepts either.
+    #[test]
+    fn hook_body_carries_the_token_only_when_set() {
+        let input = |token: Option<&str>| GitLabHookInput {
+            url: "https://example.com/hook".to_string(),
+            token: token.map(str::to_string),
+            enable_ssl_verification: true,
+            events: vec!["push_events".to_string()],
+        };
+
+        let with = hook_body(&input(Some("s3cret"))).unwrap();
+        assert_eq!(with["url"], "https://example.com/hook");
+        assert_eq!(with["token"], "s3cret");
+        assert_eq!(with["push_events"], serde_json::json!(true));
+        assert_eq!(with["issues_events"], serde_json::json!(false));
+        assert_eq!(with["enable_ssl_verification"], serde_json::json!(true));
+
+        for absent in [
+            hook_body(&input(None)).unwrap(),
+            hook_body(&input(Some(""))).unwrap(),
+        ] {
+            assert!(
+                absent.get("token").is_none(),
+                "token key omitted entirely: {absent}"
+            );
+        }
+    }
+
+    /// The create body carries the key; an update addresses it in the endpoint,
+    /// so repeating it in the body would read as a rename. Both flags are real
+    /// JSON booleans, and the value itself never touches argv.
+    #[test]
+    fn variable_body_sends_the_key_on_create_only() {
+        let created = variable_body(true, "DEPLOY_ENV", "s3cret", true, false);
+        assert_eq!(created["key"], "DEPLOY_ENV");
+        assert_eq!(created["value"], "s3cret");
+        assert_eq!(created["protected"], serde_json::json!(true));
+        assert_eq!(created["masked"], serde_json::json!(false));
+
+        let updated = variable_body(false, "DEPLOY_ENV", "s3cret", false, true);
+        assert!(
+            updated.get("key").is_none(),
+            "an update omits the key entirely: {updated}"
+        );
+        assert_eq!(updated["value"], "s3cret");
+        assert_eq!(updated["protected"], serde_json::json!(false));
+        assert_eq!(updated["masked"], serde_json::json!(true));
     }
 
     /// `(iid, position, size)` per MR, sorted — the readable shape of an inference.
@@ -9377,8 +9445,7 @@ mod tests {
 
     #[test]
     fn pipeline_variable_keys_reject_colon_and_flaggy_names() {
-        // The `key:value` token splits on the FIRST colon — a colon-bearing key
-        // would silently corrupt the value, and a leading digit isn't an env var.
+        // Env-var names only: no punctuation, no space, no leading digit.
         assert!(valid_variable_key("DEPLOY_ENV"));
         assert!(valid_variable_key("_private"));
         assert!(valid_variable_key("key2"));
@@ -9387,25 +9454,6 @@ mod tests {
         assert!(!valid_variable_key("has space"));
         assert!(!valid_variable_key("2leading"));
         assert!(!valid_variable_key("-flag"));
-    }
-
-    #[test]
-    fn pipeline_variable_values_survive_commas_and_quotes() {
-        // glab CSV-splits the --variables flag value; the token must be a fully
-        // quoted CSV field with embedded quotes doubled (forms validated live).
-        assert_eq!(variable_token("KEY", "simple"), "\"KEY:simple\"");
-        assert_eq!(
-            variable_token("REGIONS", "us-east-1,eu-west-1"),
-            "\"REGIONS:us-east-1,eu-west-1\""
-        );
-        assert_eq!(
-            variable_token("NOTE", "say \"hi\", ok"),
-            "\"NOTE:say \"\"hi\"\", ok\""
-        );
-        assert_eq!(
-            variable_token("MSG", "hello: world"),
-            "\"MSG:hello: world\""
-        );
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -4909,8 +4909,7 @@ pub async fn publish_repo(
     }
     // The branch rides the publish push's refspec — validate it here, still
     // before the create.
-    crate::git::branches::validate_ref_name(&branch)
-        .map_err(|_| AppError::InvalidArgument(format!("invalid branch name: {branch}")))?;
+    crate::git::branches::validate_ref_name(&branch)?;
     // An origin remote may have appeared since the UI's (cached) no-origin
     // check — adding one externally then publishing would otherwise strand an
     // orphaned project when the post-create `remote add` fails.
@@ -5644,9 +5643,12 @@ pub async fn play_job(repo_path: &str, job_id: u64) -> AppResult<()> {
     Ok(())
 }
 
-/// A CI/CD variable key must be a valid env-var name — it becomes an
-/// environment variable in the pipeline's jobs: `[A-Za-z_][A-Za-z0-9_]*`.
-fn valid_variable_key(k: &str) -> bool {
+/// A key for a variable passed when running a pipeline manually — it becomes an
+/// environment variable in the jobs, so `[A-Za-z_][A-Za-z0-9_]*` (no leading
+/// digit). [`validate_variable_key`] shares the charset but guards the stored
+/// project CI/CD variables, permits a leading digit, and caps length — that
+/// difference is why the two aren't folded.
+fn valid_pipeline_variable_key(k: &str) -> bool {
     !k.is_empty()
         && !k.starts_with(|c: char| c.is_ascii_digit())
         && k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
@@ -5671,7 +5673,7 @@ pub async fn run_pipeline(
     }
     let mut vars = Vec::with_capacity(variables.len());
     for (k, v) in variables {
-        if !valid_variable_key(k) {
+        if !valid_pipeline_variable_key(k) {
             return Err(AppError::InvalidArgument(format!(
                 "invalid variable name: {k} (letters, digits and _ only)"
             )));
@@ -7102,6 +7104,14 @@ fn variable_body(
     }
 }
 
+/// Does this 400 mean GitLab refused to MASK the value (length ≥ 8, one line,
+/// Base64-ish alphabet)? Measured: glab's stderr renders it as
+/// `map[message:map[value:[is invalid]]]`; older GitLab wordings said "masked".
+/// Both renderings are matched, raw JSON included.
+fn is_mask_rejection(msg: &str) -> bool {
+    msg.contains("masked") || (msg.contains("value") && msg.contains("is invalid"))
+}
+
 /// Create (`create: true`) or update a variable. Split endpoints on GitLab —
 /// POST 400s on an existing key, PUT 404s on a missing one — and the form
 /// knows which it's doing. Updates address the exact `scope` (a key can exist
@@ -7137,14 +7147,8 @@ pub async fn set_variable(
     )
     .await
     .map_err(|e| match e {
-        // GitLab enforces maskability server-side (length ≥ 8, one line, Base64-ish
-        // alphabet) with a curt 400 — spell it out. Measured: glab's stderr renders
-        // that 400 as `map[message:map[value:[is invalid]]]`; older GitLab wordings
-        // said "masked". Both renderings are matched, raw JSON included.
-        AppError::Glab(msg)
-            if masked
-                && (msg.contains("masked") || (msg.contains("value") && msg.contains("is invalid"))) =>
-        AppError::Glab(
+        // GitLab's curt 400 on an unmaskable value — spell out what it wants.
+        AppError::Glab(msg) if masked && is_mask_rejection(&msg) => AppError::Glab(
             "GitLab can't mask this value — masked values need at least 8 characters on a single line, without most special characters".into(),
         ),
         other => other,
@@ -7999,6 +8003,20 @@ mod tests {
                 "token key omitted entirely: {absent}"
             );
         }
+    }
+
+    /// A mask refusal gets the explanatory rewrite; the other measured 400s
+    /// pass through with GitLab's own message (substring match, not exhaustive).
+    #[test]
+    fn mask_rejection_matches_measured_renderings() {
+        assert!(is_mask_rejection(
+            "glab: map[message:map[value:[is invalid]]]"
+        ));
+        assert!(is_mask_rejection("value is invalid"));
+        assert!(is_mask_rejection("masked variables must be at least 8 characters"));
+        assert!(!is_mask_rejection(
+            "glab: map[message:map[key:[has already been taken]]]"
+        ));
     }
 
     /// The manual-pipeline body: the ref plus the REST `variables[]` array.
@@ -9471,14 +9489,14 @@ mod tests {
     #[test]
     fn pipeline_variable_keys_reject_invalid_env_names() {
         // Env-var names only: no punctuation, no space, no leading digit.
-        assert!(valid_variable_key("DEPLOY_ENV"));
-        assert!(valid_variable_key("_private"));
-        assert!(valid_variable_key("key2"));
-        assert!(!valid_variable_key(""));
-        assert!(!valid_variable_key("has:colon"));
-        assert!(!valid_variable_key("has space"));
-        assert!(!valid_variable_key("2leading"));
-        assert!(!valid_variable_key("-flag"));
+        assert!(valid_pipeline_variable_key("DEPLOY_ENV"));
+        assert!(valid_pipeline_variable_key("_private"));
+        assert!(valid_pipeline_variable_key("key2"));
+        assert!(!valid_pipeline_variable_key(""));
+        assert!(!valid_pipeline_variable_key("has:colon"));
+        assert!(!valid_pipeline_variable_key("has space"));
+        assert!(!valid_pipeline_variable_key("2leading"));
+        assert!(!valid_pipeline_variable_key("-flag"));
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -5652,6 +5652,12 @@ fn valid_variable_key(k: &str) -> bool {
         && k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// The manual-pipeline body. `variables[]` is a nested array, the shape flat
+/// `-f` fields can't express — which is why this request goes over stdin.
+fn pipeline_body(git_ref: &str, vars: Vec<serde_json::Value>) -> serde_json::Value {
+    serde_json::json!({ "ref": git_ref, "variables": vars })
+}
+
 /// Manually run a new pipeline on a ref — GitLab's analogue of a workflow
 /// dispatch. `variables` POST as the REST `variables[]` array over stdin, so a
 /// value a user typed never reaches argv (nor any flag-encoding rules).
@@ -5674,7 +5680,7 @@ pub async fn run_pipeline(
     }
     let enc = encode_project(&project_path(repo_path).await?);
     let endpoint = format!("projects/{enc}/pipeline");
-    let body = serde_json::json!({ "ref": git_ref, "variables": vars });
+    let body = pipeline_body(git_ref, vars);
     run_glab_ex(
         Some(repo_path),
         &json_body_args("POST", &endpoint),
@@ -6780,8 +6786,9 @@ pub struct GitLabHookInput {
 
 /// The JSON body shared by hook create/update: url + SSL + every known event
 /// flag set explicitly true/false (so unchecking sticks on update). It rides
-/// stdin, so the secret token never reaches argv — an omitted `token` key
-/// leaves the stored secret untouched.
+/// stdin, so the secret token never reaches argv. Omitting `token` relies on the
+/// hook PUT's documented partial-update semantics (omitted fields unchanged) —
+/// the contract the form's blank-means-unchanged placeholder is written against.
 fn hook_body(input: &GitLabHookInput) -> AppResult<serde_json::Value> {
     let url = input.url.trim();
     if !(url.starts_with("https://") || url.starts_with("http://")) {
@@ -7131,10 +7138,12 @@ pub async fn set_variable(
     .await
     .map_err(|e| match e {
         // GitLab enforces maskability server-side (length ≥ 8, one line, Base64-ish
-        // alphabet) with a curt 400 — spell it out. Measured wordings: current
-        // GitLab says `value:[is invalid]`; older wordings said "masked".
+        // alphabet) with a curt 400 — spell it out. Measured: glab's stderr renders
+        // that 400 as `map[message:map[value:[is invalid]]]`; older GitLab wordings
+        // said "masked". Both renderings are matched, raw JSON included.
         AppError::Glab(msg)
-            if masked && (msg.contains("masked") || msg.contains("value:[is invalid")) =>
+            if masked
+                && (msg.contains("masked") || (msg.contains("value") && msg.contains("is invalid"))) =>
         AppError::Glab(
             "GitLab can't mask this value — masked values need at least 8 characters on a single line, without most special characters".into(),
         ),
@@ -7990,6 +7999,22 @@ mod tests {
                 "token key omitted entirely: {absent}"
             );
         }
+    }
+
+    /// The manual-pipeline body: the ref plus the REST `variables[]` array.
+    #[test]
+    fn pipeline_body_carries_ref_and_variables_array() {
+        let body = pipeline_body(
+            "main",
+            vec![serde_json::json!({ "key": "DEPLOY_ENV", "value": "prod" })],
+        );
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "ref": "main",
+                "variables": [{ "key": "DEPLOY_ENV", "value": "prod" }],
+            })
+        );
     }
 
     /// The create body carries the key; an update addresses it in the endpoint,
@@ -9444,7 +9469,7 @@ mod tests {
     }
 
     #[test]
-    fn pipeline_variable_keys_reject_colon_and_flaggy_names() {
+    fn pipeline_variable_keys_reject_invalid_env_names() {
         // Env-var names only: no punctuation, no space, no leading digit.
         assert!(valid_variable_key("DEPLOY_ENV"));
         assert!(valid_variable_key("_private"));

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -154,9 +154,7 @@ pub async fn git_global_default_branch() -> AppResult<String> {
 #[tauri::command]
 pub async fn git_set_global_default_branch(branch: String) -> AppResult<()> {
     let branch = branch.trim();
-    crate::git::branches::validate_ref_name(branch).map_err(|_| {
-        crate::error::AppError::InvalidArgument(format!("invalid branch name: {branch}"))
-    })?;
+    crate::git::branches::validate_ref_name(branch)?;
     run_git(
         None,
         &["config", "--global", "init.defaultBranch", branch],

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -154,11 +154,9 @@ pub async fn git_global_default_branch() -> AppResult<String> {
 #[tauri::command]
 pub async fn git_set_global_default_branch(branch: String) -> AppResult<()> {
     let branch = branch.trim();
-    if branch.is_empty() || branch.starts_with('-') || branch.contains(' ') {
-        return Err(crate::error::AppError::InvalidArgument(format!(
-            "invalid branch name: {branch}"
-        )));
-    }
+    crate::git::branches::validate_ref_name(branch).map_err(|_| {
+        crate::error::AppError::InvalidArgument(format!("invalid branch name: {branch}"))
+    })?;
     run_git(
         None,
         &["config", "--global", "init.defaultBranch", branch],

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -3496,8 +3496,9 @@ pub async fn git_unpushed_messages(
 
 /// The tag-name rules for every path a tag rides: `refs/tags/<name>` push and
 /// delete refspecs, `gh release` argv, and GitLab release endpoint paths. Adds
-/// the forms `git check-ref-format` forbids to the shared ref validator, which
-/// permits them only for branch start-points (rev expressions may use them).
+/// the rev-expression forms `git check-ref-format` forbids to the shared ref
+/// validator, which permits them only for branch start-points (rev expressions
+/// may use them).
 /// The single-`@` rule is deliberately absent — it matches the ENTIRE refname,
 /// never `refs/tags/<name>`, so a tag named `@` is creatable (probe-verified).
 /// CI-dispatch refs are free-text branch-or-tag and deliberately skip this.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -3494,12 +3494,19 @@ pub async fn git_unpushed_messages(
     Ok(messages)
 }
 
-/// Every tag/release name the app sends anywhere — refspecs, CLI argv, endpoint
-/// paths — goes through here. It layers the rev-expression forms `git
-/// check-ref-format` forbids onto the shared ref validator, which permits them
-/// only because branch start-points may be rev expressions; a tag never is.
+/// The tag-name rules for every path a tag rides: `refs/tags/<name>` push and
+/// delete refspecs, `gh release` argv, and GitLab release endpoint paths. Adds
+/// the forms `git check-ref-format` forbids to the shared ref validator, which
+/// permits them only for branch start-points (a tag is never a rev expression).
+/// CI-dispatch refs are free-text branch-or-tag and deliberately skip this.
 pub(crate) fn validate_tag_name(name: &str) -> AppResult<()> {
-    if name.contains('~') || name.contains('^') || name == "@" || name.contains("@{") {
+    // A lone `@` component covers the whole-name `@` too.
+    if name.contains('~')
+        || name.contains('^')
+        || name.contains("..")
+        || name.contains("@{")
+        || name.split('/').any(|part| part == "@")
+    {
         return Err(AppError::InvalidArgument(format!(
             "invalid tag name: {name}"
         )));
@@ -3664,14 +3671,14 @@ mod tests {
             "a:b", "a*b", "a?", "a[b", "a b", "a\\b", "a\u{7}b", "", "-x",
             // Rev-expression forms: a tag is never one, and git forbids them in
             // a real ref name.
-            "v1~1", "v1^2", "@", "a@{b",
+            "v1~1", "v1^2", "@", "a@{b", "v1..2", "v1/@/x",
         ] {
             assert!(
                 validate_tag_name(bad).is_err(),
                 "expected {bad:?} to be rejected"
             );
         }
-        for good in ["feat/x", "release-1.2", "v1.0.0", "a@b"] {
+        for good in ["feat/x", "release-1.2", "v1.0.0", "a@b", "v1/x"] {
             assert!(
                 validate_tag_name(good).is_ok(),
                 "expected {good:?} to be accepted"
@@ -4690,9 +4697,14 @@ detached
         assert_eq!(rev(&bare, "refs/tags/v1.0.0").await, head);
 
         // A glob name never reaches the refspec (it would mirror-push every tag).
-        assert!(git_push_tag_core(&state, repo, "v1.*".to_string())
-            .await
-            .is_err());
+        // Assert on the VALIDATOR's rejection: git refusing the odd refspec later
+        // would satisfy a bare `is_err()` for the wrong reason.
+        match git_push_tag_core(&state, repo, "v1.*".to_string()).await {
+            Err(AppError::InvalidArgument(msg)) => {
+                assert!(msg.contains("invalid tag name"), "got: {msg}");
+            }
+            other => panic!("expected the tag validator to reject the glob, got {other:?}"),
+        }
     }
 
     /// A second bare repo wired to `repo` under `remote` — what a fork clone's

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -3494,11 +3494,20 @@ pub async fn git_unpushed_messages(
     Ok(messages)
 }
 
-fn validate_tag_name(name: &str) -> AppResult<()> {
-    if name.is_empty() || name.starts_with('-') {
-        return Err(AppError::InvalidArgument(format!("invalid tag name: {name}")));
+/// Every tag/release name the app sends anywhere — refspecs, CLI argv, endpoint
+/// paths — goes through here. It layers the rev-expression forms `git
+/// check-ref-format` forbids onto the shared ref validator, which permits them
+/// only because branch start-points may be rev expressions; a tag never is.
+pub(crate) fn validate_tag_name(name: &str) -> AppResult<()> {
+    if name.contains('~') || name.contains('^') || name == "@" || name.contains("@{") {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid tag name: {name}"
+        )));
     }
-    Ok(())
+    // The shared validator covers empty / leading `-` / refspec metacharacters —
+    // `*` in a `refs/tags/<name>` refspec would mirror-push every tag.
+    crate::git::branches::validate_ref_name(name)
+        .map_err(|_| AppError::InvalidArgument(format!("invalid tag name: {name}")))
 }
 
 #[tauri::command]
@@ -3644,6 +3653,30 @@ mod tests {
 
     fn dropping(content: &str, lines: &[u32]) -> String {
         remove_lines(content, &lines.iter().copied().collect())
+    }
+
+    /// Tag names are interpolated into `refs/tags/<name>` and `:refs/tags/<name>`
+    /// push refspecs, where `*` mirror-pushes every tag and `:` retargets the
+    /// push — so the metacharacters are refused before any remote work.
+    #[test]
+    fn validate_tag_name_rejects_refspec_metacharacters() {
+        for bad in [
+            "a:b", "a*b", "a?", "a[b", "a b", "a\\b", "a\u{7}b", "", "-x",
+            // Rev-expression forms: a tag is never one, and git forbids them in
+            // a real ref name.
+            "v1~1", "v1^2", "@", "a@{b",
+        ] {
+            assert!(
+                validate_tag_name(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+        for good in ["feat/x", "release-1.2", "v1.0.0", "a@b"] {
+            assert!(
+                validate_tag_name(good).is_ok(),
+                "expected {good:?} to be accepted"
+            );
+        }
     }
 
     #[test]
@@ -4638,6 +4671,28 @@ detached
         let (dir, repo) = setup_repo(marker).await;
         let (bare_dir, bare) = add_bare_remote(&repo, marker, "origin").await;
         (dir, bare_dir, repo, bare)
+    }
+
+    /// The tag push end to end against a real (file) remote: the tightened name
+    /// check must let a normal tag through, and refuse a glob before pushing.
+    #[tokio::test]
+    async fn push_tag_lands_the_tag_on_the_remote() {
+        let (_dir, _bare_dir, repo, bare) = setup_repo_with_origin("push-tag").await;
+        let head = rev(&repo, "HEAD").await;
+        let state = AppState::default();
+
+        git_tag_core(&state, repo.clone(), "v1.0.0".to_string(), head.clone())
+            .await
+            .unwrap();
+        git_push_tag_core(&state, repo.clone(), "v1.0.0".to_string())
+            .await
+            .unwrap();
+        assert_eq!(rev(&bare, "refs/tags/v1.0.0").await, head);
+
+        // A glob name never reaches the refspec (it would mirror-push every tag).
+        assert!(git_push_tag_core(&state, repo, "v1.*".to_string())
+            .await
+            .is_err());
     }
 
     /// A second bare repo wired to `repo` under `remote` — what a fork clone's

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -3497,16 +3497,12 @@ pub async fn git_unpushed_messages(
 /// The tag-name rules for every path a tag rides: `refs/tags/<name>` push and
 /// delete refspecs, `gh release` argv, and GitLab release endpoint paths. Adds
 /// the forms `git check-ref-format` forbids to the shared ref validator, which
-/// permits them only for branch start-points (a tag is never a rev expression).
+/// permits them only for branch start-points (rev expressions may use them).
+/// The single-`@` rule is deliberately absent — it matches the ENTIRE refname,
+/// never `refs/tags/<name>`, so a tag named `@` is creatable (probe-verified).
 /// CI-dispatch refs are free-text branch-or-tag and deliberately skip this.
 pub(crate) fn validate_tag_name(name: &str) -> AppResult<()> {
-    // A lone `@` component covers the whole-name `@` too.
-    if name.contains('~')
-        || name.contains('^')
-        || name.contains("..")
-        || name.contains("@{")
-        || name.split('/').any(|part| part == "@")
-    {
+    if name.contains('~') || name.contains('^') || name.contains("..") || name.contains("@{") {
         return Err(AppError::InvalidArgument(format!(
             "invalid tag name: {name}"
         )));
@@ -3669,16 +3665,17 @@ mod tests {
     fn validate_tag_name_rejects_refspec_metacharacters() {
         for bad in [
             "a:b", "a*b", "a?", "a[b", "a b", "a\\b", "a\u{7}b", "", "-x",
-            // Rev-expression forms: a tag is never one, and git forbids them in
-            // a real ref name.
-            "v1~1", "v1^2", "@", "a@{b", "v1..2", "v1/@/x",
+            // Rev-expression forms git itself refuses in a ref name.
+            "v1~1", "v1^2", "a@{b", "v1..2",
         ] {
             assert!(
                 validate_tag_name(bad).is_err(),
                 "expected {bad:?} to be rejected"
             );
         }
-        for good in ["feat/x", "release-1.2", "v1.0.0", "a@b", "v1/x"] {
+        // `@` and `@`-components are creatable tags (probe-verified) — git's
+        // anti-`@` rule matches the whole refname, never `refs/tags/<name>`.
+        for good in ["feat/x", "release-1.2", "v1.0.0", "a@b", "v1/x", "@", "v1/@/x"] {
             assert!(
                 validate_tag_name(good).is_ok(),
                 "expected {good:?} to be accepted"

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -722,11 +722,17 @@ fn build_push_args(
     args
 }
 
+/// Fully-qualified same-name push refspec: qualified so a branch named `+x`
+/// can't read as a refspec force marker and `*`/`:` can't reshape the refspec.
+pub(crate) fn publish_refspec(branch: &str) -> String {
+    format!("refs/heads/{branch}:refs/heads/{branch}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         build_push_args, cache_get, cache_invalidate, cache_put, git_push_core,
-        git_remote_remove_core, is_auth_class_failure, parse_upstream_tracking,
+        git_remote_remove_core, is_auth_class_failure, parse_upstream_tracking, publish_refspec,
         resolve_push_target, run_git_mutating_with_creds,
     };
     use crate::error::AppError;
@@ -989,6 +995,17 @@ mod tests {
                 "refs/heads/feature:refs/heads/feature"
             ]
         );
+    }
+
+    #[test]
+    fn publish_refspec_is_fully_qualified_on_both_sides() {
+        assert_eq!(
+            publish_refspec("feature"),
+            "refs/heads/feature:refs/heads/feature"
+        );
+        // A `+` lands INSIDE the ref path, never at refspec position 0 where git
+        // would read it as the force marker.
+        assert_eq!(publish_refspec("+x"), "refs/heads/+x:refs/heads/+x");
     }
 
     #[test]

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -704,7 +704,7 @@ fn build_push_args(
     if untracked || gone || set_upstream {
         // Publish + track, under the LOCAL name.
         args.extend(["-u", target].map(str::to_string));
-        args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
+        args.push(publish_refspec(branch));
     } else if target == remotename {
         // Tracked → its own remote: target the remote branch name explicitly (it
         // may differ from the local one).
@@ -717,13 +717,15 @@ fn build_push_args(
         // Tracked, but pushing to a DIFFERENT remote than the upstream — a copy
         // under the local name, no `-u`, upstream config untouched (never retrack).
         args.push(target.to_string());
-        args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
+        args.push(publish_refspec(branch));
     }
     args
 }
 
-/// Fully-qualified same-name push refspec: qualified so a branch named `+x`
-/// can't read as a refspec force marker and `*`/`:` can't reshape the refspec.
+/// Fully-qualified same-name push refspec. Qualification alone only stops a
+/// leading `+`/`-` from reading as a force/delete marker at refspec position 0;
+/// the metacharacters that could reshape the refspec (`* ? [ : \`) are rejected
+/// by [`crate::git::branches::validate_ref_name`], which every caller runs first.
 pub(crate) fn publish_refspec(branch: &str) -> String {
     format!("refs/heads/{branch}:refs/heads/{branch}")
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -9,10 +9,10 @@ use crate::github::runner::{run_gh, run_gh_input, run_gh_raw, GH_NETWORK_TIMEOUT
 use crate::state::AppState;
 
 fn validate_branch(name: &str) -> AppResult<()> {
-    if name.is_empty() || name.starts_with('-') {
-        return Err(AppError::InvalidArgument(format!("invalid branch: {name}")));
-    }
-    Ok(())
+    // The shared ref validator (empty / leading `-` / refspec metacharacters);
+    // remapped so this surface keeps its own wording.
+    crate::git::branches::validate_ref_name(name)
+        .map_err(|_| AppError::InvalidArgument(format!("invalid branch: {name}")))
 }
 
 #[derive(Serialize)]
@@ -5501,11 +5501,12 @@ pub(crate) async fn gh_pr_create_core(
 
         // Push `head` to origin — origin IS the fork; the PR's head lives there.
         let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+        let spec = crate::git::remote::publish_refspec(&head);
         crate::git::remote::run_git_mutating_with_creds(
             state,
             &repo_path,
             &cred,
-            &["push", "-u", "origin", &head],
+            &["push", "-u", "origin", &spec],
             NETWORK_TIMEOUT,
         )
         .await?;
@@ -5538,11 +5539,12 @@ pub(crate) async fn gh_pr_create_core(
 
     // gh can only open a PR for a branch that exists on the remote.
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    let spec = crate::git::remote::publish_refspec(&head);
     crate::git::remote::run_git_mutating_with_creds(
         state,
         &repo_path,
         &cred,
-        &["push", "-u", "origin", &head],
+        &["push", "-u", "origin", &spec],
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -5657,11 +5659,30 @@ mod tests {
         GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner, GhPrRestPull, GhPrRestReview,
         GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails, PrInfo, PrMergeOutcome,
         GhMergeabilityRow, PrMergeability, PrStackInfo, PrStackMember, PrTimelineEventOut,
-        batch_check_present, oid_outside_origin_graph, select_fork_pr_match, ForkPrMatch,
-        RawForkPr, RawLogin, RawPr,
+        batch_check_present, oid_outside_origin_graph, select_fork_pr_match, validate_branch,
+        ForkPrMatch, RawForkPr, RawLogin, RawPr,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
+
+    /// Both PR branches ride a push refspec, so every character that could
+    /// reshape one is refused before any remote work: `:` would retarget the
+    /// push at an arbitrary remote ref, `*` would mirror-push every branch.
+    #[test]
+    fn validate_branch_rejects_refspec_metacharacters() {
+        for bad in ["a:b", "a*b", "a?", "a[b", "a b", "a\\b", "a\u{7}b", "", "-x"] {
+            assert!(
+                validate_branch(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+        for good in ["feat/x", "release-1.2", "v1.0.0"] {
+            assert!(
+                validate_branch(good).is_ok(),
+                "expected {good:?} to be accepted"
+            );
+        }
+    }
 
     /// A bare list row — only the identity the stack join reads is meaningful.
     fn pr_row(number: u64) -> PrInfo {

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -304,6 +304,10 @@ pub async fn gh_release_generate_notes(
     previous_tag: String,
 ) -> AppResult<GeneratedNotes> {
     validate_tag(&tag)?;
+    // Empty previous_tag = GitHub auto-detects; validate only when supplied.
+    if !previous_tag.trim().is_empty() {
+        validate_tag(previous_tag.trim())?;
+    }
     // `gh api` has no `-R`; build the literal `repos/<slug>` path so a fork
     // generates notes for its OWN releases, not the parent's.
     let slug = crate::github::gh_origin_slug(&repo_path).await?;

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -16,11 +16,11 @@ where
     Ok(Option::<String>::deserialize(d)?.unwrap_or_default())
 }
 
+/// Every `gh_release_*` entry point runs this before assembling argv, so a tag
+/// reaches gh only after the shared tag rules; remapped to this surface's wording.
 fn validate_tag(tag: &str) -> AppResult<()> {
-    if tag.is_empty() || tag.starts_with('-') {
-        return Err(AppError::InvalidArgument(format!("invalid tag: {tag}")));
-    }
-    Ok(())
+    crate::git::ops::validate_tag_name(tag)
+        .map_err(|_| AppError::InvalidArgument(format!("invalid tag: {tag}")))
 }
 
 /// One release in the list view (merged with tags on the frontend by tagName).

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -16,8 +16,9 @@ where
     Ok(Option::<String>::deserialize(d)?.unwrap_or_default())
 }
 
-/// Every `gh_release_*` entry point runs this before assembling argv, so a tag
-/// reaches gh only after the shared tag rules; remapped to this surface's wording.
+/// Every tag-taking `gh_release_*` entry point runs this before assembling argv,
+/// so a tag reaches gh only after the shared tag rules; remapped to this
+/// surface's wording.
 fn validate_tag(tag: &str) -> AppResult<()> {
     crate::git::ops::validate_tag_name(tag)
         .map_err(|_| AppError::InvalidArgument(format!("invalid tag: {tag}")))

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -304,9 +304,13 @@ pub async fn gh_release_generate_notes(
     previous_tag: String,
 ) -> AppResult<GeneratedNotes> {
     validate_tag(&tag)?;
-    // Empty previous_tag = GitHub auto-detects; validate only when supplied.
-    if !previous_tag.trim().is_empty() {
-        validate_tag(previous_tag.trim())?;
+    let prev = previous_tag.trim();
+    // Empty previous_tag = GitHub auto-detects; validate only when supplied,
+    // with distinct wording — the dialog has BOTH tag fields.
+    if !prev.is_empty() {
+        crate::git::ops::validate_tag_name(prev).map_err(|_| {
+            AppError::InvalidArgument(format!("invalid previous tag: {prev}"))
+        })?;
     }
     // `gh api` has no `-R`; build the literal `repos/<slug>` path so a fork
     // generates notes for its OWN releases, not the parent's.
@@ -314,7 +318,7 @@ pub async fn gh_release_generate_notes(
     let notes_path = format!("repos/{slug}/releases/generate-notes");
     let tag_arg = format!("tag_name={tag}");
     let target_arg = format!("target_commitish={}", target.trim());
-    let prev_arg = format!("previous_tag_name={}", previous_tag.trim());
+    let prev_arg = format!("previous_tag_name={prev}");
     let mut args: Vec<&str> = vec![
         "api",
         "--method",
@@ -329,7 +333,7 @@ pub async fn gh_release_generate_notes(
         args.push(&target_arg);
     }
     // Empty = GitHub auto-detects the previous release.
-    if !previous_tag.trim().is_empty() {
+    if !prev.is_empty() {
         args.push("-f");
         args.push(&prev_arg);
     }

--- a/src-tauri/src/github/runner.rs
+++ b/src-tauri/src/github/runner.rs
@@ -112,6 +112,8 @@ pub async fn run_gh(
 /// Like `run_gh`, but pipes `input` to gh's stdin — for `gh api --input -` with
 /// a JSON body (webhook create/update), where nested `config`/`events` don't
 /// fit the flat `-f key=value` form. Non-zero exit is an error carrying stderr.
+/// gh sets `Content-Type: application/json` on an `--input` body itself; glab
+/// does NOT (both measured), which is why the GitLab side sends it explicitly.
 pub async fn run_gh_input(
     repo_path: Option<&str>,
     args: &[&str],


### PR DESCRIPTION
Two input-hardening passes over the Rust backend. Every branch or tag name the app interpolates into a push refspec now goes through the shared ref validator and is pushed as a fully-qualified, same-name refspec, so a hostile ref name can't retarget or mirror a push the user only asked to make for one branch. Separately, every `glab` call that carries a user-supplied secret now sends its JSON body over stdin instead of argv, keeping masked CI/CD variable values and webhook tokens out of the system process table.

### Push refspec hardening

- Adds `publish_refspec` in `src-tauri/src/git/remote.rs`, which builds `refs/heads/<branch>:refs/heads/<branch>` — fully qualified on both sides so a branch named `+x` can't land at refspec position 0 as a force marker. The refspec-reshaping metacharacters (`*`, `:`, `?`, `[`, `\`) are rejected by `validate_ref_name`, which every caller runs first; `build_push_args` (the main Push path) now builds its same-name refspecs through the same helper.
- Routes every publish-style push through it: both push sites in `gh_pr_create_core` (`src-tauri/src/github/pr.rs`), `create_mr` and `publish_repo` in `src-tauri/src/forge/gitlab.rs`, and `create_pr` and `publish_repo` in `src-tauri/src/forge/bitbucket.rs`.
- Replaces the per-surface `is_empty() || starts_with('-')` branch checks at those push surfaces with `crate::git::branches::validate_ref_name`, remapped so each surface keeps its own error wording: `validate_branch` in `github/pr.rs`, the `for b in [base, head]` loops in `gitlab::create_mr` and `bitbucket::create_pr`. (Read-only sibling probes keep their lighter checks — they build no refspecs.) `git_set_global_default_branch` joins the same validator.
- Both `publish_repo` implementations now validate the checked-out branch up front, before the remote project/repo is created, so a bad name can't strand a freshly created remote.
- Promotes `validate_tag_name` in `src-tauri/src/git/ops.rs` to `pub(crate)` and tightens it: on top of the shared validator it rejects the rev-expression forms `~`, `^`, `..`, and `@{` — exactly the forms `git check-ref-format` refuses for a tag ref (probe-verified), so no creatable tag name is newly rejected.
- Points the remaining tag entry points at it — `validate_tag` in `src-tauri/src/github/release.rs` (the chokepoint every tag-taking `gh_release_*` command runs first, including a supplied `previous_tag` for release notes), and `view_release`, `create_release`, `edit_release`, `delete_release`, `upload_release_asset`, and `delete_release_asset` in `src-tauri/src/forge/gitlab.rs`.

### Keeping glab secrets off argv

- Adds `json_body_args` in `src-tauri/src/forge/gitlab.rs` — the `api --method … --input - --header Content-Type: application/json` shape shared by every stdin-bodied request — and reuses it in the existing stdin callers `commit_comment_create`, `thread_create`, and `review_submit`. (glab sends no content type for `--input` bodies and GitLab rejects them with HTTP 415, measured on glab 1.105.0; gh sets the header itself, also measured — pinned in a comment at `run_gh_input`.)
- `set_variable` now assembles its payload with a new `variable_body` helper (the `key` rides the body only on create, since an update addresses the key in the endpoint) and posts it over stdin instead of `-f value=…`. The masked-value error remap (extracted as a tested `is_mask_rejection` helper) matches the measured wording of GitLab's current rejection alongside the older `masked` phrasing.
- Converts `hook_args` to `hook_body`, which returns a JSON object sent over stdin; the `token` key is omitted entirely when the form supplied none, relying on the hook PUT's documented partial-update semantics so an update can't clear GitLab's stored secret.
- Rewrites `run_pipeline` to `POST projects/:id/pipeline` with a `variables[]` array over stdin (built by the new `pipeline_body` helper), replacing `glab ci run --variables`. That removes the CSV-quoting workaround `variable_token` altogether; `valid_pipeline_variable_key` (renamed from `valid_variable_key`) stays, with its doc now describing env-var naming and how it differs from the stored-variable validator.

### Tests

- `src-tauri/src/git/ops.rs`: `validate_tag_name_rejects_refspec_metacharacters` covers metacharacters and the rev-expression forms (`~`, `^`, `..`, `@{`) and pins that creatable names like `@` and `v1/@/x` stay accepted, and `push_tag_lands_the_tag_on_the_remote` exercises tag push end to end against a real file remote, asserting a glob name (`v1.*`) is refused by the validator itself — the assertion matches the `InvalidArgument` error kind, so git refusing an odd refspec later couldn't satisfy it.
- `src-tauri/src/github/pr.rs`: `validate_branch_rejects_refspec_metacharacters`.
- `src-tauri/src/git/remote.rs`: `publish_refspec_is_fully_qualified_on_both_sides`, including the `+x` case.
- `src-tauri/src/forge/gitlab.rs`: `hook_body_carries_the_token_only_when_set`, `variable_body_sends_the_key_on_create_only`, `pipeline_body_carries_ref_and_variables_array`, and `mask_rejection_matches_measured_renderings`; the obsolete `pipeline_variable_values_survive_commas_and_quotes` is dropped with `variable_token`, and `pipeline_variable_keys_reject_invalid_env_names` keeps the key-validation assertions under its post-rewrite name.

### Changelog

- `changelog.d/fixed-push-refspec-validation.md` and `changelog.d/fixed-gitlab-secret-stdin.md`. The change is backend-only with no visible surface change, so README, site, and in-app guide are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for branch and tag names across GitHub, GitLab, Bitbucket, and Git operations.
  * Pushes now target exact branches or tags, preventing unintended remote references.
  * Improved handling and validation of CI/CD variables, webhook secrets, and pipeline settings.
  * GitLab operations now keep sensitive values out of command-line arguments.
  * Added clearer errors for invalid, masked, or unsupported variable values.

* **Documentation**
  * Documented safer push validation and secret handling.
  * Clarified JSON input behavior for GitHub CLI requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->