### PR TITLE
chore(quality,ci,git,time): add convention guards and fix existing violations

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -35,7 +35,7 @@ pnpm exec biome check ./src/           # lint/format CHECK (no mutation)
 cargo test --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
 cd site && pnpm build                  # when the marketing site changed
-pnpm run checks                        # guard scripts — blocking in CI (quality.yml)
+pnpm run checks                        # guard scripts + self-tests — CI quality.yml guards job
 ```
 
 Frontend changes run the first pair; Rust changes add the cargo pair. Not

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -35,6 +35,7 @@ pnpm exec biome check ./src/           # lint/format CHECK (no mutation)
 cargo test --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
 cd site && pnpm build                  # when the marketing site changed
+pnpm run checks                        # guard scripts — blocking in CI (quality.yml)
 ```
 
 Frontend changes run the first pair; Rust changes add the cargo pair. Not

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,14 +33,20 @@ jobs:
   guards:
     runs-on: ubuntu-latest
     steps:
+      # Nothing here uses the git credential after checkout, so it is not left
+      # in .git/config for later steps to reach.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Node
         uses: actions/setup-node@v7.0.0
         with:
           node-version: 24
 
-      # One step per script so a failure names its own check in the UI.
+      # One step per script so a failure names its own check in the UI. The same
+      # three run locally via package.json's `checks` alias — a fourth guard is
+      # added in BOTH places.
       - name: Banned frontend patterns
         run: node scripts/check-banned-patterns.mjs
 
@@ -49,6 +55,15 @@ jobs:
 
       - name: IPC surface drift
         run: node scripts/check-dead-surface.mjs
+
+      # Negative controls for the scanners themselves — their worst failure is a
+      # silent fail-open, so the fixtures that prove each predicate still fires
+      # run in CI. The test file is stdlib-only (node:test, node:assert), so this
+      # job still needs no install step. The argument is a QUOTED glob, not the
+      # `scripts` directory: node 24's runner resolves a bare directory path as
+      # an entry module and dies with MODULE_NOT_FOUND.
+      - name: Guard self-tests
+        run: node --test "scripts/*.test.mjs"
 
   # ADVISORY — informational only, triaged by humans, NEVER a merge gate; do not
   # register it as a required check. knip exits non-zero today on a known
@@ -59,11 +74,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
+      # continue-on-error from the first setup step on: an action outage must
+      # not redden a job whose contract is "never gates".
       - name: Install pnpm
+        continue-on-error: true
         uses: pnpm/action-setup@v6.0.9
 
       - name: Install Node
+        continue-on-error: true
         uses: actions/setup-node@v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,117 @@
+name: quality
+
+# Two jobs with deliberately opposite contracts.
+#
+# `guards` runs the mechanical convention checks and is a required status check
+# on master's ruleset — so it carries NO paths filter, because a paths-skipped
+# required check sits stuck "Expected" forever (GitHub required-checks docs).
+# The path-unfiltered push:master leg is the backstop re-validating the true
+# merged tree, since a PR green against a stale base merges stale-green.
+#
+# `advisory` reports; it never gates. It must not be registered as a required
+# check — see its own header for the contract.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+# One in-flight run per ref; a superseded push cancels the stale run instead of
+# stacking a second one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # BLOCKING. The three scripts are Node-stdlib-only by design, so this job
+  # needs no install step and stays a seconds-long gate on every PR.
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Node
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+
+      # One step per script so a failure names its own check in the UI.
+      - name: Banned frontend patterns
+        run: node scripts/check-banned-patterns.mjs
+
+      - name: Rust invariants
+        run: node scripts/check-rust-invariants.mjs
+
+      - name: IPC surface drift
+        run: node scripts/check-dead-surface.mjs
+
+  # ADVISORY — informational only, triaged by humans, NEVER a merge gate; do not
+  # register it as a required check. knip exits non-zero today on a known
+  # backlog of dead exports, so both tools run under continue-on-error and
+  # publish to the step summary, where findings are readable from the checks tab
+  # without opening logs.
+  advisory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: Install Node
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # continue-on-error here too: an install blip must not fail an advisory
+      # job whose contract is "never gates" — the tool steps just no-op after.
+      - name: Install dependencies
+        continue-on-error: true
+        run: pnpm install --frozen-lockfile
+
+      # jscpd's console reporter colours unconditionally (no TTY check, unlike
+      # knip), so both captures strip SGR sequences — otherwise the summary
+      # renders as escape-code soup. The tool's own exit code is preserved and
+      # absorbed by continue-on-error, so findings show on the step, not the job.
+      - name: Unused files, exports and dependencies (knip)
+        continue-on-error: true
+        run: |
+          log="$RUNNER_TEMP/knip.log"
+          set +e
+          pnpm exec knip --no-progress >"$log" 2>&1
+          status=$?
+          set -e
+          cat "$log"
+          {
+            echo "### knip — unused files, exports, dependencies"
+            echo ""
+            echo '```text'
+            sed -e 's/\x1b\[[0-9;]*m//g' "$log"
+            echo '```'
+            echo ""
+          } >>"$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Duplicate code (jscpd)
+        continue-on-error: true
+        run: |
+          log="$RUNNER_TEMP/jscpd.log"
+          set +e
+          pnpm exec jscpd >"$log" 2>&1
+          status=$?
+          set -e
+          cat "$log"
+          {
+            echo "### jscpd — duplicate code"
+            echo ""
+            echo '```text'
+            sed -e 's/\x1b\[[0-9;]*m//g' "$log"
+            echo '```'
+            echo ""
+          } >>"$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,9 +2,10 @@ name: quality
 
 # Two jobs with deliberately opposite contracts.
 #
-# `guards` runs the mechanical convention checks and is a required status check
-# on master's ruleset — so it carries NO paths filter, because a paths-skipped
-# required check sits stuck "Expected" forever (GitHub required-checks docs).
+# `guards` runs the mechanical convention checks and is meant to be registered
+# as a required status check on master's ruleset once this workflow lands there
+# — so it carries NO paths filter, because a paths-skipped required check sits
+# stuck "Expected" forever (GitHub required-checks docs).
 # The path-unfiltered push:master leg is the backstop re-validating the true
 # merged tree, since a PR green against a stale base merges stale-green.
 #
@@ -69,7 +70,8 @@ jobs:
           cache: pnpm
 
       # continue-on-error here too: an install blip must not fail an advisory
-      # job whose contract is "never gates" — the tool steps just no-op after.
+      # job whose contract is "never gates" — the tool steps then fail under
+      # their own continue-on-error (their error text lands in the summary).
       - name: Install dependencies
         continue-on-error: true
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -45,8 +45,8 @@ jobs:
           node-version: 24
 
       # One step per script so a failure names its own check in the UI. The same
