### PR TITLE
fix(worktrees,agent,git,branches): keep long-running work visible and correctly owned

### DIFF
--- a/changelog.d/fixed-agent-turn-late-writes.md
+++ b/changelog.d/fixed-agent-turn-late-writes.md
@@ -1,0 +1,3 @@
+- Cancelling an agent turn and immediately sending a new prompt keeps the two
+  turns apart: the cancelled turn keeps its own late output and saved transcript,
+  and the new turn streams and checkpoints on its own.

--- a/changelog.d/fixed-cleanup-offline-waiting.md
+++ b/changelog.d/fixed-cleanup-offline-waiting.md
@@ -1,0 +1,2 @@
+- **Clean up branches** now tells you when it's waiting for a connection to
+  check which branches are merged.

--- a/changelog.d/fixed-edit-history-conflict-details.md
+++ b/changelog.d/fixed-edit-history-conflict-details.md
@@ -1,0 +1,3 @@
+- When editing history hits a conflict, the error details now carry git's full
+  report, including the list of conflicted files — and a squash that leaves
+  nothing to commit now says so.

--- a/changelog.d/fixed-promote-stays-visible.md
+++ b/changelog.d/fixed-promote-stays-visible.md
@@ -1,0 +1,3 @@
+- Promote a worktree and its dialog closes right away — the removal step shows the
+  same in-progress line and **Removing…** row as deleting one, and the promote
+  finishes in the background.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -7127,6 +7127,64 @@ detached
         );
     }
 
