### PR TITLE
fix(git,dialogs,ai,pulls): guard destructive ops and stale UI state

### DIFF
--- a/changelog.d/fixed-cherry-pick-rollback.md
+++ b/changelog.d/fixed-cherry-pick-rollback.md
@@ -1,0 +1,3 @@
+- A cherry-pick onto another branch that fails for any reason — a conflict, a
+  timeout, an unreadable repository — now always rolls back: the target branch is
+  left exactly as it was and you end up back on the branch you started from.

--- a/changelog.d/fixed-cherry-pick-rollback.md
+++ b/changelog.d/fixed-cherry-pick-rollback.md
@@ -1,3 +1,3 @@
 - A cherry-pick onto another branch that fails for any reason — a conflict, a
-  timeout, an unreadable repository — now always rolls back: the target branch is
-  left exactly as it was and you end up back on the branch you started from.
+  timeout, an unreadable repository — now rolls the whole batch back: the target
+  branch is left as it was and you end up back on the branch you started from.

--- a/changelog.d/fixed-composer-picker-labels.md
+++ b/changelog.d/fixed-composer-picker-labels.md
@@ -1,3 +1,4 @@
 - Dropdowns read the same collapsed as they do open — the session composer's
-  agent, model, and effort pickers, the research intent picker, and the selects
-  across Settings and repository settings all show their full labels.
+  agent, model, and effort pickers, the research intent picker, the pull request
+  review provider picker, and the selects across Settings and repository
+  settings all show their full labels.

--- a/changelog.d/fixed-composer-picker-labels.md
+++ b/changelog.d/fixed-composer-picker-labels.md
@@ -1,0 +1,3 @@
+- Dropdowns read the same collapsed as they do open — the session composer's
+  agent, model, and effort pickers, the research intent picker, and the selects
+  across Settings and repository settings all show their full labels.

--- a/changelog.d/fixed-dialog-close-fade-copy.md
+++ b/changelog.d/fixed-dialog-close-fade-copy.md
@@ -1,0 +1,4 @@
+- Dialog text stays put while a dialog closes — confirms keep the branch, tag,
+  commit, file, task, pull request, or repository they were about, and the error
+  and AI result viewers keep their contents, all the way through the closing
+  animation.

--- a/changelog.d/fixed-gh-scope-refresh.md
+++ b/changelog.d/fixed-gh-scope-refresh.md
@@ -1,0 +1,2 @@
+- Reconnecting a GitHub account picks up the token scopes it just granted right
+  away, so scope-gated actions become available immediately.

--- a/changelog.d/fixed-model-catalog-error-surface.md
+++ b/changelog.d/fixed-model-catalog-error-surface.md
@@ -1,0 +1,3 @@
+- The model picker now tells you why the live model list couldn't load — the
+  provider's own message for a rejected key, or the blocked-host hint for a custom
+  server — and refreshes as soon as you save or clear the API key.

--- a/changelog.d/fixed-pr-review-button-reason.md
+++ b/changelog.d/fixed-pr-review-button-reason.md
@@ -1,0 +1,2 @@
+- The pull request **Review…** button explains why it's unavailable while the
+  pull request you picked is still loading.

--- a/changelog.d/fixed-release-notes-repo-instructions.md
+++ b/changelog.d/fixed-release-notes-repo-instructions.md
@@ -1,0 +1,2 @@
+- AI-generated release notes follow the repo's own `.gitdesktop/instructions.md`,
+  the same as every other generation.

--- a/changelog.d/fixed-release-stale-tag-switch.md
+++ b/changelog.d/fixed-release-stale-tag-switch.md
@@ -1,0 +1,3 @@
+- Release actions always act on the tag you selected: publishing, editing,
+  deleting a release and adding, downloading or removing its assets wait —
+  saying so — until that tag's release has loaded.

--- a/changelog.d/fixed-review-draft-error-toasts.md
+++ b/changelog.d/fixed-review-draft-error-toasts.md
@@ -1,0 +1,2 @@
+- Edits and deletions of a pending review comment report a failure even when you
+  move to another pull request while the write is in flight.

--- a/changelog.d/fixed-stash-mid-op-guard.md
+++ b/changelog.d/fixed-stash-mid-op-guard.md
@@ -1,0 +1,3 @@
+- Stashing is now refused while a merge, rebase or cherry-pick is in progress —
+  including one whose conflicts you have already resolved and staged — so the
+  resolution stays with the operation git is still tracking.

--- a/changelog.d/fixed-stash-mid-op-guard.md
+++ b/changelog.d/fixed-stash-mid-op-guard.md
@@ -1,3 +1,5 @@
 - Stashing is now refused while a merge, rebase or cherry-pick is in progress —
   including one whose conflicts you have already resolved and staged — so the
-  resolution stays with the operation git is still tracking.
+  resolution stays with the operation git is still tracking, and promoting a
+  worktree is blocked while the main workspace is mid-operation, before the
+  point of no return.

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -63,43 +63,6 @@ async fn autostash_pop(repo: &str) -> AppResult<GitOutput> {
     run_git_raw(Some(repo), &["stash", "pop"], DEFAULT_TIMEOUT).await
 }
 
-/// Non-empty `git ls-files --unmerged` — the conflicted entries the changes list
-/// shows.
-async fn has_unmerged(repo: &str) -> AppResult<bool> {
-    let out = run_git(Some(repo), &["ls-files", "--unmerged"], DEFAULT_TIMEOUT).await?;
-    Ok(!out.stdout_lossy().trim().is_empty())
-}
-
-/// Refuses mid-operation: `git stash push` can't write an unmerged index, and
-/// stashing a merge/rebase/cherry-pick that is only staged-resolved would destroy
-/// work git is still holding state for. Mirrors `git_stash_paths_core`'s guard,
-/// widened past unmerged entries because a fully staged resolve has none.
-async fn refuse_mid_op(repo: &str) -> AppResult<()> {
-    if has_unmerged(repo).await? {
-        return Err(AppError::InvalidArgument(
-            "Can't stash while a conflict is in progress — resolve the conflicts first.".into(),
-        ));
-    }
-    if op_in_progress(repo).await {
-        return Err(AppError::InvalidArgument(
-            "Can't stash while a merge, rebase or cherry-pick is in progress — finish or abort it first."
-                .into(),
-        ));
-    }
-    Ok(())
-}
-
-/// Whether the repo is left mid-op. Reuses `git_op_state`'s detection so this gate
-/// and the conflict banner can't drift apart. Best-effort: the underlying probes
-/// swallow read failures into "absent", so an unreadable state reads as no-op; the
-/// `Err` arm keeps the stash should `op_state` ever gain a fallible read.
-async fn op_in_progress(repo: &str) -> bool {
-    match crate::git::ops::op_state(repo).await {
-        Ok(state) => state.merging || state.rebasing || state.cherry_picking,
-        Err(_) => true,
-    }
-}
-
 /// Failure text for an outcome payload. git splits its reporting across both
 /// streams — a conflicted merge and a conflicted `stash pop` write everything to
 /// stdout and leave stderr EMPTY (measured, git 2.51.1) — so stdout backfills.
