### PR TITLE
fix(a11y,pulls,explore): explain disabled actions and name icon states

### DIFF
--- a/changelog.d/fixed-always-visible-row-actions.md
+++ b/changelog.d/fixed-always-visible-row-actions.md
@@ -1,0 +1,2 @@
+- Release-asset and linked-issue rows show their remove buttons at all times, so
+  you can see what a row lets you do without hovering it first.

--- a/changelog.d/fixed-asset-delete-confirm.md
+++ b/changelog.d/fixed-asset-delete-confirm.md
@@ -1,0 +1,2 @@
+- Deleting a release asset now asks you to confirm first, on both GitHub and
+  GitLab.

--- a/changelog.d/fixed-blocked-merge-menu.md
+++ b/changelog.d/fixed-blocked-merge-menu.md
@@ -1,0 +1,2 @@
+- A pull request's Merge menu now stays closed while merging is unavailable
+  (draft, no write access, or the merge safety check still loading).

--- a/changelog.d/fixed-disabled-reason-a11y.md
+++ b/changelog.d/fixed-disabled-reason-a11y.md
@@ -1,0 +1,3 @@
+- Buttons that are unavailable for a stated reason explain themselves on hover;
+  outside of menu and popover triggers they also stay reachable by keyboard, so
+  screen readers announce the reason.

--- a/changelog.d/fixed-icon-accessible-names.md
+++ b/changelog.d/fixed-icon-accessible-names.md
@@ -1,0 +1,4 @@
+- Screen readers now name the repository glyphs in **Explore** and the clone
+  browser, the star counts in Explore, and each CI check and workflow step's
+  state in a pull request's checks list, so nothing in those rows is left to
+  shape and color.

--- a/changelog.d/fixed-review-tab-availability.md
+++ b/changelog.d/fixed-review-tab-availability.md
@@ -1,0 +1,3 @@
+- Pull request views always open on a tab that's there: jumping to a review from
+  the activity dock, or turning AI features off while reading one, now lands you
+  on the Conversation tab whenever the AI Review tab isn't available.

--- a/changelog.d/fixed-toggle-and-list-a11y.md
+++ b/changelog.d/fixed-toggle-and-list-a11y.md
@@ -1,0 +1,4 @@
+- Reaction chips and discussion upvotes announce their on/off state to screen
+  readers, so the toggle you're on is clear without relying on the highlight.
+- The hook list in **Git hooks** walks with the arrow keys, matching the rest of
+  the app's lists.

