### PR TITLE
fix(pulls,activity): correct PR banner state and notification routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,15 +256,18 @@ PR (comments and all) in one click.
   stay the single editor for the ref block.
 - **Conflicts with the base**: an in-flow strip under a PR's header when it
   won't merge cleanly (**GitHub** and **GitLab** report it themselves;
-  **Bitbucket** gets a local prediction), plus a **Conflicts** chip on open
-  GitHub/GitLab rows in the list. **Resolve conflicts** merges the base into
-  the PR's head in a **hidden, isolated worktree** (your branch and working
-  tree untouched), hands you the conflicted files in the in-app conflict
-  editor, and **Finish & push** updates the PR's head branch, **never
-  force-pushed**: a head that moved meanwhile refuses the push and keeps
-  your work. **Discard** drops the worktree and nothing else, and an
-  unfinished resolution is offered back as **Continue resolving**. Fork PRs
-  are excluded, since their head lives in another repository.
+  **Bitbucket** falls back to a local prediction, named as such). A GitHub or
+  GitLab answer that can't be read names the forge it couldn't reach, offers
+  **Retry**, and falls back to that same prediction meanwhile. Plus a
+  **Conflicts** chip on open GitHub/GitLab rows in the list. **Resolve
+  conflicts** merges the base into the PR's head in a **hidden, isolated
+  worktree** (your branch and working tree untouched), hands you the
+  conflicted files in the in-app conflict editor, and **Finish & push**
+  updates the PR's head branch, **never force-pushed**: a head that moved
+  meanwhile refuses the push and keeps your work. **Discard** drops the
+  worktree and nothing else, and an unfinished resolution is offered back as
+  **Continue resolving**. Fork PRs are excluded, since their head lives in
+  another repository.
 - **Local PR merges**: a merge **pre-shows conflicts** and lets you resolve
   them in the in-app editor, in an isolated worktree that never touches your
   working tree, then **Finish** or **Abort**.
@@ -343,13 +346,14 @@ PR (comments and all) in one click.
 - **Maintaining a fork's PR** (GitHub): a pull request that's fallen
   **behind its base** says so under its header, and **Update branch** brings
   it up to date — a merge by default, or **Update with rebase…** behind a
-  confirmation, since that rewrites the contributor's branch. A workflow run
-  GitHub is **holding for approval** — its gate on a first-time
-  contributor — carries **Approve and run** on the run itself and in the
-  PR's checks list. And publishing a local branch that already holds an open
-  fork PR's commits offers to push them to the **contributor's fork branch**
-  instead of leaving a stray copy on `origin`, wherever the PR allows edits
-  from maintainers.
+  confirmation, since that rewrites the contributor's branch. GitHub runs that
+  update as a background job, and the strip holds on it until a fresh
+  comparison shows the branch caught up. A workflow run GitHub is **holding
+  for approval** — its gate on a first-time contributor — carries **Approve
+  and run** on the run itself and in the PR's checks list. And publishing a
+  local branch that already holds an open fork PR's commits offers to push
+  them to the **contributor's fork branch** instead of leaving a stray copy
+  on `origin`, wherever the PR allows edits from maintainers.
 - **Record management**: a local PR's context menu in the list (or the
   command palette) can **Archive / Unarchive** or **Delete** it. Delete
   confirms; the branches are untouched.

--- a/changelog.d/fixed-mergeability-offline.md
+++ b/changelog.d/fixed-mergeability-offline.md
@@ -1,0 +1,4 @@
+- A pull request whose mergeability can't be read now says which forge it couldn't
+  reach and offers **Retry**, where the strip used to stay blank. It also falls back
+  to the local conflict prediction, so a clash visible from your last fetch is still
+  named — and still resolvable — while the forge answer is out of reach.

--- a/changelog.d/fixed-pr-notification-section-routing.md
+++ b/changelog.d/fixed-pr-notification-section-routing.md
@@ -1,0 +1,4 @@
+- Clicking a pull-request notification now opens that PR on the tab the event
+  happened on — a new comment, approval, or merge lands on **Conversation**, and a
+  finished AI review lands on **Review**. Checks notifications leave your current
+  tab alone, since the checks rollup sits in the PR header either way.

--- a/changelog.d/fixed-update-branch-async.md
+++ b/changelog.d/fixed-update-branch-async.md
@@ -1,5 +1,5 @@
 - **Update branch** on a GitHub pull request now shows the update running and
-  confirms it once it has landed. GitHub does the work in the background, so the
-  strip holds on *GitHub is updating this branch…* — controls disabled, with the
-  reason on hover — until a fresh comparison shows the head caught up, so the
-  confirmation you get matches the state of the branch.
+  confirms it only once it has landed. The strip holds on *GitHub is updating
+  this branch…* — controls disabled, with the reason on hover — until the branch
+  is confirmed caught up, so the confirmation you get matches the state of the
+  branch.

--- a/changelog.d/fixed-update-branch-async.md
+++ b/changelog.d/fixed-update-branch-async.md
@@ -1,0 +1,5 @@
+- **Update branch** on a GitHub pull request now shows the update running and
+  confirms it once it has landed. GitHub does the work in the background, so the
+  strip holds on *GitHub is updating this branch…* — controls disabled, with the
+  reason on hover — until a fresh comparison shows the head caught up, so the
+  confirmation you get matches the state of the branch.

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -986,9 +986,9 @@ pub async fn gh_pr_close(repo_path: String, number: u64, lens: Option<String>) -
 }
 
 /// Updates a PR's head branch with its base (`gh pr update-branch`) — merge by
