### PR TITLE
docs(blog,conventions): add git worktree post and flag "load-bearing"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,9 @@ reader-facing prose — `README.md`, `changelog.d/` fragments, the in-app guide
   ("the key insight…", "here's the part that…").
 - **Antithesis budget**: keep "X, not Y" where the contrast IS the technical
   point; cut reflex uses.
+- **Flagged words**: the blog section's flagged-word list applies to these
+  surfaces too; code comments exempt. The list lives only in the blog bullet,
+  so additions stay a one-place edit.
 
 The in-app guide's back-catalogue predates this rule and gets swept as its own
 change; new or edited guide sections follow it now.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@ back-catalogue in the same change rather than grandfathering it.
   whole article", "it's worth").
 - **No takeaway scaffolds.** "The thing to take away is…", "here's the part that…",
   "the key insight…" — state the point, don't announce it.
+- **Flagged words.** Owner-flagged AI-register vocabulary — recast on sight in
+  reader-facing prose, even where the use feels natural; code comments exempt.
+  Current list: "load-bearing".
 - **Antithesis budget.** "X, not Y" / "isn't X — it's Y" is a density guide, not a
   ban: keep every instance where the contrast IS the technical point being made, and
   cut the rest — reflex-reaching for the scaffold is the tell, especially twice in