@@ -148,7 +111,7 @@ async fn settle(
     if let Some(stderr) = failure {
         // Popping onto an in-progress merge/rebase would tangle the stash with
         // conflicts the user still has to resolve — keep it instead.
-        if op_in_progress(repo).await {
+        if crate::git::ops::op_in_progress(repo).await {
             return Ok(AutostashOutcome::OpFailedStashKept {
                 stderr,
                 in_progress: true,
@@ -178,7 +141,7 @@ async fn settle(
         // git aborts some pops without merging at all (an untracked file already in
         // the way), leaving nothing for the user to resolve; an unreadable index
         // answers the same way.
-        conflicted: has_unmerged(repo).await.unwrap_or(false),
+        conflicted: crate::git::ops::has_unmerged(repo).await.unwrap_or(false),
     })
 }
 
@@ -211,7 +174,7 @@ pub(crate) async fn git_pull_autostash_core(
 
     let lock = state.repo_lock(&repo_path).await;
     let _guard = lock.lock().await;
-    refuse_mid_op(&repo_path).await?;
+    crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
     let op = run_git_with_creds_once(&repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await;
@@ -238,7 +201,7 @@ pub(crate) async fn git_merge_autostash_core(
 
     let lock = state.repo_lock(&repo_path).await;
     let _guard = lock.lock().await;
-    refuse_mid_op(&repo_path).await?;
+    crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
     let op = run_git_raw(
@@ -279,7 +242,7 @@ pub(crate) async fn git_switch_autostash_core(
 
     let lock = state.repo_lock(&repo_path).await;
     let _guard = lock.lock().await;
-    refuse_mid_op(&repo_path).await?;
+    crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
     let args: Vec<&str> = match &tracking {

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -531,9 +531,17 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
             // return-switch leaves the branch correct and only HEAD misplaced —
             // telling that user to `--abort` names a no-op.
             let recovery = if reset_ok {
-                format!(
-                    "the rollback restored {target_branch}, but you are still checked out on it — switch back to {original_restore}."
-                )
+                // `original_restore` is a bare SHA on the detached path, and plain
+                // `git switch <sha>` refuses it — the remedy has to be runnable.
+                if detached {
+                    format!(
+                        "the rollback restored {target_branch}, but you are still checked out on it — switch back with git switch --detach {original_restore}."
+                    )
+                } else {
+                    format!(
+                        "the rollback restored {target_branch}, but you are still checked out on it — switch back to {original_restore}."
+                    )
+                }
             } else {
                 format!(
                     "the automatic rollback also failed, so {target_branch} may still carry the commits applied so far (its tip before this run was {target_tip}); run git cherry-pick --abort if a pick is still in progress, or git reset --hard {target_tip} on {target_branch} to restore it."

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -500,13 +500,12 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
             // didn't happen. The abort is not one of them: `reset --hard` clears
             // the pick state on its own, so a failed abort with a good reset still
             // leaves nothing in progress.
-            let _abort_ok = run_git(
+            let _ = run_git(
                 Some(repo_path),
                 &["cherry-pick", "--abort"],
                 DEFAULT_TIMEOUT,
             )
-            .await
-            .is_ok();
+            .await;
             let reset_ok = if switched {
                 run_git(
                     Some(repo_path),
@@ -527,6 +526,19 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
                 .await
                 .is_ok();
             let rolled_back = reset_ok && restore_ok;
+            // The remedy has to match the damage: a failed reset can leave this
+            // run's commits on `target`, while a good reset with a failed
+            // return-switch leaves the branch correct and only HEAD misplaced —
+            // telling that user to `--abort` names a no-op.
+            let recovery = if reset_ok {
+                format!(
+                    "the rollback restored {target_branch}, but you are still checked out on it — switch back to {original_restore}."
+                )
+            } else {
+                format!(
+                    "the automatic rollback also failed, so {target_branch} may still carry the commits applied so far (its tip before this run was {target_tip}); run git cherry-pick --abort if a pick is still in progress, or git reset --hard {target_tip} on {target_branch} to restore it."
+                )
+            };
             let short = &hash[..hash.len().min(7)];
             return Err(match err {
                 AppError::Git { code, stderr } if rolled_back => AppError::Git {
@@ -538,7 +550,7 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
                 AppError::Git { code, stderr } => AppError::Git {
                     code,
                     stderr: format!(
-                        "Cherry-pick hit conflicts on {short}; the automatic rollback also failed, so the repository may still be mid-cherry-pick on {target_branch} — run git cherry-pick --abort to recover.\n{stderr}"
+                        "Cherry-pick hit conflicts on {short}; {recovery}\n{stderr}"
                     ),
                 },
                 other if rolled_back => other,
@@ -547,7 +559,7 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
                 // `Command` carrying the whole explanation beats a scheme where
                 // which variant survives depends on the failure class.
                 other => AppError::Command(format!(
-                    "Cherry-pick of {short} failed; the automatic rollback also failed, so the repository may still be mid-cherry-pick on {target_branch} — run git cherry-pick --abort to recover.\n{other}"
+                    "Cherry-pick of {short} failed; {recovery}\n{other}"
                 )),
             });
         }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -110,8 +110,9 @@ pub(crate) async fn has_unmerged(repo: &str) -> AppResult<bool> {
 }
 
 /// Whether the repo is left mid-op. Reuses [`op_state`]'s detection so this gate
-/// and the conflict banner can't drift apart. Fail-closed: an `Err` reads as
-/// in-progress, so an unreadable repo is never stashed over.
+/// and the conflict banner can't drift apart. Best-effort, not fail-closed: the
+/// probes swallow read failures into absent, so the `Err` arm is defensive
+/// should [`op_state`] ever gain a fallible read.
 pub(crate) async fn op_in_progress(repo: &str) -> bool {
     match op_state(repo).await {
         Ok(state) => state.merging || state.rebasing || state.cherry_picking,
@@ -122,8 +123,8 @@ pub(crate) async fn op_in_progress(repo: &str) -> bool {
 /// Refuses to stash mid-operation: `git stash push` can't write an unmerged
 /// index, and stashing a merge/rebase/cherry-pick that is only staged-resolved
 /// sweeps the resolution out of the operation git is still holding state for.
-/// An unreadable repo refuses too (fail-closed via [`op_in_progress`]), and a
-/// rebase paused at an `edit` step is refused as well, matching autostash. Only
+/// The mid-op detection is best-effort (see [`op_in_progress`]), and a rebase
+/// paused at an `edit` step is refused as well, matching autostash. Only
 /// lock-free runners, so callers may hold the repo lock across it.
 pub(crate) async fn refuse_mid_op(repo: &str) -> AppResult<()> {
     if has_unmerged(repo).await? {

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -102,6 +102,44 @@ pub(crate) async fn op_state(repo_path: &str) -> AppResult<RepoOpState> {
     })
 }
 
+/// Non-empty `git ls-files --unmerged` — the conflicted entries the changes list
+/// shows.
+pub(crate) async fn has_unmerged(repo: &str) -> AppResult<bool> {
+    let out = run_git(Some(repo), &["ls-files", "--unmerged"], DEFAULT_TIMEOUT).await?;
+    Ok(!out.stdout_lossy().trim().is_empty())
+}
+
+/// Whether the repo is left mid-op. Reuses [`op_state`]'s detection so this gate
+/// and the conflict banner can't drift apart. Fail-closed: an `Err` reads as
+/// in-progress, so an unreadable repo is never stashed over.
+pub(crate) async fn op_in_progress(repo: &str) -> bool {
+    match op_state(repo).await {
+        Ok(state) => state.merging || state.rebasing || state.cherry_picking,
+        Err(_) => true,
+    }
+}
+
+/// Refuses to stash mid-operation: `git stash push` can't write an unmerged
+/// index, and stashing a merge/rebase/cherry-pick that is only staged-resolved
+/// sweeps the resolution out of the operation git is still holding state for.
+/// An unreadable repo refuses too (fail-closed via [`op_in_progress`]), and a
+/// rebase paused at an `edit` step is refused as well, matching autostash. Only
+/// lock-free runners, so callers may hold the repo lock across it.
+pub(crate) async fn refuse_mid_op(repo: &str) -> AppResult<()> {
+    if has_unmerged(repo).await? {
+        return Err(AppError::InvalidArgument(
+            "Can't stash while a conflict is in progress — resolve the conflicts first.".into(),
+        ));
+    }
+    if op_in_progress(repo).await {
+        return Err(AppError::InvalidArgument(
+            "Can't stash while a merge, rebase or cherry-pick is in progress — finish or abort it first."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_op(op: &str) -> AppResult<()> {
     match op {
         "merge" | "rebase" | "cherry-pick" => Ok(()),
@@ -312,6 +350,21 @@ pub(crate) async fn cherry_pick_onto(
     hashes: &[String],
     target_branch: &str,
 ) -> AppResult<CherryPickRangeResult> {
+    cherry_pick_onto_with_pick_timeout(state, repo_path, hashes, target_branch, DEFAULT_TIMEOUT)
+        .await
+}
+
+/// [`cherry_pick_onto`] with the per-pick timeout injectable. `pick_timeout` bounds
+/// ONLY the `cherry-pick` calls in the loop — the setup reads, the switch and the
+/// rollback keep `DEFAULT_TIMEOUT`, so a tiny value exercises the failure funnel
+/// instead of aborting before the first mutation.
+pub(crate) async fn cherry_pick_onto_with_pick_timeout(
+    state: &AppState,
+    repo_path: &str,
+    hashes: &[String],
+    target_branch: &str,
+    pick_timeout: std::time::Duration,
+) -> AppResult<CherryPickRangeResult> {
     validate_branch_arg(target_branch)?;
     for h in hashes {
         validate_hash(h)?;
@@ -396,17 +449,28 @@ pub(crate) async fn cherry_pick_onto(
     .await;
 
     let result: AppResult<CherryPickRangeResult> = async {
-        run_git(
+        // `reset --hard target_tip` in the funnel below is valid ONLY with HEAD on
+        // `target`: on the user's original branch it would rewind THAT branch to the
+        // target's tip. Defensive — the only path into the funnel has already
+        // switched — so any future early exit inherits the guarantee.
+        let switched = match run_git(
             Some(repo_path),
             &["switch", target_branch],
             DEFAULT_TIMEOUT,
         )
-        .await?;
+        .await
+        {
+            Ok(_) => true,
+            Err(e) => return Err(e),
+        };
 
         let mut applied = 0usize;
         let mut skipped = 0usize;
-        for hash in hashes {
-            match run_git(Some(repo_path), &["cherry-pick", hash], DEFAULT_TIMEOUT).await {
+        // Every pick failure class — conflict, timeout, IO — leaves through the one
+        // rollback funnel below, so none of them can exit with HEAD on `target`.
+        let mut failure: Option<(String, AppError)> = None;
+        'picks: for hash in hashes {
+            match run_git(Some(repo_path), &["cherry-pick", hash], pick_timeout).await {
                 Ok(_) => applied += 1,
                 Err(AppError::Git { stderr, .. })
                     if stderr.contains("is now empty") || stderr.contains("--allow-empty") =>
@@ -419,37 +483,46 @@ pub(crate) async fn cherry_pick_onto(
                     .await;
                     skipped += 1;
                 }
-                Err(AppError::Git { code, stderr }) => {
-                    // Roll everything back: abort the in-progress pick, drop the
-                    // commits already applied in this batch, and return home.
-                    let _ = run_git(
-                        Some(repo_path),
-                        &["cherry-pick", "--abort"],
-                        DEFAULT_TIMEOUT,
-                    )
-                    .await;
-                    let _ = run_git(
-                        Some(repo_path),
-                        &["reset", "--hard", &target_tip],
-                        DEFAULT_TIMEOUT,
-                    )
-                    .await;
-                    let restore_args: Vec<&str> = if detached {
-                        vec!["switch", "--detach", &original_restore]
-                    } else {
-                        vec!["switch", &original_restore]
-                    };
-                    let _ = run_git(Some(repo_path), &restore_args, DEFAULT_TIMEOUT).await;
-                    let short = &hash[..hash.len().min(7)];
-                    return Err(AppError::Git {
-                        code,
-                        stderr: format!(
-                            "Cherry-pick hit conflicts on {short} and was rolled back; {target_branch} is unchanged.\n{stderr}"
-                        ),
-                    });
+                Err(e) => {
+                    failure = Some((hash.clone(), e));
+                    break 'picks;
                 }
-                Err(e) => return Err(e),
             }
+        }
+
+        if let Some((hash, err)) = failure {
+            // Roll everything back: abort the in-progress pick, drop the commits
+            // already applied in this batch, and return home.
+            let _ = run_git(
+                Some(repo_path),
+                &["cherry-pick", "--abort"],
+                DEFAULT_TIMEOUT,
+            )
+            .await;
+            if switched {
+                let _ = run_git(
+                    Some(repo_path),
+                    &["reset", "--hard", &target_tip],
+                    DEFAULT_TIMEOUT,
+                )
+                .await;
+            }
+            let restore_args: Vec<&str> = if detached {
+                vec!["switch", "--detach", &original_restore]
+            } else {
+                vec!["switch", &original_restore]
+            };
+            let _ = run_git(Some(repo_path), &restore_args, DEFAULT_TIMEOUT).await;
+            let short = &hash[..hash.len().min(7)];
+            return Err(match err {
+                AppError::Git { code, stderr } => AppError::Git {
+                    code,
+                    stderr: format!(
+                        "Cherry-pick hit conflicts on {short} and was rolled back; {target_branch} is unchanged.\n{stderr}"
+                    ),
+                },
+                other => other,
+            });
         }
 
         Ok(CherryPickRangeResult { applied, skipped })
@@ -533,9 +606,16 @@ pub async fn git_stash_all(state: State<'_, AppState>, repo_path: String) -> App
 }
 
 pub(crate) async fn git_stash_all_core(state: &AppState, repo_path: String) -> AppResult<()> {
-    run_git_mutating(
-        state,
-        &repo_path,
+    // Guard and stash under ONE hold, so no merge/rebase/cherry-pick can start
+    // between the check and the push. That means the lock-free `run_git` for the
+    // push itself — `run_git_mutating` re-acquires this non-reentrant lock and
+    // deadlocks — trading away its one-shot index.lock retry (as autostash does).
+    let lock = state.repo_lock(&repo_path).await;
+    let _guard = lock.lock().await;
+    refuse_mid_op(&repo_path).await?;
+
+    run_git(
+        Some(&repo_path),
         &["stash", "push", "--include-untracked"],
         DEFAULT_TIMEOUT,
     )
@@ -644,21 +724,12 @@ pub(crate) async fn git_stash_paths_core(
     let lock = state.repo_lock(&repo_path).await;
     let _guard = lock.lock().await;
 
-    // Refuse during a merge (unmerged index): a native `git stash push` can't write
-    // the index mid-conflict, and the selective slow path can't snapshot it either
-    // (`git write-tree` fails on unmerged entries). Guarding both paths here is what
-    // keeps us from leaving a partial mutation or a stash.
-    let unmerged = run_git(
-        Some(&repo_path),
-        &["ls-files", "--unmerged"],
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-    if !unmerged.stdout_lossy().trim().is_empty() {
-        return Err(AppError::InvalidArgument(
-            "Can't stash while a conflict is in progress — resolve the conflicts first.".into(),
-        ));
-    }
+    // Refuse mid-operation, before any mutation: an unmerged index blocks both a
+    // native `git stash push` and the slow path's `write-tree` snapshot, and a
+    // merge/rebase/cherry-pick that is only staged-resolved has no unmerged entries
+    // yet a stash covering the resolved paths sweeps the resolution out of the
+    // operation git is still holding state for.
+    refuse_mid_op(&repo_path).await?;
 
     // Enumerate EVERY path staged vs HEAD, NUL-safe. `--no-renames` decomposes a
     // staged rename into delete+add so the subtraction sees stable per-path names
@@ -727,9 +798,9 @@ pub(crate) async fn git_stash_paths_core(
 
     // Snapshot the full index so the unselected files' exact staged blobs can be
     // restored afterward. A `write-tree` failure aborts pre-mutation and propagates
-    // RAW: the `ls-files --unmerged` guard above already reported the merge case, so
-    // a failure reaching here is something else (corruption/permissions) and must
-    // not be mislabeled as a merge.
+    // RAW: the mid-op guard above already reported the merge case, so a failure
+    // reaching here is something else (corruption/permissions) and must not be
+    // mislabeled as a merge.
     let full_tree = run_git(Some(&repo_path), &["write-tree"], DEFAULT_TIMEOUT)
         .await?
         .stdout_lossy()
@@ -4024,6 +4095,48 @@ mod tests {
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
     }
 
+    /// The rollback must run for every failure class, not just a conflict — a
+    /// killed pick otherwise leaves HEAD on the target mid-cherry-pick.
+    #[tokio::test]
+    async fn cherry_pick_onto_rolls_back_when_a_pick_fails_non_git() {
+        let (dir, repo) = setup_repo("pick-onto-nongit").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
+        let c1 = rev(&repo, "HEAD").await;
+        let feature_tip = c1.clone();
+        let target_tip = rev(&repo, "target").await;
+
+        let state = AppState::default();
+        // A 1ms budget kills the pick itself, so the loop sees AppError::Timeout —
+        // the non-Git arm. Everything else (switch, rollback) keeps the real timeout.
+        match cherry_pick_onto_with_pick_timeout(
+            &state,
+            &repo,
+            &[c1],
+            "target",
+            std::time::Duration::from_millis(1),
+        )
+        .await
+        {
+            Err(AppError::Timeout(_)) => {}
+            Ok(_) => panic!("the killed pick must fail"),
+            Err(e) => panic!("expected the non-Git arm, got {e:?}"),
+        }
+        assert_eq!(
+            git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+                .await
+                .trim(),
+            "feature",
+            "a failed pick must leave you on the branch you started from"
+        );
+        assert_eq!(rev(&repo, "HEAD").await, feature_tip);
+        assert_eq!(rev(&repo, "target").await, target_tip);
+        assert!(!op_state(&repo).await.unwrap().cherry_picking);
+        let status = git(&repo, &["status", "--porcelain"]).await;
+        assert!(status.trim().is_empty(), "tree should be clean: {status}");
+    }
+
     #[tokio::test]
     async fn rebase_edit_refuses_a_concurrent_op() {
         let (dir, repo) = setup_repo("reentry").await;
@@ -6116,6 +6229,226 @@ detached
         assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
         // No stash created.
         assert_eq!(stash_count(&repo).await, 0);
+    }
+
+    // --- mid-operation stash guard ------------------------------------------
+    //
+    // The destructive state is a merge/rebase/cherry-pick whose conflicts are
+    // RESOLVED AND STAGED: `ls-files --unmerged` reads empty while the op marker
+    // stands, and a stash there sweeps both the resolution and the marker away.
+
+    async fn head_branch(repo: &str) -> String {
+        git(repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string()
+    }
+
+    /// A staged-resolved operation leaves no unmerged entries — the half of the
+    /// guard that cannot see it.
+    async fn nothing_unmerged(repo: &str) -> bool {
+        git(repo, &["ls-files", "--unmerged"])
+            .await
+            .trim()
+            .is_empty()
+    }
+
+    /// Two branches editing `x` divergently, merged, then resolved and staged —
+    /// MERGE_HEAD present, no unmerged entries.
+    async fn staged_resolved_merge(marker: &str) -> (tempfile::TempDir, String) {
+        let (dir, repo) = setup_repo(marker).await;
+        commit_file(&repo, dir.path(), "x", "base\n", "add x").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "other"]).await;
+        commit_file(&repo, dir.path(), "x", "other\n", "other edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "x", "main\n", "main edit").await;
+        // run_git_raw: a conflicting merge exits non-zero.
+        let merge = run_git_raw(Some(&repo), &["merge", "other"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(merge.code, 0, "merge should conflict");
+        std::fs::write(dir.path().join("x"), "resolved\n").unwrap();
+        git(&repo, &["add", "x"]).await;
+        (dir, repo)
+    }
+
+    #[tokio::test]
+    async fn stash_all_refuses_a_staged_but_uncommitted_merge() {
+        let (_dir, repo) = staged_resolved_merge("stash-all-staged-merge").await;
+        // Pins the exact gap: nothing unmerged is left, only the op marker.
+        assert!(nothing_unmerged(&repo).await);
+        assert!(op_state(&repo).await.unwrap().merging);
+
+        let state = AppState::default();
+        let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
+        assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+        assert_eq!(stash_count(&repo).await, 0);
+        assert!(
+            op_state(&repo).await.unwrap().merging,
+            "the merge must still be in progress"
+        );
+        assert_eq!(nlf(git(&repo, &["show", ":x"]).await), "resolved\n");
+    }
+
+    /// A `--no-commit` merge never conflicts at all, so an unmerged-entry check can
+    /// never see it — and stashing it drops the merged-in file entirely.
+    #[tokio::test]
+    async fn stash_all_refuses_a_no_commit_merge() {
+        let (dir, repo) = setup_repo("stash-all-no-commit-merge").await;
+        commit_file(&repo, dir.path(), "x", "base\n", "add x").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "other"]).await;
+        commit_file(&repo, dir.path(), "y", "other\n", "add y").await;
+        git(&repo, &["switch", &base]).await;
+        git(&repo, &["merge", "--no-commit", "--no-ff", "other"]).await;
+        assert!(nothing_unmerged(&repo).await);
+        assert!(op_state(&repo).await.unwrap().merging);
+
+        let state = AppState::default();
+        let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
+        assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+        assert_eq!(stash_count(&repo).await, 0);
+        assert!(op_state(&repo).await.unwrap().merging);
+        assert_eq!(nlf(git(&repo, &["show", ":y"]).await), "other\n");
+    }
+
+    /// The costliest arm: stashing here leaves the rebase running, and the later
+    /// `rebase --continue` drops the replayed commit from history outright.
+    #[tokio::test]
+    async fn stash_all_refuses_a_paused_rebase_with_a_staged_resolution() {
+        let (dir, repo) = setup_repo("stash-all-rebase").await;
+        commit_file(&repo, dir.path(), "x", "base\n", "add x").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "x", "feature\n", "feature edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "x", "main\n", "main edit").await;
+        git(&repo, &["switch", "feature"]).await;
+        let rebase = run_git_raw(Some(&repo), &["rebase", &base], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(rebase.code, 0, "rebase should conflict");
+        std::fs::write(dir.path().join("x"), "resolved\n").unwrap();
+        git(&repo, &["add", "x"]).await;
+        assert!(nothing_unmerged(&repo).await);
+        assert!(op_state(&repo).await.unwrap().rebasing);
+
+        let state = AppState::default();
+        let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
+        assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+        assert_eq!(stash_count(&repo).await, 0);
+        assert!(
+            op_state(&repo).await.unwrap().rebasing,
+            "the paused rebase must survive"
+        );
+        assert_eq!(nlf(git(&repo, &["show", ":x"]).await), "resolved\n");
+    }
+
+    #[tokio::test]
+    async fn stash_all_refuses_a_staged_cherry_pick() {
+        let (dir, repo) = setup_repo("stash-all-cherry-pick").await;
+        commit_file(&repo, dir.path(), "x", "base\n", "add x").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "other"]).await;
+        commit_file(&repo, dir.path(), "x", "other\n", "other edit").await;
+        let pick_sha = rev(&repo, "HEAD").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "x", "main\n", "main edit").await;
+        let picked = run_git_raw(Some(&repo), &["cherry-pick", &pick_sha], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(picked.code, 0, "cherry-pick should conflict");
+        std::fs::write(dir.path().join("x"), "resolved\n").unwrap();
+        git(&repo, &["add", "x"]).await;
+        assert!(nothing_unmerged(&repo).await);
+        assert!(op_state(&repo).await.unwrap().cherry_picking);
+
+        let state = AppState::default();
+        let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
+        assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+        assert_eq!(stash_count(&repo).await, 0);
+        assert!(
+            op_state(&repo).await.unwrap().cherry_picking,
+            "the cherry-pick must still be in progress"
+        );
+        assert_eq!(nlf(git(&repo, &["show", ":x"]).await), "resolved\n");
+    }
+
+    /// The selective path destroys only when the selection COVERS the resolved
+    /// path, so that is what this selects (an unrelated path is measurably safe).
+    #[tokio::test]
+    async fn refuses_selective_stash_during_a_staged_merge() {
+        let (_dir, repo) = staged_resolved_merge("stash-paths-staged-merge").await;
+        assert!(nothing_unmerged(&repo).await);
+
+        let state = AppState::default();
+        let err = git_stash_paths_core(&state, repo.clone(), vec!["x".into()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+        assert_eq!(stash_count(&repo).await, 0);
+        assert!(op_state(&repo).await.unwrap().merging);
+        assert_eq!(nlf(git(&repo, &["show", ":x"]).await), "resolved\n");
+    }
+
+    /// Both refusal sentences are user-visible copy (the toast prints them
+    /// verbatim), and each arm has its own: conflicts to resolve vs. an operation
+    /// to finish or abort.
+    #[tokio::test]
+    async fn mid_op_refusal_names_the_arm_it_caught() {
+        // Unmerged arm: a conflicting merge, nothing resolved yet.
+        let (dir, repo) = setup_repo("stash-guard-wording").await;
+        commit_file(&repo, dir.path(), "x", "base\n", "add x").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "other"]).await;
+        commit_file(&repo, dir.path(), "x", "other\n", "other edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "x", "main\n", "main edit").await;
+        run_git_raw(Some(&repo), &["merge", "other"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        fn message(err: AppError) -> String {
+            match err {
+                AppError::InvalidArgument(msg) => msg,
+                other => panic!("expected a refusal, got {other:?}"),
+            }
+        }
+
+        let state = AppState::default();
+        let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
+        assert_eq!(
+            message(err),
+            "Can't stash while a conflict is in progress — resolve the conflicts first."
+        );
+
+        // Op-state arm: the same merge, resolved and staged.
+        let (_dir, repo) = staged_resolved_merge("stash-guard-wording-staged").await;
+        let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
+        assert_eq!(
+            message(err),
+            "Can't stash while a merge, rebase or cherry-pick is in progress — finish or abort it first."
+        );
+    }
+
+    /// Over-refusal check: with no operation in flight, stash-all still puts both
+    /// tracked and untracked work away.
+    #[tokio::test]
+    async fn stash_all_succeeds_on_a_plain_dirty_tree() {
+        let (dir, repo) = setup_repo("stash-all-dirty").await;
+        commit_file(&repo, dir.path(), "A", "a0\n", "add A").await;
+        std::fs::write(dir.path().join("A"), "a1\n").unwrap();
+        std::fs::write(dir.path().join("U"), "u\n").unwrap();
+
+        let state = AppState::default();
+        git_stash_all_core(&state, repo.clone()).await.unwrap();
+
+        assert_eq!(stash_count(&repo).await, 1);
+        assert_eq!(
+            nlf(std::fs::read_to_string(dir.path().join("A")).unwrap()),
+            "a0\n"
+        );
+        assert!(!dir.path().join("U").exists(), "untracked work was stashed");
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -468,7 +468,8 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
         let mut applied = 0usize;
         let mut skipped = 0usize;
         // Every pick failure class — conflict, timeout, IO — leaves through the one
-        // rollback funnel below, so none of them can exit with HEAD on `target`.
+        // rollback funnel below, so none of them exits with HEAD on `target` unless
+        // the rollback itself fails, which the error then says.
         let mut failure: Option<(String, AppError)> = None;
         'picks: for hash in hashes {
             match run_git(Some(repo_path), &["cherry-pick", hash], pick_timeout).await {
@@ -493,36 +494,61 @@ pub(crate) async fn cherry_pick_onto_with_pick_timeout(
 
         if let Some((hash, err)) = failure {
             // Roll everything back: abort the in-progress pick, drop the commits
-            // already applied in this batch, and return home.
-            let _ = run_git(
+            // already applied in this batch, and return home. Every attempt stays
+            // best-effort, but the two that decide whether the repo actually came
+            // home are captured — the error below must not promise a rollback that
+            // didn't happen. The abort is not one of them: `reset --hard` clears
+            // the pick state on its own, so a failed abort with a good reset still
+            // leaves nothing in progress.
+            let _abort_ok = run_git(
                 Some(repo_path),
                 &["cherry-pick", "--abort"],
                 DEFAULT_TIMEOUT,
             )
-            .await;
-            if switched {
-                let _ = run_git(
+            .await
+            .is_ok();
+            let reset_ok = if switched {
+                run_git(
                     Some(repo_path),
                     &["reset", "--hard", &target_tip],
                     DEFAULT_TIMEOUT,
                 )
-                .await;
-            }
+                .await
+                .is_ok()
+            } else {
+                true
+            };
             let restore_args: Vec<&str> = if detached {
                 vec!["switch", "--detach", &original_restore]
             } else {
                 vec!["switch", &original_restore]
             };
-            let _ = run_git(Some(repo_path), &restore_args, DEFAULT_TIMEOUT).await;
+            let restore_ok = run_git(Some(repo_path), &restore_args, DEFAULT_TIMEOUT)
+                .await
+                .is_ok();
+            let rolled_back = reset_ok && restore_ok;
             let short = &hash[..hash.len().min(7)];
             return Err(match err {
-                AppError::Git { code, stderr } => AppError::Git {
+                AppError::Git { code, stderr } if rolled_back => AppError::Git {
                     code,
                     stderr: format!(
                         "Cherry-pick hit conflicts on {short} and was rolled back; {target_branch} is unchanged.\n{stderr}"
                     ),
                 },
-                other => other,
+                AppError::Git { code, stderr } => AppError::Git {
+                    code,
+                    stderr: format!(
+                        "Cherry-pick hit conflicts on {short}; the automatic rollback also failed, so the repository may still be mid-cherry-pick on {target_branch} — run git cherry-pick --abort to recover.\n{stderr}"
+                    ),
+                },
+                other if rolled_back => other,
+                // Timeout carries only a u64 and GitNotFound carries nothing, so a
+                // variant-preserving wrap isn't available for every arm — one
+                // `Command` carrying the whole explanation beats a scheme where
+                // which variant survives depends on the failure class.
+                other => AppError::Command(format!(
+                    "Cherry-pick of {short} failed; the automatic rollback also failed, so the repository may still be mid-cherry-pick on {target_branch} — run git cherry-pick --abort to recover.\n{other}"
+                )),
             });
         }
 

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -528,7 +528,9 @@ impl GitDesktopMcp {
                        (including untracked). With `paths`, stashes only those files, leaving every \
                        other file's staged and unstaged changes exactly as they were; paths and \
                        directories match exactly, set literal=false to pass a pathspec or glob. \
-                       Requires --allow-git-write.",
+                       Refused while conflicts are unresolved, or while a merge, rebase or \
+                       cherry-pick is in progress (finish or abort it first — retrying won't \
+                       help). Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn stash_push(

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -67,6 +67,7 @@ export function RunWorkflowDialog({
     dispatchable.map((w) => [String(w.id), w.name]),
   );
   // value → label map so the closed trigger shows "Default" for "", not a blank.
+  // The popup renders from it too, so the two can never drift.
   const pipelineItems: Record<string, string> = {
     "": "Default",
     ...Object.fromEntries(pipelineNames.map((n) => [n, n])),
@@ -199,10 +200,9 @@ export function RunWorkflowDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">Default</SelectItem>
-                  {pipelineNames.map((name) => (
+                  {Object.entries(pipelineItems).map(([name, label]) => (
                     <SelectItem key={name} value={name}>
-                      {name}
+                      {label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/features/automations/AutomationResultDialog.tsx
+++ b/src/features/automations/AutomationResultDialog.tsx
@@ -10,6 +10,7 @@ import { Markdown } from "@/components/ui/markdown";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAutomationResults } from "@/lib/automations/results";
 import { parseableDate } from "@/lib/time";
+import { useRetained } from "@/lib/use-retained";
 
 /**
  * Viewer for automation results that have no durable surface (commit
@@ -21,6 +22,7 @@ export function AutomationResultDialog() {
   const result = useAutomationResults((s) =>
     s.results.find((r) => r.id === s.openId),
   );
+  const shownResult = useRetained(result);
 
   return (
     <Dialog
@@ -32,20 +34,20 @@ export function AutomationResultDialog() {
       <DialogContent className="flex max-h-[80vh] flex-col sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>
-            AI {result?.mode === "security" ? "security audit" : "review"}
+            AI {shownResult?.mode === "security" ? "security audit" : "review"}
           </DialogTitle>
           <DialogDescription>
-            {result?.subject}
-            {result && parseableDate(result.createdAt) && (
+            {shownResult?.subject}
+            {shownResult && parseableDate(shownResult.createdAt) && (
               <>
                 {" — "}
-                <RelativeTime date={result.createdAt} />
+                <RelativeTime date={shownResult.createdAt} />
               </>
             )}
           </DialogDescription>
         </DialogHeader>
         <ScrollArea className="min-h-0 flex-1">
-          {result && <Markdown>{result.text}</Markdown>}
+          {shownResult && <Markdown>{shownResult.text}</Markdown>}
         </ScrollArea>
       </DialogContent>
     </Dialog>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -45,6 +45,7 @@ import { useEffectiveSyntax } from "@/lib/syntax/queries";
 import { toastError } from "@/lib/toast";
 import { useIsDark } from "@/lib/use-is-dark";
 import { useLatestRef } from "@/lib/use-latest-ref";
+import { useRetained } from "@/lib/use-retained";
 import {
   DIFF_MAX_LINE_CHARS,
   DIFF_MEGA_LINE_CHARS,
@@ -164,6 +165,8 @@ function WorkingTreeDiff({
     // confirm wording changes from "revert to last committed" to "remove".
     newFile?: boolean;
   } | null>(null);
+  // Declared with the hooks above the `!hunkMode` early return below.
+  const shownDiscard = useRetained(discard);
   // The drag-selected lines to stage/unstage/discard — file-wide, since the
   // single whole-file view lets a selection span multiple hunks.
   const [selection, setSelection] = useState<SelectedLine[] | null>(null);
@@ -407,14 +410,16 @@ function WorkingTreeDiff({
           <DialogHeader>
             <DialogTitle>Discard changes?</DialogTitle>
             <DialogDescription>
-              {discard?.newFile ? (
+              {shownDiscard?.newFile ? (
                 <>
-                  Removes <span className="font-mono">{discard?.label}</span>{" "}
-                  from {file.path}. This cannot be undone.
+                  Removes{" "}
+                  <span className="font-mono">{shownDiscard?.label}</span> from{" "}
+                  {file.path}. This cannot be undone.
                 </>
               ) : (
                 <>
-                  Reverts <span className="font-mono">{discard?.label}</span> in{" "}
+                  Reverts{" "}
+                  <span className="font-mono">{shownDiscard?.label}</span> in{" "}
                   {file.path} to the last committed version. This cannot be
                   undone.
                 </>

--- a/src/features/errors/ErrorDialog.tsx
+++ b/src/features/errors/ErrorDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useErrorDialog } from "@/lib/stores/error-dialog";
+import { useRetained } from "@/lib/use-retained";
 
 /**
  * The full-text viewer for a long error. Opened from an error toast's "Details"
@@ -20,6 +21,7 @@ import { useErrorDialog } from "@/lib/stores/error-dialog";
 export function ErrorDialog() {
   const presentation = useErrorDialog((s) => s.presentation);
   const close = useErrorDialog((s) => s.close);
+  const shownPresentation = useRetained(presentation);
   const [copied, setCopied] = useState(false);
   // Hold the copy-feedback timer so handleClose can cancel it — otherwise a
   // Copy → Close → reopen → Copy sequence lets the first dialog's orphaned
@@ -39,7 +41,8 @@ export function ErrorDialog() {
     }
   }, [presentation]);
 
-  const fullText = presentation?.fullText ?? "";
+  // Copy must hand over exactly what the pane shows, so both read the snapshot.
+  const fullText = shownPresentation?.fullText ?? "";
 
   // Controlled Base UI dialogs don't fire onOpenChange when `open` flips via the
   // prop, so the Close button clears `copied` itself — otherwise a Copy → Close
@@ -77,11 +80,11 @@ export function ErrorDialog() {
         <DialogHeader>
           <div className="flex items-center gap-2">
             <DialogTitle className="min-w-0 wrap-break-word">
-              {presentation?.summary}
+              {shownPresentation?.summary}
             </DialogTitle>
-            {presentation?.label && (
+            {shownPresentation?.label && (
               <Badge variant="secondary" className="shrink-0">
-                {presentation.label}
+                {shownPresentation.label}
               </Badge>
             )}
           </div>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -556,7 +556,8 @@ test, or review several branches at once without stashing or switching.
   out in the main workspace. The worktree must be clean first; any uncommitted work in the
   main workspace is stashed so the checkout can't be blocked (restore it with *Pop latest
   stash*), and promoting is blocked while the main workspace has a merge, rebase or
-  cherry-pick in progress. Works even on the worktree you're currently in.
+  cherry-pick in progress, or unresolved conflicts. Works even on the worktree you're
+  currently in.
 - **Repair links** (footer) re-connects worktrees if you moved or renamed the repository
   folder in your file manager, which otherwise breaks the path each worktree records.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -493,7 +493,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 
 **Stash all changes** ({{kbd:stash-all}}) sets your working changes aside; **View
 stashes** lists them to apply, pop, or drop, and **Pop latest stash** restores the most
-recent.
+recent. Setting changes aside is refused while conflicts are still unresolved, or while a
+merge, rebase or cherry-pick is in progress — finish or abort it first, so a resolution
+you've already staged can't be swept out of the operation.
 
 **Recover lost work** (in the branch ⋮ menu, or the command palette) opens the
 **Recoverable** tab in the stashes dialog. It scans your repository (with \`git fsck\`) for
@@ -553,7 +555,8 @@ test, or review several branches at once without stashing or switching.
   removes the worktree (a branch can't be checked out in two at once) and checks that branch
   out in the main workspace. The worktree must be clean first; any uncommitted work in the
   main workspace is stashed so the checkout can't be blocked (restore it with *Pop latest
-  stash*). Works even on the worktree you're currently in.
+  stash*), and promoting is blocked while the main workspace has a merge, rebase or
+  cherry-pick in progress. Works even on the worktree you're currently in.
 - **Repair links** (footer) re-connects worktrees if you moved or renamed the repository
   folder in your file manager, which otherwise breaks the path each worktree records.
 

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/git/queries";
 import { refNameWarning } from "@/lib/git/ref-name";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 
 const onError = (e: unknown) => toastError(e);
 
@@ -47,6 +48,7 @@ export function DeleteTagDialog({
   onClose: () => void;
 }) {
   const deleteTag = useDeleteTag(repoPath);
+  const shownName = useRetained(name);
   return (
     <Dialog
       open={name !== null}
@@ -56,7 +58,7 @@ export function DeleteTagDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete tag {name}?</DialogTitle>
+          <DialogTitle>Delete tag {shownName}?</DialogTitle>
           <DialogDescription>
             Removes the tag from this repository. The commit it points at is not
             affected.
@@ -115,6 +117,7 @@ export function ResetCommitDialog({
   onClose: () => void;
 }) {
   const resetMutation = useResetToCommit(repoPath);
+  const shownHash = useRetained(hash);
   return (
     <Dialog
       open={hash !== null}
@@ -126,9 +129,10 @@ export function ResetCommitDialog({
         <DialogHeader>
           <DialogTitle>Reset to commit?</DialogTitle>
           <DialogDescription>
-            Moves the current branch to {hash?.slice(0, 7)}. Changes from later
-            commits stay in your working tree as uncommitted changes (mixed
-            reset). Commits that were only on this branch will be orphaned.
+            Moves the current branch to {shownHash?.slice(0, 7)}. Changes from
+            later commits stay in your working tree as uncommitted changes
+            (mixed reset). Commits that were only on this branch will be
+            orphaned.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -184,6 +188,7 @@ export function CherryPickOntoDialog({
 }) {
   const cherryPickOnto = useCherryPickOnto(repoPath);
   const destId = useId();
+  const shownHashes = useRetained(hashes);
   function run() {
     if (!hashes || !branch) return;
     const target = branch;
@@ -222,8 +227,8 @@ export function CherryPickOntoDialog({
         <DialogHeader>
           <DialogTitle>Cherry-pick to branch</DialogTitle>
           <DialogDescription>
-            {hashes && hashes.length > 1
-              ? `Copies these ${hashes.length} commits onto the chosen branch and switches to it. `
+            {shownHashes && shownHashes.length > 1
+              ? `Copies these ${shownHashes.length} commits onto the chosen branch and switches to it. `
               : "Copies this commit onto the chosen branch and switches to it. "}
             They stay on {currentBranch ?? "this branch"} too. Commits already
             present are skipped; a conflict rolls the whole thing back.

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -231,7 +231,7 @@ export function CherryPickOntoDialog({
               ? `Copies these ${shownHashes.length} commits onto the chosen branch and switches to it. `
               : "Copies this commit onto the chosen branch and switches to it. "}
             They stay on {currentBranch ?? "this branch"} too. Commits already
-            present are skipped; a conflict rolls the whole thing back.
+            present are skipped; any failure rolls the batch back automatically.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -57,6 +57,7 @@ import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import { EditHistoryDialog } from "./EditHistoryDialog";
 import {
@@ -95,6 +96,9 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
   const [resetHash, setResetHash] = useState<string | null>(null);
   const [branchHash, setBranchHash] = useState<string | null>(null);
   const [tagHash, setTagHash] = useState<string | null>(null);
+  // Both dialogs' descriptions are built at their call sites below.
+  const shownBranchHash = useRetained(branchHash);
+  const shownTagHash = useRetained(tagHash);
   // Multi-/range-selection for "cherry-pick to branch". Kept separate from the
   // ui store's focused commit (which drives the diff panel).
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -872,7 +876,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
         open={branchHash !== null}
         onClose={() => setBranchHash(null)}
         title="Create branch from commit"
-        description={`Creates a branch starting at ${branchHash?.slice(0, 7) ?? ""} and switches to it.`}
+        description={`Creates a branch starting at ${shownBranchHash?.slice(0, 7) ?? ""} and switches to it.`}
         fieldLabel="Branch name"
         placeholder="feature/from-commit"
         submitLabel="Create branch"
@@ -883,7 +887,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
         open={tagHash !== null}
         onClose={() => setTagHash(null)}
         title="Create tag"
-        description={`Tags commit ${tagHash?.slice(0, 7) ?? ""}.`}
+        description={`Tags commit ${shownTagHash?.slice(0, 7) ?? ""}.`}
         fieldLabel="Tag name"
         placeholder="v1.0.0"
         submitLabel="Create tag"

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -34,6 +34,7 @@ import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { ReviewerNotesField } from "./ReviewerNotesField";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
@@ -76,14 +77,19 @@ export function CreateLocalPrDialog({
   const queryClient = useQueryClient();
 
   const currentName = status.data?.branch?.name ?? null;
+  // Retained on `open`, not on the values: an unseeded next open must resync to
+  // undefined (before the seed effect runs) instead of leaving the previous
+  // open's archived branch listed and selectable in both pickers.
+  const shownDefaultHead = useRetained(defaultHead, open);
+  const shownDefaultBase = useRetained(defaultBase, open);
   // Branch options with per-branch worktree chips; drops the app-internal
   // `gd/session/*` branches (a local PR must never target one) and archived
   // branches, matching BranchSwitcher. `keep` retains the seeded defaults even
   // if archived, so the head/base defaults stay selectable.
   const { names, items, annotations } = useBranchPickerOptions(repoPath, open, [
     currentName,
-    defaultHead,
-    defaultBase,
+    shownDefaultHead,
+    shownDefaultBase,
     defaultBranch.data,
   ]);
 

--- a/src/features/pulls/PendingReviewBar.tsx
+++ b/src/features/pulls/PendingReviewBar.tsx
@@ -54,10 +54,7 @@ export function DraftCommentCard({
     if (!canSave) return;
     updateDraft.mutate(
       { id: draft.id, body: next },
-      {
-        onError: (e) => toastError(e),
-        onSuccess: () => setEditing(false),
-      },
+      { onSuccess: () => setEditing(false) },
     );
   }
 
@@ -119,7 +116,6 @@ export function DraftCommentCard({
         pending={removeDraft.isPending}
         onConfirm={() =>
           removeDraft.mutate(draft.id, {
-            onError: (e) => toastError(e),
             onSuccess: () => setConfirmDelete(false),
           })
         }

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -336,6 +336,7 @@ export function PrReviewPanel({
           onPointerDownCapture={() => setModelsWanted(true)}
         >
           <Select
+            items={PROVIDER_LABELS}
             value={provider}
             onValueChange={(v) => {
               if (!v || !reviewAi) return;

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -41,6 +41,7 @@ import { useRemoteSlug, useRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { LocalPrContextMenu } from "./LocalPrContextMenu";
 import { useReconcileLocalPrs } from "./useReconcileLocalPrs";
@@ -174,6 +175,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
       ? (localPrs.data ?? []).find((p) => p.id === selectedPr.id)
       : undefined;
   const [confirmDeleteSelected, setConfirmDeleteSelected] = useState(false);
+  const shownSelectedLocalPr = useRetained(selectedLocalPr);
 
   useHotkeyAction(
     "pr-archive",
@@ -459,12 +461,12 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
           onCancel={() => setConfirmDeleteSelected(false)}
           title="Delete this local pull request?"
           body={
-            selectedLocalPr ? (
+            shownSelectedLocalPr ? (
               <>
-                Permanently deletes "{selectedLocalPr.title}"
-                {selectedLocalPr.comments.length > 0
-                  ? ` and its ${selectedLocalPr.comments.length} comment${
-                      selectedLocalPr.comments.length === 1 ? "" : "s"
+                Permanently deletes "{shownSelectedLocalPr.title}"
+                {shownSelectedLocalPr.comments.length > 0
+                  ? ` and its ${shownSelectedLocalPr.comments.length} comment${
+                      shownSelectedLocalPr.comments.length === 1 ? "" : "s"
                     }`
                   : ""}
                 . The branches are not affected. This cannot be undone.

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2310,15 +2310,21 @@ export function RemotePrView({
                       rides `canWrite` via canSubmitReview; GitLab/Bitbucket enable it
                       through the forge flag. */}
                   {isOpen && canSubmitReview && (
-                    <Button
+                    <DisabledReasonButton
                       variant="outline"
                       size="sm"
                       disabled={busy}
+                      // `busy` folds in the placeholder window, where the review
+                      // would open against the previously rendered PR. The pending
+                      // arms carry no reason here, as on the neighbours.
+                      reason={
+                        detailsStale ? "Loading this pull request…" : null
+                      }
                       onClick={() => setSubmitOpen(true)}
                       title="Submit a review (verdict, summary, and any pending comments)"
                     >
                       Review…
-                    </Button>
+                    </DisabledReasonButton>
                   )}
                   {isOpen && canApprove && (
                     <>

--- a/src/features/repo-settings/CollaboratorsSection.tsx
+++ b/src/features/repo-settings/CollaboratorsSection.tsx
@@ -38,6 +38,12 @@ const ROLES: { value: RepoRole; label: string }[] = [
   { value: "admin", label: "Admin" },
 ];
 
+/** Trigger labels for the role selects — without them Base UI shows the raw
+ *  role ("maintain"). Covers every role, including ones a narrowed picker omits. */
+const ROLE_ITEMS: Record<string, string> = Object.fromEntries(
+  ROLES.map((r) => [r.value, r.label]),
+);
+
 function validUsername(u: string): boolean {
   return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(u);
 }
@@ -112,6 +118,7 @@ export function CollaboratorsSection({
             }}
           />
           <Select
+            items={ROLE_ITEMS}
             value={role}
             onValueChange={(v) => v && setRole(v as RepoRole)}
           >
@@ -349,6 +356,7 @@ function PersonRow({
       ) : (
         <>
           <Select
+            items={ROLE_ITEMS}
             value={roleValue}
             disabled={roleDisabled}
             onValueChange={(v) => v && onRole(v as RepoRole)}

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -159,12 +159,16 @@ function CommitMessageSelect({
   const opts = options.some((o) => o.value === value)
     ? options
     : [{ value, label: `${title} / ${message}` }, ...options];
+  // Trigger labels, built per render because `opts` carries the synthesized
+  // current pair — without them Base UI shows the raw "title/message" value.
+  const items = Object.fromEntries(opts.map((o) => [o.value, o.label]));
   return (
     <div className="space-y-1.5">
       <Label htmlFor={id} className={disabled ? "text-muted-foreground" : ""}>
         {label}
       </Label>
       <Select
+        items={items}
         value={value}
         disabled={disabled}
         onValueChange={(v) => {

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -29,6 +29,13 @@ import { InlineConfirm } from "./parts";
 
 const PATHS = ["/", "/docs"];
 
+/** Trigger labels for the source select — without them Base UI shows the raw
+ *  value ("workflow"). The branch/path selects label each option as itself. */
+const MODE_ITEMS: Record<string, string> = {
+  branch: "Deploy from a branch",
+  workflow: "GitHub Actions",
+};
+
 export function PagesSection({
   repoPath,
   open,
@@ -92,6 +99,7 @@ function PagesDisabled({ repoPath }: { repoPath: string }) {
       <div className="space-y-1.5">
         <Label htmlFor="pages-mode">Source</Label>
         <Select
+          items={MODE_ITEMS}
           value={mode}
           onValueChange={(v) => v && setMode(v as "branch" | "workflow")}
         >

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -29,8 +29,9 @@ import { InlineConfirm } from "./parts";
 
 const PATHS = ["/", "/docs"];
 
-/** Trigger labels for the source select — without them Base UI shows the raw
- *  value ("workflow"). The branch/path selects label each option as itself. */
+/** Labels for the source select — without them Base UI shows the raw value
+ *  ("workflow") in the trigger; the popup renders from this map too, so the two
+ *  can never drift. The branch/path selects label each option as itself. */
 const MODE_ITEMS: Record<string, string> = {
   branch: "Deploy from a branch",
   workflow: "GitHub Actions",
@@ -107,8 +108,11 @@ function PagesDisabled({ repoPath }: { repoPath: string }) {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="branch">Deploy from a branch</SelectItem>
-            <SelectItem value="workflow">GitHub Actions</SelectItem>
+            {Object.entries(MODE_ITEMS).map(([m, label]) => (
+              <SelectItem key={m} value={m}>
+                {label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -97,8 +97,9 @@ const COMMON_EVENTS: { id: string; label: string }[] = [
   { id: "discussion", label: "Discussions" },
 ];
 
-/** Trigger labels for the webhook content-type select — without them Base UI
- *  shows the raw value ("form") instead of the media type. */
+/** Labels for the webhook content-type select — without them Base UI shows the
+ *  raw value ("form") instead of the media type in the trigger; the popup renders
+ *  from this map too, so the two can never drift. */
 const CONTENT_TYPE_ITEMS: Record<string, string> = {
   json: "application/json",
   form: "application/x-www-form-urlencoded",
@@ -848,10 +849,11 @@ function WebhookForm({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="json">application/json</SelectItem>
-              <SelectItem value="form">
-                application/x-www-form-urlencoded
-              </SelectItem>
+              {Object.entries(CONTENT_TYPE_ITEMS).map(([ct, label]) => (
+                <SelectItem key={ct} value={ct}>
+                  {label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -97,6 +97,13 @@ const COMMON_EVENTS: { id: string; label: string }[] = [
   { id: "discussion", label: "Discussions" },
 ];
 
+/** Trigger labels for the webhook content-type select — without them Base UI
+ *  shows the raw value ("form") instead of the media type. */
+const CONTENT_TYPE_ITEMS: Record<string, string> = {
+  json: "application/json",
+  form: "application/x-www-form-urlencoded",
+};
+
 function eventsSummary(events: string[]): string {
   if (events.includes("*")) return "All events";
   if (events.length === 0) return "No events";
@@ -833,6 +840,7 @@ function WebhookForm({
         <div className="space-y-1.5">
           <Label htmlFor="hook-content-type">Content type</Label>
           <Select
+            items={CONTENT_TYPE_ITEMS}
             value={contentType}
             onValueChange={(v) => setContentType(v as "json" | "form")}
           >

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -34,6 +34,19 @@ const ENFORCEMENTS: { value: RulesetEnforcement; label: string }[] = [
   { value: "disabled", label: "Disabled" },
 ];
 
+/** Trigger labels for the enforcement selects — without them Base UI shows the
+ *  raw value ("evaluate"). */
+const ENFORCEMENT_ITEMS: Record<string, string> = Object.fromEntries(
+  ENFORCEMENTS.map((e) => [e.value, e.label]),
+);
+
+/** Trigger labels for the ref-scope select. */
+const REF_SCOPE_ITEMS: Record<string, string> = {
+  default: "Default branch",
+  all: "All branches",
+  custom: "Custom patterns…",
+};
+
 /** Rule types we model in the editor. Any others on an edited ruleset are
  *  preserved untouched (so advanced rules aren't dropped). */
 const MANAGED_RULE_TYPES = [
@@ -286,6 +299,7 @@ function RulesetList({
               ) : (
                 <>
                   <Select
+                    items={ENFORCEMENT_ITEMS}
                     value={rs.enforcement}
                     disabled={setEnforcement.isPending}
                     onValueChange={(v) =>
@@ -416,6 +430,7 @@ function RulesetForm({
         <div className="space-y-1.5">
           <Label htmlFor="ruleset-enforcement">Enforcement</Label>
           <Select
+            items={ENFORCEMENT_ITEMS}
             value={d.enforcement}
             onValueChange={(v) =>
               v && set("enforcement", v as RulesetEnforcement)
@@ -438,6 +453,7 @@ function RulesetForm({
       <div className="space-y-1.5">
         <Label htmlFor="ruleset-scope">Target branches</Label>
         <Select
+          items={REF_SCOPE_ITEMS}
           value={d.refScope}
           onValueChange={(v) => v && set("refScope", v as Draft["refScope"])}
         >

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -40,7 +40,7 @@ const ENFORCEMENT_ITEMS: Record<string, string> = Object.fromEntries(
   ENFORCEMENTS.map((e) => [e.value, e.label]),
 );
 
-/** Trigger labels for the ref-scope select. */
+/** Labels for the ref-scope select — trigger and popup both render from here. */
 const REF_SCOPE_ITEMS: Record<string, string> = {
   default: "Default branch",
   all: "All branches",
@@ -461,9 +461,11 @@ function RulesetForm({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="default">Default branch</SelectItem>
-            <SelectItem value="all">All branches</SelectItem>
-            <SelectItem value="custom">Custom patterns…</SelectItem>
+            {Object.entries(REF_SCOPE_ITEMS).map(([scope, label]) => (
+              <SelectItem key={scope} value={scope}>
+                {label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
         {d.refScope === "custom" && (

--- a/src/features/repo-settings/SecretsSection.tsx
+++ b/src/features/repo-settings/SecretsSection.tsx
@@ -36,6 +36,16 @@ const APPS: { value: SecretApp; label: string }[] = [
 
 const REPO_SCOPE = "$repo";
 
+/** Trigger labels for the store select — without them Base UI shows the raw
+ *  value ("codespaces"). */
+const APP_ITEMS: Record<string, string> = Object.fromEntries(
+  APPS.map((a) => [a.value, a.label]),
+);
+
+/** Trigger label for the scope sentinel. Environment names label as themselves,
+ *  which is what an unmapped value already renders. */
+const SCOPE_ITEMS: Record<string, string> = { [REPO_SCOPE]: "Repository" };
+
 /** GitHub's rule: letters/digits/underscore, not starting with a digit, and not
  *  starting with GITHUB_. */
 function nameError(name: string): string | null {
@@ -95,6 +105,7 @@ export function SecretsSection({
               Store
             </Label>
             <Select
+              items={APP_ITEMS}
               value={app}
               onValueChange={(v) => v && setApp(v as SecretApp)}
             >
@@ -120,6 +131,7 @@ export function SecretsSection({
             Scope
           </Label>
           <Select
+            items={SCOPE_ITEMS}
             value={env ?? REPO_SCOPE}
             onValueChange={(v) => v && setScope(v)}
             disabled={!envAllowed}

--- a/src/features/repository/BranchMergePickerDialog.tsx
+++ b/src/features/repository/BranchMergePickerDialog.tsx
@@ -60,6 +60,15 @@ const PICKER_COPY: Record<
   },
 };
 
+/** Labels for the on-conflict select — without them Base UI shows the raw value
+ *  ("theirs") in the trigger; the popup renders from this map too, so the two
+ *  can never drift. */
+const CONFLICT_STRATEGY_ITEMS: Record<MergeConflictStrategy, string> = {
+  none: "Stop and let me resolve",
+  ours: "Prefer current branch",
+  theirs: "Prefer incoming branch",
+};
+
 /**
  * The merge / squash / rebase picker. Open when `mode` is set (null = closed).
  * Owns the selected branch, the advanced merge options (merge mode only), and
@@ -229,11 +238,7 @@ export function BranchMergePickerDialog({
                 On conflict
               </Label>
               <Select
-                items={{
-                  none: "Stop and let me resolve",
-                  ours: "Prefer current branch",
-                  theirs: "Prefer incoming branch",
-                }}
+                items={CONFLICT_STRATEGY_ITEMS}
                 value={mergeStrategy}
                 onValueChange={(v) =>
                   v && setMergeStrategy(v as MergeConflictStrategy)
@@ -243,9 +248,13 @@ export function BranchMergePickerDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">Stop and let me resolve</SelectItem>
-                  <SelectItem value="ours">Prefer current branch</SelectItem>
-                  <SelectItem value="theirs">Prefer incoming branch</SelectItem>
+                  {Object.entries(CONFLICT_STRATEGY_ITEMS).map(
+                    ([strategy, label]) => (
+                      <SelectItem key={strategy} value={strategy}>
+                        {label}
+                      </SelectItem>
+                    ),
+                  )}
                 </SelectContent>
               </Select>
               {mergeStrategy !== "none" &&

--- a/src/features/repository/BranchMergePickerDialog.tsx
+++ b/src/features/repository/BranchMergePickerDialog.tsx
@@ -27,6 +27,7 @@ import { Spinner } from "@/components/ui/spinner";
 import type { MergeConflictStrategy } from "@/lib/git/api";
 import { useMergePreview } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
+import { useRetained } from "@/lib/use-retained";
 
 export type PickerMode = "merge" | "squash" | "rebase";
 
@@ -82,11 +83,7 @@ export function BranchMergePickerDialog({
   currentLabel: string;
 }) {
   const [pickerBranch, setPickerBranch] = useState("");
-  // The dialog stays mounted through Base UI's ~100ms exit fade, by which time
-  // `mode` is already null — its contents render from this retained value or
-  // they blank mid-fade.
-  const [shownMode, setShownMode] = useState<PickerMode | null>(mode);
-  if (mode && mode !== shownMode) setShownMode(mode);
+  const shownMode = useRetained(mode);
   const branchSelectId = useId();
   const conflictSelectId = useId();
   // Advanced merge options (merge mode only).

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -85,6 +85,7 @@ import {
 } from "@/lib/settings/queries";
 import { type SelectedPr, useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import {
   BranchMergePickerDialog,
@@ -199,6 +200,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   const [createOpen, setCreateOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const shownDeleteTarget = useRetained(deleteTarget);
   // The worktree a branch row offers to remove (resolved from `userWorktrees`).
   const [removeWorktreeTarget, setRemoveWorktreeTarget] =
     useState<UserWorktree | null>(null);
@@ -207,6 +209,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     remote: string;
     name: string;
   } | null>(null);
+  const shownRemoteDeleteTarget = useRetained(remoteDeleteTarget);
   const [discardAllOpen, setDiscardAllOpen] = useState(false);
   const [stashAllOpen, setStashAllOpen] = useState(false);
   const [stashPopOpen, setStashPopOpen] = useState(false);
@@ -247,6 +250,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     name: string;
     path: string;
   } | null>(null);
+  const shownWorktreeSwitchTarget = useRetained(worktreeSwitchTarget);
   // The worktree pending a "Promote to main workspace" confirm — set by the
   // palette action and the Worktrees-section row menu (the Worktrees dialog
   // hosts its own promote flow).
@@ -2034,9 +2038,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         title="Delete branch?"
         body={
           <>
-            Deletes {deleteTarget} locally, including commits that exist only on
-            it.
-            {deleteTarget === currentName &&
+            Deletes {shownDeleteTarget} locally, including commits that exist
+            only on it.
+            {shownDeleteTarget === currentName &&
               " You'll be switched to another branch first."}
           </>
         }
@@ -2050,18 +2054,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         open={remoteDeleteTarget !== null}
         onCancel={() => setRemoteDeleteTarget(null)}
         title={
-          remoteDeleteTarget
-            ? `Delete branch on ${remoteDeleteTarget.remote}?`
+          shownRemoteDeleteTarget
+            ? `Delete branch on ${shownRemoteDeleteTarget.remote}?`
             : "Delete branch on remote?"
         }
         body={
-          remoteDeleteTarget ? (
+          shownRemoteDeleteTarget ? (
             <>
               Deletes{" "}
-              <span className="font-mono">{remoteDeleteTarget.name}</span> from{" "}
-              <span className="font-mono">{remoteDeleteTarget.remote}</span> for
-              everyone using that remote. This is a server-side delete and can't
-              be undone from the app.
+              <span className="font-mono">{shownRemoteDeleteTarget.name}</span>{" "}
+              from{" "}
+              <span className="font-mono">
+                {shownRemoteDeleteTarget.remote}
+              </span>{" "}
+              for everyone using that remote. This is a server-side delete and
+              can't be undone from the app.
             </>
           ) : null
         }
@@ -2110,8 +2117,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         title="Open worktree?"
         body={
           <>
-            <span className="font-mono">{worktreeSwitchTarget?.name}</span> is
-            checked out in another worktree. A branch can only be in one
+            <span className="font-mono">{shownWorktreeSwitchTarget?.name}</span>{" "}
+            is checked out in another worktree. A branch can only be in one
             worktree at a time, so open that worktree instead of switching here.
           </>
         }

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -54,6 +54,7 @@ import {
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import { ChangesContextMenuItems, type MenuTarget } from "./ChangesContextMenu";
 import { ChangesEmptyState } from "./ChangesEmptyState";
@@ -155,6 +156,9 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   // is the whole working tree (from the section-header menu).
   const [discardScope, setDiscardScope] = useState<ChangeActionScope>(null);
   const [stashScope, setStashScope] = useState<ChangeActionScope>(null);
+  // Each confirm's title/body/label is derived from its scope further down.
+  const shownDiscardScope = useRetained(discardScope);
+  const shownStashScope = useRetained(stashScope);
   // Multi-selection for bulk stash/discard, keyed like the rendered rows
   // ("staged:path" / "unstaged:path"). `selectedFile` stays the active row
   // whose diff is shown; `anchorKey` is the pivot for shift-range selection.
@@ -701,16 +705,16 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   // Confirm-dialog copy, derived from each action's scope (a single file, a
   // multi-selection, or the whole tree).
   const discardFiles =
-    discardScope?.kind === "files" ? discardScope.entries : [];
+    shownDiscardScope?.kind === "files" ? shownDiscardScope.entries : [];
   const discardOne = discardFiles.length === 1 ? discardFiles[0] : null;
   const discardTitle =
-    discardScope?.kind === "all"
+    shownDiscardScope?.kind === "all"
       ? "Discard all changes?"
       : discardOne
         ? "Discard changes?"
         : `Discard ${discardFiles.length} changes?`;
   const discardBody =
-    discardScope?.kind === "all"
+    shownDiscardScope?.kind === "all"
       ? "All uncommitted changes are discarded: tracked files reset to the last commit, untracked files move to the recycle bin."
       : discardOne
         ? discardOne.unstaged === "untracked"
@@ -718,16 +722,17 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
           : `Unstaged changes to ${discardOne.path} will be restored to the last committed version. This cannot be undone.`
         : `Changes to ${discardFiles.length} files will be discarded — tracked files are restored and untracked files moved to the recycle bin. This cannot be undone.`;
 
-  const stashFiles = stashScope?.kind === "files" ? stashScope.entries : [];
+  const stashFiles =
+    shownStashScope?.kind === "files" ? shownStashScope.entries : [];
   const stashOne = stashFiles.length === 1 ? stashFiles[0] : null;
   const stashTitle =
-    stashScope?.kind === "all"
+    shownStashScope?.kind === "all"
       ? "Stash all changes?"
       : stashOne
         ? "Stash change?"
         : `Stash ${stashFiles.length} changes?`;
   const stashBody =
-    stashScope?.kind === "all"
+    shownStashScope?.kind === "all"
       ? 'Sets your working tree back to the last commit and saves all uncommitted changes — including untracked files — to the stash. "Pop latest stash" restores them.'
       : stashOne
         ? `${stashOne.path} is saved to the stash and removed from your working tree. "Pop latest stash" restores it.`
@@ -1045,7 +1050,9 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
         onCancel={() => setDiscardScope(null)}
         title={discardTitle}
         body={discardBody}
-        confirmLabel={discardScope?.kind === "all" ? "Discard all" : "Discard"}
+        confirmLabel={
+          shownDiscardScope?.kind === "all" ? "Discard all" : "Discard"
+        }
         confirmVariant="destructive"
         pending={discardPaths.isPending || discardAll.isPending}
         onConfirm={confirmDiscard}
@@ -1056,7 +1063,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
         onCancel={() => setStashScope(null)}
         title={stashTitle}
         body={stashBody}
-        confirmLabel={stashScope?.kind === "all" ? "Stash all" : "Stash"}
+        confirmLabel={shownStashScope?.kind === "all" ? "Stash all" : "Stash"}
         pending={stashPaths.isPending || stashAll.isPending}
         onConfirm={confirmStash}
       />

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -162,6 +162,13 @@ function PromoteBody({
       mOpState.data?.rebasing ||
       mOpState.data?.cherryPicking,
   );
+  // `refuse_mid_op` refuses on unmerged index entries too, and that arm has no
+  // marker file behind it: a conflicted squash-merge leaves the conflicts with
+  // `op_state` all-false, so mirroring only the marker arm would let the stash
+  // refuse past the point of no return.
+  const mainConflicted = (mStatus.data?.entries ?? []).some(
+    (e) => e.staged === "conflicted" || e.unstaged === "conflicted",
+  );
   // A failed status read must NOT read as "clean": with `data` undefined the
   // dirty checks silently become false, which would enable Promote with unknown
   // tree state and could skip the main-WIP stash before the checkout.
@@ -173,6 +180,7 @@ function PromoteBody({
     statusError ||
     worktreeDirty ||
     mainMidOp ||
+    mainConflicted ||
     worktree.isLocked ||
     !worktree.branch;
 
@@ -284,6 +292,11 @@ function PromoteBody({
         <p className="text-xs text-warning">
           The main workspace has a merge, rebase or cherry-pick in progress —
           finish or abort it first.
+        </p>
+      ) : mainConflicted ? (
+        <p className="text-xs text-warning">
+          The main workspace has unresolved conflicts — resolve or abort them
+          first.
         </p>
       ) : worktree.isLocked ? (
         <p className="text-xs text-warning">

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import {
   gitCheckoutBranch,
+  gitOpState,
   gitStashAll,
   gitStatus,
   validateRepo,
@@ -137,23 +138,41 @@ function PromoteBody({
     queryFn: () => gitStatus(mainPath as string),
     enabled: Boolean(mainPath),
   });
+  // Main's in-progress merge/rebase/cherry-pick: the backend refuses to stash over
+  // one, and the stash here runs AFTER the worktree is removed — so it has to be a
+  // precondition, not an error past the point of no return. Inline rather than via
+  // `useOpState` (which takes no `enabled`) because mainPath resolves a tick later
+  // from the worktree list; the shared key keeps one cache entry either way.
+  const mOpState = useQuery({
+    queryKey: repoKeys.opState(mainPath ?? "__pending__"),
+    queryFn: () => gitOpState(mainPath as string),
+    enabled: Boolean(mainPath),
+  });
 
   const checking =
     worktrees.isPending ||
     wStatus.isPending ||
-    (Boolean(mainPath) && mStatus.isPending);
+    (Boolean(mainPath) && (mStatus.isPending || mOpState.isPending));
   const noMain = !worktrees.isPending && !mainPath;
   const worktreeDirty = (wStatus.data?.entries.length ?? 0) > 0;
   const mainDirty = (mStatus.data?.entries.length ?? 0) > 0;
   const mainBranch = mStatus.data?.branch?.name ?? "the default branch";
+  const mainMidOp = Boolean(
+    mOpState.data?.merging ||
+      mOpState.data?.rebasing ||
+      mOpState.data?.cherryPicking,
+  );
   // A failed status read must NOT read as "clean": with `data` undefined the
   // dirty checks silently become false, which would enable Promote with unknown
   // tree state and could skip the main-WIP stash before the checkout.
-  const statusError = wStatus.isError || (Boolean(mainPath) && mStatus.isError);
+  const statusError =
+    wStatus.isError ||
+    (Boolean(mainPath) && (mStatus.isError || mOpState.isError));
   const blocked =
     noMain ||
     statusError ||
     worktreeDirty ||
+    mainMidOp ||
     worktree.isLocked ||
     !worktree.branch;
 
@@ -260,6 +279,11 @@ function PromoteBody({
         <p className="text-xs text-warning">
           This worktree has uncommitted changes. Commit or stash them before
           promoting.
+        </p>
+      ) : mainMidOp ? (
+        <p className="text-xs text-warning">
+          The main workspace has a merge, rebase or cherry-pick in progress —
+          finish or abort it first.
         </p>
       ) : worktree.isLocked ? (
         <p className="text-xs text-warning">

--- a/src/features/repository/RenameBranchDialog.tsx
+++ b/src/features/repository/RenameBranchDialog.tsx
@@ -14,8 +14,10 @@ import { useRenameBranch } from "@/lib/git/queries";
 import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
 import {
+  type BranchNameGenerator,
   type CommittedNameSource,
   useGenerateBranchName,
 } from "./useGenerateBranchName";
@@ -64,6 +66,17 @@ export function RenameBranchDialog({
 }) {
   const renameBranch = useRenameBranch(repoPath);
   const branchNameGen = useGenerateBranchName(repoPath);
+  // The Generate affordance's copy — and so its enabled state — is retained
+  // through the close fade below, so the dispatch carries the liveness: a click
+  // after close would start an uncancellable generation whose name lands in the
+  // next open's field.
+  const guardedGen: BranchNameGenerator = {
+    ...branchNameGen,
+    generate: async (opts) => {
+      if (target === null) return;
+      await branchNameGen.generate(opts);
+    },
+  };
   // Every close path routes through here: the dialog stays mounted, so an
   // in-flight suggestion would otherwise land in the field on the NEXT open,
   // which may be naming a different branch.
@@ -71,8 +84,17 @@ export function RenameBranchDialog({
     branchNameGen.cancel();
     onClose();
   };
+  const shownTarget = useRetained(target);
+  // The parent's committed-work lookup collapses when the dialog closes, so
+  // these two retain on the dialog's own discriminant rather than their values:
+  // null / "ready" are legitimate while it's open (a branch with no commits).
+  const shownCommittedFallback = useRetained(
+    committedFallback,
+    target !== null,
+  );
+  const shownCommittedStatus = useRetained(committedStatus, target !== null);
   // Only the checked-out branch's own working tree describes it.
-  const targetIsCurrent = target !== null && target === currentName;
+  const targetIsCurrent = shownTarget !== null && shownTarget === currentName;
 
   const renameForm = useAppForm({
     defaultValues: { name: "" },
@@ -125,7 +147,7 @@ export function RenameBranchDialog({
             <DialogTitle>Rename branch</DialogTitle>
             <DialogDescription>
               Renames{" "}
-              <span className="font-mono wrap-break-word">{target}</span>.
+              <span className="font-mono wrap-break-word">{shownTarget}</span>.
             </DialogDescription>
           </DialogHeader>
           <renameForm.AppField
@@ -141,7 +163,7 @@ export function RenameBranchDialog({
             )}
           </renameForm.AppField>
           <GenerateBranchNameButton
-            gen={branchNameGen}
+            gen={guardedGen}
             aiEnabled={aiEnabled}
             aiConfigured={aiConfigured}
             hasChanges={hasChanges}
@@ -149,8 +171,8 @@ export function RenameBranchDialog({
             entries={entries}
             recentBranches={allBranchNames}
             nameTarget={targetIsCurrent ? "checked-out-branch" : "other-branch"}
-            committedFallback={committedFallback}
-            committedStatus={committedStatus}
+            committedFallback={shownCommittedFallback}
+            committedStatus={shownCommittedStatus}
             // Renaming never picks a base — the fallback always applies here.
             basedElsewhere={null}
             onName={(name) => renameForm.setFieldValue("name", name)}

--- a/src/features/repository/RenameBranchDialog.tsx
+++ b/src/features/repository/RenameBranchDialog.tsx
@@ -122,6 +122,18 @@ export function RenameBranchDialog({
     if (target !== null) seedOnOpen(target);
   }, [target]);
 
+  // Generations are bound to the target they were started for: the rename
+  // hotkey stays live over the open dialog, so `target` can swap mid-stream and
+  // a suggestion for the old branch would otherwise land in a form that is now
+  // renaming a different one. `cancel` is stable (a no-dep `useCallback` in
+  // `useAiStream`), so this re-runs only on a target change. Closing cancels
+  // here as well as in `closeDialog` — aborting twice is a no-op.
+  const cancelGenerate = branchNameGen.cancel;
+  useEffect(() => {
+    if (target === null) return;
+    return () => cancelGenerate();
+  }, [target, cancelGenerate]);
+
   return (
     <Dialog
       open={target !== null}

--- a/src/features/repository/RepoDialogs.tsx
+++ b/src/features/repository/RepoDialogs.tsx
@@ -18,6 +18,7 @@ import { type RecentRepo, repoDisplayName } from "@/lib/settings/api";
 import { useRemoveRecentRepo, useSetRepoAlias } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 
 /** OS-accurate name for the system trash: "Recycle Bin" on Windows, else "Trash". */
 const trashName = isWindows ? "Recycle Bin" : "Trash";
@@ -114,7 +115,8 @@ export function RemoveRepoDialog({
   const openRepo = useUiStore((s) => s.openRepo);
   const [moveToTrash, setMoveToTrash] = useState(false);
   const [busy, setBusy] = useState(false);
-  const display = repo ? repoDisplayName(repo) : "";
+  const shownRepo = useRetained(repo);
+  const display = shownRepo ? repoDisplayName(shownRepo) : "";
 
   async function confirm() {
     if (!repo) return;
@@ -168,8 +170,8 @@ export function RemoveRepoDialog({
           <DialogTitle>Remove {display}?</DialogTitle>
           <DialogDescription>
             Removes the repository from GitDesktop. The folder at{" "}
-            <span className="font-mono">{repo?.path}</span> is kept unless you
-            also move it to the {trashName}.
+            <span className="font-mono">{shownRepo?.path}</span> is kept unless
+            you also move it to the {trashName}.
           </DialogDescription>
         </DialogHeader>
         <label className="flex cursor-pointer items-center gap-2 text-xs">

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -30,6 +30,7 @@ import {
 import type { IgnoredFile } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 
 type Tab = "tracked" | "ignored";
@@ -97,11 +98,7 @@ export function RepositoryFilesDialog({
   const [activePath, setActivePath] = useState<string | null>(null);
   const [anchorPath, setAnchorPath] = useState<string | null>(null);
   const [pending, setPending] = useState<Pending>(null);
-  // The confirm dialog stays mounted through Base UI's ~100ms exit fade, by
-  // which time `pending` is already null — its contents render from this
-  // retained value or they blank mid-fade.
-  const [shownPending, setShownPending] = useState<Pending>(pending);
-  if (pending && pending !== shownPending) setShownPending(pending);
+  const shownPending = useRetained(pending);
 
   const tracked = useTrackedFiles(repoPath, open && tab === "tracked");
   const ignored = useIgnoredFiles(repoPath, open && tab === "ignored");

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/git/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 
 /** Which source the left list is drawn from. */
@@ -64,14 +65,9 @@ export function StashesDialog({
   const drop = useStashDrop(repoPath);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [confirmDrop, setConfirmDrop] = useState<number | null>(null);
-  // The drop confirm stays mounted through Base UI's ~100ms exit fade, by which
-  // time `confirmDrop` is already null — its contents render from this retained
-  // value or they blank mid-fade. The open gate and the drop dispatch stay live,
-  // so a mid-fade click is a no-op. Compared against null, not truthiness:
-  // stash@{0} is a valid index.
-  const [shownDrop, setShownDrop] = useState<number | null>(confirmDrop);
-  if (confirmDrop !== null && confirmDrop !== shownDrop)
-    setShownDrop(confirmDrop);
+  // The hook's nullish retain condition is load-bearing here rather than a
+  // truthiness one: stash@{0} is a valid index.
+  const shownDrop = useRetained(confirmDrop);
   const [view, setView] = useState<StashesView>(initialView);
 
   // The dialog can be opened straight to either view; seed `view` from the

--- a/src/features/repository/SwitchWithChangesDialog.tsx
+++ b/src/features/repository/SwitchWithChangesDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useRetained } from "@/lib/use-retained";
 
 /**
  * Prompt shown when switching branches with uncommitted changes: bring the
@@ -36,6 +37,7 @@ export function SwitchWithChangesDialog({
   onBringChanges: () => void;
   onStashAndSwitch: () => void;
 }) {
+  const shownTarget = useRetained(target);
   return (
     <Dialog
       open={target !== null}
@@ -47,12 +49,12 @@ export function SwitchWithChangesDialog({
         <DialogHeader>
           <DialogTitle>You have changes in progress</DialogTitle>
           <DialogDescription>
-            Bring your uncommitted changes along to {target?.name}, or stash
-            them so {currentLabel} stays as you left it.{" "}
+            Bring your uncommitted changes along to {shownTarget?.name}, or
+            stash them so {currentLabel} stays as you left it.{" "}
             {reapply ? (
               <>
-                Stashed changes are put back on {target?.name} once the switch
-                lands.
+                Stashed changes are put back on {shownTarget?.name} once the
+                switch lands.
               </>
             ) : (
               '"Pop latest stash" restores stashed changes later.'

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -171,6 +171,7 @@ function IntentPicker({
 }) {
   return (
     <Select
+      items={INTENT_LABEL}
       value={value}
       onValueChange={(v) => onChange(v === "deep" ? "deep" : "brainstorm")}
     >

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -48,11 +48,8 @@ import {
   useResearchStore,
 } from "./store";
 
-const INTENTS: { value: ResearchDepth; label: string }[] = [
-  { value: "brainstorm", label: "Brainstorm" },
-  { value: "deep", label: "Deep research" },
-];
-
+/** Labels for the research intent — the Select's trigger and popup and the
+ *  switched-to notice all read this one map, so they can never drift. */
 const INTENT_LABEL: Record<ResearchDepth, string> = {
   brainstorm: "Brainstorm",
   deep: "Deep research",
@@ -173,7 +170,13 @@ function IntentPicker({
     <Select
       items={INTENT_LABEL}
       value={value}
-      onValueChange={(v) => onChange(v === "deep" ? "deep" : "brainstorm")}
+      // The popup publishes every INTENT_LABEL key, so accept only keys that are
+      // still in it — collapsing an unknown value to "brainstorm" would let a
+      // future depth render an option that silently selects a different one.
+      onValueChange={(v) => {
+        if (typeof v === "string" && v in INTENT_LABEL)
+          onChange(v as ResearchDepth);
+      }}
     >
       <SelectTrigger
         size="sm"
@@ -186,9 +189,9 @@ function IntentPicker({
       {/* Size to content so "Deep research" isn't clipped at the narrow trigger
           width when "Brainstorm" is the selected (shorter) value. */}
       <SelectContent className="w-fit">
-        {INTENTS.map((o) => (
-          <SelectItem key={o.value} value={o.value}>
-            {o.label}
+        {Object.entries(INTENT_LABEL).map(([depth, label]) => (
+          <SelectItem key={depth} value={depth}>
+            {label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/scripts/types";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import { useAnalyzeScript } from "./useAnalyzeScript";
 import { useGenerateScript } from "./useGenerateScript";
@@ -100,6 +101,9 @@ export function TaskDialog({
   onDelete: (id: string) => void;
 }) {
   const editing = task !== "new" && task !== null ? task : null;
+  const shownTask = useRetained(task);
+  const shownEditing =
+    shownTask !== "new" && shownTask !== null ? shownTask : null;
   const repoPath = useUiStore((s) => s.repoPath);
   const openSettings = useUiStore((s) => s.openSettings);
   const aiEnabled = useAiEnabled();
@@ -250,7 +254,7 @@ export function TaskDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>{editing ? "Edit task" : "New task"}</DialogTitle>
+          <DialogTitle>{shownEditing ? "Edit task" : "New task"}</DialogTitle>
           <DialogDescription>
             A saved script you can run from here without a terminal. Point it at
             an existing script in the repo, or write one inline. Either way it
@@ -626,13 +630,13 @@ export function TaskDialog({
 
         <div className="flex items-center gap-2">
           <Button size="sm" onClick={save} disabled={!canSave}>
-            {editing ? "Save" : "Create task"}
+            {shownEditing ? "Save" : "Create task"}
           </Button>
           <Button size="sm" variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <span className="flex-1" />
-          {editing &&
+          {shownEditing &&
             (confirmDelete ? (
               <>
                 <span className="text-xs text-muted-foreground">Delete?</span>
@@ -646,7 +650,9 @@ export function TaskDialog({
                 <Button
                   size="sm"
                   variant="destructive"
-                  onClick={() => onDelete(editing.id)}
+                  onClick={() => {
+                    if (editing) onDelete(editing.id);
+                  }}
                 >
                   Delete
                 </Button>

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -629,7 +629,17 @@ export function TaskDialog({
         </label>
 
         <div className="flex items-center gap-2">
-          <Button size="sm" onClick={save} disabled={!canSave}>
+          <Button
+            size="sm"
+            // The label rides the retained task, so the dispatch carries the
+            // liveness: after close `save()` would write under an unmatched id
+            // and still toast "Saved".
+            onClick={() => {
+              if (task === null) return;
+              save();
+            }}
+            disabled={!canSave}
+          >
             {shownEditing ? "Save" : "Create task"}
           </Button>
           <Button size="sm" variant="ghost" onClick={() => onOpenChange(false)}>

--- a/src/features/scripts/TaskRunConfirm.tsx
+++ b/src/features/scripts/TaskRunConfirm.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { INTERPRETERS } from "@/lib/scripts/types";
 import { useTaskRunStore } from "@/lib/stores/taskRun";
+import { useRetained } from "@/lib/use-retained";
 
 const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
   INTERPRETERS.map((i) => [i.id, i.label]),
@@ -46,12 +47,8 @@ export function TaskRunConfirm() {
     setArgs(pending.task.args);
   }, [pending]);
 
-  // The dialog stays mounted through Base UI's ~100ms exit fade, by which time
-  // `pending` is already null — its contents render from this retained value or
-  // they blank mid-fade ("Run “undefined”?"). The open gate, the seeding effect
-  // above and the store dispatches stay live, so a mid-fade click is a no-op.
-  const [shownPending, setShownPending] = useState(pending);
-  if (pending && pending !== shownPending) setShownPending(pending);
+  // The seeding effect above stays on live `pending`.
+  const shownPending = useRetained(pending);
 
   const replacing = shownPending?.reason === "replace";
   const task = shownPending?.task ?? null;

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -72,7 +72,8 @@ export function ModelPicker({
   models: string[];
 }) {
   // Base UI renders the raw value in the trigger unless the labels are passed as
-  // `items`. Derived per render because the model set varies by agent.
+  // `items`. Derived per render because the model set varies by agent, and the
+  // popup below renders from it too so the two can never drift.
   const items = useMemo(
     () => ({
       [DEFAULT_MODEL]: "Default model",
@@ -98,10 +99,9 @@ export function ModelPicker({
           `w-(--anchor-width)` popup clips long ids (e.g. `opencode/…`). Let it
           size to its content instead, capped so it can't run off-screen. */}
       <SelectContent className="w-fit max-w-sm">
-        <SelectItem value={DEFAULT_MODEL}>Default model</SelectItem>
-        {models.map((m) => (
-          <SelectItem key={m} value={m}>
-            {m}
+        {Object.entries(items).map(([model, label]) => (
+          <SelectItem key={model} value={model}>
+            {label}
           </SelectItem>
         ))}
       </SelectContent>
@@ -117,8 +117,9 @@ const EFFORT_LEVELS = [
   { value: "xhigh", label: "Max" },
 ] as const;
 
-/** Trigger labels for the effort Select — without them Base UI shows the raw
- *  stored value ("xhigh"). Same `items` contract as the settings selects. */
+/** Labels for the effort Select — without them Base UI shows the raw stored
+ *  value ("xhigh") in the trigger. Same `items` contract as the settings selects,
+ *  and the popup renders from it too so the two can never drift. */
 const EFFORT_ITEMS: Record<string, string> = {
   [DEFAULT_EFFORT]: "Default",
   ...Object.fromEntries(EFFORT_LEVELS.map((l) => [l.value, l.label])),
@@ -149,10 +150,9 @@ export function EffortPicker({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value={DEFAULT_EFFORT}>Default</SelectItem>
-        {EFFORT_LEVELS.map((l) => (
-          <SelectItem key={l.value} value={l.value}>
-            {l.label}
+        {Object.entries(EFFORT_ITEMS).map(([level, label]) => (
+          <SelectItem key={level} value={level}>
+            {label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -6,7 +6,7 @@ import {
   UsersThreeIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
-import { type ReactNode, useId, useRef } from "react";
+import { type ReactNode, useId, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -71,8 +71,19 @@ export function ModelPicker({
   onChange: (m: string) => void;
   models: string[];
 }) {
+  // Base UI renders the raw value in the trigger unless the labels are passed as
+  // `items`. Derived per render because the model set varies by agent.
+  const items = useMemo(
+    () => ({
+      [DEFAULT_MODEL]: "Default model",
+      ...Object.fromEntries(models.map((m) => [m, m])),
+    }),
+    [models],
+  );
+
   return (
     <Select
+      items={items}
       value={value || DEFAULT_MODEL}
       onValueChange={(v) => onChange(v === DEFAULT_MODEL ? "" : String(v))}
     >
@@ -106,6 +117,13 @@ const EFFORT_LEVELS = [
   { value: "xhigh", label: "Max" },
 ] as const;
 
+/** Trigger labels for the effort Select — without them Base UI shows the raw
+ *  stored value ("xhigh"). Same `items` contract as the settings selects. */
+const EFFORT_ITEMS: Record<string, string> = {
+  [DEFAULT_EFFORT]: "Default",
+  ...Object.fromEntries(EFFORT_LEVELS.map((l) => [l.value, l.label])),
+};
+
 /** Reasoning/effort level for the next turn. Mapped per-CLI in Rust (Codex
  *  `model_reasoning_effort`, Copilot `--effort`, Claude a thinking keyword). The
  *  gauge icon marks it as effort so the collapsed value isn't mistaken for a model. */
@@ -118,6 +136,7 @@ export function EffortPicker({
 }) {
   return (
     <Select
+      items={EFFORT_ITEMS}
       value={value || DEFAULT_EFFORT}
       onValueChange={(v) => onChange(v === DEFAULT_EFFORT ? "" : String(v))}
     >
@@ -501,6 +520,16 @@ export function ComposerOptions({
   );
 }
 
+/** Trigger + popup labels for the agent Select. Deliberately not AGENT_LABELS:
+ *  this picker spells Copilot out ("GitHub Copilot") where the compact list-row
+ *  label doesn't. One source so the trigger can never drift from the popup. */
+const AGENT_PICKER_ITEMS: Record<AgentKind, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  copilot: "GitHub Copilot",
+  opencode: "opencode",
+};
+
 /** Picks the CLI for a NEW session (fixed once it starts). Every agent runs either
  *  way — host (worktree-confined; Codex adds its own OS-enforced sandbox) or
  *  container, provided that agent is baked into the image. Only Codex's MCP support
@@ -514,6 +543,7 @@ export function AgentPicker({
 }) {
   return (
     <Select
+      items={AGENT_PICKER_ITEMS}
       value={value}
       onValueChange={(v) => onChange(isAgentKind(v) ? v : "claude")}
     >
@@ -525,10 +555,11 @@ export function AgentPicker({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="claude">Claude</SelectItem>
-        <SelectItem value="codex">Codex</SelectItem>
-        <SelectItem value="copilot">GitHub Copilot</SelectItem>
-        <SelectItem value="opencode">opencode</SelectItem>
+        {Object.entries(AGENT_PICKER_ITEMS).map(([kind, label]) => (
+          <SelectItem key={kind} value={kind}>
+            {label}
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
   );

--- a/src/features/settings/AgentSandboxField.tsx
+++ b/src/features/settings/AgentSandboxField.tsx
@@ -36,6 +36,11 @@ type AgentId = "claude" | "codex" | "opencode" | "copilot";
 
 /** Node base-image versions offered (current LTS first). */
 const NODE_VERSIONS = ["24", "22", "20"];
+/** Trigger labels — without them Base UI shows the raw version, dropping the
+ *  "(LTS)" note the popup carries. */
+const NODE_VERSION_ITEMS: Record<string, string> = Object.fromEntries(
+  NODE_VERSIONS.map((v) => [v, v === "24" ? `${v} (LTS)` : v]),
+);
 /** Container-capable agents installed into the managed image. */
 const IMAGE_AGENTS: { id: AgentId; label: string }[] = [
   { id: "claude", label: "Claude Code" },
@@ -122,6 +127,7 @@ export function AgentSandboxField({
             <label className="flex items-center gap-1.5">
               <span className="text-muted-foreground">Node version</span>
               <Select
+                items={NODE_VERSION_ITEMS}
                 value={nodeVersion}
                 onValueChange={(v) => v && onNodeVersion(v)}
               >
@@ -135,7 +141,7 @@ export function AgentSandboxField({
                 <SelectContent>
                   {NODE_VERSIONS.map((v) => (
                     <SelectItem key={v} value={v}>
-                      {v === "24" ? `${v} (LTS)` : v}
+                      {NODE_VERSION_ITEMS[v]}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -67,6 +67,7 @@ import { settingsKeys, useSecretPreview } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 import { AgentSandboxField } from "./AgentSandboxField";
 import { HostAllowNote } from "./HostAllowNote";
 import { settingsFormOpts } from "./settings-form";
@@ -114,10 +115,38 @@ function ModelPicker({
     Boolean(keyPreview.data),
     allowedHosts,
   );
-  const models = availableModels.data?.models ?? [];
+  const catalog = availableModels.data;
+  const models = catalog?.models ?? [];
   const needsKey = PROVIDERS_REQUIRING_KEY.includes(value.provider);
   const isCli = isCliProvider(value.provider);
   const modelMemory = useRef<Partial<Record<AiProviderId, string>>>({});
+  // Only a failed fetch carries unbounded provider prose, so it alone is clamped and
+  // given a tooltip; every other line is short enough to render whole.
+  const failureReason =
+    catalog?.cause === "failed" ? catalog.reason : undefined;
+  // Each fallback route reads differently to a user, and the predicates are
+  // heterogeneous (query state, then cause, then whether a key is saved) — a
+  // saved-but-rejected key must never be told to save a key.
+  const hint = ((): string => {
+    switch (true) {
+      case isCli:
+        return "Model passed to the CLI — leave blank for its default";
+      case availableModels.isPending:
+        return "Loading models…";
+      case catalog?.live === true:
+        return `${models.length} models from ${PROVIDER_LABELS[value.provider]}`;
+      case failureReason !== undefined:
+        return `Suggestions only — couldn't load the live list: ${failureReason}`;
+      case catalog?.cause === "empty":
+        return "Suggestions only — the provider returned no models";
+      case catalog?.cause === "no-base":
+        return "Suggestions only — set a base URL to load the live list";
+      case needsKey && !keyPreview.data:
+        return "Suggestions only — save an API key to load the live list";
+      default:
+        return "Suggestions only — provider list unavailable";
+    }
+  })();
 
   function switchProvider(provider: AiProviderId) {
     modelMemory.current[value.provider] = value.model;
@@ -184,16 +213,14 @@ function ModelPicker({
             </ComboboxList>
           </ComboboxContent>
         </Combobox>
-        <p className="text-xs text-muted-foreground">
-          {isCli
-            ? "Model passed to the CLI — leave blank for its default"
-            : availableModels.isPending
-              ? "Loading models…"
-              : availableModels.data?.live
-                ? `${models.length} models from ${PROVIDER_LABELS[value.provider]}`
-                : needsKey
-                  ? "Suggestions only — save an API key to load the live list"
-                  : "Suggestions only — provider list unavailable"}
+        <p
+          className={cn(
+            "text-xs text-muted-foreground",
+            failureReason !== undefined && "line-clamp-2",
+          )}
+          title={failureReason !== undefined ? hint : undefined}
+        >
+          {hint}
         </p>
       </div>
     </div>
@@ -695,6 +722,10 @@ export const AiProviderSection = withForm({
           queryClient.invalidateQueries({
             queryKey: settingsKeys.secret(provider),
           });
+          // The models query keys on a BOOLEAN "a key is saved", which doesn't move
+          // when a bad key is replaced — without this the picker keeps serving the
+          // failed fetch's suggestions for the rest of its 5-minute staleTime.
+          queryClient.invalidateQueries({ queryKey: ["models"] });
           toast.success(
             `${PROVIDER_LABELS[provider]} key saved to OS keychain`,
           );
@@ -723,6 +754,7 @@ export const AiProviderSection = withForm({
         queryClient.invalidateQueries({
           queryKey: settingsKeys.secret(provider),
         });
+        queryClient.invalidateQueries({ queryKey: ["models"] });
         setConfirmClear(false);
         discardTestResult();
         toast.success("Key removed");

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -117,7 +117,6 @@ function ModelPicker({
   );
   const catalog = availableModels.data;
   const models = catalog?.models ?? [];
-  const needsKey = PROVIDERS_REQUIRING_KEY.includes(value.provider);
   const isCli = isCliProvider(value.provider);
   const modelMemory = useRef<Partial<Record<AiProviderId, string>>>({});
   // Only a failed fetch carries unbounded provider prose, so it alone is clamped and
@@ -125,8 +124,8 @@ function ModelPicker({
   const failureReason =
     catalog?.cause === "failed" ? catalog.reason : undefined;
   // Each fallback route reads differently to a user, and the predicates are
-  // heterogeneous (query state, then cause, then whether a key is saved) — a
-  // saved-but-rejected key must never be told to save a key.
+  // heterogeneous (provider kind, then query state, then the catalog's own
+  // cause) — a saved-but-rejected key must never be told to save a key.
   const hint = ((): string => {
     switch (true) {
       case isCli:
@@ -141,7 +140,7 @@ function ModelPicker({
         return "Suggestions only — the provider returned no models";
       case catalog?.cause === "no-base":
         return "Suggestions only — set a base URL to load the live list";
-      case needsKey && !keyPreview.data:
+      case catalog?.cause === "no-key":
         return "Suggestions only — save an API key to load the live list";
       default:
         return "Suggestions only — provider list unavailable";
@@ -299,6 +298,9 @@ function CliProviderConfig({
   );
 }
 
+/** Labels for the OpenAI-compatible preset select — the presets plus the manual
+ *  "Custom…" escape. Trigger and popup both render from here, so the two can
+ *  never drift. */
 const PRESET_ITEMS: Record<string, string> = {
   ...Object.fromEntries(OPENAI_COMPATIBLE_PRESETS.map((p) => [p.id, p.label])),
   custom: "Custom…",
@@ -416,12 +418,11 @@ function OpenAiCompatibleConfig({
             <SelectValue placeholder="Custom" />
           </SelectTrigger>
           <SelectContent>
-            {OPENAI_COMPATIBLE_PRESETS.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.label}
+            {Object.entries(PRESET_ITEMS).map(([id, label]) => (
+              <SelectItem key={id} value={id}>
+                {label}
               </SelectItem>
             ))}
-            <SelectItem value="custom">Custom…</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/src/features/settings/GitSection.tsx
+++ b/src/features/settings/GitSection.tsx
@@ -37,6 +37,12 @@ const AUTOCRLF_OPTIONS = [
   { value: "false", label: "False — no conversion either way" },
 ] as const;
 
+/** Trigger labels — without them Base UI shows the raw config value ("input")
+ *  instead of the explanatory option text. */
+const AUTOCRLF_ITEMS: Record<string, string> = Object.fromEntries(
+  AUTOCRLF_OPTIONS.map((o) => [o.value, o.label]),
+);
+
 /**
  * Global git identity (config --global user.name/email). Lives in gitconfig,
  * not app settings, so it applies immediately with its own Save — same
@@ -220,6 +226,7 @@ export function LineEndingsSection() {
         </p>
       </div>
       <Select
+        items={AUTOCRLF_ITEMS}
         value={value}
         onValueChange={change}
         disabled={autocrlf.isPending || setAutocrlf.isPending}

--- a/src/features/settings/mcp/GitDesktopAsServer.tsx
+++ b/src/features/settings/mcp/GitDesktopAsServer.tsx
@@ -27,6 +27,7 @@ import {
   pathLauncherStatus,
 } from "@/lib/git/api";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 
 /** Where a one-click install writes the `gitdesktop` entry: this repo's
  *  `.mcp.json`, or a client's global (all-projects) user config. */
@@ -91,16 +92,9 @@ export function GitDesktopAsServer({ repoPath }: { repoPath: string | null }) {
   const [confirmTarget, setConfirmTarget] = useState<InstallTarget | null>(
     null,
   );
-  // The confirm dialog stays mounted through Base UI's ~100ms exit fade, by
-  // which time `confirmTarget` is already null — its contents render from this
-  // retained value or they blank mid-fade. Appearance (copy and the button's
-  // disabled reason) reads the retained value; the open gate and the confirm
-  // dispatch stay on live `confirmTarget`, so a mid-fade click is a no-op.
-  const [shownTarget, setShownTarget] = useState<InstallTarget | null>(
-    confirmTarget,
-  );
-  if (confirmTarget && confirmTarget !== shownTarget)
-    setShownTarget(confirmTarget);
+  // Appearance — the copy AND the button's disabled reason — reads the retained
+  // target; the open gate and the confirm dispatch stay on live `confirmTarget`.
+  const shownTarget = useRetained(confirmTarget);
   // Which global client is mid-removal — parallel to `busyTarget` (which tracks
   // installs) so per-row Install/Reinstall/Remove disable each other.
   const [removingClient, setRemovingClient] = useState<

--- a/src/features/settings/mcp/PerRepoStateControl.tsx
+++ b/src/features/settings/mcp/PerRepoStateControl.tsx
@@ -38,8 +38,17 @@ export function PerRepoStateControl({
 }) {
   const override = pickForRepo(server.repoOverrides, repoKeys);
   const baseline = server.enabled ? "On" : "Optional";
+  // Trigger labels, built here because the inherited option names the baseline;
+  // without them Base UI shows the raw value ("optional").
+  const items: Record<string, string> = {
+    default: `Default · ${baseline}`,
+    on: "On",
+    optional: "Optional",
+    off: "Off",
+  };
   return (
     <Select
+      items={items}
       value={override ?? "default"}
       disabled={disabled}
       onValueChange={(v) =>

--- a/src/features/settings/mcp/PerRepoStateControl.tsx
+++ b/src/features/settings/mcp/PerRepoStateControl.tsx
@@ -38,8 +38,9 @@ export function PerRepoStateControl({
 }) {
   const override = pickForRepo(server.repoOverrides, repoKeys);
   const baseline = server.enabled ? "On" : "Optional";
-  // Trigger labels, built here because the inherited option names the baseline;
-  // without them Base UI shows the raw value ("optional").
+  // Labels, built here because the inherited option names the baseline; without
+  // them Base UI shows the raw value ("optional") in the trigger. The popup
+  // renders from this map too, so the two can never drift.
   const items: Record<string, string> = {
     default: `Default · ${baseline}`,
     on: "On",
@@ -63,10 +64,11 @@ export function PerRepoStateControl({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="default">Default · {baseline}</SelectItem>
-        <SelectItem value="on">On</SelectItem>
-        <SelectItem value="optional">Optional</SelectItem>
-        <SelectItem value="off">Off</SelectItem>
+        {Object.entries(items).map(([state, label]) => (
+          <SelectItem key={state} value={state}>
+            {label}
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
   );

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -54,6 +54,7 @@ import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
+import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
 import { CreateReleaseDialog } from "./CreateReleaseDialog";
 
 export function TagDetailView({
@@ -118,6 +119,32 @@ export function TagDetailView({
   const tagInfo = tagList.data?.find((t) => t.name === tag);
   const isLatest =
     (releaseList.data ?? []).find((r) => r.tagName === tag)?.isLatest ?? false;
+  // A tag switch keeps the PREVIOUS tag's release painted (the query's placeholder
+  // frees the tag key axis), so every release write holds until the two agree —
+  // this is the only gate that covers it: with placeholder data present the query
+  // reads as success (never `isLoading`), and a disabled query still serves it.
+  const relStale = release.isPlaceholderData;
+  const staleDim = relStale && "opacity-80";
+  // Why the rendered release can't be acted on at all — it gates DOWNLOAD too,
+  // which a read-only viewer is otherwise free to use. Not-ready outranks stale
+  // and never resolves on its own: a not-ready forge disables the query, which
+  // goes on serving placeholder data, so "loading" would be a wait with no end.
+  // Wording mirrors TagsPanel's release affordance.
+  const readReason = (() => {
+    switch (true) {
+      case !ghReady:
+        return isGitLab
+          ? "Sign in with the GitLab CLI (glab) to manage this release."
+          : "Connect this repository to GitHub or GitLab to manage this release.";
+      case relStale:
+        return "Loading this tag's release…";
+      default:
+        return null;
+    }
+  })();
+  // Writes take the read-only viewer's reason ahead of those: theirs never lifts
+  // either, and it's the one that still applies once the release is current.
+  const blockReason = writeBlocked ? writeReason : readReason;
 
   if (release.isLoading) {
     return (
@@ -139,6 +166,9 @@ export function TagDetailView({
   }
 
   async function onDownload(assetName: string) {
+    // Fresh `tag`, placeholder-derived name: two releases sharing an asset name
+    // would silently fetch the wrong file.
+    if (relStale) return;
     const dir = await openDialog({ directory: true });
     if (typeof dir !== "string") return;
     downloadAsset.mutate(
@@ -150,6 +180,9 @@ export function TagDetailView({
   // Shared by both provider arms, which differ in what is actually lost: GitHub's
   // uploaded binary is gone for good, while a GitLab asset link can be re-added.
   async function onDeleteAsset(assetName: string, kind: "asset" | "link") {
+    // The name comes off the rendered release, which is the previous tag's
+    // during a switch — refuse before the confirm can name the wrong asset.
+    if (relStale) return;
     const ok = await useConfirm.getState().ask({
       title: `Delete ${assetName}?`,
       body:
@@ -180,10 +213,14 @@ export function TagDetailView({
     const savePending = editRelease.isPending || syncUpdaterNotes.isPending;
     const saveLatched = syncArmed && savePending;
     return (
-      <div className="flex h-full flex-col">
+      <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
         <header className="space-y-2 border-b px-4 py-3">
           <div className="flex items-start gap-2">
-            <h2 className="text-sm font-medium">{rel.name || rel.tagName}</h2>
+            <h2
+              className={cn("text-sm font-medium", PLACEHOLDER_FADE, staleDim)}
+            >
+              {rel.name || rel.tagName}
+            </h2>
             <span className="flex-1" />
             {/* Publish only ever shows on GitHub (GitLab has no drafts). */}
             {canManage && (
@@ -192,9 +229,12 @@ export function TagDetailView({
                   <DisabledReasonButton
                     variant="outline"
                     size="xs"
-                    disabled={editRelease.isPending || writeBlocked}
-                    reason={writeReason}
-                    onClick={() =>
+                    disabled={editRelease.isPending || writeBlocked || relStale}
+                    reason={blockReason}
+                    onClick={() => {
+                      // `prerelease` rides the rendered release's flag, so a stale
+                      // one would really flip the new release's state on the forge.
+                      if (relStale) return;
                       editRelease.mutate(
                         {
                           tag,
@@ -212,8 +252,8 @@ export function TagDetailView({
                           onSuccess: () => toast.success("Published"),
                           onError,
                         },
-                      )
-                    }
+                      );
+                    }}
                   >
                     Publish
                   </DisabledReasonButton>
@@ -221,9 +261,12 @@ export function TagDetailView({
                 <DisabledReasonButton
                   variant="outline"
                   size="xs"
-                  disabled={writeBlocked}
-                  reason={writeReason}
+                  disabled={writeBlocked || relStale}
+                  reason={blockReason}
                   onClick={() => {
+                    // The seed outlives the stale window — a dialog opened here
+                    // would still save the previous release's text once it closes.
+                    if (relStale) return;
                     setEditTitle(rel.name);
                     setEditNotes(rel.body);
                     setEditPrerelease(rel.isPrerelease);
@@ -238,8 +281,8 @@ export function TagDetailView({
                 <DisabledReasonButton
                   variant="outline"
                   size="xs"
-                  disabled={writeBlocked}
-                  reason={writeReason}
+                  disabled={writeBlocked || relStale}
+                  reason={blockReason}
                   onClick={() => {
                     setCleanupTag(false);
                     setDeleteOpen(true);
@@ -261,7 +304,13 @@ export function TagDetailView({
               </Button>
             )}
           </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <div
+            className={cn(
+              "flex flex-wrap items-center gap-2 text-xs text-muted-foreground",
+              PLACEHOLDER_FADE,
+              staleDim,
+            )}
+          >
             <span className="font-mono">{rel.tagName}</span>
             {isLatest && <Badge variant="default">Latest</Badge>}
             {rel.isPrerelease && <Badge variant="secondary">Pre-release</Badge>}
@@ -277,7 +326,7 @@ export function TagDetailView({
         {/* overflow-hidden contains the content's natural height (vendored Root is
             `relative`-only) so long release notes can't leak a window scrollbar. */}
         <ScrollArea className="min-h-0 flex-1 overflow-hidden">
-          <div className="space-y-4 p-4">
+          <div className={cn("space-y-4 p-4", PLACEHOLDER_FADE, staleDim)}>
             {rel.body.trim() ? (
               <Markdown>{rel.body}</Markdown>
             ) : (
@@ -297,8 +346,8 @@ export function TagDetailView({
                   <DisabledReasonButton
                     variant="ghost"
                     size="xs"
-                    disabled={uploadAsset.isPending || writeBlocked}
-                    reason={writeReason}
+                    disabled={uploadAsset.isPending || writeBlocked || relStale}
+                    reason={blockReason}
                     onClick={onUpload}
                   >
                     {uploadAsset.isPending ? (
@@ -328,20 +377,24 @@ export function TagDetailView({
                         <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
                           {formatBytes(a.size)} · {a.downloadCount} ↓
                         </span>
-                        <Button
+                        <DisabledReasonButton
                           variant="ghost"
                           size="icon-xs"
                           aria-label={`Download ${a.name}`}
+                          disabled={relStale}
+                          reason={readReason}
                           onClick={() => onDownload(a.name)}
                         >
                           <DownloadSimpleIcon />
-                        </Button>
+                        </DisabledReasonButton>
                         <DisabledReasonButton
                           variant="ghost"
                           size="icon-xs"
                           aria-label={`Delete ${a.name}`}
-                          disabled={deleteAsset.isPending || writeBlocked}
-                          reason={writeReason}
+                          disabled={
+                            deleteAsset.isPending || writeBlocked || relStale
+                          }
+                          reason={blockReason}
                           className="text-muted-foreground"
                           onClick={() => onDeleteAsset(a.name, "asset")}
                         >
@@ -369,8 +422,10 @@ export function TagDetailView({
                             variant="ghost"
                             size="icon-xs"
                             aria-label={`Delete ${a.name}`}
-                            disabled={deleteAsset.isPending || writeBlocked}
-                            reason={writeReason}
+                            disabled={
+                              deleteAsset.isPending || writeBlocked || relStale
+                            }
+                            reason={blockReason}
                             className="text-muted-foreground"
                             onClick={() => onDeleteAsset(a.name, "link")}
                           >
@@ -399,6 +454,9 @@ export function TagDetailView({
               className="flex min-h-0 flex-1 flex-col gap-4"
               onSubmit={(e) => {
                 e.preventDefault();
+                // `draft`/`latest` below are read off the rendered release at
+                // submit time, so a switch behind the open dialog holds the save.
+                if (relStale) return;
                 // Empty notes leave the body untouched (the edit skips `--notes`),
                 // so there's nothing to carry into the manifest either.
                 const syncManifest =
@@ -464,7 +522,7 @@ export function TagDetailView({
               <DialogHeader>
                 <DialogTitle>Edit release</DialogTitle>
                 <DialogDescription>
-                  Updates {rel.tagName} on {remoteLabel}.
+                  Updates {tag} on {remoteLabel}.
                 </DialogDescription>
               </DialogHeader>
               {/* Fields scroll; header and submit footer stay pinned. */}
@@ -558,10 +616,16 @@ export function TagDetailView({
                 >
                   Cancel
                 </Button>
-                <Button type="submit" disabled={savePending}>
+                {/* An in-flight save says so with the spinner, so only the
+                    held arms carry a reason. */}
+                <DisabledReasonButton
+                  type="submit"
+                  disabled={savePending || relStale}
+                  reason={savePending ? null : blockReason}
+                >
                   {savePending && <Spinner data-icon="inline-start" />}
                   Save
-                </Button>
+                </DisabledReasonButton>
               </DialogFooter>
             </form>
           </DialogContent>
@@ -570,7 +634,9 @@ export function TagDetailView({
         <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Delete release {rel.tagName}?</DialogTitle>
+              {/* Labelled from the `tag` PROP, which is also what the delete
+                  targets — the rendered release can be the previous tag's. */}
+              <DialogTitle>Delete release {tag}?</DialogTitle>
               <DialogDescription>
                 Removes the {remoteLabel} release. This cannot be undone.
               </DialogDescription>
@@ -580,8 +646,7 @@ export function TagDetailView({
                 checked={cleanupTag}
                 onCheckedChange={(c) => setCleanupTag(c === true)}
               />
-              Also delete the <span className="font-mono">{rel.tagName}</span>{" "}
-              tag
+              Also delete the <span className="font-mono">{tag}</span> tag
             </label>
             <DialogFooter>
               <Button variant="outline" onClick={() => setDeleteOpen(false)}>

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -652,9 +652,10 @@ export function TagDetailView({
               <Button variant="outline" onClick={() => setDeleteOpen(false)}>
                 Cancel
               </Button>
-              <Button
+              <DisabledReasonButton
                 variant="destructive"
-                disabled={deleteRelease.isPending}
+                disabled={deleteRelease.isPending || relStale}
+                reason={blockReason}
                 onClick={() =>
                   deleteRelease.mutate(
                     { tag, cleanupTag },
@@ -676,7 +677,7 @@ export function TagDetailView({
                   <Spinner data-icon="inline-start" />
                 )}
                 Delete
-              </Button>
+              </DisabledReasonButton>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/src/features/tags/useGenerateReleaseNotes.ts
+++ b/src/features/tags/useGenerateReleaseNotes.ts
@@ -6,6 +6,7 @@ import {
   ghReleaseGenerateNotes,
   gitCompareBranches,
   gitRecentCommits,
+  readRepoInstructions,
 } from "@/lib/git/api";
 
 /**
@@ -87,16 +88,18 @@ export function useGenerateReleaseNotes(repoPath: string) {
     }) => {
       const buffer = await run(
         async (settings) => {
-          const { changelog, subjects } = await gatherReleaseSource(
-            repoPath,
-            opts,
-          );
+          const [source, repoInstructions] = await Promise.all([
+            gatherReleaseSource(repoPath, opts),
+            readRepoInstructions(repoPath),
+          ]);
+          const { changelog, subjects } = source;
 
           return buildReleaseNotesPrompt({
             repoName: opts.repoName,
             version: opts.tag,
             commits: subjects,
             changelog,
+            repoInstructions,
             globalInstructions: settings.globalInstructions,
           });
         },

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -6,8 +6,8 @@ import {
   type ToolSet,
 } from "ai";
 import { getSecret } from "@/lib/git/api";
-import { errorMessage } from "@/lib/tauri/invoke";
 import { probeOllamaWindowTokens } from "./context-budget";
+import { providerErrorMessage } from "./provider-error";
 import { isCliProvider, PROVIDERS_REQUIRING_KEY } from "./providers";
 import { httpToolStatusLine } from "./review-tools";
 import type { AiClient, AiSettings, AiStreamRequest } from "./types";
@@ -17,55 +17,6 @@ export class MissingApiKeyError extends Error {
     super(`No API key saved for ${provider}. Add one in Settings.`);
     this.name = "MissingApiKeyError";
   }
-}
-
-/** The human-readable reason out of a provider error payload, whether it nests under
- *  `error` as an object (OpenAI, Google), sits bare on `message`, or is a plain string
- *  under `error` (Ollama's native `/api`), array-wrapped (Google) or not. One reader
- *  for both call sites below: the parsed response body and the raw in-stream payload
- *  carry the same shapes, so they must accept the same set. */
-function errorTextOf(value: unknown): string | null {
-  const entry = (Array.isArray(value) ? value[0] : value) as {
-    error?: { message?: unknown } | string;
-    message?: unknown;
-  } | null;
-  const nested = entry?.error;
-  const message =
-    typeof nested === "string" ? nested : (nested?.message ?? entry?.message);
-  return typeof message === "string" && message.trim() ? message : null;
-}
-
-/**
- * The provider's own explanation for a failed call, falling back to the generic
- * message. Three constraints shape it: a body the SDK's error schema can't parse
- * leaves `APICallError.message` as the bare HTTP reason phrase with the cause unread
- * in `responseBody` (Google's is array-wrapped, so a rejected key reads "Bad Request"
- * rather than "Invalid Auth key."); a retry moves that body onto `RetryError.lastError`,
- * and `isRetryable` covers 429/5xx — the quota case; and an in-stream error part is the
- * provider's already-parsed payload rather than an Error.
- */
-function providerErrorMessage(e: unknown): string {
-  const unwrapped = ((e as { lastError?: unknown } | null)?.lastError ?? e) as {
-    responseBody?: unknown;
-  } | null;
-  const body = unwrapped?.responseBody;
-  if (typeof body === "string" && body.trim()) {
-    try {
-      const fromBody = errorTextOf(JSON.parse(body));
-      if (fromBody) return fromBody;
-    } catch {
-      // Not JSON — the generic message is the best we have.
-    }
-  }
-  // An Error's own `message` is what the generic fallback already returns; only a raw
-  // payload object needs reading here.
-  if (!(unwrapped instanceof Error)) {
-    const fromPayload = errorTextOf(unwrapped);
-    if (fromPayload) return fromPayload;
-  }
-  // Deliberately the wrapper, not `unwrapped`: a retry's message embeds the last
-  // error's text and adds the attempt count, which is worth keeping.
-  return errorMessage(e);
 }
 
 /**

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getSecret } from "@/lib/git/api";
 import { guardedFetch } from "./guarded-fetch";
+import { providerErrorMessage } from "./provider-error";
 import {
   GOOGLE_AI_STUDIO_BASE_URL,
   MODEL_SUGGESTIONS,
@@ -29,6 +30,16 @@ export interface AvailableModels {
   models: string[];
   /** false when these are static fallback suggestions, not a provider list. */
   live: boolean;
+  /** The provider's own explanation, set only for `cause: "failed"` — the other
+   *  fallback routes have nothing provider-specific to say. Unbounded provider
+   *  prose: clamp it wherever it renders. */
+  reason?: string;
+  /** Which fallback route produced these suggestions. The four are not
+   *  interchangeable to a user: no key saved yet, no base URL configured, the
+   *  request failed, or the provider listed nothing. A CLI provider has no live
+   *  catalog at all and lands on `empty`, so any consumer branching on `cause`
+   *  must handle the CLI case ahead of it. */
+  cause?: "no-key" | "no-base" | "failed" | "empty";
 }
 
 /** OpenAI's /v1/models mixes in embeddings, audio, images… keep chat models. */
@@ -52,10 +63,20 @@ function googleChatModels(data: { id: string }[]): string[] {
     .sort();
 }
 
+/** Returned instead of a list when a key-requiring provider has no saved key: no
+ *  request was made, so the UI must not blame a failed one. A local sentinel rather
+ *  than client.ts's MissingApiKeyError — importing that module would pull its eager
+ *  `ai` SDK core into every graph this hook renders in. */
+const MISSING_KEY = Symbol("missing-key");
+
+/** The twin of {@link MISSING_KEY} for an openai-compatible provider with a key but
+ *  no base URL: also a no-request state, but the user has a different thing to fix. */
+const MISSING_BASE_URL = Symbol("missing-base-url");
+
 async function fetchProviderModels(
   settings: AiSettings,
   allowedHosts?: readonly string[],
-): Promise<string[]> {
+): Promise<string[] | typeof MISSING_KEY | typeof MISSING_BASE_URL> {
   // The live model list hits the same hosts as inference (incl. a custom Ollama /
   // OpenAI-compatible base URL), so it goes through the same host allowlist — the
   // unsaved draft list (`allowedHosts`) when called from Settings, else the saved
@@ -64,14 +85,22 @@ async function fetchProviderModels(
   const fetchJson = async (url: string, headers?: Record<string, string>) => {
     const res = await aiFetch(url, { headers });
     if (!res.ok) {
-      throw new Error(`${url} returned ${res.status}`);
+      // The body carries the provider's own explanation (Google's rejected-key 400
+      // is array-wrapped under `error.message`). `responseBody` is the field the AI
+      // SDK sets, so providerErrorMessage reads this throw and a failed inference
+      // call alike.
+      const body = await res.text().catch(() => "");
+      throw Object.assign(new Error(`${url} returned ${res.status}`), {
+        responseBody: body,
+        status: res.status,
+      });
     }
     return res.json();
   };
   switch (settings.provider) {
     case "openai": {
       const key = await getSecret("openai");
-      if (!key) return [];
+      if (!key) return MISSING_KEY;
       const json = await fetchJson("https://api.openai.com/v1/models", {
         Authorization: `Bearer ${key}`,
       });
@@ -82,7 +111,7 @@ async function fetchProviderModels(
     }
     case "anthropic": {
       const key = await getSecret("anthropic");
-      if (!key) return [];
+      if (!key) return MISSING_KEY;
       const json = await fetchJson(
         "https://api.anthropic.com/v1/models?limit=100",
         {
@@ -94,7 +123,7 @@ async function fetchProviderModels(
     }
     case "google": {
       const key = await getSecret("google");
-      if (!key) return [];
+      if (!key) return MISSING_KEY;
       const json = await fetchJson(`${GOOGLE_AI_STUDIO_BASE_URL}/models`, {
         Authorization: `Bearer ${key}`,
       });
@@ -103,7 +132,9 @@ async function fetchProviderModels(
     case "openai-compatible": {
       const key = await getSecret("openai-compatible");
       const base = settings.openaiCompatibleBaseUrl.replace(/\/$/, "");
-      if (!key || !base) return [];
+      // Key first: with neither saved, saving a key is the step that comes first.
+      if (!key) return MISSING_KEY;
+      if (!base) return MISSING_BASE_URL;
       // OpenAI-compatible catalog endpoint on the configured base URL.
       const json = await fetchJson(`${base}/models`, {
         Authorization: `Bearer ${key}`,
@@ -129,7 +160,7 @@ async function fetchProviderModels(
     }
     case "ollama-cloud": {
       const key = await getSecret("ollama-cloud");
-      if (!key) return [];
+      if (!key) return MISSING_KEY;
       // OpenAI-compatible catalog endpoint on the cloud host.
       const json = await fetchJson(`${OLLAMA_CLOUD_HOST}/v1/models`, {
         Authorization: `Bearer ${key}`,
@@ -167,14 +198,37 @@ export function useAvailableModels(
     ] as const,
     queryFn: async (): Promise<AvailableModels> => {
       try {
-        const models = await fetchProviderModels(settings, allowedHosts);
-        if (models.length > 0) {
-          return { models, live: true };
+        const result = await fetchProviderModels(settings, allowedHosts);
+        if (result === MISSING_KEY) {
+          return {
+            models: fallbackModels(settings),
+            live: false,
+            cause: "no-key",
+          };
         }
-      } catch {
-        // fall through to suggestions
+        if (result === MISSING_BASE_URL) {
+          return {
+            models: fallbackModels(settings),
+            live: false,
+            cause: "no-base",
+          };
+        }
+        if (result.length > 0) {
+          return { models: result, live: true };
+        }
+        return {
+          models: fallbackModels(settings),
+          live: false,
+          cause: "empty",
+        };
+      } catch (e) {
+        return {
+          models: fallbackModels(settings),
+          live: false,
+          reason: providerErrorMessage(e),
+          cause: "failed",
+        };
       }
-      return { models: fallbackModels(settings), live: false };
     },
     enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -178,8 +178,9 @@ async function fetchProviderModels(
 
 /**
  * Live model list for the current provider, falling back to the static
- * suggestions when there's no key or the request fails. `opts.enabled` lets a
- * caller defer the provider request until the user shows intent to pick a model.
+ * suggestions when there's no key or base URL configured, the request fails, or
+ * the provider lists nothing. `opts.enabled` lets a caller defer the provider
+ * request until the user shows intent to pick a model.
  */
 export function useAvailableModels(
   settings: AiSettings,

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -1808,6 +1808,7 @@ export function buildReleaseNotesPrompt(input: {
   commits: string[];
   /** GitHub's auto-generated changelog (PR titles, authors, links). Preferred source. */
   changelog?: string;
+  repoInstructions?: string | null;
   globalInstructions: string;
 }): { system: string; prompt: string } {
   // Only GitHub supplies the auto-changelog; the bare-commit path uses the neutral variant.
@@ -1816,6 +1817,9 @@ export function buildReleaseNotesPrompt(input: {
       ? RELEASE_NOTES_SYSTEM
       : RELEASE_NOTES_SYSTEM_COMMITS,
   ];
+  if (input.repoInstructions) {
+    systemParts.push(`## Project instructions\n${input.repoInstructions}`);
+  }
   if (input.globalInstructions.trim()) {
     systemParts.push(
       `## User instructions\n${input.globalInstructions.trim()}`,

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -1808,7 +1808,7 @@ export function buildReleaseNotesPrompt(input: {
   commits: string[];
   /** GitHub's auto-generated changelog (PR titles, authors, links). Preferred source. */
   changelog?: string;
-  repoInstructions?: string | null;
+  repoInstructions: string | null;
   globalInstructions: string;
 }): { system: string; prompt: string } {
   // Only GitHub supplies the auto-changelog; the bare-commit path uses the neutral variant.

--- a/src/lib/ai/provider-error.ts
+++ b/src/lib/ai/provider-error.ts
@@ -1,12 +1,17 @@
 import { errorMessage } from "@/lib/tauri/invoke";
 
 /** The human-readable reason out of a provider error payload, whether it nests under
- *  `error` as an object (OpenAI, Google), sits bare on `message`, or is a plain string
- *  under `error` (Ollama's native `/api`), array-wrapped (Google) or not. One reader
- *  for both call sites below: the parsed response body and the raw in-stream payload
- *  carry the same shapes, so they must accept the same set. */
+ *  `error` as an object (OpenAI, Google), sits bare on `message`, is a plain string
+ *  under `error` (Ollama's native `/api`), or IS the whole payload — a bare JSON
+ *  string is valid JSON — array-wrapped (Google) or not. One reader for both call
+ *  sites below: the parsed response body and the raw in-stream payload carry the
+ *  same shapes, so they must accept the same set. */
 function errorTextOf(value: unknown): string | null {
-  const entry = (Array.isArray(value) ? value[0] : value) as {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  // A runtime string has to be caught before the property reads: the assertion
+  // below is compile-time only, so a bare string would fall through them as null.
+  if (typeof candidate === "string") return candidate.trim() ? candidate : null;
+  const entry = candidate as {
     error?: { message?: unknown } | string;
     message?: unknown;
   } | null;

--- a/src/lib/ai/provider-error.ts
+++ b/src/lib/ai/provider-error.ts
@@ -5,7 +5,7 @@ import { errorMessage } from "@/lib/tauri/invoke";
  *  under `error` (Ollama's native `/api`), array-wrapped (Google) or not. One reader
  *  for both call sites below: the parsed response body and the raw in-stream payload
  *  carry the same shapes, so they must accept the same set. */
-export function errorTextOf(value: unknown): string | null {
+function errorTextOf(value: unknown): string | null {
   const entry = (Array.isArray(value) ? value[0] : value) as {
     error?: { message?: unknown } | string;
     message?: unknown;

--- a/src/lib/ai/provider-error.ts
+++ b/src/lib/ai/provider-error.ts
@@ -1,0 +1,64 @@
+import { errorMessage } from "@/lib/tauri/invoke";
+
+/** The human-readable reason out of a provider error payload, whether it nests under
+ *  `error` as an object (OpenAI, Google), sits bare on `message`, or is a plain string
+ *  under `error` (Ollama's native `/api`), array-wrapped (Google) or not. One reader
+ *  for both call sites below: the parsed response body and the raw in-stream payload
+ *  carry the same shapes, so they must accept the same set. */
+export function errorTextOf(value: unknown): string | null {
+  const entry = (Array.isArray(value) ? value[0] : value) as {
+    error?: { message?: unknown } | string;
+    message?: unknown;
+  } | null;
+  const nested = entry?.error;
+  const message =
+    typeof nested === "string" ? nested : (nested?.message ?? entry?.message);
+  return typeof message === "string" && message.trim() ? message : null;
+}
+
+/**
+ * The provider's own explanation for a failed call, falling back to the generic
+ * message. Three constraints shape it: a body the SDK's error schema can't parse
+ * leaves `APICallError.message` as the bare HTTP reason phrase with the cause unread
+ * in `responseBody` (Google's is array-wrapped, so a rejected key reads "Bad Request"
+ * rather than "Invalid Auth key."); a retry moves that body onto `RetryError.lastError`,
+ * and `isRetryable` covers 429/5xx — the quota case; and an in-stream error part is the
+ * provider's already-parsed payload rather than an Error.
+ *
+ * Lives outside `client.ts` so the model-catalog fetch can reuse it without pulling
+ * that module's eager `ai` SDK core into the Settings graph.
+ */
+export function providerErrorMessage(e: unknown): string {
+  const unwrapped = ((e as { lastError?: unknown } | null)?.lastError ?? e) as {
+    responseBody?: unknown;
+  } | null;
+  const body = unwrapped?.responseBody;
+  if (typeof body === "string" && body.trim()) {
+    try {
+      const fromBody = errorTextOf(JSON.parse(body));
+      if (fromBody) return fromBody;
+    } catch {
+      // Not JSON — the generic message is the best we have.
+    }
+  }
+  // An Error's own `message` is what the generic fallback already returns; only a raw
+  // payload object needs reading here.
+  if (!(unwrapped instanceof Error)) {
+    const fromPayload = errorTextOf(unwrapped);
+    if (fromPayload) return fromPayload;
+  }
+  // Nothing installed emits a payload errorTextOf can't read; the dump is dev-only so
+  // a future provider's shape is debuggable without raw JSON reaching a user-facing
+  // banner. The literal `import.meta.env.DEV` leads the `&&` — that's what lets Vite
+  // statically drop the branch from the production bundle.
+  if (import.meta.env.DEV && unwrapped && !(unwrapped instanceof Error)) {
+    try {
+      return JSON.stringify(unwrapped).slice(0, 200);
+    } catch {
+      // cyclic
+    }
+  }
+  // Deliberately the wrapper, not `unwrapped`: a retry's message embeds the last
+  // error's text and adds the attempt count, which is worth keeping.
+  return errorMessage(e);
+}

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -126,6 +126,7 @@ export function keepPreviousDataForKeyAxes(
 export const repoKeys = {
   all: (repo: string) => ["repo", repo] as const,
   status: (repo: string) => ["repo", repo, "status"] as const,
+  opState: (repo: string) => ["repo", repo, "op-state"] as const,
   branches: (repo: string) => ["repo", repo, "branches"] as const,
   diff: (repo: string, file: string, staged: boolean) =>
     ["repo", repo, "diff", file, staged] as const,
@@ -2654,13 +2655,16 @@ export function useAccountsHealth() {
 
 /** Refresh everything a successful reconnect can change: the accounts-health list,
  *  every repo's forge-status (a dead session flips a repo back to ready) and
- *  forge-session-health, plus the gh-accounts list (which account is active). Call
- *  from a reconnect's `finished: ok` handler. */
+ *  forge-session-health, the gh-accounts list (which account is active), and the
+ *  gh token scopes (a reconnect can grant new ones). Call from a reconnect's
+ *  `finished: ok` handler. */
 export function useInvalidateAfterReconnect() {
   const queryClient = useQueryClient();
   return useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["accounts-health"] });
     queryClient.invalidateQueries({ queryKey: ["gh-accounts"] });
+    // Partial key: covers every host variant of useGhScopes' key.
+    queryClient.invalidateQueries({ queryKey: ["gh", "token-scopes"] });
     queryClient.invalidateQueries({
       predicate: (q) =>
         q.queryKey[0] === "repo" &&
@@ -3114,7 +3118,7 @@ export function useRemoveRemote(repo: string) {
 
 export function useOpState(repo: string) {
   return useQuery({
-    queryKey: ["repo", repo, "op-state"] as const,
+    queryKey: repoKeys.opState(repo),
     queryFn: () => api.gitOpState(repo),
   });
 }

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -186,7 +186,7 @@ const commitAftermathKeys = (repo: string) =>
     ["repo", repo, "file-log"],
     ["repo", repo, "blame"],
     ["repo", repo, "file-b64", "HEAD"],
-    ["repo", repo, "op-state"],
+    repoKeys.opState(repo),
     ["repo", repo, "conflict-file"],
     ["repo", repo, "merge-preview"],
     ["repo", repo, "conflict-preview"],

--- a/src/lib/pulls/review-drafts.ts
+++ b/src/lib/pulls/review-drafts.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/git/repo-identity";
 import type { RemoteLens } from "@/lib/git/types";
 import { storeName } from "@/lib/test-mode";
+import { toastError } from "@/lib/toast";
 
 /** One pending draft comment in a not-yet-submitted batch review. `id` is a local
  *  uuid (these drafts never leave the client until the review is submitted). */
@@ -234,6 +235,10 @@ export function useUpdateReviewDraft(
   return useMutation({
     mutationFn: (args: { id: string; body: string }) =>
       updateDraft(repo, lens, number, args.id, args.body),
+    // Mutation-level so the failure still reports after the card unmounts: the
+    // draft cards are keyed per draft id, so switching PR replaces them all and
+    // mutate-scoped callbacks stop firing once the observer loses its listeners.
+    onError: (e) => toastError(e),
     onSettled: () =>
       void queryClient.invalidateQueries({
         queryKey: reviewDraftsKey(repo, lens, number),
@@ -249,6 +254,8 @@ export function useRemoveReviewDraft(
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => removeDraft(repo, lens, number, id),
+    // Mutation-level: see useUpdateReviewDraft.
+    onError: (e) => toastError(e),
     onSettled: () =>
       void queryClient.invalidateQueries({
         queryKey: reviewDraftsKey(repo, lens, number),

--- a/src/lib/use-retained.ts
+++ b/src/lib/use-retained.ts
@@ -3,8 +3,9 @@ import { useState } from "react";
 /**
  * Latest value, retained through a dialog's close fade: updates only while
  * `retain` holds (default: value is non-nullish), so copy/appearance reads
- * stay populated while the live discriminant nulls at close. Render-only —
- * dispatch handlers and open= gates keep reading the live value.
+ * stay populated while the live discriminant nulls at close. Render-only by
+ * default — a dispatch that must hand over exactly what the user sees may read
+ * it too; open= gates never do.
  */
 export function useRetained<T>(value: T, retain: boolean = value != null): T {
   const [shown, setShown] = useState(value);

--- a/src/lib/use-retained.ts
+++ b/src/lib/use-retained.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+/**
+ * Latest value, retained through a dialog's close fade: updates only while
+ * `retain` holds (default: value is non-nullish), so copy/appearance reads
+ * stay populated while the live discriminant nulls at close. Render-only —
+ * dispatch handlers and open= gates keep reading the live value.
+ */
+export function useRetained<T>(value: T, retain: boolean = value != null): T {
+  const [shown, setShown] = useState(value);
+  if (retain && value !== shown) setShown(value);
+  return shown;
+}


### PR DESCRIPTION
A batch of fixes for paths where a destructive git operation could leave the repository somewhere the user never asked to be, and where the UI rendered stale, blank, or raw values instead of what the user selected. The common thread is making the guard a precondition rather than an error after the point of no return, and making what's on screen come from a snapshot that outlives the state driving it.

### Destructive git operations

- Routes every cherry-pick failure class through one rollback funnel in `src-tauri/src/git/ops.rs` — conflict, timeout, and IO errors now all abort the pick, `reset --hard` the target tip, and switch back to the original branch, so none of them can exit with `HEAD` left on the target branch; if the rollback itself fails, the error says so. The pre-funnel `switch` is bound explicitly so any future early exit inherits that guarantee.
- Adds `cherry_pick_onto_with_pick_timeout`, which bounds only the `cherry-pick` calls in the loop while setup, switch, and rollback keep `DEFAULT_TIMEOUT` — a tiny value drives the failure funnel instead of aborting before the first mutation. `cherry_pick_onto` delegates to it.
- Promotes `has_unmerged`, `op_in_progress`, and `refuse_mid_op` out of `src-tauri/src/git/autostash.rs` into `ops.rs` as shared helpers (best-effort: a failed probe reads as no operation in progress; the `Err` arm is defensive), so the stash guard and the conflict banner read the same detection; `autostash.rs` now calls through to them.
- Makes an in-progress merge/rebase/cherry-pick in the main workspace a *precondition* in `src/features/repository/PromoteWorktreeDialog.tsx` rather than a backend error: an inline `gitOpState` query blocks Promote with its own warning line, since the stash there runs after the worktree has already been removed. A failed op-state read is treated as blocked (defensive — the command only fails at the IPC layer).
- Documents the refusal on the MCP `stash_push` tool in `src-tauri/src/mcp_server/write_git.rs` ("retrying won't help").

### Dialog contents during the close fade

- Adds `src/lib/use-retained.ts`, a shared hook for the value a dialog keeps rendering through Base UI's exit fade, with an optional retain condition.
- Replaces the hand-rolled retain-in-render pattern in `BranchMergePickerDialog.tsx`, `RepositoryFilesDialog.tsx`, `StashesDialog.tsx`, `mcp/GitDesktopAsServer.tsx`, and `scripts/TaskRunConfirm.tsx` with the hook.
- Extends the same treatment to dialogs that previously blanked mid-fade: `ErrorDialog.tsx` (summary, label, and the Copy payload now read the same snapshot), `AutomationResultDialog.tsx`, `DiffViewer.tsx`'s discard confirm, `HistoryDialogs.tsx` (delete tag / reset / cherry-pick onto), `HistoryPanel.tsx` (branch- and tag-from-commit), `BranchSwitcher.tsx` (local delete, remote delete, worktree switch), `ChangesPanel.tsx` (discard and stash scope, including the confirm labels), `PullRequestsPanel.tsx`, `RepoDialogs.tsx`, and `scripts/TaskDialog.tsx`.
- Uses the hook's condition arm where the value alone isn't a valid discriminant: `CreateLocalPrDialog.tsx` retains the head/base defaults on `open` so an unseeded next open resyncs, and `RenameBranchDialog.tsx` retains `committedFallback`/`committedStatus` on `target !== null`. The rename dialog also wraps its generator in `guardedGen`, so a click landing during the fade can't start an uncancellable generation whose name arrives in the next open.

### Select trigger labels

Base UI renders the raw stored value in a `Select` trigger unless the labels are passed as `items`; these all showed things like `xhigh`, `maintain`, `evaluate`, or `codespaces` when collapsed.

- Session composer pickers in `src/features/sessions/AgentPickers.tsx` — model (`items` memoized per agent), effort, and agent (whose popup now renders from the same `AGENT_PICKER_ITEMS` map so trigger and list can't drift).
- `src/features/research/ResearchView.tsx` intent picker and `src/features/pulls/PrReviewPanel.tsx` provider picker.
- Settings: `AgentSandboxField.tsx` (Node version, preserving the "(LTS)" note), `GitSection.tsx` (autocrlf), and `mcp/PerRepoStateControl.tsx`.
- Repository settings: `CollaboratorsSection.tsx`, `GeneralSettingsSection.tsx`, `PagesSection.tsx`, `RepoSettingsDialog.tsx`, `RulesetsSection.tsx`, and `SecretsSection.tsx`.

### AI model catalog and provider errors

- Adds `src/lib/ai/provider-error.ts` and reworks `src/lib/ai/models.ts` so a catalog carries why it fell back — `failed` with the provider's own message, `empty`, or `no-base` — with `src/lib/ai/client.ts` trimmed onto the shared parser.
- Rewrites the model picker hint in `src/features/settings/AiProviderSection.tsx` as a `switch (true)` over those heterogeneous predicates, so a saved-but-rejected key is never told to save a key; the failure arm is the only one clamped (`line-clamp-2`) and given a `title` tooltip, since it's the only one carrying unbounded provider prose.
- Invalidates the `["models"]` queries when a key is saved or cleared — the query keys on a boolean "a key is saved", which doesn't move when a bad key is replaced, so the picker otherwise served the failed fetch's suggestions for the rest of its stale time.

### Releases, pull requests, and GitHub

- Gates the release actions in `src/features/tags/TagDetailView.tsx` on the selected tag's release having loaded, so publishing, editing, deleting, and asset add/download/remove can't act on the previously selected tag — and say why while they wait.
- Applies the repo's `.gitdesktop/instructions.md` to generated release notes via `src/features/tags/useGenerateReleaseNotes.ts` and `src/lib/ai/prompt.ts`, matching every other generation.
- Turns the **Review…** button in `src/features/pulls/RemotePrView.tsx` into a `DisabledReasonButton` that explains the placeholder window, where the review would otherwise open against the previously rendered PR.
- Moves the pending-review draft error toasts onto the mutations in `src/lib/pulls/review-drafts.ts` and drops the per-call `onError` handlers in `PendingReviewBar.tsx`, so an edit or delete still reports failure when you navigate to another PR mid-flight.
- Picks up freshly granted token scopes on GitHub reconnect in `src/lib/git/queries.ts`.

### Documentation

- Updates `src/features/help/content.ts` for both new refusals: stashing while conflicts are unresolved or an operation is in progress, and promoting a worktree while the main workspace is mid-operation.
- Adds ten `changelog.d/fixed-*.md` fragments, one per fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cherry-pick failures now reliably roll back without altering the target or starting branch.
  - Stashing and worktree promotion are blocked during active Git operations or unresolved conflicts.
  - Release actions wait for the selected tag’s release to load.
  - GitHub permissions and AI model lists refresh after account or API-key changes.
  - Dialog content remains stable during closing animations.
  - Review actions explain loading and failure states clearly.
  - Dropdowns show complete, human-readable labels.
  - AI provider errors provide clearer explanations.
  - Review draft failures now display error notifications.

- **Documentation**
  - Release-note generation incorporates repository instructions.
  - Help content explains operation-related stashing restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->