### PR TITLE
fix(pulls,issues,agent,settings): prevent cross-entity state bleed

### DIFF
--- a/changelog.d/fixed-agent-completion-notifications.md
+++ b/changelog.d/fixed-agent-completion-notifications.md
@@ -1,0 +1,1 @@
+- Plan, research, and agent-session completion notifications now arrive even when a different repository's Agent tab is in front.

--- a/changelog.d/fixed-agent-completion-notifications.md
+++ b/changelog.d/fixed-agent-completion-notifications.md
@@ -1,1 +1,2 @@
-- Plan, research, and agent-session completion notifications now arrive even when a different repository's Agent tab is in front.
+- Plan, research, and agent-session completion notifications now arrive
+  even when a different repository's Agent tab is in front.

--- a/changelog.d/fixed-commit-draft-stream.md
+++ b/changelog.d/fixed-commit-draft-stream.md
@@ -1,1 +1,3 @@
-- An AI-generated commit message now stays with the repository and branch it was started on — switching away mid-generation stops the stream instead of filling the other branch's commit box.
+- An AI-generated commit message now stays with the repository and branch
+  it was started on — switching away mid-generation stops the stream
+  instead of filling the other branch's commit box.

--- a/changelog.d/fixed-commit-draft-stream.md
+++ b/changelog.d/fixed-commit-draft-stream.md
@@ -1,0 +1,1 @@
+- An AI-generated commit message now stays with the repository and branch it was started on — switching away mid-generation stops the stream instead of filling the other branch's commit box.

--- a/changelog.d/fixed-composer-drafts-entity-switch.md
+++ b/changelog.d/fixed-composer-drafts-entity-switch.md
@@ -1,1 +1,3 @@
-- Comment boxes in pull request, issue, Jira, discussion, and commit views now start clean when you switch to a different item, so a draft written for one can't be posted to another.
+- Comment boxes in pull request, issue, Jira, discussion, and commit views
+  now start clean when you switch to a different item, so a draft written
+  for one can't be posted to another.

--- a/changelog.d/fixed-composer-drafts-entity-switch.md
+++ b/changelog.d/fixed-composer-drafts-entity-switch.md
@@ -1,3 +1,5 @@
-- Comment boxes in pull request, issue, Jira, discussion, and commit views
-  now start clean when you switch to a different item, so a draft written
-  for one can't be posted to another.
+- Switching items in the pull request, issue, Jira, discussion, and
+  commit views now resets everything in progress for the previous item —
+  comment drafts, open dialogs and confirmations, and label picks — and
+  stops an in-flight AI description, so nothing typed or armed for one
+  item can land on another.

--- a/changelog.d/fixed-composer-drafts-entity-switch.md
+++ b/changelog.d/fixed-composer-drafts-entity-switch.md
@@ -1,0 +1,1 @@
+- Comment boxes in pull request, issue, Jira, discussion, and commit views now start clean when you switch to a different item, so a draft written for one can't be posted to another.

--- a/changelog.d/fixed-repo-relocate-plans.md
+++ b/changelog.d/fixed-repo-relocate-plans.md
@@ -1,0 +1,1 @@
+- Plans and research runs now follow a relocated repository immediately, and stay with it after the move.

--- a/changelog.d/fixed-repo-relocate-plans.md
+++ b/changelog.d/fixed-repo-relocate-plans.md
@@ -1,1 +1,2 @@
-- Plans and research runs now follow a relocated repository immediately, and stay with it after the move.
+- Plans and research runs now follow a relocated repository immediately,
+  and stay with it after the move.

--- a/changelog.d/fixed-review-drafts-lens.md
+++ b/changelog.d/fixed-review-drafts-lens.md
@@ -1,0 +1,1 @@
+- On forks, pending review comments, AI review history, and related caches are now kept separately for your fork's pull requests and the upstream repository's, so a review can't be drafted on one and submitted against the other.

--- a/changelog.d/fixed-review-drafts-lens.md
+++ b/changelog.d/fixed-review-drafts-lens.md
@@ -1,1 +1,4 @@
-- On forks, pending review comments, AI review history, and related caches are now kept separately for your fork's pull requests and the upstream repository's, so a review can't be drafted on one and submitted against the other.
+- On forks, pending review comments, AI review history, and related caches
+  are now kept separately for your fork's pull requests and the
+  upstream repository's, so a review can't be drafted on one and
+  submitted against the other.

--- a/changelog.d/fixed-session-startup-drop.md
+++ b/changelog.d/fixed-session-startup-drop.md
@@ -1,0 +1,1 @@
+- Agent sessions started while the app is still loading are no longer dropped from the sidebar.

--- a/changelog.d/fixed-session-startup-drop.md
+++ b/changelog.d/fixed-session-startup-drop.md
@@ -1,1 +1,2 @@
-- Agent sessions started while the app is still loading are no longer dropped from the sidebar.
+- Agent sessions started while the app is still loading are no longer
+  dropped from the sidebar.

--- a/changelog.d/fixed-settings-save-race.md
+++ b/changelog.d/fixed-settings-save-race.md
@@ -1,0 +1,1 @@
+- Saving settings no longer overwrites recent-repository details that were updated in the background while the Settings screen was open.

--- a/changelog.d/fixed-settings-save-race.md
+++ b/changelog.d/fixed-settings-save-race.md
@@ -1,1 +1,2 @@
-- Saving settings no longer overwrites recent-repository details that were updated in the background while the Settings screen was open.
+- Saving settings no longer overwrites recent-repository details that were
+  updated in the background while the Settings screen was open.

--- a/changelog.d/fixed-settings-save-race.md
+++ b/changelog.d/fixed-settings-save-race.md
@@ -1,2 +1,3 @@
-- Saving settings no longer overwrites recent-repository details that were
-  updated in the background while the Settings screen was open.
+- Saving settings no longer overwrites recent-repository details or your
+  Bitbucket token's expiry date when they changed in the background while
+  the Settings screen was open.

