### PR TITLE
fix(git,pulls,issues,worktrees): stash on rebase, keep pending work visible

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -92,7 +92,10 @@ dialog.
   announcement; menu/popover trigger sites keep the reason on a titled span
   wrapper (its doc comment shows the idiom — a bare `title` on a disabled
   element never shows). A disabled submit may instead explain via the field's
-  `warning` hint.
+  `warning` hint. Raw-`<button>` sites the vendored Button can't size (reaction
+  chips, the discussion upvote chip) take the SAME contract from the shared
+  `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
+  (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
 - Per-variant copy/labels/glyphs are `Record` lookups, never ternary chains:
   an exact union discriminant gets a total `Record` (compiler
   exhaustiveness); a wide wire string gets `Partial<Record>` + explicit

--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ divergence vs. the default branch (labeled with the default's name), and a
 PR badge.
 
 - **Clean up branches** ⭐: one reviewed list that archives or deletes every
-  stale branch — merged into the default branch (directly, or by a recent
-  pull request, so squash and rebase merges count) or with no commits in a
-  chosen window. Pull-request matches go by branch name, so they only badge
-  a row with the PR that took it; pre-checking still comes from your own
-  history: merged into the default branch, or idle past that window.
+  stale branch — merged into the default branch (directly, or, where the
+  forge connection supplies them, by a recent pull request, so squash and
+  rebase merges count) or with no commits in a chosen window. Pull-request
+  matches go by branch name, so they only badge a row with the PR that took
+  it; pre-checking still comes from your own history: merged into the
+  default branch, or idle past that window. The dialog names pull requests
+  only where it read them, so its wording matches the checks behind the list.
 - **Advanced merge tooling** ⭐: predicts a merge's result in memory before
   you commit (fast-forward, already up to date, clean, or exactly which
   files will conflict), with `--no-ff` and a clearly cautioned auto-resolve
@@ -227,17 +229,18 @@ pushing and pulling stay manual.
   a file, review the proposal as a diff, and accept it (per file or all at
   once). Multi-provider, runs on local Ollama or a keyless Claude Code /
   Codex agent, and never writes until you accept.
-- **Stash and reapply**: when a pull, a merge into the branch you're on, or
-  a branch update is blocked by uncommitted changes, or you switch branches
-  with work in progress, one click stashes them (untracked files included),
-  runs the operation, and reapplies them on the other side. A reapply that
-  hits conflicts drops the files into the changes list; one that git refuses
+- **Stash and reapply**: when a pull, a merge into the branch you're on, a
+  rebase (the branch menu's *Rebase* and *Change base* alike), or a branch
+  update is blocked by uncommitted changes, or you switch branches with work
+  in progress, one click stashes them (untracked files included), runs the
+  operation, and reapplies them on the other side. A reapply that hits
+  conflicts drops the files into the changes list; one that git refuses
   outright leaves them safely stashed. The stash is kept as a backup either
   way. (A squash, no-ff, or strategy merge reports the refusal instead — the
   recovery redoes the merge plainly.) **Automatically stash and reapply on
-  pull, merge, and branch updates** (Settings → General) makes it the default
-  for all of them, and the switch prompt remembers a **Reapply after
-  switching** choice of its own.
+  pull, merge, rebase, and branch updates** (Settings → General) makes it
+  the default for all of them, and the switch prompt remembers a **Reapply
+  after switching** choice of its own.
 
 ### Pull requests
 
@@ -428,8 +431,9 @@ needed; publishable to GitHub in one click). Browse, create, and edit
 (drafting with AI from your repo's issue templates), react with emoji, and
 manage the full metadata: labels, assignees, milestones, issue type,
 sub-issues, dependencies (blocked-by / blocking), and development links
-(linked and closing PRs and branches, plus create-a-branch). Duplicate,
-transfer, pin/unpin, lock/unlock, or delete. On a **fork**, the same
+(linked and closing PRs and branches, plus create-a-branch). Close or
+reopen with a comment you've drafted posted alongside; duplicate, transfer,
+pin/unpin, lock/unlock, or delete. On a **fork**, the same
 **Fork | Upstream** lens as the PR tab browses the parent repository's
 issues (creating one under the Upstream lens opens it **on the parent**),
 and a fork with issues turned off offers a one-click switch to Upstream
@@ -451,7 +455,8 @@ any other local issue.
 ### Discussions
 
 Browse and read a repository's GitHub Discussions, create and edit them, and
-react or upvote, with Write/Preview markdown throughout.
+react or upvote, with Write/Preview markdown throughout. Close or reopen one
+with a comment you've drafted posted alongside.
 
 ### GitHub Actions
 
@@ -545,17 +550,18 @@ and Insights charts GitLab pipelines. GitHub is unchanged.
 <details>
 <summary><strong>The full GitLab surface</strong>: merge requests, issues, time tracking, pipelines and releases, project settings</summary>
 
-- **Merge requests**: comment (edit/delete your own), close/reopen, edit
-  title and description, retarget the target branch, react with emoji (on
-  descriptions and comments), edit labels and assignees, **approve /
-  unapprove**, request changes, and **merge** (merge/squash), including
-  **auto-merge** when the pipeline succeeds (cancelable in place). Plus
-  **create**: push-and-open, drafts, duplicate-MR detection. GitLab's own
-  merge status drives the **conflict** strip, the list's **Conflicts** chip,
-  and in-app conflict resolution.
-- **Issues**: create, comment, close/reopen, edit labels and assignees, set
-  **milestone**, **due date** (past-due cue), **confidential**, and **linked
-  related issues**; lock/unlock, move to another project, or delete.
+- **Merge requests**: comment (edit/delete your own), close/reopen with a
+  drafted comment posted alongside, edit title and description, retarget the
+  target branch, react with emoji (on descriptions and comments), edit labels
+  and assignees, **approve / unapprove**, request changes, and **merge**
+  (merge/squash), including **auto-merge** when the pipeline succeeds
+  (cancelable in place). Plus **create**: push-and-open, drafts,
+  duplicate-MR detection. GitLab's own merge status drives the **conflict**
+  strip, the list's **Conflicts** chip, and in-app conflict resolution.
+- **Issues**: create, comment, close/reopen with a drafted comment posted
+  alongside, edit labels and assignees, set **milestone**, **due date**
+  (past-due cue), **confidential**, and **linked related issues**;
+  lock/unlock, move to another project, or delete.
 - **Time tracking**: estimate + spent, on an issue *or* an MR.
 - **Pipelines and releases**: retry, cancel, or run pipelines with CI/CD
   variables and **play a manual job**; publish, edit, and delete

--- a/changelog.d/changed-conversation-controls-explain-holds.md
+++ b/changelog.d/changed-conversation-controls-explain-holds.md
@@ -1,5 +1,6 @@
 - Conversation controls now explain themselves when they're unavailable. Reaction
-  chips, the add-reaction picker and a comment box's **Comment** / **Clear**
-  buttons name the hold ("Loading this issue…", "Posting your comment…") as a
-  tooltip and to screen readers, and stay reachable by keyboard while they say it,
-  so you can always find out what a control is waiting on.
+  chips, a discussion's upvote chip, the add-reaction picker and a comment box's
+  **Comment** / **Clear** buttons name the hold ("Loading this issue…", "Posting
+  your comment…") as a tooltip and to screen readers, and stay reachable by
+  keyboard while they say it, so you can always find out what a control is
+  waiting on.

--- a/changelog.d/fixed-activity-strip-phantom-scrollbar.md
+++ b/changelog.d/fixed-activity-strip-phantom-scrollbar.md
@@ -1,0 +1,2 @@
+- The Welcome, Settings, Help, and Explore screens no longer grow a stray
+  window scrollbar while the activity strip is showing along the bottom.

--- a/changelog.d/fixed-agent-run-keeps-partial-output.md
+++ b/changelog.d/fixed-agent-run-keeps-partial-output.md
@@ -1,0 +1,3 @@
+- A plan, research run, or agent-session turn that fails keeps what the agent
+  had written (including agents that deliver their text only at the end), so
+  the transcript shows the partial work instead of nothing.

--- a/changelog.d/fixed-cleanup-merged-detection.md
+++ b/changelog.d/fixed-cleanup-merged-detection.md
@@ -3,4 +3,6 @@
   rebase-merged branches turn up in the list with a `merged #123` badge naming the
   pull request that took them. The match goes by branch name, so it only ever badges
   a row: what comes pre-checked is still what your own history shows — merged into
-  the default branch, or idle past the window you picked.
+  the default branch, or idle past the window you picked. The dialog names pull
+  requests only where it could read them, so its wording always matches the checks
+  behind the list in front of you.

--- a/changelog.d/fixed-cleanup-merged-detection.md
+++ b/changelog.d/fixed-cleanup-merged-detection.md
@@ -3,6 +3,4 @@
   rebase-merged branches turn up in the list with a `merged #123` badge naming the
   pull request that took them. The match goes by branch name, so it only ever badges
   a row: what comes pre-checked is still what your own history shows — merged into
-  the default branch, or idle past the window you picked. The dialog names pull
-  requests only where it could read them, so its wording always matches the checks
-  behind the list in front of you.
+  the default branch, or idle past the window you picked.

