### PR TITLE
fix(git,agent,terminal,mcp): resolve races, deadlocks and lost cancels

### DIFF
--- a/changelog.d/fixed-agent-cancel-race.md
+++ b/changelog.d/fixed-agent-cancel-race.md
@@ -1,0 +1,3 @@
+- Stopping an AI review or agent session now always takes effect, even
+  in the first moments of a run, and a stuck agent process can no longer
+  leave the run hanging past its time limit.

--- a/changelog.d/fixed-compound-git-locking.md
+++ b/changelog.d/fixed-compound-git-locking.md
@@ -1,0 +1,6 @@
+- Multi-step Git operations now run as one uninterruptible unit, so
+  editing history, resolving a conflict by taking one side, and keeping
+  or discarding an agent session can no longer collide with another Git
+  operation running at the same time — from a second window or your own
+  next click. A commit made alongside one of these is kept instead of
+  being swept away if the operation rolls itself back.

--- a/changelog.d/fixed-mcp-launcher-race.md
+++ b/changelog.d/fixed-mcp-launcher-race.md
@@ -1,0 +1,2 @@
+- Setting up the MCP launcher no longer fails with a spurious error when
+  several parts of the app prepare it at the same time.

--- a/changelog.d/fixed-slash-menu-responsiveness.md
+++ b/changelog.d/fixed-slash-menu-responsiveness.md
@@ -1,0 +1,2 @@
+- The composer's `/` command menu and Add to PATH no longer make the app
+  hitch while they read from disk.

--- a/changelog.d/fixed-stdin-runner-deadlock.md
+++ b/changelog.d/fixed-stdin-runner-deadlock.md
@@ -1,0 +1,3 @@
+- Repositories with very large ignore lists no longer hit spurious
+  30-second timeouts when listing ignored files or filtering AI-hidden
+  paths, and posting long GitHub or GitLab API bodies can no longer hang.

--- a/changelog.d/fixed-terminal-write-freeze.md
+++ b/changelog.d/fixed-terminal-write-freeze.md
@@ -1,0 +1,2 @@
+- Typing or pasting into a terminal or task that has stopped reading its
+  input no longer freezes the app, and closing it always works.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -8,12 +8,14 @@
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
+use tokio::sync::Notify;
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
@@ -1828,21 +1830,67 @@ fn kill_process_tree(child: &mut tokio::process::Child) {
     let _ = child.start_kill();
 }
 
+/// Grace for the child to exit after the pump loop ends. On a clean EOF it has
+/// normally exited already, but a grandchild (node worker, MCP server) can keep the
+/// pipes open — without a bound the command never returns, so the frontend never sees
+/// `backendDone` and the run's UI stays stuck past its own timeout.
+const CHILD_EXIT_GRACE: Duration = Duration::from_secs(10);
+/// Second, shorter grace after a tree-kill: the child is being force-killed, so this
+/// only covers reaping it.
+const CHILD_REAP_GRACE: Duration = Duration::from_secs(5);
+
+/// Whether `id` is an acceptable cancel-registry key. Every id is minted by
+/// `crypto.randomUUID()` on the frontend — an RFC 4122 v4 uuid, 36 lowercase
+/// hex-and-dash chars (`src/lib/ai/stream.ts`, `cli-client.ts`, and the plan /
+/// research / sessions stores). The gate is deliberately a superset of that: it only
+/// has to bound the key space, since an unvalidated id would let a cancel seed an
+/// unbounded number of tombstones. Same bound as the forge reconnect registry's.
+fn valid_cancel_id(id: &str) -> bool {
+    (8..=64).contains(&id.len()) && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+/// RAII cleanup for a registered agent cancel: removes the registry entry on drop, so
+/// every exit path out of `agent_review` / `agent_session` after registration — the
+/// `?` returns of the pre-stream setup included — releases it. Carries the `Notify`
+/// the run waits on, which may already hold a cancel permit.
+struct AgentCancelGuard<'a> {
+    state: &'a AppState,
+    id: String,
+    notify: Arc<Notify>,
+}
+
+impl<'a> AgentCancelGuard<'a> {
+    fn register(state: &'a AppState, id: &str) -> Self {
+        Self {
+            state,
+            id: id.to_string(),
+            notify: state.register_agent_cancel(id),
+        }
+    }
+}
+
+impl Drop for AgentCancelGuard<'_> {
+    fn drop(&mut self) {
+        self.state.clear_agent_cancel(&self.id);
+    }
+}
+
 /// Spawns an agent CLI, streams its stdout as `ReviewEvent`s until a terminal
 /// event / EOF / cancel / timeout, then emits a final `Error` if no terminal
 /// result arrived. Shared by `agent_review` (read-only) and `agent_session`
 /// (write-enabled, run in a worktree). `cwd` is the process working directory,