-      # three run locally via package.json's `checks` alias — a fourth guard is
-      # added in BOTH places.
+      # three scripts plus the self-tests below run locally via package.json's
+      # `checks` alias — a new guard is added in BOTH places.
       - name: Banned frontend patterns
         run: node scripts/check-banned-patterns.mjs
 

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,7 @@
+{
+  "path": ["src"],
+  "format": ["typescript", "tsx"],
+  "ignore": ["**/src/components/ui/**", "**/*.d.ts"],
+  "minLines": 40,
+  "reporters": ["console"]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,9 @@ every registered command needs a caller, every `invoke()` a registration.
 Each check carries an allowlist, and it ratchets one way. Adding an entry is a
 reviewed change like any other: it needs an inline rationale naming what makes
 that site safe, and it isn't the way to quiet a fresh violation. The ratchet is
-enforced, not just documented — an entry whose site is gone fails the gate as a
-stale allowlist entry, so the PR that removes the site removes its entry too.
+enforced, not just documented — an entry that no longer suppresses anything
+(its site gone, or its command back in live use) fails the gate as a stale
+allowlist entry, so the PR that removes the site removes its entry too.
 
 `knip` and `jscpd` run in the same workflow's `advisory` job — non-blocking on
 purpose. The job publishes unused-export and duplicate-code reports to the run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ expected to respect its Design Principles.
 ## Prerequisites
 
 - **Rust** toolchain (stable) — <https://rustup.rs>
-- **Node 20+**
+- **Node 24+**
 - **pnpm** (`corepack enable` will use the version pinned in `package.json`)
 - Tauri's platform build dependencies — see the
   [Tauri prerequisites guide](https://v2.tauri.app/start/prerequisites/).
@@ -112,16 +112,18 @@ paid to close once. Run them before pushing:
 pnpm run checks   # banned patterns · Rust invariants · IPC surface drift · guard self-tests
 ```
 
-They gate merges as the **blocking** `guards` job in
-[`quality.yml`](.github/workflows/quality.yml), covering banned frontend UI and
-state patterns (hover-revealed row actions, hand-rolled modifier keys,
-`setQueryData(key, undefined)`), the Rust refspec-argv and
-sync-`#[tauri::command]` invariants, and Tauri IPC drift — every registered
-command needs a caller, every `invoke()` a registration.
+They run as the `guards` job in [`quality.yml`](.github/workflows/quality.yml),
+which is meant to be registered as a required check on master once it lands
+there. The checks cover banned frontend UI and state patterns (hover-revealed
+row actions, hand-rolled modifier keys, `setQueryData(key, undefined)`), the
+Rust refspec-argv and sync-`#[tauri::command]` invariants, and Tauri IPC drift —
+every registered command needs a caller, every `invoke()` a registration.
 
 Each check carries an allowlist, and it ratchets one way. Adding an entry is a
 reviewed change like any other: it needs an inline rationale naming what makes
-that site safe, and it isn't the way to quiet a fresh violation.
+that site safe, and it isn't the way to quiet a fresh violation. The ratchet is
+enforced, not just documented — an entry whose site is gone fails the gate as a
+stale allowlist entry, so the PR that removes the site removes its entry too.
 
 `knip` and `jscpd` run in the same workflow's `advisory` job — non-blocking on
 purpose. The job publishes unused-export and duplicate-code reports to the run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,30 @@ re-measure (payload sizes, timed runs) may stay and cite their source (a PR or
 run reference is fine there). When you touch a file, trimming its comments to
 this standard in passing is welcome.
 
+### Convention checks
+
+Three dependency-free Node scripts guard convention classes a past audit already
+paid to close once. Run them before pushing:
+
+```sh
+pnpm run checks   # banned patterns · Rust invariants · IPC surface drift
+```
+
+They gate merges as the **blocking** `guards` job in
+[`quality.yml`](.github/workflows/quality.yml), covering banned frontend UI and
+state patterns (hover-revealed row actions, hand-rolled modifier keys,
+`setQueryData(key, undefined)`), the Rust refspec-argv and
+sync-`#[tauri::command]` invariants, and Tauri IPC drift — every registered
+command needs a caller, every `invoke()` a registration.
+
+Each check carries an allowlist, and it ratchets one way. Adding an entry is a
+reviewed change like any other: it needs an inline rationale naming what makes
+that site safe, and it isn't the way to quiet a fresh violation.
+
+`knip` and `jscpd` run in the same workflow's `advisory` job — non-blocking on
+purpose. The job publishes unused-export and duplicate-code reports to the run
+summary for a human to triage, and never fails a build.
+
 ### Changelog
 
 For any **user-facing** change, add a **changelog fragment** — a small Markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Three dependency-free Node scripts guard convention classes a past audit already
 paid to close once. Run them before pushing:
 
 ```sh
-pnpm run checks   # banned patterns · Rust invariants · IPC surface drift
+pnpm run checks   # banned patterns · Rust invariants · IPC surface drift · guard self-tests
 ```
 
 They gate merges as the **blocking** `guards` job in

--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ from OS code signing.
 
 ## Development
 
-Prereqs: Rust toolchain, Node 20+, pnpm.
+Prereqs: Rust toolchain, Node 24+, pnpm.
 
 ```sh
 pnpm install

--- a/biome.json
+++ b/biome.json
@@ -51,6 +51,23 @@
             "useValidTypeof": "error",
             "useYield": "error"
           },
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@/lib/settings/api": {
+                    "importNames": ["saveSettings"],
+                    "message": "Use saveSettingsMerged or the useSaveSettings hook — raw saveSettings skips the serialized merge chain."
+                  },
+                  "./api": {
+                    "importNames": ["saveSettings"],
+                    "message": "Use saveSettingsMerged or the useSaveSettings hook — raw saveSettings skips the serialized merge chain."
+                  }
+                }
+              }
+            }
+          },
           "suspicious": {
             "noAsyncPromiseExecutor": "error",
             "noCatchAssign": "error",

--- a/changelog.d/fixed-local-pr-branch-validation.md
+++ b/changelog.d/fixed-local-pr-branch-validation.md
@@ -1,0 +1,4 @@
+- Local PR branch fields now accept only real branch names — a Git revision
+  expression such as `feature~1` or `main^` (possible via the MCP server's
+  `create_local_pr`) previously passed validation and could merge a different
+  commit than the branch it named.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@6.32.1/schema.json",
+  "$schema": "https://unpkg.com/knip@6/schema.json",
   // Advisory: surfaces dead exports and unused dependencies at PR time. Scoped
   // to the root package only — pnpm-workspace.yaml also declares `site`, which
   // has its own toolchain. Naming the workspace in `workspaces` does NOT narrow

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://unpkg.com/knip@6.32.1/schema.json",
+  // Advisory: surfaces dead exports and unused dependencies at PR time. Scoped
+  // to the root package only — pnpm-workspace.yaml also declares `site`, which
+  // has its own toolchain. Naming the workspace in `workspaces` does NOT narrow
+  // the run (verified: site/ files were still reported); `ignoreWorkspaces` is
+  // what actually excludes it.
+  "ignoreWorkspaces": ["site"],
+  "workspaces": {
+    ".": {
+      // No `entry`: knip's vite plugin resolves index.html → src/main.tsx
+      // itself, and an explicit copy draws a redundant-entry config hint.
+      "project": ["src/**/*.{ts,tsx}"],
+      // Vendored shadcn/Base UI primitives, never edited here: they ship
+      // unused variants by design and are a false-positive magnet.
+      "ignore": ["src/components/ui/**"]
+    }
+  },
+  // Built empirically from the run — each entry is reachable, just not through
+  // a path the `project` glob above can see. Everything NOT listed here stays
+  // reportable on purpose.
+  "ignoreDependencies": [
+    // These four are CSS `@import`s at the top of src/App.css; `project` is
+    // ts/tsx only, so knip never parses the stylesheet that pulls them in.
+    "@fontsource-variable/jetbrains-mono",
+    "shadcn",
+    "tailwindcss",
+    "tw-animate-css",
+    // Imported solely by src/components/ui/drawer.tsx, which `ignore` excludes.
+    "vaul"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "biome check --write ./src/ ./site/",
+    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs",
     "preview": "vite preview",
     "changelog": "node scripts/changelog-draft.mjs",
     "changelog:preview": "node scripts/changelog-draft.mjs --preview",
@@ -85,6 +86,8 @@
     "@vitejs/plugin-react": "^6.0.5",
     "babel-plugin-react-compiler": "^1.0.0",
     "globals": "^17.7.0",
+    "jscpd": "^5.0.14",
+    "knip": "^6.32.1",
     "typescript": "~6.0.2",
     "vite": "^8.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "biome check --write ./src/ ./site/",
-    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs",
+    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs && node --test \"scripts/*.test.mjs\"",
     "preview": "vite preview",
     "changelog": "node scripts/changelog-draft.mjs",
     "changelog:preview": "node scripts/changelog-draft.mjs --preview",

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
     "typescript": "~6.0.2",
     "vite": "^8.1.4"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 4.3.1
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 4.3.3(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@tanstack/react-form':
         specifier: ^1.33.2
         version: 1.33.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -176,7 +176,7 @@ importers:
         version: 2.5.6
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
-        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@tauri-apps/cli':
         specifier: ^2.11.4
         version: 2.11.4
@@ -194,19 +194,25 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
       globals:
         specifier: ^17.7.0
         version: 17.7.0
+      jscpd:
+        specifier: ^5.0.14
+        version: 5.0.14
+      knip:
+        specifier: ^6.32.1
+        version: 6.32.1
       typescript:
         specifier: ~6.0.2
         version: 6.0.3
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)
+        version: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
   site:
     dependencies:
@@ -221,16 +227,16 @@ importers:
         version: 5.3.0
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.3.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       astro:
         specifier: ^6.4.8
-        version: 6.4.8(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)
+        version: 6.4.8(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(yaml@2.9.0)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
       vite:
         specifier: ^7.3.5
-        version: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     devDependencies:
       sharp:
         specifier: ^0.35.3
@@ -555,8 +561,14 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
@@ -1141,8 +1153,241 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
 
   '@phosphor-icons/react@2.1.10':
     resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
@@ -2643,6 +2888,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2681,6 +2929,11 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2750,6 +3003,9 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
+
+  get-tsconfig@4.14.1:
+    resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
 
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
@@ -2986,6 +3242,44 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
+  jscpd-darwin-arm64@5.0.14:
+    resolution: {integrity: sha512-Ojjl79SBuj9tEW6WbjZ1a/1ZOR89dneH9yLQYQu8WyWaQownttnx7RYFEHU6aGhS4jIvwUEbr+1wxzFTb37cwg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  jscpd-darwin-x64@5.0.14:
+    resolution: {integrity: sha512-DxFg5XvjMZ81iVeqillnM5apqcGCfNTbroNF+mPLr7RkHLGH6mudLgtO+ILL/hfpZXy1bF9oIY5BSudPmN/k9A==}
+    cpu: [x64]
+    os: [darwin]
+
+  jscpd-linux-arm64-gnu@5.0.14:
+    resolution: {integrity: sha512-1uw+XBHEt9pONXNICSp5HpaVWPjG6mQ6deDXaq9Yb0xCNJkX4/8gmn0vhzekIyZD2DspRYKPUolbDsqm/HEdYg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  jscpd-linux-x64-gnu@5.0.14:
+    resolution: {integrity: sha512-dFTbyyrm+Z9pcXIVzJQCw8QAgiNqIiO69sm4AfA7/wFdPoizoVzjhaXsYXcSV4bs0aoPiWbNazg0J0HgslT/5A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  jscpd-linux-x64-musl@5.0.14:
+    resolution: {integrity: sha512-SayS7qQJvixyy9eR0+UjepkTsUUwqvlsiuSxfIdHgG2qzqoh/thnkgiu4By8fsiiDpQONsQrRrZDwHRQ3GDrBQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  jscpd-windows-x64-msvc@5.0.14:
+    resolution: {integrity: sha512-DqjxlVkUanlahGgY2lY7Zkrau4BUTI+AwWky+bPGK4kSK2AIOaUziY9Q19u8b58idXmJA9FKK98Fuu4ajNXVjQ==}
+    cpu: [x64]
+    os: [win32]
+
+  jscpd@5.0.14:
+    resolution: {integrity: sha512-zge+FPZZAymt2Do5Z0+QHyIn4/XcUhrO/W7of9HcHZfx2AK8++dYhLA1uWtwXj47ml3Of8PbcUW4wUWvYMCc3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3024,6 +3318,11 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  knip@6.32.1:
+    resolution: {integrity: sha512-mIiIHMTJVUgSlz0mxEgPt7wg8DmfbCp1Txqab3WpbMCJF7YHvHtC9jeAHHXfISMl72N8WzhyG71SQlaqCOGZtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3452,6 +3751,13 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  oxc-parser@0.142.0:
+    resolution: {integrity: sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3878,6 +4184,10 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  smol-toml@1.7.2:
+    resolution: {integrity: sha512-pXFZ9B2WinEPzxWkMmlYE/oYx2BP+qLrE95wP8tCuK901uLSMGdCb6QSr82z+wnhXkG4+cO+OMLbZB2Cn+97zw==}
+    engines: {node: '>= 18'}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -3936,6 +4246,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
@@ -4023,6 +4337,10 @@ packages:
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
+
+  unbash@4.0.10:
+    resolution: {integrity: sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==}
+    engines: {node: '>=14'}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -4295,6 +4613,10 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -4331,6 +4653,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
@@ -4817,7 +5144,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5218,6 +5556,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodable/entities@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -5241,7 +5586,134 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    optional: true
+
   '@oxc-project/types@0.139.0': {}
+
+  '@oxc-project/types@0.142.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
 
   '@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -5462,14 +5934,14 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.5
       rolldown: 1.1.5
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -5698,19 +6170,19 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.3.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
-  '@tailwindcss/vite@4.3.3(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.3(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
@@ -5963,12 +6435,12 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
   '@vue/reactivity@3.5.35':
@@ -6038,7 +6510,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  astro@6.4.8(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0):
+  astro@6.4.8(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -6090,8 +6562,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)
-      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -6654,6 +7126,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -6692,6 +7168,10 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
 
   forwarded@0.2.0: {}
 
@@ -6751,6 +7231,10 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  get-tsconfig@4.14.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@5.0.0-beta.4:
     dependencies:
@@ -6984,6 +7468,33 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jscpd-darwin-arm64@5.0.14:
+    optional: true
+
+  jscpd-darwin-x64@5.0.14:
+    optional: true
+
+  jscpd-linux-arm64-gnu@5.0.14:
+    optional: true
+
+  jscpd-linux-x64-gnu@5.0.14:
+    optional: true
+
+  jscpd-linux-x64-musl@5.0.14:
+    optional: true
+
+  jscpd-windows-x64-msvc@5.0.14:
+    optional: true
+
+  jscpd@5.0.14:
+    optionalDependencies:
+      jscpd-darwin-arm64: 5.0.14
+      jscpd-darwin-x64: 5.0.14
+      jscpd-linux-arm64-gnu: 5.0.14
+      jscpd-linux-x64-gnu: 5.0.14
+      jscpd-linux-x64-musl: 5.0.14
+      jscpd-windows-x64-msvc: 5.0.14
+
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -7009,6 +7520,22 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  knip@6.32.1:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.1
+      jiti: 2.7.0
+      oxc-parser: 0.142.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.5
+      smol-toml: 1.7.2
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.10
+      yaml: 2.9.0
+      zod: 4.4.3
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7574,6 +8101,53 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  oxc-parser@0.142.0:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.142.0
+      '@oxc-parser/binding-android-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-x64': 0.142.0
+      '@oxc-parser/binding-freebsd-x64': 0.142.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-musl': 0.142.0
+      '@oxc-parser/binding-openharmony-arm64': 0.142.0
+      '@oxc-parser/binding-wasm32-wasi': 0.142.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
   p-limit@2.3.0:
     dependencies:
@@ -8193,6 +8767,8 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
+  smol-toml@1.7.2: {}
+
   sonner@2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -8240,6 +8816,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  strip-json-comments@5.0.3: {}
 
   strnum@2.4.1:
     dependencies:
@@ -8314,6 +8892,8 @@ snapshots:
   ufo@1.6.4: {}
 
   ultrahtml@1.6.0: {}
+
+  unbash@4.0.10: {}
 
   uncrypto@0.1.3: {}
 
@@ -8468,7 +9048,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
@@ -8481,8 +9061,9 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+      yaml: 2.9.0
 
-  vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0):
+  vite@8.1.4(@types/node@24.13.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -8494,12 +9075,15 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
+      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   w3c-keyname@2.2.8: {}
+
+  walk-up-path@4.0.0: {}
 
   web-namespaces@2.0.1: {}
 
@@ -8527,6 +9111,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@22.0.0: {}
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -259,6 +259,37 @@ function walk(dir, out = []) {
   return out;
 }
 
+const STALE_FIX =
+  "stale allowlist entry — nothing in this file trips the check any more " +
+  "(fixed, renamed, deleted, or excluded by appliesTo); remove the entry " +
+  "(an exception left behind pre-authorizes whatever the file grows next)";
+
+/** One check over `files`: violations from files NOT on the allowlist, plus the
+ *  allowlist entries that produced no hit at all. Allowlisted files are SCANNED
+ *  rather than skipped — a ratchet that can only loosen is not a ratchet, so an
+ *  entry whose site is gone is itself a finding. An entry naming a file the
+ *  check doesn't apply to, or that no longer exists, reads stale for the same
+ *  reason: nothing justifies it any more. */
+export function runCheck(check, files, views) {
+  const scanned = files.filter((f) => check.appliesTo(f));
+  const violations = [];
+  const seen = new Set();
+  for (const file of scanned) {
+    const lines = check.scan(views.get(file)).sort((a, b) => a - b);
+    if (lines.length === 0) continue;
+    if (check.allowlist.includes(file)) {
+      seen.add(file);
+      continue;
+    }
+    for (const line of lines) violations.push(`${file}:${line}`);
+  }
+  return {
+    scanned,
+    violations,
+    stale: check.allowlist.filter((f) => !seen.has(f)),
+  };
+}
+
 function main() {
   const files = walk(SRC);
   const views = new Map(
@@ -267,24 +298,28 @@ function main() {
   let failed = false;
 
   for (const check of CHECKS) {
-    const scanned = files.filter((f) => check.appliesTo(f));
-    const violations = [];
-    for (const file of scanned) {
-      if (check.allowlist.includes(file)) continue;
-      for (const line of check.scan(views.get(file)).sort((a, b) => a - b)) {
-        violations.push(`${file}:${line}`);
-      }
-    }
-    if (violations.length === 0) {
+    const { scanned, violations, stale } = runCheck(check, files, views);
+    if (violations.length === 0 && stale.length === 0) {
       process.stdout.write(
         `${check.name}: OK (${scanned.length} files scanned)\n`,
       );
       continue;
     }
     failed = true;
-    process.stderr.write(`${check.name}: ${violations.length} violation(s)\n`);
-    for (const v of violations) process.stderr.write(`  ${v}\n`);
-    process.stderr.write(`  → ${check.message}\n`);
+    if (violations.length > 0) {
+      process.stderr.write(
+        `${check.name}: ${violations.length} violation(s)\n`,
+      );
+      for (const v of violations) process.stderr.write(`  ${v}\n`);
+      process.stderr.write(`  → ${check.message}\n`);
+    }
+    if (stale.length > 0) {
+      process.stderr.write(
+        `${check.name}: ${stale.length} stale allowlist entry(s)\n`,
+      );
+      for (const f of stale) process.stderr.write(`  ${f}\n`);
+      process.stderr.write(`  → ${STALE_FIX}\n`);
+    }
   }
 
   // Not `process.exit`: it can truncate a pending pipe write, losing the very
@@ -292,10 +327,11 @@ function main() {
   process.exitCode = failed ? 1 : 0;
 }
 
-// Main-module detection by PATH comparison, not `import.meta.main`: that is
-// node 24.2+ only, and this repo documents a node 20 floor (CONTRIBUTING.md,
-// README) with no engines pin — on an older runtime the gate would read
-// `if (undefined)` and the script would exit 0 having scanned nothing.
+// Main-module detection by PATH comparison, not `import.meta.main`: this form
+// works on any node, while `import.meta.main` only exists from 24.2 — a cliff
+// the documented floor should not have to track, and one that fails SILENTLY
+// (the gate reads `if (undefined)` and the script exits 0 having scanned
+// nothing — the fail-open this whole file exists to prevent).
 if (
   process.argv[1] &&
   resolve(process.argv[1]) === fileURLToPath(import.meta.url)

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -1,9 +1,12 @@
+#!/usr/bin/env node
 // Mechanical guards for convention classes that a 6-wave audit already paid to
 // close once — each check exists so its class cannot silently re-open one PR at
 // a time. Node built-ins only (no deps): CI runs this with bare `node`.
 //
 // Adding a check is one CHECKS entry. An allowlist entry is a deliberate,
 // rationale-carrying exception — never a way to quiet a fresh violation.
+// The predicates are exported and pinned by scripts/checks.test.mjs; the CLI
+// body below runs only when this file is the entry point.
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,16 +22,23 @@ const PAIR_GAP = 160;
 
 const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+/** A Tailwind class name as a standalone token. Without the boundary guards a
+ *  raw-substring match for `hidden` also fires on `overflow-hidden`, pairing
+ *  layout utilities with an unrelated `group-hover:` class. */
+const token = (s) => `(?<![\\w-])${escapeRe(s)}(?![\\w-])`;
+
 /**
  * Comment text blanked out, line structure preserved — a documented example of
  * a banned pattern is not a use of it. String literals are tracked just far
  * enough that `https://` and a quoted `/*` don't read as comment starts.
- * Residual gaps, all zero-instance today: regex literals aren't parsed, quote
- * state resets per line, and JSX text isn't distinguished from code, so a `//`
- * inside a regex literal, a multi-line template, or JSX prose blanks the rest
- * of that line. Deliberately not a parser.
+ * Residual gaps, all zero-instance today: regex literals aren't parsed and JSX
+ * text isn't distinguished from code, so a `//` inside a regex literal or JSX
+ * prose blanks the rest of that line. Quote state resets at each line, but
+ * block-comment state deliberately PERSISTS across lines — so a `/*` appearing
+ * inside a multi-line template literal or JSX prose blanks everything up to the
+ * next block-comment close, potentially the rest of the file. Not a parser.
  */
-function stripComments(lines) {
+export function stripComments(lines) {
   const out = [];
   let inBlock = false;
   for (const line of lines) {
@@ -75,7 +85,7 @@ function stripComments(lines) {
 /** A file's scannable view: comment-stripped lines, plus those lines joined
  *  into one string with each line's start offset — so a match that spans a
  *  wrapped expression still reports a real line number. */
-function view(source) {
+export function view(source) {
   const lines = stripComments(source.split(/\r?\n/));
   const starts = [];
   let offset = 0;
@@ -107,14 +117,10 @@ const perLine =
   ({ lines }) =>
     lines.flatMap((line, i) => (re.test(line) ? [i + 1] : []));
 
-/** Scanner: `a` and `b` within PAIR_GAP of each other in either order, wrapped
- *  lines included. Reports the line the match starts on. */
-const nearPair = (a, b) => {
-  const [x, y] = [escapeRe(a), escapeRe(b)];
-  const re = new RegExp(
-    `${x}[\\s\\S]{0,${PAIR_GAP}}?${y}|${y}[\\s\\S]{0,${PAIR_GAP}}?${x}`,
-    "g",
-  );
+/** Scanner: every match of a `g` regex against the whitespace-normalized whole
+ *  file, so a match spanning a wrapped expression still counts. Reports the line
+ *  the match starts on. */
+const perFile = (re) => {
   return ({ text, starts }) => {
     const hits = new Set();
     for (const m of text.matchAll(re)) hits.add(lineAt(starts, m.index));
@@ -122,11 +128,72 @@ const nearPair = (a, b) => {
   };
 };
 
-const CHECKS = [
+/** Scanner: `a` and `b` within PAIR_GAP of each other in either order, wrapped
+ *  lines included. Reports the line the match starts on. */
+const nearPair = (a, b) => {
+  const [x, y] = [token(a), token(b)];
+  const re = new RegExp(
+    `${x}[\\s\\S]{0,${PAIR_GAP}}?${y}|${y}[\\s\\S]{0,${PAIR_GAP}}?${x}`,
+    "g",
+  );
+  return perFile(re);
+};
+
+/** Scanner: the union of several `nearPair`s — one check, one allowlist, every
+ *  Tailwind spelling of the same idiom. */
+const anyPair = (pairs) => {
+  const scans = pairs.map(([a, b]) => nearPair(a, b));
+  return (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
+};
+
+// The same hover-reveal in each of its Tailwind spellings: the hiding utility
+// paired with the `group-hover:` class that undoes it. `inline` and
+// `inline-flex` are separate entries because the token boundary guard stops
+// `group-hover:inline` from matching inside `group-hover:inline-flex`.
+// The `hidden` arm is the noisy one: `hidden` is common standalone (responsive
+// layout) in a way `opacity-0` is not, so two SIBLING elements within PAIR_GAP
+// can pair by accident. That failure is loud — a named file and line — and the
+// allowlist is its remedy, so it is preferred over missing the real idiom.
+const HOVER_REVEAL_PAIRS = [
+  ["opacity-0", "group-hover:opacity-100"],
+  ["invisible", "group-hover:visible"],
+  ["hidden", "group-hover:block"],
+  ["hidden", "group-hover:flex"],
+  ["hidden", "group-hover:inline"],
+  ["hidden", "group-hover:inline-flex"],
+];
+
+// `undefined` as the LAST argument of a `setQueryData` call. Two traps:
+//   1. The call wraps — the updater lands on its own line — so this runs over
+//      the whitespace-normalized whole-file view, not per line.
+//   2. Type arguments nest: `setQueryData<Record<string, Foo>>(…)`. A
+//      `<[^>]*>` generic group stops at the INNER `>` and then fails on the
+//      leftover `>`; `<[^(]*?>` is lazy and bounded by the call's own paren
+//      (the same trap check-dead-surface.mjs documents for `invoke`).
+// The argument run is greedy so a key expression containing commas still
+// resolves to the call's LAST argument, but `;`-free and length-bounded so the
+// whole-file view can't pair one call's paren with a distant `, undefined)`.
+// Both halves of that bound are approximations, in opposite directions:
+//   - a `;` INSIDE a string key (`["a;b", repo]`) ends the run early and the
+//     call is missed — the only fail-open here, zero instances today;
+//   - `;` is not the only statement boundary, so JSX props or object members
+//     within the 200-char window can still pair one call's `(` with another
+//     expression's `, undefined)` — a loud false positive, not a miss.
+// 200 chars is ~7x headroom: across the 57 call sites under src/, the longest
+// first argument measures 27 chars (PR #208 review round 1).
+const SET_QUERY_DATA_RE =
+  /setQueryData\s*(?:<[^(]*?>)?\s*\([^;]{0,200},\s*undefined\s*[),]/g;
+
+// Vendored shadcn/Base UI primitives are off-limits to edit (CLAUDE.md), so a
+// hit inside them could only ever be silenced by an allowlist entry, never
+// fixed. Their CALL SITES — the app code that composes them — stay scanned.
+const notVendoredUi = (file) => !file.startsWith("src/components/ui/");
+
+export const CHECKS = [
   {
     name: "hover-reveal",
-    appliesTo: () => true,
-    scan: nearPair("opacity-0", "group-hover:opacity-100"),
+    appliesTo: notVendoredUi,
+    scan: anyPair(HOVER_REVEAL_PAIRS),
     allowlist: [
       // Documented product decision: the file row's inline actions.
       "src/features/repository/FileRow.tsx",
@@ -140,7 +207,8 @@ const CHECKS = [
     name: "hand-rolled-mod-key",
     // The hotkeys layer IS the platform-modifier helper, so it reads the raw
     // event flags by definition.
-    appliesTo: (file) => !file.startsWith("src/lib/hotkeys/"),
+    appliesTo: (file) =>
+      !file.startsWith("src/lib/hotkeys/") && notVendoredUi(file),
     // Each flag independently: a lone `e.metaKey` is the class in its worst
     // form (a hardcoded platform modifier), and a wrapped pair must not read as
     // clean either.
@@ -169,11 +237,9 @@ const CHECKS = [
   },
   {
     name: "setQueryData-noop",
+    // Not a UI idiom — it applies wherever the cache is written, vendored or not.
     appliesTo: () => true,
-    // Greedy `.*` so a key expression containing commas still resolves to the
-    // LAST argument. Line-scoped: an `undefined` wrapped onto its own line in a
-    // multi-line call is not caught.
-    scan: perLine(/setQueryData\s*(?:<[^>]*>)?\s*\(.*,\s*undefined\s*[),]/),
+    scan: perFile(SET_QUERY_DATA_RE),
     allowlist: [],
     message:
       "setQueryData(key, undefined) is a silent no-op in TanStack v5 — snapshot and restore the previous value instead",
@@ -193,29 +259,46 @@ function walk(dir, out = []) {
   return out;
 }
 
-const files = walk(SRC);
-const views = new Map(
-  files.map((f) => [f, view(readFileSync(join(ROOT, f), "utf8"))]),
-);
-let failed = false;
+function main() {
+  const files = walk(SRC);
+  const views = new Map(
+    files.map((f) => [f, view(readFileSync(join(ROOT, f), "utf8"))]),
+  );
+  let failed = false;
 
-for (const check of CHECKS) {
-  const scanned = files.filter((f) => check.appliesTo(f));
-  const violations = [];
-  for (const file of scanned) {
-    if (check.allowlist.includes(file)) continue;
-    for (const line of check.scan(views.get(file)).sort((a, b) => a - b)) {
-      violations.push(`${file}:${line}`);
+  for (const check of CHECKS) {
+    const scanned = files.filter((f) => check.appliesTo(f));
+    const violations = [];
+    for (const file of scanned) {
+      if (check.allowlist.includes(file)) continue;
+      for (const line of check.scan(views.get(file)).sort((a, b) => a - b)) {
+        violations.push(`${file}:${line}`);
+      }
     }
+    if (violations.length === 0) {
+      process.stdout.write(
+        `${check.name}: OK (${scanned.length} files scanned)\n`,
+      );
+      continue;
+    }
+    failed = true;
+    process.stderr.write(`${check.name}: ${violations.length} violation(s)\n`);
+    for (const v of violations) process.stderr.write(`  ${v}\n`);
+    process.stderr.write(`  → ${check.message}\n`);
   }
-  if (violations.length === 0) {
-    console.log(`${check.name}: OK (${scanned.length} files scanned)`);
-    continue;
-  }
-  failed = true;
-  console.error(`${check.name}: ${violations.length} violation(s)`);
-  for (const v of violations) console.error(`  ${v}`);
-  console.error(`  → ${check.message}`);
+
+  // Not `process.exit`: it can truncate a pending pipe write, losing the very
+  // violation list the failure is about on a CI runner.
+  process.exitCode = failed ? 1 : 0;
 }
 
-process.exit(failed ? 1 : 0);
+// Main-module detection by PATH comparison, not `import.meta.main`: that is
+// node 24.2+ only, and this repo documents a node 20 floor (CONTRIBUTING.md,
+// README) with no engines pin — on an older runtime the gate would read
+// `if (undefined)` and the script would exit 0 having scanned nothing.
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -1,0 +1,221 @@
+// Mechanical guards for convention classes that a 6-wave audit already paid to
+// close once — each check exists so its class cannot silently re-open one PR at
+// a time. Node built-ins only (no deps): CI runs this with bare `node`.
+//
+// Adding a check is one CHECKS entry. An allowlist entry is a deliberate,
+// rationale-carrying exception — never a way to quiet a fresh violation.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = join(ROOT, "src");
+const EXTENSIONS = [".ts", ".tsx"];
+
+// Widest gap (normalized chars) still counted as "the same expression" for a
+// two-token match. Sized so a formatter-wrapped class list stays one match while
+// two unrelated uses elsewhere in the file don't pair up.
+const PAIR_GAP = 160;
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Comment text blanked out, line structure preserved — a documented example of
+ * a banned pattern is not a use of it. String literals are tracked just far
+ * enough that `https://` and a quoted `/*` don't read as comment starts.
+ * Residual gaps, all zero-instance today: regex literals aren't parsed, quote
+ * state resets per line, and JSX text isn't distinguished from code, so a `//`
+ * inside a regex literal, a multi-line template, or JSX prose blanks the rest
+ * of that line. Deliberately not a parser.
+ */
+function stripComments(lines) {
+  const out = [];
+  let inBlock = false;
+  for (const line of lines) {
+    let code = "";
+    let quote = null;
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      const next = line[i + 1];
+      if (inBlock) {
+        if (c === "*" && next === "/") {
+          inBlock = false;
+          i++;
+        }
+        continue;
+      }
+      if (quote) {
+        code += c;
+        if (c === "\\") {
+          code += next ?? "";
+          i++;
+        } else if (c === quote) {
+          quote = null;
+        }
+        continue;
+      }
+      if (c === '"' || c === "'" || c === "`") {
+        quote = c;
+        code += c;
+        continue;
+      }
+      if (c === "/" && next === "/") break;
+      if (c === "/" && next === "*") {
+        inBlock = true;
+        i++;
+        continue;
+      }
+      code += c;
+    }
+    out.push(code);
+  }
+  return out;
+}
+
+/** A file's scannable view: comment-stripped lines, plus those lines joined
+ *  into one string with each line's start offset — so a match that spans a
+ *  wrapped expression still reports a real line number. */
+function view(source) {
+  const lines = stripComments(source.split(/\r?\n/));
+  const starts = [];
+  let offset = 0;
+  const parts = lines.map((line) => {
+    starts.push(offset);
+    const part = line.trim();
+    offset += part.length + 1;
+    return part;
+  });
+  return { lines, text: parts.join(" "), starts };
+}
+
+/** 1-based source line owning a normalized-text offset. */
+function lineAt(starts, index) {
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (starts[mid] <= index) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo + 1;
+}
+
+/** Scanner: every line matching `re` (never pass a `g` regex — `test` is
+ *  stateful with it). */
+const perLine =
+  (re) =>
+  ({ lines }) =>
+    lines.flatMap((line, i) => (re.test(line) ? [i + 1] : []));
+
+/** Scanner: `a` and `b` within PAIR_GAP of each other in either order, wrapped
+ *  lines included. Reports the line the match starts on. */
+const nearPair = (a, b) => {
+  const [x, y] = [escapeRe(a), escapeRe(b)];
+  const re = new RegExp(
+    `${x}[\\s\\S]{0,${PAIR_GAP}}?${y}|${y}[\\s\\S]{0,${PAIR_GAP}}?${x}`,
+    "g",
+  );
+  return ({ text, starts }) => {
+    const hits = new Set();
+    for (const m of text.matchAll(re)) hits.add(lineAt(starts, m.index));
+    return [...hits];
+  };
+};
+
+const CHECKS = [
+  {
+    name: "hover-reveal",
+    appliesTo: () => true,
+    scan: nearPair("opacity-0", "group-hover:opacity-100"),
+    allowlist: [
+      // Documented product decision: the file row's inline actions.
+      "src/features/repository/FileRow.tsx",
+      // Pairs the hover reveal with group-focus-visible, so keyboard reaches it.
+      "src/features/actions/RunDetailView.tsx",
+    ],
+    message:
+      "hover-revealed actions are banned (gd-conventions) — keep actions always-visible, or add an allowlist entry with rationale",
+  },
+  {
+    name: "hand-rolled-mod-key",
+    // The hotkeys layer IS the platform-modifier helper, so it reads the raw
+    // event flags by definition.
+    appliesTo: (file) => !file.startsWith("src/lib/hotkeys/"),
+    // Each flag independently: a lone `e.metaKey` is the class in its worst
+    // form (a hardcoded platform modifier), and a wrapped pair must not read as
+    // clean either.
+    scan: perLine(/\b(?:ctrlKey|metaKey)\b/),
+    // FROZEN: these 14 files are the app-wide mod+Enter submit policy (PR #202)
+    // and the file-row multi-select modifier. The gate blocks NEW hand-rolled
+    // sites; it is not a to-do list for these.
+    allowlist: [
+      "src/components/markdown-editor.tsx",
+      "src/features/conversations/CommentComposer.tsx",
+      "src/features/conversations/CommentEditor.tsx",
+      "src/features/conversations/EditTitleBodyDialog.tsx",
+      "src/features/discussions/DiscussionView.tsx",
+      "src/features/history/HistoryPanel.tsx",
+      "src/features/plan/PlanView.tsx",
+      "src/features/pulls/CommitComments.tsx",
+      "src/features/pulls/CreateLocalPrDialog.tsx",
+      "src/features/pulls/CreatePrDialog.tsx",
+      "src/features/pulls/ReviewComposer.tsx",
+      "src/features/pulls/ReviewThreads.tsx",
+      "src/features/repository/FileRow.tsx",
+      "src/features/research/ResearchView.tsx",
+    ],
+    message:
+      "derive the platform modifier via the hotkeys helpers (formatBinding/isMac) — new hand-rolled ctrl/meta checks need an allowlist entry with rationale",
+  },
+  {
+    name: "setQueryData-noop",
+    appliesTo: () => true,
+    // Greedy `.*` so a key expression containing commas still resolves to the
+    // LAST argument. Line-scoped: an `undefined` wrapped onto its own line in a
+    // multi-line call is not caught.
+    scan: perLine(/setQueryData\s*(?:<[^>]*>)?\s*\(.*,\s*undefined\s*[),]/),
+    allowlist: [],
+    message:
+      "setQueryData(key, undefined) is a silent no-op in TanStack v5 — snapshot and restore the previous value instead",
+  },
+];
+
+/** Every .ts/.tsx file under `dir`, as repo-relative POSIX paths. */
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, out);
+    } else if (EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+      out.push(relative(ROOT, full).split("\\").join("/"));
+    }
+  }
+  return out;
+}
+
+const files = walk(SRC);
+const views = new Map(
+  files.map((f) => [f, view(readFileSync(join(ROOT, f), "utf8"))]),
+);
+let failed = false;
+
+for (const check of CHECKS) {
+  const scanned = files.filter((f) => check.appliesTo(f));
+  const violations = [];
+  for (const file of scanned) {
+    if (check.allowlist.includes(file)) continue;
+    for (const line of check.scan(views.get(file)).sort((a, b) => a - b)) {
+      violations.push(`${file}:${line}`);
+    }
+  }
+  if (violations.length === 0) {
+    console.log(`${check.name}: OK (${scanned.length} files scanned)`);
+    continue;
+  }
+  failed = true;
+  console.error(`${check.name}: ${violations.length} violation(s)`);
+  for (const v of violations) console.error(`  ${v}`);
+  console.error(`  → ${check.message}`);
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/check-dead-surface.mjs
+++ b/scripts/check-dead-surface.mjs
@@ -112,6 +112,20 @@ function readInvoked() {
 const difference = (a, b) => [...a].filter((name) => !b.has(name)).sort();
 const list = (names) => names.map((name) => `  ${name}`).join("\n");
 
+const STALE_FIX =
+  "stale allowlist entry — this command is no longer registered; remove the " +
+  "entry (an exception left behind pre-authorizes whatever is registered " +
+  "under that name next)";
+
+/** Allowlist entries naming a command the handler list no longer registers.
+ *  The suppression they bought is gone, so the entry is itself a finding — a
+ *  ratchet that can only loosen is not a ratchet. An entry whose command IS
+ *  registered but uninvoked is doing exactly its job and stays: the dead-surface
+ *  hit it suppresses is the reason it exists. */
+export function staleAllowlistEntries(allowlist, registered) {
+  return allowlist.filter((name) => !registered.has(name)).sort();
+}
+
 function main() {
   const registered = readRegistered();
   const invoked = readInvoked();
@@ -121,6 +135,7 @@ function main() {
     (name) => !allowed.has(name),
   );
   const missing = difference(invoked, registered);
+  const stale = staleAllowlistEntries(ALLOWLIST, registered);
 
   const handlerPath = relative(root, LIB_RS).split(sep).join("/");
   process.stdout.write(
@@ -128,7 +143,7 @@ function main() {
       `${invoked.size} command(s) invoked from src/\n`,
   );
 
-  if (dead.length === 0 && missing.length === 0) {
+  if (dead.length === 0 && missing.length === 0 && stale.length === 0) {
     process.stdout.write("IPC surface is in sync — no drift.\n");
     return;
   }
@@ -150,15 +165,23 @@ function main() {
     );
   }
 
+  if (stale.length > 0) {
+    process.stderr.write(
+      `\n${stale.length} stale allowlist entry(s):\n${list(stale)}\n` +
+        `\n${STALE_FIX}\n`,
+    );
+  }
+
   // Not `process.exit`: it can truncate a pending pipe write, losing the very
   // drift lists the failure is about on a CI runner.
   process.exitCode = 1;
 }
 
-// Main-module detection by PATH comparison, not `import.meta.main`: that is
-// node 24.2+ only, and this repo documents a node 20 floor (CONTRIBUTING.md,
-// README) with no engines pin — on an older runtime the gate would read
-// `if (undefined)` and the script would exit 0 having scanned nothing.
+// Main-module detection by PATH comparison, not `import.meta.main`: this form
+// works on any node, while `import.meta.main` only exists from 24.2 — a cliff
+// the documented floor should not have to track, and one that fails SILENTLY
+// (the gate reads `if (undefined)` and the script exits 0 having scanned
+// nothing — the fail-open this whole file exists to prevent).
 if (
   process.argv[1] &&
   resolve(process.argv[1]) === fileURLToPath(import.meta.url)

--- a/scripts/check-dead-surface.mjs
+++ b/scripts/check-dead-surface.mjs
@@ -113,17 +113,21 @@ const difference = (a, b) => [...a].filter((name) => !b.has(name)).sort();
 const list = (names) => names.map((name) => `  ${name}`).join("\n");
 
 const STALE_FIX =
-  "stale allowlist entry — this command is no longer registered; remove the " +
-  "entry (an exception left behind pre-authorizes whatever is registered " +
-  "under that name next)";
+  "stale allowlist entry — it suppresses nothing: the command is no longer " +
+  "registered, or it has a live caller in src/ and so never reaches the " +
+  "dead-surface list; remove the entry (an exception left behind " +
+  "pre-authorizes whatever takes that name next)";
 
-/** Allowlist entries naming a command the handler list no longer registers.
- *  The suppression they bought is gone, so the entry is itself a finding — a
- *  ratchet that can only loosen is not a ratchet. An entry whose command IS
- *  registered but uninvoked is doing exactly its job and stays: the dead-surface
- *  hit it suppresses is the reason it exists. */
-export function staleAllowlistEntries(allowlist, registered) {
-  return allowlist.filter((name) => !registered.has(name)).sort();
+/** Allowlist entries that suppress nothing, in either of its two shapes: the
+ *  command is no longer registered, or it IS invoked from src/ and so never
+ *  reaches the `dead` filter the entry exists to quiet. Both leave a standing
+ *  exception with nothing behind it — and a ratchet that can only loosen is not
+ *  a ratchet. Registered-but-uninvoked is the one live shape: that entry is
+ *  doing exactly its job and stays. */
+export function staleAllowlistEntries(allowlist, registered, invoked) {
+  return allowlist
+    .filter((name) => !registered.has(name) || invoked.has(name))
+    .sort();
 }
 
 function main() {
@@ -135,7 +139,7 @@ function main() {
     (name) => !allowed.has(name),
   );
   const missing = difference(invoked, registered);
-  const stale = staleAllowlistEntries(ALLOWLIST, registered);
+  const stale = staleAllowlistEntries(ALLOWLIST, registered, invoked);
 
   const handlerPath = relative(root, LIB_RS).split(sep).join("/");
   process.stdout.write(

--- a/scripts/check-dead-surface.mjs
+++ b/scripts/check-dead-surface.mjs
@@ -5,8 +5,10 @@
 // caller; this check keeps that from recurring silently. Node stdlib only — CI
 // runs it with bare `node`, before any install step.
 import { readdirSync, readFileSync } from "node:fs";
-import { dirname, join, relative, sep } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { stripComments } from "./check-banned-patterns.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const LIB_RS = join(root, "src-tauri", "src", "lib.rs");
@@ -23,12 +25,11 @@ const ALLOWLIST = [];
 /** Registered set: the final `::` segment of every entry in the
  *  `generate_handler!` list. Located by MARKER + bracket scan, never by line
  *  numbers — the list grows every release. */
-function readRegistered() {
-  const source = readFileSync(LIB_RS, "utf8");
+export function parseRegistered(source, label = "the handler list") {
   const marker = "tauri::generate_handler![";
   const start = source.indexOf(marker);
   if (start === -1) {
-    throw new Error(`Could not find '${marker}' in ${LIB_RS}`);
+    throw new Error(`Could not find '${marker}' in ${label}`);
   }
   let depth = 0;
   let end = start + marker.length - 1; // the marker's own '['
@@ -38,16 +39,28 @@ function readRegistered() {
     else if (ch === "]" && --depth === 0) break;
   }
   if (depth !== 0) {
-    throw new Error(`Unterminated generate_handler! list in ${LIB_RS}`);
+    throw new Error(`Unterminated generate_handler! list in ${label}`);
   }
+  // Comments go BEFORE the comma split, and the dangerous direction is why:
+  // a commented-out entry `// git::foo,` survives the split and still yields
+  // `foo` from `split("::").pop()`, so a command that is registered nowhere but
+  // still invoked reads as a FALSE CLEAN here and fails at runtime. (Stripping
+  // can at worst mis-parse a nearby entry into noise — a loud, fixable wrong.)
+  const body = source
+    .slice(start + marker.length, end)
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/[^\n]*/g, " ");
   return new Set(
-    source
-      .slice(start + marker.length, end)
+    body
       .split(",")
       .map((entry) => entry.trim())
       .filter(Boolean)
       .map((path) => path.split("::").pop()),
   );
+}
+
+function readRegistered() {
+  return parseRegistered(readFileSync(LIB_RS, "utf8"), LIB_RS);
 }
 
 // Two traps this pattern exists to survive, both live in src/lib/git/api.ts:
@@ -59,6 +72,22 @@ function readRegistered() {
 // A pattern that gets either wrong reports exactly three live commands as dead:
 // forge_pr_list_mergeability, forge_publish_targets, git_branch_tips.
 const INVOKE_RE = /invoke(?:<[^(]*?>)?\(\s*"([A-Za-z_][A-Za-z0-9_]*)"/g;
+
+/** Every command name passed to `invoke` in one file's contents. Comments are
+ *  stripped first, and for the same reason the handler list strips them: a
+ *  commented-out `// invoke("git_retired_command")` otherwise still counts as a
+ *  live call, so a command nothing invokes any more reads green forever. Lines
+ *  are re-joined rather than trimmed, so a call split across lines still
+ *  matches. */
+export function parseInvoked(contents, into = new Set()) {
+  const code = stripComments(contents.split(/\r?\n/)).join("\n");
+  INVOKE_RE.lastIndex = 0;
+  let match;
+  while ((match = INVOKE_RE.exec(code)) !== null) {
+    into.add(match[1]);
+  }
+  return into;
+}
 
 /** Invoked set: every command name passed to `invoke` anywhere under src/.
  *  The walk covers ALL of src/, not just src/lib — 13 call sites live outside it
@@ -72,12 +101,7 @@ function readInvoked() {
       const full = join(dir, entry.name);
       if (entry.isDirectory()) walk(full);
       else if (/\.tsx?$/.test(entry.name)) {
-        const contents = readFileSync(full, "utf8");
-        INVOKE_RE.lastIndex = 0;
-        let match;
-        while ((match = INVOKE_RE.exec(contents)) !== null) {
-          invoked.add(match[1]);
-        }
+        parseInvoked(readFileSync(full, "utf8"), invoked);
       }
     }
   };
@@ -88,38 +112,56 @@ function readInvoked() {
 const difference = (a, b) => [...a].filter((name) => !b.has(name)).sort();
 const list = (names) => names.map((name) => `  ${name}`).join("\n");
 
-const registered = readRegistered();
-const invoked = readInvoked();
-const allowed = new Set(ALLOWLIST);
+function main() {
+  const registered = readRegistered();
+  const invoked = readInvoked();
+  const allowed = new Set(ALLOWLIST);
 
-const dead = difference(registered, invoked).filter(
-  (name) => !allowed.has(name),
-);
-const missing = difference(invoked, registered);
-
-const handlerPath = relative(root, LIB_RS).split(sep).join("/");
-process.stdout.write(
-  `${registered.size} command(s) registered in ${handlerPath}\n` +
-    `${invoked.size} command(s) invoked from src/\n`,
-);
-
-if (dead.length === 0 && missing.length === 0) {
-  process.stdout.write("IPC surface is in sync — no drift.\n");
-  process.exit(0);
-}
-
-if (dead.length > 0) {
-  process.stderr.write(
-    `\n${dead.length} command(s) registered but never invoked from src/ — dead IPC surface (or add an allowlist entry):\n${list(dead)}\n` +
-      `\nRemove them from the tauri::generate_handler! list in ${handlerPath} (and delete the command itself if nothing else uses it).\n`,
+  const dead = difference(registered, invoked).filter(
+    (name) => !allowed.has(name),
   );
-}
+  const missing = difference(invoked, registered);
 
-if (missing.length > 0) {
-  process.stderr.write(
-    `\n${missing.length} command(s) invoked but not registered — this call fails at runtime:\n${list(missing)}\n` +
-      `\nAdd them to the tauri::generate_handler! list in ${handlerPath}.\n`,
+  const handlerPath = relative(root, LIB_RS).split(sep).join("/");
+  process.stdout.write(
+    `${registered.size} command(s) registered in ${handlerPath}\n` +
+      `${invoked.size} command(s) invoked from src/\n`,
   );
+
+  if (dead.length === 0 && missing.length === 0) {
+    process.stdout.write("IPC surface is in sync — no drift.\n");
+    return;
+  }
+
+  // Both directions always report before the exit code is set: drift usually
+  // arrives in pairs (a rename shows up as one dead + one missing), and half a
+  // picture sends the reader chasing the wrong fix.
+  if (dead.length > 0) {
+    process.stderr.write(
+      `\n${dead.length} command(s) registered but never invoked from src/ — dead IPC surface (or add an allowlist entry):\n${list(dead)}\n` +
+        `\nRemove them from the tauri::generate_handler! list in ${handlerPath} (and delete the command itself if nothing else uses it).\n`,
+    );
+  }
+
+  if (missing.length > 0) {
+    process.stderr.write(
+      `\n${missing.length} command(s) invoked but not registered — this call fails at runtime:\n${list(missing)}\n` +
+        `\nAdd them to the tauri::generate_handler! list in ${handlerPath}.\n`,
+    );
+  }
+
+  // Not `process.exit`: it can truncate a pending pipe write, losing the very
+  // drift lists the failure is about on a CI runner.
+  process.exitCode = 1;
 }
 
-process.exit(1);
+// Main-module detection by PATH comparison, not `import.meta.main`: that is
+// node 24.2+ only, and this repo documents a node 20 floor (CONTRIBUTING.md,
+// README) with no engines pin — on an older runtime the gate would read
+// `if (undefined)` and the script would exit 0 having scanned nothing.
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/check-dead-surface.mjs
+++ b/scripts/check-dead-surface.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Pins the Tauri IPC surface at zero drift: every command registered in
+// `generate_handler!` must be invoked from src/, and every `invoke("…")` must be
+// registered. A 2026-08 audit deleted 61 commands that had accumulated with no
+// caller; this check keeps that from recurring silently. Node stdlib only — CI
+// runs it with bare `node`, before any install step.
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LIB_RS = join(root, "src-tauri", "src", "lib.rs");
+const SRC = join(root, "src");
+
+// Commands that are legitimately registered without a src/ caller. Empty today,
+// and the two classes that could ever populate it: (1) a command served to a
+// second window or binary target whose frontend doesn't live under src/;
+// (2) a call site that builds the command name as a computed string, which the
+// literal-only scan below cannot see. Neither exists now — every call site in
+// the tree passes a bare string literal.
+const ALLOWLIST = [];
+
+/** Registered set: the final `::` segment of every entry in the
+ *  `generate_handler!` list. Located by MARKER + bracket scan, never by line
+ *  numbers — the list grows every release. */
+function readRegistered() {
+  const source = readFileSync(LIB_RS, "utf8");
+  const marker = "tauri::generate_handler![";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`Could not find '${marker}' in ${LIB_RS}`);
+  }
+  let depth = 0;
+  let end = start + marker.length - 1; // the marker's own '['
+  for (; end < source.length; end++) {
+    const ch = source[end];
+    if (ch === "[") depth++;
+    else if (ch === "]" && --depth === 0) break;
+  }
+  if (depth !== 0) {
+    throw new Error(`Unterminated generate_handler! list in ${LIB_RS}`);
+  }
+  return new Set(
+    source
+      .slice(start + marker.length, end)
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .map((path) => path.split("::").pop()),
+  );
+}
+
+// Two traps this pattern exists to survive, both live in src/lib/git/api.ts:
+//   1. The call can be split across lines — `invoke<T>(\n  "forge_publish_targets"`
+//      — so the gap before the literal must match newlines (`\s*`, not ` *`).
+//   2. Type arguments nest: `invoke<Record<string, string>>("git_branch_tips")`.
+//      A `<[^>]*>` generic group stops at the INNER `>` and then fails on the
+//      leftover `>`; `<[^(]*?>` is lazy and bounded by the call's own paren.
+// A pattern that gets either wrong reports exactly three live commands as dead:
+// forge_pr_list_mergeability, forge_publish_targets, git_branch_tips.
+const INVOKE_RE = /invoke(?:<[^(]*?>)?\(\s*"([A-Za-z_][A-Za-z0-9_]*)"/g;
+
+/** Invoked set: every command name passed to `invoke` anywhere under src/.
+ *  The walk covers ALL of src/, not just src/lib — 13 call sites live outside it
+ *  (App.tsx, features/app-menu/useMacAppMenu.ts, features/research/store.ts,
+ *  features/sessions/persistence.ts), reaching 10 commands nothing in src/lib
+ *  calls. Matching is done on whole file contents so trap 1 above can't bite. */
+function readInvoked() {
+  const invoked = new Set();
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(entry.name)) {
+        const contents = readFileSync(full, "utf8");
+        INVOKE_RE.lastIndex = 0;
+        let match;
+        while ((match = INVOKE_RE.exec(contents)) !== null) {
+          invoked.add(match[1]);
+        }
+      }
+    }
+  };
+  walk(SRC);
+  return invoked;
+}
+
+const difference = (a, b) => [...a].filter((name) => !b.has(name)).sort();
+const list = (names) => names.map((name) => `  ${name}`).join("\n");
+
+const registered = readRegistered();
+const invoked = readInvoked();
+const allowed = new Set(ALLOWLIST);
+
+const dead = difference(registered, invoked).filter(
+  (name) => !allowed.has(name),
+);
+const missing = difference(invoked, registered);
+
+const handlerPath = relative(root, LIB_RS).split(sep).join("/");
+process.stdout.write(
+  `${registered.size} command(s) registered in ${handlerPath}\n` +
+    `${invoked.size} command(s) invoked from src/\n`,
+);
+
+if (dead.length === 0 && missing.length === 0) {
+  process.stdout.write("IPC surface is in sync — no drift.\n");
+  process.exit(0);
+}
+
+if (dead.length > 0) {
+  process.stderr.write(
+    `\n${dead.length} command(s) registered but never invoked from src/ — dead IPC surface (or add an allowlist entry):\n${list(dead)}\n` +
+      `\nRemove them from the tauri::generate_handler! list in ${handlerPath} (and delete the command itself if nothing else uses it).\n`,
+  );
+}
+
+if (missing.length > 0) {
+  process.stderr.write(
+    `\n${missing.length} command(s) invoked but not registered — this call fails at runtime:\n${list(missing)}\n` +
+      `\nAdd them to the tauri::generate_handler! list in ${handlerPath}.\n`,
+  );
+}
+
+process.exit(1);

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -21,7 +21,7 @@
 //
 // Run: node scripts/check-rust-invariants.mjs
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SRC = join(
@@ -50,24 +50,25 @@ const REFSPEC_ALLOWLIST = [
   {
     file: "git/branches.rs",
     fn: "git_branch_merge_states",
-    rationale: "validates each pair's head/base with validate_ref_name inline",
+    rationale:
+      "validates each pair's head/base with validate_branch_name inline",
   },
   {
     file: "git/ops.rs",
     fn: "finalize_base",
     rationale:
-      "private helper; both callers (merge_local_pr, finish_local_pr_merge) validate base with validate_ref_name",
+      "private helper; both callers (merge_local_pr, finish_local_pr_merge) validate base with validate_branch_name",
   },
   {
     file: "git/ops.rs",
     fn: "push_pr_head",
     rationale:
-      "private helper; both callers (merge_remote_pr, finish_remote_pr_resolve) validate head with validate_ref_name",
+      "private helper; both callers (merge_remote_pr, finish_remote_pr_resolve) validate head with validate_branch_name",
   },
   {
     file: "git/ops.rs",
     fn: "merge_remote_pr",
-    rationale: "validates base and head with validate_ref_name at fn entry",
+    rationale: "validates base and head with validate_branch_name at fn entry",
   },
   {
     file: "git/ops.rs",
@@ -120,7 +121,8 @@ const REFSPEC_ALLOWLIST = [
   {
     file: "mcp_server/write_local.rs",
     fn: "verify_branch",
-    rationale: "validates via validate_ref_name at fn entry",
+    rationale:
+      "validates via validate_branch_name at fn entry (rev-expression syntax rejected before the probe)",
   },
 ];
 
@@ -190,9 +192,16 @@ function rustFiles(dir, out = []) {
 // Attribution is textual: the nearest preceding signature. A match inside a
 // closure or a nested block is therefore reported against the function that
 // encloses it, which is exactly the granularity the allowlists key on.
-const FN_RE = /^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+(\w+)/;
+// Every qualifier a signature can carry must be here, in any order `const`,
+// `async` and `unsafe` legally combine: a signature the pattern misses is
+// silently attributed to the PRECEDING function instead (five `const fn`s in
+// forge/model.rs were invisible to the narrower `(?:async\s+)?` form).
+// The ABI string is optional because a bare `extern fn` is legal and defaults
+// to "C".
+export const FN_RE =
+  /^\s*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe)\s+)*(?:extern(?:\s+"[^"]*")?\s+)?fn\s+(\w+)/;
 
-function enclosingFn(lines, lineIdx) {
+export function enclosingFn(lines, lineIdx) {
   for (let i = lineIdx; i >= 0; i--) {
     const m = FN_RE.exec(lines[i]);
     if (m) return m[1];
@@ -213,7 +222,7 @@ const REFSPEC_FIX =
   "names reaching a refspec route through validate_ref_name/validate_tag_name " +
   "(gd-conventions Security hot spots) — validate, or allowlist with rationale";
 
-function checkRefspecTemplates(file, src, lines, hits) {
+export function checkRefspecTemplates(file, src, lines, hits) {
   FORMAT_RE.lastIndex = 0;
   for (let m = FORMAT_RE.exec(src); m; m = FORMAT_RE.exec(src)) {
     if (!REFSPEC_MARKERS.some((marker) => m[1].includes(marker))) continue;
@@ -240,7 +249,7 @@ const SECRET_KEY_RE = /token|secret|passw|credential|api[_-]?key/i;
 const SECRET_ARGV_FIX =
   "secrets never ride argv — send them via run_gh_input / json_body_args stdin bodies";
 
-function checkSecretArgv(file, _src, lines, hits) {
+export function checkSecretArgv(file, _src, lines, hits) {
   for (let i = 0; i < lines.length; i++) {
     if (!ARGV_FLAG_RE.test(lines[i])) continue;
     const window = lines.slice(i, i + 3).join("\n");
@@ -266,7 +275,7 @@ const SYNC_COMMAND_FIX =
   "sync #[tauri::command]s run on the main thread (gd-conventions Rust) — " +
   "make it async (spawn_blocking for IO), or allowlist with rationale";
 
-function checkSyncCommands(file, _src, lines, hits) {
+export function checkSyncCommands(file, _src, lines, hits) {
   for (let i = 0; i < lines.length; i++) {
     if (!COMMAND_ATTR_RE.test(lines[i])) continue;
     // Skip the attributes, cfg gates and doc comments between the marker and
@@ -303,40 +312,55 @@ function checkSyncCommands(file, _src, lines, hits) {
 
 // ---------------------------------------------------------------------- main
 
-const CHECKS = [
-  { name: "A. refspec templates", run: checkRefspecTemplates, hits: [] },
-  { name: "B. secret-shaped argv", run: checkSecretArgv, hits: [] },
-  { name: "C. sync #[tauri::command]", run: checkSyncCommands, hits: [] },
-];
+function main() {
+  const CHECKS = [
+    { name: "A. refspec templates", run: checkRefspecTemplates, hits: [] },
+    { name: "B. secret-shaped argv", run: checkSecretArgv, hits: [] },
+    { name: "C. sync #[tauri::command]", run: checkSyncCommands, hits: [] },
+  ];
 
-const files = rustFiles(SRC);
-for (const path of files) {
-  // Normalise CRLF: on Windows a git checkout materialises these files with
-  // CRLF, and a trailing `\r` would leak into every reported line.
-  const src = readFileSync(path, "utf8").replace(/\r\n/g, "\n");
-  const lines = src.split("\n");
-  const rel = relative(SRC, path).replace(/\\/g, "/");
-  for (const check of CHECKS) check.run(rel, src, lines, check.hits);
-}
+  const files = rustFiles(SRC);
+  for (const path of files) {
+    // Normalise CRLF: on Windows a git checkout materialises these files with
+    // CRLF, and a trailing `\r` would leak into every reported line.
+    const src = readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+    const lines = src.split("\n");
+    const rel = relative(SRC, path).replace(/\\/g, "/");
+    for (const check of CHECKS) check.run(rel, src, lines, check.hits);
+  }
 
-let failed = false;
-for (const check of CHECKS) {
-  const violations = check.hits.filter((h) => !h.allowlisted);
-  const allowlisted = check.hits.length - violations.length;
-  if (violations.length === 0) {
-    process.stdout.write(
-      `${check.name}: OK (${files.length} files, ${allowlisted} allowlisted)\n`,
+  let failed = false;
+  for (const check of CHECKS) {
+    const violations = check.hits.filter((h) => !h.allowlisted);
+    const allowlisted = check.hits.length - violations.length;
+    if (violations.length === 0) {
+      process.stdout.write(
+        `${check.name}: OK (${files.length} files, ${allowlisted} allowlisted)\n`,
+      );
+      continue;
+    }
+    failed = true;
+    process.stderr.write(
+      `${check.name}: FAIL (${files.length} files, ${violations.length} violation(s), ${allowlisted} allowlisted)\n`,
     );
-    continue;
+    for (const v of violations) {
+      process.stderr.write(`  src-tauri/src/${v.file}:${v.line}  fn ${v.fn}\n`);
+      process.stderr.write(`    ${v.fix}\n`);
+    }
   }
-  failed = true;
-  process.stdout.write(
-    `${check.name}: FAIL (${files.length} files, ${violations.length} violation(s), ${allowlisted} allowlisted)\n`,
-  );
-  for (const v of violations) {
-    process.stdout.write(`  src-tauri/src/${v.file}:${v.line}  fn ${v.fn}\n`);
-    process.stdout.write(`    ${v.fix}\n`);
-  }
+
+  // Not `process.exit`: it can truncate a pending pipe write, losing the very
+  // violation list the failure is about on a CI runner.
+  process.exitCode = failed ? 1 : 0;
 }
 
-process.exit(failed ? 1 : 0);
+// Main-module detection by PATH comparison, not `import.meta.main`: that is
+// node 24.2+ only, and this repo documents a node 20 floor (CONTRIBUTING.md,
+// README) with no engines pin — on an older runtime the gate would read
+// `if (undefined)` and the script would exit 0 having scanned nothing.
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -212,6 +212,16 @@ export function enclosingFn(lines, lineIdx) {
 const allowed = (list, file, fn) =>
   list.some((e) => e.file === file && e.fn === fn);
 
+/** Allowlist records no hit mapped to. Their site is gone, so the entry is
+ *  stale — and the RATCHET RULE above is only a ratchet if a leftover entry is
+ *  a finding: left in place it silently pre-authorizes whatever that function
+ *  grows next. */
+export function staleAllowlistEntries(list, hits) {
+  return list.filter(
+    (e) => !hits.some((h) => h.file === e.file && h.fn === e.fn),
+  );
+}
+
 // -------------------------------------------------------------------- checks
 
 // `format!(` through to its template, tolerating a newline before the literal
@@ -271,6 +281,10 @@ export function checkSecretArgv(file, _src, lines, hits) {
 }
 
 const COMMAND_ATTR_RE = /^\s*#\[tauri::command/;
+const STALE_FIX =
+  "stale allowlist entry — nothing in this function trips the check any more " +
+  "(fixed, renamed, deleted, or moved to another file/fn); remove the entry " +
+  "(RATCHET RULE: the lists only shrink)";
 const SYNC_COMMAND_FIX =
   "sync #[tauri::command]s run on the main thread (gd-conventions Rust) — " +
   "make it async (spawn_blocking for IO), or allowlist with rationale";
@@ -314,9 +328,24 @@ export function checkSyncCommands(file, _src, lines, hits) {
 
 function main() {
   const CHECKS = [
-    { name: "A. refspec templates", run: checkRefspecTemplates, hits: [] },
-    { name: "B. secret-shaped argv", run: checkSecretArgv, hits: [] },
-    { name: "C. sync #[tauri::command]", run: checkSyncCommands, hits: [] },
+    {
+      name: "A. refspec templates",
+      run: checkRefspecTemplates,
+      allowlist: REFSPEC_ALLOWLIST,
+      hits: [],
+    },
+    {
+      name: "B. secret-shaped argv",
+      run: checkSecretArgv,
+      allowlist: SECRET_ARGV_ALLOWLIST,
+      hits: [],
+    },
+    {
+      name: "C. sync #[tauri::command]",
+      run: checkSyncCommands,
+      allowlist: SYNC_COMMAND_ALLOWLIST,
+      hits: [],
+    },
   ];
 
   const files = rustFiles(SRC);
@@ -333,7 +362,8 @@ function main() {
   for (const check of CHECKS) {
     const violations = check.hits.filter((h) => !h.allowlisted);
     const allowlisted = check.hits.length - violations.length;
-    if (violations.length === 0) {
+    const stale = staleAllowlistEntries(check.allowlist, check.hits);
+    if (violations.length === 0 && stale.length === 0) {
       process.stdout.write(
         `${check.name}: OK (${files.length} files, ${allowlisted} allowlisted)\n`,
       );
@@ -341,11 +371,15 @@ function main() {
     }
     failed = true;
     process.stderr.write(
-      `${check.name}: FAIL (${files.length} files, ${violations.length} violation(s), ${allowlisted} allowlisted)\n`,
+      `${check.name}: FAIL (${files.length} files, ${violations.length} violation(s), ${allowlisted} allowlisted, ${stale.length} stale)\n`,
     );
     for (const v of violations) {
       process.stderr.write(`  src-tauri/src/${v.file}:${v.line}  fn ${v.fn}\n`);
       process.stderr.write(`    ${v.fix}\n`);
+    }
+    for (const e of stale) {
+      process.stderr.write(`  src-tauri/src/${e.file}  fn ${e.fn}\n`);
+      process.stderr.write(`    ${STALE_FIX}\n`);
     }
   }
 
@@ -354,10 +388,11 @@ function main() {
   process.exitCode = failed ? 1 : 0;
 }
 
-// Main-module detection by PATH comparison, not `import.meta.main`: that is
-// node 24.2+ only, and this repo documents a node 20 floor (CONTRIBUTING.md,
-// README) with no engines pin — on an older runtime the gate would read
-// `if (undefined)` and the script would exit 0 having scanned nothing.
+// Main-module detection by PATH comparison, not `import.meta.main`: this form
+// works on any node, while `import.meta.main` only exists from 24.2 — a cliff
+// the documented floor should not have to track, and one that fails SILENTLY
+// (the gate reads `if (undefined)` and the script exits 0 having scanned
+// nothing — the fail-open this whole file exists to prevent).
 if (
   process.argv[1] &&
   resolve(process.argv[1]) === fileURLToPath(import.meta.url)

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+// Static gate for three Rust invariants that have each cost this repo a fix
+// round. Text-level checks over `src-tauri/src/**/*.rs` — no compiler, no deps,
+// Node built-ins only — so they run anywhere `node` does:
+//
+//   A. refspec templates — a user-named ref must not reach `refs/heads/<name>`
+//      (the refspec-injection class of PR #76, which re-opened once because the
+//      chokepoint was convention rather than enforcement).
+//   B. secret-shaped argv — a secret in `gh -f key=value` is world-readable in
+//      the process table.
+//   C. sync `#[tauri::command]` — a blocking command body runs on the main
+//      thread and freezes the UI.
+//
+// Each check carries an ALLOWLIST of `{ file, fn, rationale }` records. RATCHET
+// RULE: the lists only shrink by default. Adding an entry is a reviewed change —
+// it needs a rationale naming the guard that makes the site safe (a validator
+// call, a trusted producer), and it lands in review like any other diff. A
+// (file, fn) entry covers every site in that function, so entries are pruned
+// when their site goes away rather than left behind to pre-authorize whatever
+// the function grows next.
+//
+// Run: node scripts/check-rust-invariants.mjs
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src-tauri",
+  "src",
+);
+
+// ---------------------------------------------------------------- allowlists
+
+// Check A. Every entry either validates the interpolated name itself or receives
+// it from a producer that did — verified by reading each site.
+const REFSPEC_ALLOWLIST = [
+  {
+    file: "forge/bitbucket.rs",
+    fn: "ref_is_tag",
+    rationale:
+      "Bitbucket REST path, not a git refspec — every segment is encode_query_value'd",
+  },
+  {
+    file: "git/branches.rs",
+    fn: "git_default_branch",
+    rationale: "interpolates only the fixed literals main/master",
+  },
+  {
+    file: "git/branches.rs",
+    fn: "git_branch_merge_states",
+    rationale: "validates each pair's head/base with validate_ref_name inline",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "finalize_base",
+    rationale:
+      "private helper; both callers (merge_local_pr, finish_local_pr_merge) validate base with validate_ref_name",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "push_pr_head",
+    rationale:
+      "private helper; both callers (merge_remote_pr, finish_remote_pr_resolve) validate head with validate_ref_name",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "merge_remote_pr",
+    rationale: "validates base and head with validate_ref_name at fn entry",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "git_push_tag_core",
+    rationale: "validates the tag name with validate_tag_name at fn entry",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "git_delete_tag_core",
+    rationale: "validates the tag name with validate_tag_name at fn entry",
+  },
+  {
+    file: "git/remote.rs",
+    fn: "git_push_core",
+    rationale:
+      "validates branch, remote and remote_branch with validate_ref_name at fn entry",
+  },
+  {
+    file: "git/remote.rs",
+    fn: "build_push_args",
+    rationale:
+      "the push-refspec chokepoint; its only caller (git_push_core) validates every interpolated name first",
+  },
+  {
+    file: "git/remote.rs",
+    fn: "publish_refspec",
+    rationale: "the publish-refspec chokepoint; callers validate the branch",
+  },
+  {
+    file: "git/remote.rs",
+    fn: "parse_upstream_tracking_matches_real_for_each_ref_output",
+    rationale: "#[cfg(test)] fixture — the branch name is a test literal",
+  },
+  {
+    file: "github/pr.rs",
+    fn: "gh_delete_remote_head_branch",
+    rationale:
+      "server-reported head ref, and the endpoint is a REST path the API validates",
+  },
+  {
+    file: "github/pr.rs",
+    fn: "detect_fork_pr_for_branch",
+    rationale: "validates branch with validate_ref_name at fn entry",
+  },
+  {
+    file: "mcp_server/generate.rs",
+    fn: "committed_base_ref",
+    rationale: "interpolates git_default_branch's own output, never user input",
+  },
+  {
+    file: "mcp_server/write_local.rs",
+    fn: "verify_branch",
+    rationale: "validates via validate_ref_name at fn entry",
+  },
+];
+
+// Check B. Empty by design: secrets ride `run_gh_input` / `json_body_args` stdin
+// bodies, and no site pairs a `-f`-family flag with a secret-shaped key.
+const SECRET_ARGV_ALLOWLIST = [];
+
+// Check C. The 9 sync commands that predate the rule. Each is main-thread-safe
+// for its own reason; converting them is separate work, not a reason to widen
+// the gate. Entries are (file, fn), so app_menu's two cfg-twin declarations of
+// `set_recent_repos_menu` share one.
+const SYNC_COMMAND_ALLOWLIST = [
+  {
+    file: "app_menu.rs",
+    fn: "set_recent_repos_menu",
+    rationale: "menu-bar mutation — Tauri requires it on the main thread",
+  },
+  {
+    file: "github/issue.rs",
+    fn: "read_issue_templates",
+    rationale: "reads a handful of small template files from the repo dir",
+  },
+  {
+    file: "path_launcher.rs",
+    fn: "path_launcher_status",
+    rationale: "stats one shim path",
+  },
+  {
+    file: "path_launcher.rs",
+    fn: "path_launcher_remove",
+    rationale: "removes one shim file",
+  },
+  {
+    file: "pty.rs",
+    fn: "pty_write",
+    rationale: "writes to an in-memory PTY handle behind a mutex",
+  },
+  {
+    file: "pty.rs",
+    fn: "pty_resize",
+    rationale: "resizes an in-memory PTY handle behind a mutex",
+  },
+  {
+    file: "pty.rs",
+    fn: "pty_close",
+    rationale: "drops an in-memory PTY handle behind a mutex",
+  },
+  {
+    file: "tray.rs",
+    fn: "set_close_to_tray",
+    rationale: "flips one in-memory AppState flag",
+  },
+];
+
+// ------------------------------------------------------------------- helpers
+
+/** Every `.rs` file under `src-tauri/src`, as absolute paths. */
+function rustFiles(dir, out = []) {
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) rustFiles(full, out);
+    else if (entry.endsWith(".rs")) out.push(full);
+  }
+  return out;
+}
+
+// Attribution is textual: the nearest preceding signature. A match inside a
+// closure or a nested block is therefore reported against the function that
+// encloses it, which is exactly the granularity the allowlists key on.
+const FN_RE = /^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+(\w+)/;
+
+function enclosingFn(lines, lineIdx) {
+  for (let i = lineIdx; i >= 0; i--) {
+    const m = FN_RE.exec(lines[i]);
+    if (m) return m[1];
+  }
+  return "<top level>";
+}
+
+const allowed = (list, file, fn) =>
+  list.some((e) => e.file === file && e.fn === fn);
+
+// -------------------------------------------------------------------- checks
+
+// `format!(` through to its template, tolerating a newline before the literal
+// (rustfmt breaks long calls that way) and raw strings.
+const FORMAT_RE = /\bformat!\s*\(\s*r?#*"((?:[^"\\]|\\.)*)"/g;
+const REFSPEC_MARKERS = ["refs/heads/{", "refs/tags/{", ":refs/"];
+const REFSPEC_FIX =
+  "names reaching a refspec route through validate_ref_name/validate_tag_name " +
+  "(gd-conventions Security hot spots) — validate, or allowlist with rationale";
+
+function checkRefspecTemplates(file, src, lines, hits) {
+  FORMAT_RE.lastIndex = 0;
+  for (let m = FORMAT_RE.exec(src); m; m = FORMAT_RE.exec(src)) {
+    if (!REFSPEC_MARKERS.some((marker) => m[1].includes(marker))) continue;
+    const line = src.slice(0, m.index).split("\n").length;
+    const fn = enclosingFn(lines, line - 1);
+    hits.push({
+      file,
+      line,
+      fn,
+      allowlisted: allowed(REFSPEC_ALLOWLIST, file, fn),
+      fix: REFSPEC_FIX,
+    });
+  }
+}
+
+// The `-f`-family flags as standalone argv literals, and any string literal in
+// the same 3-line window whose key segment looks like a credential. The window
+// exists because rustfmt routinely splits `.arg("-f").arg(format!(…))` across
+// lines; a key built at runtime (`format!("{k}={v}")`) is invisible here by
+// construction, which is what the allowlist is for.
+const ARGV_FLAG_RE = /"(?:-f|-F|--field|--raw-field)"/;
+const STRING_RE = /"((?:[^"\\]|\\.)*)"/g;
+const SECRET_KEY_RE = /token|secret|passw|credential|api[_-]?key/i;
+const SECRET_ARGV_FIX =
+  "secrets never ride argv — send them via run_gh_input / json_body_args stdin bodies";
+
+function checkSecretArgv(file, _src, lines, hits) {
+  for (let i = 0; i < lines.length; i++) {
+    if (!ARGV_FLAG_RE.test(lines[i])) continue;
+    const window = lines.slice(i, i + 3).join("\n");
+    STRING_RE.lastIndex = 0;
+    for (let m = STRING_RE.exec(window); m; m = STRING_RE.exec(window)) {
+      const eq = m[1].indexOf("=");
+      if (eq < 0 || !SECRET_KEY_RE.test(m[1].slice(0, eq))) continue;
+      const fn = enclosingFn(lines, i);
+      hits.push({
+        file,
+        line: i + 1,
+        fn,
+        allowlisted: allowed(SECRET_ARGV_ALLOWLIST, file, fn),
+        fix: SECRET_ARGV_FIX,
+      });
+      break;
+    }
+  }
+}
+
+const COMMAND_ATTR_RE = /^\s*#\[tauri::command/;
+const SYNC_COMMAND_FIX =
+  "sync #[tauri::command]s run on the main thread (gd-conventions Rust) — " +
+  "make it async (spawn_blocking for IO), or allowlist with rationale";
+
+function checkSyncCommands(file, _src, lines, hits) {
+  for (let i = 0; i < lines.length; i++) {
+    if (!COMMAND_ATTR_RE.test(lines[i])) continue;
+    // Skip the attributes, cfg gates and doc comments between the marker and
+    // the signature.
+    let j = i + 1;
+    while (j < lines.length) {
+      const t = lines[j].trim();
+      if (t === "" || t.startsWith("#[") || t.startsWith("//")) j++;
+      else break;
+    }
+    const sig = lines[j] ?? "";
+    if (!/\bfn\s+\w+/.test(sig)) {
+      // Fail closed: an unreadable signature is a checker bug, never a pass.
+      hits.push({
+        file,
+        line: i + 1,
+        fn: "<unresolved>",
+        allowlisted: false,
+        fix: "the checker could not find this command's signature — update scripts/check-rust-invariants.mjs",
+      });
+      continue;
+    }
+    if (/\basync\s+fn\b/.test(sig)) continue;
+    const fn = /\bfn\s+(\w+)/.exec(sig)[1];
+    hits.push({
+      file,
+      line: j + 1,
+      fn,
+      allowlisted: allowed(SYNC_COMMAND_ALLOWLIST, file, fn),
+      fix: SYNC_COMMAND_FIX,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------- main
+
+const CHECKS = [
+  { name: "A. refspec templates", run: checkRefspecTemplates, hits: [] },
+  { name: "B. secret-shaped argv", run: checkSecretArgv, hits: [] },
+  { name: "C. sync #[tauri::command]", run: checkSyncCommands, hits: [] },
+];
+
+const files = rustFiles(SRC);
+for (const path of files) {
+  // Normalise CRLF: on Windows a git checkout materialises these files with
+  // CRLF, and a trailing `\r` would leak into every reported line.
+  const src = readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+  const lines = src.split("\n");
+  const rel = relative(SRC, path).replace(/\\/g, "/");
+  for (const check of CHECKS) check.run(rel, src, lines, check.hits);
+}
+
+let failed = false;
+for (const check of CHECKS) {
+  const violations = check.hits.filter((h) => !h.allowlisted);
+  const allowlisted = check.hits.length - violations.length;
+  if (violations.length === 0) {
+    process.stdout.write(
+      `${check.name}: OK (${files.length} files, ${allowlisted} allowlisted)\n`,
+    );
+    continue;
+  }
+  failed = true;
+  process.stdout.write(
+    `${check.name}: FAIL (${files.length} files, ${violations.length} violation(s), ${allowlisted} allowlisted)\n`,
+  );
+  for (const v of violations) {
+    process.stdout.write(`  src-tauri/src/${v.file}:${v.line}  fn ${v.fn}\n`);
+    process.stdout.write(`    ${v.fix}\n`);
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -371,17 +371,23 @@ test("a commented-out invoke does not read as a live call", () => {
   ]);
 });
 
-test("an allowlist entry naming an unregistered command is stale", () => {
-  const registered = new Set(["git_status", "git_commit"]);
-  // The two directions that keep this a ratchet: a registered-but-uninvoked
-  // command is what an entry is FOR, so it stays; one the handler list no longer
-  // registers has nothing left to suppress.
+test("an allowlist entry that suppresses nothing is stale, in both shapes", () => {
+  const registered = new Set(["git_status", "git_commit", "git_menu_only"]);
+  const invoked = new Set(["git_status"]);
+  // Only registered-but-uninvoked (`git_menu_only`) is what an entry is FOR, so
+  // it stays. The other two shapes both suppress nothing: a command the handler
+  // list no longer registers, and one with a live caller — which never reaches
+  // the `dead` filter, so its entry quiets a hit that cannot happen.
   assert.deepEqual(
-    staleCommandEntries(["git_commit", "git_retired_command"], registered),
-    ["git_retired_command"],
+    staleCommandEntries(
+      ["git_menu_only", "git_status", "git_retired_command"],
+      registered,
+      invoked,
+    ),
+    ["git_retired_command", "git_status"],
   );
   // The empty allowlist (today's tree) is a no-op, not a failure.
-  assert.deepEqual(staleCommandEntries([], registered), []);
+  assert.deepEqual(staleCommandEntries([], registered, invoked), []);
 });
 
 test("invoke matching survives nested generics and wrapped calls", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -2,21 +2,32 @@
 // silent fail-open — a pattern that stops matching still prints "OK" — so every
 // predicate keeps a fixture that MUST hit and a fixture that must not. The
 // scripts export their predicates and gate their CLI body on a main-module path
-// check (`process.argv[1]` vs `import.meta.url` — portable to Node 20, unlike
-// `import.meta.main`), so importing them here runs no scan and touches no disk.
+// check (`process.argv[1]` vs `import.meta.url` — portable across node versions,
+// unlike `import.meta.main`), so importing them here runs no scan, touches no
+// disk, and cannot silently no-op on a runtime older than the gate.
 //
 // Node's stdlib test runner and node: imports only, no dev dependency, so the
 // CI `guards` job runs `node --test "scripts/*.test.mjs"` with no install step.
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { CHECKS, stripComments, view } from "./check-banned-patterns.mjs";
-import { parseInvoked, parseRegistered } from "./check-dead-surface.mjs";
+import {
+  CHECKS,
+  runCheck,
+  stripComments,
+  view,
+} from "./check-banned-patterns.mjs";
+import {
+  parseInvoked,
+  parseRegistered,
+  staleAllowlistEntries as staleCommandEntries,
+} from "./check-dead-surface.mjs";
 import {
   checkRefspecTemplates,
   checkSecretArgv,
   checkSyncCommands,
   enclosingFn,
+  staleAllowlistEntries,
 } from "./check-rust-invariants.mjs";
 
 // ------------------------------------------------------- check-banned-patterns
@@ -150,6 +161,53 @@ test("setQueryData-noop does not reach across a `;` statement boundary", () => {
     "logger.debug(label, undefined);",
   ].join("\n");
   assert.deepEqual(setQueryData(source), []);
+});
+
+test("an allowlist entry whose file no longer has the pattern is stale", () => {
+  // Allowlisted files are scanned, not skipped: a live entry suppresses its hit
+  // and stays; an entry with nothing left to suppress is reported so the ratchet
+  // can only tighten.
+  const check = {
+    name: "fixture",
+    appliesTo: () => true,
+    scan: CHECKS.find((c) => c.name === "hover-reveal").scan,
+    allowlist: ["still-reveals.tsx", "now-clean.tsx", "since-deleted.tsx"],
+    message: "fixture message",
+  };
+  const files = ["still-reveals.tsx", "now-clean.tsx", "fresh.tsx"];
+  const views = new Map([
+    [
+      "still-reveals.tsx",
+      view('const c = "opacity-0 group-hover:opacity-100";'),
+    ],
+    ["now-clean.tsx", view('const c = "flex items-center gap-2";')],
+    ["fresh.tsx", view('const c = "invisible group-hover:visible";')],
+  ]);
+
+  const { violations, stale } = runCheck(check, files, views);
+  // The allowlisted hit is suppressed; the unlisted one is not.
+  assert.deepEqual(violations, ["fresh.tsx:1"]);
+  // Clean-now and no-longer-present entries both surface; the live one does not.
+  assert.deepEqual(stale, ["now-clean.tsx", "since-deleted.tsx"]);
+});
+
+test("a rust allowlist record no hit maps to is stale, matched as (file, fn)", () => {
+  const list = [
+    { file: "git/ops.rs", fn: "live_one", rationale: "x" },
+    { file: "git/ops.rs", fn: "site_removed", rationale: "x" },
+    // Same fn name, different file: the pair must match, not either half.
+    { file: "git/remote.rs", fn: "live_one", rationale: "x" },
+  ];
+  const hits = [
+    { file: "git/ops.rs", fn: "live_one", allowlisted: true },
+    { file: "git/ops.rs", fn: "unlisted", allowlisted: false },
+  ];
+  assert.deepEqual(
+    staleAllowlistEntries(list, hits).map((e) => `${e.file}::${e.fn}`),
+    ["git/ops.rs::site_removed", "git/remote.rs::live_one"],
+  );
+  // An empty allowlist (SECRET_ARGV_ALLOWLIST today) is a no-op, not a failure.
+  assert.deepEqual(staleAllowlistEntries([], hits), []);
 });
 
 test("stripComments blanks comments but not comment-shaped strings", () => {
@@ -311,6 +369,19 @@ test("a commented-out invoke does not read as a live call", () => {
     "git_open_url",
     "git_status",
   ]);
+});
+
+test("an allowlist entry naming an unregistered command is stale", () => {
+  const registered = new Set(["git_status", "git_commit"]);
+  // The two directions that keep this a ratchet: a registered-but-uninvoked
+  // command is what an entry is FOR, so it stays; one the handler list no longer
+  // registers has nothing left to suppress.
+  assert.deepEqual(
+    staleCommandEntries(["git_commit", "git_retired_command"], registered),
+    ["git_retired_command"],
+  );
+  // The empty allowlist (today's tree) is a no-op, not a failure.
+  assert.deepEqual(staleCommandEntries([], registered), []);
 });
 
 test("invoke matching survives nested generics and wrapped calls", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1,0 +1,328 @@
+// Negative controls for the three guard scanners. Their worst failure mode is
+// silent fail-open — a pattern that stops matching still prints "OK" — so every
+// predicate keeps a fixture that MUST hit and a fixture that must not. The
+// scripts export their predicates and gate their CLI body on `import.meta.main`,
+// so importing them here runs no scan and touches no disk.
+//
+// Node's stdlib test runner and node: imports only, no dev dependency, so the
+// CI `guards` job runs `node --test "scripts/*.test.mjs"` with no install step.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CHECKS, stripComments, view } from "./check-banned-patterns.mjs";
+import { parseInvoked, parseRegistered } from "./check-dead-surface.mjs";
+import {
+  checkRefspecTemplates,
+  checkSecretArgv,
+  checkSyncCommands,
+  enclosingFn,
+} from "./check-rust-invariants.mjs";
+
+// ------------------------------------------------------- check-banned-patterns
+
+/** The named check's scanner, applied to a fixture source string. */
+function scanner(name) {
+  const check = CHECKS.find((c) => c.name === name);
+  assert.ok(check, `no check named ${name}`);
+  return (source) => check.scan(view(source));
+}
+
+const hoverReveal = scanner("hover-reveal");
+const modKey = scanner("hand-rolled-mod-key");
+const setQueryData = scanner("setQueryData-noop");
+
+test("hover-reveal catches every Tailwind spelling of the idiom", () => {
+  for (const classes of [
+    "opacity-0 group-hover:opacity-100",
+    "invisible group-hover:visible",
+    "hidden group-hover:block",
+    "hidden group-hover:flex",
+    "hidden group-hover:inline",
+    "hidden group-hover:inline-flex",
+  ]) {
+    assert.deepEqual(
+      hoverReveal(`const cls = "${classes}";`),
+      [1],
+      `should flag ${classes}`,
+    );
+  }
+});
+
+test("hover-reveal pairs across a wrapped class list", () => {
+  const source = [
+    "<button",
+    "  className={cn(",
+    '    "invisible transition",',
+    '    "group-hover:visible",',
+    "  )}",
+    "/>",
+  ].join("\n");
+  assert.deepEqual(hoverReveal(source), [3]);
+});
+
+test("hover-reveal does not pair a compound utility that merely ends in the token", () => {
+  // The boundary guard's whole job: `overflow-hidden` is a layout utility, not
+  // a hidden element, and pairing it would flag ordinary scroll containers.
+  assert.deepEqual(
+    hoverReveal('const cls = "overflow-hidden group-hover:block";'),
+    [],
+  );
+  assert.deepEqual(
+    hoverReveal('const cls = "group-hover:visible-ish invisible-thing";'),
+    [],
+  );
+});
+
+test("hover-reveal ignores a hiding utility with no reveal partner", () => {
+  assert.deepEqual(hoverReveal('const cls = "hidden md:flex";'), []);
+  assert.deepEqual(hoverReveal('const cls = "opacity-0 animate-in";'), []);
+});
+
+test("hover-reveal ignores the idiom named in a comment", () => {
+  // src/main.tsx documents the vendored diff widget's own `group-hover:visible`
+  // next to our `.invisible` utility; comment stripping is what keeps it clean.
+  const source = [
+    "// the add-widget button reveals via `group-hover:visible`,",
+    "// which our `.invisible` utility would otherwise beat.",
+    'import "@git-diff-view/react/styles/diff-view.css";',
+  ].join("\n");
+  assert.deepEqual(hoverReveal(source), []);
+});
+
+test("hand-rolled-mod-key flags a single raw flag and each half of a split pair", () => {
+  assert.deepEqual(modKey("if (e.metaKey) submit();"), [1]);
+  assert.deepEqual(modKey("if (e.ctrlKey) submit();"), [1]);
+  const split = ["const mod =", "  e.metaKey ||", "  e.ctrlKey;"].join("\n");
+  assert.deepEqual(modKey(split), [2, 3]);
+});
+
+test("hand-rolled-mod-key ignores other modifiers and the helper's own name", () => {
+  assert.deepEqual(modKey("if (e.shiftKey || e.altKey) return;"), []);
+  assert.deepEqual(modKey("const label = formatBinding(binding);"), []);
+});
+
+test("setQueryData-noop catches a call wrapped across lines", () => {
+  const source = [
+    "queryClient.setQueryData(",
+    "  keys.pullRequest(repo, number),",
+    "  undefined,",
+    ");",
+  ].join("\n");
+  assert.deepEqual(setQueryData(source), [1]);
+});
+
+test("setQueryData-noop sees through nested type arguments", () => {
+  assert.deepEqual(
+    setQueryData("qc.setQueryData<Record<string, Foo>>(key, undefined);"),
+    [1],
+  );
+  assert.deepEqual(
+    setQueryData("qc.setQueryData<Foo[]>(key, undefined);"),
+    [1],
+  );
+});
+
+test("setQueryData-noop resolves the LAST argument past a comma-bearing key", () => {
+  assert.deepEqual(
+    setQueryData("qc.setQueryData(keys.pr(repo, number), undefined);"),
+    [1],
+  );
+});
+
+test("setQueryData-noop leaves real writes alone", () => {
+  assert.deepEqual(setQueryData("qc.setQueryData(key, previous);"), []);
+  assert.deepEqual(
+    setQueryData("qc.setQueryData(key, (old) => ({ ...old, x: 1 }));"),
+    [],
+  );
+});
+
+test("setQueryData-noop does not reach across a `;` statement boundary", () => {
+  // The whole-file view joins lines, so the argument run is `;`-free and
+  // length-bounded — otherwise this pairs one call with the next statement.
+  // The bound is exactly that and no more: `;` is not the only boundary in JS,
+  // so a JSX prop or object member holding `, undefined)` within 200 chars of a
+  // clean call still pairs (a loud false positive, fixable at the call site),
+  // and a `;` inside a string key ends the run early (the one fail-open).
+  const source = [
+    "qc.setQueryData(key, previous);",
+    "logger.debug(label, undefined);",
+  ].join("\n");
+  assert.deepEqual(setQueryData(source), []);
+});
+
+test("stripComments blanks comments but not comment-shaped strings", () => {
+  assert.deepEqual(stripComments(["const a = 1; // e.metaKey"]), [
+    "const a = 1; ",
+  ]);
+  assert.deepEqual(
+    stripComments([
+      "/* opacity-0",
+      "   group-hover:opacity-100 */ const a = 1;",
+    ]),
+    ["", " const a = 1;"],
+  );
+  assert.deepEqual(stripComments(['const url = "https://x.dev/a";']), [
+    'const url = "https://x.dev/a";',
+  ]);
+});
+
+// -------------------------------------------------------- check-rust-invariants
+
+test("enclosingFn attributes const, unsafe and extern signatures", () => {
+  const cases = [
+    ["pub const fn for_provider(p: Provider) -> Self {", "for_provider"],
+    ["    const fn all() -> Self {", "all"],
+    ["unsafe fn from_raw(p: *const u8) {", "from_raw"],
+    ['pub unsafe extern "C" fn callback(v: i32) {', "callback"],
+    // A bare `extern fn` is legal and defaults to the "C" ABI.
+    ["extern fn bare_abi() {", "bare_abi"],
+    ["pub(crate) const unsafe fn peek() -> u8 {", "peek"],
+    ["pub async fn ordinary(x: u8) {", "ordinary"],
+  ];
+  for (const [signature, name] of cases) {
+    // The preceding fn is the wrong answer a too-narrow pattern falls back to.
+    const lines = ["fn preceding() {}", "}", signature, "    let x = 1;"];
+    assert.equal(enclosingFn(lines, 3), name, `for ${signature}`);
+  }
+});
+
+test("refspec-template hits are attributed to the enclosing fn", () => {
+  const src = [
+    "fn preceding() {}",
+    "",
+    "pub const fn build_ref(name: &str) -> String {",
+    '    format!("refs/heads/{name}")',
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkRefspecTemplates("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "build_ref");
+  assert.equal(hits[0].line, 4);
+  assert.equal(hits[0].allowlisted, false);
+});
+
+test("refspec-template check ignores format! templates with no ref marker", () => {
+  const src = ["fn f() {", '    format!("hello {name}")', "}"].join("\n");
+  const hits = [];
+  checkRefspecTemplates("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(hits, []);
+});
+
+test("secret-shaped argv is caught next to a -f-family flag", () => {
+  const lines = [
+    "fn send(token: &str) {",
+    '    cmd.arg("-f")',
+    '        .arg(format!("token={token}"));',
+    "}",
+  ];
+  const hits = [];
+  checkSecretArgv("fixture.rs", lines.join("\n"), lines, hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "send");
+  assert.equal(hits[0].allowlisted, false);
+
+  const benign = ["fn send() {", '    cmd.arg("-f").arg("title=hello");', "}"];
+  const none = [];
+  checkSecretArgv("fixture.rs", benign.join("\n"), benign, none);
+  assert.deepEqual(none, []);
+});
+
+test("sync #[tauri::command] is caught, async is not, unreadable fails closed", () => {
+  const sync = ["#[tauri::command]", "pub fn do_thing() -> u8 { 1 }"];
+  const hits = [];
+  checkSyncCommands("fixture.rs", sync.join("\n"), sync, hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "do_thing");
+  assert.equal(hits[0].allowlisted, false);
+
+  const asyncCmd = [
+    "#[tauri::command]",
+    '#[cfg(target_os = "macos")]',
+    "pub async fn do_thing() -> u8 { 1 }",
+  ];
+  const none = [];
+  checkSyncCommands("fixture.rs", asyncCmd.join("\n"), asyncCmd, none);
+  assert.deepEqual(none, []);
+
+  const unreadable = ["#[tauri::command]", "pub struct NotAFn;"];
+  const failClosed = [];
+  checkSyncCommands(
+    "fixture.rs",
+    unreadable.join("\n"),
+    unreadable,
+    failClosed,
+  );
+  assert.equal(failClosed.length, 1);
+  assert.equal(failClosed[0].fn, "<unresolved>");
+  assert.equal(failClosed[0].allowlisted, false);
+});
+
+// ----------------------------------------------------------- check-dead-surface
+
+test("a commented-out handler entry does not read as registered", () => {
+  // The dangerous direction: `foo` survives `split("::").pop()` from a
+  // commented-out line, so a disabled-but-invoked command would read as clean.
+  const source = [
+    ".invoke_handler(tauri::generate_handler![",
+    "    git::status,",
+    "    // git::disabled_line,",
+    "    /* git::disabled_block, */",
+    "    git::commit,",
+    "])",
+  ].join("\n");
+  assert.deepEqual([...parseRegistered(source, "fixture")].sort(), [
+    "commit",
+    "status",
+  ]);
+});
+
+test("the registered parser survives nested brackets and a missing marker", () => {
+  const nested = [
+    "tauri::generate_handler![",
+    "    git::status,",
+    "    with_array::[a],",
+    "    git::commit",
+    "]",
+  ].join("\n");
+  const names = parseRegistered(nested, "fixture");
+  assert.ok(names.has("status") && names.has("commit"));
+  assert.throws(
+    () => parseRegistered("no handler here", "fixture"),
+    /Could not find/,
+  );
+});
+
+test("a commented-out invoke does not read as a live call", () => {
+  // The mirror of the handler-list bug: a retired command whose only call site
+  // is commented out would otherwise stay "invoked" and never surface as dead.
+  const source = [
+    'const a = invoke("git_status");',
+    '// const b = invoke("git_retired_command");',
+    "/*",
+    'const c = invoke("git_retired_block");',
+    "*/",
+    // A comment-shaped string is not a comment: this call still counts.
+    'const d = invoke("git_open_url"); // see https://example.dev/docs',
+  ].join("\n");
+  assert.deepEqual([...parseInvoked(source)].sort(), [
+    "git_open_url",
+    "git_status",
+  ]);
+});
+
+test("invoke matching survives nested generics and wrapped calls", () => {
+  const source = [
+    'const a = invoke<Record<string, string>>("git_branch_tips");',
+    "const b = await invoke<PublishTarget[]>(",
+    '  "forge_publish_targets",',
+    ");",
+    'const c = invoke("git_status");',
+  ].join("\n");
+  assert.deepEqual([...parseInvoked(source)].sort(), [
+    "forge_publish_targets",
+    "git_branch_tips",
+    "git_status",
+  ]);
+});

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1,8 +1,9 @@
 // Negative controls for the three guard scanners. Their worst failure mode is
 // silent fail-open — a pattern that stops matching still prints "OK" — so every
 // predicate keeps a fixture that MUST hit and a fixture that must not. The
-// scripts export their predicates and gate their CLI body on `import.meta.main`,
-// so importing them here runs no scan and touches no disk.
+// scripts export their predicates and gate their CLI body on a main-module path
+// check (`process.argv[1]` vs `import.meta.url` — portable to Node 20, unlike
+// `import.meta.main`), so importing them here runs no scan and touches no disk.
 //
 // Node's stdlib test runner and node: imports only, no dev dependency, so the
 // CI `guards` job runs `node --test "scripts/*.test.mjs"` with no install step.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -35,6 +35,19 @@ pub(crate) fn validate_ref_name(name: &str) -> AppResult<()> {
     Ok(())
 }
 
+/// The stricter gate for inputs that must name a BRANCH and nothing else: it adds
+/// a rejection of rev-expression syntax, which `rev-parse` would otherwise resolve
+/// (`feature~1` exists under `refs/heads/` as the branch's parent commit).
+pub(crate) fn validate_branch_name(name: &str) -> AppResult<()> {
+    validate_ref_name(name)?;
+    if name.contains(['~', '^']) || name.contains("..") || name.contains("@{") {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid branch name: {name}"
+        )));
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn git_branches(repo_path: String) -> AppResult<Vec<Branch>> {
     let out = run_git(
@@ -557,7 +570,10 @@ pub async fn git_branch_merge_states(
 ) -> AppResult<Vec<BranchMergeState>> {
     let mut result = Vec::with_capacity(pairs.len());
     for pair in pairs {
-        let valid_head = validate_ref_name(&pair.head).is_ok();
+        // The branch-name gate, not the ref gate: this reconciles LOCAL PR records,
+        // and a record persisted with a rev expression (`feature~1`) would pass the
+        // probe below and auto-transition the PR against a commit no branch is at.
+        let valid_head = validate_branch_name(&pair.head).is_ok();
         let head_exists = if valid_head {
             run_git_raw(
                 Some(&repo_path),
@@ -575,7 +591,7 @@ pub async fn git_branch_merge_states(
         } else {
             false
         };
-        let merged = if valid_head && validate_ref_name(&pair.base).is_ok() {
+        let merged = if valid_head && validate_branch_name(&pair.base).is_ok() {
             run_git_raw(
                 Some(&repo_path),
                 &["merge-base", "--is-ancestor", &pair.head, &pair.base],
@@ -670,8 +686,8 @@ pub async fn git_update_branch_from(
     branch: String,
     base: String,
 ) -> AppResult<String> {
-    validate_ref_name(&branch)?;
-    validate_ref_name(&base)?;
+    validate_branch_name(&branch)?;
+    validate_branch_name(&base)?;
     if branch == base {
         return Err(AppError::InvalidArgument(
             "a branch can't be updated from itself".to_string(),
@@ -837,7 +853,7 @@ fn unique_suffix() -> String {
 mod tests {
     use super::{
         build_create_branch_args, git_branches, git_create_branch_core, git_default_branch,
-        parse_upstream_track, validate_ref_name,
+        parse_upstream_track, validate_branch_name, validate_ref_name,
     };
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
     use crate::state::AppState;
@@ -931,6 +947,25 @@ mod tests {
             "main~3", "HEAD", "HEAD@{2}", "abc123def",
         ] {
             assert!(validate_ref_name(ok).is_ok(), "should accept {ok:?}");
+        }
+    }
+
+    #[test]
+    fn validate_branch_name_rejects_rev_expressions_ref_name_accepts() {
+        // The whole point of the stricter gate: `~`/`^` shapes RESOLVE under
+        // `rev-parse --verify refs/heads/…`, so an existence probe alone passes
+        // them and the caller proceeds against an ancestor commit.
+        for bad in ["feature~1", "main^", "HEAD@{1}", "main..other", "a^{commit}"] {
+            assert!(validate_ref_name(bad).is_ok(), "ref gate accepts {bad:?}");
+            assert!(
+                validate_branch_name(bad).is_err(),
+                "branch gate should reject {bad:?}"
+            );
+        }
+        // Refspec metacharacters stay rejected, and real branch names stay valid.
+        assert!(validate_branch_name("a*b").is_err());
+        for ok in ["feature", "feat/x", "release-1.0", "fix_123"] {
+            assert!(validate_branch_name(ok).is_ok(), "should accept {ok:?}");
         }
     }
 

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -37,10 +37,11 @@ pub(crate) fn validate_ref_name(name: &str) -> AppResult<()> {
 
 /// The stricter gate for inputs that must name a BRANCH and nothing else: it adds
 /// a rejection of rev-expression syntax, which `rev-parse` would otherwise resolve
-/// (`feature~1` exists under `refs/heads/` as the branch's parent commit).
+/// (`feature~1` exists under `refs/heads/` as the branch's parent commit), and of
+/// bare `@`, git's HEAD shorthand in the rev positions these names reach.
 pub(crate) fn validate_branch_name(name: &str) -> AppResult<()> {
     validate_ref_name(name)?;
-    if name.contains(['~', '^']) || name.contains("..") || name.contains("@{") {
+    if name == "@" || name.contains(['~', '^']) || name.contains("..") || name.contains("@{") {
         return Err(AppError::InvalidArgument(format!(
             "invalid branch name: {name}"
         )));
@@ -955,7 +956,7 @@ mod tests {
         // The whole point of the stricter gate: `~`/`^` shapes RESOLVE under
         // `rev-parse --verify refs/heads/…`, so an existence probe alone passes
         // them and the caller proceeds against an ancestor commit.
-        for bad in ["feature~1", "main^", "HEAD@{1}", "main..other", "a^{commit}"] {
+        for bad in ["feature~1", "main^", "HEAD@{1}", "main..other", "a^{commit}", "@"] {
             assert!(validate_ref_name(bad).is_ok(), "ref gate accepts {bad:?}");
             assert!(
                 validate_branch_name(bad).is_err(),

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -8,6 +8,9 @@ use crate::git::runner::{
 use crate::git::types::{Branch, BranchDivergence, RemoteBranch};
 use crate::state::AppState;
 
+/// The shared guard against refspec/argv injection from a user-named ref: every
+/// ref-reaching name routes through here or through `validate_tag_name`. Rev
+/// syntax (`~ ^ @ { }`) is deliberately accepted, for branch start-points.
 pub(crate) fn validate_ref_name(name: &str) -> AppResult<()> {
     if name.is_empty() || name.starts_with('-') {
         return Err(AppError::InvalidArgument(format!(

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -4701,7 +4701,7 @@ detached
     /// sharper half: `rev-parse` RESOLVES them, so `feature~1` would pass an
     /// existence probe and merge an ancestor, then fail at `refs/heads/main~1`.
     #[tokio::test]
-    async fn merge_local_pr_rejects_refspec_metacharacters() {
+    async fn merge_local_pr_rejects_metacharacters_and_rev_expressions() {
         // A real directory that is deliberately NOT a repo: without the guard the
         // first `rev-parse` fails as `AppError::Git`, so asserting the
         // `InvalidArgument` variant (not merely `is_err`) is what pins the guard.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -4710,7 +4710,7 @@ detached
         let root = dir.path().join("root");
         let state = AppState::default();
         for bad in [
-            "a*b", "a?b", "a[b", "a:b", "feature~1", "main^", "HEAD@{1}", "main..other",
+            "a*b", "a?b", "a[b", "a:b", "feature~1", "main^", "HEAD@{1}", "main..other", "@",
         ] {
             for (base, head) in [(bad, "feature"), ("main", bad)] {
                 assert!(

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -5677,12 +5677,31 @@ detached
         let root = root_holder.path().join("root");
         let state = AppState::default();
 
-        for (base, head) in [("ma*in", "feature"), ("main", "fea:ture"), ("main", "*")] {
+        // Metacharacters and rev expressions alike: on this path the names are
+        // interpolated into `+refs/heads/{head}:refs/remotes/{remote}/{head}`,
+        // whose refname rules reject all of them before anything resolves. The
+        // gate is defense-in-depth, and buys an early error naming the bad
+        // branch where the ungated path fails later as an opaque invalid-refspec
+        // fetch error. (Resolution is the LOCAL path's hazard.)
+        for (base, head) in [
+            ("ma*in", "feature"),
+            ("main", "fea:ture"),
+            ("main", "*"),
+            ("feature~1", "feature"),
+            ("main", "feature~1"),
+            ("main^", "feature"),
+            ("main", "HEAD@{1}"),
+            ("main..other", "feature"),
+            ("main", "@"),
+        ] {
             let err = merge_remote_pr(&state, &repo, 5, base, head, None, None, &root)
                 .await
                 .unwrap_err();
+            // The MESSAGE, not just the variant: this clone has no remotes, so
+            // `resolve_pr_remote` also fails as `InvalidArgument` — a variant-only
+            // assertion passes with the name gate removed entirely.
             assert!(
-                matches!(err, AppError::InvalidArgument(_)),
+                matches!(&err, AppError::InvalidArgument(m) if m.contains("invalid branch name")),
                 "{base}/{head} got: {err:?}"
             );
         }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -1992,8 +1992,6 @@ pub async fn git_merge_local_pr(
     message: String,
     strategy: String,
 ) -> AppResult<LocalPrMergeOutcome> {
-    validate_branch_arg(&base)?;
-    validate_branch_arg(&head)?;
     let root = worktree_root_dir(&repo_path)?;
     merge_local_pr(&state, &repo_path, &base, &head, &message, &strategy, &root).await
 }
@@ -2013,6 +2011,12 @@ pub(crate) async fn merge_local_pr(
     root: &Path,
 ) -> AppResult<LocalPrMergeOutcome> {
     use crate::git::runner::run_git;
+
+    // `base` reaches `refs/heads/<base>` (finalize_base's update-ref) and `head`
+    // the merge argv, so both take the refspec-metacharacter blocklist, not just
+    // the weaker empty/leading-`-` check. In the core, so every caller is gated.
+    crate::git::branches::validate_ref_name(base)?;
+    crate::git::branches::validate_ref_name(head)?;
 
     let message = if message.trim().is_empty() {
         format!("Merge {head} into {base}")
@@ -2230,7 +2234,9 @@ pub(crate) async fn finish_local_pr_merge(
     worktree_id: &str,
     op_id: Option<String>,
 ) -> AppResult<LocalPrMergeOutcome> {
-    validate_branch_arg(base)?;
+    // Same gate as `merge_local_pr` — this path reaches the identical
+    // `finalize_base` update-ref refspec.
+    crate::git::branches::validate_ref_name(base)?;
 
     // When `base` IS the current branch, `finalize_base` ends in a `merge --ff-only`
     // into the main tree — re-guard clean HERE, since the user may have dirtied it
@@ -4686,6 +4692,31 @@ detached
         assert_eq!(super::repo_hash("C:/Repos/App"), super::repo_hash("c:/repos/app"));
         assert_ne!(super::repo_hash("C:/Repos/App"), super::repo_hash("C:/Repos/Other"));
         assert_eq!(super::repo_hash("C:/Repos/App").len(), 16);
+    }
+
+    /// `base` reaches `refs/heads/<base>` in `finalize_base`'s `update-ref` and
+    /// `head` the merge argv, so both are refused for refspec metacharacters
+    /// before any git runs.
+    #[tokio::test]
+    async fn merge_local_pr_rejects_refspec_metacharacters() {
+        // A real directory that is deliberately NOT a repo: without the guard the
+        // first `rev-parse` fails as `AppError::Git`, so asserting the
+        // `InvalidArgument` variant (not merely `is_err`) is what pins the guard.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        let root = dir.path().join("root");
+        let state = AppState::default();
+        for bad in ["a*b", "a?b", "a[b", "a:b"] {
+            for (base, head) in [(bad, "feature"), ("main", bad)] {
+                assert!(
+                    matches!(
+                        merge_local_pr(&state, &repo, base, head, "m", "merge", &root).await,
+                        Err(AppError::InvalidArgument(_))
+                    ),
+                    "expected {base:?} -> {head:?} to be refused as an invalid ref name"
+                );
+            }
+        }
     }
 
     /// A clean local-PR merge where `base` is NOT the current branch: the main

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2013,10 +2013,11 @@ pub(crate) async fn merge_local_pr(
     use crate::git::runner::run_git;
 
     // `base` reaches `refs/heads/<base>` (finalize_base's update-ref) and `head`
-    // the merge argv, so both take the refspec-metacharacter blocklist, not just
-    // the weaker empty/leading-`-` check. In the core, so every caller is gated.
-    crate::git::branches::validate_ref_name(base)?;
-    crate::git::branches::validate_ref_name(head)?;
+    // the merge argv, so both take the branch-name gate: refspec metacharacters
+    // AND rev-expression syntax, which would otherwise merge/advance an ancestor
+    // (`feature~1` resolves). In the core, so every caller is gated.
+    crate::git::branches::validate_branch_name(base)?;
+    crate::git::branches::validate_branch_name(head)?;
 
     let message = if message.trim().is_empty() {
         format!("Merge {head} into {base}")
@@ -2236,7 +2237,7 @@ pub(crate) async fn finish_local_pr_merge(
 ) -> AppResult<LocalPrMergeOutcome> {
     // Same gate as `merge_local_pr` — this path reaches the identical
     // `finalize_base` update-ref refspec.
-    crate::git::branches::validate_ref_name(base)?;
+    crate::git::branches::validate_branch_name(base)?;
 
     // When `base` IS the current branch, `finalize_base` ends in a `merge --ff-only`
     // into the main tree — re-guard clean HERE, since the user may have dirtied it
@@ -2654,10 +2655,10 @@ pub(crate) async fn merge_remote_pr(
     root: &Path,
 ) -> AppResult<RemotePrResolveOutcome> {
     // Both names are interpolated into fetch/push refspecs, so they take the
-    // STRICT validator (its `*?[:\ ` blocklist is the refspec-injection defense),
-    // and they take it before anything mutates.
-    crate::git::branches::validate_ref_name(base)?;
-    crate::git::branches::validate_ref_name(head)?;
+    // STRICT validator (its `*?[:\ ` blocklist is the refspec-injection defense,
+    // plus the rev-expression rejection), and they take it before anything mutates.
+    crate::git::branches::validate_branch_name(base)?;
+    crate::git::branches::validate_branch_name(head)?;
     let remote = resolve_pr_remote(repo_path, lens).await?;
 
     // Resume before starting: an existing worktree for this (remote, PR) holds
@@ -2849,7 +2850,7 @@ pub(crate) async fn finish_remote_pr_resolve(
     lens: Option<&str>,
     root: &Path,
 ) -> AppResult<RemotePrResolveOutcome> {
-    crate::git::branches::validate_ref_name(head)?;
+    crate::git::branches::validate_branch_name(head)?;
     let remote = resolve_pr_remote(repo_path, lens).await?;
     ensure_pr_resolve_worktree(root, worktree_path)?;
     // Parse the identity this module itself encodes into the directory name —
@@ -4696,7 +4697,9 @@ detached
 
     /// `base` reaches `refs/heads/<base>` in `finalize_base`'s `update-ref` and
     /// `head` the merge argv, so both are refused for refspec metacharacters
-    /// before any git runs.
+    /// AND rev-expression syntax before any git runs. The rev cases are the
+    /// sharper half: `rev-parse` RESOLVES them, so `feature~1` would pass an
+    /// existence probe and merge an ancestor, then fail at `refs/heads/main~1`.
     #[tokio::test]
     async fn merge_local_pr_rejects_refspec_metacharacters() {
         // A real directory that is deliberately NOT a repo: without the guard the
@@ -4706,14 +4709,16 @@ detached
         let repo = dir.path().to_string_lossy().into_owned();
         let root = dir.path().join("root");
         let state = AppState::default();
-        for bad in ["a*b", "a?b", "a[b", "a:b"] {
+        for bad in [
+            "a*b", "a?b", "a[b", "a:b", "feature~1", "main^", "HEAD@{1}", "main..other",
+        ] {
             for (base, head) in [(bad, "feature"), ("main", bad)] {
                 assert!(
                     matches!(
                         merge_local_pr(&state, &repo, base, head, "m", "merge", &root).await,
                         Err(AppError::InvalidArgument(_))
                     ),
-                    "expected {base:?} -> {head:?} to be refused as an invalid ref name"
+                    "expected {base:?} -> {head:?} to be refused as an invalid branch name"
                 );
             }
         }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1971,7 +1971,6 @@ fn stack_write_outcome_from(body: &str, op: &str) -> AppResult<StackWriteOutcome
 /// Group open PRs into a NEW stack (`POST /repos/{slug}/stacks`). `pull_requests`
 /// is BOTTOM→TOP and the server neither sorts nor bridges it: each PR's base ref
 /// must be the previous PR's head ref, and two members are the minimum.
-#[tauri::command]
 pub async fn gh_stack_create(
     repo_path: String,
     pull_requests: Vec<u64>,
@@ -1988,7 +1987,6 @@ pub async fn gh_stack_create(
 /// Append PRs to an existing stack (`POST /repos/{slug}/stacks/{n}/add`). TOP only:
 /// the endpoint has no insert-in-the-middle form, and the same base-ref adjacency
 /// rule as create applies to the joint.
-#[tauri::command]
 pub async fn gh_stack_add(
     repo_path: String,
     stack_number: u64,
@@ -2007,7 +2005,6 @@ pub async fn gh_stack_add(
 /// the endpoint ignores one and always unstacks the WHOLE stack, so naming members
 /// would imply a partial-remove that doesn't exist. The PRs stay open on their
 /// branches — only the grouping goes.
-#[tauri::command]
 pub async fn gh_stack_dissolve(
     repo_path: String,
     stack_number: u64,
@@ -5070,7 +5067,6 @@ async fn gh_thread_comment_replies_topup(
 /// Empty-comment threads are skipped; line falls back to `originalLine`, then 0.
 /// Follows the cursor up to 5 pages (500 threads). A thread with >50 replies is
 /// topped up via [`gh_thread_comment_replies_topup`].
-#[tauri::command]
 pub async fn gh_pr_review_threads(
     repo_path: String,
     number: u64,
@@ -5220,7 +5216,6 @@ pub async fn gh_pr_review_threads(
 /// Replies in an existing review thread, addressed by its GraphQL node id. The id
 /// and body travel as GraphQL variables (never format!-embedded) — the
 /// injection-safe idiom `edit_comment` uses.
-#[tauri::command]
 pub async fn gh_pr_reply_review_thread(
     repo_path: String,
     thread_id: String,
@@ -5248,7 +5243,6 @@ pub async fn gh_pr_reply_review_thread(
 }
 
 /// Resolves or unresolves a review thread by its GraphQL node id.
-#[tauri::command]
 pub async fn gh_pr_resolve_review_thread(
     repo_path: String,
     thread_id: String,

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -354,10 +354,11 @@ fn filter_by_status(
 /// a remote-tracking ref would be a latent trap at merge time.
 async fn verify_branch(repo: &str, branch: &str) -> Result<(), McpError> {
     ensure_not_flag(branch, "branch")?;
-    // Same refspec-metacharacter gate as every other ref-reaching name: the
-    // probe alone would refuse these anyway, but validating keeps this site on
-    // the standard chokepoint instead of a bespoke exception.
-    crate::git::branches::validate_ref_name(branch).map_err(app_err)?;
+    // The branch-name gate, not the shared ref gate: it rejects refspec
+    // metacharacters AND the rev-expression syntax the probe below would
+    // otherwise RESOLVE (`feature~1` verifies as the branch's parent commit,
+    // persisting a record that names a commit no branch points at).
+    crate::git::branches::validate_branch_name(branch).map_err(app_err)?;
     let out = run_git_raw(
         Some(repo),
         &[

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -354,6 +354,10 @@ fn filter_by_status(
 /// a remote-tracking ref would be a latent trap at merge time.
 async fn verify_branch(repo: &str, branch: &str) -> Result<(), McpError> {
     ensure_not_flag(branch, "branch")?;
+    // Same refspec-metacharacter gate as every other ref-reaching name: the
+    // probe alone would refuse these anyway, but validating keeps this site on
+    // the standard chokepoint instead of a bespoke exception.
+    crate::git::branches::validate_ref_name(branch).map_err(app_err)?;
     let out = run_git_raw(
         Some(repo),
         &[

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -155,8 +155,10 @@ export function CleanupBranchesDialog({
   // re-render that yields an equal-but-new `candidates` array — a fresh
   // `isProtected` closure, a no-op branch refetch — would otherwise re-run this
   // and silently wipe the user's deselections. Branch names can't contain
-  // newlines (git ref rules), so the join is unambiguous.
-  const candidateNamesKey = candidateNames.join("\n");
+  // newlines (git ref rules), so the join is unambiguous — and it joins a SORTED
+  // copy, because the render order shifts as ages tick on the shared 30s clock
+  // and a pure reorder must not read as a new set.
+  const candidateNamesKey = [...candidateNames].sort().join("\n");
   useEffect(() => {
     if (running) return; // don't clobber a batch mid-flight
     setSelected(

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { RelativeTime } from "@/components/relative-time";
+import { RelativeTime, useRelativeNow } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -72,6 +72,10 @@ export function CleanupBranchesDialog({
   isInWorktree: (name: string) => boolean;
 }) {
   const queryClient = useQueryClient();
+  // Shared 30s clock: the idle-past-the-window classification below must
+  // re-evaluate as time passes, and a render-position `Date.now()` is invisible
+  // to the React Compiler, so a branch crossing the window never becomes stale.
+  const now = useRelativeNow();
   const [mode, setMode] = useState<Mode>("archive");
   const [windowDays, setWindowDays] = useState<number>(60);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -105,7 +109,6 @@ export function CleanupBranchesDialog({
   // Branches eligible for cleanup, before the per-mode exclusions. Never the
   // current or default branch, never the app-internal session branches.
   const stale = useMemo(() => {
-    const now = Date.now();
     const out: Candidate[] = [];
     for (const b of branches) {
       if (
@@ -122,7 +125,7 @@ export function CleanupBranchesDialog({
       if (merged || old) out.push({ branch: b, merged, ageDays, old });
     }
     return out;
-  }, [branches, currentBranch, defaultBranch, mergedSet, windowDays]);
+  }, [branches, currentBranch, defaultBranch, mergedSet, now, windowDays]);
 
   // Mode-specific candidates. Archive hides — already-archived branches are a
   // no-op, so drop them. Delete is permanent — drop rule-protected branches

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -411,7 +411,14 @@ export async function loadSettings(): Promise<AppSettings> {
   };
 }
 
-export async function saveSettings(settings: AppSettings): Promise<void> {
+/**
+ * Module-private on purpose: a raw save skips the serialized merge chain below,
+ * so every write rides one of this module's `serializedRecentRepoWrite` writers
+ * (or the `useSaveSettings` hook above them). Un-exported makes that
+ * compiler-enforced; the biome `noRestrictedImports` entry stays as the backstop
+ * if it is ever re-exported.
+ */
+async function saveSettings(settings: AppSettings): Promise<void> {
   const store = await getStore();
   await store.set("settings", settings);
 }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -75,15 +75,12 @@ export function formatDurationBetween(start?: string, end?: string): string {
   return `${h}h ${m % 60}m`;
 }
 
-/** "8 months ago", "2 hours ago", "just now". `now` defaults to the current
- *  time; callers that render many timestamps together (RelativeTime) pass one
- *  shared snapshot so simultaneously-mounted rows never disagree about the same
- *  date — and passing it explicitly keeps the React Compiler's memo key aware of
- *  the clock (a bare `Date.now()` read is invisible to it, freezing the output). */
-export function formatRelativeTime(
-  isoDate: string,
-  now: number = Date.now(),
-): string {
+/** "8 months ago", "2 hours ago", "just now". `now` is required: callers pass
+ *  the shared `useRelativeNow()` snapshot so simultaneously-mounted rows never
+ *  disagree about the same date, and so the React Compiler's memo key sees the
+ *  clock (a bare `Date.now()` read is invisible to it, freezing the output).
+ *  A default here would let a caller silently take the frozen path. */
+export function formatRelativeTime(isoDate: string, now: number): string {
   const seconds = (now - new Date(isoDate).getTime()) / 1000;
   // Largest-first: pick the first unit the elapsed time reaches.
   for (let i = 0; i < UNITS.length; i++) {


### PR DESCRIPTION
Turns three convention classes that a prior audit closed by hand into mechanical, blocking checks, so they can't silently re-open one PR at a time — then fixes the violations the new checks surfaced. Adds a second, deliberately non-blocking lane for advisory tools (unused exports, duplicate code) that report to humans rather than gate merges.

### Convention guard scripts

All three are Node-stdlib-only (no deps), so CI can run them with bare `node` before any install step.

- `scripts/check-banned-patterns.mjs` — scans `src/**/*.{ts,tsx}` with comments blanked out for hover-revealed row actions (`opacity-0` near `group-hover:opacity-100`), hand-rolled `ctrlKey`/`metaKey` reads outside `src/lib/hotkeys/`, and `setQueryData(key, undefined)`. Handles formatter-wrapped expressions via a normalized-text view plus a `PAIR_GAP` window, and reports real line numbers through a `lineAt` offset lookup.
- `scripts/check-rust-invariants.mjs` — three text-level invariants over `src-tauri/src/**/*.rs`: refspec-shaped `format!` templates (`refs/heads/{`, `refs/tags/{`, `:refs/`), secret-shaped keys passed to `gh` `-f`/`-F`/`--field`/`--raw-field` argv, and sync `#[tauri::command]` functions. Attribution is by nearest preceding `fn` signature; an unreadable signature fails closed rather than passing.
- `scripts/check-dead-surface.mjs` — pins the Tauri IPC surface at zero drift by bracket-scanning the `tauri::generate_handler!` list in `src-tauri/src/lib.rs` against every `invoke("…")` under `src/`, failing on commands registered with no caller or invoked with no registration. The `INVOKE_RE` comment records the two forms (line-split calls, nested generics) that a naïver pattern mis-reports.
- Each check carries an allowlist that entries must justify inline; `package.json` gains a `checks` script running all three, and `.claude/skills/gd-conventions/SKILL.md` lists `pnpm run checks` alongside the other pre-push commands.

### CI

- `.github/workflows/quality.yml` adds a blocking `guards` job on `pull_request` and `push: master`, with one step per script so a failure names itself in the UI. It deliberately carries no paths filter — a paths-skipped required check sits stuck at "Expected" — and the `push: master` leg re-validates the true merged tree.
- The same workflow's `advisory` job runs `knip` and `jscpd` under `continue-on-error`, strips SGR escape sequences from the captured logs, and appends both reports to `$GITHUB_STEP_SUMMARY`. Its header states the contract explicitly: informational only, never to be registered as a required check.
- Adds a `concurrency` group keyed on workflow + ref with `cancel-in-progress`, and `permissions: contents: read`.

### Rust violations fixed

- `src-tauri/src/git/ops.rs` — moves ref validation from the `git_merge_local_pr` command into the `merge_local_pr` core and upgrades it from `validate_branch_arg` to `validate_ref_name`, so every caller is gated by the refspec-metacharacter blocklist; `finish_local_pr_merge` takes the same gate for its `finalize_base` `update-ref` path. Adds `merge_local_pr_rejects_refspec_metacharacters`, a tokio test asserting `AppError::InvalidArgument` (not merely `is_err`) for `*`, `?`, `[` and `:` in both `base` and `head`.
- `src-tauri/src/mcp_server/write_local.rs` — `verify_branch` now routes `branch` through `validate_ref_name` instead of relying on the downstream probe to reject it.
- `src-tauri/src/github/pr.rs` — drops the `#[tauri::command]` attribute from six functions with no `invoke()` call site (`gh_stack_create`, `gh_stack_add`, `gh_stack_dissolve`, `gh_pr_review_threads`, `gh_pr_reply_review_thread`, `gh_pr_resolve_review_thread`); `src-tauri/src/lib.rs` is untouched.
- `src-tauri/src/git/branches.rs` — documents `validate_ref_name` as the shared chokepoint and records why rev syntax (`~ ^ @ { }`) is accepted.

### Frontend violations fixed

- `src/lib/time.ts` — `formatRelativeTime`'s `now` parameter loses its `Date.now()` default, so a caller can no longer silently take the frozen-clock path the React Compiler can't see.
- `src/features/repository/CleanupBranchesDialog.tsx` — consumes the shared `useRelativeNow()` snapshot and adds `now` to the `stale` memo's deps, so a branch crossing the idle window re-classifies while the dialog is open.

### Tooling config and lint rules

- `biome.json` — new `style.noRestrictedImports` rule blocking `saveSettings` from `@/lib/settings/api` and `./api`, pointing callers at `saveSettingsMerged` / `useSaveSettings` so writes stay on the serialized merge chain.
- `knip.jsonc` — scopes the run to the root workspace via `ignoreWorkspaces: ["site"]` (with a note that naming the workspace in `workspaces` does not narrow it), ignores vendored `src/components/ui/**`, and lists five `ignoreDependencies` derived empirically from the run, each with the reason it's unreachable through the `project` glob.
- `.jscpd.json` — `src` only, ts/tsx, `minLines: 40`, ignoring vendored UI and `.d.ts`.
- `package.json` / `pnpm-lock.yaml` — adds `jscpd` and `knip` as devDependencies.

### Documentation

- `CONTRIBUTING.md` gains a **Convention checks** section covering `pnpm run checks`, what the blocking `guards` job enforces, the one-way ratchet rule for allowlist entries, and the advisory job's never-gates contract.

No changelog fragment: the `src/` and `src-tauri/` edits here are validation hardening and internal cleanup rather than a released-behavior change, so the PR takes the `no-changelog` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch cleanup dialogs so stale-branch statuses refresh over time.
  * Preserved selected branches when candidate ordering changes.
  * Strengthened branch-name validation across merge, finish, and verification workflows.

* **Quality Improvements**
  * Added automated checks for unsafe patterns, command consistency, Rust invariants, unused code, and duplication.
  * Added CI reporting and contributor guidance for these checks.

* **Documentation**
  * Documented branch-validation behavior and verification workflows.
  * Updated development prerequisites to require Node 24+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->