--- a/src/components/disabled-reason-button.tsx
+++ b/src/components/disabled-reason-button.tsx
@@ -1,0 +1,71 @@
+import { useId } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type DisabledReasonButtonProps = React.ComponentProps<typeof Button> & {
+  /** Why the button is disabled. Shown as tooltip + announced to AT while disabled. */
+  reason?: string | null;
+  /** Classes for the wrapping span (layout: ml-auto, flex-1, ...). */
+  wrapperClassName?: string;
+};
+
+/**
+ * Button that explains its own disabled state. A natively-disabled button
+ * swallows its own `title` and leaves the tab order, so a button WITH a reason
+ * takes Base UI's `focusableWhenDisabled` — `aria-disabled` instead of the
+ * native attribute, focus intact, activation still blocked in its handler layer.
+ * A reason-less disable stays native rather than becoming a mute tab stop.
+ * Trigger sites keep the native attribute: wrap a titled span around
+ * `<Trigger disabled render={<Button/>}/>`, or branch when the arms differ.
+ */
+export function DisabledReasonButton({
+  reason,
+  wrapperClassName,
+  disabled,
+  title,
+  className,
+  ...props
+}: DisabledReasonButtonProps) {
+  const id = useId();
+  const blockedReason = disabled && reason ? reason : null;
+  // `aria-describedby` outranks `title` as the accessible description, so a
+  // caller's own description has to survive alongside the reason.
+  const describedBy =
+    [props["aria-describedby"], blockedReason ? id : null]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0",
+        blockedReason && "cursor-not-allowed",
+        wrapperClassName,
+      )}
+      // Both disabled paths kill pointer events on the button, so the wrapper
+      // owns the hover text whenever it is disabled — the reason when there is
+      // one, otherwise the caller's ordinary hint.
+      title={blockedReason ?? title}
+    >
+      <Button
+        {...props}
+        focusableWhenDisabled={!!blockedReason}
+        disabled={disabled}
+        title={title}
+        // A reason trades the native attribute for `aria-disabled`, which the
+        // vendored `disabled:` dim can't see; the dim lifts under focus so a
+        // keyboard user isn't left tracking a half-opacity focus ring.
+        className={cn(
+          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:focus-visible:opacity-100",
+          className,
+        )}
+        aria-describedby={describedBy}
+      />
+      {blockedReason ? (
+        <span id={id} className="sr-only">
+          {blockedReason}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -1,6 +1,7 @@
 import { ArrowClockwiseIcon, PlayIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRef, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -62,6 +63,13 @@ export function ActionsPanel({
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
   const runNoun = isPipelines ? "pipeline" : "workflow";
+  const runHint =
+    writeReason ??
+    (ghReady
+      ? `Run a ${runNoun}`
+      : isGitLab
+        ? "Sign in with the GitLab CLI (glab) to run pipelines"
+        : "Sign in with GitHub CLI to run workflows");
   const status = useRepoStatus(repoPath);
   const currentBranch = status.data?.branch.name ?? null;
 
@@ -101,61 +109,46 @@ export function ActionsPanel({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-1 border-b p-2">
-        <Button
+        <DisabledReasonButton
           variant={branchOnly ? "secondary" : "ghost"}
           size="xs"
           aria-pressed={branchOnly}
           disabled={!currentBranch}
+          reason="No current branch"
           title={
-            currentBranch
-              ? `Show runs on ${currentBranch} only`
-              : "No current branch"
+            currentBranch ? `Show runs on ${currentBranch} only` : undefined
           }
           onClick={() => setBranchOnly((v) => !v)}
         >
           This branch
-        </Button>
+        </DisabledReasonButton>
         <div className="ml-auto flex items-center gap-1">
           {canDispatch && (
-            // A natively-disabled Button swallows `title`, so the hint rides the
-            // wrapping span (house idiom) — it covers the enabled case too.
-            <span
-              title={
-                writeReason ??
-                (ghReady
-                  ? `Run a ${runNoun}`
-                  : isGitLab
-                    ? "Sign in with the GitLab CLI (glab) to run pipelines"
-                    : "Sign in with GitHub CLI to run workflows")
-              }
-              className={cn(
-                "inline-flex",
-                writeBlocked && "cursor-not-allowed",
-              )}
+            <DisabledReasonButton
+              variant="ghost"
+              size="xs"
+              disabled={!ghReady || writeBlocked}
+              reason={runHint}
+              title={runHint}
+              onClick={() => setRunOpen(true)}
             >
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={!ghReady || writeBlocked}
-                onClick={() => setRunOpen(true)}
-              >
-                <PlayIcon data-icon="inline-start" />
-                Run {runNoun}…
-              </Button>
-            </span>
+              <PlayIcon data-icon="inline-start" />
+              Run {runNoun}…
+            </DisabledReasonButton>
           )}
-          <Button
+          <DisabledReasonButton
             variant="outline"
             size="icon-sm"
             aria-label="Refresh runs"
             disabled={!ghReady || runs.isFetching}
-            title={ghReady ? "Refresh runs" : "Connect this repo to load runs"}
+            reason={ghReady ? undefined : "Connect this repo to load runs"}
+            title="Refresh runs"
             onClick={() => runs.refetch()}
           >
             <ArrowClockwiseIcon
               className={cn(runs.isFetching && "animate-spin")}
             />
-          </Button>
+          </DisabledReasonButton>
         </div>
       </div>
       <div className="border-b p-2">
@@ -227,23 +220,16 @@ export function ActionsPanel({
               </EmptyHeader>
               {canDispatch && (
                 <EmptyContent>
-                  <span
-                    title={writeReason}
-                    className={cn(
-                      "inline-flex",
-                      writeBlocked && "cursor-not-allowed",
-                    )}
+                  <DisabledReasonButton
+                    variant="outline"
+                    size="sm"
+                    disabled={writeBlocked}
+                    reason={writeReason}
+                    onClick={() => setRunOpen(true)}
                   >
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={writeBlocked}
-                      onClick={() => setRunOpen(true)}
-                    >
-                      <PlayIcon data-icon="inline-start" />
-                      Run {runNoun}…
-                    </Button>
-                  </span>
+                    <PlayIcon data-icon="inline-start" />
+                    Run {runNoun}…
+                  </DisabledReasonButton>
                 </EmptyContent>
               )}
             </Empty>

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -11,6 +11,7 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { LogBlock } from "@/components/LogBlock";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -143,32 +144,23 @@ function JobRow({
           )}
         </button>
         {onPlay && (
-          // A natively disabled button swallows `title`, so the reason rides a
-          // wrapping span.
-          <span
-            title={playDisabledReason}
-            className={
-              playDisabledReason
-                ? "inline-flex cursor-not-allowed"
-                : "inline-flex"
-            }
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            wrapperClassName="mr-2"
+            className="text-muted-foreground"
+            disabled={playing || !!playDisabledReason}
+            reason={playDisabledReason}
+            aria-label={`Run job ${job.name}`}
+            onClick={onPlay}
           >
-            <Button
-              variant="ghost"
-              size="xs"
-              className="mr-2 shrink-0 text-muted-foreground"
-              disabled={playing || !!playDisabledReason}
-              aria-label={`Run job ${job.name}`}
-              onClick={onPlay}
-            >
-              {playing ? (
-                <Spinner data-icon="inline-start" />
-              ) : (
-                <PlayIcon data-icon="inline-start" />
-              )}
-              Run job
-            </Button>
-          </span>
+            {playing ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <PlayIcon data-icon="inline-start" />
+            )}
+            Run job
+          </DisabledReasonButton>
         )}
         {onDebug && (
           <Button
@@ -336,11 +328,6 @@ export function RunDetailView({
   );
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
-  // Shared by every disabled-with-reason wrapper below (a natively-disabled
-  // Button swallows `title`, so it rides the span).
-  const blockedSpanClass = writeBlocked
-    ? "inline-flex cursor-not-allowed"
-    : "inline-flex";
   const remoteLabel = providerLabel(provider);
   // GitLab pipelines and Bitbucket steps carry no per-job step list; only GitHub
   // jobs do — so the steps placeholder is suppressed for both.
@@ -474,106 +461,90 @@ export function RunDetailView({
         <div className="mt-3 flex flex-wrap items-center gap-2">
           {active || gitlabBlocked
             ? canCancel && (
-                <span title={writeReason} className={blockedSpanClass}>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={cancel.isPending || writeBlocked}
-                    onClick={doCancel}
-                  >
-                    {cancel.isPending ? (
-                      <Spinner data-icon="inline-start" />
-                    ) : (
-                      <ProhibitIcon data-icon="inline-start" />
-                    )}
-                    Cancel run
-                  </Button>
-                </span>
+                <DisabledReasonButton
+                  variant="outline"
+                  size="sm"
+                  disabled={cancel.isPending || writeBlocked}
+                  reason={writeReason}
+                  onClick={doCancel}
+                >
+                  {cancel.isPending ? (
+                    <Spinner data-icon="inline-start" />
+                  ) : (
+                    <ProhibitIcon data-icon="inline-start" />
+                  )}
+                  Cancel run
+                </DisabledReasonButton>
               )
             : provider === "gitlab"
               ? canRerun &&
                 retryable && (
-                  <span
-                    title={
-                      writeReason ??
-                      "Restart this pipeline's failed and canceled jobs"
-                    }
-                    className={blockedSpanClass}
+                  <DisabledReasonButton
+                    variant="outline"
+                    size="sm"
+                    disabled={rerun.isPending || writeBlocked}
+                    reason={writeReason}
+                    title="Restart this pipeline's failed and canceled jobs"
+                    onClick={() => doRerun(true)}
                   >
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={rerun.isPending || writeBlocked}
-                      onClick={() => doRerun(true)}
-                    >
-                      <ArrowClockwiseIcon data-icon="inline-start" />
-                      Retry pipeline
-                    </Button>
-                  </span>
+                    <ArrowClockwiseIcon data-icon="inline-start" />
+                    Retry pipeline
+                  </DisabledReasonButton>
                 )
               : provider === "bitbucket"
                 ? canRerun &&
                   bitbucketRerunnable && (
-                    <span
-                      title={
-                        writeReason ?? "Trigger this pipeline's branch again"
-                      }
-                      className={blockedSpanClass}
+                    <DisabledReasonButton
+                      variant="outline"
+                      size="sm"
+                      disabled={rerun.isPending || writeBlocked}
+                      reason={writeReason}
+                      title="Trigger this pipeline's branch again"
+                      onClick={() => doRerun(true)}
                     >
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={rerun.isPending || writeBlocked}
-                        onClick={() => doRerun(true)}
-                      >
-                        <ArrowClockwiseIcon data-icon="inline-start" />
-                        Rerun pipeline
-                      </Button>
-                    </span>
+                      <ArrowClockwiseIcon data-icon="inline-start" />
+                      Rerun pipeline
+                    </DisabledReasonButton>
                   )
                 : canWrite && (
                     <>
-                      <span title={writeReason} className={blockedSpanClass}>
-                        <Button
+                      <DisabledReasonButton
+                        variant="outline"
+                        size="sm"
+                        disabled={rerun.isPending || writeBlocked}
+                        reason={writeReason}
+                        onClick={() => doRerun(false)}
+                      >
+                        <ArrowClockwiseIcon data-icon="inline-start" />
+                        Re-run all jobs
+                      </DisabledReasonButton>
+                      {failed && (
+                        <DisabledReasonButton
                           variant="outline"
                           size="sm"
                           disabled={rerun.isPending || writeBlocked}
-                          onClick={() => doRerun(false)}
+                          reason={writeReason}
+                          onClick={() => doRerun(true)}
                         >
                           <ArrowClockwiseIcon data-icon="inline-start" />
-                          Re-run all jobs
-                        </Button>
-                      </span>
-                      {failed && (
-                        <span title={writeReason} className={blockedSpanClass}>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            disabled={rerun.isPending || writeBlocked}
-                            onClick={() => doRerun(true)}
-                          >
-                            <ArrowClockwiseIcon data-icon="inline-start" />
-                            Re-run failed jobs
-                          </Button>
-                        </span>
+                          Re-run failed jobs
+                        </DisabledReasonButton>
                       )}
                     </>
                   )}
-          <Button
+          <DisabledReasonButton
             variant="ghost"
             size="sm"
-            className="ml-auto cursor-pointer"
+            wrapperClassName="ml-auto"
+            className="cursor-pointer"
             disabled={!run.url}
-            title={
-              run.url
-                ? `Open this run on ${remoteLabel}`
-                : "No URL for this run"
-            }
+            reason="No URL for this run"
+            title={`Open this run on ${remoteLabel}`}
             onClick={() => run.url && openUrl(run.url)}
           >
             <ArrowSquareOutIcon data-icon="inline-start" />
             View on {remoteLabel}
-          </Button>
+          </DisabledReasonButton>
         </div>
       </div>
 
@@ -586,21 +557,20 @@ export function RunDetailView({
             GitHub is waiting for a maintainer to approve this workflow run
             before it starts.
           </span>
-          <span title={writeReason} className={blockedSpanClass}>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={approveRun.isPending || writeBlocked}
-              onClick={() => void doApprove()}
-            >
-              {approveRun.isPending ? (
-                <Spinner data-icon="inline-start" />
-              ) : (
-                <PlayIcon data-icon="inline-start" />
-              )}
-              Approve and run
-            </Button>
-          </span>
+          <DisabledReasonButton
+            variant="outline"
+            size="sm"
+            disabled={approveRun.isPending || writeBlocked}
+            reason={writeReason}
+            onClick={() => void doApprove()}
+          >
+            {approveRun.isPending ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <PlayIcon data-icon="inline-start" />
+            )}
+            Approve and run
+          </DisabledReasonButton>
         </div>
       )}
 

--- a/src/features/automations/RepoAutomationsDialog.tsx
+++ b/src/features/automations/RepoAutomationsDialog.tsx
@@ -239,6 +239,9 @@ export function RepoAutomationsDialog({
             Cancel
           </Button>
           <DisabledReasonButton
+            // Below `sm` the footer stacks and stretches the wrapper span; the
+            // Button fills it to match the stretched Cancel beside it.
+            className="w-full"
             onClick={doSave}
             disabled={!dirty || save.isPending}
             reason={save.isPending ? "Saving…" : "No changes to save"}

--- a/src/features/automations/RepoAutomationsDialog.tsx
+++ b/src/features/automations/RepoAutomationsDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -218,19 +219,16 @@ export function RepoAutomationsDialog({
           ) : (
             <>
               <div className="flex justify-end">
-                <Button
+                <DisabledReasonButton
                   variant="ghost"
                   size="xs"
                   onClick={resetToGlobal}
                   disabled={!hasOverrides}
-                  title={
-                    hasOverrides
-                      ? "Remove all overrides and inherit the global defaults"
-                      : "No overrides to reset"
-                  }
+                  reason="No overrides to reset"
+                  title="Remove all overrides and inherit the global defaults"
                 >
                   Reset to global defaults
-                </Button>
+                </DisabledReasonButton>
               </div>
               <LifecycleEditor cellState={cellState} onCellPatch={patchCell} />
             </>
@@ -240,15 +238,13 @@ export function RepoAutomationsDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          {dirty && !save.isPending ? (
-            <Button onClick={doSave}>Save changes</Button>
-          ) : (
-            <span title={save.isPending ? "Saving…" : "No changes to save"}>
-              <Button onClick={doSave} disabled>
-                Save changes
-              </Button>
-            </span>
-          )}
+          <DisabledReasonButton
+            onClick={doSave}
+            disabled={!dirty || save.isPending}
+            reason={save.isPending ? "Saving…" : "No changes to save"}
+          >
+            Save changes
+          </DisabledReasonButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/branch-rules/BranchRulesDialog.tsx
+++ b/src/features/branch-rules/BranchRulesDialog.tsx
@@ -1,6 +1,7 @@
 import { GithubLogoIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -430,19 +431,13 @@ export function BranchRulesDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button
+          <DisabledReasonButton
             onClick={doSave}
             disabled={!dirty || saving.isPending}
-            title={
-              !dirty
-                ? "No changes to save"
-                : saving.isPending
-                  ? "Saving…"
-                  : undefined
-            }
+            reason={!dirty ? "No changes to save" : "Saving…"}
           >
             {scope === "shared" ? "Save to repository" : "Save changes"}
-          </Button>
+          </DisabledReasonButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/branch-rules/BranchRulesDialog.tsx
+++ b/src/features/branch-rules/BranchRulesDialog.tsx
@@ -432,6 +432,9 @@ export function BranchRulesDialog({
             Cancel
           </Button>
           <DisabledReasonButton
+            // Below `sm` the footer stacks and stretches the wrapper span; the
+            // Button fills it to match the stretched Cancel beside it.
+            className="w-full"
             onClick={doSave}
             disabled={!dirty || saving.isPending}
             reason={!dirty ? "No changes to save" : "Saving…"}

--- a/src/features/commit/CommitBox.tsx
+++ b/src/features/commit/CommitBox.tsx
@@ -2,6 +2,7 @@ import { InfoIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { AnimatePresence, m } from "motion/react";
 import { useEffect } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
@@ -223,27 +224,17 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
                 transition={quickTransition}
               >
                 {aiConfigured ? (
-                  // Wrap the (possibly) disabled button so its `title` — the
-                  // reason — still shows (a native-disabled button swallows the
-                  // tooltip via the vendored Button's pointer-events-none).
-                  <span
-                    className="inline-flex"
-                    title={
-                      stagedCount === 0
-                        ? "Stage changes to generate a commit message"
-                        : "Generate commit message with AI"
-                    }
+                  <DisabledReasonButton
+                    variant="outline"
+                    size="sm"
+                    disabled={stagedCount === 0}
+                    reason="Stage changes to generate a commit message"
+                    title="Generate commit message with AI"
+                    onClick={generate}
                   >
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={stagedCount === 0}
-                      onClick={generate}
-                    >
-                      <SparkleIcon data-icon="inline-start" />
-                      Generate
-                    </Button>
-                  </span>
+                    <SparkleIcon data-icon="inline-start" />
+                    Generate
+                  </DisabledReasonButton>
                 ) : (
                   // AI is on but no provider is set up yet — turn the dead-end
                   // Generate click into a one-time path to Settings → AI.
@@ -261,39 +252,32 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
             )}
           </AnimatePresence>
         )}
-        {/* Wrap so the disabled reason still shows on hover — a native-disabled
-            button swallows its `title` (vendored Button's pointer-events-none).
-            When enabled, the wrapper carries the keybinding hint instead. */}
-        <span
-          className="inline-flex min-w-0 flex-1"
-          title={
-            canCommit && !generating
-              ? formatBinding("mod+enter")
-              : locked
-                ? "This branch requires changes via a pull request"
-                : title.trim().length === 0
-                  ? "Enter a commit title first"
-                  : stagedCount === 0 && !amending
-                    ? "Stage changes to commit"
-                    : formatBinding("mod+enter")
+        <DisabledReasonButton
+          size="sm"
+          wrapperClassName="min-w-0 flex-1"
+          className="min-w-0 flex-1"
+          disabled={!canCommit || generating}
+          reason={
+            locked
+              ? "This branch requires changes via a pull request"
+              : title.trim().length === 0
+                ? "Enter a commit title first"
+                : stagedCount === 0 && !amending
+                  ? "Stage changes to commit"
+                  : null
           }
+          title={formatBinding("mod+enter")}
+          onClick={doCommit}
         >
-          <Button
-            size="sm"
-            className="min-w-0 flex-1"
-            disabled={!canCommit || generating}
-            onClick={doCommit}
-          >
-            {commit.isPending && <Spinner data-icon="inline-start" />}
-            <span className="truncate">
-              {amending
-                ? "Amend last commit"
-                : `Commit${stagedCount > 0 ? ` (${stagedCount})` : ""}${
-                    branchName ? ` to ${branchName}` : ""
-                  }`}
-            </span>
-          </Button>
-        </span>
+          {commit.isPending && <Spinner data-icon="inline-start" />}
+          <span className="truncate">
+            {amending
+              ? "Amend last commit"
+              : `Commit${stagedCount > 0 ? ` (${stagedCount})` : ""}${
+                  branchName ? ` to ${branchName}` : ""
+                }`}
+          </span>
+        </DisabledReasonButton>
       </div>
     </div>
   );

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -230,53 +231,39 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
           </Button>
         )}
         {canPr && compareBranch && !existingPr && (
-          // Wrap so the disabled reason still shows on hover — a native-disabled
-          // button swallows its `title` (vendored Button's pointer-events-none).
-          <span
-            className="inline-flex w-full"
-            title={
-              ahead.length === 0
-                ? `${currentName} has no commits to propose onto ${compareBranch}`
-                : `Open a ${prNoun} into ${compareBranch}`
-            }
+          <DisabledReasonButton
+            variant="outline"
+            size="sm"
+            wrapperClassName="w-full"
+            className="w-full"
+            disabled={ahead.length === 0}
+            reason={`${currentName} has no commits to propose onto ${compareBranch}`}
+            title={`Open a ${prNoun} into ${compareBranch}`}
+            onClick={() => setPrOpen(true)}
           >
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full"
-              disabled={ahead.length === 0}
-              onClick={() => setPrOpen(true)}
-            >
-              <GitPullRequestIcon data-icon="inline-start" />
-              Create {prNoun}…
-            </Button>
-          </span>
+            <GitPullRequestIcon data-icon="inline-start" />
+            Create {prNoun}…
+          </DisabledReasonButton>
         )}
         {compareBranch && compareBranch !== currentName && (
-          <span
-            className="inline-flex w-full"
-            title={
-              ahead.length === 0
-                ? `${currentName} has no commits to propose onto ${compareBranch}`
-                : `Propose merging ${currentName} into ${compareBranch} locally`
+          <DisabledReasonButton
+            variant="ghost"
+            size="sm"
+            wrapperClassName="w-full"
+            className="w-full"
+            disabled={ahead.length === 0}
+            reason={`${currentName} has no commits to propose onto ${compareBranch}`}
+            title={`Propose merging ${currentName} into ${compareBranch} locally`}
+            onClick={() =>
+              openLocalPrCreate({
+                defaultHead: currentName ?? undefined,
+                defaultBase: compareBranch ?? undefined,
+              })
             }
           >
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full"
-              disabled={ahead.length === 0}
-              onClick={() =>
-                openLocalPrCreate({
-                  defaultHead: currentName ?? undefined,
-                  defaultBase: compareBranch ?? undefined,
-                })
-              }
-            >
-              <GitBranchIcon data-icon="inline-start" />
-              Create local PR…
-            </Button>
-          </span>
+            <GitBranchIcon data-icon="inline-start" />
+            Create local PR…
+          </DisabledReasonButton>
         )}
       </div>
 

--- a/src/features/conversations/ReactionBar.tsx
+++ b/src/features/conversations/ReactionBar.tsx
@@ -56,6 +56,8 @@ export function ReactionBar({
         <button
           key={r.content}
           type="button"
+          aria-label={`${label(r.content)} reaction, ${r.count}`}
+          aria-pressed={r.viewerReacted}
           disabled={disabled}
           onClick={() => onToggle(r.content, r.viewerReacted)}
           className={cn(
@@ -95,6 +97,8 @@ export function ReactionBar({
                 <button
                   key={content}
                   type="button"
+                  aria-label={`React with ${label(content)}`}
+                  aria-pressed={reacted.has(content)}
                   disabled={disabled}
                   onClick={() => {
                     onToggle(content, reacted.has(content));

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -136,6 +136,8 @@ function UpvoteButton({
   return (
     <button
       type="button"
+      aria-label={`Upvote, ${count}`}
+      aria-pressed={active}
       disabled={disabled}
       onClick={onClick}
       className={cn(

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -1,5 +1,6 @@
 import { CaretDownIcon, PlusIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -92,6 +93,10 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
       d.categoryName.toLowerCase().includes(query),
   );
 
+  const categoryLabel = activeCat
+    ? `${activeCat.emoji ? `${activeCat.emoji} ` : ""}${activeCat.name}`
+    : "All categories";
+
   const navTargets = visible.map((d) => ({ number: d.number }));
   const onListKeyDown = listKeyboardNav({
     items: navTargets,
@@ -106,25 +111,25 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-1 border-b p-2">
         <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                variant="outline"
-                size="xs"
-                disabled={!listEnabled}
-                title={
-                  listEnabled
-                    ? undefined
-                    : "Sign in to GitHub to browse discussions"
-                }
-              />
+          {/* A trigger can't take the disabled-reason primitive — a `render`
+              target can't carry its wrapper — so the reason rides a span around
+              the trigger, whose own `disabled` keeps the button inert. */}
+          <span
+            className={cn("inline-flex", !listEnabled && "cursor-not-allowed")}
+            title={
+              listEnabled
+                ? undefined
+                : "Sign in to GitHub to browse discussions"
             }
           >
-            {activeCat
-              ? `${activeCat.emoji ? `${activeCat.emoji} ` : ""}${activeCat.name}`
-              : "All categories"}
-            <CaretDownIcon data-icon="inline-end" />
-          </DropdownMenuTrigger>
+            <DropdownMenuTrigger
+              disabled={!listEnabled}
+              render={<Button variant="outline" size="xs" />}
+            >
+              {categoryLabel}
+              <CaretDownIcon data-icon="inline-end" />
+            </DropdownMenuTrigger>
+          </span>
           <DropdownMenuContent align="start" className="min-w-52">
             <DropdownMenuItem
               onClick={() => chooseCategory(null)}
@@ -148,21 +153,18 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
-        <Button
+        <DisabledReasonButton
           variant="ghost"
           size="xs"
-          className="ml-auto"
+          wrapperClassName="ml-auto"
           disabled={!listEnabled}
-          title={
-            listEnabled
-              ? "New discussion"
-              : "Sign in to GitHub to start a discussion"
-          }
+          reason="Sign in to GitHub to start a discussion"
+          title="New discussion"
           onClick={() => setCreateOpen(true)}
         >
           <PlusIcon data-icon="inline-start" />
           New
-        </Button>
+        </DisabledReasonButton>
       </div>
       <div className="border-b p-2">
         <Input

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -34,7 +34,7 @@ import {
 import { useConfirm } from "@/lib/stores/confirm";
 import { toastError } from "@/lib/toast";
 import type { ExploreCloneTarget } from "./ExploreCloneDialog";
-import { compactNumber } from "./explore-utils";
+import { starParts } from "./explore-utils";
 
 /** The Explore detail pane: the selected repo's header, actions (clone / fork /
  *  star / view), and its lazily-fetched README. `features` gates fork/star, and
@@ -151,10 +151,7 @@ function ExploreDetailBody({
   const starLoaded = starred.data !== undefined;
   const isStarred = starred.data ?? false;
 
-  const stars = repo.stars ?? null;
-  const starText = stars === null ? "" : compactNumber.format(stars);
-  const starLabel =
-    stars === null ? null : `${starText} ${stars === 1 ? "star" : "stars"}`;
+  const star = starParts(repo.stars ?? null);
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -187,17 +184,17 @@ function ExploreDetailBody({
           </div>
         )}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
-          {starLabel !== null && (
+          {star && (
             // role="img" prunes the icon AND the number, so the label carries
             // both the count and its unit.
             <span
               role="img"
-              aria-label={starLabel}
-              title={starLabel}
+              aria-label={star.label}
+              title={star.label}
               className="flex items-center gap-0.5 tabular-nums"
             >
-              <StarIcon className="size-3" />
-              {starText}
+              <StarIcon className="size-3" aria-hidden />
+              {star.text}
             </span>
           )}
           {repo.language && <span>{repo.language}</span>}

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -5,6 +5,7 @@ import {
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -150,6 +151,11 @@ function ExploreDetailBody({
   const starLoaded = starred.data !== undefined;
   const isStarred = starred.data ?? false;
 
+  const stars = repo.stars ?? null;
+  const starText = stars === null ? "" : compactNumber.format(stars);
+  const starLabel =
+    stars === null ? null : `${starText} ${stars === 1 ? "star" : "stars"}`;
+
   return (
     <div className="flex flex-col gap-4 p-4">
       <div className="space-y-2">
@@ -181,10 +187,17 @@ function ExploreDetailBody({
           </div>
         )}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
-          {repo.stars != null && (
-            <span className="flex items-center gap-0.5 tabular-nums">
+          {starLabel !== null && (
+            // role="img" prunes the icon AND the number, so the label carries
+            // both the count and its unit.
+            <span
+              role="img"
+              aria-label={starLabel}
+              title={starLabel}
+              className="flex items-center gap-0.5 tabular-nums"
+            >
               <StarIcon className="size-3" />
-              {compactNumber.format(repo.stars)}
+              {starText}
             </span>
           )}
           {repo.language && <span>{repo.language}</span>}
@@ -236,23 +249,18 @@ function ExploreDetailBody({
         )}
         {canStar && (
           // Disabled until the starred state resolves — toggling on `undefined`
-          // would always star (`!undefined === true`). The wrapping span carries
-          // the reason since a native-disabled button swallows its `title`.
-          <span
-            className="inline-flex"
-            title={starLoaded ? undefined : "Checking star state…"}
+          // would always star (`!undefined === true`).
+          <DisabledReasonButton
+            size="sm"
+            variant="outline"
+            aria-pressed={starLoaded ? isStarred : undefined}
+            disabled={!starLoaded}
+            reason="Checking star state…"
+            onClick={toggleStar}
           >
-            <Button
-              size="sm"
-              variant="outline"
-              aria-pressed={isStarred}
-              disabled={!starLoaded}
-              onClick={toggleStar}
-            >
-              <StarIcon weight={isStarred ? "fill" : "regular"} />
-              {isStarred ? "Unstar" : "Star"}
-            </Button>
-          </span>
+            <StarIcon weight={isStarred ? "fill" : "regular"} />
+            {isStarred ? "Unstar" : "Star"}
+          </DisabledReasonButton>
         )}
         {repo.webUrl && (
           <Button

--- a/src/features/explore/ExploreResultRow.tsx
+++ b/src/features/explore/ExploreResultRow.tsx
@@ -26,6 +26,20 @@ export function ExploreResultRow({
     : repo.fork
       ? GitForkIcon
       : BookBookmarkIcon;
+  // One glyph stands for both states, so its label names both; role="img" hides
+  // the icon from readers, leaving the label to carry the meaning alone. A plain
+  // repo stays unlabelled — nothing in the app badges a repo "public".
+  const stateLabel = repo.private
+    ? repo.fork
+      ? "Private fork"
+      : "Private repository"
+    : repo.fork
+      ? "Fork"
+      : null;
+  const stars = repo.stars ?? null;
+  const starText = stars === null ? "" : compactNumber.format(stars);
+  const starLabel =
+    stars === null ? null : `${starText} ${stars === 1 ? "star" : "stars"}`;
   return (
     <button
       type="button"
@@ -39,7 +53,21 @@ export function ExploreResultRow({
       )}
     >
       <span className="flex items-center gap-2">
-        <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+        {stateLabel ? (
+          <span
+            role="img"
+            aria-label={stateLabel}
+            title={stateLabel}
+            className="flex shrink-0 items-center text-muted-foreground"
+          >
+            <Icon className="size-3.5" aria-hidden />
+          </span>
+        ) : (
+          <Icon
+            className="size-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+        )}
         <span className="min-w-0 flex-1 truncate">
           <span className="text-muted-foreground">{repo.owner}/</span>
           <span className="font-medium">{repo.name}</span>
@@ -49,10 +77,17 @@ export function ExploreResultRow({
             Archived
           </Badge>
         )}
-        {repo.stars != null && (
-          <span className="flex shrink-0 items-center gap-0.5 tabular-nums text-muted-foreground">
+        {starLabel !== null && (
+          // role="img" prunes the icon AND the number, so the label carries both
+          // the count and its unit.
+          <span
+            role="img"
+            aria-label={starLabel}
+            title={starLabel}
+            className="flex shrink-0 items-center gap-0.5 tabular-nums text-muted-foreground"
+          >
             <StarIcon className="size-3" />
-            {compactNumber.format(repo.stars)}
+            {starText}
           </span>
         )}
       </span>

--- a/src/features/explore/ExploreResultRow.tsx
+++ b/src/features/explore/ExploreResultRow.tsx
@@ -6,8 +6,9 @@ import {
 } from "@phosphor-icons/react";
 import { Badge } from "@/components/ui/badge";
 import type { ForgeSearchRepo } from "@/lib/git/types";
+import { repoStateLabel } from "@/lib/repo-labels";
 import { cn } from "@/lib/utils";
-import { compactNumber, exploreOptionId } from "./explore-utils";
+import { exploreOptionId, starParts } from "./explore-utils";
 
 /** One repository result row — a `role="option"` in the results listbox. Row
  *  anatomy mirrors the clone browser's RepoRow (leading icon by private/fork
@@ -26,20 +27,8 @@ export function ExploreResultRow({
     : repo.fork
       ? GitForkIcon
       : BookBookmarkIcon;
-  // One glyph stands for both states, so its label names both; role="img" hides
-  // the icon from readers, leaving the label to carry the meaning alone. A plain
-  // repo stays unlabelled — nothing in the app badges a repo "public".
-  const stateLabel = repo.private
-    ? repo.fork
-      ? "Private fork"
-      : "Private repository"
-    : repo.fork
-      ? "Fork"
-      : null;
-  const stars = repo.stars ?? null;
-  const starText = stars === null ? "" : compactNumber.format(stars);
-  const starLabel =
-    stars === null ? null : `${starText} ${stars === 1 ? "star" : "stars"}`;
+  const stateLabel = repoStateLabel(repo.private, repo.fork);
+  const star = starParts(repo.stars ?? null);
   return (
     <button
       type="button"
@@ -77,17 +66,17 @@ export function ExploreResultRow({
             Archived
           </Badge>
         )}
-        {starLabel !== null && (
+        {star && (
           // role="img" prunes the icon AND the number, so the label carries both
           // the count and its unit.
           <span
             role="img"
-            aria-label={starLabel}
-            title={starLabel}
+            aria-label={star.label}
+            title={star.label}
             className="flex shrink-0 items-center gap-0.5 tabular-nums text-muted-foreground"
           >
-            <StarIcon className="size-3" />
-            {starText}
+            <StarIcon className="size-3" aria-hidden />
+            {star.text}
           </span>
         )}
       </span>

--- a/src/features/explore/explore-utils.ts
+++ b/src/features/explore/explore-utils.ts
@@ -82,6 +82,18 @@ export function groupReposByOwner(
   ]);
 }
 
+/**
+ * Visible text + self-contained accessible label for a star count (role="img"
+ * suppresses descendants, so the label must carry number AND unit itself).
+ */
+export function starParts(
+  stars: number | null,
+): { text: string; label: string } | null {
+  if (stars === null) return null;
+  const text = compactNumber.format(stars);
+  return { text, label: `${text} ${stars === 1 ? "star" : "stars"}` };
+}
+
 /** Stable DOM id per result row, so the search input's aria-activedescendant can
  *  point at the keyboard-highlighted option for screen readers. */
 export const exploreOptionId = (fullName: string) =>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1980,8 +1980,8 @@ first load; any duplicates are merged and disclosed once with a toast.`,
 **Git hooks…** (in the repo ⋮ menu) manages the scripts in your repo's \`.git/hooks\` —
 the small programs Git runs at points like *before commit* or *before push*.
 
-- See every hook with its state (active / disabled / inactive) and **edit** it in a
-  built-in editor.
+- See every hook with its state (active / disabled / inactive) — the list is
+  arrow-navigable — and **edit** it in a built-in editor.
 - **Enable or disable** a hook without deleting it, or delete it outright.
 - **Templates** give you a one-click starting script for any of the standard hooks
   (pre-commit, commit-msg, pre-push, …).

--- a/src/features/history/EditHistoryDialog.tsx
+++ b/src/features/history/EditHistoryDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -330,26 +331,29 @@ export function EditHistoryDialog({
                           Cancel
                         </Button>
                       ) : (
-                        // Wrap so the title still shows when the button is
-                        // disabled — a native-disabled button swallows it.
-                        <span
-                          className="inline-flex"
+                        <DisabledReasonButton
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          disabled={ai.generating || !messages.isSuccess}
                           title="Generate this commit's message with AI"
+                          // `ai.generating` here means ANOTHER row is
+                          // generating — this row's own run renders Cancel.
+                          reason={
+                            ai.generating
+                              ? "Another commit message is generating"
+                              : messages.isError
+                                ? "Couldn't load commit messages"
+                                : "Loading commit messages…"
+                          }
+                          onClick={() => {
+                            setGenHash(row.hash);
+                            ai.generate(`${row.hash}^`, row.hash);
+                          }}
                         >
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="xs"
-                            disabled={ai.generating || !messages.isSuccess}
-                            onClick={() => {
-                              setGenHash(row.hash);
-                              ai.generate(`${row.hash}^`, row.hash);
-                            }}
-                          >
-                            <SparkleIcon data-icon="inline-start" />
-                            Generate
-                          </Button>
-                        </span>
+                          <SparkleIcon data-icon="inline-start" />
+                          Generate
+                        </DisabledReasonButton>
                       ))}
                   </div>
                 )}

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -1,6 +1,7 @@
 import { SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -187,28 +188,21 @@ export function SquashDialog({
                 Cancel
               </Button>
             ) : (
-              // Wrap so the title still shows when the button is disabled — a
-              // native-disabled button swallows the tooltip. `runHead` is the
-              // collapsing step's tip, so without it there's no range to diff.
-              <span
-                className="mr-auto"
-                title={
-                  runHead
-                    ? "Generate the commit message with AI"
-                    : "Nothing to generate from — this squash has no run of commits to combine"
-                }
+              // `runHead` is the collapsing step's tip, so without it there's no
+              // range to diff.
+              <DisabledReasonButton
+                type="button"
+                variant="outline"
+                size="sm"
+                wrapperClassName="mr-auto"
+                disabled={!runHead}
+                title="Generate the commit message with AI"
+                reason="Nothing to generate from — this squash has no run of commits to combine"
+                onClick={() => runHead && ai.generate(base, runHead)}
               >
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={!runHead}
-                  onClick={() => runHead && ai.generate(base, runHead)}
-                >
-                  <SparkleIcon data-icon="inline-start" />
-                  Generate
-                </Button>
-              </span>
+                <SparkleIcon data-icon="inline-start" />
+                Generate
+              </DisabledReasonButton>
             )}
             <Button
               type="button"

--- a/src/features/hooks/HooksDialog.tsx
+++ b/src/features/hooks/HooksDialog.tsx
@@ -26,6 +26,7 @@ import {
   useSetHookEnabled,
   useWriteHook,
 } from "@/lib/git/queries";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { HOOK_TEMPLATES } from "./templates";
@@ -144,6 +145,15 @@ export function HooksDialog({
     );
   }
 
+  // Arrow keys walk the hook list, mirroring the app's other lists.
+  const onHooksKeyDown = listKeyboardNav({
+    items: entries,
+    activeIndex: entries.findIndex((e) => e.name === selected),
+    onActivate: (e) => setSelected(e.name),
+    rowKey: (e) => e.name,
+    rowAttr: "data-hook",
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-4xl">
@@ -226,11 +236,12 @@ export function HooksDialog({
         ) : (
           <div className="flex h-112 gap-3">
             <ScrollArea className="w-52 shrink-0 border-r pr-2">
-              <div className="space-y-0.5">
+              <div className="space-y-0.5" onKeyDown={onHooksKeyDown}>
                 {entries.map((e) => (
                   <button
                     key={e.name}
                     type="button"
+                    data-hook={e.name}
                     onClick={() => setSelected(e.name)}
                     className={cn(
                       "flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs",

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -7,6 +7,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Combobox,
@@ -51,8 +52,9 @@ export function StateIcon({ state }: { state: string }) {
   );
 }
 
-/** A clickable related-issue row with a hover remove button. `pending` disables
- *  the remove button and shows a spinner so a slow unlink can't double-fire. */
+/** A clickable related-issue row with an always-visible remove button. Callers
+ *  that pass `pending` get it disabled with a spinner while their unlink is in
+ *  flight, so a slow one can't double-fire. */
 export function RelatedRow({
   issue,
   onOpen,
@@ -70,7 +72,7 @@ export function RelatedRow({
   removeDisabledReason?: string;
 }) {
   return (
-    <div className="group flex items-center gap-1.5 text-xs">
+    <div className="flex items-center gap-1.5 text-xs">
       <StateIcon state={issue.state} />
       <button
         type="button"
@@ -81,32 +83,23 @@ export function RelatedRow({
         <span className="text-muted-foreground">#{issue.number}</span>{" "}
         {issue.title}
       </button>
-      {/* A natively disabled button swallows `title`, so the reason rides a
-          wrapping span. */}
-      <span
-        title={removeDisabledReason}
-        className={
-          removeDisabledReason
-            ? "inline-flex cursor-not-allowed"
-            : "inline-flex"
-        }
+      <DisabledReasonButton
+        variant="ghost"
+        size="icon-xs"
+        aria-label={`Remove #${issue.number}`}
+        disabled={pending || !!removeDisabledReason}
+        reason={removeDisabledReason}
+        className={cn(
+          "text-muted-foreground",
+          // Full opacity only for the in-flight spinner, on both disabled
+          // paths: a reason-less pending remove is natively disabled, a
+          // permission-blocked one is aria-disabled.
+          pending && "disabled:opacity-100 aria-disabled:opacity-100",
+        )}
+        onClick={onRemove}
       >
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          aria-label={`Remove #${issue.number}`}
-          disabled={pending || !!removeDisabledReason}
-          className={cn(
-            "text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-            // Full opacity only for the in-flight spinner — a permission-blocked
-            // remove keeps the vendored disabled dim.
-            pending && "disabled:opacity-100",
-          )}
-          onClick={onRemove}
-        >
-          {pending ? <Spinner /> : <XIcon />}
-        </Button>
-      </span>
+        {pending ? <Spinner /> : <XIcon />}
+      </DisabledReasonButton>
     </div>
   );
 }

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -5,6 +5,7 @@ import {
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -357,25 +358,19 @@ export function DueDateRow({
           Due date
         </Label>
         {value !== null && (
-          // The hint sits on the controls, not the row: a disabled input or
-          // button swallows `title`, while the Label stays live either way.
-          <span
-            title={disabledReason}
-            className={
-              blocked ? "inline-flex cursor-not-allowed" : "inline-flex"
-            }
+          // The hint sits on the control, not the row — the Label stays live
+          // either way.
+          <DisabledReasonButton
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="text-muted-foreground"
+            disabled={pending || blocked}
+            reason={disabledReason}
+            onClick={() => onChange(null)}
           >
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              className="text-muted-foreground"
-              disabled={pending || blocked}
-              onClick={() => onChange(null)}
-            >
-              Clear
-            </Button>
-          </span>
+            Clear
+          </DisabledReasonButton>
         )}
       </div>
       {/* Uncontrolled while focused (key remounts on external change) so the
@@ -695,26 +690,18 @@ function IssueLinksSection({
         </span>
         <span className="flex-1" />
         {editable && !adding && (
-          // A natively disabled button swallows `title`, so the reason rides a
-          // wrapping span.
-          <span
-            title={disabledReason}
-            className={
-              disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
-            }
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            aria-label="Link a related issue"
+            disabled={!!disabledReason}
+            reason={disabledReason}
+            onClick={() => setAdding(true)}
           >
-            <Button
-              variant="ghost"
-              size="xs"
-              aria-label="Link a related issue"
-              disabled={!!disabledReason}
-              onClick={() => setAdding(true)}
-            >
-              <PlusIcon data-icon="inline-start" />
-              Add
-              <CaretDownIcon data-icon="inline-end" />
-            </Button>
-          </span>
+            <PlusIcon data-icon="inline-start" />
+            Add
+            <CaretDownIcon data-icon="inline-end" />
+          </DisabledReasonButton>
         )}
       </div>
 

--- a/src/features/issues/RepoJiraDialog.tsx
+++ b/src/features/issues/RepoJiraDialog.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -360,16 +361,17 @@ export function RepoJiraDialog({
                   />
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  <span title={validateReason ?? undefined}>
-                    <Button
-                      size="sm"
-                      disabled={!canValidate || validating}
-                      onClick={validate}
-                    >
-                      {validating && <Spinner data-icon="inline-start" />}
-                      Validate &amp; save
-                    </Button>
-                  </span>
+                  <DisabledReasonButton
+                    size="sm"
+                    disabled={!canValidate || validating}
+                    // No `reason`: the same text renders as visible warning copy
+                    // beside the button, so announcing it would double up.
+                    title={validateReason ?? undefined}
+                    onClick={validate}
+                  >
+                    {validating && <Spinner data-icon="inline-start" />}
+                    Validate &amp; save
+                  </DisabledReasonButton>
                   {validateReason && (
                     <span className="text-xs text-warning">
                       {validateReason}
@@ -464,17 +466,16 @@ export function RepoJiraDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          {canSave && dirty && !save.isPending ? (
-            <Button onClick={doSave}>Save</Button>
-          ) : (
-            <span
-              title={saveReason ?? (save.isPending ? "Saving…" : undefined)}
-            >
-              <Button onClick={doSave} disabled>
-                Save
-              </Button>
-            </span>
-          )}
+          <DisabledReasonButton
+            // Below `sm` the footer stacks and stretches the wrapper span; the
+            // Button has to fill it to match the full-width Cancel beside it.
+            className="w-full"
+            disabled={!canSave || !dirty || save.isPending}
+            reason={saveReason ?? (save.isPending ? "Saving…" : undefined)}
+            onClick={doSave}
+          >
+            Save
+          </DisabledReasonButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/issues/RepoJiraDialog.tsx
+++ b/src/features/issues/RepoJiraDialog.tsx
@@ -467,11 +467,15 @@ export function RepoJiraDialog({
             Cancel
           </Button>
           <DisabledReasonButton
-            // Below `sm` the footer stacks and stretches the wrapper span; the
-            // Button has to fill it to match the full-width Cancel beside it.
-            className="w-full"
             disabled={!canSave || !dirty || save.isPending}
-            reason={saveReason ?? (save.isPending ? "Saving…" : undefined)}
+            reason={
+              saveReason ??
+              (save.isPending
+                ? "Saving…"
+                : dirty
+                  ? undefined
+                  : "No changes to save")
+            }
             onClick={doSave}
           >
             Save

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -19,11 +19,11 @@ import {
   useRef,
   useState,
 } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { LogBlock } from "@/components/LogBlock";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { StatusIcon } from "@/features/actions/status";
+import { StatusIcon, statusLabel } from "@/features/actions/status";
 import {
   useApproveWorkflowRun,
   useRepoWriteAccess,
@@ -256,11 +256,22 @@ function RunSteps({ job }: { job: RunJob }) {
             key={step.number}
             className="flex items-center gap-2 text-[11px]"
           >
-            <StatusIcon
-              status={step.status}
-              conclusion={step.conclusion}
-              className="size-3.5"
-            />
+            {/* The step's state is shape + color alone in the icon, so a
+                wrapping role="img" names it (aria-label is not valid, nor
+                reliably announced, on a bare `<svg>`). No `title` — announced,
+                not hovered, so the row's only tooltip stays the clipped step
+                name. */}
+            <span
+              role="img"
+              aria-label={statusLabel(step.status, step.conclusion)}
+              className="flex shrink-0 items-center"
+            >
+              <StatusIcon
+                status={step.status}
+                conclusion={step.conclusion}
+                className="size-3.5"
+              />
+            </span>
             <span
               className="min-w-0 flex-1 truncate"
               onMouseEnter={clipTitle(step.name)}
@@ -331,11 +342,16 @@ function CheckRow({
         ) : (
           <CaretRightIcon className="size-3 shrink-0 text-muted-foreground" />
         ))}
-      <Icon
-        className={cn("size-3.5 shrink-0", tone)}
+      {/* The state word rides a wrapping span: aria-label is not valid (nor
+          reliably announced) on a bare `<svg>`. No `title` — a tooltip here would
+          shadow the row's own ("Open this check" / the clipped check name). */}
+      <span
+        role="img"
         aria-label={label}
-        weight="fill"
-      />
+        className="flex shrink-0 items-center"
+      >
+        <Icon className={cn("size-3.5", tone)} weight="fill" aria-hidden />
+      </span>
       <span
         className="min-w-0 flex-1 truncate font-medium"
         onMouseEnter={clipTitle(check.name)}
@@ -533,10 +549,6 @@ export function ChecksRollup({
   );
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
-  // A natively-disabled Button swallows `title`, so the reason rides the wrapper.
-  const blockedSpanClass = writeBlocked
-    ? "inline-flex cursor-not-allowed"
-    : "inline-flex";
 
   async function approveBlockedRuns() {
     if (writeBlocked) return;
@@ -649,21 +661,20 @@ export function ChecksRollup({
               blockedRunIds.length === 1 ? "" : "s"
             } awaiting maintainer approval.`}
           </span>
-          <span title={writeReason} className={blockedSpanClass}>
-            <Button
-              variant="outline"
-              size="xs"
-              disabled={approving || writeBlocked}
-              onClick={() => void approveBlockedRuns()}
-            >
-              {approving ? (
-                <Spinner data-icon="inline-start" />
-              ) : (
-                <PlayIcon data-icon="inline-start" />
-              )}
-              Approve and run
-            </Button>
-          </span>
+          <DisabledReasonButton
+            variant="outline"
+            size="xs"
+            disabled={approving || writeBlocked}
+            reason={writeReason}
+            onClick={() => void approveBlockedRuns()}
+          >
+            {approving ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <PlayIcon data-icon="inline-start" />
+            )}
+            Approve and run
+          </DisabledReasonButton>
         </div>
       )}
       <button

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -260,7 +260,8 @@ function RunSteps({ job }: { job: RunJob }) {
                 wrapping role="img" names it (aria-label is not valid, nor
                 reliably announced, on a bare `<svg>`). No `title` — announced,
                 not hovered, so the row's only tooltip stays the clipped step
-                name. */}
+                name. StatusIcon takes no aria props; the role prunes its svg
+                regardless. */}
             <span
               role="img"
               aria-label={statusLabel(step.status, step.conclusion)}

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -1,5 +1,6 @@
 import { useEffectEvent, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
@@ -570,20 +571,18 @@ export function CommitLineComposer({
         textareaClassName="max-h-48 min-h-16 resize-y"
       />
       <div className="flex items-center gap-2">
-        {/* Wrap the (possibly) disabled submit so its `title` — the reason —
-            still shows; a native-disabled button swallows the tooltip. */}
-        <span
-          title={disabledReason ?? (!body.trim() ? undefined : SUBMIT_HINT)}
+        <DisabledReasonButton
+          variant="outline"
+          size="sm"
+          disabled={!body.trim() || !canPost || createComment.isPending}
+          reason={
+            disabledReason ?? (!body.trim() ? "Write a comment first" : null)
+          }
+          title={SUBMIT_HINT}
+          onClick={submit}
         >
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={!body.trim() || !canPost || createComment.isPending}
-            onClick={submit}
-          >
-            Comment
-          </Button>
-        </span>
+          Comment
+        </DisabledReasonButton>
         <Button
           variant="ghost"
           size="sm"

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -17,7 +17,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Badge } from "@/components/ui/badge";
@@ -65,6 +65,7 @@ import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { LocalPrLifecycleRow } from "./LocalPrTimeline";
 import { PromoteLocalPrDialog } from "./PromoteLocalPrDialog";
@@ -114,17 +115,42 @@ export function LocalPrView({
   const [selectedCommitHash, setSelectedCommitHash] = useState<string | null>(
     null,
   );
+  const aiEnabled = useAiEnabled();
+  // The sub-tabs the strip renders — every writer of `section` gates on this, so
+  // no path can select a tab that isn't there. A local PR has no forge, so the
+  // Review tab rides the AI setting alone (no capability axis to consult).
+  const availableSections = useMemo<Section[]>(
+    () =>
+      aiEnabled
+        ? ["conversation", "commits", "files", "review"]
+        : ["conversation", "commits", "files"],
+    [aiEnabled],
+  );
   // The activity dock's "View" lands here via a pending hint; switch to the
-  // review sub-tab once, then clear it. Guarded on this being the *selected* PR
-  // so a still-mounted lagging view (deferredPr) can't swallow the hint first.
+  // review sub-tab once if it's available, then clear the hint either way — an
+  // unusable hint must not survive to fire against a later PR. Guarded on this
+  // being the *selected* PR so a still-mounted lagging view (deferredPr) can't
+  // swallow the hint first.
   useEffect(() => {
     const isSelected = selectedPr?.kind === "local" && selectedPr.id === id;
     if (pendingPrSection === "review" && isSelected) {
-      setSection("review");
+      if (availableSections.includes("review")) setSection("review");
       setPendingPrSection(null);
     }
-  }, [pendingPrSection, setPendingPrSection, selectedPr, id]);
-  const aiEnabled = useAiEnabled();
+  }, [
+    pendingPrSection,
+    setPendingPrSection,
+    selectedPr,
+    id,
+    availableSections,
+  ]);
+  // Availability can drop away under the selection (Hide AI toggled), which
+  // would leave a blank body under a strip with no pressed tab — fall back to
+  // the tab every PR always has. Layout effect: a passive one paints that empty
+  // frame before reconciling.
+  useLayoutEffect(() => {
+    if (!availableSections.includes(section)) setSection("conversation");
+  }, [availableSections, section]);
   const rulesConfig = useEffectiveBranchRules(repoPath);
   const {
     comment,
@@ -458,6 +484,16 @@ export function LocalPrView({
     );
   }
 
+  // The Merge control's state. Hoisted because the refusal has to sit on the
+  // wrapping span while `disabled` sits on the trigger — a disabled trigger is
+  // what actually keeps the menu shut.
+  const mergeBlocked = !canMerge || merge.isPending || dirtyBlocks;
+  const mergeReason = !canMerge
+    ? "Approve the PR before merging"
+    : dirtyBlocks
+      ? "Commit or stash your changes before merging into the current branch"
+      : `Merge ${pr.head} into ${pr.base}`;
+
   return (
     <div className="flex h-full flex-col">
       <header className="space-y-2 border-b px-4 py-3">
@@ -566,11 +602,7 @@ export function LocalPrView({
           </div>
         )}
         <div className="flex gap-1 pt-1">
-          {(
-            (aiEnabled
-              ? ["conversation", "commits", "files", "review"]
-              : ["conversation", "commits", "files"]) as Section[]
-          ).map((s) => (
+          {availableSections.map((s) => (
             <Button
               key={s}
               variant={section === s ? "secondary" : "ghost"}
@@ -842,6 +874,7 @@ export function LocalPrView({
                 <Button
                   variant={pr.approved ? "secondary" : "outline"}
                   size="sm"
+                  aria-pressed={pr.approved}
                   onClick={toggleApprove}
                 >
                   <CheckCircleIcon data-icon="inline-start" />
@@ -992,25 +1025,26 @@ export function LocalPrView({
               </Button>
             )}
             <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    size="sm"
-                    disabled={!canMerge || merge.isPending || dirtyBlocks}
-                    title={
-                      !canMerge
-                        ? "Approve the PR before merging"
-                        : dirtyBlocks
-                          ? "Commit or stash your changes before merging into the current branch"
-                          : `Merge ${pr.head} into ${pr.base}`
-                    }
-                  >
-                    <GitMergeIcon data-icon="inline-start" />
-                    Merge
-                    <CaretDownIcon data-icon="inline-end" />
-                  </Button>
-                }
-              />
+              {/* A natively-disabled Button swallows `title`, so the refusal
+                  rides a wrapping span (house idiom) — outside the trigger,
+                  which carries `disabled` itself so a blocked merge can't open
+                  the menu. */}
+              <span
+                title={mergeReason}
+                className={cn(
+                  "inline-flex",
+                  mergeBlocked && "cursor-not-allowed",
+                )}
+              >
+                <DropdownMenuTrigger
+                  disabled={mergeBlocked}
+                  render={<Button size="sm" />}
+                >
+                  <GitMergeIcon data-icon="inline-start" />
+                  Merge
+                  <CaretDownIcon data-icon="inline-end" />
+                </DropdownMenuTrigger>
+              </span>
               <DropdownMenuContent align="end" className="w-56">
                 <DropdownMenuItem
                   disabled={

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -5,6 +5,7 @@ import {
   SparkleIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -188,54 +189,41 @@ export function PrMergeabilityBanner({
             </Button>
           )}
           {conflicting && canResolveWithAi && (
-            <span
-              className="inline-flex"
-              title={forkBlocked ? FORK_BLOCKED_REASON : undefined}
-            >
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={busy || forkBlocked}
-                onClick={onResolveWithAi}
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Resolve with AI
-              </Button>
-            </span>
-          )}
-          {/* Wrap so the disabled reason still shows on hover — a native-disabled
-              button swallows its `title` (vendored Button's pointer-events-none). */}
-          <span
-            className="inline-flex"
-            title={forkBlocked ? FORK_BLOCKED_REASON : undefined}
-          >
-            <Button
+            <DisabledReasonButton
               variant="ghost"
               size="xs"
               disabled={busy || forkBlocked}
-              onClick={onResolve}
+              reason={forkBlocked ? FORK_BLOCKED_REASON : undefined}
+              onClick={onResolveWithAi}
             >
-              {resolveLabel}
-            </Button>
-          </span>
+              <SparkleIcon data-icon="inline-start" />
+              Resolve with AI
+            </DisabledReasonButton>
+          )}
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            disabled={busy || forkBlocked}
+            reason={forkBlocked ? FORK_BLOCKED_REASON : undefined}
+            onClick={onResolve}
+          >
+            {resolveLabel}
+          </DisabledReasonButton>
         </div>
       )}
 
       {arm === "behind" && (
         <div className="flex items-center gap-1.5">
-          {/* The wrapping span carries the refusal on hover — a natively-disabled
-              button swallows its own `title` (same idiom as above). */}
-          <span className="inline-flex" title={updateBlockedReason}>
-            <Button
-              variant="ghost"
-              size="xs"
-              disabled={updateDisabled}
-              onClick={onUpdateBranch}
-            >
-              {updateBusy && <Spinner data-icon="inline-start" />}
-              Update branch
-            </Button>
-          </span>
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            disabled={updateDisabled}
+            reason={updateBlockedReason}
+            onClick={onUpdateBranch}
+          >
+            {updateBusy && <Spinner data-icon="inline-start" />}
+            Update branch
+          </DisabledReasonButton>
           {/* A span-wrapped `render` would swallow the caret's disabled state — the
               vendored Button's `pointer-events-none` routes the click to the span,
               which IS the trigger — so a refused update renders no trigger at all. */}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -21,12 +21,14 @@ import {
   type ReactNode,
   useEffect,
   useEffectEvent,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { SelectControl } from "@/components/form/fields";
 import {
@@ -485,15 +487,52 @@ export function RemotePrView({
   // gate on it so a still-mounted lagging view (deferredPr) can't answer first.
   const isSelectedPr =
     selectedPr?.kind === "remote" && selectedPr.id === String(number);
+  const aiEnabled = useAiEnabled();
+  // The sub-tabs the strip renders — every writer of `section` gates on this, so
+  // no path can select a tab that isn't there. The AI Review tab needs only the
+  // diff (forge-neutral) and a way to post the result as a comment, so it
+  // follows canComment, which covers GitLab MRs too (canWrite implies
+  // canComment for GitHub).
+  const availableSections = useMemo<Section[]>(
+    () =>
+      aiEnabled && canComment
+        ? ["conversation", "commits", "files", "review"]
+        : ["conversation", "commits", "files"],
+    [aiEnabled, canComment],
+  );
+  // Until the forge probe answers, `canComment` is a provisional verdict: an
+  // unresolved provider fails open through canWrite, so the Review tab reads
+  // available and then drops once a GitLab/Bitbucket answer lands. Both effects
+  // below wait for the real answer rather than act on the guess. Only the forge
+  // query counts — `writeAccess` feeds `writeBlocked`, not availability, and it
+  // stays pending forever on a repo with no provider (it's a disabled query).
+  const capabilitiesSettled = !forge.isPending;
   // The activity dock's "View" lands here via a pending hint; switch to the
-  // review sub-tab once, then clear it.
+  // review sub-tab once if it's available, then clear the hint either way so
+  // an unusable hint can't fire against a later PR. (Until capabilities settle
+  // the hint is left armed — navigating away in that sub-second window can
+  // carry it to the next PR; accepted.)
   useEffect(() => {
+    if (!capabilitiesSettled) return;
     if (pendingPrSection === "review" && isSelectedPr) {
-      setSection("review");
+      if (availableSections.includes("review")) setSection("review");
       setPendingPrSection(null);
     }
-  }, [pendingPrSection, setPendingPrSection, isSelectedPr]);
-  const aiEnabled = useAiEnabled();
+  }, [
+    pendingPrSection,
+    setPendingPrSection,
+    isSelectedPr,
+    availableSections,
+    capabilitiesSettled,
+  ]);
+  // Availability can drop away under the selection (Hide AI toggled, a
+  // capability lost on refetch), which would leave a blank body under a strip
+  // with no pressed tab — fall back to the tab every PR always has. Layout
+  // effect: a passive one paints that empty frame before reconciling.
+  useLayoutEffect(() => {
+    if (!capabilitiesSettled) return;
+    if (!availableSections.includes(section)) setSection("conversation");
+  }, [availableSections, section, capabilitiesSettled]);
   const rulesConfig = useEffectiveBranchRules(repoPath);
   const defaultBranch = useDefaultBranch(repoPath);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -1679,6 +1718,27 @@ export function RemotePrView({
     );
   }
 
+  // The Merge control's state. Hoisted because the refusal has to sit on the
+  // wrapping span while `disabled` sits on the trigger — a disabled trigger is
+  // what actually keeps the menu (and with it an unguarded merge) shut.
+  const mergeBlocked =
+    busy ||
+    writeBlocked ||
+    pr.isDraft ||
+    mergeGuardMissing ||
+    allMergeMethodsBlocked;
+  // Permission outranks the availability hints: a viewer who can't push can't
+  // act on any of them.
+  const mergeReason =
+    writeReason ??
+    (pr.isDraft
+      ? `Mark the ${prNoun} ready before merging`
+      : mergeGuardMissing
+        ? "Reload to merge — couldn't load the head commit to guard the merge"
+        : allMergeMethodsBlocked
+          ? "No merge method is enabled by both this repository's settings and its branch rules"
+          : `Merge this ${prNoun}`);
+
   return (
     <div className="flex h-full flex-col">
       <header className="space-y-2 border-b px-4 py-3">
@@ -1693,11 +1753,17 @@ export function RemotePrView({
           {isOpen &&
             canWrite &&
             (repoStatus.data?.branch?.name === pr.headRefName ? (
-              <span title={`${pr.headRefName} is the current branch`}>
-                <Button variant="outline" size="xs" disabled>
-                  <CheckCircleIcon data-icon="inline-start" />
-                  Checked out
-                </Button>
+              // A status, not an action — no button role and no tab stop.
+              // role="img" prunes the icon AND the wording, so the label states
+              // the whole thing on its own.
+              <span
+                role="img"
+                aria-label={`Checked out — ${pr.headRefName} is the current branch`}
+                title={`${pr.headRefName} is the current branch`}
+                className="inline-flex h-6 shrink-0 items-center gap-1 border border-border bg-background pr-2 pl-1.5 text-xs font-medium whitespace-nowrap text-muted-foreground"
+              >
+                <CheckCircleIcon className="size-3" aria-hidden />
+                Checked out
               </span>
             ) : (
               <Button
@@ -1946,14 +2012,7 @@ export function RemotePrView({
           crossRepository={!!pr.crossRepository}
         />
         <div className="flex gap-1 pt-1">
-          {/* The AI Review tab needs only the diff (forge-neutral) and a way to
-              post the result as a comment — so it follows canComment, which
-              covers GitLab MRs too (canWrite implies canComment for GitHub). */}
-          {(
-            (aiEnabled && canComment
-              ? ["conversation", "commits", "files", "review"]
-              : ["conversation", "commits", "files"]) as Section[]
-          ).map((s) => (
+          {availableSections.map((s) => (
             <Button
               key={s}
               variant={section === s ? "secondary" : "ghost"}
@@ -2505,23 +2564,35 @@ export function RemotePrView({
                 )}
                 {isOpen && canApprove && (
                   <>
-                    <Button
+                    <DisabledReasonButton
                       variant="outline"
                       size="sm"
                       // On an approvals read-error we can't know the viewer's state,
                       // so disable rather than present a confident (possibly wrong)
-                      // Approve that would fire the wrong direction on click.
+                      // Approve that would fire the wrong direction on click. The
+                      // failed read has no other surface, so it rides `reason` —
+                      // hoverable and announced while the button is unavailable.
                       disabled={
                         busy || approvals.isPending || approvals.isError
                       }
-                      aria-pressed={approval?.viewerHasApproved ?? false}
-                      onClick={toggleApproval}
-                      title={
+                      reason={
                         approvals.isError
                           ? "Couldn't load approval state"
-                          : approval?.viewerHasApproved
-                            ? "Revoke your approval"
-                            : `Approve this ${prNoun}`
+                          : null
+                      }
+                      // Unknown state is announced as unknown: a failed read
+                      // must not claim "not pressed" while the reason says the
+                      // state couldn't be loaded.
+                      aria-pressed={
+                        approvals.isError
+                          ? undefined
+                          : (approval?.viewerHasApproved ?? false)
+                      }
+                      onClick={toggleApproval}
+                      title={
+                        approval?.viewerHasApproved
+                          ? "Revoke your approval"
+                          : `Approve this ${prNoun}`
                       }
                       className={cn(
                         approval?.viewerHasApproved &&
@@ -2530,7 +2601,7 @@ export function RemotePrView({
                     >
                       <CheckCircleIcon data-icon="inline-start" />
                       {approval?.viewerHasApproved ? "Approved" : "Approve"}
-                    </Button>
+                    </DisabledReasonButton>
                     {approvalNote && (
                       <span
                         className="text-xs text-muted-foreground"
@@ -2546,27 +2617,36 @@ export function RemotePrView({
                   </>
                 )}
                 {isOpen && canRequestChanges && (
-                  <Button
+                  <DisabledReasonButton
                     variant="outline"
                     size="sm"
                     // Bitbucket: a true toggle. GitLab: one-shot — once requested
                     // the button is the state indicator (the direct undo is
-                    // Premium-only). It stays FOCUSABLE then (the handler no-ops)
-                    // so keyboard/AT users can reach the how-to-clear title. Same
-                    // disable-on-unknown posture as the approve toggle.
+                    // Premium-only), so it stays ENABLED with a no-op handler and
+                    // its how-to-clear title reachable. Same disable-on-unknown
+                    // posture as the approve toggle: `reason` carries the read
+                    // failure nothing else reports, and DisabledReasonButton keeps
+                    // the disabled button focusable so that reason is announced
+                    // rather than lost.
                     disabled={busy || approvals.isPending || approvals.isError}
-                    aria-pressed={approval?.viewerRequestedChanges ?? false}
+                    reason={
+                      approvals.isError ? "Couldn't load review state" : null
+                    }
+                    // Unknown state is announced as unknown (same as approve).
+                    aria-pressed={
+                      approvals.isError
+                        ? undefined
+                        : (approval?.viewerRequestedChanges ?? false)
+                    }
                     onClick={requestChanges}
                     title={
-                      approvals.isError
-                        ? "Couldn't load review state"
-                        : approval?.viewerRequestedChanges
-                          ? canUnrequestChanges
-                            ? "Revoke your change request"
-                            : "You've requested changes — approve, or remove yourself as a reviewer on GitLab, to clear"
-                          : composeBody.trim()
-                            ? "Request changes, posting your draft as a comment"
-                            : `Request changes on this ${prNoun} (adds you as a reviewer)`
+                      approval?.viewerRequestedChanges
+                        ? canUnrequestChanges
+                          ? "Revoke your change request"
+                          : "You've requested changes — approve, or remove yourself as a reviewer on GitLab, to clear"
+                        : composeBody.trim()
+                          ? "Request changes, posting your draft as a comment"
+                          : `Request changes on this ${prNoun} (adds you as a reviewer)`
                     }
                     className={cn(
                       approval?.viewerRequestedChanges &&
@@ -2577,7 +2657,7 @@ export function RemotePrView({
                     {approval?.viewerRequestedChanges
                       ? "Changes requested"
                       : "Request changes"}
-                  </Button>
+                  </DisabledReasonButton>
                 )}
                 {composeBody.trim() && (
                   <Button
@@ -2746,28 +2826,20 @@ export function RemotePrView({
                 <ClockCountdownIcon className="size-3.5 shrink-0" />
                 Auto-merge enabled
               </span>
-              <span
-                title={writeReason}
-                className={
-                  writeBlocked
-                    ? "inline-flex cursor-not-allowed"
-                    : "inline-flex"
+              <DisabledReasonButton
+                variant="outline"
+                size="sm"
+                disabled={busy || writeBlocked}
+                reason={writeReason}
+                onClick={() =>
+                  cancelAutoMerge.mutate(number, {
+                    onSuccess: () => toast.success("Auto-merge canceled"),
+                    onError,
+                  })
                 }
               >
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={busy || writeBlocked}
-                  onClick={() =>
-                    cancelAutoMerge.mutate(number, {
-                      onSuccess: () => toast.success("Auto-merge canceled"),
-                      onError,
-                    })
-                  }
-                >
-                  Cancel auto-merge
-                </Button>
-              </span>
+                Cancel auto-merge
+              </DisabledReasonButton>
             </div>
           )}
           <span className="flex-1" />
@@ -2789,41 +2861,26 @@ export function RemotePrView({
           {canMerge && (
             <DropdownMenu>
               {/* A natively-disabled Button swallows `title`, so the hint rides a
-                  wrapping span (house idiom). */}
-              <DropdownMenuTrigger
-                render={
-                  <span
-                    title={
-                      // Permission outranks the availability hints: a viewer who
-                      // can't push can't act on any of them.
-                      writeReason ??
-                      (pr.isDraft
-                        ? `Mark the ${prNoun} ready before merging`
-                        : mergeGuardMissing
-                          ? "Reload to merge — couldn't load the head commit to guard the merge"
-                          : allMergeMethodsBlocked
-                            ? "No merge method is enabled by both this repository's settings and its branch rules"
-                            : `Merge this ${prNoun}`)
-                    }
-                    className={writeBlocked ? "cursor-not-allowed" : undefined}
-                  >
-                    <Button
-                      size="sm"
-                      disabled={
-                        busy ||
-                        writeBlocked ||
-                        pr.isDraft ||
-                        mergeGuardMissing ||
-                        allMergeMethodsBlocked
-                      }
-                    >
-                      <GitMergeIcon data-icon="inline-start" />
-                      Merge
-                      <CaretDownIcon data-icon="inline-end" />
-                    </Button>
-                  </span>
-                }
-              />
+                  wrapping span (house idiom). The span stays OUTSIDE the trigger:
+                  as the trigger it would take the click the disabled button
+                  refuses and open the menu anyway — merging past every gate,
+                  including GitLab's stale-head guard. */}
+              <span
+                title={mergeReason}
+                className={cn(
+                  "inline-flex",
+                  mergeBlocked && "cursor-not-allowed",
+                )}
+              >
+                <DropdownMenuTrigger
+                  disabled={mergeBlocked}
+                  render={<Button size="sm" />}
+                >
+                  <GitMergeIcon data-icon="inline-start" />
+                  Merge
+                  <CaretDownIcon data-icon="inline-end" />
+                </DropdownMenuTrigger>
+              </span>
               <DropdownMenuContent align="end" className="w-56">
                 {/* GitLab has no per-MR rebase-merge (that's the project's merge_method
                     setting), so it gets only merge + squash. Bitbucket offers

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1833,10 +1833,14 @@ export function RemotePrView({
         {/* The three metadata pickers below are keyed on the entity: each seeds a
             draft on open and commits it on close by diffing against LIVE props, and
             a keyboard PR switch leaves the popover open (no outside press to close
-            it) — so without the key the old PR's draft lands on the new one. */}
+            it) — so without the key the old PR's draft lands on the new one. The
+            keys carry a per-slot prefix because they are SIBLINGS: duplicate keys
+            in one children array make React drop the earlier duplicates' unmount
+            on key change — the old picker's DOM leaks into the sidebar, one stale
+            row per PR switch (reproduced live; the last duplicate reconciles). */}
         {isOpen && canEditLabels ? (
           <LabelsPopover
-            key={entityKey}
+            key={`labels-${entityKey}`}
             repoPath={repoPath}
             enabled
             number={number}
@@ -1859,7 +1863,7 @@ export function RemotePrView({
             read-only chips, like the labels row. */}
         {isOpen && canEditAssignees ? (
           <AssigneesPopover
-            key={entityKey}
+            key={`assignees-${entityKey}`}
             repoPath={repoPath}
             enabled
             value={pr.assignees}
@@ -1895,7 +1899,7 @@ export function RemotePrView({
         {isOpen && canEditReviewers ? (
           <div className="flex flex-wrap items-center gap-1.5">
             <ReviewersPopover
-              key={entityKey}
+              key={`reviewers-${entityKey}`}
               repoPath={repoPath}
               number={number}
               enabled

--- a/src/features/pulls/ResolveConflictsView.tsx
+++ b/src/features/pulls/ResolveConflictsView.tsx
@@ -5,6 +5,7 @@ import {
 } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { ConflictFileView } from "@/features/repository/ConflictFileView";
@@ -202,21 +203,15 @@ export function ResolveConflictsView({
           >
             Abort
           </Button>
-          {/* Wrap so the disabled reason still shows on hover — a native-disabled
-              button swallows its `title` (vendored Button's pointer-events-none). */}
-          <span
-            className="inline-flex"
-            title={remaining > 0 ? "Resolve every conflict first" : undefined}
+          <DisabledReasonButton
+            size="xs"
+            disabled={busy || remaining > 0}
+            reason={remaining > 0 ? "Resolve every conflict first" : undefined}
+            onClick={onFinish}
           >
-            <Button
-              size="xs"
-              disabled={busy || remaining > 0}
-              onClick={onFinish}
-            >
-              {finish.isPending && <Spinner data-icon="inline-start" />}
-              Finish merge
-            </Button>
-          </span>
+            {finish.isPending && <Spinner data-icon="inline-start" />}
+            Finish merge
+          </DisabledReasonButton>
         </div>
       </div>
 

--- a/src/features/pulls/ResolveRemotePrView.tsx
+++ b/src/features/pulls/ResolveRemotePrView.tsx
@@ -5,6 +5,7 @@ import {
 } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { ConflictFileView } from "@/features/repository/ConflictFileView";
@@ -195,21 +196,15 @@ export function ResolveRemotePrView({
           >
             Discard
           </Button>
-          {/* Wrap so the disabled reason still shows on hover — a native-disabled
-              button swallows its `title` (vendored Button's pointer-events-none). */}
-          <span
-            className="inline-flex"
-            title={remaining > 0 ? "Resolve every conflict first" : undefined}
+          <DisabledReasonButton
+            size="xs"
+            disabled={busy || remaining > 0}
+            reason={remaining > 0 ? "Resolve every conflict first" : undefined}
+            onClick={onFinish}
           >
-            <Button
-              size="xs"
-              disabled={busy || remaining > 0}
-              onClick={onFinish}
-            >
-              {finish.isPending && <Spinner data-icon="inline-start" />}
-              Finish &amp; push
-            </Button>
-          </span>
+            {finish.isPending && <Spinner data-icon="inline-start" />}
+            Finish &amp; push
+          </DisabledReasonButton>
         </div>
       </div>
 

--- a/src/features/pulls/ReviewComposer.tsx
+++ b/src/features/pulls/ReviewComposer.tsx
@@ -1,4 +1,5 @@
 import { type KeyboardEvent, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { useCreateReviewThread } from "@/lib/git/queries";
@@ -161,19 +162,16 @@ export function ReviewComposer({
         <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
           {anchorLabel}
         </span>
-        {/* Wrap the (possibly) disabled suggestion button so its `title` — the
-            reason — still shows (a native-disabled button swallows the tooltip). */}
-        <span title={suggestionDisabledReason ?? undefined}>
-          <Button
-            variant="ghost"
-            size="xs"
-            className="shrink-0 text-muted-foreground"
-            disabled={!canSuggest}
-            onClick={insertSuggestion}
-          >
-            Add suggestion
-          </Button>
-        </span>
+        <DisabledReasonButton
+          variant="ghost"
+          size="xs"
+          className="shrink-0 text-muted-foreground"
+          disabled={!canSuggest}
+          reason={suggestionDisabledReason}
+          onClick={insertSuggestion}
+        >
+          Add suggestion
+        </DisabledReasonButton>
       </div>
       {provider === "bitbucket" && isRange && (
         <p className="text-[11px] text-muted-foreground">

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -396,8 +397,7 @@ export interface SuggestionApply {
  * Apply shows only when the originals were recovered — the thread's own hunk
  * (GitHub) or one synthesized from the file's diff section (GitLab/Bitbucket) must
  * fully cover the range — AND an `apply` prop is present; otherwise it degrades to
- * a labeled replacement-only block. Every disabled state explains WHY via a
- * wrapping `<span title>` (a native-disabled button swallows its own tooltip).
+ * a labeled replacement-only block.
  */
 function SuggestionBlock({
   thread,
@@ -469,19 +469,16 @@ function SuggestionBlock({
         {originals && apply && (
           <>
             <span className="flex-1" />
-            {/* Wrap the (possibly) disabled Button so its `title` still shows —
-                a native-disabled button swallows the tooltip. */}
-            <span title={disabledReason ?? undefined}>
-              <Button
-                variant="outline"
-                size="xs"
-                disabled={pending || applied || disabledReason !== null}
-                onClick={runApply}
-              >
-                {pending && <Spinner className="size-3" />}
-                {applied ? "Applied ✓" : "Apply"}
-              </Button>
-            </span>
+            <DisabledReasonButton
+              variant="outline"
+              size="xs"
+              disabled={pending || applied || disabledReason !== null}
+              reason={disabledReason}
+              onClick={runApply}
+            >
+              {pending && <Spinner className="size-3" />}
+              {applied ? "Applied ✓" : "Apply"}
+            </DisabledReasonButton>
           </>
         )}
       </div>
@@ -766,23 +763,17 @@ export function ReviewThreadCard({
                   textareaClassName="max-h-32 min-h-12 resize-y"
                 />
                 <div className="flex items-center gap-2">
-                  {/* Wrap the disabled Button so its `title` (the "why") still
-                      shows — a natively-disabled button swallows the tooltip. */}
-                  <span
-                    title={
-                      !replyBody.trim() ? "Write a reply first" : SUBMIT_HINT
-                    }
+                  <DisabledReasonButton
+                    variant="outline"
+                    size="sm"
+                    disabled={!replyBody.trim() || replyPending}
+                    reason={!replyBody.trim() ? "Write a reply first" : null}
+                    title={SUBMIT_HINT}
+                    onClick={submitReply}
                   >
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={!replyBody.trim() || replyPending}
-                      onClick={submitReply}
-                    >
-                      {replyPending && <Spinner className="size-3" />}
-                      Reply
-                    </Button>
-                  </span>
+                    {replyPending && <Spinner className="size-3" />}
+                    Reply
+                  </DisabledReasonButton>
                   <Button
                     variant="ghost"
                     size="sm"

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
 import {
@@ -217,19 +218,17 @@ export function SubmitReviewDialog({
           >
             Cancel
           </Button>
-          {/* Wrap the (possibly) disabled submit so its `title` — the reason —
-              still shows; a native-disabled button swallows the tooltip. */}
-          <span
-            title={
+          <DisabledReasonButton
+            disabled={summaryMissing || pending}
+            reason={
               summaryMissing
                 ? "A summary is required to request changes."
                 : undefined
             }
+            onClick={submit}
           >
-            <Button disabled={summaryMissing || pending} onClick={submit}>
-              Submit review
-            </Button>
-          </span>
+            Submit review
+          </DisabledReasonButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/repo-settings/BitbucketSchedulesSection.tsx
+++ b/src/features/repo-settings/BitbucketSchedulesSection.tsx
@@ -2,6 +2,7 @@ import { PlusIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -223,16 +224,15 @@ function ScheduleRow({
           onAct={onRemove}
         />
       ) : syncing ? (
-        <span title="Syncing with Bitbucket…" className="inline-flex">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="text-muted-foreground"
-            disabled
-          >
-            Delete
-          </Button>
-        </span>
+        <DisabledReasonButton
+          size="sm"
+          variant="ghost"
+          className="text-muted-foreground"
+          disabled
+          reason="Syncing with Bitbucket…"
+        >
+          Delete
+        </DisabledReasonButton>
       ) : (
         <Button
           size="sm"

--- a/src/features/repo-settings/BitbucketVariablesSection.tsx
+++ b/src/features/repo-settings/BitbucketVariablesSection.tsx
@@ -2,6 +2,7 @@ import { PlusIcon, XIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -280,23 +281,23 @@ function VariableRow({
             onAct={onRemove}
           />
         ) : syncing ? (
-          // A natively-disabled Button drops its title, so wrap it to explain why.
-          <span title="Syncing with Bitbucket…" className="inline-flex">
-            <Button
-              size="sm"
-              variant="ghost"
-              className="text-muted-foreground"
-              disabled
-            >
-              <XIcon />
-            </Button>
-          </span>
+          <DisabledReasonButton
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            disabled
+            aria-label="Delete variable"
+            reason="Syncing with Bitbucket…"
+          >
+            <XIcon />
+          </DisabledReasonButton>
         ) : (
           <Button
             size="sm"
             variant="ghost"
             className="text-muted-foreground hover:text-destructive"
             onClick={onConfirm}
+            aria-label="Delete variable"
             title="Delete"
           >
             <XIcon />
@@ -313,11 +314,14 @@ function VariableRow({
           spellCheck={false}
         />
         {syncing ? (
-          <span title="Syncing with Bitbucket…" className="inline-flex">
-            <Button size="sm" variant="outline" disabled>
-              Save
-            </Button>
-          </span>
+          <DisabledReasonButton
+            size="sm"
+            variant="outline"
+            disabled
+            reason="Syncing with Bitbucket…"
+          >
+            Save
+          </DisabledReasonButton>
         ) : (
           <Button
             size="sm"

--- a/src/features/repo-settings/BitbucketVariablesSection.tsx
+++ b/src/features/repo-settings/BitbucketVariablesSection.tsx
@@ -286,7 +286,7 @@ function VariableRow({
             variant="ghost"
             className="text-muted-foreground"
             disabled
-            aria-label="Delete variable"
+            aria-label={`Delete ${variable.key}`}
             reason="Syncing with Bitbucket…"
           >
             <XIcon />
@@ -297,7 +297,7 @@ function VariableRow({
             variant="ghost"
             className="text-muted-foreground hover:text-destructive"
             onClick={onConfirm}
-            aria-label="Delete variable"
+            aria-label={`Delete ${variable.key}`}
             title="Delete"
           >
             <XIcon />

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -47,7 +48,6 @@ import { deleteRepoLens } from "@/lib/repo-lens/store";
 import { settingsKeys, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
-import { cn } from "@/lib/utils";
 import { InlineConfirm } from "./parts";
 import { ScopeRefreshHint } from "./ScopeRefreshHint";
 
@@ -156,18 +156,23 @@ function Row({
 
 const OWNER_HINT = "Needs the Owner role on GitLab";
 
-/** A danger-zone trigger whose disabled state still explains itself: the
- *  vendored Button renders a NATIVE `disabled`, which swallows pointer events
- *  (so a `title` on the button never shows) — the hint rides a wrapping span. */
+/** A danger-zone trigger whose disabled state still explains itself. `className`
+ *  stays the row's layout hook (it lands on the wrapper, as it always has). */
 function DangerButton({
   hint,
   className,
   ...props
-}: ComponentProps<typeof Button> & { hint?: string }) {
+}: Omit<ComponentProps<typeof Button>, "className"> & {
+  hint?: string;
+  className?: string;
+}) {
   return (
-    <span title={hint} className={cn("inline-flex", className)}>
-      <Button size="sm" {...props} />
-    </span>
+    <DisabledReasonButton
+      size="sm"
+      reason={hint}
+      wrapperClassName={className}
+      {...props}
+    />
   );
 }
 

--- a/src/features/repo-settings/GitLabProtectedBranchesSection.tsx
+++ b/src/features/repo-settings/GitLabProtectedBranchesSection.tsx
@@ -1,6 +1,7 @@
 import { CaretLeftIcon, PlusIcon } from "@phosphor-icons/react";
 import { useId, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -186,18 +187,15 @@ function ProtectedBranchRow({
             onAct={onUnprotect}
           />
         ) : branch.inherited ? (
-          // A natively disabled Button swallows pointer events, so its own title
-          // never shows — wrap it so the explanation surfaces on hover.
-          <span title={inheritedHint} className="inline-flex">
-            <Button
-              size="sm"
-              variant="ghost"
-              className="text-muted-foreground"
-              disabled
-            >
-              Unprotect
-            </Button>
-          </span>
+          <DisabledReasonButton
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            disabled
+            reason={inheritedHint}
+          >
+            Unprotect
+          </DisabledReasonButton>
         ) : (
           <Button
             size="sm"

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1582,16 +1582,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           }
         }}
       >
-        {/* The reason rides the wrapper because the trigger's `render` target
-            can't carry one: a disabled trigger drops pointer events, so its own
-            `title` never surfaces. The wrapper is the header's flex item, so it
-            carries the large shrink factor — flex removes space proportionally
-            to factor × base size, so the cascade collapses branch (20) → CI
-            badge (4) while the repo switcher holds its natural width, and the
-            branch label absorbs the pressure first. The
-            button must opt back in with `shrink`: the vendored Button ships
-            `shrink-0`, which would otherwise pin it at full width inside a
-            shrinking wrapper. */}
+        {/* The reason rides the wrapper (a disabled trigger drops pointer
+            events, so its own `title` never surfaces), and the wrapper is the
+            header's flex item, so it owns the shrink-20 that makes the branch
+            label collapse before the CI badge (4); the inner Button needs
+            `shrink` to undo the vendored `shrink-0`, or nothing truncates. */}
         <span
           className={cn(
             "inline-flex min-w-0 shrink-20",

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1582,51 +1582,58 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           }
         }}
       >
-        <Popover.Trigger
-          render={
-            <Button
-              variant="ghost"
-              size="sm"
-              // Large shrink factor: flex removes space proportionally to
-              // factor × base size, so the header cascade collapses branch (20)
-              // → CI badge (4) → repo (1) — the label absorbs the pressure
-              // first.
-              className="min-w-0 shrink-20"
-              disabled={busy || amending}
-              title={
-                amending
-                  ? "Finish or stop amending to switch branches"
-                  : undefined
-              }
-            >
-              <GitBranchIcon data-icon="inline-start" />
-              <span
-                className="min-w-0 truncate"
-                // Only expose the full label as a tooltip when it's actually
-                // clipped — measured just-in-time on hover, so no ref needed.
-                // Remove the attribute (not title="") when unclipped: an empty
-                // title="" is still a title in Chromium and would suppress the
-                // Button's own conditional (amending) title above.
-                onMouseEnter={(e) => {
-                  const el = e.currentTarget;
-                  if (el) {
-                    if (el.scrollWidth > el.clientWidth)
-                      el.title = currentLabel;
-                    else el.removeAttribute("title");
-                  }
-                }}
-              >
-                {currentLabel}
-              </span>
-              {head?.detached && (
-                <Badge variant="secondary" className="ml-1 shrink-0">
-                  detached
-                </Badge>
-              )}
-              <CaretDownIcon data-icon="inline-end" />
-            </Button>
+        {/* The reason rides the wrapper because the trigger's `render` target
+            can't carry one: a disabled trigger drops pointer events, so its own
+            `title` never surfaces. The wrapper is the header's flex item, so it
+            carries the large shrink factor — flex removes space proportionally
+            to factor × base size, so the cascade collapses branch (20) → CI
+            badge (4) while the repo switcher holds its natural width, and the
+            branch label absorbs the pressure first. The
+            button must opt back in with `shrink`: the vendored Button ships
+            `shrink-0`, which would otherwise pin it at full width inside a
+            shrinking wrapper. */}
+        <span
+          className={cn(
+            "inline-flex min-w-0 shrink-20",
+            amending && "cursor-not-allowed",
+          )}
+          title={
+            amending ? "Finish or stop amending to switch branches" : undefined
           }
-        />
+        >
+          <Popover.Trigger
+            disabled={busy || amending}
+            render={
+              <Button variant="ghost" size="sm" className="min-w-0 shrink">
+                <GitBranchIcon data-icon="inline-start" />
+                <span
+                  className="min-w-0 truncate"
+                  // Only expose the full label as a tooltip when it's actually
+                  // clipped — measured just-in-time on hover, so no ref needed.
+                  // Remove the attribute (not title="") when unclipped: an empty
+                  // title="" is still a title in Chromium and would suppress the
+                  // wrapper's conditional (amending) title above.
+                  onMouseEnter={(e) => {
+                    const el = e.currentTarget;
+                    if (el) {
+                      if (el.scrollWidth > el.clientWidth)
+                        el.title = currentLabel;
+                      else el.removeAttribute("title");
+                    }
+                  }}
+                >
+                  {currentLabel}
+                </span>
+                {head?.detached && (
+                  <Badge variant="secondary" className="ml-1 shrink-0">
+                    detached
+                  </Badge>
+                )}
+                <CaretDownIcon data-icon="inline-end" />
+              </Button>
+            }
+          />
+        </span>
         <Popover.Portal>
           <Popover.Positioner
             align="start"

--- a/src/features/repository/ConflictBanner.tsx
+++ b/src/features/repository/ConflictBanner.tsx
@@ -1,6 +1,7 @@
 import { InfoIcon, SparkleIcon, WarningIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -123,34 +124,27 @@ export function ConflictBanner({
             >
               Abort
             </Button>
-            {/* Wrap so the disabled reason still shows on hover — a
-                native-disabled button swallows its `title` (vendored Button's
-                pointer-events-none). */}
-            <span
-              className="inline-flex"
-              title={
+            <DisabledReasonButton
+              size="xs"
+              disabled={busy || conflictedCount > 0}
+              reason={
                 conflictedCount > 0 ? "Resolve every conflict first" : undefined
               }
+              onClick={() =>
+                continueOp.mutate(op, {
+                  onSuccess: () =>
+                    toast.success(
+                      op === "merge"
+                        ? "Merge completed"
+                        : `${opVerb} continued`,
+                    ),
+                  onError,
+                })
+              }
             >
-              <Button
-                size="xs"
-                disabled={busy || conflictedCount > 0}
-                onClick={() =>
-                  continueOp.mutate(op, {
-                    onSuccess: () =>
-                      toast.success(
-                        op === "merge"
-                          ? "Merge completed"
-                          : `${opVerb} continued`,
-                      ),
-                    onError,
-                  })
-                }
-              >
-                {continueOp.isPending && <Spinner data-icon="inline-start" />}
-                {OP_LABELS[op].cont}
-              </Button>
-            </span>
+              {continueOp.isPending && <Spinner data-icon="inline-start" />}
+              {OP_LABELS[op].cont}
+            </DisabledReasonButton>
 
             <Dialog open={confirmAbort} onOpenChange={setConfirmAbort}>
               <DialogContent>

--- a/src/features/repository/GenerateBranchNameButton.tsx
+++ b/src/features/repository/GenerateBranchNameButton.tsx
@@ -1,4 +1,5 @@
 import { SparkleIcon } from "@phosphor-icons/react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { FileEntry } from "@/lib/git/types";
@@ -121,34 +122,33 @@ export function GenerateBranchNameButton({
           Generating…
         </Button>
       ) : (
-        // Wrap so the reason still shows when the button is disabled — a
-        // native-disabled button swallows the tooltip.
-        <span className="inline-flex" title={reason}>
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            className="text-muted-foreground"
-            disabled={!canGenerate}
-            onClick={() =>
-              gen.generate({
-                entries,
-                recentBranches: recentBranches.slice(0, 20),
-                useWorkingTree,
-                // Only when naming the very branch those commits sit on.
-                workingTreeSubjects:
-                  nameTarget === "checked-out-branch"
-                    ? (committedFallback?.subjects ?? [])
-                    : [],
-                committedFallback,
-                onName,
-              })
-            }
-          >
-            <SparkleIcon data-icon="inline-start" />
-            Generate from changes
-          </Button>
-        </span>
+        <DisabledReasonButton
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="text-muted-foreground"
+          disabled={!canGenerate}
+          // `reason` doubles as the enabled-state hint ("Suggest a name from…").
+          reason={canGenerate ? null : reason}
+          title={reason}
+          onClick={() =>
+            gen.generate({
+              entries,
+              recentBranches: recentBranches.slice(0, 20),
+              useWorkingTree,
+              // Only when naming the very branch those commits sit on.
+              workingTreeSubjects:
+                nameTarget === "checked-out-branch"
+                  ? (committedFallback?.subjects ?? [])
+                  : [],
+              committedFallback,
+              onName,
+            })
+          }
+        >
+          <SparkleIcon data-icon="inline-start" />
+          Generate from changes
+        </DisabledReasonButton>
       )}
     </div>
   );

--- a/src/features/repository/PublishRepoControl.tsx
+++ b/src/features/repository/PublishRepoControl.tsx
@@ -1,5 +1,6 @@
 import { CaretDownIcon, UploadSimpleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -107,13 +108,15 @@ export function PublishRepoControl({
           Publish repository…
         </Button>
       ) : disabledTitle ? (
-        // `title` on a natively-disabled Button never shows — wrap it in a span.
-        <span title={disabledTitle}>
-          <Button variant="outline" size="sm" disabled>
-            <UploadSimpleIcon data-icon="inline-start" />
-            Publish repository…
-          </Button>
-        </span>
+        <DisabledReasonButton
+          variant="outline"
+          size="sm"
+          disabled
+          reason={disabledTitle}
+        >
+          <UploadSimpleIcon data-icon="inline-start" />
+          Publish repository…
+        </DisabledReasonButton>
       ) : null}
       <PublishDialog
         repoPath={repoPath}

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import {
@@ -373,65 +374,65 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
 
   return (
     <div className="flex items-center gap-2">
-      {/* Every segment is wrapped in a `title` <span> so a disabled button's
-          reason still shows on hover (a natively disabled button swallows its
-          own tooltip). Those spans have no `data-slot`, so they opt out of
-          ButtonGroup's border-collapse/rounding child selectors
-          (`*:data-slot:rounded-r-none` + `[&>[data-slot]~[data-slot]]`) — the
-          primitive then contributes only layout + `role="group"`, and THIS call
-          site owns the seams explicitly on the Buttons. The vendored Button is
-          square (`rounded-none` in its cva root and `sm` variant), so the only
+      {/* Every segment rides a wrapper span — DisabledReasonButton's own, and
+          the dropdown trigger's. Those spans have no `data-slot`, so they opt
+          out of ButtonGroup's border-collapse/rounding child selectors
+          (`*:data-slot:rounded-r-none` + `[&>[data-slot]~[data-slot]]`) —
+          ButtonGroup then contributes only layout + `role="group"`, and THIS
+          call site owns the seams explicitly on the Buttons. The vendored Button
+          is square (`rounded-none` in its cva root and `sm` variant), so the only
           load-bearing seam class is `border-l-0` on the joins. Keep it that way: a
-          future reorder must set these classes, not lean on the primitive's
+          future reorder must set these classes, not lean on ButtonGroup's
           adjacency magic (it has now misfired on two arrangements). The group's
           `*:focus-visible:z-10` also can't reach the Buttons through the spans,
           so each Button carries `focus-visible:relative focus-visible:z-10`. */}
       <ButtonGroup>
-        <span className="inline-flex" title={fetchHintTitle}>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy}
-            aria-keyshortcuts={fetchKeyshortcuts}
-            className="focus-visible:relative focus-visible:z-10"
-            onClick={() => doFetch(false)}
-          >
-            {fetchRemote.isPending ? (
-              <Spinner data-icon="inline-start" />
-            ) : (
-              <ArrowsClockwiseIcon data-icon="inline-start" />
-            )}
-            Fetch
-          </Button>
-        </span>
-        <span className="inline-flex" title={pullTitle}>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy || !hasUpstream || diverged}
-            aria-label={pullDescription}
-            aria-keyshortcuts={pullKeyshortcuts}
-            className="border-l-0 focus-visible:relative focus-visible:z-10"
-            onClick={() => doPull("ffOnly")}
-          >
-            {/* Covers the recovery compounds too: with the preference on they
-                run with no dialog open to show progress. */}
-            {pull.isPending || recovery.pending ? (
-              <Spinner data-icon="inline-start" />
-            ) : (
-              <ArrowDownIcon data-icon="inline-start" />
-            )}
-            Pull
-            {behindCount > 0 && (
-              <span
-                aria-hidden="true"
-                className="text-muted-foreground tabular-nums"
-              >
-                {behindCount}
-              </span>
-            )}
-          </Button>
-        </span>
+        <DisabledReasonButton
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          title={fetchHintTitle}
+          aria-keyshortcuts={fetchKeyshortcuts}
+          className="focus-visible:relative focus-visible:z-10"
+          onClick={() => doFetch(false)}
+        >
+          {fetchRemote.isPending ? (
+            <Spinner data-icon="inline-start" />
+          ) : (
+            <ArrowsClockwiseIcon data-icon="inline-start" />
+          )}
+          Fetch
+        </DisabledReasonButton>
+        <DisabledReasonButton
+          variant="outline"
+          size="sm"
+          disabled={busy || !hasUpstream || diverged}
+          // No `reason` on Pull or Push: `aria-label` already announces the
+          // description, so a describedby copy would read it twice; the wrapper
+          // still hovers `pullTitle`, shortcut included.
+          title={pullTitle}
+          aria-label={pullDescription}
+          aria-keyshortcuts={pullKeyshortcuts}
+          className="border-l-0 focus-visible:relative focus-visible:z-10"
+          onClick={() => doPull("ffOnly")}
+        >
+          {/* Covers the recovery compounds too: with the preference on they
+              run with no dialog open to show progress. */}
+          {pull.isPending || recovery.pending ? (
+            <Spinner data-icon="inline-start" />
+          ) : (
+            <ArrowDownIcon data-icon="inline-start" />
+          )}
+          Pull
+          {behindCount > 0 && (
+            <span
+              aria-hidden="true"
+              className="text-muted-foreground tabular-nums"
+            >
+              {behindCount}
+            </span>
+          )}
+        </DisabledReasonButton>
         <span className="inline-flex">
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -473,40 +474,39 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             </DropdownMenuContent>
           </DropdownMenu>
         </span>
-        <span className="inline-flex" title={pushTitle}>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy || detached}
-            aria-label={pushDescription}
-            aria-keyshortcuts={pushKeyshortcuts}
-            className="border-l-0 focus-visible:relative focus-visible:z-10"
-            onClick={() => {
-              if (diverged) {
-                setForceConfirmOpen(true);
-              } else {
-                void beginPush(false);
-              }
-            }}
-          >
-            {push.isPending || detecting ? (
-              <Spinner data-icon="inline-start" />
-            ) : diverged ? (
-              <WarningIcon data-icon="inline-start" />
-            ) : (
-              <ArrowUpIcon data-icon="inline-start" />
-            )}
-            {pushLabel}
-            {aheadCount > 0 && (
-              <span
-                aria-hidden="true"
-                className="text-muted-foreground tabular-nums"
-              >
-                {aheadCount}
-              </span>
-            )}
-          </Button>
-        </span>
+        <DisabledReasonButton
+          variant="outline"
+          size="sm"
+          disabled={busy || detached}
+          title={pushTitle}
+          aria-label={pushDescription}
+          aria-keyshortcuts={pushKeyshortcuts}
+          className="border-l-0 focus-visible:relative focus-visible:z-10"
+          onClick={() => {
+            if (diverged) {
+              setForceConfirmOpen(true);
+            } else {
+              void beginPush(false);
+            }
+          }}
+        >
+          {push.isPending || detecting ? (
+            <Spinner data-icon="inline-start" />
+          ) : diverged ? (
+            <WarningIcon data-icon="inline-start" />
+          ) : (
+            <ArrowUpIcon data-icon="inline-start" />
+          )}
+          {pushLabel}
+          {aheadCount > 0 && (
+            <span
+              aria-hidden="true"
+              className="text-muted-foreground tabular-nums"
+            >
+              {aheadCount}
+            </span>
+          )}
+        </DisabledReasonButton>
       </ButtonGroup>
 
       <Dialog open={forceConfirmOpen} onOpenChange={setForceConfirmOpen}>

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -402,30 +403,23 @@ export function TaskDialog({
                 Analyzing…
               </Button>
             ) : (
-              // A natively-disabled button swallows pointer events, so its own
-              // `title` never shows — the explanation lives on a wrapping span
-              // (the repo's established pattern for disabled-control tooltips).
-              <span
-                title={
-                  canAnalyze
-                    ? "Read the script and fill in the name, description, and documented arguments"
-                    : sourceKind === "file"
-                      ? "Choose a script file first"
-                      : "Write or generate a script first"
+              <DisabledReasonButton
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="text-muted-foreground"
+                disabled={!canAnalyze}
+                reason={
+                  sourceKind === "file"
+                    ? "Choose a script file first"
+                    : "Write or generate a script first"
                 }
+                title="Read the script and fill in the name, description, and documented arguments"
+                onClick={runAnalyze}
               >
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  className="text-muted-foreground"
-                  disabled={!canAnalyze}
-                  onClick={runAnalyze}
-                >
-                  <SparkleIcon data-icon="inline-start" />
-                  Analyze with AI
-                </Button>
-              </span>
+                <SparkleIcon data-icon="inline-start" />
+                Analyze with AI
+              </DisabledReasonButton>
             ))}
         </div>
 

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useRef, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -1263,25 +1264,22 @@ export function FindingsPanel({
       <div className="flex items-center gap-1 border-b p-2">
         <p className="text-xs text-muted-foreground">Security findings</p>
         <div className="ml-auto flex items-center gap-1">
-          {/* A `title` on a disabled Button never surfaces — the wrapper span is
-              what carries the explanation while the control is unusable. */}
-          <span title={refreshReason}>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              aria-label="Refresh findings"
-              disabled={!enabled || refreshing}
-              onClick={() =>
-                queryClient.invalidateQueries({
-                  queryKey: ["repo", repoPath, "findings"],
-                })
-              }
-            >
-              <ArrowClockwiseIcon
-                className={cn(refreshing && "animate-spin")}
-              />
-            </Button>
-          </span>
+          <DisabledReasonButton
+            variant="outline"
+            size="icon-sm"
+            aria-label="Refresh findings"
+            disabled={!enabled || refreshing}
+            // `refreshReason` doubles as the enabled-state hint ("Refresh findings").
+            reason={enabled ? null : refreshReason}
+            title={refreshReason}
+            onClick={() =>
+              queryClient.invalidateQueries({
+                queryKey: ["repo", repoPath, "findings"],
+              })
+            }
+          >
+            <ArrowClockwiseIcon className={cn(refreshing && "animate-spin")} />
+          </DisabledReasonButton>
         </div>
       </div>
       <div className="border-b p-2">

--- a/src/features/settings/AccountsSection.tsx
+++ b/src/features/settings/AccountsSection.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -234,15 +235,18 @@ function GitHubAccounts() {
                             </Button>
                           )}
                           {!account.active && (
-                            <Button
+                            <DisabledReasonButton
                               variant="outline"
                               size="xs"
                               disabled={!canSwitch || switchAccount.isPending}
-                              title={
+                              // Only the CLI-version term is a reason; an
+                              // in-flight switch would announce it falsely.
+                              reason={
                                 canSwitch
-                                  ? `Make ${account.login} the active account on ${account.host}`
+                                  ? undefined
                                   : "Switching needs GitHub CLI 2.40 or newer"
                               }
+                              title={`Make ${account.login} the active account on ${account.host}`}
                               onClick={() =>
                                 switchAccount.mutate(
                                   { host: account.host, login: account.login },
@@ -260,7 +264,7 @@ function GitHubAccounts() {
                                 <Spinner data-icon="inline-start" />
                               )}
                               Switch
-                            </Button>
+                            </DisabledReasonButton>
                           )}
                         </div>
                       );
@@ -565,24 +569,21 @@ function GitLabAccount() {
               </form.AppField>
 
               <div className="flex items-center gap-2">
-                {/* A natively-disabled button swallows its title tooltip, so wrap
-                    it in a span that carries the reason. */}
-                <span
+                <DisabledReasonButton
+                  type="submit"
+                  size="sm"
+                  disabled={!canSubmit || setToken.isPending}
+                  // No `reason`: the same text renders as the visible warning
+                  // beside the button, so announcing it would double up.
                   title={
                     canSubmit
                       ? undefined
                       : "Paste a project or group access token"
                   }
                 >
-                  <Button
-                    type="submit"
-                    size="sm"
-                    disabled={!canSubmit || setToken.isPending}
-                  >
-                    {setToken.isPending && <Spinner data-icon="inline-start" />}
-                    Connect
-                  </Button>
-                </span>
+                  {setToken.isPending && <Spinner data-icon="inline-start" />}
+                  Connect
+                </DisabledReasonButton>
                 {!canSubmit && (
                   <span className="text-xs text-warning">
                     Paste a project or group access token
@@ -859,13 +860,16 @@ function BitbucketAccount() {
               </div>
 
               <div className="flex items-center gap-2">
-                {/* A natively-disabled button swallows its title tooltip, so wrap
-                    it in a span that carries the reason. */}
-                <span title={disabledReason ?? undefined}>
-                  <Button type="submit" size="sm" disabled={!canSubmit}>
-                    {connected ? "Save token" : "Connect"}
-                  </Button>
-                </span>
+                <DisabledReasonButton
+                  type="submit"
+                  size="sm"
+                  disabled={!canSubmit}
+                  // No `reason`: the same text renders as the visible warning
+                  // beside the button, so announcing it would double up.
+                  title={disabledReason ?? undefined}
+                >
+                  {connected ? "Save token" : "Connect"}
+                </DisabledReasonButton>
                 {replacing && (
                   <Button
                     type="button"

--- a/src/features/settings/mcp/GitDesktopAsServer.tsx
+++ b/src/features/settings/mcp/GitDesktopAsServer.tsx
@@ -2,6 +2,7 @@ import { CaretRightIcon, CheckIcon, CopyIcon } from "@phosphor-icons/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -350,48 +351,44 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
           <span className="text-xs font-medium">{label}</span>
           <div className="flex items-center gap-2">
             {status?.installed && (
-              // A title on a natively-disabled button never surfaces, so wrap it.
-              <span title={removeReason ?? undefined}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  disabled={removeReason !== null}
-                  onClick={() => removeGlobal(client)}
-                >
-                  {removing ? (
-                    <>
-                      <Spinner className="size-3" /> Removing…
-                    </>
-                  ) : (
-                    "Remove"
-                  )}
-                </Button>
-              </span>
-            )}
-            {/* A title on a natively-disabled button never surfaces, so wrap it. */}
-            <span title={installReason ?? undefined}>
-              <Button
+              <DisabledReasonButton
                 type="button"
-                variant="outline"
+                variant="ghost"
                 size="sm"
-                disabled={installReason !== null}
-                onClick={() => install(client, false)}
+                disabled={removeReason !== null}
+                reason={removeReason}
+                onClick={() => removeGlobal(client)}
               >
-                {installing ? (
+                {removing ? (
                   <>
-                    <Spinner className="size-3" />{" "}
-                    {status?.installed && (!status.current || drift)
-                      ? "Reinstalling…"
-                      : "Adding…"}
+                    <Spinner className="size-3" /> Removing…
                   </>
-                ) : status?.installed && (!status.current || drift) ? (
-                  "Reinstall"
                 ) : (
-                  "Install"
+                  "Remove"
                 )}
-              </Button>
-            </span>
+              </DisabledReasonButton>
+            )}
+            <DisabledReasonButton
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={installReason !== null}
+              reason={installReason}
+              onClick={() => install(client, false)}
+            >
+              {installing ? (
+                <>
+                  <Spinner className="size-3" />{" "}
+                  {status?.installed && (!status.current || drift)
+                    ? "Reinstalling…"
+                    : "Adding…"}
+                </>
+              ) : status?.installed && (!status.current || drift) ? (
+                "Reinstall"
+              ) : (
+                "Install"
+              )}
+            </DisabledReasonButton>
           </div>
         </div>
         {globalStatusLoading ? (
@@ -590,54 +587,49 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
               Paste into your client's MCP config
             </span>
             <div className="flex items-center gap-2">
-              {/* A title on a natively-disabled button never surfaces, so wrap it. */}
-              <span title={entryDisabledReason ?? undefined}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  disabled={entryDisabledReason !== null}
-                  onClick={copy}
-                >
-                  {copied ? (
-                    <>
-                      <CheckIcon data-icon="inline-start" /> Copied
-                    </>
-                  ) : (
-                    <>
-                      <CopyIcon data-icon="inline-start" /> Copy
-                    </>
-                  )}
-                </Button>
-              </span>
-              <span
-                title={
+              <DisabledReasonButton
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={entryDisabledReason !== null}
+                reason={entryDisabledReason}
+                onClick={copy}
+              >
+                {copied ? (
+                  <>
+                    <CheckIcon data-icon="inline-start" /> Copied
+                  </>
+                ) : (
+                  <>
+                    <CopyIcon data-icon="inline-start" /> Copy
+                  </>
+                )}
+              </DisabledReasonButton>
+              <DisabledReasonButton
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={
+                  !repoPath ||
+                  busyTarget !== null ||
+                  entryDisabledReason !== null
+                }
+                reason={
                   entryDisabledReason ??
                   (repoPath
                     ? undefined
                     : "Open a repository to write its .mcp.json")
                 }
+                onClick={() => install("project", false)}
               >
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={
-                    !repoPath ||
-                    busyTarget !== null ||
-                    entryDisabledReason !== null
-                  }
-                  onClick={() => install("project", false)}
-                >
-                  {busyTarget === "project" ? (
-                    <>
-                      <Spinner className="size-3" /> Writing…
-                    </>
-                  ) : (
-                    "Write to .mcp.json"
-                  )}
-                </Button>
-              </span>
+                {busyTarget === "project" ? (
+                  <>
+                    <Spinner className="size-3" /> Writing…
+                  </>
+                ) : (
+                  "Write to .mcp.json"
+                )}
+              </DisabledReasonButton>
             </div>
           </div>
           {launcherErrorMessage && (
@@ -762,27 +754,23 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
                 >
                   Cancel
                 </Button>
-                {/* A title on a natively-disabled button never surfaces, so wrap it. */}
-                <span title={confirmDisabledReason ?? undefined}>
-                  <Button
-                    type="button"
-                    size="sm"
-                    disabled={
-                      busyTarget !== null || confirmDisabledReason !== null
-                    }
-                    onClick={() =>
-                      confirmTarget && install(confirmTarget, true)
-                    }
-                  >
-                    {busyTarget !== null ? (
-                      <>
-                        <Spinner className="size-3" /> Replacing…
-                      </>
-                    ) : (
-                      "Replace entry"
-                    )}
-                  </Button>
-                </span>
+                <DisabledReasonButton
+                  type="button"
+                  size="sm"
+                  disabled={
+                    busyTarget !== null || confirmDisabledReason !== null
+                  }
+                  reason={confirmDisabledReason}
+                  onClick={() => confirmTarget && install(confirmTarget, true)}
+                >
+                  {busyTarget !== null ? (
+                    <>
+                      <Spinner className="size-3" /> Replacing…
+                    </>
+                  ) : (
+                    "Replace entry"
+                  )}
+                </DisabledReasonButton>
               </DialogFooter>
             </DialogContent>
           </Dialog>

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -8,6 +8,7 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -47,6 +48,7 @@ import {
   writeAccessReason,
 } from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
@@ -85,11 +87,6 @@ export function TagDetailView({
   const writeAccess = useRepoWriteAccess(repoPath, undefined, !!provider);
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
-  // A natively-disabled Button swallows `title`, so every hint below rides a
-  // wrapping span (house idiom).
-  const blockedSpanClass = writeBlocked
-    ? "inline-flex cursor-not-allowed"
-    : "inline-flex";
   const remoteLabel = providerLabel(provider);
   // Ask the provider for a release only when connected; otherwise it's just a tag.
   const release = useReleaseDetails(repoPath, ghReady ? tag : null);
@@ -157,6 +154,25 @@ export function TagDetailView({
     );
   }
 
+  // Shared by both provider arms, which differ in what is actually lost: GitHub's
+  // uploaded binary is gone for good, while a GitLab asset link can be re-added.
+  async function onDeleteAsset(assetName: string, kind: "asset" | "link") {
+    const ok = await useConfirm.getState().ask({
+      title: `Delete ${assetName}?`,
+      body:
+        kind === "asset"
+          ? "Removes this asset from the release. This cannot be undone."
+          : "Removes this link from the release.",
+      confirmLabel: "Delete",
+      confirmVariant: "destructive",
+    });
+    if (!ok) return;
+    deleteAsset.mutate(
+      { tag, assetName },
+      { onSuccess: () => toast.success("Asset deleted"), onError },
+    );
+  }
+
   // ── Release view ───────────────────────────────────────────────────────────
   if (rel) {
     // The updater manifest is a GitHub-only Tauri asset, so the sync affordance only
@@ -180,67 +196,64 @@ export function TagDetailView({
             {canManage && (
               <>
                 {rel.isDraft && (
-                  <span title={writeReason} className={blockedSpanClass}>
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      disabled={editRelease.isPending || writeBlocked}
-                      onClick={() =>
-                        editRelease.mutate(
-                          {
-                            tag,
-                            title: "",
-                            notes: "",
-                            prerelease: rel.isPrerelease,
-                            draft: false,
-                            // Omit --latest so GitHub applies its default (a newly
-                            // published stable release becomes Latest, like the web UI).
-                            // A draft's isLatest is structurally false — sending it here
-                            // was the bug that stripped Latest on publish.
-                            latest: undefined,
-                          },
-                          {
-                            onSuccess: () => toast.success("Published"),
-                            onError,
-                          },
-                        )
-                      }
-                    >
-                      Publish
-                    </Button>
-                  </span>
+                  <DisabledReasonButton
+                    variant="outline"
+                    size="xs"
+                    disabled={editRelease.isPending || writeBlocked}
+                    reason={writeReason}
+                    onClick={() =>
+                      editRelease.mutate(
+                        {
+                          tag,
+                          title: "",
+                          notes: "",
+                          prerelease: rel.isPrerelease,
+                          draft: false,
+                          // Omit --latest so GitHub applies its default (a newly
+                          // published stable release becomes Latest, like the web UI).
+                          // A draft's isLatest is structurally false — sending it here
+                          // was the bug that stripped Latest on publish.
+                          latest: undefined,
+                        },
+                        {
+                          onSuccess: () => toast.success("Published"),
+                          onError,
+                        },
+                      )
+                    }
+                  >
+                    Publish
+                  </DisabledReasonButton>
                 )}
-                <span title={writeReason} className={blockedSpanClass}>
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    disabled={writeBlocked}
-                    onClick={() => {
-                      setEditTitle(rel.name);
-                      setEditNotes(rel.body);
-                      setEditPrerelease(rel.isPrerelease);
-                      setEditLatest(isLatest);
-                      setEditSyncUpdater(true);
-                      setSyncArmed(false);
-                      setEditOpen(true);
-                    }}
-                  >
-                    Edit
-                  </Button>
-                </span>
-                <span title={writeReason} className={blockedSpanClass}>
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    disabled={writeBlocked}
-                    onClick={() => {
-                      setCleanupTag(false);
-                      setDeleteOpen(true);
-                    }}
-                  >
-                    Delete
-                  </Button>
-                </span>
+                <DisabledReasonButton
+                  variant="outline"
+                  size="xs"
+                  disabled={writeBlocked}
+                  reason={writeReason}
+                  onClick={() => {
+                    setEditTitle(rel.name);
+                    setEditNotes(rel.body);
+                    setEditPrerelease(rel.isPrerelease);
+                    setEditLatest(isLatest);
+                    setEditSyncUpdater(true);
+                    setSyncArmed(false);
+                    setEditOpen(true);
+                  }}
+                >
+                  Edit
+                </DisabledReasonButton>
+                <DisabledReasonButton
+                  variant="outline"
+                  size="xs"
+                  disabled={writeBlocked}
+                  reason={writeReason}
+                  onClick={() => {
+                    setCleanupTag(false);
+                    setDeleteOpen(true);
+                  }}
+                >
+                  Delete
+                </DisabledReasonButton>
               </>
             )}
             {rel.url && (
@@ -286,21 +299,20 @@ export function TagDetailView({
                 <span className="flex-1" />
                 {/* GitHub attaches a binary; GitLab uploads + links the file. */}
                 {canManage && (
-                  <span title={writeReason} className={blockedSpanClass}>
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      disabled={uploadAsset.isPending || writeBlocked}
-                      onClick={onUpload}
-                    >
-                      {uploadAsset.isPending ? (
-                        <Spinner data-icon="inline-start" />
-                      ) : (
-                        <UploadSimpleIcon data-icon="inline-start" />
-                      )}
-                      Upload
-                    </Button>
-                  </span>
+                  <DisabledReasonButton
+                    variant="ghost"
+                    size="xs"
+                    disabled={uploadAsset.isPending || writeBlocked}
+                    reason={writeReason}
+                    onClick={onUpload}
+                  >
+                    {uploadAsset.isPending ? (
+                      <Spinner data-icon="inline-start" />
+                    ) : (
+                      <UploadSimpleIcon data-icon="inline-start" />
+                    )}
+                    Upload
+                  </DisabledReasonButton>
                 )}
               </div>
               {rel.assets.length === 0 ? (
@@ -309,10 +321,7 @@ export function TagDetailView({
                 </p>
               ) : (
                 rel.assets.map((a) => (
-                  <div
-                    key={a.name}
-                    className="group flex items-center gap-2 text-xs"
-                  >
+                  <div key={a.name} className="flex items-center gap-2 text-xs">
                     <span
                       className="min-w-0 flex-1 truncate font-mono"
                       title={a.name}
@@ -332,27 +341,17 @@ export function TagDetailView({
                         >
                           <DownloadSimpleIcon />
                         </Button>
-                        <span title={writeReason} className={blockedSpanClass}>
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            aria-label={`Delete ${a.name}`}
-                            disabled={writeBlocked}
-                            className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                            onClick={() =>
-                              deleteAsset.mutate(
-                                { tag, assetName: a.name },
-                                {
-                                  onSuccess: () =>
-                                    toast.success("Asset deleted"),
-                                  onError,
-                                },
-                              )
-                            }
-                          >
-                            <TrashIcon />
-                          </Button>
-                        </span>
+                        <DisabledReasonButton
+                          variant="ghost"
+                          size="icon-xs"
+                          aria-label={`Delete ${a.name}`}
+                          disabled={deleteAsset.isPending || writeBlocked}
+                          reason={writeReason}
+                          className="text-muted-foreground"
+                          onClick={() => onDeleteAsset(a.name, "asset")}
+                        >
+                          <TrashIcon />
+                        </DisabledReasonButton>
                       </>
                     ) : (
                       // GitLab asset links carry no size/download count — open the
@@ -371,30 +370,17 @@ export function TagDetailView({
                           </Button>
                         )}
                         {canManage && (
-                          <span
-                            title={writeReason}
-                            className={blockedSpanClass}
+                          <DisabledReasonButton
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label={`Delete ${a.name}`}
+                            disabled={deleteAsset.isPending || writeBlocked}
+                            reason={writeReason}
+                            className="text-muted-foreground"
+                            onClick={() => onDeleteAsset(a.name, "link")}
                           >
-                            <Button
-                              variant="ghost"
-                              size="icon-xs"
-                              aria-label={`Delete ${a.name}`}
-                              disabled={writeBlocked}
-                              className="text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-                              onClick={() =>
-                                deleteAsset.mutate(
-                                  { tag, assetName: a.name },
-                                  {
-                                    onSuccess: () =>
-                                      toast.success("Asset deleted"),
-                                    onError,
-                                  },
-                                )
-                              }
-                            >
-                              <TrashIcon />
-                            </Button>
-                          </span>
+                            <TrashIcon />
+                          </DisabledReasonButton>
                         )}
                       </>
                     )}
@@ -646,16 +632,15 @@ export function TagDetailView({
           <h2 className="font-mono text-sm font-medium">{tag}</h2>
           <span className="flex-1" />
           {ghReady && canCreate && (
-            <span title={writeReason} className={blockedSpanClass}>
-              <Button
-                variant="outline"
-                size="xs"
-                disabled={writeBlocked}
-                onClick={() => setCreateReleaseOpen(true)}
-              >
-                Create release
-              </Button>
-            </span>
+            <DisabledReasonButton
+              variant="outline"
+              size="xs"
+              disabled={writeBlocked}
+              reason={writeReason}
+              onClick={() => setCreateReleaseOpen(true)}
+            >
+              Create release
+            </DisabledReasonButton>
           )}
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -504,6 +504,17 @@ function RepoRow({
     : repo.fork
       ? GitForkIcon
       : BookBookmarkIcon;
+  // One glyph stands for both states, so its label names both; role="img" hides
+  // the icon from readers, leaving the label to carry the meaning alone. A plain
+  // repo stays unlabelled — nothing in the app badges a repo "public". The glyph
+  // takes no `title`: the row already hovers its description / full name.
+  const stateLabel = repo.private
+    ? repo.fork
+      ? "Private fork"
+      : "Private repository"
+    : repo.fork
+      ? "Fork"
+      : null;
   return (
     <button
       type="button"
@@ -517,7 +528,17 @@ function RepoRow({
         active ? "bg-accent text-accent-foreground" : "hover:bg-muted/60",
       )}
     >
-      <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+      {stateLabel ? (
+        <span
+          role="img"
+          aria-label={stateLabel}
+          className="flex shrink-0 items-center text-muted-foreground"
+        >
+          <Icon className="size-3.5" aria-hidden />
+        </span>
+      ) : (
+        <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      )}
       <span className="min-w-0 flex-1 truncate">{repo.name}</span>
       {repo.archived && (
         <Badge variant="secondary" className="shrink-0 text-[10px]">

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -27,6 +27,7 @@ import { cloneRepo, forgeClone, validateRepo } from "@/lib/git/api";
 import { useForgeRepos } from "@/lib/git/queries";
 import type { ForgeProvider, ForgeRepo } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { repoStateLabel } from "@/lib/repo-labels";
 import { useAddRecentRepo, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage, isAppError } from "@/lib/tauri/invoke";
@@ -504,17 +505,9 @@ function RepoRow({
     : repo.fork
       ? GitForkIcon
       : BookBookmarkIcon;
-  // One glyph stands for both states, so its label names both; role="img" hides
-  // the icon from readers, leaving the label to carry the meaning alone. A plain
-  // repo stays unlabelled — nothing in the app badges a repo "public". The glyph
-  // takes no `title`: the row already hovers its description / full name.
-  const stateLabel = repo.private
-    ? repo.fork
-      ? "Private fork"
-      : "Private repository"
-    : repo.fork
-      ? "Fork"
-      : null;
+  // The glyph takes no `title`: the row already hovers its description / full
+  // name.
+  const stateLabel = repoStateLabel(repo.private, repo.fork);
   return (
     <button
       type="button"

--- a/src/lib/repo-labels.ts
+++ b/src/lib/repo-labels.ts
@@ -1,0 +1,17 @@
+/**
+ * Accessible name for a repo-state glyph. One glyph stands for both states, so
+ * the label names both; a plain repo stays unlabelled — nothing in the app
+ * badges a repo "public".
+ */
+export function repoStateLabel(
+  isPrivate: boolean,
+  isFork: boolean,
+): string | null {
+  return isPrivate
+    ? isFork
+      ? "Private fork"
+      : "Private repository"
+    : isFork
+      ? "Fork"
+      : null;
+}


### PR DESCRIPTION
Disabled buttons across the app carried their reason in a `title` on a wrapping `<span>` — a hand-rolled idiom repeated in ~40 files that leaves the button out of the tab order, so screen-reader users never hear why an action is refused. This introduces a single `DisabledReasonButton` primitive that keeps a reason-bearing disabled button focusable and announces its reason, then migrates every hand-rolled site to it and closes out the surrounding accessibility gaps (icon-only states, toggle states, hover-only row actions, arrow-key nav).

### Disabled-reason primitive

- Adds `src/components/disabled-reason-button.tsx`: when `disabled` and `reason` are both set it swaps the native attribute for Base UI's `focusableWhenDisabled` (`aria-disabled`), keeps the button in the tab order, wires the reason through `aria-describedby` (preserving any caller-supplied description) plus an `sr-only` node, and puts the hover text on the wrapper span since both disabled paths kill pointer events. A reason-less disable stays natively disabled rather than becoming a mute tab stop. The `aria-disabled:` dim lifts under focus so a keyboard user isn't tracking a half-opacity focus ring.
- Migrates the hand-rolled `<span title>` wrappers to the primitive across the app — `features/actions/ActionsPanel.tsx` and `RunDetailView.tsx`, `commit/CommitBox.tsx`, `compare/ComparePanel.tsx`, `pulls/ChecksRollup.tsx`, `PrMergeabilityBanner.tsx`, `CommitComments.tsx`, `ResolveConflictsView.tsx`, `ResolveRemotePrView.tsx`, `ReviewComposer.tsx`, `ReviewThreads.tsx`, `SubmitReviewDialog.tsx`, `issues/RemoteIssueViewParts.tsx`, `IssueRelations.tsx`, `RepoJiraDialog.tsx`, `history/EditHistoryDialog.tsx`, `RewriteDialogs.tsx`, `repository/*`, `repo-settings/*`, `settings/*`, `tags/TagDetailView.tsx`, `scripts/TaskDialog.tsx`, `security-findings/FindingsPanel.tsx`, `automations/RepoAutomationsDialog.tsx`, `branch-rules/BranchRulesDialog.tsx`, `welcome/CloneRepoDialog.tsx`, and others.
- Documents the trigger-site carve-out where a `render` target can't carry the wrapper: `discussions/DiscussionsPanel.tsx` keeps a titled span *around* the `DropdownMenuTrigger`, whose own `disabled` is what keeps the menu inert.

### Pull request views

- Keeps the Merge menu shut while merging is unavailable in `pulls/LocalPrView.tsx` and `RemotePrView.tsx`: the blocked state and refusal text are hoisted, `disabled` moves onto the trigger, and the reason rides the wrapping span. `RemotePrView` folds draft, missing merge guard, and all-methods-blocked into one reason with write permission outranking them.
- Derives the PR sub-tab strip from an `availableSections` list in both views so no path can select a tab that isn't rendered. The activity dock's pending "review" hint now clears even when the Review tab is unavailable, and a `useLayoutEffect` falls back to Conversation when availability drops away (Hide AI toggled, a capability lost on refetch) — `RemotePrView` gates both on `capabilitiesSettled` so the provisional `canComment` verdict isn't acted on.
- Replaces the fake disabled "Checked out" button in `RemotePrView.tsx` with a `role="img"` status element — no button role, no tab stop, and a label that states the whole thing.
- Adds `aria-pressed` to the local PR approve toggle in `LocalPrView.tsx`.

### Icon-only and toggle states

- Names each check and workflow step's state in `pulls/ChecksRollup.tsx` via a wrapping `role="img"` span (using `statusLabel`), since `aria-label` isn't valid or reliably announced on a bare `<svg>`, and deliberately omits `title` so the row's own tooltip isn't shadowed.
- Labels the repository glyph and star counts in `explore/ExploreResultRow.tsx` and `ExploreDetail.tsx` — private/fork glyphs get a state label, star counts get a labelled `role="img"` carrying the number and its unit, and a plain repo stays unlabelled.
- Adds `aria-label` + `aria-pressed` to the reaction chips in `conversations/ReactionBar.tsx` and the upvote button in `discussions/DiscussionView.tsx`.

### Rows and lists

- Makes the linked-issue remove button always visible in `issues/IssueRelations.tsx` (drops the `group-hover:opacity-100` reveal), keeping full opacity for the in-flight spinner on both the native and `aria-disabled` paths.
- Wires arrow-key navigation into the hook list in `hooks/HooksDialog.tsx` via `listKeyboardNav`, matching the rest of the app's lists.

### Changelog

- Adds seven fragments under `changelog.d/` covering the disabled-reason behavior, icon accessible names, toggle and list a11y, always-visible row actions, the blocked Merge menu, the review-tab availability fix, and the release-asset delete confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release-asset deletion now requires confirmation on GitHub and GitLab.
  * Remove actions for release assets and linked issues remain visible.
  * Merge menus stay closed when merging is unavailable.
  * Pull request views fall back to Conversation when AI Review is unavailable.

* **Accessibility**
  * Disabled actions explain why they are unavailable and remain keyboard- and screen-reader accessible.
  * Improved accessible labels for repository states, counts, checks, workflow steps, reactions, and votes.
  * Added arrow-key navigation for Git hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->