--- a/site/src/content/blog/work-on-two-branches-at-once.md
+++ b/site/src/content/blog/work-on-two-branches-at-once.md
@@ -1,0 +1,205 @@
+---
+title: "Work on two branches at once with git worktree"
+description: "git worktree gives a second branch its own folder — one repository, two working trees, no stash dance. The rules that keep it safe, and the cleanup."
+pubDate: 2026-08-19
+author: theBGuy
+pillar: git-safety
+tags: ["git", "worktrees", "workflow"]
+---
+
+You're an hour into a parser rework. Half the call sites are on the new
+signature, the tests are red on purpose, and there's an untracked file
+of notes you'd rather not explain. Then a bug report lands: production
+crashes on a null payload. The fix belongs on `main`, and it can't wait
+for your rework.
+
+So you do the stash dance: `git stash`, switch, fix, push, switch back,
+`git stash pop`, and hope the pop applies. Usually it does. The times
+it doesn't, you're resolving conflicts inside work that was
+half-finished on purpose, the one place where you have no idea what
+"correct" looks like.
+
+Underneath the dance sits an assumption: a repository has one working
+tree, so branches take turns using it. That assumption became optional
+in 2015, when Git 2.5 shipped `git worktree`.
+
+## A second folder, same repository
+
+Leave the mess exactly where it is:
+
+```sh
+$ git branch --show-current
+feature
+$ git status --short
+ M src/parser.js
+?? notes.md
+$ git worktree add -b fix-crash ../hotfix origin/main
+Preparing worktree (new branch 'fix-crash')
+branch 'fix-crash' set up to track 'origin/main'.
+HEAD is now at 812aeba Expand usage docs (#12)
+```
+
+That created a *linked worktree*: a second working tree in its own
+folder, attached to the repository you ran the command from.
+`-b fix-crash` cuts the branch, `../hotfix` is where the checkout
+goes, and `origin/main` is the base (fetch first, so the fix starts
+from what's actually deployed). The tracking line is ordinary
+branching-from-a-remote behavior, nothing worktree-specific.
+
+"Attached" is the key word. This is not a second clone. There is one
+object database, one set of branches, one config, one list of
+remotes; the new folder holds a checkout and nothing else:
+
+```sh
+$ git worktree list
+…/app     542eaf6 [feature]
+…/hotfix  812aeba [fix-crash]
+$ cat ../hotfix/.git
+gitdir: …/app/.git/worktrees/hotfix
+```
+
+The `.git` in a linked worktree is a file, not a directory: a pointer
+back to the real repository, which keeps the linked checkout's
+bookkeeping under `.git/worktrees/`. What each worktree does own is a
+HEAD, an index, and its working files. The split runs along one line:
+the things that make up "where I'm standing" are per-worktree, and the
+things that make up "the repository" exist once.
+
+## The fix, without the dance
+
+Open `../hotfix` in a second editor window, make the fix, and commit
+it over there:
+
+```sh
+$ git -C ../hotfix commit -am "fix: guard null payload"
+[fix-crash 0a21336] fix: guard null payload
+ 1 file changed, 1 insertion(+)
+$ git log --oneline -1 fix-crash
+0a21336 fix: guard null payload
+$ git push origin fix-crash
+To …/origin.git
+ * [new branch]      fix-crash -> fix-crash
+$ git status --short
+ M src/parser.js
+?? notes.md
+```
+
+Look where the last three commands ran: in your original checkout, the
+seat you never left. The commit was made in `../hotfix`, yet `feature`
+could already see it: not fetched, not copied, just there, because
+there is only one repository. The push works from either folder for
+the same reason. And your own working tree sat out the whole thing:
+the same modified file, the same untracked notes, the dev server still
+warm. Open a PR for `fix-crash` and get back to the rework.
+
+## One branch, one checkout
+
+If both folders share the branches, can they share a branch?
+
+```sh
+$ git switch fix-crash
+fatal: 'fix-crash' is already used by worktree at '…/hotfix'
+```
+
+No, and the refusal is the design. A branch is one shared pointer, but
+each worktree built its index and working files against wherever its
+own HEAD stood. If two worktrees stood on `fix-crash` and one of them
+committed, the other would be standing on history that had moved under
+it. Git refuses up front instead.
+
+You've met this guard before if you've read [the branch-updating
+post](/blog/update-a-branch-without-checking-it-out/): it's the same
+rule that stops `git fetch origin main:main` while `main` is checked
+out anywhere, and the same reason `git branch -D` declines to delete
+a branch a worktree is using; in every case the error names the
+folder to go look at. When you want the files without any branch
+question at all, add the worktree with `--detach` — a checkout
+pinned to a commit, no branch involved, the throwaway form that
+post leaned on.
+
+## The stash is shared too
+
+The stash list is a ref, and refs belong to the repository:
+
+```sh
+$ git stash push -m "parser rework, half done"
+Saved working directory and index state On feature: parser rework, half done
+$ git -C ../hotfix stash list
+stash@{0}: On feature: parser rework, half done
+```
+
+One list, visible from every seat. Pop it back from the seat that
+pushed it. Nothing enforces that: a stash applies to whichever
+working tree runs the pop. If you use worktrees and stashes together,
+the "On feature" prefix and a real message are what tell you, later,
+where a stash came from and where it belongs.
+
+## Folders are disposable, the bookkeeping isn't
+
+The fix is pushed and the PR is open, so the hotfix worktree has
+done its job:
+
+```sh
+$ git worktree remove ../hotfix
+$ git branch --list fix-crash
+  fix-crash
+```
+
+`remove` succeeds without a word: the folder and the repository's
+record of it are gone, and nothing else; the branch survives. If the
+worktree still had modified or untracked files, the same command
+refuses: `contains modified or untracked files, use --force to delete it`.
+
+What you shouldn't do is delete the folder by hand. Git copes with
+that too, though:
+
+```sh
+$ git worktree add --detach ../scratch
+Preparing worktree (detached HEAD 542eaf6)
+HEAD is now at 542eaf6 wip: extract tokenizer
+$ rm -rf ../scratch
+$ git worktree list
+…/app      542eaf6 [feature]
+…/scratch  542eaf6 (detached HEAD) prunable
+$ git worktree prune
+$ git worktree list
+…/app  542eaf6 [feature]
+```
+
+The folder died; the record remained, flagged `prunable`, until
+`git worktree prune` collected it.
+
+One more state you'll meet eventually: a worktree on a USB stick or a
+network share isn't always mounted, and from the repository's side an
+unmounted folder looks exactly like a deleted one; a prune would sever
+it. `git worktree lock --reason "on the USB drive" ../usb` protects
+it: a locked worktree can't be pruned, and `remove` refuses, quoting
+your reason back at you.
+
+Moving is allowed, with one asymmetry. `git worktree move` relocates a
+linked worktree cleanly, while moving the main repository folder by
+hand breaks every link; `git worktree repair`, run from the new
+location, mends them.
+
+## Or don't do any of this
+
+The post you're reading was written in a worktree. GitDesktop's
+repository has a website lane, and on my machine that lane lives in a
+linked worktree, so drafting a post never touches the branch the app
+work is standing on. The client managing those worktrees is
+[GitDesktop](/features/), which I build. Its **Worktrees…** dialog
+carries the whole lifecycle (add, open, rename, lock, promote,
+delete), with the guards built in: deleting a dirty or locked
+worktree asks first, and a moved repository folder gets re-connected
+by its **Repair links** button.
+
+Two of its choices map straight onto the rules above. Switch to a
+branch that lives in another worktree and you don't get the
+`already used by worktree` error: the branch is badged, and choosing
+it offers to open that worktree instead. And **Promote to main
+workspace** collapses the sequence the one-checkout rule forces
+(remove the worktree first, then check its branch out in the main
+workspace) into one action, once the worktree is clean.
+
+Branches take turns only when you give them one folder to take turns
+in. The habit outlived the constraint by a decade.

--- a/site/src/content/blog/work-on-two-branches-at-once.md
+++ b/site/src/content/blog/work-on-two-branches-at-once.md
@@ -43,8 +43,9 @@ That created a *linked worktree*: a second working tree in its own
 folder, attached to the repository you ran the command from.
 `-b fix-crash` cuts the branch, `../hotfix` is where the checkout
 goes, and `origin/main` is the base (fetch first, so the fix starts
-from what's actually deployed). The tracking line is ordinary
-branching-from-a-remote behavior, nothing worktree-specific.
+from the `main` the remote has, not your clone's stale copy). The
+tracking line is ordinary branching-from-a-remote behavior; nothing
+about it is worktree-specific.
 
 "Attached" is the key word. This is not a second clone. There is one
 object database, one set of branches, one config, one list of
@@ -68,7 +69,9 @@ things that make up "the repository" exist once.
 ## The fix, without the dance
 
 Open `../hotfix` in a second editor window, make the fix, and commit
-it over there:
+it over there. A fresh worktree checks out tracked files only, so
+ignored things like `node_modules` and build output start absent;
+this one-line fix doesn't miss them:
 
 ```sh
 $ git -C ../hotfix commit -am "fix: guard null payload"
@@ -85,12 +88,13 @@ $ git status --short
 ```
 
 Look where the last three commands ran: in your original checkout, the
-seat you never left. The commit was made in `../hotfix`, yet `feature`
-could already see it: not fetched, not copied, just there, because
-there is only one repository. The push works from either folder for
-the same reason. And your own working tree sat out the whole thing:
-the same modified file, the same untracked notes, the dev server still
-warm. Open a PR for `fix-crash` and get back to the rework.
+seat you never left. The commit was made in `../hotfix`, yet from the
+`feature` seat it was already there: not fetched, not copied, just
+there, because there is only one repository. The push works from
+either folder for the same reason. And your own working tree sat out
+the whole thing: the same modified file, the same untracked notes,
+the dev server still warm. Open a PR for `fix-crash` and get back
+to the rework.
 
 ## One branch, one checkout
 
@@ -114,12 +118,12 @@ out anywhere, and the same reason `git branch -D` declines to delete
 a branch a worktree is using; in every case the error names the
 folder to go look at. When you want the files without any branch
 question at all, add the worktree with `--detach` — a checkout
-pinned to a commit, no branch involved, the throwaway form that
-post leaned on.
+pinned to a commit, no branch involved.
 
 ## The stash is shared too
 
-The stash list is a ref, and refs belong to the repository:
+The stash list is a ref, and it belongs to the repository, not to
+any one checkout:
 
 ```sh
 $ git stash push -m "parser rework, half done"

--- a/site/src/content/blog/work-on-two-branches-at-once.md
+++ b/site/src/content/blog/work-on-two-branches-at-once.md
@@ -42,10 +42,9 @@ HEAD is now at 812aeba Expand usage docs (#12)
 That created a *linked worktree*: a second working tree in its own
 folder, attached to the repository you ran the command from.
 `-b fix-crash` cuts the branch, `../hotfix` is where the checkout
-goes, and `origin/main` is the base (fetch first, so the fix starts
-from the `main` the remote has, not your clone's stale copy). The
-tracking line is ordinary branching-from-a-remote behavior; nothing
-about it is worktree-specific.
+goes, and `origin/main` is the base (fetch first, so it sits at the
+remote's tip when you branch off it). The tracking line is ordinary
+branching-from-a-remote behavior; nothing about it is worktree-specific.
 
 "Attached" is the key word. This is not a second clone. There is one
 object database, one set of branches, one config, one list of
@@ -68,10 +67,10 @@ things that make up "the repository" exist once.
 
 ## The fix, without the dance
 
-Open `../hotfix` in a second editor window, make the fix, and commit
-it over there. A fresh worktree checks out tracked files only, so
-ignored things like `node_modules` and build output start absent;
-this one-line fix doesn't miss them:
+A fresh worktree checks out tracked files only, so ignored files
+like `node_modules` and build output start absent; this one-line
+fix doesn't need them. Open `../hotfix` in a second editor window,
+make the fix, and commit it over there:
 
 ```sh
 $ git -C ../hotfix commit -am "fix: guard null payload"


### PR DESCRIPTION
Adds a new `git worktree` article to the marketing site's blog and codifies an owner-flagged word in the blog copy rules, so future posts (and sweeps) have the rule written down rather than carried in review comments.

### New blog post

- Adds `site/src/content/blog/work-on-two-branches-at-once.md` — "Work on two branches at once with git worktree", bylined `theBGuy` under the `git-safety` pillar, tagged `git` / `worktrees` / `workflow`.
- `pubDate: 2026-08-19` is a bare future date, so the post behaves as a draft in production and goes live on the first production build after that date (the daily `site-scheduled-publish` cron, or any earlier rebuild).
- Content walks a hotfix-during-a-rework scenario through `git worktree add -b`, `git worktree list`, and the `.git` pointer file in a linked worktree, then the one-branch-one-checkout guard, the shared stash list, and the cleanup surface: `remove`, `prune`, `lock`, `move`, `repair`.
- Cross-links `/blog/update-a-branch-without-checking-it-out/` for the shared refusal rule and `/features/` in the closing section, which covers GitDesktop's **Worktrees…** dialog (add, open, rename, lock, promote, delete), the **Repair links** button, branch badging on switch, and **Promote to main workspace**.

### Writing conventions

- Adds a **Flagged words** bullet to the blog anti-AI-tell rules in `CLAUDE.md`, alongside the existing earnestness/takeaway-scaffold rules: owner-flagged AI-register vocabulary gets recast on sight in reader-facing prose, code comments exempt, current list `"load-bearing"`.

No `src/` or `src-tauri/` files change, so this is site-and-docs-only work and carries no `changelog.d/` fragment. No existing posts are edited in this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blog post explaining how to use Git worktrees to work on multiple branches simultaneously.
  * Covers setup, shared repository state, stash behavior, detached worktrees, cleanup, locking, repair, and lifecycle management.

* **Documentation**
  * Added guidance for adapting flagged terminology in reader-facing content.
  * Guidance now applies across blogs, READMEs, changelogs, in-app guides, and site copy, while remaining acceptable in code comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->