### PR TITLE
feat(conversations,discussions,pulls,issues): keep comment drafts per entity

### DIFF
--- a/changelog.d/changed-drafts-per-entity.md
+++ b/changelog.d/changed-drafts-per-entity.md
@@ -1,3 +1,3 @@
 - The comment box now keeps a separate draft for each discussion, pull request,
-  issue, and commit you're working in, so you can switch between them and pick
-  up where you left off.
+  issue, and History commit you're working in, so you can switch between them
+  and pick up where you left off.

--- a/changelog.d/changed-drafts-per-entity.md
+++ b/changelog.d/changed-drafts-per-entity.md
@@ -1,0 +1,2 @@
+- Comment drafts now stick to the discussion, pull request, issue, or commit
+  they were written on — switch away and come back without losing typed text.

--- a/changelog.d/changed-drafts-per-entity.md
+++ b/changelog.d/changed-drafts-per-entity.md
@@ -1,2 +1,3 @@
-- Comment drafts now stick to the discussion, pull request, issue, or commit
-  they were written on — switch away and come back without losing typed text.
+- The comment box now keeps a separate draft for each discussion, pull request,
+  issue, and commit you're working in, so you can switch between them and pick
+  up where you left off.

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -7,11 +7,11 @@ import { Button } from "@/components/ui/button";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
 
 /**
- * The bottom "leave a comment" bar every conversation surface ends with. The
- * draft lives in CALLER state — each view clears it when the entity it shows
- * changes, which a composer-owned draft would silently break — so this is a
- * fully controlled component. Per-surface extras (Approve, Close, Review…) ride
- * the `actions` slot rather than growing the prop list.
+ * The bottom "leave a comment" bar every conversation surface ends with. Fully
+ * controlled: the draft lives in CALLER state, keyed there per entity so a
+ * switch retains it, which a composer-owned draft could not do. Per-surface
+ * extras (Approve, Close, Review…) ride the `actions` slot rather than growing
+ * the prop list.
  */
 export function CommentComposer({
   ref,

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -34,9 +34,9 @@ export function LabelsPopover({
   labels: RepoLabel[];
   /** The origin|upstream lens the parent PR/issue surface resolved. */
   lens: RemoteLens;
-  /** Set when the viewer lacks the access this picker's action needs — callers
-   *  pass the reason for the matching axis. The trigger stays visible but
-   *  disabled and this text explains why. Absent = editable as before. */
+  /** Set when this picker can't be edited right now — the viewer lacks the access
+   *  its action needs, or the surface is still loading the entity. The trigger
+   *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
 }) {
   const repoLabels = useRepoLabels(repoPath, enabled, lens);

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -90,6 +90,7 @@ export function Thread({
   thread,
   onQuote,
   onSaveEdit,
+  editHeld = false,
   onDelete,
   onHide,
   onUnhide,
@@ -112,6 +113,11 @@ export function Thread({
   copyMarkdown?: string;
   /** Present when the viewer may edit this comment; saves the new body. */
   onSaveEdit?: (body: string) => void;
+  /** Holds an ALREADY-OPEN editor's Save without claiming a write is running —
+   *  withholding `onSaveEdit` only removes the menu's Edit entry, so an editor
+   *  opened before the caller went stale would otherwise save into nothing and
+   *  close, discarding the text. */
+  editHeld?: boolean;
   /** Present when the viewer may delete this comment. */
   onDelete?: () => void;
   /** Hide (minimize) the comment with a reason. */
@@ -249,8 +255,13 @@ export function Thread({
           ariaLabel="Edit comment"
           value={draft}
           onChange={setDraft}
-          canSubmit={!!draft.trim() && draft.trim() !== thread.body.trim()}
+          canSubmit={
+            !!draft.trim() && draft.trim() !== thread.body.trim() && !editHeld
+          }
           onSubmit={() => {
+            // Return BEFORE closing: a held save must keep the draft on screen
+            // rather than swallow it.
+            if (editHeld) return;
             onSaveEdit?.(draft.trim());
             setEditing(false);
           }}

--- a/src/features/conversations/useLocalConversation.ts
+++ b/src/features/conversations/useLocalConversation.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import type { MarkdownEditorHandle } from "@/components/markdown-editor";
+import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { makeQuoteReply } from "./quoteReply";
 
 /** A comment on a local (offline) PR or issue. */
@@ -29,13 +30,18 @@ export interface LocalConvEntity {
  * guards on it.
  *
  * `openEdit`/`editForm` stay at the call site (they need the per-view title);
- * this hook owns only conversation/label/composer state.
+ * this hook owns only conversation/label/composer state. The comment draft is
+ * keyed on `id` — the same identity the views reset on — so each entity keeps
+ * its own unsent text while the view stays mounted.
  */
 export function useLocalConversation<T extends LocalConvEntity>(
+  id: string,
   entity: T | undefined,
   apply: (mutate: (cur: T) => T) => void,
 ) {
-  const [comment, setComment] = useState("");
+  const draft = useKeyedEntityState(id, "");
+  const comment = draft.value;
+  const setComment = draft.set;
   const [labelInput, setLabelInput] = useState("");
   const [deletingCommentId, setDeletingCommentId] = useState<string | null>(
     null,

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -271,8 +271,13 @@ export function DiscussionView({
 
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
   // React Compiler bail out of this whole component (refs-in-render rule).
-  const quoteReply = (body: string) =>
+  const quoteReply = (body: string) => {
+    // Every quotable body — the discussion's and each rendered comment's — belongs
+    // to the discussion on screen, which mid-switch is the previous one, while the
+    // draft it would land in is keyed to the new one.
+    if (details.isPlaceholderData) return;
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
+  };
 
   function saveCommentEdit(commentId: string, body: string) {
     updateComment.mutate(
@@ -541,7 +546,10 @@ export function DiscussionView({
                   >
                     Copy link
                   </DropdownMenuItem>
-                  {hasVisibleBody(d.body) && (
+                  {/* Absent, not disabled, while the body belongs to the previous
+                      discussion — the same shape the comment menus take when their
+                      `onQuote` is withheld. */}
+                  {hasVisibleBody(d.body) && !details.isPlaceholderData && (
                     <DropdownMenuItem onClick={() => quoteReply(d.body)}>
                       Quote reply
                     </DropdownMenuItem>
@@ -587,7 +595,11 @@ export function DiscussionView({
                 )}
                 <Thread
                   thread={toThread(c)}
-                  onQuote={() => quoteReply(c.body)}
+                  onQuote={
+                    details.isPlaceholderData
+                      ? undefined
+                      : () => quoteReply(c.body)
+                  }
                   onSaveEdit={
                     c.viewerDidAuthor
                       ? (body) => saveCommentEdit(c.id, body)
@@ -650,7 +662,11 @@ export function DiscussionView({
                     <Thread
                       key={r.id}
                       thread={toThread(r)}
-                      onQuote={() => quoteReply(r.body)}
+                      onQuote={
+                        details.isPlaceholderData
+                          ? undefined
+                          : () => quoteReply(r.body)
+                      }
                       onSaveEdit={
                         r.viewerDidAuthor
                           ? (body) => saveCommentEdit(r.id, body)

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -5,7 +5,7 @@ import {
   DotsThreeIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffectEvent, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   MarkdownEditor,
@@ -74,6 +74,7 @@ import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
+import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { cn } from "@/lib/utils";
 
 /** A discussion comment/reply shares the conversation shape minus review state. */
@@ -118,6 +119,11 @@ const CLOSE_REASONS: [string, DiscussionCloseReason][] = [
   ["Outdated", "OUTDATED"],
   ["Duplicate", "DUPLICATE"],
 ];
+
+/** Which comment the reply box is open under, and the text typed into it —
+ *  one value so both travel together per discussion. */
+type ReplyDraft = { targetId: string | null; body: string };
+const EMPTY_REPLY: ReplyDraft = { targetId: null, body: "" };
 
 function UpvoteButton({
   count,
@@ -187,39 +193,31 @@ export function DiscussionView({
   const setPendingIssueDraft = useUiStore((s) => s.setPendingIssueDraft);
   const selectDiscussion = useUiStore((s) => s.selectDiscussion);
 
-  const [composeBody, setComposeBody] = useState("");
   const composerRef = useRef<MarkdownEditorHandle>(null);
-  const [replyingTo, setReplyingTo] = useState<string | null>(null);
-  const [replyBody, setReplyBody] = useState("");
   const [deletingCommentId, setDeletingCommentId] = useState<string | null>(
     null,
   );
   const [deletingDiscussion, setDeletingDiscussion] = useState(false);
-  // A different discussion must never inherit this one's unsent drafts, reply
-  // target, or delete confirm — render-time, not an effect. The repo is part of
-  // the identity because discussion numbers repeat across repos.
+  // The repo is part of the identity because discussion numbers repeat across
+  // repos.
   const discussionIdentity = `${repoPath}#${number}`;
+  const compose = useKeyedEntityState(discussionIdentity, "");
+  const reply = useKeyedEntityState(
+    discussionIdentity,
+    EMPTY_REPLY,
+    (v) => v.targetId === null && v.body === "",
+  );
+  // A different discussion must never inherit this one's delete confirm — a
+  // render-time state adjustment, not an effect.
   const [lastIdentity, setLastIdentity] = useState(discussionIdentity);
   if (discussionIdentity !== lastIdentity) {
+    // Reply drafts reset on switch, unlike the compose draft: the reply box
+    // autoFocuses, so a restored one would steal focus and scroll on return.
+    reply.clearFor(lastIdentity);
     setLastIdentity(discussionIdentity);
-    setComposeBody("");
-    setReplyingTo(null);
-    setReplyBody("");
     setDeletingCommentId(null);
     setDeletingDiscussion(false);
   }
-  // Both submits clear their composer only once the mutation resolves, which can
-  // be after a switch — an effect event reads the LIVE identity so a late success
-  // can't wipe text the user has since typed against another discussion.
-  const clearComposeIfSame = useEffectEvent((submittedFor: string) => {
-    if (submittedFor !== discussionIdentity) return;
-    setComposeBody("");
-  });
-  const clearReplyIfSame = useEffectEvent((submittedFor: string) => {
-    if (submittedFor !== discussionIdentity) return;
-    setReplyBody("");
-    setReplyingTo(null);
-  });
 
   const onError = (e: unknown) => toastError(e);
   const d = details.data;
@@ -237,25 +235,34 @@ export function DiscussionView({
     return <DiffPlaceholder message="Could not load this discussion" />;
   }
 
+  // Placeholder details are the PREVIOUSLY shown discussion's, so every write
+  // during the switch window would target that one — gate them all on it.
   const busy =
-    addComment.isPending || markAnswer.isPending || deleteComment.isPending;
+    addComment.isPending ||
+    markAnswer.isPending ||
+    deleteComment.isPending ||
+    details.isPlaceholderData;
 
   function submitComment() {
-    if (!d || !composeBody.trim()) return;
+    if (!d || details.isPlaceholderData || !compose.value.trim()) return;
     const submittedFor = discussionIdentity;
     addComment.mutate(
-      { discussionId: d.id, body: composeBody.trim() },
-      { onSuccess: () => clearComposeIfSame(submittedFor), onError },
+      { discussionId: d.id, body: compose.value.trim() },
+      { onSuccess: () => compose.clearFor(submittedFor), onError },
     );
   }
 
   function submitReply(commentId: string) {
-    if (!d || !replyBody.trim()) return;
+    if (!d || details.isPlaceholderData || !reply.value.body.trim()) return;
     const submittedFor = discussionIdentity;
     addComment.mutate(
-      { discussionId: d.id, body: replyBody.trim(), replyToId: commentId },
       {
-        onSuccess: () => clearReplyIfSame(submittedFor),
+        discussionId: d.id,
+        body: reply.value.body.trim(),
+        replyToId: commentId,
+      },
+      {
+        onSuccess: () => reply.clearFor(submittedFor),
         onError,
       },
     );
@@ -264,7 +271,7 @@ export function DiscussionView({
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
   // React Compiler bail out of this whole component (refs-in-render rule).
   const quoteReply = (body: string) =>
-    makeQuoteReply({ composerRef, setBody: setComposeBody })(body);
+    makeQuoteReply({ composerRef, setBody: compose.set })(body);
 
   function saveCommentEdit(commentId: string, body: string) {
     updateComment.mutate(
@@ -615,10 +622,12 @@ export function DiscussionView({
                   size="xs"
                   variant="ghost"
                   disabled={busy}
-                  onClick={() => {
-                    setReplyBody("");
-                    setReplyingTo(replyingTo === c.id ? null : c.id);
-                  }}
+                  onClick={() =>
+                    reply.set((prev) => ({
+                      targetId: prev.targetId === c.id ? null : c.id,
+                      body: "",
+                    }))
+                  }
                 >
                   Reply
                 </Button>
@@ -634,7 +643,7 @@ export function DiscussionView({
                   </Button>
                 )}
               </div>
-              {(c.replies.length > 0 || replyingTo === c.id) && (
+              {(c.replies.length > 0 || reply.value.targetId === c.id) && (
                 <div className="space-y-3 border-l pl-4">
                   {c.replies.map((r) => (
                     <Thread
@@ -665,14 +674,16 @@ export function DiscussionView({
                       }
                     />
                   ))}
-                  {replyingTo === c.id && (
+                  {reply.value.targetId === c.id && (
                     <div className="space-y-2">
                       <MarkdownEditor
                         autoFocus
                         aria-label="Write a reply"
                         placeholder="Write a reply…"
-                        value={replyBody}
-                        onChange={setReplyBody}
+                        value={reply.value.body}
+                        onChange={(v) =>
+                          reply.set((prev) => ({ ...prev, body: v }))
+                        }
                         onKeyDown={(e) => {
                           if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
                             // preventDefault unconditionally: `commit` is bound to
@@ -680,7 +691,8 @@ export function DiscussionView({
                             // this handler declines to submit would otherwise reach
                             // the global action.
                             e.preventDefault();
-                            if (replyBody.trim() && !busy) submitReply(c.id);
+                            if (reply.value.body.trim() && !busy)
+                              submitReply(c.id);
                           }
                         }}
                         rows={2}
@@ -690,7 +702,7 @@ export function DiscussionView({
                         <Button
                           size="xs"
                           variant="outline"
-                          disabled={!replyBody.trim() || busy}
+                          disabled={!reply.value.body.trim() || busy}
                           onClick={() => submitReply(c.id)}
                           title={SUBMIT_HINT}
                         >
@@ -699,7 +711,9 @@ export function DiscussionView({
                         <Button
                           size="xs"
                           variant="ghost"
-                          onClick={() => setReplyingTo(null)}
+                          onClick={() =>
+                            reply.set((prev) => ({ ...prev, targetId: null }))
+                          }
                         >
                           Cancel
                         </Button>
@@ -717,10 +731,10 @@ export function DiscussionView({
       </ScrollArea>
       <CommentComposer
         ref={composerRef}
-        value={composeBody}
-        onChange={setComposeBody}
+        value={compose.value}
+        onChange={compose.set}
         onSubmit={submitComment}
-        onClear={() => setComposeBody("")}
+        onClear={() => compose.set("")}
         submitLabel="Comment"
         ariaLabel="Add to the discussion"
         placeholder="Add to the discussion…"

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -235,9 +235,9 @@ export function DiscussionView({
     return <DiffPlaceholder message="Could not load this discussion" />;
   }
 
-  // Placeholder details are the previous discussion's, so actions addressing the
-  // DISCUSSION (composer, reply box, mark-as-answer) hold until it's on screen;
-  // per-comment actions stay live — a comment id names what the user saw.
+  // Placeholder details are the previous discussion's: `busy` holds the composer,
+  // reply box and mark-as-answer. Lock/close, delete, upvote/reactions and labels
+  // also read `d.id` and stay live — pre-existing exposure, tracked separately.
   const busy =
     addComment.isPending ||
     markAnswer.isPending ||

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -236,16 +236,18 @@ export function DiscussionView({
   }
 
   // Placeholder details are the previous discussion's: `busy` holds the composer,
-  // reply box and mark-as-answer. Lock/close, delete, upvote/reactions and labels
-  // also read `d.id` and stay live — pre-existing exposure, tracked separately.
+  // reply box and mark-as-answer, and the seeding actions below read this too.
+  // Lock/close, delete, upvote/reactions and labels also read `d.id` and stay
+  // live — pre-existing exposure, tracked separately.
+  const detailsStale = details.isPlaceholderData;
   const busy =
     addComment.isPending ||
     markAnswer.isPending ||
     deleteComment.isPending ||
-    details.isPlaceholderData;
+    detailsStale;
 
   function submitComment() {
-    if (!d || details.isPlaceholderData || !compose.value.trim()) return;
+    if (!d || detailsStale || !compose.value.trim()) return;
     const submittedFor = discussionIdentity;
     addComment.mutate(
       { discussionId: d.id, body: compose.value.trim() },
@@ -254,7 +256,7 @@ export function DiscussionView({
   }
 
   function submitReply(commentId: string) {
-    if (!d || details.isPlaceholderData || !reply.value.body.trim()) return;
+    if (!d || detailsStale || !reply.value.body.trim()) return;
     const submittedFor = discussionIdentity;
     addComment.mutate(
       {
@@ -275,7 +277,7 @@ export function DiscussionView({
     // Every quotable body — the discussion's and each rendered comment's — belongs
     // to the discussion on screen, which mid-switch is the previous one, while the
     // draft it would land in is keyed to the new one.
-    if (details.isPlaceholderData) return;
+    if (detailsStale) return;
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
   };
 
@@ -320,7 +322,9 @@ export function DiscussionView({
   }
 
   function referenceInNewIssue() {
-    if (!d) return;
+    // The draft is seeded entirely from the rendered discussion, which mid-switch
+    // is the previous one — the new issue would open against it.
+    if (!d || detailsStale) return;
     setPendingIssueDraft({
       title: d.title,
       body: `Referenced from discussion [#${d.number}](${d.url}).`,
@@ -393,9 +397,11 @@ export function DiscussionView({
               <DropdownMenuItem onClick={() => copyText(d.url, "Link copied")}>
                 Copy link
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={referenceInNewIssue}>
-                Create issue from discussion
-              </DropdownMenuItem>
+              {!detailsStale && (
+                <DropdownMenuItem onClick={referenceInNewIssue}>
+                  Create issue from discussion
+                </DropdownMenuItem>
+              )}
               {/* Pin and transfer aren't in GitHub's public API (GraphQL or
                   CLI) — open the discussion on GitHub where the web UI has them. */}
               <DropdownMenuItem onClick={() => openUrl(d.url)}>
@@ -549,7 +555,7 @@ export function DiscussionView({
                   {/* Absent, not disabled, while the body belongs to the previous
                       discussion — the same shape the comment menus take when their
                       `onQuote` is withheld. */}
-                  {hasVisibleBody(d.body) && !details.isPlaceholderData && (
+                  {hasVisibleBody(d.body) && !detailsStale && (
                     <DropdownMenuItem onClick={() => quoteReply(d.body)}>
                       Quote reply
                     </DropdownMenuItem>
@@ -595,11 +601,7 @@ export function DiscussionView({
                 )}
                 <Thread
                   thread={toThread(c)}
-                  onQuote={
-                    details.isPlaceholderData
-                      ? undefined
-                      : () => quoteReply(c.body)
-                  }
+                  onQuote={detailsStale ? undefined : () => quoteReply(c.body)}
                   onSaveEdit={
                     c.viewerDidAuthor
                       ? (body) => saveCommentEdit(c.id, body)
@@ -663,9 +665,7 @@ export function DiscussionView({
                       key={r.id}
                       thread={toThread(r)}
                       onQuote={
-                        details.isPlaceholderData
-                          ? undefined
-                          : () => quoteReply(r.body)
+                        detailsStale ? undefined : () => quoteReply(r.body)
                       }
                       onSaveEdit={
                         r.viewerDidAuthor

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -235,8 +235,9 @@ export function DiscussionView({
     return <DiffPlaceholder message="Could not load this discussion" />;
   }
 
-  // Placeholder details are the PREVIOUSLY shown discussion's, so every write
-  // during the switch window would target that one — gate them all on it.
+  // Placeholder details are the previous discussion's, so actions addressing the
+  // DISCUSSION (composer, reply box, mark-as-answer) hold until it's on screen;
+  // per-comment actions stay live — a comment id names what the user saw.
   const busy =
     addComment.isPending ||
     markAnswer.isPending ||
@@ -711,9 +712,7 @@ export function DiscussionView({
                         <Button
                           size="xs"
                           variant="ghost"
-                          onClick={() =>
-                            reply.set((prev) => ({ ...prev, targetId: null }))
-                          }
+                          onClick={() => reply.set(EMPTY_REPLY)}
                         >
                           Cancel
                         </Button>

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -131,8 +131,14 @@ export function CommitDetailView({
     providerKey === "github" ? remoteSections : undefined,
     commentsEnabled ? deferredPath : null,
   );
+  // Both commit queries keep serving the PREVIOUS commit while the selected one
+  // loads, so everything derived from them is that commit's until it lands.
+  const stale = details.isPlaceholderData || files.isPlaceholderData;
   const lineWidget = useMemo<LineWidget | undefined>(() => {
     if (!commentsEnabled || !deferredPath) return undefined;
+    // A line click while stale would address `hash` — the newly selected commit —
+    // with a path and line read off the previous one's diff.
+    if (stale) return undefined;
     // On GitHub the composer recovers its `position` from the FORGE diff; until
     // that fetch succeeds `remoteSections` is empty, so every line would open the
     // composer disabled with "This line isn't in the commit's diff for this file"
@@ -164,6 +170,7 @@ export function CommitDetailView({
     };
   }, [
     commentsEnabled,
+    stale,
     deferredPath,
     repoPath,
     hash,
@@ -200,11 +207,9 @@ export function CommitDetailView({
   const commit = details.data;
   const totalAdded = files.data.reduce((sum, f) => sum + f.added, 0);
   const totalDeleted = files.data.reduce((sum, f) => sum + f.deleted, 0);
-  // Everything derived from these two queries is the PREVIOUS commit's until the
-  // selected one lands; fade it so the pane never passes stale content off as
-  // current. The ⋯ actions act on the `hash` prop, so they stay solid.
-  const staleDim =
-    (details.isPlaceholderData || files.isPlaceholderData) && "opacity-80";
+  // Fade the stale content so the pane never passes it off as current. The ⋯
+  // actions act on the `hash` prop, so they stay solid.
+  const staleDim = stale && "opacity-80";
   // The diff pane keeps serving the previous file's diff for longer than the rest
   // (its query stays on placeholder data through the gated window above), so it
   // fades on its own state. Never nested inside another dim — 0.8² reads as
@@ -441,20 +446,21 @@ export function CommitDetailView({
         </main>
       </div>
 
-      {commentsEnabled ? (
-        <div className="max-h-[45%] shrink-0 border-t">
-          <CommitComments
-            repoPath={repoPath}
-            sha={hash}
-            canComment={canCommentCommits}
-            remoteLabel={remoteLabel}
-            diffSections={providerKey === "github" ? remoteSections : undefined}
-            selectedPath={deferredPath}
-            onSelectFile={selectFileFromComments}
-            lens="origin"
-          />
-        </div>
-      ) : gate && onRemote.data === false ? (
+      {/* Mounted for every commit, rendering only where comments are supported:
+          arrowing through history must not tear down its per-commit drafts. */}
+      <CommitComments
+        enabled={commentsEnabled}
+        repoPath={repoPath}
+        sha={hash}
+        canComment={canCommentCommits}
+        remoteLabel={remoteLabel}
+        diffSections={providerKey === "github" ? remoteSections : undefined}
+        selectedPath={deferredPath}
+        onSelectFile={selectFileFromComments}
+        lens="origin"
+        stale={stale}
+      />
+      {gate && onRemote.data === false ? (
         // The forge query RESOLVED false — this commit isn't pushed yet. Shown
         // only after resolution (never while pending), so there's no flash for a
         // commit that is on the remote.

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -134,11 +134,14 @@ export function CommitDetailView({
   // Both commit queries keep serving the PREVIOUS commit while the selected one
   // loads, so everything derived from them is that commit's until it lands.
   const stale = details.isPlaceholderData || files.isPlaceholderData;
+  // The diff query outlasts that window with the previous FILE's diff, so the
+  // rendered lines can belong to another file or commit than `hash`+`deferredPath`.
+  const diffStale = stale || diff.isPlaceholderData;
   const lineWidget = useMemo<LineWidget | undefined>(() => {
     if (!commentsEnabled || !deferredPath) return undefined;
     // A line click while stale would address `hash` — the newly selected commit —
     // with a path and line read off the previous one's diff.
-    if (stale) return undefined;
+    if (diffStale) return undefined;
     // On GitHub the composer recovers its `position` from the FORGE diff; until
     // that fetch succeeds `remoteSections` is empty, so every line would open the
     // composer disabled with "This line isn't in the commit's diff for this file"
@@ -170,7 +173,7 @@ export function CommitDetailView({
     };
   }, [
     commentsEnabled,
-    stale,
+    diffStale,
     deferredPath,
     repoPath,
     hash,

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -78,9 +78,9 @@ export function AssigneesPopover({
   commitOnClose?: boolean;
   /** The origin|upstream lens the parent surface resolved. */
   lens: RemoteLens;
-  /** Set when the viewer lacks the access this picker's action needs — callers
-   *  pass the reason for the matching axis. The trigger stays visible but
-   *  disabled and this text explains why. Absent = editable as before. */
+  /** Set when this picker can't be edited right now — the viewer lacks the access
+   *  its action needs, or the surface is still loading the entity. The trigger
+   *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
 }) {
   const users = useAssignableUsers(repoPath, enabled, lens);

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -66,9 +66,10 @@ export function RelatedRow({
   onOpen: (n: number) => void;
   onRemove: () => void;
   pending?: boolean;
-  /** Set when the viewer lacks the access this row's remove needs — callers pass
-   *  the reason for the matching axis (sub-issues are write, dependency and
-   *  related-issue links are triage). The button stays visible but disabled. */
+  /** Set when this row's remove can't be used right now — the viewer lacks the
+   *  access it needs (sub-issues are write, dependency and related-issue links
+   *  are triage), or the surface is still loading the entity. The button stays
+   *  visible but disabled. */
   removeDisabledReason?: string;
 }) {
   return (
@@ -211,7 +212,8 @@ export function IssueSubIssues({
   number: number;
   /** The origin|upstream lens the parent issue view resolved. */
   lens: RemoteLens;
-  /** Set when the viewer may not write to the repo: the add + remove
+  /** Set when these edits can't be used right now — the viewer may not write to
+   *  the repo, or the surface is still loading the entity: the add + remove
    *  affordances stay visible but disabled, with this text as their hint. The
    *  parent breadcrumb and the checklist itself are reads and stay live. */
   disabledReason?: string;

--- a/src/features/issues/JiraIssueSidebar.tsx
+++ b/src/features/issues/JiraIssueSidebar.tsx
@@ -40,6 +40,7 @@ export function JiraIssueSidebar({
   canDeleteOwnWorklogs,
   canEditAllWorklogs,
   canDeleteAllWorklogs,
+  stale = false,
   className,
 }: {
   repoPath: string;
@@ -56,6 +57,10 @@ export function JiraIssueSidebar({
   canDeleteOwnWorklogs: boolean;
   canEditAllWorklogs: boolean;
   canDeleteAllWorklogs: boolean;
+  /** `issue` is a previously selected one the caller is still rendering, so rows
+   *  carrying ITS ids (the worklog entries) hold their write actions; everything
+   *  addressed by `issueKey` alone stays live. */
+  stale?: boolean;
   /** Merged into the rail's own classes — the caller owns the placeholder fade,
    *  since it holds the query whose data these rows render. */
   className?: string;
@@ -304,6 +309,7 @@ export function JiraIssueSidebar({
           canDeleteOwnWorklogs={canDeleteOwnWorklogs}
           canEditAllWorklogs={canEditAllWorklogs}
           canDeleteAllWorklogs={canDeleteAllWorklogs}
+          stale={stale}
         />
       )}
     </aside>

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -849,7 +849,9 @@ function JiraCommentItem({
           onSubmit={saveEdit}
           onCancel={() => setEditing(false)}
           canSubmit={
-            draft.trim().length > 0 && draft.trim() !== comment.bodyMd.trim()
+            draft.trim().length > 0 &&
+            draft.trim() !== comment.bodyMd.trim() &&
+            !stale
           }
           pending={edit.isPending}
           textareaClassName="max-h-48 min-h-16 resize-y"

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1534,7 +1534,7 @@ export function JiraIssueView({
 
   function submitComment() {
     const body = compose.value.trim();
-    if (!body) return;
+    if (!body || details.isPlaceholderData) return;
     // Clear the draft immediately (perceived speed); restore it on error, but only
     // if that issue's composer is still empty so we never clobber newly-typed text.
     const submittedFor = issueIdentity;
@@ -1713,7 +1713,9 @@ export function JiraIssueView({
               onSubmit={submitComment}
               onClear={() => compose.set("")}
               submitLabel="Comment"
-              busy={comment.isPending}
+              // A placeholder issue is the previously selected one, so submitting
+              // would comment on it; typing stays live through the window.
+              busy={comment.isPending || details.isPlaceholderData}
               disabled={comment.isPending}
             />
           )}

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -12,7 +12,6 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
-  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -84,6 +83,7 @@ import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { useDebouncedValue } from "@/lib/use-debounced-value";
+import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
 
 /** The category icon + tone shared by the chip and every menu row (so meaning is
@@ -1483,24 +1483,12 @@ export function JiraIssueView({
   const comment = useJiraComment(repoPath, link.data);
   const transition = useJiraTransition(repoPath, link.data);
   const transitionTo = useJiraTransitionTo(repoPath, link.data);
-  const [composeBody, setComposeBody] = useState("");
   const composerRef = useRef<MarkdownEditorHandle>(null);
-  // A different issue must never inherit this one's unsent comment draft — a
-  // render-time state adjustment, not an effect. The repo is part of the identity
-  // because two repos linked to DIFFERENT Jira sites can share an issue key. The
-  // same identity keys the sidebar below, remounting its own per-issue drafts.
+  // The repo is part of the identity because two repos linked to DIFFERENT Jira
+  // sites can share an issue key. The same identity keys the sidebar below,
+  // remounting its own per-issue drafts.
   const issueIdentity = `${repoPath}#${issueKey}`;
-  const [lastIdentity, setLastIdentity] = useState(issueIdentity);
-  if (issueIdentity !== lastIdentity) {
-    setLastIdentity(issueIdentity);
-    setComposeBody("");
-  }
-  // The restore below can land after the user switched issues; an effect event
-  // reads the LIVE identity so a late rejection can't resurrect text elsewhere.
-  const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
-    if (submittedFor !== issueIdentity) return;
-    setComposeBody((cur) => (cur.trim() ? cur : body));
-  });
+  const compose = useKeyedEntityState(issueIdentity, "");
 
   // The link resolved to nothing (unlinked, or unlinked while this view was
   // open): the issue query is disabled, so it would otherwise sit on a pending
@@ -1545,17 +1533,17 @@ export function JiraIssueView({
   const staleDim = details.isPlaceholderData && "opacity-80";
 
   function submitComment() {
-    const body = composeBody.trim();
+    const body = compose.value.trim();
     if (!body) return;
-    // Clear the draft immediately (perceived speed); restore it on error, but
-    // only if the composer is still empty so we never clobber newly-typed text.
+    // Clear the draft immediately (perceived speed); restore it on error, but only
+    // if that issue's composer is still empty so we never clobber newly-typed text.
     const submittedFor = issueIdentity;
-    setComposeBody("");
+    compose.set("");
     comment.mutate(
       { issueKey, bodyMd: body },
       {
         onError: (e) => {
-          restoreDraft(submittedFor, body);
+          compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
           toastError(e);
         },
       },
@@ -1720,10 +1708,10 @@ export function JiraIssueView({
               ref={composerRef}
               ariaLabel="Leave a comment"
               placeholder="Leave a comment…"
-              value={composeBody}
-              onChange={setComposeBody}
+              value={compose.value}
+              onChange={compose.set}
               onSubmit={submitComment}
-              onClear={() => setComposeBody("")}
+              onClear={() => compose.set("")}
               submitLabel="Comment"
               busy={comment.isPending}
               disabled={comment.isPending}

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -722,6 +722,7 @@ function JiraCommentItem({
   canDeleteOwn,
   canEditAll,
   canDeleteAll,
+  stale = false,
 }: {
   repoPath: string;
   /** `null` during the link-pending window (a cached detail can still render
@@ -739,6 +740,10 @@ function JiraCommentItem({
   canEditAll: boolean;
   /** Delete ANYONE's comment — project admins (DELETE_ALL_COMMENTS). */
   canDeleteAll: boolean;
+  /** The caller is rendering a previously selected issue, so this comment's id
+   *  belongs to that one while the writes address the current `issueKey` — the
+   *  menu is absent and the editor's save holds until they agree. */
+  stale?: boolean;
 }) {
   const edit = useJiraCommentEdit(repoPath, link);
   const del = useJiraCommentDelete(repoPath, link);
@@ -751,8 +756,9 @@ function JiraCommentItem({
   const canEdit = (isOwn && canEditOwn) || canEditAll;
   const canDelete = (isOwn && canDeleteOwn) || canDeleteAll;
   // Edit/delete require a live link (the mutations key on its site). During the
-  // link-pending window the menu is simply absent — the comment still renders.
-  const showMenu = link !== null && (canEdit || canDelete);
+  // link-pending window — and while the caller's issue is stale — the menu is
+  // simply absent; the comment still renders.
+  const showMenu = link !== null && !stale && (canEdit || canDelete);
   const edited =
     comment.updatedAt != null && comment.updatedAt !== comment.createdAt;
 
@@ -763,6 +769,9 @@ function JiraCommentItem({
 
   function saveEdit() {
     const body = draft.trim();
+    // An editor opened before the switch would pair this comment's id with the
+    // newly selected `issueKey`, which Jira routes as a 404.
+    if (stale) return;
     edit.mutate(
       { issueKey, commentId: comment.id, bodyMd: body },
       {
@@ -773,6 +782,7 @@ function JiraCommentItem({
   }
 
   function doDelete() {
+    if (stale) return;
     del.mutate(
       { issueKey, commentId: comment.id },
       {
@@ -884,6 +894,7 @@ function JiraWorklogItem({
   canDeleteOwn,
   canEditAll,
   canDeleteAll,
+  stale = false,
 }: {
   repoPath: string;
   /** `null` during the link-pending window — the read-only row always renders;
@@ -900,6 +911,10 @@ function JiraWorklogItem({
   canEditAll: boolean;
   /** Delete ANYONE's worklog — project admins (DELETE_ALL_WORKLOGS). */
   canDeleteAll: boolean;
+  /** The caller is rendering a previously selected issue, so this entry's id
+   *  belongs to that one while the writes address the current `issueKey` — the
+   *  actions are absent and the editor's save holds until they agree. */
+  stale?: boolean;
 }) {
   const update = useJiraUpdateWorklog(repoPath, link);
   const del = useJiraDeleteWorklog(repoPath, link);
@@ -913,8 +928,9 @@ function JiraWorklogItem({
   const canEdit = (isOwn && canEditOwn) || canEditAll;
   const canDelete = (isOwn && canDeleteOwn) || canDeleteAll;
   // Edit/delete require a live link (the mutations key on its site). During the
-  // link-pending window the actions are simply absent — the row still renders.
-  const showActions = link !== null && (canEdit || canDelete);
+  // link-pending window — and while the caller's issue is stale — the actions are
+  // simply absent; the row still renders.
+  const showActions = link !== null && !stale && (canEdit || canDelete);
   const hadNote = worklog.commentMd.trim().length > 0;
 
   const durationTrimmed = durationDraft.trim();
@@ -923,7 +939,10 @@ function JiraWorklogItem({
   // Blocked: the user cleared a note that previously existed. Jira can't remove a
   // note once set — explain rather than silently drop or 400.
   const noteRemoved = hadNote && noteChanged && noteDraft.trim().length === 0;
-  const canSaveEdit = durationValid && !noteRemoved && !update.isPending;
+  // An editor opened before the switch would pair this entry's id with the newly
+  // selected `issueKey`, which Jira routes as a 404.
+  const canSaveEdit =
+    durationValid && !noteRemoved && !update.isPending && !stale;
 
   function beginEdit() {
     setDurationDraft(worklog.timeSpent);
@@ -953,6 +972,7 @@ function JiraWorklogItem({
   }
 
   function doDelete() {
+    if (stale) return;
     del.mutate(
       { issueKey, worklogId: worklog.id },
       {
@@ -1122,6 +1142,7 @@ export function JiraTimeTrackingSection({
   canDeleteOwnWorklogs,
   canEditAllWorklogs,
   canDeleteAllWorklogs,
+  stale = false,
 }: {
   repoPath: string;
   link: JiraLink | null;
@@ -1137,6 +1158,10 @@ export function JiraTimeTrackingSection({
   canDeleteOwnWorklogs: boolean;
   canEditAllWorklogs: boolean;
   canDeleteAllWorklogs: boolean;
+  /** The caller is rendering a previously selected issue: its worklog ids don't
+   *  belong to `issueKey`, so the per-entry edit/delete actions hold. Logging new
+   *  work and the estimate editors address `issueKey` alone and stay live. */
+  stale?: boolean;
 }) {
   const logWork = useJiraLogWork(repoPath, link);
   const setOriginal = useJiraSetOriginalEstimate(repoPath, link);
@@ -1332,6 +1357,7 @@ export function JiraTimeTrackingSection({
               canDeleteOwn={canDeleteOwnWorklogs}
               canEditAll={canEditAllWorklogs}
               canDeleteAll={canDeleteAllWorklogs}
+              stale={stale}
             />
           ))}
           {worklogsTotal > worklogs.length && (
@@ -1530,11 +1556,12 @@ export function JiraIssueView({
   const browseUrl = link.data
     ? `https://${link.data.siteHost}/browse/${issueKey}`
     : issue.url;
-  const staleDim = details.isPlaceholderData && "opacity-80";
+  const detailsStale = details.isPlaceholderData;
+  const staleDim = detailsStale && "opacity-80";
 
   function submitComment() {
     const body = compose.value.trim();
-    if (!body || details.isPlaceholderData) return;
+    if (!body || detailsStale) return;
     // Clear the draft immediately (perceived speed); restore it on error, but only
     // if that issue's composer is still empty so we never clobber newly-typed text.
     const submittedFor = issueIdentity;
@@ -1589,7 +1616,7 @@ export function JiraIssueView({
               LOADED issue's status, so a click during that window would fire the
               wrong transition against the issue you actually selected. */}
           {canTransition &&
-            !details.isPlaceholderData &&
+            !detailsStale &&
             (isDone ? (
               <Button
                 variant="outline"
@@ -1641,7 +1668,10 @@ export function JiraIssueView({
               issueKey={issueKey}
               category={issue.statusCategory}
               name={issue.statusName}
-              busy={busy}
+              // The menu marks its current row by matching the rendered status,
+              // which mid-switch is the previous issue's — hold it shut until the
+              // selected issue is on screen. Its targets are already key-addressed.
+              busy={busy || detailsStale}
               transitionTo={transitionTo}
             />
           ) : (
@@ -1693,6 +1723,7 @@ export function JiraIssueView({
                   canDeleteOwn={canDeleteOwnComments}
                   canEditAll={canEditAllComments}
                   canDeleteAll={canDeleteAllComments}
+                  stale={detailsStale}
                 />
               ))}
               {issue.comments.length === 0 && (
@@ -1715,7 +1746,7 @@ export function JiraIssueView({
               submitLabel="Comment"
               // A placeholder issue is the previously selected one, so submitting
               // would comment on it; typing stays live through the window.
-              busy={comment.isPending || details.isPlaceholderData}
+              busy={comment.isPending || detailsStale}
               disabled={comment.isPending}
             />
           )}
@@ -1740,6 +1771,7 @@ export function JiraIssueView({
           canDeleteOwnWorklogs={canDeleteOwnWorklogs}
           canEditAllWorklogs={canEditAllWorklogs}
           canDeleteAllWorklogs={canDeleteAllWorklogs}
+          stale={detailsStale}
         />
       </div>
     </div>

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -92,7 +92,7 @@ export function LocalIssueView({
     setCommentHidden,
     addLabel,
     removeLabel,
-  } = useLocalConversation(issue, (mutate) => {
+  } = useLocalConversation(id, issue, (mutate) => {
     if (issue) update.mutate({ id: issue.id, mutate });
   });
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -106,12 +106,11 @@ export function LocalIssueView({
       });
     },
   });
-  // A different issue must never inherit this one's unsent drafts or open
+  // A different issue must never inherit this one's half-typed label or open
   // confirm/promote/edit dialogs — a render-time state adjustment, not an effect.
   const [lastId, setLastId] = useState(id);
   if (id !== lastId) {
     setLastId(id);
-    setComment("");
     setLabelInput("");
     setDeletingCommentId(null);
     setConfirmDelete(false);

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -287,13 +287,18 @@ export function RemoteIssueView({
   }
 
   const isOpen = issue.state === "OPEN";
+  // The rendered issue is the previous one during a switch, so the composer-row
+  // actions hold until the selected issue is on screen.
   const busy =
-    comment.isPending || closeIssue.isPending || reopenIssue.isPending;
+    comment.isPending ||
+    closeIssue.isPending ||
+    reopenIssue.isPending ||
+    details.isPlaceholderData;
   const comments = issue.comments.filter((c) => hasVisibleBody(c.body));
 
   function submitComment() {
     const body = compose.value.trim();
-    if (!body) return;
+    if (!body || details.isPlaceholderData) return;
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
     // that issue's composer is still empty so we never clobber newly-typed text.

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -317,8 +317,13 @@ export function RemoteIssueView({
 
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
   // React Compiler bail out of this whole component (refs-in-render rule).
-  const quoteReply = (body: string) =>
+  const quoteReply = (body: string) => {
+    // Every quotable body — the issue's and each rendered comment's — belongs to
+    // the issue on screen, which mid-switch is the previous one, while the draft
+    // it would land in is keyed to the new one.
+    if (details.isPlaceholderData) return;
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
+  };
 
   function doClose(reason: "completed" | "not_planned") {
     closeIssue.mutate(
@@ -722,13 +727,18 @@ export function RemoteIssueView({
                       >
                         Copy link
                       </DropdownMenuItem>
-                      {canWrite && hasVisibleBody(issue.body) && (
-                        <DropdownMenuItem
-                          onClick={() => quoteReply(issue.body)}
-                        >
-                          Quote reply
-                        </DropdownMenuItem>
-                      )}
+                      {/* Absent, not disabled, while the body belongs to the
+                          previous issue — the same shape the comment menus take
+                          when their `onQuote` is withheld. */}
+                      {canWrite &&
+                        hasVisibleBody(issue.body) &&
+                        !details.isPlaceholderData && (
+                          <DropdownMenuItem
+                            onClick={() => quoteReply(issue.body)}
+                          >
+                            Quote reply
+                          </DropdownMenuItem>
+                        )}
                       <DropdownMenuItem
                         onClick={() => copyText(issue.body, "Markdown copied")}
                       >
@@ -778,7 +788,11 @@ export function RemoteIssueView({
                 <Thread
                   key={c.id}
                   thread={c}
-                  onQuote={canWrite ? () => quoteReply(c.body) : undefined}
+                  onQuote={
+                    canWrite && !details.isPlaceholderData
+                      ? () => quoteReply(c.body)
+                      : undefined
+                  }
                   onSaveEdit={
                     canEditOwnComments && c.viewerDidAuthor
                       ? (body) => saveCommentEdit(c.id, body)

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -287,18 +287,20 @@ export function RemoteIssueView({
   }
 
   const isOpen = issue.state === "OPEN";
-  // The rendered issue is the previous one during a switch, so the composer-row
-  // actions hold until the selected issue is on screen.
+  // The rendered issue is the previous one during a switch while `number` is
+  // already the new one, so everything that seeds a dialog from it, or reads a
+  // verb off it, holds until the selected issue is on screen.
+  const detailsStale = details.isPlaceholderData;
   const busy =
     comment.isPending ||
     closeIssue.isPending ||
     reopenIssue.isPending ||
-    details.isPlaceholderData;
+    detailsStale;
   const comments = issue.comments.filter((c) => hasVisibleBody(c.body));
 
   function submitComment() {
     const body = compose.value.trim();
-    if (!body || details.isPlaceholderData) return;
+    if (!body || detailsStale) return;
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
     // that issue's composer is still empty so we never clobber newly-typed text.
@@ -321,7 +323,7 @@ export function RemoteIssueView({
     // Every quotable body — the issue's and each rendered comment's — belongs to
     // the issue on screen, which mid-switch is the previous one, while the draft
     // it would land in is keyed to the new one.
-    if (details.isPlaceholderData) return;
+    if (detailsStale) return;
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
   };
 
@@ -333,6 +335,9 @@ export function RemoteIssueView({
   }
 
   function saveCommentEdit(commentId: string, body: string) {
+    // The comment id is the rendered issue's while the write addresses `number`
+    // — GitLab routes by both, so a mismatched pair 404s.
+    if (detailsStale) return;
     editComment.mutate(
       { number, commentId, body },
       { onSuccess: () => toast.success("Comment updated"), onError },
@@ -357,10 +362,16 @@ export function RemoteIssueView({
     toggleReactionMutation.mutate({ subjectId, content, active }, { onError });
   }
 
+  /** Opens the title/body editor seeded from the issue as it stands. */
+  function openIssueEdit() {
+    if (!issue || detailsStale) return;
+    edit.openEdit({ title: issue.title, body: issue.body });
+  }
+
   // Seeds + opens the GitHub create dialog (IssuesPanel consumes the draft).
   // Labels carry over since they're from this same repo.
   function duplicateIssue() {
-    if (!issue) return;
+    if (!issue || detailsStale) return;
     setPendingIssueDraft({
       title: issue.title,
       body: issue.body,
@@ -500,21 +511,26 @@ export function RemoteIssueView({
             </span>
           </h2>
           <span className="flex-1" />
-          <PlanIssueButton title={issue.title} body={issue.body} />
-          {isOpen && (
-            <SolveIssueButton
-              repoPath={repoPath}
-              title={issue.title}
-              body={issue.body}
-            />
+          {/* Both seed an AI run from the rendered issue, so they're absent while
+              that issue isn't the one you selected. */}
+          {!detailsStale && (
+            <>
+              <PlanIssueButton title={issue.title} body={issue.body} />
+              {isOpen && (
+                <SolveIssueButton
+                  repoPath={repoPath}
+                  title={issue.title}
+                  body={issue.body}
+                />
+              )}
+            </>
           )}
           {isOpen && canEdit && (
             <Button
               variant="outline"
               size="xs"
-              onClick={() =>
-                edit.openEdit({ title: issue.title, body: issue.body })
-              }
+              disabled={detailsStale}
+              onClick={openIssueEdit}
               title="Edit the title and description"
             >
               <PencilSimpleIcon data-icon="inline-start" />
@@ -547,7 +563,9 @@ export function RemoteIssueView({
               <DropdownMenuContent align="end" className="min-w-52">
                 {canWrite && (
                   <DropdownMenuItem
-                    disabled={writeBlocked}
+                    // The verb comes from the rendered issue's pin state while the
+                    // write addresses `number` — hold rather than flip the wrong way.
+                    disabled={writeBlocked || detailsStale}
                     onClick={() =>
                       pinIssue.mutate(
                         { number, pinned: !issue.isPinned },
@@ -565,7 +583,11 @@ export function RemoteIssueView({
                     {itemSuffix}
                   </DropdownMenuItem>
                 )}
+                {/* Absent while a placeholder is served: which affordance renders
+                    comes from the LOADED issue's lock state, so a click during that
+                    window would lock or unlock the issue you actually selected. */}
                 {canLock &&
+                  !detailsStale &&
                   (issue.locked ? (
                     <DropdownMenuItem
                       disabled={lockBlocked}
@@ -629,7 +651,9 @@ export function RemoteIssueView({
                     </DropdownMenuSub>
                   ))}
                 {(canWrite || canLock) && <DropdownMenuSeparator />}
-                {canDuplicate && (
+                {/* Absent while a placeholder is served: the draft it seeds is the
+                    rendered issue's, which isn't the one you selected. */}
+                {canDuplicate && !detailsStale && (
                   <DropdownMenuItem onClick={duplicateIssue}>
                     Duplicate issue
                   </DropdownMenuItem>
@@ -649,7 +673,9 @@ export function RemoteIssueView({
                 {canDelete && (
                   <DropdownMenuItem
                     variant="destructive"
-                    disabled={writeBlocked}
+                    // The confirm names the rendered issue's title while the delete
+                    // addresses `number` — hold the open rather than mismatch them.
+                    disabled={writeBlocked || detailsStale}
                     onClick={() => setDeleteOpen(true)}
                   >
                     Delete issue…{itemSuffix}
@@ -732,7 +758,7 @@ export function RemoteIssueView({
                           when their `onQuote` is withheld. */}
                       {canWrite &&
                         hasVisibleBody(issue.body) &&
-                        !details.isPlaceholderData && (
+                        !detailsStale && (
                           <DropdownMenuItem
                             onClick={() => quoteReply(issue.body)}
                           >
@@ -746,12 +772,8 @@ export function RemoteIssueView({
                       </DropdownMenuItem>
                       {isOpen && canEdit && (
                         <DropdownMenuItem
-                          onClick={() =>
-                            edit.openEdit({
-                              title: issue.title,
-                              body: issue.body,
-                            })
-                          }
+                          disabled={detailsStale}
+                          onClick={openIssueEdit}
                         >
                           Edit
                         </DropdownMenuItem>
@@ -777,11 +799,19 @@ export function RemoteIssueView({
               </div>
               {canWrite && (
                 <IssueSubIssues
+                  // Remounts per issue like the sidebar: its add/create state is
+                  // local, and a dialog left open across a switch would re-point
+                  // its parent id as the placeholder resolves.
+                  key={issueIdentity}
                   repoPath={repoPath}
                   issueId={issue.id}
                   number={number}
                   lens={lens}
-                  disabledReason={writeReason}
+                  // The writes take the rendered issue's id while the list is
+                  // fetched for `number` — hold them until the two agree.
+                  disabledReason={
+                    detailsStale ? "Loading this issue…" : writeReason
+                  }
                 />
               )}
               {comments.map((c) => (
@@ -789,17 +819,17 @@ export function RemoteIssueView({
                   key={c.id}
                   thread={c}
                   onQuote={
-                    canWrite && !details.isPlaceholderData
+                    canWrite && !detailsStale
                       ? () => quoteReply(c.body)
                       : undefined
                   }
                   onSaveEdit={
-                    canEditOwnComments && c.viewerDidAuthor
+                    canEditOwnComments && c.viewerDidAuthor && !detailsStale
                       ? (body) => saveCommentEdit(c.id, body)
                       : undefined
                   }
                   onDelete={
-                    canEditOwnComments && c.viewerDidAuthor
+                    canEditOwnComments && c.viewerDidAuthor && !detailsStale
                       ? () => setDeletingCommentId(c.id)
                       : undefined
                   }

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -828,6 +828,9 @@ export function RemoteIssueView({
                       ? (body) => saveCommentEdit(c.id, body)
                       : undefined
                   }
+                  // Withholding the handler only drops the menu entry; an editor
+                  // already open when the switch began needs its Save held too.
+                  editHeld={detailsStale}
                   onDelete={
                     canEditOwnComments && c.viewerDidAuthor && !detailsStale
                       ? () => setDeletingCommentId(c.id)

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -6,7 +6,7 @@ import {
   PencilSimpleIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffectEvent, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import type { MarkdownEditorHandle } from "@/components/markdown-editor";
@@ -75,6 +75,7 @@ import { useRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
+import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { PlanIssueButton } from "../plan/PlanIssueButton";
 import { SolveIssueButton } from "../sessions/SolveIssueButton";
 import { IssueSubIssues } from "./IssueRelations";
@@ -209,7 +210,6 @@ export function RemoteIssueView({
     { target: "issue", number },
   );
 
-  const [composeBody, setComposeBody] = useState("");
   const composerRef = useRef<MarkdownEditorHandle>(null);
   const [deletingCommentId, setDeletingCommentId] = useState<string | null>(
     null,
@@ -223,28 +223,22 @@ export function RemoteIssueView({
     },
     successToast: "Issue updated",
   });
-  // A different issue must never inherit this one's unsent draft or open
-  // delete/transfer/edit dialogs — a render-time state adjustment, not an effect.
-  // The lens is part of the identity: it can collapse to "origin" without a
-  // remount (upstream remote goes away), leaving the number pointing at another repo.
-  // The same identity keys the sidebar below, remounting its own per-issue drafts.
+  // A different issue must never inherit this one's open delete/transfer/edit
+  // dialogs — a render-time state adjustment, not an effect. The lens is part of
+  // the identity: it can collapse to "origin" without a remount (upstream remote
+  // goes away), leaving the number pointing at another repo. The same identity
+  // keys the sidebar below, remounting its own per-issue drafts.
   const issueIdentity = `${repoPath}#${lens}#${number}`;
+  const compose = useKeyedEntityState(issueIdentity, "");
   const [lastIdentity, setLastIdentity] = useState(issueIdentity);
   if (issueIdentity !== lastIdentity) {
     setLastIdentity(issueIdentity);
-    setComposeBody("");
     setDeletingCommentId(null);
     setDeleteOpen(false);
     setTransferOpen(false);
     setTransferDest("");
     edit.setOpen(false);
   }
-  // The restore below can land after the user switched issues; an effect event
-  // reads the LIVE identity so a late rejection can't resurrect text elsewhere.
-  const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
-    if (submittedFor !== issueIdentity) return;
-    setComposeBody((cur) => (cur.trim() ? cur : body));
-  });
   // Destination suggestions come from the viewer's repos on the SAME provider
   // as this repo; each query only fires while its dialog variant is open. The
   // GitLab list is repo-scoped so it targets the repo's own (possibly
@@ -298,18 +292,18 @@ export function RemoteIssueView({
   const comments = issue.comments.filter((c) => hasVisibleBody(c.body));
 
   function submitComment() {
-    const body = composeBody.trim();
+    const body = compose.value.trim();
     if (!body) return;
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
-    // the composer is still empty so we never clobber newly-typed text.
+    // that issue's composer is still empty so we never clobber newly-typed text.
     const submittedFor = issueIdentity;
-    setComposeBody("");
+    compose.set("");
     comment.mutate(
       { number, body, author: forge.data?.login ?? "You" },
       {
         onError: (e) => {
-          restoreDraft(submittedFor, body);
+          compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
           onError(e);
         },
       },
@@ -319,7 +313,7 @@ export function RemoteIssueView({
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
   // React Compiler bail out of this whole component (refs-in-render rule).
   const quoteReply = (body: string) =>
-    makeQuoteReply({ composerRef, setBody: setComposeBody })(body);
+    makeQuoteReply({ composerRef, setBody: compose.set })(body);
 
   function doClose(reason: "completed" | "not_planned") {
     closeIssue.mutate(
@@ -828,8 +822,8 @@ export function RemoteIssueView({
               ref={composerRef}
               ariaLabel="Leave a comment"
               placeholder="Leave a comment…"
-              value={composeBody}
-              onChange={setComposeBody}
+              value={compose.value}
+              onChange={compose.set}
               onSubmit={submitComment}
               submitLabel="Comment"
               busy={busy}
@@ -837,12 +831,12 @@ export function RemoteIssueView({
               // close/reopen arm follows it, and the shared Clear is `ml-auto`.
               actions={
                 <>
-                  {composeBody.trim() && (
+                  {compose.value.trim() && (
                     <Button
                       variant="ghost"
                       size="sm"
                       disabled={busy}
-                      onClick={() => setComposeBody("")}
+                      onClick={() => compose.set("")}
                       title="Discard this draft (e.g. a quote reply)"
                     >
                       Clear

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -1,4 +1,4 @@
-import { useEffectEvent, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
@@ -23,6 +23,7 @@ import type {
 } from "@/lib/git/types";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
 import { toastError } from "@/lib/toast";
+import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 
 export type DiffSections = ReturnType<typeof splitUnifiedDiff>;
 
@@ -243,25 +244,18 @@ export function CommitComments({
   const editComment = useEditCommitComment(repoPath, lens);
   const deleteComment = useDeleteCommitComment(repoPath, lens);
 
-  const [body, setBody] = useState("");
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  // Neither call site keys this component on the commit, so a different commit
-  // must never inherit the previous one's draft or pending delete confirm — a
-  // render-time state adjustment, not an effect. Identity is the same triple the
-  // comments are read and written under.
+  // Identity is the same triple the comments are read and written under.
   const commitIdentity = `${repoPath}#${lens}#${sha}`;
+  const draft = useKeyedEntityState(commitIdentity, "");
+  // Neither call site keys this component on the commit, so a different commit
+  // must never inherit the previous one's pending delete confirm — a render-time
+  // state adjustment, not an effect.
   const [lastIdentity, setLastIdentity] = useState(commitIdentity);
   if (commitIdentity !== lastIdentity) {
     setLastIdentity(commitIdentity);
-    setBody("");
     setDeletingId(null);
   }
-  // The restore below can land after the user moved to another commit; an effect
-  // event reads the LIVE identity so a late rejection can't resurrect text there.
-  const restoreDraft = useEffectEvent((submittedFor: string, text: string) => {
-    if (submittedFor !== commitIdentity) return;
-    setBody((cur) => (cur.trim() ? cur : text));
-  });
 
   const list = comments.data ?? [];
   const whole = list.filter((c) => c.path == null);
@@ -285,19 +279,19 @@ export function CommitComments({
     createComment.isPending || editComment.isPending || deleteComment.isPending;
 
   function submit() {
-    const text = body.trim();
+    const text = draft.value.trim();
     if (!text) return;
     // Clear the draft immediately (perceived-speed win); the hook appends the
     // synthetic comment optimistically. On error restore the draft, but only if
-    // the composer is still empty so newly-typed text is never clobbered.
+    // that commit's composer is still empty so newly-typed text is never clobbered.
     const submittedFor = commitIdentity;
-    setBody("");
+    draft.set("");
     createComment.mutate(
       { sha, body: text },
       {
         onSuccess: () => toast.success("Comment added"),
         onError: (e) => {
-          restoreDraft(submittedFor, text);
+          draft.setFor(submittedFor, (prev) => (prev.trim() ? prev : text));
           toastError(e);
         },
       },
@@ -396,8 +390,8 @@ export function CommitComments({
         <CommentComposer
           ariaLabel="Comment on this commit"
           placeholder="Leave a comment…"
-          value={body}
-          onChange={setBody}
+          value={draft.value}
+          onChange={draft.set}
           onSubmit={submit}
           submitLabel="Comment"
           busy={busy}

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -316,6 +316,9 @@ export function CommitComments({
   }
 
   function saveEdit(commentId: string, next: string) {
+    // The comment id is the previous commit's while the write addresses `sha`,
+    // so a mismatched pair would edit against a commit that never showed it.
+    if (stale) return;
     editComment.mutate(
       { sha, commentId, body: next },
       {
@@ -343,10 +346,17 @@ export function CommitComments({
                 key={c.id}
                 thread={toThread(c)}
                 onSaveEdit={
-                  c.viewerDidAuthor ? (next) => saveEdit(c.id, next) : undefined
+                  c.viewerDidAuthor && !stale
+                    ? (next) => saveEdit(c.id, next)
+                    : undefined
                 }
+                // Withholding the handler only drops the menu entry; an editor
+                // already open when the commit changed needs its Save held too.
+                editHeld={stale}
                 onDelete={
-                  c.viewerDidAuthor ? () => setDeletingId(c.id) : undefined
+                  c.viewerDidAuthor && !stale
+                    ? () => setDeletingId(c.id)
+                    : undefined
                 }
               />
             ))}
@@ -382,12 +392,13 @@ export function CommitComments({
                       <Thread
                         thread={toThread(c)}
                         onSaveEdit={
-                          c.viewerDidAuthor
+                          c.viewerDidAuthor && !stale
                             ? (next) => saveEdit(c.id, next)
                             : undefined
                         }
+                        editHeld={stale}
                         onDelete={
-                          c.viewerDidAuthor
+                          c.viewerDidAuthor && !stale
                             ? () => setDeletingId(c.id)
                             : undefined
                         }

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -222,6 +222,8 @@ export function CommitComments({
   selectedPath,
   onSelectFile,
   lens,
+  stale = false,
+  enabled = true,
 }: {
   repoPath: string;
   sha: string;
@@ -238,8 +240,15 @@ export function CommitComments({
   /** Which repo the commit's comments live on: "origin" (the History surface, or
    *  a non-fork) or the parent under the upstream lens (PR-commit context). */
   lens: RemoteLens;
+  /** The parent is still showing the PREVIOUS commit's content (placeholder data)
+   *  while `sha` already names the new one — pass it so writes hold. */
+  stale?: boolean;
+  /** Whether this commit takes comments at all. False renders nothing, but the
+   *  component STAYS MOUNTED so per-commit drafts survive a commit that doesn't
+   *  (yet) support them; the read is disabled with it. */
+  enabled?: boolean;
 }) {
-  const comments = useCommitComments(repoPath, sha, lens);
+  const comments = useCommitComments(repoPath, enabled ? sha : null, lens);
   const createComment = useCreateCommitComment(repoPath, lens);
   const editComment = useEditCommitComment(repoPath, lens);
   const deleteComment = useDeleteCommitComment(repoPath, lens);
@@ -275,12 +284,17 @@ export function CommitComments({
       .filter(({ path, line }) => !(path === selectedPath && line != null));
   }, [anchored, diffSections, selectedPath]);
 
+  // Parents serve the previous commit's content as placeholder while arrowing
+  // through history, so hold writes until the shown commit is the addressed one.
   const busy =
-    createComment.isPending || editComment.isPending || deleteComment.isPending;
+    createComment.isPending ||
+    editComment.isPending ||
+    deleteComment.isPending ||
+    stale;
 
   function submit() {
     const text = draft.value.trim();
-    if (!text) return;
+    if (!text || stale) return;
     // Clear the draft immediately (perceived-speed win); the hook appends the
     // synthetic comment optimistically. On error restore the draft, but only if
     // that commit's composer is still empty so newly-typed text is never clobbered.
@@ -308,8 +322,12 @@ export function CommitComments({
     );
   }
 
+  // After every hook: an unsupported commit renders nothing, but the mounted
+  // component keeps this surface's per-commit drafts alive across it.
+  if (!enabled) return null;
+
   return (
-    <div className="flex min-h-0 flex-col">
+    <div className="flex max-h-[45%] min-h-0 shrink-0 flex-col border-t">
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-3">
         {comments.isError ? (
           <p className="text-xs text-destructive">

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -212,6 +212,9 @@ function toThread(c: CommitCommentOut): PrThreadOut {
  * the selected file — so the labelled group here lists every anchored comment that
  * isn't visible inline (another file, or unresolvable to a new-side line), so none
  * is ever silently dropped.
+ *
+ * It owns its pane sizing: a bottom pane capped at 45% of its flex-column parent,
+ * so a caller drops it in as a sibling rather than wrapping it.
  */
 export function CommitComments({
   repoPath,

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -187,7 +187,7 @@ export function LocalPrView({
     setCommentHidden,
     addLabel,
     removeLabel,
-  } = useLocalConversation(pr, (mutate) => {
+  } = useLocalConversation(id, pr, (mutate) => {
     if (pr) update.mutate({ id: pr.id, mutate });
   });
   const [promoteOpen, setPromoteOpen] = useState(false);
@@ -210,13 +210,13 @@ export function LocalPrView({
       });
     },
   });
-  // A different PR must never inherit this one's drill-in, unsent drafts, or open
-  // delete/promote/edit dialogs — a render-time state adjustment, not an effect.
+  // A different PR must never inherit this one's drill-in, half-typed label, or
+  // open delete/promote/edit dialogs — a render-time state adjustment, not an
+  // effect.
   const [lastId, setLastId] = useState(id);
   if (id !== lastId) {
     setLastId(id);
     setSelectedCommitHash(null);
-    setComment("");
     setLabelInput("");
     setDeletingCommentId(null);
     setPromoteOpen(false);

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -159,6 +159,7 @@ export function PrActivityFeed({
   onDeleteThreadComment,
   onEditComment,
   onDeleteComment,
+  editHeld,
   onHideComment,
   onUnhideComment,
   onToggleReaction,
@@ -189,10 +190,18 @@ export function PrActivityFeed({
   onQuote?: (body: string) => void;
   onThreadReply: (threadId: string, body: string) => Promise<void>;
   onThreadResolve: (threadId: string, resolved: boolean) => Promise<void>;
-  onEditThreadComment: (commentId: string, body: string) => void;
-  onDeleteThreadComment: (commentId: string) => void;
-  onEditComment: (commentId: string, body: string) => void;
-  onDeleteComment: (commentId: string) => void;
+  /** Absent hides the thread-comment edit affordance — the caller withholds it
+   *  while the PR on screen isn't the one the write would address. */
+  onEditThreadComment?: (commentId: string, body: string) => void;
+  /** Absent hides the thread-comment delete affordance (same reason). */
+  onDeleteThreadComment?: (commentId: string) => void;
+  /** Absent hides the conversation-comment edit affordance (same reason). */
+  onEditComment?: (commentId: string, body: string) => void;
+  /** Absent hides the conversation-comment delete affordance (same reason). */
+  onDeleteComment?: (commentId: string) => void;
+  /** Holds an ALREADY-OPEN comment editor's Save: withholding the callbacks only
+   *  drops the menu entries, so a stale caller sets this too. */
+  editHeld?: boolean;
   onHideComment: (commentId: string, classifier: MinimizeReason) => void;
   onUnhideComment: (commentId: string) => void;
   onToggleReaction: (
@@ -326,6 +335,7 @@ export function PrActivityFeed({
                 onDeleteComment={
                   canEditOwnThreadComments ? onDeleteThreadComment : undefined
                 }
+                editHeld={editHeld}
                 provider={providerKey}
                 apply={suggestionApply}
                 fileDiffLookup={fileDiffLookup}
@@ -352,12 +362,13 @@ export function PrActivityFeed({
             thread={c}
             onQuote={onQuote && canWrite ? () => onQuote(c.body) : undefined}
             onSaveEdit={
-              canEditOwnComments && c.viewerDidAuthor
+              onEditComment && canEditOwnComments && c.viewerDidAuthor
                 ? (body) => onEditComment(c.id, body)
                 : undefined
             }
+            editHeld={editHeld}
             onDelete={
-              canEditOwnComments && c.viewerDidAuthor
+              onDeleteComment && canEditOwnComments && c.viewerDidAuthor
                 ? () => onDeleteComment(c.id)
                 : undefined
             }

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -184,7 +184,9 @@ export function PrActivityFeed({
   canEditOwnThreadComments: boolean;
   canEditOwnComments: boolean;
   canReact: boolean;
-  onQuote: (body: string) => void;
+  /** Absent hides the Quote affordance wherever this feed offers it — the caller
+   *  withholds it while the PR on screen isn't the one a quote would land on. */
+  onQuote?: (body: string) => void;
   onThreadReply: (threadId: string, body: string) => Promise<void>;
   onThreadResolve: (threadId: string, resolved: boolean) => Promise<void>;
   onEditThreadComment: (commentId: string, body: string) => void;
@@ -300,7 +302,7 @@ export function PrActivityFeed({
           <Thread
             thread={r}
             onQuote={
-              canWrite && hasVisibleBody(r.body)
+              onQuote && canWrite && hasVisibleBody(r.body)
                 ? () => onQuote(r.body)
                 : undefined
             }
@@ -348,7 +350,7 @@ export function PrActivityFeed({
         <div key={`comment-${c.id}`} data-comment-id={c.id}>
           <Thread
             thread={c}
-            onQuote={canWrite ? () => onQuote(c.body) : undefined}
+            onQuote={onQuote && canWrite ? () => onQuote(c.body) : undefined}
             onSaveEdit={
               canEditOwnComments && c.viewerDidAuthor
                 ? (body) => onEditComment(c.id, body)

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -270,18 +270,16 @@ export function PrCommitDetail({
                 <DiffPlaceholder message="No file changes in this commit" />
               )}
             </div>
-            <div className="max-h-[45%] shrink-0 border-t">
-              <CommitComments
-                repoPath={repoPath}
-                sha={commit.oid}
-                canComment={canCommentCommits}
-                remoteLabel={remoteLabel}
-                diffSections={sections}
-                selectedPath={effectivePath}
-                onSelectFile={setSelectedPath}
-                lens={lens}
-              />
-            </div>
+            <CommitComments
+              repoPath={repoPath}
+              sha={commit.oid}
+              canComment={canCommentCommits}
+              remoteLabel={remoteLabel}
+              diffSections={sections}
+              selectedPath={effectivePath}
+              onSelectFile={setSelectedPath}
+              lens={lens}
+            />
           </main>
         </div>
       )}

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -293,7 +293,7 @@ export function PrReviewPanel({
   }
 
   async function post() {
-    if (!onPost || !text.trim() || posting) return;
+    if (!onPost || !text.trim() || posting || stale) return;
     // A failed OR cancelled run keeps whatever streamed before it stopped, and that
     // partial text stays postable — publishing an unfinished review is consequential,
     // so confirm first, naming which way the run ended.
@@ -541,7 +541,12 @@ export function PrReviewPanel({
             </Button>
           )}
           {onPost && text.trim() && !generating && (
-            <Button variant="ghost" size="sm" disabled={posting} onClick={post}>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={posting || stale}
+              onClick={post}
+            >
               {posting && <Spinner data-icon="inline-start" />}
               Post as comment
             </Button>

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -487,6 +487,7 @@ export function PrReviewPanel({
                   <Button
                     variant="ghost"
                     size="sm"
+                    disabled={stale}
                     onClick={() =>
                       run(mode === "security" ? "general" : "security")
                     }

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -83,6 +83,7 @@ export function PrReviewPanel({
   prNoun = "PR",
   onPost,
   posting,
+  stale = false,
 }: {
   context: ReviewContext;
   /** Whether this PR is a GitHub PR or a local-only one. */
@@ -94,6 +95,9 @@ export function PrReviewPanel({
   prNoun?: string;
   onPost?: (body: string, opts?: { asBot?: boolean }) => void | Promise<void>;
   posting?: boolean;
+  /** The caller is still rendering a previously selected PR, so `context` describes
+   *  that one while the run would persist under this `prRef` — holds the run. */
+  stale?: boolean;
 }) {
   const settings = useSettings();
   const repoName = useUiStore((s) => s.repoName) ?? "";
@@ -266,6 +270,7 @@ export function PrReviewPanel({
   }
 
   function run(mode: ReviewMode) {
+    if (stale) return;
     // An explicit in-panel pick wins for BOTH buttons; untouched, a security
     // audit uses the dedicated `securityReviewAi` when configured, and every
     // other mode uses the global review model.
@@ -504,13 +509,18 @@ export function PrReviewPanel({
                 exit={{ opacity: 0, scale: 0.96 }}
                 transition={quickTransition}
               >
-                <Button size="sm" onClick={() => run("general")}>
+                <Button
+                  size="sm"
+                  disabled={stale}
+                  onClick={() => run("general")}
+                >
                   <SparkleIcon data-icon="inline-start" />
                   Review
                 </Button>
                 <Button
                   variant="outline"
                   size="sm"
+                  disabled={stale}
                   onClick={() => run("security")}
                 >
                   <ShieldCheckIcon data-icon="inline-start" />

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1556,7 +1556,7 @@ export function RemotePrView({
 
   // The pane keeps rendering the previous PR's diff through a switch, so its lines
   // can belong to another PR than the `number` a new thread would be created under.
-  const diffStale = details.isPlaceholderData || prDiff.isPlaceholderData;
+  const diffStale = detailsStale || prDiff.isPlaceholderData;
   // The inline line-comment composer for the Files tab: only when the provider allows
   // creating a thread, anchored to the selected file (its section prefills a
   // suggestion's code). Absent otherwise ⇒ read-only diff.
@@ -1978,20 +1978,20 @@ export function RemotePrView({
           currentNumber={number}
           onSelect={(n) => selectPr({ kind: "remote", id: String(n) })}
           onDissolve={canDissolveStack ? dissolveStack : undefined}
-          // Busy-shaped hold: `dissolveStack` refuses while the rendered stack is
-          // the previous PR's, so its control can't sit enabled and do nothing.
-          dissolving={stackDissolve.isPending || detailsStale}
+          dissolving={stackDissolve.isPending}
+          // `dissolveStack` refuses while the rendered stack is the previous PR's,
+          // so hold its control — without the spinner a real write would show.
+          disabled={detailsStale}
         />
         {stackOffer && (
           <StackOffer
             ref={offerRef}
             offer={stackOffer}
             rows={offerRows}
+            pending={stackCreate.isPending || stackAdd.isPending}
             // Same hold as the dissolve control: `confirmStackOffer` refuses while
-            // the offer's eligibility came from the previous PR.
-            pending={
-              stackCreate.isPending || stackAdd.isPending || detailsStale
-            }
+            // the offer's eligibility came from the previous PR. Cancel stays live.
+            disabled={detailsStale}
             error={
               stackWriteError ? presentError(stackWriteError).summary : null
             }
@@ -2029,14 +2029,14 @@ export function RemotePrView({
         busy={
           mergeRemotePr.isPending ||
           abortRemotePrResolve.isPending ||
-          details.isPlaceholderData
+          detailsStale
         }
         conflictFiles={predictedFiles}
         behindBy={behindBy}
         updateBlockedReason={updateBlockedReason}
         // Busy-shaped, not a reason: `runUpdateBranch` refuses through the switch
         // window, and a sub-second hold needs no explaining text.
-        updateBusy={updateBranch.isPending || details.isPlaceholderData}
+        updateBusy={updateBranch.isPending || detailsStale}
         onResolve={() => runResolve(false)}
         onResolveWithAi={() => runResolve(true)}
         onDiscard={() => void discardResolve()}
@@ -2082,8 +2082,8 @@ export function RemotePrView({
           // Both hold through a switch: the context above is seeded from the
           // rendered PR, so a run would persist — and a post would publish — the
           // previous PR's content under this one.
-          posting={comment.isPending || details.isPlaceholderData}
-          stale={details.isPlaceholderData}
+          posting={comment.isPending || detailsStale}
+          stale={detailsStale}
           // The panel posts its AI review as a comment and passes `asBot: true`,
           // forwarded to the mutation so GitLab attributes it to the review-bot
           // identity (other providers ignore the flag).
@@ -2139,12 +2139,14 @@ export function RemotePrView({
                       >
                         Copy link
                       </DropdownMenuItem>
-                      <DropdownMenuItem
-                        disabled={detailsStale}
-                        onClick={() => quoteReply(pr.body)}
-                      >
-                        Quote reply
-                      </DropdownMenuItem>
+                      {/* Absent, not disabled, while the description belongs to
+                          the previous PR — the same shape the thread menus take
+                          when their `onQuote` is withheld. */}
+                      {!detailsStale && (
+                        <DropdownMenuItem onClick={() => quoteReply(pr.body)}>
+                          Quote reply
+                        </DropdownMenuItem>
+                      )}
                       <DropdownMenuItem
                         onClick={() => copyText(pr.body, "Markdown copied")}
                       >

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -690,7 +690,10 @@ export function RemotePrView({
   const stackWriteError = stackCreate.error ?? stackAdd.error ?? null;
 
   function confirmStackOffer() {
-    if (!stackOffer) return;
+    // `offerEnabled` reads the rendered PR's stack state, so during a switch the
+    // offer can be computed under the previous PR's eligibility — refuse rather
+    // than write a stack on that basis.
+    if (!stackOffer || details.isPlaceholderData) return;
     if (stackOffer.kind === "create") {
       stackCreate.mutate(stackOffer.members, {
         onSuccess: (outcome) =>
@@ -753,7 +756,9 @@ export function RemotePrView({
 
   async function dissolveStack() {
     const info = details.data?.stack;
-    if (!info || dissolveStackNumber === null) return;
+    // The confirm names this stack's id and size, both read off the rendered PR.
+    if (!info || dissolveStackNumber === null || details.isPlaceholderData)
+      return;
     const count = details.data?.stackMembers.length || info.size;
     const ok = await useConfirm.getState().ask({
       title: `Dissolve stack #${info.id}?`,
@@ -844,7 +849,7 @@ export function RemotePrView({
    *  and just pushes when there are none. `withAi` hands the conflicts the backend
    *  just reported straight to the AI walk, so the takeover opens already working. */
   function runResolve(withAi: boolean) {
-    if (resolve) return;
+    if (details.isPlaceholderData || resolve) return;
     const info = details.data;
     if (!info) return;
     // Always route through the backend, even when `findResolve` reports a worktree: it
@@ -913,11 +918,13 @@ export function RemotePrView({
    *  rewrites the head's history and force-pushes it — on a fork that branch is the
    *  contributor's — so it asks first. */
   async function runUpdateBranch(rebase: boolean) {
+    if (details.isPlaceholderData) return;
     const base = details.data?.baseRefName;
     if (!base) return;
     // The one refusal rule, shared by the button, the menu item, the palette and
     // any future caller — no UI gate is the only thing between a viewer who may
-    // not push (or a second click) and the mutation.
+    // not push (or a second click) and the mutation. It derives from the rendered
+    // PR, the previous one during a switch — hence the placeholder refusal above.
     if (updateBlockedReason !== undefined || updateBranch.isPending) return;
     if (rebase) {
       const ok = await useConfirm.getState().ask({
@@ -1054,8 +1061,13 @@ export function RemotePrView({
 
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
   // React Compiler bail out of this whole component (refs-in-render rule).
-  const quoteReply = (body: string) =>
+  const quoteReply = (body: string) => {
+    // Every quotable body — the description and each rendered comment — belongs to
+    // the PR on screen, which mid-switch is the previous one, while the draft it
+    // would land in is keyed to the new one.
+    if (details.isPlaceholderData) return;
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
+  };
 
   // GitLab + Bitbucket approve/unapprove — one toggle keyed on whether the viewer
   // approved. GitLab's `user_can_approve` is unreliable on Free (false even when
@@ -1388,6 +1400,12 @@ export function RemotePrView({
         ? `${approval.approvedBy.length} of ${approval.approvalsRequired} approvals`
         : `${approval.approvedBy.length} approval${approval.approvedBy.length === 1 ? "" : "s"}`
       : null;
+  // The metadata pickers seed from the rendered PR and commit the WHOLE set on
+  // close, so one opened mid-switch would write the previous PR's members under
+  // the new number. Their triggers disable on a reason, so this rides that seam.
+  const pickerReason = details.isPlaceholderData
+    ? "Loading this pull request…"
+    : triageReason;
 
   if (details.isPending) {
     return (
@@ -1429,6 +1447,9 @@ export function RemotePrView({
   // because TS doesn't carry the outer `!pr` guard into these hoisted closures.
   const prForGen = pr;
   function openEditWithChips() {
+    // Every seed below is read off the rendered PR, which is the previous one
+    // during a switch — an edit opened then would carry its title and body.
+    if (details.isPlaceholderData) return;
     // Seed the base picker from the PR as it stands, so a re-open never carries
     // a previous session's unsaved pick.
     setEditBase(prForGen.baseRefName);
@@ -1801,7 +1822,7 @@ export function RemotePrView({
             labelableId={pr.id}
             labels={pr.labels}
             lens={lens}
-            disabledReason={triageReason}
+            disabledReason={pickerReason}
           />
         ) : (
           pr.labels.length > 0 && (
@@ -1822,7 +1843,7 @@ export function RemotePrView({
             value={pr.assignees}
             commitOnClose
             lens={lens}
-            disabledReason={triageReason}
+            disabledReason={pickerReason}
             onChange={(next) =>
               setAssignees.mutate(
                 { number, assignees: next },
@@ -1858,7 +1879,7 @@ export function RemotePrView({
               enabled
               value={humanReviewers}
               lens={lens}
-              disabledReason={triageReason}
+              disabledReason={pickerReason}
               onChange={(next) =>
                 setReviewers.mutate(
                   { number, reviewers: next },
@@ -1989,11 +2010,17 @@ export function RemotePrView({
         provider={provider}
         forkBlocked={!!pr.crossRepository}
         hasResolveWorktree={resolveWorktree !== null}
-        busy={mergeRemotePr.isPending || abortRemotePrResolve.isPending}
+        busy={
+          mergeRemotePr.isPending ||
+          abortRemotePrResolve.isPending ||
+          details.isPlaceholderData
+        }
         conflictFiles={predictedFiles}
         behindBy={behindBy}
         updateBlockedReason={updateBlockedReason}
-        updateBusy={updateBranch.isPending}
+        // Busy-shaped, not a reason: `runUpdateBranch` refuses through the switch
+        // window, and a sub-second hold needs no explaining text.
+        updateBusy={updateBranch.isPending || details.isPlaceholderData}
         onResolve={() => runResolve(false)}
         onResolveWithAi={() => runResolve(true)}
         onDiscard={() => void discardResolve()}
@@ -2036,7 +2063,11 @@ export function RemotePrView({
                   })),
                 })),
           }}
-          posting={comment.isPending}
+          // Both hold through a switch: the context above is seeded from the
+          // rendered PR, so a run would persist — and a post would publish — the
+          // previous PR's content under this one.
+          posting={comment.isPending || details.isPlaceholderData}
+          stale={details.isPlaceholderData}
           // The panel posts its AI review as a comment and passes `asBot: true`,
           // forwarded to the mutation so GitLab attributes it to the review-bot
           // identity (other providers ignore the flag).

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2079,10 +2079,10 @@ export function RemotePrView({
                   })),
                 })),
           }}
-          // Both hold through a switch: the context above is seeded from the
-          // rendered PR, so a run would persist — and a post would publish — the
-          // previous PR's content under this one.
-          posting={comment.isPending || detailsStale}
+          posting={comment.isPending}
+          // The context above is seeded from the rendered PR, so through a switch
+          // `stale` holds both the run and the post — without the spinner that
+          // `posting` shows for a real one.
           stale={detailsStale}
           // The panel posts its AI review as a comment and passes `asBot: true`,
           // forwarded to the mutation so GitLab attributes it to the review-bot

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -552,13 +552,17 @@ export function RemotePrView({
   const providerKey: ForgeProvider = provider ?? "github";
 
   // Palette-only PR actions — mounted here so they live only while a remote PR is
-  // open.
+  // open. Every one whose enablement reads `details.data` also gates on
+  // `!details.isPlaceholderData`: during a switch that data is the previous PR's,
+  // so the command would offer (and act on) a PR the user never opened.
   const draftCount = drafts.data?.length ?? 0;
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   useHotkeyAction(
     "submit-review",
     () => setSubmitOpen(true),
-    canSubmitReview && details.data?.state === "OPEN",
+    canSubmitReview &&
+      details.data?.state === "OPEN" &&
+      !details.isPlaceholderData,
   );
   useHotkeyAction(
     "discard-pending-review",
@@ -572,8 +576,10 @@ export function RemotePrView({
   const draftPairVisible = canToggleDraft || (isGitHubProvider && canWrite);
   // One in-flight PR mutation at a time: every footer/state control and its palette
   // twin disables while any of these runs. Declared above the palette wiring so both
-  // share the exact same gate.
+  // share the exact same gate. Placeholder details are the previously shown PR's and
+  // the footer's verbs derive from them, so the same gate holds through a switch.
   const busy =
+    details.isPlaceholderData ||
     comment.isPending ||
     mergePr.isPending ||
     closePr.isPending ||
@@ -639,12 +645,12 @@ export function RemotePrView({
   useHotkeyAction(
     "pr-stack-next",
     () => goToStackNeighbor(1),
-    isSelectedPr && !!stackNeighbor(1),
+    isSelectedPr && !details.isPlaceholderData && !!stackNeighbor(1),
   );
   useHotkeyAction(
     "pr-stack-previous",
     () => goToStackNeighbor(-1),
-    isSelectedPr && !!stackNeighbor(-1),
+    isSelectedPr && !details.isPlaceholderData && !!stackNeighbor(-1),
   );
 
   // Stack writes are GitHub-only, and the chain that would be stacked is read
@@ -765,17 +771,20 @@ export function RemotePrView({
   useHotkeyAction(
     "pr-stack-create",
     () => offerRef.current?.expand(),
-    isSelectedPr && stackOffer?.kind === "create",
+    isSelectedPr && !details.isPlaceholderData && stackOffer?.kind === "create",
   );
   useHotkeyAction(
     "pr-stack-add",
     () => offerRef.current?.expand(),
-    isSelectedPr && stackOffer?.kind === "add",
+    isSelectedPr && !details.isPlaceholderData && stackOffer?.kind === "add",
   );
   useHotkeyAction(
     "pr-stack-dissolve",
     () => void dissolveStack(),
-    isSelectedPr && canDissolveStack && !stackDissolve.isPending,
+    isSelectedPr &&
+      !details.isPlaceholderData &&
+      canDissolveStack &&
+      !stackDissolve.isPending,
   );
 
   // Server truth first; the local preview only fills the gap where the forge has none.
@@ -894,6 +903,7 @@ export function RemotePrView({
     "pr-resolve-conflicts",
     () => runResolve(false),
     isSelectedPr &&
+      !details.isPlaceholderData &&
       (canResolveConflicts || resolveWorktree !== null) &&
       !resolve &&
       !mergeRemotePr.isPending,
@@ -929,7 +939,7 @@ export function RemotePrView({
   useHotkeyAction(
     "pr-update-branch",
     () => void runUpdateBranch(false),
-    isSelectedPr && canUpdateBranch,
+    isSelectedPr && !details.isPlaceholderData && canUpdateBranch,
   );
 
   const compose = useKeyedEntityState(entityKey, "");
@@ -1054,6 +1064,7 @@ export function RemotePrView({
   // otherwise the label lags a full approve-POST + refetch. Success invalidation
   // reconciles; errors roll back.
   async function toggleApproval() {
+    if (details.isPlaceholderData) return;
     const approved = approvals.data?.viewerHasApproved ?? false;
     const action = approved ? unapprovePr : approvePr;
     // Must mirror usePrApprovals' key exactly — its lens segment is always the
@@ -1103,6 +1114,7 @@ export function RemotePrView({
   // optimistic flip as the approve toggle — the state lives in the separate
   // approvals query.
   async function requestChanges() {
+    if (details.isPlaceholderData) return;
     const requested = approvals.data?.viewerRequestedChanges ?? false;
     // Already requested on GitLab: the button is a focusable state indicator
     // (its title says how to clear); a re-click must not fire the Premium-only
@@ -1155,7 +1167,7 @@ export function RemotePrView({
 
   function submitComment() {
     const body = compose.value.trim();
-    if (!body) return;
+    if (!body || details.isPlaceholderData) return;
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
     // that PR's composer is still empty so we never clobber newly-typed text.

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1628,6 +1628,9 @@ export function RemotePrView({
   // overlaps (its completed reviewers have already left `pr.reviewers`).
   const completedLogins = new Set(completedReviewers.map((c) => c.login));
   function saveCommentEdit(commentId: string, body: string) {
+    // The comment id is the rendered PR's while the write addresses `number` —
+    // GitLab routes by both, so a mismatched pair edits nothing it showed.
+    if (detailsStale) return;
     editComment.mutate(
       { number, commentId, body },
       {
@@ -1638,6 +1641,8 @@ export function RemotePrView({
   }
 
   function saveThreadCommentEdit(commentId: string, body: string) {
+    // Same pairing as saveCommentEdit, on the review-thread side.
+    if (detailsStale) return;
     editReviewComment.mutate(
       { number, commentId, body },
       {
@@ -2212,10 +2217,20 @@ export function RemotePrView({
                 onThreadResolve={(threadId, resolved) =>
                   threadResolve.mutateAsync({ threadId, resolved })
                 }
-                onEditThreadComment={saveThreadCommentEdit}
-                onDeleteThreadComment={setDeletingThreadCommentId}
-                onEditComment={saveCommentEdit}
-                onDeleteComment={setDeletingCommentId}
+                // All four pair a rendered comment id with `number`, so they're
+                // withheld through a switch; `editHeld` covers an editor already
+                // open when it began.
+                onEditThreadComment={
+                  detailsStale ? undefined : saveThreadCommentEdit
+                }
+                onDeleteThreadComment={
+                  detailsStale ? undefined : setDeletingThreadCommentId
+                }
+                onEditComment={detailsStale ? undefined : saveCommentEdit}
+                onDeleteComment={
+                  detailsStale ? undefined : setDeletingCommentId
+                }
+                editHeld={detailsStale}
                 onHideComment={hideComment}
                 onUnhideComment={unhideComment}
                 onToggleReaction={toggleReaction}
@@ -2246,13 +2261,16 @@ export function RemotePrView({
                     : undefined
                 }
                 onEditComment={
-                  canEditOwnThreadComments ? saveThreadCommentEdit : undefined
+                  canEditOwnThreadComments && !detailsStale
+                    ? saveThreadCommentEdit
+                    : undefined
                 }
                 onDeleteComment={
-                  canEditOwnThreadComments
+                  canEditOwnThreadComments && !detailsStale
                     ? setDeletingThreadCommentId
                     : undefined
                 }
+                editHeld={detailsStale}
                 provider={providerKey}
                 apply={suggestionApply}
                 fileDiffLookup={fileDiffLookup}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1402,10 +1402,14 @@ export function RemotePrView({
         ? `${approval.approvedBy.length} of ${approval.approvalsRequired} approvals`
         : `${approval.approvedBy.length} approval${approval.approvedBy.length === 1 ? "" : "s"}`
       : null;
+  // Every handler that refuses while the rendered PR is the previous one reads
+  // this, so each of their entry points can hold too rather than sit enabled and
+  // do nothing.
+  const detailsStale = details.isPlaceholderData;
   // The metadata pickers seed from the rendered PR and commit the WHOLE set on
   // close, so one opened mid-switch would write the previous PR's members under
   // the new number. Their triggers disable on a reason, so this rides that seam.
-  const pickerReason = details.isPlaceholderData
+  const pickerReason = detailsStale
     ? "Loading this pull request…"
     : triageReason;
 
@@ -1772,6 +1776,7 @@ export function RemotePrView({
             <Button
               variant="outline"
               size="xs"
+              disabled={detailsStale}
               onClick={openEditWithChips}
               title="Edit the title and description"
             >
@@ -1973,14 +1978,20 @@ export function RemotePrView({
           currentNumber={number}
           onSelect={(n) => selectPr({ kind: "remote", id: String(n) })}
           onDissolve={canDissolveStack ? dissolveStack : undefined}
-          dissolving={stackDissolve.isPending}
+          // Busy-shaped hold: `dissolveStack` refuses while the rendered stack is
+          // the previous PR's, so its control can't sit enabled and do nothing.
+          dissolving={stackDissolve.isPending || detailsStale}
         />
         {stackOffer && (
           <StackOffer
             ref={offerRef}
             offer={stackOffer}
             rows={offerRows}
-            pending={stackCreate.isPending || stackAdd.isPending}
+            // Same hold as the dissolve control: `confirmStackOffer` refuses while
+            // the offer's eligibility came from the previous PR.
+            pending={
+              stackCreate.isPending || stackAdd.isPending || detailsStale
+            }
             error={
               stackWriteError ? presentError(stackWriteError).summary : null
             }
@@ -2128,7 +2139,10 @@ export function RemotePrView({
                       >
                         Copy link
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => quoteReply(pr.body)}>
+                      <DropdownMenuItem
+                        disabled={detailsStale}
+                        onClick={() => quoteReply(pr.body)}
+                      >
                         Quote reply
                       </DropdownMenuItem>
                       <DropdownMenuItem
@@ -2137,7 +2151,10 @@ export function RemotePrView({
                         Copy markdown
                       </DropdownMenuItem>
                       {isOpen && canEdit && (
-                        <DropdownMenuItem onClick={openEditWithChips}>
+                        <DropdownMenuItem
+                          disabled={detailsStale}
+                          onClick={openEditWithChips}
+                        >
                           Edit
                         </DropdownMenuItem>
                       )}
@@ -2186,7 +2203,7 @@ export function RemotePrView({
                 canEditOwnThreadComments={canEditOwnThreadComments}
                 canEditOwnComments={canEditOwnComments}
                 canReact={canReact}
-                onQuote={quoteReply}
+                onQuote={detailsStale ? undefined : quoteReply}
                 onThreadReply={(threadId, body) =>
                   threadReply.mutateAsync({ threadId, body })
                 }
@@ -2213,7 +2230,7 @@ export function RemotePrView({
                     : "Review comments"
                 }
                 isError={reviewThreads.isError}
-                onQuote={quoteReply}
+                onQuote={detailsStale ? undefined : quoteReply}
                 onReply={
                   canThreadReply
                     ? (threadId, body) =>
@@ -2450,7 +2467,7 @@ export function RemotePrView({
             lens={lens}
             number={number}
             lineWidget={reviewLineWidget}
-            onQuote={quoteReply}
+            onQuote={detailsStale ? undefined : quoteReply}
             onReply={
               canThreadReply
                 ? (threadId, body) =>

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1455,7 +1455,7 @@ export function RemotePrView({
   function openEditWithChips() {
     // Every seed below is read off the rendered PR, which is the previous one
     // during a switch — an edit opened then would carry its title and body.
-    if (details.isPlaceholderData) return;
+    if (detailsStale) return;
     // Seed the base picker from the PR as it stands, so a re-open never carries
     // a previous session's unsaved pick.
     setEditBase(prForGen.baseRefName);

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -560,14 +560,15 @@ export function RemotePrView({
   useHotkeyAction(
     "submit-review",
     () => setSubmitOpen(true),
-    canSubmitReview &&
+    isSelectedPr &&
+      canSubmitReview &&
       details.data?.state === "OPEN" &&
       !details.isPlaceholderData,
   );
   useHotkeyAction(
     "discard-pending-review",
     () => setDiscardConfirmOpen(true),
-    draftCount > 0,
+    isSelectedPr && draftCount > 0,
   );
   // The shared Ready / Convert-to-draft pair: visible when a wired provider
   // (GitLab/Bitbucket) flags `mrDraftToggle`, or on GitHub via `canWrite` (its
@@ -606,7 +607,7 @@ export function RemotePrView({
           onError,
         },
       ),
-    draftPairVisible && !!details.data?.isDraft && !busy,
+    isSelectedPr && draftPairVisible && !!details.data?.isDraft && !busy,
   );
   useHotkeyAction(
     "pr-convert-to-draft",
@@ -618,7 +619,8 @@ export function RemotePrView({
           onError,
         },
       ),
-    draftPairVisible &&
+    isSelectedPr &&
+      draftPairVisible &&
       !details.data?.isDraft &&
       details.data?.state === "OPEN" &&
       !busy,
@@ -1548,11 +1550,14 @@ export function RemotePrView({
   const fileDiffLookup = (path: string): string | undefined =>
     fileSections.get(path);
 
+  // The pane keeps rendering the previous PR's diff through a switch, so its lines
+  // can belong to another PR than the `number` a new thread would be created under.
+  const diffStale = details.isPlaceholderData || prDiff.isPlaceholderData;
   // The inline line-comment composer for the Files tab: only when the provider allows
   // creating a thread, anchored to the selected file (its section prefills a
   // suggestion's code). Absent otherwise ⇒ read-only diff.
   const reviewLineWidget: LineWidget | undefined =
-    canCreateThread && effectivePath
+    canCreateThread && effectivePath && !diffStale
       ? {
           enabled: true,
           render: ({ side, line, fromLine, onClose }) => (

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -161,6 +161,7 @@ import { useConfirm } from "@/lib/stores/confirm";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { cn } from "@/lib/utils";
 import { ChecksRollup } from "./ChecksRollup";
 import { LinkedIssuesField } from "./LinkedIssuesField";
@@ -931,18 +932,7 @@ export function RemotePrView({
     isSelectedPr && canUpdateBranch,
   );
 
-  const [composeBody, setComposeBody] = useState("");
-  // Both land after a mutation settles, by which time the user may have switched
-  // PRs — an effect event reads the LIVE identity, so a late settle can never
-  // resurrect text on, or blank the draft of, whatever PR is on screen now.
-  const restoreDraft = useEffectEvent((submittedFor: string, body: string) => {
-    if (submittedFor !== entityKey) return;
-    setComposeBody((cur) => (cur.trim() ? cur : body));
-  });
-  const clearDraft = useEffectEvent((submittedFor: string) => {
-    if (submittedFor !== entityKey) return;
-    setComposeBody("");
-  });
+  const compose = useKeyedEntityState(entityKey, "");
   const [deletingCommentId, setDeletingCommentId] = useState<string | null>(
     null,
   );
@@ -1055,7 +1045,7 @@ export function RemotePrView({
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
   // React Compiler bail out of this whole component (refs-in-render rule).
   const quoteReply = (body: string) =>
-    makeQuoteReply({ composerRef, setBody: setComposeBody })(body);
+    makeQuoteReply({ composerRef, setBody: compose.set })(body);
 
   // GitLab + Bitbucket approve/unapprove — one toggle keyed on whether the viewer
   // approved. GitLab's `user_can_approve` is unreliable on Free (false even when
@@ -1147,15 +1137,13 @@ export function RemotePrView({
       });
       return;
     }
-    // Guard the deferred clear like submitComment's restore: after a PR
-    // switch it would wipe text just typed on the newly shown PR.
     const submittedFor = entityKey;
     requestChangesPr.mutate(
-      { number, body: composeBody.trim() },
+      { number, body: compose.value.trim() },
       {
         onSuccess: () => {
           toast.success("Requested changes");
-          clearDraft(submittedFor);
+          compose.clearFor(submittedFor);
         },
         onError: (e) => {
           if (prev) queryClient.setQueryData(key, prev);
@@ -1166,19 +1154,19 @@ export function RemotePrView({
   }
 
   function submitComment() {
-    const body = composeBody.trim();
+    const body = compose.value.trim();
     if (!body) return;
     // Clear the draft immediately (the perceived-speed win) and append the
     // synthetic comment optimistically; on error restore the draft, but only if
-    // the composer is still empty so we never clobber newly-typed text.
+    // that PR's composer is still empty so we never clobber newly-typed text.
     const submittedFor = entityKey;
-    setComposeBody("");
+    compose.set("");
     comment.mutate(
       { number, body, author: forge.data?.login ?? "You" },
       {
         onSuccess: () => toast.success("Comment added"),
         onError: (e) => {
-          restoreDraft(submittedFor, body);
+          compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
           onError(e);
         },
       },
@@ -1312,10 +1300,9 @@ export function RemotePrView({
     setSelectedPath(null);
     setSelectedCommitOid(null);
     // Everything below is bound to the PR it was opened on — the conflict-resolution
-    // takeover, the dialogs and confirmations, the unsent draft — so a different PR
-    // must inherit none of it.
+    // takeover, the dialogs and confirmations — so a different PR must inherit
+    // none of it.
     setResolve(null);
-    setComposeBody("");
     setDeletingCommentId(null);
     setDeletingThreadCommentId(null);
     setSubmitOpen(false);
@@ -2223,10 +2210,10 @@ export function RemotePrView({
           {canComment && (
             <CommentComposer
               ref={composerRef}
-              value={composeBody}
-              onChange={setComposeBody}
+              value={compose.value}
+              onChange={compose.set}
               onSubmit={submitComment}
-              onClear={() => setComposeBody("")}
+              onClear={() => compose.set("")}
               submitLabel="Comment"
               ariaLabel="Leave a comment"
               placeholder="Leave a comment…"
@@ -2332,7 +2319,7 @@ export function RemotePrView({
                           ? canUnrequestChanges
                             ? "Revoke your change request"
                             : "You've requested changes — approve, or remove yourself as a reviewer on GitLab, to clear"
-                          : composeBody.trim()
+                          : compose.value.trim()
                             ? "Request changes, posting your draft as a comment"
                             : `Request changes on this ${prNoun} (adds you as a reviewer)`
                       }

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -56,6 +56,10 @@ interface ThreadCallbacks {
   /** Present when the viewer may delete their own thread comments; opens the
    *  delete confirmation. Wired only for a comment the viewer wrote. */
   onDeleteComment?: (commentId: string) => void;
+  /** Holds an ALREADY-OPEN comment editor's Save — withholding `onEditComment`
+   *  only drops the menu entry, so a caller whose threads went stale sets this
+   *  too. Threaded straight through to every card's Thread. */
+  editHeld?: boolean;
 }
 
 /** The anchor label: "Lines a–b" for a range, "Line b" for a single line, "" at
@@ -506,6 +510,7 @@ export function ReviewThreadCard({
   onReply,
   onResolve,
   onEditComment,
+  editHeld,
   onDeleteComment,
   compact = false,
   onRowFocus,
@@ -702,6 +707,7 @@ export function ReviewThreadCard({
                     ? (body) => onEditComment(c.id, body)
                     : undefined
                 }
+                editHeld={editHeld}
                 onDelete={
                   onDeleteComment && c.viewerDidAuthor
                     ? () => onDeleteComment(c.id)
@@ -851,6 +857,7 @@ export function ReviewThreadList({
   onResolve,
   onEditComment,
   onDeleteComment,
+  editHeld,
   provider = "github",
   apply,
   fileDiffLookup,
@@ -1020,6 +1027,7 @@ export function ReviewThreadList({
                   onResolve={onResolve}
                   onEditComment={onEditComment}
                   onDeleteComment={onDeleteComment}
+                  editHeld={editHeld}
                   provider={provider}
                   apply={apply}
                   fileDiffLookup={fileDiffLookup}
@@ -1051,6 +1059,7 @@ export function ReviewThreadList({
                         onResolve={onResolve}
                         onEditComment={onEditComment}
                         onDeleteComment={onDeleteComment}
+                        editHeld={editHeld}
                         provider={provider}
                         apply={apply}
                         fileDiffLookup={fileDiffLookup}
@@ -1085,6 +1094,7 @@ export function ReviewThreadsBlock({
   onResolve,
   onEditComment,
   onDeleteComment,
+  editHeld,
   provider = "github",
   apply,
   fileDiffLookup,
@@ -1135,6 +1145,7 @@ export function ReviewThreadsBlock({
         onResolve={onResolve}
         onEditComment={onEditComment}
         onDeleteComment={onDeleteComment}
+        editHeld={editHeld}
         provider={provider}
         apply={apply}
         fileDiffLookup={fileDiffLookup}

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -55,9 +55,9 @@ export function ReviewersPopover({
   onChange: (next: ForgeUserRef[]) => void;
   /** The origin|upstream lens the parent surface resolved (create dialog: "origin"). */
   lens: RemoteLens;
-  /** Set when the viewer lacks the access this picker's action needs — callers
-   *  pass the reason for the matching axis. The trigger stays visible but
-   *  disabled and this text explains why. Absent = editable as before. */
+  /** Set when this picker can't be edited right now — the viewer lacks the access
+   *  its action needs, or the surface is still loading the entity. The trigger
+   *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
 }) {
   const candidates = useReviewerCandidates(repoPath, number, enabled, lens);

--- a/src/features/pulls/StackSection.tsx
+++ b/src/features/pulls/StackSection.tsx
@@ -144,6 +144,7 @@ export function StackSection({
   onSelect,
   onDissolve,
   dissolving,
+  disabled,
 }: {
   stack: PrStackInfo | null | undefined;
   members: PrStackMember[] | undefined;
@@ -155,6 +156,9 @@ export function StackSection({
    *  the caller owns the eligibility (native stack, open, writable). */
   onDissolve?: () => void;
   dissolving?: boolean;
+  /** Holds the Dissolve action without claiming a write is running — the caller
+   *  sets it while its own handler would refuse (e.g. a PR switch in flight). */
+  disabled?: boolean;
 }) {
   if (!stack) return null;
   const rows = byPosition(members ?? []);
@@ -172,6 +176,7 @@ export function StackSection({
           label={`Stack · ${stack.position} of ${Math.max(stack.size, stack.position)}`}
           onDissolve={onDissolve}
           dissolving={dissolving}
+          disabled={disabled}
         />
         <p className="mt-1.5 text-xs text-muted-foreground">
           Couldn't load the stack's members.
@@ -197,6 +202,7 @@ export function StackSection({
         label={`Stack · ${stack.position} of ${Math.max(rows.length, stack.position)}`}
         onDissolve={onDissolve}
         dissolving={dissolving}
+        disabled={disabled}
       />
       {/* Capped like the checks rollup so a deep stack can't push the tab row
           out of the header; arrow-nav scrolls the active row into view. */}
@@ -252,10 +258,12 @@ function StackHeader({
   label,
   onDissolve,
   dissolving,
+  disabled,
 }: {
   label: string;
   onDissolve?: () => void;
   dissolving?: boolean;
+  disabled?: boolean;
 }) {
   return (
     <div className="flex items-center gap-2">
@@ -267,7 +275,7 @@ function StackHeader({
           variant="ghost"
           size="xs"
           className="shrink-0 cursor-pointer text-muted-foreground hover:text-destructive focus-visible:text-destructive"
-          disabled={dissolving}
+          disabled={dissolving || disabled}
           onClick={onDissolve}
         >
           {dissolving && <Spinner data-icon="inline-start" />}
@@ -304,6 +312,7 @@ export function StackOffer({
   error,
   onConfirm,
   onCancel,
+  disabled,
   ref,
 }: {
   offer: StackOfferKind;
@@ -316,6 +325,9 @@ export function StackOffer({
   onConfirm: () => void;
   /** Collapses the preview; the caller also clears any error with it. */
   onCancel: () => void;
+  /** Holds Confirm without claiming a write is running — the caller sets it while
+   *  its own handler would refuse. Cancel stays live: it only dismisses. */
+  disabled?: boolean;
   ref?: Ref<StackOfferHandle>;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -429,7 +441,7 @@ export function StackOffer({
           ref={confirmRef}
           size="xs"
           className="cursor-pointer"
-          disabled={pending}
+          disabled={pending || disabled}
           onClick={onConfirm}
         >
           {pending && <Spinner data-icon="inline-start" />}

--- a/src/features/pulls/StackSection.tsx
+++ b/src/features/pulls/StackSection.tsx
@@ -325,8 +325,10 @@ export function StackOffer({
   onConfirm: () => void;
   /** Collapses the preview; the caller also clears any error with it. */
   onCancel: () => void;
-  /** Holds Confirm without claiming a write is running — the caller sets it while
-   *  its own handler would refuse. Cancel stays live: it only dismisses. */
+  /** Holds Confirm and the collapsed expand button without claiming a write is
+   *  running — the caller sets it while its own handler would refuse. Expanding
+   *  has to hold too: it focuses Confirm, which is disabled here. Cancel stays
+   *  live: it only dismisses. */
   disabled?: boolean;
   ref?: Ref<StackOfferHandle>;
 }) {
@@ -375,6 +377,7 @@ export function StackOffer({
           variant="outline"
           size="xs"
           className="shrink-0 cursor-pointer"
+          disabled={disabled}
           onClick={() => setExpanded(true)}
         >
           {offer.kind === "create" ? "Create stack" : "Add to stack"}

--- a/src/lib/use-keyed-entity-state.ts
+++ b/src/lib/use-keyed-entity-state.ts
@@ -1,0 +1,47 @@
+// Per-entity draft state, keyed by an entity identity: a settle callback holds
+// the key captured at submit, so a late mutation can only ever touch its own
+// entity's entry. Every write is a functional update, so a captured setter can't
+// go stale. Entries matching `isEmpty` are pruned rather than stored, so a long
+// session can't accumulate blank drafts.
+import { useState } from "react";
+
+function without<T>(map: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in map)) return map;
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+
+export function useKeyedEntityState<T>(
+  entityKey: string,
+  empty: T,
+  isEmpty: (value: T) => boolean = (v) => Object.is(v, empty),
+): {
+  /** The active entity's value (`empty` when none stored). */
+  value: T;
+  /** Write the ACTIVE entity's value. Accepts a value or functional updater. */
+  set: (next: T | ((prev: T) => T)) => void;
+  /** Update the entry for a CAPTURED key (settle callbacks use this). */
+  setFor: (key: string, updater: (prev: T) => T) => void;
+  /** Remove the entry for a captured key. */
+  clearFor: (key: string) => void;
+} {
+  const [entries, setEntries] = useState<Record<string, T>>({});
+
+  const setFor = (key: string, updater: (prev: T) => T) => {
+    setEntries((cur) => {
+      const next = updater(key in cur ? cur[key] : empty);
+      return isEmpty(next) ? without(cur, key) : { ...cur, [key]: next };
+    });
+  };
+
+  return {
+    value: entityKey in entries ? entries[entityKey] : empty,
+    set: (next) =>
+      setFor(entityKey, (prev) =>
+        typeof next === "function" ? (next as (prev: T) => T)(prev) : next,
+      ),
+    setFor,
+    clearFor: (key) => setEntries((cur) => without(cur, key)),
+  };
+}

--- a/src/lib/use-keyed-entity-state.ts
+++ b/src/lib/use-keyed-entity-state.ts
@@ -1,8 +1,10 @@
-// Per-entity draft state, keyed by an entity identity: a settle callback holds
-// the key captured at submit, so a late mutation can only ever touch its own
-// entity's entry. Every write is a functional update, so a captured setter can't
-// go stale. Entries matching `isEmpty` are pruned rather than stored, so a long
-// session can't accumulate blank drafts.
+// Per-entity draft state keyed by entity identity: a settle callback holds the
+// key captured at submit, so a late mutation can only touch its own entity's
+// entry. Every write is a functional update, so a captured setter can't go
+// stale, and entries matching `isEmpty` are pruned so blank drafts can't pile
+// up. Unless a custom `isEmpty` is passed, `empty` must be a primitive or a
+// stable module-level constant: the default is Object.is against it, so a
+// per-render literal never prunes and re-identifies `value` every render.
 import { useState } from "react";
 
 function without<T>(map: Record<string, T>, key: string): Record<string, T> {


### PR DESCRIPTION
Comment drafts were cleared whenever the view switched to a different entity, so navigating away from a discussion, PR, issue, or commit and back lost whatever had been typed. This replaces those render-time clears with per-entity draft storage behind a new shared hook, so each entity keeps its own unsent text while the view stays mounted.

### Shared hook

- Adds `useKeyedEntityState` in `src/lib/use-keyed-entity-state.ts`: a map of entity key → value with `value` / `set` for the active entity and `setFor` / `clearFor` for a key captured at submit time, so a late-settling mutation can only touch its own entity's entry. Every write is a functional update, and entries matching `isEmpty` (default `Object.is(v, empty)`) are pruned instead of stored so blank drafts can't accumulate over a long session.
- Because settle callbacks now address a captured key directly, the `useEffectEvent`-based `restoreDraft` / `clearDraft` identity guards are removed from `DiscussionView.tsx`, `JiraIssueView.tsx`, `RemoteIssueView.tsx`, `CommitComments.tsx`, and `RemotePrView.tsx`.

### Discussions

- `src/features/discussions/DiscussionView.tsx` keys the compose draft on `${repoPath}#${number}` and moves the reply box into a single `ReplyDraft` (`targetId` + `body`) with a custom `isEmpty`, so the open reply target and its text travel together per discussion. Reply drafts are still cleared on switch via `reply.clearFor(lastIdentity)` — the reply editor `autoFocus`es, so a restored one would steal focus on return.
- Gates `busy`, `submitComment`, and `submitReply` on `details.isPlaceholderData`: during the switch window the placeholder details belong to the previously shown discussion, so writes would target the wrong entity.
- The render-time identity block now resets only the delete confirms (`deletingCommentId`, `deletingDiscussion`).

### Remote PRs, issues, and commit comments

- `src/features/pulls/RemotePrView.tsx` keys the composer on the existing `entityKey`; `requestChanges` clears via `compose.clearFor(submittedFor)` and `submitComment` restores on error via `compose.setFor`, still only when that PR's composer is empty. The PR-switch block no longer blanks the draft.
- `src/features/issues/RemoteIssueView.tsx` keys on `${repoPath}#${lens}#${number}` and keeps the identity block for the delete/transfer/edit dialogs only; the `Clear` action and quote-reply now go through `compose.set`.
- `src/features/issues/JiraIssueView.tsx` keys on `${repoPath}#${issueKey}` and drops its own draft-clearing identity block.
- `src/features/pulls/CommitComments.tsx` keys the draft on `${repoPath}#${lens}#${sha}`, leaving the identity block to reset only the pending delete confirm.

### Local PRs and issues

- `src/features/conversations/useLocalConversation.ts` takes an `id` argument and stores the comment draft under it via `useKeyedEntityState`, matching the identity the views already reset on.
- `src/features/pulls/LocalPrView.tsx` and `src/features/issues/LocalIssueView.tsx` pass `id` into the hook and stop calling `setComment("")` on switch; their identity blocks still clear the half-typed label and open dialogs.
- Updates the `CommentComposer` doc comment in `src/features/conversations/CommentComposer.tsx` to describe the caller-owned, per-entity keyed draft.

### Changelog

- Adds `changelog.d/changed-drafts-per-entity.md` describing the retained drafts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comment drafts now persist separately for each discussion, pull request, issue, and commit.
  * Switching between items preserves in-progress comments without showing drafts on the wrong item.
  * Failed comment submissions restore the draft for the originating item.

* **Bug Fixes**
  * Prevented actions, reviews, and inline comments from targeting previously displayed items while content loads.
  * Improved comment panel behavior across commit navigation.
  * Loading states now clearly explain why metadata controls may be temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->