-/// `cancel_id` keys the cancel registry, and `noun` colors the failure copy.
+/// `cancel` is the caller's registered cancel handle (registered at command entry,
+/// so a cancel racing the setup below is never lost), and `noun` colors the failure
+/// copy.
 #[allow(clippy::too_many_arguments)]
 async fn stream_agent(
-    state: &AppState,
+    cancel: Arc<Notify>,
     kind: AgentKind,
     binary: &Path,
     args: Vec<String>,
     stdin_text: String,
     cwd: &str,
     timeout: Duration,
-    cancel_id: &str,
     noun: &str,
     // Whether a timeout message may point at the "Review timeout" setting — true
     // only for the review flows that setting governs (see `timeout_message`).
@@ -1896,7 +1944,7 @@ async fn stream_agent(
 
     // Drain stderr concurrently; surfaced only if no terminal result arrives.
     let stderr = child.stderr.take();
-    let stderr_task = tokio::spawn(async move {
+    let mut stderr_task = tokio::spawn(async move {
         let mut buf = String::new();
         if let Some(s) = stderr {
             let _ = BufReader::new(s).read_to_string(&mut buf).await;
@@ -1906,8 +1954,6 @@ async fn stream_agent(
 
     let stdout = child.stdout.take().expect("stdout was piped");
     let mut lines = BufReader::new(stdout).lines();
-
-    let cancel = state.register_agent_cancel(cancel_id).await;
 
     let mut saw_result = false;
     let mut last_message = String::new(); // codex: accumulates the final message
@@ -1983,8 +2029,17 @@ async fn stream_agent(
         }
     }
 
-    state.clear_agent_cancel(cancel_id).await;
-    let _ = child.wait().await;
+    // The EOF / read-error breaks reach here with nothing having killed the child, so
+    // both waits below are bounded: a surviving grandchild holding the pipes must cost
+    // a bounded delay, never a hung command. Nothing is killed on the timeout-free
+    // path until this grace actually elapses — a clean EOF normally exits at once.
+    if tokio::time::timeout(CHILD_EXIT_GRACE, child.wait())
+        .await
+        .is_err()
+    {
+        kill_process_tree(&mut child);
+        let _ = tokio::time::timeout(CHILD_REAP_GRACE, child.wait()).await;
+    }
     // A killed `docker/podman run` client doesn't stop the container — force-
     // remove it so a cancelled/timed-out agent isn't left running detached.
     if cancelled || timed_out {
@@ -1992,7 +2047,15 @@ async fn stream_agent(
             let _ = run_capture(runtime, &["rm", "-f", name], DETECT_TIMEOUT).await;
         }
     }
-    let stderr_text = stderr_task.await.unwrap_or_default();
+    let stderr_text = match tokio::time::timeout(CHILD_EXIT_GRACE, &mut stderr_task).await {
+        Ok(joined) => joined.unwrap_or_default(),
+        // The read never ended (something still holds the pipe open) — abandon it and
+        // report with no stderr, which only weakens the no-result message below.
+        Err(_) => {
+            stderr_task.abort();
+            String::new()
+        }
+    };
 
     if cancelled {
         // The frontend tore down its UI on cancel; nothing to emit.
@@ -2050,6 +2113,14 @@ pub async fn agent_review(
     review_id: String,
     on_event: Channel<ReviewEvent>,
 ) -> AppResult<()> {
+    if !valid_cancel_id(&review_id) {
+        return Err(AppError::InvalidArgument("invalid review id".into()));
+    }
+    // Register BEFORE the setup below (binary resolve, MCP config writes): a racing
+    // cancel then lands its permit on this entry — or leaves a tombstone this
+    // register adopts. The guard clears the entry on every exit path.
+    let cancel = AgentCancelGuard::register(&state, &review_id);
+
     let binary = resolve(kind, bin_path.as_deref()).await.ok_or_else(|| {
         AppError::Command(format!(
             "{} CLI not found. Install it or set its path in Settings.",
@@ -2146,14 +2217,13 @@ pub async fn agent_review(
         timeout_secs,
     );
     let result = stream_agent(
-        &state,
+        cancel.notify.clone(),
         kind,
         &binary,
         args,
         stdin_text,
         &repo_path,
         timeout,
-        &review_id,
         "review",
         timeout_configurable.unwrap_or(false),
         None,
@@ -2173,7 +2243,12 @@ pub async fn agent_review_cancel(
     state: tauri::State<'_, AppState>,
     review_id: String,
 ) -> AppResult<()> {
-    state.cancel_agent(&review_id).await;
+    // Validate before touching the registry — same gate as the run commands, so a
+    // malformed id can't seed a tombstone (see `valid_cancel_id`).
+    if !valid_cancel_id(&review_id) {
+        return Err(AppError::InvalidArgument("invalid review id".into()));
+    }
+    state.cancel_agent(&review_id);
     Ok(())
 }
 
@@ -2230,6 +2305,14 @@ pub async fn agent_session(
     mcp_servers: Option<Vec<crate::mcp::McpServerSpec>>,
     on_event: Channel<ReviewEvent>,
 ) -> AppResult<()> {
+    if !valid_cancel_id(&session_id) {
+        return Err(AppError::InvalidArgument("invalid session id".into()));
+    }
+    // Register BEFORE the setup below (the container path runs several runtime
+    // probes): a racing cancel then lands its permit on this entry — or leaves a
+    // tombstone this register adopts. The guard clears the entry on every exit path.
+    let cancel = AgentCancelGuard::register(&state, &session_id);
+
     // Strict: reject an unknown agent rather than silently coercing it.
     let kind = match agent.as_str() {
         "claude" => AgentKind::Claude,
@@ -2560,14 +2643,13 @@ pub async fn agent_session(
             &inner,
         );
         return stream_agent(
-            &state,
+            cancel.notify.clone(),
             kind,
             &runtime,
             args,
             stdin_text,
             &worktree_path,
             SESSION_TIMEOUT,
-            &session_id,
             "session",
             false,
             Some((runtime.clone(), name)),
@@ -2596,14 +2678,13 @@ pub async fn agent_session(
         host_extra_env.push(("OPENCODE_ENABLE_EXA", "1".to_string()));
     }
     stream_agent(
-        &state,
+        cancel.notify.clone(),
         kind,
         &binary,
         inner,
         stdin_text,
         &worktree_path,
         SESSION_TIMEOUT,
-        &session_id,
         "session",
         false,
         None,
@@ -2838,6 +2919,18 @@ mod tests {
     const TEXT_B: &str = r#"{"type":"text","sessionID":"ses_abc","part":{"id":"p2","type":"text","text":"Second."}}"#;
     const FINISH_TOOLS: &str = r#"{"type":"step_finish","sessionID":"ses_abc","part":{"type":"step-finish","reason":"tool-calls"}}"#;
     const FINISH_STOP: &str = r#"{"type":"step_finish","sessionID":"ses_abc","part":{"type":"step-finish","reason":"stop"}}"#;
+
+    #[test]
+    fn cancel_id_gate_accepts_uuids_and_rejects_the_rest() {
+        // What the frontend actually mints (`crypto.randomUUID()`).
+        assert!(valid_cancel_id("3f2a1c7e-9b4d-4a61-8f0c-2d5e7a91b3c4"));
+        // Bounded and charset-limited, so no id can smuggle a path or a huge key.
+        assert!(!valid_cancel_id(""));
+        assert!(!valid_cancel_id("short"));
+        assert!(!valid_cancel_id("../../etc/passwd"));
+        assert!(!valid_cancel_id("has spaces in it"));
+        assert!(!valid_cancel_id(&"a".repeat(65)));
+    }
 
     #[test]
     fn opencode_step_start_yields_native_session_id() {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1830,10 +1830,10 @@ fn kill_process_tree(child: &mut tokio::process::Child) {
     let _ = child.start_kill();
 }
 
-/// Grace for the child to exit after the pump loop ends. On a clean EOF it has
-/// normally exited already, but a grandchild (node worker, MCP server) can keep the
-/// pipes open — without a bound the command never returns, so the frontend never sees
-/// `backendDone` and the run's UI stays stuck past its own timeout.
+/// Bounds each trailing wait once the pump loop ends — first the child's exit, then the
+/// stderr drain's join. On a clean EOF both finish at once, but a grandchild (node
+/// worker, MCP server) can hold the pipes open, and unbounded that means the command
+/// never returns: the frontend never sees `backendDone` and the run's UI stays stuck.
 const CHILD_EXIT_GRACE: Duration = Duration::from_secs(10);
 /// Second, shorter grace after a tree-kill: the child is being force-killed, so this
 /// only covers reaping it.

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -297,19 +297,27 @@ pub async fn run_glab_ex(
             AppError::Io(e)
         }
     })?;
-    if let Some(body) = input {
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(body.as_bytes())
-                .await
-                .map_err(AppError::Io)?;
-            stdin.shutdown().await.ok();
+    // The write runs INSIDE the timeout: a stalled stdin write is unbounded, so
+    // outside it a stall hangs the caller forever instead of failing at the
+    // deadline. It still precedes the drain rather than running concurrently the
+    // way the git runner has to — one API body in, one small JSON document back —
+    // and the timeout now bounds the exchange whatever a caller sends.
+    let exchange = async move {
+        if let Some(body) = input {
+            // Dropping the handle after the write closes the pipe so glab reads EOF.
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin
+                    .write_all(body.as_bytes())
+                    .await
+                    .map_err(AppError::Io)?;
+                stdin.shutdown().await.ok();
+            }
         }
-    }
-    let output = tokio::time::timeout(timeout, child.wait_with_output())
+        child.wait_with_output().await.map_err(AppError::Io)
+    };
+    let output = tokio::time::timeout(timeout, exchange)
         .await
-        .map_err(|_| AppError::Timeout(timeout.as_secs()))?
-        .map_err(AppError::Io)?;
+        .map_err(|_| AppError::Timeout(timeout.as_secs()))??;
     let out = GlabOutput {
         stdout: output.stdout,
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
-use crate::git::runner::{run_git_mutating, run_git_raw, DEFAULT_TIMEOUT};
+use crate::git::runner::{run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT};
 use crate::state::AppState;
 
 /// Cap on a conflicted file's working-tree size for AI resolution. Past this the
@@ -183,14 +183,23 @@ pub(crate) async fn git_checkout_conflict_side_core(
     // this side for its glob-siblings too, silently resolving conflicts the user
     // never opened.
     let spec = crate::git::pathspec::literal(&path);
-    run_git_mutating(
-        state,
-        &repo_path,
+
+    // Hold the per-repo lock across checkout→add, not once per step: between the two
+    // a concurrent stage or discard can rewrite the working-tree file, and the `add`
+    // would then stage THAT content as the user's chosen side. `repo_lock` is a
+    // non-reentrant `tokio::sync::Mutex`, so use the lock-free `run_git` while
+    // holding it — `run_git_mutating` re-acquires it and deadlocks. The steps lose
+    // its one-shot index.lock retry, the trade-off every compound here accepts.
+    let lock = state.repo_lock(&repo_path).await;
+    let _guard = lock.lock().await;
+
+    run_git(
+        Some(&repo_path),
         &["checkout", flag, "--", &spec],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    run_git_mutating(state, &repo_path, &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
+    run_git(Some(&repo_path), &["add", "--", &spec], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -184,12 +184,10 @@ pub(crate) async fn git_checkout_conflict_side_core(
     // never opened.
     let spec = crate::git::pathspec::literal(&path);
 
-    // Hold the per-repo lock across checkout→add, not once per step: between the two
-    // a concurrent stage or discard can rewrite the working-tree file, and the `add`
-    // would then stage THAT content as the user's chosen side. `repo_lock` is a
-    // non-reentrant `tokio::sync::Mutex`, so use the lock-free `run_git` while
-    // holding it — `run_git_mutating` re-acquires it and deadlocks. The steps lose
-    // its one-shot index.lock retry, the trade-off every compound here accepts.
+    // One hold across checkout→add: between the two a concurrent stage or discard can
+    // rewrite the working-tree file, and the `add` would then stage THAT content as
+    // the user's chosen side. Lock-free runners only while held (see
+    // `run_git_mutating`).
     let lock = state.repo_lock(&repo_path).await;
     let _guard = lock.lock().await;
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -323,15 +323,10 @@ pub(crate) async fn cherry_pick_onto(
         });
     }
 
-    // Hold the per-repo lock across the WHOLE guard → capture → pick → rollback
-    // sequence, not once per step: the rollback hard-resets `target` to the
-    // `target_tip` captured up here, so a commit another caller in this process
-    // lands in between is silently destroyed by a reset to a tip that predates it
-    // (a separate MCP-server process has its own locks and is NOT covered). `repo_lock` is a `tokio::sync::Mutex` (safe to hold
-    // across `.await`) but non-reentrant — use the lock-free `run_git` below, never
-    // `run_git_mutating`, which would deadlock. The inner steps therefore lose its
-    // one-shot index.lock retry, the same trade-off `git_stash_paths_core` and the
-    // autostash compounds accept.
+    // One hold across guard → capture → pick → rollback: the rollback hard-resets
+    // `target` to the `target_tip` captured up here, so a commit another caller lands
+    // in between would be destroyed by a reset to a tip that predates it. Lock-free
+    // runners only while held (see `run_git_mutating`).
     let lock = state.repo_lock(repo_path).await;
     let guard = lock.lock().await;
 
@@ -3174,16 +3169,11 @@ pub(crate) async fn rewrite_commits(
         // are all expressible.
     }
 
-    // Hold the per-repo lock across the WHOLE gate → capture → replay → rollback
-    // sequence, not once per step: the rollback hard-resets to the `orig` captured up
-    // here, so a commit another caller in this process lands mid-replay is silently
-    // destroyed (a separate MCP-server process has its own locks and is NOT covered),
-    // and between the `reset --hard base` and the picks the branch sits rewound where
-    // a concurrent read sees a truncated history. `repo_lock` is a `tokio::sync::Mutex` (safe to hold across `.await`)
-    // but non-reentrant — use the lock-free `run_git` below, never
-    // `run_git_mutating`, which would deadlock. The inner steps therefore lose its
-    // one-shot index.lock retry, the same trade-off `git_stash_paths_core` and the
-    // autostash compounds accept.
+    // One hold across gate → capture → replay → rollback: the rollback hard-resets to
+    // the `orig` captured up here, so a commit another caller lands mid-replay would be
+    // destroyed, and between `reset --hard base` and the picks the branch sits rewound
+    // where a concurrent read sees a truncated history. Lock-free runners only while
+    // held (see `run_git_mutating`).
     let lock = state.repo_lock(repo_path).await;
     let guard = lock.lock().await;
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -301,10 +301,19 @@ pub async fn git_cherry_pick_onto(
     hashes: Vec<String>,
     target_branch: String,
 ) -> AppResult<CherryPickRangeResult> {
-    use crate::git::runner::run_git;
+    cherry_pick_onto(&state, &repo_path, &hashes, &target_branch).await
+}
 
-    validate_branch_arg(&target_branch)?;
-    for h in &hashes {
+/// Testable core of [`git_cherry_pick_onto`] — takes a plain `&AppState` so the
+/// real-repo tokio tests can drive it (mirrors `rewrite_commits`).
+pub(crate) async fn cherry_pick_onto(
+    state: &AppState,
+    repo_path: &str,
+    hashes: &[String],
+    target_branch: &str,
+) -> AppResult<CherryPickRangeResult> {
+    validate_branch_arg(target_branch)?;
+    for h in hashes {
         validate_hash(h)?;
     }
     if hashes.is_empty() {
@@ -313,14 +322,27 @@ pub async fn git_cherry_pick_onto(
             skipped: 0,
         });
     }
+
+    // Hold the per-repo lock across the WHOLE guard → capture → pick → rollback
+    // sequence, not once per step: the rollback hard-resets `target` to the
+    // `target_tip` captured up here, so a commit another caller in this process
+    // lands in between is silently destroyed by a reset to a tip that predates it
+    // (a separate MCP-server process has its own locks and is NOT covered). `repo_lock` is a `tokio::sync::Mutex` (safe to hold
+    // across `.await`) but non-reentrant — use the lock-free `run_git` below, never
+    // `run_git_mutating`, which would deadlock. The inner steps therefore lose its
+    // one-shot index.lock retry, the same trade-off `git_stash_paths_core` and the
+    // autostash compounds accept.
+    let lock = state.repo_lock(repo_path).await;
+    let guard = lock.lock().await;
+
     // The failure path hard-resets `target` to its prior tip, which would discard
     // uncommitted work when target is the current branch — refuse first.
-    ensure_clean_tree(&repo_path).await?;
+    ensure_clean_tree(repo_path).await?;
 
     // Where we are now, so we can return on failure. A detached HEAD has no
     // branch name, so fall back to restoring its commit directly.
     let original_ref = run_git(
-        Some(&repo_path),
+        Some(repo_path),
         &["rev-parse", "--abbrev-ref", "HEAD"],
         DEFAULT_TIMEOUT,
     )
@@ -330,7 +352,7 @@ pub async fn git_cherry_pick_onto(
     .to_string();
     let detached = original_ref == "HEAD";
     let original_restore = if detached {
-        run_git(Some(&repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT)
+        run_git(Some(repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT)
             .await?
             .stdout_lossy()
             .trim()
@@ -341,8 +363,8 @@ pub async fn git_cherry_pick_onto(
 
     // The target's tip before we touch it, so we can roll back cleanly.
     let target_tip = run_git(
-        Some(&repo_path),
-        &["rev-parse", &target_branch],
+        Some(repo_path),
+        &["rev-parse", target_branch],
         DEFAULT_TIMEOUT,
     )
     .await?
@@ -352,7 +374,9 @@ pub async fn git_cherry_pick_onto(
 
     // Journal a pending entry AFTER the guards + state capture, BEFORE the first
     // mutation. Best-effort: a journal failure returns None and the op proceeds.
-    let original_sha = run_git(Some(&repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT)
+    // Runs under the lock (app-data I/O, not git) because the anchors it records
+    // are only valid while the hold that captured them is unbroken.
+    let original_sha = run_git(Some(repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT)
         .await
         .ok()
         .map(|o| o.stdout_lossy().trim().to_string())
@@ -367,7 +391,7 @@ pub async fn git_cherry_pick_onto(
         original_restore.clone()
     };
     let op_id = crate::oplog::begin(
-        &repo_path,
+        repo_path,
         "cherry_pick_onto",
         &label,
         Some(original_ref_label),
@@ -377,20 +401,23 @@ pub async fn git_cherry_pick_onto(
     .await;
 
     let result: AppResult<CherryPickRangeResult> = async {
-        run_git_mutating(&state, &repo_path, &["switch", &target_branch], DEFAULT_TIMEOUT).await?;
+        run_git(
+            Some(repo_path),
+            &["switch", target_branch],
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
 
         let mut applied = 0usize;
         let mut skipped = 0usize;
-        for hash in &hashes {
-            match run_git_mutating(&state, &repo_path, &["cherry-pick", hash], DEFAULT_TIMEOUT).await
-            {
+        for hash in hashes {
+            match run_git(Some(repo_path), &["cherry-pick", hash], DEFAULT_TIMEOUT).await {
                 Ok(_) => applied += 1,
                 Err(AppError::Git { stderr, .. })
                     if stderr.contains("is now empty") || stderr.contains("--allow-empty") =>
                 {
-                    let _ = run_git_mutating(
-                        &state,
-                        &repo_path,
+                    let _ = run_git(
+                        Some(repo_path),
                         &["cherry-pick", "--skip"],
                         DEFAULT_TIMEOUT,
                     )
@@ -400,16 +427,14 @@ pub async fn git_cherry_pick_onto(
                 Err(AppError::Git { code, stderr }) => {
                     // Roll everything back: abort the in-progress pick, drop the
                     // commits already applied in this batch, and return home.
-                    let _ = run_git_mutating(
-                        &state,
-                        &repo_path,
+                    let _ = run_git(
+                        Some(repo_path),
                         &["cherry-pick", "--abort"],
                         DEFAULT_TIMEOUT,
                     )
                     .await;
-                    let _ = run_git_mutating(
-                        &state,
-                        &repo_path,
+                    let _ = run_git(
+                        Some(repo_path),
                         &["reset", "--hard", &target_tip],
                         DEFAULT_TIMEOUT,
                     )
@@ -419,8 +444,7 @@ pub async fn git_cherry_pick_onto(
                     } else {
                         vec!["switch", &original_restore]
                     };
-                    let _ =
-                        run_git_mutating(&state, &repo_path, &restore_args, DEFAULT_TIMEOUT).await;
+                    let _ = run_git(Some(repo_path), &restore_args, DEFAULT_TIMEOUT).await;
                     let short = &hash[..hash.len().min(7)];
                     return Err(AppError::Git {
                         code,
@@ -437,8 +461,12 @@ pub async fn git_cherry_pick_onto(
     }
     .await;
 
+    // Every git step (including the rollback) is done — release before the
+    // journal's app-data I/O so it doesn't extend the hold.
+    drop(guard);
+
     crate::oplog::finish(
-        &repo_path,
+        repo_path,
         &op_id,
         result.as_ref().err().map(|e| e.to_string()),
     )
@@ -3146,6 +3174,19 @@ pub(crate) async fn rewrite_commits(
         // are all expressible.
     }
 
+    // Hold the per-repo lock across the WHOLE gate → capture → replay → rollback
+    // sequence, not once per step: the rollback hard-resets to the `orig` captured up
+    // here, so a commit another caller in this process lands mid-replay is silently
+    // destroyed (a separate MCP-server process has its own locks and is NOT covered),
+    // and between the `reset --hard base` and the picks the branch sits rewound where
+    // a concurrent read sees a truncated history. `repo_lock` is a `tokio::sync::Mutex` (safe to hold across `.await`)
+    // but non-reentrant — use the lock-free `run_git` below, never
+    // `run_git_mutating`, which would deadlock. The inner steps therefore lose its
+    // one-shot index.lock retry, the same trade-off `git_stash_paths_core` and the
+    // autostash compounds accept.
+    let lock = state.repo_lock(repo_path).await;
+    let guard = lock.lock().await;
+
     // reset --hard would destroy uncommitted work — refuse instead.
     let status = run_git(
         Some(repo_path),
@@ -3196,7 +3237,8 @@ pub(crate) async fn rewrite_commits(
 
     // Journal a pending entry AFTER the guards + `orig` capture, BEFORE the first
     // mutation (`reset --hard`). Best-effort: a journal failure returns None and
-    // the op proceeds unchanged.
+    // the op proceeds unchanged. Runs under the lock (app-data I/O, not git) because
+    // the `orig` anchor it records is only valid while this hold is unbroken.
     let original_ref = run_git(
         Some(repo_path),
         &["rev-parse", "--abbrev-ref", "HEAD"],
@@ -3218,20 +3260,20 @@ pub(crate) async fn rewrite_commits(
     .await;
 
     let op_result: AppResult<()> = async {
-        run_git_mutating(state, repo_path, &["reset", "--hard", base], DEFAULT_TIMEOUT).await?;
+        run_git(Some(repo_path), &["reset", "--hard", base], DEFAULT_TIMEOUT).await?;
         let mut failure: Option<AppError> = None;
         'steps: for step in steps {
             let single_pick = step.hashes.len() == 1 && step.message.is_none();
             if single_pick {
                 let args = ["cherry-pick", step.hashes[0].as_str()];
-                if let Err(e) = run_git_mutating(state, repo_path, &args, DEFAULT_TIMEOUT).await {
+                if let Err(e) = run_git(Some(repo_path), &args, DEFAULT_TIMEOUT).await {
                     failure = Some(e);
                     break 'steps;
                 }
             } else {
                 let mut args = vec!["cherry-pick", "-n"];
                 args.extend(step.hashes.iter().map(String::as_str));
-                if let Err(e) = run_git_mutating(state, repo_path, &args, DEFAULT_TIMEOUT).await {
+                if let Err(e) = run_git(Some(repo_path), &args, DEFAULT_TIMEOUT).await {
                     failure = Some(e);
                     break 'steps;
                 }
@@ -3243,9 +3285,7 @@ pub(crate) async fn rewrite_commits(
                 } else {
                     vec!["commit", "-m", message]
                 };
-                if let Err(e) =
-                    run_git_mutating(state, repo_path, &commit_args, DEFAULT_TIMEOUT).await
-                {
+                if let Err(e) = run_git(Some(repo_path), &commit_args, DEFAULT_TIMEOUT).await {
                     failure = Some(e);
                     break 'steps;
                 }
@@ -3253,16 +3293,13 @@ pub(crate) async fn rewrite_commits(
         }
 
         if let Some(err) = failure {
-            let _ = run_git_mutating(
-                state,
-                repo_path,
+            let _ = run_git(
+                Some(repo_path),
                 &["cherry-pick", "--abort"],
                 DEFAULT_TIMEOUT,
             )
             .await;
-            let _ =
-                run_git_mutating(state, repo_path, &["reset", "--hard", &orig], DEFAULT_TIMEOUT)
-                    .await;
+            let _ = run_git(Some(repo_path), &["reset", "--hard", &orig], DEFAULT_TIMEOUT).await;
             return Err(match err {
                 AppError::Git { code, stderr } => AppError::Git {
                     code,
@@ -3276,6 +3313,10 @@ pub(crate) async fn rewrite_commits(
         Ok(())
     }
     .await;
+
+    // Every git step (including the rollback) is done — release before the
+    // journal's app-data I/O so it doesn't extend the hold.
+    drop(guard);
 
     crate::oplog::finish(
         repo_path,
@@ -3867,6 +3908,130 @@ mod tests {
         let status = git(&repo, &["status", "--porcelain"]).await;
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
 
+    }
+
+    /// Negative control for the compound-lock fix: a rewrite that rolls back must
+    /// not take a concurrent commit down with it. The second task waits until the
+    /// rewrite observably holds the repo lock, then commits the way every other
+    /// mutating command does; tokio's fair mutex queues it behind the whole
+    /// compound. When the lock was taken per STEP instead, that commit landed
+    /// between two cycles and the rollback's `reset --hard orig` destroyed it.
+    /// Multi-threaded flavor deliberately: the concurrent task must genuinely run
+    /// in parallel instead of starving on a current-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_commit_survives_a_rolled_back_rewrite() {
+        let (dir, repo) = setup_repo("interleave").await;
+        let base = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
+        let c1 = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "two").await;
+        commit_file(&repo, dir.path(), "a.txt", "v2\n", "three").await;
+        let c3 = rev(&repo, "HEAD").await;
+        let orig = rev(&repo, "HEAD").await;
+
+        let state = std::sync::Arc::new(AppState::default());
+        let concurrent = {
+            let state = state.clone();
+            let repo = repo.clone();
+            tokio::spawn(async move {
+                let lock = state.repo_lock(&repo).await;
+                // Bounded wait: if the compound somehow finished first we still
+                // commit, and the assertions below stay meaningful either way.
+                for _ in 0..500 {
+                    if lock.try_lock().is_err() {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+                }
+                run_git_mutating(
+                    &state,
+                    &repo,
+                    &["commit", "--allow-empty", "-m", "concurrent"],
+                    DEFAULT_TIMEOUT,
+                )
+                .await
+                .expect("the queued commit must succeed once the compound releases");
+            })
+        };
+
+        // "three"'s patch (v1→v2) can't apply after only "one" replayed, so the
+        // SECOND pick conflicts — the compound has already mutated the branch by
+        // the time it rolls back.
+        let result = rewrite_commits(&state, &repo, &base, &[pick(&c1), pick(&c3)]).await;
+        assert!(result.is_err(), "the second pick must conflict");
+        concurrent.await.expect("concurrent task panicked");
+
+        let log = subjects(&repo).await;
+        assert_eq!(
+            log.first().map(String::as_str),
+            Some("concurrent"),
+            "the concurrent commit must survive the rollback: {log:?}"
+        );
+        assert_eq!(
+            rev(&repo, "HEAD~1").await,
+            orig,
+            "and it must sit directly on the tip the rewrite rolled back to"
+        );
+    }
+
+    #[tokio::test]
+    async fn cherry_pick_onto_copies_commits_to_the_target_branch() {
+        let (dir, repo) = setup_repo("pick-onto").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
+        let c1 = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "c.txt", "c\n", "two").await;
+        let c2 = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        let out = cherry_pick_onto(&state, &repo, &[c1, c2], "target")
+            .await
+            .unwrap();
+        assert_eq!((out.applied, out.skipped), (2, 0));
+        // Success leaves you ON the target branch, both commits copied in order.
+        assert_eq!(
+            git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).await.trim(),
+            "target"
+        );
+        assert_eq!(subjects(&repo).await, vec!["two", "one", "base"]);
+        let status = git(&repo, &["status", "--porcelain"]).await;
+        assert!(status.trim().is_empty(), "tree should be clean: {status}");
+    }
+
+    #[tokio::test]
+    async fn cherry_pick_onto_conflict_rolls_back_and_returns_home() {
+        let (dir, repo) = setup_repo("pick-onto-conflict").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        // Diverge target on the same file so the pick can't apply.
+        git(&repo, &["checkout", "target"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        let target_tip = rev(&repo, "HEAD").await;
+        git(&repo, &["checkout", "feature"]).await;
+        let feature_tip = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        match cherry_pick_onto(&state, &repo, &[c1], "target").await {
+            Err(AppError::Git { stderr, .. }) => assert!(
+                stderr.contains("rolled back"),
+                "the error must tell the user the target is unchanged: {stderr}"
+            ),
+            Ok(_) => panic!("the conflicting pick must fail"),
+            Err(e) => panic!("expected a Git error, got {e}"),
+        }
+        // Rolled fully back: the target's tip is untouched, no pick is in progress,
+        // and we're back on the branch we started from.
+        assert_eq!(rev(&repo, "target").await, target_tip);
+        assert_eq!(rev(&repo, "HEAD").await, feature_tip);
+        assert_eq!(
+            git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).await.trim(),
+            "feature"
+        );
+        let status = git(&repo, &["status", "--porcelain"]).await;
+        assert!(status.trim().is_empty(), "tree should be clean: {status}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -342,6 +342,14 @@ pub(crate) async fn worktree_toplevel(repo_path: &str) -> AppResult<String> {
 
 /// Runs a mutating git command under the per-repo lock, retrying once on
 /// index.lock contention caused by external tools (editors, other clients).
+///
+/// Compound sequences take `repo_lock` themselves, so their guards, anchors and
+/// rollback see one unbroken view — and must NOT call this from inside that hold,
+/// which re-acquires the same non-reentrant mutex and deadlocks. Use the lock-free
+/// runners there (`run_git`, `run_git_raw`, the `_input` pair,
+/// `remote::run_git_with_creds_once`), accepting the loss of the retry above.
+/// Either way the lock serializes callers in THIS process: a separate MCP-server
+/// process has its own and is not covered.
 pub async fn run_git_mutating(
     state: &AppState,
     repo_path: &str,

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -207,31 +207,68 @@ pub async fn run_git_raw_input(
         }
     };
     let run = async {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
         let mut child = cmd.spawn().map_err(spawn_err)?;
         #[cfg(windows)]
         let job = child.raw_handle().and_then(GitJob::arm);
-        if let Some(text) = input {
-            use tokio::io::AsyncWriteExt;
-            // Dropping the handle closes the pipe so git sees EOF.
-            let mut stdin = child.stdin.take().expect("stdin was piped");
-            stdin.write_all(text.as_bytes()).await.map_err(AppError::Io)?;
-        }
-        let result = child.wait_with_output().await;
+
+        // git interleaves reading stdin with writing stdout, so the write and both
+        // drains have to run CONCURRENTLY: writing all of stdin first wedges as soon
+        // as git's output fills its pipe buffer — git stops reading, our write
+        // blocks behind it, and the whole exchange dies on the timeout below.
+        // Local futures rather than `tokio::spawn`, because `input` is borrowed and
+        // a `'static` copy would clone a multi-MB patch on every hunk stage.
+        let stdin_pipe = child.stdin.take();
+        let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
+        let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+        let write = async move {
+            let (Some(mut pipe), Some(text)) = (stdin_pipe, input) else {
+                return Ok(());
+            };
+            let written = pipe.write_all(text.as_bytes()).await;
+            // Close the pipe the moment the write ends (error path included) so
+            // git sees EOF while the drains still poll — `--stdin` blocks forever
+            // without it; the explicit drop pins that close point across refactors.
+            drop(pipe);
+            written
+        };
+        let drain_stdout = async move {
+            let mut buf = Vec::new();
+            stdout_pipe.read_to_end(&mut buf).await.map(|_| buf)
+        };
+        let drain_stderr = async move {
+            let mut buf = Vec::new();
+            stderr_pipe.read_to_end(&mut buf).await.map(|_| buf)
+        };
+        let (written, stdout, stderr) = tokio::join!(write, drain_stdout, drain_stderr);
+
+        // The child's own verdict outranks a failed stdin write: that write fails
+        // almost exclusively as a broken pipe from git exiting early, and git's
+        // stderr and exit code are what say why. The write error surfaces only when
+        // there is no child result to report instead.
+        let reaped = match (stdout, stderr) {
+            (Ok(out), Ok(err)) => child.wait().await.map(|status| (out, err, status)),
+            (Err(e), _) | (_, Err(e)) => Err(e),
+        };
+        let (stdout, stderr, status) = match reaped {
+            Ok(reaped) => reaped,
+            // Abandoned without a reaped child, so the job stays ARMED (see `disarm`).
+            Err(e) => return Err(AppError::Io(written.err().unwrap_or(e))),
+        };
         #[cfg(windows)]
-        if let (Ok(_), Some(job)) = (&result, job) {
+        if let Some(job) = job {
             job.disarm();
         }
-        result.map_err(AppError::Io)
+        Ok(GitOutput {
+            stdout,
+            stderr: strip_eol_warnings(&String::from_utf8_lossy(&stderr)),
+            code: status.code().unwrap_or(-1),
+        })
     };
-    let output = tokio::time::timeout(timeout, run)
+    tokio::time::timeout(timeout, run)
         .await
-        .map_err(|_| AppError::Timeout(timeout.as_secs()))??;
-
-    Ok(GitOutput {
-        stdout: output.stdout,
-        stderr: strip_eol_warnings(&String::from_utf8_lossy(&output.stderr)),
-        code: output.status.code().unwrap_or(-1),
-    })
+        .map_err(|_| AppError::Timeout(timeout.as_secs()))?
 }
 
 /// With core.autocrlf on, git emits a "LF will be replaced by CRLF the next
@@ -330,6 +367,84 @@ pub async fn run_git_mutating_input(
             run_git_input(Some(repo_path), args, input, timeout).await
         }
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod stdin_tests {
+    use super::*;
+
+    /// Both sides have to clear the point where a write-then-read runner wedges,
+    /// and that point is platform-specific: on unix the stdin write blocks once the
+    /// 64KB pipe buffer fills, while on Windows tokio absorbs the first
+    /// `DEFAULT_MAX_BUF_SIZE` (2 MiB, measured against tokio 1.53) into its
+    /// `Blocking` wrapper before the write can stall at all. 50k paths of 100 bytes
+    /// send ~4.8 MiB and draw ~5.5 MiB back (four NUL-joined tokens per match, 15
+    /// bytes of them fixed), which clears both by a wide margin.
+    const PATH_COUNT: usize = 50_000;
+    const PAD: usize = 80;
+
+    /// Output far larger than the pipe buffer, produced while stdin is still being
+    /// written: the shape that deadlocked a write-then-read runner into a spurious
+    /// timeout. `git_ignored_files` hits it for real — every path it sends matches
+    /// by construction, and `--verbose` answers with four tokens per one sent.
+    #[tokio::test]
+    async fn large_interleaved_stdin_and_output_complete() {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-runner-stdin-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        run_git(Some(&repo), &["init", "-q"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        // `*` in the repo's own `.gitignore` outranks any global excludes the
+        // machine happens to carry, so every path matches this one rule.
+        std::fs::write(dir.path().join(".gitignore"), "*\n").unwrap();
+
+        // One directory, long names: the bytes come from the filename so git has a
+        // single parent to look for nested ignore files in.
+        let pad = "f".repeat(PAD);
+        let paths: Vec<String> = (0..PATH_COUNT)
+            .map(|i| format!("generated/{pad}{i:06}.bin"))
+            .collect();
+        let input: String = paths.iter().map(|p| format!("{p}\0")).collect();
+        assert!(
+            input.len() > 4 * 1024 * 1024,
+            "stdin must outrun tokio's 2 MiB Windows write buffer, got {} bytes",
+            input.len()
+        );
+
+        // The deadlock can only present as a timeout, so any explicit bound keeps
+        // a regression finite; 30s leaves ~10x headroom for slow contended CI
+        // runners (measured ~0.8s idle on a 32-thread dev machine).
+        let out = run_git_raw_input(
+            Some(&repo),
+            &["check-ignore", "--verbose", "-z", "--stdin"],
+            Some(&input),
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("check-ignore answers inside the timeout");
+        assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+        assert!(
+            out.stdout.len() > 1024 * 1024,
+            "output must exceed every pipe buffer, got {} bytes",
+            out.stdout.len()
+        );
+
+        // Byte-compared, not lossy-parsed: partial or interleaved drains would
+        // corrupt exactly here. `-z` terminates every token, so the split's last
+        // element is empty.
+        let tokens: Vec<&[u8]> = out.stdout.split(|b| *b == 0).collect();
+        assert_eq!(tokens.len(), PATH_COUNT * 4 + 1, "one record per path sent");
+        assert_eq!(tokens[PATH_COUNT * 4], b"");
+        for (i, path) in paths.iter().enumerate() {
+            assert_eq!(tokens[i * 4], b".gitignore");
+            assert_eq!(tokens[i * 4 + 1], b"1");
+            assert_eq!(tokens[i * 4 + 2], b"*");
+            assert_eq!(tokens[i * 4 + 3], path.as_bytes(), "record {i}");
+        }
     }
 }
 

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -446,13 +446,26 @@ pub(crate) async fn remove_worktree(
         args.push("--force");
     }
     args.push(path);
+
+    // Hold the per-repo lock across remove → prune → `branch -D`, not once per step:
+    // the branch delete is decided from state observed before the removal, so a
+    // concurrent checkout or commit landing in between would be destroyed by a `-D`
+    // that no longer reflects the repo. `repo_lock` is a non-reentrant
+    // `tokio::sync::Mutex`, so every step below uses the lock-free `run_git` —
+    // `run_git_mutating` would re-acquire it and deadlock — accepting the loss of
+    // its one-shot index.lock retry like every other compound here. The
+    // `remove_dir_all` fallback runs under the hold too: releasing around it would
+    // reopen the same window, and it only fires when git's own delete already failed.
+    let lock = state.repo_lock(repo_path).await;
+    let _guard = lock.lock().await;
+
     // `git worktree remove` deletes the directory itself, but its recursive delete
     // mishandles Windows reparse points: a worktree with pnpm-installed deps
     // (`node_modules/*` junctioned into `.pnpm/`) fails with `failed to delete
     // '<path>': Invalid argument`, half-removed. Finish it ourselves —
     // `std::fs::remove_dir_all` deletes reparse points as links (hardened since Rust
     // 1.63) — then `prune` to reconcile git's dangling admin entry.
-    if let Err(git_err) = run_git_mutating(state, repo_path, &args, WORKTREE_OP_TIMEOUT).await {
+    if let Err(git_err) = run_git(Some(repo_path), &args, WORKTREE_OP_TIMEOUT).await {
         // Two measured orderings: git's own FAILED delete still unregisters, so a live
         // registration means a policy refusal (dirty, locked, main) — surface it, since
         // the frontend reads that error to offer the forced retry. A KILLED delete
@@ -484,12 +497,12 @@ pub(crate) async fn remove_worktree(
         }
         // Best-effort reconcile: a prune hiccup must never turn a successful removal
         // into a reported failure.
-        let _ = run_git_mutating(state, repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+        let _ = run_git(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
     }
     // The branch can only be deleted once it's no longer checked out (i.e. after
     // the worktree is gone). Best-effort: a failure here shouldn't fail removal.
     if let Some(branch) = branch.as_deref().filter(|b| !b.is_empty()) {
-        let _ = run_git_mutating(state, repo_path, &["branch", "-D", branch], DEFAULT_TIMEOUT).await;
+        let _ = run_git(Some(repo_path), &["branch", "-D", branch], DEFAULT_TIMEOUT).await;
     }
     Ok(())
 }
@@ -512,6 +525,16 @@ pub async fn git_worktree_commit_all(
     worktree_path: String,
     message: String,
 ) -> AppResult<Option<String>> {
+    // Hold the worktree's lock across the emptiness check → add → commit → HEAD read,
+    // not once per step: otherwise a concurrent write can land between the check and
+    // the `add -A` (sweeping files this commit never meant to carry), and the HEAD
+    // read can report someone else's commit as this one's. `repo_lock` is a
+    // non-reentrant `tokio::sync::Mutex`, so use the lock-free `run_git` while
+    // holding it — `run_git_mutating` re-acquires it and deadlocks — accepting the
+    // loss of its one-shot index.lock retry like every other compound here.
+    let lock = state.repo_lock(&worktree_path).await;
+    let _guard = lock.lock().await;
+
     let status = run_git(
         Some(&worktree_path),
         &["status", "--porcelain"],
@@ -521,10 +544,9 @@ pub async fn git_worktree_commit_all(
     if status.stdout_lossy().trim().is_empty() {
         return Ok(None);
     }
-    run_git_mutating(&state, &worktree_path, &["add", "-A"], DEFAULT_TIMEOUT).await?;
-    run_git_mutating(
-        &state,
-        &worktree_path,
+    run_git(Some(&worktree_path), &["add", "-A"], DEFAULT_TIMEOUT).await?;
+    run_git(
+        Some(&worktree_path),
         &["commit", "-m", &message],
         DEFAULT_TIMEOUT,
     )
@@ -550,6 +572,16 @@ pub async fn git_worktree_squash(
     base: String,
     message: String,
 ) -> AppResult<bool> {
+    // Hold the worktree's lock across the HEAD check → soft-reset → commit, not once
+    // per step: between the reset and the commit the branch sits rewound with every
+    // turn's changes staged, so a concurrent commit or discard there either loses the
+    // session's work or folds foreign changes into the squash. `repo_lock` is a
+    // non-reentrant `tokio::sync::Mutex`, so use the lock-free `run_git` while
+    // holding it — `run_git_mutating` re-acquires it and deadlocks — accepting the
+    // loss of its one-shot index.lock retry like every other compound here.
+    let lock = state.repo_lock(&worktree_path).await;
+    let _guard = lock.lock().await;
+
     let head = run_git(
         Some(&worktree_path),
         &["rev-parse", "HEAD"],
@@ -559,16 +591,14 @@ pub async fn git_worktree_squash(
     if head.stdout_lossy().trim() == base.trim() {
         return Ok(false);
     }
-    run_git_mutating(
-        &state,
-        &worktree_path,
+    run_git(
+        Some(&worktree_path),
         &["reset", "--soft", &base],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    run_git_mutating(
-        &state,
-        &worktree_path,
+    run_git(
+        Some(&worktree_path),
         &["commit", "-m", &message],
         DEFAULT_TIMEOUT,
     )

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -447,15 +447,11 @@ pub(crate) async fn remove_worktree(
     }
     args.push(path);
 
-    // Hold the per-repo lock across remove → prune → `branch -D`, not once per step:
-    // the branch delete is decided from state observed before the removal, so a
-    // concurrent checkout or commit landing in between would be destroyed by a `-D`
-    // that no longer reflects the repo. `repo_lock` is a non-reentrant
-    // `tokio::sync::Mutex`, so every step below uses the lock-free `run_git` —
-    // `run_git_mutating` would re-acquire it and deadlock — accepting the loss of
-    // its one-shot index.lock retry like every other compound here. The
-    // `remove_dir_all` fallback runs under the hold too: releasing around it would
-    // reopen the same window, and it only fires when git's own delete already failed.
+    // One hold across remove → prune → `branch -D`: the delete is decided from state
+    // observed before the removal, so a concurrent checkout or commit in between would
+    // be destroyed by a `-D` that no longer reflects the repo. The `remove_dir_all`
+    // fallback stays under it — releasing around it reopens that window. Lock-free
+    // runners only while held (see `run_git_mutating`).
     let lock = state.repo_lock(repo_path).await;
     let _guard = lock.lock().await;
 
@@ -525,18 +521,24 @@ pub async fn git_worktree_commit_all(
     worktree_path: String,
     message: String,
 ) -> AppResult<Option<String>> {
-    // Hold the worktree's lock across the emptiness check → add → commit → HEAD read,
-    // not once per step: otherwise a concurrent write can land between the check and
-    // the `add -A` (sweeping files this commit never meant to carry), and the HEAD
-    // read can report someone else's commit as this one's. `repo_lock` is a
-    // non-reentrant `tokio::sync::Mutex`, so use the lock-free `run_git` while
-    // holding it — `run_git_mutating` re-acquires it and deadlocks — accepting the
-    // loss of its one-shot index.lock retry like every other compound here.
-    let lock = state.repo_lock(&worktree_path).await;
+    worktree_commit_all(&state, &worktree_path, &message).await
+}
+
+/// The body of `git_worktree_commit_all`, callable without a Tauri `State`.
+pub(crate) async fn worktree_commit_all(
+    state: &AppState,
+    worktree_path: &str,
+    message: &str,
+) -> AppResult<Option<String>> {
+    // One hold across the emptiness check → add → commit → HEAD read: otherwise a
+    // concurrent write lands between the check and `add -A` (sweeping files this
+    // commit never meant to carry), and the HEAD read can report someone else's commit
+    // as this one's. Lock-free runners only while held (see `run_git_mutating`).
+    let lock = state.repo_lock(worktree_path).await;
     let _guard = lock.lock().await;
 
     let status = run_git(
-        Some(&worktree_path),
+        Some(worktree_path),
         &["status", "--porcelain"],
         DEFAULT_TIMEOUT,
     )
@@ -544,15 +546,15 @@ pub async fn git_worktree_commit_all(
     if status.stdout_lossy().trim().is_empty() {
         return Ok(None);
     }
-    run_git(Some(&worktree_path), &["add", "-A"], DEFAULT_TIMEOUT).await?;
+    run_git(Some(worktree_path), &["add", "-A"], DEFAULT_TIMEOUT).await?;
     run_git(
-        Some(&worktree_path),
-        &["commit", "-m", &message],
+        Some(worktree_path),
+        &["commit", "-m", message],
         DEFAULT_TIMEOUT,
     )
     .await?;
     let head = run_git(
-        Some(&worktree_path),
+        Some(worktree_path),
         &["rev-parse", "HEAD"],
         DEFAULT_TIMEOUT,
     )
@@ -572,13 +574,10 @@ pub async fn git_worktree_squash(
     base: String,
     message: String,
 ) -> AppResult<bool> {
-    // Hold the worktree's lock across the HEAD check → soft-reset → commit, not once
-    // per step: between the reset and the commit the branch sits rewound with every
-    // turn's changes staged, so a concurrent commit or discard there either loses the
-    // session's work or folds foreign changes into the squash. `repo_lock` is a
-    // non-reentrant `tokio::sync::Mutex`, so use the lock-free `run_git` while
-    // holding it — `run_git_mutating` re-acquires it and deadlocks — accepting the
-    // loss of its one-shot index.lock retry like every other compound here.
+    // One hold across the HEAD check → soft-reset → commit: between the reset and the
+    // commit the branch sits rewound with every turn's changes staged, so a concurrent
+    // commit or discard there either loses the session's work or folds foreign changes
+    // into the squash. Lock-free runners only while held (see `run_git_mutating`).
     let lock = state.repo_lock(&worktree_path).await;
     let _guard = lock.lock().await;
 
@@ -1185,5 +1184,61 @@ prunable gitdir file points to non-existent location
             !registry(&repo_s).await.contains("/gone-wt"),
             "the stale admin entry is gone"
         );
+    }
+
+    /// Sibling of `git::ops`'s rewrite interleave control, for the other compound
+    /// shape: status check → `add -A` → commit → HEAD read. The second task commits
+    /// through the normal mutating path once the turn observably holds the lock, and
+    /// tokio's fair mutex queues it behind the whole turn — so neither side's work is
+    /// lost and the hash handed back is the turn's OWN commit. Per-step locking let
+    /// that commit land mid-sequence, where `add -A` swept it into the turn or the
+    /// HEAD read misreported it as the turn's.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_commit_never_loses_a_worktree_turn() {
+        let (_base, repo_s) = setup_repo("commit-all-race").await;
+        // The turn's output: an untracked file only `add -A` picks up.
+        std::fs::write(std::path::Path::new(&repo_s).join("agent.txt"), "turn\n").unwrap();
+
+        let state = std::sync::Arc::new(AppState::default());
+        let concurrent = {
+            let state = state.clone();
+            let repo = repo_s.clone();
+            tokio::spawn(async move {
+                let lock = state.repo_lock(&repo).await;
+                // Bounded wait: if the turn somehow finished first we still commit,
+                // and the assertions below stay meaningful either way.
+                for _ in 0..500 {
+                    if lock.try_lock().is_err() {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+                }
+                run_git_mutating(
+                    &state,
+                    &repo,
+                    &["commit", "--allow-empty", "-m", "concurrent"],
+                    DEFAULT_TIMEOUT,
+                )
+                .await
+                .expect("the queued commit must succeed once the turn releases");
+            })
+        };
+
+        let hash = worktree_commit_all(&state, &repo_s, "session turn")
+            .await
+            .expect("committing a dirty worktree succeeds")
+            .expect("a dirty worktree produces a commit");
+        concurrent.await.expect("concurrent task panicked");
+
+        // The hash handed back names the TURN's commit, never the racing one.
+        let subject = run(&repo_s, &["log", "-1", "--format=%s", &hash]).await;
+        assert_eq!(subject.trim(), "session turn");
+        // Both commits survive, in whichever order they queued.
+        let log = run(&repo_s, &["log", "--format=%s"]).await;
+        assert!(log.contains("concurrent"), "concurrent commit lost: {log}");
+        assert!(log.contains("session turn"), "turn commit lost: {log}");
+        // And the turn's own output rode along in the turn's commit, not a later one.
+        let files = run(&repo_s, &["show", "--name-only", "--format=", &hash]).await;
+        assert!(files.contains("agent.txt"), "turn's output missing: {files}");
     }
 }

--- a/src-tauri/src/github/runner.rs
+++ b/src-tauri/src/github/runner.rs
@@ -148,16 +148,22 @@ pub async fn run_gh_input(
             AppError::Io(e)
         }
     })?;
-    // Write the body and close stdin so gh reads EOF (body is small — no
-    // deadlock risk from not draining stdout concurrently).
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(input.as_bytes()).await.map_err(AppError::Io)?;
-        stdin.shutdown().await.ok();
-    }
-    let output = tokio::time::timeout(timeout, child.wait_with_output())
+    // The write runs INSIDE the timeout: a stalled stdin write is unbounded, so
+    // outside it a stall hangs the caller forever instead of failing at the
+    // deadline. It still precedes the drain rather than running concurrently the
+    // way the git runner has to — one API body in, one small JSON document back —
+    // and the timeout now bounds the exchange whatever a caller sends.
+    let exchange = async move {
+        // Dropping the handle after the write closes the pipe so gh reads EOF.
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(input.as_bytes()).await.map_err(AppError::Io)?;
+            stdin.shutdown().await.ok();
+        }
+        child.wait_with_output().await.map_err(AppError::Io)
+    };
+    let output = tokio::time::timeout(timeout, exchange)
         .await
-        .map_err(|_| AppError::Timeout(timeout.as_secs()))?
-        .map_err(AppError::Io)?;
+        .map_err(|_| AppError::Timeout(timeout.as_secs()))??;
 
     let out = GhOutput {
         stdout: output.stdout,

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -206,14 +206,31 @@ pub struct AgentCommand {
 /// with an empty `prompt` (invoked by name, not inlined). Deduped by (kind,
 /// lowercased name): the first dir in priority order wins, so project beats
 /// global and the canonical `.agents` dir beats a vendor mirror (junction).
+///
+/// The walk reads up to eight directories and every file in them, so it runs in
+/// `spawn_blocking` — on the main thread it stalls the first `/` in the composer.
 #[tauri::command]
-pub fn read_agent_commands(
+pub async fn read_agent_commands(
     app: tauri::AppHandle,
     repo_path: String,
     agent: String,
 ) -> AppResult<Vec<AgentCommand>> {
-    let repo = Path::new(&repo_path);
+    // Resolve home HERE: it's the only thing the walk needs the `AppHandle` for,
+    // and keeping it out of the blocking core leaves that core app-state-free.
     let home = app.path().home_dir().ok();
+    tauri::async_runtime::spawn_blocking(move || discover_agent_commands(&repo_path, &agent, home))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))
+}
+
+/// The blocking core of [`read_agent_commands`] — pure filesystem work, no
+/// `AppHandle`.
+fn discover_agent_commands(
+    repo_path: &str,
+    agent: &str,
+    home: Option<PathBuf>,
+) -> Vec<AgentCommand> {
+    let repo = Path::new(repo_path);
     let home = home.as_deref();
 
     let mut seen: HashSet<(String, String)> = HashSet::new();
@@ -221,7 +238,7 @@ pub fn read_agent_commands(
 
     // Commands: a prompt template per `*.md`. We expand the body on the frontend,
     // so execution is provider-agnostic — the dirs are just where each CLI looks.
-    for (dir, scope) in command_dirs(&agent, repo, home) {
+    for (dir, scope) in command_dirs(agent, repo, home) {
         for path in md_files(&dir) {
             let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
                 continue;
@@ -255,7 +272,7 @@ pub fn read_agent_commands(
 
     // Skills: each is a `<name>/SKILL.md` directory. Surfaced for display + a
     // by-name nudge; the body isn't sent (the CLI already loaded the real skill).
-    for (dir, scope) in skill_dirs(&agent, repo, home) {
+    for (dir, scope) in skill_dirs(agent, repo, home) {
         let Ok(entries) = std::fs::read_dir(&dir) else {
             continue;
         };
@@ -297,7 +314,7 @@ pub fn read_agent_commands(
         }
     }
 
-    Ok(out)
+    out
 }
 
 /// Per-agent custom-command directories, project before global (project wins

--- a/src-tauri/src/mcp_launcher.rs
+++ b/src-tauri/src/mcp_launcher.rs
@@ -17,10 +17,20 @@
 //! exercise it). Otherwise the launcher path is simply `current_exe()`.
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
+
+/// Serializes the whole ensure/refresh path process-wide — three writers can
+/// reach it at once (the startup refresh, the launcher-path command, Add to
+/// PATH). Unserialized, `sweep_strays` deletes a concurrent writer's in-flight
+/// temp or just-moved-aside exe (Windows handles share DELETE), so the loser
+/// fails with a misleading error after a wasted ~50MB copy. Held only across
+/// synchronous fs work, never an `.await`; poison is ignored — a panicked
+/// writer leaves nothing the next one can't overwrite.
+static ENSURE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Env override for the managed bin directory. Set → that dir is used as the
 /// managed bin dir in ALL builds (this is how dev/live validation exercises the
@@ -198,10 +208,9 @@ fn copy_into_place(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
         let _ = std::fs::remove_file(&tmp);
         return Err(AppError::Io(e));
     }
-    // 4. Move an existing dest exe ASIDE first: on Windows `fs::rename` FAILS if
-    //    the target exists (no POSIX overwrite), and a RUNNING image can be
-    //    renamed but never deleted or replaced — so rename-aside works even while
-    //    an old MCP server is still running that copy.
+    // 4. Move an existing dest exe ASIDE first: on Windows a RUNNING image can be
+    //    renamed but never deleted or replaced — so rename-aside is what lets the
+    //    promotion succeed while an old MCP server still runs that copy.
     let mut moved_old: Option<PathBuf> = None;
     if dest.exists() {
         let old = unique_sibling(dest, "old");
@@ -294,7 +303,15 @@ fn refresh_dest_if_stale(source: &Path, dest: &Path, want: &Marker) {
 
 /// The re-copy core, parameterized on `source`/`dest`/`want` so tests drive it
 /// against a temp dir without touching process-global env or the real bin dir.
+///
+/// Serialized by [`ENSURE_LOCK`], with the staleness check RE-run inside it: a
+/// waiter whose racer just finished the same copy returns without redoing it
+/// (callers' pre-lock checks are only a lock-free fast path).
 fn ensure_in_dir(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
+    let _guard = ENSURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    if !is_stale(dest, want) {
+        return Ok(());
+    }
     copy_into_place(source, dest, want)
 }
 
@@ -418,10 +435,82 @@ mod tests {
         // Second call with the same marker is a no-op: nothing is stale, so the
         // recipe isn't re-run. (Guarded via is_stale, mirroring `ensure`.)
         assert!(!is_stale(&dest, &want));
-        // Re-running the recipe anyway still succeeds and leaves a valid copy.
+        // Calling in anyway succeeds — the under-lock re-check short-circuits it.
         ensure_in_dir(&source, &dest, &want).unwrap();
         assert!(dest.exists());
         assert_eq!(read_marker(&dest).as_ref(), Some(&want));
+    }
+
+    /// A stand-in source exe plus the bin dir it gets copied into, so the
+    /// concurrency tests copy kilobytes (not the real ~50MB binary) and can tell
+    /// a fresh copy from a tampered one by content.
+    fn fake_source(dir: &Path, body: &[u8]) -> (PathBuf, PathBuf, PathBuf) {
+        let source = dir.join("source-exe");
+        std::fs::write(&source, body).unwrap();
+        let bin = dir.join("bin");
+        let dest = bin.join(LAUNCHER_FILE);
+        (source, bin, dest)
+    }
+
+    #[test]
+    fn concurrent_ensure_in_dir_never_errors_or_leaves_strays() {
+        // Four writers racing the same copy — the real overlap is the startup
+        // refresh still running when Settings (or Add to PATH) ensures. Without
+        // the lock, one writer's `sweep_strays` deletes another's in-flight temp
+        // and that writer fails with a misleading error.
+        let (_guard, dir) = scratch_dir("race");
+        let (source, bin, dest) = fake_source(&dir, &vec![b'S'; 64 * 1024]);
+        let want = marker_for(&source, "1.2.3").unwrap();
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let (source, dest, want) = (source.clone(), dest.clone(), want.clone());
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    ensure_in_dir(&source, &dest, &want)
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join()
+                .expect("writer thread panicked")
+                .expect("a racing writer must not fail");
+        }
+
+        assert_eq!(read_marker(&dest).as_ref(), Some(&want));
+        assert_eq!(
+            std::fs::read(&dest).unwrap(),
+            std::fs::read(&source).unwrap(),
+            "the surviving copy is the source, in full"
+        );
+        let strays: Vec<String> = std::fs::read_dir(&bin)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with('.'))
+            .collect();
+        assert!(strays.is_empty(), "temp/old strays survived: {strays:?}");
+    }
+
+    #[test]
+    fn ensure_in_dir_skips_the_copy_a_racer_already_did() {
+        // What makes the loser of the race cheap instead of a redundant ~50MB
+        // copy: the under-lock staleness re-check. Tampering with the dest body
+        // (the marker still matches) makes the skipped copy observable.
+        let (_guard, dir) = scratch_dir("skip-redundant");
+        let (source, _bin, dest) = fake_source(&dir, b"launcher bytes");
+        let want = marker_for(&source, "1.2.3").unwrap();
+        ensure_in_dir(&source, &dest, &want).unwrap();
+
+        std::fs::write(&dest, b"tampered").unwrap();
+        ensure_in_dir(&source, &dest, &want).unwrap();
+        assert_eq!(
+            std::fs::read(&dest).unwrap(),
+            b"tampered".to_vec(),
+            "fresh marker ⇒ the copy is skipped, not redone"
+        );
     }
 
     #[test]

--- a/src-tauri/src/mcp_launcher.rs
+++ b/src-tauri/src/mcp_launcher.rs
@@ -241,6 +241,21 @@ fn copy_into_place(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
     Ok(())
 }
 
+/// The single framing every launcher failure wears. Settings renders the
+/// message verbatim (inline, and as the reason the write-config buttons are
+/// disabled) and the Add-to-PATH toast shows the same string, so a bare
+/// `io error: …` there would name nothing the user recognizes. `at` carries the
+/// managed path once it's resolved.
+fn launcher_error(at: Option<&Path>, e: impl std::fmt::Display) -> AppError {
+    match at {
+        Some(dest) => AppError::Command(format!(
+            "Couldn't prepare the MCP launcher at {}: {e}",
+            dest.display()
+        )),
+        None => AppError::Command(format!("Couldn't prepare the MCP launcher: {e}")),
+    }
+}
+
 /// Ensure the managed launcher exists and is fresh for `version`, returning its
 /// absolute path (inactive ⇒ `current_exe()`; fresh ⇒ no writes; stale ⇒ copy).
 ///
@@ -248,20 +263,22 @@ fn copy_into_place(source: &Path, dest: &Path, want: &Marker) -> AppResult<()> {
 /// NEVER falls back to the installed exe's path, which would quietly
 /// reintroduce the file-lock / kill-by-name bugs this exists to fix.
 pub fn ensure(version: &str) -> AppResult<PathBuf> {
-    match resolve()? {
+    match resolve().map_err(|e| launcher_error(None, e))? {
         Resolution::Inactive(exe) => Ok(exe),
         Resolution::Managed(dest) => {
-            let source = current_exe()?;
-            let want = marker_for(&source, version)?;
+            let source = current_exe().map_err(|e| launcher_error(Some(&dest), e))?;
+            let want = marker_for(&source, version).map_err(|e| launcher_error(Some(&dest), e))?;
             if !is_stale(&dest, &want) {
                 return Ok(dest);
             }
             ensure_in_dir(&source, &dest, &want).map_err(|e| {
-                AppError::Command(format!(
-                    "Couldn't prepare the MCP launcher at {}: {e}. If an antivirus \
-                     quarantined it, restore/allow it and retry.",
-                    dest.display()
-                ))
+                // Quarantine explains a failure only here, where the exe is
+                // actually copied and renamed; the steps above just read paths
+                // and metadata.
+                launcher_error(
+                    Some(&dest),
+                    format!("{e}. If an antivirus quarantined it, restore/allow it and retry."),
+                )
             })?;
             Ok(dest)
         }
@@ -323,7 +340,7 @@ pub async fn mcp_launcher_path(app: tauri::AppHandle) -> AppResult<String> {
     let version = app.package_info().version.to_string();
     let path = tauri::async_runtime::spawn_blocking(move || ensure(&version))
         .await
-        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;
+        .map_err(|e| launcher_error(None, e))??;
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -354,6 +371,25 @@ mod tests {
         assert!(s.contains("\"sourceMtimeMs\""), "expected camelCase: {s}");
         let back: Marker = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(back, m);
+    }
+
+    #[test]
+    fn launcher_errors_always_name_the_launcher() {
+        // Settings renders these verbatim — inline, and as the reason the
+        // write-config buttons are disabled — so a message that doesn't name the
+        // launcher reads as an unattributed IO error.
+        let bare = launcher_error(None, "io error: os error 2").to_string();
+        assert_eq!(
+            bare,
+            "Couldn't prepare the MCP launcher: io error: os error 2"
+        );
+        let dest = Path::new("C:").join("bin").join(LAUNCHER_FILE);
+        let framed = launcher_error(Some(&dest), "io error: os error 2").to_string();
+        assert!(
+            framed.starts_with("Couldn't prepare the MCP launcher at "),
+            "{framed}"
+        );
+        assert!(framed.contains(&dest.display().to_string()), "{framed}");
     }
 
     /// Set up a temp bin dir with a copied launcher + marker and return

--- a/src-tauri/src/mcp_launcher.rs
+++ b/src-tauri/src/mcp_launcher.rs
@@ -150,6 +150,12 @@ fn marker_path(dest: &Path) -> PathBuf {
 /// Whether the managed copy at `dest` is stale relative to `want`. Stale ⇔ the
 /// dest exe is absent, OR the marker is missing/unparseable, OR any of its three
 /// fields differs from `want`.
+///
+/// The marker attests WHICH source/version the copy was made from — not the
+/// copy's bytes. In-place tampering of `dest` is outside the contract: a writer
+/// with that access could forge the sibling marker too, and every crash or
+/// quarantine path self-repairs (dest-absent is stale; `copy_into_place` writes
+/// the marker only after the exe rename lands).
 fn is_stale(dest: &Path, want: &Marker) -> bool {
     if !dest.exists() {
         return true;
@@ -533,8 +539,10 @@ mod tests {
     #[test]
     fn ensure_in_dir_skips_the_copy_a_racer_already_did() {
         // What makes the loser of the race cheap instead of a redundant ~50MB
-        // copy: the under-lock staleness re-check. Tampering with the dest body
-        // (the marker still matches) makes the skipped copy observable.
+        // copy: the under-lock staleness re-check. Rewriting the dest body while
+        // the marker matches is ONLY the observable for "the copy was skipped" —
+        // content integrity is deliberately not the marker's contract (see
+        // `is_stale`).
         let (_guard, dir) = scratch_dir("skip-redundant");
         let (source, _bin, dest) = fake_source(&dir, b"launcher bytes");
         let want = marker_for(&source, "1.2.3").unwrap();
@@ -545,7 +553,7 @@ mod tests {
         assert_eq!(
             std::fs::read(&dest).unwrap(),
             b"tampered".to_vec(),
-            "fresh marker ⇒ the copy is skipped, not redone"
+            "fresh marker ⇒ the copy is skipped, not redone (skip observable; integrity is not the marker contract)"
         );
     }
 

--- a/src-tauri/src/path_launcher.rs
+++ b/src-tauri/src/path_launcher.rs
@@ -54,17 +54,23 @@ pub fn path_launcher_status() -> AppResult<PathLauncherStatus> {
     status_impl()
 }
 
+/// Installs the launcher off the main thread: on Windows the install
+/// materializes the managed MCP copy first, which is a ~50MB file copy.
 #[tauri::command]
-pub fn path_launcher_install(app: tauri::AppHandle) -> AppResult<PathLauncherStatus> {
+pub async fn path_launcher_install(app: tauri::AppHandle) -> AppResult<PathLauncherStatus> {
     let _version = app.package_info().version.to_string();
-    #[cfg(windows)]
-    {
-        install_impl(&_version)
-    }
-    #[cfg(not(windows))]
-    {
-        install_impl()
-    }
+    tauri::async_runtime::spawn_blocking(move || {
+        #[cfg(windows)]
+        {
+            install_impl(&_version)
+        }
+        #[cfg(not(windows))]
+        {
+            install_impl()
+        }
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -39,11 +39,14 @@ pub struct PtyState {
     ptys: Arc<Mutex<HashMap<String, PtyHandle>>>,
 }
 
-/// Control side of one PTY: the master (resize), a writer (input), and the child
+/// Control side of one PTY: the master (resize), an input queue, and the child
 /// (kill). The reader is owned by the streaming thread, not here.
 struct PtyHandle {
     master: Box<dyn MasterPty + Send>,
-    writer: Box<dyn Write + Send>,
+    /// Queues input for the PTY's writer thread. The writer itself lives there, so
+    /// a child that stops reading can never block a caller holding the PTY map
+    /// lock; dropping this handle closes the channel, which ends that thread.
+    input: std::sync::mpsc::Sender<Vec<u8>>,
     child: Box<dyn Child + Send + Sync>,
     /// A temp script file to delete once the process exits (Tasks runs write the
     /// script body to a temp file); `None` for host/container shells.
@@ -448,6 +451,21 @@ fn teardown_handle(mut h: PtyHandle) {
     cleanup_handle(&mut h);
 }
 
+/// Drains queued input to the PTY on a dedicated thread. Writing can block for as
+/// long as the child ignores its input, so it must never happen under the PTY map
+/// lock (that froze the app once, and made `pty_close` unreachable). A single
+/// consumer keeps per-PTY writes in the order they were queued. Returns — dropping
+/// the writer, which sends EOF to the slave — when the channel closes (the handle
+/// was torn down) or the write fails.
+fn pump_pty_input(mut writer: impl Write, rx: std::sync::mpsc::Receiver<Vec<u8>>) {
+    while let Ok(chunk) = rx.recv() {
+        if writer.write_all(&chunk).is_err() {
+            break;
+        }
+        let _ = writer.flush();
+    }
+}
+
 /// Opens a PTY, starts streaming its output to `on_event`, and registers it under
 /// `id`. The frontend writes/resizes/closes it by that id.
 #[tauri::command]
@@ -510,13 +528,18 @@ pub async fn pty_open(
         Err(e) => return Err(fail(format!("terminal writer: {e}"))),
     };
 
+    // Input goes through a channel to a thread that owns the writer — see
+    // `pump_pty_input`.
+    let (input, input_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || pump_pty_input(writer, input_rx));
+
     let gen = PTY_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let cleanup_path = cleanup.clone();
     let prev = state.ptys.lock().unwrap().insert(
         id.clone(),
         PtyHandle {
             master: pair.master,
-            writer,
+            input,
             child,
             cleanup,
             tree_kill,
@@ -603,13 +626,15 @@ pub async fn pty_open(
     Ok(())
 }
 
-/// Writes the user's keystrokes (UTF-8) to the PTY.
+/// Queues the user's keystrokes (UTF-8) for the PTY. Sync command (main thread),
+/// so it only enqueues — the blocking write happens on the writer thread. A closed
+/// channel (that thread already exited) drops the keystrokes: the caller discards
+/// write errors anyway, and `Exit` is what reports a dead terminal.
 #[tauri::command]
 pub fn pty_write(state: State<'_, PtyState>, id: String, data: String) -> AppResult<()> {
-    let mut map = state.ptys.lock().unwrap();
-    if let Some(h) = map.get_mut(&id) {
-        h.writer.write_all(data.as_bytes()).map_err(AppError::Io)?;
-        let _ = h.writer.flush();
+    let map = state.ptys.lock().unwrap();
+    if let Some(h) = map.get(&id) {
+        let _ = h.input.send(data.into_bytes());
     }
     Ok(())
 }
@@ -827,6 +852,196 @@ async fn task_open_terminal_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{channel, Sender};
+    use std::sync::Condvar;
+    use std::time::Duration;
+
+    /// The input side of the PTY map. A real `PtyHandle` needs a live child, so the
+    /// concurrency tests key on the sender alone — the field `pty_write` touches.
+    type TestPtys = Arc<Mutex<HashMap<String, Sender<Vec<u8>>>>>;
+
+    /// Appends every write to a shared buffer, so a test can assert ordering.
+    struct RecordingWriter(Arc<Mutex<Vec<u8>>>);
+    impl Write for RecordingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Blocks inside `write` until released — a child that has stopped reading its
+    /// input (a full ConPTY input buffer).
+    struct WedgedWriter {
+        entered: Sender<()>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+    impl Write for WedgedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let _ = self.entered.send(());
+            let (lock, cv) = &*self.release;
+            let mut go = lock.lock().unwrap();
+            while !*go {
+                go = cv.wait(go).unwrap();
+            }
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn release(gate: &Arc<(Mutex<bool>, Condvar)>) {
+        let (lock, cv) = &**gate;
+        *lock.lock().unwrap() = true;
+        cv.notify_all();
+    }
+
+    /// Reports its own drop — the observable that stands in for "EOF reached the
+    /// slave", which dropping the writer is what produces.
+    struct DropSpy {
+        dropped: Arc<AtomicBool>,
+        fail: bool,
+    }
+    impl Write for DropSpy {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.fail {
+                Err(std::io::Error::other("the child is gone"))
+            } else {
+                Ok(buf.len())
+            }
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl Drop for DropSpy {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn queued_writes_reach_the_pty_in_order() {
+        // One consumer, so keystrokes land in the order the frontend queued them —
+        // it fires unordered, unawaited invokes, one per keystroke.
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = channel();
+        let writer = RecordingWriter(sink.clone());
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+
+        let mut expected = Vec::new();
+        for i in 0..1000u32 {
+            let chunk = format!("{i};").into_bytes();
+            expected.extend_from_slice(&chunk);
+            tx.send(chunk).unwrap();
+        }
+        drop(tx);
+        pump.join().unwrap();
+        assert_eq!(*sink.lock().unwrap(), expected);
+    }
+
+    #[test]
+    fn a_wedged_write_leaves_the_pty_map_lock_free() {
+        // Mirrors the commands: `pty_write` sends under the map lock, `pty_close`
+        // takes that same lock — which must stay reachable while a write is stuck.
+        let ptys: TestPtys = Arc::default();
+        let (tx, rx) = channel();
+        ptys.lock().unwrap().insert("t".to_string(), tx);
+        let (entered_tx, entered) = channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let writer = WedgedWriter {
+            entered: entered_tx,
+            release: gate.clone(),
+        };
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+
+        // `pty_write`: lock → get → send → drop the guard.
+        {
+            let map = ptys.lock().unwrap();
+            map.get("t").unwrap().send(b"hello".to_vec()).unwrap();
+        }
+        entered
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the writer thread should have reached the blocking write");
+        assert!(
+            ptys.try_lock().is_ok(),
+            "a wedged write is holding the PTY map lock — pty_close would be stuck"
+        );
+
+        release(&gate);
+        ptys.lock().unwrap().remove("t");
+        pump.join().unwrap();
+    }
+
+    #[test]
+    fn writing_under_the_map_lock_blocks_close_control() {
+        // Negative control for the test above: the pre-fix shape (write_all under the
+        // map lock) DOES block a `pty_close`-style acquire, so that assertion can fail.
+        let writers: Arc<Mutex<HashMap<String, WedgedWriter>>> = Arc::default();
+        let (entered_tx, entered) = channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        writers.lock().unwrap().insert(
+            "t".to_string(),
+            WedgedWriter {
+                entered: entered_tx,
+                release: gate.clone(),
+            },
+        );
+
+        let writing = writers.clone();
+        let write = std::thread::spawn(move || {
+            let mut map = writing.lock().unwrap();
+            let _ = map.get_mut("t").unwrap().write_all(b"hello");
+        });
+        entered
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the writing thread should have reached the blocking write");
+        assert!(
+            writers.try_lock().is_err(),
+            "control failed: the write is not actually holding the lock"
+        );
+
+        release(&gate);
+        write.join().unwrap();
+    }
+
+    #[test]
+    fn closing_the_channel_drops_the_writer() {
+        // Dropping the writer is what sends EOF to the slave, so a torn-down handle
+        // (close, or a StrictMode re-open displacing it) must end the pump.
+        let dropped = Arc::new(AtomicBool::new(false));
+        let writer = DropSpy {
+            dropped: dropped.clone(),
+            fail: false,
+        };
+        let (tx, rx) = channel();
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+        tx.send(b"hi".to_vec()).unwrap();
+        drop(tx);
+        pump.join().unwrap();
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn a_failed_write_ends_the_writer_thread() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let writer = DropSpy {
+            dropped: dropped.clone(),
+            fail: true,
+        };
+        let (tx, rx) = channel();
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+        tx.send(b"hi".to_vec()).unwrap();
+        pump.join().unwrap();
+        assert!(dropped.load(Ordering::SeqCst));
+        // Later keystrokes then find a closed channel: `pty_write` drops them and
+        // still answers Ok — the Exit event is what reports the dead terminal.
+        assert!(tx.send(b"more".to_vec()).is_err());
+    }
 
     #[test]
     fn task_interp_maps_every_key_the_frontend_offers() {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -47,6 +47,9 @@ struct PtyHandle {
     /// a child that stops reading can never block a caller holding the PTY map
     /// lock; dropping this handle closes the channel, which ends that thread.
     input: std::sync::mpsc::Sender<Vec<u8>>,
+    /// Bytes sitting in `input` — added on queue, subtracted once written. Shared
+    /// with the writer thread; see [`PTY_INPUT_QUEUE_CAP`].
+    queued: Arc<std::sync::atomic::AtomicUsize>,
     child: Box<dyn Child + Send + Sync>,
     /// A temp script file to delete once the process exits (Tasks runs write the
     /// script body to a temp file); `None` for host/container shells.
@@ -64,6 +67,14 @@ struct PtyHandle {
 
 /// Monotonic source for [`PtyHandle::gen`].
 static PTY_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Bytes one PTY may have queued for its writer thread. Deliberately far above any
+/// legitimate burst (the largest paste anyone would make), because its only job is
+/// to bound memory against a child that has genuinely stopped reading — a healthy
+/// child that's merely busy must never lose a keystroke to it. Input past the cap
+/// is dropped rather than queued: a wedged PTY's input is already lost, and
+/// dropping it beats growing without bound.
+const PTY_INPUT_QUEUE_CAP: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -451,18 +462,46 @@ fn teardown_handle(mut h: PtyHandle) {
     cleanup_handle(&mut h);
 }
 
+/// Hands `data` to a PTY's writer thread, unless that PTY is already sitting on
+/// [`PTY_INPUT_QUEUE_CAP`] bytes it hasn't managed to write. Counts the bytes in
+/// BEFORE queuing them, so the writer can never subtract a chunk it hasn't seen.
+fn queue_pty_input(
+    input: &std::sync::mpsc::Sender<Vec<u8>>,
+    queued: &std::sync::atomic::AtomicUsize,
+    data: Vec<u8>,
+) {
+    let len = data.len();
+    if queued.load(std::sync::atomic::Ordering::Relaxed) + len > PTY_INPUT_QUEUE_CAP {
+        return;
+    }
+    queued.fetch_add(len, std::sync::atomic::Ordering::Relaxed);
+    if input.send(data).is_err() {
+        // Nothing will ever write it — the writer thread is gone.
+        queued.fetch_sub(len, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Drains queued input to the PTY on a dedicated thread. Writing can block for as
 /// long as the child ignores its input, so it must never happen under the PTY map
 /// lock (that froze the app once, and made `pty_close` unreachable). A single
 /// consumer keeps per-PTY writes in the order they were queued. Returns — dropping
 /// the writer, which sends EOF to the slave — when the channel closes (the handle
 /// was torn down) or the write fails.
-fn pump_pty_input(mut writer: impl Write, rx: std::sync::mpsc::Receiver<Vec<u8>>) {
+fn pump_pty_input(
+    mut writer: impl Write,
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+    queued: Arc<std::sync::atomic::AtomicUsize>,
+) {
     while let Ok(chunk) = rx.recv() {
-        if writer.write_all(&chunk).is_err() {
+        let written = writer.write_all(&chunk).is_ok();
+        if written {
+            let _ = writer.flush();
+        }
+        // Off the books either way: a failed chunk is gone, not pending.
+        queued.fetch_sub(chunk.len(), std::sync::atomic::Ordering::Relaxed);
+        if !written {
             break;
         }
-        let _ = writer.flush();
     }
 }
 
@@ -531,7 +570,9 @@ pub async fn pty_open(
     // Input goes through a channel to a thread that owns the writer — see
     // `pump_pty_input`.
     let (input, input_rx) = std::sync::mpsc::channel::<Vec<u8>>();
-    std::thread::spawn(move || pump_pty_input(writer, input_rx));
+    let queued = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let pump_queued = queued.clone();
+    std::thread::spawn(move || pump_pty_input(writer, input_rx, pump_queued));
 
     let gen = PTY_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let cleanup_path = cleanup.clone();
@@ -540,6 +581,7 @@ pub async fn pty_open(
         PtyHandle {
             master: pair.master,
             input,
+            queued,
             child,
             cleanup,
             tree_kill,
@@ -627,14 +669,15 @@ pub async fn pty_open(
 }
 
 /// Queues the user's keystrokes (UTF-8) for the PTY. Sync command (main thread),
-/// so it only enqueues — the blocking write happens on the writer thread. A closed
-/// channel (that thread already exited) drops the keystrokes: the caller discards
-/// write errors anyway, and `Exit` is what reports a dead terminal.
+/// so it only enqueues — the blocking write happens on the writer thread. Input
+/// that can't be delivered (the thread exited, or the queue is at
+/// [`PTY_INPUT_QUEUE_CAP`] because the child stopped reading) is dropped: the
+/// caller discards write errors anyway, and `Exit` is what reports a dead terminal.
 #[tauri::command]
 pub fn pty_write(state: State<'_, PtyState>, id: String, data: String) -> AppResult<()> {
     let map = state.ptys.lock().unwrap();
     if let Some(h) = map.get(&id) {
-        let _ = h.input.send(data.into_bytes());
+        queue_pty_input(&h.input, &h.queued, data.into_bytes());
     }
     Ok(())
 }
@@ -852,14 +895,14 @@ async fn task_open_terminal_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc::{channel, Sender};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::mpsc::{channel, Receiver, Sender};
     use std::sync::Condvar;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     /// The input side of the PTY map. A real `PtyHandle` needs a live child, so the
-    /// concurrency tests key on the sender alone — the field `pty_write` touches.
-    type TestPtys = Arc<Mutex<HashMap<String, Sender<Vec<u8>>>>>;
+    /// concurrency tests key on the two fields `pty_write` touches.
+    type TestPtys = Arc<Mutex<HashMap<String, (Sender<Vec<u8>>, Arc<AtomicUsize>)>>>;
 
     /// Appends every write to a shared buffer, so a test can assert ordering.
     struct RecordingWriter(Arc<Mutex<Vec<u8>>>);
@@ -878,6 +921,7 @@ mod tests {
     struct WedgedWriter {
         entered: Sender<()>,
         release: Arc<(Mutex<bool>, Condvar)>,
+        written: Arc<AtomicUsize>,
     }
     impl Write for WedgedWriter {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
@@ -887,6 +931,7 @@ mod tests {
             while !*go {
                 go = cv.wait(go).unwrap();
             }
+            self.written.fetch_add(buf.len(), Ordering::SeqCst);
             Ok(buf.len())
         }
         fn flush(&mut self) -> std::io::Result<()> {
@@ -894,10 +939,45 @@ mod tests {
         }
     }
 
+    /// The control side of a [`WedgedWriter`]: `entered` fires as each write blocks,
+    /// `gate` releases them, `written` totals the bytes that got through.
+    struct Wedge {
+        entered: Receiver<()>,
+        gate: Arc<(Mutex<bool>, Condvar)>,
+        written: Arc<AtomicUsize>,
+    }
+
+    fn wedged_writer() -> (WedgedWriter, Wedge) {
+        let (entered_tx, entered) = channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let written = Arc::new(AtomicUsize::new(0));
+        (
+            WedgedWriter {
+                entered: entered_tx,
+                release: gate.clone(),
+                written: written.clone(),
+            },
+            Wedge {
+                entered,
+                gate,
+                written,
+            },
+        )
+    }
+
     fn release(gate: &Arc<(Mutex<bool>, Condvar)>) {
         let (lock, cv) = &**gate;
         *lock.lock().unwrap() = true;
         cv.notify_all();
+    }
+
+    /// Waits for the writer thread to work the queue down to nothing.
+    fn wait_for_drain(queued: &AtomicUsize) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while queued.load(Ordering::SeqCst) != 0 {
+            assert!(Instant::now() < deadline, "the writer never drained the queue");
+            std::thread::sleep(Duration::from_millis(1));
+        }
     }
 
     /// Reports its own drop — the observable that stands in for "EOF reached the
@@ -929,9 +1009,10 @@ mod tests {
         // One consumer, so keystrokes land in the order the frontend queued them —
         // it fires unordered, unawaited invokes, one per keystroke.
         let sink = Arc::new(Mutex::new(Vec::new()));
+        let queued = Arc::new(AtomicUsize::new(0));
         let (tx, rx) = channel();
         let writer = RecordingWriter(sink.clone());
-        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx, queued));
 
         let mut expected = Vec::new();
         for i in 0..1000u32 {
@@ -949,22 +1030,22 @@ mod tests {
         // Mirrors the commands: `pty_write` sends under the map lock, `pty_close`
         // takes that same lock — which must stay reachable while a write is stuck.
         let ptys: TestPtys = Arc::default();
+        let queued = Arc::new(AtomicUsize::new(0));
         let (tx, rx) = channel();
-        ptys.lock().unwrap().insert("t".to_string(), tx);
-        let (entered_tx, entered) = channel();
-        let gate = Arc::new((Mutex::new(false), Condvar::new()));
-        let writer = WedgedWriter {
-            entered: entered_tx,
-            release: gate.clone(),
-        };
-        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+        ptys.lock()
+            .unwrap()
+            .insert("t".to_string(), (tx, queued.clone()));
+        let (writer, wedge) = wedged_writer();
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx, queued));
 
-        // `pty_write`: lock → get → send → drop the guard.
+        // `pty_write`: lock → get → queue → drop the guard.
         {
             let map = ptys.lock().unwrap();
-            map.get("t").unwrap().send(b"hello".to_vec()).unwrap();
+            let (input, queued) = map.get("t").unwrap();
+            queue_pty_input(input, queued, b"hello".to_vec());
         }
-        entered
+        wedge
+            .entered
             .recv_timeout(Duration::from_secs(10))
             .expect("the writer thread should have reached the blocking write");
         assert!(
@@ -972,7 +1053,7 @@ mod tests {
             "a wedged write is holding the PTY map lock — pty_close would be stuck"
         );
 
-        release(&gate);
+        release(&wedge.gate);
         ptys.lock().unwrap().remove("t");
         pump.join().unwrap();
     }
@@ -982,22 +1063,16 @@ mod tests {
         // Negative control for the test above: the pre-fix shape (write_all under the
         // map lock) DOES block a `pty_close`-style acquire, so that assertion can fail.
         let writers: Arc<Mutex<HashMap<String, WedgedWriter>>> = Arc::default();
-        let (entered_tx, entered) = channel();
-        let gate = Arc::new((Mutex::new(false), Condvar::new()));
-        writers.lock().unwrap().insert(
-            "t".to_string(),
-            WedgedWriter {
-                entered: entered_tx,
-                release: gate.clone(),
-            },
-        );
+        let (writer, wedge) = wedged_writer();
+        writers.lock().unwrap().insert("t".to_string(), writer);
 
         let writing = writers.clone();
         let write = std::thread::spawn(move || {
             let mut map = writing.lock().unwrap();
             let _ = map.get_mut("t").unwrap().write_all(b"hello");
         });
-        entered
+        wedge
+            .entered
             .recv_timeout(Duration::from_secs(10))
             .expect("the writing thread should have reached the blocking write");
         assert!(
@@ -1005,8 +1080,84 @@ mod tests {
             "control failed: the write is not actually holding the lock"
         );
 
-        release(&gate);
+        release(&wedge.gate);
         write.join().unwrap();
+    }
+
+    #[test]
+    fn input_past_the_queue_cap_is_dropped_while_the_pty_is_wedged() {
+        // A child that stopped reading must not let continued typing grow the queue
+        // without bound — but nothing under the cap may ever be dropped.
+        let ptys: TestPtys = Arc::default();
+        let queued = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = channel();
+        ptys.lock()
+            .unwrap()
+            .insert("t".to_string(), (tx, queued.clone()));
+        let (writer, wedge) = wedged_writer();
+        let pump = {
+            let queued = queued.clone();
+            std::thread::spawn(move || pump_pty_input(writer, rx, queued))
+        };
+
+        let mib = vec![b'x'; 1024 * 1024];
+        let queue = |data: Vec<u8>| {
+            let map = ptys.lock().unwrap();
+            let (input, queued) = map.get("t").unwrap();
+            queue_pty_input(input, queued, data);
+        };
+        for _ in 0..8 {
+            queue(mib.clone());
+        }
+        wedge
+            .entered
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the writer thread should have reached the blocking write");
+        assert_eq!(queued.load(Ordering::SeqCst), PTY_INPUT_QUEUE_CAP);
+
+        queue(mib.clone());
+        queue(mib.clone());
+        assert_eq!(
+            queued.load(Ordering::SeqCst),
+            PTY_INPUT_QUEUE_CAP,
+            "input past the cap must be dropped, not queued"
+        );
+        assert!(
+            ptys.try_lock().is_ok(),
+            "a wedged write is holding the PTY map lock — pty_close would be stuck"
+        );
+
+        release(&wedge.gate);
+        ptys.lock().unwrap().remove("t");
+        pump.join().unwrap();
+        assert_eq!(
+            wedge.written.load(Ordering::SeqCst),
+            PTY_INPUT_QUEUE_CAP,
+            "the over-cap writes reached the PTY after all"
+        );
+        assert_eq!(queued.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn a_drained_queue_accepts_input_again() {
+        // The cap gates a backlog, it isn't a latch: once the child catches up, the
+        // next keystroke goes through.
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let queued = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = channel();
+        let writer = RecordingWriter(sink.clone());
+        let pump = {
+            let queued = queued.clone();
+            std::thread::spawn(move || pump_pty_input(writer, rx, queued))
+        };
+
+        queue_pty_input(&tx, &queued, b"first".to_vec());
+        wait_for_drain(&queued);
+        queue_pty_input(&tx, &queued, b"second".to_vec());
+        drop(tx);
+        pump.join().unwrap();
+        assert_eq!(*sink.lock().unwrap(), b"firstsecond".to_vec());
+        assert_eq!(queued.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -1018,8 +1169,9 @@ mod tests {
             dropped: dropped.clone(),
             fail: false,
         };
+        let queued = Arc::new(AtomicUsize::new(0));
         let (tx, rx) = channel();
-        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
+        let pump = std::thread::spawn(move || pump_pty_input(writer, rx, queued));
         tx.send(b"hi".to_vec()).unwrap();
         drop(tx);
         pump.join().unwrap();
@@ -1033,14 +1185,22 @@ mod tests {
             dropped: dropped.clone(),
             fail: true,
         };
+        let queued = Arc::new(AtomicUsize::new(0));
         let (tx, rx) = channel();
-        let pump = std::thread::spawn(move || pump_pty_input(writer, rx));
-        tx.send(b"hi".to_vec()).unwrap();
+        let pump = {
+            let queued = queued.clone();
+            std::thread::spawn(move || pump_pty_input(writer, rx, queued))
+        };
+        queue_pty_input(&tx, &queued, b"hi".to_vec());
         pump.join().unwrap();
         assert!(dropped.load(Ordering::SeqCst));
+        // The failed chunk comes off the books too, so a live handle whose writer
+        // died doesn't sit at a phantom backlog.
+        assert_eq!(queued.load(Ordering::SeqCst), 0);
         // Later keystrokes then find a closed channel: `pty_write` drops them and
         // still answers Ok — the Exit event is what reports the dead terminal.
-        assert!(tx.send(b"more".to_vec()).is_err());
+        queue_pty_input(&tx, &queued, b"more".to_vec());
+        assert_eq!(queued.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -73,7 +73,9 @@ static PTY_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new
 /// to bound memory against a child that has genuinely stopped reading — a healthy
 /// child that's merely busy must never lose a keystroke to it. Input past the cap
 /// is dropped rather than queued: a wedged PTY's input is already lost, and
-/// dropping it beats growing without bound.
+/// dropping it beats growing without bound. The gate reads the BACKLOG only, so
+/// one oversized chunk still lands (memory bound = cap + one in-flight chunk)
+/// rather than a healthy giant paste being dropped whole.
 const PTY_INPUT_QUEUE_CAP: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
@@ -471,7 +473,7 @@ fn queue_pty_input(
     data: Vec<u8>,
 ) {
     let len = data.len();
-    if queued.load(std::sync::atomic::Ordering::Relaxed) + len > PTY_INPUT_QUEUE_CAP {
+    if queued.load(std::sync::atomic::Ordering::Relaxed) >= PTY_INPUT_QUEUE_CAP {
         return;
     }
     queued.fetch_add(len, std::sync::atomic::Ordering::Relaxed);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,17 +1,25 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as SyncMutex};
+use std::time::Duration;
 use tokio::sync::{Mutex, Notify, OnceCell};
 
 use crate::git::types::GitInfo;
 
+/// The agent cancel registry: run id → the `Notify` the cancel command fires.
+type AgentCancels = SyncMutex<HashMap<String, Arc<Notify>>>;
+
 pub struct AppState {
     repo_locks: Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>,
     pub git_info: OnceCell<GitInfo>,
-    /// In-flight agent-CLI reviews keyed by a frontend-supplied id, so a
-    /// separate cancel command can signal the streaming run to stop.
-    agent_cancels: Mutex<HashMap<String, Arc<Notify>>>,
+    /// In-flight agent-CLI reviews and sessions keyed by a frontend-supplied id, so a
+    /// separate cancel command can signal the streaming run to stop. A blocking mutex:
+    /// every critical section is a map lookup, which lets the tombstone sweep run
+    /// without an async accessor. The `Arc` lets that sweep task outlive the borrow of
+    /// `self` that scheduled it.
+    agent_cancels: Arc<AgentCancels>,
     /// Whether closing the window hides the app to the tray (keeping it running)
     /// instead of quitting. Mirrors the user's setting, pushed from the frontend;
     /// defaults to true so the first close behaves correctly before that sync.
@@ -23,7 +31,7 @@ impl Default for AppState {
         Self {
             repo_locks: Mutex::new(HashMap::new()),
             git_info: OnceCell::new(),
-            agent_cancels: Mutex::new(HashMap::new()),
+            agent_cancels: Arc::new(SyncMutex::new(HashMap::new())),
             close_to_tray: AtomicBool::new(true),
         }
     }
@@ -39,25 +47,61 @@ impl AppState {
             .clone()
     }
 
-    /// Registers a cancellation handle for a review id and returns it. The
-    /// caller awaits `notified()` and must call `clear_agent_cancel` when done.
-    pub async fn register_agent_cancel(&self, id: &str) -> Arc<Notify> {
-        let notify = Arc::new(Notify::new());
+    /// Register (or adopt) the cancellation handle for a run id and return it. The
+    /// caller awaits `notified()` and must remove the entry when done (agent.rs does
+    /// that with an RAII guard).
+    ///
+    /// Uses `entry().or_insert_with(...)`, NOT `insert`: a cancel that landed FIRST
+    /// left a tombstone holding a `notify_one` permit, and replacing it would drop
+    /// that permit — the run would then stream on to its full timeout. The adopted
+    /// permit is consumed by the run's first `.notified()` poll.
+    pub fn register_agent_cancel(&self, id: &str) -> Arc<Notify> {
         self.agent_cancels
             .lock()
-            .await
-            .insert(id.to_string(), notify.clone());
-        notify
+            .expect("agent cancel registry poisoned")
+            .entry(id.to_string())
+            .or_insert_with(|| Arc::new(Notify::new()))
+            .clone()
     }
 
-    pub async fn clear_agent_cancel(&self, id: &str) {
-        self.agent_cancels.lock().await.remove(id);
+    /// Remove `id` from the registry (idempotent — safe on every exit path).
+    pub fn clear_agent_cancel(&self, id: &str) {
+        self.agent_cancels
+            .lock()
+            .expect("agent cancel registry poisoned")
+            .remove(id);
     }
 
-    /// Signals an in-flight review to cancel. No-op if the id is unknown.
-    pub async fn cancel_agent(&self, id: &str) {
-        if let Some(notify) = self.agent_cancels.lock().await.get(id) {
-            notify.notify_waiters();
+    /// Signal an in-flight run to cancel — adopting the registered handle when present,
+    /// else leaving a tombstone the later registration adopts. `notify_one` stores a
+    /// permit, so a cancel is never lost whether it arrives mid-run or ahead of the
+    /// command's registration.
+    ///
+    /// A tombstone this call CREATES may never be adopted (the run already finished, or
+    /// never started), which would grow the map unbounded — so in that case only,
+    /// schedule `sweep_unadopted_tombstone` to reclaim it if it stays unadopted.
+    pub fn cancel_agent(&self, id: &str) {
+        let mut map = self
+            .agent_cancels
+            .lock()
+            .expect("agent cancel registry poisoned");
+        let (notify, created) = match map.entry(id.to_string()) {
+            // A live run already registered here → adopt its handle (do NOT sweep: the
+            // command's RAII guard removes the entry when it returns).
+            Entry::Occupied(e) => (e.get().clone(), false),
+            // Absent → leave a tombstone for the later-registering run to adopt (or for
+            // the sweep below to reclaim if nothing ever does).
+            Entry::Vacant(e) => (e.insert(Arc::new(Notify::new())).clone(), true),
+        };
+        drop(map);
+        notify.notify_one();
+        if created {
+            let registry = Arc::clone(&self.agent_cancels);
+            let id = id.to_string();
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(TOMBSTONE_SWEEP_DELAY).await;
+                sweep_unadopted_tombstone(&registry, &id);
+            });
         }
     }
 
@@ -67,5 +111,87 @@ impl AppState {
 
     pub fn set_close_to_tray(&self, enabled: bool) {
         self.close_to_tray.store(enabled, Ordering::Relaxed);
+    }
+}
+
+/// How long a cancel-created tombstone is kept before the sweep reclaims it if
+/// unadopted. Comfortably longer than the window between a run's command entry
+/// (where it registers) and the cancel that raced ahead of it.
+const TOMBSTONE_SWEEP_DELAY: Duration = Duration::from_secs(60);
+
+/// Remove `id` ONLY IF it's still an unadopted tombstone — i.e. the map holds the sole
+/// `Arc` (`strong_count == 1` under the lock). A run that adopted the entry holds a
+/// clone and removes it itself via its RAII guard, so any higher count means the sweep
+/// must not touch it.
+fn sweep_unadopted_tombstone(registry: &AgentCancels, id: &str) {
+    let mut map = registry.lock().expect("agent cancel registry poisoned");
+    if let Some(n) = map.get(id) {
+        if Arc::strong_count(n) == 1 {
+            map.remove(id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod agent_cancel_tests {
+    use super::*;
+
+    /// The cancel-before-register race: the frontend can fire a cancel before the
+    /// command has reached its registration (fast Esc, or a teardown right after
+    /// start). The permit must survive for the later registration to adopt.
+    #[tokio::test]
+    async fn cancel_before_register_delivers_permit() {
+        let state = AppState::default();
+        let id = "cancel-before-register-0001";
+        state.cancel_agent(id);
+        let notify = state.register_agent_cancel(id);
+        // A zero-duration timeout still resolves ⇒ the permit was waiting.
+        let got = tokio::time::timeout(Duration::ZERO, notify.notified()).await;
+        assert!(
+            got.is_ok(),
+            "the cancel permit must be waiting for the later-registering run"
+        );
+        state.clear_agent_cancel(id);
+    }
+
+    /// The ordinary order, but with the cancel landing before the run polls: a stored
+    /// permit means it is still delivered on the first poll.
+    #[tokio::test]
+    async fn cancel_after_register_before_poll_delivers_permit() {
+        let state = AppState::default();
+        let id = "register-then-cancel-0002";
+        let notify = state.register_agent_cancel(id);
+        state.cancel_agent(id);
+        let got = tokio::time::timeout(Duration::ZERO, notify.notified()).await;
+        assert!(got.is_ok(), "a post-register cancel must still deliver");
+        state.clear_agent_cancel(id);
+    }
+
+    #[tokio::test]
+    async fn sweep_reclaims_only_unadopted_tombstones() {
+        let state = AppState::default();
+        let unadopted = "tombstone-unadopted-0003";
+        let adopted = "tombstone-adopted-0004";
+        state.cancel_agent(unadopted);
+        state.cancel_agent(adopted);
+        // A run that registers later adopts the tombstone and holds its own clone,
+        // which is exactly what the sweep's strong-count check must see.
+        let _held = state.register_agent_cancel(adopted);
+
+        sweep_unadopted_tombstone(&state.agent_cancels, unadopted);
+        sweep_unadopted_tombstone(&state.agent_cancels, adopted);
+
+        let map = state
+            .agent_cancels
+            .lock()
+            .expect("agent cancel registry poisoned");
+        assert!(
+            !map.contains_key(unadopted),
+            "an unadopted tombstone must be reclaimed"
+        );
+        assert!(
+            map.contains_key(adopted),
+            "an adopted entry belongs to its run's guard, not the sweep"
+        );
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -258,8 +258,9 @@ mod agent_cancel_tests {
         let adopted = "tombstone-adopted-0004";
         state.cancel_agent(unadopted);
         state.cancel_agent(adopted);
-        // A run that registers later adopts the tombstone and holds its own clone,
-        // which is exactly what the sweep's strong-count check must see.
+        // A run that registers later adopts the tombstone, CLEARING its stamp — the
+        // stamp short-circuit is what saves it from the sweep; the strong-count arm
+        // guards the separate transient-clone race, not this path.
         let _held = state.register_agent_cancel(adopted);
 
         sweep_unadopted_tombstone(&state.agent_cancels, unadopted);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,13 +3,47 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as SyncMutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify, OnceCell};
 
 use crate::git::types::GitInfo;
 
 /// The agent cancel registry: run id → the `Notify` the cancel command fires.
-type AgentCancels = SyncMutex<HashMap<String, Arc<Notify>>>;
+type AgentCancels = SyncMutex<HashMap<String, CancelEntry>>;
+
+/// One registry entry. `tombstoned_at` is set ONLY while the entry is a tombstone — one
+/// a cancel created ahead of any run — and is the seam both the adoption age-gate and
+/// the sweep read; a live run's entry never carries it.
+struct CancelEntry {
+    notify: Arc<Notify>,
+    tombstoned_at: Option<Instant>,
+}
+
+impl CancelEntry {
+    /// A fresh handle for a live run, so it is never age-checked.
+    fn live() -> Self {
+        Self {
+            notify: Arc::new(Notify::new()),
+            tombstoned_at: None,
+        }
+    }
+
+    /// A cancel that found no registered run: same handle, stamped so adoption and the
+    /// sweep can tell an adoptable race from a leftover.
+    fn tombstone() -> Self {
+        Self {
+            notify: Arc::new(Notify::new()),
+            tombstoned_at: Some(Instant::now()),
+        }
+    }
+
+    /// A tombstone past the adoption window — its permit belongs to a run that has
+    /// already ended.
+    fn is_stale_tombstone(&self) -> bool {
+        self.tombstoned_at
+            .is_some_and(|at| at.elapsed() > TOMBSTONE_ADOPTION_WINDOW)
+    }
+}
 
 pub struct AppState {
     repo_locks: Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>,
@@ -51,47 +85,62 @@ impl AppState {
     /// caller awaits `notified()` and must remove the entry when done (agent.rs does
     /// that with an RAII guard).
     ///
-    /// Uses `entry().or_insert_with(...)`, NOT `insert`: a cancel that landed FIRST
-    /// left a tombstone holding a `notify_one` permit, and replacing it would drop
-    /// that permit — the run would then stream on to its full timeout. The adopted
-    /// permit is consumed by the run's first `.notified()` poll.
+    /// A cancel that landed FIRST left a tombstone holding a `notify_one` permit: adopt
+    /// it (clearing the stamp — it is a live entry from here) so the run this cancel was
+    /// aimed at still stops. That race is sub-second, since registration is the
+    /// command's first statement. A tombstone past `TOMBSTONE_ADOPTION_WINDOW` is
+    /// REPLACED instead, permit discarded: it can only be a Stop aimed at a run that
+    /// already ended, and session turns reuse one id, so adopting it would silently
+    /// blank the next turn.
     pub fn register_agent_cancel(&self, id: &str) -> Arc<Notify> {
-        self.agent_cancels
+        let mut map = self
+            .agent_cancels
             .lock()
-            .expect("agent cancel registry poisoned")
-            .entry(id.to_string())
-            .or_insert_with(|| Arc::new(Notify::new()))
-            .clone()
+            .unwrap_or_else(|p| p.into_inner());
+        match map.entry(id.to_string()) {
+            Entry::Occupied(mut e) => {
+                if e.get().is_stale_tombstone() {
+                    let entry = CancelEntry::live();
+                    let notify = Arc::clone(&entry.notify);
+                    e.insert(entry);
+                    notify
+                } else {
+                    e.get_mut().tombstoned_at = None;
+                    Arc::clone(&e.get().notify)
+                }
+            }
+            Entry::Vacant(e) => Arc::clone(&e.insert(CancelEntry::live()).notify),
+        }
     }
 
     /// Remove `id` from the registry (idempotent — safe on every exit path).
     pub fn clear_agent_cancel(&self, id: &str) {
         self.agent_cancels
             .lock()
-            .expect("agent cancel registry poisoned")
+            .unwrap_or_else(|p| p.into_inner())
             .remove(id);
     }
 
-    /// Signal an in-flight run to cancel — adopting the registered handle when present,
-    /// else leaving a tombstone the later registration adopts. `notify_one` stores a
-    /// permit, so a cancel is never lost whether it arrives mid-run or ahead of the
-    /// command's registration.
+    /// Signal an in-flight run to cancel — firing the registered handle when present,
+    /// else leaving a tombstone for a registration racing just behind it (only within
+    /// `TOMBSTONE_ADOPTION_WINDOW`). `notify_one` stores a permit, so a cancel is never
+    /// lost whether it arrives mid-run or a moment ahead of the command's registration.
     ///
     /// A tombstone this call CREATES may never be adopted (the run already finished, or
     /// never started), which would grow the map unbounded — so in that case only,
-    /// schedule `sweep_unadopted_tombstone` to reclaim it if it stays unadopted.
+    /// schedule `sweep_unadopted_tombstone` to reclaim it.
     pub fn cancel_agent(&self, id: &str) {
         let mut map = self
             .agent_cancels
             .lock()
-            .expect("agent cancel registry poisoned");
+            .unwrap_or_else(|p| p.into_inner());
         let (notify, created) = match map.entry(id.to_string()) {
-            // A live run already registered here → adopt its handle (do NOT sweep: the
+            // A live run already registered here → fire its handle (do NOT sweep: the
             // command's RAII guard removes the entry when it returns).
-            Entry::Occupied(e) => (e.get().clone(), false),
-            // Absent → leave a tombstone for the later-registering run to adopt (or for
-            // the sweep below to reclaim if nothing ever does).
-            Entry::Vacant(e) => (e.insert(Arc::new(Notify::new())).clone(), true),
+            Entry::Occupied(e) => (Arc::clone(&e.get().notify), false),
+            // Absent → leave a tombstone for a registration racing just behind (or for
+            // the sweep below to reclaim if none arrives).
+            Entry::Vacant(e) => (Arc::clone(&e.insert(CancelEntry::tombstone()).notify), true),
         };
         drop(map);
         notify.notify_one();
@@ -114,21 +163,26 @@ impl AppState {
     }
 }
 
-/// How long a cancel-created tombstone is kept before the sweep reclaims it if
-/// unadopted. Comfortably longer than the window between a run's command entry
-/// (where it registers) and the cancel that raced ahead of it.
-const TOMBSTONE_SWEEP_DELAY: Duration = Duration::from_secs(60);
+/// How long a cancel-created tombstone stays adoptable. The race it exists for is
+/// sub-second — registration is the run command's first statement — while a Stop
+/// clicked between two turns of one session (same id, still-enabled button) lands with
+/// no run registered too, and its permit must never reach the next turn.
+const TOMBSTONE_ADOPTION_WINDOW: Duration = Duration::from_secs(5);
 
-/// Remove `id` ONLY IF it's still an unadopted tombstone — i.e. the map holds the sole
-/// `Arc` (`strong_count == 1` under the lock). A run that adopted the entry holds a
-/// clone and removes it itself via its RAII guard, so any higher count means the sweep
-/// must not touch it.
+/// A tombstone that outlived adoptability has no reason to live, so sweep and window
+/// are the same age by construction.
+const TOMBSTONE_SWEEP_DELAY: Duration = TOMBSTONE_ADOPTION_WINDOW;
+
+/// Remove `id` ONLY IF it's still an unadopted tombstone: the stamp is still set (a run
+/// that adopted it cleared the stamp) and the map holds the sole `Arc` — a live run
+/// holds a clone via its RAII guard and removes the entry itself.
 fn sweep_unadopted_tombstone(registry: &AgentCancels, id: &str) {
-    let mut map = registry.lock().expect("agent cancel registry poisoned");
-    if let Some(n) = map.get(id) {
-        if Arc::strong_count(n) == 1 {
-            map.remove(id);
-        }
+    let mut map = registry.lock().unwrap_or_else(|p| p.into_inner());
+    if map
+        .get(id)
+        .is_some_and(|e| e.tombstoned_at.is_some() && Arc::strong_count(&e.notify) == 1)
+    {
+        map.remove(id);
     }
 }
 
@@ -150,6 +204,36 @@ mod agent_cancel_tests {
         assert!(
             got.is_ok(),
             "the cancel permit must be waiting for the later-registering run"
+        );
+        state.clear_agent_cancel(id);
+    }
+
+    /// The counter-case: a Stop clicked in the gap between two turns of one session
+    /// (turn N's guard already dropped, turn N+1 not yet started — the same cancel id
+    /// throughout) must NOT carry into the next turn, which would complete it blank.
+    #[tokio::test]
+    async fn stale_tombstone_is_not_adopted() {
+        let state = AppState::default();
+        let id = "stale-tombstone-0005";
+        state.cancel_agent(id);
+        {
+            let mut map = state
+                .agent_cancels
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let entry = map.get_mut(id).expect("the cancel left a tombstone");
+            entry.tombstoned_at = Some(
+                Instant::now()
+                    .checked_sub(2 * TOMBSTONE_ADOPTION_WINDOW)
+                    .expect("the monotonic clock must be older than two windows"),
+            );
+        }
+
+        let notify = state.register_agent_cancel(id);
+        let got = tokio::time::timeout(Duration::ZERO, notify.notified()).await;
+        assert!(
+            got.is_err(),
+            "a stale tombstone's permit must not cancel the next run under that id"
         );
         state.clear_agent_cancel(id);
     }
@@ -184,7 +268,7 @@ mod agent_cancel_tests {
         let map = state
             .agent_cancels
             .lock()
-            .expect("agent cancel registry poisoned");
+            .unwrap_or_else(|p| p.into_inner());
         assert!(
             !map.contains_key(unadopted),
             "an unadopted tombstone must be reclaimed"

--- a/src/features/settings/mcp/GitDesktopAsServer.tsx
+++ b/src/features/settings/mcp/GitDesktopAsServer.tsx
@@ -641,9 +641,7 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
             </div>
           </div>
           {launcherErrorMessage && (
-            <p className="text-xs text-warning">
-              Couldn't prepare the MCP launcher: {launcherErrorMessage}
-            </p>
+            <p className="text-xs text-warning">{launcherErrorMessage}</p>
           )}
           <pre className="overflow-x-auto rounded border bg-muted/40 p-3 font-mono text-[11px] leading-relaxed">
             {snippet}


### PR DESCRIPTION
Fixes a family of backend concurrency defects found in the Rust layer: multi-step Git operations that could be interleaved by a second caller (destroying commits on rollback), stdin-writing subprocess runners that deadlock or hang unbounded, cancels that were dropped when they raced a run's own registration, terminal writes that froze the app under the PTY map lock, and an MCP launcher copy that failed when several writers prepared it at once. Each fix ships with a regression test where the failure mode is reproducible, plus a changelog fragment.

### Compound Git operations take the per-repo lock once

- `cherry_pick_onto` in `src-tauri/src/git/ops.rs` now holds `state.repo_lock` across the whole guard → capture → pick → rollback sequence, so the rollback's hard reset to the captured `target_tip` can no longer destroy a commit another in-process caller landed in between. The command body was split into a testable `cherry_pick_onto` core taking `&AppState` (mirroring `rewrite_commits`) so real-repo tokio tests can drive it.
- `git_checkout_conflict_side_core` in `src-tauri/src/git/conflict.rs` holds the lock across checkout → add, closing the window where a concurrent stage or discard rewrote the working-tree file between the two steps.
- `remove_worktree`, `git_worktree_commit_all` and `git_worktree_squash` in `src-tauri/src/git/worktree.rs` hold the lock across remove → prune → `branch -D`, the emptiness check → `add -A` → commit → HEAD read, and the HEAD check → soft reset → commit respectively.
- All of these switch their inner steps from `run_git_mutating` to the lock-free `run_git`, since `repo_lock` is a non-reentrant `tokio::sync::Mutex` and re-acquiring it would deadlock; each site documents the accepted loss of the one-shot `index.lock` retry.

### Subprocess stdin no longer deadlocks or hangs

- `run_git_raw_input` in `src-tauri/src/git/runner.rs` now runs the stdin write and both output drains concurrently via `tokio::join!` instead of writing everything first, which wedged as soon as git's output filled its pipe buffer. The stdin handle is explicitly dropped at the end of the write so `--stdin` commands see EOF, the child's exit code/stderr outranks a broken-pipe write error, and the Windows `GitJob` is only disarmed once the child is actually reaped.
- Adds `stdin_tests` in the same file: a real-repo test that sends ~4.8 MiB of paths through `git check-ignore --stdin --verbose` and draws ~5.5 MiB back, sized to clear both the unix 64KB pipe buffer and tokio's 2 MiB Windows `Blocking` buffer.
- `run_gh_input` (`src-tauri/src/github/runner.rs`) and `run_glab_ex` (`src-tauri/src/forge/glab.rs`) move the stdin write inside the `tokio::time::timeout`, so a stalled write fails at the deadline instead of hanging the caller forever.

### Agent cancels can't be lost, and runs can't hang

- `src-tauri/src/state.rs`: the cancel registry becomes a blocking `SyncMutex<HashMap<..>>` behind an `Arc`, `register_agent_cancel` uses `entry().or_insert_with` (so a cancel that arrived first isn't overwritten), and `cancel_agent` uses `notify_one` — storing a permit — leaving a tombstone when no run has registered yet. Tombstones it creates are reclaimed by `sweep_unadopted_tombstone` after `TOMBSTONE_SWEEP_DELAY` so the map can't grow unbounded.
- `src-tauri/src/agent.rs`: registration moves to command entry behind a new `AgentCancelGuard` RAII type, so every `?` return in the pre-stream setup releases the entry; `stream_agent` now takes the registered `Arc<Notify>` instead of `&AppState` and a `cancel_id`. Adds `valid_cancel_id` to bound the registry key space.
- Also in `agent.rs`: the post-pump `child.wait()` and the stderr join are bounded by `CHILD_EXIT_GRACE` / `CHILD_REAP_GRACE`, with a tree-kill on expiry, so a grandchild holding the pipes open can't leave the command — and the run's UI — hung past its own timeout.

### Terminal input moves off the PTY map lock

- `src-tauri/src/pty.rs` replaces `PtyHandle.writer` with an `mpsc::Sender<Vec<u8>>`; the writer is owned by a dedicated thread running the new `pump_pty_input`, and `pty_write` only enqueues under the map lock. A child that stops reading its input can no longer block every other PTY caller (including `pty_close`). Dropping the handle closes the channel, which ends the thread and drops the writer, sending EOF to the slave.
- Adds a test module covering ordering (`RecordingWriter`), a wedged child that must not block other ids (`WedgedWriter`), and writer-drop-on-teardown/write-failure (`DropSpy`).

### MCP launcher and main-thread responsiveness

- `src-tauri/src/mcp_launcher.rs` adds a process-wide `ENSURE_LOCK` around `ensure_in_dir`, with the staleness check re-run under the lock so the loser of a race skips a redundant ~50MB copy. Without it, one writer's `sweep_strays` deleted a concurrent writer's in-flight temp. Adds `concurrent_ensure_in_dir_never_errors_or_leaves_strays` and `ensure_in_dir_skips_the_copy_a_racer_already_did`, plus a `fake_source` helper so the tests copy kilobytes.
- `read_agent_commands` (`src-tauri/src/instructions.rs`) becomes async and runs its directory walk in `spawn_blocking`, extracted into an `AppHandle`-free `discover_agent_commands` core — the walk previously stalled the first `/` in the composer.
- `path_launcher_install` (`src-tauri/src/path_launcher.rs`) becomes async and defers `install_impl` to `spawn_blocking`, since on Windows it materializes the managed MCP copy.
- `src/features/settings/mcp/GitDesktopAsServer.tsx` renders `launcherErrorMessage` on its own instead of prefixing it with "Couldn't prepare the MCP launcher:".

### Changelog

- Six fragments under `changelog.d/`: `fixed-compound-git-locking.md`, `fixed-stdin-runner-deadlock.md`, `fixed-agent-cancel-race.md`, `fixed-terminal-write-freeze.md`, `fixed-mcp-launcher-race.md`, and `fixed-slash-menu-responsiveness.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Agent cancellation and early review actions now stop reliably without leaving stuck processes.
  - Multi-step Git operations are protected from concurrent changes, preserving commits during rollback.
  - Large file lists and long GitHub/GitLab requests no longer trigger false timeouts or hangs.
  - Terminal and task input remains responsive after reads stop, with reliable closing and bounded input handling.
  - Concurrent MCP launcher setup no longer produces spurious errors.
  - Composer command menus and PATH setup no longer cause application hitching.
  - Simplified MCP launcher error messages provide clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->