--- a/changelog.d/fixed-close-posts-your-draft.md
+++ b/changelog.d/fixed-close-posts-your-draft.md
@@ -1,0 +1,5 @@
+- A comment you've typed now goes out with **Close** or **Reopen**. On issues,
+  pull requests, discussions and local PRs/issues the control says so while a
+  draft is waiting (**Close with comment** on the buttons, *posts your draft* on
+  a discussion's menu items); the comment posts first, then the state changes,
+  and your text stays put if the comment can't be posted.

--- a/changelog.d/fixed-conflict-details-file-lists.md
+++ b/changelog.d/fixed-conflict-details-file-lists.md
@@ -1,0 +1,2 @@
+- Revert, cherry-pick and rebase conflicts now list the conflicted files in the
+  error details, and a Continue that still has unresolved paths names them.

--- a/changelog.d/fixed-merge-stash-recovery.md
+++ b/changelog.d/fixed-merge-stash-recovery.md
@@ -1,6 +1,7 @@
 - Merging a branch into the one you're on while you have uncommitted changes now
   offers to set them aside, merge, and put them back — the same stash-and-reapply
   recovery pulling and updating a branch already offer, and **Automatically stash
-  and reapply on pull, merge, rebase, and branch updates** (Settings → General) covers
-  merges along with the rest. Squash, no-fast-forward, and strategy merges still
-  report the refusal, since the recovery would have to redo them as a plain merge.
+  and reapply on pull, merge, rebase, and branch updates** (Settings → General)
+  covers merges along with the rest. Squash, no-fast-forward, and strategy
+  merges still report the refusal, since the recovery would have to redo them
+  as a plain merge.

--- a/changelog.d/fixed-merge-stash-recovery.md
+++ b/changelog.d/fixed-merge-stash-recovery.md
@@ -1,6 +1,6 @@
 - Merging a branch into the one you're on while you have uncommitted changes now
   offers to set them aside, merge, and put them back — the same stash-and-reapply
   recovery pulling and updating a branch already offer, and **Automatically stash
-  and reapply on pull, merge, and branch updates** (Settings → General) covers
+  and reapply on pull, merge, rebase, and branch updates** (Settings → General) covers
   merges along with the rest. Squash, no-fast-forward, and strategy merges still
   report the refusal, since the recovery would have to redo them as a plain merge.

--- a/changelog.d/fixed-pull-conflict-details.md
+++ b/changelog.d/fixed-pull-conflict-details.md
@@ -1,0 +1,2 @@
+- A pull that runs into merge conflicts now reports git's own verdict and the
+  conflicted files it stopped on.

--- a/changelog.d/fixed-rebase-stash-recovery.md
+++ b/changelog.d/fixed-rebase-stash-recovery.md
@@ -1,0 +1,3 @@
+- Rebasing with uncommitted changes now offers to stash and reapply them, the
+  way pull and merge already do. **Change base…** no longer refuses to run on a
+  dirty working tree either.

--- a/changelog.d/fixed-review-history-overflow.md
+++ b/changelog.d/fixed-review-history-overflow.md
@@ -1,0 +1,4 @@
+- An expanded review under **Previous reviews** now scrolls inside its own box, so
+  the pull request's Close and Merge controls stay reachable however long the
+  findings run. Any stored review, and any kept partial output, can now be copied
+  in one click.

--- a/changelog.d/fixed-review-timeout-partial.md
+++ b/changelog.d/fixed-review-timeout-partial.md
@@ -2,5 +2,8 @@
   The findings stay on screen (including for Codex, which delivers its answer in
   one piece at the end) and are saved with the pull request, labelled **Timed
   out — partial output kept**, so they're still there after a restart. Kept output
-  is never treated as a finished review: it doesn't feed the next run's context and
-  doesn't count as coverage for automated reviews.
+  also gets its own row under **Previous reviews**, where it can be read, copied or
+  cleared like any other record, and an automated review that runs out of time
+  keeps its output the same way. Kept output is never treated as a finished review:
+  it doesn't feed the next run's context and doesn't count as coverage for
+  automated reviews.

--- a/changelog.d/fixed-worktree-removal-stays-visible.md
+++ b/changelog.d/fixed-worktree-removal-stays-visible.md
@@ -1,0 +1,6 @@
+- Removing a worktree now stays on screen until it finishes. A big folder can
+  take minutes, and closing the confirmation used to take the spinner with it,
+  leaving nothing to say the removal was still running; it now shows at the top
+  of the repository the whole time, its row in **Worktrees** says "Removing…"
+  and stops accepting actions, and a second attempt on the same worktree is
+  turned away instead of queueing behind the first.

--- a/changelog.d/fixed-worktree-removal-stays-visible.md
+++ b/changelog.d/fixed-worktree-removal-stays-visible.md
@@ -1,6 +1,6 @@
 - Removing a worktree now stays on screen until it finishes. A big folder can
-  take minutes, and closing the confirmation used to take the spinner with it,
-  leaving nothing to say the removal was still running; it now shows at the top
-  of the repository the whole time, its row in **Worktrees** says "Removing…"
-  and stops accepting actions, and a second attempt on the same worktree is
-  turned away instead of queueing behind the first.
+  take minutes, so the removal shows at the top of the repository the whole
+  time, even after the confirmation closes; its row in **Worktrees** says
+  "Removing…" and holds every action except copying its path, and a second
+  attempt on the same worktree is turned away instead of queueing behind the
+  first.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -133,7 +133,7 @@ export const capabilities: Capability[] = [
   {
     group: "Rewrite & recovery",
     label:
-      "Stash and reapply — one click when a pull, merge, update or switch is blocked",
+      "Stash and reapply — one click when a pull, merge, rebase, update or switch is blocked",
   },
   {
     group: "Rewrite & recovery",
@@ -273,6 +273,11 @@ export const capabilities: Capability[] = [
   {
     group: "Issues & discussions",
     label: "GitHub Discussions — read, post & react",
+  },
+  {
+    group: "Issues & discussions",
+    label:
+      "Close or reopen with a comment — on PRs, issues & discussions, your draft posts alongside",
   },
 
   // — CI, tags & releases —

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1061,9 +1061,11 @@ fn copilot_effort(level: &str) -> Option<&'static str> {
     }
 }
 
-/// App effort level → a Claude "thinking" keyword. The Claude CLI has no effort
-/// flag; including one of these phrases in the user turn raises the thinking
-/// budget (think < think hard < think harder < ultrathink). "" = none.
+/// App effort level → a Claude "thinking" keyword. The Claude CLI does ship
+/// `--effort` (2.1.227), but this app deliberately stays on the keyword
+/// mechanism, which works on every installed version: one of these phrases in
+/// the user turn raises the thinking budget
+/// (think < think hard < think harder < ultrathink). "" = none.
 fn claude_thinking_keyword(level: &str) -> Option<&'static str> {
     match level {
         "low" => Some("think"),
@@ -2186,8 +2188,9 @@ pub async fn agent_review(
     // diff on stdin; Codex has no system-prompt flag, so both go on stdin.
     let (args, stdin_text) = match kind {
         AgentKind::Claude => {
-            // Claude has no effort flag — raise the thinking budget by appending a
-            // keyword to the user turn (same as a session).
+            // Claude's own `--effort` is deliberately unused: the thinking keyword
+            // appended to the user turn works on every installed CLI version
+            // (same as a session).
             let prompt = match claude_thinking_keyword(&effort) {
                 Some(kw) => format!("{user_prompt}\n\n{kw}"),
                 None => user_prompt,
@@ -2436,8 +2439,9 @@ pub async fn agent_session(
     // 1 only — a resumed Codex session already has it in context).
     let (inner, stdin_text) = match kind {
         AgentKind::Claude => {
-            // Claude has no effort flag — raise the thinking budget by appending a
-            // keyword to the user turn (applies per-turn, so on resume too).
+            // Claude's own `--effort` is deliberately unused: the thinking keyword
+            // appended to the user turn works on every installed CLI version, and
+            // applies per-turn, so on resume too.
             let prompt = match claude_thinking_keyword(&effort) {
                 Some(kw) => format!("{user_prompt}\n\n{kw}"),
                 None => user_prompt,

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -1,4 +1,4 @@
-//! App-level stash → op → reapply compounds for pull, merge and switch.
+//! App-level stash → op → reapply compounds for pull, merge, rebase and switch.
 //!
 //! Each command acquires `repo_lock` ONCE and uses only the lock-free runners
 //! while holding it — `run_git_mutating` re-acquires the same non-reentrant
@@ -64,12 +64,16 @@ async fn autostash_pop(repo: &str) -> AppResult<GitOutput> {
 }
 
 /// Shapes a non-zero raw result for the no-stash arm, which reports the plain
-/// command's own failures. Plain pull and switch have no stdout backfill yet, so
-/// against those two this is better output rather than identical output.
+/// command's own failures — so the shaping has to match what those cores now do.
+/// Merge and pull both carry their stdout report into the error (`git_merge_core`,
+/// `run_git_mutating_with_creds`), and the parity tests below pin that. Switch is
+/// the exception in the other direction: a FAILING `git switch` emits no stdout at
+/// all (measured across its refusal modes — stdout there is success-path chatter),
+/// so the combined shaping is identical to stderr alone for it.
 fn git_error(out: GitOutput) -> AppError {
     AppError::Git {
         code: out.code,
-        stderr: out.failure_text(),
+        stderr: out.full_failure_text(),
     }
 }
 
@@ -93,7 +97,11 @@ async fn settle(
 
     let failure = match &op {
         Ok(out) if out.code == 0 => None,
-        Ok(out) => Some(out.failure_text()),
+        // Combined, matching the no-stash arm's `git_error` and the plain cores:
+        // a substitution reports a conflicted pull's fetch summary alone and says
+        // nothing about the conflict, so the stashed and unstashed paths would
+        // disagree on the same failure.
+        Ok(out) => Some(out.full_failure_text()),
         Err(err) => Some(err.to_string()),
     };
 
@@ -120,6 +128,9 @@ async fn settle(
     if !reapply {
         return Ok(AutostashOutcome::StashedOnly);
     }
+    // Substitution here, unlike the op-failure arms' combined text: a conflicted pop
+    // reports on stdout alone, and a refused pop leads with stderr NAMING the blocking
+    // file while its stdout is generic `status` noise (measured, git 2.51.1.windows.1).
     let stderr = match autostash_pop(repo).await {
         Ok(out) if out.code == 0 => return Ok(AutostashOutcome::Reapplied),
         Ok(out) => out.failure_text(),
@@ -196,6 +207,86 @@ pub(crate) async fn git_merge_autostash_core(
     let op = run_git_raw(
         Some(&repo_path),
         &["merge", "--no-edit", &branch],
+        DEFAULT_TIMEOUT,
+    )
+    .await;
+    settle(&repo_path, stashed, true, op).await
+}
+
+/// Rebase the current branch onto `branch` with the uncommitted changes stashed
+/// across the rebase and reapplied afterwards. Rebase refuses on ANY dirty
+/// tracked file, not just one the replay would touch, so this is the arm that
+/// fires most often.
+#[tauri::command]
+pub async fn git_rebase_autostash(
+    state: State<'_, AppState>,
+    repo_path: String,
+    branch: String,
+) -> AppResult<AutostashOutcome> {
+    git_rebase_autostash_core(&state, repo_path, branch).await
+}
+
+pub(crate) async fn git_rebase_autostash_core(
+    state: &AppState,
+    repo_path: String,
+    branch: String,
+) -> AppResult<AutostashOutcome> {
+    validate_ref_name(&branch)?;
+
+    let lock = state.repo_lock(&repo_path).await;
+    let _guard = lock.lock().await;
+    crate::git::ops::refuse_mid_op(&repo_path).await?;
+
+    let stashed = autostash_push(&repo_path).await?;
+    // Inlined rather than delegating to `git_rebase_core`: that one runs through
+    // `run_git_mutating_raw`, which re-acquires the lock held here (module doc).
+    // `core.editor=true` mirrors it so git never blocks on an editor.
+    let op = run_git_raw(
+        Some(&repo_path),
+        &["-c", "core.editor=true", "rebase", &branch],
+        DEFAULT_TIMEOUT,
+    )
+    .await;
+    settle(&repo_path, stashed, true, op).await
+}
+
+/// `git rebase --onto <new_base> <old_base>` — replaying only `old_base..HEAD`
+/// — with the uncommitted changes stashed across it and reapplied afterwards.
+#[tauri::command]
+pub async fn git_rebase_onto_autostash(
+    state: State<'_, AppState>,
+    repo_path: String,
+    new_base: String,
+    old_base: String,
+) -> AppResult<AutostashOutcome> {
+    git_rebase_onto_autostash_core(&state, repo_path, new_base, old_base).await
+}
+
+pub(crate) async fn git_rebase_onto_autostash_core(
+    state: &AppState,
+    repo_path: String,
+    new_base: String,
+    old_base: String,
+) -> AppResult<AutostashOutcome> {
+    validate_ref_name(&new_base)?;
+    validate_ref_name(&old_base)?;
+
+    let lock = state.repo_lock(&repo_path).await;
+    let _guard = lock.lock().await;
+    crate::git::ops::refuse_mid_op(&repo_path).await?;
+
+    let stashed = autostash_push(&repo_path).await?;
+    // Inlined for the same reason as `git_rebase_autostash_core` above.
+    let op = run_git_raw(
+        Some(&repo_path),
+        &[
+            "-c",
+            "core.editor=true",
+            "rebase",
+            "--onto",
+            &new_base,
+            &old_base,
+        ],
         DEFAULT_TIMEOUT,
     )
     .await;
@@ -600,6 +691,150 @@ mod tests {
         assert!(!stash_list(&repo).await.is_empty());
     }
 
+    // ---- rebase -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn rebase_autostash_reapplies_non_overlapping_changes() {
+        let (dir, repo) = setup_with_feat("rebase-reapply").await;
+        // Plain `rebase` refuses on a dirty `b.txt` even though the replay never
+        // touches it — the gap this compound closes.
+        write(dir.path(), "b.txt", "mine\n");
+
+        let state = AppState::default();
+        let outcome = git_rebase_autostash_core(&state, repo.clone(), "feat".into())
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, AutostashOutcome::Reapplied),
+            "{outcome:?}"
+        );
+        assert_eq!(read(dir.path(), "a.txt"), "feat\n");
+        assert_eq!(read(dir.path(), "b.txt"), "mine\n");
+        assert!(stash_list(&repo).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rebase_autostash_reports_a_conflicted_reapply() {
+        let (dir, repo) = setup_with_feat("rebase-conflict").await;
+        write(dir.path(), "a.txt", "mine\n");
+
+        let state = AppState::default();
+        let outcome = git_rebase_autostash_core(&state, repo.clone(), "feat".into())
+            .await
+            .unwrap();
+        assert!(
+            matches!(
+                outcome,
+                AutostashOutcome::ReapplyConflicted {
+                    conflicted: true,
+                    ..
+                }
+            ),
+            "{outcome:?}"
+        );
+        assert!(!stash_list(&repo).await.is_empty());
+        assert!(unmerged(&repo).await.contains("a.txt"));
+    }
+
+    #[tokio::test]
+    async fn rebase_autostash_on_a_clean_tree_stashes_nothing() {
+        let (dir, repo) = setup_with_feat("rebase-clean").await;
+
+        let state = AppState::default();
+        let outcome = git_rebase_autostash_core(&state, repo.clone(), "feat".into())
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, AutostashOutcome::NothingStashed),
+            "{outcome:?}"
+        );
+        assert_eq!(read(dir.path(), "a.txt"), "feat\n");
+        assert!(stash_list(&repo).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rebase_autostash_restores_changes_when_the_rebase_is_rejected() {
+        let (dir, repo) = setup_with_feat("rebase-restore").await;
+        write(dir.path(), "b.txt", "dirty\n");
+
+        let state = AppState::default();
+        // An unknown upstream fails before any replay starts — nothing in progress.
+        let outcome = git_rebase_autostash_core(&state, repo.clone(), "nope".into())
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, AutostashOutcome::OpFailedRestored { .. }),
+            "{outcome:?}"
+        );
+        assert!(!stderr_of(&outcome).is_empty());
+        assert_eq!(read(dir.path(), "b.txt"), "dirty\n");
+        assert!(stash_list(&repo).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rebase_autostash_keeps_the_stash_when_the_rebase_conflicts() {
+        let (dir, repo) = setup_with_feat("rebase-kept").await;
+        write(dir.path(), "a.txt", "main\n");
+        commit_all(&repo, "main side").await;
+        write(dir.path(), "b.txt", "dirty\n");
+
+        let state = AppState::default();
+        let outcome = git_rebase_autostash_core(&state, repo.clone(), "feat".into())
+            .await
+            .unwrap();
+        assert!(
+            matches!(
+                outcome,
+                AutostashOutcome::OpFailedStashKept {
+                    in_progress: true,
+                    ..
+                }
+            ),
+            "{outcome:?}"
+        );
+        // A conflicted rebase splits its report across both streams, so the
+        // combined shaping has to carry the stdout half too.
+        let stderr = stderr_of(&outcome);
+        assert!(stderr.contains("could not apply"), "{stderr}");
+        assert!(stderr.contains("CONFLICT ("), "{stderr}");
+        assert!(crate::git::ops::op_state(&repo).await.unwrap().rebasing);
+        assert!(!stash_list(&repo).await.is_empty());
+    }
+
+    /// `topic` branched off `wrong` when it meant to sit on `main` — the shape
+    /// `rebase --onto main wrong` fixes, replaying `topic`'s own commit only.
+    async fn setup_with_wrong_base(marker: &str) -> (tempfile::TempDir, String) {
+        let (dir, repo) = setup_repo(marker).await;
+        git(&repo, &["switch", "-c", "wrong"]).await;
+        write(dir.path(), "c.txt", "wrong base\n");
+        commit_all(&repo, "wrong base work").await;
+        git(&repo, &["switch", "-c", "topic"]).await;
+        write(dir.path(), "d.txt", "topic\n");
+        commit_all(&repo, "topic work").await;
+        (dir, repo)
+    }
+
+    #[tokio::test]
+    async fn rebase_onto_autostash_reapplies_and_drops_the_old_base() {
+        let (dir, repo) = setup_with_wrong_base("rebase-onto-reapply").await;
+        write(dir.path(), "b.txt", "mine\n");
+
+        let state = AppState::default();
+        let outcome =
+            git_rebase_onto_autostash_core(&state, repo.clone(), "main".into(), "wrong".into())
+                .await
+                .unwrap();
+        assert!(
+            matches!(outcome, AutostashOutcome::Reapplied),
+            "{outcome:?}"
+        );
+        // `topic`'s own commit moved; the wrong base's did not come along.
+        assert_eq!(read(dir.path(), "d.txt"), "topic\n");
+        assert!(!dir.path().join("c.txt").exists());
+        assert_eq!(read(dir.path(), "b.txt"), "mine\n");
+        assert!(stash_list(&repo).await.is_empty());
+    }
+
     // ---- switch -----------------------------------------------------------
 
     #[tokio::test]
@@ -713,9 +948,11 @@ mod tests {
             "your local changes to the following files would be overwritten by checkout";
         const CHECKOUT_UNTRACKED: &str =
             "the following untracked working tree files would be overwritten by checkout";
-        const REBASE_UNSTAGED: &str = "cannot pull with rebase: you have unstaged changes";
-        const REBASE_STAGED: &str =
+        const PULL_REBASE_UNSTAGED: &str = "cannot pull with rebase: you have unstaged changes";
+        const PULL_REBASE_STAGED: &str =
             "cannot pull with rebase: your index contains uncommitted changes";
+        const REBASE_UNSTAGED: &str = "cannot rebase: you have unstaged changes";
+        const REBASE_STAGED: &str = "cannot rebase: your index contains uncommitted changes";
 
         async fn refusal(repo: &str, args: &[&str]) -> String {
             let out = run_git_raw(Some(repo), args, DEFAULT_TIMEOUT)
@@ -766,17 +1003,47 @@ mod tests {
         write(&dir.path().join("clone"), "b.txt", "dirty\n");
         assert_marker(
             &refusal(&clone, &["pull", "--rebase"]).await,
-            REBASE_UNSTAGED,
+            PULL_REBASE_UNSTAGED,
         );
         git(&clone, &["add", "b.txt"]).await;
-        assert_marker(&refusal(&clone, &["pull", "--rebase"]).await, REBASE_STAGED);
+        assert_marker(
+            &refusal(&clone, &["pull", "--rebase"]).await,
+            PULL_REBASE_STAGED,
+        );
+
+        // A plain `rebase` refuses on ANY dirty tracked file, overlapping or not
+        // — `b.txt` is untouched by `feat` on purpose — and says it in its own
+        // wording, which the "cannot pull with rebase" lines above do not cover.
+        let (dir, repo) = setup_with_feat("markers-rebase-plain").await;
+        write(dir.path(), "b.txt", "dirty\n");
+        assert_marker(&refusal(&repo, &["rebase", "feat"]).await, REBASE_UNSTAGED);
+        git(&repo, &["add", "b.txt"]).await;
+        assert_marker(&refusal(&repo, &["rebase", "feat"]).await, REBASE_STAGED);
+
+        // `--onto` refuses with the same two lines, so one marker pair covers both
+        // compounds.
+        let (dir, repo) = setup_with_feat("markers-rebase-onto").await;
+        write(dir.path(), "b.txt", "dirty\n");
+        assert_marker(
+            &refusal(&repo, &["rebase", "--onto", "feat", "main"]).await,
+            REBASE_UNSTAGED,
+        );
+        git(&repo, &["add", "b.txt"]).await;
+        assert_marker(
+            &refusal(&repo, &["rebase", "--onto", "feat", "main"]).await,
+            REBASE_STAGED,
+        );
     }
 
     /// The conflict summary in `src/lib/error-summary.ts` keys off the ANCHORED
     /// shapes of these lines, so a git release that reworded one would silently
     /// change how conflicts present. Markers 1-2 guard live toast classification;
     /// markers 3-4 ride stdout, which only the paths shaping their error through
-    /// `GitOutput::failure_text` carry.
+    /// `GitOutput::failure_text` / `full_failure_text` carry.
+    ///
+    /// The STREAM SPLIT each family reports on is pinned here too, because the
+    /// shaping choice depends on it: a family that writes to both streams needs
+    /// the combined text, and a substitution would silently drop half its report.
     #[tokio::test]
     async fn conflict_output_still_matches_the_anchored_frontend_markers() {
         // Mirrors of the four CONFLICT_MARKERS regexes, in plain string ops.
@@ -856,6 +1123,16 @@ mod tests {
             "CONFLICT (…",
             &cherry.stdout_lossy(),
         );
+        // The split itself: both halves non-empty, which is why the sequencer
+        // families shape their error with `full_failure_text` rather than
+        // substituting one stream for the other.
+        assert!(
+            !cherry.stderr.trim().is_empty() && !cherry.stdout_lossy().trim().is_empty(),
+            "a conflicted cherry-pick still splits its report across both streams — \
+             stderr:\n{}\nstdout:\n{}",
+            cherry.stderr,
+            cherry.stdout_lossy()
+        );
         assert!(
             advises_continue(&cherry.stderr, "cherry-pick"),
             "git no longer advises `git cherry-pick --continue` outside the subject-echo line — \
@@ -885,8 +1162,18 @@ mod tests {
             rebase.stderr
         );
 
-        // Continuing without resolving reports on STDOUT (`core.editor` is pinned
-        // so a future git that got past the check can't block on an editor).
+        assert!(
+            !rebase.stderr.trim().is_empty() && !rebase.stdout_lossy().trim().is_empty(),
+            "a conflicted rebase still splits its report across both streams — \
+             stderr:\n{}\nstdout:\n{}",
+            rebase.stderr,
+            rebase.stdout_lossy()
+        );
+
+        // Continuing without resolving is the one sequencer case that is
+        // stdout-ONLY: `core.editor` is pinned so a future git that got past the
+        // check can't block on an editor. `op_continue` shapes its error through
+        // the combined text, so an empty stderr here must not swallow the report.
         let cont = run_git_raw(
             Some(&repo),
             &["-c", "core.editor=true", "rebase", "--continue"],
@@ -900,11 +1187,17 @@ mod tests {
             "<path>: needs merge",
             &cont.stdout_lossy(),
         );
+        assert!(
+            cont.stderr.trim().is_empty(),
+            "a refused `rebase --continue` still reports on stdout alone — the reason \
+             op_continue carries stdout into its error. Actual stderr:\n{}",
+            cont.stderr
+        );
         git(&repo, &["rebase", "--abort"]).await;
 
-        // Revert: its own advice verb, plus the `could not revert` echo — which is
-        // the ONLY conflict marker a revert's error carries, since its runner
-        // keeps stderr alone. Reverting the SECOND-newest commit conflicts; the
+        // Revert: its own advice verb, the `could not revert` echo on stderr, and
+        // the `CONFLICT (…` list on stdout — `git_revert_core` carries both, so
+        // both are pinned. Reverting the SECOND-newest commit conflicts; the
         // newest would apply cleanly.
         write(dir.path(), "a.txt", "one\n");
         commit_all(&repo, "one").await;
@@ -923,6 +1216,18 @@ mod tests {
             "error: could not revert <sha>…",
             &revert.stderr,
         );
+        assert_shape(
+            conflict_paren(&revert.stdout_lossy()),
+            "CONFLICT (…",
+            &revert.stdout_lossy(),
+        );
+        assert!(
+            !revert.stderr.trim().is_empty() && !revert.stdout_lossy().trim().is_empty(),
+            "a conflicted revert still splits its report across both streams — \
+             stderr:\n{}\nstdout:\n{}",
+            revert.stderr,
+            revert.stdout_lossy()
+        );
         assert!(
             advises_continue(&revert.stderr, "revert"),
             "git no longer advises `git revert --continue` outside the subject-echo line — \
@@ -932,9 +1237,9 @@ mod tests {
         git(&repo, &["revert", "--abort"]).await;
 
         // Merge is the one conflict family with NO `--continue` advice: it reports
-        // on stdout and leaves stderr EMPTY, which is why `git_merge_core` carries
-        // stdout into the error. Asserting the advice here would fail against
-        // correct git — this pins the reality instead.
+        // on stdout and leaves stderr EMPTY, so the frontend reads the verdict line
+        // to name it. Asserting the advice here would fail against correct git —
+        // this pins the reality instead.
         let merge = run_git_raw(
             Some(&repo),
             &["merge", "--no-edit", "feat"],
@@ -960,6 +1265,37 @@ mod tests {
             "a conflicted merge still leaves stderr empty — the reason git_merge_core \
              backfills stdout. Actual stderr:\n{}",
             merge.stderr
+        );
+
+        // A merge-mode PULL is the same conflict on stdout, but its stderr is NOT
+        // empty: the fetch writes its summary there. That combination is what makes
+        // a stderr-or-stdout substitution a silent no-op for pull, and the reason
+        // `run_git_mutating_with_creds` shapes with `full_failure_text`.
+        let (pull_dir, work, clone) = setup_clone("conflict-markers-pull").await;
+        write(&pull_dir.path().join("work"), "a.txt", "upstream\n");
+        commit_all(&work, "upstream").await;
+        git(&work, &["push"]).await;
+        write(&pull_dir.path().join("clone"), "a.txt", "mine\n");
+        commit_all(&clone, "local").await;
+
+        let pull = run_git_raw(Some(&clone), &["pull", "--no-rebase"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(pull.code, 0, "expected the pull to conflict");
+        assert_shape(
+            conflict_paren(&pull.stdout_lossy()),
+            "CONFLICT (…",
+            &pull.stdout_lossy(),
+        );
+        assert_shape(
+            lines(&pull.stdout_lossy()).any(|l| l.starts_with("Automatic merge failed")),
+            "Automatic merge failed…",
+            &pull.stdout_lossy(),
+        );
+        assert!(
+            !pull.stderr.trim().is_empty(),
+            "a conflicted pull still writes its fetch summary to stderr — the reason \
+             substituting stdout for an empty stderr would drop the merge verdict"
         );
     }
 
@@ -1162,8 +1498,8 @@ mod tests {
     /// merge reports on STDOUT and leaves stderr empty, and this arm is reached
     /// exactly when nothing was stashed — the clean tree a dirty-tree recovery
     /// leaves behind once the user commits or the changes are already away.
-    /// Merge is the only pair either parity test can compare: the plain pull and
-    /// switch cores carry no stdout backfill to match against yet.
+    /// Pull has its own arm below (a different stream split); switch never will,
+    /// since a failing `git switch` writes no stdout to lose.
     #[tokio::test]
     async fn a_conflict_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, repo) = setup_with_feat("plain-parity-conflict").await;
@@ -1206,6 +1542,77 @@ mod tests {
                 // Mirrors the frontend's anchored CONFLICT_MARKERS: without the
                 // stdout backfill both sides carry an empty stderr instead, which
                 // renders as "git exited with code 1".
+                assert!(
+                    a_err.lines().any(|l| l.starts_with("CONFLICT (")),
+                    "the conflict line must reach the frontend: {a_err}"
+                );
+                assert!(
+                    a_err.contains("Automatic merge failed"),
+                    "and the verdict line that names it a merge: {a_err}"
+                );
+            }
+            other => panic!("expected two git errors, got {other:?}"),
+        }
+    }
+
+    /// Pull's version of the same parity, on the split that hides the loss: the
+    /// fetch summary fills stderr while the merge verdict rides stdout, so an
+    /// error carrying stderr alone looks populated and still says nothing about
+    /// the conflict. Both sides must carry the whole report, identically.
+    #[tokio::test]
+    async fn a_conflicted_pull_with_nothing_stashed_carries_the_stdout_report() {
+        let (dir, work, clone) = setup_clone("pull-parity-conflict").await;
+        // TWO clones, one per side: the fetch half of a pull reports
+        // `<old>..<new> main -> origin/main` on stderr and only when a ref
+        // actually moves, so running both pulls in ONE clone would compare a
+        // fetching pull against an already-up-to-date one. Cloned before the
+        // upstream push so each is behind by the same commit.
+        let url = format!(
+            "file://{}",
+            dir.path()
+                .join("origin.git")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+        let root = dir.path().to_string_lossy().into_owned();
+        git(&root, &["-c", "core.autocrlf=false", "clone", &url, "clone2"]).await;
+        let clone2 = dir.path().join("clone2").to_string_lossy().into_owned();
+        configure(&clone2).await;
+
+        write(&dir.path().join("work"), "a.txt", "upstream\n");
+        commit_all(&work, "upstream").await;
+        git(&work, &["push"]).await;
+
+        // A local commit on the same file diverges each branch, so `--no-rebase`
+        // merges and conflicts; both trees stay CLEAN so `settle` takes its
+        // no-stash arm.
+        for (path, repo) in [("clone", &clone), ("clone2", &clone2)] {
+            write(&dir.path().join(path), "a.txt", "mine\n");
+            commit_all(repo, "local").await;
+        }
+        let state = AppState::default();
+
+        let compound = git_pull_autostash_core(&state, clone.clone(), "merge".into())
+            .await
+            .unwrap_err();
+        assert!(stash_list(&clone).await.is_empty(), "nothing was stashed");
+        let plain = crate::git::remote::git_pull_core(&state, clone2.clone(), "merge".into())
+            .await
+            .unwrap_err();
+
+        match (&compound, &plain) {
+            (
+                AppError::Git {
+                    code: a,
+                    stderr: a_err,
+                },
+                AppError::Git {
+                    code: b,
+                    stderr: b_err,
+                },
+            ) => {
+                assert_eq!(a, b);
+                assert_eq!(a_err, b_err);
                 assert!(
                     a_err.lines().any(|l| l.starts_with("CONFLICT (")),
                     "the conflict line must reach the frontend: {a_err}"

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -62,13 +62,34 @@ async fn git_path_exists(repo: &str, name: &str) -> bool {
     }
 }
 
+/// The repo's OWN git dir, absolute — one spawn, so [`op_state`]'s eight marker
+/// probes become plain filesystem reads instead of eight `rev-parse` children.
+///
+/// `--absolute-git-dir`, never `--git-common-dir`: a linked worktree keeps its
+/// op markers (`MERGE_HEAD`, `rebase-merge`, the sequencer) under
+/// `<main>/.git/worktrees/<name>/`, and the common dir names the MAIN checkout's
+/// `.git` — reading markers there would report the wrong tree's operation
+/// (measured, git 2.51.1; same call as `git::stats`). `None` for anything that
+/// isn't a repo, which callers must read as "no operation", not as an error.
+async fn absolute_git_dir(repo: &str) -> Option<std::path::PathBuf> {
+    let out = run_git(
+        Some(repo),
+        &["rev-parse", "--absolute-git-dir"],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .ok()?;
+    let raw = out.stdout_lossy();
+    // Line endings ONLY: a trailing space can be part of the directory name, and
+    // `trim()` would strip it into a path that does not exist.
+    let dir = raw.trim_end_matches(['\r', '\n']);
+    (!dir.is_empty()).then(|| std::path::PathBuf::from(dir))
+}
+
 /// True when an interactive rebase is paused at an `edit` instruction (the last
 /// executed todo line is `edit`/`e`), as opposed to a conflict.
-async fn rebase_stopped_for_edit(repo: &str) -> bool {
-    let Some(path) = git_dir_path(repo, "rebase-merge/done").await else {
-        return false;
-    };
-    let Ok(done) = std::fs::read_to_string(path) else {
+fn rebase_stopped_for_edit(git_dir: &Path) -> bool {
+    let Ok(done) = std::fs::read_to_string(git_dir.join("rebase-merge/done")) else {
         return false;
     };
     done.lines()
@@ -89,14 +110,11 @@ async fn rebase_stopped_for_edit(repo: &str) -> bool {
 /// squash/fixup engine creates it. An unreadable or empty todo reads as
 /// cherry-pick, matching the best-effort probes around it. Interactive rebase
 /// uses `rebase-merge/git-rebase-todo` instead, so it can never land here.
-async fn sequencer_reverting(repo: &str) -> Option<bool> {
-    if !git_path_exists(repo, "sequencer").await {
+fn sequencer_reverting(git_dir: &Path) -> Option<bool> {
+    if !git_dir.join("sequencer").exists() {
         return None;
     }
-    let todo = git_dir_path(repo, "sequencer/todo")
-        .await
-        .and_then(|path| std::fs::read_to_string(path).ok())
-        .unwrap_or_default();
+    let todo = std::fs::read_to_string(git_dir.join("sequencer/todo")).unwrap_or_default();
     let verb = todo
         .lines()
         .find(|line| !line.trim().is_empty() && !line.starts_with('#'))
@@ -115,21 +133,35 @@ pub async fn git_op_state(repo_path: String) -> AppResult<RepoOpState> {
 /// touch a tree with in-progress state gate on the SAME marker files the banner
 /// reports on.
 pub(crate) async fn op_state(repo_path: &str) -> AppResult<RepoOpState> {
-    let rebasing = git_path_exists(repo_path, "rebase-merge").await
-        || git_path_exists(repo_path, "rebase-apply").await;
-    let edit_paused = rebasing && rebase_stopped_for_edit(repo_path).await;
-    let cherry_head = git_path_exists(repo_path, "CHERRY_PICK_HEAD").await;
-    let revert_head = git_path_exists(repo_path, "REVERT_HEAD").await;
+    let quiet = RepoOpState {
+        merging: false,
+        rebasing: false,
+        cherry_picking: false,
+        reverting: false,
+        edit_paused: false,
+    };
+    // An unresolvable git dir reads as "nothing in flight", NEVER an error:
+    // `op_in_progress` maps `Err` to true, so failing here would fail-close every
+    // stash / history-edit / promotion guard in the app.
+    let Some(git_dir) = absolute_git_dir(repo_path).await else {
+        return Ok(quiet);
+    };
+    let exists = |name: &str| git_dir.join(name).exists();
+
+    let rebasing = exists("rebase-merge") || exists("rebase-apply");
+    let edit_paused = rebasing && rebase_stopped_for_edit(&git_dir);
+    let cherry_head = exists("CHERRY_PICK_HEAD");
+    let revert_head = exists("REVERT_HEAD");
     // The sequencer only decides the verb when neither head marker names it —
     // folding a revert into `cherry_picking` would mislabel the banner and hand
     // Continue/Abort the wrong git command.
     let sequencer = if cherry_head || revert_head {
         None
     } else {
-        sequencer_reverting(repo_path).await
+        sequencer_reverting(&git_dir)
     };
     Ok(RepoOpState {
-        merging: git_path_exists(repo_path, "MERGE_HEAD").await,
+        merging: exists("MERGE_HEAD"),
         rebasing,
         cherry_picking: cherry_head || sequencer == Some(false),
         reverting: revert_head || sequencer == Some(true),
@@ -193,13 +225,19 @@ pub async fn git_op_abort(
     op: String,
 ) -> AppResult<()> {
     validate_op(&op)?;
-    run_git_mutating(
+    let out = run_git_mutating_raw(
         &state,
         &repo_path,
         &[op.as_str(), "--abort"],
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
     Ok(())
 }
 
@@ -226,7 +264,16 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
         "merge" => vec!["commit", "--no-edit", "--cleanup=strip"],
         other => vec!["-c", "core.editor=true", other, "--continue"],
     };
-    run_git_mutating(state, repo_path, &args, DEFAULT_TIMEOUT).await?;
+    // Raw: a `--continue` refused over unresolved paths reports `<path>: needs
+    // merge` on STDOUT with stderr empty (measured, git 2.51.1), which a
+    // stderr-only error renders as "git exited with code 1".
+    let out = run_git_mutating_raw(state, repo_path, &args, DEFAULT_TIMEOUT).await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
     Ok(())
 }
 
@@ -316,8 +363,21 @@ pub(crate) async fn git_revert_core(
 ) -> AppResult<()> {
     validate_hash(&hash)?;
     // -m is not supported here; reverting merge commits needs a parent choice
-    run_git_mutating(state, &repo_path, &["revert", "--no-edit", &hash], DEFAULT_TIMEOUT)
-        .await?;
+    // Raw: a conflicted revert splits its report — `could not revert` on stderr,
+    // the `CONFLICT (…` file list on stdout — so the error needs both halves.
+    let out = run_git_mutating_raw(
+        state,
+        &repo_path,
+        &["revert", "--no-edit", &hash],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
     Ok(())
 }
 
@@ -339,22 +399,29 @@ pub(crate) async fn git_cherry_pick_core(
     hash: String,
 ) -> AppResult<bool> {
     validate_hash(&hash)?;
-    match run_git_mutating(state, &repo_path, &["cherry-pick", &hash], DEFAULT_TIMEOUT).await {
-        Ok(_) => Ok(true),
-        Err(AppError::Git { stderr, .. })
-            if stderr.contains("is now empty") || stderr.contains("--allow-empty") =>
-        {
-            let _ = run_git_mutating(
-                state,
-                &repo_path,
-                &["cherry-pick", "--skip"],
-                DEFAULT_TIMEOUT,
-            )
-            .await;
-            Ok(false)
-        }
-        Err(e) => Err(e),
+    // Raw: a conflicted pick splits its report — `could not apply` on stderr, the
+    // `CONFLICT (…` file list on stdout — so the error needs both halves.
+    let out =
+        run_git_mutating_raw(state, &repo_path, &["cherry-pick", &hash], DEFAULT_TIMEOUT).await?;
+    if out.code == 0 {
+        return Ok(true);
     }
+    // The already-applied sentence arrives on stderr (measured); gating on the raw
+    // stream keeps the stdout backfill from widening what counts as "empty".
+    if out.stderr.contains("is now empty") || out.stderr.contains("--allow-empty") {
+        let _ = run_git_mutating_raw(
+            state,
+            &repo_path,
+            &["cherry-pick", "--skip"],
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+        return Ok(false);
+    }
+    Err(AppError::Git {
+        code: out.code,
+        stderr: out.full_failure_text(),
+    })
 }
 
 #[derive(serde::Serialize)]
@@ -519,24 +586,43 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
         // the rollback itself fails, which the error then says.
         let mut failure: Option<(String, AppError)> = None;
         'picks: for hash in hashes {
-            match run_git(Some(repo_path), &["cherry-pick", hash], pick_timeout).await {
-                Ok(_) => applied += 1,
-                Err(AppError::Git { stderr, .. })
-                    if stderr.contains("is now empty") || stderr.contains("--allow-empty") =>
-                {
-                    let _ = run_git(
-                        Some(repo_path),
-                        &["cherry-pick", "--skip"],
-                        DEFAULT_TIMEOUT,
-                    )
-                    .await;
-                    skipped += 1;
-                }
+            // Raw plus an explicit code check, never a mutating runner: this loop
+            // runs inside the compound's own `repo_lock` hold. A conflicted pick
+            // splits its report — `could not apply` on stderr, the `CONFLICT (…`
+            // file list on stdout — so the rollback verdict below needs both.
+            let out = match run_git_raw(Some(repo_path), &["cherry-pick", hash], pick_timeout).await
+            {
+                Ok(out) => out,
                 Err(e) => {
                     failure = Some((hash.clone(), e));
                     break 'picks;
                 }
+            };
+            if out.code == 0 {
+                applied += 1;
+                continue;
             }
+            // The already-applied sentence arrives on stderr (measured); gating on
+            // the raw stream keeps the stdout half from widening what counts as
+            // "empty".
+            if out.stderr.contains("is now empty") || out.stderr.contains("--allow-empty") {
+                let _ = run_git(
+                    Some(repo_path),
+                    &["cherry-pick", "--skip"],
+                    DEFAULT_TIMEOUT,
+                )
+                .await;
+                skipped += 1;
+                continue;
+            }
+            failure = Some((
+                hash.clone(),
+                AppError::Git {
+                    code: out.code,
+                    stderr: out.full_failure_text(),
+                },
+            ));
+            break 'picks;
         }
 
         if let Some((hash, err)) = failure {
@@ -1862,13 +1948,21 @@ pub(crate) async fn git_rebase_core(
     branch: String,
 ) -> AppResult<()> {
     validate_branch_arg(&branch)?;
-    run_git_mutating(
+    // Raw: a conflicted rebase splits its report — `could not apply` plus the
+    // resolve hints on stderr, the `CONFLICT (…` file list on stdout.
+    let out = run_git_mutating_raw(
         state,
         &repo_path,
         &["-c", "core.editor=true", "rebase", &branch],
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
     Ok(())
 }
 
@@ -1886,7 +1980,8 @@ async fn rebase_onto(
 ) -> AppResult<()> {
     validate_branch_arg(new_base)?;
     validate_branch_arg(old_base)?;
-    run_git_mutating(
+    // Raw, for the same split report as `git_rebase_core`.
+    let out = run_git_mutating_raw(
         state,
         repo_path,
         &[
@@ -1900,6 +1995,12 @@ async fn rebase_onto(
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
     Ok(())
 }
 
@@ -2346,9 +2447,11 @@ pub(crate) async fn merge_local_pr(
                 )
                 .await
                 .and_then(check_code),
+                // Hand-rolled rather than `check_code` because the success arm
+                // chains a commit; the failure shaping has to match it.
                 Ok(o) => Err(AppError::Git {
                     code: o.code,
-                    stderr: o.stderr,
+                    stderr: o.full_failure_text(),
                 }),
                 Err(e) => Err(e),
             }
@@ -3303,9 +3406,11 @@ fn check_code(o: crate::git::runner::GitOutput) -> AppResult<()> {
     if o.code == 0 {
         Ok(())
     } else {
+        // Both streams: the cherry-pick/merge strategies below conflict with their
+        // file list on stdout, which a stderr-only error would drop.
         Err(AppError::Git {
             code: o.code,
-            stderr: o.stderr,
+            stderr: o.full_failure_text(),
         })
     }
 }
@@ -4609,6 +4714,13 @@ mod tests {
                     stderr.contains("target is unchanged"),
                     "the error must tell the user the target is unchanged: {stderr}"
                 );
+                // Below the verdict, git's whole report: the batch loop splits it
+                // across both streams exactly like the single-pick path.
+                assert!(
+                    stderr.contains("could not apply")
+                        && stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
+                    "the verdict must carry git's diagnostic AND its file list: {stderr}"
+                );
             }
             Ok(_) => panic!("the conflicting pick must fail"),
             Err(e) => panic!("expected a Git error, got {e}"),
@@ -4939,6 +5051,150 @@ mod tests {
         std::fs::remove_dir_all(&seq).unwrap();
         let state = op_state(&repo).await.unwrap();
         assert!(!state.cherry_picking && !state.reverting);
+    }
+
+    /// A linked worktree keeps its op markers under
+    /// `<main>/.git/worktrees/<name>/`, so the banner and every mid-op guard read
+    /// the WRONG tree unless the git dir is resolved with `--absolute-git-dir`:
+    /// under the common dir the FIRST assertion below fails. The second is a
+    /// redundancy check that the marker really is worktree-local — it reads the
+    /// main `.git` either way, so it discriminates nothing on its own.
+    #[tokio::test]
+    async fn op_state_reads_a_linked_worktrees_own_markers() {
+        let (dir, repo) = setup_repo("worktree-markers").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        let tip = rev(&repo, "HEAD").await;
+
+        // Outside the repo's own tree, so the checkout isn't a nested untracked
+        // directory; both temp dirs are removed when the test ends.
+        let link_dir = tempfile::Builder::new()
+            .prefix("gd-rewrite-worktree-link-")
+            .tempdir()
+            .expect("create temp dir");
+        let link = link_dir.path().join("linked").to_string_lossy().into_owned();
+        git(&repo, &["worktree", "add", "--detach", &link, &tip]).await;
+
+        let merge = run_git_raw(
+            Some(&link),
+            &["merge", "--no-edit", "feature"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(merge.code, 0, "the merge inside the worktree should conflict");
+
+        assert!(
+            op_state(&link).await.unwrap().merging,
+            "the worktree's own MERGE_HEAD must be the one that's read"
+        );
+        assert!(op_in_progress(&link).await);
+        assert!(
+            !op_state(&repo).await.unwrap().merging,
+            "and the main checkout stays quiet — nothing is in progress there"
+        );
+
+        git(&repo, &["worktree", "remove", "--force", &link]).await;
+    }
+
+    /// Conflicted revert / cherry-pick / rebase all split ONE report across both
+    /// streams: the diagnostic on stderr, the conflicted-file list on stdout. An
+    /// error carrying either alone looks populated while dropping exactly what
+    /// the user needs to decide how to resolve.
+    #[tokio::test]
+    async fn a_conflicted_revert_carries_both_streams() {
+        let (dir, repo) = setup_repo("revert-details").await;
+        commit_file(&repo, dir.path(), "a.txt", "one\n", "one").await;
+        let target = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "two\n", "two").await;
+
+        let state = AppState::default();
+        let err = git_revert_core(&state, repo.clone(), target)
+            .await
+            .unwrap_err();
+        assert_both_streams(&err, "could not revert");
+    }
+
+    #[tokio::test]
+    async fn a_conflicted_cherry_pick_carries_both_streams() {
+        let (dir, repo) = setup_repo("pick-details").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        let feature = rev(&repo, "HEAD").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+
+        let state = AppState::default();
+        let err = git_cherry_pick_core(&state, repo.clone(), feature)
+            .await
+            .unwrap_err();
+        assert_both_streams(&err, "could not apply");
+    }
+
+    #[tokio::test]
+    async fn a_conflicted_rebase_carries_both_streams() {
+        let (dir, repo) = setup_repo("rebase-details").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+
+        let state = AppState::default();
+        let err = git_rebase_core(&state, repo.clone(), "feature".into())
+            .await
+            .unwrap_err();
+        assert_both_streams(&err, "ould not apply");
+    }
+
+    /// The one stdout-ONLY case in the family: `--continue` with paths still
+    /// unmerged names them on stdout and writes nothing to stderr, which a
+    /// stderr-only error renders to the user as "git exited with code 1".
+    #[tokio::test]
+    async fn a_refused_continue_names_the_unresolved_file() {
+        let (dir, repo) = setup_repo("continue-unresolved").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+
+        let state = AppState::default();
+        assert!(
+            git_rebase_core(&state, repo.clone(), "feature".into())
+                .await
+                .is_err(),
+            "the rebase must conflict for --continue to have something to refuse"
+        );
+
+        let err = op_continue(&state, &repo, "rebase").await.unwrap_err();
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a git error, got {err:?}");
+        };
+        assert!(
+            stderr.contains("a.txt: needs merge"),
+            "the refusal must name the unresolved file: {stderr}"
+        );
+    }
+
+    /// Both halves of a conflicted sequencer op's report reached the error:
+    /// `diagnostic` on stderr, and the `CONFLICT (…` file list on stdout.
+    fn assert_both_streams(err: &AppError, diagnostic: &str) {
+        let AppError::Git { stderr, .. } = err else {
+            panic!("expected a git error, got {err:?}");
+        };
+        assert!(
+            stderr.contains(diagnostic),
+            "stderr's own diagnostic ({diagnostic:?}) must survive: {stderr}"
+        );
+        assert!(
+            stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
+            "and stdout's conflicted-file list with it: {stderr}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -122,9 +122,14 @@ pub(crate) async fn run_git_mutating_with_creds(
         out = run_git_with_creds_once(repo_path, cred, sub, timeout).await?;
     }
     if out.code != 0 {
+        // Both streams: a merge-mode `pull` that conflicts puts the fetch summary
+        // on stderr and the whole merge verdict (`CONFLICT (…`, `Automatic merge
+        // failed`) on stdout, so substituting one for the other would drop the
+        // verdict. Inert for fetch/set-head/push, whose failures write no stdout.
+        // The classifier above reads raw `out.stderr` on purpose — keep it there.
         return Err(AppError::Git {
             code: out.code,
-            stderr: out.stderr,
+            stderr: out.full_failure_text(),
         });
     }
     Ok(out)
@@ -870,6 +875,65 @@ mod tests {
             }
             Err(other) => panic!("expected AppError::Git, got {other:?}"),
             Ok(_) => panic!("merging a missing ref should fail"),
+        }
+    }
+
+    /// The half that stderr alone cannot carry: a merge-mode pull that conflicts
+    /// writes only its fetch summary to stderr and the whole merge verdict to
+    /// stdout, so an error shaped from stderr looks populated while saying
+    /// nothing about the conflict the user now has to resolve.
+    #[tokio::test]
+    async fn a_conflicted_pull_surfaces_gits_merge_verdict() {
+        let (_base, base) = temp_base("pull-conflict");
+        let origin = base.join("origin.git");
+        let work = base.join("work");
+        let clone = base.join("clone");
+        std::fs::create_dir_all(&work).unwrap();
+        let base_s = base.to_string_lossy().into_owned();
+        let work_s = work.to_string_lossy().into_owned();
+        let clone_s = clone.to_string_lossy().into_owned();
+        let url = format!("file://{}", origin.to_string_lossy().replace('\\', "/"));
+
+        run(&base_s, &["init", "-q", "--bare", "-b", "main", "origin.git"]).await;
+        init_repo(&work_s, "a.txt").await;
+        run(&work_s, &["branch", "-M", "main"]).await;
+        run(&work_s, &["remote", "add", "origin", &url]).await;
+        run(&work_s, &["push", "-q", "-u", "origin", "main"]).await;
+        run(&base_s, &["-c", "core.autocrlf=false", "clone", "-q", &url, "clone"]).await;
+        run(&clone_s, &["config", "core.autocrlf", "false"]).await;
+        run(&clone_s, &["config", "user.email", "t@t.local"]).await;
+        run(&clone_s, &["config", "user.name", "T"]).await;
+
+        // Both sides rewrite the same file, so `--no-rebase` merges and conflicts.
+        std::fs::write(work.join("a.txt"), "upstream\n").unwrap();
+        run(&work_s, &["commit", "-qam", "upstream"]).await;
+        run(&work_s, &["push", "-q"]).await;
+        std::fs::write(clone.join("a.txt"), "mine\n").unwrap();
+        run(&clone_s, &["commit", "-qam", "local"]).await;
+
+        let state = AppState::default();
+        let result = run_git_mutating_with_creds(
+            &state,
+            &clone_s,
+            &[],
+            &["pull", "--no-rebase"],
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+        match result {
+            Err(AppError::Git { code, stderr }) => {
+                assert_eq!(code, 1);
+                assert!(
+                    stderr.contains("Automatic merge failed"),
+                    "the merge verdict rides stdout and must reach the error, got: {stderr}"
+                );
+                assert!(
+                    stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
+                    "and the conflicted-file list with it, got: {stderr}"
+                );
+            }
+            Err(other) => panic!("expected AppError::Git, got {other:?}"),
+            Ok(_) => panic!("a diverged pull with an overlapping edit should conflict"),
         }
     }
 

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -29,10 +29,11 @@ impl GitOutput {
     }
 
     /// The text describing a non-zero exit: stderr, or stdout when stderr is
-    /// EMPTY. git splits its reporting across both streams — a conflicted merge,
-    /// `stash pop` or `revert` writes everything to stdout and leaves stderr
-    /// empty (measured, git 2.51.1) — and an error carrying only that empty
-    /// stderr renders as "git exited with code N".
+    /// EMPTY. Correct only for the families that report on stdout ALONE — a
+    /// conflicted merge or `stash pop` (measured, git 2.51.1) — where an error
+    /// carrying that empty stderr renders as "git exited with code N". Anything
+    /// that splits ONE report across both streams needs
+    /// [`full_failure_text`](Self::full_failure_text) instead.
     pub fn failure_text(&self) -> String {
         let stderr = self.stderr.trim();
         if stderr.is_empty() {
@@ -40,6 +41,36 @@ impl GitOutput {
         } else {
             stderr.to_string()
         }
+    }
+
+    /// Both halves of a non-zero exit, stderr first and stdout below it, each
+    /// omitted when empty.
+    ///
+    /// [`failure_text`](Self::failure_text) substitutes rather than combines, so
+    /// it is a silent no-op wherever git splits ONE report across both streams:
+    /// a conflicted revert/cherry-pick/rebase puts its diagnostic on stderr and
+    /// its `CONFLICT (…)` file list on stdout, and a merge-mode `pull` puts the
+    /// fetch summary on stderr and the whole merge verdict on stdout (measured,
+    /// git 2.51.1). Dropping either half is data loss at the moment the user is
+    /// deciding how to resolve.
+    ///
+    /// stderr leads because the frontend reads line 1 alone: `ROLLBACK_VERDICTS`
+    /// and `firstMeaningfulLine` (`src/lib/error-summary.ts`), and the rollback
+    /// funnels in `git::ops` prepend their verdict above whatever this returns.
+    /// `strip_eol_warnings` runs over the stdout half too — the runner filters
+    /// only stderr, so autocrlf advisories would otherwise ride into Details.
+    ///
+    /// One consequence to know: git's sequencer status stdout can carry
+    /// `(all conflicts fixed: run "git cherry-pick --continue")`, which matches
+    /// the frontend's `OP_ADVICE`, so combining the streams puts stdout advice
+    /// within reach of the summary scanner.
+    pub fn full_failure_text(&self) -> String {
+        let stdout = strip_eol_warnings(&self.stdout_lossy());
+        [self.stderr.trim(), stdout.trim()]
+            .into_iter()
+            .filter(|half| !half.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }
 
@@ -381,8 +412,9 @@ pub async fn run_git_mutating(
 
 /// `run_git_mutating` without its non-zero-exit verdict: same lock and same
 /// one-shot index.lock retry, but the raw output comes back so the caller can
-/// read STDOUT on failure. Use it wherever git reports a failure there —
-/// [`GitOutput::failure_text`] is the shaping those callers share.
+/// read STDOUT on failure. [`GitOutput::full_failure_text`] is the shaping those
+/// callers share; [`GitOutput::failure_text`] only suits the ones whose failure
+/// lands on stdout ALONE, which is merge.
 pub async fn run_git_mutating_raw(
     state: &AppState,
     repo_path: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,6 +125,8 @@ pub fn run() {
             git::branches::git_checkout_remote_branch,
             git::autostash::git_pull_autostash,
             git::autostash::git_merge_autostash,
+            git::autostash::git_rebase_autostash,
+            git::autostash::git_rebase_onto_autostash,
             git::autostash::git_switch_autostash,
             git::branches::git_create_branch,
             git::branches::git_rename_branch,

--- a/src/components/disabled-reason-button.tsx
+++ b/src/components/disabled-reason-button.tsx
@@ -1,5 +1,8 @@
-import { useId } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  ARIA_DISABLED_CLASS,
+  useDisabledReason,
+} from "@/lib/use-disabled-reason";
 import { cn } from "@/lib/utils";
 
 type DisabledReasonButtonProps = React.ComponentProps<typeof Button> & {
@@ -10,16 +13,14 @@ type DisabledReasonButtonProps = React.ComponentProps<typeof Button> & {
 };
 
 /**
- * Button that explains its own disabled state. A natively-disabled button
- * swallows its own `title` and leaves the tab order, so a button WITH a reason
- * takes Base UI's `focusableWhenDisabled` — `aria-disabled` instead of the
- * native attribute, focus intact, activation still blocked in its handler layer.
- * A reason-less disable stays native rather than becoming a mute tab stop.
+ * Button that explains its own disabled state — the vendored-Button arm of the
+ * `useDisabledReason` contract, where a reason takes Base UI's
+ * `focusableWhenDisabled` (activation still blocked in its own handler layer).
  * Trigger sites pick an arm by who needs the reason: a titled span around
  * `<Trigger disabled render={<Button/>}/>` is hover-only, so keyboard/AT reach
  * takes `<Trigger render={<DisabledReasonButton disabled reason/>}/>` instead —
  * disabled on the button, never the trigger, whose open handler the inner
- * `useButton` then swallows. `ReactionBar` hand-rolls this on a raw `<button>`.
+ * `useButton` then swallows.
  */
 export function DisabledReasonButton({
   reason,
@@ -29,14 +30,13 @@ export function DisabledReasonButton({
   className,
   ...props
 }: DisabledReasonButtonProps) {
-  const id = useId();
-  const blockedReason = disabled && reason ? reason : null;
-  // `aria-describedby` outranks `title` as the accessible description, so a
-  // caller's own description has to survive alongside the reason.
-  const describedBy =
-    [props["aria-describedby"], blockedReason ? id : null]
-      .filter(Boolean)
-      .join(" ") || undefined;
+  const { blockedReason, reasonId, wrapperTitle, describedBy } =
+    useDisabledReason({
+      disabled,
+      reason,
+      title,
+      describedBy: props["aria-describedby"],
+    });
 
   return (
     <span
@@ -45,27 +45,18 @@ export function DisabledReasonButton({
         blockedReason && "cursor-not-allowed",
         wrapperClassName,
       )}
-      // Both disabled paths kill pointer events on the button, so the wrapper
-      // owns the hover text whenever it is disabled — the reason when there is
-      // one, otherwise the caller's ordinary hint.
-      title={blockedReason ?? title}
+      title={wrapperTitle}
     >
       <Button
         {...props}
         focusableWhenDisabled={!!blockedReason}
         disabled={disabled}
         title={title}
-        // A reason trades the native attribute for `aria-disabled`, which the
-        // vendored `disabled:` dim can't see; the dim lifts under focus so a
-        // keyboard user isn't left tracking a half-opacity focus ring.
-        className={cn(
-          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:focus-visible:opacity-100",
-          className,
-        )}
+        className={cn(ARIA_DISABLED_CLASS, className)}
         aria-describedby={describedBy}
       />
       {blockedReason ? (
-        <span id={id} className="sr-only">
+        <span id={reasonId} className="sr-only">
           {blockedReason}
         </span>
       ) : null}

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -89,7 +89,10 @@ export function ActivityStrip() {
     return null;
   }
   return (
-    <div className="flex h-7 shrink-0 items-center border-t bg-background px-1.5">
+    // box-content: the trigger inside is h-7 too, so border-box would leave a
+    // 27px content box and hang the child 0.5px past the viewport — the last
+    // element in the h-screen column, so the document grows a window scrollbar.
+    <div className="box-content flex h-7 shrink-0 items-center border-t bg-background px-1.5">
       <ActivityBell variant="strip" />
     </div>
   );

--- a/src/features/conversations/ReactionBar.tsx
+++ b/src/features/conversations/ReactionBar.tsx
@@ -1,8 +1,12 @@
 import { Popover } from "@base-ui/react/popover";
 import { SmileyIcon } from "@phosphor-icons/react";
-import { type ComponentProps, useId, useState } from "react";
+import { type ComponentProps, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import type { Reaction } from "@/lib/git/types";
+import {
+  ARIA_DISABLED_CLASS,
+  useDisabledReason,
+} from "@/lib/use-disabled-reason";
 import { cn } from "@/lib/utils";
 
 /** GitHub's eight reactions, in their canonical picker order. */
@@ -31,13 +35,8 @@ const REACTION_ORDER = [
 const label = (content: string) => content.toLowerCase().replace(/_/g, " ");
 
 /**
- * `DisabledReasonButton`'s contract on a plain `<button>` — chips and picker cells
- * carry their own sizing, which none of the vendored Button's sizes match. A
- * reason trades the native `disabled` attribute for `aria-disabled`, keeping the
- * tab stop and an sr-only description a natively-disabled element could never
- * announce; both disabled paths kill pointer events, so the wrapper owns the
- * hover text. The contract lives in two places now and has to change in both; a
- * third site extracts it to a shared hook instead.
+ * The `useDisabledReason` contract on a plain `<button>` — chips and picker
+ * cells carry their own sizing, which none of the vendored Button's sizes match.
  */
 function ReactionButton({
   reason,
@@ -47,36 +46,30 @@ function ReactionButton({
   className,
   ...props
 }: ComponentProps<"button"> & { reason?: string | null }) {
-  const id = useId();
-  const blockedReason = disabled && reason ? reason : null;
-  // `aria-describedby` outranks `title` as the accessible description, so a
-  // caller's own description has to survive alongside the reason.
-  const describedBy =
-    [props["aria-describedby"], blockedReason ? id : null]
-      .filter(Boolean)
-      .join(" ") || undefined;
+  const { blockedReason, reasonId, wrapperTitle, describedBy, nativeProps } =
+    useDisabledReason({
+      disabled,
+      reason,
+      title,
+      describedBy: props["aria-describedby"],
+      onClick,
+    });
 
   return (
     <span
       className={cn("inline-flex", blockedReason && "cursor-not-allowed")}
-      title={blockedReason ?? title}
+      title={wrapperTitle}
     >
       <button
         {...props}
+        {...nativeProps}
         type="button"
         title={title}
-        disabled={blockedReason ? undefined : disabled}
-        aria-disabled={blockedReason ? true : undefined}
         aria-describedby={describedBy}
-        // `aria-disabled` is advisory only, so activation is withheld here.
-        onClick={blockedReason ? undefined : onClick}
-        className={cn(
-          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:focus-visible:opacity-100",
-          className,
-        )}
+        className={cn(ARIA_DISABLED_CLASS, className)}
       />
       {blockedReason ? (
-        <span id={id} className="sr-only">
+        <span id={reasonId} className="sr-only">
           {blockedReason}
         </span>
       ) : null}

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -74,7 +74,11 @@ import type { PrThreadOut } from "@/lib/git/types";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
-import { toastError } from "@/lib/toast";
+import { toastError, toastErrorWithNote } from "@/lib/toast";
+import {
+  ARIA_DISABLED_CLASS,
+  useDisabledReason,
+} from "@/lib/use-disabled-reason";
 import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { cn } from "@/lib/utils";
 
@@ -126,35 +130,57 @@ const CLOSE_REASONS: [string, DiscussionCloseReason][] = [
 type ReplyDraft = { targetId: string | null; body: string };
 const EMPTY_REPLY: ReplyDraft = { targetId: null, body: "" };
 
+/** The `useDisabledReason` contract on a plain `<button>` — the chip carries its
+ *  own sizing, which none of the vendored Button's sizes match (same arm as
+ *  `ReactionButton`, which it sits beside). */
 function UpvoteButton({
   count,
   active,
   onClick,
   disabled,
+  reason,
 }: {
   count: number;
   active: boolean;
   onClick: () => void;
   disabled?: boolean;
+  /** Why the toggle is held — shown and announced while `disabled` holds.
+   *  Absent leaves a native disable, which explains nothing. */
+  reason?: string | null;
 }) {
+  const title = active ? "Remove upvote" : "Upvote";
+  const { blockedReason, reasonId, wrapperTitle, describedBy, nativeProps } =
+    useDisabledReason({ disabled, reason, title, onClick });
+
   return (
-    <button
-      type="button"
-      aria-label={`Upvote, ${count}`}
-      aria-pressed={active}
-      disabled={disabled}
-      onClick={onClick}
-      className={cn(
-        "flex items-center gap-1 border px-1.5 py-0.5 text-[11px] tabular-nums transition-colors",
-        active
-          ? "border-primary bg-primary/10 text-foreground"
-          : "text-muted-foreground hover:bg-muted/60",
-      )}
-      title={active ? "Remove upvote" : "Upvote"}
+    <span
+      className={cn("inline-flex", blockedReason && "cursor-not-allowed")}
+      title={wrapperTitle}
     >
-      <CaretUpIcon className="size-3" weight="bold" />
-      {count}
-    </button>
+      <button
+        {...nativeProps}
+        type="button"
+        aria-label={`Upvote, ${count}`}
+        aria-pressed={active}
+        aria-describedby={describedBy}
+        title={title}
+        className={cn(
+          ARIA_DISABLED_CLASS,
+          "flex items-center gap-1 border px-1.5 py-0.5 text-[11px] tabular-nums transition-colors",
+          active
+            ? "border-primary bg-primary/10 text-foreground"
+            : "text-muted-foreground hover:bg-muted/60",
+        )}
+      >
+        <CaretUpIcon className="size-3" weight="bold" />
+        {count}
+      </button>
+      {blockedReason ? (
+        <span id={reasonId} className="sr-only">
+          {blockedReason}
+        </span>
+      ) : null}
+    </span>
   );
 }
 
@@ -265,6 +291,26 @@ export function DiscussionView({
         return undefined;
     }
   })();
+  const upvoteHeld = toggleUpvoteMutation.isPending || detailsStale;
+  // Ranked like `busyReason`: the switch window outranks the write the viewer
+  // started, being the hold they can't have caused themselves.
+  const upvoteReason = (() => {
+    switch (true) {
+      case detailsStale:
+        return staleReason;
+      case toggleUpvoteMutation.isPending:
+        return "Recording your upvote…";
+      default:
+        return undefined;
+    }
+  })();
+  // A typed draft rides Close/Reopen rather than being discarded by them.
+  const draftRidesStateChange = !!compose.value.trim();
+  // Both live on menu items, which drop pointer events when disabled and have no
+  // room for a title, so the draft promise rides the label like the reasons
+  // above — but a hold outranks it: a held item posts nothing.
+  const draftSuffix =
+    staleSuffix || (draftRidesStateChange ? " — posts your draft" : "");
 
   function submitComment() {
     if (!d || detailsStale || !compose.value.trim()) return;
@@ -382,19 +428,63 @@ export function DiscussionView({
     });
   }
 
-  function doClose(reason: DiscussionCloseReason) {
-    if (!d || detailsStale) return;
+  /** Posts the riding draft ahead of a state change. False means the comment
+   *  failed and the state change is abandoned: the draft stays put for a retry,
+   *  so a lost note can never be the price of a failed close. */
+  async function postRidingDraft(discussionId: string): Promise<boolean> {
+    if (!draftRidesStateChange) return true;
+    const submittedFor = discussionIdentity;
+    try {
+      await addComment.mutateAsync({
+        discussionId,
+        body: compose.value.trim(),
+      });
+      // Only a landed comment clears the draft.
+      compose.clearFor(submittedFor);
+      return true;
+    } catch (e) {
+      onError(e);
+      return false;
+    }
+  }
+
+  async function doClose(reason: DiscussionCloseReason) {
+    // Unlike the button surfaces, a menu item can be reached again during the
+    // comment round trip (the menu closes on click, but reopens) — so the
+    // in-flight post is the re-entry guard the item's own `disabled` can't be.
+    if (!d || detailsStale || addComment.isPending) return;
+    // Captured before the await: posting clears the draft, and the error arm
+    // below has to know a comment already went out.
+    const withComment = draftRidesStateChange;
+    if (!(await postRidingDraft(d.id))) return;
     closeDiscussion.mutate(
       { discussionId: d.id, reason },
-      { onSuccess: () => toast.success("Discussion closed"), onError },
+      {
+        onSuccess: () => toast.success("Discussion closed"),
+        onError: (e) =>
+          withComment
+            ? toastErrorWithNote(
+                e,
+                "Your comment was posted, but closing failed — try Close again.",
+              )
+            : onError(e),
+      },
     );
   }
 
-  function doReopen() {
-    if (!d || detailsStale) return;
+  async function doReopen() {
+    if (!d || detailsStale || addComment.isPending) return;
+    const withComment = draftRidesStateChange;
+    if (!(await postRidingDraft(d.id))) return;
     reopenDiscussion.mutate(d.id, {
       onSuccess: () => toast.success("Discussion reopened"),
-      onError,
+      onError: (e) =>
+        withComment
+          ? toastErrorWithNote(
+              e,
+              "Your comment was posted, but reopening failed — try Reopen again.",
+            )
+          : onError(e),
     });
   }
 
@@ -466,7 +556,7 @@ export function DiscussionView({
                   disabled={reopenDiscussion.isPending || detailsStale}
                   onClick={doReopen}
                 >
-                  Reopen discussion{staleSuffix}
+                  Reopen discussion{draftSuffix}
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuSub>
@@ -476,7 +566,7 @@ export function DiscussionView({
                     disabled={closeDiscussion.isPending || detailsStale}
                     className="data-disabled:opacity-50"
                   >
-                    Close discussion…{staleSuffix}
+                    Close discussion…{draftSuffix}
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
                     {CLOSE_REASONS.map(([label, reason]) => (
@@ -636,16 +726,14 @@ export function DiscussionView({
                 No description provided.
               </p>
             )}
-            {/* The counts are a read and stay; the toggles hold through a switch.
-                Disabled buttons swallow `title`, so the wait rides this row. */}
-            <div
-              title={staleReason}
-              className="flex flex-wrap items-center gap-2 pt-1"
-            >
+            {/* The counts are a read and stay; the toggles hold through a
+                switch, each carrying its own reason. */}
+            <div className="flex flex-wrap items-center gap-2 pt-1">
               <UpvoteButton
                 count={d.upvoteCount}
                 active={d.viewerHasUpvoted}
-                disabled={toggleUpvoteMutation.isPending || detailsStale}
+                disabled={upvoteHeld}
+                reason={upvoteReason}
                 onClick={() => toggleUpvote(d.id, d.viewerHasUpvoted)}
               />
               <ReactionBar
@@ -702,14 +790,13 @@ export function DiscussionView({
                   reactionsReason={staleReason}
                 />
               </div>
-              <div
-                title={staleReason}
-                className="flex flex-wrap items-center gap-2"
-              >
+              {/* Every control in the row carries its own reason. */}
+              <div className="flex flex-wrap items-center gap-2">
                 <UpvoteButton
                   count={c.upvoteCount}
                   active={c.viewerHasUpvoted}
-                  disabled={toggleUpvoteMutation.isPending || detailsStale}
+                  disabled={upvoteHeld}
+                  reason={upvoteReason}
                   onClick={() => toggleUpvote(c.id, c.viewerHasUpvoted)}
                 />
                 <DisabledReasonButton

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -439,14 +439,16 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   push publishes it under its own name — pairs with pushing a branch without switching to it
   (below).
 - **Clean up branches** — from the switcher's menu or the command palette — opens a bulk
-  sweep of stale branches: those **merged** into the default branch — directly, or through a
-  recent pull request, so squash- and rebase-merged branches turn up too, each badged
-  **merged #123** with the pull request that took them — and those with no commits in a
-  chosen window (30/60/90 days). Branches your own history calls merged, and idle ones,
-  start **pre-checked**; a pull-request match goes by branch name, so it never pre-checks
-  a row on its own — it badges one for you to confirm. Review the list, then **archive**
-  them (reversible) or **delete** them together. The current branch, the default branch,
-  and protected branches are never included.
+  sweep of stale branches: those **merged** into the default branch — directly, or, where
+  the repository's forge connection can supply them, through a recent pull request, so
+  squash- and rebase-merged branches turn up too, each badged **merged #123** with the pull
+  request that took them — and those with no commits in a chosen window (30/60/90 days).
+  The dialog describes exactly the checks it made, naming pull requests only where it read
+  them, so you always know what the list in front of you covers. Branches your own history
+  calls merged, and idle ones, start **pre-checked**; a pull-request match goes by branch
+  name, so it never pre-checks a row on its own — it badges one for you to confirm. Review
+  the list, then **archive** them (reversible) or **delete** them together. The current
+  branch, the default branch, and protected branches are never included.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
   or renaming one. Whenever the working tree can't describe the branch being named —
   it's clean, or you're renaming a branch you aren't on — it names it from that
@@ -466,6 +468,8 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   branch you meant to base on and the branch you actually did, and only your branch's own
   commits move — the wrong base's commits are left behind. A preview lists exactly which
   commits will move before you run it, and any conflicts drop into the resolve flow below.
+  Run it with uncommitted changes and it offers to stash them, rebase, and put them back
+  (see *Stash and reapply*).
 - **Update a branch from its own upstream** without switching to it: when a branch is
   behind the remote it tracks, its context menu offers **Update from _origin/…_**. This
   is the "just merged a PR — bring the default branch current before I switch back" flow;
@@ -554,9 +558,13 @@ test, or review several branches at once without stashing or switching.
   removed: renaming needs an unlock first, and deleting asks for a forced confirmation.
   Useful for one on a removable or network drive; **Unlock** to undo.
 - **Delete** a worktree to remove its folder; its branch is kept. A worktree with
-  uncommitted changes, or a locked one, asks before force-removing. The main worktree,
-  and whichever one you're currently in, can't be renamed or deleted — switch away first.
-  A locked worktree can't be renamed until you unlock it.
+  uncommitted changes, or a locked one, asks before force-removing. Removing a worktree can
+  take a few minutes, and you can close the dialog and carry on: the removal keeps a line at
+  the top of the repository view until it finishes, its row here reads **Removing…**, and
+  the actions held while it runs say *removal in progress*. It runs to completion once
+  started, so there's nothing to cancel. The main worktree, and whichever one you're
+  currently in, can't be renamed or deleted — switch away first. A locked worktree can't be
+  renamed until you unlock it.
 - **Promote to main workspace** brings a worktree's branch into your main checkout: it
   removes the worktree (a branch can't be checked out in two at once) and checks that branch
   out in the main workspace. The worktree must be clean first; any uncommitted work in the
@@ -609,15 +617,16 @@ the pull runs, then they come back on top of it. If reapplying them hits conflic
 conflicted files appear in **Changes** to resolve as usual and the stash is kept as a backup
 until you're done; if they can't go back at all (say the pull brought in a file with the
 same name), they stay safely in the stash. The same recovery covers
-**Update from upstream**, updating the branch you're on from another branch, and **merging**
-a branch into the one you're on. A **squash**, **no-fast-forward**, or strategy merge reports
+**Update from upstream**, updating the branch you're on from another branch, **merging**
+a branch into the one you're on, and **rebasing** (the branch menu's **Rebase** and
+**Change base…** alike). A **squash**, **no-fast-forward**, or strategy merge reports
 the refusal instead: the recovery redoes the merge plainly, so offering it there would drop
 the option you chose.
 
 Tick **Always stash and reapply** in the prompt — or turn on **Automatically stash and
-reapply on pull, merge, and branch updates** under **Settings → General** — and those
-operations recover on their own, with no prompt. Either way it only ever kicks in when git
-actually refuses the operation.
+reapply on pull, merge, rebase, and branch updates** under **Settings → General** — and
+those operations recover on their own, with no prompt. Either way it only kicks in when
+uncommitted changes would otherwise block the operation.
 
 ## Update a fork from upstream
 
@@ -966,7 +975,8 @@ is open, {{kbd:generate-commit-message}} runs its **Generate** for you.{{/ai}}
 Point the app at a **GitLab** repo and the same tab lists its **merge requests** (open and
 closed/merged) next to any local PRs. Open one for the description, comments, commits, and a
 highlighted **diff** (with an **Open on GitLab** link) — and the GitLab MR writes:
-**comment** on it (and **edit** or **delete** your own comments), **close / reopen** it,
+**comment** on it (and **edit** or **delete** your own comments), **close / reopen** it
+(posting your drafted comment alongside, as **request changes** does),
 **edit** its title and description (and **retarget** its target branch),
 **approve / unapprove** it (a reviewer action,
 with the approval count shown inline), **request changes** (the blocking reviewer state —
@@ -1072,9 +1082,10 @@ or GitLab read that couldn't get through.
 ## Local PRs
 
 A **local PR** is the same review workflow against any two branches with **no remote at
-all** — describe it in Markdown, comment, label, approve, and merge locally. Local PRs
-are private to you and never written into the repo. When you're ready, **promote** a
-local PR to a real GitHub PR or GitLab MR in one click, history preserved.
+all** — describe it in Markdown, comment, label, approve, close or reopen (posting your
+drafted comment alongside), and merge locally. Local PRs are private to you and never
+written into the repo. When you're ready, **promote** a local PR to a real GitHub PR or
+GitLab MR in one click, history preserved.
 
 Its Conversation is the same **date-sorted activity feed** as the hosted PRs: it opens with
 a **created** marker, interleaves the branch's **pushed commits** (grouped, each short SHA
@@ -1138,9 +1149,11 @@ reviewing model's context window (probing Ollama live), or pick Compact / Standa
 Expanded. **Review timeout** (shown when an agent CLI drives reviews or security audits)
 caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
 the review is agentic — always, for Codex), or pin a fixed limit that applies to every
-agent-CLI review. Whatever the reviewer already wrote is kept when the limit hits: it stays
-on screen and is saved with the pull request, labelled **Timed out — partial output kept**,
-so it's still there after a restart. Kept output is never treated as a finished review — it
+agent-CLI review. Whatever the reviewer already wrote is kept when the limit hits, for an
+automated pull-request review as much as one you started yourself: it stays on screen and is saved with
+the pull request, labelled **Timed out — partial output kept**, so it's still there after a
+restart. It also gets its own row under **Previous reviews**, where you can read, copy, or
+delete it like any other record. Kept output is never treated as a finished review — it
 doesn't feed the next run's context and doesn't count as coverage for an automated review,
 so run it again for a full one.
 
@@ -1151,9 +1164,9 @@ breach.
 **One review at a time — queue the other.** A PR streams one AI review at a time,
 but you don't have to pick between a code review and a security audit: start one
 while the other is running and it **queues**, then starts automatically when the
-first finishes (whose result moves to **Previous reviews**). A chip shows what's up
-next; **Dismiss** drops it, and cancelling the running review still lets the queued
-one proceed.
+first finishes (whose result moves to **Previous reviews**, kept partial output
+included). A chip shows what's up next; **Dismiss** drops it, and cancelling the running
+review still lets the queued one proceed.
 
 **Agentic review.** The panel's **Agentic review** toggle gives the reviewer read-only
 tools so that, instead of relying on the prompt's truncated summary, it pulls the **full PR
@@ -1200,7 +1213,8 @@ GitLab actions are available.)
 Browse, filter, and open issues in a full view: body, comments, labels, assignees,
 milestone, and reactions. The **funnel** filter is the same searchable author/label
 popup as the PR list. **Create** an issue, comment with the Markdown editor, edit,
-add labels, **close / reopen**, **lock**, and **transfer** an issue to another repo.
+add labels, **close / reopen** (posting your drafted comment alongside), **lock**, and
+**transfer** an issue to another repo.
 
 - **Sub-issues** — break an issue into a parent/child checklist with completion tracking.
 - **Dependencies** — link issues as blocked-by / blocking.
@@ -1233,7 +1247,7 @@ reads **Create in \<parent\>**.
 Point the app at a **GitLab** repo and the same tab lists its **issues** (open and closed)
 next to any local issues. Open one to read the description and comments — and the GitLab
 issue **writes**: **comment** on the issue (and **edit** or **delete** your own comments),
-**close / reopen** it, **edit** its title and
+**close / reopen** it (posting your drafted comment alongside), **edit** its title and
 description, **react** with emoji on the description and comments (GitLab's award emoji),
 and set its **assignees**, **labels**, and **milestone** right in the side
 rail. The rail also carries GitLab-unique fields: a **due date** (type a date and
@@ -1316,9 +1330,9 @@ credential** with one button instead of re-entering it.
 ## Local issues
 
 A **local issue** is a private, offline to-do tracked in the app — create, edit, label,
-and close it with no remote. When it's ready to share, **promote** it to a GitHub or
-GitLab issue — or, when the repo has a **linked Jira project**, to a Jira issue — in one
-click.
+and close or reopen it with no remote, your drafted comment posted alongside. When it's
+ready to share, **promote** it to a GitHub or GitLab issue — or, when the repo has a
+**linked Jira project**, to a Jira issue — in one click.
 {{ai}}
 ## Hand off to an agent
 
@@ -1336,9 +1350,12 @@ part in GitHub Discussions for the repo. (Discussions must be enabled on the rep
 - Read **threaded conversations** — top-level comments with nested replies — and post,
   edit, delete, or hide comments with the Markdown editor.
 - In a Q&A discussion, **mark a reply as the answer**.
-- Add **reactions** and upvotes.
+- Add **reactions** and upvotes. The upvote chip stays keyboard-reachable while a vote is
+  being recorded, or while the discussion you picked is still loading, and says what it's
+  waiting on.
 - Manage a discussion's lifecycle: **close** (as resolved / outdated / duplicate),
-  **reopen**, **lock**, and **delete**.
+  **reopen**, **lock**, and **delete**. Closing or reopening posts your drafted comment
+  alongside, and the menu item says so while a draft is waiting.
 - **Create a discussion**, or **create an issue from a discussion** when a thread turns
   into actionable work (the new issue links back to it).`,
   },
@@ -2128,8 +2145,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   background work continues; launching the app again while it's running —
   tray-hidden or not — focuses the existing window), **automatically fetch from your
   remotes** (a background fetch on an interval you pick — it never pulls, merges, or
-  changes your files), **automatically stash and reapply on pull, merge, and branch
-  updates** (an operation git would refuse over uncommitted changes recovers on its own,
+  changes your files), **automatically stash and reapply on pull, merge, rebase, and branch
+  updates** (an operation uncommitted changes would otherwise block recovers on its own,
   no prompt), **reapply stashed changes after switching branches** (*Stash and switch*
   puts your changes back once the switch lands), **create pull requests as drafts** by
   default (off by default — pre-checks the Create-PR dialog's draft box, still

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -13,9 +13,9 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
-import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -123,10 +123,49 @@ export function LocalIssueView({
   }
 
   const isOpen = issue.status === "open";
+  // A typed note rides Close/Reopen rather than being discarded by them.
+  const draftRidesStateChange = !!comment.trim();
 
   function openEdit() {
     if (!issue) return;
     edit.openEdit({ title: issue.title, body: issue.body });
+  }
+
+  /** Close/Reopen, carrying any typed note. The note is appended in the SAME
+   *  record mutation as the status flip, so the store can never persist one
+   *  without the other; the draft clears only once that write lands. */
+  function setStatus(next: "open" | "closed") {
+    // Appending the note makes this non-idempotent, and the mutate callback
+    // re-reads the record from disk — so a second click lands after the first
+    // note is already stored and would post it twice.
+    if (!issue || update.isPending) return;
+    const note = comment.trim();
+    update.mutate(
+      {
+        id: issue.id,
+        mutate: (cur) => ({
+          ...cur,
+          comments: note
+            ? [
+                ...cur.comments,
+                {
+                  id: crypto.randomUUID(),
+                  body: note,
+                  createdAt: new Date().toISOString(),
+                },
+              ]
+            : cur.comments,
+          status: next,
+          closedAt: next === "closed" ? new Date().toISOString() : undefined,
+        }),
+      },
+      {
+        onSuccess: () => setComment(""),
+        // Nothing was written, the note included — say so rather than leave a
+        // silent no-op behind a button that promised to post it.
+        onError: toastError,
+      },
+    );
   }
 
   return (
@@ -371,21 +410,19 @@ export function LocalIssueView({
                     : `Publish to ${ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}`}
               </Button>
             )}
+            {/* The label swaps while a note rides along: the action changed
+                meaning, and only the label reaches a viewer before the click. */}
             <Button
               variant="outline"
               size="sm"
-              onClick={() =>
-                update.mutate({
-                  id: issue.id,
-                  mutate: (cur) => ({
-                    ...cur,
-                    status: "closed",
-                    closedAt: new Date().toISOString(),
-                  }),
-                })
+              onClick={() => setStatus("closed")}
+              title={
+                draftRidesStateChange
+                  ? "Closes and posts your draft as a comment"
+                  : undefined
               }
             >
-              Close
+              {draftRidesStateChange ? "Close with comment" : "Close"}
             </Button>
           </>
         )}
@@ -393,15 +430,15 @@ export function LocalIssueView({
           <Button
             variant="outline"
             size="sm"
-            onClick={() =>
-              update.mutate({
-                id: issue.id,
-                mutate: (cur) => ({ ...cur, status: "open" }),
-              })
+            onClick={() => setStatus("open")}
+            title={
+              draftRidesStateChange
+                ? "Reopens and posts your draft as a comment"
+                : undefined
             }
           >
             <ArrowCounterClockwiseIcon data-icon="inline-start" />
-            Reopen
+            {draftRidesStateChange ? "Reopen with comment" : "Reopen"}
           </Button>
         )}
       </div>

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -15,6 +15,7 @@ import {
 import { useState } from "react";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -412,9 +413,11 @@ export function LocalIssueView({
             )}
             {/* The label swaps while a note rides along: the action changed
                 meaning, and only the label reaches a viewer before the click. */}
-            <Button
+            <DisabledReasonButton
               variant="outline"
               size="sm"
+              disabled={update.isPending}
+              reason="Saving…"
               onClick={() => setStatus("closed")}
               title={
                 draftRidesStateChange
@@ -423,13 +426,15 @@ export function LocalIssueView({
               }
             >
               {draftRidesStateChange ? "Close with comment" : "Close"}
-            </Button>
+            </DisabledReasonButton>
           </>
         )}
         {!isOpen && (
-          <Button
+          <DisabledReasonButton
             variant="outline"
             size="sm"
+            disabled={update.isPending}
+            reason="Saving…"
             onClick={() => setStatus("open")}
             title={
               draftRidesStateChange
@@ -439,7 +444,7 @@ export function LocalIssueView({
           >
             <ArrowCounterClockwiseIcon data-icon="inline-start" />
             {draftRidesStateChange ? "Reopen with comment" : "Reopen"}
-          </Button>
+          </DisabledReasonButton>
         )}
       </div>
 

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -376,6 +376,10 @@ export function RemoteIssueView({
   }
 
   async function doClose(reason: "completed" | "not_planned") {
+    // The caret menu can sit open across a selection switch or a mutation, so
+    // the hold has to be re-checked here — item clicks bypass the trigger's
+    // disable.
+    if (busy || triageBlocked) return;
     // Captured before the await: posting clears the draft, and the error arm
     // below has to know a comment already went out.
     const withComment = draftRidesStateChange;
@@ -396,6 +400,7 @@ export function RemoteIssueView({
   }
 
   async function doReopen() {
+    if (busy || triageBlocked) return;
     const withComment = draftRidesStateChange;
     if (!(await postRidingDraft())) return;
     reopenIssue.mutate(number, {

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -74,7 +74,7 @@ import { providerLabel } from "@/lib/git/types";
 import { useRepoLens } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
-import { toastError } from "@/lib/toast";
+import { toastError, toastErrorWithNote } from "@/lib/toast";
 import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { PlanIssueButton } from "../plan/PlanIssueButton";
 import { SolveIssueButton } from "../sessions/SolveIssueButton";
@@ -347,11 +347,67 @@ export function RemoteIssueView({
     makeQuoteReply({ composerRef, setBody: compose.set })(body);
   };
 
-  function doClose(reason: "completed" | "not_planned") {
+  // A typed draft rides Close/Reopen rather than being discarded by them. Gated
+  // on `canComment` so the labels below never promise a comment the provider
+  // won't take.
+  const draftRidesStateChange = canComment && !!compose.value.trim();
+  const draftSuffix = draftRidesStateChange ? " — posts your draft" : "";
+
+  /** Posts the riding draft ahead of a state change. False means the comment
+   *  failed and the state change is abandoned: the draft stays put for a retry,
+   *  so a lost note can never be the price of a failed close. */
+  async function postRidingDraft(): Promise<boolean> {
+    if (!draftRidesStateChange) return true;
+    const body = compose.value.trim();
+    const submittedFor = issueIdentity;
+    try {
+      await comment.mutateAsync({
+        number,
+        body,
+        author: forge.data?.login ?? "You",
+      });
+      // Only a landed comment clears the draft.
+      compose.clearFor(submittedFor);
+      return true;
+    } catch (e) {
+      onError(e);
+      return false;
+    }
+  }
+
+  async function doClose(reason: "completed" | "not_planned") {
+    // Captured before the await: posting clears the draft, and the error arm
+    // below has to know a comment already went out.
+    const withComment = draftRidesStateChange;
+    if (!(await postRidingDraft())) return;
     closeIssue.mutate(
       { number, reason },
-      { onSuccess: () => toast.success(`Closed #${number}`), onError },
+      {
+        onSuccess: () => toast.success(`Closed #${number}`),
+        onError: (e) =>
+          withComment
+            ? toastErrorWithNote(
+                e,
+                "Your comment was posted, but closing failed — try Close again.",
+              )
+            : onError(e),
+      },
     );
+  }
+
+  async function doReopen() {
+    const withComment = draftRidesStateChange;
+    if (!(await postRidingDraft())) return;
+    reopenIssue.mutate(number, {
+      onSuccess: () => toast.success(`Reopened #${number}`),
+      onError: (e) =>
+        withComment
+          ? toastErrorWithNote(
+              e,
+              "Your comment was posted, but reopening failed — try Reopen again.",
+            )
+          : onError(e),
+    });
   }
 
   function saveCommentEdit(commentId: string, body: string) {
@@ -470,14 +526,21 @@ export function RemoteIssueView({
       {canChangeState &&
         (isOpen ? (
           <>
+            {/* The label swaps while a draft rides along: the action changed
+                meaning, and only the label reaches a viewer before the click. */}
             <DisabledReasonButton
               variant="outline"
               size="sm"
               disabled={busy || triageBlocked}
               reason={triageReason ?? staleReason}
               onClick={() => doClose("completed")}
+              title={
+                draftRidesStateChange
+                  ? "Closes and posts your draft as a comment"
+                  : undefined
+              }
             >
-              Close issue
+              {draftRidesStateChange ? "Close with comment" : "Close issue"}
             </DisabledReasonButton>
             {/* Close reasons are a GitHub concept; GitLab has none. The caret is
                 a menu TRIGGER: native `disabled` holds the menu shut, and the
@@ -503,11 +566,14 @@ export function RemoteIssueView({
                   </DropdownMenuTrigger>
                 </span>
                 <DropdownMenuContent align="end" className="min-w-52">
+                  {/* A menu item drops pointer events when disabled and has no
+                      room for a title, so the draft promise rides the label —
+                      the same reason-in-label idiom the items above use. */}
                   <DropdownMenuItem onClick={() => doClose("completed")}>
-                    Close as completed
+                    Close as completed{draftSuffix}
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => doClose("not_planned")}>
-                    Close as not planned
+                    Close as not planned{draftSuffix}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -519,15 +585,15 @@ export function RemoteIssueView({
             size="sm"
             disabled={busy || triageBlocked}
             reason={triageReason ?? staleReason}
-            onClick={() =>
-              reopenIssue.mutate(number, {
-                onSuccess: () => toast.success(`Reopened #${number}`),
-                onError,
-              })
+            onClick={doReopen}
+            title={
+              draftRidesStateChange
+                ? "Reopens and posts your draft as a comment"
+                : undefined
             }
           >
             <ArrowCounterClockwiseIcon data-icon="inline-start" />
-            Reopen
+            {draftRidesStateChange ? "Reopen with comment" : "Reopen"}
           </DisabledReasonButton>
         ))}
     </>

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -313,8 +313,10 @@ export const usePlanStore = create<PlanState>((set, get) => {
             // Keep what a killed run wrote — a whole-message agent (codex) delivers it
             // only here, so adopt it when nothing streamed and fold it in exactly as the
             // done branch does. `errored` returns before `extractPlanDraft` below, so a
-            // truncated plan can still never become a draft.
-            if (ev.partialText?.trim() && !finalText) {
+            // truncated plan can still never become a draft. Superseded-guarded like the
+            // error patch: a stopped or restarted run's dying event must not write into
+            // the transcript that replaced it.
+            if (!superseded() && ev.partialText?.trim() && !finalText) {
               finalText = ev.partialText;
               const cur = get().runs.find((r) => r.id === id);
               patch(id, {

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -310,6 +310,18 @@ export const usePlanStore = create<PlanState>((set, get) => {
             }
           } else if (ev.kind === "error") {
             errored = true;
+            // Keep what a killed run wrote — a whole-message agent (codex) delivers it
+            // only here, so adopt it when nothing streamed and fold it in exactly as the
+            // done branch does. `errored` returns before `extractPlanDraft` below, so a
+            // truncated plan can still never become a draft.
+            if (ev.partialText?.trim() && !finalText) {
+              finalText = ev.partialText;
+              const cur = get().runs.find((r) => r.id === id);
+              patch(id, {
+                text: finalText,
+                segments: ensureTranscriptText(cur?.segments ?? [], finalText),
+              });
+            }
             if (!superseded()) patch(id, { error: ev.message });
           }
         },

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -342,6 +342,46 @@ export function LocalPrView({
     });
   }
 
+  // A typed note rides Close/Reopen rather than being discarded by them.
+  const draftRidesStateChange = !!comment.trim();
+
+  /** Close/Reopen, carrying any typed note. The note is appended in the SAME
+   *  record mutation as the status flip, so the store can never persist one
+   *  without the other; the draft clears only once that write lands. */
+  function setStatus(next: "open" | "closed") {
+    // Appending the note makes this non-idempotent, and the mutate callback
+    // re-reads the record from disk — so a second click lands after the first
+    // note is already stored and would post it twice.
+    if (!pr || update.isPending) return;
+    const note = comment.trim();
+    update.mutate(
+      {
+        id: pr.id,
+        mutate: (cur) => ({
+          ...cur,
+          comments: note
+            ? [
+                ...cur.comments,
+                {
+                  id: crypto.randomUUID(),
+                  body: note,
+                  createdAt: new Date().toISOString(),
+                },
+              ]
+            : cur.comments,
+          status: next,
+          closedAt: next === "closed" ? new Date().toISOString() : undefined,
+        }),
+      },
+      {
+        onSuccess: () => setComment(""),
+        // Nothing was written, the note included — say so rather than leave a
+        // silent no-op behind a button that promised to post it.
+        onError: toastError,
+      },
+    );
+  }
+
   function openEdit() {
     if (!pr) return;
     // The chips OWN the trailing ref block: peel any exact `Closes #N` /
@@ -938,21 +978,19 @@ export function LocalPrView({
                 {ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}
               </Button>
             )}
+            {/* The label swaps while a note rides along: the action changed
+                meaning, and only the label reaches a viewer before the click. */}
             <Button
               variant="outline"
               size="sm"
-              onClick={() =>
-                update.mutate({
-                  id: pr.id,
-                  mutate: (cur) => ({
-                    ...cur,
-                    status: "closed",
-                    closedAt: new Date().toISOString(),
-                  }),
-                })
+              onClick={() => setStatus("closed")}
+              title={
+                draftRidesStateChange
+                  ? "Closes and posts your draft as a comment"
+                  : undefined
               }
             >
-              Close
+              {draftRidesStateChange ? "Close with comment" : "Close"}
             </Button>
             <span className="flex-1" />
             {/* GitHub-style "Update branch": only when head has fallen behind
@@ -1055,19 +1093,15 @@ export function LocalPrView({
             <Button
               variant="outline"
               size="sm"
-              onClick={() =>
-                update.mutate({
-                  id: pr.id,
-                  mutate: (cur) => ({
-                    ...cur,
-                    status: "open",
-                    closedAt: undefined,
-                  }),
-                })
+              onClick={() => setStatus("open")}
+              title={
+                draftRidesStateChange
+                  ? "Reopens and posts your draft as a comment"
+                  : undefined
               }
             >
               <ArrowCounterClockwiseIcon data-icon="inline-start" />
-              Reopen
+              {draftRidesStateChange ? "Reopen with comment" : "Reopen"}
             </Button>
           </>
         )}

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -21,6 +21,7 @@ import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -980,9 +981,11 @@ export function LocalPrView({
             )}
             {/* The label swaps while a note rides along: the action changed
                 meaning, and only the label reaches a viewer before the click. */}
-            <Button
+            <DisabledReasonButton
               variant="outline"
               size="sm"
+              disabled={update.isPending}
+              reason="Saving…"
               onClick={() => setStatus("closed")}
               title={
                 draftRidesStateChange
@@ -991,7 +994,7 @@ export function LocalPrView({
               }
             >
               {draftRidesStateChange ? "Close with comment" : "Close"}
-            </Button>
+            </DisabledReasonButton>
             <span className="flex-1" />
             {/* GitHub-style "Update branch": only when head has fallen behind
                 base. Merges base into head (in a throwaway worktree, so it
@@ -1090,9 +1093,11 @@ export function LocalPrView({
         {pr.status === "closed" && (
           <>
             <span className="flex-1" />
-            <Button
+            <DisabledReasonButton
               variant="outline"
               size="sm"
+              disabled={update.isPending}
+              reason="Saving…"
               onClick={() => setStatus("open")}
               title={
                 draftRidesStateChange
@@ -1102,7 +1107,7 @@ export function LocalPrView({
             >
               <ArrowCounterClockwiseIcon data-icon="inline-start" />
               {draftRidesStateChange ? "Reopen with comment" : "Reopen"}
-            </Button>
+            </DisabledReasonButton>
           </>
         )}
       </div>

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -19,9 +19,9 @@ import {
 import type { ReactNode } from "react";
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
-import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -56,6 +56,7 @@ import {
   type PersistedReview,
   partialReviewReason,
   reviewPartialKey,
+  reviewText,
 } from "@/lib/pulls/reviews-history";
 import { useSecretPreview, useSettings } from "@/lib/settings/queries";
 import { useConfirm } from "@/lib/stores/confirm";
@@ -80,12 +81,6 @@ const DELTA_NOTE: Partial<Record<string, string>> = {
 };
 
 const PROVIDER_IDS = Object.keys(PROVIDER_LABELS) as AiProviderId[];
-
-/** A stored review's findings text. The plugin-store JSON is untrusted (a
- *  hand-edited `pr-reviews.json` reaches here verbatim), so a non-string `text` reads
- *  as no text instead of throwing mid-render. */
-const reviewText = (r: PersistedReview): string =>
-  typeof r.text === "string" ? r.text : "";
 
 export function PrReviewPanel({
   context,
@@ -360,7 +355,10 @@ export function PrReviewPanel({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="space-y-2 border-b p-3">
+      {/* shrink-0: the header holds growable content (banners, the history disclosure),
+          and a flex child that may shrink would squeeze the output ScrollArea below to
+          nothing instead of scrolling itself. */}
+      <div className="shrink-0 space-y-2 border-b p-3">
         {/* DOM capture, not Base UI event props. Pointer-down is load-bearing:
             WebKit doesn't focus buttons on click, and the Select moves focus into
             a portalled popup outside this container. */}
@@ -792,6 +790,19 @@ export function PrReviewPanel({
                 </span>
               </p>
               <Markdown>{reviewText(keptPartial)}</Markdown>
+              {/* After a restart this record is the only copy of the output, so it needs
+                  its own copy path — the live run's Copy above is gone with the run. */}
+              <Button
+                variant="ghost"
+                size="xs"
+                className="text-muted-foreground"
+                onClick={() =>
+                  copyText(reviewText(keptPartial), "Partial output copied")
+                }
+              >
+                <CopyIcon data-icon="inline-start" />
+                Copy
+              </Button>
             </div>
           ) : (
             <p className="text-xs text-muted-foreground">

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -162,7 +162,7 @@ import { useAiEnabled } from "@/lib/settings/queries";
 import { useConfirm } from "@/lib/stores/confirm";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { useUiStore } from "@/lib/stores/ui";
-import { toastError } from "@/lib/toast";
+import { toastError, toastErrorWithNote } from "@/lib/toast";
 import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
@@ -1345,6 +1345,78 @@ export function RemotePrView({
         },
       },
     );
+  }
+
+  // A typed draft rides Close/Reopen rather than being discarded by them. Gated
+  // on `canComment` so the labels below never promise a comment the provider
+  // won't take.
+  const draftRidesStateChange = canComment && !!compose.value.trim();
+
+  /** Posts the riding draft ahead of a state change. False means the comment
+   *  failed and the state change is abandoned: the draft stays put for a retry,
+   *  so a lost note can never be the price of a failed close. */
+  async function postRidingDraft(): Promise<boolean> {
+    if (!draftRidesStateChange) return true;
+    const body = compose.value.trim();
+    const submittedFor = entityKey;
+    try {
+      await comment.mutateAsync({
+        number,
+        body,
+        author: forge.data?.login ?? "You",
+      });
+      // Only a landed comment clears the draft.
+      compose.clearFor(submittedFor);
+      return true;
+    } catch (e) {
+      onError(e);
+      return false;
+    }
+  }
+
+  async function doClose() {
+    // Captured before the await: posting clears the draft, and the error arm
+    // below has to know a comment already went out.
+    const withComment = draftRidesStateChange;
+    if (!(await postRidingDraft())) return;
+    closePr.mutate(number, {
+      // The riding comment posts through `mutateAsync`, which skips the
+      // "Comment added" toast the ordinary submit gets, so the confirmation
+      // here has to account for both writes.
+      onSuccess: () =>
+        toast.success(
+          withComment
+            ? `Closed #${number} and posted your comment`
+            : `Closed #${number}`,
+        ),
+      onError: (e) =>
+        withComment
+          ? toastErrorWithNote(
+              e,
+              "Your comment was posted, but closing failed — try Close again.",
+            )
+          : onError(e),
+    });
+  }
+
+  async function doReopen() {
+    const withComment = draftRidesStateChange;
+    if (!(await postRidingDraft())) return;
+    reopenPr.mutate(number, {
+      onSuccess: () =>
+        toast.success(
+          withComment
+            ? `Reopened #${number} and posted your comment`
+            : `Reopened #${number}`,
+        ),
+      onError: (e) =>
+        withComment
+          ? toastErrorWithNote(
+              e,
+              "Your comment was posted, but reopening failed — try Reopen again.",
+            )
+          : onError(e),
+    });
   }
 
   function confirmMerge() {
@@ -2840,19 +2912,21 @@ export function RemotePrView({
           )}
           <span className="flex-1" />
           {canChangeState && (
+            // The label swaps while a draft rides along: the action changed
+            // meaning, and only the label reaches a viewer before the click.
             <DisabledReasonButton
               variant="outline"
               size="sm"
               disabled={busy || triageBlocked}
               reason={triageReason ?? staleReason}
-              onClick={() =>
-                closePr.mutate(number, {
-                  onSuccess: () => toast.success(`Closed #${number}`),
-                  onError,
-                })
+              onClick={doClose}
+              title={
+                draftRidesStateChange
+                  ? "Closes and posts your draft as a comment"
+                  : undefined
               }
             >
-              Close
+              {draftRidesStateChange ? "Close with comment" : "Close"}
             </DisabledReasonButton>
           )}
           {canMerge && (
@@ -2952,15 +3026,15 @@ export function RemotePrView({
             size="sm"
             disabled={busy || triageBlocked}
             reason={triageReason ?? staleReason}
-            onClick={() =>
-              reopenPr.mutate(number, {
-                onSuccess: () => toast.success(`Reopened #${number}`),
-                onError,
-              })
+            onClick={doReopen}
+            title={
+              draftRidesStateChange
+                ? "Reopens and posts your draft as a comment"
+                : undefined
             }
           >
             <ArrowCounterClockwiseIcon data-icon="inline-start" />
-            Reopen
+            {draftRidesStateChange ? "Reopen with comment" : "Reopen"}
           </DisabledReasonButton>
         </div>
       )}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1375,6 +1375,9 @@ export function RemotePrView({
   }
 
   async function doClose() {
+    // Re-checked in the handler: the footer disables on the same hold, but a
+    // click can land across a selection switch before the disable repaints.
+    if (busy || triageBlocked) return;
     // Captured before the await: posting clears the draft, and the error arm
     // below has to know a comment already went out.
     const withComment = draftRidesStateChange;
@@ -1400,6 +1403,7 @@ export function RemotePrView({
   }
 
   async function doReopen() {
+    if (busy || triageBlocked) return;
     const withComment = draftRidesStateChange;
     if (!(await postRidingDraft())) return;
     reopenPr.mutate(number, {

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -1,6 +1,7 @@
 import {
   CaretDownIcon,
   CaretRightIcon,
+  CopyIcon,
   PencilSimpleIcon,
   TrashIcon,
 } from "@phosphor-icons/react";
@@ -10,24 +11,32 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { Textarea } from "@/components/ui/textarea";
+import { copyText } from "@/lib/clipboard";
 import type { RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
   useClearReviews,
   useDeleteReview,
   useReviewHistory,
+  useReviewPartials,
   useUpdateReviewText,
 } from "@/lib/pulls/queries";
+import {
+  isPartialReview,
+  partialReviewReason,
+  reviewText,
+} from "@/lib/pulls/reviews-history";
 import { formatDuration, validEpochMs } from "@/lib/time";
 import { ThoughtsDisclosure } from "./ThoughtsDisclosure";
 
 /**
- * The "Previous reviews" disclosure — past AI reviews for this PR (both modes),
- * each expandable to its text. The latest per mode is what the next run feeds as
- * soft context, so each row is **editable** ("trim before re-running"): deleting
- * a false finding here persists, and the trimmed text is what travels next round.
- * Rows are arrow-key navigable; every text surface is `ph-no-capture` (it quotes
- * the user's source + AI output).
+ * The "Previous reviews" disclosure — past AI reviews for this PR (both modes) plus
+ * any kept partial output from a run that stopped early, each expandable to its text.
+ * The latest completed review per mode is what the next run feeds as soft context, so
+ * those rows are **editable** ("trim before re-running"): deleting a false finding here
+ * persists, and the trimmed text is what travels next round. Kept partials feed nothing,
+ * so they offer no trim. Rows are arrow-key navigable; every text surface is
+ * `ph-no-capture` (it quotes the user's source + AI output).
  */
 export function ReviewHistory({
   repoPath,
@@ -43,6 +52,7 @@ export function ReviewHistory({
   prRef: string;
 }) {
   const history = useReviewHistory(repoPath, lens, prKind, prRef);
+  const partials = useReviewPartials(repoPath, lens, prKind, prRef);
   const del = useDeleteReview(repoPath, lens, prKind, prRef);
   const clear = useClearReviews(repoPath, lens, prKind, prRef);
   const update = useUpdateReviewText(repoPath, lens, prKind, prRef);
@@ -53,7 +63,13 @@ export function ReviewHistory({
   const [confirmingClear, setConfirmingClear] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
 
-  const records = history.data ?? [];
+  // ONE list: completed reviews and kept partial runs interleave by time, so the
+  // disclosure, its count, and the arrow-key walk all cover every stored record — a PR
+  // whose only record is a kept partial still gets its row (and its Clear).
+  const partialRecords = partials.data ?? [];
+  const records = [...(history.data ?? []), ...partialRecords].sort(
+    (a, b) => b.finishedAt - a.finishedAt,
+  );
   if (records.length === 0) return null;
 
   function toggleExpand(id: string) {
@@ -97,8 +113,12 @@ export function ReviewHistory({
         {open &&
           (confirmingClear ? (
             <span className="ml-auto flex items-center gap-1">
+              {/* Clearing takes the kept partials with it (the store's filter carries no
+                  phase test), so say so whenever there is one to lose. */}
               <span className="text-muted-foreground">
-                Clear this PR's history?
+                {partialRecords.length > 0
+                  ? "Clear this PR's history, including the kept partial output?"
+                  : "Clear this PR's history?"}
               </span>
               <Button
                 variant="ghost"
@@ -152,6 +172,7 @@ export function ReviewHistory({
               r.finishedAt - r.startedAt > 0
                 ? formatDuration(r.finishedAt - r.startedAt)
                 : null;
+            const partial = isPartialReview(r);
             return (
               <div key={r.id} role="listitem" className="border">
                 <div className="flex items-center gap-2 px-2 py-1">
@@ -173,6 +194,17 @@ export function ReviewHistory({
                     <Badge variant="secondary" className="shrink-0">
                       {r.mode === "security" ? "Security" : "Review"}
                     </Badge>
+                    {/* Says in words what the tone shows — kept output is not a review. */}
+                    {partial && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 border-warning/40 bg-warning/10 text-warning"
+                      >
+                        {partialReviewReason(r).timedOut
+                          ? "Timed out — partial output"
+                          : "Stopped early"}
+                      </Badge>
+                    )}
                     <span className="truncate font-mono text-muted-foreground">
                       {r.model || "model"}
                     </span>
@@ -194,7 +226,11 @@ export function ReviewHistory({
                   </button>
                   <button
                     type="button"
-                    aria-label="Delete this review from history"
+                    aria-label={
+                      partial
+                        ? "Delete this kept partial output from history"
+                        : "Delete this review from history"
+                    }
                     className="shrink-0 text-muted-foreground hover:text-destructive"
                     onClick={() => del.mutate(r.id)}
                   >
@@ -235,19 +271,44 @@ export function ReviewHistory({
                       </div>
                     ) : (
                       <>
-                        <Markdown>{r.text}</Markdown>
-                        {r.thoughts?.trim() && (
-                          <ThoughtsDisclosure thoughts={r.thoughts} />
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="xs"
-                          className="mt-1 text-muted-foreground"
-                          onClick={() => startEdit(r.id, r.text)}
-                        >
-                          <PencilSimpleIcon data-icon="inline-start" />
-                          Trim before re-running
-                        </Button>
+                        {/* Capped + self-scrolling: an expanded review is arbitrarily long,
+                            and this disclosure sits in the panel's fixed header, above the
+                            Close/Merge controls. */}
+                        <div className="max-h-64 overflow-y-auto">
+                          <Markdown>{reviewText(r)}</Markdown>
+                          {r.thoughts?.trim() && (
+                            <ThoughtsDisclosure thoughts={r.thoughts} />
+                          )}
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-1">
+                          {/* Kept output feeds no later run, so it gets no trim — only the
+                              copy path, since it may be the only copy left. */}
+                          {!partial && (
+                            <Button
+                              variant="ghost"
+                              size="xs"
+                              className="text-muted-foreground"
+                              onClick={() => startEdit(r.id, reviewText(r))}
+                            >
+                              <PencilSimpleIcon data-icon="inline-start" />
+                              Trim before re-running
+                            </Button>
+                          )}
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            className="text-muted-foreground"
+                            onClick={() =>
+                              copyText(
+                                reviewText(r),
+                                partial ? "Partial output copied" : "Review copied",
+                              )
+                            }
+                          >
+                            <CopyIcon data-icon="inline-start" />
+                            Copy
+                          </Button>
+                        </div>
                       </>
                     )}
                   </div>

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -301,7 +301,9 @@ export function ReviewHistory({
                             onClick={() =>
                               copyText(
                                 reviewText(r),
-                                partial ? "Partial output copied" : "Review copied",
+                                partial
+                                  ? "Partial output copied"
+                                  : "Review copied",
                               )
                             }
                           >

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -599,7 +599,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // keys on this — an untracked-only tree rebases fine, and stashing it
   // unasked would move those files into a stash on any replay conflict.
   const hasTrackedChanges = (status.data?.entries ?? []).some(
-    (e) => e.staged !== null || (e.unstaged !== null && e.unstaged !== "untracked"),
+    (e) =>
+      e.staged !== null || (e.unstaged !== null && e.unstaged !== "untracked"),
   );
   // Naming a branch from changes needs a commit to diff against; an unborn HEAD
   // (no commits) has nothing to compare the working tree to.
@@ -890,9 +891,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       { newBase, oldBase },
       {
         onSuccess: () => toast.success(`Rebased onto ${newBase}`),
-        // `hasChanges` is a query-state read that can trail the tree: a file
-        // saved between the check and the run still deserves the offer, so a
-        // dirty refusal routes back into the same recovery.
+        // `hasTrackedChanges` is a query-state read that can trail the tree: a
+        // file saved between the check and the run still deserves the offer, so
+        // a dirty refusal routes back into the same recovery.
         onError: (e) => {
           if (recovery.handleError(e, request)) return;
           onError(e);

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -595,6 +595,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   });
   const stashes = stashCount.data ?? 0;
   const hasChanges = (status.data?.entries.length ?? 0) > 0;
+  // Rebase refuses only on dirty TRACKED files, so the proactive stash offer
+  // keys on this — an untracked-only tree rebases fine, and stashing it
+  // unasked would move those files into a stash on any replay conflict.
+  const hasTrackedChanges = (status.data?.entries ?? []).some(
+    (e) => e.staged !== null || (e.unstaged !== null && e.unstaged !== "untracked"),
+  );
   // Naming a branch from changes needs a commit to diff against; an unborn HEAD
   // (no commits) has nothing to compare the working tree to.
   const headExists = Boolean(head?.oid);
@@ -868,22 +874,29 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // compound up front beats a round-trip that can only fail.
   function runRebaseOnto(newBase: string, oldBase: string) {
     setRebaseOntoOpen(false);
-    if (hasChanges) {
-      recovery.begin({
-        operationLabel: "rebase",
-        detail: newBase,
-        detailPreposition: "onto",
-        reappliedMessage: `Rebased onto ${newBase} and reapplied your changes.`,
-        plainMessage: `Rebased onto ${newBase}`,
-        run: { op: "rebaseOnto", newBase, oldBase },
-      });
+    const request = {
+      operationLabel: "rebase",
+      detail: newBase,
+      detailPreposition: "onto",
+      reappliedMessage: `Rebased onto ${newBase} and reapplied your changes.`,
+      plainMessage: `Rebased onto ${newBase}`,
+      run: { op: "rebaseOnto", newBase, oldBase },
+    } as const;
+    if (hasTrackedChanges) {
+      recovery.begin(request);
       return;
     }
     rebaseOnto.mutate(
       { newBase, oldBase },
       {
         onSuccess: () => toast.success(`Rebased onto ${newBase}`),
-        onError,
+        // `hasChanges` is a query-state read that can trail the tree: a file
+        // saved between the check and the run still deserves the offer, so a
+        // dirty refusal routes back into the same recovery.
+        onError: (e) => {
+          if (recovery.handleError(e, request)) return;
+          onError(e);
+        },
       },
     );
   }

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -92,7 +92,10 @@ import {
   type MergeRunOptions,
   type PickerMode,
 } from "./BranchMergePickerDialog";
-import { CleanupBranchesDialog } from "./CleanupBranchesDialog";
+import {
+  CleanupBranchesDialog,
+  prCheckStateFrom,
+} from "./CleanupBranchesDialog";
 import { CreateBranchDialog } from "./CreateBranchDialog";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
 import { ForkPrPublishGuard } from "./ForkPrPublishGuard";
@@ -787,6 +790,20 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     });
   }
 
+  // Rebase refuses on ANY dirty tracked file, not just one the replay would
+  // touch, so this dead-ends more often than the merge above — offer the same
+  // stash → rebase → reapply compound. `false` leaves the error to the caller.
+  function beginRebaseRecovery(e: unknown, branch: string) {
+    return recovery.handleError(e, {
+      operationLabel: "rebase",
+      detail: branch,
+      detailPreposition: "onto",
+      reappliedMessage: `Rebased onto ${branch} and reapplied your changes.`,
+      plainMessage: `Rebased onto ${branch}`,
+      run: { op: "rebase", ref: branch },
+    });
+  }
+
   // The dialog collects the branch + options; the switcher owns the mutations
   // (they feed `busy`) and dispatches them here after closing the picker.
   function runPicker(
@@ -798,7 +815,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     if (mode === "rebase") {
       rebaseBranch.mutate(branch, {
         onSuccess: () => toast.success(`Rebased onto ${branch}`),
-        onError,
+        onError: (e) => {
+          if (beginRebaseRecovery(e, branch)) return;
+          onError(e);
+        },
       });
     } else {
       const squash = mode === "squash";
@@ -842,8 +862,23 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // The dialog collects the two branches; the switcher owns the mutation (it
   // feeds `busy`). Conflicts leave the rebase in progress for the conflict
   // banner, exactly like the plain rebase above.
+  //
+  // Proactive rather than error-triggered: the dialog already knows the tree is
+  // dirty, and git would refuse before touching anything, so offering the
+  // compound up front beats a round-trip that can only fail.
   function runRebaseOnto(newBase: string, oldBase: string) {
     setRebaseOntoOpen(false);
+    if (hasChanges) {
+      recovery.begin({
+        operationLabel: "rebase",
+        detail: newBase,
+        detailPreposition: "onto",
+        reappliedMessage: `Rebased onto ${newBase} and reapplied your changes.`,
+        plainMessage: `Rebased onto ${newBase}`,
+        run: { op: "rebaseOnto", newBase, oldBase },
+      });
+      return;
+    }
     rebaseOnto.mutate(
       { newBase, oldBase },
       {
@@ -2077,14 +2112,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
         isInWorktree={(name) => worktreeByBranch.has(name)}
         prMergedByBranch={mergedPrByBranch}
-        // Only the closed list carries merged PRs. A failed read ends the wait
-        // but is not an answer, so the dialog is told which of the two it got.
-        prMergedPending={
-          prsWanted &&
-          !closedPrs.isError &&
-          (closedPrs.isFetching || closedPrs.isPlaceholderData)
-        }
-        prMergedFailed={prsWanted && closedPrs.isError}
+        // Only the closed list carries merged PRs, and `canGh` is what says the
+        // query runs at all — so the dialog is told which of the four it got,
+        // never-ran included.
+        prCheckState={prCheckStateFrom(canGh, closedPrs)}
       />
 
       <ConfirmDialog
@@ -2268,7 +2299,6 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         otherBranches={otherBranches}
         currentLabel={currentLabel}
         defaultBranch={defaultName}
-        hasChanges={hasChanges}
         isPushed={Boolean(head?.upstream) && !head?.upstreamGone}
       />
 

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -84,7 +84,9 @@ export function prCheckStateFrom(
 
 /** The empty state's merged clause, per PR-check outcome. It names pull requests
  *  only where they were actually read: a failed read gets its own caveat below,
- *  and a check that never ran says nothing about them either way. */
+ *  and a check that never ran says nothing about them either way. The `pending`
+ *  arm is unreachable — `checkingMerged` paints the skeleton over this empty
+ *  state — and mirrors `checked` only to keep the record total. */
 const EMPTY_MERGED_CLAUSE: Record<PrCheckState, string> = {
   checked:
     ", directly or through a recent pull request, and nothing is idle for ",
@@ -402,9 +404,12 @@ export function CleanupBranchesDialog({
               <span className="font-mono">
                 {defaultBranch ?? "the default branch"}
               </span>
-              {prCheckState === "unavailable"
-                ? ", or with no commits in a while. "
-                : " — directly or through a recent pull request — or with no commits in a while. "}
+              {/* The clause claims pull requests contribute, so it renders only
+                  while that is true or underway — a FAILED check's note below
+                  says the opposite, and the two must never disagree. */}
+              {prCheckState === "checked" || prCheckState === "pending"
+                ? " — directly or through a recent pull request — or with no commits in a while. "
+                : ", or with no commits in a while. "}
               {mode === "archive"
                 ? "Archiving hides them from the switcher — unarchive anytime."
                 : "Deleting removes them permanently, including commits only on them."}

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -43,6 +43,57 @@ interface Candidate {
 
 const pluralBranches = (n: number) => `${n} branch${n === 1 ? "" : "es"}`;
 
+/**
+ * What the dialog is entitled to say about the pull-request half of merged
+ * detection: `"unavailable"` — it never ran, so pull requests go unmentioned;
+ * `"pending"` — still reading; `"failed"` — the read failed, which is a coverage
+ * gap worth naming; `"checked"` — read and complete.
+ */
+export type PrCheckState = "unavailable" | "pending" | "failed" | "checked";
+
+/**
+ * Derives that state from the forge capability and the closed-PR query. It takes
+ * `canGh` rather than the query flags alone because a repo whose forge has no
+ * pull requests never STARTS the query: its flags are indistinguishable from a
+ * finished, empty read, and "we looked and found none" is a claim the app hasn't
+ * earned there.
+ *
+ * `isPending` carries the same weight for a query that HAS started: status-pending
+ * means no data yet, which is also how an offline read looks, since react-query's
+ * default `networkMode: "online"` PAUSES the fetch rather than failing it
+ * (`isFetching` false, `isError` false). Without that arm an offline dialog would
+ * claim the pull requests came back clean.
+ */
+export function prCheckStateFrom(
+  canGh: boolean,
+  closedPrs: {
+    isError: boolean;
+    isPending: boolean;
+    isFetching: boolean;
+    isPlaceholderData: boolean;
+  },
+): PrCheckState {
+  if (!canGh) return "unavailable";
+  if (closedPrs.isError) return "failed";
+  if (closedPrs.isPending) return "pending";
+  // Data in hand, but a background refetch or a previous key's rows: still not an
+  // answer about THIS repo's pull requests.
+  if (closedPrs.isFetching || closedPrs.isPlaceholderData) return "pending";
+  return "checked";
+}
+
+/** The empty state's merged clause, per PR-check outcome. It names pull requests
+ *  only where they were actually read: a failed read gets its own caveat below,
+ *  and a check that never ran says nothing about them either way. */
+const EMPTY_MERGED_CLAUSE: Record<PrCheckState, string> = {
+  checked:
+    ", directly or through a recent pull request, and nothing is idle for ",
+  pending:
+    ", directly or through a recent pull request, and nothing is idle for ",
+  failed: " and nothing is idle for ",
+  unavailable: " and nothing is idle for ",
+};
+
 /** The one state badge a row can carry, in precedence order. Text carries the
  *  meaning — the color never stands alone. */
 function RowBadge({
@@ -96,8 +147,7 @@ export function CleanupBranchesDialog({
   isProtected,
   isInWorktree,
   prMergedByBranch,
-  prMergedPending,
-  prMergedFailed,
+  prCheckState,
 }: {
   repoPath: string;
   open: boolean;
@@ -114,12 +164,10 @@ export function CleanupBranchesDialog({
    *  Name-keyed and limited to the PRs the app has fetched, so it labels rows,
    *  never selects them. */
   prMergedByBranch: Map<string, string>;
-  /** True while that map is still filling — the empty state must not claim the
-   *  pull requests were checked before they were read. */
-  prMergedPending: boolean;
-  /** True when reading them FAILED. A read the app couldn't make is not an
-   *  absence of merges, so the copy drops the pull-request claim and says so. */
-  prMergedFailed: boolean;
+  /** How far the pull-request half of merged detection got. Every line that
+   *  mentions pull requests renders off this: a read that failed says so, and
+   *  one that never ran leaves them out rather than passing for a clean check. */
+  prCheckState: PrCheckState;
 }) {
   const queryClient = useQueryClient();
   // Shared 30s clock: the idle-past-the-window classification below must
@@ -237,7 +285,8 @@ export function CleanupBranchesDialog({
   // Age-based candidates already show instantly (branch data is cached), so this
   // only gates the truly-empty first paint.
   const checkingMerged =
-    (Boolean(defaultBranch) && divergence.isLoading) || prMergedPending;
+    (Boolean(defaultBranch) && divergence.isLoading) ||
+    prCheckState === "pending";
 
   const selectedCount = candidateNames.filter((n) => selected.has(n)).length;
   const allChecked =
@@ -352,9 +401,10 @@ export function CleanupBranchesDialog({
               Local branches already merged into{" "}
               <span className="font-mono">
                 {defaultBranch ?? "the default branch"}
-              </span>{" "}
-              — directly or through a recent pull request — or with no commits
-              in a while.{" "}
+              </span>
+              {prCheckState === "unavailable"
+                ? ", or with no commits in a while. "
+                : " — directly or through a recent pull request — or with no commits in a while. "}
               {mode === "archive"
                 ? "Archiving hides them from the switcher — unarchive anytime."
                 : "Deleting removes them permanently, including commits only on them."}
@@ -464,11 +514,9 @@ export function CleanupBranchesDialog({
               <span className="font-mono">
                 {defaultBranch ?? "the default branch"}
               </span>
-              {prMergedFailed
-                ? " and nothing is idle for "
-                : ", directly or through a recent pull request, and nothing is idle for "}
+              {EMPTY_MERGED_CLAUSE[prCheckState]}
               {windowDays} days. Try a shorter window.
-              {prMergedFailed
+              {prCheckState === "failed"
                 ? " Pull requests couldn't be checked, so a branch merged through one may be missing here."
                 : null}
             </p>
@@ -482,7 +530,7 @@ export function CleanupBranchesDialog({
                   Checking which branches are merged…
                 </p>
               )}
-              {prMergedFailed && (
+              {prCheckState === "failed" && (
                 <p className="px-1 py-1 text-[11px] text-muted-foreground">
                   Pull requests couldn't be checked — a branch merged through
                   one may be missing.

--- a/src/features/repository/DeleteWorktreeDialog.tsx
+++ b/src/features/repository/DeleteWorktreeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,14 +10,31 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { useRemoveUserWorktree } from "@/lib/git/queries";
 import type { UserWorktree } from "@/lib/git/worktree";
+import {
+  registerRemovalListener,
+  useIsRemovingWorktree,
+  useWorktreeRemovalStore,
+} from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
+import { useLatestRef } from "@/lib/use-latest-ref";
+
+/** Last path segment, tolerating both separators — what to call a detached
+ *  worktree that has no branch name. */
+function folderName(p: string) {
+  const parts = p.replace(/[/\\]+$/, "").split(/[/\\]/);
+  return parts[parts.length - 1] || p;
+}
 
 /**
  * Confirms removing a worktree's folder while keeping its branch. Escalates to a
  * force remove when git refuses a dirty or locked worktree. Shared by the
  * worktree manager and the branch switcher's "Delete worktree…" actions.
+ *
+ * The removal itself belongs to `worktree-removal`, not this dialog: it can run
+ * for minutes, and closing the dialog must not take its spinner (or its failure)
+ * with it. While one runs this dialog is a view of it — dismissible, with no
+ * cancel to offer.
  */
 export function DeleteWorktreeDialog({
   repoPath,
@@ -28,34 +45,52 @@ export function DeleteWorktreeDialog({
   worktree: UserWorktree | null;
   onClose: () => void;
 }) {
-  const remove = useRemoveUserWorktree(repoPath);
+  const startRemoval = useWorktreeRemovalStore((s) => s.startRemoval);
+  const removing = useIsRemovingWorktree(repoPath, worktree?.path);
   // A locked worktree always needs --force; a dirty one reveals it on first try.
   const [forceNeeded, setForceNeeded] = useState(worktree?.isLocked ?? false);
 
+  // Behind a ref because the store invokes these from its own async stack, long
+  // after the render that wrote them: what gets registered is a plain object
+  // whose methods read the ref, so nothing bound to a render escapes into the
+  // module-level registry.
+  const handlersRef = useLatestRef({
+    onSuccess: () => onClose(),
+    onError: (e: unknown, force: boolean) => {
+      if (!worktree) return;
+      const msg = String((e as { message?: string })?.message ?? e);
+      // git refuses a non-force remove of a dirty/locked worktree; surface
+      // the escalation rather than failing silently. The path is stripped
+      // first so a folder NAMED e.g. "locked-tools" can't turn every
+      // refusal into a force offer.
+      const reason = msg.replaceAll(worktree.path, "");
+      if (!force && /force|modified|untracked|locked/i.test(reason)) {
+        setForceNeeded(true);
+      } else {
+        toastError(e);
+      }
+    },
+  });
+
+  // Claim this target's outcome for as long as the dialog is mounted; the store
+  // falls back to a toast once it isn't, so a failure surfaces exactly once.
+  useEffect(() => {
+    if (!worktree) return;
+    return registerRemovalListener(repoPath, worktree.path, {
+      onSuccess: () => handlersRef.current.onSuccess(),
+      onError: (e, force) => handlersRef.current.onError(e, force),
+    });
+  }, [repoPath, worktree]);
+
   function doRemove(force: boolean) {
     if (!worktree) return;
-    remove.mutate(
-      { path: worktree.path, force },
-      {
-        onSuccess: () => {
-          toast.success("Worktree removed");
-          onClose();
-        },
-        onError: (e) => {
-          const msg = String((e as { message?: string })?.message ?? e);
-          // git refuses a non-force remove of a dirty/locked worktree; surface
-          // the escalation rather than failing silently. The path is stripped
-          // first so a folder NAMED e.g. "locked-tools" can't turn every
-          // refusal into a force offer.
-          const reason = msg.replaceAll(worktree.path, "");
-          if (!force && /force|modified|untracked|locked/i.test(reason)) {
-            setForceNeeded(true);
-          } else {
-            toastError(e);
-          }
-        },
-      },
-    );
+    const refused = startRemoval({
+      repoPath,
+      path: worktree.path,
+      name: worktree.branch || folderName(worktree.path),
+      force,
+    });
+    if (refused) toast.info(refused);
   }
 
   return (
@@ -90,21 +125,26 @@ export function DeleteWorktreeDialog({
             This worktree has uncommitted changes. Force-removing discards them.
           </p>
         )}
+        {removing && (
+          <p className="text-xs text-muted-foreground">
+            Removing a worktree can take a few minutes. You can close this and
+            keep working; it stays visible at the top of the repository until it
+            finishes.
+          </p>
+        )}
 
         <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={onClose}
-            disabled={remove.isPending}
-          >
-            Cancel
+          <Button variant="outline" onClick={onClose}>
+            {/* Never "Cancel" while a removal runs: closing this dialog is all
+                it does — the removal itself can't be called off. */}
+            {removing ? "Close" : "Cancel"}
           </Button>
           <Button
             variant="destructive"
-            disabled={remove.isPending}
+            disabled={removing}
             onClick={() => doRemove(forceNeeded)}
           >
-            {remove.isPending && <Spinner data-icon="inline-start" />}
+            {removing && <Spinner data-icon="inline-start" />}
             {forceNeeded ? "Force remove" : "Remove"}
           </Button>
         </DialogFooter>

--- a/src/features/repository/RebaseOntoDialog.tsx
+++ b/src/features/repository/RebaseOntoDialog.tsx
@@ -44,7 +44,6 @@ export function RebaseOntoDialog({
   otherBranches,
   currentLabel,
   defaultBranch,
-  hasChanges,
   isPushed,
 }: {
   repoPath: string;
@@ -55,8 +54,6 @@ export function RebaseOntoDialog({
   otherBranches: Branch[];
   currentLabel: string;
   defaultBranch: string | null;
-  /** Dirty working tree — a rebase can't run until it's clean. */
-  hasChanges: boolean;
   /** The current branch tracks a remote — rebasing will need a force-push. */
   isPushed: boolean;
 }) {
@@ -92,12 +89,10 @@ export function RebaseOntoDialog({
   );
   const moving = comparison.data?.ahead ?? [];
   const movingCount = moving.length;
+  // No clean-tree term: uncommitted changes are handled by the caller's stash →
+  // rebase → reapply offer, not by blocking the run.
   const canRun =
-    !hasChanges &&
-    Boolean(newBase) &&
-    Boolean(oldBase) &&
-    !sameBranch &&
-    movingCount > 0;
+    Boolean(newBase) && Boolean(oldBase) && !sameBranch && movingCount > 0;
 
   function run() {
     if (!canRun) return;
@@ -105,17 +100,6 @@ export function RebaseOntoDialog({
   }
 
   function renderPreview() {
-    if (hasChanges) {
-      return (
-        <span className="flex items-start gap-1.5 text-warning">
-          <WarningIcon className="mt-px size-3.5 shrink-0" />
-          <span>
-            Commit or stash your changes first — a rebase needs a clean working
-            tree.
-          </span>
-        </span>
-      );
-    }
     if (sameBranch) {
       return (
         <span className="text-muted-foreground">

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -84,6 +84,7 @@ import { OpRecoveryBanner } from "./OpRecoveryBanner";
 import { RepoHeader } from "./RepoHeader";
 import { usePrNotifications } from "./usePrNotifications";
 import { useRepoVisibilityProbe } from "./useRepoVisibilityProbe";
+import { WorktreeRemovalBanner } from "./WorktreeRemovalBanner";
 
 // Base OS window title. In a `tauri dev` session (Vite serving) it gets a
 // "(Dev)" suffix so the dev instance is tellable apart in the taskbar / Alt-Tab
@@ -399,6 +400,7 @@ export function RepositoryView() {
     <div className="flex min-h-0 flex-1 flex-col">
       <RepoHeader repoPath={repoPath} />
       <OpRecoveryBanner repoPath={repoPath} />
+      <WorktreeRemovalBanner repoPath={repoPath} />
       <div className="flex min-h-0 flex-1">
         <aside className="flex w-96 shrink-0 flex-col border-r">
           <Tabs

--- a/src/features/repository/StashReapplyDialog.tsx
+++ b/src/features/repository/StashReapplyDialog.tsx
@@ -16,14 +16,18 @@ import { Spinner } from "@/components/ui/spinner";
 export interface StashReapplyTarget {
   operationLabel: string;
   detail?: string;
+  /** Preposition joining `detail` to the operation word. Defaults to "from";
+   *  a rebase runs *onto* its target, so it supplies its own. */
+  detailPreposition?: string;
 }
 
 /**
- * Offered when git refuses a pull, update, or merge because it would overwrite
- * uncommitted changes: set them aside, run the operation, put them back. Open
- * when `target` is the pending recovery (null = closed). Presentational — the
- * caller owns the compound mutation, the pending flag, and persisting the
- * preference when `always` comes back true.
+ * Offered when git refuses a pull, update, merge, or rebase because it would
+ * overwrite uncommitted changes: set them aside, run the operation, put them
+ * back. Open when `target` is the pending recovery (null = closed). Also
+ * offered proactively by a surface that already knows the tree is dirty.
+ * Presentational — the caller owns the compound mutation, the pending flag, and
+ * persisting the preference when `always` comes back true.
  */
 export function StashReapplyDialog({
   target,
@@ -39,6 +43,9 @@ export function StashReapplyDialog({
   const open = target !== null;
   const [always, setAlways] = useState(false);
   const confirmRef = useRef<HTMLButtonElement>(null);
+  const detailPhrase = target?.detail
+    ? ` ${target.detailPreposition ?? "from"} ${target.detail}`
+    : "";
 
   // Reset the checkbox each time the dialog opens — it only ever shows while
   // the preference is off, so a remembered tick would be meaningless.
@@ -62,9 +69,9 @@ export function StashReapplyDialog({
           <DialogDescription>
             GitDesktop can set your uncommitted changes aside, run the{" "}
             {target?.operationLabel}
-            {target?.detail ? ` from ${target.detail}` : ""}, then put them back
-            where they were — including untracked files. If putting them back
-            hits conflicts, your stash is kept as a backup.
+            {detailPhrase}, then put them back where they were — including
+            untracked files. If putting them back hits conflicts, your stash is
+            kept as a backup.
           </DialogDescription>
         </DialogHeader>
         <label className="flex cursor-pointer items-center gap-2 text-xs">

--- a/src/features/repository/WorktreeRemovalBanner.tsx
+++ b/src/features/repository/WorktreeRemovalBanner.tsx
@@ -1,0 +1,36 @@
+import { Spinner } from "@/components/ui/spinner";
+import { useWorktreeRemovals } from "@/lib/stores/worktree-removal";
+
+/**
+ * Keeps a running worktree removal visible after its dialog is dismissed. A
+ * removal holds the repo lock and can run for minutes, so it lives in the repo
+ * view's layout flow (one line per removal, pushing content down) rather than
+ * in a toast that expires or an overlay that covers the header. There is
+ * nothing to press: a removal can't be cancelled, only waited out.
+ */
+export function WorktreeRemovalBanner({ repoPath }: { repoPath: string }) {
+  const removals = useWorktreeRemovals(repoPath);
+
+  return (
+    // Mounted unconditionally: a live region created together with its text
+    // announces unreliably, so the region pre-exists and only its CONTENT
+    // changes. `sr-only` keeps the empty state out of layout entirely, so no
+    // phantom border sits above the panels.
+    // No aria-busy: on a live region it tells a screen reader to withhold
+    // announcements until it clears, the opposite of what this line is for.
+    <div role="status" className={removals.length > 0 ? "border-b" : "sr-only"}>
+      {removals.map((r) => (
+        <div
+          key={r.path}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs"
+        >
+          <Spinner aria-hidden className="size-3.5 shrink-0" />
+          <span className="min-w-0 truncate" title={r.path}>
+            Removing worktree <span className="font-mono">{r.name}</span>… This
+            can take a few minutes.
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -55,6 +55,7 @@ import {
 import type { UserWorktree } from "@/lib/git/worktree";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
+import { useWorktreeRemovals } from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
@@ -148,6 +149,10 @@ function WorktreeList({
 
   const list = worktrees.data ?? [];
   const linkedCount = list.filter((w) => !w.isMain).length;
+  // A row whose folder is being removed still lists (the removal can outlive
+  // this dialog), but nothing may act on it until it settles.
+  const removals = useWorktreeRemovals(repoPath);
+  const removingPaths = new Set(removals.map((r) => r.path));
 
   const onKeyDown = listKeyboardNav({
     items: list,
@@ -159,6 +164,7 @@ function WorktreeList({
 
   async function handleOpen(w: UserWorktree) {
     if (norm(w.path) === activeNorm) return; // already here
+    if (removingPaths.has(w.path)) return; // its folder is going away
     await openWorktree(w.path);
     onClose();
   }
@@ -201,6 +207,7 @@ function WorktreeList({
                 worktree={w}
                 highlighted={i === highlight}
                 isCurrent={norm(w.path) === activeNorm}
+                isRemoving={removingPaths.has(w.path)}
                 onFocus={() => setHighlight(i)}
                 onOpen={() => handleOpen(w)}
                 onRename={() => setRenameTarget(w)}
@@ -287,6 +294,7 @@ function WorktreeRow({
   worktree,
   highlighted,
   isCurrent,
+  isRemoving,
   onFocus,
   onOpen,
   onRename,
@@ -298,6 +306,8 @@ function WorktreeRow({
   worktree: UserWorktree;
   highlighted: boolean;
   isCurrent: boolean;
+  /** Its folder is being removed right now — every action on it is off. */
+  isRemoving: boolean;
   onFocus: () => void;
   onOpen: () => void;
   onRename: () => void;
@@ -307,6 +317,15 @@ function WorktreeRow({
   onPromote: () => void;
 }) {
   const { path, branch, isMain, isDetached, isLocked, lockReason } = worktree;
+
+  // A disabled menu item can't carry a tooltip, so its blocking reason rides the
+  // label. A removal in progress outranks the other reasons — the worktree is on
+  // its way out, whatever else is true of it.
+  const itemLabel = (label: string, otherReason?: string) => {
+    if (isRemoving) return `${label} (removal in progress)`;
+    return otherReason ? `${label} (${otherReason})` : label;
+  };
+  const openTitle = isCurrent ? "Current worktree" : "Open this worktree";
 
   return (
     <div
@@ -325,16 +344,17 @@ function WorktreeRow({
         role="option"
         aria-selected={highlighted}
         // Not `disabled`: the current row must stay focusable so arrow-key nav
-        // can move through it. onOpen already no-ops on the current worktree.
-        aria-disabled={isCurrent || undefined}
+        // can move through it. onOpen already no-ops on the current worktree
+        // and on one being removed.
+        aria-disabled={isCurrent || isRemoving || undefined}
         data-wt-path={path}
         onFocus={onFocus}
         onClick={onOpen}
         className={cn(
           "flex min-w-0 flex-1 items-center gap-2.5 px-3 py-2 text-left",
-          isCurrent && "cursor-default",
+          (isCurrent || isRemoving) && "cursor-default",
         )}
-        title={isCurrent ? "Current worktree" : "Open this worktree"}
+        title={isRemoving ? "Removal in progress" : openTitle}
       >
         <GitBranchIcon
           weight={isCurrent ? "fill" : "regular"}
@@ -354,6 +374,7 @@ function WorktreeRow({
               isDetached={isDetached}
               isLocked={isLocked}
               lockReason={lockReason}
+              isRemoving={isRemoving}
             />
           </span>
           <span
@@ -382,10 +403,11 @@ function WorktreeRow({
           <DotsThreeVerticalIcon />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
-          <DropdownMenuItem disabled={isCurrent} onClick={onOpen}>
+          <DropdownMenuItem disabled={isCurrent || isRemoving} onClick={onOpen}>
             <FolderOpenIcon />
-            {isCurrent ? "Current worktree" : "Open worktree"}
+            {itemLabel(isCurrent ? "Current worktree" : "Open worktree")}
           </DropdownMenuItem>
+          {/* Copying a path acts on nothing, so a removal doesn't block it. */}
           <DropdownMenuItem onClick={() => copyText(path, "Path copied")}>
             <CopyIcon />
             Copy path
@@ -394,44 +416,48 @@ function WorktreeRow({
             // git can't move the main worktree or a locked one, and moving the
             // one you're standing in risks a cwd lock + a stale active path —
             // rename it after switching away.
-            disabled={isMain || isCurrent || isLocked}
+            disabled={isMain || isCurrent || isLocked || isRemoving}
             onClick={onRename}
           >
             <PencilSimpleIcon />
-            {isLocked ? "Rename… (locked)" : "Rename…"}
+            {itemLabel("Rename…", isLocked ? "locked" : undefined)}
           </DropdownMenuItem>
           {!isMain &&
             (isLocked ? (
-              <DropdownMenuItem onClick={onUnlock}>
+              <DropdownMenuItem disabled={isRemoving} onClick={onUnlock}>
                 <LockSimpleOpenIcon />
-                Unlock
+                {itemLabel("Unlock")}
               </DropdownMenuItem>
             ) : (
-              <DropdownMenuItem onClick={onLock}>
+              <DropdownMenuItem disabled={isRemoving} onClick={onLock}>
                 <LockSimpleIcon />
-                Lock…
+                {itemLabel("Lock…")}
               </DropdownMenuItem>
             ))}
           {/* Promote moves this worktree's branch into the main workspace: it
               removes the worktree (a branch can't live in two) and checks the
               branch out in main. Only for a linked worktree that has a branch. */}
           {!isMain && !isDetached && (
-            <DropdownMenuItem disabled={isLocked} onClick={onPromote}>
+            <DropdownMenuItem
+              disabled={isLocked || isRemoving}
+              onClick={onPromote}
+            >
               <ArrowLineUpIcon />
-              {isLocked
-                ? "Promote to main workspace… (locked)"
-                : "Promote to main workspace…"}
+              {itemLabel(
+                "Promote to main workspace…",
+                isLocked ? "locked" : undefined,
+              )}
             </DropdownMenuItem>
           )}
           <DropdownMenuItem
             variant="destructive"
             // Can't delete the main worktree, nor the one you're standing in
             // (it'd leave the app pointing at a removed folder) — switch away first.
-            disabled={isMain || isCurrent}
+            disabled={isMain || isCurrent || isRemoving}
             onClick={onDelete}
           >
             <TrashIcon />
-            Delete worktree…
+            {itemLabel("Delete worktree…")}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -445,15 +471,25 @@ function RowTags({
   isDetached,
   isLocked,
   lockReason,
+  isRemoving,
 }: {
   isMain: boolean;
   isCurrent: boolean;
   isDetached: boolean;
   isLocked: boolean;
   lockReason: string;
+  isRemoving: boolean;
 }) {
   return (
     <>
+      {/* First and in words: it's why every action on this row is off, and the
+          repo banner behind this dialog is the only other place it shows. */}
+      {isRemoving && (
+        <Badge variant="outline" className="shrink-0">
+          <Spinner aria-hidden data-icon="inline-start" />
+          Removing…
+        </Badge>
+      )}
       {isMain && (
         <Badge variant="secondary" className="shrink-0">
           Main

--- a/src/features/repository/useStashReapplyRecovery.tsx
+++ b/src/features/repository/useStashReapplyRecovery.tsx
@@ -2,7 +2,12 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { isDirtyTreeRefusal, presentError } from "@/lib/error-summary";
 import type { AutostashOutcome, PullMode } from "@/lib/git/api";
-import { useMergeAutostash, usePullAutostash } from "@/lib/git/queries";
+import {
+  useMergeAutostash,
+  usePullAutostash,
+  useRebaseAutostash,
+  useRebaseOntoAutostash,
+} from "@/lib/git/queries";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { errorToastAction, toastError, toastErrorWithNote } from "@/lib/toast";
 import {
@@ -90,7 +95,9 @@ export function reportAutostashOutcome(
 /** Which compound to run once the user confirms. */
 export type StashReapplyRun =
   | { op: "pull"; mode: PullMode }
-  | { op: "merge"; ref: string };
+  | { op: "merge"; ref: string }
+  | { op: "rebase"; ref: string }
+  | { op: "rebaseOnto"; newBase: string; oldBase: string };
 
 /** One surface's pending recovery: what to say, and what to run. */
 export interface StashReapplyRequest {
@@ -98,6 +105,9 @@ export interface StashReapplyRequest {
   operationLabel: string;
   /** Optional phrase naming the operation's target, e.g. `upstream/main`. */
   detail?: string;
+  /** Preposition joining `detail` to the operation word in the prompt.
+   *  Defaults to "from"; a rebase runs *onto* its target. */
+  detailPreposition?: string;
   /** Toast for a clean stash → run → reapply. */
   reappliedMessage: string;
   /** Toast when nothing needed stashing. Required — the user confirmed this
@@ -109,8 +119,12 @@ export interface StashReapplyRequest {
 /**
  * The classify → prompt → retry → report choreography shared by every surface
  * that can hit a dirty-tree refusal (pull, update from upstream, update branch
- * from). Owns the prompt's state and the two compound mutations, so a call site
- * only says what it was doing and how to redo it.
+ * from, rebase). Owns the prompt's state and the compound mutations, so a call
+ * site only says what it was doing and how to redo it.
+ *
+ * `begin` is also the proactive entry point: a surface that already knows the
+ * tree is dirty (the rebase-onto dialog) offers the compound instead of letting
+ * git refuse first.
  *
  * With "Always stash and reapply" saved, the prompt is skipped and the compound
  * runs straight away.
@@ -120,9 +134,15 @@ export function useStashReapplyRecovery(repoPath: string) {
   const saveSettings = useSaveSettings();
   const pullAutostash = usePullAutostash(repoPath);
   const mergeAutostash = useMergeAutostash(repoPath);
+  const rebaseAutostash = useRebaseAutostash(repoPath);
+  const rebaseOntoAutostash = useRebaseOntoAutostash(repoPath);
   const [request, setRequest] = useState<StashReapplyRequest | null>(null);
 
-  const pending = pullAutostash.isPending || mergeAutostash.isPending;
+  const pending =
+    pullAutostash.isPending ||
+    mergeAutostash.isPending ||
+    rebaseAutostash.isPending ||
+    rebaseOntoAutostash.isPending;
 
   function runRecovery(req: StashReapplyRequest) {
     const copy: AutostashCopy = {
@@ -140,8 +160,24 @@ export function useStashReapplyRecovery(repoPath: string) {
         toastError(e);
       },
     };
-    if (req.run.op === "pull") pullAutostash.mutate(req.run.mode, opts);
-    else mergeAutostash.mutate(req.run.ref, opts);
+    const run = req.run;
+    switch (run.op) {
+      case "pull":
+        pullAutostash.mutate(run.mode, opts);
+        return;
+      case "merge":
+        mergeAutostash.mutate(run.ref, opts);
+        return;
+      case "rebase":
+        rebaseAutostash.mutate(run.ref, opts);
+        return;
+      case "rebaseOnto":
+        rebaseOntoAutostash.mutate(
+          { newBase: run.newBase, oldBase: run.oldBase },
+          opts,
+        );
+        return;
+    }
   }
 
   /** Start the recovery for an already-classified refusal. */
@@ -179,6 +215,7 @@ export function useStashReapplyRecovery(repoPath: string) {
             ? ({
                 operationLabel: request.operationLabel,
                 detail: request.detail,
+                detailPreposition: request.detailPreposition,
               } satisfies StashReapplyTarget)
             : null
         }

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -389,6 +389,18 @@ export const useResearchStore = create<ResearchState>((set, get) => {
             }
           } else if (ev.kind === "error") {
             errored = true;
+            // Keep what a killed run wrote — a whole-message agent (codex) delivers it
+            // only here, so adopt it when nothing streamed and fold it in exactly as the
+            // done branch does. `errored` returns before `extractResearchReport` below,
+            // so a truncated report can still never become the saved report.
+            if (ev.partialText?.trim() && !finalText) {
+              finalText = ev.partialText;
+              const cur = get().runs.find((r) => r.id === id);
+              patch(id, {
+                text: finalText,
+                segments: ensureTranscriptText(cur?.segments ?? [], finalText),
+              });
+            }
             if (!superseded()) patch(id, { error: ev.message });
           }
         },
@@ -618,6 +630,8 @@ export const useResearchStore = create<ResearchState>((set, get) => {
               if (ev.costUsd != null) patch(id, { costUsd: ev.costUsd });
               if (ev.isError) errored = true;
             } else if (ev.kind === "error") {
+              // A killed distill's `partialText` is deliberately dropped: the errored
+              // path hands off the RAW report, which beats a truncated synthesis of it.
               errored = true;
             }
           },

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -392,8 +392,10 @@ export const useResearchStore = create<ResearchState>((set, get) => {
             // Keep what a killed run wrote — a whole-message agent (codex) delivers it
             // only here, so adopt it when nothing streamed and fold it in exactly as the
             // done branch does. `errored` returns before `extractResearchReport` below,
-            // so a truncated report can still never become the saved report.
-            if (ev.partialText?.trim() && !finalText) {
+            // so a truncated report can still never become the saved report. Superseded-
+            // guarded like the error patch: a stopped or restarted run's dying event
+            // must not write into the transcript that replaced it.
+            if (!superseded() && ev.partialText?.trim() && !finalText) {
               finalText = ev.partialText;
               const cur = get().runs.find((r) => r.id === id);
               patch(id, {

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -420,7 +420,22 @@ async function runTurn(
             statusText: "",
           });
         else if (ev.kind === "error")
-          patchTurn({ status: "error", error: ev.message, statusText: "" });
+          patchTurn({
+            status: "error",
+            error: ev.message,
+            statusText: "",
+            // Keep what a killed turn wrote — a whole-message agent (codex) delivers it
+            // only here, so adopt it when nothing streamed, mirroring the done branch.
+            ...(ev.partialText?.trim() && !last.narration
+              ? {
+                  narration: ev.partialText,
+                  segments: appendTranscriptText(
+                    last.segments ?? [],
+                    ev.partialText,
+                  ),
+                }
+              : {}),
+          });
         else if (ev.kind === "done")
           patchTurn({
             costUsd: ev.costUsd,

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -374,6 +374,9 @@ async function runTurn(
     });
   };
 
+  // The turn this run owns: cancel + a fresh prompt appends a NEW last turn
+  // while this closure is still live, so adoption below must re-check it.
+  const turnIndex = (find()?.turns.length ?? 0) - 1;
   setSession((s) => ({ ...s, running: true }));
   try {
     await runAgentSession({
@@ -426,7 +429,11 @@ async function runTurn(
             statusText: "",
             // Keep what a killed turn wrote — a whole-message agent (codex) delivers it
             // only here, so adopt it when nothing streamed, mirroring the done branch.
-            ...(ev.partialText?.trim() && !last.narration
+            // Only into the turn this run owns: a dying event after cancel + a new
+            // prompt must not write into the replacement turn.
+            ...(s.turns.length - 1 === turnIndex &&
+            ev.partialText?.trim() &&
+            !last.narration
               ? {
                   narration: ev.partialText,
                   segments: appendTranscriptText(

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -111,14 +111,14 @@ export const GeneralSection = withForm({
           <form.AppField name="autoStashOnPull">
             {(field) => (
               <field.CheckboxField
-                label="Automatically stash and reapply on pull, merge, and branch updates"
+                label="Automatically stash and reapply on pull, merge, rebase, and branch updates"
                 className="flex cursor-pointer items-center gap-2 text-xs"
               />
             )}
           </form.AppField>
           <p className="text-xs text-muted-foreground">
-            When a pull, merge, or branch update would overwrite uncommitted
-            changes, stash them, run it, then reapply.
+            When a pull, merge, rebase, or branch update would overwrite
+            uncommitted changes, stash them, run it, then reapply.
           </p>
         </div>
         <div className="space-y-1.5">

--- a/src/lib/ai/cli-client.ts
+++ b/src/lib/ai/cli-client.ts
@@ -148,6 +148,9 @@ export function createCliClient(settings: AiSettings): AiClient {
             return;
           } else if (event.kind === "error") {
             settled = true;
+            // `partialText` is intentionally discarded on this path: the contract above
+            // is that a failed run never paints text into the caller's draft field, and
+            // these Tier-1 callers write straight into an editable field.
             throw new Error(event.message);
           }
           // status / tool / nativeSession are ignored: Tier-1 runs no tools and

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -36,6 +36,8 @@ import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import {
   listReviews,
   type PersistedReview,
+  reviewHistoryKey,
+  reviewPartialKey,
   saveReview,
 } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
@@ -430,6 +432,8 @@ async function run(
     // Wall-clock start, mirrored into the persisted history record so an automated review
     // carries a real duration.
     const runStartedMs = Date.now();
+    // Per-action, so a second mode's run never inherits the first's text or verdict.
+    const progress: RunProgress = { text: "", timedOut: false };
     // Let-box so the rerun closure carries THIS run's own key (assigned right
     // after registration): a re-run of the fresh row must replace the fresh row,
     // not the stale one it grew from.
@@ -494,6 +498,7 @@ async function run(
         event,
         controller.signal,
         handle.setCliId,
+        progress,
       );
       if (handle.isCancelled()) {
         // The dock's Cancel already patched the row to "cancelled" (keeping its Re-run)
@@ -568,6 +573,31 @@ async function run(
       // errorMessage unwraps AppError/Error shapes — a raw interpolation renders
       // Tauri invoke rejections as "[object Object]" (observed live).
       const message = errorMessage(e);
+      // A run the backend killed at its deadline keeps whatever it wrote first: nothing
+      // else holds that text (the dock row is memory-only, no comment was delivered), so
+      // this record is its only copy. ONLY the timeout arm — the `looksLikeProviderError`
+      // throw's accumulated text is the provider's error message, not review output.
+      // Coverage stays safe for free: a PARTIAL is dropped by `listReviews`, so the
+      // pr-sync gate still sees this head as un-reviewed and re-reviews it.
+      let keptPartial = false;
+      if (
+        progress.timedOut &&
+        progress.text.trim() !== "" &&
+        (event.kind === "pr-open" || event.kind === "pr-sync")
+      ) {
+        // Resolved from the write itself, so the notification below only promises kept
+        // output when a record actually landed.
+        keptPartial = await persistPartialReviewHistory(
+          event,
+          action,
+          progress.text,
+          reviewCfg.model,
+          message,
+          runStartedMs,
+        )
+          .then(() => true)
+          .catch(() => false);
+      }
       toast.error(`AI ${label} failed: ${message}`);
       // Inbox parity with manual runs (reviews.ts's notifyReviewDone): a genuine failure
       // records an inbox row too, gated on the same automations pref.
@@ -578,7 +608,12 @@ async function run(
           event.kind === "commit"
             ? `"${event.hash.slice(0, 7)}"`
             : `"${event.title}"`;
-        const subtitle = message.trim() ? `${subject} — ${message}` : subject;
+        const reason = message.trim() ? `${subject} — ${message}` : subject;
+        // The inbox row is where a kept partial gets discovered — a durable failure that
+        // doesn't mention it reads as a run with nothing to show for it.
+        const subtitle = keptPartial
+          ? `${reason}${reason.endsWith(".") ? "" : "."} Partial output is kept under Previous reviews.`
+          : reason;
         // Local alias for the loop's `action: ReviewMode` — the Re-run closure's
         // `run` body sees the outer `action` fine, but aliasing keeps the object
         // literal (which also has a field named `action`) unambiguous to read.
@@ -692,6 +727,18 @@ interface ReviewResult {
   thoughts: string;
 }
 
+/** Live progress of one review run, owned by the CALLER so a run that throws can still
+ *  read what streamed before it died — {@link generateReviewText}'s return value is
+ *  reachable only on the success path. CLI providers only: the HTTP branch has no
+ *  backend deadline, so it never reports a timeout and its buffer is never kept. */
+interface RunProgress {
+  /** The newest text the stream reported (already the agent's own output — a killed
+   *  whole-message CLI's answer is adopted upstream in `runCliStream`). */
+  text: string;
+  /** The backend killed the run at its deadline, rather than the run failing outright. */
+  timedOut: boolean;
+}
+
 /** The whole unified diff a review event covers, from whichever source can serve
  *  it — every branch here lands unfiltered text that the caller then filters. */
 async function resolveDiff(
@@ -742,6 +789,8 @@ async function resolveDiff(
  * `signal` aborts the HTTP stream; `onCliId` reports the CLI run's id so the
  * caller can kill the subprocess (CLI providers don't take an AbortSignal).
  * Returns the final answer plus any agentic narration, or null for no changes.
+ * `progress` is filled as the run streams, so the caller's catch can keep a
+ * timed-out run's output (see {@link RunProgress}).
  */
 async function generateReviewText(
   ai: AiSettings,
@@ -749,6 +798,7 @@ async function generateReviewText(
   event: AutomationEvent,
   signal: AbortSignal,
   onCliId: (id: string) => void,
+  progress: RunProgress,
 ): Promise<ReviewResult | null> {
   // Independent of each other, and the settings are only needed by the filter
   // below (the budget profile reuses the same read) — so they resolve alongside
@@ -912,7 +962,6 @@ async function generateReviewText(
   // CLI providers (claude-cli/codex-cli) run as a subprocess, not the AI SDK —
   // route them the same way the interactive review does.
   if (isCliProvider(ai.provider)) {
-    let result = "";
     let thoughts = "";
     await runCliStream({
       ai,
@@ -925,18 +974,23 @@ async function generateReviewText(
       // The user's Review-timeout override (null = the backend's tier defaults).
       timeoutSecs: reviewTimeoutSecs(appSettings.reviewTimeout),
       timeoutConfigurable: true,
+      // Sunk into the caller-owned `progress` rather than a local: a timed-out run
+      // rejects, so a local would be unreachable exactly when the text matters most.
       // runCliStream replaces with the agent's final answer on done; the last
       // setText carries that clean review body (narration is peeled into onThoughts).
       setText: (t) => {
-        result = t;
+        progress.text = t;
       },
       setStatus: () => undefined,
       registerId: onCliId,
       onThoughts: (t) => {
         thoughts = t;
       },
+      onTimedOut: () => {
+        progress.timedOut = true;
+      },
     });
-    return { text: result, thoughts };
+    return { text: progress.text, thoughts };
   }
 
   const client = await createAiClient(ai);
@@ -1083,6 +1137,55 @@ async function persistReviewHistory(
     finishedAt: now,
   });
   await queryClient.invalidateQueries({
-    queryKey: ["review-history", event.repoPath, "origin", kind, ref],
+    queryKey: reviewHistoryKey(event.repoPath, "origin", kind, ref),
   });
+}
+
+/**
+ * Persists the output a TIMED-OUT automated review left behind, as a partial record
+ * (`phase: "error"`) — the failure-path sibling of {@link persistReviewHistory}. Callers
+ * must gate on the timeout arm: any other failure's accumulated text may be a provider
+ * error message rather than review output, so `timedOut` is true by construction here.
+ * A partial is invisible to every "previous review" read, so it neither feeds the next
+ * run's context nor marks this head covered for the pr-sync gate. Both query keys are
+ * invalidated — the partial key is the one the panel's restored output reads.
+ */
+async function persistPartialReviewHistory(
+  event: PrAutomationEvent,
+  mode: ReviewMode,
+  text: string,
+  model: string,
+  /** The failure reason shown with the kept output. */
+  error: string,
+  startedAtMs: number,
+): Promise<void> {
+  if (!text.trim()) return;
+  const kind = event.target.type;
+  const ref = targetRef(event);
+  await saveReview(event.repoPath, {
+    schemaVersion: 1,
+    id: crypto.randomUUID(),
+    kind,
+    ref,
+    // Origin-pinned like the rest of this path — the poller is origin-scoped.
+    lens: "origin",
+    mode,
+    model,
+    title: event.title,
+    text,
+    phase: "error",
+    error,
+    timedOut: true,
+    headSha: event.headSha ?? "",
+    startedAt: startedAtMs,
+    finishedAt: Date.now(),
+  });
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: reviewHistoryKey(event.repoPath, "origin", kind, ref),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: reviewPartialKey(event.repoPath, "origin", kind, ref),
+    }),
+  ]);
 }

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -76,10 +76,11 @@ function firstMeaningfulLine(message: string): string {
 const CONFLICT_MARKERS = [
   // git emits both `error: could not apply …` and a bare `Could not apply
   // <sha>…` tail line (rebase); a revert says `could not revert` for the same
-  // thing, and that line is the ONLY marker a conflicted revert produces — the
-  // rest of its report (`CONFLICT (…`) rides stdout, which `git_revert_core`'s
-  // runner drops. Deliberately the same shape as SUBJECT_ECHO_LINE below: the
-  // line that PROVES a conflict is the one that must not be read as its NAME.
+  // thing. The rest of that report (`CONFLICT (…`) rides stdout, which the
+  // revert/cherry-pick/rebase cores now carry into the error alongside stderr,
+  // so both markers arrive. Deliberately the same shape as SUBJECT_ECHO_LINE
+  // below: the line that PROVES a conflict is the one that must not be read as
+  // its NAME.
   /^(?:error: )?[Cc]ould not (?:apply|revert) /m,
   /^(?:error: |hint: )Resolve all conflicts/m,
   // Git's own line is always uppercase; a path named "conflict (old)" is not.
@@ -127,12 +128,18 @@ const DIRTY_TREE_MARKERS = [
   // `pull --rebase` refuses up front, with a distinct line per dirty kind.
   "cannot pull with rebase: you have unstaged changes",
   "cannot pull with rebase: your index contains uncommitted changes",
+  // Plain `rebase` and `rebase --onto` refuse the same way, on ANY dirty tracked
+  // file rather than an overlapping one. Kept at full length: the bare
+  // "you have unstaged changes" suffix would subsume the two lines above and
+  // widen the match against arbitrary git output.
+  "cannot rebase: you have unstaged changes",
+  "cannot rebase: your index contains uncommitted changes",
 ];
 
 /**
  * Whether a thrown value is git refusing an operation because it would
- * overwrite uncommitted work — the pull / merge / switch dirty-tree family that
- * stash-and-reapply recovers from. Anything else (including real merge
+ * overwrite uncommitted work — the pull / merge / rebase / switch dirty-tree
+ * family that stash-and-reapply recovers from. Anything else (including real merge
  * conflicts) returns false and keeps its normal error presentation.
  */
 export function isDirtyTreeRefusal(e: unknown): boolean {
@@ -156,12 +163,14 @@ const SUBJECT_ECHO_LINE = /^(?:error: )?[Cc]ould not (?:apply|revert) /;
 const OP_ADVICE = /\bgit (rebase|merge|cherry-pick|revert) --continue\b/;
 
 /** A conflicted merge is the one family git gives no `--continue` advice for —
- *  it prints this verdict instead, on stdout, with stderr empty (which is why
- *  `git_merge_core` backfills stdout into the error). Line-anchored, because the
- *  phrase is otherwise reachable as user text. Rebase and cherry-pick emit it on
- *  neither stream, so it names a merge unambiguously — both halves are pinned by
- *  the Rust canary `conflict_output_still_matches_the_anchored_frontend_markers`
- *  (autostash.rs); keep the two in step. */
+ *  it prints this verdict instead, on stdout. Both the plain merge and a
+ *  merge-mode `pull` carry that stdout into the error (`git_merge_core` and
+ *  `run_git_mutating_with_creds`), so this names either one. Line-anchored,
+ *  because the phrase is otherwise reachable as user text. Rebase and
+ *  cherry-pick emit it on neither stream, so it means a merge unambiguously —
+ *  all of it pinned by the Rust canary
+ *  `conflict_output_still_matches_the_anchored_frontend_markers` (autostash.rs);
+ *  keep the two in step. */
 const MERGE_VERDICT = /^Automatic merge failed/;
 
 /** The paused operation and the action that finishes it. The name is read only

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -757,6 +757,20 @@ export const gitPullAutostash = (repoPath: string, mode: PullMode = "ffOnly") =>
 export const gitMergeAutostash = (repoPath: string, branch: string) =>
   invoke<AutostashOutcome>("git_merge_autostash", { repoPath, branch });
 
+export const gitRebaseAutostash = (repoPath: string, branch: string) =>
+  invoke<AutostashOutcome>("git_rebase_autostash", { repoPath, branch });
+
+export const gitRebaseOntoAutostash = (
+  repoPath: string,
+  newBase: string,
+  oldBase: string,
+) =>
+  invoke<AutostashOutcome>("git_rebase_onto_autostash", {
+    repoPath,
+    newBase,
+    oldBase,
+  });
+
 export const gitSwitchAutostash = (
   repoPath: string,
   name: string,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -65,8 +65,6 @@ import {
   listUserWorktrees,
   lockWorktree,
   moveUserWorktree,
-  pruneWorktrees,
-  removeWorktree,
   repairWorktrees,
   unlockWorktree,
 } from "./worktree";
@@ -318,22 +316,6 @@ export function useRepairWorktrees(repo: string) {
   return useRepoMutation(repo, (_: void) => repairWorktrees(repo), {
     invalidate: [worktreeKey(repo)],
   });
-}
-
-/** Removes a user worktree (keeping its branch), then prunes any stale admin
- *  entry. `force` drops a worktree with uncommitted changes. */
-export function useRemoveUserWorktree(repo: string) {
-  return useRepoMutation(
-    repo,
-    async (args: { path: string; force: boolean }) => {
-      // Pass branch=null: removing a worktree leaves the branch intact (deleting
-      // a user's branch is a separate, more destructive action).
-      await removeWorktree(repo, args.path, null, args.force);
-      // Best-effort cleanup; a clean remove already drops its own admin entry.
-      await pruneWorktrees(repo).catch(() => undefined);
-    },
-    { invalidate: [worktreeKey(repo), repoKeys.branches(repo)] },
-  );
 }
 
 /** Owners (from each repo's origin remote) for grouping the repo list. */
@@ -3675,7 +3657,7 @@ export function usePull(repo: string) {
   );
 }
 
-/** Stash → run → reapply variants of pull, merge, and switch. Whole-repo
+/** Stash → run → reapply variants of pull, merge, rebase, and switch. Whole-repo
  *  invalidation like their plain counterparts: each moves HEAD and rewrites the
  *  working tree, and the stash list changes too. */
 export function usePullAutostash(repo: string) {
@@ -3687,6 +3669,18 @@ export function usePullAutostash(repo: string) {
 export function useMergeAutostash(repo: string) {
   return useRepoMutation(repo, (branch: string) =>
     api.gitMergeAutostash(repo, branch),
+  );
+}
+
+export function useRebaseAutostash(repo: string) {
+  return useRepoMutation(repo, (branch: string) =>
+    api.gitRebaseAutostash(repo, branch),
+  );
+}
+
+export function useRebaseOntoAutostash(repo: string) {
+  return useRepoMutation(repo, (args: { newBase: string; oldBase: string }) =>
+    api.gitRebaseOntoAutostash(repo, args.newBase, args.oldBase),
   );
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -250,7 +250,8 @@ export function useRemoteBranches(repo: string, enabled = true) {
   });
 }
 
-const worktreeKey = (repo: string) => ["repo", repo, "user-worktrees"] as const;
+export const worktreeKey = (repo: string) =>
+  ["repo", repo, "user-worktrees"] as const;
 
 /** The repo's user-facing worktrees (session worktrees filtered out by the
  *  backend). `enabled` gates the fetch so it only runs while the manager is open. */

--- a/src/lib/pulls/queries.ts
+++ b/src/lib/pulls/queries.ts
@@ -16,8 +16,11 @@ import {
 import {
   clearReviewsFor,
   deleteReview,
+  listPartialReviews,
   listReviews,
+  reviewHistoryKey,
   reviewPartialKey,
+  reviewPartialsKey,
   updateReviewText,
 } from "./reviews-history";
 
@@ -64,13 +67,6 @@ export function useDeleteLocalPr(repo: string) {
 
 type PrKind = "remote" | "local";
 
-const reviewHistoryKey = (
-  repo: string,
-  lens: RemoteLens,
-  kind: PrKind,
-  ref: string,
-) => ["review-history", repo, lens, kind, ref] as const;
-
 /** Persisted AI reviews for a PR (both modes), newest first. Read-only — never
  *  creates a record, so a never-reviewed PR's first run stays unchanged. */
 export function useReviewHistory(
@@ -82,6 +78,22 @@ export function useReviewHistory(
   return useQuery({
     queryKey: reviewHistoryKey(repo, lens, kind, ref),
     queryFn: () => listReviews(repo, lens, kind, ref),
+  });
+}
+
+/** Kept PARTIAL runs for a PR (both modes), newest first — the timed-out output the
+ *  history list shows beside completed reviews. Its own hook, never a widening of
+ *  {@link useReviewHistory}: callers that mean "the previous review" (the panel's
+ *  context banner, the automation gates) must not be able to read a partial by accident. */
+export function useReviewPartials(
+  repo: string,
+  lens: RemoteLens,
+  kind: PrKind,
+  ref: string,
+) {
+  return useQuery({
+    queryKey: reviewPartialsKey(repo, lens, kind, ref),
+    queryFn: () => listPartialReviews(repo, lens, kind, ref),
   });
 }
 
@@ -98,6 +110,8 @@ function useReviewHistoryMutation<TArgs>(
     // Both keys: every mutation here writes the whole record set, and clear/delete
     // remove kept PARTIAL runs too (they carry no phase filter). Refreshing only the
     // completed-review key would leave a deleted partial's cached text on screen.
+    // The partial key is invalidated as a PREFIX, which covers the list read keyed
+    // under it as well as the single latest-partial read.
     onSettled: () =>
       Promise.all([
         queryClient.invalidateQueries({

--- a/src/lib/pulls/reviews-history.ts
+++ b/src/lib/pulls/reviews-history.ts
@@ -58,6 +58,13 @@ export function isPartialReview(r: Pick<PersistedReview, "phase">): boolean {
   return r.phase === "error";
 }
 
+/** A stored record's findings text, type-checked out of untrusted store JSON (a
+ *  hand-edited `pr-reviews.json` reaches the UI verbatim): a non-string `text` reads
+ *  as no text instead of throwing mid-render. Shared by every surface that renders a
+ *  record's body. */
+export const reviewText = (r: Pick<PersistedReview, "text">): string =>
+  typeof r.text === "string" ? r.text : "";
+
 /** A partial record's stop reason, type-checked out of untrusted store JSON: a
  *  non-boolean `timedOut` reads as "failed", a non-string `error` as no reason. */
 export function partialReviewReason(
@@ -233,6 +240,17 @@ export async function getLatestReview(
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
 }
 
+/** Query key for {@link listReviews}. Homed here beside the read it keys, for the
+ *  same reason as {@link reviewPartialKey}: the review store and the automations
+ *  runner both invalidate it after a write, and neither may pull `queries.ts`'s
+ *  react-query/forge-status graph in to do so. */
+export const reviewHistoryKey = (
+  repo: string,
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+) => ["review-history", repo, lens, kind, ref] as const;
+
 /** Query key for {@link getLatestPartialReview}. Lives here, beside the read it keys,
  *  so all three consumers share one builder: any writer that can remove a partial
  *  record (history clear, per-record delete) must invalidate it, and a hand-written
@@ -268,11 +286,45 @@ export async function getLatestPartialReview(
     .sort((a, b) => b.finishedAt - a.finishedAt)[0];
 }
 
-/** Every COMPLETED review for a PR (both modes), newest first. Two consumers, so
- *  narrowing what this returns is not a UI-only change: the "Previous reviews"
- *  disclosure, and the runner's pr-sync gate, which reads the whole retained set to
- *  decide whether a head was already covered. Kept partial runs are excluded for that
- *  second reason above all — a timed-out run must not mark a head as reviewed
+/** Query key for {@link listPartialReviews}. Deliberately a CHILD of
+ *  {@link reviewPartialKey}: react-query matches by prefix, so every writer that already
+ *  invalidates that key refreshes this list too, and the set of keys a partial-removing
+ *  writer must remember stays at two. */
+export const reviewPartialsKey = (
+  repo: string,
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+) => [...reviewPartialKey(repo, lens, kind, ref), "list"] as const;
+
+/** Every kept PARTIAL run for a PR, newest first — at most one per mode, so at most two.
+ *  A separate read rather than a widening of {@link listReviews} because that read's other
+ *  consumers are the automation coverage gates (the runner's pr-open/pr-sync gate and
+ *  `prOpenEligible`): a partial visible there would mark a head as already reviewed and
+ *  silently stop the automated re-review the timeout made necessary. */
+export async function listPartialReviews(
+  repo: string,
+  lens: RemoteLens,
+  kind: "remote" | "local",
+  ref: string,
+): Promise<PersistedReview[]> {
+  const all = await read(repo);
+  return all
+    .filter(
+      (r) =>
+        lensOf(r) === lens &&
+        r.kind === kind &&
+        r.ref === ref &&
+        isPartialReview(r),
+    )
+    .sort((a, b) => b.finishedAt - a.finishedAt);
+}
+
+/** Every COMPLETED review for a PR (both modes), newest first. Three consumers, so
+ *  what this returns is not a UI-only concern: the "Previous reviews" disclosure, the
+ *  runner's pr-open/pr-sync gate, and `prOpenEligible` — the two gates read the whole
+ *  retained set to decide whether a head was already covered. Kept partial runs are
+ *  excluded for that reason above all — a timed-out run must not mark a head as reviewed
  *  ({@link getLatestPartialReview} is the one reader that wants them). `fresh`
  *  re-reads the store from disk first — see {@link read}. */
 export async function listReviews(
@@ -339,9 +391,11 @@ export async function deleteReview(repo: string, id: string): Promise<void> {
   });
 }
 
-/** Clears every persisted review for ONE PR (both modes) — scoped so clearing
- *  from a PR's panel never touches the other PRs' history in the same repo, nor the
- *  other lens's same-numbered PR. */
+/** Clears every persisted record for ONE PR (both modes) — completed reviews AND
+ *  kept partial runs, since the filter deliberately carries no phase test: "clear this
+ *  PR's history" means every stored copy of its output. Scoped so clearing from a PR's
+ *  panel never touches the other PRs' history in the same repo, nor the other lens's
+ *  same-numbered PR. */
 export async function clearReviewsFor(
   repo: string,
   lens: RemoteLens,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -33,7 +33,11 @@ import { track } from "@/lib/analytics";
 import { readRepoInstructions } from "@/lib/git/api";
 import type { DiffStatEntry, RemoteLens } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
-import { reviewPartialKey, saveReview } from "@/lib/pulls/reviews-history";
+import {
+  reviewHistoryKey,
+  reviewPartialKey,
+  saveReview,
+} from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
 import { pushNotification } from "@/lib/stores/notifications";
@@ -788,13 +792,12 @@ export async function startReview(
         // not just on the next window focus / remount.
         .then(() =>
           queryClient.invalidateQueries({
-            queryKey: [
-              "review-history",
+            queryKey: reviewHistoryKey(
               target.repoPath,
               context.lens,
               target.kind,
               target.ref,
-            ],
+            ),
           }),
         )
         .catch(() => undefined);

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -38,14 +38,17 @@ interface WorktreeRemovalState {
   }) => string | null;
 }
 
-/** Removal outlives the dialog that started it, so the outcome goes to whichever
- *  dialog is still mounted for that target — and to a toast when none is. That
- *  keeps every failure to exactly one surface. Listeners never affect rendering,
- *  so they live beside the store rather than in its state. */
-const listeners = new Map<string, RemovalListener>();
-// A separator no path contains: with a space, ("C:/a b", "c") and
-// ("C:/a", "b c") would share one key.
-const listenerKey = (repoPath: string, path: string) => `${repoPath}::${path}`;
+/** Removal outlives the dialog that started it, so the outcome goes to the
+ *  NEWEST dialog still mounted for that target — and to a toast when none is.
+ *  That keeps every failure to exactly one, live surface. A stack rather than
+ *  one slot: each disposer splices only itself, so an unmounted dialog can
+ *  never linger as a stale recipient while a mounted one exists. Listeners
+ *  never affect rendering, so they live beside the store, not in its state. */
+const listeners = new Map<string, RemovalListener[]>();
+// NUL is the one separator no filesystem path can contain — POSIX allows `:`,
+// so ("a::b", "c") and ("a", "b::c") would share a "::"-joined key.
+const listenerKey = (repoPath: string, path: string) =>
+  `${repoPath}\u0000${path}`;
 
 /** Registers a dialog's outcome handlers for one target; call the returned
  *  function on unmount. */
@@ -55,9 +58,15 @@ export function registerRemovalListener(
   listener: RemovalListener,
 ): () => void {
   const key = listenerKey(repoPath, path);
-  listeners.set(key, listener);
+  const stack = listeners.get(key) ?? [];
+  stack.push(listener);
+  listeners.set(key, stack);
   return () => {
-    if (listeners.get(key) === listener) listeners.delete(key);
+    const cur = listeners.get(key);
+    if (!cur) return;
+    const i = cur.indexOf(listener);
+    if (i !== -1) cur.splice(i, 1);
+    if (cur.length === 0) listeners.delete(key);
   };
 }
 
@@ -129,7 +138,7 @@ async function run(repoPath: string, path: string, force: boolean) {
     queryKey: ["repo", repoPath, "branches"],
   });
 
-  const listener = listeners.get(listenerKey(repoPath, path));
+  const listener = listeners.get(listenerKey(repoPath, path))?.at(-1);
   if (!failure) {
     toast.success("Worktree removed");
     listener?.onSuccess();

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -1,0 +1,157 @@
+import { toast } from "sonner";
+import { create } from "zustand";
+import { pruneWorktrees, removeWorktree } from "@/lib/git/worktree";
+import { queryClient } from "@/lib/query-client";
+import { toastError } from "@/lib/toast";
+
+/** A worktree removal the app is still waiting on. */
+export interface WorktreeRemoval {
+  /** Absolute path of the worktree being removed (as git reports it). */
+  path: string;
+  /** What to call it on screen — its branch, or the folder name when detached. */
+  name: string;
+  /** Epoch ms the removal started. */
+  startedAt: number;
+}
+
+/** The open delete dialog's hooks for the removal it launched. */
+export interface RemovalListener {
+  /** The worktree is gone; the dialog has nothing left to confirm. */
+  onSuccess: () => void;
+  /** Removal failed. `force` is what the attempt used, so the dialog can tell a
+   *  "needs --force" refusal from a real failure. */
+  onError: (error: unknown, force: boolean) => void;
+}
+
+interface WorktreeRemovalState {
+  /** repoPath → worktree path → the removal in flight. Keyed by repo so a repo
+   *  switch reads an empty set rather than another repo's removals. */
+  byRepo: Record<string, Record<string, WorktreeRemoval>>;
+  /** Starts a removal and keeps it visible until it settles. Returns null once
+   *  started, or the reason it was refused: a second attempt on the same
+   *  worktree only queues behind the per-repo git lock and then removes nothing. */
+  startRemoval: (args: {
+    repoPath: string;
+    path: string;
+    name: string;
+    force: boolean;
+  }) => string | null;
+}
+
+/** Removal outlives the dialog that started it, so the outcome goes to whichever
+ *  dialog is still mounted for that target — and to a toast when none is. That
+ *  keeps every failure to exactly one surface. Listeners never affect rendering,
+ *  so they live beside the store rather than in its state. */
+const listeners = new Map<string, RemovalListener>();
+// A separator no path contains: with a space, ("C:/a b", "c") and
+// ("C:/a", "b c") would share one key.
+const listenerKey = (repoPath: string, path: string) => `${repoPath}::${path}`;
+
+/** Registers a dialog's outcome handlers for one target; call the returned
+ *  function on unmount. */
+export function registerRemovalListener(
+  repoPath: string,
+  path: string,
+  listener: RemovalListener,
+): () => void {
+  const key = listenerKey(repoPath, path);
+  listeners.set(key, listener);
+  return () => {
+    if (listeners.get(key) === listener) listeners.delete(key);
+  };
+}
+
+const NO_REMOVALS: WorktreeRemoval[] = [];
+
+export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
+  (set, get) => ({
+    byRepo: {},
+
+    startRemoval: ({ repoPath, path, name, force }) => {
+      if (get().byRepo[repoPath]?.[path])
+        return "This worktree is already being removed.";
+      set((s) => ({
+        byRepo: {
+          ...s.byRepo,
+          [repoPath]: {
+            ...s.byRepo[repoPath],
+            [path]: { path, name, startedAt: Date.now() },
+          },
+        },
+      }));
+      void run(repoPath, path, force);
+      return null;
+    },
+  }),
+);
+
+function clearRemoval(repoPath: string, path: string) {
+  useWorktreeRemovalStore.setState((s) => {
+    const repo = s.byRepo[repoPath];
+    if (!repo?.[path]) return s;
+    const { [path]: _settled, ...rest } = repo;
+    const { [repoPath]: _emptied, ...otherRepos } = s.byRepo;
+    return {
+      byRepo:
+        Object.keys(rest).length > 0
+          ? { ...s.byRepo, [repoPath]: rest }
+          : otherRepos,
+    };
+  });
+}
+
+/**
+ * Runs one removal to completion. There is deliberately no cancel: the backend
+ * removal is uninterruptible past its first steps, and killing it midway strands
+ * a half-removed worktree with a live admin entry.
+ */
+async function run(repoPath: string, path: string, force: boolean) {
+  let failure: { error: unknown } | null = null;
+  try {
+    // branch=null: removing a worktree leaves its branch intact (deleting a
+    // user's branch is a separate, more destructive action).
+    await removeWorktree(repoPath, path, null, force);
+    // Best-effort cleanup; a clean remove already drops its own admin entry.
+    await pruneWorktrees(repoPath).catch(() => undefined);
+  } catch (error) {
+    failure = { error };
+  }
+
+  // Drop the entry before handing the outcome over, so a dialog re-offering a
+  // force remove already sees its Remove button live again.
+  clearRemoval(repoPath, path);
+  // The same set the worktree mutations invalidate: the manager's list, plus
+  // branches (a removed worktree frees its branch for checkout elsewhere).
+  void queryClient.invalidateQueries({
+    queryKey: ["repo", repoPath, "user-worktrees"],
+  });
+  void queryClient.invalidateQueries({
+    queryKey: ["repo", repoPath, "branches"],
+  });
+
+  const listener = listeners.get(listenerKey(repoPath, path));
+  if (!failure) {
+    toast.success("Worktree removed");
+    listener?.onSuccess();
+    return;
+  }
+  if (listener) listener.onError(failure.error, force);
+  else toastError(failure.error);
+}
+
+/** The removals in flight for one repo, oldest first. */
+export function useWorktreeRemovals(repoPath: string): WorktreeRemoval[] {
+  const entries = useWorktreeRemovalStore((s) => s.byRepo[repoPath]);
+  if (!entries) return NO_REMOVALS;
+  return Object.values(entries).sort((a, b) => a.startedAt - b.startedAt);
+}
+
+/** True while this exact worktree is being removed. */
+export function useIsRemovingWorktree(
+  repoPath: string,
+  path: string | undefined,
+): boolean {
+  return useWorktreeRemovalStore((s) =>
+    Boolean(path && s.byRepo[repoPath]?.[path]),
+  );
+}

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import { create } from "zustand";
+import { repoKeys, worktreeKey } from "@/lib/git/queries";
 import { pruneWorktrees, removeWorktree } from "@/lib/git/worktree";
 import { queryClient } from "@/lib/query-client";
 import { toastError } from "@/lib/toast";
@@ -131,12 +132,8 @@ async function run(repoPath: string, path: string, force: boolean) {
   clearRemoval(repoPath, path);
   // The same set the worktree mutations invalidate: the manager's list, plus
   // branches (a removed worktree frees its branch for checkout elsewhere).
-  void queryClient.invalidateQueries({
-    queryKey: ["repo", repoPath, "user-worktrees"],
-  });
-  void queryClient.invalidateQueries({
-    queryKey: ["repo", repoPath, "branches"],
-  });
+  void queryClient.invalidateQueries({ queryKey: worktreeKey(repoPath) });
+  void queryClient.invalidateQueries({ queryKey: repoKeys.branches(repoPath) });
 
   const listener = listeners.get(listenerKey(repoPath, path))?.at(-1);
   if (!failure) {

--- a/src/lib/use-disabled-reason.ts
+++ b/src/lib/use-disabled-reason.ts
@@ -1,12 +1,9 @@
-// The disabled-reason contract's shared internals. A natively-disabled control
-// swallows its own `title` and leaves the tab order, so one WITH a reason trades
-// the native attribute for `aria-disabled`: focus intact, the reason announced
-// through an sr-only node joined into `aria-describedby`, and the hover text
-// moved onto a wrapper span since both disabled paths kill pointer events on the
-// control itself. A reason-less disable stays native rather than becoming a mute
-// tab stop. The JSX stays per-caller — the vendored Button and a raw `<button>`
-// carry different markup and sizing — so this owns only the derivations every
-// site has to get right.
+// Shared internals of the disabled-reason contract. A natively-disabled control
+// swallows its own `title` and leaves the tab order, so a reasoned disable trades
+// it for `aria-disabled`: focus intact, the reason announced via an sr-only node
+// joined into `aria-describedby`, hover text on a wrapper span. A reason-less
+// disable stays native rather than becoming a mute tab stop. JSX stays per-caller
+// (the vendored Button and a raw `<button>` differ); this owns the derivations.
 import { type MouseEventHandler, useId } from "react";
 
 /** The dim `aria-disabled` needs: the vendored `disabled:` variants can't see

--- a/src/lib/use-disabled-reason.ts
+++ b/src/lib/use-disabled-reason.ts
@@ -1,0 +1,59 @@
+// The disabled-reason contract's shared internals. A natively-disabled control
+// swallows its own `title` and leaves the tab order, so one WITH a reason trades
+// the native attribute for `aria-disabled`: focus intact, the reason announced
+// through an sr-only node joined into `aria-describedby`, and the hover text
+// moved onto a wrapper span since both disabled paths kill pointer events on the
+// control itself. A reason-less disable stays native rather than becoming a mute
+// tab stop. The JSX stays per-caller — the vendored Button and a raw `<button>`
+// carry different markup and sizing — so this owns only the derivations every
+// site has to get right.
+import { type MouseEventHandler, useId } from "react";
+
+/** The dim `aria-disabled` needs: the vendored `disabled:` variants can't see
+ *  it, and it lifts under focus so a keyboard user isn't left tracking a
+ *  half-opacity focus ring. */
+export const ARIA_DISABLED_CLASS =
+  "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:focus-visible:opacity-100";
+
+export function useDisabledReason({
+  disabled,
+  reason,
+  title,
+  describedBy,
+  onClick,
+}: {
+  disabled?: boolean;
+  /** Why the control is held. Absent leaves an ordinary native disable. */
+  reason?: string | null;
+  /** The caller's ordinary hover hint, shown while nothing blocks. */
+  title?: string;
+  /** The caller's own `aria-describedby`, which has to survive alongside the
+   *  reason — it outranks `title` as the accessible description. */
+  describedBy?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}) {
+  const reasonId = useId();
+  const blockedReason = disabled && reason ? reason : null;
+
+  return {
+    /** The reason while it actually blocks, else null. Callers render the
+     *  sr-only node under `reasonId` (and the not-allowed cursor) only for it. */
+    blockedReason,
+    reasonId,
+    /** The wrapper span's hover text: the reason when there is one, otherwise
+     *  the caller's ordinary hint. */
+    wrapperTitle: blockedReason ?? title,
+    describedBy:
+      [describedBy, blockedReason ? reasonId : null]
+        .filter(Boolean)
+        .join(" ") || undefined,
+    /** For a RAW `<button>` only. `aria-disabled` is advisory, so activation is
+     *  withheld here too. The vendored Button instead takes
+     *  `focusableWhenDisabled={!!blockedReason}` and blocks activation itself. */
+    nativeProps: {
+      disabled: blockedReason ? undefined : disabled,
+      "aria-disabled": blockedReason ? true : undefined,
+      onClick: blockedReason ? undefined : onClick,
+    },
+  };
+}


### PR DESCRIPTION
A patch batch built around one theme: work that's in flight should stay visible and recoverable instead of being silently dropped. Rebase joins the stash-and-reapply family, long worktree removals keep a presence after their dialog closes, a typed comment now rides Close/Reopen instead of being discarded, and git's conflict verdicts stop being swallowed by stderr-only error shaping.

### Stash and reapply on rebase

- Adds `git_rebase_autostash` and `git_rebase_onto_autostash` (plus their `_core` fns and tokio tests) in `src-tauri/src/git/autostash.rs`, registered in `src-tauri/src/lib.rs`. Both inline their `git rebase` invocation rather than delegating to `git_rebase_core`, which would re-acquire the `repo_lock` already held.
- Wires the pair through `src/lib/git/api.ts` and `src/lib/git/queries.ts`, and adds `rebase` / `rebaseOnto` run ops to `src/features/repository/useStashReapplyRecovery.tsx` and `StashReapplyDialog.tsx`.
- `src/features/repository/BranchSwitcher.tsx` gains `beginRebaseRecovery` for the picker's error path, and `runRebaseOnto` now begins the recovery proactively when the tree is dirty, since git would refuse before touching anything.
- `src/features/repository/RebaseOntoDialog.tsx` drops its `hasChanges` refusal, and the Settings toggle copy in `src/features/settings/GeneralSection.tsx` now names rebase alongside pull, merge and branch updates.

### Git failure text and conflict details

- Adds `GitOutput::full_failure_text()` in `src-tauri/src/git/runner.rs`, joining stderr then stdout (EOL advisories stripped from the stdout half) for the families that split one report across both streams. `failure_text`'s doc is narrowed to the stdout-only cases.
- `run_git_mutating_with_creds` in `src-tauri/src/git/remote.rs` now errors with the combined text, so a conflicted merge-mode pull carries its `CONFLICT (…)` list and `Automatic merge failed` verdict; pinned by the new `a_conflicted_pull_surfaces_gits_merge_verdict` test.
- `git_op_abort` and `op_continue` in `src-tauri/src/git/ops.rs` move to `run_git_mutating_raw` + the combined text, so a `--continue` refused over `<path>: needs merge` (stdout, empty stderr) no longer renders as "git exited with code 1".
- `src/features/git/autostash.rs`'s `git_error` and `settle` adopt the same shaping so the stashed and unstashed arms can't disagree on the same failure; `src/lib/error-summary.ts` is updated for the scanners that read the leading line of that text.
- `op_state` now resolves the repo's git dir once via a new `absolute_git_dir` helper (`--absolute-git-dir`, correct for linked worktrees) and does the eight marker probes as filesystem reads; `rebase_stopped_for_edit` and `sequencer_reverting` become sync `&Path` fns, and an unresolvable git dir reads as "nothing in flight" rather than fail-closing every guard.

### Worktree removal stays visible

- New `src/lib/stores/worktree-removal.ts` tracks in-flight removals and turns away a second attempt on the same worktree.
- New `src/features/repository/WorktreeRemovalBanner.tsx`, rendered from `RepositoryView.tsx`, keeps the removal on screen at the top of the repository after the dialog closes.
- `DeleteWorktreeDialog.tsx` hands the removal to the store instead of owning the spinner; `WorktreesDialog.tsx` shows a "Removing…" row and holds that row's actions while it runs.

### Close / Reopen posts your draft

- `src/features/issues/RemoteIssueView.tsx`, `src/features/pulls/RemotePrView.tsx` and `src/features/discussions/DiscussionView.tsx` add a `postRidingDraft` step ahead of the state change: the comment posts first, a failure abandons the state change and leaves the draft intact, and a partial failure reports through `toastErrorWithNote`.
- Buttons swap to **Close with comment** / **Reopen with comment** while a draft is waiting; menu items, which can't carry a title, take a `— posts your draft` label suffix (outranked by any hold reason). `DiscussionView`'s `doClose`/`doReopen` also guard re-entry on the in-flight post, since a menu item is reachable again during the round trip.
- `src/features/issues/LocalIssueView.tsx` and `src/features/pulls/LocalPrView.tsx` get a `setStatus` helper that appends the note in the *same* record mutation as the status flip, with an `update.isPending` guard against double-posting.

### Shared disabled-reason contract

- Extracts the hand-rolled contract into `src/lib/use-disabled-reason.ts` (`useDisabledReason` + `ARIA_DISABLED_CLASS`), now consumed by `src/components/disabled-reason-button.tsx` and `src/features/conversations/ReactionBar.tsx`.
- `DiscussionView`'s `UpvoteButton` adopts it and gains an `upvoteReason`, ranked so the stale-details window outranks the viewer's own pending write.
- `.claude/skills/gd-conventions/SKILL.md` records the hook as the required arm for raw-`<button>` sites.

### Review history and kept partial output

- `src/features/pulls/ReviewHistory.tsx` scrolls an expanded review inside its own box so the PR's Close/Merge controls stay reachable, and adds per-record copy; `PrReviewPanel.tsx` marks its header `shrink-0` and gives the kept partial its own Copy button. `reviewText` moves to `src/lib/pulls/reviews-history.ts`.
- `src/lib/automations/runner.ts` keeps an automated review's partial output on timeout, stored via `src/lib/stores/reviews.ts` and `reviews-history.ts` so it appears as its own **Previous reviews** row.
- `src/features/plan/store.ts`, `src/features/research/store.ts` and `src/features/sessions/store.ts` adopt `ev.partialText` on the error path, which is the only delivery point for a whole-message agent; `src/lib/ai/cli-client.ts` documents why Tier-1 callers still discard it.

### Smaller fixes

- `src/features/repository/CleanupBranchesDialog.tsx` exports `prCheckStateFrom`, replacing the `prMergedPending`/`prMergedFailed` pair passed from `BranchSwitcher.tsx` with a four-state value that includes "never ran", so the dialog only names pull requests where it actually read them (`src/lib/pulls/queries.ts` adjusted alongside).
- `src/features/activity/ActivityDock.tsx` sets `box-content` on the strip so its `h-7` child doesn't hang half a pixel past the viewport and grow a window scrollbar.
- Corrects the `--effort` doc comments in `src-tauri/src/agent.rs`: the Claude CLI does ship the flag, and the thinking-keyword mechanism is a deliberate choice for version portability.

### Documentation

- `README.md`: rebase added to the stash-and-reapply bullet and the Settings toggle name, close/reopen-with-comment noted for issues, discussions and GitLab merge requests, and the clean-up-branches bullet qualified on forge availability.
- `src/features/help/content.ts`: updates the stash-and-reapply, branch clean-up, change-base and worktree-removal sections.
- `site/src/data/capabilities.ts`: rebase added to the stash-and-reapply line, plus a new close/reopen-with-comment capability.
- `changelog.d/`: seven new fragments (rebase recovery, worktree removal, close posts your draft, conflict details, pull conflict details, review history overflow, activity strip scrollbar) and four updated ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebase and rebase-onto operations support automatic stash and reapply recovery.
  * Close/reopen actions can post drafted comments before changing status.
  * Timed-out reviews retain partial output with viewing, copying, and clearing options.
  * Worktree removals show persistent progress and prevent duplicate actions.
* **Bug Fixes**
  * Git conflict errors now show verdicts and conflicted files.
  * Fixed phantom scrollbars on several screens.
  * Preserved partial output from failed runs.
* **Accessibility**
  * Disabled controls provide clearer reasons, tooltips, and screen-reader descriptions.
  * Discussion upvote controls now explain pending or unavailable actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->