-/// default, `rebase` to rebase instead. Synchronous by contract: GitHub's
-/// update-branch PUT returns the decision itself, unlike the async merge queue,
-/// so there is nothing to poll for here.
+/// default, `rebase` to rebase instead. Queued, not synchronous: the underlying PUT
+/// answers 202 Accepted and GitHub runs the update afterwards, so `Ok` means the job
+/// was accepted; a caller that needs the moved head has to poll for it.
 #[tauri::command]
 pub async fn gh_pr_update_branch(
     repo_path: String,

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -27,6 +27,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { displayLogin } from "@/lib/git/bot-login";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import type { PrSection } from "@/lib/pulls/pr-section";
 import {
   type AppNotification,
   clearAllNotifications,
@@ -160,7 +161,7 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   const tasks = useReviewTasks();
   const notifs = useNotifications();
   const repoPath = useUiStore((s) => s.repoPath);
-  const openPrReview = useUiStore((s) => s.openPrReview);
+  const openPr = useUiStore((s) => s.openPr);
   const openRun = useUiStore((s) => s.openRun);
   const openAgentTab = useUiStore((s) => s.openAgentTab);
   const [focusedId, setFocusedId] = useState<string | null>(null);
@@ -181,11 +182,12 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
     markNotificationRead(n.id);
     const t = n.target;
     if (t?.type === "pr") {
-      openPrReview({
+      openPr({
         kind: t.kind,
         repoPath: n.repoPath,
         repoName: n.repoName,
         ref: t.ref,
+        section: KIND_SECTION[n.kind] ?? null,
       });
     } else if (t?.type === "run") {
       openRun({ repoPath: n.repoPath, repoName: n.repoName, runId: t.runId });
@@ -588,6 +590,27 @@ const KIND_GLYPH: Record<string, typeof CheckCircleIcon> = {
   "agent-done": SparkleIcon,
   "research-done": MagnifyingGlassIcon,
   "plan-done": ListChecksIcon,
+};
+
+/** PR sub-tab a notification's click-through lands on, per event kind. Kinds not
+ *  listed get no override (the user's current tab stands) — deliberate for the
+ *  checks family, whose rollup renders in the PR header above the tab strip and
+ *  is therefore already on screen from every section. A `review-failed` from an
+ *  *automation* still points at Review even though the panel shows idle: those
+ *  runs use a separate `auto:<n>` key namespace, but Review is where the Run
+ *  button lives. Keyed by plain string — a hydrated row can carry a kind from an
+ *  older build. */
+const KIND_SECTION: Record<string, PrSection> = {
+  "review-ready": "review",
+  "review-failed": "review",
+  "pr-opened": "conversation",
+  "pr-merged": "conversation",
+  "pr-closed": "conversation",
+  "pr-approved": "conversation",
+  "pr-changes-requested": "conversation",
+  "pr-review": "conversation",
+  "pr-comment": "conversation",
+  "review-requested": "conversation",
 };
 
 /** Fallback glyph for kinds `KIND_GLYPH` doesn't name — the tone is then the

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -756,11 +756,14 @@ header says so, naming the base branch. Whenever GitDesktop can work out **which
 clash**, it lists them right under that sentence — up to five paths, then *and N more*
 (hover it for the rest). **GitHub** and **GitLab** answer that question themselves; while
 a forge is still working it out the strip reads **Checking mergeability…**, and if the
-answer never arrives, **Retry** asks again. On **GitHub** a conflicting pull request also
-runs no checks until the conflicts are resolved, and the strip says so — an empty checks
-list there means *never ran*, not *passed*. In the list, **GitHub** and **GitLab** rows
-carry a **Conflicts** chip (icon plus the word) on open pull requests, so you can spot a
-blocked one without opening it.
+answer never arrives, **Retry** asks again. When the answer can't be read at all, the
+strip names the forge it couldn't reach, offers that same **Retry**, and falls back to
+the local prediction below — so a clash visible from your last fetch is still named, and
+still resolvable. On **GitHub** a conflicting pull request also runs no checks until the
+conflicts are resolved, and the strip says so — an empty checks list there means *never
+ran*, not *passed*. In the list, **GitHub** and **GitLab** rows carry a **Conflicts**
+chip (icon plus the word) on open pull requests, so you can spot a blocked one without
+opening it.
 
 **Resolve conflicts** settles it right here. GitDesktop merges the base branch into the
 pull request's **head** branch in an **isolated worktree** — your own branch and working
@@ -790,16 +793,20 @@ too — no default shortcut, so give it one in **Settings → Keyboard**.
 
 When an open pull request merges cleanly but its base has moved on since, that same
 strip reads **This branch is N commits behind \`main\`**, and **Update branch** brings
-the head up to date on the forge — a merge of the base into it. The caret beside the
-button offers **Update with rebase…** instead, which rewrites the pull request
-branch's history and force-pushes it, so it asks you to confirm first: on a pull
-request from a fork, that branch is the contributor's. Both controls are disabled with
-the reason on hover when you don't have push access, or when a fork's author left
-GitHub's *Allow edits by maintainers* off. This reads GitHub's own comparison of the
-two branches, so it's **GitHub** only, and the line yields to anything more pressing —
-a conflict, or an unfinished resolution. **Update pull request branch** is in the
-command palette ({{kbd:command-palette}}) too — no default shortcut, so give it one in
-**Settings → Keyboard**.
+the head up to date on the forge — a merge of the base into it. GitHub runs that update
+as a background job, so the strip switches to **GitHub is updating this branch from
+\`main\`…** — controls disabled, the reason on hover — and holds there until a fresh
+comparison shows the head caught up, which is when the confirmation arrives. If GitHub
+is still working by the time GitDesktop stops watching, the line returns to the behind
+count and says as much. The caret beside the button offers **Update with rebase…**
+instead, which rewrites the pull request branch's history and force-pushes it, so it
+asks you to confirm first: on a pull request from a fork, that branch is the
+contributor's. Both controls are disabled with the reason on hover when you don't have
+push access, or when a fork's author left GitHub's *Allow edits by maintainers* off.
+This reads GitHub's own comparison of the two branches, so it's **GitHub** only, and the
+line yields to anything more pressing — a conflict, or an unfinished resolution.
+**Update pull request branch** is in the command palette ({{kbd:command-palette}}) too —
+no default shortcut, so give it one in **Settings → Keyboard**.
 
 ## Maintaining a pull request from a fork
 
@@ -1039,7 +1046,9 @@ Bitbucket exposes no fetchable job logs, so these don't peek inline the way GitH
 and GitLab pipeline jobs do. Bitbucket publishes no mergeability field either, so a
 conflict here is **predicted locally** — GitDesktop merges your fetched copies of the two
 branches in memory and labels the strip as a local prediction — and **Resolve conflicts**
-then works just as it does elsewhere (see *Conflicts with the base branch* above).
+then works just as it does elsewhere (see *Conflicts with the base branch* above). That
+same local prediction stands in anywhere the forge answer is missing, including a GitHub
+or GitLab read that couldn't get through.
 
 ## Local PRs
 
@@ -2117,9 +2126,11 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   Whatever you enable here also lands in the header's **Activity & notifications** bell — a
   persistent, click-to-open history (it survives a restart) so a finished review or a PR
   update is never a missed moment. Open it from the command palette
-  ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump to it,
-  arrow-key through the list, and clear items or mark all read.{{ai}} A review still
-  running shows a live **elapsed timer** so you can see how long it's taken. When an
+  ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump
+  to it, arrow-key through the list, and clear items or mark all read. A
+  pull-request entry opens that PR on the tab its event happened on, so a new
+  comment or approval lands on **Conversation**.{{ai}} A review still running shows
+  a live **elapsed timer** so you can see how long it's taken. When an
   **automated** review or security audit is cancelled or fails, it stays in the popover
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
   **Dismiss** — a stopped row notes how long it ran before it stopped — and a failed

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -797,14 +797,16 @@ the head up to date on the forge — a merge of the base into it. GitHub runs th
 as a background job, so the strip switches to **GitHub is updating this branch from
 \`main\`…** — controls disabled, the reason on hover — and holds there until a fresh
 comparison shows the head caught up, which is when the confirmation arrives. If GitHub
-is still working by the time GitDesktop stops watching, the line returns to the behind
-count and says as much. The caret beside the button offers **Update with rebase…**
-instead, which rewrites the pull request branch's history and force-pushes it, so it
-asks you to confirm first: on a pull request from a fork, that branch is the
-contributor's. Both controls are disabled with the reason on hover when you don't have
-push access, or when a fork's author left GitHub's *Allow edits by maintainers* off.
-This reads GitHub's own comparison of the two branches, so it's **GitHub** only, and the
-line yields to anything more pressing — a conflict, or an unfinished resolution.
+is still working by the time GitDesktop stops watching, a notice says so and the strip
+falls back to whatever the mergeability read is reporting by then — often still
+**Checking mergeability…**, since GitHub leaves that undecided while it works. The caret
+beside the button offers **Update with rebase…** instead, which rewrites the pull
+request branch's history and force-pushes it, so it asks you to confirm first: on a pull
+request from a fork, that branch is the contributor's. Both controls are disabled with
+the reason on hover when you don't have push access, or when a fork's author left
+GitHub's *Allow edits by maintainers* off. This reads GitHub's own comparison of the two
+branches, so it's **GitHub** only, and the line yields to anything more pressing — a
+conflict, an unfinished resolution, or a mergeability answer the app couldn't read.
 **Update pull request branch** is in the command palette ({{kbd:command-palette}}) too —
 no default shortcut, so give it one in **Settings → Keyboard**.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -798,8 +798,9 @@ as a background job, so the strip switches to **GitHub is updating this branch f
 \`main\`…** — controls disabled, the reason on hover — and holds there until a fresh
 comparison shows the head caught up, which is when the confirmation arrives. If GitHub
 is still working by the time GitDesktop stops watching, a notice says so and the strip
-falls back to whatever the mergeability read is reporting by then — often still
-**Checking mergeability…**, since GitHub leaves that undecided while it works. The caret
+falls back to whatever the mergeability read is reporting by then — usually **Couldn't
+determine mergeability.** with a **Retry**, since GitHub leaves the answer undecided
+while it works and the mergeability check has stopped asking by then. The caret
 beside the button offers **Update with rebase…** instead, which rewrites the pull
 request branch's history and force-pushes it, so it asks you to confirm first: on a pull
 request from a fork, that branch is the contributor's. Both controls are disabled with

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/lib/git/queries";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import type { PrSection } from "@/lib/pulls/pr-section";
 import { useLocalPrs, useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -76,7 +77,6 @@ import {
   sortTimeline,
   type TimelineEntry,
 } from "./PrTimeline";
-import type { PrSection } from "./pr-section";
 import { ResolveConflictsView } from "./ResolveConflictsView";
 import {
   useCancelOnIdentityChange,

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -146,15 +146,16 @@ export function LocalPrView({
         : ["conversation", "commits", "files"],
     [aiEnabled],
   );
-  // The activity dock's "View" lands here via a pending hint; switch to the
-  // review sub-tab once if it's available, then clear the hint either way — an
+  // A notification's click-through lands here via a pending hint; switch to the
+  // hinted sub-tab once if it's available, then clear the hint either way — an
   // unusable hint must not survive to fire against a later PR. Guarded on this
   // being the *selected* PR so a still-mounted lagging view (deferredPr) can't
   // swallow the hint first.
   useEffect(() => {
     const isSelected = selectedPr?.kind === "local" && selectedPr.id === id;
-    if (pendingPrSection === "review" && isSelected) {
-      if (availableSections.includes("review")) setSection("review");
+    if (pendingPrSection !== null && isSelected) {
+      if (availableSections.includes(pendingPrSection))
+        setSection(pendingPrSection);
       setPendingPrSection(null);
     }
   }, [

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -28,6 +28,10 @@ const FORK_BLOCKED_REASON =
 /** How many conflicting paths get their own row before the rest collapse to a count. */
 const MAX_FILE_ROWS = 5;
 
+/** What a control held open through the PR-switch window says. Shared with the view's
+ *  own stale-held controls so the one wording can't drift into two. */
+export const PR_SWITCH_LOADING_REASON = "Loading this pull request…";
+
 /** Which line the banner shows. `predicted` is the local fallback wherever the forge has
  *  no mergeability to give — Bitbucket by design, or a read that failed; `unknown` is a
  *  `checking` poll that gave up, `unreachable` a read that never landed at all, and
@@ -230,7 +234,7 @@ export function PrMergeabilityBanner({
       case updateSubmitting:
         return "Submitting the update…";
       default:
-        return "Loading this pull request…";
+        return PR_SWITCH_LOADING_REASON;
     }
   })();
   const updateDisabledReason =

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
-import type { ForgeProvider } from "@/lib/git/types";
+import { type ForgeProvider, providerLabel } from "@/lib/git/types";
 import { useAiEnabled, useReviewConfigured } from "@/lib/settings/queries";
 import { cn } from "@/lib/utils";
 
@@ -28,26 +28,34 @@ const FORK_BLOCKED_REASON =
 /** How many conflicting paths get their own row before the rest collapse to a count. */
 const MAX_FILE_ROWS = 5;
 
-/** Which line the banner shows. `predicted` is the local fallback when the forge answers
- *  but has no mergeability to give (Bitbucket) — not when the read itself failed;
- *  `unknown` is a `checking` poll that gave up. */
+/** Which line the banner shows. `predicted` is the local fallback wherever the forge has
+ *  no mergeability to give — Bitbucket by design, or a read that failed; `unknown` is a
+ *  `checking` poll that gave up, `unreachable` a read that never landed at all, and
+ *  `updating` the forge's queued update-branch job still running. */
 export type PrMergeabilityArm =
   | "conflicting"
   | "predicted"
   | "checking"
   | "unknown"
+  | "unreachable"
   | "resume"
   | "behind"
+  | "updating"
   | null;
 
 /** Words carry the meaning; the icon and tone only reinforce it. */
-const ARM_ICON: Record<Exclude<PrMergeabilityArm, null>, PhosphorIcon> = {
+const ARM_ICON: Record<
+  Exclude<PrMergeabilityArm, null>,
+  PhosphorIcon | typeof Spinner
+> = {
   conflicting: WarningIcon,
   predicted: WarningIcon,
   checking: ClockIcon,
   unknown: ClockIcon,
+  unreachable: ClockIcon,
   resume: InfoIcon,
   behind: InfoIcon,
+  updating: Spinner,
 };
 
 /** The line each arm says. */
@@ -57,6 +65,8 @@ const ARM_MESSAGE: Record<
     base: string;
     provider: ForgeProvider | null | undefined;
     behindBy: number;
+    predictedClean: boolean;
+    forgeUnreachable: boolean;
   }) => ReactNode
 > = {
   conflicting: ({ base, provider }) => (
@@ -69,9 +79,13 @@ const ARM_MESSAGE: Record<
       {provider === "github" ? " Checks won't run until they're resolved." : ""}
     </>
   ),
-  predicted: ({ base }) => (
+  // The qualifier only rides along when the forge answer never landed; where the forge
+  // simply has none to give (Bitbucket) there is nothing that failed to say.
+  predicted: ({ base, provider, forgeUnreachable }) => (
     <>
-      {"Merging into "}
+      {forgeUnreachable
+        ? `Couldn't reach ${providerLabel(provider)} to check mergeability. Merging into `
+        : "Merging into "}
       <span className="font-mono">{base}</span>
       {/* Names the staleness: the prediction runs on remote-tracking refs
           and never fetches, so it can only be as fresh as the last fetch. */}
@@ -80,6 +94,27 @@ const ARM_MESSAGE: Record<
   ),
   checking: () => "Checking mergeability…",
   unknown: () => "Couldn't determine mergeability.",
+  // The local prediction needs no network, so a clean one is a real answer even with
+  // the forge unreachable — and the only one this arm can stand behind.
+  unreachable: ({ base, provider, predictedClean }) => (
+    <>
+      {`Couldn't reach ${providerLabel(provider)} to check mergeability.`}
+      {predictedClean ? (
+        <>
+          {" No conflicts with "}
+          <span className="font-mono">{base}</span>
+          {" in your last fetch."}
+        </>
+      ) : null}
+    </>
+  ),
+  updating: ({ base, provider }) => (
+    <>
+      {`${providerLabel(provider)} is updating this branch from `}
+      <span className="font-mono">{base}</span>
+      {"…"}
+    </>
+  ),
   resume: () =>
     "An unfinished conflict resolution exists for this pull request.",
   behind: ({ base, behindBy }) => (
@@ -105,9 +140,12 @@ export function PrMergeabilityBanner({
   hasResolveWorktree,
   busy,
   conflictFiles,
+  predictedClean,
+  forgeUnreachable,
   behindBy,
   updateBlockedReason,
   updateBusy,
+  updateSubmitting,
   onResolve,
   onResolveWithAi,
   onDiscard,
@@ -125,11 +163,20 @@ export function PrMergeabilityBanner({
   busy: boolean;
   /** Predicted conflicting paths; empty when the prediction is clean or unavailable. */
   conflictFiles: string[];
+  /** The local prediction came back CLEAN — false also covers unknown and not-run, so
+   *  it is the only form the `unreachable` arm may make a claim from. */
+  predictedClean: boolean;
+  /** The forge answer never landed, as opposed to a forge that has none to give. Adds
+   *  the couldn't-reach qualifier and a Retry to the arms driven by the prediction. */
+  forgeUnreachable: boolean;
   /** Commits the base is ahead of the head — only read on the `behind` arm. */
   behindBy: number;
   /** Why updating the branch is refused, if it is; undefined = allowed. */
   updateBlockedReason: string | undefined;
   updateBusy: boolean;
+  /** The update call itself is in flight — the slice of `updateBusy` before the forge
+   *  has even accepted the job. */
+  updateSubmitting: boolean;
   onResolve: () => void;
   onResolveWithAi: () => void;
   onDiscard: () => void;
@@ -172,6 +219,22 @@ export function PrMergeabilityBanner({
   );
   const Icon = ARM_ICON[arm];
   const updateDisabled = updateBusy || updateBlockedReason !== undefined;
+  // The busy hold now spans the forge's whole queued update, so a silent disabled
+  // control would leave the user waiting on nothing they can read. Each cause gets its
+  // own words: the queued job, the call that hasn't been accepted yet, and the
+  // PR-switch window are three different waits.
+  const updateBusyReason = (() => {
+    switch (true) {
+      case arm === "updating":
+        return `${providerLabel(provider)} is still updating this branch.`;
+      case updateSubmitting:
+        return "Submitting the update…";
+      default:
+        return "Loading this pull request…";
+    }
+  })();
+  const updateDisabledReason =
+    updateBlockedReason ?? (updateBusy ? updateBusyReason : undefined);
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b px-3 py-1.5 text-xs">
@@ -181,14 +244,35 @@ export function PrMergeabilityBanner({
           conflicting ? "text-warning" : "text-muted-foreground",
         )}
       >
-        <Icon className="size-3.5 shrink-0" />
+        {/* Decorative throughout — the sentence carries the meaning, and the `updating`
+            arm's spinner would otherwise announce a bare "Loading" beside it. */}
+        <Icon aria-hidden className="size-3.5 shrink-0" />
         <span className="min-w-0">
-          {ARM_MESSAGE[arm]({ base, provider, behindBy })}
+          {ARM_MESSAGE[arm]({
+            base,
+            provider,
+            behindBy,
+            predictedClean,
+            forgeUnreachable,
+          })}
         </span>
       </span>
 
       {(conflicting || arm === "resume") && (
         <div className="flex items-center gap-1.5">
+          {/* Only where a read FAILED — a forge with no mergeability to give (Bitbucket)
+              answers without an HTTP call, so a Retry there would be a dead button.
+              First in the row: the real answer outranks acting on a prediction. */}
+          {arm === "predicted" && forgeUnreachable && (
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={retryBusy}
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          )}
           {/* Discard rides along wherever a worktree exists, not just the resume
               arm: a paused resolve keeps the server answer "conflicting", so the
               way out has to be reachable from that arm too. */}
@@ -226,23 +310,27 @@ export function PrMergeabilityBanner({
         </div>
       )}
 
-      {arm === "behind" && (
+      {(arm === "behind" || arm === "updating") && (
         <div className="flex items-center gap-1.5">
           <DisabledReasonButton
             variant="ghost"
             size="xs"
             disabled={updateDisabled}
-            reason={updateBlockedReason}
+            reason={updateDisabledReason}
             onClick={onUpdateBranch}
           >
-            {updateBusy && <Spinner data-icon="inline-start" />}
+            {/* The `updating` arm already spins in the sentence — one progress mark
+                per strip, so the button only carries the momentary holds. */}
+            {updateBusy && arm !== "updating" && (
+              <Spinner data-icon="inline-start" />
+            )}
             Update branch
           </DisabledReasonButton>
           {/* A span-wrapped `render` would swallow the caret's disabled state — the
               vendored Button's `pointer-events-none` routes the click to the span,
               which IS the trigger — so a refused update renders no trigger at all. */}
           {updateDisabled ? (
-            <span className="inline-flex" title={updateBlockedReason}>
+            <span className="inline-flex" title={updateDisabledReason}>
               <Button
                 variant="ghost"
                 size="icon-xs"
@@ -278,7 +366,7 @@ export function PrMergeabilityBanner({
         </div>
       )}
 
-      {arm === "unknown" && (
+      {(arm === "unknown" || arm === "unreachable") && (
         <div className="flex items-center gap-1.5">
           <Button
             variant="ghost"

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -393,17 +393,26 @@ export function RemotePrView({
   );
   const lensRemote = lensRemoteName(lens);
   const serverState = mergeability.data?.state;
-  // The local prediction does double duty: it stands in where the forge ANSWERS but has
-  // no truth to give (Bitbucket), and it NAMES the conflicting files when the forge says
-  // "conflicting" but won't say where. A FAILED read is not covered — it leaves
-  // `serverState` undefined, which disables this too. Never for a fork head either: its
-  // branch may not exist under our remote. Hoisted because a DISABLED query keeps
-  // serving its last value, so every reader of the prediction has to gate on this too.
+  // A read that never landed — unreachable, not undecided. A settled answer that a later
+  // refresh failed on keeps that answer: server truth outranks the local prediction, so
+  // a bare `isError` here would paint a stale prediction over a mergeable PR.
+  const forgeUnreachable = mergeability.isError && !mergeability.data;
+  // The local prediction stands in wherever the forge has no mergeability to give —
+  // Bitbucket by design, or a read that never landed (it runs on local refs and never
+  // fetches, so it answers with the forge unreachable) — and it NAMES the conflicting
+  // files when the forge says "conflicting" but won't say where. Never for a fork head:
+  // a same-named branch under our remote would make the prediction lie. The placeholder
+  // term is the PR-switch guard — details serves the PREVIOUS PR's refs while the new
+  // mergeability read has none. Hoisted because a DISABLED query keeps serving its last
+  // value, so every reader of the prediction has to gate on this too.
   const previewEnabled =
     repoTab === "pulls" &&
     isOpenPr &&
+    !details.isPlaceholderData &&
     !details.data?.crossRepository &&
-    (serverState === "unavailable" || serverState === "conflicting");
+    (serverState === "unavailable" ||
+      serverState === "conflicting" ||
+      forgeUnreachable);
   const conflictPreview = useConflictPreview(
     repoPath,
     `${lensRemote}/${details.data?.baseRefName ?? ""}`,
@@ -430,6 +439,9 @@ export function RemotePrView({
     lens,
     divergenceEnabled,
   );
+  // The divergence query's own identity axes, so an awaited update-branch answer can
+  // tell "still this PR" from "the view moved on".
+  const divergenceIdentity = [repoPath, number, lens].join("|");
   const updateBranch = usePrUpdateBranch(repoPath);
   const mergeRemotePr = useMergeRemotePr(repoPath, lens);
   const abortRemotePrResolve = useAbortRemotePrResolve(repoPath);
@@ -507,15 +519,16 @@ export function RemotePrView({
   // query counts — `writeAccess` feeds `writeBlocked`, not availability, and it
   // stays pending forever on a repo with no provider (it's a disabled query).
   const capabilitiesSettled = !forge.isPending;
-  // The activity dock's "View" lands here via a pending hint; switch to the
-  // review sub-tab once if it's available, then clear the hint either way so
+  // A notification's click-through lands here via a pending hint; switch to the
+  // hinted sub-tab once if it's available, then clear the hint either way so
   // an unusable hint can't fire against a later PR. (Until capabilities settle
   // the hint is left armed — navigating away in that sub-second window can
   // carry it to the next PR; accepted.)
   useEffect(() => {
     if (!capabilitiesSettled) return;
-    if (pendingPrSection === "review" && isSelectedPr) {
-      if (availableSections.includes("review")) setSection("review");
+    if (pendingPrSection !== null && isSelectedPr) {
+      if (availableSections.includes(pendingPrSection))
+        setSection(pendingPrSection);
       setPendingPrSection(null);
     }
   }, [
@@ -816,7 +829,39 @@ export function RemotePrView({
     !!isOpenPr &&
     !details.data?.crossRepository &&
     (serverConflicting || predictedConflict);
+  // Only a clean prediction is a claim worth making on the unreachable arm; an unknown
+  // or still-running one has nothing to say. Gated like every other prediction reader.
+  const predictedClean =
+    previewEnabled && conflictPreview.data?.status === "clean";
   const behindBy = divergenceEnabled ? (divergence.data?.behindBy ?? 0) : 0;
+  // Same gate as `behindBy` — a disabled divergence query keeps serving its last value,
+  // and a latch left armed on one PR must never paint onto the next.
+  const updatingBranch = divergenceEnabled && divergence.updating;
+  // Only a click arms the word on an update, so a background divergence read can never
+  // toast; the identity travels with it because a PR or lens switch retires the answer
+  // rather than reporting it against whatever is on screen now.
+  const awaitedUpdate = useRef<{ identity: string; base: string } | null>(null);
+  const settleUpdate = useEffectEvent(() => {
+    const awaited = awaitedUpdate.current;
+    if (!awaited) return;
+    awaitedUpdate.current = null;
+    if (awaited.identity !== divergenceIdentity) return;
+    if (behindBy === 0) {
+      toast.success(`Branch updated from ${awaited.base}.`);
+      return;
+    }
+    // The ladder conceded with the head still behind: GitHub's job outlived it. Say
+    // where things stand rather than claiming either outcome.
+    toast.info(`GitHub is still updating this branch from ${awaited.base}.`);
+  });
+  // Runs on mount and on either dep's change, not only the transition out of updating —
+  // the ref guard is what makes a run with nothing pending a no-op. Held off while the
+  // divergence query is disabled: `updatingBranch` reads false there for reasons that
+  // have nothing to do with the job finishing.
+  useEffect(() => {
+    if (updatingBranch || !divergenceEnabled) return;
+    settleUpdate();
+  }, [updatingBranch, divergenceEnabled]);
   // Updating the branch pushes the base onto the head, so it takes push permission —
   // and on a fork the contributor's "allow edits by maintainers" too. Only an
   // explicit denial blocks; unknown must never read as one.
@@ -828,27 +873,40 @@ export function RemotePrView({
 
   // The banner's arm: server truth, then the local prediction where the forge has
   // none, then the resume offer — the resolve worktree is only worth its own line
-  // when there's nothing more urgent to say about the merge. Behind-the-base is the
-  // quietest line of all, so it fills only the arm that would otherwise stay silent.
-  const bannerArm: PrMergeabilityArm = !isOpenPr
-    ? null
-    : serverConflicting
-      ? "conflicting"
-      : predictedConflict
-        ? "predicted"
-        : findResolve.data
-          ? "resume"
-          : mergeability.data?.state !== "checking"
-            ? behindBy > 0
-              ? "behind"
-              : null
-            : mergeability.polling
-              ? "checking"
-              : "unknown";
+  // when there's nothing more urgent to say about the merge. `updating` outranks
+  // `checking` because GitHub reports mergeability UNKNOWN for the whole async update
+  // window, and that arm would otherwise hide the very thing the user just started.
+  // Behind-the-base and the unreachable line are the quietest of all, so they fill
+  // only an arm that would otherwise stay silent.
+  const bannerArm: PrMergeabilityArm = (() => {
+    switch (true) {
+      case !isOpenPr:
+        return null;
+      case serverConflicting:
+        return "conflicting";
+      case predictedConflict:
+        return "predicted";
+      case !!findResolve.data:
+        return "resume";
+      case updatingBranch:
+        return "updating";
+      case mergeability.data?.state === "checking":
+        return mergeability.polling ? "checking" : "unknown";
+      // A settled answer that a later read failed to refresh stays invisible; only a
+      // read that never landed leaves the banner with nothing but the local prediction.
+      case forgeUnreachable:
+        return "unreachable";
+      case behindBy > 0:
+        return "behind";
+      default:
+        return null;
+    }
+  })();
   const canUpdateBranch =
     bannerArm === "behind" &&
     updateBlockedReason === undefined &&
-    !updateBranch.isPending;
+    !updateBranch.isPending &&
+    !updatingBranch;
 
   /** Enter the isolated-worktree resolution: a merge that pauses there on conflicts,
    *  and just pushes when there are none. `withAi` hands the conflicts the backend
@@ -930,7 +988,12 @@ export function RemotePrView({
     // any future caller — no UI gate is the only thing between a viewer who may
     // not push (or a second click) and the mutation. It derives from the rendered
     // PR, the previous one during a switch — hence the placeholder refusal above.
-    if (updateBlockedReason !== undefined || updateBranch.isPending) return;
+    if (
+      updateBlockedReason !== undefined ||
+      updateBranch.isPending ||
+      updatingBranch
+    )
+      return;
     if (rebase) {
       const ok = await useConfirm.getState().ask({
         title: `Rebase onto ${base}?`,
@@ -942,7 +1005,13 @@ export function RemotePrView({
     updateBranch.mutate(
       { number, rebase, lens },
       {
-        onSuccess: () => toast.success(`Branch updated from ${base}.`),
+        // GitHub only ACCEPTED the job here, so the word goes to the poll: the strip
+        // holds the updating line and `settleUpdate` speaks once a read has seen the
+        // head catch up (or the ladder concede).
+        onSuccess: () => {
+          awaitedUpdate.current = { identity: divergenceIdentity, base };
+          divergence.awaitUpdate();
+        },
         onError,
       },
     );
@@ -2056,11 +2125,14 @@ export function RemotePrView({
           detailsStale
         }
         conflictFiles={predictedFiles}
+        predictedClean={predictedClean}
+        forgeUnreachable={forgeUnreachable}
         behindBy={behindBy}
         updateBlockedReason={updateBlockedReason}
-        // Busy-shaped, not a reason: `runUpdateBranch` refuses through the switch
-        // window, and a sub-second hold needs no explaining text.
-        updateBusy={updateBranch.isPending || detailsStale}
+        // Busy-shaped, not a reason — the banner supplies its own words for the wait,
+        // which now spans GitHub's whole queued update rather than one CLI call.
+        updateBusy={updateBranch.isPending || updatingBranch || detailsStale}
+        updateSubmitting={updateBranch.isPending}
         onResolve={() => runResolve(false)}
         onResolveWithAi={() => runResolve(true)}
         onDiscard={() => void discardResolve()}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -82,6 +82,7 @@ import {
   forgeFeatureReady,
   PIPELINE_IN_FLIGHT,
   prDiffOptions,
+  prUpdateBranchKeys,
   TRIAGE_ACCESS_ITEM_REASON,
   triageAccessReason,
   useAbortRemotePrResolve,
@@ -151,6 +152,7 @@ import {
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink } from "@/lib/jira/queries";
+import type { PrSection } from "@/lib/pulls/pr-section";
 import {
   useClearReviewDrafts,
   useReviewDrafts,
@@ -174,7 +176,6 @@ import {
 } from "./PrMergeabilityBanner";
 import { PrReviewPanel } from "./PrReviewPanel";
 import { PrTasksChip, PrTasksSection } from "./PrTasksSection";
-import type { PrSection } from "./pr-section";
 import {
   MergePrDialog,
   MrTimeTracking,
@@ -845,13 +846,26 @@ export function RemotePrView({
     const awaited = awaitedUpdate.current;
     if (!awaited) return;
     awaitedUpdate.current = null;
+    // Past this line the component's repoPath/number/lens ARE the awaited PR's — they
+    // are what `divergenceIdentity` is built from, and the guard above just matched it.
     if (awaited.identity !== divergenceIdentity) return;
     if (behindBy === 0) {
+      // The mutation's invalidation ran at 202-accept time, against a head that had not
+      // moved yet, so details/commits/files and the checks rollup still hold the
+      // pre-update read. Refresh them before the toast claims the update landed. The
+      // divergence key stays out: the poll just read it, and that read is what got here.
+      void Promise.all(
+        prUpdateBranchKeys(repoPath, number, lens).map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey }),
+        ),
+      );
       toast.success(`Branch updated from ${awaited.base}.`);
       return;
     }
     // The ladder conceded with the head still behind: GitHub's job outlived it. Say
-    // where things stand rather than claiming either outcome.
+    // where things stand rather than claiming either outcome, and DON'T invalidate —
+    // nothing has been observed to change, and the strip is on the mergeability read's
+    // authority here; window focus and the stale windows catch the eventual landing.
     toast.info(`GitHub is still updating this branch from ${awaited.base}.`);
   });
   // Runs on mount and on either dep's change, not only the transition out of updating —
@@ -902,11 +916,12 @@ export function RemotePrView({
         return null;
     }
   })();
+  // No `updating` term needed: the arm only reads "behind" once the ladder has fallen
+  // past that case. The submitting window is its own thing — it precedes the latch.
   const canUpdateBranch =
     bannerArm === "behind" &&
     updateBlockedReason === undefined &&
-    !updateBranch.isPending &&
-    !updatingBranch;
+    !updateBranch.isPending;
 
   /** Enter the isolated-worktree resolution: a merge that pauses there on conflicts,
    *  and just pushes when there are none. `withAi` hands the conflicts the backend

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -171,6 +171,7 @@ import { PendingReviewBar } from "./PendingReviewBar";
 import { PrActivityFeed, usePrThreadClaims } from "./PrActivityFeed";
 import { PrCommitDetail } from "./PrCommitDetail";
 import {
+  PR_SWITCH_LOADING_REASON,
   type PrMergeabilityArm,
   PrMergeabilityBanner,
 } from "./PrMergeabilityBanner";
@@ -846,9 +847,9 @@ export function RemotePrView({
     const awaited = awaitedUpdate.current;
     if (!awaited) return;
     awaitedUpdate.current = null;
+    if (awaited.identity !== divergenceIdentity) return;
     // Past this line the component's repoPath/number/lens ARE the awaited PR's — they
     // are what `divergenceIdentity` is built from, and the guard above just matched it.
-    if (awaited.identity !== divergenceIdentity) return;
     if (behindBy === 0) {
       // The mutation's invalidation ran at 202-accept time, against a head that had not
       // moved yet, so details/commits/files and the checks rollup still hold the
@@ -859,13 +860,19 @@ export function RemotePrView({
           queryClient.invalidateQueries({ queryKey }),
         ),
       );
+      // A long update spends the mergeability ladder against the UNKNOWN that GitHub
+      // reports throughout, so the refetch above would land on a gave-up arm. The head
+      // just moved: the question is new again, and the ladder has to start over with it.
+      mergeability.retry();
       toast.success(`Branch updated from ${awaited.base}.`);
       return;
     }
     // The ladder conceded with the head still behind: GitHub's job outlived it. Say
-    // where things stand rather than claiming either outcome, and DON'T invalidate —
-    // nothing has been observed to change, and the strip is on the mergeability read's
-    // authority here; window focus and the stale windows catch the eventual landing.
+    // where things stand rather than claiming either outcome, and DON'T invalidate or
+    // restart the mergeability ladder — nothing has been observed to change, the job is
+    // still running so six fresh rungs would just exhaust against UNKNOWN again, and the
+    // strip's own Retry is the honest affordance. Focus and the stale windows catch the
+    // eventual landing.
     toast.info(`GitHub is still updating this branch from ${awaited.base}.`);
   });
   // Runs on mount and on either dep's change, not only the transition out of updating —
@@ -1022,10 +1029,12 @@ export function RemotePrView({
       {
         // GitHub only ACCEPTED the job here, so the word goes to the poll: the strip
         // holds the updating line and `settleUpdate` speaks once a read has seen the
-        // head catch up (or the ladder concede).
+        // head catch up (or the ladder concede). Arming only follows a ladder that
+        // actually took the request — a refused one would leave the ref waiting for a
+        // poll that never runs, and fire its toast on some later visit to this PR.
         onSuccess: () => {
-          awaitedUpdate.current = { identity: divergenceIdentity, base };
-          divergence.awaitUpdate();
+          if (divergence.awaitUpdate())
+            awaitedUpdate.current = { identity: divergenceIdentity, base };
         },
         onError,
       },
@@ -1496,7 +1505,7 @@ export function RemotePrView({
   // What a control that holds through the switch says, in one wording. It ranks
   // BELOW any permission or read-error reason wherever both hold: those never
   // lift on their own and are the ones still true once the switch lands.
-  const staleReason = detailsStale ? "Loading this pull request…" : undefined;
+  const staleReason = detailsStale ? PR_SWITCH_LOADING_REASON : undefined;
   // The metadata pickers seed from the rendered PR and commit the WHOLE set on
   // close, so one opened mid-switch would write the previous PR's members under
   // the new number. Their triggers disable on a reason, so this rides that seam.

--- a/src/features/pulls/pr-section.ts
+++ b/src/features/pulls/pr-section.ts
@@ -1,1 +1,0 @@
-export type { PrSection } from "@/lib/pulls/pr-section";

--- a/src/features/pulls/pr-section.ts
+++ b/src/features/pulls/pr-section.ts
@@ -1,3 +1,1 @@
-/** The tabs a PR view can show. Shared by the remote and local views so the two
- *  stay in step; each keeps its own labels, since only the counts differ. */
-export type PrSection = "conversation" | "commits" | "files" | "review";
+export type { PrSection } from "@/lib/pulls/pr-section";

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2451,7 +2451,8 @@ export const forgePrReopen = (
 ) => invoke<void>("forge_pr_reopen", { repoPath, number, lens });
 
 /** Merge (or `rebase`) the base branch into a PR's head — GitHub's
- *  "Update branch". Synchronous: the call resolves once GitHub has decided. */
+ *  "Update branch". Queued, not synchronous: GitHub answers 202 Accepted and runs
+ *  the update afterwards, so resolving means accepted, not that the head has moved. */
 export const ghPrUpdateBranch = (
   repoPath: string,
   number: number,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1086,7 +1086,9 @@ const MERGEABILITY_POLL_LIMIT = 6;
  *  re-polls on the bounded ladder above, and `polling` lets the banner tell "still
  *  climbing" from "gave up". The ladder counts per MOUNT and per PR rather than off the
  *  cache entry's cumulative `dataUpdateCount`, which would leave a PR that once hit the
- *  ceiling unable to poll again all session; `retry` restarts it by hand. */
+ *  ceiling unable to poll again all session; `retry` restarts it by hand. `isError`
+ *  with no `data` is the read that never landed at all — unreachable rather than
+ *  undecided, which the banner answers with the local prediction instead. */
 export function usePrMergeability(
   repo: string,
   number: number | null,
@@ -1151,36 +1153,126 @@ export function usePrMergeability(
     isFetching: query.isFetching,
     /** Still climbing the ladder, so "checking" is an honest thing to show. */
     polling: checking && pollsUsed < MERGEABILITY_POLL_LIMIT,
+    /** The last read failed. Only meaningful paired with `data`: without one the forge
+     *  was never reached for this PR; with one, a settled answer survives the failure. */
+    isError: query.isError,
+    error: query.error,
     /** Restart the ladder and read again — the gave-up banner's Retry. */
     retry,
   };
 }
 
-/** The key `usePrBaseDivergence` reads. Update-branch relies on the repo-wide
- *  prefix invalidation, which covers this key; nothing invalidates it
- *  individually today. */
+/** The divergence key's repo+PR prefix, deliberately lens-free so one invalidation
+ *  covers both lenses. A SIBLING of the PR subtree rather than a child, so
+ *  `["repo", repo, "pr", …]` does not prefix-cover it — update-branch has to name it. */
+export const prBaseDivergencePrefix = (repo: string, number: number) =>
+  ["repo", repo, "pr-base-divergence", number] as const;
+
+/** The full key `usePrBaseDivergence` reads — the prefix plus its lens axis. */
 const prBaseDivergenceKey = (
   repo: string,
   number: number,
   lens: RemoteLens | undefined,
-) => ["repo", repo, "pr-base-divergence", number, lens ?? "origin"] as const;
+) => [...prBaseDivergencePrefix(repo, number), lens ?? "origin"] as const;
+
+/** How many reads the post-update ladder gets before it concedes. Each rung costs TWO
+ *  gh calls (the PR view, then the compare), so the budget is tighter per second than
+ *  the mergeability ladder's; ~16s covers the usual update job without leaving a
+ *  spinner up forever on one that never lands. */
+const DIVERGENCE_UPDATE_POLL_LIMIT = 8;
 
 /** How far a PR's head is ahead of / behind its base — the "Update branch"
  *  affordance's driver. `retry: false` keeps a repo without the permission (or a
- *  non-GitHub one) from a retry storm; consumers treat an error as "unknown". */
+ *  non-GitHub one) from a retry storm; consumers treat an error as "unknown".
+ *  GitHub runs update-branch as a queued job, so `awaitUpdate` arms a bounded poll
+ *  and `updating` stays true until a read OBSERVES the head caught up — the only
+ *  honest completion signal there is. */
 export function usePrBaseDivergence(
   repo: string,
   number: number | null,
   lens: RemoteLens | undefined,
   enabled: boolean,
 ) {
-  return useQuery({
+  // Same ref/state split as the mergeability ladder: `refetchInterval` runs outside
+  // render, and a render-time read of mutable state goes stale once the React Compiler
+  // memoizes it. The mirror carries the IDENTITY it was armed for rather than a bare
+  // boolean, so a PR or lens change retires it in the same render — an effect-cleared
+  // flag paints the old PR's line onto the new one for a frame first.
+  const awaiting = useRef(false);
+  const polls = useRef(0);
+  const ladderFor = useRef("");
+  const seen = useRef({ ok: 0, failed: 0 });
+  const [latch, setLatch] = useState<string | null>(null);
+  const identity = [repo, number, lens].join("|");
+  const query = useQuery({
     queryKey: prBaseDivergenceKey(repo, number ?? 0, lens),
     queryFn: () => api.ghPrBaseDivergence(repo, number ?? 0, lens ?? "origin"),
     enabled: enabled && number !== null,
     staleTime: 60_000,
     retry: false,
+    refetchInterval: (q) =>
+      awaiting.current &&
+      (q.state.data?.behindBy ?? 0) > 0 &&
+      polls.current < DIVERGENCE_UPDATE_POLL_LIMIT
+        ? 2_000
+        : false,
+    refetchIntervalInBackground: false,
   });
+
+  const behind = (query.data?.behindBy ?? 0) > 0;
+  const updatedAt = query.dataUpdatedAt;
+  const failedAt = query.errorUpdatedAt;
+  // One rung per COMPLETED read that still shows the head behind — a success or a
+  // failure alike. The query is `retry: false`, so counting failures is the only thing
+  // bounding a forge that has started refusing: the cached `behindBy` would otherwise
+  // keep the latch armed and poll forever. Timestamps guard against an unrelated
+  // re-render spending a rung; a PR or lens change is a different question entirely,
+  // so it clears the latch rather than inheriting it.
+  useEffect(() => {
+    if (ladderFor.current !== identity) {
+      ladderFor.current = identity;
+      awaiting.current = false;
+      polls.current = 0;
+      seen.current = { ok: 0, failed: 0 };
+      // The mirror already reads false against the new identity; dropping the stale
+      // string keeps a switch BACK to that PR from re-arming it.
+      setLatch(null);
+    }
+    const advanced =
+      updatedAt > seen.current.ok || failedAt > seen.current.failed;
+    seen.current = { ok: updatedAt, failed: failedAt };
+    if (advanced && awaiting.current && behind) polls.current += 1;
+    if (
+      awaiting.current &&
+      (!behind || polls.current >= DIVERGENCE_UPDATE_POLL_LIMIT)
+    ) {
+      awaiting.current = false;
+      setLatch(null);
+    }
+  }, [identity, behind, updatedAt, failedAt]);
+
+  const refetch = query.refetch;
+  const awaitUpdate = useCallback(() => {
+    // A stale closure (the view moved to another PR mid-submit) must not arm the
+    // shared refs against the new key — the mount effect keeps ladderFor current.
+    if (ladderFor.current !== identity) return;
+    awaiting.current = true;
+    polls.current = 0;
+    setLatch(identity);
+    void refetch();
+  }, [refetch, identity]);
+
+  return {
+    data: query.data,
+    isFetching: query.isFetching,
+    /** An update was asked for and the head has not been seen caught up yet. Clears on
+     *  `behindBy === 0`, on rung exhaustion, and on a PR/lens change; a query disabled
+     *  mid-poll holds the latch until it re-enables or the PR changes, so readers must
+     *  gate this on the same `enabled` they passed. */
+    updating: latch === identity,
+    /** Arm the ladder after a queued update-branch and read again now. */
+    awaitUpdate,
+  };
 }
 
 export function usePrDiff(
@@ -4398,15 +4490,29 @@ export function useMergePr(repo: string, lens: RemoteLens) {
 }
 
 /** Merge (or rebase) the base branch into a PR's head — GitHub's "Update branch".
- *  Takes the merge mutation's whole-repo invalidation: the head branch moved on the
- *  remote, so mergeability, checks, PR details and the PR list are all stale at once
- *  (the `pr-base-divergence` key sits under the same repo prefix). */
+ *  GitHub QUEUES the work and answers 202, so resolving means accepted, not done —
+ *  `usePrBaseDivergence.awaitUpdate` is what waits for the head to move. Only the
+ *  remote moved, so the invalidation is narrow: the PR subtree (details, mergeability,
+ *  diff, threads), the divergence key by name (it is a sibling, not a child), and the
+ *  rows that carry PR state. Keyed off the args like the label mutation, which
+ *  `useRepoMutation`'s static option can't do. */
 export function usePrUpdateBranch(repo: string) {
-  return useRepoMutation(
-    repo,
-    (args: { number: number; rebase: boolean; lens: RemoteLens }) =>
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { number: number; rebase: boolean; lens: RemoteLens }) =>
       api.ghPrUpdateBranch(repo, args.number, args.rebase, args.lens),
-  );
+    onSettled: (_d, _e, args) => {
+      const keys: QueryKey[] = [
+        ["repo", repo, "pr", args.lens, args.number],
+        prBaseDivergencePrefix(repo, args.number),
+        ["repo", repo, "pr-list", args.lens],
+        ["repo", repo, "prs", args.lens],
+      ];
+      return void Promise.all(
+        keys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+      );
+    },
+  });
 }
 
 /** Approve a workflow run GitHub is holding for maintainer approval (a first-time

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1254,11 +1254,12 @@ export function usePrBaseDivergence(
   const awaitUpdate = useCallback(() => {
     // A stale closure (the view moved to another PR mid-submit) must not arm the
     // shared refs against the new key — the mount effect keeps ladderFor current.
-    if (ladderFor.current !== identity) return;
+    if (ladderFor.current !== identity) return false;
     awaiting.current = true;
     polls.current = 0;
     setLatch(identity);
     void refetch();
+    return true;
   }, [refetch, identity]);
 
   return {
@@ -1269,7 +1270,9 @@ export function usePrBaseDivergence(
      *  mid-poll holds the latch until it re-enables or the PR changes, so readers must
      *  gate this on the same `enabled` they passed. */
     updating: latch === identity,
-    /** Arm the ladder after a queued update-branch and read again now. */
+    /** Arm the ladder after a queued update-branch and read again now. Returns false
+     *  without arming anything when the view has already moved to another PR or lens,
+     *  so the caller drops an answer that is no longer about what's on screen. */
     awaitUpdate,
   };
 }

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1156,7 +1156,6 @@ export function usePrMergeability(
     /** The last read failed. Only meaningful paired with `data`: without one the forge
      *  was never reached for this PR; with one, a settled answer survives the failure. */
     isError: query.isError,
-    error: query.error,
     /** Restart the ladder and read again — the gave-up banner's Retry. */
     retry,
   };
@@ -4489,12 +4488,28 @@ export function useMergePr(repo: string, lens: RemoteLens) {
   );
 }
 
+/** What an update-branch makes stale on the PR side: the PR subtree (details and its
+ *  commits/files/checks rollup, mergeability, diff, review threads) plus the rows that
+ *  carry PR state. Exported because the set has to run TWICE — once when the forge
+ *  accepts the job, and again once the poll sees the head actually move, since the
+ *  first pass reads a head that has not shifted yet. */
+export const prUpdateBranchKeys = (
+  repo: string,
+  number: number,
+  lens: RemoteLens,
+) =>
+  [
+    ["repo", repo, "pr", lens, number],
+    ["repo", repo, "pr-list", lens],
+    ["repo", repo, "prs", lens],
+  ] as const;
+
 /** Merge (or rebase) the base branch into a PR's head — GitHub's "Update branch".
  *  GitHub QUEUES the work and answers 202, so resolving means accepted, not done —
- *  `usePrBaseDivergence.awaitUpdate` is what waits for the head to move. Only the
- *  remote moved, so the invalidation is narrow: the PR subtree (details, mergeability,
- *  diff, threads), the divergence key by name (it is a sibling, not a child), and the
- *  rows that carry PR state. Keyed off the args like the label mutation, which
+ *  `usePrBaseDivergence.awaitUpdate` is what waits for the head to move, and the caller
+ *  re-runs `prUpdateBranchKeys` once it has. Only the remote moved, so this pass is
+ *  narrow: those keys plus the divergence key by name (it is a sibling of the PR
+ *  subtree, not a child). Keyed off the args like the label mutation, which
  *  `useRepoMutation`'s static option can't do. */
 export function usePrUpdateBranch(repo: string) {
   const queryClient = useQueryClient();
@@ -4503,10 +4518,8 @@ export function usePrUpdateBranch(repo: string) {
       api.ghPrUpdateBranch(repo, args.number, args.rebase, args.lens),
     onSettled: (_d, _e, args) => {
       const keys: QueryKey[] = [
-        ["repo", repo, "pr", args.lens, args.number],
+        ...prUpdateBranchKeys(repo, args.number, args.lens),
         prBaseDivergencePrefix(repo, args.number),
-        ["repo", repo, "pr-list", args.lens],
-        ["repo", repo, "prs", args.lens],
       ];
       return void Promise.all(
         keys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),

--- a/src/lib/pulls/pr-section.ts
+++ b/src/lib/pulls/pr-section.ts
@@ -1,0 +1,4 @@
+/** The tabs a PR view can show. Shared by the remote and local views so the two
+ *  stay in step; each keeps its own labels, since only the counts differ. Lives
+ *  in lib so the UI store can reference it — lib never imports from features. */
+export type PrSection = "conversation" | "commits" | "files" | "review";

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -65,7 +65,7 @@ export interface ReviewContext {
   }>;
 }
 
-/** Identifies the PR a review belongs to — also the dock's "View" target. */
+/** Identifies the PR a review belongs to — also where its notification row navigates. */
 export interface ReviewTarget {
   kind: "remote" | "local";
   repoPath: string;
@@ -101,7 +101,7 @@ export interface ReviewEntry {
   local: boolean;
   /** PR title — the activity dock's row label. */
   title: string;
-  /** Where the run came from — drives the dock's "View" navigation. */
+  /** Where the run came from — drives its notification row's click-through. */
   target: ReviewTarget;
   /** Monotonic start order — drives newest-first display and FIFO queue
    *  position exactly (a timestamp can collide within a millisecond). */

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { CommitAuthor, RepoInfo } from "@/lib/git/types";
+import type { PrSection } from "@/lib/pulls/pr-section";
 import { startViewTransition } from "@/lib/view-transition";
 
 export type AppView = "welcome" | "repo" | "settings" | "help" | "explore";
@@ -136,7 +137,7 @@ const EMPTY_COMMIT_DRAFT: CommitDraft = {
 };
 
 /** Selections cleared when a navigation switches to a *different* repo — the
- *  same set openRepo / openPrReview reset, hoisted so the run/agent navigations
+ *  same set openRepo / openPr reset, hoisted so the run/agent navigations
  *  stay in lockstep. Staying in the same repo keeps the user's other selections. */
 const CROSS_REPO_RESET: Partial<UiState> = {
   compareBranch: null,
@@ -209,10 +210,10 @@ interface UiState {
   compareBranch: string | null;
   /** Selected PR on the Pull Requests tab. */
   selectedPr: SelectedPr | null;
-  /** PR sub-tab to land on when the Pulls view next opens a PR — set by the
-   *  activity dock's "View" so a finished review opens straight to it;
-   *  consumed and cleared by the PR detail views. */
-  pendingPrSection: "review" | null;
+  /** PR sub-tab to land on when the Pulls view next opens a PR — set from a
+   *  notification row's click-through so the event's own tab opens; null asks
+   *  for no switch. Consumed and cleared by the PR detail views. */
+  pendingPrSection: PrSection | null;
   /** Selected issue on the Issues tab. */
   selectedIssue: SelectedIssue | null;
   /** Selected discussion (by number) on the Discussions tab. */
@@ -278,17 +279,19 @@ interface UiState {
 
   openRepo: (info: RepoInfo) => void;
   closeRepo: () => void;
-  /** Open a repo (if not already open) and land on a PR's AI-review sub-tab —
-   *  used by the activity dock's "View". One atomic update so the landing
-   *  target survives openRepo's own reset. */
-  openPrReview: (target: {
+  /** Open a repo (if not already open) and select a PR — used by a notification
+   *  row's click-through. `section` is the sub-tab to land on, or null to leave
+   *  whichever tab the user is on. One atomic update so the landing target
+   *  survives openRepo's own reset. */
+  openPr: (target: {
     kind: "remote" | "local";
     repoPath: string;
     repoName: string;
     ref: string;
+    section: PrSection | null;
   }) => void;
   /** Open a repo (if not already) and land on a workflow run in the Actions tab —
-   *  used by a notification's click-through. Atomic, like openPrReview. */
+   *  used by a notification's click-through. Atomic, like openPr. */
   openRun: (target: {
     repoPath: string;
     repoName: string;
@@ -321,7 +324,7 @@ interface UiState {
   setRepoTab: (tab: RepoTab) => void;
   setCompareBranch: (branch: string | null) => void;
   selectPr: (pr: SelectedPr | null) => void;
-  setPendingPrSection: (section: "review" | null) => void;
+  setPendingPrSection: (section: PrSection | null) => void;
   selectIssue: (issue: SelectedIssue | null) => void;
   selectDiscussion: (discussion: { number: number } | null) => void;
   setPendingIssueDraft: (
@@ -474,7 +477,7 @@ export const useUiStore = create<UiState>()((set, get) => {
           ...CROSS_REPO_RESET,
         }),
       ),
-    openPrReview: (target) =>
+    openPr: (target) =>
       startViewTransition(() => {
         const switchingRepo = get().repoPath !== target.repoPath;
         set({
@@ -488,7 +491,7 @@ export const useUiStore = create<UiState>()((set, get) => {
           // The explicit PR keys come AFTER the spread so it can't null them.
           ...(switchingRepo ? CROSS_REPO_RESET : {}),
           selectedPr: { kind: target.kind, id: target.ref },
-          pendingPrSection: "review",
+          pendingPrSection: target.section,
         });
       }),
     openRun: (target) =>


### PR DESCRIPTION
Three PR-surface defects shared one root: state the UI reported without observing it. `Update branch` claimed success on GitHub's 202-Accepted, a failed mergeability read left the strip blank, and every PR notification routed to the Review tab regardless of the event. This corrects each to report what was actually observed, and routes notifications to the tab their event happened on.

### Update branch — queued, not synchronous

- Reworks `usePrBaseDivergence` in `src/lib/git/queries.ts` into a bounded post-update poll: `awaitUpdate()` arms an 8-rung ladder (`DIVERGENCE_UPDATE_POLL_LIMIT`, 2s interval) and `updating` stays true until a read observes `behindBy === 0`. The ladder counts a rung per *completed* read — success or failure alike, since `retry: false` means a refusing forge would otherwise poll forever on cached `behindBy` — and carries the `[repo, number, lens]` identity so a PR or lens switch retires the latch in the same render.
- Rewrites `usePrUpdateBranch` off `useRepoMutation` onto a keyed `onSettled` invalidation naming the PR subtree, `prBaseDivergencePrefix` (a sibling key, not prefix-covered), and both PR row lists.
- Adds the `updating` arm to `PrMergeabilityBanner.tsx` — spinner in the sentence, *"<Forge> is updating this branch from `base`…"* — and a `updateDisabledReason` ladder (`switch (true)`) so the disabled controls explain which of the three waits is in play: the queued job, `updateSubmitting`, or the PR-switch window. The arm outranks `checking`, since GitHub reports mergeability UNKNOWN for the whole update window.
- In `RemotePrView.tsx`, moves the success toast off `onSuccess` into an `awaitedUpdate` ref plus a `settleUpdate` `useEffectEvent`, which confirms *"Branch updated"* only once a read has seen the head catch up, and says GitHub is still working when the ladder concedes. `canUpdateBranch` and `runUpdateBranch`'s no-UI-gate guard both now refuse while `updatingBranch`.
- Corrects the now-false "synchronous by contract" doc comments on `gh_pr_update_branch` in `src-tauri/src/github/pr.rs` and `ghPrUpdateBranch` in `src/lib/git/api.ts`.

### Unreachable mergeability

- Adds the `unreachable` arm to `PrMergeabilityBanner.tsx`, which names the forge via `providerLabel`, offers **Retry**, and reports a clean local prediction when there is one. The `predicted` arm gains a `forgeUnreachable` qualifier so a failed read reads differently from Bitbucket's by-design absence — and Retry only renders on the failed-read case, since a Retry on Bitbucket would be a dead button.
- Exposes `isError` / `error` from `usePrMergeability` in `src/lib/git/queries.ts`.
- Derives `forgeUnreachable = mergeability.isError && !mergeability.data` in `RemotePrView.tsx`, so a settled answer that a later refresh failed on keeps its answer rather than being painted over by a stale prediction. Extends `previewEnabled` to run the local prediction on that path, and adds a `!details.isPlaceholderData` guard so the PR-switch window can't feed the previous PR's refs into the new PR's prediction.
- Replaces the nested-ternary `bannerArm` chain with a `switch (true)` ladder covering the two new arms.

### Notification section routing

- Adds `KIND_SECTION` in `src/features/activity/ActivityDock.tsx`, mapping each notification kind to its PR sub-tab — `review-ready` / `review-failed` → Review, the comment/approval/merge family → Conversation — and deliberately omitting the checks kinds, whose rollup renders in the PR header above the tab strip.
- Renames `openPrReview` to `openPr` in `src/lib/stores/ui.ts`, widening `pendingPrSection` from `"review" | null` to `PrSection | null` and taking the target section as a parameter.
- Generalizes the pending-hint effects in `RemotePrView.tsx` and `LocalPrView.tsx` from the hardcoded `"review"` check to any hinted section, still clearing the hint either way so an unusable one can't fire against a later PR.
- Moves the `PrSection` type to a new `src/lib/pulls/pr-section.ts` so the UI store can reference it without lib importing from features; `src/features/pulls/pr-section.ts` becomes a re-export.

### Documentation

- Three changelog fragments: `changelog.d/fixed-update-branch-async.md`, `fixed-mergeability-offline.md`, and `fixed-pr-notification-section-routing.md`.
- Updates the conflicts and fork-maintenance bullets in `README.md` and the matching *Conflicts with the base branch*, Bitbucket, and Settings → notifications passages in `src/features/help/content.ts` to describe the unreachable fallback, the queued update hold, and the per-event tab landing.
- Refreshes the stale "dock's View" wording in `src/lib/stores/reviews.ts` comments to match the notification-row click-through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer pull-request mergeability states when forge data is unavailable, including retry actions and local conflict predictions.
  - Added progress indicators for asynchronous branch updates, with disabled controls and completion confirmation.
  - Improved pull-request notification navigation to open the relevant Conversation or Review section.
  - Expanded pull-request guidance for rebasing, fork maintenance, approvals, and conflict resolution.

- **Documentation**
  - Updated help content and release documentation with retry, mergeability, branch-update, and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->