+    /// The premise the two conclude-with-commit legs rest on
+    /// (`finish_local_pr_merge`, `finish_remote_pr_resolve`): a `git commit` that
+    /// refuses writes its whole report to STDOUT and leaves stderr EMPTY, so an
+    /// error carrying stderr alone renders as the bare "git exited with code 1".
+    /// That is the split `full_failure_text` exists to close.
+    ///
+    /// Pinned here rather than at those call sites because no real-repo fixture
+    /// can reach them with this shape: every OTHER commit refusal measured (git
+    /// 2.51.1) — a rejecting hook, an empty message, a signing failure — reports
+    /// on stderr, and git redirects hook output to stderr too, so a hook cannot
+    /// stage the stdout case either.
+    #[tokio::test]
+    async fn a_refusing_commit_reports_on_stdout_with_stderr_empty() {
+        let (dir, repo) = setup_repo("commit-streams").await;
+
+        // Clean tree, nothing staged.
+        let clean = run_git_raw(Some(&repo), &["commit", "-m", "x"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(clean.code, 0, "a commit with nothing staged must refuse");
+        assert!(
+            clean.stderr.trim().is_empty(),
+            "stderr staying empty is the whole problem: {}",
+            clean.stderr
+        );
+        assert!(
+            clean.stdout_lossy().contains("nothing to commit"),
+            "git's report rides stdout: {}",
+            clean.stdout_lossy()
+        );
+
+        // Same refusal with an untracked file present is a DIFFERENT sentence —
+        // and the one neither `already` allow-list substring matches, so it is the
+        // shape that reaches the error build rather than being swallowed.
+        std::fs::write(dir.path().join("untracked.txt"), "u\n").unwrap();
+        let untracked = run_git_raw(Some(&repo), &["commit", "-m", "x"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(untracked.code, 0, "a commit with nothing staged must refuse");
+        assert!(
+            untracked.stderr.trim().is_empty(),
+            "stderr staying empty is the whole problem: {}",
+            untracked.stderr
+        );
+        let report = untracked.stdout_lossy();
+        assert!(
+            report.contains("nothing added to commit but untracked files present"),
+            "git's report rides stdout: {report}"
+        );
+        // The legs read their allow-list off stderr, which this refusal never
+        // populates — so the tolerate-it arm cannot fire and the error build does.
+        let lower = untracked.stderr.to_lowercase();
+        assert!(
+            !lower.contains("nothing to commit") && !lower.contains("no changes added"),
+            "a stderr-read allow-list cannot see a stdout-only refusal: {report}"
+        );
+    }
+
     /// The PR head moving while the user resolves must FAIL honestly (the push is
     /// never forced) and KEEP the worktree — it holds resolutions that would
     /// otherwise be lost.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2676,9 +2676,12 @@ pub(crate) async fn finish_local_pr_merge(
                     let already = lower.contains("nothing to commit")
                         || lower.contains("no changes added");
                     if !already {
+                        // Both streams: a failing `commit` can report on stdout alone
+                        // (measured, git 2.51.1), which stderr-only renders as the
+                        // bare "git exited with code 1".
                         return Err(AppError::Git {
                             code: commit.code,
-                            stderr: commit.stderr,
+                            stderr: commit.full_failure_text(),
                         });
                     }
                 }
@@ -3275,9 +3278,12 @@ pub(crate) async fn finish_remote_pr_resolve(
             let already =
                 lower.contains("nothing to commit") || lower.contains("no changes added");
             if !already {
+                // Both streams: a failing `commit` can report on stdout alone
+                // (measured, git 2.51.1), which stderr-only renders as the bare
+                // "git exited with code 1".
                 return Err(AppError::Git {
                     code: commit.code,
-                    stderr: commit.stderr,
+                    stderr: commit.full_failure_text(),
                 });
             }
         }
@@ -3399,8 +3405,8 @@ pub(crate) async fn find_remote_pr_resolve(
 }
 
 /// Maps a raw git output into a `Result`, turning a non-zero exit into
-/// `AppError::Git` (so `run_git_raw` calls in the worktree can distinguish a
-/// clean commit from a conflict via the returned `Err`, while still surfacing the
+/// `AppError::Git` (so `run_git_raw` call sites can distinguish a clean commit
+/// from a conflict via the returned `Err`, while still surfacing the
 /// unmerged-paths signal for the conflict branch).
 fn check_code(o: crate::git::runner::GitOutput) -> AppResult<()> {
     if o.code == 0 {
@@ -3653,18 +3659,30 @@ pub(crate) async fn rewrite_commits_with_timeouts(
         // the branch position — a killed reset can still have moved it).
         let rewound = failure.is_none();
         if failure.is_none() {
+            // Raw plus `check_code`, never a mutating runner: this loop runs inside
+            // the compound's own `repo_lock` hold. Failures land on either stream —
+            // a conflicted pick splits `could not apply` (stderr) from its `CONFLICT (…`
+            // file list (stdout), and `commit` reports a squash that left nothing to
+            // commit on stdout alone — so a stderr-only error would carry half a
+            // message, or none at all.
             'steps: for step in steps {
                 let single_pick = step.hashes.len() == 1 && step.message.is_none();
                 if single_pick {
                     let args = ["cherry-pick", step.hashes[0].as_str()];
-                    if let Err(e) = run_git(Some(repo_path), &args, pick_timeout).await {
+                    if let Err(e) = run_git_raw(Some(repo_path), &args, pick_timeout)
+                        .await
+                        .and_then(check_code)
+                    {
                         failure = Some(e);
                         break 'steps;
                     }
                 } else {
                     let mut args = vec!["cherry-pick", "-n"];
                     args.extend(step.hashes.iter().map(String::as_str));
-                    if let Err(e) = run_git(Some(repo_path), &args, pick_timeout).await {
+                    if let Err(e) = run_git_raw(Some(repo_path), &args, pick_timeout)
+                        .await
+                        .and_then(check_code)
+                    {
                         failure = Some(e);
                         break 'steps;
                     }
@@ -3676,7 +3694,10 @@ pub(crate) async fn rewrite_commits_with_timeouts(
                     } else {
                         vec!["commit", "-m", message]
                     };
-                    if let Err(e) = run_git(Some(repo_path), &commit_args, DEFAULT_TIMEOUT).await {
+                    if let Err(e) = run_git_raw(Some(repo_path), &commit_args, DEFAULT_TIMEOUT)
+                        .await
+                        .and_then(check_code)
+                    {
                         failure = Some(e);
                         break 'steps;
                     }
@@ -4413,6 +4434,13 @@ mod tests {
                     stderr.contains("your branch is unchanged"),
                     "a completed rollback must say so: {stderr}"
                 );
+                // Below the verdict, git's whole report: the replay loop splits it
+                // across both streams exactly like `cherry_pick_onto`'s loop.
+                assert!(
+                    stderr.contains("could not apply")
+                        && stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
+                    "the verdict must carry git's diagnostic AND its file list: {stderr}"
+                );
             }
             Ok(()) => panic!("the conflicting rewrite must fail"),
             Err(e) => panic!("expected a Git error, got {e:?}"),
@@ -4421,6 +4449,94 @@ mod tests {
         let status = git(&repo, &["status", "--porcelain"]).await;
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
 
+    }
+
+    /// The multi-hash pick splits its report the same way the single-hash one
+    /// does, and it is a separate call site — so it needs its own conflict.
+    #[tokio::test]
+    async fn conflicting_squash_rolls_back_and_carries_gits_report() {
+        let (dir, repo) = setup_repo("conflict-squash").await;
+        let base = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "one").await;
+        let c1 = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v2\n", "two").await;
+        let c2 = rev(&repo, "HEAD").await;
+        let orig = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        // Squashing them newest-first replays "two"'s patch (v1→v2) onto v0 first,
+        // so the `cherry-pick -n` leg conflicts before any commit is attempted.
+        let result = rewrite_commits(
+            &state,
+            &repo,
+            &base,
+            &[RewriteStep {
+                hashes: vec![c2, c1],
+                message: Some("combined".into()),
+                edit: false,
+            }],
+        )
+        .await;
+        match result {
+            Err(AppError::Git { ref stderr, .. }) => {
+                assert_verdict_shape(stderr, "was rolled back");
+                assert!(
+                    stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
+                    "the verdict must carry git's stdout file list: {stderr}"
+                );
+            }
+            Ok(()) => panic!("the conflicting squash must fail"),
+            Err(e) => panic!("expected a Git error, got {e:?}"),
+        }
+        assert_eq!(rev(&repo, "HEAD").await, orig);
+        let status = git(&repo, &["status", "--porcelain"]).await;
+        assert!(status.trim().is_empty(), "tree should be clean: {status}");
+    }
+
+    /// The other half of the family: a squash whose commits cancel out fails at
+    /// `commit`, which reports on STDOUT alone — a stderr-only error would leave
+    /// the verdict with no explanation under it at all.
+    #[tokio::test]
+    async fn empty_squash_rolls_back_and_carries_gits_report() {
+        let (dir, repo) = setup_repo("empty-squash").await;
+        let base = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "one").await;
+        let c1 = rev(&repo, "HEAD").await;
+        // Restores the base content, so replaying the pair as one commit onto
+        // `base` nets an empty tree change.
+        commit_file(&repo, dir.path(), "a.txt", "v0\n", "two").await;
+        let c2 = rev(&repo, "HEAD").await;
+        let orig = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        let result = rewrite_commits(
+            &state,
+            &repo,
+            &base,
+            &[RewriteStep {
+                hashes: vec![c1, c2],
+                message: Some("combined".into()),
+                edit: false,
+            }],
+        )
+        .await;
+        match result {
+            Err(AppError::Git { ref stderr, .. }) => {
+                assert_verdict_shape(stderr, "was rolled back");
+                // git's whole sentence, not the bare "nothing to commit": the
+                // verdict's own cause line already says that much, so the short
+                // form passes even when git's report was dropped entirely.
+                assert!(
+                    stderr.contains("nothing to commit, working tree clean"),
+                    "the verdict must carry git's stdout-only report: {stderr}"
+                );
+            }
+            Ok(()) => panic!("the empty squash must fail"),
+            Err(e) => panic!("expected a Git error, got {e:?}"),
+        }
+        assert_eq!(rev(&repo, "HEAD").await, orig);
+        let status = git(&repo, &["status", "--porcelain"]).await;
+        assert!(status.trim().is_empty(), "tree should be clean: {status}");
     }
 
     /// The rollback must run for every failure class, not just a conflict — a

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -7165,7 +7165,10 @@ detached
         let untracked = run_git_raw(Some(&repo), &["commit", "-m", "x"], DEFAULT_TIMEOUT)
             .await
             .unwrap();
-        assert_ne!(untracked.code, 0, "a commit with nothing staged must refuse");
+        assert_ne!(
+            untracked.code, 0,
+            "a commit refusing over only-untracked files must still refuse"
+        );
         assert!(
             untracked.stderr.trim().is_empty(),
             "stderr staying empty is the whole problem: {}",
@@ -7176,12 +7179,13 @@ detached
             report.contains("nothing added to commit but untracked files present"),
             "git's report rides stdout: {report}"
         );
-        // The legs read their allow-list off stderr, which this refusal never
-        // populates — so the tolerate-it arm cannot fire and the error build does.
-        let lower = untracked.stderr.to_lowercase();
+        // This variant's sentence matches NEITHER allow-list substring, so it
+        // reaches the error build even off combined output — the blind spot that
+        // makes full_failure_text() load-bearing at both conclude-with-commit legs.
+        let lower = report.to_lowercase();
         assert!(
             !lower.contains("nothing to commit") && !lower.contains("no changes added"),
-            "a stderr-read allow-list cannot see a stdout-only refusal: {report}"
+            "the untracked refusal must not match the tolerate-it substrings: {report}"
         );
     }
 

--- a/src/features/compare/CompareBranchCombobox.tsx
+++ b/src/features/compare/CompareBranchCombobox.tsx
@@ -15,12 +15,9 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import { normPath } from "@/lib/git/path";
 import { useBranchDivergence, useUserWorktrees } from "@/lib/git/queries";
 import type { Branch, BranchDivergence } from "@/lib/git/types";
-
-/** Lower-cased, forward-slashed path for cross-source comparison — git emits
- *  "/", the app stores "\" on Windows (mirrors BranchSwitcher's helper). */
-const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 /**
  * The Compare tab's base-branch picker: a searchable combobox over the local

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -571,7 +571,9 @@ test, or review several branches at once without stashing or switching.
   main workspace is stashed so the checkout can't be blocked (restore it with *Pop latest
   stash*), and promoting is blocked while the main workspace has a merge, rebase,
   cherry-pick or revert in progress, or unresolved conflicts. Works even on the worktree
-  you're currently in.
+  you're currently in. The dialog closes right away and the promote finishes on its own;
+  its removal step shows the same line at the top of the repository view and the same
+  **Removing…** row as a delete.
 - **Repair links** (footer) re-connects worktrees if you moved or renamed the repository
   folder in your file manager, which otherwise breaks the path each worktree records.
 

--- a/src/features/pulls/useBranchPickerOptions.tsx
+++ b/src/features/pulls/useBranchPickerOptions.tsx
@@ -1,10 +1,7 @@
 import { ArchiveIcon, TreeStructureIcon } from "@phosphor-icons/react";
 import { type ReactNode, useMemo } from "react";
+import { normPath } from "@/lib/git/path";
 import { useBranches, useUserWorktrees } from "@/lib/git/queries";
-
-/** Lower-cased, forward-slashed path for cross-source comparison — git emits
- *  "/", the app stores "\" on Windows (mirrors BranchSwitcher's helper). */
-const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 export interface BranchPickerOptions {
   /** Selectable branch names in git order; session + archived branches excluded

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -14,16 +14,13 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import { normPath } from "@/lib/git/path";
 import {
   useBranches,
   useRemoteBranches,
   useUserWorktrees,
 } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
-
-/** Lower-cased, forward-slashed path for cross-source comparison — git emits
- *  "/", the app stores "\" on Windows (mirrors BranchSwitcher's helper). */
-const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 /** Whether a local branch may be offered as a base: drop the agent-session
  *  namespace (a hard repo invariant — every branch surface filters

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -34,6 +34,7 @@ import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
 import { copyText } from "@/lib/clipboard";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
 import { forgeDetectForkPrForBranch } from "@/lib/git/api";
+import { normPath } from "@/lib/git/path";
 import {
   forgeFeatureReady,
   useBranchDivergence,
@@ -111,10 +112,6 @@ import {
   useStashReapplyRecovery,
 } from "./useStashReapplyRecovery";
 import { LockWorktreeDialog, RenameWorktreeDialog } from "./WorktreesDialog";
-
-/** Lower-cased, forward-slashed path for cross-source comparison — git emits
- *  "/", the app stores "\" on Windows. */
-const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 /** Last path segment (folder name), tolerating either separator. */
 const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -2130,6 +2130,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         // query runs at all — so the dialog is told which of the four it got,
         // never-ran included.
         prCheckState={prCheckStateFrom(canGh, closedPrs)}
+        // react-query's own signal for "offline": networkMode "online" parks the
+        // fetch, which is otherwise indistinguishable from one in flight.
+        prCheckPaused={closedPrs.fetchStatus === "paused"}
       />
 
       <ConfirmDialog

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -96,6 +96,32 @@ const EMPTY_MERGED_CLAUSE: Record<PrCheckState, string> = {
   unavailable: " and nothing is idle for ",
 };
 
+/** The one-line status above the candidate list while merged detection runs.
+ *  A parked check has no progress to report, so it names what it's waiting on
+ *  rather than implying the read is underway. */
+function MergedCheckLine({ paused }: { paused: boolean }) {
+  return (
+    <p className="px-1 py-1 text-[11px] text-muted-foreground">
+      {paused
+        ? "Waiting for a connection to check which branches are merged…"
+        : "Checking which branches are merged…"}
+    </p>
+  );
+}
+
+/** Empty first paint while merged detection runs. An animated skeleton over a
+ *  parked check would be a false activity signal. */
+function CheckingMergedPlaceholder({ paused }: { paused: boolean }) {
+  if (paused) return <MergedCheckLine paused />;
+  return (
+    <div className="space-y-1 py-2" aria-busy>
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="h-7 animate-pulse rounded-none bg-muted/50" />
+      ))}
+    </div>
+  );
+}
+
 /** The one state badge a row can carry, in precedence order. Text carries the
  *  meaning — the color never stands alone. */
 function RowBadge({
@@ -150,6 +176,7 @@ export function CleanupBranchesDialog({
   isInWorktree,
   prMergedByBranch,
   prCheckState,
+  prCheckPaused,
 }: {
   repoPath: string;
   open: boolean;
@@ -170,6 +197,10 @@ export function CleanupBranchesDialog({
    *  mentions pull requests renders off this: a read that failed says so, and
    *  one that never ran leaves them out rather than passing for a clean check. */
   prCheckState: PrCheckState;
+  /** True when the pull-request read is parked on a missing connection rather
+   *  than in flight. It only retitles the waiting copy — the check itself
+   *  resumes on its own once the connection returns. */
+  prCheckPaused: boolean;
 }) {
   const queryClient = useQueryClient();
   // Shared 30s clock: the idle-past-the-window classification below must
@@ -505,14 +536,7 @@ export function CleanupBranchesDialog({
 
           {/* List / skeleton / empty */}
           {checkingMerged && candidates.length === 0 ? (
-            <div className="space-y-1 py-2" aria-busy>
-              {[0, 1, 2].map((i) => (
-                <div
-                  key={i}
-                  className="h-7 animate-pulse rounded-none bg-muted/50"
-                />
-              ))}
-            </div>
+            <CheckingMergedPlaceholder paused={prCheckPaused} />
           ) : candidates.length === 0 ? (
             <p className="py-6 text-center text-xs text-muted-foreground">
               No stale branches — nothing is merged into{" "}
@@ -530,11 +554,7 @@ export function CleanupBranchesDialog({
               className="-mx-1 max-h-[45vh] space-y-0.5 overflow-x-hidden overflow-y-auto px-1"
               onKeyDown={onKeyDown}
             >
-              {checkingMerged && (
-                <p className="px-1 py-1 text-[11px] text-muted-foreground">
-                  Checking which branches are merged…
-                </p>
-              )}
+              {checkingMerged && <MergedCheckLine paused={prCheckPaused} />}
               {prCheckState === "failed" && (
                 <p className="px-1 py-1 text-[11px] text-muted-foreground">
                   Pull requests couldn't be checked — a branch merged through

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,46 +11,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  gitCheckoutBranch,
-  gitOpState,
-  gitStashAll,
-  gitStatus,
-  validateRepo,
-} from "@/lib/git/api";
+import { gitOpState, gitStatus } from "@/lib/git/api";
 import { repoKeys, useUserWorktrees } from "@/lib/git/queries";
-import {
-  pruneWorktrees,
-  removeWorktree,
-  type UserWorktree,
-} from "@/lib/git/worktree";
-import { toastError } from "@/lib/toast";
-import { useOpenWorktree } from "./useOpenRepoByPath";
-
-/** Remove a worktree while keeping its branch, retrying once if the folder is
- *  momentarily still held. The app has just switched off this worktree, but its
- *  last in-flight git-status poll (or the OS) can keep the directory busy for a
- *  beat — and `openRepo`'s switch is deferred by a View Transition, so the app
- *  may not have fully let go yet. The retry covers that window; a real, lasting
- *  hold (an editor/terminal in the folder) still surfaces the actionable error. */
-async function removeWorktreeFreeingBranch(repoPath: string, path: string) {
-  try {
-    await removeWorktree(repoPath, path, null, false);
-  } catch (e) {
-    // Path stripped before matching — a folder NAMED e.g. "docs-in-use" must
-    // not read as a transient hold.
-    const msg = String((e as { message?: string })?.message ?? e).replaceAll(
-      path,
-      "",
-    );
-    if (/close any program|in use|being used|invalid argument/i.test(msg)) {
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      await removeWorktree(repoPath, path, null, false);
-    } else {
-      throw e;
-    }
-  }
-}
+import type { UserWorktree } from "@/lib/git/worktree";
+import { useWorktreeRemovalStore } from "@/lib/stores/worktree-removal";
 
 /**
  * Promotes a linked worktree's branch into the MAIN workspace. A branch can only
@@ -64,6 +28,12 @@ async function removeWorktreeFreeingBranch(repoPath: string, path: string) {
  * is polled), so moving the app off the worktree and letting its last poll
  * settle is what lets the folder delete cleanly — even when you promote the very
  * worktree you're standing in.
+ *
+ * This dialog only gathers and checks those preconditions. The composite itself
+ * is store-owned (`worktree-removal`), so nothing that closes or unmounts this
+ * dialog can cut it short — which is why it closes as soon as the store accepts
+ * the promote instead of holding the user in a modal for the whole run. Its
+ * removal step shows in the repo view's removal line and the manager's row.
  */
 export function PromoteWorktreeDialog({
   repoPath,
@@ -74,27 +44,13 @@ export function PromoteWorktreeDialog({
   worktree: UserWorktree | null;
   onClose: () => void;
 }) {
-  // `pending` lives here (not in PromoteBody) so it gates dismissal: while a
-  // promote runs, Esc / the X / an outside click must NOT tear the dialog down —
-  // the async chain would keep going with the dialog gone (a background recovery
-  // toast; or a second concurrent promote after a quick reopen re-mounts a fresh
-  // re-entry latch). Controlled Base UI funnels every dismissal through
-  // onOpenChange, so gating onClose on !pending blocks them all.
-  const [pending, setPending] = useState(false);
   return (
-    <Dialog
-      open={worktree !== null}
-      onOpenChange={(o) => {
-        if (!o && !pending) onClose();
-      }}
-    >
+    <Dialog open={worktree !== null} onOpenChange={(o) => !o && onClose()}>
       <DialogContent>
         {worktree && (
           <PromoteBody
             repoPath={repoPath}
             worktree={worktree}
-            pending={pending}
-            setPending={setPending}
             onClose={onClose}
           />
         )}
@@ -106,21 +62,16 @@ export function PromoteWorktreeDialog({
 function PromoteBody({
   repoPath,
   worktree,
-  pending,
-  setPending,
   onClose,
 }: {
   repoPath: string;
   worktree: UserWorktree;
-  pending: boolean;
-  setPending: (value: boolean) => void;
   onClose: () => void;
 }) {
   const worktrees = useUserWorktrees(repoPath);
-  const openWorktree = useOpenWorktree();
-  const queryClient = useQueryClient();
-  // Synchronous re-entry latch: `setPending` is async, so two fast clicks could
-  // both pass the pending check before a re-render — this stops the second.
+  const startPromote = useWorktreeRemovalStore((s) => s.startPromote);
+  // Synchronous re-entry latch: no re-render separates two clicks in the same
+  // tick, so only a ref can refuse the second.
   const runningRef = useRef(false);
 
   const mainPath = (worktrees.data ?? []).find((w) => w.isMain)?.path ?? null;
@@ -186,67 +137,24 @@ function PromoteBody({
     worktree.isLocked ||
     !worktree.branch;
 
-  async function doPromote() {
+  function doPromote() {
     if (!mainPath || !worktree.branch || blocked) return;
-    // Synchronous latch — beat a double-click before `setPending` re-renders.
     if (runningRef.current) return;
     runningRef.current = true;
-    const willStash = mainDirty;
-    // Track how far the composite got. Once the worktree is removed we're past
-    // the point of no return: a later failure needs recovery guidance (the
-    // folder is gone, the branch is free but unchecked-out), not git's raw error.
-    let removed = false;
-    let stashed = false;
-    setPending(true);
-    try {
-      // Verify the main workspace is reachable BEFORE any mutation.
-      // `useOpenWorktree` swallows its own errors (it toasts, never throws), so a
-      // moved/unmounted main path would otherwise let the app stay on the
-      // worktree while we go on to delete it. Throwing here aborts cleanly.
-      await validateRepo(mainPath);
-      // Move the app onto the main workspace — we're about to delete this
-      // worktree's folder, and nothing should keep reading git status inside it.
-      // There's no fs-watcher (status is polled), so switching away stops future
-      // polls; `removeWorktreeFreeingBranch` retries once for any last in-flight
-      // poll that hasn't drained (openRepo's switch is deferred by a transition).
-      await openWorktree(mainPath);
-      await new Promise((resolve) => setTimeout(resolve, 80));
-      // Free the branch: remove the worktree but KEEP the branch (null) — we
-      // check it out in main next. force=false: the clean-tree guard already ran.
-      await removeWorktreeFreeingBranch(mainPath, worktree.path);
-      removed = true;
-      await pruneWorktrees(mainPath).catch(() => undefined);
-      // The branch's working tree is free now; stash main's own WIP (if any) so
-      // the checkout can't be blocked, then land main on the promoted branch.
-      if (willStash) {
-        await gitStashAll(mainPath);
-        stashed = true;
-      }
-      await gitCheckoutBranch(mainPath, worktree.branch);
-      await queryClient.invalidateQueries({ queryKey: repoKeys.all(mainPath) });
-      toast.success(
-        willStash
-          ? `Promoted ${worktree.branch} — your main workspace changes were stashed; Pop latest stash brings them back`
-          : `Promoted ${worktree.branch} to your main workspace`,
-      );
-      setPending(false);
-      onClose();
-    } catch (e) {
-      if (removed) {
-        // The worktree is already gone and the branch is free but not checked
-        // out — surface the recovery path (with git's error as the detail).
-        toast.error(
-          `Removed the worktree, but couldn't check out ${worktree.branch} in your main workspace — switch to it there manually.${
-            stashed ? " Your changes are stashed — use Pop latest stash." : ""
-          }`,
-          { description: e instanceof Error ? e.message : String(e) },
-        );
-      } else {
-        toastError(e);
-      }
+    // Resolved here, while the dialog still holds its precondition queries; the
+    // store runs the composite from there and outlives this dialog.
+    const refused = startPromote({
+      mainPath,
+      worktreePath: worktree.path,
+      branch: worktree.branch,
+      willStash: mainDirty,
+    });
+    if (refused) {
       runningRef.current = false;
-      setPending(false);
+      toast.info(refused);
+      return;
     }
+    onClose();
   }
 
   return (
@@ -313,11 +221,10 @@ function PromoteBody({
       ) : null}
 
       <DialogFooter>
-        <Button variant="outline" onClick={onClose} disabled={pending}>
+        <Button variant="outline" onClick={onClose}>
           Cancel
         </Button>
-        <Button disabled={checking || blocked || pending} onClick={doPromote}>
-          {pending && <Spinner data-icon="inline-start" />}
+        <Button disabled={checking || blocked} onClick={doPromote}>
           {mainDirty && !blocked ? "Stash & promote" : "Promote"}
         </Button>
       </DialogFooter>

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { copyText } from "@/lib/clipboard";
+import { normPath } from "@/lib/git/path";
 import {
   useAddUserWorktree,
   useBranches,
@@ -61,11 +62,6 @@ import { cn } from "@/lib/utils";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
 import { PromoteWorktreeDialog } from "./PromoteWorktreeDialog";
 import { useOpenWorktree } from "./useOpenRepoByPath";
-
-/** Lower-cased, forward-slashed path — git emits "/", the app stores "\" on
- *  Windows. Mirrors the backend's `normalize_wt_path` so "current" detection and
- *  default-path derivation compare apples to apples. */
-const norm = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 /** Sets a hover title only when a Select item is actually clipped. Base UI pins
  *  the popup to the trigger width and clips `overflow-x`, and the inner item text
@@ -139,7 +135,7 @@ function WorktreeList({
   const unlock = useUnlockUserWorktree(repoPath);
   const repair = useRepairWorktrees(repoPath);
   const activeRepo = useUiStore((s) => s.repoPath);
-  const activeNorm = activeRepo ? norm(activeRepo) : "";
+  const activeNorm = activeRepo ? normPath(activeRepo) : "";
 
   const [highlight, setHighlight] = useState(-1);
   const [deleteTarget, setDeleteTarget] = useState<UserWorktree | null>(null);
@@ -163,7 +159,7 @@ function WorktreeList({
   });
 
   async function handleOpen(w: UserWorktree) {
-    if (norm(w.path) === activeNorm) return; // already here
+    if (normPath(w.path) === activeNorm) return; // already here
     if (removingPaths.has(w.path)) return; // its folder is going away
     await openWorktree(w.path);
     onClose();
@@ -206,7 +202,7 @@ function WorktreeList({
                 key={w.path}
                 worktree={w}
                 highlighted={i === highlight}
-                isCurrent={norm(w.path) === activeNorm}
+                isCurrent={normPath(w.path) === activeNorm}
                 isRemoving={removingPaths.has(w.path)}
                 onFocus={() => setHighlight(i)}
                 onOpen={() => handleOpen(w)}
@@ -536,7 +532,8 @@ export function RenameWorktreeDialog({
 
   const trimmed = name.trim();
   const newPath = parent ? `${parent}/${trimmed}` : trimmed;
-  const unchanged = !!worktree && norm(newPath) === norm(worktree.path);
+  const unchanged =
+    !!worktree && normPath(newPath) === normPath(worktree.path);
   // A rename keeps the worktree in place, so block path separators (that'd be a
   // move into another folder) — keep this a simple in-place rename.
   const invalid = /[\\/]/.test(trimmed);

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -532,8 +532,7 @@ export function RenameWorktreeDialog({
 
   const trimmed = name.trim();
   const newPath = parent ? `${parent}/${trimmed}` : trimmed;
-  const unchanged =
-    !!worktree && normPath(newPath) === normPath(worktree.path);
+  const unchanged = !!worktree && normPath(newPath) === normPath(worktree.path);
   // A rename keeps the worktree in place, so block path separators (that'd be a
   // move into another folder) — keep this a simple in-place rename.
   const invalid = /[\\/]/.test(trimmed);

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -42,7 +42,6 @@ import {
   removeTranscript,
   setKept,
 } from "./persistence";
-import { sessionStatus } from "./status";
 import { isWatchingAgentSurface } from "./watching";
 
 /** Fire-and-forget a transcript write: persistence must never break a session,
@@ -288,6 +287,10 @@ async function runTurn(
   const find = () => get().sessions.find((s) => s.id === id);
   const s0 = find();
   if (!s0) return;
+  // The turn this run owns, captured before the first await: a cancel + a fresh
+  // prompt appends a NEW last turn while this run is still live, and turns are
+  // append-only, so this index addresses the owned turn for the whole run.
+  const turnIndex = s0.turns.length - 1;
   const {
     claudeSessionId,
     worktreePath,
@@ -326,22 +329,25 @@ async function runTurn(
     });
   const patchTurn = (p: Partial<SessionTurn>) =>
     setSession((s) => {
-      if (s.turns.length === 0) return s;
+      if (turnIndex < 0 || turnIndex >= s.turns.length) return s;
       const turns = s.turns.slice();
-      turns[turns.length - 1] = { ...turns[turns.length - 1], ...p };
+      turns[turnIndex] = { ...turns[turnIndex], ...p };
       return { ...s, turns };
     });
-  // End of a turn: persist the now-terminal last turn (one append per turn) and,
+  // `running` is session-level, so only the run still owning the LAST turn may clear
+  // it: a stale run's late teardown would otherwise re-enable the composer over the
+  // live run and leave that one uncancellable (`cancel` bails on `!s.running`).
+  const ownsLastTurn = (s: AgentSession) => s.turns.length - 1 === turnIndex;
+  // End of a turn: persist this run's now-terminal turn (one append per turn) and,
   // unless you're watching this session live, fire an OS notification.
   const endTurn = () => {
     const s = find();
-    const i = (s?.turns.length ?? 0) - 1;
-    const t = s?.turns[i];
+    const t = s?.turns[turnIndex];
     if (!s || !t) return;
     persist(
       appendResult(
         id,
-        i,
+        turnIndex,
         t.status,
         t.narration,
         t.segments,
@@ -359,7 +365,7 @@ async function runTurn(
     const label =
       s.turns[0]?.prompt.trim().replace(/\s+/g, " ").slice(0, 70) ||
       "Agent session";
-    const failed = sessionStatus(s).kind === "error";
+    const failed = t.status === "error";
     const headline = failed ? "Agent failed" : "Agent finished";
     void notify(headline, label);
     pushNotification({
@@ -370,13 +376,10 @@ async function runTurn(
       repoPath: s.repoPath,
       repoName: repoNameFromPath(s.repoPath),
       target: { type: "agent" },
-      dedupeKey: `agent:${id}:${i}`,
+      dedupeKey: `agent:${id}:${turnIndex}`,
     });
   };
 
-  // The turn this run owns: cancel + a fresh prompt appends a NEW last turn
-  // while this closure is still live, so adoption below must re-check it.
-  const turnIndex = (find()?.turns.length ?? 0) - 1;
   setSession((s) => ({ ...s, running: true }));
   try {
     await runAgentSession({
@@ -404,19 +407,19 @@ async function runTurn(
           }
           return;
         }
-        const last = s.turns[s.turns.length - 1];
-        if (!last) return;
+        const own = s.turns[turnIndex];
+        if (!own) return;
         if (ev.kind === "delta")
           patchTurn({
-            narration: last.narration + ev.text,
-            segments: appendTranscriptText(last.segments ?? [], ev.text),
+            narration: own.narration + ev.text,
+            segments: appendTranscriptText(own.segments ?? [], ev.text),
             statusText: "",
           });
         else if (ev.kind === "status") patchTurn({ statusText: ev.text });
         else if (ev.kind === "tool")
           patchTurn({
             segments: appendTranscriptTool(
-              last.segments ?? [],
+              own.segments ?? [],
               ev.tool,
               ev.target,
             ),
@@ -429,15 +432,13 @@ async function runTurn(
             statusText: "",
             // Keep what a killed turn wrote — a whole-message agent (codex) delivers it
             // only here, so adopt it when nothing streamed, mirroring the done branch.
-            // Only into the turn this run owns: a dying event after cancel + a new
-            // prompt must not write into the replacement turn.
-            ...(s.turns.length - 1 === turnIndex &&
-            ev.partialText?.trim() &&
-            !last.narration
+            // A dying event after cancel + a new prompt must never write into the
+            // replacement turn.
+            ...(ev.partialText?.trim() && !own.narration
               ? {
                   narration: ev.partialText,
                   segments: appendTranscriptText(
-                    last.segments ?? [],
+                    own.segments ?? [],
                     ev.partialText,
                   ),
                 }
@@ -452,10 +453,10 @@ async function runTurn(
             // a text segment too so the transcript shows it after its tool steps; streaming
             // agents already have both. Never on an errored Done, whose text is the failure
             // REASON — adopting it would render the reason as the agent's own message.
-            ...(ev.text && !last.narration && !ev.isError
+            ...(ev.text && !own.narration && !ev.isError
               ? {
                   narration: ev.text,
-                  segments: appendTranscriptText(last.segments ?? [], ev.text),
+                  segments: appendTranscriptText(own.segments ?? [], ev.text),
                 }
               : {}),
             ...(ev.isError
@@ -472,15 +473,15 @@ async function runTurn(
     });
   } catch (e) {
     patchTurn({ status: "error", error: errorMessage(e), statusText: "" });
-    setSession((s) => ({ ...s, running: false }));
+    setSession((s) => (ownsLastTurn(s) ? { ...s, running: false } : s));
     endTurn();
     return;
   }
 
   const s1 = find();
   if (!s1) return;
-  if (s1.turns[s1.turns.length - 1]?.status === "error") {
-    setSession((s) => ({ ...s, running: false }));
+  if (s1.turns[turnIndex]?.status === "error") {
+    setSession((s) => (ownsLastTurn(s) ? { ...s, running: false } : s));
     endTurn();
     return;
   }
@@ -490,18 +491,26 @@ async function runTurn(
     const hash = await commitWorktreeAll(worktreePath, msg);
     setSession((s) => {
       const turns = s.turns.slice();
-      turns[turns.length - 1] = {
-        ...turns[turns.length - 1],
-        status: "done",
-        statusText: "",
-        commitHash: hash,
+      if (turnIndex >= 0 && turnIndex < turns.length)
+        turns[turnIndex] = {
+          ...turns[turnIndex],
+          status: "done",
+          statusText: "",
+          commitHash: hash,
+        };
+      // `headHash` is session state and the checkpoint really landed, so it applies
+      // whichever turn is last now.
+      return {
+        ...s,
+        running: ownsLastTurn(s) ? false : s.running,
+        turns,
+        headHash: hash ?? s.headHash,
       };
-      return { ...s, running: false, turns, headHash: hash ?? s.headHash };
     });
     endTurn();
   } catch (e) {
     patchTurn({ status: "error", error: errorMessage(e), statusText: "" });
-    setSession((s) => ({ ...s, running: false }));
+    setSession((s) => (ownsLastTurn(s) ? { ...s, running: false } : s));
     endTurn();
   }
 }

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/ai/agent";
 import { cleanupContainerSandbox, stopTestContainer } from "@/lib/ai/sandbox";
 import { terminalErrorMessage } from "@/lib/ai/terminal-error";
+import { normPath } from "@/lib/git/path";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import {
   commitWorktreeAll,
@@ -230,12 +231,6 @@ function newTurn(prompt: string): SessionTurn {
 type Get = () => SessionsState;
 type SetState = (partial: Partial<SessionsState>) => void;
 
-/** Normalize a path for comparison (git reports forward slashes; Windows paths
- *  arrive with backslashes, and are case-insensitive). */
-function normPath(p: string): string {
-  return p.replace(/\\/g, "/").toLowerCase();
-}
-
 /** A session loaded from disk can't have a live turn — its CLI process is gone.
  *  Mark a mid-run turn as interrupted so the session is idle (resumes on the
  *  next message). */
@@ -327,17 +322,19 @@ async function runTurn(
     set({
       sessions: get().sessions.map((s) => (s.id === id ? updater(s) : s)),
     });
+  const hasOwnTurn = (s: AgentSession) =>
+    turnIndex >= 0 && turnIndex < s.turns.length;
+  // Session-level fields (`running`, `nativeSessionId`) may only be written by the run
+  // that still owns the LAST turn: a stale run's late write would re-enable the composer
+  // over the live run (leaving it uncancellable, since `cancel` bails on `!s.running`).
+  const ownsLastTurn = (s: AgentSession) => s.turns.length - 1 === turnIndex;
   const patchTurn = (p: Partial<SessionTurn>) =>
     setSession((s) => {
-      if (turnIndex < 0 || turnIndex >= s.turns.length) return s;
+      if (!hasOwnTurn(s)) return s;
       const turns = s.turns.slice();
       turns[turnIndex] = { ...turns[turnIndex], ...p };
       return { ...s, turns };
     });
-  // `running` is session-level, so only the run still owning the LAST turn may clear
-  // it: a stale run's late teardown would otherwise re-enable the composer over the
-  // live run and leave that one uncancellable (`cancel` bails on `!s.running`).
-  const ownsLastTurn = (s: AgentSession) => s.turns.length - 1 === turnIndex;
   // End of a turn: persist this run's now-terminal turn (one append per turn) and,
   // unless you're watching this session live, fire an OS notification.
   const endTurn = () => {
@@ -401,7 +398,9 @@ async function runTurn(
         if (!s) return;
         if (ev.kind === "nativeSession") {
           // Capture once (turn 1) + persist, so a host resume targets this session.
-          if (!s.nativeSessionId) {
+          // Only the run still owning the last turn may capture: a stale run's late id
+          // would rebind later resumes to a dead conversation and block the live one.
+          if (ownsLastTurn(s) && !s.nativeSessionId) {
             setSession((x) => ({ ...x, nativeSessionId: ev.id }));
             persist(appendNativeSession(id, ev.id));
           }
@@ -491,7 +490,7 @@ async function runTurn(
     const hash = await commitWorktreeAll(worktreePath, msg);
     setSession((s) => {
       const turns = s.turns.slice();
-      if (turnIndex >= 0 && turnIndex < turns.length)
+      if (hasOwnTurn(s))
         turns[turnIndex] = {
           ...turns[turnIndex],
           status: "done",

--- a/src/lib/git/path.ts
+++ b/src/lib/git/path.ts
@@ -1,0 +1,13 @@
+/**
+ * Compares repo and worktree paths, which reach the frontend in two spellings:
+ * git prints forward slashes (`worktree list`), while `validate_repo` hands back
+ * backslashes on Windows — where paths also compare case-insensitively. Use the
+ * result for comparison only: it is lower-cased, so it must never be shown to
+ * the user, written to disk, or handed to git.
+ *
+ * Mirrors the backend's `normalize_wt_path`, so a path compared on one side of
+ * the IPC boundary compares the same way on the other.
+ */
+export function normPath(p: string): string {
+  return p.replace(/\\/g, "/").toLowerCase();
+}

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -1,9 +1,11 @@
 import { toast } from "sonner";
 import { create } from "zustand";
+import { gitCheckoutBranch, gitStashAll, validateRepo } from "@/lib/git/api";
 import { repoKeys, worktreeKey } from "@/lib/git/queries";
 import { pruneWorktrees, removeWorktree } from "@/lib/git/worktree";
 import { queryClient } from "@/lib/query-client";
 import { toastError } from "@/lib/toast";
+import { useUiStore } from "./ui";
 
 /** A worktree removal the app is still waiting on. */
 export interface WorktreeRemoval {
@@ -36,6 +38,21 @@ interface WorktreeRemovalState {
     path: string;
     name: string;
     force: boolean;
+  }) => string | null;
+  /** Starts a promote — remove the worktree to free its branch, then check that
+   *  branch out in the main workspace — and keeps its removal step visible the
+   *  same way `startRemoval` does. Returns null once started, or the reason it
+   *  was refused. Every precondition is the caller's to check first; this runs
+   *  past the point of no return with no dialog left to report to. */
+  startPromote: (args: {
+    /** The main workspace, and the repo the app is switched onto to run this. */
+    mainPath: string;
+    /** The worktree whose folder goes away to free the branch. */
+    worktreePath: string;
+    /** The branch to check out in the main workspace once it's free. */
+    branch: string;
+    /** Stash the main workspace's own uncommitted changes before checking out. */
+    willStash: boolean;
   }) => string | null;
 }
 
@@ -73,27 +90,72 @@ export function registerRemovalListener(
 
 const NO_REMOVALS: WorktreeRemoval[] = [];
 
+// One directory reaches this module in two spellings: git's worktree list prints
+// forward slashes on Windows, while `validate_repo` hands back backslashes. Same
+// comparator the rest of the app uses for this (BranchSwitcher, WorktreesDialog).
+const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
+
+/** True while this worktree is being removed, whichever spelling either path
+ *  arrived in — the promote path holds git's, the delete path the ui store's. */
+function isRemovalInFlight(
+  byRepo: Record<string, Record<string, WorktreeRemoval>>,
+  repoPath: string,
+  path: string,
+): boolean {
+  const repo = normPath(repoPath);
+  const target = normPath(path);
+  return Object.entries(byRepo).some(
+    ([r, entries]) =>
+      normPath(r) === repo &&
+      Object.keys(entries).some((p) => normPath(p) === target),
+  );
+}
+
+/** Main workspaces with a promote running, keyed by {@link normPath} so the two
+ *  spellings can't both pass. Two promotes into the same checkout would fight
+ *  over the final `gitCheckoutBranch`, and the dialog that started the first is
+ *  gone by then — so the latch lives here, not in a component ref. */
+const promoting = new Set<string>();
+
+// `_set` unused: every write goes through the module-level helpers below, so a
+// runner that outlives its dialog reaches state the same way the starters do.
 export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
-  (set, get) => ({
+  (_set, get) => ({
     byRepo: {},
 
     startRemoval: ({ repoPath, path, name, force }) => {
       if (get().byRepo[repoPath]?.[path])
         return "This worktree is already being removed.";
-      set((s) => ({
-        byRepo: {
-          ...s.byRepo,
-          [repoPath]: {
-            ...s.byRepo[repoPath],
-            [path]: { path, name, startedAt: Date.now() },
-          },
-        },
-      }));
+      markRemoval(repoPath, path, name);
       void run(repoPath, path, force);
+      return null;
+    },
+
+    startPromote: ({ mainPath, worktreePath, branch, willStash }) => {
+      // `mainPath` is git's spelling; the entry this would collide with was
+      // written under the ui store's. Match on the directory, not the string.
+      if (isRemovalInFlight(get().byRepo, mainPath, worktreePath))
+        return "This worktree is already being removed.";
+      if (promoting.has(normPath(mainPath)))
+        return "Another worktree is already being promoted to your main workspace.";
+      promoting.add(normPath(mainPath));
+      void runPromote(mainPath, worktreePath, branch, willStash);
       return null;
     },
   }),
 );
+
+function markRemoval(repoPath: string, path: string, name: string) {
+  useWorktreeRemovalStore.setState((s) => ({
+    byRepo: {
+      ...s.byRepo,
+      [repoPath]: {
+        ...s.byRepo[repoPath],
+        [path]: { path, name, startedAt: Date.now() },
+      },
+    },
+  }));
+}
 
 function clearRemoval(repoPath: string, path: string) {
   useWorktreeRemovalStore.setState((s) => {
@@ -108,6 +170,15 @@ function clearRemoval(repoPath: string, path: string) {
           : otherRepos,
     };
   });
+}
+
+/** Drops the entry and refreshes what a settled removal changed: the manager's
+ *  list, plus branches (a removed worktree frees its branch for checkout
+ *  elsewhere) — the same set the worktree mutations invalidate. */
+function settleRemoval(repoPath: string, path: string) {
+  clearRemoval(repoPath, path);
+  void queryClient.invalidateQueries({ queryKey: worktreeKey(repoPath) });
+  void queryClient.invalidateQueries({ queryKey: repoKeys.branches(repoPath) });
 }
 
 /**
@@ -129,11 +200,7 @@ async function run(repoPath: string, path: string, force: boolean) {
 
   // Drop the entry before handing the outcome over, so a dialog re-offering a
   // force remove already sees its Remove button live again.
-  clearRemoval(repoPath, path);
-  // The same set the worktree mutations invalidate: the manager's list, plus
-  // branches (a removed worktree frees its branch for checkout elsewhere).
-  void queryClient.invalidateQueries({ queryKey: worktreeKey(repoPath) });
-  void queryClient.invalidateQueries({ queryKey: repoKeys.branches(repoPath) });
+  settleRemoval(repoPath, path);
 
   const listener = listeners.get(listenerKey(repoPath, path))?.at(-1);
   if (!failure) {
@@ -143,6 +210,117 @@ async function run(repoPath: string, path: string, force: boolean) {
   }
   if (listener) listener.onError(failure.error, force);
   else toastError(failure.error);
+}
+
+/** Remove a worktree while keeping its branch, retrying once if the folder is
+ *  momentarily still held. The app has just switched off this worktree, but its
+ *  last in-flight git-status poll (or the OS) can keep the directory busy for a
+ *  beat — and `openRepo`'s switch is deferred by a View Transition, so the app
+ *  may not have fully let go yet. The retry covers that window; a real, lasting
+ *  hold (an editor/terminal in the folder) still surfaces the actionable error. */
+async function removeWorktreeFreeingBranch(repoPath: string, path: string) {
+  try {
+    await removeWorktree(repoPath, path, null, false);
+  } catch (e) {
+    // Path stripped before matching — a folder NAMED e.g. "docs-in-use" must
+    // not read as a transient hold.
+    const msg = String((e as { message?: string })?.message ?? e).replaceAll(
+      path,
+      "",
+    );
+    if (/close any program|in use|being used|invalid argument/i.test(msg)) {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await removeWorktree(repoPath, path, null, false);
+    } else {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Runs one promote to completion: free the branch (remove its worktree, keep the
+ * branch) then check it out in the main workspace. Store-owned so the composite
+ * survives its dialog, which closes as soon as the store accepts the promote;
+ * its removal step shows in the main workspace's own removal line and manager
+ * row like any other.
+ *
+ * The generic removal toast and the listener stack stay out of this path: they
+ * are the delete dialog's contract, and promote ends on its own composite toast.
+ */
+async function runPromote(
+  mainPath: string,
+  worktreePath: string,
+  branch: string,
+  willStash: boolean,
+) {
+  // Track how far the composite got. Once the worktree is removed we're past
+  // the point of no return: a later failure needs recovery guidance (the
+  // folder is gone, the branch is free but unchecked-out), not git's raw error.
+  let removed = false;
+  let stashed = false;
+  // The key the removal entry was marked under, or null once it has settled.
+  let markedKey: string | null = null;
+  try {
+    // Verify the main workspace is reachable BEFORE any mutation: a
+    // moved/unmounted main path would otherwise let the app stay on the
+    // worktree while we go on to delete it. Throwing here aborts cleanly.
+    const info = await validateRepo(mainPath);
+    // Every consumer keys off `info.root`: `openRepo` writes it straight to the
+    // ui store's repoPath, and the banner, the manager's list query and its row
+    // badges all read that. `mainPath` came from git's worktree list, which
+    // spells the same directory with forward slashes on Windows — state or
+    // invalidations keyed by it miss every mounted consumer silently. The git
+    // calls below keep taking `mainPath`; either spelling works for git.
+    const activeKey = info.root;
+    // Move the app onto the main workspace — we're about to delete this
+    // worktree's folder, and nothing should keep reading git status inside it.
+    // There's no fs-watcher (status is polled), so switching away stops future
+    // polls; `removeWorktreeFreeingBranch` retries once for any last in-flight
+    // poll that hasn't drained (openRepo's switch is deferred by a transition).
+    useUiStore.getState().openRepo(info);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    // Main is the active repo now, so the removal is visible where the user is.
+    markRemoval(activeKey, worktreePath, branch);
+    markedKey = activeKey;
+    // Free the branch: remove the worktree but KEEP the branch (null) — we
+    // check it out in main next. force=false: the clean-tree guard already ran.
+    await removeWorktreeFreeingBranch(mainPath, worktreePath);
+    removed = true;
+    await pruneWorktrees(mainPath).catch(() => undefined);
+    settleRemoval(activeKey, worktreePath);
+    markedKey = null;
+    // The branch's working tree is free now; stash main's own WIP (if any) so
+    // the checkout can't be blocked, then land main on the promoted branch.
+    if (willStash) {
+      await gitStashAll(mainPath);
+      stashed = true;
+    }
+    await gitCheckoutBranch(mainPath, branch);
+    await queryClient.invalidateQueries({ queryKey: repoKeys.all(activeKey) });
+    toast.success(
+      willStash
+        ? `Promoted ${branch} — your main workspace changes were stashed; Pop latest stash brings them back`
+        : `Promoted ${branch} to your main workspace`,
+    );
+  } catch (e) {
+    // Never leave the removal line spinning over a step that has stopped.
+    if (markedKey) settleRemoval(markedKey, worktreePath);
+    if (removed) {
+      // The worktree is already gone and the branch is free but not checked
+      // out — surface the recovery path (with git's error as the detail).
+      toast.error(
+        `Removed the worktree, but couldn't check out ${branch} in your main workspace — switch to it there manually.${
+          stashed ? " Your changes are stashed — use Pop latest stash." : ""
+        }`,
+        { description: e instanceof Error ? e.message : String(e) },
+      );
+    } else {
+      toastError(e);
+    }
+  } finally {
+    // Same expression `startPromote` added under, or the latch never releases.
+    promoting.delete(normPath(mainPath));
+  }
 }
 
 /** The removals in flight for one repo, oldest first. */

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -117,7 +117,7 @@ function isRemovalInFlight(
  *  spellings can't both pass. Two promotes into the same checkout would fight
  *  over the final `gitCheckoutBranch`, and the dialog that started the first is
  *  gone by then — so the latch lives here, not in a component ref. */
-const promoting = new Set<string>();
+const promotingMains = new Set<string>();
 
 /** Worktrees claimed by a promote, keyed by {@link normPath} and GLOBAL rather
  *  than per-repo: a promote reserves its source before it knows which repo key
@@ -150,9 +150,11 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
       // written under the ui store's. Match on the directory, not the string.
       if (isRemovalInFlight(get().byRepo, mainPath, worktreePath))
         return "This worktree is already being removed.";
-      if (promoting.has(normPath(mainPath)))
+      if (promotingWorktrees.has(normPath(worktreePath)))
+        return "This worktree is being promoted.";
+      if (promotingMains.has(normPath(mainPath)))
         return "Another worktree is already being promoted to your main workspace.";
-      promoting.add(normPath(mainPath));
+      promotingMains.add(normPath(mainPath));
       // Claim the source worktree BEFORE the first await: `validateRepo` plus
       // the repo switch is long enough for a delete of the same folder to be
       // accepted, and this promote's dialog has already closed.
@@ -334,7 +336,7 @@ async function runPromote(
     }
   } finally {
     // Same expressions `startPromote` claimed under, or a latch never releases.
-    promoting.delete(normPath(mainPath));
+    promotingMains.delete(normPath(mainPath));
     promotingWorktrees.delete(normPath(worktreePath));
   }
 }

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { create } from "zustand";
 import { gitCheckoutBranch, gitStashAll, validateRepo } from "@/lib/git/api";
+import { normPath } from "@/lib/git/path";
 import { repoKeys, worktreeKey } from "@/lib/git/queries";
 import { pruneWorktrees, removeWorktree } from "@/lib/git/worktree";
 import { queryClient } from "@/lib/query-client";
@@ -28,7 +29,13 @@ export interface RemovalListener {
 
 interface WorktreeRemovalState {
   /** repoPath → worktree path → the removal in flight. Keyed by repo so a repo
-   *  switch reads an empty set rather than another repo's removals. */
+   *  switch reads an empty set rather than another repo's removals.
+   *
+   *  The repo key is ALWAYS the ui store's repoPath spelling (`RepoInfo.root`),
+   *  because every consumer reads it from there; the worktree key is git's list
+   *  spelling. A writer holding git's spelling of the repo (the promote path)
+   *  must resolve it through `validateRepo` first, or its entry lands in a
+   *  bucket the banner and the manager's rows never read. */
   byRepo: Record<string, Record<string, WorktreeRemoval>>;
   /** Starts a removal and keeps it visible until it settles. Returns null once
    *  started, or the reason it was refused: a second attempt on the same
@@ -89,11 +96,6 @@ export function registerRemovalListener(
 }
 
 const NO_REMOVALS: WorktreeRemoval[] = [];
-
-// One directory reaches this module in two spellings: git's worktree list prints
-// forward slashes on Windows, while `validate_repo` hands back backslashes. Same
-// comparator the rest of the app uses for this (BranchSwitcher, WorktreesDialog).
-const normPath = (p: string) => p.replace(/\\/g, "/").toLowerCase();
 
 /** True while this worktree is being removed, whichever spelling either path
  *  arrived in — the promote path holds git's, the delete path the ui store's. */
@@ -265,12 +267,9 @@ async function runPromote(
     // moved/unmounted main path would otherwise let the app stay on the
     // worktree while we go on to delete it. Throwing here aborts cleanly.
     const info = await validateRepo(mainPath);
-    // Every consumer keys off `info.root`: `openRepo` writes it straight to the
-    // ui store's repoPath, and the banner, the manager's list query and its row
-    // badges all read that. `mainPath` came from git's worktree list, which
-    // spells the same directory with forward slashes on Windows — state or
-    // invalidations keyed by it miss every mounted consumer silently. The git
-    // calls below keep taking `mainPath`; either spelling works for git.
+    // The spelling every consumer keys by (see `byRepo`), including the
+    // invalidations below, which have to hit the mounted query keys. The git
+    // calls keep taking `mainPath`; either spelling works for git.
     const activeKey = info.root;
     // Move the app onto the main workspace — we're about to delete this
     // worktree's folder, and nothing should keep reading git status inside it.

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -119,6 +119,14 @@ function isRemovalInFlight(
  *  gone by then — so the latch lives here, not in a component ref. */
 const promoting = new Set<string>();
 
+/** Worktrees claimed by a promote, keyed by {@link normPath} and GLOBAL rather
+ *  than per-repo: a promote reserves its source before it knows which repo key
+ *  it will mark under, and the same folder can be targeted from another
+ *  checkout's context. Deliberately NOT a `byRepo` entry — that map paints the
+ *  banner, and a promote that fails `validateRepo` would leave a removal on
+ *  screen that never started. */
+const promotingWorktrees = new Set<string>();
+
 // `_set` unused: every write goes through the module-level helpers below, so a
 // runner that outlives its dialog reaches state the same way the starters do.
 export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
@@ -126,8 +134,12 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
     byRepo: {},
 
     startRemoval: ({ repoPath, path, name, force }) => {
-      if (get().byRepo[repoPath]?.[path])
+      // Matched on the directory, not the string: today's callers all spell it
+      // the ui store's way, but the admission rule shouldn't depend on that.
+      if (isRemovalInFlight(get().byRepo, repoPath, path))
         return "This worktree is already being removed.";
+      if (promotingWorktrees.has(normPath(path)))
+        return "This worktree is being promoted.";
       markRemoval(repoPath, path, name);
       void run(repoPath, path, force);
       return null;
@@ -141,6 +153,10 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
       if (promoting.has(normPath(mainPath)))
         return "Another worktree is already being promoted to your main workspace.";
       promoting.add(normPath(mainPath));
+      // Claim the source worktree BEFORE the first await: `validateRepo` plus
+      // the repo switch is long enough for a delete of the same folder to be
+      // accepted, and this promote's dialog has already closed.
+      promotingWorktrees.add(normPath(worktreePath));
       void runPromote(mainPath, worktreePath, branch, willStash);
       return null;
     },
@@ -317,8 +333,9 @@ async function runPromote(
       toastError(e);
     }
   } finally {
-    // Same expression `startPromote` added under, or the latch never releases.
+    // Same expressions `startPromote` claimed under, or a latch never releases.
     promoting.delete(normPath(mainPath));
+    promotingWorktrees.delete(normPath(worktreePath));
   }
 }
 


### PR DESCRIPTION
Four async paths could lose state or mislead the user once the UI that started them went away or the environment changed. This makes each one own its work explicitly and report it honestly: promote runs in the store instead of the dialog, an agent run writes only to the turn it owns, a failed history rewrite carries git's full report, and a parked merged-check says it's waiting for a connection.

### Store-owned worktree promote

- Moves the promote composite out of `PromoteWorktreeDialog.tsx` into `runPromote` in `src/lib/stores/worktree-removal.ts`, exposed as `startPromote`. The dialog now closes as soon as the store accepts the promote, so nothing that unmounts it can cut the run short; the `pending` state, the dismissal gate on `onOpenChange`, and the footer spinner all go away.
- Extracts `markRemoval` / `settleRemoval` from the existing `run` path and reuses them for the promote's removal step, so it surfaces in the repo view's removal line and the manager's **Removing…** row like a delete. `settleRemoval` also carries the shared list + branches invalidation.
- Adds re-entry guards that outlive the dialog: `isRemovalInFlight` plus a module-level `promoting` set, both keyed through a new `normPath` comparator, since git's worktree list and `validate_repo` spell the same Windows directory differently. The `runningRef` in `PromoteBody` stays only as a same-tick double-click latch.
- Keys the removal entry and the final `repoKeys.all` invalidation by `validateRepo(mainPath).root` and switches the app with `useUiStore.getState().openRepo(info)` rather than `useOpenWorktree`, so mounted consumers see the same path spelling the ui store holds.
- Relocates `removeWorktreeFreeingBranch` (with its single retry for a folder still momentarily held) into the store, and clears the latch in a `finally` while the failure path settles the removal entry so the line can't spin over a stopped step.

### Agent turn ownership

- `src/features/sessions/store.ts` captures `turnIndex` before the first await and addresses that index everywhere: `patchTurn`, the `delta` / `status` / `tool` / dying / done handlers (reading `own` instead of the last turn), and `endTurn`'s `appendResult` and `dedupeKey`.
- Only the run that still owns the last turn clears the session-level `running` flag (`ownsLastTurn`), so a cancelled run's late teardown can't re-enable the composer over the live run and leave it uncancellable via `cancel`.
- The finish notification derives failure from the owned turn (`t.status === "error"`) instead of `sessionStatus(s)`, dropping the `./status` import.
- The checkpoint path writes `done` / `commitHash` into the owned turn while `headHash` still applies to the session, since the commit really landed.

### Git history rewrite error detail

- The replay loop in `rewrite_commits_with_timeouts` (`src-tauri/src/git/ops.rs`) now uses `run_git_raw` + `check_code` for the single pick, the `cherry-pick -n` leg, and the `commit`, so a failure carries both streams: a conflicted pick splits `could not apply` (stderr) from its `CONFLICT (…)` file list (stdout), and a squash that leaves nothing to commit reports on stdout alone.
- `finish_local_pr_merge` and `finish_remote_pr_resolve` return `commit.full_failure_text()` instead of `commit.stderr`, so a stdout-only commit failure no longer renders as a bare exit code.
- Adds `conflicting_squash_rolls_back_and_carries_gits_report` and `empty_squash_rolls_back_and_carries_gits_report`, and extends the existing single-pick rollback test to assert both the diagnostic and the conflicted-file list.

### Clean up branches while offline

- `BranchSwitcher.tsx` passes `prCheckPaused={closedPrs.fetchStatus === "paused"}`, react-query's own signal for a fetch parked by `networkMode: "online"`.
- `CleanupBranchesDialog.tsx` adds `MergedCheckLine` and `CheckingMergedPlaceholder`: a parked check reads "Waiting for a connection to check which branches are merged…" and drops the animated skeleton, which would otherwise be a false activity signal.

### Documentation

- Updates the *Promote* bullet in `src/features/help/content.ts` to say the dialog closes right away and where the removal step shows.
- Adds four `changelog.d/` fragments: `fixed-promote-stays-visible.md`, `fixed-agent-turn-late-writes.md`, `fixed-edit-history-conflict-details.md`, and `fixed-cleanup-offline-waiting.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled agent turns now keep late output and transcripts separate while new turns stream independently.
  * Git conflict and empty-commit errors now show complete diagnostic details.
  * Branch cleanup now indicates when it is waiting for a connection.
  * Worktree promotion closes its dialog promptly and shows removal progress while completing in the background.
  * Worktree removal is more resilient to temporary “in use” errors.
  * Path comparisons are more consistent across platforms.
* **Documentation**
  * Updated worktree promotion guidance to reflect asynchronous completion and progress indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->