--- a/src/features/commit/useGenerateCommitMessage.ts
+++ b/src/features/commit/useGenerateCommitMessage.ts
@@ -29,6 +29,8 @@ export function useGenerateCommitMessage(repoPath: string) {
     // switched repo or branch — drop the remaining writes and abort the stream.
     const startKey = useUiStore.getState().activeDraftKey;
     // A null startKey (pre-branch-resolution) treats any later key as a move.
+    // On a move, cancel() always aborts THIS run: a second generation can't
+    // start while `generating` is set (CommitBox gates the button and hotkey).
     const keyMoved = () => useUiStore.getState().activeDraftKey !== startKey;
     setGenerating(true);
     const buffer = await run(

--- a/src/features/commit/useGenerateCommitMessage.ts
+++ b/src/features/commit/useGenerateCommitMessage.ts
@@ -24,6 +24,12 @@ export function useGenerateCommitMessage(repoPath: string) {
   const generating = useUiStore((s) => s.generating);
 
   const generate = useCallback(async () => {
+    // The key is captured at start and re-checked at every write: setDraftFields
+    // mirrors into commitDrafts under the LIVE key, so a moved key means the user
+    // switched repo or branch — drop the remaining writes and abort the stream.
+    const startKey = useUiStore.getState().activeDraftKey;
+    // A null startKey (pre-branch-resolution) treats any later key as a move.
+    const keyMoved = () => useUiStore.getState().activeDraftKey !== startKey;
     setGenerating(true);
     const buffer = await run(
       async (settings) => {
@@ -58,6 +64,10 @@ export function useGenerateCommitMessage(repoPath: string) {
       },
       {
         onChunk: (buffer) => {
+          if (keyMoved()) {
+            cancel();
+            return;
+          }
           const { title, body } = splitCommitMessage(buffer);
           setCommitDraft(title, body);
         },
@@ -65,9 +75,16 @@ export function useGenerateCommitMessage(repoPath: string) {
     );
     // A non-null buffer means the stream ran to completion (not aborted, not
     // bailed) — mark the draft as AI-generated just as the old skeleton did.
-    if (buffer !== null) setCommitAiGenerated(true);
+    if (buffer !== null && !keyMoved()) setCommitAiGenerated(true);
     setGenerating(false);
-  }, [repoPath, run, setCommitDraft, setGenerating, setCommitAiGenerated]);
+  }, [
+    repoPath,
+    run,
+    cancel,
+    setCommitDraft,
+    setGenerating,
+    setCommitAiGenerated,
+  ]);
 
   return { generate, cancel, generating };
 }

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -6,7 +6,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
 import { useEditPrLabels, useRepoLabels } from "@/lib/git/queries";
 import type { RemoteLens, RepoLabel } from "@/lib/git/types";
-import { toastError } from "@/lib/toast";
 import { LabelChip } from "./Thread";
 
 /**
@@ -73,20 +72,17 @@ export function LabelsPopover({
     // would skip every GitLab edit. GitHub keys on the ids derived here; GitLab on
     // the names — the forge command takes whichever pair its provider addresses by.
     if (addNames.length > 0 || removeNames.length > 0) {
-      editLabels.mutate(
-        {
-          // `target` is this popover's surface ("issue" | "mr"); it doubles as the
-          // reconcile `kind`. (Discussions use their own view, not this popover.)
-          kind: target,
-          number,
-          labelableId,
-          addIds: ids(addNames),
-          removeIds: ids(removeNames),
-          addNames,
-          removeNames,
-        },
-        { onError: toastError },
-      );
+      editLabels.mutate({
+        // `target` is this popover's surface ("issue" | "mr"); it doubles as the
+        // reconcile `kind`. (Discussions use their own view, not this popover.)
+        kind: target,
+        number,
+        labelableId,
+        addIds: ids(addNames),
+        removeIds: ids(removeNames),
+        addNames,
+        removeNames,
+      });
     }
   }
 

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -341,16 +341,13 @@ export function DiscussionView({
     const addIds = ids([...draftLabels].filter((n) => !applied.has(n)));
     const removeIds = ids([...applied].filter((n) => !draftLabels.has(n)));
     if (addIds.length > 0 || removeIds.length > 0) {
-      editLabels.mutate(
-        {
-          kind: "discussion",
-          number: d.number,
-          labelableId: d.id,
-          addIds,
-          removeIds,
-        },
-        { onError },
-      );
+      editLabels.mutate({
+        kind: "discussion",
+        number: d.number,
+        labelableId: d.id,
+        addIds,
+        removeIds,
+      });
     }
   }
 

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -202,27 +202,30 @@ export function DiscussionView({
   const [labelsOpen, setLabelsOpen] = useState(false);
   const [draftLabels, setDraftLabels] = useState<Set<string>>(new Set());
   const [deletingDiscussion, setDeletingDiscussion] = useState(false);
-  // A different discussion must never inherit this one's unsent drafts, nor a
-  // reply target or delete confirm that no longer exists here — render-time,
-  // not an effect.
-  const [lastNumber, setLastNumber] = useState(number);
-  if (number !== lastNumber) {
-    setLastNumber(number);
+  // A different discussion must never inherit this one's unsent drafts, reply
+  // target, delete confirm, or label draft — render-time, not an effect. The
+  // repo is part of the identity because discussion numbers repeat across repos.
+  const discussionIdentity = `${repoPath}#${number}`;
+  const [lastIdentity, setLastIdentity] = useState(discussionIdentity);
+  if (discussionIdentity !== lastIdentity) {
+    setLastIdentity(discussionIdentity);
     setComposeBody("");
     setReplyingTo(null);
     setReplyBody("");
     setDeletingCommentId(null);
     setDeletingDiscussion(false);
+    setLabelsOpen(false);
+    setDraftLabels(new Set());
   }
   // Both submits clear their composer only once the mutation resolves, which can
-  // be after a switch — an effect event reads the LIVE number so a late success
+  // be after a switch — an effect event reads the LIVE identity so a late success
   // can't wipe text the user has since typed against another discussion.
-  const clearComposeIfSame = useEffectEvent((submittedFor: number) => {
-    if (submittedFor !== number) return;
+  const clearComposeIfSame = useEffectEvent((submittedFor: string) => {
+    if (submittedFor !== discussionIdentity) return;
     setComposeBody("");
   });
-  const clearReplyIfSame = useEffectEvent((submittedFor: number) => {
-    if (submittedFor !== number) return;
+  const clearReplyIfSame = useEffectEvent((submittedFor: string) => {
+    if (submittedFor !== discussionIdentity) return;
     setReplyBody("");
     setReplyingTo(null);
   });
@@ -248,7 +251,7 @@ export function DiscussionView({
 
   function submitComment() {
     if (!d || !composeBody.trim()) return;
-    const submittedFor = number;
+    const submittedFor = discussionIdentity;
     addComment.mutate(
       { discussionId: d.id, body: composeBody.trim() },
       { onSuccess: () => clearComposeIfSame(submittedFor), onError },
@@ -257,7 +260,7 @@ export function DiscussionView({
 
   function submitReply(commentId: string) {
     if (!d || !replyBody.trim()) return;
-    const submittedFor = number;
+    const submittedFor = discussionIdentity;
     addComment.mutate(
       { discussionId: d.id, body: replyBody.trim(), replyToId: commentId },
       {

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -7,7 +7,7 @@ import {
   TagIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   MarkdownEditor,
@@ -202,6 +202,30 @@ export function DiscussionView({
   const [labelsOpen, setLabelsOpen] = useState(false);
   const [draftLabels, setDraftLabels] = useState<Set<string>>(new Set());
   const [deletingDiscussion, setDeletingDiscussion] = useState(false);
+  // A different discussion must never inherit this one's unsent drafts, nor a
+  // reply target or delete confirm that no longer exists here — render-time,
+  // not an effect.
+  const [lastNumber, setLastNumber] = useState(number);
+  if (number !== lastNumber) {
+    setLastNumber(number);
+    setComposeBody("");
+    setReplyingTo(null);
+    setReplyBody("");
+    setDeletingCommentId(null);
+    setDeletingDiscussion(false);
+  }
+  // Both submits clear their composer only once the mutation resolves, which can
+  // be after a switch — an effect event reads the LIVE number so a late success
+  // can't wipe text the user has since typed against another discussion.
+  const clearComposeIfSame = useEffectEvent((submittedFor: number) => {
+    if (submittedFor !== number) return;
+    setComposeBody("");
+  });
+  const clearReplyIfSame = useEffectEvent((submittedFor: number) => {
+    if (submittedFor !== number) return;
+    setReplyBody("");
+    setReplyingTo(null);
+  });
 
   const onError = (e: unknown) => toastError(e);
   const d = details.data;
@@ -224,21 +248,20 @@ export function DiscussionView({
 
   function submitComment() {
     if (!d || !composeBody.trim()) return;
+    const submittedFor = number;
     addComment.mutate(
       { discussionId: d.id, body: composeBody.trim() },
-      { onSuccess: () => setComposeBody(""), onError },
+      { onSuccess: () => clearComposeIfSame(submittedFor), onError },
     );
   }
 
   function submitReply(commentId: string) {
     if (!d || !replyBody.trim()) return;
+    const submittedFor = number;
     addComment.mutate(
       { discussionId: d.id, body: replyBody.trim(), replyToId: commentId },
       {
-        onSuccess: () => {
-          setReplyBody("");
-          setReplyingTo(null);
-        },
+        onSuccess: () => clearReplyIfSame(submittedFor),
         onError,
       },
     );

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1546,7 +1546,8 @@ export function JiraIssueView({
   const composerRef = useRef<MarkdownEditorHandle>(null);
   // A different issue must never inherit this one's unsent comment draft — a
   // render-time state adjustment, not an effect. The repo is part of the identity
-  // because two repos linked to DIFFERENT Jira sites can share an issue key.
+  // because two repos linked to DIFFERENT Jira sites can share an issue key. The
+  // same identity keys the sidebar below, remounting its own per-issue drafts.
   const issueIdentity = `${repoPath}#${issueKey}`;
   const [lastIdentity, setLastIdentity] = useState(issueIdentity);
   if (issueIdentity !== lastIdentity) {
@@ -1819,6 +1820,9 @@ export function JiraIssueView({
         </div>
 
         <JiraIssueSidebar
+          // Remounts the rail per issue so its sections' drafts (log-work
+          // duration/note, the labels popover) can't commit against a new key.
+          key={issueIdentity}
           className={cn(PLACEHOLDER_FADE, staleDim)}
           repoPath={repoPath}
           issueKey={issueKey}

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1545,16 +1545,18 @@ export function JiraIssueView({
   const [composeBody, setComposeBody] = useState("");
   const composerRef = useRef<MarkdownEditorHandle>(null);
   // A different issue must never inherit this one's unsent comment draft — a
-  // render-time state adjustment, not an effect.
-  const [lastKey, setLastKey] = useState(issueKey);
-  if (issueKey !== lastKey) {
-    setLastKey(issueKey);
+  // render-time state adjustment, not an effect. The repo is part of the identity
+  // because two repos linked to DIFFERENT Jira sites can share an issue key.
+  const issueIdentity = `${repoPath}#${issueKey}`;
+  const [lastIdentity, setLastIdentity] = useState(issueIdentity);
+  if (issueIdentity !== lastIdentity) {
+    setLastIdentity(issueIdentity);
     setComposeBody("");
   }
   // The restore below can land after the user switched issues; an effect event
-  // reads the LIVE key so a late rejection can't resurrect text elsewhere.
+  // reads the LIVE identity so a late rejection can't resurrect text elsewhere.
   const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
-    if (submittedFor !== issueKey) return;
+    if (submittedFor !== issueIdentity) return;
     setComposeBody((cur) => (cur.trim() ? cur : body));
   });
 
@@ -1605,7 +1607,7 @@ export function JiraIssueView({
     if (!body) return;
     // Clear the draft immediately (perceived speed); restore it on error, but
     // only if the composer is still empty so we never clobber newly-typed text.
-    const submittedFor = issueKey;
+    const submittedFor = issueIdentity;
     setComposeBody("");
     comment.mutate(
       { issueKey, bodyMd: body },

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -13,6 +13,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -1543,6 +1544,19 @@ export function JiraIssueView({
   const transitionTo = useJiraTransitionTo(repoPath, link.data);
   const [composeBody, setComposeBody] = useState("");
   const composerRef = useRef<MarkdownEditorHandle>(null);
+  // A different issue must never inherit this one's unsent comment draft — a
+  // render-time state adjustment, not an effect.
+  const [lastKey, setLastKey] = useState(issueKey);
+  if (issueKey !== lastKey) {
+    setLastKey(issueKey);
+    setComposeBody("");
+  }
+  // The restore below can land after the user switched issues; an effect event
+  // reads the LIVE key so a late rejection can't resurrect text elsewhere.
+  const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
+    if (submittedFor !== issueKey) return;
+    setComposeBody((cur) => (cur.trim() ? cur : body));
+  });
 
   // The link resolved to nothing (unlinked, or unlinked while this view was
   // open): the issue query is disabled, so it would otherwise sit on a pending
@@ -1591,12 +1605,13 @@ export function JiraIssueView({
     if (!body) return;
     // Clear the draft immediately (perceived speed); restore it on error, but
     // only if the composer is still empty so we never clobber newly-typed text.
+    const submittedFor = issueKey;
     setComposeBody("");
     comment.mutate(
       { issueKey, bodyMd: body },
       {
         onError: (e) => {
-          setComposeBody((cur) => (cur.trim() ? cur : body));
+          restoreDraft(submittedFor, body);
           toastError(e);
         },
       },

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -101,6 +101,16 @@ export function LocalIssueView({
     if (issue) update.mutate({ id: issue.id, mutate });
   });
   const [confirmDelete, setConfirmDelete] = useState(false);
+  // A different issue must never inherit this one's unsent drafts or pending
+  // delete confirm — a render-time state adjustment, not an effect.
+  const [lastId, setLastId] = useState(id);
+  if (id !== lastId) {
+    setLastId(id);
+    setComment("");
+    setLabelInput("");
+    setDeletingCommentId(null);
+    setConfirmDelete(false);
+  }
   const [promoteOpen, setPromoteOpen] = useState(false);
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -101,16 +101,6 @@ export function LocalIssueView({
     if (issue) update.mutate({ id: issue.id, mutate });
   });
   const [confirmDelete, setConfirmDelete] = useState(false);
-  // A different issue must never inherit this one's unsent drafts or pending
-  // delete confirm — a render-time state adjustment, not an effect.
-  const [lastId, setLastId] = useState(id);
-  if (id !== lastId) {
-    setLastId(id);
-    setComment("");
-    setLabelInput("");
-    setDeletingCommentId(null);
-    setConfirmDelete(false);
-  }
   const [promoteOpen, setPromoteOpen] = useState(false);
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {
@@ -121,6 +111,18 @@ export function LocalIssueView({
       });
     },
   });
+  // A different issue must never inherit this one's unsent drafts or open
+  // confirm/promote/edit dialogs — a render-time state adjustment, not an effect.
+  const [lastId, setLastId] = useState(id);
+  if (id !== lastId) {
+    setLastId(id);
+    setComment("");
+    setLabelInput("");
+    setDeletingCommentId(null);
+    setConfirmDelete(false);
+    setPromoteOpen(false);
+    edit.setOpen(false);
+  }
 
   if (!issue) {
     return <DiffPlaceholder message="This local issue no longer exists" />;

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -232,6 +232,7 @@ export function RemoteIssueView({
   // delete/transfer/edit dialogs — a render-time state adjustment, not an effect.
   // The lens is part of the identity: it can collapse to "origin" without a
   // remount (upstream remote goes away), leaving the number pointing at another repo.
+  // The same identity keys the sidebar below, remounting its own per-issue drafts.
   const issueIdentity = `${repoPath}#${lens}#${number}`;
   const [lastIdentity, setLastIdentity] = useState(issueIdentity);
   if (issueIdentity !== lastIdentity) {
@@ -862,6 +863,9 @@ export function RemoteIssueView({
           )}
         </div>
         <IssueSidebar
+          // Remounts the rail per issue so its sections' drafts (the uncontrolled
+          // "Add spent" input, the link picker) can't commit against a new number.
+          key={issueIdentity}
           repoPath={repoPath}
           number={number}
           issue={issue}

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -6,7 +6,7 @@ import {
   PencilSimpleIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   MarkdownEditor,
@@ -222,6 +222,24 @@ export function RemoteIssueView({
   const [transferOpen, setTransferOpen] = useState(false);
   const [transferDest, setTransferDest] = useState("");
   const [deleteOpen, setDeleteOpen] = useState(false);
+  // A different issue must never inherit this one's unsent draft or pending
+  // delete confirm — a render-time state adjustment, not an effect. The lens is
+  // part of the identity: it can collapse to "origin" without a remount (the
+  // upstream remote goes away), leaving the same number pointing at another repo.
+  const issueIdentity = `${lens}#${number}`;
+  const [lastIdentity, setLastIdentity] = useState(issueIdentity);
+  if (issueIdentity !== lastIdentity) {
+    setLastIdentity(issueIdentity);
+    setComposeBody("");
+    setDeletingCommentId(null);
+    setDeleteOpen(false);
+  }
+  // The restore below can land after the user switched issues; an effect event
+  // reads the LIVE identity so a late rejection can't resurrect text elsewhere.
+  const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
+    if (submittedFor !== issueIdentity) return;
+    setComposeBody((cur) => (cur.trim() ? cur : body));
+  });
   // Destination suggestions come from the viewer's repos on the SAME provider
   // as this repo; each query only fires while its dialog variant is open. The
   // GitLab list is repo-scoped so it targets the repo's own (possibly
@@ -286,12 +304,13 @@ export function RemoteIssueView({
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
     // the composer is still empty so we never clobber newly-typed text.
+    const submittedFor = issueIdentity;
     setComposeBody("");
     comment.mutate(
       { number, body, author: forge.data?.login ?? "You" },
       {
         onError: (e) => {
-          setComposeBody((cur) => (cur.trim() ? cur : body));
+          restoreDraft(submittedFor, body);
           onError(e);
         },
       },

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -222,17 +222,26 @@ export function RemoteIssueView({
   const [transferOpen, setTransferOpen] = useState(false);
   const [transferDest, setTransferDest] = useState("");
   const [deleteOpen, setDeleteOpen] = useState(false);
-  // A different issue must never inherit this one's unsent draft or pending
-  // delete confirm — a render-time state adjustment, not an effect. The lens is
-  // part of the identity: it can collapse to "origin" without a remount (the
-  // upstream remote goes away), leaving the same number pointing at another repo.
-  const issueIdentity = `${lens}#${number}`;
+  const edit = useEditTitleBody({
+    onSave: async ({ title, body }) => {
+      await editIssue.mutateAsync({ number, title, body });
+    },
+    successToast: "Issue updated",
+  });
+  // A different issue must never inherit this one's unsent draft or open
+  // delete/transfer/edit dialogs — a render-time state adjustment, not an effect.
+  // The lens is part of the identity: it can collapse to "origin" without a
+  // remount (upstream remote goes away), leaving the number pointing at another repo.
+  const issueIdentity = `${repoPath}#${lens}#${number}`;
   const [lastIdentity, setLastIdentity] = useState(issueIdentity);
   if (issueIdentity !== lastIdentity) {
     setLastIdentity(issueIdentity);
     setComposeBody("");
     setDeletingCommentId(null);
     setDeleteOpen(false);
+    setTransferOpen(false);
+    setTransferDest("");
+    edit.setOpen(false);
   }
   // The restore below can land after the user switched issues; an effect event
   // reads the LIVE identity so a late rejection can't resurrect text elsewhere.
@@ -253,12 +262,6 @@ export function RemoteIssueView({
   const onError = (e: unknown) => toastError(e);
 
   const issue = details.data;
-  const edit = useEditTitleBody({
-    onSave: async ({ title, body }) => {
-      await editIssue.mutateAsync({ number, title, body });
-    },
-    successToast: "Issue updated",
-  });
 
   if (details.isPending) {
     return (

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -40,7 +40,6 @@ import type {
   RemoteLens,
 } from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
-import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { IssueDevelopment } from "./IssueDevelopment";
 import {
@@ -103,7 +102,6 @@ export function IssueSidebar({
   const setType = useSetIssueType(repoPath, lens);
   const setConfidential = useSetIssueConfidential(repoPath);
   const setDueDate = useSetIssueDueDate(repoPath);
-  const onError = (e: unknown) => toastError(e);
 
   // A provider we can only read from (Bitbucket, or a not-ready repo): static rail.
   if (
@@ -148,7 +146,7 @@ export function IssueSidebar({
             lens={lens}
             disabledReason={pickerDisabledReason}
             onChange={(next) =>
-              setAssignees.mutate({ number, assignees: next }, { onError })
+              setAssignees.mutate({ number, assignees: next })
             }
           />
         )}
@@ -161,7 +159,7 @@ export function IssueSidebar({
             lens={lens}
             disabledReason={pickerDisabledReason}
             onChange={(m, title) =>
-              setMilestone.mutate({ number, milestone: m, title }, { onError })
+              setMilestone.mutate({ number, milestone: m, title })
             }
           />
         ) : (
@@ -180,9 +178,7 @@ export function IssueSidebar({
             open={issue.state === "OPEN"}
             pending={setDueDate.isPending}
             disabledReason={pickerDisabledReason}
-            onChange={(dueDate) =>
-              setDueDate.mutate({ number, dueDate }, { onError })
-            }
+            onChange={(dueDate) => setDueDate.mutate({ number, dueDate })}
           />
         )}
         {canSetConfidential && (
@@ -191,7 +187,7 @@ export function IssueSidebar({
             pending={setConfidential.isPending}
             disabledReason={pickerDisabledReason}
             onChange={(confidential) =>
-              setConfidential.mutate({ number, confidential }, { onError })
+              setConfidential.mutate({ number, confidential })
             }
           />
         )}
@@ -236,10 +232,7 @@ export function IssueSidebar({
         lens={lens}
         disabledReason={pickerDisabledReason}
         onChange={(type) =>
-          setType.mutate(
-            { number, typeName: type?.name ?? null, type },
-            { onError },
-          )
+          setType.mutate({ number, typeName: type?.name ?? null, type })
         }
       />
       <AssigneesPopover
@@ -249,9 +242,7 @@ export function IssueSidebar({
         commitOnClose
         lens={lens}
         disabledReason={pickerDisabledReason}
-        onChange={(next) =>
-          setAssignees.mutate({ number, assignees: next }, { onError })
-        }
+        onChange={(next) => setAssignees.mutate({ number, assignees: next })}
       />
       <LabelsPopover
         repoPath={repoPath}
@@ -271,7 +262,7 @@ export function IssueSidebar({
         lens={lens}
         disabledReason={pickerDisabledReason}
         onChange={(m, title) =>
-          setMilestone.mutate({ number, milestone: m, title }, { onError })
+          setMilestone.mutate({ number, milestone: m, title })
         }
       />
       <div className="space-y-1.5">
@@ -643,7 +634,6 @@ function IssueTimeTrackingSection({
   const stats = useGlIssueTimeStats(repoPath, number);
   const setEstimate = useSetIssueTimeEstimate(repoPath);
   const addSpent = useAddIssueSpentTime(repoPath);
-  const onError = (e: unknown) => toastError(e);
 
   return (
     <div className="space-y-1.5">
@@ -657,12 +647,8 @@ function IssueTimeTrackingSection({
           pending={setEstimate.isPending || addSpent.isPending}
           disabledReason={disabledReason}
           idPrefix="issue"
-          onSetEstimate={(duration) =>
-            setEstimate.mutate({ number, duration }, { onError })
-          }
-          onAddSpent={(duration) =>
-            addSpent.mutate({ number, duration }, { onError })
-          }
+          onSetEstimate={(duration) => setEstimate.mutate({ number, duration })}
+          onAddSpent={(duration) => addSpent.mutate({ number, duration })}
         />
       )}
     </div>
@@ -693,7 +679,6 @@ function IssueLinksSection({
   const unlinkIssue = useUnlinkIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
   const [adding, setAdding] = useState(false);
-  const onError = (e: unknown) => toastError(e);
 
   const data = links.data ?? [];
   const exclude = new Set<number>([number, ...data.map((l) => l.number)]);
@@ -739,9 +724,7 @@ function IssueLinksSection({
           issue={toRelated(l)}
           onOpen={open}
           removeDisabledReason={disabledReason}
-          onRemove={() =>
-            unlinkIssue.mutate({ number, linkId: l.linkId }, { onError })
-          }
+          onRemove={() => unlinkIssue.mutate({ number, linkId: l.linkId })}
         />
       ))}
 
@@ -767,7 +750,7 @@ function IssueLinksSection({
               onPick={(target) =>
                 linkIssue.mutate(
                   { number, targetNumber: target },
-                  { onSuccess: () => setAdding(false), onError },
+                  { onSuccess: () => setAdding(false) },
                 )
               }
             />

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -19,6 +19,7 @@ import {
 import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { gitListTracked, readRepoInstructions } from "@/lib/git/api";
 import { notify } from "@/lib/notify";
+import { norm } from "@/lib/repo-data-migration";
 import { loadSettings } from "@/lib/settings/api";
 import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";
 import { errorMessage } from "@/lib/tauri/invoke";
@@ -144,6 +145,10 @@ interface PlanState {
   restart: (id: string) => void;
   /** Drop a run from the list (cancelling any in-flight turn). */
   remove: (id: string) => void;
+  /** Repoint every run of a relocated repo at its new path, so they stay in the
+   *  sidebar and the next autosave writes the migrated paths back (an unpatched
+   *  list would re-persist the old ones over the on-disk migration). */
+  relocateRepoPath: (oldPath: string, newPath: string) => void;
 }
 
 function repoName(p: string): string {
@@ -211,7 +216,10 @@ export const usePlanStore = create<PlanState>((set, get) => {
     const notifyDone = (failed: boolean, hasQuestions = false) => {
       const run = get().runs.find((r) => r.id === id);
       if (!run) return;
-      if (!hasQuestions && isWatchingAgentSurface(get().activePlanId, id))
+      if (
+        !hasQuestions &&
+        isWatchingAgentSurface(get().activePlanId, id, run.repoPath)
+      )
         return;
       const label =
         run.origin?.issueTitle?.trim() || run.origin?.goal?.trim() || "Plan";
@@ -492,6 +500,17 @@ export const usePlanStore = create<PlanState>((set, get) => {
       set({
         runs: get().runs.filter((r) => r.id !== id),
         activePlanId: get().activePlanId === id ? null : get().activePlanId,
+      });
+    },
+
+    relocateRepoPath: (oldPath, newPath) => {
+      // No-match guard: a fresh array would trip the persistence subscribe
+      // into rewriting plans.json with identical content.
+      if (!get().runs.some((r) => norm(r.repoPath) === norm(oldPath))) return;
+      set({
+        runs: get().runs.map((r) =>
+          norm(r.repoPath) === norm(oldPath) ? { ...r, repoPath: newPath } : r,
+        ),
       });
     },
   };

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffectEvent, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
@@ -242,6 +242,23 @@ export function CommitComments({
 
   const [body, setBody] = useState("");
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  // Neither call site keys this component on the commit, so a different commit
+  // must never inherit the previous one's draft or pending delete confirm — a
+  // render-time state adjustment, not an effect. Identity is the same triple the
+  // comments are read and written under.
+  const commitIdentity = `${repoPath}#${lens}#${sha}`;
+  const [lastIdentity, setLastIdentity] = useState(commitIdentity);
+  if (commitIdentity !== lastIdentity) {
+    setLastIdentity(commitIdentity);
+    setBody("");
+    setDeletingId(null);
+  }
+  // The restore below can land after the user moved to another commit; an effect
+  // event reads the LIVE identity so a late rejection can't resurrect text there.
+  const restoreDraft = useEffectEvent((submittedFor: string, text: string) => {
+    if (submittedFor !== commitIdentity) return;
+    setBody((cur) => (cur.trim() ? cur : text));
+  });
 
   const list = comments.data ?? [];
   const whole = list.filter((c) => c.path == null);
@@ -270,13 +287,14 @@ export function CommitComments({
     // Clear the draft immediately (perceived-speed win); the hook appends the
     // synthetic comment optimistically. On error restore the draft, but only if
     // the composer is still empty so newly-typed text is never clobbered.
+    const submittedFor = commitIdentity;
     setBody("");
     createComment.mutate(
       { sha, body: text },
       {
         onSuccess: () => toast.success("Comment added"),
         onError: (e) => {
-          setBody((cur) => (cur.trim() ? cur : text));
+          restoreDraft(submittedFor, text);
           toastError(e);
         },
       },

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -111,11 +111,6 @@ export function LocalPrView({
   const [selectedCommitHash, setSelectedCommitHash] = useState<string | null>(
     null,
   );
-  const [lastId, setLastId] = useState(id);
-  if (id !== lastId) {
-    setLastId(id);
-    setSelectedCommitHash(null);
-  }
   // The activity dock's "View" lands here via a pending hint; switch to the
   // review sub-tab once, then clear it. Guarded on this being the *selected* PR
   // so a still-mounted lagging view (deferredPr) can't swallow the hint first.
@@ -146,6 +141,16 @@ export function LocalPrView({
   } = useLocalConversation(pr, (mutate) => {
     if (pr) update.mutate({ id: pr.id, mutate });
   });
+  // A different PR must never inherit this one's drill-in, unsent drafts, or
+  // pending delete confirm — a render-time state adjustment, not an effect.
+  const [lastId, setLastId] = useState(id);
+  if (id !== lastId) {
+    setLastId(id);
+    setSelectedCommitHash(null);
+    setComment("");
+    setLabelInput("");
+    setDeletingCommentId(null);
+  }
   const [promoteOpen, setPromoteOpen] = useState(false);
   const ghStatus = useForgeStatus(repoPath);
   // Linked-issue chips on the local-PR edit path: the chips OWN the trailing ref
@@ -586,6 +591,9 @@ export function LocalPrView({
             body: pr.body,
             commitSubjects: ahead.map((c) => c.subject),
             repoPath,
+            // A local PR has no forge lens; "origin" keeps its per-PR review stores
+            // on the keys they used before the lens dimension existed.
+            lens: "origin",
             // `ahead` (git log) is newest-first, so the head is the first entry.
             headSha: ahead[0]?.hash,
             loadDiff: () =>

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -17,7 +17,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Badge } from "@/components/ui/badge";
@@ -75,7 +75,10 @@ import {
   type TimelineEntry,
 } from "./PrTimeline";
 import { ResolveConflictsView } from "./ResolveConflictsView";
-import { useGeneratePrDescription } from "./useGeneratePrDescription";
+import {
+  useCancelOnIdentityChange,
+  useGeneratePrDescription,
+} from "./useGeneratePrDescription";
 import {
   composeBodyWithRefs,
   splitBodyRefBlock,
@@ -174,16 +177,9 @@ export function LocalPrView({
     edit.setOpen(false);
   }
   const prGen = useGeneratePrDescription(repoPath);
-  // The edit dialog's in-flight generation belongs to the PR it was started on,
-  // but cancelling ABORTS a live stream — an imperative effect, never part of the
-  // render-time block above, which React may discard and replay.
-  const cancelGeneration = useEffectEvent(() => prGen.cancel());
-  const generatingFor = useRef(id);
-  useEffect(() => {
-    if (generatingFor.current === id) return;
-    generatingFor.current = id;
-    cancelGeneration();
-  }, [id]);
+  // The edit dialog's in-flight generation belongs to the PR it was started on; the
+  // cancel is imperative, so it rides an effect rather than the block above.
+  useCancelOnIdentityChange(id, prGen.cancel);
   // Context-sensitive reuse of the generate-commit-message binding (mod+g by
   // default) for the Edit dialog's chord + button hint — a rebinding drives both.
   const generateBinding =

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -17,7 +17,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Badge } from "@/components/ui/badge";
@@ -141,16 +141,6 @@ export function LocalPrView({
   } = useLocalConversation(pr, (mutate) => {
     if (pr) update.mutate({ id: pr.id, mutate });
   });
-  // A different PR must never inherit this one's drill-in, unsent drafts, or
-  // pending delete confirm — a render-time state adjustment, not an effect.
-  const [lastId, setLastId] = useState(id);
-  if (id !== lastId) {
-    setLastId(id);
-    setSelectedCommitHash(null);
-    setComment("");
-    setLabelInput("");
-    setDeletingCommentId(null);
-  }
   const [promoteOpen, setPromoteOpen] = useState(false);
   const ghStatus = useForgeStatus(repoPath);
   // Linked-issue chips on the local-PR edit path: the chips OWN the trailing ref
@@ -171,7 +161,29 @@ export function LocalPrView({
       });
     },
   });
+  // A different PR must never inherit this one's drill-in, unsent drafts, or open
+  // delete/promote/edit dialogs — a render-time state adjustment, not an effect.
+  const [lastId, setLastId] = useState(id);
+  if (id !== lastId) {
+    setLastId(id);
+    setSelectedCommitHash(null);
+    setComment("");
+    setLabelInput("");
+    setDeletingCommentId(null);
+    setPromoteOpen(false);
+    edit.setOpen(false);
+  }
   const prGen = useGeneratePrDescription(repoPath);
+  // The edit dialog's in-flight generation belongs to the PR it was started on,
+  // but cancelling ABORTS a live stream — an imperative effect, never part of the
+  // render-time block above, which React may discard and replay.
+  const cancelGeneration = useEffectEvent(() => prGen.cancel());
+  const generatingFor = useRef(id);
+  useEffect(() => {
+    if (generatingFor.current === id) return;
+    generatingFor.current = id;
+    cancelGeneration();
+  }, [id]);
   // Context-sensitive reuse of the generate-commit-message binding (mod+g by
   // default) for the Edit dialog's chord + button hint — a rebinding drives both.
   const generateBinding =

--- a/src/features/pulls/PendingReviewBar.tsx
+++ b/src/features/pulls/PendingReviewBar.tsx
@@ -4,6 +4,7 @@ import { MarkdownEditor } from "@/components/markdown-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
+import type { RemoteLens } from "@/lib/git/types";
 import {
   type ReviewDraft,
   useClearReviewDrafts,
@@ -30,18 +31,21 @@ function draftLabel(draft: ReviewDraft): string {
  */
 export function DraftCommentCard({
   repoPath,
+  lens,
   number,
   draft,
 }: {
   repoPath: string;
+  /** The origin|upstream lens the parent PR view resolved (scopes the drafts). */
+  lens: RemoteLens;
   number: number;
   draft: ReviewDraft;
 }) {
   const [editing, setEditing] = useState(false);
   const [body, setBody] = useState(draft.body);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const updateDraft = useUpdateReviewDraft(repoPath, number);
-  const removeDraft = useRemoveReviewDraft(repoPath, number);
+  const updateDraft = useUpdateReviewDraft(repoPath, lens, number);
+  const removeDraft = useRemoveReviewDraft(repoPath, lens, number);
 
   function saveEdit() {
     const next = body.trim();
@@ -147,15 +151,18 @@ export function DraftCommentCard({
  */
 export function PendingReviewBar({
   repoPath,
+  lens,
   number,
   onSubmit,
 }: {
   repoPath: string;
+  /** The origin|upstream lens the parent PR view resolved (scopes the drafts). */
+  lens: RemoteLens;
   number: number;
   onSubmit: () => void;
 }) {
-  const drafts = useReviewDrafts(repoPath, number);
-  const clearDrafts = useClearReviewDrafts(repoPath, number);
+  const drafts = useReviewDrafts(repoPath, lens, number);
+  const clearDrafts = useClearReviewDrafts(repoPath, lens, number);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const count = drafts.data?.length ?? 0;
 

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -128,7 +128,12 @@ export function PrReviewPanel({
 
   // Prior reviews for this PR, used for the per-mode context banner. Read-only —
   // never creates a record, so a first-ever review is unaffected.
-  const history = useReviewHistory(context.repoPath, prKind, prRef);
+  const history = useReviewHistory(
+    context.repoPath,
+    context.lens,
+    prKind,
+    prRef,
+  );
   const latestByMode = useMemo(() => {
     const out: Partial<Record<ReviewMode, PersistedReview>> = {};
     // The list is newest-first, so the first hit per mode is the latest. Skip
@@ -687,6 +692,7 @@ export function PrReviewPanel({
           )}
         <ReviewHistory
           repoPath={context.repoPath}
+          lens={context.lens}
           prKind={prKind}
           prRef={prRef}
         />

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -95,16 +95,18 @@ export function PrReviewPanel({
 }) {
   const settings = useSettings();
   const repoName = useUiStore((s) => s.repoName) ?? "";
-  // The review run is keyed by repo + PR so it survives this panel unmounting;
-  // memoized so its identity is stable across the panel's many re-renders.
+  // The review run is keyed by repo + lens + PR so it survives this panel
+  // unmounting; memoized so its identity is stable across the panel's many
+  // re-renders.
   const target = useMemo<ReviewTarget>(
     () => ({
       kind: prKind,
       repoPath: context.repoPath,
       repoName,
+      lens: context.lens,
       ref: prRef,
     }),
-    [prKind, context.repoPath, repoName, prRef],
+    [prKind, context.repoPath, repoName, context.lens, prRef],
   );
   const {
     generate,

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -288,14 +288,11 @@ export function RemotePrView({
   // targets the fork (origin) or its parent (upstream) — "origin" everywhere but a
   // GitHub fork whose lens is set upstream.
   const lens = useRepoLens(repoPath);
-  // Which PR is on screen. The lens is IN the identity because it can flip while
-  // this view stays mounted — removing the upstream remote collapses the gate, so
-  // the same number becomes a different repo's PR.
-  const entityKey = `${lens}#${number}`;
-  // The same identity for async mutation callbacks, which close over the entity
-  // they fired for and need the live one to compare against. Updated by the
-  // render-time reset below, so it can never lag a switch.
-  const liveEntityKey = useRef(entityKey);
+  // Which PR is on screen. `repoPath` because a number is only unique within one
+  // repo, and the lens because it can flip while this view stays MOUNTED —
+  // removing the upstream remote collapses the gate, so the same number becomes a
+  // different repo's PR.
+  const entityKey = `${repoPath}#${lens}#${number}`;
   // The viewer's push permission on the lens repo — the axis the per-action
   // forge flags don't cover. Only fetched once a provider is known; an
   // unanswered probe leaves every control exactly as it is.
@@ -894,6 +891,17 @@ export function RemotePrView({
   );
 
   const [composeBody, setComposeBody] = useState("");
+  // Both land after a mutation settles, by which time the user may have switched
+  // PRs — an effect event reads the LIVE identity, so a late settle can never
+  // resurrect text on, or blank the draft of, whatever PR is on screen now.
+  const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
+    if (submittedFor !== entityKey) return;
+    setComposeBody((cur) => (cur.trim() ? cur : body));
+  });
+  const clearDraft = useEffectEvent((submittedFor: string) => {
+    if (submittedFor !== entityKey) return;
+    setComposeBody("");
+  });
   const [deletingCommentId, setDeletingCommentId] = useState<string | null>(
     null,
   );
@@ -1100,13 +1108,13 @@ export function RemotePrView({
     }
     // Guard the deferred clear like submitComment's restore: after a PR
     // switch it would wipe text just typed on the newly shown PR.
-    const firedFor = entityKey;
+    const submittedFor = entityKey;
     requestChangesPr.mutate(
       { number, body: composeBody.trim() },
       {
         onSuccess: () => {
           toast.success("Requested changes");
-          if (liveEntityKey.current === firedFor) setComposeBody("");
+          clearDraft(submittedFor);
         },
         onError: (e) => {
           if (prev) queryClient.setQueryData(key, prev);
@@ -1122,18 +1130,14 @@ export function RemotePrView({
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
     // the composer is still empty so we never clobber newly-typed text.
-    const firedFor = entityKey;
+    const submittedFor = entityKey;
     setComposeBody("");
     comment.mutate(
       { number, body, author: forge.data?.login ?? "You" },
       {
         onSuccess: () => toast.success("Comment added"),
         onError: (e) => {
-          // Only restore onto the PR this text was written for: the composer is
-          // empty after a switch too, so an unguarded restore plants it on
-          // whatever PR is on screen when the failure lands.
-          if (liveEntityKey.current === firedFor)
-            setComposeBody((cur) => (cur.trim() ? cur : body));
+          restoreDraft(submittedFor, body);
           onError(e);
         },
       },
@@ -1306,15 +1310,33 @@ export function RemotePrView({
   const [lastEntity, setLastEntity] = useState(entityKey);
   if (entityKey !== lastEntity) {
     setLastEntity(entityKey);
-    liveEntityKey.current = entityKey;
     setSelectedPath(null);
     setSelectedCommitOid(null);
-    // A different PR must never inherit this one's conflict-resolution takeover,
-    // its unsent comment draft, or a comment-delete confirmation still open.
+    // Everything below is bound to the PR it was opened on — the conflict-resolution
+    // takeover, the dialogs and confirmations, the unsent draft — so a different PR
+    // must inherit none of it.
     setResolve(null);
     setComposeBody("");
     setDeletingCommentId(null);
+    setDeletingThreadCommentId(null);
+    setSubmitOpen(false);
+    setDiscardConfirmOpen(false);
+    setMergeOpen(false);
+    setMergeAuto(false);
+    setMergeStrategy("merge");
+    setDeleteBranch(false);
+    edit.setOpen(false);
   }
+  // The edit dialog's in-flight generation belongs to the PR it was started on,
+  // but cancelling ABORTS a live stream — an imperative effect, never part of the
+  // render-time block above, which React may discard and replay.
+  const cancelGeneration = useEffectEvent(() => prGen.cancel());
+  const generatingFor = useRef(entityKey);
+  useEffect(() => {
+    if (generatingFor.current === entityKey) return;
+    generatingFor.current = entityKey;
+    cancelGeneration();
+  }, [entityKey]);
   // Default to the first changed file until the user picks one.
   const effectivePath =
     selectedPath && pr?.files.some((f) => f.path === selectedPath)
@@ -3029,8 +3051,12 @@ export function RemotePrView({
       />
 
       {/* The batch submit-review dialog (Review control, pending-review bar, palette
-          action). Verdict caps ride canWrite for GitHub, forge flags elsewhere. */}
+          action). Verdict caps ride canWrite for GitHub, forge flags elsewhere.
+          Keyed on the entity: it owns verdict/summary/error state that ONLY its own
+          onOpenChange resets, so a switch has to remount it — closing it from the
+          reset block alone would leave the previous PR's verdict on the next open. */}
       <SubmitReviewDialog
+        key={entityKey}
         repoPath={repoPath}
         number={number}
         open={submitOpen}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -288,6 +288,14 @@ export function RemotePrView({
   // targets the fork (origin) or its parent (upstream) — "origin" everywhere but a
   // GitHub fork whose lens is set upstream.
   const lens = useRepoLens(repoPath);
+  // Which PR is on screen. The lens is IN the identity because it can flip while
+  // this view stays mounted — removing the upstream remote collapses the gate, so
+  // the same number becomes a different repo's PR.
+  const entityKey = `${lens}#${number}`;
+  // The same identity for async mutation callbacks, which close over the entity
+  // they fired for and need the live one to compare against. Updated by the
+  // render-time reset below, so it can never lag a switch.
+  const liveEntityKey = useRef(entityKey);
   // The viewer's push permission on the lens repo — the axis the per-action
   // forge flags don't cover. Only fetched once a provider is known; an
   // unanswered probe leaves every control exactly as it is.
@@ -498,8 +506,8 @@ export function RemotePrView({
   const [submitOpen, setSubmitOpen] = useState(false);
   // Pending-review drafts (local-only until submitted); shared by the Files-tab
   // anchors, the PendingReviewBar count, and the ReviewComposer's draft count.
-  const drafts = useReviewDrafts(repoPath, number);
-  const clearDrafts = useClearReviewDrafts(repoPath, number);
+  const drafts = useReviewDrafts(repoPath, lens, number);
+  const clearDrafts = useClearReviewDrafts(repoPath, lens, number);
   // The composer/thread-create side of the forge detection: a strict provider key
   // (default "github" — gh is the authoritative default for an unrecognized host).
   const providerKey: ForgeProvider = provider ?? "github";
@@ -1090,12 +1098,15 @@ export function RemotePrView({
       });
       return;
     }
+    // Guard the deferred clear like submitComment's restore: after a PR
+    // switch it would wipe text just typed on the newly shown PR.
+    const firedFor = entityKey;
     requestChangesPr.mutate(
       { number, body: composeBody.trim() },
       {
         onSuccess: () => {
           toast.success("Requested changes");
-          setComposeBody("");
+          if (liveEntityKey.current === firedFor) setComposeBody("");
         },
         onError: (e) => {
           if (prev) queryClient.setQueryData(key, prev);
@@ -1111,13 +1122,18 @@ export function RemotePrView({
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
     // the composer is still empty so we never clobber newly-typed text.
+    const firedFor = entityKey;
     setComposeBody("");
     comment.mutate(
       { number, body, author: forge.data?.login ?? "You" },
       {
         onSuccess: () => toast.success("Comment added"),
         onError: (e) => {
-          setComposeBody((cur) => (cur.trim() ? cur : body));
+          // Only restore onto the PR this text was written for: the composer is
+          // empty after a switch too, so an unguarded restore plants it on
+          // whatever PR is on screen when the failure lands.
+          if (liveEntityKey.current === firedFor)
+            setComposeBody((cur) => (cur.trim() ? cur : body));
           onError(e);
         },
       },
@@ -1284,15 +1300,20 @@ export function RemotePrView({
     [prDiff.data],
   );
 
-  // Reset the manual file selection when a different PR is shown — a
-  // render-time state adjustment, not an effect.
-  const [lastNumber, setLastNumber] = useState(number);
-  if (number !== lastNumber) {
-    setLastNumber(number);
+  // Reset per-PR view state when a different PR is shown — a render-time state
+  // adjustment, not an effect. Keyed on the lens-bearing identity, not the number:
+  // a lens flip under a mounted view is a different repo's PR at the same number.
+  const [lastEntity, setLastEntity] = useState(entityKey);
+  if (entityKey !== lastEntity) {
+    setLastEntity(entityKey);
+    liveEntityKey.current = entityKey;
     setSelectedPath(null);
     setSelectedCommitOid(null);
-    // A different PR must never inherit this one's conflict-resolution takeover.
+    // A different PR must never inherit this one's conflict-resolution takeover,
+    // its unsent comment draft, or a comment-delete confirmation still open.
     setResolve(null);
+    setComposeBody("");
+    setDeletingCommentId(null);
   }
   // Default to the first changed file until the user picks one.
   const effectivePath =
@@ -1956,6 +1977,9 @@ export function RemotePrView({
             body: pr.body,
             commitSubjects: pr.commits.map((c) => c.headline),
             repoPath,
+            // Scopes the run's per-PR stores (prior reviews, own-comments digest) to
+            // the lens this view resolved — a fork's two lenses are different PRs.
+            lens,
             // Provider-aware review copy (MR/merge-request noun, markdown flavor).
             provider: provider ?? undefined,
             // gh GraphQL returns commits oldest-first, so the head is the last.
@@ -2588,6 +2612,7 @@ export function RemotePrView({
           {/* Pending-review status bar — hidden until a draft exists. */}
           <PendingReviewBar
             repoPath={repoPath}
+            lens={lens}
             number={number}
             onSubmit={() => setSubmitOpen(true)}
           />
@@ -2604,6 +2629,7 @@ export function RemotePrView({
             threads={reviewThreads.data}
             drafts={drafts.data}
             repoPath={repoPath}
+            lens={lens}
             number={number}
             lineWidget={reviewLineWidget}
             onQuote={quoteReply}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -216,7 +216,10 @@ import {
 } from "./StackSection";
 import { SubmitReviewDialog } from "./SubmitReviewDialog";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
-import { useGeneratePrDescription } from "./useGeneratePrDescription";
+import {
+  useCancelOnIdentityChange,
+  useGeneratePrDescription,
+} from "./useGeneratePrDescription";
 import {
   composeBodyWithJiraRefs,
   composeBodyWithRefs,
@@ -1327,16 +1330,9 @@ export function RemotePrView({
     setDeleteBranch(false);
     edit.setOpen(false);
   }
-  // The edit dialog's in-flight generation belongs to the PR it was started on,
-  // but cancelling ABORTS a live stream — an imperative effect, never part of the
-  // render-time block above, which React may discard and replay.
-  const cancelGeneration = useEffectEvent(() => prGen.cancel());
-  const generatingFor = useRef(entityKey);
-  useEffect(() => {
-    if (generatingFor.current === entityKey) return;
-    generatingFor.current = entityKey;
-    cancelGeneration();
-  }, [entityKey]);
+  // The edit dialog's in-flight generation belongs to the PR it was started on; the
+  // cancel is imperative, so it rides an effect rather than the block above.
+  useCancelOnIdentityChange(entityKey, prGen.cancel);
   // Default to the first changed file until the user picks one.
   const effectivePath =
     selectedPath && pr?.files.some((f) => f.path === selectedPath)

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1310,6 +1310,7 @@ export function RemotePrView({
   // Reset per-PR view state when a different PR is shown — a render-time state
   // adjustment, not an effect. Keyed on the lens-bearing identity, not the number:
   // a lens flip under a mounted view is a different repo's PR at the same number.
+  // The same identity re-keys the metadata pickers, whose drafts live inside them.
   const [lastEntity, setLastEntity] = useState(entityKey);
   if (entityKey !== lastEntity) {
     setLastEntity(entityKey);
@@ -1763,8 +1764,13 @@ export function RemotePrView({
           <span className="text-success">+{pr.additions}</span>
           <span className="text-destructive">-{pr.deletions}</span>
         </div>
+        {/* The three metadata pickers below are keyed on the entity: each seeds a
+            draft on open and commits it on close by diffing against LIVE props, and
+            a keyboard PR switch leaves the popover open (no outside press to close
+            it) — so without the key the old PR's draft lands on the new one. */}
         {isOpen && canEditLabels ? (
           <LabelsPopover
+            key={entityKey}
             repoPath={repoPath}
             enabled
             number={number}
@@ -1787,6 +1793,7 @@ export function RemotePrView({
             read-only chips, like the labels row. */}
         {isOpen && canEditAssignees ? (
           <AssigneesPopover
+            key={entityKey}
             repoPath={repoPath}
             enabled
             value={pr.assignees}
@@ -1822,6 +1829,7 @@ export function RemotePrView({
         {isOpen && canEditReviewers ? (
           <div className="flex flex-wrap items-center gap-1.5">
             <ReviewersPopover
+              key={entityKey}
               repoPath={repoPath}
               number={number}
               enabled

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -37,7 +37,6 @@ import type {
 } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { ReviewDraft } from "@/lib/pulls/review-drafts";
-import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { DraftCommentCard } from "./PendingReviewBar";
 import { ReviewThreadCard, type SuggestionApply } from "./ReviewThreads";
@@ -457,7 +456,6 @@ export function MrTimeTracking({
   const stats = useGlMrTimeStats(repoPath, number);
   const setEstimate = useSetMrTimeEstimate(repoPath);
   const addSpent = useAddMrSpentTime(repoPath);
-  const onError = (e: unknown) => toastError(e);
 
   const data = stats.data;
   const humanEstimate = data?.humanTimeEstimate ?? "";
@@ -520,11 +518,9 @@ export function MrTimeTracking({
             disabledReason={disabledReason}
             idPrefix="mr"
             onSetEstimate={(duration) =>
-              setEstimate.mutate({ number, duration }, { onError })
+              setEstimate.mutate({ number, duration })
             }
-            onAddSpent={(duration) =>
-              addSpent.mutate({ number, duration }, { onError })
-            }
+            onAddSpent={(duration) => addSpent.mutate({ number, duration })}
           />
         )}
       </PopoverContent>

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -30,7 +30,11 @@ import {
   useGlMrTimeStats,
   useSetMrTimeEstimate,
 } from "@/lib/git/queries";
-import type { ForgeProvider, ReviewThreadOut } from "@/lib/git/types";
+import type {
+  ForgeProvider,
+  RemoteLens,
+  ReviewThreadOut,
+} from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { ReviewDraft } from "@/lib/pulls/review-drafts";
 import { toastError } from "@/lib/toast";
@@ -114,6 +118,7 @@ export function PrFilesPane({
   threads,
   drafts,
   repoPath,
+  lens,
   number,
   lineWidget,
   onQuote,
@@ -133,9 +138,12 @@ export function PrFilesPane({
   /** All PR review threads; the pane anchors those on the selected file. */
   threads?: ReviewThreadOut[];
   /** Pending-review drafts; those on the selected file render as anchored cards
-   *  under their line (needs `repoPath`/`number` for the edit/delete writes). */
+   *  under their line (needs `repoPath`/`lens`/`number` for the edit/delete writes). */
   drafts?: ReviewDraft[];
   repoPath?: string;
+  /** The origin|upstream lens the parent PR view resolved — part of the draft
+   *  store's key, so the cards can't edit the other lens's same-numbered PR. */
+  lens?: RemoteLens;
   number?: number;
   /** The inline line-comment composer, passed straight to the diff. Absent =
    *  a read-only diff (unchanged). */
@@ -168,8 +176,8 @@ export function PrFilesPane({
       else threadsBySideLine.set(key, [t]);
     }
     const draftsBySideLine = new Map<string, ReviewDraft[]>();
-    // Drafts only render when the store owner keys (repoPath/number) are present.
-    if (repoPath !== undefined && number !== undefined) {
+    // Drafts only render when the store owner keys (repoPath/lens/number) are present.
+    if (repoPath !== undefined && lens !== undefined && number !== undefined) {
       for (const d of drafts ?? []) {
         if (d.path !== effectivePath || d.line <= 0) continue;
         const key = `${d.side}:${d.line}`;
@@ -203,11 +211,13 @@ export function PrFilesPane({
               />
             )}
             {repoPath !== undefined &&
+              lens !== undefined &&
               number !== undefined &&
               draftGroup.map((d) => (
                 <DraftCommentCard
                   key={d.id}
                   repoPath={repoPath}
+                  lens={lens}
                   number={number}
                   draft={d}
                 />
@@ -221,6 +231,7 @@ export function PrFilesPane({
     threads,
     drafts,
     repoPath,
+    lens,
     number,
     onQuote,
     onReply,

--- a/src/features/pulls/ReviewComposer.tsx
+++ b/src/features/pulls/ReviewComposer.tsx
@@ -57,7 +57,7 @@ export function ReviewComposer({
   const [body, setBody] = useState("");
   const [pending, setPending] = useState(false);
   const createThread = useCreateReviewThread(repoPath, lens);
-  const addDraft = useAddReviewDraft(repoPath, number);
+  const addDraft = useAddReviewDraft(repoPath, lens, number);
 
   // The multi-line range, normalized: [from, line] with from <= line.
   const rangeFrom = fromLine !== undefined && fromLine < line ? fromLine : line;

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { Textarea } from "@/components/ui/textarea";
+import type { RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
   useClearReviews,
@@ -29,17 +30,21 @@ import { ThoughtsDisclosure } from "./ThoughtsDisclosure";
  */
 export function ReviewHistory({
   repoPath,
+  lens,
   prKind,
   prRef,
 }: {
   repoPath: string;
+  /** The origin|upstream lens the PR was opened under — a fork's two lenses keep
+   *  separate histories for the same PR number. */
+  lens: RemoteLens;
   prKind: "remote" | "local";
   prRef: string;
 }) {
-  const history = useReviewHistory(repoPath, prKind, prRef);
-  const del = useDeleteReview(repoPath, prKind, prRef);
-  const clear = useClearReviews(repoPath, prKind, prRef);
-  const update = useUpdateReviewText(repoPath, prKind, prRef);
+  const history = useReviewHistory(repoPath, lens, prKind, prRef);
+  const del = useDeleteReview(repoPath, lens, prKind, prRef);
+  const clear = useClearReviews(repoPath, lens, prKind, prRef);
+  const update = useUpdateReviewText(repoPath, lens, prKind, prRef);
   const [open, setOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -46,9 +46,9 @@ export function SubmitReviewDialog({
   /** The origin|upstream lens the parent PR view resolved. */
   lens: RemoteLens;
 }) {
-  const drafts = useReviewDrafts(repoPath, number);
+  const drafts = useReviewDrafts(repoPath, lens, number);
   const submitReview = useSubmitReview(repoPath, lens);
-  const clearDrafts = useClearReviewDrafts(repoPath, number);
+  const clearDrafts = useClearReviewDrafts(repoPath, lens, number);
   const [verdict, setVerdict] = useState<ReviewVerdict>("comment");
   const [summary, setSummary] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -54,9 +54,11 @@ export function SubmitReviewDialog({
   const [summary, setSummary] = useState("");
   const [error, setError] = useState<string | null>(null);
   // The parent re-keys this dialog on the PR identity, so a switch can unmount it
-  // mid-submit — past `handleOpenChange`'s pending guard. The inline error below
-  // then has nowhere to render, and a failed (or PARTIAL) post would read as
-  // success; this is what lets the catch route it to a toast instead.
+  // mid-submit — past `handleOpenChange`'s pending guard. That takes away BOTH of
+  // this component's report channels: the inline error below has nowhere to render
+  // (hence the catch's toast fallback), and react-query stops delivering `mutate`
+  // callbacks once the observer loses its listeners (hence `mutateAsync` in the
+  // cleanup). Either loss would let a failed or PARTIAL post read as success.
   const mounted = useRef(true);
   useEffect(() => {
     mounted.current = true;
@@ -133,12 +135,13 @@ export function SubmitReviewDialog({
     // Clearing the (client-only) drafts is a best-effort cleanup AFTER the post
     // landed; a failure here can't un-post, so surface it as a non-blocking
     // warning pointing at the pending bar's Discard — never as a submit error.
-    clearDrafts.mutate(undefined, {
-      onError: () =>
+    clearDrafts
+      .mutateAsync()
+      .catch(() =>
         toast.warning(
           "Review posted, but clearing the pending comments failed — discard them from the pending review bar so they aren't submitted again.",
         ),
-    });
+      );
   }
 
   return (

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
@@ -18,6 +18,7 @@ import {
   useClearReviewDrafts,
   useReviewDrafts,
 } from "@/lib/pulls/review-drafts";
+import { toastError } from "@/lib/toast";
 
 /**
  * The submit-a-review dialog: a capability-gated verdict radio (Comment always;
@@ -52,6 +53,17 @@ export function SubmitReviewDialog({
   const [verdict, setVerdict] = useState<ReviewVerdict>("comment");
   const [summary, setSummary] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // The parent re-keys this dialog on the PR identity, so a switch can unmount it
+  // mid-submit — past `handleOpenChange`'s pending guard. The inline error below
+  // then has nowhere to render, and a failed (or PARTIAL) post would read as
+  // success; this is what lets the catch route it to a toast instead.
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   const draftList = drafts.data ?? [];
   const count = draftList.length;
@@ -102,8 +114,13 @@ export function SubmitReviewDialog({
     } catch (e) {
       // The post itself failed — keep the dialog open, Submit re-armed, and show
       // the message verbatim (on GitLab/Bitbucket it can disclose partial posting,
-      // which the user needs to see in full).
-      setError(e instanceof Error ? e.message : String(e));
+      // which the user needs to see in full). Unmounted mid-submit, that surface is
+      // gone, so the failure rides a toast rather than vanishing.
+      if (mounted.current) {
+        setError(e instanceof Error ? e.message : String(e));
+      } else {
+        toastError(e);
+      }
       return;
     }
     // The review posted. From here Submit must NEVER re-arm — a second click

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
 import { aiExcludePatterns } from "@/lib/ai/ignore";
@@ -229,4 +229,28 @@ export function useGeneratePrDescription(repoPath: string) {
   );
 
   return { generate, generateFromDiff, cancel, generating };
+}
+
+/**
+ * Cancels an in-flight generation when the entity on screen changes — the PR views
+ * keep their edit dialog mounted across a switch, so a stream started on one PR would
+ * otherwise keep writing into the next one's dialog.
+ *
+ * An EFFECT, not a render-time reset: cancelling aborts a live stream, and React may
+ * discard and replay a render. The ref is seeded with the current identity, so
+ * mounting cancels nothing, and it advances before the call so a re-render mid-cancel
+ * can't fire twice. `cancel` rides an effect event, so a caller passing an unstable
+ * function can't re-trigger the effect.
+ */
+export function useCancelOnIdentityChange(
+  identity: string,
+  cancel: () => void,
+): void {
+  const cancelNow = useEffectEvent(() => cancel());
+  const activeFor = useRef(identity);
+  useEffect(() => {
+    if (activeFor.current === identity) return;
+    activeFor.current = identity;
+    cancelNow();
+  }, [identity]);
 }

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -45,6 +45,7 @@ import {
 import { type ForgeProvider, providerLabel } from "@/lib/git/types";
 import { deleteRepoLens } from "@/lib/repo-lens/store";
 import { settingsKeys, useSettings } from "@/lib/settings/queries";
+import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { InlineConfirm } from "./parts";
@@ -333,6 +334,13 @@ function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
                       // Fire-and-forget — the lens read safe-defaults to origin,
                       // so a failure here is harmless.
                       deleteRepoLens(repoPath).catch(() => undefined);
+                      // Removing upstream collapses the lens to origin, so a still-
+                      // selected remote number would resolve against the other repo.
+                      // Same clears `useSetRepoLens` does on an explicit lens flip.
+                      const ui = useUiStore.getState();
+                      if (ui.selectedPr?.kind === "remote") ui.selectPr(null);
+                      if (ui.selectedIssue?.kind === "remote")
+                        ui.selectIssue(null);
                       toast.success("Upstream remote removed");
                       setConfirming(false);
                     },

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -1,6 +1,8 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback } from "react";
 import { toast } from "sonner";
+import { usePlanStore } from "@/features/plan/store";
+import { useResearchStore } from "@/features/research/store";
 import { track } from "@/lib/analytics";
 import { validateRepo } from "@/lib/git/api";
 import type { RepoInfo } from "@/lib/git/types";
@@ -84,6 +86,11 @@ export function useOpenRepoByPath() {
         // automations, Jira link, …) onto the new location's identity key. Purely
         // best-effort — a migration failure must never block opening the repo.
         await migrateRepoData(oldPath, info.root).catch(() => undefined);
+        // The plan/research stores hydrate once at startup, so their live runs
+        // still carry the old path — repoint them, or the sidebar loses them and
+        // their debounced autosave writes the pre-migration paths back to disk.
+        usePlanStore.getState().relocateRepoPath(oldPath, info.root);
+        useResearchStore.getState().relocateRepoPath(oldPath, info.root);
         await recordOpenAndTrack(info, "relocate");
       } catch (e) {
         if (isAppError(e) && e.kind === "notARepo") {

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -21,6 +21,7 @@ import {
 import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { readRepoInstructions } from "@/lib/git/api";
 import { notify } from "@/lib/notify";
+import { norm } from "@/lib/repo-data-migration";
 import { loadSettings } from "@/lib/settings/api";
 import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";
 import { errorMessage, invoke } from "@/lib/tauri/invoke";
@@ -176,6 +177,10 @@ interface ResearchState {
   restart: (id: string) => void;
   /** Drop a run from the list (cancelling any in-flight turn). */
   remove: (id: string) => void;
+  /** Repoint every run of a relocated repo at its new path, so they stay in the
+   *  sidebar and the next autosave writes the migrated paths back (an unpatched
+   *  list would re-persist the old ones over the on-disk migration). */
+  relocateRepoPath: (oldPath: string, newPath: string) => void;
 }
 
 function repoName(p: string): string {
@@ -296,7 +301,8 @@ export const useResearchStore = create<ResearchState>((set, get) => {
     const notifyDone = (failed: boolean) => {
       const run = get().runs.find((r) => r.id === id);
       if (!run) return;
-      if (isWatchingAgentSurface(get().activeResearchId, id)) return;
+      if (isWatchingAgentSurface(get().activeResearchId, id, run.repoPath))
+        return;
       const label = run.origin?.topic?.trim() || "Research";
       const headline = failed ? "Research failed" : "Research ready";
       void notify(headline, label);
@@ -681,6 +687,17 @@ export const useResearchStore = create<ResearchState>((set, get) => {
         runs: get().runs.filter((r) => r.id !== id),
         activeResearchId:
           get().activeResearchId === id ? null : get().activeResearchId,
+      });
+    },
+
+    relocateRepoPath: (oldPath, newPath) => {
+      // No-match guard: a fresh array would trip the persistence subscribe
+      // into rewriting research.json with identical content.
+      if (!get().runs.some((r) => norm(r.repoPath) === norm(oldPath))) return;
+      set({
+        runs: get().runs.map((r) =>
+          norm(r.repoPath) === norm(oldPath) ? { ...r, repoPath: newPath } : r,
+        ),
       });
     },
   };

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -350,10 +350,11 @@ async function runTurn(
         t.error,
       ),
     );
-    // "Watching" = focused + Agent tab on screen + this session selected; then the streamed
-    // result is already visible, so stay quiet. Notifying otherwise covers multi-session and
-    // other-tab cases. A user Cancel is intentional, so it's never announced.
-    if (isWatchingAgentSurface(get().activeId, id)) return;
+    // "Watching" = focused + this session's repo open on its Agent tab + this session
+    // selected; then the streamed result is already visible, so stay quiet. Notifying
+    // otherwise covers multi-session, other-repo and other-tab cases. A user Cancel is
+    // intentional, so it's never announced.
+    if (isWatchingAgentSurface(get().activeId, id, s.repoPath)) return;
     if (t.status === "error" && t.error === "Cancelled.") return;
     const label =
       s.turns[0]?.prompt.trim().replace(/\s+/g, " ").slice(0, 70) ||
@@ -536,7 +537,15 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
         )
           persist(removeTranscript(s.id));
       }
-      set({ sessions: alive });
+      // Merge under any sessions created before hydration finished (newest state
+      // wins) — `start` isn't gated on hydration, so a replace would drop one.
+      const created = new Set(get().sessions.map((s) => s.id));
+      set({
+        sessions: [
+          ...alive.filter((s) => !created.has(s.id)),
+          ...get().sessions,
+        ],
+      });
     }
     set({ hydrated: true });
   },

--- a/src/features/sessions/watching.ts
+++ b/src/features/sessions/watching.ts
@@ -2,24 +2,33 @@ import { useUiStore } from "@/lib/stores/ui";
 
 /**
  * True when the user is actually looking at agent surface `id` right now: the
- * window is focused, the **Agent tab** is the visible tab, and `id` is the
- * selected plan/session.
+ * window is focused, the run's repo (`runRepoPath`) is the open one, the **Agent
+ * tab** is the visible tab, and `id` is the selected plan/session.
  *
  * Both agent stores use this to decide whether a finished run still needs an OS
  * notification — staying quiet only when the result is already on screen.
  * `document.hasFocus()` alone is window-level: it can't tell the Agent tab from
  * Changes/Pulls, so a focused user on a different tab was wrongly treated as
- * "watching" and got no nudge. Plan and session selection are mutually exclusive
- * (see `agentSelect.ts`), so `activeId === id` plus `repoTab === "agent"` is a
- * precise "this exact surface is on screen".
+ * "watching" and got no nudge. The repo is the same axis: the surface only lists
+ * the OPEN repo's runs, so one finishing for another repo is off screen whatever
+ * the tab shows. Plan and session selection are mutually exclusive (see
+ * `agentSelect.ts`), so `activeId === id` plus `repoTab === "agent"` is a precise
+ * "this exact surface is on screen".
+ *
+ * `runRepoPath` is the run's REPO, never its worktree (sessions run in per-task
+ * worktrees, which never equal the open repo path), compared verbatim like every
+ * other repo filter on this surface.
  */
 export function isWatchingAgentSurface(
   activeId: string | null,
   id: string,
+  runRepoPath: string,
 ): boolean {
+  const ui = useUiStore.getState();
   return (
     document.hasFocus() &&
-    useUiStore.getState().repoTab === "agent" &&
+    ui.repoPath === runRepoPath &&
+    ui.repoTab === "agent" &&
     activeId === id
   );
 }

--- a/src/lib/ai/own-context.ts
+++ b/src/lib/ai/own-context.ts
@@ -1,7 +1,12 @@
 import { forgePrExternalReviews } from "@/lib/git/api";
-import type { ExternalReviewItem } from "@/lib/git/types";
+import type { ExternalReviewItem, RemoteLens } from "@/lib/git/types";
 import { GD_COMMENT_ANCHOR } from "./comment-branding";
-import { getDigest, recordDigestFailure, saveDigest } from "./own-digest-store";
+import {
+  digestKey,
+  getDigest,
+  recordDigestFailure,
+  saveDigest,
+} from "./own-digest-store";
 import { distillOwnComments } from "./own-distill";
 import {
   allocateBodyCaps,
@@ -268,6 +273,7 @@ function formatOwnComments(
  */
 export async function resolveOwnCommentsContext(
   repoPath: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   provider: string = "github",
@@ -369,7 +375,7 @@ export async function resolveOwnCommentsContext(
     // (`distillBlockCap`, own-distill.ts), so the same fields now yield a
     // different ledger — no field moves, hence the tag.
     const fingerprint = `v4#${survivors.length}#${newest}#${budget}#${cappedJoinedLen}#${uncappedLen}`;
-    const cacheKey = `${kind}#${ref}`;
+    const cacheKey = digestKey(lens, kind, ref);
     // The generation model this attempt used, reported by the distiller as soon as it
     // resolves settings (one load, not two that could disagree). Empty if that load
     // threw or the provider runs on its account-default model.
@@ -391,14 +397,14 @@ export async function resolveOwnCommentsContext(
     // composed inside `distillOwnComments`, so a timeout still records.
     const rememberFailure = async () => {
       if (opts.signal?.aborted) return;
-      await recordDigestFailure(repoPath, kind, ref, {
+      await recordDigestFailure(repoPath, lens, kind, ref, {
         fingerprint,
         at: Date.now(),
         model: attemptedModel,
       });
     };
     try {
-      const cached = await getDigest(repoPath, kind, ref);
+      const cached = await getDigest(repoPath, lens, kind, ref);
       if (cached?.fingerprint === fingerprint && cached.ledger.trim()) {
         return {
           ownItems: [capLedger(cached.ledger, budget)],

--- a/src/lib/ai/own-digest-store.ts
+++ b/src/lib/ai/own-digest-store.ts
@@ -1,5 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { identityKeyFor, repoIdentity } from "@/lib/git/repo-identity";
+import type { RemoteLens } from "@/lib/git/types";
 import { storeName } from "@/lib/test-mode";
 
 /**
@@ -17,7 +18,7 @@ import { storeName } from "@/lib/test-mode";
  */
 export interface OwnCommentsDigest {
   schemaVersion: 1;
-  /** `${kind}#${ref}` — one PR's ledger. */
+  /** `${lens}#${kind}#${ref}` — one PR's ledger (see {@link digestKey}). */
   key: string;
   /** Invalidation token:
    *  `v4#${count}#${newestCreatedAt}#${budget}#${cappedJoinedChars}#${uncappedChars}`
@@ -56,10 +57,24 @@ export interface OwnCommentsDigest {
   failed?: { fingerprint: string; at: number; model: string };
 }
 
+/** Store key for one PR's ledger. The lens is part of it because a fork's origin
+ *  and upstream lenses surface DIFFERENT PRs under the same number. */
+export const digestKey = (
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+) => `${lens}#${kind}#${ref}`;
+
+/** The pre-lens key a lens key supersedes — records written before the lens
+ *  dimension existed, which can only have been the origin lens. */
+function legacyDigestKey(key: string): string | undefined {
+  return key.startsWith("origin#") ? key.slice("origin#".length) : undefined;
+}
+
 // Records live in personal app-data, keyed by the repo's worktree-stable identity
 // (not its checkout path) so a PR's cached digest is shared across the main
 // checkout and every worktree. Routed through storeName() so cold-start/test mode
-// never pollutes real data. One digest per `${kind}#${ref}` key.
+// never pollutes real data. One digest per `digestKey` key.
 let storePromise: Promise<Store> | null = null;
 function getStore(): Promise<Store> {
   storePromise ??= load(storeName("own-comments-digest.json"), {
@@ -109,6 +124,7 @@ async function keyFor(repo: string): Promise<string> {
  *  returns undefined). */
 export async function getDigest(
   repoPath: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
 ): Promise<OwnCommentsDigest | undefined> {
@@ -121,10 +137,13 @@ export async function getDigest(
       ? {}
       : ((await store.get<Record<string, OwnCommentsDigest>>(repoPath)) ?? {});
   const bag = { ...legacy, ...primary };
-  return bag[`${kind}#${ref}`];
+  const key = digestKey(lens, kind, ref);
+  const preLens = legacyDigestKey(key);
+  // A pre-lens record still serves the origin lens until the next write folds it.
+  return bag[key] ?? (preLens === undefined ? undefined : bag[preLens]);
 }
 
-/** Upserts one PR's digest under its `${kind}#${ref}` key — replaces the prior
+/** Upserts one PR's digest under its {@link digestKey} — replaces the prior
  *  record for that key (one digest per PR). Serialized + force-saved so an
  *  overlapping save can't reload a pre-flush snapshot.
  *
@@ -142,6 +161,10 @@ export async function saveDigest(
     const store = await getStore();
     const bag = (await store.get<Record<string, OwnCommentsDigest>>(key)) ?? {};
     bag[record.key] = record;
+    // This write supersedes any pre-lens record for the same PR — dropping it here
+    // is the fold, one PR at a time, never a sweep over the store.
+    const preLens = legacyDigestKey(record.key);
+    if (preLens !== undefined) delete bag[preLens];
     await store.set(key, bag);
     // Flush now instead of on autoSave's debounce, so the next serialized reload
     // can't re-read a pre-write disk snapshot and drop this change.
@@ -166,6 +189,7 @@ export async function saveDigest(
  */
 export async function recordDigestFailure(
   repoPath: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   failed: NonNullable<OwnCommentsDigest["failed"]>,
@@ -175,8 +199,13 @@ export async function recordDigestFailure(
     const key = await keyFor(repoPath);
     const store = await getStore();
     const bag = (await store.get<Record<string, OwnCommentsDigest>>(key)) ?? {};
-    const recordKey = `${kind}#${ref}`;
-    const existing = bag[recordKey];
+    const recordKey = digestKey(lens, kind, ref);
+    // Adopt any pre-lens record for this PR rather than stranding its ledger — the
+    // same one-PR-at-a-time fold `saveDigest` does.
+    const preLens = legacyDigestKey(recordKey);
+    const existing =
+      bag[recordKey] ?? (preLens === undefined ? undefined : bag[preLens]);
+    if (preLens !== undefined) delete bag[preLens];
     bag[recordKey] = {
       // No record yet → a ledger-less skeleton, so the failure has somewhere to
       // live without inventing a ledger that was never produced.

--- a/src/lib/ai/own-digest-store.ts
+++ b/src/lib/ai/own-digest-store.ts
@@ -65,8 +65,8 @@ export const digestKey = (
   ref: string,
 ) => `${lens}#${kind}#${ref}`;
 
-/** The pre-lens key a lens key supersedes — records written before the lens
- *  dimension existed, which can only have been the origin lens. */
+/** The pre-lens key a lens key supersedes. Pre-lens records recorded no lens, so policy
+ *  adopts them as origin — the safe default (the fork's own PR). */
 function legacyDigestKey(key: string): string | undefined {
   return key.startsWith("origin#") ? key.slice("origin#".length) : undefined;
 }

--- a/src/lib/ai/prior-context.ts
+++ b/src/lib/ai/prior-context.ts
@@ -1,4 +1,5 @@
 import { gitDiffBetweenRefs, gitFetchObjects } from "@/lib/git/api";
+import type { RemoteLens } from "@/lib/git/types";
 import { getLatestReview } from "@/lib/pulls/reviews-history";
 import { filterDiffByAiIgnore } from "./ignore";
 import type { ReviewDeltaState, ReviewMode } from "./types";
@@ -40,13 +41,14 @@ export interface PriorContext {
  */
 export async function resolvePriorContext(
   repoPath: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
   currentHeadSha: string | undefined,
   exclude: string[],
 ): Promise<PriorContext> {
-  const prior = await getLatestReview(repoPath, kind, ref, mode);
+  const prior = await getLatestReview(repoPath, lens, kind, ref, mode);
   if (!prior?.text.trim()) return {};
   const base: PriorContext = {
     priorFindings: prior.text,

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -19,14 +19,20 @@ import { ALL_ACTION_IDS } from "./types";
  */
 type DismissalMap = Record<string, string>;
 
-/** Cell key for one PR + mode. The lens leads it because a fork's origin and
- *  upstream lenses surface DIFFERENT PRs under the same number. */
+/** The cell-key prefix shared by every mode of one PR under one lens — the scan in
+ *  {@link getDismissedHeadMap} and {@link cellKey} compose from this one shape. The
+ *  lens leads it because a fork's origin and upstream lenses surface DIFFERENT PRs
+ *  under the same number. */
+const cellPrefix = (lens: RemoteLens, kind: "remote" | "local", ref: string) =>
+  `${lens}#${kind}#${ref}#`;
+
+/** Cell key for one PR + mode. */
 const cellKey = (
   lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
-) => `${lens}#${kind}#${ref}#${mode}`;
+) => `${cellPrefix(lens, kind, ref)}${mode}`;
 
 /** The pre-lens cell prefix a lens cell supersedes. Pre-lens cells recorded no lens, so
  *  policy adopts them as origin — the safe default. Undefined on any other lens: the fold
@@ -136,7 +142,7 @@ export async function getDismissedHeadMap(
   // lens cell leads with the lens, a pre-lens one with the kind.
   const prefixes = [
     legacyCellPrefix(lens, kind, ref),
-    `${lens}#${kind}#${ref}#`,
+    cellPrefix(lens, kind, ref),
   ];
   for (const prefix of prefixes) {
     if (prefix === undefined) continue;

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -28,9 +28,9 @@ const cellKey = (
   mode: ReviewMode,
 ) => `${lens}#${kind}#${ref}#${mode}`;
 
-/** The pre-lens cell prefix/key a lens cell supersedes — cells written before the
- *  lens dimension existed, which can only have been the origin lens. Undefined on
- *  any other lens, which has no legacy data by construction. */
+/** The pre-lens cell prefix a lens cell supersedes. Pre-lens cells recorded no lens, so
+ *  policy adopts them as origin — the safe default. Undefined on any other lens: the fold
+ *  targets only the bare pre-lens key, which policy assigns to origin. */
 const legacyCellPrefix = (
   lens: RemoteLens,
   kind: "remote" | "local",

--- a/src/lib/automations/dismissals.ts
+++ b/src/lib/automations/dismissals.ts
@@ -1,6 +1,7 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import type { ReviewMode } from "@/lib/ai/types";
 import { identityKeyFor, repoIdentity } from "@/lib/git/repo-identity";
+import type { RemoteLens } from "@/lib/git/types";
 import { storeName } from "@/lib/test-mode";
 import { ALL_ACTION_IDS } from "./types";
 
@@ -9,8 +10,8 @@ import { ALL_ACTION_IDS } from "./types";
  * auto re-review only aborts the in-flight run; without a persisted marker the
  * same head re-fires after an app relaunch (cancel advances no watermark). So on
  * cancel the runner records the PR head that was dismissed, keyed by
- * `(kind, ref, mode)` — the runner then skips a pr-sync whose head still matches
- * a dismissed head, and only re-fires once the head genuinely advances.
+ * `(lens, kind, ref, mode)` — the runner then skips a pr-sync whose head still
+ * matches a dismissed head, and only re-fires once the head genuinely advances.
  *
  * Keyed by the repo's worktree-stable identity (not its checkout path), mirroring
  * the review-history store, so a dismissal is shared across the main checkout and
@@ -18,8 +19,23 @@ import { ALL_ACTION_IDS } from "./types";
  */
 type DismissalMap = Record<string, string>;
 
-const cellKey = (kind: "remote" | "local", ref: string, mode: ReviewMode) =>
-  `${kind}#${ref}#${mode}`;
+/** Cell key for one PR + mode. The lens leads it because a fork's origin and
+ *  upstream lenses surface DIFFERENT PRs under the same number. */
+const cellKey = (
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+  mode: ReviewMode,
+) => `${lens}#${kind}#${ref}#${mode}`;
+
+/** The pre-lens cell prefix/key a lens cell supersedes — cells written before the
+ *  lens dimension existed, which can only have been the origin lens. Undefined on
+ *  any other lens, which has no legacy data by construction. */
+const legacyCellPrefix = (
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+) => (lens === "origin" ? `${kind}#${ref}#` : undefined);
 
 // Personal app-data, keyed by repo identity — never written into the repo itself.
 // Routed through storeName() so cold-start/test mode never pollutes real data.
@@ -108,20 +124,30 @@ const isReviewMode = (v: string): v is ReviewMode =>
  *  `fresh` re-reads the store from disk first — see {@link readDismissals}. */
 export async function getDismissedHeadMap(
   repo: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   opts?: { fresh?: boolean },
 ): Promise<Partial<Record<ReviewMode, string>>> {
   const all = await readDismissals(repo, opts);
-  const prefix = `${kind}#${ref}#`;
   const byMode: Partial<Record<ReviewMode, string>> = {};
-  for (const [cell, headSha] of Object.entries(all)) {
-    if (!cell.startsWith(prefix)) continue;
-    // Cell and value both come from the store, so both are untrusted — keep only real
-    // modes, and only string heads (a hand-edited value would throw inside sameSha).
-    const mode = cell.slice(prefix.length);
-    if (isReviewMode(mode) && typeof headSha === "string")
-      byMode[mode] = headSha;
+  // Pre-lens cells still serve the origin lens until the next write folds them, and
+  // they lose to a lens cell for the same mode. No cell can match both prefixes: a
+  // lens cell leads with the lens, a pre-lens one with the kind.
+  const prefixes = [
+    legacyCellPrefix(lens, kind, ref),
+    `${lens}#${kind}#${ref}#`,
+  ];
+  for (const prefix of prefixes) {
+    if (prefix === undefined) continue;
+    for (const [cell, headSha] of Object.entries(all)) {
+      if (!cell.startsWith(prefix)) continue;
+      // Cell and value both come from the store, so both are untrusted — keep only real
+      // modes, and only string heads (a hand-edited value would throw inside sameSha).
+      const mode = cell.slice(prefix.length);
+      if (isReviewMode(mode) && typeof headSha === "string")
+        byMode[mode] = headSha;
+    }
   }
   return byMode;
 }
@@ -129,6 +155,7 @@ export async function getDismissedHeadMap(
 /** Records the head SHA dismissed for a PR + mode (overwriting any prior). */
 export async function setDismissedHead(
   repo: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
@@ -140,8 +167,12 @@ export async function setDismissedHead(
     // basing it on a launch-time cache would drop another instance's cells.
     await reloadRaw();
     const key = await keyFor(repo);
-    const all = (await store.get<DismissalMap>(key)) ?? {};
-    await store.set(key, { ...all, [cellKey(kind, ref, mode)]: headSha });
+    const all = { ...((await store.get<DismissalMap>(key)) ?? {}) };
+    // This watermark supersedes any pre-lens cell for the same PR + mode — dropping
+    // it here is the fold, one cell at a time, never a sweep over the store.
+    const preLens = legacyCellPrefix(lens, kind, ref);
+    if (preLens !== undefined) delete all[`${preLens}${mode}`];
+    await store.set(key, { ...all, [cellKey(lens, kind, ref, mode)]: headSha });
     // Flush past autoSave's ~100ms debounce so the next queued reload reads this
     // write back instead of a pre-write snapshot.
     await store.save();
@@ -157,6 +188,7 @@ export async function setDismissedHead(
  */
 export async function clearDismissedHead(
   repo: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
@@ -166,8 +198,12 @@ export async function clearDismissedHead(
     // Same reload-first rationale as setDismissedHead.
     await reloadRaw();
     const key = await keyFor(repo);
-    const all = (await store.get<DismissalMap>(key)) ?? {};
-    delete all[cellKey(kind, ref, mode)];
+    const all = { ...((await store.get<DismissalMap>(key)) ?? {}) };
+    delete all[cellKey(lens, kind, ref, mode)];
+    // The pre-lens cell goes too — it reads as this lens's watermark, so leaving it
+    // would keep re-blocking the re-run this call exists to unblock.
+    const preLens = legacyCellPrefix(lens, kind, ref);
+    if (preLens !== undefined) delete all[`${preLens}${mode}`];
     await store.set(key, all);
     // Flush for the same reason: an unflushed clear would be undone by the next
     // queued reload, re-blocking the re-run this call exists to unblock.

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -278,12 +278,19 @@ async function run(
   const gateState = async (prEvent: PrAutomationEvent) => {
     if (!gateSnapshot) {
       // Separate stores with independent queues, so neither read waits on the other.
+      // Origin-pinned like every other store touch on this path — the poller is
+      // origin-scoped, so these gates only ever cover the fork's own PRs.
       const [reviews, dismissed] = await Promise.all([
-        listReviews(prEvent.repoPath, prEvent.target.type, targetRef(prEvent), {
-          fresh: true,
-        }),
+        listReviews(
+          prEvent.repoPath,
+          "origin",
+          prEvent.target.type,
+          targetRef(prEvent),
+          { fresh: true },
+        ),
         getDismissedHeadMap(
           prEvent.repoPath,
+          "origin",
           prEvent.target.type,
           targetRef(prEvent),
           { fresh: true },
@@ -446,6 +453,7 @@ async function run(
       if (event.kind === "commit" || !event.headSha) return;
       void setDismissedHead(
         event.repoPath,
+        "origin",
         event.target.type,
         targetRef(event),
         action,
@@ -640,6 +648,7 @@ export function rerunAutomation(
       if (event.kind !== "commit") {
         await clearDismissedHead(
           event.repoPath,
+          "origin",
           event.target.type,
           targetRef(event),
           only,
@@ -772,6 +781,7 @@ async function generateReviewText(
       ? {}
       : await resolvePriorContext(
           event.repoPath,
+          "origin",
           event.target.type,
           targetRef(event),
           mode,
@@ -838,6 +848,7 @@ async function generateReviewText(
         ),
         resolveOwnCommentsContext(
           event.repoPath,
+          "origin",
           "remote",
           targetRef(event),
           provider,
@@ -1030,8 +1041,8 @@ async function deliver(
 /**
  * Persists an automated PR review into the keyed history store (same shape + key the
  * interactive path uses), so the next review of that PR + mode builds on it. Keyed by
- * `(kind, ref, mode)`; `text` is the raw findings, not the comment-wrapped body.
- * `thoughts` is display-only narration, never fed forward.
+ * `(lens, kind, ref, mode)`; `text` is the raw findings, not the comment-wrapped
+ * body. `thoughts` is display-only narration, never fed forward.
  */
 async function persistReviewHistory(
   event: PrAutomationEvent,
@@ -1051,6 +1062,8 @@ async function persistReviewHistory(
     id: crypto.randomUUID(),
     kind,
     ref,
+    // Origin-pinned like the rest of this path — the poller is origin-scoped.
+    lens: "origin",
     mode,
     model,
     title: event.title,
@@ -1061,6 +1074,6 @@ async function persistReviewHistory(
     finishedAt: now,
   });
   await queryClient.invalidateQueries({
-    queryKey: ["review-history", event.repoPath, kind, ref],
+    queryKey: ["review-history", event.repoPath, "origin", kind, ref],
   });
 }

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -170,13 +170,22 @@ function looksLikeProviderError(text: string): boolean {
  */
 function automationTarget(event: AutomationEvent): ReviewTarget {
   const repoName = event.repoPath.split(/[/\\]/).pop() ?? event.repoPath;
+  // Origin-pinned like every other store touch on this path — the poller is
+  // origin-scoped, so an automation row always belongs to the fork's own PR.
   if (event.kind === "commit") {
-    return { kind: "remote", repoPath: event.repoPath, repoName, ref: "" };
+    return {
+      kind: "remote",
+      repoPath: event.repoPath,
+      repoName,
+      lens: "origin",
+      ref: "",
+    };
   }
   return {
     kind: event.target.type,
     repoPath: event.repoPath,
     repoName,
+    lens: "origin",
     ref: targetRef(event),
   };
 }

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -191,9 +191,11 @@ export async function prOpenEligible(
     // concurrently — separate stores, independent queues. `fresh` reloads from disk and
     // queues behind any writer: this is a gate, so it must see another instance's
     // just-written record, not this process's launch-time cache.
+    // Origin-pinned: this gate mirrors the origin-scoped poller, so it reads the
+    // fork's own PRs only.
     const [reviews, dismissedByMode] = await Promise.all([
-      listReviews(repoPath, "remote", ref, { fresh: true }),
-      getDismissedHeadMap(repoPath, "remote", ref, { fresh: true }),
+      listReviews(repoPath, "origin", "remote", ref, { fresh: true }),
+      getDismissedHeadMap(repoPath, "origin", "remote", ref, { fresh: true }),
     ]);
     for (const mode of ALL_ACTION_IDS) {
       // Newest-first, so this mode's first entry is the latest review for it.

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
 import { isAppError } from "@/lib/tauri/invoke";
 import { COLD_START_NO_GH, COLD_START_NO_GIT } from "@/lib/test-mode";
+import { toastError } from "@/lib/toast";
 import * as api from "./api";
 import { primeCommitAuthorIndex } from "./commit-avatar";
 import {
@@ -1793,11 +1794,17 @@ function useOptimisticIssueMutation<TArgs extends { number: number }, TData>(
       }
       return { key, restore };
     },
-    onError: (_e, _args, ctx) => {
-      if (!ctx?.restore) return;
-      queryClient.setQueryData<IssueDetails>(ctx.key, (cur) =>
-        cur ? { ...cur, ...ctx.restore } : cur,
-      );
+    // Reporting lives HERE, not in each caller's `mutate` options: react-query
+    // only runs mutate-scoped callbacks while the observer has listeners, and the
+    // views re-key their metadata rail per entity — so a switch mid-flight would
+    // roll the cache back with nothing said.
+    onError: (e, _args, ctx) => {
+      if (ctx?.restore) {
+        queryClient.setQueryData<IssueDetails>(ctx.key, (cur) =>
+          cur ? { ...cur, ...ctx.restore } : cur,
+        );
+      }
+      toastError(e);
     },
     // Narrow reconciliation: only the one issue's detail subtree (not repo-wide),
     // scoped to the lens the mutation ran under.
@@ -1916,6 +1923,10 @@ function useTimeTrackingMutation(
 ) {
   const queryClient = useQueryClient();
   return useMutation({
+    // Mutation-level so the report survives the caller unmounting mid-flight (the
+    // views re-key their rail per entity, and mutate-scoped callbacks stop firing
+    // once the observer loses its listeners).
+    onError: (e) => toastError(e),
     mutationFn,
     onSuccess: (stats, args) => {
       queryClient.setQueryData<GitLabTimeStats>(
@@ -1991,6 +2002,8 @@ export function useLinkIssue(repo: string) {
   return useMutation({
     mutationFn: (args: { number: number; targetNumber: number }) =>
       api.forgeGlIssueLink(repo, args.number, args.targetNumber),
+    // Mutation-level: see useTimeTrackingMutation.
+    onError: (e) => toastError(e),
     onSuccess: (_d, args) => {
       queryClient.invalidateQueries({
         queryKey: issueLinksKey(repo, args.number),
@@ -2009,6 +2022,8 @@ export function useUnlinkIssue(repo: string) {
   return useMutation({
     mutationFn: (args: { number: number; linkId: string }) =>
       api.forgeGlIssueUnlink(repo, args.number, args.linkId),
+    // Mutation-level: see useTimeTrackingMutation.
+    onError: (e) => toastError(e),
     onSuccess: (_d, args) =>
       queryClient.invalidateQueries({
         queryKey: issueLinksKey(repo, args.number),
@@ -5993,6 +6008,9 @@ export function useEditPrLabels(repo: string, lens: RemoteLens) {
         args.addNames ?? [],
         args.removeNames ?? [],
       ),
+    // Mutation-level: see useTimeTrackingMutation. The label pickers are keyed per
+    // entity, so a switch mid-flight used to drop the failure silently.
+    onError: (e) => toastError(e),
     onSettled: (_d, _e, args) => {
       // Issue/MR narrow keys carry the lens they were read under; discussions are
       // not lens-scoped (GitHub Discussions have no fork lens) — keyed as before.

--- a/src/lib/pulls/queries.ts
+++ b/src/lib/pulls/queries.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/ai/external-context";
 import { resolveReviewerNotesContext } from "@/lib/ai/notes-context";
 import { useForgeStatus } from "@/lib/git/queries";
+import type { RemoteLens } from "@/lib/git/types";
 import {
   createLocalPr,
   deleteLocalPr,
@@ -62,20 +63,30 @@ export function useDeleteLocalPr(repo: string) {
 
 type PrKind = "remote" | "local";
 
-const reviewHistoryKey = (repo: string, kind: PrKind, ref: string) =>
-  ["review-history", repo, kind, ref] as const;
+const reviewHistoryKey = (
+  repo: string,
+  lens: RemoteLens,
+  kind: PrKind,
+  ref: string,
+) => ["review-history", repo, lens, kind, ref] as const;
 
 /** Persisted AI reviews for a PR (both modes), newest first. Read-only — never
  *  creates a record, so a never-reviewed PR's first run stays unchanged. */
-export function useReviewHistory(repo: string, kind: PrKind, ref: string) {
+export function useReviewHistory(
+  repo: string,
+  lens: RemoteLens,
+  kind: PrKind,
+  ref: string,
+) {
   return useQuery({
-    queryKey: reviewHistoryKey(repo, kind, ref),
-    queryFn: () => listReviews(repo, kind, ref),
+    queryKey: reviewHistoryKey(repo, lens, kind, ref),
+    queryFn: () => listReviews(repo, lens, kind, ref),
   });
 }
 
 function useReviewHistoryMutation<TArgs>(
   repo: string,
+  lens: RemoteLens,
   kind: PrKind,
   ref: string,
   fn: (args: TArgs) => Promise<void>,
@@ -85,15 +96,21 @@ function useReviewHistoryMutation<TArgs>(
     mutationFn: fn,
     onSettled: () =>
       queryClient.invalidateQueries({
-        queryKey: reviewHistoryKey(repo, kind, ref),
+        queryKey: reviewHistoryKey(repo, lens, kind, ref),
       }),
   });
 }
 
 /** Edits a stored review's text — backs "trim before re-running". */
-export function useUpdateReviewText(repo: string, kind: PrKind, ref: string) {
+export function useUpdateReviewText(
+  repo: string,
+  lens: RemoteLens,
+  kind: PrKind,
+  ref: string,
+) {
   return useReviewHistoryMutation(
     repo,
+    lens,
     kind,
     ref,
     ({ id, text }: { id: string; text: string }) =>
@@ -101,15 +118,25 @@ export function useUpdateReviewText(repo: string, kind: PrKind, ref: string) {
   );
 }
 
-export function useDeleteReview(repo: string, kind: PrKind, ref: string) {
-  return useReviewHistoryMutation(repo, kind, ref, (id: string) =>
+export function useDeleteReview(
+  repo: string,
+  lens: RemoteLens,
+  kind: PrKind,
+  ref: string,
+) {
+  return useReviewHistoryMutation(repo, lens, kind, ref, (id: string) =>
     deleteReview(repo, id),
   );
 }
 
-export function useClearReviews(repo: string, kind: PrKind, ref: string) {
-  return useReviewHistoryMutation(repo, kind, ref, () =>
-    clearReviewsFor(repo, kind, ref),
+export function useClearReviews(
+  repo: string,
+  lens: RemoteLens,
+  kind: PrKind,
+  ref: string,
+) {
+  return useReviewHistoryMutation(repo, lens, kind, ref, () =>
+    clearReviewsFor(repo, lens, kind, ref),
   );
 }
 

--- a/src/lib/pulls/review-drafts.ts
+++ b/src/lib/pulls/review-drafts.ts
@@ -5,6 +5,7 @@ import {
   mergeById,
   repoIdentity,
 } from "@/lib/git/repo-identity";
+import type { RemoteLens } from "@/lib/git/types";
 import { storeName } from "@/lib/test-mode";
 
 /** One pending draft comment in a not-yet-submitted batch review. `id` is a local
@@ -21,8 +22,17 @@ export interface ReviewDraft {
   createdAt: string;
 }
 
-/** Drafts for one PR/MR, keyed by its number as a string. */
+/** Drafts for one PR/MR, keyed `${lens}#${number}`. The lens is part of the key
+ *  because a fork's origin and upstream lenses surface DIFFERENT PRs under the same
+ *  number — without it a draft written on one would be submitted against the other. */
 type PrDrafts = Record<string, ReviewDraft[]>;
+
+const draftKey = (lens: RemoteLens, number: number) => `${lens}#${number}`;
+
+/** The bare-number key this lens key supersedes — records written before the lens
+ *  dimension existed, which can only have been the origin lens. */
+const legacyDraftKey = (lens: RemoteLens, number: number) =>
+  lens === "origin" ? String(number) : undefined;
 
 // Personal app-data, keyed by repo path → per-PR drafts — never written into the
 // repo itself. Mirrors `local.ts`'s store idiom.
@@ -90,37 +100,59 @@ async function writeRepo(key: string, drafts: PrDrafts): Promise<void> {
   await store.save();
 }
 
+/** Folds a pre-lens bare-number entry onto its `origin#…` key, returning the map to
+ *  mutate. Non-destructive and incremental like the checkout-path fold above: the
+ *  drafts move with the caller's own write, one PR at a time, never as a sweep. */
+function foldLegacyKey(
+  all: PrDrafts,
+  lens: RemoteLens,
+  number: number,
+): PrDrafts {
+  const legacy = legacyDraftKey(lens, number);
+  if (legacy === undefined || all[legacy] === undefined) return all;
+  const k = draftKey(lens, number);
+  const next = { ...all, [k]: mergeById(all[k], all[legacy]) };
+  delete next[legacy];
+  return next;
+}
+
 export async function listDrafts(
   repo: string,
+  lens: RemoteLens,
   number: number,
 ): Promise<ReviewDraft[]> {
   const all = await readMerged(repo);
-  return all[String(number)] ?? [];
+  const own = all[draftKey(lens, number)];
+  const legacy = legacyDraftKey(lens, number);
+  const legacyDrafts = legacy === undefined ? undefined : all[legacy];
+  return legacyDrafts ? mergeById(own, legacyDrafts) : (own ?? []);
 }
 
 export async function addDraft(
   repo: string,
+  lens: RemoteLens,
   number: number,
   draft: ReviewDraft,
 ): Promise<void> {
   return serialize(async () => {
     const repoKey = await keyFor(repo);
-    const all = await readByKey(repoKey);
-    const k = String(number);
+    const all = foldLegacyKey(await readByKey(repoKey), lens, number);
+    const k = draftKey(lens, number);
     await writeRepo(repoKey, { ...all, [k]: [...(all[k] ?? []), draft] });
   });
 }
 
 export async function updateDraft(
   repo: string,
+  lens: RemoteLens,
   number: number,
   id: string,
   body: string,
 ): Promise<void> {
   return serialize(async () => {
     const repoKey = await keyFor(repo);
-    const all = await readByKey(repoKey);
-    const k = String(number);
+    const all = foldLegacyKey(await readByKey(repoKey), lens, number);
+    const k = draftKey(lens, number);
     const next = (all[k] ?? []).map((d) => (d.id === id ? { ...d, body } : d));
     await writeRepo(repoKey, { ...all, [k]: next });
   });
@@ -128,13 +160,14 @@ export async function updateDraft(
 
 export async function removeDraft(
   repo: string,
+  lens: RemoteLens,
   number: number,
   id: string,
 ): Promise<void> {
   return serialize(async () => {
     const repoKey = await keyFor(repo);
-    const all = await readByKey(repoKey);
-    const k = String(number);
+    const all = foldLegacyKey(await readByKey(repoKey), lens, number);
+    const k = draftKey(lens, number);
     await writeRepo(repoKey, {
       ...all,
       [k]: (all[k] ?? []).filter((d) => d.id !== id),
@@ -142,71 +175,98 @@ export async function removeDraft(
   });
 }
 
-export async function clearDrafts(repo: string, number: number): Promise<void> {
+export async function clearDrafts(
+  repo: string,
+  lens: RemoteLens,
+  number: number,
+): Promise<void> {
   return serialize(async () => {
     const repoKey = await keyFor(repo);
-    const all = await readByKey(repoKey);
-    const next = { ...all };
-    delete next[String(number)];
+    // Fold first: a discard must take the pre-lens entry with it, or `listDrafts`
+    // would read the legacy drafts straight back after the clear. Copied before the
+    // delete — the fold passes the store's own object through when there's nothing
+    // to fold, and that must not be mutated in place.
+    const next = { ...foldLegacyKey(await readByKey(repoKey), lens, number) };
+    delete next[draftKey(lens, number)];
     await writeRepo(repoKey, next);
   });
 }
 
 // ── React-query wrappers ─────────────────────────────────────────────────────
 
-const reviewDraftsKey = (repo: string, number: number) =>
-  ["repo", repo, "pr", number, "review-drafts"] as const;
+const reviewDraftsKey = (repo: string, lens: RemoteLens, number: number) =>
+  ["repo", repo, "pr", lens, number, "review-drafts"] as const;
 
 /** The persisted pending-review drafts for a PR/MR. */
-export function useReviewDrafts(repo: string, number: number) {
+export function useReviewDrafts(
+  repo: string,
+  lens: RemoteLens,
+  number: number,
+) {
   return useQuery({
-    queryKey: reviewDraftsKey(repo, number),
-    queryFn: () => listDrafts(repo, number),
+    queryKey: reviewDraftsKey(repo, lens, number),
+    queryFn: () => listDrafts(repo, lens, number),
     staleTime: Number.POSITIVE_INFINITY,
   });
 }
 
-export function useAddReviewDraft(repo: string, number: number) {
+export function useAddReviewDraft(
+  repo: string,
+  lens: RemoteLens,
+  number: number,
+) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (draft: ReviewDraft) => addDraft(repo, number, draft),
+    mutationFn: (draft: ReviewDraft) => addDraft(repo, lens, number, draft),
     onSettled: () =>
       void queryClient.invalidateQueries({
-        queryKey: reviewDraftsKey(repo, number),
+        queryKey: reviewDraftsKey(repo, lens, number),
       }),
   });
 }
 
-export function useUpdateReviewDraft(repo: string, number: number) {
+export function useUpdateReviewDraft(
+  repo: string,
+  lens: RemoteLens,
+  number: number,
+) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: { id: string; body: string }) =>
-      updateDraft(repo, number, args.id, args.body),
+      updateDraft(repo, lens, number, args.id, args.body),
     onSettled: () =>
       void queryClient.invalidateQueries({
-        queryKey: reviewDraftsKey(repo, number),
+        queryKey: reviewDraftsKey(repo, lens, number),
       }),
   });
 }
 
-export function useRemoveReviewDraft(repo: string, number: number) {
+export function useRemoveReviewDraft(
+  repo: string,
+  lens: RemoteLens,
+  number: number,
+) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => removeDraft(repo, number, id),
+    mutationFn: (id: string) => removeDraft(repo, lens, number, id),
     onSettled: () =>
       void queryClient.invalidateQueries({
-        queryKey: reviewDraftsKey(repo, number),
+        queryKey: reviewDraftsKey(repo, lens, number),
       }),
   });
 }
 
-export function useClearReviewDrafts(repo: string, number: number) {
+export function useClearReviewDrafts(
+  repo: string,
+  lens: RemoteLens,
+  number: number,
+) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => clearDrafts(repo, number),
+    mutationFn: () => clearDrafts(repo, lens, number),
     onSettled: () =>
       void queryClient.invalidateQueries({
-        queryKey: reviewDraftsKey(repo, number),
+        queryKey: reviewDraftsKey(repo, lens, number),
       }),
   });
 }

--- a/src/lib/pulls/review-drafts.ts
+++ b/src/lib/pulls/review-drafts.ts
@@ -29,8 +29,8 @@ type PrDrafts = Record<string, ReviewDraft[]>;
 
 const draftKey = (lens: RemoteLens, number: number) => `${lens}#${number}`;
 
-/** The bare-number key this lens key supersedes — records written before the lens
- *  dimension existed, which can only have been the origin lens. */
+/** The bare-number key this lens key supersedes. Pre-lens drafts recorded no lens, so
+ *  policy adopts them as origin — the safe default (the fork's own PR). */
 const legacyDraftKey = (lens: RemoteLens, number: number) =>
   lens === "origin" ? String(number) : undefined;
 

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -5,13 +5,14 @@ import {
   mergeById,
   repoIdentity,
 } from "@/lib/git/repo-identity";
+import type { RemoteLens } from "@/lib/git/types";
 import { storeName } from "@/lib/test-mode";
 
 /**
  * A finished AI review, persisted so the NEXT run of the same PR + mode can feed
  * it back as soft context. Free-form `text` is never parsed into structured data
  * — it stays the model's own markdown, which the next run must re-verify against
- * the current diff. Identity for "the previous review" is `(kind, ref, mode)`;
+ * the current diff. Identity for "the previous review" is `(lens, kind, ref, mode)`;
  * `mode` is part of the key so a security re-run never inherits general findings.
  */
 export interface PersistedReview {
@@ -20,6 +21,11 @@ export interface PersistedReview {
   kind: "remote" | "local";
   /** Remote PR number (as a string) or local PR id. */
   ref: string;
+  /** Which lens's PR this review covers — a fork's origin and upstream lenses
+   *  surface DIFFERENT PRs under the same number. Optional and additive
+   *  (`schemaVersion` stays 1): records written before the lens dimension read as
+   *  "origin", which is what they were. Local PRs carry the same "origin". */
+  lens?: RemoteLens;
   mode: ReviewMode;
   model: string;
   title: string;
@@ -36,12 +42,17 @@ export interface PersistedReview {
   finishedAt: number;
 }
 
-/** Reviews kept per `(kind, ref, mode)` — enough to show iteration, bounded so
- *  the store file never balloons. Pruned on every write. */
+/** Reviews kept per `(lens, kind, ref, mode)` — enough to show iteration, bounded
+ *  so the store file never balloons. Pruned on every write. */
 const MAX_PER_GROUP = 3;
 
-const groupKey = (r: Pick<PersistedReview, "kind" | "ref" | "mode">) =>
-  `${r.kind}#${r.ref}#${r.mode}`;
+/** A record's lens, defaulting the absent field on pre-lens records to the lens
+ *  they were written under. */
+const lensOf = (r: Pick<PersistedReview, "lens">): RemoteLens =>
+  r.lens ?? "origin";
+
+const groupKey = (r: Pick<PersistedReview, "lens" | "kind" | "ref" | "mode">) =>
+  `${lensOf(r)}#${r.kind}#${r.ref}#${r.mode}`;
 
 // Personal app-data, keyed by the repo's worktree-stable identity — never written
 // into the repo itself (the text quotes user source + may contain AI false
@@ -126,7 +137,7 @@ async function writeAll(
   await store.save();
 }
 
-/** Keeps only the newest `MAX_PER_GROUP` reviews per `(kind, ref, mode)`. */
+/** Keeps only the newest `MAX_PER_GROUP` reviews per `(lens, kind, ref, mode)`. */
 function prune(records: PersistedReview[]): PersistedReview[] {
   const groups = new Map<string, PersistedReview[]>();
   for (const r of records) {
@@ -164,6 +175,7 @@ async function read(
  *  re-reads the store from disk first — see {@link read}. */
 export async function getLatestReview(
   repo: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   mode: ReviewMode,
@@ -171,7 +183,13 @@ export async function getLatestReview(
 ): Promise<PersistedReview | undefined> {
   const all = await read(repo, opts);
   return all
-    .filter((r) => r.kind === kind && r.ref === ref && r.mode === mode)
+    .filter(
+      (r) =>
+        lensOf(r) === lens &&
+        r.kind === kind &&
+        r.ref === ref &&
+        r.mode === mode,
+    )
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
 }
 
@@ -182,13 +200,14 @@ export async function getLatestReview(
  *  first — see {@link read}. */
 export async function listReviews(
   repo: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
   opts?: { fresh?: boolean },
 ): Promise<PersistedReview[]> {
   const all = await read(repo, opts);
   return all
-    .filter((r) => r.kind === kind && r.ref === ref)
+    .filter((r) => lensOf(r) === lens && r.kind === kind && r.ref === ref)
     .sort((a, b) => b.finishedAt - a.finishedAt);
 }
 
@@ -237,9 +256,11 @@ export async function deleteReview(repo: string, id: string): Promise<void> {
 }
 
 /** Clears every persisted review for ONE PR (both modes) — scoped so clearing
- *  from a PR's panel never touches the other PRs' history in the same repo. */
+ *  from a PR's panel never touches the other PRs' history in the same repo, nor the
+ *  other lens's same-numbered PR. */
 export async function clearReviewsFor(
   repo: string,
+  lens: RemoteLens,
   kind: "remote" | "local",
   ref: string,
 ): Promise<void> {
@@ -249,7 +270,9 @@ export async function clearReviewsFor(
     const all = await readByKey(key);
     await writeAll(
       key,
-      all.filter((r) => !(r.kind === kind && r.ref === ref)),
+      all.filter(
+        (r) => !(lensOf(r) === lens && r.kind === kind && r.ref === ref),
+      ),
     );
   });
 }

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -50,8 +50,10 @@ function loadStore(file: string) {
 }
 
 /** Normalize a path/key for comparison: forward slashes, no trailing slash,
- *  lower-cased (Windows paths differ in case in the wild). */
-function norm(s: string): string {
+ *  lower-cased (Windows paths differ in case in the wild). Exported because the
+ *  live plan/research stores re-home their in-memory runs on the same relocate —
+ *  they must match exactly the rows {@link migrateRawPathStore} rewrote. */
+export function norm(s: string): string {
   return s.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
 }
 

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -667,3 +667,23 @@ export function setBitbucketTokenExpiresAt(
     await saveSettings({ ...settings, bitbucketTokenExpiresAt: value });
   });
 }
+
+/**
+ * Saves a whole settings object built by the UI (which holds a snapshot from before the
+ * user started editing) without losing what the chained writers changed meanwhile.
+ *
+ * `recentRepos` and `bitbucketTokenExpiresAt` are the only fields those writers own, so
+ * they're re-pinned from a read taken INSIDE the critical section — the caller's snapshot
+ * of them is stale by definition, every other field is the user's intent. Serialization is
+ * per-runtime: a second window writing settings is a separate chain.
+ */
+export function saveSettingsMerged(settings: AppSettings): Promise<void> {
+  return serializedRecentRepoWrite(async () => {
+    const fresh = await loadSettings();
+    await saveSettings({
+      ...settings,
+      recentRepos: fresh.recentRepos,
+      bitbucketTokenExpiresAt: fresh.bitbucketTokenExpiresAt,
+    });
+  });
+}

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -12,7 +12,7 @@ import {
   persistRepoOwners,
   relocateRecentRepo,
   removeRecentRepo,
-  saveSettings,
+  saveSettingsMerged,
   setRepoAlias,
 } from "./api";
 import type { RepoKeys } from "./mcp";
@@ -100,7 +100,7 @@ export function useReviewConfigured(): boolean {
 export function useSaveSettings() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (settings: AppSettings) => saveSettings(settings),
+    mutationFn: (settings: AppSettings) => saveSettingsMerged(settings),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
   });

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -70,6 +70,9 @@ export interface ReviewTarget {
   kind: "remote" | "local";
   repoPath: string;
   repoName: string;
+  /** The lens the PR was opened under — part of the identity, since a fork's two
+   *  lenses surface different PRs at the same `ref`. "origin" for local PRs. */
+  lens: RemoteLens;
   /** Remote PR number (as a string) or local PR id. */
   ref: string;
 }
@@ -143,6 +146,7 @@ const EMPTY_TARGET: ReviewTarget = {
   kind: "remote",
   repoPath: "",
   repoName: "",
+  lens: "origin",
   ref: "",
 };
 
@@ -158,13 +162,15 @@ const EMPTY_ENTRY: ReviewEntry = {
   error: "",
 };
 
-/** Stable store key for a review run. */
+/** Stable store key for a review run. The lens segment keeps a fork's origin and
+ *  upstream PRs — same number, different repos — on separate runs. */
 export function reviewKey(t: {
   kind: string;
   repoPath: string;
+  lens: RemoteLens;
   ref: string;
 }): string {
-  return `${t.kind}:${t.repoPath}#${t.ref}`;
+  return `${t.kind}:${t.repoPath}#${t.lens}#${t.ref}`;
 }
 
 interface ReviewStore {
@@ -368,7 +374,11 @@ async function notifyReviewDone(
       repoPath: target.repoPath,
       repoName: target.repoName,
       target: { type: "pr", kind: target.kind, ref: target.ref },
-      dedupeKey: `review:${target.kind}:${target.repoPath}:${target.ref}:${ok}`,
+      // The lens is in the dedupe key because a fork's origin and upstream PRs share
+      // a number: without it, two reviews settling in the same window collapse into
+      // one notification. (The `target` above carries no lens, so the click-through
+      // still lands on whichever lens the repo is currently set to.)
+      dedupeKey: `review:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
     });
     void notifyIfUnfocused(headline, subtitle);
   } catch {
@@ -889,7 +899,7 @@ export function dismissQueuedReview(key: string): void {
  * `fail()` instead keeps it as a stopped "Failed" row.
  *
  * The key lives in a dedicated `auto:<n>` namespace off `reviewSeq`, which can never
- * collide with a panel run's `reviewKey` (`kind:repoPath#ref`).
+ * collide with a panel run's `reviewKey` (`kind:repoPath#lens#ref`).
  */
 export function registerAutomationRun(opts: {
   title: string;

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -31,7 +31,7 @@ import type {
 } from "@/lib/ai/types";
 import { track } from "@/lib/analytics";
 import { readRepoInstructions } from "@/lib/git/api";
-import type { DiffStatEntry } from "@/lib/git/types";
+import type { DiffStatEntry, RemoteLens } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
 import { saveReview } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
@@ -45,6 +45,11 @@ export interface ReviewContext {
   commitSubjects: string[];
   /** Repo working directory — the CLI agent runs here. */
   repoPath: string;
+  /** The origin|upstream lens the PR was opened under — scopes every per-PR store
+   *  this run touches (prior reviews, the own-comments digest), since a fork's two
+   *  lenses surface DIFFERENT PRs under the same number. "origin" for local PRs,
+   *  which have no forge lens. */
+  lens: RemoteLens;
   /** Target host — swaps the change-request noun + markdown flavor in the review
    *  system prompt. Absent (local PRs / commit reviews) keeps the base GitHub
    *  wording. */
@@ -548,6 +553,7 @@ export async function startReview(
       ? {}
       : await resolvePriorContext(
           target.repoPath,
+          context.lens,
           target.kind,
           target.ref,
           mode,
@@ -601,6 +607,7 @@ export async function startReview(
       ),
       resolveOwnCommentsContext(
         target.repoPath,
+        context.lens,
         target.kind,
         target.ref,
         context.provider,
@@ -746,6 +753,7 @@ export async function startReview(
         id: crypto.randomUUID(),
         kind: target.kind,
         ref: target.ref,
+        lens: context.lens,
         mode,
         model: ai.model,
         title,
@@ -765,6 +773,7 @@ export async function startReview(
             queryKey: [
               "review-history",
               target.repoPath,
+              context.lens,
               target.kind,
               target.ref,
             ],


### PR DESCRIPTION
Per-entity state was leaking across the boundaries that identify it: a comment draft written for one pull request could survive a switch and be posted against another; a fork's `origin` and `upstream` lenses shared review drafts, review history, own-comment digests and dismissal watermarks under the same PR number; agent-run notifications keyed only on the selected id, ignoring which repo was open. This change makes every one of those surfaces carry its full identity — entity key, lens, or repo path — and re-checks it at write time so a late async callback can't land on whatever is on screen now.

### Composer drafts reset on entity switch

- `RemotePrView.tsx` builds a lens-bearing `entityKey` (`${lens}#${number}`) plus a `liveEntityKey` ref, resets `composeBody`/`deletingCommentId` in the existing render-time switch block, and guards the deferred clear in `requestChanges` and the error-restore in `submitComment` against the live key.
- `LocalPrView.tsx` moves its render-time reset below `useLocalConversation` so it can also clear `comment`, `labelInput` and `deletingCommentId` alongside the existing `selectedCommitHash`.
- `RemoteIssueView.tsx` keys its reset on `${lens}#${number}` (the lens can collapse to `origin` without a remount) and routes the error-restore through a `useEffectEvent` that compares against the live identity; `JiraIssueView.tsx` does the same on `issueKey`, `LocalIssueView.tsx` on `id`.
- `DiscussionView.tsx` resets compose/reply/delete state on `number` change and clears each composer through `clearComposeIfSame` / `clearReplyIfSame` effect events, so a late mutation success can't wipe newly typed text.
- `CommitComments.tsx` resets on a `${repoPath}#${lens}#${sha}` identity — neither call site keys the component on the commit.

### Fork lens threaded through per-PR stores

- `src/lib/pulls/review-drafts.ts` keys drafts `${lens}#${number}`, adds `foldLegacyKey` to migrate pre-lens bare-number entries one PR at a time on write (including on `clearDrafts`, so a discard takes the legacy entry with it), and threads `lens` through `listDrafts`/`addDraft`/`updateDraft`/`removeDraft`/`clearDrafts` and their query hooks and keys.
- `src/lib/pulls/reviews-history.ts` adds an optional `lens` field to `PersistedReview` (schema stays 1; absent reads as `origin`), folds it into `groupKey`, and filters `getLatestReview`/`listReviews`/`clearReviewsFor` on it.
- `src/lib/ai/own-digest-store.ts` introduces an exported `digestKey(lens, kind, ref)` with a `legacyDigestKey` fallback read and a fold-on-write in `saveDigest` and `recordDigestFailure`; `src/lib/ai/own-context.ts` and `src/lib/ai/prior-context.ts` take `lens` and pass it down.
- `src/lib/automations/dismissals.ts` prefixes cells with the lens, reads both the lens and pre-lens prefixes in `getDismissedHeadMap`, and drops the superseded legacy cell in `setDismissedHead` / `clearDismissedHead`.
- Call sites updated: `src/lib/pulls/queries.ts` (`review-history` query key gains `lens`), `PendingReviewBar.tsx`, `DraftCommentCard`, `ReviewComposer.tsx`, `SubmitReviewDialog.tsx`, `ReviewHistory.tsx`, `PrReviewPanel.tsx`, `RemotePrViewParts.tsx` (drafts only render once `repoPath`/`lens`/`number` are all present), and `src/lib/stores/reviews.ts`.
- `src/lib/automations/runner.ts` and `src/lib/automations/sync.ts` pin `"origin"` explicitly, since the poller is origin-scoped.
- `LocalPrView.tsx` passes `lens: "origin"` for local PRs, keeping their per-PR stores on their pre-lens keys.
- `DangerZone.tsx`'s remove-upstream action now clears a selected remote PR/issue, mirroring what `useSetRepoLens` does on an explicit lens flip — the collapsed lens would otherwise resolve the number against the other repo.

### Agent notifications and repo relocation

- `src/features/sessions/watching.ts` takes the run's `runRepoPath` and requires `ui.repoPath === runRepoPath`, so a run finishing for a repo that isn't open still notifies; `features/plan/store.ts`, `features/research/store.ts` and `features/sessions/store.ts` pass it.
- `features/plan/store.ts` and `features/research/store.ts` gain `relocateRepoPath`, with a no-match guard so the persistence subscribe isn't tripped into a no-op rewrite; `useOpenRepoByPath.ts` calls both after `migrateRepoData`.
- `src/lib/repo-data-migration.ts` exports `norm` so those stores match the same rows the on-disk migration rewrote.
- `features/sessions/store.ts` merges hydrated sessions under any created before hydration finished, instead of replacing the array and dropping them.

### Commit-message streaming and settings saves

- `useGenerateCommitMessage.ts` captures `activeDraftKey` at start and re-checks it on every chunk, cancelling the stream and skipping the AI-generated flag once the user switches repo or branch.
- `src/lib/settings/api.ts` adds `saveSettingsMerged`, which re-pins `recentRepos` and `bitbucketTokenExpiresAt` from a read inside the serialized critical section; `src/lib/settings/queries.ts` points `useSaveSettings` at it so a Settings save can't clobber background recent-repo updates.

### Changelog

- Seven fragments under `changelog.d/`: composer drafts on entity switch, fork-lens review drafts and history, agent completion notifications, session startup drop, repo-relocate plans/research, commit draft stream, and the settings save race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Notifications now arrive reliably for plans, research runs, and agent sessions across repository context changes.
  - Drafts, dialogs, AI-generated content, and review data no longer carry over between items, branches, repositories, or pull-request sources.
  - Fork and upstream pull requests maintain separate review drafts and history.
  - Agent sessions created during startup are preserved.
  - Repository relocation keeps active plans and research runs connected.
  - Settings saves preserve background repository updates.
  - Failed submissions restore drafts only in the correct item.
  - Removing an upstream remote clears related selections.
  - Errors continue to display even when the originating view changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->