### PR TITLE
fix(git,diff,pulls,conversations): handle reverts, explain held actions

### DIFF
--- a/.github/workflows/appimage-check.yml
+++ b/.github/workflows/appimage-check.yml
@@ -29,7 +29,7 @@ jobs:
   appimage:
     # Paired with release.yml's Linux leg by convention only — nothing enforces
     # it, so a runner bump there must be mirrored here or this proves nothing.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         include:
           - platform: windows-latest
             args: ""
-          - platform: ubuntu-22.04
+          - platform: ubuntu-24.04
             args: ""
           # macOS: a universal binary (Intel + Apple Silicon), signed with a
           # Developer ID cert and notarized via the APPLE_* secrets below.
@@ -82,7 +82,7 @@ jobs:
           workspaces: "./src-tauri -> target"
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -300,7 +300,7 @@ jobs:
       matrix:
         platform:
           - windows-latest
-          - ubuntu-22.04
+          - ubuntu-24.04
           - macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
@@ -315,7 +315,7 @@ jobs:
           workspaces: "./src-tauri -> target"
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -991,8 +991,8 @@ under `changelog.d/` (see its README); those are assembled here at release time 
 
 - Large diffs in TextMate-highlighted languages (Rust, TSX, Astro, Svelte, and
   other Shiki-rendered or custom-grammar languages) no longer lose their
-  VSCode-fidelity highlighting past the size budget, in every read-only diff
-  surface: commits and history, pull requests, branch compare, stashes, file
+  VSCode-fidelity highlighting past the size budget, in the read-only diff
+  surfaces: commits and history, pull requests, branch compare, stashes, file
   history, session changes, and conflict resolution. They now tokenize in a
   background thread and fill in when ready, with standard highlighting shown in
   the interim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -991,9 +991,11 @@ under `changelog.d/` (see its README); those are assembled here at release time 
 
 - Large diffs in TextMate-highlighted languages (Rust, TSX, Astro, Svelte, and
   other Shiki-rendered or custom-grammar languages) no longer lose their
-  VSCode-fidelity highlighting past the size budget in commit, history, and
-  pull-request diffs — they now tokenize in a background thread and fill in when
-  ready, with standard highlighting shown in the interim.
+  VSCode-fidelity highlighting past the size budget, in every read-only diff
+  surface: commits and history, pull requests, branch compare, stashes, file
+  history, session changes, and conflict resolution. They now tokenize in a
+  background thread and fill in when ready, with standard highlighting shown in
+  the interim.
 - Opening a pull request now targets a repository explicitly. On a **fork** the
   create dialog lets you choose where the PR lands — your **fork** or the
   **upstream** repository (defaulting to upstream), listing the chosen

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ PR badge.
 - **Clean up branches** ⭐: one reviewed list that archives or deletes every
   stale branch (merged into the default branch — directly or by a recent
   pull request, so squash and rebase merges count — or with no commits in a
-  chosen window). Pull-request matches are by branch name, so those rows
-  start unchecked, badged with the PR that took them.
+  chosen window). Pull-request matches go by branch name, so they only badge
+  a row with the PR that took it; pre-checking still comes from your own
+  history — merged into the default branch, or idle past that window.
 - **Advanced merge tooling** ⭐: predicts a merge's result in memory before
   you commit (fast-forward, already up to date, clean, or exactly which
   files will conflict), with `--no-ff` and a clearly cautioned auto-resolve

--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ delete), and deep links to the settings GitHub keeps browser-only.
 A unified or split diff with syntax highlighting, collapsible surrounding
 context, and image diffing. Filter the changes list by path or category. The
 working-tree diff is one whole-file view with hunk- and line-level staging
-and discarding (drag across the line numbers), including committing or
-discarding only part of a brand-new (untracked) file. Stage, unstage, or
-discard single files or a multi-selection from the context menu; discarding a
-whole untracked file goes to the recycle bin. Commit with title + body,
+and discarding (drag across the line numbers; hold Ctrl — Cmd on macOS — to
+add to a selection, so one selection can mix added and removed lines across
+hunks), including committing or discarding only part of a brand-new
+(untracked) file. Stage, unstage, or discard single files or a
+multi-selection from the context menu; discarding a whole untracked file
+goes to the recycle bin. Commit with title + body,
 co-authors suggested from history, amend, undo, reset, and revert.
 
 ### Branches
@@ -131,8 +133,10 @@ divergence vs. the default branch (labeled with the default's name), and a
 PR badge.
 
 - **Clean up branches** ⭐: one reviewed list that archives or deletes every
-  stale branch (merged into the default branch, or with no commits in a
-  chosen window).
+  stale branch (merged into the default branch — directly or by a recent
+  pull request, so squash and rebase merges count — or with no commits in a
+  chosen window). Pull-request matches are by branch name, so those rows
+  start unchecked, badged with the PR that took them.
 - **Advanced merge tooling** ⭐: predicts a merge's result in memory before
   you commit (fast-forward, already up to date, clean, or exactly which
   files will conflict), with `--no-ff` and a clearly cautioned auto-resolve
@@ -213,23 +217,25 @@ interval while the window is focused, so the behind-count and incoming
 commits stay current without pressing Fetch; it never pulls or merges, and
 pushing and pulling stay manual.
 
-- **Conflict editor**: an in-progress merge, rebase, or cherry-pick gets a
-  conflict banner with gated Continue / Abort. Selecting a conflicted file
-  opens an in-app editor: each region shows Current (ours) over Incoming
-  (theirs) with Accept current / incoming / both, plus whole-file Accept all
-  current / incoming and Open in editor.
+- **Conflict editor**: an in-progress merge, rebase, cherry-pick, or revert
+  gets a conflict banner naming it, with gated Continue / Abort. Selecting
+  a conflicted file opens an in-app editor: each region shows Current (ours)
+  over Incoming (theirs) with Accept current / incoming / both, plus
+  whole-file Accept all current / incoming and Open in editor.
 - **AI conflict resolution**: one more option there. Ask your model to merge
   a file, review the proposal as a diff, and accept it (per file or all at
   once). Multi-provider, runs on local Ollama or a keyless Claude Code /
   Codex agent, and never writes until you accept.
-- **Stash and reapply**: when a pull or branch update is blocked by
-  uncommitted changes, or you switch branches with work in progress, one
-  click stashes them (untracked files included), runs the operation, and
-  reapplies them on the other side. A reapply that hits conflicts drops the
-  files into the changes list; one that git refuses outright leaves them
-  safely stashed. The stash is kept as a backup either way. **Automatically
-  stash and reapply on pull and branch updates** (Settings → General) makes
-  it the default for both, and the switch prompt remembers a **Reapply after
+- **Stash and reapply**: when a pull, a merge into the branch you're on, or
+  a branch update is blocked by uncommitted changes, or you switch branches
+  with work in progress, one click stashes them (untracked files included),
+  runs the operation, and reapplies them on the other side. A reapply that
+  hits conflicts drops the files into the changes list; one that git refuses
+  outright leaves them safely stashed. The stash is kept as a backup either
+  way. (A squash, no-ff, or strategy merge reports the refusal instead — the
+  recovery redoes the merge plainly.) **Automatically stash and reapply on
+  pull, merge, and branch updates** (Settings → General) makes it the default
+  for all of them, and the switch prompt remembers a **Reapply after
   switching** choice of its own.
 
 ### Pull requests
@@ -301,7 +307,8 @@ PR (comments and all) in one click.
   Post a single comment, or **start a review** to batch drafts (persisted
   per-PR, surviving restarts) that render at their anchors with a
   pending-review count, then **Submit** with a verdict (Comment / Approve /
-  Request changes, capability-gated per provider), inserting a
+  Request changes — all three always shown, one that isn't wired up yet
+  disabled and saying what it's waiting on), inserting a
   **provider-correct suggestion** pre-filled with the selected code.
 - **Commit-level comments**: the Commits tab is arrow-navigable; open a
   commit for its full message, per-file diffs, and a whole-commit thread
@@ -750,7 +757,7 @@ agents read this repo through GitDesktop.
     cut releases, and file or comment on issues (creating a PR pushes its
     head branch, so it also needs `--allow-git-write`)
   - **`--allow-git-write`**: recoverable git ops (stage, commit, branch,
-    push/pull/fetch, stash, merge, rebase, cherry-pick, tags)
+    push/pull/fetch, stash, merge, rebase, revert, cherry-pick, tags)
   - **`--allow-destructive`**: the irreversible ones (discard, reset,
     force-push, delete branch/tag)
 - **Generation recipes**: hands a connected agent the fully assembled

--- a/changelog.d/changed-conversation-controls-explain-holds.md
+++ b/changelog.d/changed-conversation-controls-explain-holds.md
@@ -1,0 +1,5 @@
+- Conversation controls now explain themselves when they're unavailable. Reaction
+  chips, the add-reaction picker and a comment box's **Comment** / **Clear**
+  buttons name the hold — "Loading this issue…", "Posting your comment…" — as a
+  tooltip and to screen readers, and stay reachable by keyboard while they say it,
+  so you can always find out what a control is waiting on.

--- a/changelog.d/changed-linux-runner-baseline.md
+++ b/changelog.d/changed-linux-runner-baseline.md
@@ -1,0 +1,3 @@
+- Linux builds now target the Ubuntu 24.04 toolchain, so the packages track a
+  current system baseline. This raises the minimum glibc generation they need:
+  distributions older than the 24.04 era can no longer run them.

--- a/changelog.d/changed-verdict-radio-reasons.md
+++ b/changelog.d/changed-verdict-radio-reasons.md
@@ -1,0 +1,4 @@
+- **Submit review** always shows all three verdicts. **Approve** and **Request
+  changes** stay on screen and say what they're waiting on — a note that they
+  become available once GitDesktop connects to that repository's host — so it's
+  clear the option exists and what makes it usable.

--- a/changelog.d/fixed-cleanup-merged-detection.md
+++ b/changelog.d/fixed-cleanup-merged-detection.md
@@ -1,0 +1,5 @@
+- **Clean up branches** now sees the work that landed through a pull request, not
+  only merges your local history records — so squash- and rebase-merged branches
+  turn up in the list with a `merged #123` badge naming the pull request that took
+  them. Those rows start unchecked: the match is by branch name, so you confirm
+  each one before archiving or deleting it.

--- a/changelog.d/fixed-cleanup-merged-detection.md
+++ b/changelog.d/fixed-cleanup-merged-detection.md
@@ -1,5 +1,6 @@
-- **Clean up branches** now sees the work that landed through a pull request, not
-  only merges your local history records — so squash- and rebase-merged branches
-  turn up in the list with a `merged #123` badge naming the pull request that took
-  them. Those rows start unchecked: the match is by branch name, so you confirm
-  each one before archiving or deleting it.
+- **Clean up branches** now sees the work that landed on the default branch through
+  a pull request, not only the merges your local history records — so squash- and
+  rebase-merged branches turn up in the list with a `merged #123` badge naming the
+  pull request that took them. The match goes by branch name, so it only ever badges
+  a row: what comes pre-checked is still what your own history shows — merged into
+  the default branch, or idle past the window you picked.

--- a/changelog.d/fixed-conflict-notice-names-the-operation.md
+++ b/changelog.d/fixed-conflict-notice-names-the-operation.md
@@ -1,0 +1,4 @@
+- A conflict now names the operation it paused — "Revert paused — resolve the
+  conflicts, then continue", and likewise for a merge, cherry-pick or rebase —
+  with git's own output kept under **Details** and the conflict bar in
+  **Changes** ready to finish or abort it.

--- a/changelog.d/fixed-conflict-notice-names-the-operation.md
+++ b/changelog.d/fixed-conflict-notice-names-the-operation.md
@@ -1,4 +1,4 @@
-- A conflict now names the operation it paused — "Revert paused — resolve the
-  conflicts, then continue", and likewise for a merge, cherry-pick or rebase —
-  with git's own output kept under **Details** and the conflict bar in
-  **Changes** ready to finish or abort it.
+- Conflicted **reverts** and **merges** now name themselves the way a cherry-pick
+  or rebase already did — "Revert paused — resolve the conflicts, then
+  continue" — with git's own output kept under **Details** and the conflict bar
+  in **Changes** ready to finish or abort it.

--- a/changelog.d/fixed-conflict-resolve-repo-switch.md
+++ b/changelog.d/fixed-conflict-resolve-repo-switch.md
@@ -1,0 +1,3 @@
+- Conflict resolution now belongs to the repository it started in. Switching
+  repositories ends any resolution in progress, so a **Resolve all** walk always
+  works through the conflicts of the repository you're looking at.

--- a/changelog.d/fixed-deep-hunk-diff-paints-immediately.md
+++ b/changelog.d/fixed-deep-hunk-diff-paints-immediately.md
@@ -1,0 +1,4 @@
+- A small change deep in a very large file now shows its diff immediately.
+  Diffs whose line numbers run past the highlighter's ceiling skip the grammar
+  download and the background tokenizing pass entirely — work whose result the
+  renderer would discard — instead of leaving the pane blank while it finished.

--- a/changelog.d/fixed-deep-hunk-diff-paints-immediately.md
+++ b/changelog.d/fixed-deep-hunk-diff-paints-immediately.md
@@ -1,4 +1,3 @@
 - A small change deep in a very large file now shows its diff immediately.
-  Diffs whose line numbers run past the highlighter's ceiling skip the grammar
-  download and the background tokenizing pass entirely — work whose result the
-  renderer would discard — instead of leaving the pane blank while it finished.
+  Diffs past the highlighter's line ceiling render as plain text either way, and
+  the pane no longer sits blank waiting on highlighting it wasn't going to use.

--- a/changelog.d/fixed-diff-expansion-survives-highlighting.md
+++ b/changelog.d/fixed-diff-expansion-survives-highlighting.md
@@ -1,0 +1,5 @@
+- Context you expanded in a large diff now stays expanded when its
+  background-thread syntax highlighting arrives. Highlighting for big
+  TextMate-rendered files (Rust, TSX, Astro, Svelte, and the rest) paints into
+  the diff already on screen, so the view keeps your expanded context and your
+  place instead of snapping back to the collapsed layout.

--- a/changelog.d/fixed-discussion-stale-actions.md
+++ b/changelog.d/fixed-discussion-stale-actions.md
@@ -1,5 +1,7 @@
-- **Lock**, **Unlock**, **Close**, **Reopen**, **Delete** and the **Labels** picker
-  on a discussion now wait — and say they're waiting — until the discussion on
-  screen is the one you selected. Arrowing quickly through the list used to leave a
-  window where all six acted on the discussion you'd just left, so a label toggle
-  could land on the wrong thread.
+- Every action on a conversation now waits — and says it's waiting — until the
+  entity on screen is the one you selected. On a discussion that covers **Lock**,
+  **Unlock**, **Close**, **Reopen**, **Delete**, the **Labels** picker and the
+  per-comment **Edit**, **Delete**, **Hide**, **Unhide** and **Mark as answer**; on
+  issues and pull requests it covers comment **Hide** / **Unhide**. Arrowing
+  quickly through a list used to leave a window where any of them acted on the
+  entity you'd just left, so a label toggle or a hide could land on the wrong one.

--- a/changelog.d/fixed-discussion-stale-actions.md
+++ b/changelog.d/fixed-discussion-stale-actions.md
@@ -1,0 +1,5 @@
+- **Lock**, **Unlock**, **Close**, **Reopen**, **Delete** and the **Labels** picker
+  on a discussion now wait — and say they're waiting — until the discussion on
+  screen is the one you selected. Arrowing quickly through the list used to leave a
+  window where all six acted on the discussion you'd just left, so a label toggle
+  could land on the wrong thread.

--- a/changelog.d/fixed-draft-pair-stale-flip.md
+++ b/changelog.d/fixed-draft-pair-stale-flip.md
@@ -1,0 +1,5 @@
+- Switching between pull requests no longer flashes the wrong footer action:
+  **Ready for review** and **Convert to draft** now wait for the incoming pull
+  request's own draft state instead of borrowing the previous one's for a beat.
+  Their keyboard shortcuts wait on the same state, so neither can act on the pull
+  request you just left.

--- a/changelog.d/fixed-line-selection-both-sides.md
+++ b/changelog.d/fixed-line-selection-both-sides.md
@@ -1,0 +1,7 @@
+- A line selection in the staging diff can now cover added **and** removed lines
+  at once. Hold the platform modifier (**Ctrl**, **Cmd** on macOS) while dragging
+  the line numbers and the new run joins the selection instead of replacing it,
+  so a single **Stage**, **Unstage**, or **Discard** can carry a whole edit —
+  both halves of a rewritten line, across as many hunks as you like. A plain
+  drag still starts a fresh selection, and the hint above the diff names the key
+  for your platform.

--- a/changelog.d/fixed-local-pr-merge-base-moved.md
+++ b/changelog.d/fixed-local-pr-merge-base-moved.md
@@ -1,0 +1,5 @@
+- Completing a local pull-request merge now keeps every commit on the base
+  branch. If the branch picked up a commit while the merge was being prepared —
+  from another window, another worktree, or a long conflict-resolution session —
+  the merge stops and says so, with your resolution still waiting where you left
+  it, ready to re-run.

--- a/changelog.d/fixed-local-pr-merge-base-moved.md
+++ b/changelog.d/fixed-local-pr-merge-base-moved.md
@@ -1,5 +1,6 @@
-- Completing a local pull-request merge now keeps every commit on the base
-  branch. If the branch picked up a commit while the merge was being prepared —
-  from another window, another worktree, or a long conflict-resolution session —
-  the merge stops and says so, with your resolution still waiting where you left
-  it, ready to re-run.
+- Completing a local pull-request merge now leaves the base branch's own history
+  alone. If the branch moved at all while the merge was being prepared — a commit
+  landing from another window or worktree, or a reset winding it back during a
+  long conflict-resolution session — the merge stops and says so, with your
+  resolution still waiting where you left it, ready to re-run from where the
+  branch now stands.

--- a/changelog.d/fixed-menu-dialog-stacking.md
+++ b/changelog.d/fixed-menu-dialog-stacking.md
@@ -1,4 +1,5 @@
 - On macOS, the menu bar's **New repository**, **Add local repository**, **Clone
-  repository**, and **Settings** entries now wait while a dialog owns the screen —
-  including **Explore**'s own clone dialog — so the dialog you're filling in stays
-  in front instead of a second one landing on top of it.
+  repository**, and **Settings** entries now wait while one of the dialogs they
+  would collide with is open — the app's repo dialogs, and **Explore**'s own clone
+  dialog — so what you're filling in stays in front instead of a second dialog
+  landing on top of it.

--- a/changelog.d/fixed-menu-dialog-stacking.md
+++ b/changelog.d/fixed-menu-dialog-stacking.md
@@ -1,0 +1,4 @@
+- On macOS, the menu bar's **New repository**, **Add local repository**, **Clone
+  repository**, and **Settings** entries now wait while a dialog owns the screen —
+  including **Explore**'s own clone dialog — so the dialog you're filling in stays
+  in front instead of a second one landing on top of it.

--- a/changelog.d/fixed-merge-stash-recovery.md
+++ b/changelog.d/fixed-merge-stash-recovery.md
@@ -1,0 +1,6 @@
+- Merging a branch into the one you're on while you have uncommitted changes now
+  offers to set them aside, merge, and put them back — the same stash-and-reapply
+  recovery pulling and updating a branch already offer, and **Automatically stash
+  and reapply on pull, merge, and branch updates** (Settings → General) covers
+  merges along with the rest. Squash, no-fast-forward, and strategy merges still
+  report the refusal, since the recovery would have to redo them as a plain merge.

--- a/changelog.d/fixed-model-catalog-error-copy.md
+++ b/changelog.d/fixed-model-catalog-error-copy.md
@@ -1,0 +1,4 @@
+- When a provider's model list arrives in a shape GitDesktop can't read, the model
+  picker says so in its own words — "The provider's response didn't match the
+  expected format." A genuine provider or network failure still quotes the
+  provider's own explanation, so the two cases stay tellable apart.

--- a/changelog.d/fixed-pr-offline-placeholder.md
+++ b/changelog.d/fixed-pr-offline-placeholder.md
@@ -1,4 +1,4 @@
-- A pull request that won't load now opens with a plain explanation — which host
-  couldn't be reached, with the underlying error kept beneath it — so starting up
-  offline reads as a connection problem rather than a pull request that has gone
-  missing. **Retry** shows that it's working while the read is in flight.
+- A pull request that won't load now opens with a plain explanation: which host
+  it couldn't be loaded from, with the underlying error kept beneath it. Starting
+  up offline reads as a connection problem rather than a pull request that has
+  gone missing, and **Retry** shows that it's working while the read is in flight.

--- a/changelog.d/fixed-pr-offline-placeholder.md
+++ b/changelog.d/fixed-pr-offline-placeholder.md
@@ -1,0 +1,4 @@
+- A pull request that won't load now opens with a plain explanation — which host
+  couldn't be reached, with the underlying error kept beneath it — so starting up
+  offline reads as a connection problem rather than a pull request that has gone
+  missing. **Retry** shows that it's working while the read is in flight.

--- a/changelog.d/fixed-revert-and-sequencer-op-state.md
+++ b/changelog.d/fixed-revert-and-sequencer-op-state.md
@@ -1,0 +1,5 @@
+- A **revert** that hits a conflict now gets the same treatment as a merge or
+  rebase: the conflict bar names it and offers **Continue revert** and **Abort**,
+  and the guards that protect an operation in flight — stashing, editing history,
+  promoting a worktree — hold while it is open. The same guards now also cover the
+  window a multi-commit squash or fixup leaves behind when it stops on a conflict.

--- a/changelog.d/fixed-review-draft-clear-toast.md
+++ b/changelog.d/fixed-review-draft-clear-toast.md
@@ -1,3 +1,3 @@
-- Discarding a pending review always reports a failure, even when you move to
-  another tab while it's clearing — so pending comments can never quietly survive a
-  discard you believed had worked.
+- When discarding a pending review fails, GitDesktop now says so — even if you
+  moved to another tab while it was clearing — so pending comments can never
+  quietly survive a discard you believed had worked.

--- a/changelog.d/fixed-review-draft-clear-toast.md
+++ b/changelog.d/fixed-review-draft-clear-toast.md
@@ -1,0 +1,3 @@
+- Discarding a pending review always reports a failure, even when you move to
+  another tab while it's clearing — so pending comments can never quietly survive a
+  discard you believed had worked.

--- a/changelog.d/fixed-review-timeout-partial.md
+++ b/changelog.d/fixed-review-timeout-partial.md
@@ -1,0 +1,6 @@
+- An AI review that hits its time limit now keeps what the reviewer already wrote.
+  The findings stay on screen — including for Codex, which delivers its answer in
+  one piece at the end — and are saved with the pull request, labelled **Timed
+  out — partial output kept**, so they're still there after a restart. Kept output
+  is never treated as a finished review: it doesn't feed the next run's context and
+  doesn't count as coverage for automated reviews.

--- a/changelog.d/fixed-stack-offer-notes.md
+++ b/changelog.d/fixed-stack-offer-notes.md
@@ -1,4 +1,4 @@
 - Stack suggestions now explain themselves when they stay quiet: a full page of
-  open pull requests to scan, a stack state that hasn't loaded yet, or fork pull
+  open pull requests to scan, a stack state it couldn't read, or fork pull
   requests that can't be chained each get a one-line note where the suggestion
   would otherwise sit.

--- a/changelog.d/fixed-stack-offer-notes.md
+++ b/changelog.d/fixed-stack-offer-notes.md
@@ -1,0 +1,4 @@
+- Stack suggestions now explain themselves when they stay quiet: a full page of
+  open pull requests to scan, a stack state that hasn't loaded yet, or fork pull
+  requests that can't be chained each get a one-line note where the suggestion
+  would otherwise sit.

--- a/changelog.d/fixed-welcome-overflow.md
+++ b/changelog.d/fixed-welcome-overflow.md
@@ -1,0 +1,3 @@
+- The welcome screen scrolls within its own pane, keeping the header and the
+  activity strip in place. A long list of repositories or a short window stays
+  fully reachable, and the content is still centered whenever it fits.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -213,14 +213,17 @@ export const CHECKS = [
     // form (a hardcoded platform modifier), and a wrapped pair must not read as
     // clean either.
     scan: perLine(/\b(?:ctrlKey|metaKey)\b/),
-    // FROZEN: these 14 files are the app-wide mod+Enter submit policy (PR #202)
-    // and the file-row multi-select modifier. The gate blocks NEW hand-rolled
-    // sites; it is not a to-do list for these.
+    // FROZEN: the mod+Enter submit policy files (PR #202), the file-row
+    // multi-select modifier, and DiffViewer's additive-drag capture listener
+    // (the vendored selection manager's callbacks carry no event, so it reads
+    // the raw flags; the modifier itself stays isMac-derived). The gate blocks
+    // NEW hand-rolled sites; it is not a to-do list for these.
     allowlist: [
       "src/components/markdown-editor.tsx",
       "src/features/conversations/CommentComposer.tsx",
       "src/features/conversations/CommentEditor.tsx",
       "src/features/conversations/EditTitleBodyDialog.tsx",
+      "src/features/diff/DiffViewer.tsx",
       "src/features/discussions/DiscussionView.tsx",
       "src/features/history/HistoryPanel.tsx",
       "src/features/plan/PlanView.tsx",

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -55,6 +55,12 @@ const REFSPEC_ALLOWLIST = [
   },
   {
     file: "git/ops.rs",
+    fn: "branch_tip",
+    rationale:
+      "private helper reading a branch tip (never a refspec); both callers (merge_local_pr, finalize_base via its own callers) validate base with validate_branch_name",
+  },
+  {
+    file: "git/ops.rs",
     fn: "finalize_base",
     rationale:
       "private helper; both callers (merge_local_pr, finish_local_pr_merge) validate base with validate_branch_name",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -42,7 +42,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Diffs & staging",
-    label: "Line, hunk & file staging — drag across the line numbers",
+    label:
+      "Line, hunk & file staging — drag the line numbers, mixing added and removed lines in one selection",
   },
   {
     group: "Diffs & staging",
@@ -92,7 +93,7 @@ export const capabilities: Capability[] = [
   {
     group: "Branches & history",
     label:
-      "Clean up branches in bulk — archive or delete stale ones in one sweep",
+      "Clean up branches in bulk — archive or delete stale ones in one sweep, including branches a pull request merged",
     highlight: true,
   },
   {
@@ -132,7 +133,7 @@ export const capabilities: Capability[] = [
   {
     group: "Rewrite & recovery",
     label:
-      "Stash and reapply — one click when a pull, update or switch is blocked",
+      "Stash and reapply — one click when a pull, merge, update or switch is blocked",
   },
   {
     group: "Rewrite & recovery",

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -169,14 +169,33 @@ pub enum ReviewEvent {
         is_error: bool,
         cost_usd: Option<f64>,
     },
-    /// Terminal failure with a message to surface to the user.
-    Error { message: String },
+    /// Terminal failure with a message to surface to the user. `partial_text` carries
+    /// output a whole-message CLI accumulated but never streamed as deltas (Codex), so a
+    /// killed run keeps its work; `timed_out` marks OUR deadline kill, which the frontend
+    /// persists as the reason the kept output is partial.
+    Error {
+        message: String,
+        partial_text: Option<String>,
+        timed_out: bool,
+    },
     /// The CLI's own generated resume id, captured on turn 1 — Codex's thread id
     /// (`thread.started`) or opencode's `sessionID`. The frontend persists it so a
     /// **host** session resumes the *right* conversation (Codex `exec resume <id>`,
     /// opencode `--session <id>`) instead of "continue last", which could grab a
     /// concurrent session sharing the CLI's home. Ignored for reviews / Claude / container.
     NativeSession { id: String },
+}
+
+impl ReviewEvent {
+    /// A failure carrying nothing but its reason — every source except the deadline
+    /// kill, whose partial output is the whole point of the two fields above.
+    fn error(message: impl Into<String>) -> Self {
+        ReviewEvent::Error {
+            message: message.into(),
+            partial_text: None,
+            timed_out: false,
+        }
+    }
 }
 
 /// Sink for streaming agent events — one emitter, N consumers (the Tauri
@@ -1362,19 +1381,17 @@ fn parse_codex_line(
         }
         "turn.failed" => {
             *saw_terminal = true;
-            Some(ReviewEvent::Error {
-                message: "Codex review failed — see the Codex CLI for details.".to_string(),
-            })
+            Some(ReviewEvent::error(
+                "Codex review failed — see the Codex CLI for details.",
+            ))
         }
         "error" => {
             *saw_terminal = true;
-            Some(ReviewEvent::Error {
-                message: v
-                    .get("message")
+            Some(ReviewEvent::error(
+                v.get("message")
                     .and_then(|m| m.as_str())
-                    .unwrap_or("Codex reported an error.")
-                    .to_string(),
-            })
+                    .unwrap_or("Codex reported an error."),
+            ))
         }
         _ => None,
     }
@@ -1582,14 +1599,12 @@ fn parse_opencode_line(
         }
         "error" => {
             *saw_terminal = true;
-            Some(ReviewEvent::Error {
-                message: v
-                    .get("error")
+            Some(ReviewEvent::error(
+                v.get("error")
                     .and_then(|e| e.get("message").or(Some(e)))
                     .and_then(|m| m.as_str())
-                    .unwrap_or("opencode reported an error.")
-                    .to_string(),
-            })
+                    .unwrap_or("opencode reported an error."),
+            ))
         }
         _ => None,
     }
@@ -2062,8 +2077,19 @@ async fn stream_agent(
         return Ok(());
     }
     if timed_out {
+        // Codex accumulates whole messages and only surfaces them at `turn.completed`, so
+        // a kill at the deadline would drop everything it wrote; the streaming CLIs already
+        // sent theirs as deltas and carry none.
+        let partial_text = match kind {
+            AgentKind::Codex if !last_message.trim().is_empty() => {
+                Some(std::mem::take(&mut last_message))
+            }
+            _ => None,
+        };
         on_event.send(ReviewEvent::Error {
             message: timeout_message(noun, timeout, timeout_hint),
+            partial_text,
+            timed_out: true,
         });
         return Ok(());
     }
@@ -2071,13 +2097,11 @@ async fn stream_agent(
         // No terminal result event — surface stderr. Covers auth/quota
         // failures and the empty-stdout-without-a-TTY class of CLI bugs.
         let msg = stderr_text.trim();
-        on_event.send(ReviewEvent::Error {
-            message: if msg.is_empty() {
-                format!("The {noun} process ended without producing any output.")
-            } else {
-                msg.to_string()
-            },
-        });
+        on_event.send(ReviewEvent::error(if msg.is_empty() {
+            format!("The {noun} process ended without producing any output.")
+        } else {
+            msg.to_string()
+        }));
     }
     Ok(())
 }
@@ -3194,9 +3218,30 @@ mod tests {
         // Variant tags are camelCase too (single-word ones are casing-identical).
         let err = serde_json::to_value(ReviewEvent::Error {
             message: "boom".to_string(),
+            partial_text: Some("half a review".to_string()),
+            timed_out: true,
         })
         .expect("Error serializes");
         assert_eq!(err["kind"], "error");
+        let err_obj = err.as_object().expect("Error is a JSON object");
+        let mut err_keys: Vec<&str> = err_obj.keys().map(String::as_str).collect();
+        err_keys.sort_unstable();
+        assert_eq!(err_keys, ["kind", "message", "partialText", "timedOut"]);
+        assert_eq!(err_obj["partialText"], "half a review");
+        assert_eq!(err_obj["timedOut"], true);
+        assert!(
+            err_obj.get("partial_text").is_none(),
+            "snake_case field must not ship"
+        );
+        assert!(
+            err_obj.get("timed_out").is_none(),
+            "snake_case field must not ship"
+        );
+        // A failure with nothing kept still ships both keys — the TS mirror types them
+        // as always-present (`string | null` / `boolean`), like `Done.costUsd`.
+        let bare = serde_json::to_value(ReviewEvent::error("boom")).expect("Error serializes");
+        assert_eq!(bare["partialText"], serde_json::Value::Null);
+        assert_eq!(bare["timedOut"], false);
         let native = serde_json::to_value(ReviewEvent::NativeSession {
             id: "ses_1".to_string(),
         })
@@ -3743,14 +3788,12 @@ mod tests {
         dyn_sink.send(ReviewEvent::Delta {
             text: "hello".to_string(),
         });
-        dyn_sink.send(ReviewEvent::Error {
-            message: "boom".to_string(),
-        });
+        dyn_sink.send(ReviewEvent::error("boom"));
 
         let events = sink.events.lock().unwrap();
         assert_eq!(events.len(), 2);
         assert!(matches!(&events[0], ReviewEvent::Delta { text } if text == "hello"));
-        assert!(matches!(&events[1], ReviewEvent::Error { message } if message == "boom"));
+        assert!(matches!(&events[1], ReviewEvent::Error { message, .. } if message == "boom"));
     }
 
     #[test]

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -63,25 +63,13 @@ async fn autostash_pop(repo: &str) -> AppResult<GitOutput> {
     run_git_raw(Some(repo), &["stash", "pop"], DEFAULT_TIMEOUT).await
 }
 
-/// Failure text for an outcome payload. git splits its reporting across both
-/// streams — a conflicted merge and a conflicted `stash pop` write everything to
-/// stdout and leave stderr EMPTY (measured, git 2.51.1) — so stdout backfills.
-fn failure_text(out: &GitOutput) -> String {
-    let stderr = out.stderr.trim();
-    if stderr.is_empty() {
-        out.stdout_lossy().trim().to_string()
-    } else {
-        stderr.to_string()
-    }
-}
-
-/// Shapes a non-zero raw result with `failure_text`'s stdout backfill — a
-/// conflicted merge or pop leaves stderr EMPTY, which renders as "git exited with
-/// code N". Byte-matches `git_merge_core`; plain pull/switch have none yet.
+/// Shapes a non-zero raw result for the no-stash arm, which reports the plain
+/// command's own failures. Plain pull and switch have no stdout backfill yet, so
+/// against those two this is better output rather than identical output.
 fn git_error(out: GitOutput) -> AppError {
     AppError::Git {
         code: out.code,
-        stderr: failure_text(&out),
+        stderr: out.failure_text(),
     }
 }
 
@@ -105,7 +93,7 @@ async fn settle(
 
     let failure = match &op {
         Ok(out) if out.code == 0 => None,
-        Ok(out) => Some(failure_text(out)),
+        Ok(out) => Some(out.failure_text()),
         Err(err) => Some(err.to_string()),
     };
 
@@ -134,7 +122,7 @@ async fn settle(
     }
     let stderr = match autostash_pop(repo).await {
         Ok(out) if out.code == 0 => return Ok(AutostashOutcome::Reapplied),
-        Ok(out) => failure_text(&out),
+        Ok(out) => out.failure_text(),
         Err(err) => err.to_string(),
     };
     Ok(AutostashOutcome::ReapplyConflicted {
@@ -787,8 +775,8 @@ mod tests {
     /// The conflict summary in `src/lib/error-summary.ts` keys off the ANCHORED
     /// shapes of these lines, so a git release that reworded one would silently
     /// change how conflicts present. Markers 1-2 guard live toast classification;
-    /// markers 3-4 ride stdout, which only the paths that backfill it carry
-    /// (`git_merge_core`, `failure_text`).
+    /// markers 3-4 ride stdout, which only the paths shaping their error through
+    /// `GitOutput::failure_text` carry.
     #[tokio::test]
     async fn conflict_output_still_matches_the_anchored_frontend_markers() {
         // Mirrors of the four CONFLICT_MARKERS regexes, in plain string ops.

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -75,12 +75,9 @@ fn failure_text(out: &GitOutput) -> String {
     }
 }
 
-/// Shapes a non-zero raw result the way the plain command does — stdout backfill
-/// included (see `failure_text` and `git_merge_core`) — so the no-stash path's
-/// error reaches the frontend identical to the plain command's. Without the
-/// backfill a conflict here renders as "git exited with code 1", since that arm
-/// is reached exactly when nothing was stashed, i.e. on the clean tree where a
-/// merge/pull/switch conflicts with no stash to unwind.
+/// Shapes a non-zero raw result with `failure_text`'s stdout backfill — a
+/// conflicted merge or pop leaves stderr EMPTY, which renders as "git exited with
+/// code N". Byte-matches `git_merge_core`; plain pull/switch have none yet.
 fn git_error(out: GitOutput) -> AppError {
     AppError::Git {
         code: out.code,
@@ -1177,6 +1174,8 @@ mod tests {
     /// merge reports on STDOUT and leaves stderr empty, and this arm is reached
     /// exactly when nothing was stashed — the clean tree a dirty-tree recovery
     /// leaves behind once the user commits or the changes are already away.
+    /// Merge is the only pair either parity test can compare: the plain pull and
+    /// switch cores carry no stdout backfill to match against yet.
     #[tokio::test]
     async fn a_conflict_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, repo) = setup_with_feat("plain-parity-conflict").await;

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -75,12 +75,16 @@ fn failure_text(out: &GitOutput) -> String {
     }
 }
 
-/// Shapes a non-zero raw result exactly as `run_git` would, so the no-stash path's
-/// error reaches the frontend identical to the plain command's.
+/// Shapes a non-zero raw result the way the plain command does — stdout backfill
+/// included (see `failure_text` and `git_merge_core`) — so the no-stash path's
+/// error reaches the frontend identical to the plain command's. Without the
+/// backfill a conflict here renders as "git exited with code 1", since that arm
+/// is reached exactly when nothing was stashed, i.e. on the clean tree where a
+/// merge/pull/switch conflicts with no stash to unwind.
 fn git_error(out: GitOutput) -> AppError {
     AppError::Git {
         code: out.code,
-        stderr: out.stderr,
+        stderr: failure_text(&out),
     }
 }
 
@@ -786,8 +790,8 @@ mod tests {
     /// The conflict summary in `src/lib/error-summary.ts` keys off the ANCHORED
     /// shapes of these lines, so a git release that reworded one would silently
     /// change how conflicts present. Markers 1-2 guard live toast classification;
-    /// markers 3-4 ride stdout, which `AppError::Git` does not carry today —
-    /// guarded here against the day it does.
+    /// markers 3-4 ride stdout, which only the paths that backfill it carry
+    /// (`git_merge_core`, `failure_text`).
     #[tokio::test]
     async fn conflict_output_still_matches_the_anchored_frontend_markers() {
         // Mirrors of the four CONFLICT_MARKERS regexes, in plain string ops.
@@ -797,11 +801,12 @@ mod tests {
         fn lines(text: &str) -> std::str::Split<'_, [char; 2]> {
             text.split(['\n', '\r'])
         }
-        fn could_not_apply(text: &str) -> bool {
-            lines(text).any(|line| {
-                let rest = line.strip_prefix("error: ").unwrap_or(line);
-                rest.starts_with("could not apply ") || rest.starts_with("Could not apply ")
-            })
+        // Mirrors CONFLICT_MARKERS[0], which covers BOTH verbs — rebase and
+        // cherry-pick echo `could not apply`, revert `could not revert`, and for a
+        // revert that line is the only conflict evidence the error carries. Same
+        // shape as `is_subject_echo` on purpose (see the marker's comment).
+        fn could_not_apply_or_revert(text: &str) -> bool {
+            lines(text).any(is_subject_echo)
         }
         fn resolve_all_conflicts(text: &str) -> bool {
             lines(text).any(|line| {
@@ -857,7 +862,7 @@ mod tests {
             .unwrap();
         assert_ne!(cherry.code, 0, "expected the cherry-pick to conflict");
         assert_shape(
-            could_not_apply(&cherry.stderr),
+            could_not_apply_or_revert(&cherry.stderr),
             "error: could not apply <sha>…",
             &cherry.stderr,
         );
@@ -884,7 +889,7 @@ mod tests {
             &rebase.stderr,
         );
         assert_shape(
-            could_not_apply(&rebase.stderr),
+            could_not_apply_or_revert(&rebase.stderr),
             "Could not apply <sha>…",
             &rebase.stderr,
         );
@@ -909,6 +914,67 @@ mod tests {
             needs_merge(&cont.stdout_lossy()),
             "<path>: needs merge",
             &cont.stdout_lossy(),
+        );
+        git(&repo, &["rebase", "--abort"]).await;
+
+        // Revert: its own advice verb, plus the `could not revert` echo — which is
+        // the ONLY conflict marker a revert's error carries, since its runner
+        // keeps stderr alone. Reverting the SECOND-newest commit conflicts; the
+        // newest would apply cleanly.
+        write(dir.path(), "a.txt", "one\n");
+        commit_all(&repo, "one").await;
+        write(dir.path(), "a.txt", "two\n");
+        commit_all(&repo, "two").await;
+        let revert = run_git_raw(
+            Some(&repo),
+            &["revert", "--no-edit", "HEAD~1"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(revert.code, 0, "expected the revert to conflict");
+        assert_shape(
+            could_not_apply_or_revert(&revert.stderr),
+            "error: could not revert <sha>…",
+            &revert.stderr,
+        );
+        assert!(
+            advises_continue(&revert.stderr, "revert"),
+            "git no longer advises `git revert --continue` outside the subject-echo line — \
+             the frontend would name every paused revert \"Operation\". Actual stderr:\n{}",
+            revert.stderr
+        );
+        git(&repo, &["revert", "--abort"]).await;
+
+        // Merge is the one conflict family with NO `--continue` advice: it reports
+        // on stdout and leaves stderr EMPTY, which is why `git_merge_core` carries
+        // stdout into the error. Asserting the advice here would fail against
+        // correct git — this pins the reality instead.
+        let merge = run_git_raw(
+            Some(&repo),
+            &["merge", "--no-edit", "feat"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(merge.code, 0, "expected the merge to conflict");
+        assert_shape(
+            conflict_paren(&merge.stdout_lossy()),
+            "CONFLICT (…",
+            &merge.stdout_lossy(),
+        );
+        // Line-anchored, mirroring MERGE_VERDICT (error-summary.ts) — that is the
+        // only line naming the op for a merge, since there is no advice to read.
+        assert_shape(
+            lines(&merge.stdout_lossy()).any(|l| l.starts_with("Automatic merge failed")),
+            "Automatic merge failed…",
+            &merge.stdout_lossy(),
+        );
+        assert!(
+            merge.stderr.trim().is_empty(),
+            "a conflicted merge still leaves stderr empty — the reason git_merge_core \
+             backfills stdout. Actual stderr:\n{}",
+            merge.stderr
         );
     }
 
@@ -1102,6 +1168,65 @@ mod tests {
             ) => {
                 assert_eq!(a, b);
                 assert_eq!(a_err, b_err);
+            }
+            other => panic!("expected two git errors, got {other:?}"),
+        }
+    }
+
+    /// The same parity in the shape that actually loses information: a conflicted
+    /// merge reports on STDOUT and leaves stderr empty, and this arm is reached
+    /// exactly when nothing was stashed — the clean tree a dirty-tree recovery
+    /// leaves behind once the user commits or the changes are already away.
+    #[tokio::test]
+    async fn a_conflict_with_nothing_stashed_carries_the_stdout_report() {
+        let (dir, repo) = setup_with_feat("plain-parity-conflict").await;
+        // Diverge `main` so the merge conflicts instead of fast-forwarding, and
+        // leave the tree CLEAN so `settle` takes its no-stash arm.
+        write(dir.path(), "a.txt", "mine\n");
+        commit_all(&repo, "local change").await;
+        let state = AppState::default();
+
+        let compound = git_merge_autostash_core(&state, repo.clone(), "feat".into())
+            .await
+            .unwrap_err();
+        assert!(stash_list(&repo).await.is_empty(), "nothing was stashed");
+        git(&repo, &["merge", "--abort"]).await;
+        let plain = crate::git::ops::git_merge_core(
+            &state,
+            repo.clone(),
+            "feat".into(),
+            false,
+            false,
+            "none".into(),
+        )
+        .await
+        .unwrap_err();
+        git(&repo, &["merge", "--abort"]).await;
+
+        match (&compound, &plain) {
+            (
+                AppError::Git {
+                    code: a,
+                    stderr: a_err,
+                },
+                AppError::Git {
+                    code: b,
+                    stderr: b_err,
+                },
+            ) => {
+                assert_eq!(a, b);
+                assert_eq!(a_err, b_err);
+                // Mirrors the frontend's anchored CONFLICT_MARKERS: without the
+                // stdout backfill both sides carry an empty stderr instead, which
+                // renders as "git exited with code 1".
+                assert!(
+                    a_err.lines().any(|l| l.starts_with("CONFLICT (")),
+                    "the conflict line must reach the frontend: {a_err}"
+                );
+                assert!(
+                    a_err.contains("Automatic merge failed"),
+                    "and the verdict line that names it a merge: {a_err}"
+                );
             }
             other => panic!("expected two git errors, got {other:?}"),
         }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2068,6 +2068,23 @@ fn orphaned_resolve_worktrees(all_paths: &[String], keep: &[String]) -> Vec<Stri
         .collect()
 }
 
+/// A branch's tip, read through its fully-qualified ref. Never a bare name:
+/// gitrevisions resolves `refs/tags/<name>` BEFORE `refs/heads/<name>`, so a tag
+/// sharing the branch name would silently anchor a merge to the tag's commit
+/// (git only warns, and exits 0). Callers validate `base` with
+/// `validate_branch_name`, so the interpolation carries no refspec syntax.
+async fn branch_tip(repo_path: &str, base: &str) -> AppResult<String> {
+    Ok(run_git(
+        Some(repo_path),
+        &["rev-parse", "--verify", &format!("refs/heads/{base}")],
+        DEFAULT_TIMEOUT,
+    )
+    .await?
+    .stdout_lossy()
+    .trim()
+    .to_string())
+}
+
 /// Advances `base` to `new_sha` after the merge landed in the resolve worktree,
 /// picking the safe mechanic for wherever `base` is checked out:
 /// - the MAIN repo's current branch → `merge --ff-only` there (the tree was gated
@@ -2101,15 +2118,7 @@ async fn finalize_base(
     };
     // One read, before any arm: whatever `base` points at now has to match the
     // tip the merge was built on.
-    let tip_now = run_git(
-        Some(repo_path),
-        &["rev-parse", "--verify", &format!("refs/heads/{base}")],
-        DEFAULT_TIMEOUT,
-    )
-    .await?
-    .stdout_lossy()
-    .trim()
-    .to_string();
+    let tip_now = branch_tip(repo_path, base).await?;
     if let Some(expected) = expected_tip {
         if tip_now != expected {
             return Err(AppError::Command(moved()));
@@ -2267,11 +2276,9 @@ pub(crate) async fn merge_local_pr(
     .stdout_lossy()
     .trim()
     .to_string();
-    let base_tip = run_git(Some(repo_path), &["rev-parse", base], DEFAULT_TIMEOUT)
-        .await?
-        .stdout_lossy()
-        .trim()
-        .to_string();
+    // Fully-qualified: this one read anchors the journal, the resolve worktree's
+    // start point, and the rebase strategy's replay range.
+    let base_tip = branch_tip(repo_path, base).await?;
 
     // Only advancing the CURRENT branch touches the main tree — gate that one
     // case on a clean tree (finalize_base's `merge --ff-only` would otherwise
@@ -6394,6 +6401,115 @@ detached
             other.stderr.contains("cannot lock ref") && !other.stderr.contains("but expected"),
             "a non-mismatch failure must not read as a moved base: {}",
             other.stderr
+        );
+    }
+
+    /// A tag sharing the base branch's name must not steer the merge: gitrevisions
+    /// resolves `refs/tags/<name>` BEFORE `refs/heads/<name>`, and git only warns
+    /// (exit 0), so a bare-name read would anchor the journal, the resolve
+    /// worktree and the replay range to the tag's commit.
+    #[tokio::test]
+    async fn local_pr_merge_ignores_a_tag_sharing_the_base_branch_name() {
+        let (dir, repo) = setup_repo("lpr-tag-shadow").await;
+        let base = head_branch(&repo).await;
+        let stale = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+        let base_before = rev(&repo, "HEAD").await;
+        git(&repo, &["switch", "-c", "feature", &stale]).await;
+        commit_file(&repo, dir.path(), "f.txt", "feature\n", "feat commit").await;
+        // Off base for the update-ref arm. By SHA, and every bare-name read above
+        // happens first: once the tag lands, the test's own scaffolding could not
+        // resolve the name either (git refuses an ambiguous object name outright).
+        git(&repo, &["switch", "-c", "work", &base_before]).await;
+        // A tag on an OLDER commit, named exactly like the base branch.
+        git(&repo, &["tag", &base, &stale]).await;
+        assert_ne!(stale, base_before, "the tag points somewhere else");
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_local_pr(&state, &repo, &base, "feature", "merge it", "merge", &root)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, "merged");
+        assert_eq!(
+            outcome.base_tip, base_before,
+            "the merge is anchored to the BRANCH tip, not the tag's commit"
+        );
+        // Read through the qualified ref — a bare name is ambiguous here now.
+        let base_after = branch_tip(&repo, &base).await.unwrap();
+        assert_ne!(base_after, base_before, "base advanced from its own tip");
+        git(
+            &repo,
+            &["merge-base", "--is-ancestor", &base_before, &base_after],
+        )
+        .await;
+        git(&repo, &["cat-file", "-e", &format!("{base_after}:f.txt")]).await;
+    }
+
+    /// The green direction, and the only test that would catch an anchor that is
+    /// present but WRONG: the refusal tests stay green against any anchor that
+    /// merely differs from base's tip — including the pre-op HEAD its sibling
+    /// journal calls record — so one successful finish through a real `op_id` is
+    /// what pins `pre_op_tip` to base's tip and the `"preOpTip"` store key to the
+    /// reader.
+    #[tokio::test]
+    async fn local_pr_finish_through_the_journaled_anchor_still_merges() {
+        let (dir, repo) = setup_repo("lpr-anchor-green").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+        // Off base, so finalize takes the update-ref arm. Its own branch tip is
+        // deliberately NOT base's, so a HEAD-shaped anchor would refuse here.
+        git(&repo, &["switch", "-c", "work"]).await;
+        commit_file(&repo, dir.path(), "w.txt", "w\n", "work edit").await;
+        let base_before = rev(&repo, &base).await;
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_local_pr(&state, &repo, &base, "feature", "merge it", "merge", &root)
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, "conflicts");
+        let wt = outcome.worktree_path.clone().expect("worktree path set");
+        assert!(
+            outcome.op_id.is_some(),
+            "the anchor under test comes from the oplog entry"
+        );
+
+        git(&wt, &["checkout", "--theirs", "a.txt"]).await;
+        git(&wt, &["add", "a.txt"]).await;
+        let resolved = rev(&wt, "HEAD").await;
+
+        // Nothing touches `base` in between — the anchor must accept it.
+        let done = finish_local_pr_merge(
+            &state,
+            &repo,
+            &base,
+            "merge",
+            "merge it",
+            &wt,
+            &outcome.worktree_id.clone().unwrap_or_default(),
+            outcome.op_id.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(done.status, "merged");
+        let base_after = rev(&repo, &base).await;
+        assert_ne!(base_after, base_before, "base advanced");
+        assert_eq!(
+            base_after, done.base_tip,
+            "base is at the commit the resolve worktree produced"
+        );
+        assert_ne!(resolved, base_after, "the merge commit is the resolution");
+        assert!(
+            !std::path::Path::new(&wt).exists(),
+            "the resolve worktree is torn down on success"
         );
     }
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -80,6 +80,30 @@ async fn rebase_stopped_for_edit(repo: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Which verb a pending `.git/sequencer` is replaying: `Some(true)` for revert,
+/// `Some(false)` for cherry-pick, `None` when no sequencer state exists.
+///
+/// A multi-commit `cherry-pick -n` that conflicts leaves the sequencer with NO
+/// `CHERRY_PICK_HEAD` (measured, git 2.51.1: `--no-commit` never writes one), so
+/// the todo's verb is the only signal for that window — the app's own
+/// squash/fixup engine creates it. An unreadable or empty todo reads as
+/// cherry-pick, matching the best-effort probes around it. Interactive rebase
+/// uses `rebase-merge/git-rebase-todo` instead, so it can never land here.
+async fn sequencer_reverting(repo: &str) -> Option<bool> {
+    if !git_path_exists(repo, "sequencer").await {
+        return None;
+    }
+    let todo = git_dir_path(repo, "sequencer/todo")
+        .await
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    let verb = todo
+        .lines()
+        .find(|line| !line.trim().is_empty() && !line.starts_with('#'))
+        .and_then(|line| line.split_whitespace().next());
+    Some(verb == Some("revert"))
+}
+
 /// Which multi-step git operation, if any, is mid-flight — drives the
 /// conflict-resolution banner.
 #[tauri::command]
@@ -94,10 +118,21 @@ pub(crate) async fn op_state(repo_path: &str) -> AppResult<RepoOpState> {
     let rebasing = git_path_exists(repo_path, "rebase-merge").await
         || git_path_exists(repo_path, "rebase-apply").await;
     let edit_paused = rebasing && rebase_stopped_for_edit(repo_path).await;
+    let cherry_head = git_path_exists(repo_path, "CHERRY_PICK_HEAD").await;
+    let revert_head = git_path_exists(repo_path, "REVERT_HEAD").await;
+    // The sequencer only decides the verb when neither head marker names it —
+    // folding a revert into `cherry_picking` would mislabel the banner and hand
+    // Continue/Abort the wrong git command.
+    let sequencer = if cherry_head || revert_head {
+        None
+    } else {
+        sequencer_reverting(repo_path).await
+    };
     Ok(RepoOpState {
         merging: git_path_exists(repo_path, "MERGE_HEAD").await,
         rebasing,
-        cherry_picking: git_path_exists(repo_path, "CHERRY_PICK_HEAD").await,
+        cherry_picking: cherry_head || sequencer == Some(false),
+        reverting: revert_head || sequencer == Some(true),
         edit_paused,
     })
 }
@@ -115,14 +150,15 @@ pub(crate) async fn has_unmerged(repo: &str) -> AppResult<bool> {
 /// should [`op_state`] ever gain a fallible read.
 pub(crate) async fn op_in_progress(repo: &str) -> bool {
     match op_state(repo).await {
-        Ok(state) => state.merging || state.rebasing || state.cherry_picking,
+        Ok(state) => state.merging || state.rebasing || state.cherry_picking || state.reverting,
         Err(_) => true,
     }
 }
 
 /// Refuses to stash mid-operation: `git stash push` can't write an unmerged
-/// index, and stashing a merge/rebase/cherry-pick that is only staged-resolved
-/// sweeps the resolution out of the operation git is still holding state for.
+/// index, and stashing a merge/rebase/cherry-pick/revert that is only
+/// staged-resolved sweeps the resolution out of the operation git still holds
+/// state for.
 /// The mid-op detection is best-effort (see [`op_in_progress`]), and a rebase
 /// paused at an `edit` step is refused as well, matching autostash. Only
 /// lock-free runners, so callers may hold the repo lock across it.
@@ -134,7 +170,7 @@ pub(crate) async fn refuse_mid_op(repo: &str) -> AppResult<()> {
     }
     if op_in_progress(repo).await {
         return Err(AppError::InvalidArgument(
-            "Can't stash while a merge, rebase or cherry-pick is in progress — finish or abort it first."
+            "Can't stash while a merge, rebase, cherry-pick or revert is in progress — finish or abort it first."
                 .into(),
         ));
     }
@@ -143,12 +179,12 @@ pub(crate) async fn refuse_mid_op(repo: &str) -> AppResult<()> {
 
 fn validate_op(op: &str) -> AppResult<()> {
     match op {
-        "merge" | "rebase" | "cherry-pick" => Ok(()),
+        "merge" | "rebase" | "cherry-pick" | "revert" => Ok(()),
         _ => Err(AppError::InvalidArgument(format!("unknown operation: {op}"))),
     }
 }
 
-/// Abandons an in-progress merge/rebase/cherry-pick, restoring the
+/// Abandons an in-progress merge/rebase/cherry-pick/revert, restoring the
 /// pre-operation state.
 #[tauri::command]
 pub async fn git_op_abort(
@@ -168,7 +204,7 @@ pub async fn git_op_abort(
 }
 
 /// Finishes an in-progress operation once every conflict is resolved and
-/// staged. A merge concludes with its commit; rebase/cherry-pick continue
+/// staged. A merge concludes with its commit; rebase/cherry-pick/revert continue
 /// with `core.editor=true` so git never tries to open an editor.
 #[tauri::command]
 pub async fn git_op_continue(
@@ -1701,7 +1737,33 @@ pub(crate) async fn git_merge_core(
         }
     }
     args.push(&branch);
-    run_git_mutating(state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
+    // Raw under the lock rather than `run_git_mutating`, because a conflicted
+    // merge reports entirely on STDOUT and leaves stderr EMPTY (measured, git
+    // 2.51.1) — a stderr-only error degrades to "git exited with code 1", where
+    // the stdout text carries the `CONFLICT (…` line the frontend classifies on.
+    let lock = state.repo_lock(&repo_path).await;
+    let _guard = lock.lock().await;
+    let mut out = run_git_raw(Some(&repo_path), &args, DEFAULT_TIMEOUT).await?;
+    // Mirrors `run_git_mutating`'s one-shot retry for index.lock contention from
+    // other tools, which this path would otherwise lose.
+    if out.code != 0 && out.stderr.contains("index.lock") {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        out = run_git_raw(Some(&repo_path), &args, DEFAULT_TIMEOUT).await?;
+    }
+    if out.code != 0 {
+        // Same rule as autostash's `failure_text`, trimming included: its
+        // no-stash arm reports THIS command's failures and a parity test compares
+        // the two byte for byte.
+        let stderr = if out.stderr.trim().is_empty() {
+            out.stdout_lossy().trim().to_string()
+        } else {
+            out.stderr.trim().to_string()
+        };
+        return Err(AppError::Git {
+            code: out.code,
+            stderr,
+        });
+    }
     Ok(())
 }
 
@@ -2031,7 +2093,8 @@ fn orphaned_resolve_worktrees(all_paths: &[String], keep: &[String]) -> Vec<Stri
 /// - checked out in ANOTHER worktree → run the ff-only INSIDE that worktree so its
 ///   index and working tree advance too. A bare `update-ref` would desync it
 ///   (phantom reverts). A dirty one fails cleanly and `base` stays unchanged.
-/// - checked out nowhere → `update-ref`, no working tree touched.
+/// - checked out nowhere → a compare-and-swap `update-ref`, no working tree
+///   touched; a `base` that moved under us is refused, never overwritten.
 async fn finalize_base(
     state: &AppState,
     repo_path: &str,
@@ -2091,13 +2154,53 @@ async fn finalize_base(
     }
 
     // Not checked out anywhere — move the ref directly, no working tree touched.
-    run_git_mutating(
-        state,
-        repo_path,
-        &["update-ref", &format!("refs/heads/{base}"), new_sha],
+    // Compare-and-swap, because `new_sha` was built from a tip read seconds (a
+    // clean merge) or a whole resolution session (a conflicted one) ago: a bare
+    // update-ref would silently drop any commit a concurrent writer landed on
+    // `base` meanwhile. The ancestor check is the readable refusal; git's own
+    // `<oldvalue>` argument closes the window between it and the write.
+    let ref_name = format!("refs/heads/{base}");
+    let old_sha = run_git(
+        Some(repo_path),
+        &["rev-parse", "--verify", &ref_name],
+        DEFAULT_TIMEOUT,
+    )
+    .await?
+    .stdout_lossy()
+    .trim()
+    .to_string();
+    let moved = || {
+        format!(
+            "{base} moved while this merge was being prepared, so advancing it would drop the \
+             commit(s) that landed there. {base} is unchanged — re-run the merge to include them."
+        )
+    };
+    let contains_old = run_git_raw(
+        Some(repo_path),
+        &["merge-base", "--is-ancestor", &old_sha, new_sha],
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if contains_old.code != 0 {
+        return Err(AppError::Command(moved()));
+    }
+    run_git_mutating(
+        state,
+        repo_path,
+        &["update-ref", &ref_name, new_sha, &old_sha],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .map_err(|e| match e {
+        // Only a CAS mismatch means `base` moved — git says `is at <sha> but
+        // expected <sha>` (measured, 2.51.1). "cannot lock ref" alone does NOT
+        // discriminate: a stale .lock file and a permissions failure say it too,
+        // and must keep git's own message rather than a wrong explanation.
+        AppError::Git { stderr, .. } if stderr.contains("but expected") => {
+            AppError::Command(format!("{}\n{stderr}", moved()))
+        }
+        other => other,
+    })?;
     Ok(())
 }
 
@@ -3460,10 +3563,10 @@ pub(crate) async fn rewrite_commits_with_timeouts(
         if let Some(err) = failure {
             // Roll back: abort any in-progress pick, then return the branch to its
             // pre-run tip. The abort stays best-effort and outside the verdict —
-            // `reset --hard` clears the unmerged index and CHERRY_PICK_HEAD, so a
-            // failed abort with a good reset blocks no later git work (a multi-hash
-            // step's `.git/sequencer` survives the reset but refuses nothing; only
-            // `--abort` clears it, which is why the recovery text names it). The
+            // `reset --hard` clears the unmerged index and CHERRY_PICK_HEAD, but a
+            // multi-hash step's `.git/sequencer` survives it and only `--abort`
+            // clears it, which is why the recovery text names that command: while
+            // it is there the repo still reads as mid-op (see `op_state`). The
             // reset itself is captured: the error must not promise a rollback that
             // didn't happen.
             let _ = run_git(
@@ -3564,13 +3667,11 @@ pub async fn git_rebase_edit(
     // pending message files (its `exec ... -F msg` lines would then fail on
     // --continue, losing the message), and the post-run check would mask it as
     // success.
-    if git_path_exists(&repo_path, "rebase-merge").await
-        || git_path_exists(&repo_path, "rebase-apply").await
-        || git_path_exists(&repo_path, "MERGE_HEAD").await
-        || git_path_exists(&repo_path, "CHERRY_PICK_HEAD").await
-    {
+    // Shares [`op_state`]'s detection rather than re-listing markers: the
+    // hand-rolled copy this replaces missed the sequencer-only and revert windows.
+    if op_in_progress(&repo_path).await {
         return Err(AppError::InvalidArgument(
-            "a rebase, merge, or cherry-pick is already in progress — finish or abort it from the banner first".into(),
+            "a rebase, merge, cherry-pick or revert is already in progress — finish or abort it from the banner first".into(),
         ));
     }
     // git rebase refuses a dirty tree too, but a clear message here is nicer.
@@ -4685,6 +4786,111 @@ mod tests {
 
     }
 
+    /// The state the app's own squash/fixup engine creates: a multi-hash
+    /// `cherry-pick -n` that conflicts leaves `.git/sequencer` and NO
+    /// `CHERRY_PICK_HEAD` (measured, git 2.51.1), which every marker-file gate
+    /// used to read as "nothing in flight".
+    #[tokio::test]
+    async fn op_state_sees_a_sequencer_only_cherry_pick() {
+        let (dir, repo) = setup_repo("seq-pick").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "f1\n", "feat one").await;
+        commit_file(&repo, dir.path(), "a.txt", "f2\n", "feat two").await;
+        let f1 = rev(&repo, "feature~1").await;
+        let f2 = rev(&repo, "feature").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        let tip = rev(&repo, "HEAD").await;
+
+        let attempt = run_git_raw(
+            Some(&repo),
+            &["cherry-pick", "-n", &f1, &f2],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(attempt.code, 0, "the multi-hash pick should conflict");
+        assert!(
+            !git_path_exists(&repo, "CHERRY_PICK_HEAD").await,
+            "`-n` writes no CHERRY_PICK_HEAD — the whole point of the sequencer probe"
+        );
+
+        let state = op_state(&repo).await.unwrap();
+        assert!(state.cherry_picking, "the sequencer names the pick");
+        assert!(!state.reverting);
+        assert!(op_in_progress(&repo).await);
+
+        // Reachable through the guard that clears another op's pending files. The
+        // message is load-bearing: the dirty-tree guard below it also refuses this
+        // tree, so only the wording proves WHICH guard caught it.
+        let refused = git_rebase_edit(repo.clone(), tip, vec![pick(&f1)]).await;
+        let Err(AppError::InvalidArgument(msg)) = &refused else {
+            panic!("edit-rebase must refuse over sequencer state, got {refused:?}");
+        };
+        assert!(
+            msg.contains("already in progress"),
+            "the mid-op guard must be the one that refuses: {msg}"
+        );
+    }
+
+    /// A conflicted `git revert` is its own operation: labeled as a revert, never
+    /// folded into cherry-pick (which would hand Continue the wrong git command).
+    #[tokio::test]
+    async fn op_state_sees_a_revert_and_continues_it() {
+        let (dir, repo) = setup_repo("revert-op").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "one").await;
+        let target = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v2\n", "two").await;
+
+        let revert = run_git_raw(
+            Some(&repo),
+            &["revert", "--no-edit", &target],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(revert.code, 0, "the revert should conflict");
+
+        let state = op_state(&repo).await.unwrap();
+        assert!(state.reverting);
+        assert!(!state.cherry_picking, "a revert is not a cherry-pick");
+        assert!(op_in_progress(&repo).await);
+
+        // The `revert` arms of validate_op / op_continue are now reachable.
+        std::fs::write(dir.path().join("a.txt"), "resolved\n").unwrap();
+        git(&repo, &["add", "a.txt"]).await;
+        let app = AppState::default();
+        op_continue(&app, &repo, "revert").await.unwrap();
+        assert!(!op_state(&repo).await.unwrap().reverting);
+        assert_eq!(subjects(&repo).await.len(), 4, "the revert commit landed");
+    }
+
+    /// The sequencer's verb decides which op it is; anything unreadable stays a
+    /// cherry-pick, matching the best-effort contract of the probes around it.
+    #[tokio::test]
+    async fn sequencer_verb_discriminates_revert_from_cherry_pick() {
+        let (_dir, repo) = setup_repo("seq-verb").await;
+        let seq = std::path::Path::new(&repo).join(".git/sequencer");
+        std::fs::create_dir_all(&seq).unwrap();
+
+        std::fs::write(seq.join("todo"), "revert abc1234 undo it\n").unwrap();
+        let state = op_state(&repo).await.unwrap();
+        assert!(state.reverting && !state.cherry_picking);
+
+        std::fs::write(seq.join("todo"), "pick abc1234 add it\n").unwrap();
+        let state = op_state(&repo).await.unwrap();
+        assert!(state.cherry_picking && !state.reverting);
+
+        std::fs::write(seq.join("todo"), "").unwrap();
+        let state = op_state(&repo).await.unwrap();
+        assert!(state.cherry_picking && !state.reverting);
+
+        std::fs::remove_dir_all(&seq).unwrap();
+        let state = op_state(&repo).await.unwrap();
+        assert!(!state.cherry_picking && !state.reverting);
+    }
+
     #[tokio::test]
     async fn rebase_onto_moves_only_its_own_commits() {
         // The "branched off the wrong branch" scenario: `fix` was branched off
@@ -4723,6 +4929,45 @@ mod tests {
             "fix's commits sit directly on the new base's tip"
         );
 
+    }
+
+    /// A conflicted merge writes everything to stdout and leaves stderr empty
+    /// (measured, git 2.51.1), so the error has to carry stdout — `AppError::Git`
+    /// renders an empty stderr as "git exited with code N", which the frontend's
+    /// conflict markers cannot classify.
+    #[tokio::test]
+    async fn merge_conflict_error_carries_the_classifiable_output() {
+        let (dir, repo) = setup_repo("merge-conflict-payload").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+
+        let state = AppState::default();
+        let err = git_merge_core(
+            &state,
+            repo.clone(),
+            "feature".into(),
+            false,
+            false,
+            "none".into(),
+        )
+        .await
+        .unwrap_err();
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a git error, got {err:?}");
+        };
+        // Mirrors the frontend's anchored CONFLICT_MARKERS (error-summary.ts).
+        assert!(
+            stderr.lines().any(|l| l.starts_with("CONFLICT (")),
+            "the conflict line must reach the frontend: {stderr}"
+        );
+        assert!(
+            stderr.contains("Automatic merge failed"),
+            "git's merge verdict must survive: {stderr}"
+        );
+        assert!(op_state(&repo).await.unwrap().merging);
     }
 
     #[tokio::test]
@@ -6097,6 +6342,123 @@ detached
         );
     }
 
+    /// The wording `finalize_base`'s CAS refusal discriminates on. Both failures
+    /// say "cannot lock ref", so only `is at <sha> but expected <sha>` marks the
+    /// compare-and-swap mismatch — a git release that reworded it would turn every
+    /// other update-ref failure into a wrong "base moved" explanation.
+    #[tokio::test]
+    async fn update_ref_names_a_cas_mismatch_distinctly() {
+        let (dir, repo) = setup_repo("cas-wording").await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "second").await;
+        let tip = rev(&repo, "HEAD").await;
+        git(&repo, &["branch", "target", "HEAD~1"]).await;
+
+        // `target` is at HEAD~1, so claiming it is at `tip` is a CAS mismatch.
+        let mismatch = run_git_raw(
+            Some(&repo),
+            &["update-ref", "refs/heads/target", &tip, &tip],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(mismatch.code, 0);
+        assert!(
+            mismatch.stderr.contains("but expected"),
+            "git no longer names a CAS mismatch distinctly: {}",
+            mismatch.stderr
+        );
+
+        // A different update-ref failure: same "cannot lock ref" lead-in, no
+        // mismatch phrase — the half that makes the discriminant necessary.
+        let other = run_git_raw(
+            Some(&repo),
+            &["update-ref", "refs/heads/absent", &tip, &tip],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(other.code, 0);
+        assert!(
+            other.stderr.contains("cannot lock ref") && !other.stderr.contains("but expected"),
+            "a non-mismatch failure must not read as a moved base: {}",
+            other.stderr
+        );
+    }
+
+    /// The resolve session is unbounded, so `base` can gain a commit while the
+    /// user works. Advancing it anyway would drop that commit silently — the
+    /// compare-and-swap refuses instead, and the worktree survives so the
+    /// resolution isn't lost with it.
+    #[tokio::test]
+    async fn local_pr_finish_refuses_when_base_moved_and_keeps_the_worktree() {
+        let (dir, repo) = setup_repo("lpr-base-moved").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+        // Off base, so finalize_base takes the update-ref path.
+        git(&repo, &["switch", "-c", "work"]).await;
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_local_pr(&state, &repo, &base, "feature", "merge it", "merge", &root)
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, "conflicts");
+        let wt = outcome.worktree_path.clone().expect("worktree path set");
+
+        git(&wt, &["checkout", "--ours", "a.txt"]).await;
+        git(&wt, &["add", "a.txt"]).await;
+
+        // A concurrent writer lands a commit on `base` mid-resolution. Plumbing,
+        // so the main tree stays where the flow left it.
+        let base_before = rev(&repo, &base).await;
+        let tree = git(&repo, &["rev-parse", &format!("{base_before}^{{tree}}")])
+            .await
+            .trim()
+            .to_string();
+        let landed = git(
+            &repo,
+            &["commit-tree", &tree, "-p", &base_before, "-m", "concurrent"],
+        )
+        .await
+        .trim()
+        .to_string();
+        // `branch -f` rather than an interpolated `refs/heads/<base>` refspec:
+        // the static invariant gate treats those templates as a reviewed surface.
+        git(&repo, &["branch", "-f", &base, &landed]).await;
+
+        let done = finish_local_pr_merge(
+            &state,
+            &repo,
+            &base,
+            "merge",
+            "merge it",
+            &wt,
+            &outcome.worktree_id.clone().unwrap_or_default(),
+            None,
+        )
+        .await;
+        let Err(err) = done else {
+            panic!("expected the moved base to be refused");
+        };
+        assert!(
+            err.to_string().contains("moved"),
+            "the refusal names the moved base: {err}"
+        );
+        assert_eq!(
+            rev(&repo, &base).await,
+            landed,
+            "the concurrent commit is still base's tip — nothing was eaten"
+        );
+        assert!(
+            std::path::Path::new(&wt).exists(),
+            "the resolve worktree survives so the user can retry"
+        );
+    }
+
     /// KNOWN degenerate case, pinned deliberately (NOT changed this round):
     /// `merge --squash` writes no MERGE_HEAD (measured, git 2.51.1), so an
     /// all-"ours" squash genuinely stages nothing, the commit is skipped, and
@@ -6993,7 +7355,7 @@ detached
         let err = git_stash_all_core(&state, repo.clone()).await.unwrap_err();
         assert_eq!(
             message(err),
-            "Can't stash while a merge, rebase or cherry-pick is in progress — finish or abort it first."
+            "Can't stash while a merge, rebase, cherry-pick or revert is in progress — finish or abort it first."
         );
     }
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -7,8 +7,8 @@ use crate::error::{AppError, AppResult};
 use crate::git::diff::parse_numstat_z;
 use crate::git::history::validate_hash;
 use crate::git::runner::{
-    run_git, run_git_mutating, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT, NETWORK_TIMEOUT,
-    WORKTREE_OP_TIMEOUT,
+    run_git, run_git_mutating, run_git_mutating_raw, run_git_raw, run_git_raw_input,
+    DEFAULT_TIMEOUT, NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::git::types::{FileDiff, RepoOpState, RewriteStep, StashEntry, TagInfo};
 use crate::state::AppState;
@@ -1737,31 +1737,13 @@ pub(crate) async fn git_merge_core(
         }
     }
     args.push(&branch);
-    // Raw under the lock rather than `run_git_mutating`, because a conflicted
-    // merge reports entirely on STDOUT and leaves stderr EMPTY (measured, git
-    // 2.51.1) — a stderr-only error degrades to "git exited with code 1", where
-    // the stdout text carries the `CONFLICT (…` line the frontend classifies on.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
-    let mut out = run_git_raw(Some(&repo_path), &args, DEFAULT_TIMEOUT).await?;
-    // Mirrors `run_git_mutating`'s one-shot retry for index.lock contention from
-    // other tools, which this path would otherwise lose.
-    if out.code != 0 && out.stderr.contains("index.lock") {
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        out = run_git_raw(Some(&repo_path), &args, DEFAULT_TIMEOUT).await?;
-    }
+    // Raw, because a conflicted merge reports entirely on stdout and leaves
+    // stderr empty — `failure_text` is what keeps that report in the error.
+    let out = run_git_mutating_raw(state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
     if out.code != 0 {
-        // Same rule as autostash's `failure_text`, trimming included: its
-        // no-stash arm reports THIS command's failures and a parity test compares
-        // the two byte for byte.
-        let stderr = if out.stderr.trim().is_empty() {
-            out.stdout_lossy().trim().to_string()
-        } else {
-            out.stderr.trim().to_string()
-        };
         return Err(AppError::Git {
             code: out.code,
-            stderr,
+            stderr: out.failure_text(),
         });
     }
     Ok(())
@@ -2094,14 +2076,58 @@ fn orphaned_resolve_worktrees(all_paths: &[String], keep: &[String]) -> Vec<Stri
 ///   index and working tree advance too. A bare `update-ref` would desync it
 ///   (phantom reverts). A dirty one fails cleanly and `base` stays unchanged.
 /// - checked out nowhere → a compare-and-swap `update-ref`, no working tree
-///   touched; a `base` that moved under us is refused, never overwritten.
+///   touched.
+///
+/// `expected_tip` is where `base` stood when the merge was built. Every arm is
+/// refused unless `base` is still exactly there, because all three would
+/// otherwise honor a rewind as readily as a fresh commit: `merge --ff-only`
+/// fast-forwards happily from a `reset --hard <ancestor>`, and a containment
+/// test accepts it too. `None` means the anchor could not be established (an
+/// unjournaled merge) — the containment test alone then stands, which still
+/// refuses a diverged base but cannot see a deliberate rewind.
 async fn finalize_base(
     state: &AppState,
     repo_path: &str,
     base: &str,
     new_sha: &str,
     current: &str,
+    expected_tip: Option<&str>,
 ) -> AppResult<()> {
+    let moved = || {
+        format!(
+            "{base} moved while this merge was being prepared, so advancing it would discard \
+             that change. {base} is unchanged — re-run the merge from its current tip."
+        )
+    };
+    // One read, before any arm: whatever `base` points at now has to match the
+    // tip the merge was built on.
+    let tip_now = run_git(
+        Some(repo_path),
+        &["rev-parse", "--verify", &format!("refs/heads/{base}")],
+        DEFAULT_TIMEOUT,
+    )
+    .await?
+    .stdout_lossy()
+    .trim()
+    .to_string();
+    if let Some(expected) = expected_tip {
+        if tip_now != expected {
+            return Err(AppError::Command(moved()));
+        }
+    } else {
+        // Anchor unknown: fall back to containment, which catches a base that
+        // gained commits but not one deliberately moved back.
+        let contains = run_git_raw(
+            Some(repo_path),
+            &["merge-base", "--is-ancestor", &tip_now, new_sha],
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+        if contains.code != 0 {
+            return Err(AppError::Command(moved()));
+        }
+    }
+
     if base == current {
         // `base` is the main repo's current branch — fast-forward its working
         // tree to the merged commit. (Guaranteed a fast-forward: `new_sha` was
@@ -2154,40 +2180,12 @@ async fn finalize_base(
     }
 
     // Not checked out anywhere — move the ref directly, no working tree touched.
-    // Compare-and-swap, because `new_sha` was built from a tip read seconds (a
-    // clean merge) or a whole resolution session (a conflicted one) ago: a bare
-    // update-ref would silently drop any commit a concurrent writer landed on
-    // `base` meanwhile. The ancestor check is the readable refusal; git's own
-    // `<oldvalue>` argument closes the window between it and the write.
-    let ref_name = format!("refs/heads/{base}");
-    let old_sha = run_git(
-        Some(repo_path),
-        &["rev-parse", "--verify", &ref_name],
-        DEFAULT_TIMEOUT,
-    )
-    .await?
-    .stdout_lossy()
-    .trim()
-    .to_string();
-    let moved = || {
-        format!(
-            "{base} moved while this merge was being prepared, so advancing it would drop the \
-             commit(s) that landed there. {base} is unchanged — re-run the merge to include them."
-        )
-    };
-    let contains_old = run_git_raw(
-        Some(repo_path),
-        &["merge-base", "--is-ancestor", &old_sha, new_sha],
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-    if contains_old.code != 0 {
-        return Err(AppError::Command(moved()));
-    }
+    // git's own `<oldvalue>` argument closes the window between the check above
+    // and this write.
     run_git_mutating(
         state,
         repo_path,
-        &["update-ref", &ref_name, new_sha, &old_sha],
+        &["update-ref", &format!("refs/heads/{base}"), new_sha, &tip_now],
         DEFAULT_TIMEOUT,
     )
     .await
@@ -2372,7 +2370,10 @@ pub(crate) async fn merge_local_pr(
                 .stdout_lossy()
                 .trim()
                 .to_string();
-            if let Err(err) = finalize_base(state, repo_path, base, &new_sha, &current).await {
+            // The tip is still in scope here — no need to recover it.
+            if let Err(err) =
+                finalize_base(state, repo_path, base, &new_sha, &current, Some(&base_tip)).await
+            {
                 // base couldn't be advanced (e.g. checked out elsewhere, or the
                 // ff-only failed) — clean up the worktree and surface the cause.
                 remove_resolve_worktree(state, repo_path, &worktree_path).await;
@@ -2582,7 +2583,18 @@ pub(crate) async fn finish_local_pr_merge(
         .stdout_lossy()
         .trim()
         .to_string();
-    finalize_base(state, repo_path, base, &new_sha, &current).await?;
+    // The resolution session is unbounded, so the tip this merge was built on has
+    // to come from the journal `merge_local_pr` wrote before it started.
+    let expected_tip = crate::oplog::pre_op_tip(repo_path, &op_id).await;
+    finalize_base(
+        state,
+        repo_path,
+        base,
+        &new_sha,
+        &current,
+        expected_tip.as_deref(),
+    )
+    .await?;
     remove_resolve_worktree(state, repo_path, worktree_path).await;
     crate::oplog::finish(repo_path, &op_id, None).await;
     Ok(LocalPrMergeOutcome {
@@ -6385,10 +6397,79 @@ detached
         );
     }
 
+    /// A backward move is intent too: someone resetting `base` to an ancestor
+    /// mid-resolution means it, and every finalize arm would honor the rewind as
+    /// readily as a commit (`merge --ff-only` fast-forwards from it; containment
+    /// accepts it). Only the journaled pre-op tip can tell "we started here" from
+    /// "someone moved it back", so this drives the real `op_id`.
+    #[tokio::test]
+    async fn local_pr_finish_refuses_a_base_reset_backwards_during_resolution() {
+        let (dir, repo) = setup_repo("lpr-base-rewound").await;
+        let base = head_branch(&repo).await;
+        let root_tip = rev(&repo, "HEAD").await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+        git(&repo, &["switch", "-c", "work"]).await;
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_local_pr(&state, &repo, &base, "feature", "merge it", "merge", &root)
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, "conflicts");
+        let wt = outcome.worktree_path.clone().expect("worktree path set");
+        // Without a journaled id there is no anchor and this test would pass
+        // vacuously through the containment fallback.
+        assert!(
+            outcome.op_id.is_some(),
+            "the anchor under test comes from the oplog entry"
+        );
+
+        git(&wt, &["checkout", "--ours", "a.txt"]).await;
+        git(&wt, &["add", "a.txt"]).await;
+
+        // Someone deliberately rewinds `base` to the commit before the merge was
+        // started — an ancestor of what the worktree built, so containment alone
+        // would wave it through.
+        git(&repo, &["branch", "-f", &base, &root_tip]).await;
+
+        let done = finish_local_pr_merge(
+            &state,
+            &repo,
+            &base,
+            "merge",
+            "merge it",
+            &wt,
+            &outcome.worktree_id.clone().unwrap_or_default(),
+            outcome.op_id.clone(),
+        )
+        .await;
+        let Err(err) = done else {
+            panic!("expected the rewound base to be refused");
+        };
+        assert!(
+            err.to_string().contains("moved"),
+            "the refusal names the moved base: {err}"
+        );
+        assert_eq!(
+            rev(&repo, &base).await,
+            root_tip,
+            "the rewind stands — the merge did not re-advance it"
+        );
+        assert!(
+            std::path::Path::new(&wt).exists(),
+            "the resolve worktree survives so the user can retry"
+        );
+    }
+
     /// The resolve session is unbounded, so `base` can gain a commit while the
     /// user works. Advancing it anyway would drop that commit silently — the
-    /// compare-and-swap refuses instead, and the worktree survives so the
-    /// resolution isn't lost with it.
+    /// refusal keeps it, and the worktree survives so the resolution isn't lost.
+    /// Drives `op_id: None` on purpose: this is the containment fallback that
+    /// stands in for an unjournaled merge.
     #[tokio::test]
     async fn local_pr_finish_refuses_when_base_moved_and_keeps_the_worktree() {
         let (dir, repo) = setup_repo("lpr-base-moved").await;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -6417,9 +6417,10 @@ detached
         let base_before = rev(&repo, "HEAD").await;
         git(&repo, &["switch", "-c", "feature", &stale]).await;
         commit_file(&repo, dir.path(), "f.txt", "feature\n", "feat commit").await;
-        // Off base for the update-ref arm. By SHA, and every bare-name read above
-        // happens first: once the tag lands, the test's own scaffolding could not
-        // resolve the name either (git refuses an ambiguous object name outright).
+        // Off base for the update-ref arm, by SHA and before the tag exists:
+        // `git switch -c <new> <start-point>` refuses an ambiguous start-point
+        // outright (`fatal: ambiguous object name`, exit 128), unlike the
+        // `rev-parse` read this test is about, which quietly picks the tag.
         git(&repo, &["switch", "-c", "work", &base_before]).await;
         // A tag on an OLDER commit, named exactly like the base branch.
         git(&repo, &["tag", &base, &stale]).await;
@@ -6481,9 +6482,10 @@ detached
             "the anchor under test comes from the oplog entry"
         );
 
+        // Resolve toward the incoming side, so base's new tip must carry
+        // feature's content rather than its own.
         git(&wt, &["checkout", "--theirs", "a.txt"]).await;
         git(&wt, &["add", "a.txt"]).await;
-        let resolved = rev(&wt, "HEAD").await;
 
         // Nothing touches `base` in between — the anchor must accept it.
         let done = finish_local_pr_merge(
@@ -6506,7 +6508,11 @@ detached
             base_after, done.base_tip,
             "base is at the commit the resolve worktree produced"
         );
-        assert_ne!(resolved, base_after, "the merge commit is the resolution");
+        assert_eq!(
+            nlf(git(&repo, &["show", &format!("{base_after}:a.txt")]).await),
+            "feature-side\n",
+            "base carries the resolution staged in the worktree"
+        );
         assert!(
             !std::path::Path::new(&wt).exists(),
             "the resolve worktree is torn down on success"

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -150,7 +150,7 @@ pub(crate) async fn has_unmerged(repo: &str) -> AppResult<bool> {
 /// should [`op_state`] ever gain a fallible read.
 pub(crate) async fn op_in_progress(repo: &str) -> bool {
     match op_state(repo).await {
-        Ok(state) => state.merging || state.rebasing || state.cherry_picking || state.reverting,
+        Ok(state) => state.mid_op(),
         Err(_) => true,
     }
 }
@@ -4883,6 +4883,37 @@ mod tests {
         op_continue(&app, &repo, "revert").await.unwrap();
         assert!(!op_state(&repo).await.unwrap().reverting);
         assert_eq!(subjects(&repo).await.len(), 4, "the revert commit landed");
+    }
+
+    /// Every flag counts, and `edit_paused` alone does not — the gates that once
+    /// re-listed these fields each missed a different one, so the predicate they
+    /// now share is pinned per flag rather than through any single caller.
+    #[test]
+    fn mid_op_covers_every_operation_flag() {
+        let clear = RepoOpState {
+            merging: false,
+            rebasing: false,
+            cherry_picking: false,
+            reverting: false,
+            edit_paused: false,
+        };
+        assert!(!clear.mid_op(), "a quiet repo is not mid-op");
+        for set in [
+            |s: &mut RepoOpState| s.merging = true,
+            |s: &mut RepoOpState| s.rebasing = true,
+            |s: &mut RepoOpState| s.cherry_picking = true,
+            |s: &mut RepoOpState| s.reverting = true,
+        ] {
+            let mut state = clear.clone();
+            set(&mut state);
+            assert!(state.mid_op(), "{state:?} is mid-op");
+        }
+        let mut paused = clear.clone();
+        paused.edit_paused = true;
+        assert!(
+            !paused.mid_op(),
+            "edit_paused qualifies `rebasing`; it never stands alone"
+        );
     }
 
     /// The sequencer's verb decides which op it is; anything unreadable stays a

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -27,6 +27,20 @@ impl GitOutput {
     pub fn stdout_lossy(&self) -> String {
         String::from_utf8_lossy(&self.stdout).into_owned()
     }
+
+    /// The text describing a non-zero exit: stderr, or stdout when stderr is
+    /// EMPTY. git splits its reporting across both streams — a conflicted merge,
+    /// `stash pop` or `revert` writes everything to stdout and leaves stderr
+    /// empty (measured, git 2.51.1) — and an error carrying only that empty
+    /// stderr renders as "git exited with code N".
+    pub fn failure_text(&self) -> String {
+        let stderr = self.stderr.trim();
+        if stderr.is_empty() {
+            self.stdout_lossy().trim().to_string()
+        } else {
+            stderr.to_string()
+        }
+    }
 }
 
 /// The resolved `git` binary, memoized for the process lifetime.
@@ -363,6 +377,26 @@ pub async fn run_git_mutating(
     timeout: Duration,
 ) -> AppResult<GitOutput> {
     run_git_mutating_input(state, repo_path, args, None, timeout).await
+}
+
+/// `run_git_mutating` without its non-zero-exit verdict: same lock and same
+/// one-shot index.lock retry, but the raw output comes back so the caller can
+/// read STDOUT on failure. Use it wherever git reports a failure there —
+/// [`GitOutput::failure_text`] is the shaping those callers share.
+pub async fn run_git_mutating_raw(
+    state: &AppState,
+    repo_path: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> AppResult<GitOutput> {
+    let lock = state.repo_lock(repo_path).await;
+    let _guard = lock.lock().await;
+    let out = run_git_raw(Some(repo_path), args, timeout).await?;
+    if out.code != 0 && out.stderr.contains("index.lock") {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        return run_git_raw(Some(repo_path), args, timeout).await;
+    }
+    Ok(out)
 }
 
 /// `run_git_mutating` with optional stdin input.

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -246,6 +246,7 @@ pub struct RepoOpState {
     pub merging: bool,
     pub rebasing: bool,
     pub cherry_picking: bool,
+    pub reverting: bool,
     /// An interactive rebase is paused at an `edit` (vs a conflict) — the user
     /// should amend the commit, then continue.
     pub edit_paused: bool,

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -251,3 +251,13 @@ pub struct RepoOpState {
     /// should amend the commit, then continue.
     pub edit_paused: bool,
 }
+
+impl RepoOpState {
+    /// Whether a multi-step operation is mid-flight — the single home of the flag
+    /// list, so a gate can't drift by re-listing the fields and missing one.
+    /// `edit_paused` is excluded: it qualifies `rebasing` rather than standing on
+    /// its own.
+    pub fn mid_op(&self) -> bool {
+        self.merging || self.rebasing || self.cherry_picking || self.reverting
+    }
+}

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -528,9 +528,9 @@ impl GitDesktopMcp {
                        (including untracked). With `paths`, stashes only those files, leaving every \
                        other file's staged and unstaged changes exactly as they were; paths and \
                        directories match exactly, set literal=false to pass a pathspec or glob. \
-                       Refused while conflicts are unresolved, or while a merge, rebase or \
-                       cherry-pick is in progress (finish or abort it first — retrying won't \
-                       help). Requires --allow-git-write.",
+                       Refused while conflicts are unresolved, or while a merge, rebase, \
+                       cherry-pick or revert is in progress (finish or abort it first — \
+                       retrying won't help). Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]
     async fn stash_push(

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -428,6 +428,27 @@ pub async fn finish(repo: &str, id: &Option<String>, error: Option<String>) {
     }
 }
 
+/// The `preOpTip` a [`begin`] recorded for `id` — the ref position the operation
+/// was built on, for a later step that must refuse to move a ref that has since
+/// been changed by anyone else. `None` whenever it can't be established
+/// (unjournaled op, pruned entry, unreadable store), so callers must treat the
+/// absence as "unknown", never as "unchanged".
+pub(crate) async fn pre_op_tip(repo: &str, id: &Option<String>) -> Option<String> {
+    let id = id.as_ref()?;
+    let path = store_path().ok()?;
+    let entries = {
+        let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let store = read_store(&path).ok()?;
+        repo_entries(&store, repo)
+    };
+    entries
+        .iter()
+        .find(|e| e.get("id").and_then(Value::as_str) == Some(id.as_str()))
+        .and_then(|e| e.get("preOpTip"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
 /// Return `repo`'s journal entries newest-first by `startedAt`. Pure store read,
 /// no git access. Missing repo key → `[]`.
 #[tauri::command]

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -292,9 +292,10 @@ fn is_interrupted(
 
 /// Reconcile `repo`'s pending entries against real git state, persist, and return
 /// the still-`"pending"` entries newest-first (0 or 1). `mid_op` = a merge,
-/// cherry-pick, or rebase is currently in progress; `tree_dirty` = tracked changes
-/// are present (catches a mid-squash interrupt git_op_state can't see);
-/// `current_branch` = the branch HEAD is on now. Guarded by [`OPLOG_LOCK`].
+/// cherry-pick, rebase or revert is currently in progress ([`RepoOpState::mid_op`]);
+/// `tree_dirty` = tracked changes are present (catches a mid-squash interrupt
+/// git_op_state can't see); `current_branch` = the branch HEAD is on now. Guarded
+/// by [`OPLOG_LOCK`].
 fn reconcile(
     repo: &str,
     mid_op: bool,
@@ -474,7 +475,10 @@ pub async fn git_oplog_check(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
 
     let state = crate::git::ops::git_op_state(repo_path.clone()).await?;
-    let mid_op = state.merging || state.cherry_picking || state.rebasing;
+    // `mid_op` over a hand-listed set: the flag list lives on `RepoOpState`. Not
+    // `op_in_progress`, whose Err arm answers `true` — that would manufacture an
+    // interrupt from a failed read, which the two probes below refuse to do.
+    let mid_op = state.mid_op();
     // A squash-merge leaves none of those markers, so git_op_state alone misses a
     // mid-squash interrupt. Corroborate with a *tracked*-dirty check (untracked is
     // allowed — mirrors ensure_clean_tree) + the current branch.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { syncAnalytics, track } from "@/lib/analytics";
 import { useBackgroundPrSync } from "@/lib/automations/useBackgroundPrSync";
 import { useGitInstalled } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
+import { useModalGateOpen } from "@/lib/hotkeys/modal-gate";
 import { reloadLocalPrs } from "@/lib/pulls/local";
 import { reloadReviewNotes } from "@/lib/review-notes/store";
 import {
@@ -56,11 +57,13 @@ function App() {
   const pickAndOpen = usePickAndOpenRepo();
   const [cloneOpen, setCloneOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
-  const dialogOpen = cloneOpen || createOpen;
+  // Screens with their own modals (e.g. Explore's clone dialog) register there.
+  const screenModalOpen = useModalGateOpen();
+  const dialogOpen = cloneOpen || createOpen || screenModalOpen;
 
-  // The dialogs live above the view switch, so navigation no longer unmounts
-  // them (e.g. the clone dialog's "Open Settings → Accounts") — close them
-  // when the screen changes, or the new screen mounts behind the modal.
+  // The dialogs live above the view switch, so navigation doesn't unmount them
+  // (e.g. the clone dialog's "Open Settings → Accounts") — close them when the
+  // screen changes, or the new screen mounts behind a still-open modal.
   // biome-ignore lint/correctness/useExhaustiveDependencies: `view` is an intentional close trigger, not read directly
   useEffect(() => {
     setCloneOpen(false);
@@ -159,9 +162,9 @@ function App() {
   // (Settings/Help/Explore mount neither the welcome list nor the repo
   // switcher), and duplicate registrations would shadow by mount order.
   // Disabled until git resolves — the dialogs render below the early returns,
-  // so a click before then would stash a stale `open` that pops later. An open
-  // clone/create dialog suppresses all four: the native menu bar sits outside
-  // the webview's modal overlay, so a menu click there would stack a second.
+  // so a click before then would stash a stale `open` that pops later. Any open
+  // dialog suppresses all four: the native menu bar sits outside the webview's
+  // modal overlay, so a menu click there would stack a second.
   useHotkeyAction(
     "add-local-repository",
     pickAndOpen,

--- a/src/components/disabled-reason-button.tsx
+++ b/src/components/disabled-reason-button.tsx
@@ -15,8 +15,11 @@ type DisabledReasonButtonProps = React.ComponentProps<typeof Button> & {
  * takes Base UI's `focusableWhenDisabled` — `aria-disabled` instead of the
  * native attribute, focus intact, activation still blocked in its handler layer.
  * A reason-less disable stays native rather than becoming a mute tab stop.
- * Trigger sites keep the native attribute: wrap a titled span around
- * `<Trigger disabled render={<Button/>}/>`, or branch when the arms differ.
+ * Trigger sites pick an arm by who needs the reason: a titled span around
+ * `<Trigger disabled render={<Button/>}/>` is hover-only, so keyboard/AT reach
+ * takes `<Trigger render={<DisabledReasonButton disabled reason/>}/>` instead —
+ * disabled on the button, never the trigger, whose open handler the inner
+ * `useButton` then swallows. `ReactionBar` hand-rolls this on a raw `<button>`.
  */
 export function DisabledReasonButton({
   reason,

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -34,6 +34,7 @@ import {
   clearNotification,
   markAllNotificationsRead,
   markNotificationRead,
+  type NotificationKind,
   type NotificationTone,
   useNotifications,
   useUnreadCount,
@@ -187,7 +188,7 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
         repoPath: n.repoPath,
         repoName: n.repoName,
         ref: t.ref,
-        section: KIND_SECTION[n.kind] ?? null,
+        section: KIND_SECTION[n.kind as NotificationKind] ?? null,
       });
     } else if (t?.type === "run") {
       openRun({ repoPath: n.repoPath, repoName: n.repoName, runId: t.runId });
@@ -574,7 +575,7 @@ const TONE_CLASS: Record<NotificationTone, string> = {
 
 /** Glyph per event kind; kinds not listed fall back to a tone-appropriate mark
  *  (e.g. `ci-run`, whose success/failure lives in the tone). */
-const KIND_GLYPH: Record<string, typeof CheckCircleIcon> = {
+const KIND_GLYPH: Partial<Record<NotificationKind, typeof CheckCircleIcon>> = {
   "review-ready": SparkleIcon,
   "review-failed": SparkleIcon,
   "checks-passed": CheckCircleIcon,
@@ -598,9 +599,9 @@ const KIND_GLYPH: Record<string, typeof CheckCircleIcon> = {
  *  is therefore already on screen from every section. A `review-failed` from an
  *  *automation* still points at Review even though the panel shows idle: those
  *  runs use a separate `auto:<n>` key namespace, but Review is where the Run
- *  button lives. Keyed by plain string — a hydrated row can carry a kind from an
- *  older build. */
-const KIND_SECTION: Record<string, PrSection> = {
+ *  button lives. Read with a row's plain-string kind — a hydrated row can carry
+ *  a kind from an older build, so a lookup must miss, never fail. */
+const KIND_SECTION: Partial<Record<NotificationKind, PrSection>> = {
   "review-ready": "review",
   "review-failed": "review",
   "pr-opened": "conversation",
@@ -625,5 +626,7 @@ const TONE_ICON: Record<NotificationTone, typeof CheckCircleIcon> = {
 };
 
 function glyphFor(n: AppNotification): typeof CheckCircleIcon {
-  return KIND_GLYPH[n.kind] ?? TONE_ICON[n.tone];
+  // The cast reads a maybe-unknown kind against a closed map: hydrated rows are
+  // untrusted, so the lookup must be allowed to miss into the tone fallback.
+  return KIND_GLYPH[n.kind as NotificationKind] ?? TONE_ICON[n.tone];
 }

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode, Ref } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import {
   MarkdownEditor,
   type MarkdownEditorHandle,
 } from "@/components/markdown-editor";
-import { Button } from "@/components/ui/button";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
 
 /**
@@ -23,6 +23,7 @@ export function CommentComposer({
   ariaLabel,
   placeholder,
   busy,
+  reason,
   disabled,
   actions,
 }: {
@@ -39,6 +40,9 @@ export function CommentComposer({
   placeholder: string;
   /** A submit is in flight: gates the chord, the submit button and Clear. */
   busy?: boolean;
+  /** Why `busy` holds — announced and shown on the buttons it disables. An empty
+   *  draft is an ordinary form affordance and needs none. */
+  reason?: string | null;
   /** Freeze the text input too — only surfaces that block typing mid-submit
    *  pass it. */
   disabled?: boolean;
@@ -46,6 +50,9 @@ export function CommentComposer({
   actions?: ReactNode;
 }) {
   const hasDraft = value.trim().length > 0;
+  // Only the `busy` hold gets words: an empty draft explains itself, and a reason
+  // there would add a tab stop for every viewer who simply hasn't typed yet.
+  const blockedReason = busy ? (reason ?? null) : null;
   return (
     <div className="space-y-2 border-t p-3">
       <MarkdownEditor
@@ -68,27 +75,29 @@ export function CommentComposer({
         textareaClassName="max-h-32 min-h-12 resize-y"
       />
       <div className="flex items-center gap-2">
-        <Button
+        <DisabledReasonButton
           variant="outline"
           size="sm"
           disabled={!hasDraft || busy}
+          reason={blockedReason}
           onClick={onSubmit}
           title={SUBMIT_HINT}
         >
           {submitLabel}
-        </Button>
+        </DisabledReasonButton>
         {actions}
         {onClear && hasDraft && (
-          <Button
+          <DisabledReasonButton
             variant="ghost"
             size="sm"
-            className="ml-auto"
+            wrapperClassName="ml-auto"
             disabled={busy}
+            reason={blockedReason}
             onClick={onClear}
             title="Discard this draft (e.g. a quote reply)"
           >
             Clear
-          </Button>
+          </DisabledReasonButton>
         )}
       </div>
     </div>

--- a/src/features/conversations/ReactionBar.tsx
+++ b/src/features/conversations/ReactionBar.tsx
@@ -1,7 +1,7 @@
 import { Popover } from "@base-ui/react/popover";
 import { SmileyIcon } from "@phosphor-icons/react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { type ComponentProps, useId, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import type { Reaction } from "@/lib/git/types";
 import { cn } from "@/lib/utils";
 
@@ -31,6 +31,60 @@ const REACTION_ORDER = [
 const label = (content: string) => content.toLowerCase().replace(/_/g, " ");
 
 /**
+ * `DisabledReasonButton`'s contract on a plain `<button>` — chips and picker cells
+ * carry their own sizing, which none of the vendored Button's sizes match. A
+ * reason trades the native `disabled` attribute for `aria-disabled`, keeping the
+ * tab stop and an sr-only description a natively-disabled element could never
+ * announce; both disabled paths kill pointer events, so the wrapper owns the
+ * hover text. The contract lives in two places now and has to change in both; a
+ * third site extracts it to a shared hook instead.
+ */
+function ReactionButton({
+  reason,
+  disabled,
+  title,
+  onClick,
+  className,
+  ...props
+}: ComponentProps<"button"> & { reason?: string | null }) {
+  const id = useId();
+  const blockedReason = disabled && reason ? reason : null;
+  // `aria-describedby` outranks `title` as the accessible description, so a
+  // caller's own description has to survive alongside the reason.
+  const describedBy =
+    [props["aria-describedby"], blockedReason ? id : null]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  return (
+    <span
+      className={cn("inline-flex", blockedReason && "cursor-not-allowed")}
+      title={blockedReason ?? title}
+    >
+      <button
+        {...props}
+        type="button"
+        title={title}
+        disabled={blockedReason ? undefined : disabled}
+        aria-disabled={blockedReason ? true : undefined}
+        aria-describedby={describedBy}
+        // `aria-disabled` is advisory only, so activation is withheld here.
+        onClick={blockedReason ? undefined : onClick}
+        className={cn(
+          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:focus-visible:opacity-100",
+          className,
+        )}
+      />
+      {blockedReason ? (
+        <span id={id} className="sr-only">
+          {blockedReason}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/**
  * Emoji reactions for a reactable subject (issue/PR body or comment). Existing
  * reactions render as toggle chips (highlighted when the viewer reacted); the
  * smiley opens a picker of all eight. `onToggle(content, active)` — `active` is
@@ -40,10 +94,14 @@ export function ReactionBar({
   reactions,
   onToggle,
   disabled,
+  reason,
 }: {
   reactions: Reaction[];
   onToggle: (content: string, active: boolean) => void;
   disabled?: boolean;
+  /** Why the toggles are held — shown and announced on every control `disabled`
+   *  turns off. Absent leaves a native disable, which explains nothing. */
+  reason?: string | null;
 }) {
   const [open, setOpen] = useState(false);
   const reacted = new Set(
@@ -53,12 +111,12 @@ export function ReactionBar({
   return (
     <div className="flex flex-wrap items-center gap-1">
       {reactions.map((r) => (
-        <button
+        <ReactionButton
           key={r.content}
-          type="button"
           aria-label={`${label(r.content)} reaction, ${r.count}`}
           aria-pressed={r.viewerReacted}
           disabled={disabled}
+          reason={reason}
           onClick={() => onToggle(r.content, r.viewerReacted)}
           className={cn(
             "flex items-center gap-1 border px-1.5 py-0.5 text-[11px] tabular-nums transition-colors",
@@ -70,16 +128,17 @@ export function ReactionBar({
         >
           <span aria-hidden>{REACTION_EMOJI[r.content] ?? "?"}</span>
           {r.count}
-        </button>
+        </ReactionButton>
       ))}
       <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger
           render={
-            <Button
+            <DisabledReasonButton
               variant="ghost"
               size="icon-xs"
               aria-label="Add reaction"
               disabled={disabled}
+              reason={reason}
               className="text-muted-foreground hover:text-foreground data-popup-open:text-foreground"
             />
           }
@@ -94,12 +153,12 @@ export function ReactionBar({
           >
             <Popover.Popup className="flex gap-0.5 rounded-none bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10">
               {REACTION_ORDER.map((content) => (
-                <button
+                <ReactionButton
                   key={content}
-                  type="button"
                   aria-label={`React with ${label(content)}`}
                   aria-pressed={reacted.has(content)}
                   disabled={disabled}
+                  reason={reason}
                   onClick={() => {
                     onToggle(content, reacted.has(content));
                     setOpen(false);
@@ -111,7 +170,7 @@ export function ReactionBar({
                   title={label(content)}
                 >
                   {REACTION_EMOJI[content]}
-                </button>
+                </ReactionButton>
               ))}
             </Popover.Popup>
           </Popover.Positioner>

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -97,6 +97,7 @@ export function Thread({
   reactions,
   onToggleReaction,
   reactionsHeld = false,
+  reactionsReason,
   renderBody,
   copyMarkdown,
   disabledReason,
@@ -138,6 +139,9 @@ export function Thread({
    *  the chips stay visible (a read) but can't fire a write whose subject id and
    *  target entity would disagree. Same posture as `editHeld`. */
   reactionsHeld?: boolean;
+  /** Why `reactionsHeld` holds — the bar shows and announces it on every control
+   *  it disables. Absent leaves a plain disable no viewer can interrogate. */
+  reactionsReason?: string | null;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -304,6 +308,7 @@ export function Thread({
         <ReactionBar
           reactions={reactions ?? []}
           disabled={reactionsHeld}
+          reason={reactionsReason}
           onToggle={onToggleReaction}
         />
       )}

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -1,4 +1,4 @@
-import type { DiffAST } from "@git-diff-view/core";
+import type { DiffAST, DiffFileHighlighter } from "@git-diff-view/core";
 import {
   DiffFile,
   DiffModeEnum,
@@ -260,14 +260,17 @@ const EMPTY_WORKER_AST: DiffAST = { type: "root", children: [] };
 /**
  * A @git-diff-view highlighter backed by ASTs the worker already tokenized:
  * `getAST` looks the side up by the raw text's djb2 hash — no engine on the
- * main thread; a miss returns the empty AST (that side plain). Must be fed to a
- * REAL local `initSyntax` so `syntaxFile` populates — otherwise the view's
- * clone WIPES the highlighting on mount. `type: "style"` matches Shiki's spans.
+ * main thread; a miss returns the empty AST (that side plain). Handed to the
+ * view as `registerHighlighter`, whose effect runs `initSyntax` on the view's
+ * OWN clone in place — so the ASTs paint without rebuilding the DiffFile.
+ * `name`/`type` must stay `"shiki"`/`"style"`: the core's re-entry guards
+ * (DiffFile.initSyntax, File.doSyntax) bail on a highlighter matching the one
+ * already applied, so a pair matching the interim "lowlight" pass would keep it.
  */
-function precomputedHighlighter(asts: WorkerAsts) {
+function precomputedHighlighter(asts: WorkerAsts): DiffFileHighlighter {
   return {
     name: "shiki",
-    type: "style" as const,
+    type: "style",
     maxLineToIgnoreSyntax: SYNTAX_LINE_CAP,
     setMaxLineToIgnoreSyntax: () => undefined,
     ignoreSyntaxHighlightList: [],
@@ -312,10 +315,6 @@ export function createDiffFile(
   // files (correct comment/string state) and maps tokens onto the diff lines —
   // and switches to collapsible full-file context instead of a bare hunk.
   content?: { old: string | null; new: string | null },
-  // Per-side ASTs the highlight worker already tokenized. Passed only for an
-  // over-budget Shiki-routed file (the sync path SKIPPED Shiki): run a REAL
-  // local initSyntax off them to paint the worker's highlighting in.
-  workerAsts?: WorkerAsts,
 ): DiffFile | null {
   if (!text.trim()) return null;
   try {
@@ -351,17 +350,6 @@ export function createDiffFile(
       },
       hunks: [text],
     };
-    // Precomputed worker ASTs: a REAL local initSyntax off them yields a
-    // genuinely-highlighted instance (syntaxFile populated) the view's clone
-    // restores instead of wiping — as it would a getBundle-merged Shiki instance.
-    if (workerAsts) {
-      const file = DiffFile.createInstance(data);
-      file.initRaw();
-      file.initSyntax({
-        registerHighlighter: precomputedHighlighter(workerAsts),
-      });
-      return file;
-    }
     const file = DiffFile.createInstance(data);
     file.initRaw();
     // Gate on the char budget for the engine this diff routes to (~8× apart —
@@ -469,11 +457,12 @@ export function useFileContent(
  * and off-thread worker ASTs for an over-budget Shiki-routed diff. Shared by
  * both {@link createDiffFile} call sites so they apply the same routing rules.
  *
- * Contract: callers must list both returned `grammarState` and `workerAsts` in
- * their {@link createDiffFile} memo's deps. `workerAsts` is passed into
- * createDiffFile and is an ordinary dep; `grammarState` is read only via module
- * state (isShikiLang), so listing it explicitly is what forces the rebuild that
- * picks the loaded grammar up.
+ * Contract: callers must list `grammarState` in their {@link createDiffFile}
+ * memo's deps — it's read only via module state (isShikiLang), so listing it
+ * explicitly is what forces the rebuild that picks the loaded grammar up.
+ * `workerHighlighter` goes to the view as its `registerHighlighter` prop and
+ * must NOT be a build dep: keeping the DiffFile identity stable across the
+ * ASTs' arrival is what preserves the view's expansion state.
  */
 export function useShikiRouting({
   filePath,
@@ -499,7 +488,7 @@ export function useShikiRouting({
 }): {
   holdForGrammar: boolean;
   grammarState: Record<string, "ready" | "failed">;
-  workerAsts: WorkerAsts | null;
+  workerHighlighter: DiffFileHighlighter | undefined;
 } {
   // Built-in Shiki grammars load lazily (off the startup bundle). Hold the paint
   // until the load settles rather than rebuild on arrival (highlight pop-in).
@@ -512,12 +501,23 @@ export function useShikiRouting({
     () => diffLang(filePath, syntaxMap),
     [filePath, syntaxMap],
   );
+  // The core ignores syntax outright once the RECONSTRUCTED file passes
+  // SYNTAX_LINE_CAP lines, and hunk-only mode pads to the highest line number
+  // the hunks reference (`rawLength` = that + 1, hence `>=`) — so a small hunk
+  // deep in a big file gets no highlighting from ANY engine. Nothing would
+  // consume a grammar, a paint hold, or worker ASTs here. Content mode can't
+  // reach this: its reads cap at HIGHLIGHT_MAX_LINES.
+  const syntaxIgnored = useMemo(() => {
+    const max = diffMaxLineNumbers(text);
+    return Math.max(max.old, max.new) >= SYNTAX_LINE_CAP;
+  }, [text]);
   useEffect(() => {
     if (
       !lang ||
       // A blocked mega file shows a placeholder, not a diff — don't fetch a
       // grammar it will never render.
       blocked ||
+      syntaxIgnored ||
       !isBuiltinShikiLang(lang) ||
       isShikiLang(lang) ||
       grammarState[lang] !== undefined ||
@@ -536,7 +536,7 @@ export function useShikiRouting({
     return () => {
       cancelled = true;
     };
-  }, [lang, grammarState, text.length, blocked]);
+  }, [lang, grammarState, text.length, blocked, syntaxIgnored]);
 
   // A built-in Shiki grammar this diff needs is still loading (never seen a
   // "ready"/"failed" result for it): hold the paint. `isShikiLang(lang)` already
@@ -571,20 +571,26 @@ export function useShikiRouting({
     // still settling — the worker input would be built on interim text and
     // superseded. (Over budget we never hold the paint on grammarPending, so it
     // isn't gated on here.)
-    enabled: overBudget && useShikiWorker && !contentPending,
+    enabled: overBudget && useShikiWorker && !contentPending && !syntaxIgnored,
     filePath,
     text,
     lang: lang ?? null,
     content,
     tmGrammar,
   });
+  // Memoized: the view's `registerHighlighter` effect re-runs on identity, so a
+  // fresh object each render would re-tokenize the clone every render.
+  const workerHighlighter = useMemo(
+    () => (workerAsts ? precomputedHighlighter(workerAsts) : undefined),
+    [workerAsts],
+  );
 
   // Over budget the main thread never Shiki-tokenizes, so holding the paint for
   // a grammar only the worker needs would just delay the interim paint. Under
   // budget, hold — so the lazy-grammar rebuild still lands in one paint.
-  const holdForGrammar = grammarPending && !overBudget;
+  const holdForGrammar = grammarPending && !overBudget && !syntaxIgnored;
 
-  return { holdForGrammar, grammarState, workerAsts };
+  return { holdForGrammar, grammarState, workerHighlighter };
 }
 
 /** The per-side line -> render() maps the vendored DiffView consumes. */
@@ -696,7 +702,7 @@ function RenderedDiff({
   const activeRepo = useUiStore((s) => s.repoPath);
   const { syntaxMap, customLanguages } = useEffectiveSyntax(activeRepo);
 
-  const { holdForGrammar, grammarState, workerAsts } = useShikiRouting({
+  const { holdForGrammar, grammarState, workerHighlighter } = useShikiRouting({
     filePath: deferredPath,
     text: shown,
     content: content ?? null,
@@ -706,7 +712,7 @@ function RenderedDiff({
     customLanguages,
   });
 
-  // grammarState + workerAsts: rebuild-trigger deps — see useShikiRouting's contract.
+  // grammarState: rebuild-trigger dep — see useShikiRouting's contract.
   // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>
@@ -717,7 +723,6 @@ function RenderedDiff({
             shown,
             { syntaxMap, customLanguages },
             content ?? undefined,
-            workerAsts ?? undefined,
           ),
     [
       shown,
@@ -729,7 +734,6 @@ function RenderedDiff({
       contentPending,
       holdForGrammar,
       grammarState,
-      workerAsts,
     ],
   );
 
@@ -1046,6 +1050,9 @@ function RenderedDiff({
         <DiffViewWithMultiSelect<{ render: () => ReactNode }>
           ref={multiSelectRef}
           diffFile={diffFile}
+          // Worker ASTs land as a highlighter PROP, not a rebuild: the view's
+          // effect applies them to its own clone, so expansion state survives.
+          registerHighlighter={workerHighlighter}
           diffViewMode={diffViewMode}
           diffViewTheme={isDark ? "dark" : "light"}
           diffViewHighlight
@@ -1072,6 +1079,7 @@ function RenderedDiff({
       ) : (
         <DiffView<{ render: () => ReactNode }>
           diffFile={diffFile}
+          registerHighlighter={workerHighlighter}
           diffViewMode={diffViewMode}
           diffViewTheme={isDark ? "dark" : "light"}
           diffViewHighlight

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -37,6 +37,7 @@ import {
   useFileDiff,
   useRepoStatus,
 } from "@/lib/git/queries";
+import { formatBinding, isMac } from "@/lib/hotkeys/binding";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import type { SelectedFile } from "@/lib/stores/ui";
@@ -361,7 +362,9 @@ function WorkingTreeDiff({
             <InfoIcon className="size-3.5 shrink-0" />
             <span className="flex-1 leading-snug">
               Drag across the line numbers to{" "}
-              {file.staged ? "unstage" : "stage"} just those lines.
+              {file.staged ? "unstage" : "stage"} just those lines. Hold{" "}
+              {ADDITIVE_MODIFIER} while dragging to add to the selection, so one
+              selection can mix added and removed lines.
             </span>
             <button
               type="button"
@@ -449,6 +452,11 @@ function WorkingTreeDiff({
 
 const SELECT_CLASS = "gd-line-selected";
 
+// The additive-drag modifier, derived per platform (never a hardcoded key):
+// Cmd on macOS, Ctrl elsewhere — Ctrl-click is the secondary click on macOS.
+const ADDITIVE_MODIFIER = formatBinding("mod");
+const isAdditiveDrag = (e: MouseEvent) => (isMac ? e.metaKey : e.ctrlKey);
+
 /** The diff row for a line. Unified mode tags the number span with
  *  `data-line-{new,old}-num`; split mode uses a generic `data-line-num` inside a
  *  cell marked `data-side`. Try both so either view works. */
@@ -477,7 +485,9 @@ function paintLines(container: HTMLElement, lines: SelectedLine[]) {
   }
 }
 
-/** Highlight an in-progress drag range for live feedback (includes context). */
+/** Highlight an in-progress drag range for live feedback (includes context),
+ *  over `base` — the lines an additive drag is merging into, which would
+ *  otherwise vanish on the next mousemove (this repaints from scratch). */
 function paintRange(
   container: HTMLElement,
   range: {
@@ -485,14 +495,33 @@ function paintRange(
     startLineNumber: number;
     endLineNumber: number;
   } | null,
+  base: SelectedLine[],
 ) {
-  clearPaint(container);
+  paintLines(container, base);
   if (!range) return;
   const lo = Math.min(range.startLineNumber, range.endLineNumber);
   const hi = Math.max(range.startLineNumber, range.endLineNumber);
   for (let n = lo; n <= hi; n++) {
     rowForLine(container, range.side, n)?.classList.add(SELECT_CLASS);
   }
+}
+
+/** Union of two line selections, deduped by side+line — an additive drag adds
+ *  to the committed selection instead of replacing it, and the two can overlap
+ *  or (unlike one library-reported drag) span both sides. */
+function mergeSelection(
+  base: SelectedLine[] | null,
+  added: SelectedLine[],
+): SelectedLine[] {
+  const merged = [...(base ?? [])];
+  const seen = new Set(merged.map((s) => `${s.side}|${s.line}`));
+  for (const line of added) {
+    const key = `${line.side}|${line.line}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(line);
+  }
+  return merged;
 }
 
 /** A hunk's first old/new line number, from its `@@ -a,b +c,d @@` header. */
@@ -628,7 +657,7 @@ function StagingDiffView({
   );
   // `blocked` is omitted: a mega-line file never reaches this view —
   // WorkingTreeDiff routes it to the whole-file DiffSurface fallback first.
-  const { holdForGrammar, grammarState, workerAsts } = useShikiRouting({
+  const { holdForGrammar, grammarState, workerHighlighter } = useShikiRouting({
     filePath: deferredPath,
     text: displayText,
     content: content ?? null,
@@ -641,7 +670,7 @@ function StagingDiffView({
   // stage/unstage/discard patch (see WorkingTreeDiff). Null while content reads
   // are pending: don't build an intermediate diff the arriving reads would
   // immediately restructure.
-  // grammarState + workerAsts: rebuild-trigger deps — see useShikiRouting's contract.
+  // grammarState: rebuild-trigger dep — see useShikiRouting's contract.
   // biome-ignore lint/correctness/useExhaustiveDependencies: grammarState is an intentional rebuild trigger, read via module state not directly
   const diffFile = useMemo(
     () =>
@@ -652,7 +681,6 @@ function StagingDiffView({
             displayText,
             { syntaxMap, customLanguages },
             content ?? undefined,
-            workerAsts ?? undefined,
           ),
     [
       deferredPath,
@@ -663,7 +691,6 @@ function StagingDiffView({
       contentPending,
       holdForGrammar,
       grammarState,
-      workerAsts,
     ],
   );
 
@@ -677,13 +704,28 @@ function StagingDiffView({
   const onSelectRef = useLatestRef(onSelect);
   const selectedRef = useLatestRef(selection);
 
+  // Whether the drag in progress started modifier-held. The library's callbacks
+  // carry no event, so it's captured from the container's own mousedown on the
+  // CAPTURE phase — the manager listens on the same element, bubble phase.
+  const additiveRef = useRef(false);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !diffFile) return;
+    const onMouseDownCapture = (e: MouseEvent) => {
+      additiveRef.current = isAdditiveDrag(e);
+    };
+    container.addEventListener("mousedown", onMouseDownCapture, true);
+    // An additive drag paints over the committed selection; a plain one replaces
+    // it, so its base is empty (the pre-additive behavior).
+    const paintBase = () =>
+      additiveRef.current ? (selectedRef.current ?? []) : [];
     const manager = createDiffMultiSelectManager(container, diffFile, {
       isUnifiedMode: viewMode !== "split",
-      onSelectionChange: (range) => paintRange(container, range),
+      onSelectionChange: (range) => paintRange(container, range, paintBase()),
       onSelectionComplete: (result) => {
+        // One drag is single-sided by library contract; the union across drags
+        // is what lets a selection carry added AND deleted lines.
         const lines = (result?.lines ?? [])
           .filter((l) => l.isAdd || l.isDelete)
           .map(
@@ -692,11 +734,17 @@ function StagingDiffView({
               line: l.lineNumber,
             }),
           );
-        onSelectRef.current(lines.length ? lines : null);
+        const next = additiveRef.current
+          ? mergeSelection(selectedRef.current, lines)
+          : lines;
+        onSelectRef.current(next.length ? next : null);
       },
     });
     paintLines(container, selectedRef.current ?? []); // re-assert after (re)mount
-    return () => manager.destroy();
+    return () => {
+      container.removeEventListener("mousedown", onMouseDownCapture, true);
+      manager.destroy();
+    };
   }, [diffFile, viewMode]);
 
   // Paint the committed selection from state (incl. cleared → []).
@@ -810,6 +858,9 @@ function StagingDiffView({
       )}
       <DiffView
         diffFile={diffFile}
+        // Worker ASTs land as a highlighter PROP, not a rebuild: the view's
+        // effect applies them to its own clone, so expansion state survives.
+        registerHighlighter={workerHighlighter}
         diffViewMode={
           viewMode === "split" ? DiffModeEnum.Split : DiffModeEnum.Unified
         }

--- a/src/features/diff/use-worker-highlight.ts
+++ b/src/features/diff/use-worker-highlight.ts
@@ -93,7 +93,7 @@ function signatureOf(args: WorkerHighlightArgs): string {
 
 /**
  * Off-thread Shiki highlighting for over-budget Shiki-routed diffs. Returns the
- * per-side tokenized ASTs to hand `createDiffFile(..., workerAsts)` once they
+ * per-side tokenized ASTs that become the view's `registerHighlighter` once they
  * land, or null until then (and forever if the worker is unavailable or the
  * tokenize fails) — the caller keeps its interim paint. Latest-wins: a response
  * for a superseded request (rapid file navigation) is discarded, so no

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -7,6 +7,7 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import {
   MarkdownEditor,
   type MarkdownEditorHandle,
@@ -235,19 +236,35 @@ export function DiscussionView({
     return <DiffPlaceholder message="Could not load this discussion" />;
   }
 
-  // Placeholder details are the previous discussion's: `busy` holds the composer,
-  // reply box and mark-as-answer, the seeding actions below read this too, and the
-  // upvote/reaction toggles hold on it — their optimistic patch would land the
-  // rendered discussion's subject under the selected one's cache key. Lock/close,
-  // delete and labels also read `d.id` and stay live — tracked separately.
+  // Placeholder details are the previous discussion's, and every write on this
+  // surface addresses `d.id` — so all of them hold until the rendered discussion
+  // is the selected one, or they land on the discussion the viewer just left.
   const detailsStale = details.isPlaceholderData;
   // Matches the wording the PR and issue views use for the same wait.
   const staleReason = detailsStale ? "Loading this discussion…" : undefined;
+  // A disabled menu item drops pointer events, so its reason rides the label.
+  const staleSuffix = staleReason ? ` — ${staleReason}` : "";
   const busy =
     addComment.isPending ||
     markAnswer.isPending ||
     deleteComment.isPending ||
     detailsStale;
+  // Which term of `busy` the composer names, ranked: the switch window outranks a
+  // write the viewer started, being the hold they can't have caused themselves.
+  const composerReason = (() => {
+    switch (true) {
+      case detailsStale:
+        return staleReason;
+      case addComment.isPending:
+        return "Posting your comment…";
+      case markAnswer.isPending:
+        return "Updating the answer…";
+      case deleteComment.isPending:
+        return "Deleting a comment…";
+      default:
+        return undefined;
+    }
+  })();
 
   function submitComment() {
     if (!d || detailsStale || !compose.value.trim()) return;
@@ -340,8 +357,10 @@ export function DiscussionView({
     setRepoTab("issues");
   }
 
+  // Each of these addresses the rendered discussion's id while the menu belongs to
+  // the selected one; the items disable too, and these arms back them up.
   function doLock(reason: DiscussionLockReason | null) {
-    if (!d) return;
+    if (!d || detailsStale) return;
     lockDiscussion.mutate(
       { discussionId: d.id, reason },
       { onSuccess: () => toast.success("Conversation locked"), onError },
@@ -349,7 +368,7 @@ export function DiscussionView({
   }
 
   function doUnlock() {
-    if (!d) return;
+    if (!d || detailsStale) return;
     unlockDiscussion.mutate(d.id, {
       onSuccess: () => toast.success("Conversation unlocked"),
       onError,
@@ -357,7 +376,7 @@ export function DiscussionView({
   }
 
   function doClose(reason: DiscussionCloseReason) {
-    if (!d) return;
+    if (!d || detailsStale) return;
     closeDiscussion.mutate(
       { discussionId: d.id, reason },
       { onSuccess: () => toast.success("Discussion closed"), onError },
@@ -365,10 +384,25 @@ export function DiscussionView({
   }
 
   function doReopen() {
-    if (!d) return;
+    if (!d || detailsStale) return;
     reopenDiscussion.mutate(d.id, {
       onSuccess: () => toast.success("Discussion reopened"),
       onError,
+    });
+  }
+
+  function doDelete() {
+    if (!d || detailsStale) return;
+    deleteDiscussion.mutate(d.id, {
+      onSuccess: () => {
+        toast.success("Discussion deleted");
+        setDeletingDiscussion(false);
+        selectDiscussion(null);
+      },
+      onError: (e) => {
+        onError(e);
+        setDeletingDiscussion(false);
+      },
     });
   }
 
@@ -422,21 +456,26 @@ export function DiscussionView({
               </DropdownMenuItem>
               {d.closed ? (
                 <DropdownMenuItem
-                  disabled={reopenDiscussion.isPending}
+                  disabled={reopenDiscussion.isPending || detailsStale}
                   onClick={doReopen}
                 >
-                  Reopen discussion
+                  Reopen discussion{staleSuffix}
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuSub>
-                  <DropdownMenuSubTrigger disabled={closeDiscussion.isPending}>
-                    Close discussion…
+                  {/* The vendored sub-trigger carries no disabled styling of its
+                      own (unlike menu items), so the dim rides a call-site class. */}
+                  <DropdownMenuSubTrigger
+                    disabled={closeDiscussion.isPending || detailsStale}
+                    className="data-disabled:opacity-50"
+                  >
+                    Close discussion…{staleSuffix}
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
                     {CLOSE_REASONS.map(([label, reason]) => (
                       <DropdownMenuItem
                         key={reason}
-                        disabled={closeDiscussion.isPending}
+                        disabled={closeDiscussion.isPending || detailsStale}
                         onClick={() => doClose(reason)}
                       >
                         {label}
@@ -447,21 +486,24 @@ export function DiscussionView({
               )}
               {d.locked ? (
                 <DropdownMenuItem
-                  disabled={unlockDiscussion.isPending}
+                  disabled={unlockDiscussion.isPending || detailsStale}
                   onClick={doUnlock}
                 >
-                  Unlock conversation
+                  Unlock conversation{staleSuffix}
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuSub>
-                  <DropdownMenuSubTrigger disabled={lockDiscussion.isPending}>
-                    Lock conversation…
+                  <DropdownMenuSubTrigger
+                    disabled={lockDiscussion.isPending || detailsStale}
+                    className="data-disabled:opacity-50"
+                  >
+                    Lock conversation…{staleSuffix}
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
                     {LOCK_REASONS.map(([label, reason]) => (
                       <DropdownMenuItem
                         key={reason ?? "none"}
-                        disabled={lockDiscussion.isPending}
+                        disabled={lockDiscussion.isPending || detailsStale}
                         onClick={() => doLock(reason)}
                       >
                         {label}
@@ -472,9 +514,10 @@ export function DiscussionView({
               )}
               <DropdownMenuItem
                 variant="destructive"
+                disabled={detailsStale}
                 onClick={() => setDeletingDiscussion(true)}
               >
-                Delete discussion
+                Delete discussion{staleSuffix}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -525,6 +568,9 @@ export function DiscussionView({
           labelableId={d.id}
           labels={d.labels}
           lens="origin"
+          // `labelableId` is the rendered discussion's while the popover is keyed
+          // to the selected one, so a toggle mid-switch would label the wrong one.
+          disabledReason={staleReason}
         />
       </header>
       {/* overflow-hidden contains the thread's natural height (vendored Root is
@@ -598,6 +644,7 @@ export function DiscussionView({
               <ReactionBar
                 reactions={reactions.data?.body ?? []}
                 disabled={detailsStale}
+                reason={staleReason}
                 onToggle={(content, active) =>
                   toggleReaction(d.id, content, active)
                 }
@@ -639,6 +686,7 @@ export function DiscussionView({
                     toggleReaction(c.id, content, active)
                   }
                   reactionsHeld={detailsStale}
+                  reactionsReason={staleReason}
                 />
               </div>
               <div
@@ -708,6 +756,7 @@ export function DiscussionView({
                         toggleReaction(r.id, content, active)
                       }
                       reactionsHeld={detailsStale}
+                      reactionsReason={staleReason}
                     />
                   ))}
                   {reply.value.targetId === c.id && (
@@ -773,6 +822,7 @@ export function DiscussionView({
         ariaLabel="Add to the discussion"
         placeholder="Add to the discussion…"
         busy={busy}
+        reason={composerReason}
       />
 
       <DeleteCommentDialog
@@ -809,28 +859,17 @@ export function DiscussionView({
             >
               Cancel
             </Button>
-            <Button
+            <DisabledReasonButton
               variant="destructive"
-              disabled={deleteDiscussion.isPending}
-              onClick={() =>
-                deleteDiscussion.mutate(d.id, {
-                  onSuccess: () => {
-                    toast.success("Discussion deleted");
-                    setDeletingDiscussion(false);
-                    selectDiscussion(null);
-                  },
-                  onError: (e) => {
-                    onError(e);
-                    setDeletingDiscussion(false);
-                  },
-                })
-              }
+              disabled={deleteDiscussion.isPending || detailsStale}
+              reason={staleReason}
+              onClick={doDelete}
             >
               {deleteDiscussion.isPending && (
                 <Spinner data-icon="inline-start" />
               )}
               Delete
-            </Button>
+            </DisabledReasonButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -249,9 +249,9 @@ export function DiscussionView({
     markAnswer.isPending ||
     deleteComment.isPending ||
     detailsStale;
-  // Which term of `busy` the composer names, ranked: the switch window outranks a
-  // write the viewer started, being the hold they can't have caused themselves.
-  const composerReason = (() => {
+  // Which term of `busy` a control disabled on it names, ranked: the switch window
+  // outranks a write the viewer started, being the hold they can't have caused.
+  const busyReason = (() => {
     switch (true) {
       case detailsStale:
         return staleReason;
@@ -301,7 +301,11 @@ export function DiscussionView({
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
   };
 
+  // Every comment id below comes off the rendered discussion, which mid-switch is
+  // the previous one — so each write would land on the discussion the viewer just
+  // left. The affordances withhold or disable too; these arms back them up.
   function saveCommentEdit(commentId: string, body: string) {
+    if (detailsStale) return;
     updateComment.mutate(
       { commentId, body },
       { onSuccess: () => toast.success("Comment updated"), onError },
@@ -309,6 +313,7 @@ export function DiscussionView({
   }
 
   function hideComment(commentId: string, classifier: MinimizeReason) {
+    if (detailsStale) return;
     minimizeComment.mutate(
       { commentId, classifier },
       { onSuccess: () => toast.success("Comment hidden"), onError },
@@ -316,6 +321,7 @@ export function DiscussionView({
   }
 
   function unhideComment(commentId: string) {
+    if (detailsStale) return;
     unminimizeComment.mutate(commentId, {
       onSuccess: () => toast.success("Comment shown"),
       onError,
@@ -323,6 +329,7 @@ export function DiscussionView({
   }
 
   function toggleAnswer(commentId: string, isAnswer: boolean) {
+    if (detailsStale) return;
     markAnswer.mutate(
       { commentId, answer: !isAnswer },
       {
@@ -664,12 +671,15 @@ export function DiscussionView({
                   thread={toThread(c)}
                   onQuote={detailsStale ? undefined : () => quoteReply(c.body)}
                   onSaveEdit={
-                    c.viewerDidAuthor
+                    c.viewerDidAuthor && !detailsStale
                       ? (body) => saveCommentEdit(c.id, body)
                       : undefined
                   }
+                  // Withholding the handler only drops the menu entry; an editor
+                  // already open when the switch began needs its Save held too.
+                  editHeld={detailsStale}
                   onDelete={
-                    c.viewerDidAuthor
+                    c.viewerDidAuthor && !detailsStale
                       ? () => setDeletingCommentId(c.id)
                       : undefined
                   }
@@ -681,6 +691,9 @@ export function DiscussionView({
                   onUnhide={
                     c.isMinimized ? () => unhideComment(c.id) : undefined
                   }
+                  // Hide/Unhide stay visible but disabled — the items carry their
+                  // own reason, unlike the entries withheld above.
+                  disabledReason={staleReason}
                   reactions={reactions.data?.comments[c.id]}
                   onToggleReaction={(content, active) =>
                     toggleReaction(c.id, content, active)
@@ -699,10 +712,11 @@ export function DiscussionView({
                   disabled={toggleUpvoteMutation.isPending || detailsStale}
                   onClick={() => toggleUpvote(c.id, c.viewerHasUpvoted)}
                 />
-                <Button
+                <DisabledReasonButton
                   size="xs"
                   variant="ghost"
                   disabled={busy}
+                  reason={busyReason}
                   onClick={() =>
                     reply.set((prev) => ({
                       targetId: prev.targetId === c.id ? null : c.id,
@@ -711,17 +725,18 @@ export function DiscussionView({
                   }
                 >
                   Reply
-                </Button>
+                </DisabledReasonButton>
                 {d.isAnswerable && (
-                  <Button
+                  <DisabledReasonButton
                     size="xs"
                     variant={c.isAnswer ? "secondary" : "outline"}
                     disabled={busy}
+                    reason={busyReason}
                     onClick={() => toggleAnswer(c.id, c.isAnswer)}
                   >
                     <CheckCircleIcon data-icon="inline-start" />
                     {c.isAnswer ? "Unmark answer" : "Mark as answer"}
-                  </Button>
+                  </DisabledReasonButton>
                 )}
               </div>
               {(c.replies.length > 0 || reply.value.targetId === c.id) && (
@@ -734,12 +749,13 @@ export function DiscussionView({
                         detailsStale ? undefined : () => quoteReply(r.body)
                       }
                       onSaveEdit={
-                        r.viewerDidAuthor
+                        r.viewerDidAuthor && !detailsStale
                           ? (body) => saveCommentEdit(r.id, body)
                           : undefined
                       }
+                      editHeld={detailsStale}
                       onDelete={
-                        r.viewerDidAuthor
+                        r.viewerDidAuthor && !detailsStale
                           ? () => setDeletingCommentId(r.id)
                           : undefined
                       }
@@ -751,6 +767,7 @@ export function DiscussionView({
                       onUnhide={
                         r.isMinimized ? () => unhideComment(r.id) : undefined
                       }
+                      disabledReason={staleReason}
                       reactions={reactions.data?.comments[r.id]}
                       onToggleReaction={(content, active) =>
                         toggleReaction(r.id, content, active)
@@ -784,15 +801,18 @@ export function DiscussionView({
                         textareaClassName="max-h-32 min-h-12 resize-y"
                       />
                       <div className="flex items-center gap-2">
-                        <Button
+                        <DisabledReasonButton
                           size="xs"
                           variant="outline"
                           disabled={!reply.value.body.trim() || busy}
+                          // An empty draft explains itself; only the `busy` hold
+                          // needs words.
+                          reason={busy ? busyReason : null}
                           onClick={() => submitReply(c.id)}
                           title={SUBMIT_HINT}
                         >
                           Reply
-                        </Button>
+                        </DisabledReasonButton>
                         <Button
                           size="xs"
                           variant="ghost"
@@ -822,7 +842,7 @@ export function DiscussionView({
         ariaLabel="Add to the discussion"
         placeholder="Add to the discussion…"
         busy={busy}
-        reason={composerReason}
+        reason={busyReason}
       />
 
       <DeleteCommentDialog

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -27,6 +27,7 @@ import {
   useForgeSearchRepos,
 } from "@/lib/git/queries";
 import type { ForgeProvider, ForgeSearchRepo } from "@/lib/git/types";
+import { useModalGateRegistration } from "@/lib/hotkeys/modal-gate";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage, isAppError } from "@/lib/tauri/invoke";
@@ -75,6 +76,11 @@ export function ExploreScreen() {
   // them regardless of which mode is on screen.
   const [flatRepos, setFlatRepos] = useState<ForgeSearchRepo[]>([]);
   const detailRef = useRef<HTMLDivElement>(null);
+
+  // App's repo/settings actions stay reachable from the macOS menu bar, which
+  // sits outside this dialog's modal overlay — register so they refuse while
+  // the clone dialog owns the screen.
+  useModalGateRegistration(cloneTarget !== null);
 
   // 400ms sized against GitHub code search's ~30 req/min bucket — a
   // keystroke-per-request would burn it.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -325,7 +325,9 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 - **Hunk-level staging** — in a file's diff, each hunk has its own Stage / Unstage /
   Discard buttons.
 - **Line-level staging** — drag across the line-number gutter to select specific lines,
-  then stage or discard just those.
+  then stage or discard just those. Hold {{key:mod}} while dragging and the new run joins
+  the selection instead of replacing it, so one selection can mix added and removed lines
+  across as many hunks as you like; a plain drag starts a fresh one.
 - Select multiple files ({{key:mod}}-click, or Shift-click for a range), then {{secondaryclick}}
   for **Stage / Unstage / Discard / Stash** of the whole selection.
 - Filter the list by path, or by category (new / modified / deleted, included /
@@ -437,10 +439,14 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   push publishes it under its own name — pairs with pushing a branch without switching to it
   (below).
 - **Clean up branches** — from the switcher's menu or the command palette — opens a bulk
-  sweep of stale branches: those **merged** into the default branch, or with no commits in a
-  chosen window (30/60/90 days). Review the pre-checked list, then **archive** them
-  (reversible) or **delete** them together. The current branch, the default branch, and
-  protected branches are never included.
+  sweep of stale branches: those **merged** into the default branch — directly, or through a
+  recent pull request, so squash- and rebase-merged branches turn up too, each badged
+  **merged #123** with the pull request that took them — and those with no commits in a
+  chosen window (30/60/90 days). Branches your own history calls merged, and idle ones,
+  start **pre-checked**; a pull-request match goes by branch name, so those rows start
+  unchecked for you to confirm each one. Review the list, then **archive** them (reversible)
+  or **delete** them together. The current branch, the default branch, and protected
+  branches are never included.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
   or renaming one. Whenever the working tree can't describe the branch being named —
   it's clean, or you're renaming a branch you aren't on — it names it from that
@@ -494,8 +500,8 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 **Stash all changes** ({{kbd:stash-all}}) sets your working changes aside; **View
 stashes** lists them to apply, pop, or drop, and **Pop latest stash** restores the most
 recent. Setting changes aside is refused while conflicts are still unresolved, or while a
-merge, rebase or cherry-pick is in progress — finish or abort it first, so a resolution
-you've already staged can't be swept out of the operation.
+merge, rebase, cherry-pick or revert is in progress — finish or abort it first, so a
+resolution you've already staged can't be swept out of the operation.
 
 **Recover lost work** (in the branch ⋮ menu, or the command palette) opens the
 **Recoverable** tab in the stashes dialog. It scans your repository (with \`git fsck\`) for
@@ -512,9 +518,9 @@ from, and whether it finished, failed, or is still pending. If one of these oper
 interrupted (a crash or a restart mid-op), a calm recovery line appears above the **Changes**
 list naming what was interrupted and the state it started from. That notice only informs — it
 never resets or continues anything on its own (the git-native **Continue**/**Abort** for an
-in-progress merge, rebase, or cherry-pick live in the conflict bar right above it); from it
-you can open this history, jump to **Recover lost work** to rescue any orphaned changes, or
-dismiss the notice.
+in-progress merge, rebase, cherry-pick, or revert live in the conflict bar right above it);
+from it you can open this history, jump to **Recover lost work** to rescue any orphaned
+changes, or dismiss the notice.
 
 ## Compare
 
@@ -555,9 +561,9 @@ test, or review several branches at once without stashing or switching.
   removes the worktree (a branch can't be checked out in two at once) and checks that branch
   out in the main workspace. The worktree must be clean first; any uncommitted work in the
   main workspace is stashed so the checkout can't be blocked (restore it with *Pop latest
-  stash*), and promoting is blocked while the main workspace has a merge, rebase or
-  cherry-pick in progress, or unresolved conflicts. Works even on the worktree you're
-  currently in.
+  stash*), and promoting is blocked while the main workspace has a merge, rebase,
+  cherry-pick or revert in progress, or unresolved conflicts. Works even on the worktree
+  you're currently in.
 - **Repair links** (footer) re-connects worktrees if you moved or renamed the repository
   folder in your file manager, which otherwise breaks the path each worktree records.
 
@@ -603,12 +609,15 @@ the pull runs, then they come back on top of it. If reapplying them hits conflic
 conflicted files appear in **Changes** to resolve as usual and the stash is kept as a backup
 until you're done; if they can't go back at all (say the pull brought in a file with the
 same name), they stay safely in the stash. The same recovery covers
-**Update from upstream** and updating the branch you're on from another branch.
+**Update from upstream**, updating the branch you're on from another branch, and **merging**
+a branch into the one you're on. A **squash**, **no-fast-forward**, or strategy merge reports
+the refusal instead: the recovery redoes the merge plainly, so offering it there would drop
+the option you chose.
 
 Tick **Always stash and reapply** in the prompt — or turn on **Automatically stash and
-reapply on pull and branch updates** under **Settings → General** — and those operations
-recover on their own, with no prompt. Either way it only ever kicks in when git actually
-refuses the operation.
+reapply on pull, merge, and branch updates** under **Settings → General** — and those
+operations recover on their own, with no prompt. Either way it only ever kicks in when git
+actually refuses the operation.
 
 ## Update a fork from upstream
 
@@ -640,13 +649,15 @@ pushed in the meantime.
 
 ## Resolving conflicts
 
-During a **merge**, **rebase**, or **cherry-pick**, a slim banner appears in **Changes**
-with the conflict count and **Abort** / **Finish** controls. Select a conflicted file (the
-\`!\` badge) to open the **conflict editor**: each conflict region shows **Current (ours)**
-over **Incoming (theirs)** with **Accept current**, **Accept incoming**, or **Accept both**,
-and the header adds whole-file **Accept all current** / **Accept all incoming** and **Open in
-editor**. Files mark themselves resolved as you go — the \`!\` badge clears — and **Finish**
-stays disabled until every conflict is resolved.
+During a **merge**, **rebase**, **cherry-pick**, or **revert**, a slim banner appears in
+**Changes** naming the operation and its conflict count, with **Abort** and a finish control
+that names it too (**Finish merge**, **Continue rebase**, **Continue cherry-pick**,
+**Continue revert**). Select a conflicted file (the \`!\` badge) to open the **conflict
+editor**: each conflict region shows **Current (ours)** over **Incoming (theirs)** with
+**Accept current**, **Accept incoming**, or **Accept both**, and the header adds whole-file
+**Accept all current** / **Accept all incoming** and **Open in editor**. Files mark
+themselves resolved as you go — the \`!\` badge clears — and the finish control stays
+disabled, saying so, until every conflict is resolved.
 
 {{ai}}## Resolve conflicts with AI
 
@@ -885,10 +896,13 @@ range. From there you can:
 
 A **Review in progress** bar shows the pending count with **Submit review…** and
 **Discard**. Submitting opens a dialog to choose a **verdict** — **Comment**, **Approve**,
-or **Request changes** — each offered only where the provider allows it; **Request changes**
-requires a summary. Submit posts all your pending drafts as one batch review (it works with
-no drafts too, for a plain verdict + summary). **Submit review…** and **Discard pending
-review** are also available from the command palette ({{kbd:command-palette}}).
+or **Request changes**. All three always show: one that isn't usable yet stays on screen,
+disabled, and names what it's waiting on — *available once GitDesktop connects to GitHub*
+(or GitLab, or Bitbucket) — so you can see the option exists and what makes it work.
+**Request changes** requires a summary. Submit posts all your pending drafts as one batch
+review (it works with no drafts too, for a plain verdict + summary). **Submit review…** and
+**Discard pending review** are also available from the command palette
+({{kbd:command-palette}}).
 
 ## The Commits tab
 
@@ -1014,9 +1028,11 @@ this pull request already sits on, and shows you a **preview** of exactly what w
 stacked, bottom to top, before anything is created. Confirm it and the chain becomes a real
 stack: one that navigates as a unit and **merges bottom-up as a single operation**. Only
 this repository's own pull requests can chain — a **fork** pull request never joins a
-stack — and where a repository has more open pull requests than fit one page, the offer
-stays quiet rather than guess at a chain it can't see whole. (GitLab finds stacked merge
-requests on its own and Bitbucket has no stacks, so this is GitHub-only.)
+stack — and where a repository has more open pull requests than fit one page, it won't
+guess at a chain it can't see whole. When one of those holds it back, a short note sits
+where the offer would: too many open pull requests to scan, stack state still loading, or a
+fork pull request targeting this branch. (GitLab finds stacked merge requests on its own and
+Bitbucket has no stacks, so this is GitHub-only.)
 
 A stacked pull request's **Stack** section also offers **Dissolve**, behind a confirmation.
 Dissolving takes the stack apart and nothing else: every pull request in it **stays open on
@@ -1122,7 +1138,11 @@ reviewing model's context window (probing Ollama live), or pick Compact / Standa
 Expanded. **Review timeout** (shown when an agent CLI drives reviews or security audits)
 caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
 the review is agentic — always, for Codex), or pin a fixed limit that applies to every
-agent-CLI review.
+agent-CLI review. Whatever the reviewer already wrote is kept when the limit hits: it stays
+on screen and is saved with the pull request, labelled **Timed out — partial output kept**,
+so it's still there after a restart. Kept output is never treated as a finished review — it
+doesn't feed the next run's context and doesn't count as coverage for an automated review,
+so run it again for a full one.
 
 **Critical** is the top severity an audit finding can carry — remote code execution,
 execution triggered by content you only clone or open, full compromise, or a mass data
@@ -2108,9 +2128,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   background work continues; launching the app again while it's running —
   tray-hidden or not — focuses the existing window), **automatically fetch from your
   remotes** (a background fetch on an interval you pick — it never pulls, merges, or
-  changes your files), **automatically stash and reapply on pull and branch updates**
-  (an operation git would refuse over uncommitted changes recovers on its own, no
-  prompt), **reapply stashed changes after switching branches** (*Stash and switch*
+  changes your files), **automatically stash and reapply on pull, merge, and branch
+  updates** (an operation git would refuse over uncommitted changes recovers on its own,
+  no prompt), **reapply stashed changes after switching branches** (*Stash and switch*
   puts your changes back once the switch lands), **create pull requests as drafts** by
   default (off by default — pre-checks the Create-PR dialog's draft box, still
   overridable per PR; pairs with *Review draft PRs when created* so a draft's automated

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -443,10 +443,10 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   recent pull request, so squash- and rebase-merged branches turn up too, each badged
   **merged #123** with the pull request that took them — and those with no commits in a
   chosen window (30/60/90 days). Branches your own history calls merged, and idle ones,
-  start **pre-checked**; a pull-request match goes by branch name, so those rows start
-  unchecked for you to confirm each one. Review the list, then **archive** them (reversible)
-  or **delete** them together. The current branch, the default branch, and protected
-  branches are never included.
+  start **pre-checked**; a pull-request match goes by branch name, so it never pre-checks
+  a row on its own — it badges one for you to confirm. Review the list, then **archive**
+  them (reversible) or **delete** them together. The current branch, the default branch,
+  and protected branches are never included.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
   or renaming one. Whenever the working tree can't describe the branch being named —
   it's clean, or you're renaming a branch you aren't on — it names it from that
@@ -897,8 +897,8 @@ range. From there you can:
 A **Review in progress** bar shows the pending count with **Submit review…** and
 **Discard**. Submitting opens a dialog to choose a **verdict** — **Comment**, **Approve**,
 or **Request changes**. All three always show: one that isn't usable yet stays on screen,
-disabled, and names what it's waiting on — *available once GitDesktop connects to GitHub*
-(or GitLab, or Bitbucket) — so you can see the option exists and what makes it work.
+disabled, and names what it's waiting on — *available once GitDesktop connects to GitLab*
+(or Bitbucket) — so you can see the option exists and what makes it work.
 **Request changes** requires a summary. Submit posts all your pending drafts as one batch
 review (it works with no drafts too, for a plain verdict + summary). **Submit review…** and
 **Discard pending review** are also available from the command palette
@@ -1030,8 +1030,8 @@ stack: one that navigates as a unit and **merges bottom-up as a single operation
 this repository's own pull requests can chain — a **fork** pull request never joins a
 stack — and where a repository has more open pull requests than fit one page, it won't
 guess at a chain it can't see whole. When one of those holds it back, a short note sits
-where the offer would: too many open pull requests to scan, stack state still loading, or a
-fork pull request targeting this branch. (GitLab finds stacked merge requests on its own and
+where the offer would: too many open pull requests to scan, stack state GitDesktop couldn't
+read, or a fork pull request targeting this branch. (GitLab finds stacked merge requests on its own and
 Bitbucket has no stacks, so this is GitHub-only.)
 
 A stacked pull request's **Stack** section also offers **Dissolve**, behind a confirmation.

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -446,13 +446,14 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     firstMerge === -1 ? Number.POSITIVE_INFINITY : firstMerge,
   );
   if (editLen === commits.length && !log.hasNextPage) editLen -= 1;
-  // Block editing history while a merge/rebase/cherry-pick is mid-flight — a
-  // new edit-rebase would clobber the in-flight one's state (the banner drives
+  // Block editing history while a merge/rebase/cherry-pick/revert is mid-flight —
+  // a new edit-rebase would clobber the in-flight one's state (the banner drives
   // it). The backend refuses too; this just keeps the action from looking live.
   const opInProgress = Boolean(
     opState.data?.merging ||
       opState.data?.rebasing ||
-      opState.data?.cherryPicking,
+      opState.data?.cherryPicking ||
+      opState.data?.reverting,
   );
   const canEditHistory = editLen >= 1 && !opInProgress;
   const editHistoryHint = opInProgress

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1560,6 +1560,18 @@ export function JiraIssueView({
     : issue.url;
   const detailsStale = details.isPlaceholderData;
   const staleDim = detailsStale && "opacity-80";
+  // Which hold the composer names, ranked: the switch window outranks a write the
+  // viewer started, being the hold they can't have caused themselves.
+  const composerReason = (() => {
+    switch (true) {
+      case detailsStale:
+        return "Loading this issue…";
+      case comment.isPending:
+        return "Posting your comment…";
+      default:
+        return undefined;
+    }
+  })();
 
   function submitComment() {
     const body = compose.value.trim();
@@ -1749,6 +1761,7 @@ export function JiraIssueView({
               // A placeholder issue is the previously selected one, so submitting
               // would comment on it; typing stays live through the window.
               busy={comment.isPending || detailsStale}
+              reason={composerReason}
               disabled={comment.isPending}
             />
           )}

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -300,6 +300,22 @@ export function RemoteIssueView({
     closeIssue.isPending ||
     reopenIssue.isPending ||
     detailsStale;
+  // Which term of `busy` the composer names, ranked: the switch window outranks a
+  // write the viewer started, being the hold they can't have caused themselves.
+  const composerReason = (() => {
+    switch (true) {
+      case detailsStale:
+        return staleReason;
+      case comment.isPending:
+        return "Posting your comment…";
+      case closeIssue.isPending:
+        return "Closing this issue…";
+      case reopenIssue.isPending:
+        return "Reopening this issue…";
+      default:
+        return undefined;
+    }
+  })();
   const comments = issue.comments.filter((c) => hasVisibleBody(c.body));
 
   function submitComment() {
@@ -818,17 +834,15 @@ export function RemoteIssueView({
                   </p>
                 )}
                 {canReact && (
-                  // The counts are a read and stay; only the toggles hold. A
-                  // disabled button swallows `title`, so the wait rides the span.
-                  <span title={staleReason} className="inline-flex">
-                    <ReactionBar
-                      reactions={reactions.data?.body ?? []}
-                      disabled={detailsStale}
-                      onToggle={(content, active) =>
-                        toggleReaction(issue.id, content, active)
-                      }
-                    />
-                  </span>
+                  // The counts are a read and stay; only the toggles hold.
+                  <ReactionBar
+                    reactions={reactions.data?.body ?? []}
+                    disabled={detailsStale}
+                    reason={staleReason}
+                    onToggle={(content, active) =>
+                      toggleReaction(issue.id, content, active)
+                    }
+                  />
                 )}
               </div>
               {canWrite && (
@@ -891,6 +905,7 @@ export function RemoteIssueView({
                       : undefined
                   }
                   reactionsHeld={detailsStale}
+                  reactionsReason={staleReason}
                 />
               ))}
               {comments.length === 0 && (
@@ -914,20 +929,22 @@ export function RemoteIssueView({
               onSubmit={submitComment}
               submitLabel="Comment"
               busy={busy}
+              reason={composerReason}
               // Clear is site-rendered rather than the shared `onClear` one: the
               // close/reopen arm follows it, and the shared Clear is `ml-auto`.
               actions={
                 <>
                   {compose.value.trim() && (
-                    <Button
+                    <DisabledReasonButton
                       variant="ghost"
                       size="sm"
                       disabled={busy}
+                      reason={composerReason}
                       onClick={() => compose.set("")}
                       title="Discard this draft (e.g. a quote reply)"
                     >
                       Clear
-                    </Button>
+                    </DisabledReasonButton>
                   )}
                   {stateActions}
                 </>

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -364,7 +364,11 @@ export function RemoteIssueView({
     );
   }
 
+  // Both take a comment id off the RENDERED issue, which through a switch is the
+  // previous one, so either would hide a comment on the issue the viewer just
+  // left. The menu items disable on the same wait; these arms back them up.
   function hideComment(commentId: string, classifier: MinimizeReason) {
+    if (detailsStale) return;
     minimizeComment.mutate(
       { commentId, classifier },
       { onSuccess: () => toast.success("Comment hidden"), onError },
@@ -372,6 +376,7 @@ export function RemoteIssueView({
   }
 
   function unhideComment(commentId: string) {
+    if (detailsStale) return;
     unminimizeComment.mutate(commentId, {
       onSuccess: () => toast.success("Comment shown"),
       onError,
@@ -894,7 +899,10 @@ export function RemoteIssueView({
                       ? () => unhideComment(c.id)
                       : undefined
                   }
-                  disabledReason={triageItemReason}
+                  // Hide/Unhide stay visible but disabled through the switch. The
+                  // permission reason ranks first — it's the one still true once
+                  // the selected issue is on screen.
+                  disabledReason={triageItemReason ?? staleReason}
                   reactions={
                     canReact ? reactions.data?.comments[c.id] : undefined
                   }

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -294,6 +294,22 @@ export function CommitComments({
     editComment.isPending ||
     deleteComment.isPending ||
     stale;
+  // Which term of `busy` the composer names, ranked: the switch window outranks a
+  // write the viewer started, being the hold they can't have caused themselves.
+  const composerReason = (() => {
+    switch (true) {
+      case stale:
+        return "Loading this commit…";
+      case createComment.isPending:
+        return "Posting your comment…";
+      case editComment.isPending:
+        return "Saving a comment edit…";
+      case deleteComment.isPending:
+        return "Deleting a comment…";
+      default:
+        return undefined;
+    }
+  })();
 
   function submit() {
     const text = draft.value.trim();
@@ -427,6 +443,7 @@ export function CommitComments({
           onSubmit={submit}
           submitLabel="Comment"
           busy={busy}
+          reason={composerReason}
         />
       )}
 

--- a/src/features/pulls/PendingReviewBar.tsx
+++ b/src/features/pulls/PendingReviewBar.tsx
@@ -12,7 +12,6 @@ import {
   useReviewDrafts,
   useUpdateReviewDraft,
 } from "@/lib/pulls/review-drafts";
-import { toastError } from "@/lib/toast";
 
 /** The anchor label for a draft: "Lines a–b" for a range, "Line b" otherwise. */
 function draftLabel(draft: ReviewDraft): string {
@@ -178,7 +177,6 @@ export function PendingReviewBar({
         pending={clearDrafts.isPending}
         onConfirm={() =>
           clearDrafts.mutate(undefined, {
-            onError: (e) => toastError(e),
             onSuccess: () => setConfirmDiscard(false),
           })
         }

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -164,6 +164,7 @@ export function PrActivityFeed({
   onUnhideComment,
   onToggleReaction,
   reactionsHeld = false,
+  reactionsReason,
 }: {
   pr: PrDetails;
   timeline: PrTimelineEvent[] | undefined;
@@ -213,6 +214,9 @@ export function PrActivityFeed({
   /** Holds the comment reaction toggles: their subject ids come from the rendered
    *  PR, while the write addresses the selected one. The counts stay visible. */
   reactionsHeld?: boolean;
+  /** Why `reactionsHeld` holds — shown and announced on every control it
+   *  disables. Absent leaves a plain disable no viewer can interrogate. */
+  reactionsReason?: string | null;
 }) {
   const {
     renderedReviews,
@@ -388,6 +392,7 @@ export function PrActivityFeed({
             }
             disabledReason={disabledReason}
             reactionsHeld={reactionsHeld}
+            reactionsReason={reactionsReason}
             reactions={canReact ? reactions?.comments[c.id] : undefined}
             onToggleReaction={
               canReact

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -55,6 +55,7 @@ import {
   getLatestPartialReview,
   type PersistedReview,
   partialReviewReason,
+  reviewPartialKey,
 } from "@/lib/pulls/reviews-history";
 import { useSecretPreview, useSettings } from "@/lib/settings/queries";
 import { useConfirm } from "@/lib/stores/confirm";
@@ -166,13 +167,7 @@ export function PrReviewPanel({
   // so this is the only copy after a restart; it's shown solely when nothing newer
   // completed, so a finished review always wins the surface.
   const partialRun = useQuery({
-    queryKey: [
-      "review-partial",
-      context.repoPath,
-      context.lens,
-      prKind,
-      prRef,
-    ] as const,
+    queryKey: reviewPartialKey(context.repoPath, context.lens, prKind, prRef),
     queryFn: () =>
       getLatestPartialReview(context.repoPath, context.lens, prKind, prRef),
   });

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -51,7 +51,11 @@ import {
   useReviewerNotes,
   useReviewHistory,
 } from "@/lib/pulls/queries";
-import type { PersistedReview } from "@/lib/pulls/reviews-history";
+import {
+  getLatestPartialReview,
+  type PersistedReview,
+  partialReviewReason,
+} from "@/lib/pulls/reviews-history";
 import { useSecretPreview, useSettings } from "@/lib/settings/queries";
 import { useConfirm } from "@/lib/stores/confirm";
 import {
@@ -75,6 +79,12 @@ const DELTA_NOTE: Partial<Record<string, string>> = {
 };
 
 const PROVIDER_IDS = Object.keys(PROVIDER_LABELS) as AiProviderId[];
+
+/** A stored review's findings text. The plugin-store JSON is untrusted (a
+ *  hand-edited `pr-reviews.json` reaches here verbatim), so a non-string `text` reads
+ *  as no text instead of throwing mid-render. */
+const reviewText = (r: PersistedReview): string =>
+  typeof r.text === "string" ? r.text : "";
 
 export function PrReviewPanel({
   context,
@@ -148,10 +158,39 @@ export function PrReviewPanel({
     // empty-text records (trimmed to nothing) — the run feeds them no context,
     // so the banner shouldn't claim it'll "build on" them.
     for (const r of history.data ?? []) {
-      if (r.text.trim() && out[r.mode] == null) out[r.mode] = r;
+      if (reviewText(r).trim() && out[r.mode] == null) out[r.mode] = r;
     }
     return out;
   }, [history.data]);
+  // The output a failed/timed-out run left behind. The live run store is memory-only,
+  // so this is the only copy after a restart; it's shown solely when nothing newer
+  // completed, so a finished review always wins the surface.
+  const partialRun = useQuery({
+    queryKey: [
+      "review-partial",
+      context.repoPath,
+      context.lens,
+      prKind,
+      prRef,
+    ] as const,
+    queryFn: () =>
+      getLatestPartialReview(context.repoPath, context.lens, prKind, prRef),
+  });
+  const keptPartial = useMemo(() => {
+    const record = partialRun.data;
+    // History pending (undefined) withholds it rather than guessing: showing kept
+    // output that a since-completed review supersedes, then yanking it, reads as a flash.
+    if (
+      !record ||
+      !reviewText(record).trim() ||
+      !validEpochMs(record.finishedAt) ||
+      !history.data
+    )
+      return undefined;
+    return record.finishedAt > (history.data[0]?.finishedAt ?? 0)
+      ? record
+      : undefined;
+  }, [partialRun.data, history.data]);
   // Which modes the next run should ignore the prior review for — derived from
   // the clicked button's mode, never the shared store entry (avoids mislabeling).
   const [ignoredModes, setIgnoredModes] = useState<Set<ReviewMode>>(new Set());
@@ -746,6 +785,19 @@ export function PrReviewPanel({
               <Spinner className="size-3" />
               {status || "Starting review…"}
             </p>
+          ) : keptPartial ? (
+            <div className="space-y-2">
+              <p className="flex items-start gap-1.5 text-xs text-warning">
+                <ClockIcon className="mt-0.5 size-3.5 shrink-0" />
+                <span>
+                  {partialReviewReason(keptPartial).timedOut
+                    ? "Timed out"
+                    : "Stopped early"}{" "}
+                  — partial output kept. Run it again for a full review.
+                </span>
+              </p>
+              <Markdown>{reviewText(keptPartial)}</Markdown>
+            </div>
           ) : (
             <p className="text-xs text-muted-foreground">
               Run a general review or a security audit of this {prNoun}'s

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -164,6 +164,7 @@ import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import { ChecksRollup } from "./ChecksRollup";
 import { LinkedIssuesField } from "./LinkedIssuesField";
@@ -607,11 +608,28 @@ export function RemotePrView({
     armAutoMerge.isPending ||
     cancelAutoMerge.isPending ||
     setDraft.isPending;
-  // Palette twins of the footer's draft controls — same `setDraft` mutation; Ready
-  // also fires the ready-review automation.
+  // WHICH draft action exists is picked off `isDraft`, so placeholder details would
+  // offer the PREVIOUS PR's. Retain the last FRESH value and the PR it belonged to;
+  // a mismatch means nothing fresh has landed for this one yet, and neither action is
+  // offered. Both retained values are primitives — an object would re-set every
+  // render. The stale arms feed null so a mount landing mid-switch seeds neither.
+  const retainedDraftFor = useRetained(
+    details.isPlaceholderData ? null : entityKey,
+    !details.isPlaceholderData,
+  );
+  const retainedIsDraft = useRetained(
+    details.isPlaceholderData ? null : (details.data?.isDraft ?? null),
+    !details.isPlaceholderData,
+  );
+  const shownIsDraft = retainedDraftFor === entityKey ? retainedIsDraft : null;
+  // Palette twins of the footer's draft controls — same `setDraft` mutation, same
+  // frozen identity, and Ready also fires the ready-review automation. Registration
+  // is effect-synced, so an `enabled` term alone still leaves the keypress a frame
+  // to land mid-switch; each handler re-checks the identity it is about to write.
   useHotkeyAction(
     "pr-ready-for-review",
-    () =>
+    () => {
+      if (shownIsDraft !== true) return;
       setDraft.mutate(
         { number, draft: false },
         {
@@ -621,22 +639,25 @@ export function RemotePrView({
           },
           onError,
         },
-      ),
-    isSelectedPr && draftPairVisible && !!details.data?.isDraft && !busy,
+      );
+    },
+    isSelectedPr && draftPairVisible && shownIsDraft === true && !busy,
   );
   useHotkeyAction(
     "pr-convert-to-draft",
-    () =>
+    () => {
+      if (shownIsDraft !== false) return;
       setDraft.mutate(
         { number, draft: true },
         {
           onSuccess: () => toast.success("Converted to draft"),
           onError,
         },
-      ),
+      );
+    },
     isSelectedPr &&
       draftPairVisible &&
-      !details.data?.isDraft &&
+      shownIsDraft === false &&
       details.data?.state === "OPEN" &&
       !busy,
   );
@@ -709,6 +730,37 @@ export function RemotePrView({
     return row ? [{ number: row.number, title: row.title }] : [];
   });
   const stackWriteError = stackCreate.error ?? stackAdd.error ?? null;
+  // A fork row is dropped from the chain rather than voiding the list, so it only
+  // explains THIS PR's missing offer when it would have been its CHILD. The mirror
+  // test (a fork whose head is this PR's base) is not specific: fork PRs are
+  // routinely opened from `main`, which is most PRs' base, so it would make the note
+  // permanent furniture on ordinary pull requests.
+  const forkChild =
+    currentRow != null &&
+    openPrs.some(
+      (p) =>
+        p.crossRepository === true && p.baseRefName === currentRow.headRefName,
+    );
+  // Why a chain that may well exist still gets no offer. Only the ADVISORY refusals
+  // are named — the detector's structural arms (no chain, ambiguity, a stacked
+  // neighbor) genuinely mean "nothing to stack", and a note there is noise. Read off
+  // `openPrs`, so a disabled offer query can never speak for a PR the suggestion was
+  // never attempted on.
+  const stackOfferNote = (() => {
+    if (stackOffer) return null;
+    switch (true) {
+      // Ordered as `detectStackOffer` refuses: the two fail-closed list guards
+      // first, then the row-level fork exclusion.
+      case openPrs.some((p) => p.stackUnknown === true):
+        return "Stack suggestions are paused until every open pull request's stack state loads.";
+      case openPrs.length >= STACK_OFFER_PAGE_LIMIT:
+        return "Stack suggestions are paused — too many open pull requests to scan reliably.";
+      case forkChild:
+        return "A fork pull request targets this branch, but fork pull requests can't join a stack — their branches live in another repository.";
+      default:
+        return null;
+    }
+  })();
 
   function confirmStackOffer() {
     // `offerEnabled` withholds the offer entirely until details are the selected
@@ -1506,6 +1558,38 @@ export function RemotePrView({
   // BELOW any permission or read-error reason wherever both hold: those never
   // lift on their own and are the ones still true once the switch lands.
   const staleReason = detailsStale ? PR_SWITCH_LOADING_REASON : undefined;
+  // Which term of `busy` the composer names, ranked: the switch window outranks a
+  // write the viewer started, being the hold they can't have caused themselves.
+  const composerReason = (() => {
+    switch (true) {
+      case detailsStale:
+        return staleReason;
+      case comment.isPending:
+        return "Posting your comment…";
+      case mergePr.isPending:
+        return `Merging this ${prNoun}…`;
+      case closePr.isPending:
+        return `Closing this ${prNoun}…`;
+      case reopenPr.isPending:
+        return `Reopening this ${prNoun}…`;
+      case approvePr.isPending:
+        return "Submitting your approval…";
+      case unapprovePr.isPending:
+        return "Revoking your approval…";
+      case requestChangesPr.isPending:
+        return "Requesting changes…";
+      case unrequestChangesPr.isPending:
+        return "Revoking your change request…";
+      case armAutoMerge.isPending:
+        return "Enabling auto-merge…";
+      case cancelAutoMerge.isPending:
+        return "Canceling auto-merge…";
+      case setDraft.isPending:
+        return "Updating draft status…";
+      default:
+        return undefined;
+    }
+  })();
   // The metadata pickers seed from the rendered PR and commit the WHOLE set on
   // close, so one opened mid-switch would write the previous PR's members under
   // the new number. Their triggers disable on a reason, so this rides that seam.
@@ -1521,23 +1605,37 @@ export function RemotePrView({
     );
   }
   if (details.isError || !pr) {
+    // A read that never landed says so in the forge's own name — the raw summary
+    // alone reads like a missing PR when the real answer is "you're offline". The
+    // provider stays unnamed when its own probe hasn't answered, rather than guessed.
+    const unreachable = provider
+      ? `Couldn't reach ${remoteLabel} to load this ${prNoun}.`
+      : `Couldn't reach the remote to load this ${prNoun}.`;
+    const errorSummary = details.error
+      ? presentError(details.error).summary
+      : null;
     return (
       <DiffPlaceholder
         message={
-          details.error
-            ? presentError(details.error).summary
-            : "Could not load this pull request"
+          details.isError ? unreachable : "Could not load this pull request"
         }
         action={
           details.isError ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="cursor-pointer"
-              onClick={() => details.refetch()}
-            >
-              Retry
-            </Button>
+            <div className="flex flex-col items-center gap-2">
+              {/* The underlying summary keeps the detail the headline generalizes. */}
+              {errorSummary ? (
+                <p className="max-w-md text-center text-xs">{errorSummary}</p>
+              ) : null}
+              <Button
+                variant="outline"
+                size="sm"
+                className="cursor-pointer"
+                disabled={details.isFetching}
+                onClick={() => details.refetch()}
+              >
+                {details.isFetching ? "Retrying…" : "Retry"}
+              </Button>
+            </div>
           ) : undefined
         }
       />
@@ -2116,6 +2214,11 @@ export function RemotePrView({
             onCancel={cancelStackOffer}
           />
         )}
+        {/* Sits where the offer would, and only when there is none — plain text in
+            flow, so the absence explains itself instead of reading as a dead slot. */}
+        {stackOfferNote ? (
+          <p className="text-xs text-muted-foreground">{stackOfferNote}</p>
+        ) : null}
         <ChecksRollup
           checks={pr.checks}
           repoPath={repoPath}
@@ -2284,17 +2387,16 @@ export function RemotePrView({
                   </DropdownMenu>
                 </div>
                 {canReact && (
-                  // The counts are a read and stay; only the toggles hold. A
-                  // disabled button swallows `title`, so the wait rides the span.
-                  <span title={staleReason} className="inline-flex">
-                    <ReactionBar
-                      reactions={reactions.data?.body ?? []}
-                      disabled={detailsStale}
-                      onToggle={(content, active) =>
-                        toggleReaction(pr.id, content, active)
-                      }
-                    />
-                  </span>
+                  // The counts are a read and stay; only the toggles hold, and the
+                  // bar carries the wait itself (a disabled button swallows `title`).
+                  <ReactionBar
+                    reactions={reactions.data?.body ?? []}
+                    disabled={detailsStale}
+                    reason={staleReason}
+                    onToggle={(content, active) =>
+                      toggleReaction(pr.id, content, active)
+                    }
+                  />
                 )}
               </div>
               {/* Bitbucket-only PR tasks checklist, between the description and the
@@ -2355,6 +2457,7 @@ export function RemotePrView({
                 onUnhideComment={unhideComment}
                 onToggleReaction={toggleReaction}
                 reactionsHeld={detailsStale}
+                reactionsReason={staleReason ?? null}
               />
               {/* Residual review threads — those NOT shown inline under a review
                   above: all threads on GitLab/Bitbucket (no reviewId), plus
@@ -2424,6 +2527,10 @@ export function RemotePrView({
               ariaLabel="Leave a comment"
               placeholder="Leave a comment…"
               busy={busy}
+              // Every term of `busy` gets words, so a held Submit is never mute —
+              // including the switch, where the comment would post against the
+              // previously rendered PR.
+              reason={composerReason}
               actions={
                 <>
                   {/* The Review control opens the batch submit dialog for every
@@ -2647,7 +2754,7 @@ export function RemotePrView({
               GitHub folds in via `canWrite` and routes the same `setDraft` mutation
               through `gh pr ready [--undo]`. Draft → primary Ready (fires the
               ready-review automation); open → a quieter Convert-to-draft. */}
-          {draftPairVisible && pr.isDraft && (
+          {draftPairVisible && shownIsDraft === true && (
             <DisabledReasonButton
               variant="outline"
               size="sm"
@@ -2669,7 +2776,7 @@ export function RemotePrView({
               Ready for review
             </DisabledReasonButton>
           )}
-          {draftPairVisible && !pr.isDraft && (
+          {draftPairVisible && shownIsDraft === false && (
             <DisabledReasonButton
               variant="ghost"
               size="sm"
@@ -3015,7 +3122,6 @@ export function RemotePrView({
         pending={clearDrafts.isPending}
         onConfirm={() =>
           clearDrafts.mutate(undefined, {
-            onError,
             onSuccess: () => setDiscardConfirmOpen(false),
           })
         }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1605,24 +1605,26 @@ export function RemotePrView({
     );
   }
   if (details.isError || !pr) {
-    // A read that never landed says so in the forge's own name — the raw summary
-    // alone reads like a missing PR when the real answer is "you're offline". The
-    // provider stays unnamed when its own probe hasn't answered, rather than guessed.
-    const unreachable = provider
-      ? `Couldn't reach ${remoteLabel} to load this ${prNoun}.`
-      : `Couldn't reach the remote to load this ${prNoun}.`;
+    // Offline, deleted, access lost — the class isn't knowable here, so the headline
+    // claims only what is: which host the read was aimed at. Naming one class would
+    // demote the true reason to the summary beneath. The host goes unnamed when its
+    // own probe hasn't answered, rather than guessed.
+    const loadFailed = provider
+      ? `Couldn't load this ${prNoun} from ${remoteLabel}.`
+      : `Couldn't load this ${prNoun} from the remote.`;
     const errorSummary = details.error
       ? presentError(details.error).summary
       : null;
     return (
       <DiffPlaceholder
         message={
-          details.isError ? unreachable : "Could not load this pull request"
+          details.isError ? loadFailed : `Could not load this ${prNoun}`
         }
         action={
           details.isError ? (
             <div className="flex flex-col items-center gap-2">
-              {/* The underlying summary keeps the detail the headline generalizes. */}
+              {/* The headline can't name the failure class, so the real reason —
+                  offline, deleted, no access — lives here. */}
               {errorSummary ? (
                 <p className="max-w-md text-center text-xs">{errorSummary}</p>
               ) : null}
@@ -1857,7 +1859,11 @@ export function RemotePrView({
     toggleReactionMutation.mutate({ subjectId, content, active }, { onError });
   }
 
+  // Both take a comment id off the RENDERED pr, which through a switch is the
+  // previous one, so either would hide a comment on the PR the viewer just left.
+  // The menu items disable on the same wait; these arms back them up.
   function hideComment(commentId: string, classifier: MinimizeReason) {
+    if (detailsStale) return;
     minimizeComment.mutate(
       { commentId, classifier },
       { onSuccess: () => toast.success("Comment hidden"), onError },
@@ -1865,6 +1871,7 @@ export function RemotePrView({
   }
 
   function unhideComment(commentId: string) {
+    if (detailsStale) return;
     unminimizeComment.mutate(commentId, {
       onSuccess: () => toast.success("Comment shown"),
       onError,
@@ -2405,7 +2412,10 @@ export function RemotePrView({
                 <PrTasksSection
                   repoPath={repoPath}
                   number={number}
-                  editable={pr.state === "OPEN"}
+                  // The open-state verb comes off the rendered pr while the task
+                  // writes address `number`, so a switch would offer Add against a
+                  // pull request whose own state hasn't arrived yet.
+                  editable={pr.state === "OPEN" && !detailsStale}
                 />
               )}
               <PrActivityFeed
@@ -2416,7 +2426,10 @@ export function RemotePrView({
                 providerKey={providerKey}
                 suggestionApply={suggestionApply}
                 fileDiffLookup={fileDiffLookup}
-                disabledReason={triageItemReason}
+                // Hide/Unhide stay visible but disabled through the switch. The
+                // permission reason ranks first — it's the one still true once the
+                // selected pull request is on screen.
+                disabledReason={triageItemReason ?? staleReason}
                 revealThreadId={revealThreadId}
                 setRevealThreadId={setRevealThreadId}
                 setSection={setSection}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -752,7 +752,7 @@ export function RemotePrView({
       // Ordered as `detectStackOffer` refuses: the two fail-closed list guards
       // first, then the row-level fork exclusion.
       case openPrs.some((p) => p.stackUnknown === true):
-        return "Stack suggestions are paused until every open pull request's stack state loads.";
+        return "Stack suggestions are paused — GitDesktop couldn't read every open pull request's stack state.";
       case openPrs.length >= STACK_OFFER_PAGE_LIMIT:
         return "Stack suggestions are paused — too many open pull requests to scan reliably.";
       case forkChild:

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1617,9 +1617,7 @@ export function RemotePrView({
       : null;
     return (
       <DiffPlaceholder
-        message={
-          details.isError ? loadFailed : `Could not load this ${prNoun}`
-        }
+        message={details.isError ? loadFailed : `Could not load this ${prNoun}`}
         action={
           details.isError ? (
             <div className="flex flex-col items-center gap-2">

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
@@ -20,10 +20,52 @@ import {
   useReviewDrafts,
 } from "@/lib/pulls/review-drafts";
 import { toastError } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 
 /**
- * The submit-a-review dialog: a capability-gated verdict radio (Comment always;
- * Approve / Request changes only when the provider allows), an optional summary
+ * One verdict option. An unavailable verdict stays VISIBLE and disabled, its reason
+ * taking the hint's place — the radio twin of `DisabledReasonButton` (wrapper title +
+ * `aria-describedby`), except the reason renders visibly: a natively-disabled radio
+ * can't take focus, so a hover-only tooltip would reach neither keyboard nor AT users.
+ */
+function VerdictOption({
+  value,
+  label,
+  hint,
+  reason,
+}: {
+  value: ReviewVerdict;
+  label: string;
+  /** What choosing this verdict does — shown when it's available. */
+  hint: string;
+  /** Why it isn't available; absent when it is. */
+  reason?: string;
+}) {
+  const hintId = useId();
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-2",
+        reason ? "cursor-not-allowed text-muted-foreground" : "cursor-pointer",
+      )}
+      title={reason}
+    >
+      <Radio
+        value={value}
+        disabled={Boolean(reason)}
+        aria-describedby={hintId}
+      />
+      {label}
+      <span id={hintId} className="text-muted-foreground">
+        — {reason ?? hint}
+      </span>
+    </label>
+  );
+}
+
+/**
+ * The submit-a-review dialog: a verdict radio (Comment always; Approve / Request
+ * changes disabled-with-reason until the provider allows them), an optional summary
  * (REQUIRED for Request changes), and a submit that posts the pending drafts as
  * one batch review. On success it clears the drafts, closes, and toasts the
  * posted count; on error it stays open and surfaces the error verbatim (it may
@@ -50,7 +92,11 @@ export function SubmitReviewDialog({
 }) {
   const drafts = useReviewDrafts(repoPath, lens, number);
   const submitReview = useSubmitReview(repoPath, lens);
-  const clearDrafts = useClearReviewDrafts(repoPath, lens, number);
+  // Silent: the post already landed by the time this runs, so a clear failure is
+  // reported below in words that say the drafts are still safe — not as a bare error.
+  const clearDrafts = useClearReviewDrafts(repoPath, lens, number, {
+    silent: true,
+  });
   const [verdict, setVerdict] = useState<ReviewVerdict>("comment");
   const [summary, setSummary] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -82,6 +128,10 @@ export function SubmitReviewDialog({
   const summaryRequired = effectiveVerdict === "request_changes";
   const summaryMissing = summaryRequired && summary.trim() === "";
   const pending = submitReview.isPending || clearDrafts.isPending;
+  // Both verdicts are gated on the same thing (`usePrCapabilities`): the host's
+  // approve / request-changes wiring, which reads as unavailable until the forge
+  // connection resolves. One reason serves both.
+  const unavailable = `available once GitDesktop connects to ${remoteLabel}`;
 
   // Reset transient state whenever the dialog closes (for ANY reason — Cancel,
   // Esc, backdrop, or a successful submit), so a reopen never shows a stale
@@ -163,31 +213,23 @@ export function SubmitReviewDialog({
             onValueChange={(v) => setVerdict(v as ReviewVerdict)}
             className="gap-2 text-xs"
           >
-            <label className="flex cursor-pointer items-center gap-2">
-              <Radio value="comment" />
-              Comment
-              <span className="text-muted-foreground">
-                — leave feedback without an explicit approval
-              </span>
-            </label>
-            {caps.canApprove && (
-              <label className="flex cursor-pointer items-center gap-2">
-                <Radio value="approve" />
-                Approve
-                <span className="text-muted-foreground">
-                  — approve these changes
-                </span>
-              </label>
-            )}
-            {caps.canRequestChanges && (
-              <label className="flex cursor-pointer items-center gap-2">
-                <Radio value="request_changes" />
-                Request changes
-                <span className="text-muted-foreground">
-                  — ask for changes before merging
-                </span>
-              </label>
-            )}
+            <VerdictOption
+              value="comment"
+              label="Comment"
+              hint="leave feedback without an explicit approval"
+            />
+            <VerdictOption
+              value="approve"
+              label="Approve"
+              hint="approve these changes"
+              reason={caps.canApprove ? undefined : unavailable}
+            />
+            <VerdictOption
+              value="request_changes"
+              label="Request changes"
+              hint="ask for changes before merging"
+              reason={caps.canRequestChanges ? undefined : unavailable}
+            />
           </RadioGroup>
 
           <MarkdownEditor

--- a/src/features/pulls/SubmitReviewDialog.tsx
+++ b/src/features/pulls/SubmitReviewDialog.tsx
@@ -130,7 +130,10 @@ export function SubmitReviewDialog({
   const pending = submitReview.isPending || clearDrafts.isPending;
   // Both verdicts are gated on the same thing (`usePrCapabilities`): the host's
   // approve / request-changes wiring, which reads as unavailable until the forge
-  // connection resolves. One reason serves both.
+  // connection resolves. One reason serves both, and "connects" holds in every
+  // reachable state: GitLab and Bitbucket both implement the verdicts
+  // (forge/model.rs `for_provider`), so a false cap on them means disconnected,
+  // and GitHub never reaches the disabled arm (`canWrite ||` at the call site).
   const unavailable = `available once GitDesktop connects to ${remoteLabel}`;
 
   // Reset transient state whenever the dialog closes (for ANY reason — Cancel,

--- a/src/features/pulls/usePrCapabilities.ts
+++ b/src/features/pulls/usePrCapabilities.ts
@@ -21,9 +21,12 @@ import type {
  *   duplicate a GitHub control that lives elsewhere.
  *
  * Axes, never conflated: every `can*` flag above is AVAILABILITY (is this action
- * wired for this provider?) and decides what RENDERS. `writeBlocked` is
- * PERMISSION and decides only what is ENABLED — consumers disable-with-reason
- * and never hide on permission. Triage is a SEPARATE, lower tier granting
+ * wired for this provider?) and decides what RENDERS. One carve-out: when the
+ * flag is false only because a `forgeFeatureReady` gate hasn't connected yet
+ * (transient within a session, e.g. the review-verdict radios), consumers
+ * disable-with-reason instead of hiding — connecting un-disables in place.
+ * `writeBlocked` is PERMISSION and decides only what is ENABLED — consumers
+ * disable-with-reason and never hide on permission. Triage is a SEPARATE, lower tier granting
  * labels, assignees, milestones, review requests, hiding comments and
  * close/reopen without push, so a triage control keys on `triageAccessReason`,
  * never on `writeBlocked`. Absent or unanswered probe data leaves

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -2077,13 +2077,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
         isInWorktree={(name) => worktreeByBranch.has(name)}
         prMergedByBranch={mergedPrByBranch}
-        // Only the closed list carries merged PRs. A failed read is an answer —
-        // an unreachable forge must not leave the dialog checking forever.
+        // Only the closed list carries merged PRs. A failed read ends the wait
+        // but is not an answer, so the dialog is told which of the two it got.
         prMergedPending={
           prsWanted &&
           !closedPrs.isError &&
           (closedPrs.isFetching || closedPrs.isPlaceholderData)
         }
+        prMergedFailed={prsWanted && closedPrs.isError}
       />
 
       <ConfirmDialog

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -121,6 +121,12 @@ const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
 const secondaryClickCapitalized =
   secondaryClickLabel.charAt(0).toUpperCase() + secondaryClickLabel.slice(1);
 
+/** How many closed PRs the branch surfaces scan. Merged state lives only in the
+ *  closed list, and gh's default 30 covers too little history for the cleanup
+ *  dialog's merged badge. The open list keeps the default so it goes on sharing a
+ *  cache entry with the session PR audit. */
+const CLOSED_PR_SCAN_LIMIT = 100;
+
 interface BranchPr {
   state: PrAuditState;
   /** "#123" for a remote PR, "local" for a local-only one. */
@@ -303,25 +309,22 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   );
 
   // Per-branch PR badge: remote PRs (open + closed, the latter carrying merged)
-  // fetched only while the menu is open AND the repo's forge reports pull-request
-  // support — mirrors the divergence gate above. Local PRs are not gated. Both
-  // reads are forge-neutral: they work for GitHub and GitLab alike.
+  // fetched while the menu OR the cleanup dialog is open AND the repo's forge
+  // reports pull-request support — mirrors the divergence gate above. The cleanup
+  // hotkey closes the menu on its way to the dialog, so gating on `open` alone
+  // would leave that dialog's merged badges permanently empty. Local PRs are not
+  // gated. Both reads are forge-neutral: they work for GitHub and GitLab alike.
   const gh = useForgeStatus(repoPath);
   const canGh = forgeFeatureReady(gh.data, "pullRequests");
+  const prsWanted = canGh && (open || cleanupOpen);
   // Origin lens: the branch popover lists the FORK's own branch PRs; the
   // fork/upstream lens is a Pulls/Issues-tab affordance.
-  const openPrs = usePrList(
-    repoPath,
-    canGh && open,
-    "open",
-    undefined,
-    "origin",
-  );
+  const openPrs = usePrList(repoPath, prsWanted, "open", undefined, "origin");
   const closedPrs = usePrList(
     repoPath,
-    canGh && open,
+    prsWanted,
     "closed",
-    undefined,
+    CLOSED_PR_SCAN_LIMIT,
     "origin",
   );
   const localPrs = useLocalPrs(repoPath);
@@ -365,6 +368,18 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     }
     return map;
   }, [openPrs.data, closedPrs.data, localPrs.data]);
+
+  // Branch name → the merged PR that carries it, for the cleanup dialog. Remote
+  // PRs only: a local PR's merge is a real git merge, which divergence already
+  // sees, and it has no PR number to attribute the badge to.
+  const mergedPrByBranch = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const [name, pr] of prByBranch) {
+      if (pr.state === "merged" && pr.select.kind === "remote")
+        map.set(name, pr.label);
+    }
+    return map;
+  }, [prByBranch]);
 
   const openPr = (select: SelectedPr) => {
     // A remote PR here is a fork (origin) PR — force the origin lens (which also
@@ -746,6 +761,20 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     setPickerMode(mode);
   }
 
+  // A merge into the current branch touches the working tree, so git refuses it
+  // outright when uncommitted changes are in the way — offer the stash → merge →
+  // reapply compound instead of a dead-end toast. `false` leaves the error to
+  // the caller.
+  function beginMergeRecovery(e: unknown, branch: string) {
+    return recovery.handleError(e, {
+      operationLabel: "merge",
+      detail: branch,
+      reappliedMessage: `Merged ${branch} and reapplied your changes.`,
+      plainMessage: `Merged ${branch}`,
+      run: { op: "merge", ref: branch },
+    });
+  }
+
   // The dialog collects the branch + options; the switcher owns the mutations
   // (they feed `busy`) and dispatches them here after closing the picker.
   function runPicker(
@@ -760,22 +789,27 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         onError,
       });
     } else {
+      const squash = mode === "squash";
+      // Options apply to a regular merge only, not squash.
+      const noFf = mode === "merge" && options.noFf;
+      const strategy = mode === "merge" ? options.strategy : "none";
+      // The stash-and-retry compound runs a bare `merge --no-edit`, so it can
+      // only redo a merge that asked for nothing else — offering it for the
+      // others would quietly drop the option the user chose.
+      const plain = !squash && !noFf && strategy === "none";
       mergeBranch.mutate(
-        {
-          branch,
-          squash: mode === "squash",
-          // Options apply to a regular merge only, not squash.
-          noFf: mode === "merge" && options.noFf,
-          strategy: mode === "merge" ? options.strategy : "none",
-        },
+        { branch, squash, noFf, strategy },
         {
           onSuccess: () =>
             toast.success(
-              mode === "squash"
+              squash
                 ? `Squashed ${branch} — changes are staged, review and commit`
                 : `Merged ${branch}`,
             ),
-          onError,
+          onError: (e) => {
+            if (plain && beginMergeRecovery(e, branch)) return;
+            onError(e);
+          },
         },
       );
     }
@@ -2030,6 +2064,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         currentBranch={currentName}
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
         isInWorktree={(name) => worktreeByBranch.has(name)}
+        prMergedByBranch={mergedPrByBranch}
+        // Only the closed list carries merged PRs. A failed read is an answer —
+        // an unreachable forge must not leave the dialog checking forever.
+        prMergedPending={
+          prsWanted &&
+          !closedPrs.isError &&
+          (closedPrs.isFetching || closedPrs.isPlaceholderData)
+        }
       />
 
       <ConfirmDialog

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -131,6 +131,9 @@ interface BranchPr {
   state: PrAuditState;
   /** "#123" for a remote PR, "local" for a local-only one. */
   label: string;
+  /** The branch this PR targets. A merge into anything but the default branch
+   *  can't stand in for "merged into the default branch". */
+  base: string;
   select: SelectedPr;
 }
 
@@ -355,6 +358,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       consider(pr.headRefName, {
         state,
         label: `#${pr.number}`,
+        base: pr.baseRefName,
         select: { kind: "remote", id: String(pr.number) },
       });
     }
@@ -363,6 +367,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       consider(pr.head, {
         state,
         label: "local",
+        base: pr.base,
         select: { kind: "local", id: pr.id },
       });
     }
@@ -371,15 +376,22 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   // Branch name → the merged PR that carries it, for the cleanup dialog. Remote
   // PRs only: a local PR's merge is a real git merge, which divergence already
-  // sees, and it has no PR number to attribute the badge to.
+  // sees, and it has no PR number to attribute the badge to. The base must be the
+  // default branch — a PR merged into a release branch or a stack parent says
+  // nothing about the default branch, which is what that dialog is about. A null
+  // `defaultName` matches nothing, so an unresolved default badges nothing.
   const mergedPrByBranch = useMemo(() => {
     const map = new Map<string, string>();
     for (const [name, pr] of prByBranch) {
-      if (pr.state === "merged" && pr.select.kind === "remote")
+      if (
+        pr.state === "merged" &&
+        pr.select.kind === "remote" &&
+        pr.base === defaultName
+      )
         map.set(name, pr.label);
     }
     return map;
-  }, [prByBranch]);
+  }, [prByBranch, defaultName]);
 
   const openPr = (select: SelectedPr) => {
     // A remote PR here is a fork (origin) PR — force the origin lens (which also

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -65,7 +65,7 @@ function RowBadge({
     return (
       <span
         className="text-merged"
-        title={`Merged via pull request ${prMerged}`}
+        title={`Merged via pull request ${prMerged} — matched by branch name`}
       >
         merged {prMerged}
       </span>

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -97,6 +97,7 @@ export function CleanupBranchesDialog({
   isInWorktree,
   prMergedByBranch,
   prMergedPending,
+  prMergedFailed,
 }: {
   repoPath: string;
   open: boolean;
@@ -116,6 +117,9 @@ export function CleanupBranchesDialog({
   /** True while that map is still filling — the empty state must not claim the
    *  pull requests were checked before they were read. */
   prMergedPending: boolean;
+  /** True when reading them FAILED. A read the app couldn't make is not an
+   *  absence of merges, so the copy drops the pull-request claim and says so. */
+  prMergedFailed: boolean;
 }) {
   const queryClient = useQueryClient();
   // Shared 30s clock: the idle-past-the-window classification below must
@@ -460,8 +464,13 @@ export function CleanupBranchesDialog({
               <span className="font-mono">
                 {defaultBranch ?? "the default branch"}
               </span>
-              , directly or through a recent pull request, and nothing is idle
-              for {windowDays} days. Try a shorter window.
+              {prMergedFailed
+                ? " and nothing is idle for "
+                : ", directly or through a recent pull request, and nothing is idle for "}
+              {windowDays} days. Try a shorter window.
+              {prMergedFailed
+                ? " Pull requests couldn't be checked, so a branch merged through one may be missing here."
+                : null}
             </p>
           ) : (
             <div
@@ -471,6 +480,12 @@ export function CleanupBranchesDialog({
               {checkingMerged && (
                 <p className="px-1 py-1 text-[11px] text-muted-foreground">
                   Checking which branches are merged…
+                </p>
+              )}
+              {prMergedFailed && (
+                <p className="px-1 py-1 text-[11px] text-muted-foreground">
+                  Pull requests couldn't be checked — a branch merged through
+                  one may be missing.
                 </p>
               )}
               {candidates.map((c, idx) => {

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -31,6 +31,10 @@ interface Candidate {
   branch: Branch;
   /** Fully merged into the default branch (0 commits it doesn't have). */
   merged: boolean;
+  /** Label of the merged pull request this branch's name maps to ("#123"), or
+   *  null. Squash and rebase merges leave no ancestor link, so the PR is the
+   *  only evidence they landed. */
+  prMerged: string | null;
   /** Whole days since the branch tip's commit. */
   ageDays: number;
   /** Idle beyond the selected age window. */
@@ -38,6 +42,36 @@ interface Candidate {
 }
 
 const pluralBranches = (n: number) => `${n} branch${n === 1 ? "" : "es"}`;
+
+/** The one state badge a row can carry, in precedence order. Text carries the
+ *  meaning — the color never stands alone. */
+function RowBadge({
+  error,
+  merged,
+  prMerged,
+}: {
+  error: string | undefined;
+  merged: boolean;
+  prMerged: string | null;
+}) {
+  if (error)
+    return (
+      <span className="text-destructive" title={error}>
+        failed
+      </span>
+    );
+  if (merged) return <span className="text-merged">merged</span>;
+  if (prMerged)
+    return (
+      <span
+        className="text-merged"
+        title={`Merged via pull request ${prMerged}`}
+      >
+        merged {prMerged}
+      </span>
+    );
+  return null;
+}
 
 /**
  * Bulk "clean up branches" dialog, launched from the branch switcher. Gathers
@@ -47,7 +81,10 @@ const pluralBranches = (n: number) => `${n} branch${n === 1 ? "" : "es"}`;
  * one pass. The current branch, the default branch, and `gd/session/*` branches
  * are never candidates; Delete additionally excludes rule-protected branches.
  *
- * Merged detection reuses branch divergence (`ahead === 0`) — no extra backend.
+ * Merged detection has two sources: branch divergence (`ahead === 0`, no extra
+ * backend) and the switcher's PR map, which catches the squash and rebase merges
+ * divergence can't see. The PR side matches by branch NAME only, so it badges a
+ * row but never pre-selects it for deletion.
  */
 export function CleanupBranchesDialog({
   repoPath,
@@ -58,6 +95,8 @@ export function CleanupBranchesDialog({
   currentBranch,
   isProtected,
   isInWorktree,
+  prMergedByBranch,
+  prMergedPending,
 }: {
   repoPath: string;
   open: boolean;
@@ -70,6 +109,13 @@ export function CleanupBranchesDialog({
   /** True when a branch is checked out in another worktree — git can't delete it,
    *  so it's dropped from the delete candidates (it can still be archived). */
   isInWorktree: (name: string) => boolean;
+  /** Branch name → the label of the merged pull request it maps to ("#123").
+   *  Name-keyed and limited to the PRs the app has fetched, so it labels rows,
+   *  never selects them. */
+  prMergedByBranch: Map<string, string>;
+  /** True while that map is still filling — the empty state must not claim the
+   *  pull requests were checked before they were read. */
+  prMergedPending: boolean;
 }) {
   const queryClient = useQueryClient();
   // Shared 30s clock: the idle-past-the-window classification below must
@@ -121,11 +167,21 @@ export function CleanupBranchesDialog({
       const ts = Date.parse(b.lastCommitDate);
       const ageDays = Number.isFinite(ts) ? Math.floor((now - ts) / DAY_MS) : 0;
       const merged = mergedSet.has(b.name);
+      const prMerged = prMergedByBranch.get(b.name) ?? null;
       const old = ageDays >= windowDays;
-      if (merged || old) out.push({ branch: b, merged, ageDays, old });
+      if (merged || old || prMerged)
+        out.push({ branch: b, merged, prMerged, ageDays, old });
     }
     return out;
-  }, [branches, currentBranch, defaultBranch, mergedSet, now, windowDays]);
+  }, [
+    branches,
+    currentBranch,
+    defaultBranch,
+    mergedSet,
+    now,
+    prMergedByBranch,
+    windowDays,
+  ]);
 
   // Mode-specific candidates. Archive hides — already-archived branches are a
   // no-op, so drop them. Delete is permanent — drop rule-protected branches
@@ -150,7 +206,15 @@ export function CleanupBranchesDialog({
     () => candidates.map((c) => c.branch.name),
     [candidates],
   );
-  // Re-seed the selection only when the SET of candidate names actually changes,
+  // Pre-checked rows: the ones this repo's own history proves are done with.
+  // A row that only a pull request calls merged is matched by branch NAME, which
+  // can't confirm the tip is what that PR merged, so it stays unchecked until the
+  // user says otherwise.
+  const autoSelectNames = useMemo(
+    () => candidates.filter((c) => c.merged || c.old).map((c) => c.branch.name),
+    [candidates],
+  );
+  // Re-seed the selection only when the SET of pre-checked names actually changes,
   // keyed on their joined value rather than the array identity. A parent
   // re-render that yields an equal-but-new `candidates` array — a fresh
   // `isProtected` closure, a no-op branch refetch — would otherwise re-run this
@@ -158,19 +222,18 @@ export function CleanupBranchesDialog({
   // newlines (git ref rules), so the join is unambiguous — and it joins a SORTED
   // copy, because the render order shifts as ages tick on the shared 30s clock
   // and a pure reorder must not read as a new set.
-  const candidateNamesKey = [...candidateNames].sort().join("\n");
+  const autoSelectKey = [...autoSelectNames].sort().join("\n");
   useEffect(() => {
     if (running) return; // don't clobber a batch mid-flight
-    setSelected(
-      new Set(candidateNamesKey ? candidateNamesKey.split("\n") : []),
-    );
+    setSelected(new Set(autoSelectKey ? autoSelectKey.split("\n") : []));
     setActiveName(null);
-  }, [candidateNamesKey, running]);
+  }, [autoSelectKey, running]);
 
-  // First load: divergence still fetching and nothing has surfaced yet. Age-based
-  // candidates already show instantly (branch data is cached), so this only gates
-  // the truly-empty first paint.
-  const checkingMerged = Boolean(defaultBranch) && divergence.isLoading;
+  // First load: a merged signal still in flight and nothing has surfaced yet.
+  // Age-based candidates already show instantly (branch data is cached), so this
+  // only gates the truly-empty first paint.
+  const checkingMerged =
+    (Boolean(defaultBranch) && divergence.isLoading) || prMergedPending;
 
   const selectedCount = candidateNames.filter((n) => selected.has(n)).length;
   const allChecked =
@@ -282,11 +345,12 @@ export function CleanupBranchesDialog({
           <DialogHeader>
             <DialogTitle>Clean up branches</DialogTitle>
             <DialogDescription>
-              Local branches merged into{" "}
+              Local branches already merged into{" "}
               <span className="font-mono">
                 {defaultBranch ?? "the default branch"}
               </span>{" "}
-              or with no commits in a while.{" "}
+              — directly or through a recent pull request — or with no commits
+              in a while.{" "}
               {mode === "archive"
                 ? "Archiving hides them from the switcher — unarchive anytime."
                 : "Deleting removes them permanently, including commits only on them."}
@@ -395,8 +459,9 @@ export function CleanupBranchesDialog({
               No stale branches — nothing is merged into{" "}
               <span className="font-mono">
                 {defaultBranch ?? "the default branch"}
-              </span>{" "}
-              or idle for {windowDays} days. Try a shorter window.
+              </span>
+              , directly or through a recent pull request, and nothing is idle
+              for {windowDays} days. Try a shorter window.
             </p>
           ) : (
             <div
@@ -434,13 +499,11 @@ export function CleanupBranchesDialog({
                       {name}
                     </span>
                     <span className="flex shrink-0 items-center gap-2">
-                      {err ? (
-                        <span className="text-destructive" title={err}>
-                          failed
-                        </span>
-                      ) : c.merged ? (
-                        <span className="text-merged">merged</span>
-                      ) : null}
+                      <RowBadge
+                        error={err}
+                        merged={c.merged}
+                        prMerged={c.prMerged}
+                      />
                       <span className="tabular-nums text-muted-foreground">
                         <RelativeTime date={c.branch.lastCommitDate} />
                       </span>

--- a/src/features/repository/ConflictBanner.tsx
+++ b/src/features/repository/ConflictBanner.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { useOpAbort, useOpContinue, useOpState } from "@/lib/git/queries";
-import type { RepoOp } from "@/lib/git/types";
+import type { RepoOp, RepoOpState } from "@/lib/git/types";
 import { useAiEnabled, useReviewConfigured } from "@/lib/settings/queries";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { toastError } from "@/lib/toast";
@@ -34,10 +34,30 @@ const OP_LABELS: Record<
     cont: "Continue cherry-pick",
     verb: "Cherry-picking",
   },
+  revert: {
+    banner: "Revert in progress",
+    cont: "Continue revert",
+    verb: "Reverting",
+  },
 };
 
+/** The `RepoOpState` flags that name an operation. Derived, so a renamed field
+ *  breaks here; `editPaused` is excluded because it modifies `rebasing` rather
+ *  than naming an op of its own. */
+type RepoOpFlag = Exclude<keyof RepoOpState, "editPaused">;
+
+/** Which op the banner names. `RepoOpState`'s flags are independent booleans and
+ *  the banner shows one op, so the precedence lives here rather than in a
+ *  ternary chain that has to be re-read every time an op is added. */
+const OP_BY_FLAG: readonly (readonly [RepoOpFlag, RepoOp])[] = [
+  ["merging", "merge"],
+  ["rebasing", "rebase"],
+  ["cherryPicking", "cherry-pick"],
+  ["reverting", "revert"],
+];
+
 /**
- * Guides an in-progress merge/rebase/cherry-pick to its end: shows what's
+ * Guides an in-progress merge/rebase/cherry-pick/revert to its end: shows what's
  * mid-flight and how many conflicts remain, with Continue gated on every
  * conflict being resolved (staged) and Abort behind a confirm. Renders
  * nothing when the repo is in a normal state.
@@ -58,13 +78,8 @@ export function ConflictBanner({
   const [confirmAbort, setConfirmAbort] = useState(false);
 
   const conflictedCount = conflictedPaths.length;
-  const op: RepoOp | null = opState.data?.merging
-    ? "merge"
-    : opState.data?.rebasing
-      ? "rebase"
-      : opState.data?.cherryPicking
-        ? "cherry-pick"
-        : null;
+  const op: RepoOp | null =
+    OP_BY_FLAG.find(([flag]) => opState.data?.[flag])?.[1] ?? null;
   if (!op && conflictedCount === 0) return null;
 
   const canResolveWithAi = aiEnabled && reviewConfigured && conflictedCount > 0;

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -138,11 +138,12 @@ function PromoteBody({
     queryFn: () => gitStatus(mainPath as string),
     enabled: Boolean(mainPath),
   });
-  // Main's in-progress merge/rebase/cherry-pick: the backend refuses to stash over
-  // one, and the stash here runs AFTER the worktree is removed — so it has to be a
-  // precondition, not an error past the point of no return. Inline rather than via
-  // `useOpState` (which takes no `enabled`) because mainPath resolves a tick later
-  // from the worktree list; the shared key keeps one cache entry either way.
+  // Main's in-progress merge/rebase/cherry-pick/revert: the backend refuses to
+  // stash over one, and the stash here runs AFTER the worktree is removed — so it
+  // has to be a precondition, not an error past the point of no return. Inline
+  // rather than via `useOpState` (which takes no `enabled`) because mainPath
+  // resolves a tick later from the worktree list; the shared key keeps one cache
+  // entry either way.
   const mOpState = useQuery({
     queryKey: repoKeys.opState(mainPath ?? "__pending__"),
     queryFn: () => gitOpState(mainPath as string),
@@ -160,7 +161,8 @@ function PromoteBody({
   const mainMidOp = Boolean(
     mOpState.data?.merging ||
       mOpState.data?.rebasing ||
-      mOpState.data?.cherryPicking,
+      mOpState.data?.cherryPicking ||
+      mOpState.data?.reverting,
   );
   // `refuse_mid_op` refuses on unmerged index entries too, and that arm has no
   // marker file behind it: a conflicted squash-merge leaves the conflicts with
@@ -290,8 +292,8 @@ function PromoteBody({
         </p>
       ) : mainMidOp ? (
         <p className="text-xs text-warning">
-          The main workspace has a merge, rebase or cherry-pick in progress —
-          finish or abort it first.
+          The main workspace has a merge, rebase, cherry-pick or revert in
+          progress — finish or abort it first.
         </p>
       ) : mainConflicted ? (
         <p className="text-xs text-warning">

--- a/src/features/repository/usePrNotifications.ts
+++ b/src/features/repository/usePrNotifications.ts
@@ -13,6 +13,7 @@ import type { PrPollInfo } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import {
+  type NotificationKind,
   type NotificationTone,
   pushNotification,
   repoNameFromPath,
@@ -155,7 +156,7 @@ export function usePrNotifications(repoPath: string) {
     // when unfocused. One pref gates both, so turning a category off also hides it
     // from the inbox.
     const record = (
-      kind: string,
+      kind: NotificationKind,
       tone: NotificationTone,
       title: string,
       pr: PrPollInfo,

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -111,14 +111,14 @@ export const GeneralSection = withForm({
           <form.AppField name="autoStashOnPull">
             {(field) => (
               <field.CheckboxField
-                label="Automatically stash and reapply on pull and branch updates"
+                label="Automatically stash and reapply on pull, merge, and branch updates"
                 className="flex cursor-pointer items-center gap-2 text-xs"
               />
             )}
           </form.AppField>
           <p className="text-xs text-muted-foreground">
-            When a pull or branch update would overwrite uncommitted changes,
-            stash them, run it, then reapply.
+            When a pull, merge, or branch update would overwrite uncommitted
+            changes, stash them, run it, then reapply.
           </p>
         </div>
         <div className="space-y-1.5">

--- a/src/features/welcome/WelcomeScreen.tsx
+++ b/src/features/welcome/WelcomeScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { BrandMark } from "@/components/BrandMark";
 import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useUpdateCheck } from "@/features/updates/useUpdateCheck";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { dispatchAction, useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
@@ -118,73 +119,87 @@ export function WelcomeScreen() {
         </div>
       </header>
 
-      <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center gap-6 p-8">
-        {settings.data && !settings.data.seenGuideNudge && (
-          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border bg-muted/40 px-3 py-2">
-            <span className="flex items-center gap-2 text-xs text-muted-foreground">
-              <BookOpenIcon className="size-4 shrink-0 text-foreground" />
-              New to GitDesktop? The built-in guide walks through the whole
-              workflow.
-            </span>
-            <span className="flex shrink-0 items-center gap-1">
-              <Button size="xs" variant="ghost" onClick={dismissNudge}>
-                Dismiss
-              </Button>
-              <Button size="xs" onClick={openGuide}>
-                Open guide
-              </Button>
-            </span>
-          </div>
-        )}
-
-        <div className="grid items-center gap-y-8 md:grid-cols-2">
-          <div className="flex flex-col gap-6 md:pr-10">
-            <div className="space-y-2">
-              <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
-                The whole loop,
-                <br className="hidden sm:block" /> one window.
-              </h1>
-              <p className="text-xs/relaxed text-muted-foreground">
-                Open a repository to start reviewing, committing, and shipping
-                {aiEnabled ? " — with AI in the loop when you want it." : "."}
-              </p>
-            </div>
-
-            <div className="space-y-2">
-              <div className="flex flex-col gap-2">
-                {actions.map(({ id, label, icon: Icon, variant, onClick }) => {
-                  const binding = bindings.get(id);
-                  return (
-                    <Button
-                      key={id}
-                      variant={variant}
-                      onClick={onClick}
-                      className="w-full justify-between"
-                    >
-                      <span className="flex items-center gap-2">
-                        <Icon className="size-4" />
-                        {label}
-                      </span>
-                      {binding && (
-                        <span className="text-[11px] tabular-nums opacity-60">
-                          {formatBinding(binding)}
-                        </span>
-                      )}
-                    </Button>
-                  );
-                })}
+      {/* overflow-hidden contains the content's natural height (vendored Root is
+          `relative`-only), so a tall welcome pane can't leak a window scrollbar. */}
+      <ScrollArea className="min-h-0 flex-1 overflow-hidden">
+        {/* `my-auto` centers the content while it fits and resolves to zero once
+            it doesn't — unlike `justify-center`, which would push the top of an
+            overflowing pane out of the scrollable region. */}
+        <main className="mx-auto flex min-h-full w-full max-w-4xl flex-col p-8">
+          <div className="my-auto flex w-full flex-col gap-6">
+            {settings.data && !settings.data.seenGuideNudge && (
+              <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border bg-muted/40 px-3 py-2">
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <BookOpenIcon className="size-4 shrink-0 text-foreground" />
+                  New to GitDesktop? The built-in guide walks through the whole
+                  workflow.
+                </span>
+                <span className="flex shrink-0 items-center gap-1">
+                  <Button size="xs" variant="ghost" onClick={dismissNudge}>
+                    Dismiss
+                  </Button>
+                  <Button size="xs" onClick={openGuide}>
+                    Open guide
+                  </Button>
+                </span>
               </div>
-              <p className="pt-1 text-[11px] text-muted-foreground">
-                …or drag a repo folder anywhere onto the window.
-              </p>
+            )}
+
+            <div className="grid items-center gap-y-8 md:grid-cols-2">
+              <div className="flex flex-col gap-6 md:pr-10">
+                <div className="space-y-2">
+                  <h1 className="font-heading text-2xl font-semibold tracking-tight text-balance">
+                    The whole loop,
+                    <br className="hidden sm:block" /> one window.
+                  </h1>
+                  <p className="text-xs/relaxed text-muted-foreground">
+                    Open a repository to start reviewing, committing, and
+                    shipping
+                    {aiEnabled
+                      ? " — with AI in the loop when you want it."
+                      : "."}
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex flex-col gap-2">
+                    {actions.map(
+                      ({ id, label, icon: Icon, variant, onClick }) => {
+                        const binding = bindings.get(id);
+                        return (
+                          <Button
+                            key={id}
+                            variant={variant}
+                            onClick={onClick}
+                            className="w-full justify-between"
+                          >
+                            <span className="flex items-center gap-2">
+                              <Icon className="size-4" />
+                              {label}
+                            </span>
+                            {binding && (
+                              <span className="text-[11px] tabular-nums opacity-60">
+                                {formatBinding(binding)}
+                              </span>
+                            )}
+                          </Button>
+                        );
+                      },
+                    )}
+                  </div>
+                  <p className="pt-1 text-[11px] text-muted-foreground">
+                    …or drag a repo folder anywhere onto the window.
+                  </p>
+                </div>
+              </div>
+
+              <div className="self-stretch md:border-l md:border-border md:pl-10">
+                <RecentRepoList />
+              </div>
             </div>
           </div>
-
-          <div className="self-stretch md:border-l md:border-border md:pl-10">
-            <RecentRepoList />
-          </div>
-        </div>
-      </main>
+        </main>
+      </ScrollArea>
     </div>
   );
 }

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -141,7 +141,16 @@ export type ReviewEvent =
    *  timeline; `tool` is the normalized category, `target` the thing it acted on. */
   | { kind: "tool"; tool: AgentToolKind; target: string | null }
   | { kind: "done"; text: string; isError: boolean; costUsd: number | null }
-  | { kind: "error"; message: string }
+  /** Terminal failure. `partialText` carries output a whole-message CLI (Codex)
+   *  accumulated but never streamed as deltas — null when the run's text already
+   *  streamed. `timedOut` marks the backend's own kill at the run deadline. Both keys
+   *  always ship (see `review_event_wire_shape_is_camel_case`). */
+  | {
+      kind: "error";
+      message: string;
+      partialText: string | null;
+      timedOut: boolean;
+    }
   /** The CLI's own resume id captured on turn 1 (Codex thread / opencode session)
    *  — persisted so a host session resumes the right conversation. Only sessions
    *  care; reviews ignore it. */

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -73,6 +73,28 @@ const MISSING_KEY = Symbol("missing-key");
  *  no base URL: also a no-request state, but the user has a different thing to fix. */
 const MISSING_BASE_URL = Symbol("missing-base-url");
 
+/** A catalog response our own shape casts couldn't read. Distinct from every other
+ *  failure here because the message is OURS: routing it through
+ *  `providerErrorMessage` would quote a TypeError to the user as the provider's
+ *  explanation of what went wrong. */
+class CatalogShapeError extends Error {
+  constructor() {
+    super("The provider's response didn't match the expected format.");
+    this.name = "CatalogShapeError";
+  }
+}
+
+/** Runs a fetched catalog body through its provider's shape mapping, converting a
+ *  shape failure into {@link CatalogShapeError}. Only the mapping is wrapped — the
+ *  fetch stays outside, so HTTP/network failures keep the provider's own words. */
+function shaped(map: () => string[]): string[] {
+  try {
+    return map();
+  } catch {
+    throw new CatalogShapeError();
+  }
+}
+
 async function fetchProviderModels(
   settings: AiSettings,
   allowedHosts?: readonly string[],
@@ -104,10 +126,12 @@ async function fetchProviderModels(
       const json = await fetchJson("https://api.openai.com/v1/models", {
         Authorization: `Bearer ${key}`,
       });
-      return (json.data as { id: string }[])
-        .map((m) => m.id)
-        .filter((id) => !OPENAI_NON_CHAT.test(id))
-        .sort();
+      return shaped(() =>
+        (json.data as { id: string }[])
+          .map((m) => m.id)
+          .filter((id) => !OPENAI_NON_CHAT.test(id))
+          .sort(),
+      );
     }
     case "anthropic": {
       const key = await getSecret("anthropic");
@@ -119,7 +143,7 @@ async function fetchProviderModels(
           "anthropic-version": "2023-06-01",
         },
       );
-      return (json.data as { id: string }[]).map((m) => m.id);
+      return shaped(() => (json.data as { id: string }[]).map((m) => m.id));
     }
     case "google": {
       const key = await getSecret("google");
@@ -127,7 +151,7 @@ async function fetchProviderModels(
       const json = await fetchJson(`${GOOGLE_AI_STUDIO_BASE_URL}/models`, {
         Authorization: `Bearer ${key}`,
       });
-      return googleChatModels(json.data as { id: string }[]);
+      return shaped(() => googleChatModels(json.data as { id: string }[]));
     }
     case "openai-compatible": {
       const key = await getSecret("openai-compatible");
@@ -139,24 +163,28 @@ async function fetchProviderModels(
       const json = await fetchJson(`${base}/models`, {
         Authorization: `Bearer ${key}`,
       });
-      const data = json.data as { id: string }[];
-      // A custom base URL can still point at Google's catalog (and saved settings
-      // from the retired Gemini preset do), which needs the `google` normalization;
-      // other endpoints list only their own models.
-      if (base === GOOGLE_AI_STUDIO_BASE_URL) return googleChatModels(data);
-      return data.map((m) => m.id).sort();
+      return shaped(() => {
+        const data = json.data as { id: string }[];
+        // A custom base URL can still point at Google's catalog (and saved settings
+        // from the retired Gemini preset do), which needs the `google` normalization;
+        // other endpoints list only their own models.
+        if (base === GOOGLE_AI_STUDIO_BASE_URL) return googleChatModels(data);
+        return data.map((m) => m.id).sort();
+      });
     }
     case "openrouter": {
       // public endpoint, no key required
       const json = await fetchJson("https://openrouter.ai/api/v1/models");
-      return (json.data as { id: string }[]).map((m) => m.id).sort();
+      return shaped(() =>
+        (json.data as { id: string }[]).map((m) => m.id).sort(),
+      );
     }
     case "ollama": {
       const base = settings.ollamaBaseUrl.replace(/\/$/, "");
       const json = await fetchJson(`${base}/api/tags`);
-      return ((json.models ?? []) as { name: string }[])
-        .map((m) => m.name)
-        .sort();
+      return shaped(() =>
+        ((json.models ?? []) as { name: string }[]).map((m) => m.name).sort(),
+      );
     }
     case "ollama-cloud": {
       const key = await getSecret("ollama-cloud");
@@ -165,7 +193,9 @@ async function fetchProviderModels(
       const json = await fetchJson(`${OLLAMA_CLOUD_HOST}/v1/models`, {
         Authorization: `Bearer ${key}`,
       });
-      return (json.data as { id: string }[]).map((m) => m.id).sort();
+      return shaped(() =>
+        (json.data as { id: string }[]).map((m) => m.id).sort(),
+      );
     }
     case "claude-cli":
     case "codex-cli":
@@ -226,7 +256,12 @@ export function useAvailableModels(
         return {
           models: fallbackModels(settings),
           live: false,
-          reason: providerErrorMessage(e),
+          // A shape failure is ours to explain; everything else here is the
+          // provider's request that failed, so it keeps the provider's words.
+          reason:
+            e instanceof CatalogShapeError
+              ? e.message
+              : providerErrorMessage(e),
           cause: "failed",
         };
       }

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -52,13 +52,13 @@ const OPENAI_NON_CHAT =
  *  excludes future media families by default instead of chasing each new name. */
 const GOOGLE_CHAT_FAMILY = /^(gemini|gemma)-/;
 
-/** Google's catalog, normalized for the model picker. The prefix strip must run
+/** Google's catalog ids, normalized for the model picker. The prefix strip must run
  *  BEFORE the family test — a `models/`-prefixed id fails `^gemini-` and would
  *  filter the whole catalog away. Also used for a custom base URL aimed at the
  *  same endpoint. */
-function googleChatModels(data: { id: string }[]): string[] {
-  return data
-    .map((m) => m.id.replace(/^models\//, ""))
+function googleChatModels(ids: string[]): string[] {
+  return ids
+    .map((id) => id.replace(/^models\//, ""))
     .filter((id) => GOOGLE_CHAT_FAMILY.test(id) && !OPENAI_NON_CHAT.test(id))
     .sort();
 }
@@ -86,13 +86,36 @@ class CatalogShapeError extends Error {
 
 /** Runs a fetched catalog body through its provider's shape mapping, converting a
  *  shape failure into {@link CatalogShapeError}. Only the mapping is wrapped — the
- *  fetch stays outside, so HTTP/network failures keep the provider's own words. */
+ *  fetch stays outside, so HTTP/network failures keep the provider's own words.
+ *  {@link catalogIds} does the element-level work; this stays the net that keeps a
+ *  future unguarded access in some arm from reaching `providerErrorMessage`. */
 function shaped(map: () => string[]): string[] {
   try {
     return map();
   } catch {
     throw new CatalogShapeError();
   }
+}
+
+/** Reads a catalog payload's entries into the ids under `idKey`. Drift is a
+ *  {@link CatalogShapeError}: a payload that isn't an array at all, or a non-empty one
+ *  whose entries yield no usable id — a 200 response can carry a drifted body, so
+ *  emptiness there means "we couldn't read this", not "there are no models". An EMPTY
+ *  payload is NOT drift: a provider may genuinely list nothing, which the caller
+ *  reports as `cause: "empty"`. Individual malformed entries beside usable ones are
+ *  dropped, so one bad row can't cost the user the catalog. Domain filters (chat-only,
+ *  family allowlists) run on the RESULT for the same reason — filtering every id away
+ *  is an empty catalog, not a failure to read one. */
+function catalogIds(payload: unknown, idKey: "id" | "name"): string[] {
+  if (!Array.isArray(payload)) throw new CatalogShapeError();
+  const ids: string[] = [];
+  for (const entry of payload) {
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as Record<string, unknown>)[idKey];
+    if (typeof id === "string" && id.trim()) ids.push(id);
+  }
+  if (payload.length > 0 && ids.length === 0) throw new CatalogShapeError();
+  return ids;
 }
 
 async function fetchProviderModels(
@@ -127,8 +150,7 @@ async function fetchProviderModels(
         Authorization: `Bearer ${key}`,
       });
       return shaped(() =>
-        (json.data as { id: string }[])
-          .map((m) => m.id)
+        catalogIds(json.data, "id")
           .filter((id) => !OPENAI_NON_CHAT.test(id))
           .sort(),
       );
@@ -143,7 +165,7 @@ async function fetchProviderModels(
           "anthropic-version": "2023-06-01",
         },
       );
-      return shaped(() => (json.data as { id: string }[]).map((m) => m.id));
+      return shaped(() => catalogIds(json.data, "id"));
     }
     case "google": {
       const key = await getSecret("google");
@@ -151,7 +173,7 @@ async function fetchProviderModels(
       const json = await fetchJson(`${GOOGLE_AI_STUDIO_BASE_URL}/models`, {
         Authorization: `Bearer ${key}`,
       });
-      return shaped(() => googleChatModels(json.data as { id: string }[]));
+      return shaped(() => googleChatModels(catalogIds(json.data, "id")));
     }
     case "openai-compatible": {
       const key = await getSecret("openai-compatible");
@@ -164,27 +186,25 @@ async function fetchProviderModels(
         Authorization: `Bearer ${key}`,
       });
       return shaped(() => {
-        const data = json.data as { id: string }[];
+        const ids = catalogIds(json.data, "id");
         // A custom base URL can still point at Google's catalog (and saved settings
         // from the retired Gemini preset do), which needs the `google` normalization;
         // other endpoints list only their own models.
-        if (base === GOOGLE_AI_STUDIO_BASE_URL) return googleChatModels(data);
-        return data.map((m) => m.id).sort();
+        if (base === GOOGLE_AI_STUDIO_BASE_URL) return googleChatModels(ids);
+        return ids.sort();
       });
     }
     case "openrouter": {
       // public endpoint, no key required
       const json = await fetchJson("https://openrouter.ai/api/v1/models");
-      return shaped(() =>
-        (json.data as { id: string }[]).map((m) => m.id).sort(),
-      );
+      return shaped(() => catalogIds(json.data, "id").sort());
     }
     case "ollama": {
       const base = settings.ollamaBaseUrl.replace(/\/$/, "");
       const json = await fetchJson(`${base}/api/tags`);
-      return shaped(() =>
-        ((json.models ?? []) as { name: string }[]).map((m) => m.name).sort(),
-      );
+      // `?? []` kept: an absent `models` key stays an empty catalog, as before. A
+      // PRESENT but non-array one is drift, which `catalogIds` refuses.
+      return shaped(() => catalogIds(json.models ?? [], "name").sort());
     }
     case "ollama-cloud": {
       const key = await getSecret("ollama-cloud");
@@ -193,9 +213,7 @@ async function fetchProviderModels(
       const json = await fetchJson(`${OLLAMA_CLOUD_HOST}/v1/models`, {
         Authorization: `Bearer ${key}`,
       });
-      return shaped(() =>
-        (json.data as { id: string }[]).map((m) => m.id).sort(),
-      );
+      return shaped(() => catalogIds(json.data, "id").sort());
     }
     case "claude-cli":
     case "codex-cli":

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -47,6 +47,10 @@ export interface CliStreamOpts {
    *  called when there is none — a codex run (no deltas) or a run whose whole
    *  buffer IS the final answer. */
   onThoughts?: (text: string) => void;
+  /** Called before the run rejects when the backend killed it at its deadline — the
+   *  reason a caller keeps and labels whatever text arrived. The rejection still
+   *  carries the timeout message, so a caller that ignores this is unaffected. */
+  onTimedOut?: () => void;
 }
 
 /** A short, human status line for a tool step, from the normalized kind + target
@@ -90,6 +94,7 @@ export async function runCliStream({
   timeoutSecs,
   timeoutConfigurable,
   onThoughts,
+  onTimedOut,
 }: CliStreamOpts): Promise<void> {
   const kind = providerKind(ai.provider);
   if (!kind) throw new Error(`Unsupported CLI provider: ${ai.provider}`);
@@ -171,6 +176,15 @@ export async function runCliStream({
             resolve();
           } else if (event.kind === "error") {
             settled = true;
+            // A whole-message CLI (Codex) streams no deltas, so a killed run's output
+            // arrives only here — adopt it when nothing streamed, so the failure keeps
+            // the work instead of discarding it.
+            const partial = event.partialText?.trim() ? event.partialText : "";
+            if (partial && !buffer) {
+              buffer = partial;
+              setText(buffer);
+            }
+            if (event.timedOut) onTimedOut?.();
             reject(new Error(event.message));
           }
           // nativeSession (the CLI's turn-1 resume id) is session-only — reviews ignore it.
@@ -218,6 +232,9 @@ export interface StreamAiOpts {
    *  before the final answer (agentic CLI + HTTP runs only). The plain HTTP text
    *  path has no narration and never calls it. */
   onThoughts?: (text: string) => void;
+  /** Called when the backend killed a CLI run at its deadline, before the rejection.
+   *  CLI path only — an HTTP stream has no backend deadline. */
+  onTimedOut?: () => void;
   /** CLI path: receives the agent review id (cancel via `cancelAgentReview`). */
   onCliId: (id: string) => void;
   /** HTTP path: receives the AbortController driving the stream (cancel via
@@ -245,6 +262,7 @@ export async function streamAi({
   setText,
   setStatus,
   onThoughts,
+  onTimedOut,
   onCliId,
   onAbort,
 }: StreamAiOpts): Promise<void> {
@@ -262,6 +280,7 @@ export async function streamAi({
       setStatus,
       registerId: onCliId,
       onThoughts,
+      onTimedOut,
     });
     return;
   }

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -164,26 +164,37 @@ const OP_ADVICE = /\bgit (rebase|merge|cherry-pick|revert) --continue\b/;
  *  (autostash.rs); keep the two in step. */
 const MERGE_VERDICT = /^Automatic merge failed/;
 
-/** The paused operation, capitalized for the summary. Read only from git's
- *  advice and verdict lines — never the whole blob — so a cherry-pick of a commit
- *  titled "rebase the parser" still reads "Cherry-pick". The split mirrors the
- *  markers' `m` flag, which ends a line at a bare CR too — git has been observed
- *  joining its `Rebasing (n/m)` progress to the diagnostic after it with one. */
-function conflictOp(text: string): string {
+/** The paused operation and the action that finishes it. The name is read only
+ *  from git's advice and verdict lines — never the whole blob — so a cherry-pick
+ *  of a commit titled "rebase the parser" still reads "Cherry-pick". The split
+ *  mirrors the markers' `m` flag, which ends a line at a bare CR too — git has
+ *  been observed joining its `Rebasing (n/m)` progress to the diagnostic after it
+ *  with one.
+ *
+ *  A merge known only by its verdict ends in "commit", not "continue": that arm
+ *  also covers `merge --squash`, which writes no MERGE_HEAD (pinned by
+ *  `local_pr_finish_squash_all_ours_is_a_known_no_op`), so no banner Continue
+ *  exists to point at — and committing is how a plain merge finishes anyway. */
+function conflictSummary(text: string): string {
+  const paused = (op: string, finish: string) =>
+    `${op} paused — resolve the conflicts, then ${finish}.`;
   const lines = text.split(/\r\n|[\n\r]/);
   for (const line of lines) {
     if (SUBJECT_ECHO_LINE.test(line)) continue;
     const op = OP_ADVICE.exec(line)?.[1];
     if (op) {
-      return op === "cherry-pick"
-        ? "Cherry-pick"
-        : op.charAt(0).toUpperCase() + op.slice(1);
+      const name =
+        op === "cherry-pick"
+          ? "Cherry-pick"
+          : op.charAt(0).toUpperCase() + op.slice(1);
+      return paused(name, "continue");
     }
   }
   // Advice first: it is the stronger signal, and only its absence leaves the
   // merge verdict as the sole name for the paused operation.
-  if (lines.some((line) => MERGE_VERDICT.test(line))) return "Merge";
-  return "Operation";
+  if (lines.some((line) => MERGE_VERDICT.test(line)))
+    return paused("Merge", "commit");
+  return paused("Operation", "continue");
 }
 
 /** Count of non-empty lines in a string. */
@@ -217,7 +228,7 @@ export function presentError(e: unknown): ErrorPresentation {
       !rolledBack && CONFLICT_MARKERS.some((m) => m.test(combined));
     const label = KIND_LABELS[e.kind];
     const summary = isConflict
-      ? `${conflictOp(combined)} paused — resolve the conflicts, then continue.`
+      ? conflictSummary(combined)
       : firstMeaningfulLine(message) || label;
 
     const distinctStderr = stderr !== "" && !message.includes(stderr);

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -75,8 +75,12 @@ function firstMeaningfulLine(message: string): string {
  *  which re-runs real conflicts and asserts these shapes still hold. */
 const CONFLICT_MARKERS = [
   // git emits both `error: could not apply …` and a bare `Could not apply
-  // <sha>…` tail line (rebase).
-  /^(?:error: )?[Cc]ould not apply /m,
+  // <sha>…` tail line (rebase); a revert says `could not revert` for the same
+  // thing, and that line is the ONLY marker a conflicted revert produces — the
+  // rest of its report (`CONFLICT (…`) rides stdout, which `git_revert_core`'s
+  // runner drops. Deliberately the same shape as SUBJECT_ECHO_LINE below: the
+  // line that PROVES a conflict is the one that must not be read as its NAME.
+  /^(?:error: )?[Cc]ould not (?:apply|revert) /m,
   /^(?:error: |hint: )Resolve all conflicts/m,
   // Git's own line is always uppercase; a path named "conflict (old)" is not.
   /^CONFLICT \(/m,
@@ -151,13 +155,23 @@ const SUBJECT_ECHO_LINE = /^(?:error: )?[Cc]ould not (?:apply|revert) /;
  *  remedy inside another operation's message must not name the op. */
 const OP_ADVICE = /\bgit (rebase|merge|cherry-pick|revert) --continue\b/;
 
+/** A conflicted merge is the one family git gives no `--continue` advice for —
+ *  it prints this verdict instead, on stdout, with stderr empty (which is why
+ *  `git_merge_core` backfills stdout into the error). Line-anchored, because the
+ *  phrase is otherwise reachable as user text. Rebase and cherry-pick emit it on
+ *  neither stream, so it names a merge unambiguously — both halves are pinned by
+ *  the Rust canary `conflict_output_still_matches_the_anchored_frontend_markers`
+ *  (autostash.rs); keep the two in step. */
+const MERGE_VERDICT = /^Automatic merge failed/;
+
 /** The paused operation, capitalized for the summary. Read only from git's
- *  advice lines — never the whole blob — so a cherry-pick of a commit titled
- *  "rebase the parser" still reads "Cherry-pick". The split mirrors the markers'
- *  `m` flag, which ends a line at a bare CR too — git has been observed joining
- *  its `Rebasing (n/m)` progress to the diagnostic after it with one. */
+ *  advice and verdict lines — never the whole blob — so a cherry-pick of a commit
+ *  titled "rebase the parser" still reads "Cherry-pick". The split mirrors the
+ *  markers' `m` flag, which ends a line at a bare CR too — git has been observed
+ *  joining its `Rebasing (n/m)` progress to the diagnostic after it with one. */
 function conflictOp(text: string): string {
-  for (const line of text.split(/\r\n|[\n\r]/)) {
+  const lines = text.split(/\r\n|[\n\r]/);
+  for (const line of lines) {
     if (SUBJECT_ECHO_LINE.test(line)) continue;
     const op = OP_ADVICE.exec(line)?.[1];
     if (op) {
@@ -166,6 +180,9 @@ function conflictOp(text: string): string {
         : op.charAt(0).toUpperCase() + op.slice(1);
     }
   }
+  // Advice first: it is the stronger signal, and only its absence leaves the
+  // merge verdict as the sole name for the paused operation.
+  if (lines.some((line) => MERGE_VERDICT.test(line))) return "Merge";
   return "Operation";
 }
 

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -387,11 +387,12 @@ export interface RepoOpState {
   merging: boolean;
   rebasing: boolean;
   cherryPicking: boolean;
+  reverting: boolean;
   /** An interactive rebase is paused at an `edit` (vs a conflict). */
   editPaused: boolean;
 }
 
-export type RepoOp = "merge" | "rebase" | "cherry-pick";
+export type RepoOp = "merge" | "rebase" | "cherry-pick" | "revert";
 
 /**
  * One journaled entry from GitDesktop's operation log (`oplog.rs`) — a risky compound

--- a/src/lib/hotkeys/modal-gate.ts
+++ b/src/lib/hotkeys/modal-gate.ts
@@ -1,0 +1,50 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+/**
+ * Dialogs that must suppress App's global repo/settings actions while they are
+ * open. A competing registration can't do that job: `dispatchAction` runs the
+ * newest ENABLED handler and falls THROUGH disabled ones, so the only way to
+ * refuse an action is App's own `enabled` flag — hence a shared signal rather
+ * than a rival handler. The command palette deliberately never registers: it
+ * dispatches these actions itself and must stay live while open.
+ */
+const openModals = new Set<object>();
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const fn of subscribers) fn();
+}
+
+function subscribe(fn: () => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+function getSnapshot(): boolean {
+  return openModals.size > 0;
+}
+
+/**
+ * Registers this component's dialog as open for as long as `open` holds, so
+ * App's gated actions (which the native menu bar can fire from outside the
+ * webview's modal overlay) refuse while it is on screen.
+ */
+export function useModalGateRegistration(open: boolean): void {
+  useEffect(() => {
+    if (!open) return;
+    const token = {};
+    openModals.add(token);
+    notify();
+    return () => {
+      openModals.delete(token);
+      notify();
+    };
+  }, [open]);
+}
+
+/** True while any registered dialog is open. */
+export function useModalGateOpen(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/lib/pulls/queries.ts
+++ b/src/lib/pulls/queries.ts
@@ -17,6 +17,7 @@ import {
   clearReviewsFor,
   deleteReview,
   listReviews,
+  reviewPartialKey,
   updateReviewText,
 } from "./reviews-history";
 
@@ -94,10 +95,18 @@ function useReviewHistoryMutation<TArgs>(
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: fn,
+    // Both keys: every mutation here writes the whole record set, and clear/delete
+    // remove kept PARTIAL runs too (they carry no phase filter). Refreshing only the
+    // completed-review key would leave a deleted partial's cached text on screen.
     onSettled: () =>
-      queryClient.invalidateQueries({
-        queryKey: reviewHistoryKey(repo, lens, kind, ref),
-      }),
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: reviewHistoryKey(repo, lens, kind, ref),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: reviewPartialKey(repo, lens, kind, ref),
+        }),
+      ]),
   });
 }
 

--- a/src/lib/pulls/review-drafts.ts
+++ b/src/lib/pulls/review-drafts.ts
@@ -263,14 +263,25 @@ export function useRemoveReviewDraft(
   });
 }
 
+/** Discards every pending draft for a PR/MR. `silent` suppresses the hook-level
+ *  failure toast — for a caller that reports the failure in its own words (react-query
+ *  fires this callback for `mutateAsync` too, so without the opt-out that caller
+ *  double-toasts). */
 export function useClearReviewDrafts(
   repo: string,
   lens: RemoteLens,
   number: number,
+  opts?: { silent?: boolean },
 ) {
   const queryClient = useQueryClient();
+  const silent = opts?.silent ?? false;
   return useMutation({
     mutationFn: () => clearDrafts(repo, lens, number),
+    // Mutation-level: see useUpdateReviewDraft. The pending-review bar unmounts on a
+    // tab switch away from Files, which is exactly when a slow discard fails.
+    onError: (e) => {
+      if (!silent) toastError(e);
+    },
     onSettled: () =>
       void queryClient.invalidateQueries({
         queryKey: reviewDraftsKey(repo, lens, number),

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -40,19 +40,52 @@ export interface PersistedReview {
   headSha: string;
   startedAt: number;
   finishedAt: number;
+  /** Present only on a PARTIAL record: a run that failed with output worth keeping.
+   *  Its absence is what makes a record a completed review, so every reader that means
+   *  "the previous review" goes through {@link listReviews} / {@link getLatestReview},
+   *  which drop partials. Additive optional field; schemaVersion stays 1. */
+  phase?: "error";
+  /** Why a partial run stopped, as shown to the user. Partial records only. */
+  error?: string;
+  /** The partial run was killed at its timeout (rather than failing outright) — the
+   *  distinction the kept output is labeled with. Partial records only. */
+  timedOut?: boolean;
+}
+
+/** Whether a stored record is a kept PARTIAL run rather than a completed review.
+ *  Store JSON is untrusted, so the flag is compared by exact value, never coerced. */
+export function isPartialReview(r: Pick<PersistedReview, "phase">): boolean {
+  return r.phase === "error";
+}
+
+/** A partial record's stop reason, type-checked out of untrusted store JSON: a
+ *  non-boolean `timedOut` reads as "failed", a non-string `error` as no reason. */
+export function partialReviewReason(
+  r: Pick<PersistedReview, "timedOut" | "error">,
+): { timedOut: boolean; error: string } {
+  return {
+    timedOut: r.timedOut === true,
+    error: typeof r.error === "string" ? r.error : "",
+  };
 }
 
 /** Reviews kept per `(lens, kind, ref, mode)` — enough to show iteration, bounded
  *  so the store file never balloons. Pruned on every write. */
 const MAX_PER_GROUP = 3;
 
+/** Partial runs are grouped separately and capped at one: the latest kept output is
+ *  all the panel offers, and a run of timeouts must never evict completed reviews. */
+const MAX_PARTIAL_PER_GROUP = 1;
+
 /** A record's lens, defaulting the absent field on pre-lens records to the lens
  *  they were written under. */
 const lensOf = (r: Pick<PersistedReview, "lens">): RemoteLens =>
   r.lens ?? "origin";
 
-const groupKey = (r: Pick<PersistedReview, "lens" | "kind" | "ref" | "mode">) =>
-  `${lensOf(r)}#${r.kind}#${r.ref}#${r.mode}`;
+const groupKey = (
+  r: Pick<PersistedReview, "lens" | "kind" | "ref" | "mode" | "phase">,
+) =>
+  `${lensOf(r)}#${r.kind}#${r.ref}#${r.mode}#${isPartialReview(r) ? "partial" : "done"}`;
 
 // Personal app-data, keyed by the repo's worktree-stable identity — never written
 // into the repo itself (the text quotes user source + may contain AI false
@@ -137,7 +170,8 @@ async function writeAll(
   await store.save();
 }
 
-/** Keeps only the newest `MAX_PER_GROUP` reviews per `(lens, kind, ref, mode)`. */
+/** Keeps only the newest few records per `(lens, kind, ref, mode)` — completed
+ *  reviews and kept partial runs are separate groups with their own caps. */
 function prune(records: PersistedReview[]): PersistedReview[] {
   const groups = new Map<string, PersistedReview[]>();
   for (const r of records) {
@@ -149,7 +183,12 @@ function prune(records: PersistedReview[]): PersistedReview[] {
   const kept: PersistedReview[] = [];
   for (const group of groups.values()) {
     group.sort((a, b) => b.finishedAt - a.finishedAt);
-    kept.push(...group.slice(0, MAX_PER_GROUP));
+    // Every member of a group shares its partial-ness (it's part of the key), so the
+    // first member decides the cap.
+    const cap = isPartialReview(group[0])
+      ? MAX_PARTIAL_PER_GROUP
+      : MAX_PER_GROUP;
+    kept.push(...group.slice(0, cap));
   }
   return kept;
 }
@@ -188,16 +227,41 @@ export async function getLatestReview(
         lensOf(r) === lens &&
         r.kind === kind &&
         r.ref === ref &&
-        r.mode === mode,
+        r.mode === mode &&
+        !isPartialReview(r),
     )
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
 }
 
-/** Every persisted review for a PR (both modes), newest first. Two consumers, so
+/** The most recent kept PARTIAL run for a PR (either mode), or undefined if none —
+ *  the output a timed-out run left behind, which the panel can show after a restart.
+ *  Deliberately its own read: a partial is not a review, so nothing that builds on
+ *  "the previous review" (prior context, the automation coverage gates) may see it. */
+export async function getLatestPartialReview(
+  repo: string,
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+): Promise<PersistedReview | undefined> {
+  const all = await read(repo);
+  return all
+    .filter(
+      (r) =>
+        lensOf(r) === lens &&
+        r.kind === kind &&
+        r.ref === ref &&
+        isPartialReview(r),
+    )
+    .sort((a, b) => b.finishedAt - a.finishedAt)[0];
+}
+
+/** Every COMPLETED review for a PR (both modes), newest first. Two consumers, so
  *  narrowing what this returns is not a UI-only change: the "Previous reviews"
  *  disclosure, and the runner's pr-sync gate, which reads the whole retained set to
- *  decide whether a head was already covered. `fresh` re-reads the store from disk
- *  first — see {@link read}. */
+ *  decide whether a head was already covered. Kept partial runs are excluded for that
+ *  second reason above all — a timed-out run must not mark a head as reviewed
+ *  ({@link getLatestPartialReview} is the one reader that wants them). `fresh`
+ *  re-reads the store from disk first — see {@link read}. */
 export async function listReviews(
   repo: string,
   lens: RemoteLens,
@@ -207,11 +271,18 @@ export async function listReviews(
 ): Promise<PersistedReview[]> {
   const all = await read(repo, opts);
   return all
-    .filter((r) => lensOf(r) === lens && r.kind === kind && r.ref === ref)
+    .filter(
+      (r) =>
+        lensOf(r) === lens &&
+        r.kind === kind &&
+        r.ref === ref &&
+        !isPartialReview(r),
+    )
     .sort((a, b) => b.finishedAt - a.finishedAt);
 }
 
-/** Upserts a finished review by id, then prunes its group to the newest few. */
+/** Upserts a finished review — or a kept partial run — by id, then prunes its group
+ *  to the newest few. */
 export async function saveReview(
   repo: string,
   record: PersistedReview,

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -233,6 +233,19 @@ export async function getLatestReview(
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
 }
 
+/** Query key for {@link getLatestPartialReview}. Lives here, beside the read it keys,
+ *  so all three consumers share one builder: any writer that can remove a partial
+ *  record (history clear, per-record delete) must invalidate it, and a hand-written
+ *  copy that drifts leaves deleted output on screen. Homed in this module rather than
+ *  `queries.ts` so the review store can use it without pulling that module's
+ *  react-query/forge-status graph in. */
+export const reviewPartialKey = (
+  repo: string,
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+) => ["review-partial", repo, lens, kind, ref] as const;
+
 /** The most recent kept PARTIAL run for a PR (either mode), or undefined if none —
  *  the output a timed-out run left behind, which the panel can show after a restart.
  *  Deliberately its own read: a partial is not a review, so nothing that builds on

--- a/src/lib/stores/conflict-resolve.ts
+++ b/src/lib/stores/conflict-resolve.ts
@@ -65,3 +65,17 @@ export const useConflictResolve = create<ConflictResolveState>()(
     stop: () => set({ activePath: null, queue: [] }),
   }),
 );
+
+// A resolve walk belongs to the repo it started in. `conflict-resolve` is a
+// separate store, so the ui store's CROSS_REPO_RESET can't reach it — subscribe
+// to repo changes and drop the walk here. Without this the walk survives a repo
+// switch: the diff pane opens a resolution view for a path that belongs to the
+// OLD tree (or, on a same-named path, resolves the wrong file), and a queued
+// "resolve all" run keeps advancing through the previous repo's conflicts.
+useUiStore.subscribe((s, prev) => {
+  if (s.repoPath === prev.repoPath) return;
+  const { activePath, queue } = useConflictResolve.getState();
+  if (activePath !== null || queue.length > 0) {
+    useConflictResolve.setState({ activePath: null, queue: [] });
+  }
+});

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -12,6 +12,28 @@ export type NotificationTone =
   | "merged"
   | "neutral";
 
+/** Every event kind an emitter may push. Closed on the WRITE side only, so a
+ *  typo'd kind fails to compile instead of rendering a fallback glyph forever;
+ *  {@link AppNotification.kind} stays `string` because a hydrated row can carry a
+ *  kind minted by an older build. */
+export type NotificationKind =
+  | "review-ready"
+  | "review-failed"
+  | "review-requested"
+  | "checks-passed"
+  | "checks-failed"
+  | "ci-run"
+  | "pr-opened"
+  | "pr-merged"
+  | "pr-closed"
+  | "pr-approved"
+  | "pr-changes-requested"
+  | "pr-review"
+  | "pr-comment"
+  | "agent-done"
+  | "research-done"
+  | "plan-done";
+
 /** How clicking a notification routes. Data only — the surface maps it to the UI
  *  store's atomic navigation actions, so this module stays free of view logic. */
 export type NotificationTarget =
@@ -24,7 +46,9 @@ export type NotificationTarget =
  *  the row and the target navigates (switching repos when needed). */
 export interface AppNotification {
   id: string;
-  /** Event kind — drives the glyph in the surface (see `notificationGlyph`). */
+  /** Event kind — drives the glyph in the surface (see `notificationGlyph`).
+   *  Deliberately `string`, not {@link NotificationKind}: hydrated rows are
+   *  untrusted and an older build's kind must still render. */
   kind: string;
   tone: NotificationTone;
   title: string;
@@ -205,7 +229,7 @@ void (async () => {
  * since the window has elapsed).
  */
 export function pushNotification(input: {
-  kind: string;
+  kind: NotificationKind;
   tone: NotificationTone;
   title: string;
   subtitle?: string;

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -484,12 +484,17 @@ export async function startReview(
   // while queued wakes this too — `control.cancelled` then short-circuits below.
   await acquireSlot(lane, control);
 
+  // Both read by the catch below, which persists whatever a failed run produced —
+  // so they live outside the try. `startedAtMs` stays undefined for a failure that
+  // never reached the stream (there's no run to have timed the span of).
+  let startedAtMs: number | undefined;
+  let timedOut = false;
   try {
     if (control.cancelled) return;
     // Wall-clock start, stamped once the run leaves the queue — the queue wait is
     // excluded. One value feeds both the live entry and the persisted record, so they
     // measure the same span.
-    const startedAtMs = Date.now();
+    startedAtMs = Date.now();
     patch({ phase: "running", startedAt: startedAtMs });
     // Count a review when it actually starts — covers manual runs AND a drained queued
     // run, and skips a queued-then-dismissed one (which never reaches here).
@@ -728,6 +733,9 @@ export async function startReview(
       setText: pushText,
       setStatus: (s) => patch({ status: s }),
       onThoughts: (t) => patch({ thoughts: t }),
+      onTimedOut: () => {
+        timedOut = true;
+      },
       onCliId: (id) => {
         control.cliReviewId = id;
       },
@@ -804,6 +812,42 @@ export async function startReview(
         endedAt: Date.now(),
       });
       void notifyReviewDone(title, mode, false, target, message);
+      // Whatever the run produced before it failed — this store is memory-only, so
+      // without a record a timed-out 20-minute run is gone at the next restart. Saved
+      // as a PARTIAL record (`phase`), which the history reads exclude: it's kept
+      // output, never a review the next run may build on.
+      const partial = useReviewStore.getState().texts[key] ?? "";
+      if (partial.trim() && startedAtMs !== undefined) {
+        void saveReview(target.repoPath, {
+          schemaVersion: 1,
+          id: crypto.randomUUID(),
+          kind: target.kind,
+          ref: target.ref,
+          lens: context.lens,
+          mode,
+          model: ai.model,
+          title,
+          text: partial,
+          phase: "error",
+          error: message,
+          ...(timedOut ? { timedOut: true } : {}),
+          headSha: context.headSha ?? "",
+          startedAt: startedAtMs,
+          finishedAt: Date.now(),
+        })
+          .then(() =>
+            queryClient.invalidateQueries({
+              queryKey: [
+                "review-partial",
+                target.repoPath,
+                context.lens,
+                target.kind,
+                target.ref,
+              ],
+            }),
+          )
+          .catch(() => undefined);
+      }
     }
   } finally {
     // Release the lane slot for the next queued run (only if this run actually

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -33,7 +33,7 @@ import { track } from "@/lib/analytics";
 import { readRepoInstructions } from "@/lib/git/api";
 import type { DiffStatEntry, RemoteLens } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
-import { saveReview } from "@/lib/pulls/reviews-history";
+import { reviewPartialKey, saveReview } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
 import { pushNotification } from "@/lib/stores/notifications";
@@ -837,13 +837,12 @@ export async function startReview(
         })
           .then(() =>
             queryClient.invalidateQueries({
-              queryKey: [
-                "review-partial",
+              queryKey: reviewPartialKey(
                 target.repoPath,
                 context.lens,
                 target.kind,
                 target.ref,
-              ],
+              ),
             }),
           )
           .catch(() => undefined);


### PR DESCRIPTION
This is the v0.9.2 patch batch: a run of correctness and clarity fixes across git operation state, the diff surface, pull-request review flows, and conversation controls. The two largest themes are teaching the app that **revert** is a first-class in-flight operation (it previously had no op state, no conflict banner, and no guards) and replacing bare `disabled` attributes with controls that say what they're waiting on and stay reachable by keyboard while they say it.

Related: the additive line-selection work addresses the drag-selection half of #211 — one drag can now stage added and removed lines together. The other half of that issue (dedicated diff keybind actions) remains open, so this deliberately doesn't close it.

### Git operations & conflicts

- Adds `reverting` to `RepoOpState` (`src-tauri/src/git/types.rs`) and detects it in `src-tauri/src/git/ops.rs`: `op_state` reads `REVERT_HEAD`, and a new `sequencer_reverting` helper parses `.git/sequencer/todo` for the replaying verb, covering the window a multi-commit `cherry-pick -n` leaves with no `CHERRY_PICK_HEAD`. `op_in_progress`, `refuse_mid_op`, and `validate_op` all now account for revert.
- Rewrites `git_merge_core` to run raw under the repo lock instead of `run_git_mutating`, because a conflicted merge reports on **stdout** and leaves stderr empty — the stdout text carries the `CONFLICT (…` line the frontend classifies on. Keeps the one-shot `index.lock` retry.
- `src-tauri/src/git/autostash.rs`: `git_error` now backfills stdout via `failure_text`, so the no-stash path's conflict no longer degrades to "git exited with code 1". Extends the marker-shape test to cover revert's `could not revert` echo and pins the reality that a conflicted merge leaves stderr empty.
- Frontend consumers follow: `ConflictBanner.tsx` names the paused operation, `HistoryPanel.tsx` blocks history editing during a revert, `PromoteWorktreeDialog.tsx` and `src/lib/error-summary.ts` are updated for the new op, and `src/lib/stores/conflict-resolve.ts` clears resolution state on repo switch.
- Updates the `stash_push` tool description in `src-tauri/src/mcp_server/write_git.rs` to mention revert.

### Diff surface & staging

- Reworks how worker-tokenized ASTs reach the view (`src/features/diff/DiffSurface.tsx`): `createDiffFile` no longer takes `workerAsts` and runs a local `initSyntax`; instead `useShikiRouting` returns a `workerHighlighter` handed to the view as `registerHighlighter`, keeping the `DiffFile` identity stable so expanded context survives highlighting arrival. Documents why `name`/`type` must stay `"shiki"`/`"style"` against the core's re-entry guards.
- Adds a `syntaxIgnored` short-circuit in `useShikiRouting` so a small hunk deep in a huge file skips the grammar fetch and worker pass entirely, painting immediately.
- Adds additive line selection in `src/features/diff/DiffViewer.tsx`: a capture-phase `mousedown` records the platform modifier (`isAdditiveDrag`, derived via `isMac`), `mergeSelection` unions runs deduped by side+line, and `paintRange` repaints over the committed base. The hint text names the modifier via `formatBinding("mod")`.
- Updates the doc comment in `src/features/diff/use-worker-highlight.ts` to match the new contract.

### Pull requests & reviews

- `src-tauri/src/agent.rs`: `ReviewEvent::Error` gains `partial_text` and `timed_out`, with a `ReviewEvent::error` constructor for the reason-only cases. `stream_agent` keeps Codex's accumulated `last_message` on a deadline kill, since Codex only surfaces whole messages at `turn.completed`. A serialization test pins the camelCase wire shape and asserts the snake_case fields never ship.
- `src/lib/ai/stream.ts`, `src/lib/ai/agent.ts`, and `src/lib/pulls/reviews-history.ts` persist that partial output labelled as timed-out, and keep it from counting as finished review coverage.
- `SubmitReviewDialog.tsx` and `usePrCapabilities.ts` always render all three verdicts, disabling unwired ones with a reason instead of hiding them.
- `RemotePrView.tsx` gains an offline/error placeholder naming the unreachable host, and fixes the draft-pair stale flip so **Ready for review** / **Convert to draft** wait for the incoming PR's own state.
- `PendingReviewBar.tsx` drops its local `onError` toast so `src/lib/pulls/review-drafts.ts` and `src/lib/stores/reviews.ts` own failure reporting for a discard.
- `PrReviewPanel.tsx`, `PrActivityFeed.tsx`, `CommitComments.tsx`, and `usePrNotifications.ts` pick up the surrounding changes.

### Conversations & disabled-state affordances

- `src/features/conversations/ReactionBar.tsx` adds a `ReactionButton` that hand-rolls the `DisabledReasonButton` contract on a raw `<button>` — `aria-disabled` plus an sr-only description, keeping the tab stop — and threads a `reason` through chips and the picker.
- `CommentComposer.tsx` swaps `Button` for `DisabledReasonButton` on **Comment** / **Clear**, gated so only the `busy` hold gets words; `Thread.tsx` forwards `reactionsReason`.
- `DiscussionView.tsx` holds **Lock**, **Unlock**, **Close**, **Reopen**, **Delete**, and the **Labels** picker on `detailsStale`, appends the reason to menu labels (a disabled item drops pointer events), and adds a ranked `composerReason`.
- `src/components/disabled-reason-button.tsx` documents the trigger-site arms; `RemoteIssueView.tsx` and `JiraIssueView.tsx` adopt the same pattern.

### Dialogs, branches & shell

- Adds `src/lib/hotkeys/modal-gate.ts` (`useModalGateOpen` / `useModalGateRegistration`) so screen-owned modals suppress the macOS menu bar's repo and settings actions; `App.tsx` folds it into `dialogOpen` and `ExploreScreen.tsx` registers its clone dialog.
- `CleanupBranchesDialog.tsx` and `BranchSwitcher.tsx` detect branches merged via pull request by name, badging those rows and leaving them unchecked.
- `WelcomeScreen.tsx` scrolls within its own pane so the header and activity strip stay put.
- `ActivityDock.tsx` types `KIND_GLYPH` / `KIND_SECTION` as `Partial<Record<NotificationKind, …>>` with documented casts for hydrated rows from older builds, alongside the new kind in `src/lib/stores/notifications.ts`.
- `src/lib/ai/models.ts` distinguishes a malformed model-catalog response from a genuine provider failure in its error copy.

### CI & documentation

- Moves the Linux runner from `ubuntu-22.04` to `ubuntu-24.04` across `.github/workflows/release.yml`, `rust-tests.yml`, and `appimage-check.yml`, including the paired `if:` conditions.
- Updates `README.md` (staging, cleanup, conflict editor, stash-and-reapply, review verdicts, MCP `--allow-git-write`), `site/src/data/capabilities.ts` (three capability lines), and `src/features/help/content.ts`.
- Adds 21 fragments under `changelog.d/` covering each user-facing change, and rewords an existing `CHANGELOG.md` entry to list every read-only diff surface the background highlighting now covers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-line staging and discarding with platform-specific modifier keys.
  * Branch cleanup recognizes pull-request merges, including squash and rebase merges.
  * Added stash-and-reapply recovery for standard merges and branch updates.
  * Timed-out AI reviews retain readable partial results.
  * Review verdicts remain visible with explanations when unavailable.
  * Disabled conversation controls now explain their status accessibly.

* **Bug Fixes**
  * Improved diff highlighting, deep-file rendering, and selection persistence.
  * Clarified conflict handling for reverts and merges.
  * Prevented stale actions during navigation, repository switching, and modal stacking.
  * Improved offline pull-request and model-catalog error messages.
  * Welcome content now scrolls correctly.
  * Linux builds now target Ubuntu 24.04.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
