### PR TITLE
fix(git,pulls,glab,branches): explain conflicts and blocked merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ PR (comments and all) in one click.
 - **Blocked by branch protection** (GitHub): a PR that merges cleanly but
   whose base branch rules aren't satisfied gets its own strip line, naming
   the required checks still outstanding (four, then *and N more*).
-  **Merge** stays available (a ruleset's bypass actors can still merge), and
-  a refused merge repeats the same line beside the forge's own message.
+  **Merge** stays available (whoever holds bypass permission can merge anyway),
+  and a refused merge repeats the same line beside the forge's own message.
 - **Local PR merges**: a merge **pre-shows conflicts** and lets you resolve
   them in the in-app editor, in an isolated worktree that never touches your
   working tree, then **Finish** or **Abort**.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ PR (comments and all) in one click.
   worktree and nothing else, and an unfinished resolution is offered back as
   **Continue resolving**. Fork PRs are excluded, since their head lives in
   another repository.
+- **Blocked by branch protection** (GitHub): a PR that merges cleanly but
+  whose base branch rules aren't satisfied gets its own strip line, naming
+  the required checks still outstanding (four, then *and N more*).
+  **Merge** stays available (a ruleset's bypass actors can still merge), and
+  a refused merge repeats the same line beside the forge's own message.
 - **Local PR merges**: a merge **pre-shows conflicts** and lets you resolve
   them in the in-app editor, in an isolated worktree that never touches your
   working tree, then **Finish** or **Abort**.

--- a/changelog.d/changed-merge-blocked-names-rules.md
+++ b/changelog.d/changed-merge-blocked-names-rules.md
@@ -1,0 +1,5 @@
+- **A blocked merge names what it's waiting on.** When a GitHub pull request
+  merges cleanly but the base branch's protection rules won't let it land, the
+  strip under the header now says so and lists the required checks still
+  outstanding, and a refused merge repeats that line alongside the forge's own
+  message. **Merge** stays available, since a bypass actor can still merge.

--- a/changelog.d/changed-merge-blocked-names-rules.md
+++ b/changelog.d/changed-merge-blocked-names-rules.md
@@ -2,4 +2,5 @@
   merges cleanly but the base branch's protection rules won't let it land, the
   strip under the header now says so and lists the required checks still
   outstanding, and a refused merge repeats that line alongside the forge's own
-  message. **Merge** stays available, since a bypass actor can still merge.
+  message. **Merge** stays available, since whoever holds bypass permission on
+  those rules can merge anyway.

--- a/changelog.d/fixed-cleanup-offline-divergence.md
+++ b/changelog.d/fixed-cleanup-offline-divergence.md
@@ -1,2 +1,3 @@
 - **Clean up branches** shows which branches are merged from your local history
-  even with no connection, and announces its progress line to screen readers.
+  even with no connection (the branch switcher's ahead/behind counts work
+  offline too), and announces its progress line to screen readers.

--- a/changelog.d/fixed-cleanup-offline-divergence.md
+++ b/changelog.d/fixed-cleanup-offline-divergence.md
@@ -1,0 +1,2 @@
+- **Clean up branches** shows which branches are merged from your local history
+  even with no connection, and announces its progress line to screen readers.

--- a/changelog.d/fixed-cleanup-offline-waiting.md
+++ b/changelog.d/fixed-cleanup-offline-waiting.md
@@ -1,2 +1,2 @@
 - **Clean up branches** now tells you when it's waiting for a connection to
-  check which branches are merged.
+  check which branches a pull request merged.

--- a/changelog.d/fixed-cleanup-offline-waiting.md
+++ b/changelog.d/fixed-cleanup-offline-waiting.md
@@ -1,2 +1,2 @@
 - **Clean up branches** now tells you when it's waiting for a connection to
-  check which branches a pull request merged.
+  check which branches were merged through a pull request.

--- a/changelog.d/fixed-commit-refusal-report.md
+++ b/changelog.d/fixed-commit-refusal-report.md
@@ -1,0 +1,3 @@
+- When git refuses a commit (a rejecting hook, nothing staged), the error now
+  shows git's own report. Covers the commit box, an agent session's commit, and
+  the squash behind **Keep**.

--- a/changelog.d/fixed-commit-refusal-report.md
+++ b/changelog.d/fixed-commit-refusal-report.md
@@ -1,3 +1,3 @@
-- When git refuses a commit (a rejecting hook, nothing staged), the error now
-  shows git's own report. Covers the commit box, an agent session's commit, and
-  the squash behind **Keep**.
+- When git refuses a commit (a hook rejects it, or nothing is staged), the error
+  now shows git's own report. Covers the commit box, an agent session's commit,
+  and the squash behind **Keep**.

--- a/changelog.d/fixed-conflict-error-details.md
+++ b/changelog.d/fixed-conflict-error-details.md
@@ -1,0 +1,4 @@
+- Conflicts now name what they hit. **Update from main** on the branch you're
+  on, a stash pop or apply, and merge, rebase, cherry-pick, revert and pull all
+  list the conflicted files and carry git's full report in **Details** — and a
+  conflicted stash reapply says the stash was kept.

--- a/changelog.d/fixed-glab-config-hosts.md
+++ b/changelog.d/fixed-glab-config-hosts.md
@@ -1,0 +1,3 @@
+- GitLab sign-in, accounts, and Git credentials now pick up self-managed hosts
+  from hand-edited `glab` configs, including ones written with YAML anchors,
+  aliases, comments, or quoted host names.

--- a/changelog.d/fixed-glab-update-notice.md
+++ b/changelog.d/fixed-glab-update-notice.md
@@ -1,0 +1,2 @@
+- GitLab error messages and the sign-in code screen no longer carry `glab`'s own
+  "update available" notice when the installed CLI is out of date.

--- a/changelog.d/fixed-pr-finish-continue-report.md
+++ b/changelog.d/fixed-pr-finish-continue-report.md
@@ -1,0 +1,2 @@
+- When finishing a pull-request conflict resolution fails, the error now carries
+  git's whole explanation.

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -403,8 +403,10 @@ export function checkSyncCommands(file, _src, lines, hits) {
 // An `AppError::Git { … }` whose `stderr:` field is built from stderr alone.
 // The verdict is read from the FIELD VALUE as an expression, never from the
 // surrounding text: a comment naming `full_failure_text` must not disarm the
-// check, and a value that only names a binding is chased to that binding's
-// initializer, so substituting `.stderr` into it later is still caught.
+// check, and a value that only names a binding is chased through its
+// initializers, so substituting `.stderr` anywhere along that chain is caught.
+// The constructor is delimited by brace balance, not a line count — every
+// fail-open this check has had came from a scan that ended too early.
 //
 // Requiring a `stderr:` FIELD is what keeps destructuring out — `{ stderr, .. }`
 // binds a name, it does not assign one. A pattern that RENAMES (`stderr: a_err`)
@@ -439,6 +441,42 @@ export function testModuleStart(lines) {
   return idx === -1 ? Number.POSITIVE_INFINITY : idx;
 }
 
+/** Index of a char literal's closing quote at `i`, or -1 when the `'` opens a
+ *  LIFETIME (`&'a str`, `State<'_, AppState>`) instead. Rust reuses the
+ *  character, and reading a lifetime as an open quote swallows the rest of the
+ *  scan as string content — silently, and as a pass. */
+function charLiteralEnd(text, i) {
+  const m = /^'(?:\\u\{[0-9a-fA-F]*\}|\\.|[^\\'])'/.exec(text.slice(i, i + 24));
+  return m ? i + m[0].length - 1 : -1;
+}
+
+/** The body of the `{ … }` opening at `openIdx`, brace-balanced. Rustfmt and a
+ *  long field expression can push `stderr:` arbitrarily far down a constructor,
+ *  and a fixed line window that ends before it reads as "no stderr field" — a
+ *  pass, on the shape most likely to be wrong. */
+export function braceBody(text, openIdx) {
+  let depth = 0;
+  for (let i = openIdx; i < text.length; i++) {
+    const c = text[i];
+    if (c === '"') {
+      for (i++; i < text.length && text[i] !== '"'; i++) {
+        if (text[i] === "\\") i++;
+      }
+      continue;
+    }
+    if (c === "'") {
+      const end = charLiteralEnd(text, i);
+      if (end >= 0) i = end;
+      continue;
+    }
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return text.slice(openIdx + 1, i);
+  }
+  // Unbalanced (a truncated file): hand back the remainder rather than nothing,
+  // so a `stderr:` below still gets read.
+  return text.slice(openIdx + 1);
+}
+
 /** The `stderr:` field's value expression, or null when the text has no such
  *  field. Scans to the `,` or `}` that closes the field at bracket depth 0,
  *  skipping string literals so a `format!("…{stderr}")` brace cannot end it. */
@@ -446,22 +484,24 @@ export function stderrFieldValue(text) {
   const at = /\bstderr\s*:/.exec(text);
   if (!at) return null;
   let depth = 0;
-  let quote = null;
   let out = "";
   for (let i = at.index + at[0].length; i < text.length; i++) {
     const c = text[i];
-    if (quote) {
-      out += c;
-      if (c === "\\") {
-        out += text[i + 1] ?? "";
-        i++;
-      } else if (c === quote) quote = null;
+    if (c === '"') {
+      const start = i;
+      for (i++; i < text.length && text[i] !== '"'; i++) {
+        if (text[i] === "\\") i++;
+      }
+      out += text.slice(start, i + 1);
       continue;
     }
-    if (c === '"' || c === "'") {
-      quote = c;
-      out += c;
-      continue;
+    if (c === "'") {
+      const end = charLiteralEnd(text, i);
+      if (end >= 0) {
+        out += text.slice(i, end + 1);
+        i = end;
+        continue;
+      }
     }
     if ("([{".includes(c)) depth++;
     else if (")]".includes(c)) depth--;
@@ -498,28 +538,40 @@ export function bindingInitializer(lines, fromIdx, name) {
   return null;
 }
 
-/** The fix a stderr field value earns, or null when it is correctly shaped. */
+/** The fix a stderr field value earns, or null when it is correctly shaped.
+ *
+ *  Follows a chain of bare-ident aliases (`let stderr = out.stderr; let report =
+ *  stderr; … stderr: report`), because stopping after one hop lands on a value
+ *  none of the shaping tests match — which reads as correctly shaped. The
+ *  seen-set bounds the walk and makes a mutually-recursive pair fail closed,
+ *  like every other step the checker cannot resolve. */
 function stderrValueVerdict(value, lines, ctorIdx) {
-  if (FULL_FAILURE_TEXT_RE.test(value)) return null;
-  if (SUBSTITUTING_RE.test(value)) return SUBSTITUTION_FIX;
-  if (STDERR_READ_RE.test(value)) return STDERR_ONLY_FIX;
-  if (!BARE_IDENT_RE.test(value)) return null;
-  const init = bindingInitializer(lines, ctorIdx, value);
-  if (init === null) return UNRESOLVED_FIX;
-  if (FULL_FAILURE_TEXT_RE.test(init)) return null;
-  if (SUBSTITUTING_RE.test(init)) return SUBSTITUTION_FIX;
-  if (STDERR_READ_RE.test(init)) return STDERR_ONLY_FIX;
-  return null;
+  const seen = new Set();
+  for (let expr = value; ; ) {
+    if (FULL_FAILURE_TEXT_RE.test(expr)) return null;
+    if (SUBSTITUTING_RE.test(expr)) return SUBSTITUTION_FIX;
+    if (STDERR_READ_RE.test(expr)) return STDERR_ONLY_FIX;
+    if (!BARE_IDENT_RE.test(expr)) return null;
+    if (seen.has(expr)) return UNRESOLVED_FIX;
+    seen.add(expr);
+    const init = bindingInitializer(lines, ctorIdx, expr);
+    if (init === null) return UNRESOLVED_FIX;
+    // The initializer is captured to end-of-statement, so the `;` (and anything
+    // rustfmt put after it) has to come off before the next hop can be an ident.
+    expr = init.split(";")[0].trim();
+  }
 }
 
-export function checkStderrOnlyGitError(file, src, lines, hits) {
+export function checkStderrOnlyGitError(file, _src, lines, hits) {
   const code = stripComments(lines);
+  const codeSrc = code.join("\n");
   const limit = testModuleStart(lines);
   GIT_CTOR_RE.lastIndex = 0;
-  for (let m = GIT_CTOR_RE.exec(src); m; m = GIT_CTOR_RE.exec(src)) {
-    const line = src.slice(0, m.index).split("\n").length;
+  for (let m = GIT_CTOR_RE.exec(codeSrc); m; m = GIT_CTOR_RE.exec(codeSrc)) {
+    const line = codeSrc.slice(0, m.index).split("\n").length;
     if (line - 1 >= limit) continue;
-    const value = stderrFieldValue(code.slice(line - 1, line + 5).join("\n"));
+    const open = m.index + m[0].length - 1;
+    const value = stderrFieldValue(braceBody(codeSrc, open));
     if (value === null) continue;
     const fix = stderrValueVerdict(value, code, line - 1);
     if (fix === null) continue;

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -411,7 +411,7 @@ export function checkSyncCommands(file, _src, lines, hits) {
 // Requiring a `stderr:` FIELD is what keeps destructuring out — `{ stderr, .. }`
 // binds a name, it does not assign one. A pattern that RENAMES (`stderr: a_err`)
 // still looks like a field, and its binding resolves to nothing; those live in
-// test code, which this check does not scan (see `testModuleStart`).
+// test code, which this check skips by span (see `testModuleSpans`).
 const GIT_CTOR_RE = /AppError::Git\s*\{/g;
 const STDERR_READ_RE = /\b[A-Za-z_]\w*\s*\.\s*stderr\b/;
 const BARE_IDENT_RE = /^[A-Za-z_]\w*$/;
@@ -440,8 +440,11 @@ const UNRESOLVED_FIX =
  *  statics, functions and even `if let` blocks (`app_store.rs`), whose next
  *  brace would otherwise be read as a module body. */
 export function testModuleSpans(text) {
+  // Outer attributes may sit between the gate and the module
+  // (`#[cfg(test)] #[allow(…)] mod tests {`); only whitespace separates them, so
+  // tolerating a run of them cannot skip over an intervening ITEM.
   const attr =
-    /#\[cfg\(\s*(?:all\(\s*)?test\b[^\]]*\]\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+\w+\s*\{/g;
+    /#\[cfg\(\s*(?:all\(\s*)?test\b[^\]]*\]\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?mod\s+\w+\s*\{/g;
   const spans = [];
   for (let m = attr.exec(text); m; m = attr.exec(text)) {
     const open = m.index + m[0].length - 1;
@@ -462,10 +465,23 @@ function charLiteralEnd(text, i) {
 }
 
 /** Index of the closing delimiter of the string or char literal starting at `i`,
- *  or -1 when the character opens neither. An unterminated string ends at the
- *  text, so a scan can never run past its own input. */
+ *  or -1 when the character opens neither.
+ *
+ *  A RAW literal (`r"…"`, `br#"…"#`) ends at a quote followed by its own hash
+ *  count and honors no escapes at all, so it needs its own branch: the
+ *  escape-aware scan walks straight past the closing quote of
+ *  `r"\\?\"` (`git/worktree.rs`) and reads the rest of the file as string
+ *  content. `b"…"` / `c"…"` are NOT raw and stay on the escape-aware branch.
+ *  An unterminated literal ends at the text, so a scan can never run past its
+ *  own input. */
 function literalEnd(text, i) {
   if (text[i] === "'") return charLiteralEnd(text, i);
+  const raw = /^(?:b|c)?r(#*)"/.exec(text.slice(i, i + 16));
+  if (raw) {
+    const close = `"${raw[1]}`;
+    const at = text.indexOf(close, i + raw[0].length);
+    return at === -1 ? text.length - 1 : at + close.length - 1;
+  }
   if (text[i] !== '"') return -1;
   for (let j = i + 1; j < text.length; j++) {
     if (text[j] === "\\") j++;

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Static gate for three Rust invariants that have each cost this repo a fix
+// Static gate for four Rust invariants that have each cost this repo a fix
 // round. Text-level checks over `src-tauri/src/**/*.rs` — no compiler, no deps,
 // Node built-ins only — so they run anywhere `node` does:
 //
@@ -10,6 +10,13 @@
 //      the process table.
 //   C. sync `#[tauri::command]` — a blocking command body runs on the main
 //      thread and freezes the UI.
+//   D. stderr-only `AppError::Git` — whole families of git command report a
+//      failure on STDOUT with stderr EMPTY (a conflicted merge, a refused
+//      `commit`, a conflicted `stash pop`), so an error built from stderr alone
+//      renders to the user as the bare "git exited with code N".
+//      `GitOutput::full_failure_text()` is the shaping that carries both halves.
+//      Scoped to `AppError::Git` constructions on purpose: the `Gh`/`Glab`
+//      variants are tuple-shaped and their CLIs do not split a report this way.
 //
 // Each check carries an ALLOWLIST of `{ file, fn, rationale }` records. RATCHET
 // RULE: the lists only shrink by default. Adding an entry is a reviewed change —
@@ -23,6 +30,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { stripComments } from "./check-banned-patterns.mjs";
 
 const SRC = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -183,6 +192,67 @@ const SYNC_COMMAND_ALLOWLIST = [
   },
 ];
 
+// Check D. Sites whose git command provably reports on stderr alone, verified by
+// reading each one: read-only scans and parses, where a non-zero exit is git
+// refusing the READ (bad revision, unreadable path) rather than a working-tree
+// operation half-finishing across two streams.
+const STDERR_ONLY_ALLOWLIST = [
+  {
+    file: "git/ai_ignore.rs",
+    fn: "filter_ignored",
+    rationale: "`check-ignore` read — stdout is the match list, never a report",
+  },
+  {
+    file: "git/branches.rs",
+    fn: "git_set_branch_archived",
+    rationale: "`config` write — no working-tree operation to half-finish",
+  },
+  {
+    file: "git/compare.rs",
+    fn: "run_grep",
+    rationale: "`grep` read — stdout is the match list, never a report",
+  },
+  {
+    file: "git/conflict.rs",
+    fn: "git_diff_contents",
+    rationale:
+      "`show`/`cat-file` read — stdout is the file content being parsed",
+  },
+  {
+    file: "git/diff.rs",
+    fn: "git_diff_file",
+    rationale: "`diff` read — stdout is the patch being parsed",
+  },
+  {
+    file: "git/diff.rs",
+    fn: "git_session_file_diff",
+    rationale: "`diff --no-index` read — stdout is the patch being parsed",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "classify_failure",
+    rationale:
+      "`report` is a parameter, so no binding is in range — its doc contract requires full_failure_text() and every caller passes it",
+  },
+  {
+    file: "git/ops.rs",
+    fn: "git_rebase_edit",
+    rationale:
+      "interactive-rebase START failure, reached only when nothing is in progress — a paused rebase returns Ok, so there is no stdout report to lose",
+  },
+  {
+    file: "git/runner.rs",
+    fn: "run_git_input",
+    rationale:
+      "THE stderr-only contract itself — callers whose failure rides stdout take run_git_raw and shape it with full_failure_text()",
+  },
+  {
+    file: "git/todos.rs",
+    fn: "git_todo_scan",
+    rationale: "`grep` read — stdout is the match list, never a report",
+  },
+];
+
 // ------------------------------------------------------------------- helpers
 
 /** Every `.rs` file under `src-tauri/src`, as absolute paths. */
@@ -330,6 +400,140 @@ export function checkSyncCommands(file, _src, lines, hits) {
   }
 }
 
+// An `AppError::Git { … }` whose `stderr:` field is built from stderr alone.
+// The verdict is read from the FIELD VALUE as an expression, never from the
+// surrounding text: a comment naming `full_failure_text` must not disarm the
+// check, and a value that only names a binding is chased to that binding's
+// initializer, so substituting `.stderr` into it later is still caught.
+//
+// Requiring a `stderr:` FIELD is what keeps destructuring out — `{ stderr, .. }`
+// binds a name, it does not assign one. A pattern that RENAMES (`stderr: a_err`)
+// still looks like a field, and its binding resolves to nothing; those live in
+// test code, which this check does not scan (see `testModuleStart`).
+const GIT_CTOR_RE = /AppError::Git\s*\{/g;
+const STDERR_READ_RE = /\b[A-Za-z_]\w*\s*\.\s*stderr\b/;
+const BARE_IDENT_RE = /^[A-Za-z_]\w*$/;
+const FULL_FAILURE_TEXT_RE = /\bfull_failure_text\s*\(/;
+// `full_failure_text` ENDS with this name, so the character in front is the only
+// thing telling the substituting helper from the combining one.
+const SUBSTITUTING_RE = /(?:^|[^_\w])failure_text\s*\(/;
+const STDERR_ONLY_FIX =
+  "a failing git command can report on STDOUT with stderr empty (gd-conventions) — " +
+  "shape the error with GitOutput::full_failure_text(), or allowlist with rationale";
+const SUBSTITUTION_FIX =
+  "GitOutput::failure_text() SUBSTITUTES one stream for the other, so it drops half " +
+  "of any report that splits — use full_failure_text(), or allowlist with rationale";
+const UNRESOLVED_FIX =
+  "this stderr value names a binding the checker cannot resolve, so it cannot tell " +
+  "which shaping built it — inline the shaping, or allowlist with rationale";
+
+/** First line of a `#[cfg(test)]` module, or `Infinity`. The invariant governs
+ *  how PRODUCTION code shapes a user-facing error; test code destructures these
+ *  same shapes, and a fail-closed binding check reads every renaming pattern as
+ *  an unresolvable field. Rests on test modules coming last in the file, which
+ *  is this codebase's layout. */
+export function testModuleStart(lines) {
+  const idx = lines.findIndex((l) =>
+    /^\s*#\[cfg\(\s*(?:all\(\s*)?test\b/.test(l),
+  );
+  return idx === -1 ? Number.POSITIVE_INFINITY : idx;
+}
+
+/** The `stderr:` field's value expression, or null when the text has no such
+ *  field. Scans to the `,` or `}` that closes the field at bracket depth 0,
+ *  skipping string literals so a `format!("…{stderr}")` brace cannot end it. */
+export function stderrFieldValue(text) {
+  const at = /\bstderr\s*:/.exec(text);
+  if (!at) return null;
+  let depth = 0;
+  let quote = null;
+  let out = "";
+  for (let i = at.index + at[0].length; i < text.length; i++) {
+    const c = text[i];
+    if (quote) {
+      out += c;
+      if (c === "\\") {
+        out += text[i + 1] ?? "";
+        i++;
+      } else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      out += c;
+      continue;
+    }
+    if ("([{".includes(c)) depth++;
+    else if (")]".includes(c)) depth--;
+    else if (c === "}") {
+      if (depth === 0) break;
+      depth--;
+    } else if (c === "," && depth === 0) break;
+    out += c;
+  }
+  return out.trim();
+}
+
+/** The initializer of the nearest preceding `let <name> = …`, bounded by the
+ *  enclosing signature so a same-named binding in another function can't answer.
+ *  null when there is none — a parameter, or a pattern's binding. */
+export function bindingInitializer(lines, fromIdx, name) {
+  const decl = new RegExp(
+    `\\blet\\s+(?:mut\\s+)?${name}\\s*(?::[^=]*)?=\\s*(.*)$`,
+  );
+  for (let i = fromIdx; i >= 0 && i > fromIdx - 40; i--) {
+    if (FN_RE.test(lines[i])) return null;
+    const m = decl.exec(lines[i]);
+    if (!m) continue;
+    let init = m[1];
+    for (
+      let j = i + 1;
+      !init.includes(";") && j < i + 6 && j < lines.length;
+      j++
+    ) {
+      init += lines[j];
+    }
+    return init;
+  }
+  return null;
+}
+
+/** The fix a stderr field value earns, or null when it is correctly shaped. */
+function stderrValueVerdict(value, lines, ctorIdx) {
+  if (FULL_FAILURE_TEXT_RE.test(value)) return null;
+  if (SUBSTITUTING_RE.test(value)) return SUBSTITUTION_FIX;
+  if (STDERR_READ_RE.test(value)) return STDERR_ONLY_FIX;
+  if (!BARE_IDENT_RE.test(value)) return null;
+  const init = bindingInitializer(lines, ctorIdx, value);
+  if (init === null) return UNRESOLVED_FIX;
+  if (FULL_FAILURE_TEXT_RE.test(init)) return null;
+  if (SUBSTITUTING_RE.test(init)) return SUBSTITUTION_FIX;
+  if (STDERR_READ_RE.test(init)) return STDERR_ONLY_FIX;
+  return null;
+}
+
+export function checkStderrOnlyGitError(file, src, lines, hits) {
+  const code = stripComments(lines);
+  const limit = testModuleStart(lines);
+  GIT_CTOR_RE.lastIndex = 0;
+  for (let m = GIT_CTOR_RE.exec(src); m; m = GIT_CTOR_RE.exec(src)) {
+    const line = src.slice(0, m.index).split("\n").length;
+    if (line - 1 >= limit) continue;
+    const value = stderrFieldValue(code.slice(line - 1, line + 5).join("\n"));
+    if (value === null) continue;
+    const fix = stderrValueVerdict(value, code, line - 1);
+    if (fix === null) continue;
+    const fn = enclosingFn(lines, line - 1);
+    hits.push({
+      file,
+      line,
+      fn,
+      allowlisted: allowed(STDERR_ONLY_ALLOWLIST, file, fn),
+      fix,
+    });
+  }
+}
+
 // ---------------------------------------------------------------------- main
 
 function main() {
@@ -350,6 +554,12 @@ function main() {
       name: "C. sync #[tauri::command]",
       run: checkSyncCommands,
       allowlist: SYNC_COMMAND_ALLOWLIST,
+      hits: [],
+    },
+    {
+      name: "D. stderr-only AppError::Git",
+      run: checkStderrOnlyGitError,
+      allowlist: STDERR_ONLY_ALLOWLIST,
       hits: [],
     },
   ];

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -429,16 +429,27 @@ const UNRESOLVED_FIX =
   "this stderr value names a binding the checker cannot resolve, so it cannot tell " +
   "which shaping built it — inline the shaping, or allowlist with rationale";
 
-/** First line of a `#[cfg(test)]` module, or `Infinity`. The invariant governs
- *  how PRODUCTION code shapes a user-facing error; test code destructures these
- *  same shapes, and a fail-closed binding check reads every renaming pattern as
- *  an unresolvable field. Rests on test modules coming last in the file, which
- *  is this codebase's layout. */
-export function testModuleStart(lines) {
-  const idx = lines.findIndex((l) =>
-    /^\s*#\[cfg\(\s*(?:all\(\s*)?test\b/.test(l),
-  );
-  return idx === -1 ? Number.POSITIVE_INFINITY : idx;
+/** Character spans of every `#[cfg(test)]`-gated `mod`, as `[open, close]` brace
+ *  indices. The invariant governs how PRODUCTION code shapes a user-facing
+ *  error; test code destructures those same shapes, and a fail-closed binding
+ *  check reads every renaming pattern as an unresolvable field.
+ *
+ *  Spans, not a cut at the first attribute: a cut leaves every constructor after
+ *  a test module unscanned, which is a fail-open that grows with the file.
+ *  Matching `mod` specifically is load-bearing too — `#[cfg(test)]` also gates
+ *  statics, functions and even `if let` blocks (`app_store.rs`), whose next
+ *  brace would otherwise be read as a module body. */
+export function testModuleSpans(text) {
+  const attr =
+    /#\[cfg\(\s*(?:all\(\s*)?test\b[^\]]*\]\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+\w+\s*\{/g;
+  const spans = [];
+  for (let m = attr.exec(text); m; m = attr.exec(text)) {
+    const open = m.index + m[0].length - 1;
+    const close = open + 1 + braceBody(text, open).length;
+    spans.push([open, close]);
+    attr.lastIndex = close;
+  }
+  return spans;
 }
 
 /** Index of a char literal's closing quote at `i`, or -1 when the `'` opens a
@@ -450,6 +461,19 @@ function charLiteralEnd(text, i) {
   return m ? i + m[0].length - 1 : -1;
 }
 
+/** Index of the closing delimiter of the string or char literal starting at `i`,
+ *  or -1 when the character opens neither. An unterminated string ends at the
+ *  text, so a scan can never run past its own input. */
+function literalEnd(text, i) {
+  if (text[i] === "'") return charLiteralEnd(text, i);
+  if (text[i] !== '"') return -1;
+  for (let j = i + 1; j < text.length; j++) {
+    if (text[j] === "\\") j++;
+    else if (text[j] === '"') return j;
+  }
+  return text.length - 1;
+}
+
 /** The body of the `{ … }` opening at `openIdx`, brace-balanced. Rustfmt and a
  *  long field expression can push `stderr:` arbitrarily far down a constructor,
  *  and a fixed line window that ends before it reads as "no stderr field" — a
@@ -457,52 +481,69 @@ function charLiteralEnd(text, i) {
 export function braceBody(text, openIdx) {
   let depth = 0;
   for (let i = openIdx; i < text.length; i++) {
-    const c = text[i];
-    if (c === '"') {
-      for (i++; i < text.length && text[i] !== '"'; i++) {
-        if (text[i] === "\\") i++;
-      }
+    const lit = literalEnd(text, i);
+    if (lit >= 0) {
+      i = lit;
       continue;
     }
-    if (c === "'") {
-      const end = charLiteralEnd(text, i);
-      if (end >= 0) i = end;
-      continue;
-    }
-    if (c === "{") depth++;
-    else if (c === "}" && --depth === 0) return text.slice(openIdx + 1, i);
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}" && --depth === 0)
+      return text.slice(openIdx + 1, i);
   }
   // Unbalanced (a truncated file): hand back the remainder rather than nothing,
   // so a `stderr:` below still gets read.
   return text.slice(openIdx + 1);
 }
 
-/** The `stderr:` field's value expression, or null when the text has no such
- *  field. Scans to the `,` or `}` that closes the field at bracket depth 0,
- *  skipping string literals so a `format!("…{stderr}")` brace cannot end it. */
-export function stderrFieldValue(text) {
-  const at = /\bstderr\s*:/.exec(text);
-  if (!at) return null;
+/** Index just past the `stderr:` field's colon in a constructor `body`, or -1.
+ *  Found by scanning at depth 0 outside literals rather than by matching text:
+ *  an earlier field whose STRING happens to contain `stderr: …` would otherwise
+ *  answer for the real field and hide it. */
+function stderrFieldStart(body) {
   let depth = 0;
-  let out = "";
-  for (let i = at.index + at[0].length; i < text.length; i++) {
-    const c = text[i];
-    if (c === '"') {
-      const start = i;
-      for (i++; i < text.length && text[i] !== '"'; i++) {
-        if (text[i] === "\\") i++;
-      }
-      out += text.slice(start, i + 1);
+  for (let i = 0; i < body.length; i++) {
+    const lit = literalEnd(body, i);
+    if (lit >= 0) {
+      i = lit;
       continue;
     }
-    if (c === "'") {
-      const end = charLiteralEnd(text, i);
-      if (end >= 0) {
-        out += text.slice(i, end + 1);
-        i = end;
-        continue;
-      }
+    const c = body[i];
+    if ("([{".includes(c)) depth++;
+    else if (")]}".includes(c)) depth--;
+    else if (depth === 0 && /[A-Za-z_]/.test(c)) {
+      let j = i;
+      while (j < body.length && /\w/.test(body[j])) j++;
+      let k = j;
+      while (k < body.length && /\s/.test(body[k])) k++;
+      // `::` is a path, not a field.
+      if (
+        body.slice(i, j) === "stderr" &&
+        body[k] === ":" &&
+        body[k + 1] !== ":"
+      )
+        return k + 1;
+      i = j - 1;
     }
+  }
+  return -1;
+}
+
+/** The `stderr:` field's value expression, or null when the constructor `body`
+ *  has no such field. Scans to the `,` or `}` that closes the field at bracket
+ *  depth 0, skipping literals so a `format!("…{stderr}")` brace cannot end it. */
+export function stderrFieldValue(body) {
+  const start = stderrFieldStart(body);
+  if (start < 0) return null;
+  let depth = 0;
+  let out = "";
+  for (let i = start; i < body.length; i++) {
+    const lit = literalEnd(body, i);
+    if (lit >= 0) {
+      out += body.slice(i, lit + 1);
+      i = lit;
+      continue;
+    }
+    const c = body[i];
     if ("([{".includes(c)) depth++;
     else if (")]".includes(c)) depth--;
     else if (c === "}") {
@@ -556,8 +597,12 @@ function stderrValueVerdict(value, lines, ctorIdx) {
     seen.add(expr);
     const init = bindingInitializer(lines, ctorIdx, expr);
     if (init === null) return UNRESOLVED_FIX;
-    // The initializer is captured to end-of-statement, so the `;` (and anything
-    // rustfmt put after it) has to come off before the next hop can be an ident.
+    // Judge the WHOLE initializer. The split below truncates at the first `;`,
+    // including one inside a string (`format!("a; {}", out.stderr)`), so it is
+    // only ever good enough to name the next alias — never to decide a verdict.
+    if (FULL_FAILURE_TEXT_RE.test(init)) return null;
+    if (SUBSTITUTING_RE.test(init)) return SUBSTITUTION_FIX;
+    if (STDERR_READ_RE.test(init)) return STDERR_ONLY_FIX;
     expr = init.split(";")[0].trim();
   }
 }
@@ -565,11 +610,11 @@ function stderrValueVerdict(value, lines, ctorIdx) {
 export function checkStderrOnlyGitError(file, _src, lines, hits) {
   const code = stripComments(lines);
   const codeSrc = code.join("\n");
-  const limit = testModuleStart(lines);
+  const spans = testModuleSpans(codeSrc);
   GIT_CTOR_RE.lastIndex = 0;
   for (let m = GIT_CTOR_RE.exec(codeSrc); m; m = GIT_CTOR_RE.exec(codeSrc)) {
+    if (spans.some(([s, e]) => m.index > s && m.index < e)) continue;
     const line = codeSrc.slice(0, m.index).split("\n").length;
-    if (line - 1 >= limit) continue;
     const open = m.index + m[0].length - 1;
     const value = stderrFieldValue(braceBody(codeSrc, open));
     if (value === null) continue;

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -440,6 +440,77 @@ test("a comment naming full_failure_text does not disarm the check", () => {
   assert.equal(hits[0].fn, "commented");
 });
 
+test("a chain of stderr aliases is followed to its shaping", () => {
+  // One hop lands on a bare ident that matches none of the shaping tests, which
+  // reads as correctly shaped — so the walk has to continue.
+  const src = [
+    "async fn chained_bad(out: GitOutput) -> AppError {",
+    "    let raw = out.stderr;",
+    "    let report = raw;",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: report,",
+    "    }",
+    "}",
+    "async fn chained_ok(out: GitOutput) -> AppError {",
+    "    let raw = out.full_failure_text();",
+    "    let report = raw;",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: report,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(
+    hits.map((h) => h.fn),
+    ["chained_bad"],
+  );
+  assert.match(hits[0].fix, /full_failure_text/);
+});
+
+test("a cycle of stderr aliases fails closed", () => {
+  const src = [
+    "async fn looped(out: GitOutput) -> AppError {",
+    "    let first = second;",
+    "    let second = first;",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: first,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.match(hits[0].fix, /cannot resolve/);
+});
+
+test("a stderr field beyond a six-line constructor is still read", () => {
+  // Brace balance, not a line count: rustfmt and a long field list push the
+  // field down, and a window that ends first reads as "no stderr field".
+  const src = [
+    "async fn padded(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    "        // one",
+    "        // two",
+    "        // three",
+    "        // four",
+    "        // five",
+    "        // six",
+    "        // seven",
+    "        code: out.code,",
+    "        stderr: out.stderr,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "padded");
+});
+
 test("stderr-only check does not scan test modules", () => {
   // A renaming pattern (`stderr: text`) is indistinguishable from an
   // unresolvable field, and only tests carry them — they assert on these shapes

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -511,10 +511,47 @@ test("a stderr field beyond a six-line constructor is still read", () => {
   assert.equal(hits[0].fn, "padded");
 });
 
-test("stderr-only check does not scan test modules", () => {
+test("an alias initializer is judged whole, not truncated at a `;`", () => {
+  // The `;` that ends the statement can also sit inside a string literal, and
+  // the truncated head matches no shaping test and is not an ident — a pass.
+  const src = [
+    "async fn semicolon_in_literal(out: GitOutput) -> AppError {",
+    '    let report = format!("a; {}", out.stderr);',
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: report,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "semicolon_in_literal");
+  assert.match(hits[0].fix, /full_failure_text/);
+});
+
+test("a `stderr:` inside a string literal does not answer for the real field", () => {
+  // Matching the first `stderr:` in the text lets an earlier field's STRING
+  // stand in for the field — and a string naming the correct helper passes.
+  const src = [
+    "async fn masked(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    '        code: fallback("shape it as stderr: out.full_failure_text()"),',
+    "        stderr: out.stderr,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "masked");
+  assert.match(hits[0].fix, /full_failure_text/);
+});
+
+test("test modules are skipped by SPAN, so production code after one is scanned", () => {
   // A renaming pattern (`stderr: text`) is indistinguishable from an
-  // unresolvable field, and only tests carry them — they assert on these shapes
-  // rather than building them.
+  // unresolvable field, and only tests carry them. Cutting the scan at the
+  // module instead of bounding it would leave everything below unchecked.
   const src = [
     "#[cfg(test)]",
     "mod tests {",
@@ -524,10 +561,19 @@ test("stderr-only check does not scan test modules", () => {
     "        }",
     "    }",
     "}",
+    "async fn after_tests(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: out.stderr,",
+    "    }",
+    "}",
   ].join("\n");
   const hits = [];
   checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
-  assert.deepEqual(hits, []);
+  assert.deepEqual(
+    hits.map((h) => h.fn),
+    ["after_tests"],
+  );
 });
 
 // ----------------------------------------------------------- check-dead-surface

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -25,6 +25,7 @@ import {
 import {
   checkRefspecTemplates,
   checkSecretArgv,
+  checkStderrOnlyGitError,
   checkSyncCommands,
   enclosingFn,
   staleAllowlistEntries,
@@ -316,6 +317,146 @@ test("sync #[tauri::command] is caught, async is not, unreadable fails closed", 
   assert.equal(failClosed.length, 1);
   assert.equal(failClosed[0].fn, "<unresolved>");
   assert.equal(failClosed[0].allowlisted, false);
+});
+
+test("stderr-only AppError::Git is caught, bare and format!-wrapped", () => {
+  const src = [
+    "async fn plain(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: out.stderr,",
+    "    }",
+    "}",
+    "async fn wrapped(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    "        code: out.code,",
+    '        stderr: format!("prefix\\n{}", out.stderr),',
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(
+    hits.map((h) => h.fn),
+    ["plain", "wrapped"],
+  );
+  assert.equal(hits[0].allowlisted, false);
+});
+
+test("stderr-only check ignores correct shaping and bare binding patterns", () => {
+  const src = [
+    "async fn shaped(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: out.full_failure_text(),",
+    "    }",
+    "}",
+    "fn matched(e: AppError) -> bool {",
+    '    matches!(e, AppError::Git { stderr, .. } if stderr.contains("x"))',
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(hits, []);
+});
+
+test("a stderr value naming a binding is judged by that binding's initializer", () => {
+  // The shape the conflict batch itself uses (`let report = …; stderr: report`):
+  // the field alone says nothing, so substituting `.stderr` into the binding
+  // later has to stay visible.
+  const src = [
+    "async fn good(commit: GitOutput) -> AppError {",
+    "    let report = commit.full_failure_text();",
+    "    let _lower = report.to_lowercase();",
+    "    AppError::Git {",
+    "        code: commit.code,",
+    "        stderr: report,",
+    "    }",
+    "}",
+    "async fn bad(commit: GitOutput) -> AppError {",
+    "    let report = commit.stderr;",
+    "    AppError::Git {",
+    "        code: commit.code,",
+    "        stderr: report,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(
+    hits.map((h) => h.fn),
+    ["bad"],
+  );
+});
+
+test("an unresolvable stderr binding fails closed", () => {
+  // A parameter has no initializer in range, so the checker cannot know which
+  // shaping built it — that is a finding, not a pass.
+  const src = [
+    "async fn passthrough(code: i32, report: String) -> AppError {",
+    "    AppError::Git {",
+    "        code,",
+    "        stderr: report,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "passthrough");
+  assert.match(hits[0].fix, /cannot resolve/);
+});
+
+test("failure_text() substitution is caught apart from the combining helper", () => {
+  const src = [
+    "async fn substituting(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: out.failure_text(),",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.match(hits[0].fix, /SUBSTITUTES/);
+});
+
+test("a comment naming full_failure_text does not disarm the check", () => {
+  // The verdict is read from the field VALUE as an expression; a window-wide
+  // substring test would have accepted this site on the strength of its prose.
+  const src = [
+    "async fn commented(out: GitOutput) -> AppError {",
+    "    // full_failure_text() is what this should use.",
+    "    AppError::Git {",
+    "        code: out.code,",
+    "        stderr: out.stderr,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "commented");
+});
+
+test("stderr-only check does not scan test modules", () => {
+  // A renaming pattern (`stderr: text`) is indistinguishable from an
+  // unresolvable field, and only tests carry them — they assert on these shapes
+  // rather than building them.
+  const src = [
+    "#[cfg(test)]",
+    "mod tests {",
+    "    fn renamed(e: &AppError) {",
+    "        if let AppError::Git { code: c, stderr: text } = e {",
+    "            drop((c, text));",
+    "        }",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(hits, []);
 });
 
 // ----------------------------------------------------------- check-dead-surface

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -548,6 +548,43 @@ test("a `stderr:` inside a string literal does not answer for the real field", (
   assert.match(hits[0].fix, /full_failure_text/);
 });
 
+test("a raw string literal does not swallow the rest of a constructor", () => {
+  // `r"\\?\"` ends at its own quote — raw literals honor no escapes — but an
+  // escape-aware scan reads the trailing backslash as escaping that quote and
+  // consumes everything after it, so the real field is never reached.
+  const src = [
+    "async fn raw_in_ctor(out: GitOutput) -> AppError {",
+    "    AppError::Git {",
+    String.raw`        code: parse(r"\\?\"),`,
+    "        stderr: out.stderr,",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fn, "raw_in_ctor");
+});
+
+test("an attribute-decorated test module is still recognized as a span", () => {
+  // The gate and the `mod` can be separated by outer attributes; missing the
+  // span reads every renaming pattern inside it as an unresolvable field.
+  const src = [
+    "#[cfg(test)]",
+    "#[allow(clippy::too_many_lines)]",
+    "mod tests {",
+    "    fn renamed(e: &AppError) {",
+    "        if let AppError::Git { code: c, stderr: text } = e {",
+    "            drop((c, text));",
+    "        }",
+    "    }",
+    "}",
+  ].join("\n");
+  const hits = [];
+  checkStderrOnlyGitError("fixture.rs", src, src.split("\n"), hits);
+  assert.deepEqual(hits, []);
+});
+
 test("test modules are skipped by SPAN, so production code after one is scanned", () => {
   // A renaming pattern (`stderr: text`) is indistinguishable from an
   // unresolvable field, and only tests carry them. Cutting the scan at the

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -165,6 +165,11 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Pull requests & review",
+    label:
+      "A merge blocked by branch protection names the required checks still unmet (GitHub)",
+  },
+  {
+    group: "Pull requests & review",
     label: "Set labels & assignees when you open a PR/MR (GitHub & GitLab)",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -93,7 +93,7 @@ export const capabilities: Capability[] = [
   {
     group: "Branches & history",
     label:
-      "Clean up branches in bulk — archive or delete stale ones in one sweep, including branches a pull request merged",
+      "Clean up branches in bulk — archive or delete stale ones in one sweep, including branches merged through a pull request",
     highlight: true,
   },
   {

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -5,6 +5,15 @@ use serde::Serialize;
 pub enum AppError {
     #[error("{}", git_message(*code, stderr))]
     Git { code: i32, stderr: String },
+    /// A git operation stopped on merge conflicts and left the repo mid-op for
+    /// the user to resolve. `report` is the full both-stream text; `paths` the
+    /// unmerged files at classification time.
+    #[error("{}", conflict_message(op, report))]
+    Conflict {
+        op: String,
+        paths: Vec<String>,
+        report: String,
+    },
     #[error("not a git repository: {0}")]
     NotARepo(String),
     #[error("git executable not found")]
@@ -46,10 +55,26 @@ fn git_message(code: i32, stderr: &str) -> String {
     }
 }
 
+/// The frontend renders a conflict from `op`/`report`, so this is what the
+/// non-presenting readers get: `Display` feeds `to_string()` embeds (the oplog
+/// entry, the compound funnels' wrapped messages). A report can only be empty if
+/// git wrote to neither stream, which still has to say something.
+fn conflict_message(op: &str, report: &str) -> String {
+    let trimmed = report.trim();
+    if trimmed.is_empty() {
+        format!("{op} stopped on merge conflicts")
+    } else {
+        trimmed.to_string()
+    }
+}
+
 impl Serialize for AppError {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let kind = match self {
             AppError::Git { .. } => "git",
+            // Stable serialized kind — `presentError` branches on it BEFORE the
+            // prose markers to name the paused operation from `op`.
+            AppError::Conflict { .. } => "conflict",
             AppError::NotARepo(_) => "notARepo",
             AppError::GitNotFound => "gitNotFound",
             AppError::GhNotFound => "ghNotFound",
@@ -71,12 +96,64 @@ impl Serialize for AppError {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("kind", kind)?;
         map.serialize_entry("message", &self.to_string())?;
-        if let AppError::Git { code, stderr } = self {
-            map.serialize_entry("code", code)?;
-            map.serialize_entry("stderr", stderr)?;
+        match self {
+            AppError::Git { code, stderr } => {
+                map.serialize_entry("code", code)?;
+                map.serialize_entry("stderr", stderr)?;
+            }
+            AppError::Conflict { op, paths, report } => {
+                map.serialize_entry("op", op)?;
+                map.serialize_entry("paths", paths)?;
+                map.serialize_entry("report", report)?;
+            }
+            _ => {}
         }
         map.end()
     }
 }
 
 pub type AppResult<T> = Result<T, AppError>;
+
+#[cfg(test)]
+mod tests {
+    use super::AppError;
+
+    /// The frontend reads these exact keys off a conflict error. Every one is a
+    /// single word, so no casing convention can rescue a rename — pinned byte-for
+    /// -byte, mirroring `AutostashOutcome`'s wire-shape pin.
+    #[test]
+    fn conflict_serializes_to_the_pinned_wire_shape() {
+        let err = AppError::Conflict {
+            op: "merge".to_string(),
+            paths: vec!["a.txt".to_string(), "dir/b.txt".to_string()],
+            report: "CONFLICT (content): Merge conflict in a.txt".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_string(&err).unwrap(),
+            r#"{"kind":"conflict","message":"CONFLICT (content): Merge conflict in a.txt","op":"merge","paths":["a.txt","dir/b.txt"],"report":"CONFLICT (content): Merge conflict in a.txt"}"#
+        );
+    }
+
+    /// `Git`'s payload arm is the one this variant was modeled on — it must keep
+    /// its own shape now that the two share a `match`.
+    #[test]
+    fn git_still_serializes_to_its_own_wire_shape() {
+        let err = AppError::Git {
+            code: 1,
+            stderr: "boom".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_string(&err).unwrap(),
+            r#"{"kind":"git","message":"boom","code":1,"stderr":"boom"}"#
+        );
+    }
+
+    /// A payload-free variant carries kind + message and nothing else.
+    #[test]
+    fn a_plain_variant_carries_no_payload_keys() {
+        assert_eq!(
+            serde_json::to_string(&AppError::GitNotFound).unwrap(),
+            r#"{"kind":"gitNotFound","message":"git executable not found"}"#
+        );
+    }
+}

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -72,10 +72,18 @@ pub async fn run_glab_raw(
         cmd.current_dir(repo);
     }
     // Keep glab non-interactive + quiet (stdin null already blocks prompts).
+    // GLAB_CHECK_UPDATE is glab's update-notice switch and its polarity is
+    // inverted from gh's GH_NO_UPDATE_NOTIFIER — glab gates on the value being
+    // TRUE (cmd/glab/main.go `isUpdateCheckEnabled`, verified against v1.105.0).
+    // The value is `strconv.ParseBool`'d, so it must be a bool literal: an empty
+    // string logs a parse warning to stderr instead of disabling anything, and
+    // the notice it suppresses writes to stderr, where it would ride along in
+    // AppError::Glab and in the reconnect child's merged line scan.
     cmd.env("GLAB_PAGER", "")
         .env("PAGER", "")
         .env("NO_COLOR", "1")
-        .env("CLICOLOR", "0");
+        .env("CLICOLOR", "0")
+        .env("GLAB_CHECK_UPDATE", "false");
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -168,22 +176,78 @@ fn normalize_host(value: &str) -> Option<String> {
     (!host.is_empty()).then(|| host.to_ascii_lowercase())
 }
 
-/// The host keys of the `hosts:` section of a glab config.yml. A minimal
-/// line scanner, not a YAML parser: glab writes plain unquoted keys, and the
-/// file also holds live tokens — only key NAMES may leave this function, so
-/// values are never inspected at all.
+/// True for the `hosts:` section header. Only a trailing comment may follow the
+/// colon: `hosts2:` is a different key, and a flow-form `hosts: {…}` holds no
+/// line-scannable entries.
+fn is_hosts_header(trimmed: &str) -> bool {
+    let Some(rest) = trimmed.strip_prefix("hosts:") else {
+        return false;
+    };
+    if rest.is_empty() {
+        return true;
+    }
+    // YAML opens a comment only after whitespace, so `hosts:#x` is a plain
+    // scalar value — a section header with a value holds no scannable entries.
+    rest.starts_with(char::is_whitespace) && rest.trim_start().starts_with('#')
+}
+
+/// The line with a leading `<scheme>://` removed, so the first colon left is the
+/// key's own. Guarded on the scheme's own shape: a bare `://` search would also
+/// hit a URL in the line's VALUE (a trailing comment, a flow map) and eat the key.
+fn strip_scheme(trimmed: &str) -> &str {
+    match trimmed.split_once("://") {
+        Some((scheme, after))
+            if !scheme.is_empty()
+                && scheme
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')) =>
+        {
+            after
+        }
+        _ => trimmed,
+    }
+}
+
+/// The host a line at host-key indent declares, if it declares one. Whatever
+/// follows the colon is a value — an anchor, alias, flow map, or comment — and
+/// is never inspected, so any `key:`-shaped line names a host except the YAML
+/// merge key `<<`, which is a mapping directive. A key carrying whitespace or a
+/// comma is never a hostname and is refused: that is the one shape a stray value
+/// fragment (a mis-indented flow continuation) could otherwise arrive in.
+fn host_from_key_line(trimmed: &str) -> Option<String> {
+    let key = strip_scheme(trimmed).split_once(':')?.0.trim();
+    if key == "<<" || key.contains(char::is_whitespace) || key.contains(',') {
+        return None;
+    }
+    // Quotes around a key are YAML syntax; left on they bake into the hostname.
+    let unquoted = ['\'', '"']
+        .iter()
+        .find_map(|q| key.strip_prefix(*q)?.strip_suffix(*q))
+        .unwrap_or(key);
+    normalize_host(unquoted)
+}
+
+/// The host keys of the `hosts:` section of a glab config.yml. A minimal line
+/// scanner, not a YAML parser: it accepts the hand-written forms glab's own
+/// writer never emits (anchors, aliases, comments, quoted keys) because a
+/// dropped host silently disables GitLab detection for that config. The file
+/// also holds live tokens — only key NAMES may leave this function, so values
+/// are never inspected at all. A non-host key under `hosts:` (an anchor-definition
+/// block, an alias key) is therefore reported as a host — parity with glab, which
+/// unmarshals the section as host→config and reads that key as a host too.
 fn hosts_from_config(text: &str) -> Vec<String> {
     let mut hosts = Vec::new();
     let mut in_hosts = false;
     let mut key_indent: Option<usize> = None;
     for line in text.lines() {
         let content = line.trim_end();
-        if content.trim_start().starts_with('#') || content.trim().is_empty() {
+        let trimmed = content.trim_start();
+        if trimmed.starts_with('#') || trimmed.is_empty() {
             continue;
         }
-        let indent = content.len() - content.trim_start().len();
+        let indent = content.len() - trimmed.len();
         if !in_hosts {
-            in_hosts = indent == 0 && content == "hosts:";
+            in_hosts = indent == 0 && is_hosts_header(trimmed);
             continue;
         }
         // Any top-level key (or a dedent past the host level) ends the section.
@@ -197,11 +261,8 @@ fn hosts_from_config(text: &str) -> Vec<String> {
         if indent < level {
             break;
         }
-        // A host entry is `<host>:` with nothing after the colon.
-        if let Some(key) = content.trim_start().strip_suffix(':') {
-            if let Some(host) = normalize_host(key) {
-                hosts.push(host);
-            }
+        if let Some(host) = host_from_key_line(trimmed) {
+            hosts.push(host);
         }
     }
     hosts
@@ -275,7 +336,8 @@ pub async fn run_glab_ex(
     cmd.env("GLAB_PAGER", "")
         .env("PAGER", "")
         .env("NO_COLOR", "1")
-        .env("CLICOLOR", "0");
+        .env("CLICOLOR", "0")
+        .env("GLAB_CHECK_UPDATE", "false"); // see run_glab_raw for the polarity
     for (k, v) in envs {
         cmd.env(k, v);
     }
@@ -336,7 +398,14 @@ pub async fn run_glab_ex(
 
 #[cfg(test)]
 mod known_hosts_tests {
-    use super::{hosts_from_config, normalize_host};
+    use super::{hosts_from_config, known_hosts, normalize_host};
+
+    /// Table driver: `(label, config, expected hosts)`.
+    fn check(cases: &[(&str, &str, &[&str])]) {
+        for (label, config, expected) in cases {
+            assert_eq!(hosts_from_config(config), *expected, "case: {label}");
+        }
+    }
 
     #[test]
     fn extracts_host_keys_only() {
@@ -393,5 +462,179 @@ hosts:
             Some("gitlab.example.com".into())
         );
         assert_eq!(normalize_host("  "), None);
+    }
+
+    #[test]
+    fn structural_forms_keep_scanning() {
+        // The forms that already worked: they must survive the key-grammar
+        // widening, which is otherwise free to swallow non-host lines.
+        check(&[
+            (
+                "plain key",
+                "hosts:\n  gitlab.example.com:\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "port in the key — split at the first colon, then normalized away",
+                "hosts:\n  gitlab.example.com:443:\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "scheme on the key",
+                "hosts:\n  https://gitlab.example.com:\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "scheme and port on the key",
+                "hosts:\n  https://gitlab.example.com:8443:\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a URL in the value must not be mistaken for the key's scheme",
+                "hosts:\n  gitlab.example.com: # see https://docs.example.com\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "CRLF line endings",
+                "hosts:\r\n  gitlab.example.com:\r\n    token: secret\r\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "document marker ahead of the section",
+                "---\nhosts:\n  gitlab.example.com:\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "trailing whitespace on the header",
+                "hosts:  \n  gitlab.example.com:\n",
+                &["gitlab.example.com"],
+            ),
+            ("empty section", "hosts:\ncheck_update: true\n", &[]),
+            (
+                "the YAML merge key is a directive, not a host",
+                "hosts:\n  <<: *defaults\n  gitlab.example.com:\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a wrapped flow map's continuation is a value fragment, not a key",
+                "hosts:\n  gitlab.example.com: {token: abc,\n  def456, user: someone}\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a host's own sub-keys",
+                "hosts:\n  gitlab.example.com:\n    api_host: nested.example.com\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a dedent past host level ends the section",
+                "hosts:\n    gitlab.example.com:\n  stray.example.com:\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a top-level key ends the section",
+                "hosts:\n  gitlab.example.com:\ncheck_update: true\nstray.example.com:\n",
+                &["gitlab.example.com"],
+            ),
+        ]);
+    }
+
+    #[test]
+    fn reads_decorated_host_keys() {
+        // glab's writer emits a bare `<host>:`, but a hand-edited config can
+        // decorate the key or hang any value off it — dropping those hosts
+        // disables GitLab detection silently.
+        check(&[
+            (
+                "anchor",
+                "hosts:\n  gitlab.example.com: &defaults\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "alias",
+                "hosts:\n  gitlab.example.com: *defaults\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "trailing comment",
+                "hosts:\n  gitlab.example.com: # work instance\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "flow map",
+                "hosts:\n  gitlab.example.com: {token: secret}\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "quoted keys",
+                "hosts:\n  \"gitlab.example.com\":\n  'other.example.com':\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+        ]);
+    }
+
+    #[test]
+    fn reads_a_commented_hosts_header() {
+        check(&[(
+            "a comment on the header must not hide the whole section",
+            "hosts: # my instances\n  gitlab.example.com:\n    token: secret\n",
+            &["gitlab.example.com"],
+        )]);
+    }
+
+    #[test]
+    fn lookalike_headers_open_nothing() {
+        check(&[
+            ("a longer key", "hosts2:\n  stray.example.com:\n", &[]),
+            (
+                "a value, not a section",
+                "hosts: mine\n  stray.example.com:\n",
+                &[],
+            ),
+            (
+                "`#` without leading whitespace is a scalar, not a comment",
+                "hosts:#mine\n  stray.example.com:\n",
+                &[],
+            ),
+            (
+                "flow-form mapping",
+                "hosts: {}\n  stray.example.com:\n",
+                &[],
+            ),
+            (
+                "not at top level",
+                "  hosts:\n    stray.example.com:\n",
+                &[],
+            ),
+        ]);
+    }
+
+    #[tokio::test]
+    async fn known_hosts_never_claims_github_or_bitbucket() {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-glab-cfg")
+            .tempdir()
+            .expect("tempdir");
+        std::fs::write(
+            dir.path().join("config.yml"),
+            "hosts:\n  github.com:\n  bitbucket.org:\n  gitlab.example.com:\n",
+        )
+        .expect("write config");
+        // SAFETY: GLAB_CONFIG_DIR/GITLAB_HOST are read only by `known_hosts`, and
+        // no other test drives it. GLAB_CONFIG_DIR is exclusive when set, so this
+        // pins the read to the fixture instead of the developer's real config.
+        // Both are snapshotted and restored: this process may have inherited them.
+        let prior_dir = std::env::var_os("GLAB_CONFIG_DIR");
+        let prior_host = std::env::var_os("GITLAB_HOST");
+        std::env::set_var("GLAB_CONFIG_DIR", dir.path());
+        std::env::remove_var("GITLAB_HOST");
+        let hosts = known_hosts().await;
+        match prior_dir {
+            Some(d) => std::env::set_var("GLAB_CONFIG_DIR", d),
+            None => std::env::remove_var("GLAB_CONFIG_DIR"),
+        }
+        if let Some(h) = prior_host {
+            std::env::set_var("GITLAB_HOST", h);
+        }
+        assert_eq!(hosts, vec!["gitlab.example.com"]);
     }
 }

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -208,6 +208,21 @@ fn strip_scheme(trimmed: &str) -> &str {
     }
 }
 
+/// The flow-collection nesting depth after `text`, counting bracket characters
+/// only — no value is read. A trailing comment is dropped first so a stray `{`
+/// in prose can't wedge the scanner open across the rest of the section.
+fn flow_depth_after(depth: usize, text: &str) -> usize {
+    let code = text
+        .char_indices()
+        .find(|&(i, c)| c == '#' && text[..i].ends_with(char::is_whitespace))
+        .map_or(text, |(i, _)| &text[..i]);
+    code.chars().fold(depth, |d, c| match c {
+        '{' | '[' => d + 1,
+        '}' | ']' => d.saturating_sub(1),
+        _ => d,
+    })
+}
+
 /// The host a line at host-key indent declares, if it declares one. Whatever
 /// follows the colon is a value — an anchor, alias, flow map, or comment — and
 /// is never inspected, so any `key:`-shaped line names a host except the YAML
@@ -239,6 +254,7 @@ fn hosts_from_config(text: &str) -> Vec<String> {
     let mut hosts = Vec::new();
     let mut in_hosts = false;
     let mut key_indent: Option<usize> = None;
+    let mut flow_depth = 0usize;
     for line in text.lines() {
         let content = line.trim_end();
         let trimmed = content.trim_start();
@@ -250,13 +266,22 @@ fn hosts_from_config(text: &str) -> Vec<String> {
             in_hosts = indent == 0 && is_hosts_header(trimmed);
             continue;
         }
+        // A line continuing an open flow collection is value text whatever its
+        // indent, so it is never a key and never ends the section.
+        if flow_depth > 0 {
+            flow_depth = flow_depth_after(flow_depth, trimmed);
+            continue;
+        }
         // Any top-level key (or a dedent past the host level) ends the section.
         if indent == 0 {
             break;
         }
         let level = *key_indent.get_or_insert(indent);
         if indent > level {
-            continue; // a host's own sub-keys (token, api_host, …)
+            // A host's own sub-keys (token, api_host, …) — not hosts, but their
+            // values can open a flow collection that wraps onto later lines.
+            flow_depth = flow_depth_after(flow_depth, trimmed);
+            continue;
         }
         if indent < level {
             break;
@@ -264,7 +289,29 @@ fn hosts_from_config(text: &str) -> Vec<String> {
         if let Some(host) = host_from_key_line(trimmed) {
             hosts.push(host);
         }
+        flow_depth = flow_depth_after(flow_depth, trimmed);
     }
+    hosts
+}
+
+/// The hosts of the first readable config in `paths`, plus `env_host` when set,
+/// with the canonical non-GitLab hosts dropped. The env-free core of
+/// [`known_hosts`]: every environment read lives in that wrapper, so this stays
+/// testable without mutating process-global state.
+async fn known_hosts_from(paths: &[PathBuf], env_host: Option<&str>) -> Vec<String> {
+    let mut hosts = Vec::new();
+    for path in paths {
+        if let Ok(text) = tokio::fs::read_to_string(path).await {
+            hosts = hosts_from_config(&text);
+            break;
+        }
+    }
+    if let Some(host) = env_host.and_then(normalize_host) {
+        if !hosts.contains(&host) {
+            hosts.push(host);
+        }
+    }
+    hosts.retain(|h| h != "github.com" && h != "bitbucket.org");
     hosts
 }
 
@@ -273,22 +320,8 @@ fn hosts_from_config(text: &str) -> Vec<String> {
 /// are never claimed, whatever the config says. Missing/unreadable config →
 /// just the env var (or empty), so the GitHub default stays authoritative.
 pub async fn known_hosts() -> Vec<String> {
-    let mut hosts = Vec::new();
-    for path in glab_config_paths() {
-        if let Ok(text) = tokio::fs::read_to_string(&path).await {
-            hosts = hosts_from_config(&text);
-            break;
-        }
-    }
-    if let Ok(env_host) = std::env::var("GITLAB_HOST") {
-        if let Some(host) = normalize_host(&env_host) {
-            if !hosts.contains(&host) {
-                hosts.push(host);
-            }
-        }
-    }
-    hosts.retain(|h| h != "github.com" && h != "bitbucket.org");
-    hosts
+    let env_host = std::env::var("GITLAB_HOST").ok();
+    known_hosts_from(&glab_config_paths(), env_host.as_deref()).await
 }
 
 /// Runs glab, treating any non-zero exit as an error carrying glab's stderr
@@ -398,7 +431,7 @@ pub async fn run_glab_ex(
 
 #[cfg(test)]
 mod known_hosts_tests {
-    use super::{hosts_from_config, known_hosts, normalize_host};
+    use super::{hosts_from_config, known_hosts_from, normalize_host};
 
     /// Table driver: `(label, config, expected hosts)`.
     fn check(cases: &[(&str, &str, &[&str])]) {
@@ -516,8 +549,23 @@ hosts:
                 &["gitlab.example.com"],
             ),
             (
-                "a wrapped flow map's continuation is a value fragment, not a key",
-                "hosts:\n  gitlab.example.com: {token: abc,\n  def456, user: someone}\n",
+                "a wrapped flow map's continuation lines are values, not keys",
+                "hosts:\n  gitlab.example.com: {token: secret,\n  api_host: https://gitlab.example.com}\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a sub-key's flow value wrapping onto later lines",
+                "hosts:\n  gitlab.example.com:\n    custom_headers: {a: [1,\n  b: 2]}\n  other.example.com:\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+            (
+                "a brace in a trailing comment must not wedge the section open",
+                "hosts:\n  gitlab.example.com: # a { brace\n  other.example.com:\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+            (
+                "a mis-indented value fragment is not a key",
+                "hosts:\n  gitlab.example.com: >\n  a folded, continued: line\n",
                 &["gitlab.example.com"],
             ),
             (
@@ -608,33 +656,47 @@ hosts:
         ]);
     }
 
-    #[tokio::test]
-    async fn known_hosts_never_claims_github_or_bitbucket() {
+    /// A config.yml in a throwaway dir, returned as the candidate-path list
+    /// `known_hosts_from` takes — the seam that keeps this off process env.
+    fn fixture_paths(body: &str) -> (tempfile::TempDir, Vec<std::path::PathBuf>) {
         let dir = tempfile::Builder::new()
             .prefix("gd-glab-cfg")
             .tempdir()
             .expect("tempdir");
-        std::fs::write(
-            dir.path().join("config.yml"),
-            "hosts:\n  github.com:\n  bitbucket.org:\n  gitlab.example.com:\n",
-        )
-        .expect("write config");
-        // SAFETY: GLAB_CONFIG_DIR/GITLAB_HOST are read only by `known_hosts`, and
-        // no other test drives it. GLAB_CONFIG_DIR is exclusive when set, so this
-        // pins the read to the fixture instead of the developer's real config.
-        // Both are snapshotted and restored: this process may have inherited them.
-        let prior_dir = std::env::var_os("GLAB_CONFIG_DIR");
-        let prior_host = std::env::var_os("GITLAB_HOST");
-        std::env::set_var("GLAB_CONFIG_DIR", dir.path());
-        std::env::remove_var("GITLAB_HOST");
-        let hosts = known_hosts().await;
-        match prior_dir {
-            Some(d) => std::env::set_var("GLAB_CONFIG_DIR", d),
-            None => std::env::remove_var("GLAB_CONFIG_DIR"),
-        }
-        if let Some(h) = prior_host {
-            std::env::set_var("GITLAB_HOST", h);
-        }
-        assert_eq!(hosts, vec!["gitlab.example.com"]);
+        let path = dir.path().join("config.yml");
+        std::fs::write(&path, body).expect("write config");
+        (dir, vec![path])
+    }
+
+    #[tokio::test]
+    async fn known_hosts_never_claims_github_or_bitbucket() {
+        let (_dir, paths) =
+            fixture_paths("hosts:\n  github.com:\n  bitbucket.org:\n  gitlab.example.com:\n");
+        assert_eq!(
+            known_hosts_from(&paths, None).await,
+            vec!["gitlab.example.com"]
+        );
+        // GITLAB_HOST joins the list but is filtered by the same rule.
+        assert_eq!(
+            known_hosts_from(&paths, Some("https://GitLab.Other.dev:8443")).await,
+            vec!["gitlab.example.com", "gitlab.other.dev"]
+        );
+        assert_eq!(
+            known_hosts_from(&paths, Some("github.com")).await,
+            vec!["gitlab.example.com"]
+        );
+    }
+
+    #[tokio::test]
+    async fn known_hosts_falls_back_past_unreadable_candidates() {
+        let (_dir, paths) = fixture_paths("hosts:\n  gitlab.example.com:\n");
+        let mut candidates = vec![std::path::PathBuf::from("no-such-dir/config.yml")];
+        candidates.extend(paths);
+        assert_eq!(
+            known_hosts_from(&candidates, None).await,
+            vec!["gitlab.example.com"]
+        );
+        // No readable config at all → just the env host, so GitHub stays default.
+        assert!(known_hosts_from(&[], None).await.is_empty());
     }
 }

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -209,8 +209,9 @@ fn strip_scheme(trimmed: &str) -> &str {
 }
 
 /// The flow-collection nesting depth after `text`, counting bracket characters
-/// only — no value is read. A trailing comment is dropped first so a stray `{`
-/// in prose can't wedge the scanner open across the rest of the section.
+/// only — no value is read. Only ever runs on text already known to sit inside a
+/// flow collection: the value that opened it, or a later continuation line. A
+/// trailing comment is dropped first so a `{` in prose can't wedge it open.
 fn flow_depth_after(depth: usize, text: &str) -> usize {
     let code = text
         .char_indices()
@@ -221,6 +222,24 @@ fn flow_depth_after(depth: usize, text: &str) -> usize {
         '}' | ']' => d.saturating_sub(1),
         _ => d,
     })
+}
+
+/// The flow-collection depth a key line OPENS. Zero unless its value BEGINS with
+/// `{`/`[` — that is the only place YAML starts a flow collection, so a bracket
+/// inside a plain scalar (`token: abc[def`) must not latch the scanner shut.
+fn flow_open_depth(trimmed: &str) -> usize {
+    // The same key/value split `host_from_key_line` uses, scheme term included:
+    // without it a `https://host: {…}` line splits at the scheme and its flow map
+    // goes unseen, so the wrapped continuation is read back as a host key.
+    let Some((_, value)) = strip_scheme(trimmed).split_once(':') else {
+        return 0;
+    };
+    let value = value.trim_start();
+    if value.starts_with(['{', '[']) {
+        flow_depth_after(0, value)
+    } else {
+        0
+    }
 }
 
 /// The host a line at host-key indent declares, if it declares one. Whatever
@@ -280,7 +299,7 @@ fn hosts_from_config(text: &str) -> Vec<String> {
         if indent > level {
             // A host's own sub-keys (token, api_host, …) — not hosts, but their
             // values can open a flow collection that wraps onto later lines.
-            flow_depth = flow_depth_after(flow_depth, trimmed);
+            flow_depth = flow_open_depth(trimmed);
             continue;
         }
         if indent < level {
@@ -289,7 +308,7 @@ fn hosts_from_config(text: &str) -> Vec<String> {
         if let Some(host) = host_from_key_line(trimmed) {
             hosts.push(host);
         }
-        flow_depth = flow_depth_after(flow_depth, trimmed);
+        flow_depth = flow_open_depth(trimmed);
     }
     hosts
 }
@@ -559,7 +578,22 @@ hosts:
                 &["gitlab.example.com", "other.example.com"],
             ),
             (
-                "a brace in a trailing comment must not wedge the section open",
+                "a scheme'd key opening a wrapped flow map",
+                "hosts:\n  https://gitlab.example.com: {token: secret,\n  api_host: x}\n  other.example.com:\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+            (
+                "a bracket in a plain scalar is not a flow collection",
+                "hosts:\n  gitlab.example.com:\n    token: abc[def\n  other.example.com:\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+            (
+                "a brace in a comment trailing a flow map must not wedge it open",
+                "hosts:\n  gitlab.example.com: {token: secret} # a { brace\n  other.example.com:\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+            (
+                "a brace in a comment is not a flow collection either",
                 "hosts:\n  gitlab.example.com: # a { brace\n  other.example.com:\n",
                 &["gitlab.example.com", "other.example.com"],
             ),

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -948,7 +948,12 @@ async fn run_reconnect_child(
     if is_github {
         cmd.env("GH_NO_UPDATE_NOTIFIER", "1");
     } else {
-        cmd.env("GLAB_PAGER", "").env("PAGER", "");
+        // An update notice lands on stderr, which this child scans for the
+        // one-time code. glab's switch is inverted from gh's and is ParseBool'd
+        // (see `glab::run_glab_raw`), so it must read "false", not "" or "1".
+        cmd.env("GLAB_PAGER", "")
+            .env("PAGER", "")
+            .env("GLAB_CHECK_UPDATE", "false");
     }
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -1035,11 +1035,13 @@ mod tests {
         );
     }
 
-    /// The conflict summary in `src/lib/error-summary.ts` keys off the ANCHORED
-    /// shapes of these lines, so a git release that reworded one would silently
-    /// change how conflicts present. Markers 1-2 guard live toast classification;
-    /// markers 3-4 ride stdout, which only the paths shaping their error through
-    /// `GitOutput::failure_text` / `full_failure_text` carry.
+    /// The FALLBACK conflict summary in `src/lib/error-summary.ts` keys off the
+    /// ANCHORED shapes of these lines — the arm that classifies any producer not
+    /// carrying `AppError::Conflict`, this compound's own outcomes included — so a
+    /// git release that reworded one would silently change how those present.
+    /// Markers 1-2 guard live toast classification; markers 3-4 ride stdout, which
+    /// only the paths shaping their error through `GitOutput::failure_text` /
+    /// `full_failure_text` carry.
     ///
     /// The STREAM SPLIT each family reports on is pinned here too, because the
     /// shaping choice depends on it: a family that writes to both streams needs
@@ -1500,6 +1502,11 @@ mod tests {
     /// leaves behind once the user commits or the changes are already away.
     /// Pull has its own arm below (a different stream split); switch never will,
     /// since a failing `git switch` writes no stdout to lose.
+    ///
+    /// The parity is over git's TEXT, not the variant: the plain core names the
+    /// paused operation structurally while this compound reports its own outcome
+    /// enum and shapes the no-stash arm as a plain git error, which the frontend's
+    /// prose markers still classify identically.
     #[tokio::test]
     async fn a_conflict_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, repo) = setup_with_feat("plain-parity-conflict").await;
@@ -1528,17 +1535,16 @@ mod tests {
 
         match (&compound, &plain) {
             (
-                AppError::Git {
-                    code: a,
-                    stderr: a_err,
-                },
-                AppError::Git {
-                    code: b,
-                    stderr: b_err,
+                AppError::Git { stderr: a_err, .. },
+                AppError::Conflict {
+                    op,
+                    paths,
+                    report: b_err,
                 },
             ) => {
-                assert_eq!(a, b);
                 assert_eq!(a_err, b_err);
+                assert_eq!(op, "merge");
+                assert_eq!(paths, &vec!["a.txt".to_string()]);
                 // Mirrors the frontend's anchored CONFLICT_MARKERS: without the
                 // stdout backfill both sides carry an empty stderr instead, which
                 // renders as "git exited with code 1".
@@ -1551,14 +1557,15 @@ mod tests {
                     "and the verdict line that names it a merge: {a_err}"
                 );
             }
-            other => panic!("expected two git errors, got {other:?}"),
+            other => panic!("expected a git error and a conflict, got {other:?}"),
         }
     }
 
     /// Pull's version of the same parity, on the split that hides the loss: the
     /// fetch summary fills stderr while the merge verdict rides stdout, so an
     /// error carrying stderr alone looks populated and still says nothing about
-    /// the conflict. Both sides must carry the whole report, identically.
+    /// the conflict. Both sides must carry the whole report, identically — the
+    /// plain core additionally naming the operation it paused.
     #[tokio::test]
     async fn a_conflicted_pull_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, work, clone) = setup_clone("pull-parity-conflict").await;
@@ -1602,17 +1609,16 @@ mod tests {
 
         match (&compound, &plain) {
             (
-                AppError::Git {
-                    code: a,
-                    stderr: a_err,
-                },
-                AppError::Git {
-                    code: b,
-                    stderr: b_err,
+                AppError::Git { stderr: a_err, .. },
+                AppError::Conflict {
+                    op,
+                    paths,
+                    report: b_err,
                 },
             ) => {
-                assert_eq!(a, b);
                 assert_eq!(a_err, b_err);
+                assert_eq!(op, "merge", "a merge-mode pull pauses a merge");
+                assert_eq!(paths, &vec!["a.txt".to_string()]);
                 assert!(
                     a_err.lines().any(|l| l.starts_with("CONFLICT (")),
                     "the conflict line must reach the frontend: {a_err}"
@@ -1622,7 +1628,7 @@ mod tests {
                     "and the verdict line that names it a merge: {a_err}"
                 );
             }
-            other => panic!("expected two git errors, got {other:?}"),
+            other => panic!("expected a git error and a conflict, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -687,8 +687,19 @@ pub async fn git_update_branch_from(
     branch: String,
     base: String,
 ) -> AppResult<String> {
-    validate_branch_name(&branch)?;
-    validate_branch_name(&base)?;
+    update_branch_from(&state, &repo_path, &branch, &base).await
+}
+
+/// Testable core of [`git_update_branch_from`] — takes a plain `&AppState` so
+/// real-repo tokio tests can drive it (mirrors `git::ops`' `*_core` pairs).
+pub(crate) async fn update_branch_from(
+    state: &AppState,
+    repo_path: &str,
+    branch: &str,
+    base: &str,
+) -> AppResult<String> {
+    validate_branch_name(branch)?;
+    validate_branch_name(base)?;
     if branch == base {
         return Err(AppError::InvalidArgument(
             "a branch can't be updated from itself".to_string(),
@@ -696,11 +707,11 @@ pub async fn git_update_branch_from(
     }
 
     // Mutating refs — serialize against other writes to this repo.
-    let lock = state.repo_lock(&repo_path).await;
+    let lock = state.repo_lock(repo_path).await;
     let _guard = lock.lock().await;
 
     let current = run_git(
-        Some(&repo_path),
+        Some(repo_path),
         &["rev-parse", "--abbrev-ref", "HEAD"],
         DEFAULT_TIMEOUT,
     )
@@ -711,19 +722,33 @@ pub async fn git_update_branch_from(
 
     // The current branch is already checked out, so just merge in place.
     if branch == current {
-        run_git(
-            Some(&repo_path),
-            &["merge", "--no-edit", &base],
+        let already_unmerged = crate::git::ops::unmerged_paths(repo_path).await;
+        // Raw: a conflicted merge reports entirely on stdout and leaves stderr
+        // empty (measured, git 2.51.1), which a stderr-only error renders as
+        // "git exited with code 1". Lock-free runners only — the hold is ours.
+        let out = run_git_raw(
+            Some(repo_path),
+            &["merge", "--no-edit", base],
             DEFAULT_TIMEOUT,
         )
         .await?;
+        if out.code != 0 {
+            return Err(crate::git::ops::classify_failure(
+                repo_path,
+                "merge",
+                &already_unmerged,
+                out.code,
+                out.full_failure_text(),
+            )
+            .await);
+        }
         return Ok("merge".to_string());
     }
 
     // base already reachable from branch → nothing to bring in.
     let already = run_git_raw(
-        Some(&repo_path),
-        &["merge-base", "--is-ancestor", &base, &branch],
+        Some(repo_path),
+        &["merge-base", "--is-ancestor", base, branch],
         DEFAULT_TIMEOUT,
     )
     .await?;
@@ -735,14 +760,14 @@ pub async fn git_update_branch_from(
     // `fetch .` refuses to touch a checked-out branch, but we've excluded the
     // current branch above, so this only ever updates an idle branch.
     let ff = run_git_raw(
-        Some(&repo_path),
-        &["merge-base", "--is-ancestor", &branch, &base],
+        Some(repo_path),
+        &["merge-base", "--is-ancestor", branch, base],
         DEFAULT_TIMEOUT,
     )
     .await?;
     if ff.code == 0 {
         run_git(
-            Some(&repo_path),
+            Some(repo_path),
             &["fetch", ".", &format!("{base}:{branch}")],
             DEFAULT_TIMEOUT,
         )
@@ -755,8 +780,8 @@ pub async fn git_update_branch_from(
     let tmp_str = tmp.to_string_lossy().to_string();
 
     run_git(
-        Some(&repo_path),
-        &["worktree", "add", "--quiet", &tmp_str, &branch],
+        Some(repo_path),
+        &["worktree", "add", "--quiet", &tmp_str, branch],
         WORKTREE_OP_TIMEOUT,
     )
     .await?;
@@ -765,7 +790,7 @@ pub async fn git_update_branch_from(
     // the whole tree, and both arms below tear the temp worktree down regardless.
     let merged = run_git(
         Some(&tmp_str),
-        &["merge", "--no-edit", &base],
+        &["merge", "--no-edit", base],
         DEFAULT_TIMEOUT,
     )
     .await;
@@ -783,12 +808,12 @@ pub async fn git_update_branch_from(
 
     // Always tear the throwaway worktree down, success or failure.
     let _ = run_git_raw(
-        Some(&repo_path),
+        Some(repo_path),
         &["worktree", "remove", "--force", &tmp_str],
         WORKTREE_OP_TIMEOUT,
     )
     .await;
-    let _ = run_git_raw(Some(&repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    let _ = run_git_raw(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
 
     result
 }
@@ -854,8 +879,9 @@ fn unique_suffix() -> String {
 mod tests {
     use super::{
         build_create_branch_args, git_branches, git_create_branch_core, git_default_branch,
-        parse_upstream_track, validate_branch_name, validate_ref_name,
+        parse_upstream_track, update_branch_from, validate_branch_name, validate_ref_name,
     };
+    use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
     use crate::state::AppState;
 
@@ -1267,6 +1293,49 @@ mod tests {
             git_default_branch(repo_s).await.expect("resolves"),
             None,
             "a remote with no HEAD symref and no main/master resolves to nothing"
+        );
+    }
+
+    /// "Update from main" on the branch you are ON merges in place, so a conflict
+    /// is a PAUSED merge in the user's own checkout — the app has to hand back
+    /// git's CONFLICT list and leave the tree mid-merge for the banner to drive.
+    /// The conflicted merge writes all of that to stdout with stderr EMPTY, which
+    /// is what a stderr-only error turned into "git exited with code 1".
+    #[tokio::test]
+    async fn update_branch_from_in_place_conflict_names_the_paused_merge() {
+        let (_base, base) = temp_base("update-in-place-conflict");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "a.txt").await;
+
+        let main = run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+        run(&repo_s, &["switch", "-qc", "feature"]).await;
+        std::fs::write(repo.join("a.txt"), "feature-side\n").unwrap();
+        run(&repo_s, &["commit", "-qam", "feature edit"]).await;
+        run(&repo_s, &["switch", "-q", &main]).await;
+        std::fs::write(repo.join("a.txt"), "main-side\n").unwrap();
+        run(&repo_s, &["commit", "-qam", "main edit"]).await;
+
+        let state = AppState::default();
+        let err = update_branch_from(&state, &repo_s, &main, "feature")
+            .await
+            .unwrap_err();
+        let AppError::Conflict { op, paths, report } = &err else {
+            panic!("expected a conflict error, got {err:?}");
+        };
+        assert_eq!(op, "merge");
+        assert_eq!(paths, &vec!["a.txt".to_string()]);
+        assert!(
+            report.contains("CONFLICT (content): Merge conflict in a.txt"),
+            "git's conflict list must survive: {report}"
+        );
+        assert!(
+            crate::git::ops::op_state(&repo_s).await.unwrap().merging,
+            "the merge is left in progress for the conflict banner to finish"
         );
     }
 }

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -1,7 +1,9 @@
 use tauri::State;
 
-use crate::error::AppResult;
-use crate::git::runner::{run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT};
+use crate::error::{AppError, AppResult};
+use crate::git::runner::{
+    run_git, run_git_mutating, run_git_mutating_raw, run_git_raw, DEFAULT_TIMEOUT,
+};
 use crate::git::types::{CommitAuthor, CommitResult, CommitSummary};
 use crate::state::AppState;
 
@@ -226,7 +228,16 @@ pub(crate) async fn git_commit_core(
     if let Some(body) = &body {
         args.extend(["-m", body.as_str()]);
     }
-    run_git_mutating(state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
+    // Raw: a refusing `commit` writes its whole report to stdout and leaves
+    // stderr EMPTY (measured, git 2.51.1) — this is the commit box's own error
+    // path, so "git exited with code 1" would be the user's only explanation.
+    let commit = run_git_mutating_raw(state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
+    if commit.code != 0 {
+        return Err(AppError::Git {
+            code: commit.code,
+            stderr: commit.full_failure_text(),
+        });
+    }
     let out = run_git(Some(&repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT).await?;
     Ok(CommitResult {
         hash: out.stdout_lossy().trim().to_string(),

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -269,10 +269,10 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
     // stderr-only error renders as "git exited with code 1".
     let out = run_git_mutating_raw(state, repo_path, &args, DEFAULT_TIMEOUT).await?;
     if out.code != 0 {
-        return Err(AppError::Git {
-            code: out.code,
-            stderr: out.full_failure_text(),
-        });
+        // Empty baseline, unlike every other site: a refused `--continue` reports
+        // the paths the operation the CALLER named is already paused on, so they
+        // are attributable by construction rather than by having just appeared.
+        return Err(classify_failure(repo_path, op, &[], out.code, out.full_failure_text()).await);
     }
     Ok(())
 }
@@ -362,6 +362,7 @@ pub(crate) async fn git_revert_core(
     hash: String,
 ) -> AppResult<()> {
     validate_hash(&hash)?;
+    let already_unmerged = unmerged_paths(&repo_path).await;
     // -m is not supported here; reverting merge commits needs a parent choice
     // Raw: a conflicted revert splits its report — `could not revert` on stderr,
     // the `CONFLICT (…` file list on stdout — so the error needs both halves.
@@ -373,10 +374,14 @@ pub(crate) async fn git_revert_core(
     )
     .await?;
     if out.code != 0 {
-        return Err(AppError::Git {
-            code: out.code,
-            stderr: out.full_failure_text(),
-        });
+        return Err(classify_failure(
+            &repo_path,
+            "revert",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
     }
     Ok(())
 }
@@ -399,6 +404,7 @@ pub(crate) async fn git_cherry_pick_core(
     hash: String,
 ) -> AppResult<bool> {
     validate_hash(&hash)?;
+    let already_unmerged = unmerged_paths(&repo_path).await;
     // Raw: a conflicted pick splits its report — `could not apply` on stderr, the
     // `CONFLICT (…` file list on stdout — so the error needs both halves.
     let out =
@@ -418,10 +424,14 @@ pub(crate) async fn git_cherry_pick_core(
         .await;
         return Ok(false);
     }
-    Err(AppError::Git {
-        code: out.code,
-        stderr: out.full_failure_text(),
-    })
+    Err(classify_failure(
+        &repo_path,
+        "cherry-pick",
+        &already_unmerged,
+        out.code,
+        out.full_failure_text(),
+    )
+    .await)
 }
 
 #[derive(serde::Serialize)]
@@ -1059,7 +1069,21 @@ pub async fn git_stash_pop(state: State<'_, AppState>, repo_path: String) -> App
 }
 
 pub(crate) async fn git_stash_pop_core(state: &AppState, repo_path: String) -> AppResult<()> {
-    run_git_mutating(state, &repo_path, &["stash", "pop"], DEFAULT_TIMEOUT).await?;
+    let already_unmerged = unmerged_paths(&repo_path).await;
+    // Raw: a conflicted pop reports entirely on stdout and leaves stderr empty
+    // (measured, git 2.51.1), so a stderr-only error is blind to the whole report
+    // — and to the fact that git kept the stash entry.
+    let out = run_git_mutating_raw(state, &repo_path, &["stash", "pop"], DEFAULT_TIMEOUT).await?;
+    if out.code != 0 {
+        return Err(classify_failure(
+            &repo_path,
+            "stash-pop",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
+    }
     Ok(())
 }
 
@@ -1714,15 +1738,45 @@ pub async fn git_orphaned_stash_file_diff(
 }
 
 /// Restore a dangling (orphaned) stash into the working tree. Applies (never
-/// drops or commits); a conflict surfaces through the normal error path.
+/// drops or commits); a conflict surfaces through the normal error path under
+/// its own `stash-restore` op, because there is no stash-list entry left to send
+/// the user back to — that is the whole point of the orphaned path.
 #[tauri::command]
 pub async fn git_restore_orphaned(
     state: State<'_, AppState>,
     repo_path: String,
     sha: String,
 ) -> AppResult<()> {
+    git_restore_orphaned_core(&state, repo_path, sha).await
+}
+
+/// Testable core of [`git_restore_orphaned`] — takes a plain `&AppState` so the
+/// real-repo tokio tests can drive it (mirrors [`git_stash_apply_core`]).
+pub(crate) async fn git_restore_orphaned_core(
+    state: &AppState,
+    repo_path: String,
+    sha: String,
+) -> AppResult<()> {
     validate_hash(&sha)?;
-    run_git_mutating(&state, &repo_path, &["stash", "apply", &sha], DEFAULT_TIMEOUT).await?;
+    let already_unmerged = unmerged_paths(&repo_path).await;
+    // Raw, for the same stdout-only conflict report as `git_stash_pop_core`.
+    let out = run_git_mutating_raw(
+        state,
+        &repo_path,
+        &["stash", "apply", &sha],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Err(classify_failure(
+            &repo_path,
+            "stash-restore",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
+    }
     Ok(())
 }
 
@@ -1744,7 +1798,21 @@ pub(crate) async fn git_stash_apply_core(
 ) -> AppResult<()> {
     let spec = format!("stash@{{{index}}}");
     let sub = if pop { "pop" } else { "apply" };
-    run_git_mutating(state, &repo_path, &["stash", sub, &spec], DEFAULT_TIMEOUT).await?;
+    let already_unmerged = unmerged_paths(&repo_path).await;
+    // Raw, for the same stdout-only conflict report as `git_stash_pop_core`.
+    let out =
+        run_git_mutating_raw(state, &repo_path, &["stash", sub, &spec], DEFAULT_TIMEOUT).await?;
+    if out.code != 0 {
+        let op = if pop { "stash-pop" } else { "stash-apply" };
+        return Err(classify_failure(
+            &repo_path,
+            op,
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
+    }
     Ok(())
 }
 
@@ -1823,14 +1891,19 @@ pub(crate) async fn git_merge_core(
         }
     }
     args.push(&branch);
+    let already_unmerged = unmerged_paths(&repo_path).await;
     // Raw, because a conflicted merge reports entirely on stdout and leaves
-    // stderr empty — `failure_text` is what keeps that report in the error.
+    // stderr empty — the combined text is what keeps that report in the error.
     let out = run_git_mutating_raw(state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
     if out.code != 0 {
-        return Err(AppError::Git {
-            code: out.code,
-            stderr: out.failure_text(),
-        });
+        return Err(classify_failure(
+            &repo_path,
+            "merge",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
     }
     Ok(())
 }
@@ -1847,11 +1920,11 @@ pub struct MergePreview {
 
 /// Predicts merging `branch` into the current branch **without touching the
 /// working tree or index**: merge-base for the up-to-date / fast-forward cases,
-/// then `git merge-tree --write-tree` (needs git 2.38+; file names need 2.40+) for
-/// a real in-memory merge, honoring `strategy` ("ours"/"theirs" → `-X`) so the
-/// prediction matches the real merge — content conflicts auto-resolve, structural
-/// ones still report as conflicts. Older git or any error degrades to "unknown"
-/// so the UI hides the preview.
+/// then `git merge-tree --write-tree` (needs git 2.38+, which is also where
+/// `--name-only` landed) for a real in-memory merge, honoring `strategy`
+/// ("ours"/"theirs" → `-X`) so the prediction matches the real merge — content
+/// conflicts auto-resolve, structural ones still report as conflicts. Older git
+/// or any error degrades to "unknown" so the UI hides the preview.
 #[tauri::command]
 pub async fn git_merge_preview(
     repo_path: String,
@@ -1948,6 +2021,7 @@ pub(crate) async fn git_rebase_core(
     branch: String,
 ) -> AppResult<()> {
     validate_branch_arg(&branch)?;
+    let already_unmerged = unmerged_paths(&repo_path).await;
     // Raw: a conflicted rebase splits its report — `could not apply` plus the
     // resolve hints on stderr, the `CONFLICT (…` file list on stdout.
     let out = run_git_mutating_raw(
@@ -1958,10 +2032,14 @@ pub(crate) async fn git_rebase_core(
     )
     .await?;
     if out.code != 0 {
-        return Err(AppError::Git {
-            code: out.code,
-            stderr: out.full_failure_text(),
-        });
+        return Err(classify_failure(
+            &repo_path,
+            "rebase",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
     }
     Ok(())
 }
@@ -1980,6 +2058,7 @@ async fn rebase_onto(
 ) -> AppResult<()> {
     validate_branch_arg(new_base)?;
     validate_branch_arg(old_base)?;
+    let already_unmerged = unmerged_paths(repo_path).await;
     // Raw, for the same split report as `git_rebase_core`.
     let out = run_git_mutating_raw(
         state,
@@ -1996,10 +2075,14 @@ async fn rebase_onto(
     )
     .await?;
     if out.code != 0 {
-        return Err(AppError::Git {
-            code: out.code,
-            stderr: out.full_failure_text(),
-        });
+        return Err(classify_failure(
+            repo_path,
+            "rebase",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
     }
     Ok(())
 }
@@ -2048,7 +2131,7 @@ pub struct LocalPrMergeOutcome {
 /// `diff --name-only --diff-filter=U`. Uses `run_git_raw` so a non-zero exit
 /// (e.g. mid-operation) is treated as "no readable conflicts" rather than an
 /// error. Empty ⇒ no conflicts / a clean tree.
-async fn unmerged_paths(repo_path: &str) -> Vec<String> {
+pub(crate) async fn unmerged_paths(repo_path: &str) -> Vec<String> {
     let out = run_git_raw(
         Some(repo_path),
         &["diff", "--name-only", "--diff-filter=U"],
@@ -2064,6 +2147,59 @@ async fn unmerged_paths(repo_path: &str) -> Vec<String> {
             .map(str::to_string)
             .collect(),
         _ => Vec::new(),
+    }
+}
+
+/// Shapes a failed mutating git op, telling a PAUSED operation from a plain
+/// failure: an op that ADDED an unmerged path stopped mid-way and left the tree
+/// for the user to resolve, which is a different thing for the frontend to say
+/// than "the command failed". Otherwise the `AppError::Git` the site produced
+/// before, byte-identical.
+///
+/// `already_unmerged` is the site's unmerged set from BEFORE the op, and it is
+/// what keeps a pre-existing conflict from being re-attributed: git refuses
+/// outright on an unmerged index rather than adding to it — a pull answers
+/// "Pulling is not possible because you have unmerged files", a `stash pop`
+/// "error: could not write index", and one with nothing to pop "No stash entries
+/// found" (measured, git 2.51.1). Every one of those leaves the index untouched,
+/// so the post-failure snapshot alone would hand the paused merge's files to
+/// whichever op merely bounced off them, under that op's copy. `op_continue`
+/// passes an empty baseline on purpose: the paths it reports are the ones the
+/// operation it names is already paused on.
+///
+/// A baseline rather than matching `op` against [`op_state`]'s flags, which
+/// would look equivalent and is not: a conflicted `merge --squash` writes NO
+/// marker at all (measured, git 2.51.1 — the same fact
+/// `local_pr_finish_squash_all_ours_is_a_known_no_op` rests on), so a flag gate
+/// would silently stop classifying every squash-merge conflict.
+///
+/// `op` is the closed set the frontend's copy table keys on — `merge`, `rebase`,
+/// `cherry-pick`, `revert`, `stash-pop`, `stash-apply`, `stash-restore` — and
+/// names the operation the user now has to finish, not the git subcommand that
+/// failed (a refused `commit --no-edit` concluding a merge is a paused `merge`).
+///
+/// `report` must be [`GitOutput::full_failure_text`]: the conflict families split
+/// ONE report across both streams, so either half alone is silent data loss.
+/// Lock-free (the probe uses `run_git_raw`), so compounds may call it while
+/// holding `repo_lock`.
+pub(crate) async fn classify_failure(
+    repo_path: &str,
+    op: &str,
+    already_unmerged: &[String],
+    code: i32,
+    report: String,
+) -> AppError {
+    let paths = unmerged_paths(repo_path).await;
+    if paths.iter().all(|p| already_unmerged.contains(p)) {
+        return AppError::Git {
+            code,
+            stderr: report,
+        };
+    }
+    AppError::Conflict {
+        op: op.to_string(),
+        paths,
+        report,
     }
 }
 
@@ -2636,12 +2772,16 @@ pub(crate) async fn finish_local_pr_merge(
                 });
             }
             // A non-conflict, non-zero exit means something genuinely failed
-            // (e.g. "no cherry-pick in progress" when nothing was staged). Surface
-            // it rather than silently reporting success.
-            if out.code != 0 && !out.stderr.trim().is_empty() {
+            // (e.g. "no cherry-pick in progress" when nothing was staged) — surface
+            // it on the exit code ALONE, since git can refuse with stderr empty and
+            // its whole report on stdout
+            // (`a_refusing_commit_reports_on_stdout_with_stderr_empty`), which a
+            // stderr gate would report as "merged". Defensive, not behavior-changing:
+            // no `--continue` failure measured on 2.51.1 is stdout-only (3 shapes).
+            if out.code != 0 {
                 return Err(AppError::Git {
                     code: out.code,
-                    stderr: out.stderr,
+                    stderr: out.full_failure_text(),
                 });
             }
         }
@@ -2672,16 +2812,18 @@ pub(crate) async fn finish_local_pr_merge(
                 )
                 .await?;
                 if commit.code != 0 {
-                    let lower = commit.stderr.to_lowercase();
+                    // Both streams, for the tolerance test as well as the error: a
+                    // refusing `commit` reports on stdout with stderr EMPTY
+                    // (`a_refusing_commit_reports_on_stdout_with_stderr_empty`), so
+                    // reading stderr alone can never see the sentence it looks for.
+                    let report = commit.full_failure_text();
+                    let lower = report.to_lowercase();
                     let already = lower.contains("nothing to commit")
                         || lower.contains("no changes added");
                     if !already {
-                        // Both streams: a failing `commit` can report on stdout alone
-                        // (measured, git 2.51.1), which stderr-only renders as the
-                        // bare "git exited with code 1".
                         return Err(AppError::Git {
                             code: commit.code,
-                            stderr: commit.full_failure_text(),
+                            stderr: report,
                         });
                     }
                 }
@@ -3274,16 +3416,18 @@ pub(crate) async fn finish_remote_pr_resolve(
         };
         let commit = run_git_raw(Some(worktree_path), &args, DEFAULT_TIMEOUT).await?;
         if commit.code != 0 {
-            let lower = commit.stderr.to_lowercase();
+            // Both streams, for the tolerance test as well as the error: a
+            // refusing `commit` reports on stdout with stderr EMPTY
+            // (`a_refusing_commit_reports_on_stdout_with_stderr_empty`), so
+            // reading stderr alone can never see the sentence it looks for.
+            let report = commit.full_failure_text();
+            let lower = report.to_lowercase();
             let already =
                 lower.contains("nothing to commit") || lower.contains("no changes added");
             if !already {
-                // Both streams: a failing `commit` can report on stdout alone
-                // (measured, git 2.51.1), which stderr-only renders as the bare
-                // "git exited with code 1".
                 return Err(AppError::Git {
                     code: commit.code,
-                    stderr: commit.full_failure_text(),
+                    stderr: report,
                 });
             }
         }
@@ -3423,8 +3567,8 @@ fn check_code(o: crate::git::runner::GitOutput) -> AppResult<()> {
 
 /// Predicts whether merging `head` into `base` would conflict, **without touching
 /// the working tree or index** — the read-only precheck for a local-PR merge.
-/// Reuses `git merge-tree --write-tree --name-only` (git 2.38+, file names need
-/// 2.40+): exit 0 ⇒ `"clean"`; exit 1 ⇒ `"conflict"` with the conflicted names;
+/// Reuses `git merge-tree --write-tree --name-only` (both landed in git 2.38):
+/// exit 0 ⇒ `"clean"`; exit 1 ⇒ `"conflict"` with the conflicted names;
 /// anything else / old git ⇒ `"unknown"`. Up-to-date and fast-forward cases are
 /// short-circuited via merge-base and reported as `"clean"` (the merge would
 /// succeed).
@@ -5219,7 +5363,8 @@ mod tests {
     /// Conflicted revert / cherry-pick / rebase all split ONE report across both
     /// streams: the diagnostic on stderr, the conflicted-file list on stdout. An
     /// error carrying either alone looks populated while dropping exactly what
-    /// the user needs to decide how to resolve.
+    /// the user needs to decide how to resolve — and each leaves the repo PAUSED,
+    /// which the structured variant says outright instead of by prose match.
     #[tokio::test]
     async fn a_conflicted_revert_carries_both_streams() {
         let (dir, repo) = setup_repo("revert-details").await;
@@ -5231,7 +5376,7 @@ mod tests {
         let err = git_revert_core(&state, repo.clone(), target)
             .await
             .unwrap_err();
-        assert_both_streams(&err, "could not revert");
+        assert_both_streams(&err, "revert", "could not revert");
     }
 
     #[tokio::test]
@@ -5248,7 +5393,7 @@ mod tests {
         let err = git_cherry_pick_core(&state, repo.clone(), feature)
             .await
             .unwrap_err();
-        assert_both_streams(&err, "could not apply");
+        assert_both_streams(&err, "cherry-pick", "could not apply");
     }
 
     #[tokio::test]
@@ -5264,7 +5409,30 @@ mod tests {
         let err = git_rebase_core(&state, repo.clone(), "feature".into())
             .await
             .unwrap_err();
-        assert_both_streams(&err, "ould not apply");
+        assert_both_streams(&err, "rebase", "ould not apply");
+    }
+
+    /// `rebase --onto` shares the shaping but not the argv, so it gets its own
+    /// conflict test: `fix` branched off `feature` (the wrong base) and replaying
+    /// only its own commits onto the default branch collides there.
+    #[tokio::test]
+    async fn a_conflicted_rebase_onto_carries_both_streams() {
+        let (dir, repo) = setup_repo("rebase-onto-conflict").await;
+        let main = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "f.txt", "f\n", "feature edit").await;
+        git(&repo, &["switch", "-c", "fix"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "fix edit").await;
+        git(&repo, &["switch", &main]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        git(&repo, &["switch", "fix"]).await;
+
+        let state = AppState::default();
+        let err = rebase_onto(&state, &repo, &main, "feature")
+            .await
+            .unwrap_err();
+        assert_both_streams(&err, "rebase", "ould not apply");
+        assert!(op_state(&repo).await.unwrap().rebasing);
     }
 
     /// The one stdout-ONLY case in the family: `--continue` with paths still
@@ -5288,28 +5456,173 @@ mod tests {
         );
 
         let err = op_continue(&state, &repo, "rebase").await.unwrap_err();
-        let AppError::Git { stderr, .. } = &err else {
-            panic!("expected a git error, got {err:?}");
+        let AppError::Conflict { op, paths, report } = &err else {
+            panic!("expected a conflict error, got {err:?}");
         };
+        // The caller's own op passes through: this refusal names no operation, and
+        // a `--continue` that did nothing leaves no diagnostic to read one from.
+        assert_eq!(op, "rebase");
+        assert_eq!(paths, &vec!["a.txt".to_string()]);
         assert!(
-            stderr.contains("a.txt: needs merge"),
-            "the refusal must name the unresolved file: {stderr}"
+            report.contains("a.txt: needs merge"),
+            "the refusal must name the unresolved file: {report}"
         );
     }
 
-    /// Both halves of a conflicted sequencer op's report reached the error:
-    /// `diagnostic` on stderr, and the `CONFLICT (…` file list on stdout.
-    fn assert_both_streams(err: &AppError, diagnostic: &str) {
-        let AppError::Git { stderr, .. } = err else {
-            panic!("expected a git error, got {err:?}");
+    /// The paused operation is named, the conflicted file listed, and both halves
+    /// of git's report reached `report`: `diagnostic` on stderr, and the
+    /// `CONFLICT (…` file list on stdout.
+    fn assert_both_streams(err: &AppError, op: &str, diagnostic: &str) {
+        let AppError::Conflict {
+            op: named,
+            paths,
+            report,
+        } = err
+        else {
+            panic!("expected a conflict error, got {err:?}");
         };
-        assert!(
-            stderr.contains(diagnostic),
-            "stderr's own diagnostic ({diagnostic:?}) must survive: {stderr}"
+        assert_eq!(named, op, "the paused operation must be named");
+        assert_eq!(
+            paths,
+            &vec!["a.txt".to_string()],
+            "the conflicted file must be listed"
         );
         assert!(
-            stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
-            "and stdout's conflicted-file list with it: {stderr}"
+            report.contains(diagnostic),
+            "stderr's own diagnostic ({diagnostic:?}) must survive: {report}"
+        );
+        assert!(
+            report.contains("CONFLICT (content): Merge conflict in a.txt"),
+            "and stdout's conflicted-file list with it: {report}"
+        );
+    }
+
+    /// A stash holding an edit to `a.txt`, and a committed `a.txt` in the way, so
+    /// reapplying it conflicts. git keeps the entry either way (measured, 2.51.1).
+    async fn stash_over_a_conflicting_commit(marker: &str) -> (tempfile::TempDir, String) {
+        let (dir, repo) = setup_repo(marker).await;
+        std::fs::write(dir.path().join("a.txt"), "mine\n").unwrap();
+        git(&repo, &["stash", "push", "--include-untracked"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "diverge").await;
+        (dir, repo)
+    }
+
+    /// The whole stash family reports a conflict on stdout with stderr EMPTY, so a
+    /// stderr-only error rendered as "git exited with code 1" — and said nothing
+    /// about the entry git kept.
+    fn assert_stash_conflict(err: &AppError, expected_op: &str) {
+        let AppError::Conflict { op, paths, report } = err else {
+            panic!("expected a conflict error, got {err:?}");
+        };
+        assert_eq!(op, expected_op);
+        assert_eq!(paths, &vec!["a.txt".to_string()]);
+        assert!(
+            report.contains("CONFLICT (content): Merge conflict in a.txt"),
+            "the stdout-only report must survive: {report}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_conflicted_stash_pop_names_its_op_and_keeps_the_entry() {
+        let (_dir, repo) = stash_over_a_conflicting_commit("stash-pop-conflict").await;
+        let state = AppState::default();
+
+        let err = git_stash_pop_core(&state, repo.clone()).await.unwrap_err();
+        assert_stash_conflict(&err, "stash-pop");
+        // The copy this drives promises the stash is still there — pin that.
+        assert!(
+            !git(&repo, &["stash", "list"]).await.trim().is_empty(),
+            "a conflicted pop keeps the entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_conflicted_stash_apply_names_the_sub_command_it_ran() {
+        let (_dir, repo) = stash_over_a_conflicting_commit("stash-apply-conflict").await;
+        let state = AppState::default();
+
+        let err = git_stash_apply_core(&state, repo.clone(), 0, false)
+            .await
+            .unwrap_err();
+        assert_stash_conflict(&err, "stash-apply");
+
+        // The same entrypoint with `pop` set names the other op.
+        git(&repo, &["checkout", "--ours", "a.txt"]).await;
+        git(&repo, &["reset", "--hard", "HEAD"]).await;
+        let err = git_stash_apply_core(&state, repo.clone(), 0, true)
+            .await
+            .unwrap_err();
+        assert_stash_conflict(&err, "stash-pop");
+    }
+
+    /// The orphaned path takes its OWN op: the entry it restores is dangling —
+    /// dropped from the list, as this fixture does — so the stash-apply copy's
+    /// promise that "your stash was kept" would send the user to a `stash list`
+    /// that no longer holds their work.
+    #[tokio::test]
+    async fn a_conflicted_orphaned_restore_takes_its_own_op() {
+        let (_dir, repo) = stash_over_a_conflicting_commit("stash-orphan-conflict").await;
+        // Browse the entry by sha, then drop it: that dangling commit is exactly
+        // what the orphaned-stash restore is handed.
+        let sha = rev(&repo, "stash@{0}").await;
+        git(&repo, &["stash", "drop"]).await;
+        assert!(
+            git(&repo, &["stash", "list"]).await.trim().is_empty(),
+            "the fixture's entry really is off the list"
+        );
+        let state = AppState::default();
+
+        let err = git_restore_orphaned_core(&state, repo.clone(), sha)
+            .await
+            .unwrap_err();
+        assert_stash_conflict(&err, "stash-restore");
+    }
+
+    /// A tree already paused on conflicts, so every op below fails by BOUNCING
+    /// off the unmerged index rather than adding to it. The pre-op baseline is
+    /// what keeps the paused merge's files from being re-attributed to whichever
+    /// op merely refused — the toast would otherwise name an operation the
+    /// conflict banner (which reads op_state) disagrees with.
+    async fn repo_paused_on_a_conflicted_merge(marker: &str) -> (tempfile::TempDir, String) {
+        let (dir, repo) = setup_repo(marker).await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "side"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "side edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        let merge = run_git_raw(
+            Some(&repo),
+            &["merge", "--no-edit", "side"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(merge.code, 0, "the fixture's merge must conflict");
+        assert_eq!(unmerged_paths(&repo).await, vec!["a.txt".to_string()]);
+        assert!(op_state(&repo).await.unwrap().merging);
+        (dir, repo)
+    }
+
+    /// Popping with NOTHING to pop, on a tree already paused on a merge: git
+    /// answers "No stash entries found." without touching the index, so the
+    /// paused merge's file is still the only unmerged path. Attributing it to the
+    /// pop would tell the user their stash was kept when there was never a stash.
+    #[tokio::test]
+    async fn a_stashless_pop_on_a_paused_tree_is_not_a_stash_conflict() {
+        let (_dir, repo) = repo_paused_on_a_conflicted_merge("stash-pop-misattrib").await;
+        let state = AppState::default();
+
+        let err = git_stash_pop_core(&state, repo.clone()).await.unwrap_err();
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a plain git error, got {err:?}");
+        };
+        assert!(
+            stderr.contains("No stash entries found"),
+            "git's own answer must reach the user: {stderr}"
+        );
+        assert!(
+            op_state(&repo).await.unwrap().merging,
+            "and the merge it bounced off is still the operation in progress"
         );
     }
 
@@ -5377,17 +5690,20 @@ mod tests {
         )
         .await
         .unwrap_err();
-        let AppError::Git { stderr, .. } = &err else {
-            panic!("expected a git error, got {err:?}");
+        let AppError::Conflict { op, paths, report } = &err else {
+            panic!("expected a conflict error, got {err:?}");
         };
-        // Mirrors the frontend's anchored CONFLICT_MARKERS (error-summary.ts).
+        assert_eq!(op, "merge");
+        assert_eq!(paths, &vec!["a.txt".to_string()]);
+        // Kept against `report`: the same text still classifies through the
+        // frontend's anchored CONFLICT_MARKERS fallback (error-summary.ts).
         assert!(
-            stderr.lines().any(|l| l.starts_with("CONFLICT (")),
-            "the conflict line must reach the frontend: {stderr}"
+            report.lines().any(|l| l.starts_with("CONFLICT (")),
+            "the conflict line must reach the frontend: {report}"
         );
         assert!(
-            stderr.contains("Automatic merge failed"),
-            "git's merge verdict must survive: {stderr}"
+            report.contains("Automatic merge failed"),
+            "git's merge verdict must survive: {report}"
         );
         assert!(op_state(&repo).await.unwrap().merging);
     }
@@ -7186,6 +7502,126 @@ detached
         assert!(
             !lower.contains("nothing to commit") && !lower.contains("no changes added"),
             "the untracked refusal must not match the tolerate-it substrings: {report}"
+        );
+    }
+
+    /// Resolving and committing BY HAND in the resolve worktree still finishes the
+    /// merge. The arm that carries it is the SKIP above the conclude-with-commit
+    /// step: a hand commit clears MERGE_HEAD and leaves nothing staged, so no
+    /// commit is attempted at all. The "nothing to commit" tolerance below it now
+    /// reads git's combined output, which is where that sentence actually lands —
+    /// it covers a commit refused between the staged probe and the commit itself.
+    #[tokio::test]
+    async fn local_pr_finish_accepts_a_hand_committed_resolution() {
+        let (dir, repo) = setup_repo("lpr-hand-commit").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+        // Off `base` so advancing it never touches the main working tree.
+        git(&repo, &["switch", "-c", "work"]).await;
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_local_pr(&state, &repo, &base, "feature", "merge it", "merge", &root)
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, "conflicts");
+        let wt = outcome.worktree_path.clone().expect("worktree path set");
+
+        std::fs::write(Path::new(&wt).join("a.txt"), "resolved\n").unwrap();
+        git(&wt, &["add", "a.txt"]).await;
+        git(&wt, &["commit", "-m", "resolved by hand"]).await;
+        let resolved = rev(&wt, "HEAD").await;
+        assert!(
+            !git_path_exists(&wt, "MERGE_HEAD").await,
+            "a hand commit concludes the merge, clearing MERGE_HEAD"
+        );
+
+        let done = finish_local_pr_merge(
+            &state,
+            &repo,
+            &base,
+            "merge",
+            "merge it",
+            &wt,
+            &outcome.worktree_id.clone().unwrap_or_default(),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(done.status, "merged");
+        assert_eq!(
+            rev(&repo, &base).await,
+            resolved,
+            "base advances to the commit the user made"
+        );
+        assert!(
+            !Path::new(&wt).exists(),
+            "the resolve worktree is torn down"
+        );
+    }
+
+    /// The `rebase` strategy's `cherry-pick --continue` can fail with no conflict
+    /// left to report — an all-"ours" resolution makes the pick empty. That is a
+    /// failure, never "merged", and the report splits: git explains itself on
+    /// stderr while the state of the tree rides stdout.
+    #[tokio::test]
+    async fn local_pr_finish_rebase_reports_a_failed_continue_from_both_streams() {
+        let (dir, repo) = setup_repo("lpr-rebase-continue").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature-side\n", "feat edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "base-side\n", "base edit").await;
+        git(&repo, &["switch", "-c", "work"]).await;
+        let base_before = rev(&repo, &base).await;
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_local_pr(&state, &repo, &base, "feature", "", "rebase", &root)
+            .await
+            .unwrap();
+        assert_eq!(outcome.status, "conflicts");
+        let wt = outcome.worktree_path.clone().expect("worktree path set");
+
+        // Every conflict resolved as "ours": nothing unmerged is left, so the
+        // continue runs — and lands on a pick with no content.
+        git(&wt, &["checkout", "--ours", "a.txt"]).await;
+        git(&wt, &["add", "a.txt"]).await;
+
+        let err = finish_local_pr_merge(
+            &state,
+            &repo,
+            &base,
+            "rebase",
+            "",
+            &wt,
+            &outcome.worktree_id.clone().unwrap_or_default(),
+            None,
+        )
+        .await;
+        let Err(err) = err else {
+            panic!("expected the failed continue to be reported");
+        };
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a git error, got {err:?}");
+        };
+        assert!(
+            stderr.contains("is now empty"),
+            "git's own explanation (stderr) must survive: {stderr}"
+        );
+        assert!(
+            stderr.contains("nothing to commit"),
+            "and the stdout half that says what the tree looks like: {stderr}"
+        );
+        assert_eq!(
+            rev(&repo, &base).await,
+            base_before,
+            "a failed continue never advances base"
         );
     }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -466,8 +466,33 @@ pub(crate) async fn git_pull_core(
         "merge" => "--no-rebase",
         _ => "--ff-only",
     };
+    // The paused operation a conflicted pull leaves behind is the mode it RAN, so
+    // it is named here rather than inside the runner: `run_git_mutating_with_creds`
+    // also carries fetch and push, whose failures are never a paused conflict and
+    // would each pay for an unmerged probe that can only come back empty.
+    // A refused `--ff-only` leaves nothing unmerged, so its label never surfaces.
+    let op = if mode == "rebase" { "rebase" } else { "merge" };
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    run_git_mutating_with_creds(state, &repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await?;
+    let already_unmerged = crate::git::ops::unmerged_paths(&repo_path).await;
+    if let Err(err) =
+        run_git_mutating_with_creds(state, &repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await
+    {
+        // The runner already folded both streams into `stderr`, so the report is
+        // relabeled here rather than re-running git.
+        return Err(match err {
+            AppError::Git { code, stderr } => {
+                crate::git::ops::classify_failure(
+                    &repo_path,
+                    op,
+                    &already_unmerged,
+                    code,
+                    stderr,
+                )
+                .await
+            }
+            other => other,
+        });
+    }
     Ok(())
 }
 
@@ -738,7 +763,7 @@ pub(crate) fn publish_refspec(branch: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_push_args, cache_get, cache_invalidate, cache_put, git_push_core,
+        build_push_args, cache_get, cache_invalidate, cache_put, git_pull_core, git_push_core,
         git_remote_remove_core, is_auth_class_failure, parse_upstream_tracking, publish_refspec,
         resolve_push_target, run_git_mutating_with_creds,
     };
@@ -935,6 +960,135 @@ mod tests {
             Err(other) => panic!("expected AppError::Git, got {other:?}"),
             Ok(_) => panic!("a diverged pull with an overlapping edit should conflict"),
         }
+    }
+
+    /// A clone diverged from its origin on `a.txt`, so a reconciling pull in
+    /// either mode conflicts. Returns the temp guard (drop removes the fixture)
+    /// and the clone's path.
+    async fn diverged_clone(tag: &str) -> (tempfile::TempDir, String) {
+        let (guard, base) = temp_base(tag);
+        let origin = base.join("origin.git");
+        let work = base.join("work");
+        let clone = base.join("clone");
+        std::fs::create_dir_all(&work).unwrap();
+        let base_s = base.to_string_lossy().into_owned();
+        let work_s = work.to_string_lossy().into_owned();
+        let clone_s = clone.to_string_lossy().into_owned();
+        let url = format!("file://{}", origin.to_string_lossy().replace('\\', "/"));
+
+        run(&base_s, &["init", "-q", "--bare", "-b", "main", "origin.git"]).await;
+        init_repo(&work_s, "a.txt").await;
+        run(&work_s, &["branch", "-M", "main"]).await;
+        run(&work_s, &["remote", "add", "origin", &url]).await;
+        run(&work_s, &["push", "-q", "-u", "origin", "main"]).await;
+        run(&base_s, &["-c", "core.autocrlf=false", "clone", "-q", &url, "clone"]).await;
+        run(&clone_s, &["config", "core.autocrlf", "false"]).await;
+        run(&clone_s, &["config", "user.email", "t@t.local"]).await;
+        run(&clone_s, &["config", "user.name", "T"]).await;
+
+        std::fs::write(work.join("a.txt"), "upstream\n").unwrap();
+        run(&work_s, &["commit", "-qam", "upstream"]).await;
+        run(&work_s, &["push", "-q"]).await;
+        std::fs::write(clone.join("a.txt"), "mine\n").unwrap();
+        run(&clone_s, &["commit", "-qam", "local"]).await;
+        (guard, clone_s)
+    }
+
+    /// A pull that conflicts leaves a PAUSED merge/rebase, and `git_pull_core` is
+    /// where that gets named — the runner it goes through also carries fetch and
+    /// push, whose failures are never paused.
+    #[tokio::test]
+    async fn a_conflicted_pull_reports_a_paused_merge() {
+        let (_guard, clone_s) = diverged_clone("pull-conflict-op").await;
+
+        let state = AppState::default();
+        let err = git_pull_core(&state, clone_s.clone(), "merge".into())
+            .await
+            .unwrap_err();
+        let AppError::Conflict { op, paths, report } = &err else {
+            panic!("expected a conflict error, got {err:?}");
+        };
+        assert_eq!(op, "merge", "a merge-mode pull pauses a merge");
+        assert_eq!(paths, &vec!["a.txt".to_string()]);
+        // Both halves: the fetch summary fills stderr while the merge verdict and
+        // its file list ride stdout, so either alone loses the conflict.
+        assert!(
+            report.contains("CONFLICT (content): Merge conflict in a.txt"),
+            "git's conflict list must survive: {report}"
+        );
+        assert!(
+            report.contains("Automatic merge failed"),
+            "and the verdict line with it: {report}"
+        );
+    }
+
+    /// The other half of the mode→op branch: the same divergence pulled with
+    /// `--rebase` leaves a paused REBASE, and the frontend's copy for the two
+    /// differs (a merge finishes with a commit, a rebase with `--continue`).
+    #[tokio::test]
+    async fn a_conflicted_rebase_pull_reports_a_paused_rebase() {
+        let (_guard, clone_s) = diverged_clone("pull-conflict-rebase").await;
+
+        let state = AppState::default();
+        let err = git_pull_core(&state, clone_s.clone(), "rebase".into())
+            .await
+            .unwrap_err();
+        let AppError::Conflict { op, paths, report } = &err else {
+            panic!("expected a conflict error, got {err:?}");
+        };
+        assert_eq!(op, "rebase", "a rebase-mode pull pauses a rebase");
+        assert_eq!(paths, &vec!["a.txt".to_string()]);
+        assert!(
+            report.contains("CONFLICT (content): Merge conflict in a.txt"),
+            "git's conflict list must survive: {report}"
+        );
+        assert!(
+            crate::git::ops::op_state(&clone_s).await.unwrap().rebasing,
+            "and the rebase really is the operation left in progress"
+        );
+    }
+
+    /// Pulling on a tree already paused on a MERGE: git refuses without touching
+    /// the index ("Pulling is not possible because you have unmerged files",
+    /// measured on git 2.51.1), so the only unmerged path belongs to that merge.
+    /// Attributing it to the pull would toast "Rebase paused…" over a tree whose
+    /// conflict banner reads *merge*.
+    #[tokio::test]
+    async fn a_pull_refused_over_someone_elses_conflict_is_not_a_paused_rebase() {
+        let (_guard, clone_s) = diverged_clone("pull-refused-misattrib").await;
+        // Pause a merge from a side branch, so the tree is unmerged before the pull.
+        run(&clone_s, &["switch", "-q", "-c", "side", "HEAD~1"]).await;
+        std::fs::write(
+            std::path::Path::new(&clone_s).join("a.txt"),
+            "side\n",
+        )
+        .unwrap();
+        run(&clone_s, &["commit", "-qam", "side"]).await;
+        run(&clone_s, &["switch", "-q", "main"]).await;
+        let merged = run_git(
+            Some(&clone_s),
+            &["merge", "--no-edit", "side"],
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+        assert!(merged.is_err(), "the fixture's merge must conflict");
+        assert!(crate::git::ops::op_state(&clone_s).await.unwrap().merging);
+
+        let state = AppState::default();
+        let err = git_pull_core(&state, clone_s.clone(), "rebase".into())
+            .await
+            .unwrap_err();
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a plain git error, got {err:?}");
+        };
+        assert!(
+            stderr.contains("unmerged files"),
+            "git's own refusal must reach the user: {stderr}"
+        );
+        assert!(
+            !crate::git::ops::op_state(&clone_s).await.unwrap().rebasing,
+            "no rebase was ever started — naming one would contradict the banner"
+        );
     }
 
     // --- Pure arg-building for a named-branch push. ---

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -547,12 +547,21 @@ pub(crate) async fn worktree_commit_all(
         return Ok(None);
     }
     run_git(Some(worktree_path), &["add", "-A"], DEFAULT_TIMEOUT).await?;
-    run_git(
+    // Raw: a refusing `commit` writes its whole report to stdout and leaves
+    // stderr EMPTY (measured, git 2.51.1), which a stderr-only error renders as
+    // the bare "git exited with code 1".
+    let commit = run_git_raw(
         Some(worktree_path),
         &["commit", "-m", message],
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if commit.code != 0 {
+        return Err(AppError::Git {
+            code: commit.code,
+            stderr: commit.full_failure_text(),
+        });
+    }
     let head = run_git(
         Some(worktree_path),
         &["rev-parse", "HEAD"],
@@ -596,12 +605,21 @@ pub async fn git_worktree_squash(
         DEFAULT_TIMEOUT,
     )
     .await?;
-    run_git(
+    // Raw, for the same stdout-only commit refusal as `worktree_commit_all` — and
+    // this one leaves the branch rewound with everything staged, so the error the
+    // user reads has to say why.
+    let commit = run_git_raw(
         Some(&worktree_path),
         &["commit", "-m", &message],
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if commit.code != 0 {
+        return Err(AppError::Git {
+            code: commit.code,
+            stderr: commit.full_failure_text(),
+        });
+    }
     Ok(true)
 }
 

--- a/src-tauri/src/github/rulesets.rs
+++ b/src-tauri/src/github/rulesets.rs
@@ -148,23 +148,43 @@ fn required_check_contexts(rules: &Value) -> Vec<String> {
     out
 }
 
+/// A branch name made safe for the `rules/branches/{branch}` path. gh parses the URL
+/// with Go's `url.Parse`, where a raw `#` opens a FRAGMENT — `master#x` reads
+/// `master`'s rules, naming another branch's checks — and a bare `%` fails the parse.
+/// `/` stays raw on purpose: the endpoint takes the rest of the path as the branch, so
+/// `release/1.0` must survive intact. That is why `encode_query_value` is the wrong
+/// tool here — it emits `%2F`.
+fn escape_branch_path(branch: &str) -> String {
+    // `%` first: escaping it second would rewrite the `%` of the `%23` just written.
+    branch.replace('%', "%25").replace('#', "%23")
+}
+
 /// The status-check contexts the branch's active rules require, for the pull-request
 /// view's blocked-merge line. `/rules/branches` aggregates every ruleset that applies
 /// and answers `[]` for a readable branch under no rules. A branch the token can't
-/// read is an Err, like every other `run_gh` non-zero exit; the caller may treat that
-/// the same as empty, but it is not reported as empty here.
+/// read — or a name the ref gate refuses — is an Err, like every other `run_gh`
+/// non-zero exit; the caller may treat that as empty, but it is not reported as empty.
 #[tauri::command]
 pub async fn gh_branch_required_checks(
     repo_path: String,
     branch: String,
     lens: Option<String>,
 ) -> AppResult<Vec<String>> {
+    // Both guards are needed: the ref gate rejects refspec metacharacters but permits
+    // `#`/`%`, which are legal in a git ref and special in a URL.
+    crate::git::branches::validate_branch_name(&branch)?;
     // The lens slug, not the origin one: a fork PR's base branch — and its rules —
     // live in the repo the PR targets.
     let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     let out = run_gh(
         Some(&repo_path),
-        &["api", &format!("repos/{slug}/rules/branches/{branch}")],
+        &[
+            "api",
+            &format!(
+                "repos/{slug}/rules/branches/{}",
+                escape_branch_path(&branch)
+            ),
+        ],
         GH_NETWORK_TIMEOUT,
     )
     .await?;
@@ -236,6 +256,21 @@ mod tests {
             {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"build"}]}}
         ]"#;
         assert_eq!(contexts(raw), vec!["build", "test"]);
+    }
+
+    #[test]
+    fn escapes_only_what_go_url_parse_would_misread() {
+        // Measured against `gh api`: `…/branches/master#x` returns MASTER's rules (the
+        // `#` opened a fragment), and `…/branches/master%x` fails url.Parse outright.
+        assert_eq!(escape_branch_path("feat#2"), "feat%232");
+        assert_eq!(escape_branch_path("100%done"), "100%25done");
+        // A name that already reads like an escape is data, not an escape.
+        assert_eq!(escape_branch_path("v%23"), "v%2523");
+        // Order proof: `#` first would re-escape the `%` of its own `%23`.
+        assert_eq!(escape_branch_path("a#b%c"), "a%23b%25c");
+        // `/` rides raw — the endpoint matches the rest of the path as the branch.
+        assert_eq!(escape_branch_path("release/1.0"), "release/1.0");
+        assert_eq!(escape_branch_path("master"), "master");
     }
 
     #[test]

--- a/src-tauri/src/github/rulesets.rs
+++ b/src-tauri/src/github/rulesets.rs
@@ -123,6 +123,56 @@ pub async fn gh_ruleset_delete(repo_path: String, id: u64) -> AppResult<()> {
     Ok(())
 }
 
+/// The `required_status_checks` contexts in a `/rules/branches/{branch}` response,
+/// in GitHub's own order and deduplicated — several rulesets may require the same
+/// context. Pure so the shape is pinned without a live `gh` call.
+fn required_check_contexts(rules: &Value) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for rule in rules.as_array().into_iter().flatten() {
+        if rule.get("type").and_then(Value::as_str) != Some("required_status_checks") {
+            continue;
+        }
+        let checks = rule
+            .pointer("/parameters/required_status_checks")
+            .and_then(Value::as_array);
+        for check in checks.into_iter().flatten() {
+            let Some(context) = check.get("context").and_then(Value::as_str) else {
+                continue;
+            };
+            if context.is_empty() || out.iter().any(|c| c == context) {
+                continue;
+            }
+            out.push(context.to_string());
+        }
+    }
+    out
+}
+
+/// The status-check contexts the branch's active rules require, for the pull-request
+/// view's blocked-merge line. `/rules/branches` aggregates every ruleset that applies
+/// and answers `[]` for a readable branch under no rules. A branch the token can't
+/// read is an Err, like every other `run_gh` non-zero exit; the caller may treat that
+/// the same as empty, but it is not reported as empty here.
+#[tauri::command]
+pub async fn gh_branch_required_checks(
+    repo_path: String,
+    branch: String,
+    lens: Option<String>,
+) -> AppResult<Vec<String>> {
+    // The lens slug, not the origin one: a fork PR's base branch — and its rules —
+    // live in the repo the PR targets.
+    let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
+    let out = run_gh(
+        Some(&repo_path),
+        &["api", &format!("repos/{slug}/rules/branches/{branch}")],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let rules: Value = serde_json::from_str(&out.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not parse the branch rules: {e}")))?;
+    Ok(required_check_contexts(&rules))
+}
+
 /// Flips only `enforcement` (the reversible soft-off). PUT is a full replace, so
 /// we GET the ruleset and resend its writable fields with the new enforcement —
 /// the rules are preserved.
@@ -151,4 +201,59 @@ pub async fn gh_ruleset_set_enforcement(
         "rules": full.get("rules").cloned().unwrap_or(json!([])),
     });
     gh_ruleset_update(repo_path, id, body).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contexts(raw: &str) -> Vec<String> {
+        required_check_contexts(&serde_json::from_str::<Value>(raw).expect("valid JSON"))
+    }
+
+    #[test]
+    fn reads_the_contexts_of_a_live_rules_response() {
+        // Verbatim `gh api repos/theBGuy/GitDesktop/rules/branches/master`, so the
+        // parser is pinned against the shape the endpoint actually returns.
+        let raw = r#"[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"do_not_enforce_on_create":false,"required_status_checks":[{"context":"build"},{"context":"fragment"}]},"ruleset_source_type":"Repository","ruleset_source":"theBGuy/GitDesktop","ruleset_id":20332127}]"#;
+        assert_eq!(contexts(raw), vec!["build", "fragment"]);
+    }
+
+    #[test]
+    fn ignores_rules_of_every_other_type() {
+        let raw = r#"[
+            {"type":"pull_request","parameters":{"required_approving_review_count":1}},
+            {"type":"deletion"},
+            {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"lint","integration_id":15368}]}}
+        ]"#;
+        assert_eq!(contexts(raw), vec!["lint"]);
+    }
+
+    #[test]
+    fn dedupes_a_context_required_by_two_rulesets() {
+        let raw = r#"[
+            {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"build"},{"context":"test"}]}},
+            {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"build"}]}}
+        ]"#;
+        assert_eq!(contexts(raw), vec!["build", "test"]);
+    }
+
+    #[test]
+    fn an_unprotected_branch_requires_nothing() {
+        assert_eq!(contexts("[]"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn tolerates_shapes_the_endpoint_never_promised() {
+        // A rules read that isn't a list of well-formed rules yields no contexts
+        // rather than panicking — the banner falls back to its generic line.
+        for raw in [
+            r#"{"message":"Not Found"}"#,
+            r#"[{"type":"required_status_checks"}]"#,
+            r#"[{"type":"required_status_checks","parameters":{"required_status_checks":{}}}]"#,
+            r#"[{"type":"required_status_checks","parameters":{"required_status_checks":[{},{"context":42},{"context":""}]}}]"#,
+        ] {
+            assert_eq!(contexts(raw), Vec::<String>::new(), "raw: {raw}");
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -558,6 +558,7 @@ pub fn run() {
             github::rulesets::gh_ruleset_update,
             github::rulesets::gh_ruleset_delete,
             github::rulesets::gh_ruleset_set_enforcement,
+            github::rulesets::gh_branch_required_checks,
             github::secrets::gh_secrets_list,
             github::secrets::gh_secret_set,
             github::secrets::gh_secret_delete,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -784,8 +784,8 @@ the local prediction below — so a clash visible from your last fetch is still 
 still resolvable. On **GitHub** a conflicting pull request also runs no checks until the
 conflicts are resolved, and the strip says so — an empty checks list there means *never
 ran*, not *passed*. In the list, **GitHub** and **GitLab** rows carry a **Conflicts**
-chip (icon plus the word) on open pull requests, so you can spot a blocked one without
-opening it.
+chip (icon plus the word) on open pull requests, so you can spot a conflicting one
+without opening it.
 
 **Resolve conflicts** settles it right here. GitDesktop merges the base branch into the
 pull request's **head** branch in an **isolated worktree** — your own branch and working
@@ -828,10 +828,32 @@ request branch's history and force-pushes it, so it asks you to confirm first: o
 request from a fork, that branch is the contributor's. Both controls are disabled with
 the reason on hover when you don't have push access, or when a fork's author left
 GitHub's *Allow edits by maintainers* off. This reads GitHub's own comparison of the two
-branches, so it's **GitHub** only, and the line yields to anything more pressing — a
-conflict, an unfinished resolution, or a mergeability answer the app couldn't read.
-**Update pull request branch** is in the command palette ({{kbd:command-palette}}) too —
-no default shortcut, so give it one in **Settings → Keyboard**.
+branches, so it's **GitHub** only, and the line yields to anything more pressing: a
+conflict, an unfinished resolution, a merge the base branch's rules are blocking, or
+a mergeability answer the app couldn't read. **Update pull request branch** is in the
+command palette ({{kbd:command-palette}}) too — no default shortcut, so give it one in
+**Settings → Keyboard**.
+
+## Blocked by branch protection
+
+A pull request can merge cleanly and still be refused. **GitHub** reports one as
+blocked while the base branch's rules go unmet, and the strip says so, naming what is
+outstanding: **Merge is blocked — waiting on: build, fragment.** GitDesktop asks
+GitHub what that branch requires and matches it against the checks on this pull
+request, counting one as outstanding when it has failed, is still running, or has
+never reported. Four are named, then *and N more*. Wherever the specific
+requirements can't be named, the line falls back to **Merge is blocked by the
+base branch's protection rules.**
+
+Where the head is also behind its base, the refusal says so in the same breath and
+**Update branch** stays on the strip, so a blocked pull request never loses the route
+to updating it.
+
+**Merge** stays available throughout. A repository admin, or anyone a ruleset lists as
+a bypass actor, can merge a blocked pull request, and GitDesktop can't tell from here
+whether that's you, so the decision stays yours. If the forge does refuse the merge,
+the notice carries that same line beside the forge's own words. This reads GitHub's
+rules, so it's **GitHub** only.
 
 ## Maintaining a pull request from a fork
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -849,11 +849,11 @@ Where the head is also behind its base, the refusal says so in the same breath a
 **Update branch** stays on the strip, so a blocked pull request never loses the route
 to updating it.
 
-**Merge** stays available throughout. A repository admin, or anyone a ruleset lists as
-a bypass actor, can merge a blocked pull request, and GitDesktop can't tell from here
-whether that's you, so the decision stays yours. If the forge does refuse the merge,
-the notice carries that same line beside the forge's own words. This reads GitHub's
-rules, so it's **GitHub** only.
+**Merge** stays available throughout. Whoever holds bypass permission on those rules
+can merge anyway, and nothing GitDesktop can read from here says whether you're one of
+them — so the button stays live and the call stays yours. If the forge does refuse the
+merge, the notice carries that same line beside the forge's own words. This reads
+GitHub's rules, so it's **GitHub** only.
 
 ## Maintaining a pull request from a fork
 

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -44,6 +44,7 @@ import { useConfirm } from "@/lib/stores/confirm";
 import { formatDurationBetween } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
+import { checkPresentation } from "./check-presentation";
 
 /** The one wording for releasing a held workflow run — this strip and the Actions
  *  run view both ask through it, so the two prompts can't drift apart. It lives
@@ -54,73 +55,6 @@ export const APPROVE_RUN_CONFIRM = {
   body: "This runs the contributor's workflow code in this repository's CI.",
   confirmLabel: "Approve and run",
 } as const;
-
-/** Tone + glyph for a CI check, so pass/fail is never conveyed by color alone.
- *  `provider` only distinguishes ACTION_REQUIRED — the one state whose meaning
- *  differs per forge. */
-export function checkPresentation(
-  status: string,
-  provider: ForgeProvider,
-): {
-  tone: string;
-  Icon: typeof CheckCircleIcon;
-  label: string;
-  /** Coarse bucket for the rollup summary + failures-first sort. */
-  bucket: "passed" | "failed" | "pending" | "skipped";
-} {
-  const s = status.toUpperCase();
-  if (s === "SUCCESS") {
-    return {
-      tone: "text-success",
-      Icon: CheckCircleIcon,
-      label: "passed",
-      bucket: "passed",
-    };
-  }
-  if (
-    ["FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE"].includes(
-      s,
-    )
-  ) {
-    return {
-      tone: "text-destructive",
-      Icon: XCircleIcon,
-      label: "failed",
-      bucket: "failed",
-    };
-  }
-  if (["SKIPPED", "NEUTRAL", "STALE"].includes(s)) {
-    return {
-      tone: "text-muted-foreground",
-      Icon: MinusCircleIcon,
-      // The three share a bucket/icon/tone, but the accessible label is each
-      // status's own word ("skipped" / "neutral" / "stale") so a screen reader
-      // announces the actual result. The summary segment still says "skipped".
-      label: s.toLowerCase(),
-      bucket: "skipped",
-    };
-  }
-  if (s === "ACTION_REQUIRED" && provider === "github") {
-    // GitHub's is the one ACTION_REQUIRED a maintainer can act on from here (a
-    // fork PR's run held for approval), so it names the wait instead of reading
-    // as generic pending. It keeps the pending bucket: nothing has run yet.
-    return {
-      tone: "text-warning",
-      Icon: WarningIcon,
-      label: "awaiting approval",
-      bucket: "pending",
-    };
-  }
-  // Everything still in flight — IN_PROGRESS/QUEUED/PENDING — plus non-GitHub
-  // ACTION_REQUIRED (deliberately here: it awaits a human, so the amber warning
-  // tone fits) falls through to the pending bucket.
-  return {
-    tone: "text-warning",
-    Icon: CircleIcon,
-    label: "pending",
-    bucket: "pending",
-  };
-}
 
 /** A GitHub Actions check that hasn't finished: a parsed run id, GitHub, no
  *  `completedAt`, AND a still-pending status. The bucket check guards a

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -58,7 +58,7 @@ export const APPROVE_RUN_CONFIRM = {
 /** Tone + glyph for a CI check, so pass/fail is never conveyed by color alone.
  *  `provider` only distinguishes ACTION_REQUIRED — the one state whose meaning
  *  differs per forge. */
-function checkPresentation(
+export function checkPresentation(
   status: string,
   provider: ForgeProvider,
 ): {

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -28,14 +28,32 @@ const FORK_BLOCKED_REASON =
 /** How many conflicting paths get their own row before the rest collapse to a count. */
 const MAX_FILE_ROWS = 5;
 
+/** How many unmet requirements the blocked line names before the rest collapse. */
+const MAX_REQUIREMENT_NAMES = 4;
+
+/** The one wording for a merge the base branch's rules are refusing — the strip says
+ *  it, and so does the note on a refused merge, so the two can't drift apart. With
+ *  nothing named (the rules read failed, or named nothing the app could join) it
+ *  still states where things stand rather than going quiet. */
+export function blockedMergeLine(requirements: string[]): string {
+  if (requirements.length === 0)
+    return "Merge is blocked by the base branch's protection rules.";
+  const shown = requirements.slice(0, MAX_REQUIREMENT_NAMES);
+  const extra = requirements.length - shown.length;
+  const names =
+    extra > 0 ? `${shown.join(", ")} and ${extra} more` : shown.join(", ");
+  return `Merge is blocked — waiting on: ${names}.`;
+}
+
 /** What a control held open through the PR-switch window says. Shared with the view's
  *  own stale-held controls so the one wording can't drift into two. */
 export const PR_SWITCH_LOADING_REASON = "Loading this pull request…";
 
 /** Which line the banner shows. `predicted` is the local fallback wherever the forge has
  *  no mergeability to give — Bitbucket by design, or a read that failed; `unknown` is a
- *  `checking` poll that gave up, `unreachable` a read that never landed at all, and
- *  `updating` the forge's queued update-branch job still running. */
+ *  `checking` poll that gave up, `unreachable` a read that never landed at all,
+ *  `updating` the forge's queued update-branch job still running, and `blocked` a PR
+ *  that merges cleanly but whose base branch rules are refusing it. */
 export type PrMergeabilityArm =
   | "conflicting"
   | "predicted"
@@ -45,6 +63,7 @@ export type PrMergeabilityArm =
   | "resume"
   | "behind"
   | "updating"
+  | "blocked"
   | null;
 
 /** Words carry the meaning; the icon and tone only reinforce it. */
@@ -60,6 +79,9 @@ const ARM_ICON: Record<
   resume: InfoIcon,
   behind: InfoIcon,
   updating: Spinner,
+  // Informational, not a warning: nothing is wrong with the pull request, and a
+  // viewer who can bypass the rules may still merge it.
+  blocked: InfoIcon,
 };
 
 /** The line each arm says. */
@@ -71,6 +93,7 @@ const ARM_MESSAGE: Record<
     behindBy: number;
     predictedClean: boolean;
     forgeUnreachable: boolean;
+    blockedRequirements: string[];
   }) => ReactNode
 > = {
   conflicting: ({ base, provider }) => (
@@ -121,6 +144,21 @@ const ARM_MESSAGE: Record<
   ),
   resume: () =>
     "An unfinished conflict resolution exists for this pull request.",
+  // The behind clause rides along in the `behind` arm's own words, because the update
+  // controls come with it — a bare refusal beside an Update branch button would leave
+  // the button unexplained.
+  blocked: ({ base, behindBy, blockedRequirements }) => (
+    <>
+      {blockedMergeLine(blockedRequirements)}
+      {behindBy > 0 ? (
+        <>
+          {` It is also ${behindBy} commit${behindBy === 1 ? "" : "s"} behind `}
+          <span className="font-mono">{base}</span>
+          {"."}
+        </>
+      ) : null}
+    </>
+  ),
   behind: ({ base, behindBy }) => (
     <>
       {`This branch is ${behindBy} commit${behindBy === 1 ? "" : "s"} behind `}
@@ -147,6 +185,7 @@ export function PrMergeabilityBanner({
   predictedClean,
   forgeUnreachable,
   behindBy,
+  blockedRequirements,
   updateBlockedReason,
   updateBusy,
   updateSubmitting,
@@ -173,8 +212,13 @@ export function PrMergeabilityBanner({
   /** The forge answer never landed, as opposed to a forge that has none to give. Adds
    *  the couldn't-reach qualifier and a Retry to the arms driven by the prediction. */
   forgeUnreachable: boolean;
-  /** Commits the base is ahead of the head — only read on the `behind` arm. */
+  /** Commits the base is ahead of the head — read on the `behind` arm, and on
+   *  `blocked` where it decides whether the update controls ride along. */
   behindBy: number;
+  /** Unmet requirements of the base branch's rules — only read on the `blocked`
+   *  arm, where an empty list means the app couldn't name any and the line stays
+   *  generic. */
+  blockedRequirements: string[];
   /** Why updating the branch is refused, if it is; undefined = allowed. */
   updateBlockedReason: string | undefined;
   updateBusy: boolean;
@@ -258,6 +302,7 @@ export function PrMergeabilityBanner({
             behindBy,
             predictedClean,
             forgeUnreachable,
+            blockedRequirements,
           })}
         </span>
       </span>
@@ -314,7 +359,12 @@ export function PrMergeabilityBanner({
         </div>
       )}
 
-      {(arm === "behind" || arm === "updating") && (
+      {/* The blocked arm re-admits these EXISTING controls when the head is also
+          behind: the ladder gives that PR the blocked sentence, and losing the only
+          route to the update along with it would be a refusal the app never intended. */}
+      {(arm === "behind" ||
+        arm === "updating" ||
+        (arm === "blocked" && behindBy > 0)) && (
         <div className="flex items-center gap-1.5">
           <DisabledReasonButton
             variant="ghost"

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -172,6 +172,7 @@ import { PendingReviewBar } from "./PendingReviewBar";
 import { PrActivityFeed, usePrThreadClaims } from "./PrActivityFeed";
 import { PrCommitDetail } from "./PrCommitDetail";
 import {
+  blockedMergeLine,
   PR_SWITCH_LOADING_REASON,
   type PrMergeabilityArm,
   PrMergeabilityBanner,
@@ -198,6 +199,10 @@ import {
 } from "./StackSection";
 import { SubmitReviewDialog } from "./SubmitReviewDialog";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
+import {
+  unmetRequiredChecks,
+  useBranchRequiredChecks,
+} from "./useBranchRequiredChecks";
 import {
   useCancelOnIdentityChange,
   useGeneratePrDescription,
@@ -887,6 +892,13 @@ export function RemotePrView({
   // or still-running one has nothing to say. Gated like every other prediction reader.
   const predictedClean =
     previewEnabled && conflictPreview.data?.status === "clean";
+  // GitHub reports a PR the base branch's rules are refusing as MERGEABLE with a
+  // BLOCKED merge-state — the merge itself is clean, the rules are the refusal.
+  // GitLab/Bitbucket `detail` values are not interpreted here.
+  const blockedByRules =
+    provider === "github" &&
+    serverState === "mergeable" &&
+    mergeability.data?.detail === "BLOCKED";
   const behindBy = divergenceEnabled ? (divergence.data?.behindBy ?? 0) : 0;
   // Same gate as `behindBy` — a disabled divergence query keeps serving its last value,
   // and a latch left armed on one PR must never paint onto the next.
@@ -969,16 +981,50 @@ export function RemotePrView({
       // read that never landed leaves the banner with nothing but the local prediction.
       case forgeUnreachable:
         return "unreachable";
+      // Below the answer-shaped arms above only for reading order: a BLOCKED detail
+      // rides a settled "mergeable" answer, which neither `checking` nor
+      // `unreachable` can be true of. It does outrank `behind` — rules the base is
+      // enforcing are more pressing than a base that has merely moved on.
+      case blockedByRules:
+        return "blocked";
       case behindBy > 0:
         return "behind";
       default:
         return null;
     }
   })();
-  // No `updating` term needed: the arm only reads "behind" once the ladder has fallen
-  // past that case. The submitting window is its own thing — it precedes the latch.
+  // Both halves below read `details`, which through a PR switch still serves the
+  // PREVIOUS pull request — and revisiting a blocked PR serves its cached mergeability
+  // synchronously, so the arm can be "blocked" while the base ref and checks belong to
+  // the last one. Naming that PR's checks, or reading rules for its base, would both
+  // be wrong.
+  const blockedDetailsReady =
+    bannerArm === "blocked" && !details.isPlaceholderData;
+  // The base branch's required checks, read only for the arm that names them. The
+  // repoTab term is the <Activity> gate every sibling read here carries: a hidden
+  // subtree still refetches, and this one would respawn `gh` on every focus regain.
+  const requiredChecks = useBranchRequiredChecks(
+    repoPath,
+    details.data?.baseRefName ?? "",
+    lens,
+    repoTab === "pulls" && blockedDetailsReady,
+  );
+  // A failed or empty rules read leaves this empty and the line stays generic — the
+  // banner never waits on the join to say that the merge is blocked.
+  const blockedRequirements = blockedDetailsReady
+    ? unmetRequiredChecks(
+        requiredChecks.data ?? [],
+        details.data?.checks ?? [],
+        providerKey,
+      )
+    : [];
+  // `blocked` outranks `behind` on the ladder, so a PR that is both would otherwise
+  // lose every route to the update (button, caret, hotkey, palette) while the rules
+  // block it: the strip's sentence changes, the affordance does not. Neither arm
+  // needs an `updating` term — both sit below it. The submitting window precedes
+  // the latch.
   const canUpdateBranch =
-    bannerArm === "behind" &&
+    (bannerArm === "behind" || (bannerArm === "blocked" && behindBy > 0)) &&
     updateBlockedReason === undefined &&
     !updateBranch.isPending;
 
@@ -1477,7 +1523,12 @@ export function RemotePrView({
           setMergeOpen(false);
         },
         onError: (e) => {
-          onError(e);
+          // The forge's own refusal text advises flags this app doesn't offer, so
+          // where the rules are the known reason, say which requirement is unmet
+          // alongside it — the same line the strip is already showing.
+          if (bannerArm === "blocked")
+            toastErrorWithNote(e, blockedMergeLine(blockedRequirements));
+          else onError(e);
           setMergeOpen(false);
         },
       },
@@ -2336,6 +2387,7 @@ export function RemotePrView({
         predictedClean={predictedClean}
         forgeUnreachable={forgeUnreachable}
         behindBy={behindBy}
+        blockedRequirements={blockedRequirements}
         updateBlockedReason={updateBlockedReason}
         // Busy-shaped, not a reason — the banner supplies its own words for the wait,
         // which now spans GitHub's whole queued update rather than one CLI call.

--- a/src/features/pulls/check-presentation.ts
+++ b/src/features/pulls/check-presentation.ts
@@ -1,0 +1,77 @@
+import {
+  CheckCircleIcon,
+  CircleIcon,
+  MinusCircleIcon,
+  WarningIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import type { ForgeProvider } from "@/lib/git/types";
+
+/** Tone + glyph for a CI check, so pass/fail is never conveyed by color alone.
+ *  `provider` only distinguishes ACTION_REQUIRED — the one state whose meaning
+ *  differs per forge. Its own module rather than the rollup's: the required-checks
+ *  join reads `bucket` too, and importing it from the component would drag that
+ *  component's log/query/opener graph into a hook that needs none of it. */
+export function checkPresentation(
+  status: string,
+  provider: ForgeProvider,
+): {
+  tone: string;
+  Icon: typeof CheckCircleIcon;
+  label: string;
+  /** Coarse bucket for the rollup summary + failures-first sort. */
+  bucket: "passed" | "failed" | "pending" | "skipped";
+} {
+  const s = status.toUpperCase();
+  if (s === "SUCCESS") {
+    return {
+      tone: "text-success",
+      Icon: CheckCircleIcon,
+      label: "passed",
+      bucket: "passed",
+    };
+  }
+  if (
+    ["FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE"].includes(
+      s,
+    )
+  ) {
+    return {
+      tone: "text-destructive",
+      Icon: XCircleIcon,
+      label: "failed",
+      bucket: "failed",
+    };
+  }
+  if (["SKIPPED", "NEUTRAL", "STALE"].includes(s)) {
+    return {
+      tone: "text-muted-foreground",
+      Icon: MinusCircleIcon,
+      // The three share a bucket/icon/tone, but the accessible label is each
+      // status's own word ("skipped" / "neutral" / "stale") so a screen reader
+      // announces the actual result. The summary segment still says "skipped".
+      label: s.toLowerCase(),
+      bucket: "skipped",
+    };
+  }
+  if (s === "ACTION_REQUIRED" && provider === "github") {
+    // GitHub's is the one ACTION_REQUIRED a maintainer can act on from here (a
+    // fork PR's run held for approval), so it names the wait instead of reading
+    // as generic pending. It keeps the pending bucket: nothing has run yet.
+    return {
+      tone: "text-warning",
+      Icon: WarningIcon,
+      label: "awaiting approval",
+      bucket: "pending",
+    };
+  }
+  // Everything still in flight — IN_PROGRESS/QUEUED/PENDING — plus non-GitHub
+  // ACTION_REQUIRED (deliberately here: it awaits a human, so the amber warning
+  // tone fits) falls through to the pending bucket.
+  return {
+    tone: "text-warning",
+    Icon: CircleIcon,
+    label: "pending",
+    bucket: "pending",
+  };
+}

--- a/src/features/pulls/useBranchRequiredChecks.ts
+++ b/src/features/pulls/useBranchRequiredChecks.ts
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+import { ghBranchRequiredChecks } from "@/lib/git/api";
+import type { ForgeProvider, PrCheckOut, RemoteLens } from "@/lib/git/types";
+import { checkPresentation } from "./ChecksRollup";
+
+/**
+ * The status-check contexts a pull request's BASE branch requires, read from
+ * GitHub's active rules for that branch. Never polls, and it is enabled only where
+ * the answer is about to be shown — the read exists to name what a blocked merge is
+ * waiting on. It can still refetch on the usual triggers (focus, reconnect, remount)
+ * once stale, so the caller's gate carries the <Activity> term too. An empty answer
+ * is the honest one for a branch with no rules this viewer can see.
+ */
+export function useBranchRequiredChecks(
+  repo: string,
+  branch: string,
+  lens: RemoteLens,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: [
+      "repo",
+      repo,
+      "branch",
+      lens,
+      branch,
+      "required-checks",
+    ] as const,
+    queryFn: () => ghBranchRequiredChecks(repo, branch, lens),
+    enabled: enabled && branch !== "",
+    // Branch rules change on a human timescale, so one read covers a visit.
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Which required contexts the PR's own checks have not satisfied, in the order the
+ * rules named them. Joined by NAME — the rules speak in contexts and the rollup in
+ * check names, and that string is all the two share.
+ */
+export function unmetRequiredChecks(
+  required: string[],
+  checks: PrCheckOut[],
+  provider: ForgeProvider,
+): string[] {
+  if (required.length === 0) return [];
+  // Indexed once: GitHub allows several checks under one name, and every run of a
+  // required context has to be consulted before that context counts as satisfied.
+  const runs = new Map<string, PrCheckOut[]>();
+  for (const check of checks) {
+    const existing = runs.get(check.name);
+    if (existing) existing.push(check);
+    else runs.set(check.name, [check]);
+  }
+  return required.filter((context) => {
+    const named = runs.get(context);
+    if (!named) return true;
+    // Unmet = never reported, still running, or failed — the three a viewer is
+    // waiting on. A skipped or neutral run has reported a conclusion, so naming
+    // it as something still to come would be wrong.
+    return named.some((check) => {
+      const { bucket } = checkPresentation(check.status, provider);
+      return bucket === "failed" || bucket === "pending";
+    });
+  });
+}

--- a/src/features/pulls/useBranchRequiredChecks.ts
+++ b/src/features/pulls/useBranchRequiredChecks.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ghBranchRequiredChecks } from "@/lib/git/api";
 import type { ForgeProvider, PrCheckOut, RemoteLens } from "@/lib/git/types";
-import { checkPresentation } from "./ChecksRollup";
+import { checkPresentation } from "./check-presentation";
 
 /**
  * The status-check contexts a pull request's BASE branch requires, read from

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -98,21 +98,35 @@ const EMPTY_MERGED_CLAUSE: Record<PrCheckState, string> = {
 
 /** The one-line status above the candidate list while merged detection runs.
  *  A parked check has no progress to report, so it names what it's waiting on
- *  rather than implying the read is underway. */
-function MergedCheckLine({ paused }: { paused: boolean }) {
+ *  rather than implying the read is underway — and only the pull-request half
+ *  can park, since divergence reads local objects with no connection at all.
+ *  `srOnly` announces it without drawing it, for the states that show no
+ *  status line today. */
+function MergedCheckLine({
+  paused,
+  srOnly,
+}: {
+  paused: boolean;
+  srOnly?: boolean;
+}) {
   return (
-    <p className="px-1 py-1 text-[11px] text-muted-foreground">
+    <p
+      className={
+        srOnly ? "sr-only" : "px-1 py-1 text-[11px] text-muted-foreground"
+      }
+    >
       {paused
-        ? "Waiting for a connection to check which branches are merged…"
+        ? "Waiting for a connection to check which branches a pull request merged…"
         : "Checking which branches are merged…"}
     </p>
   );
 }
 
 /** Empty first paint while merged detection runs. An animated skeleton over a
- *  parked check would be a false activity signal. */
+ *  parked check would be a false activity signal, so a parked check paints
+ *  nothing here — the status region above already names what it's waiting on. */
 function CheckingMergedPlaceholder({ paused }: { paused: boolean }) {
-  if (paused) return <MergedCheckLine paused />;
+  if (paused) return null;
   return (
     <div className="space-y-1 py-2" aria-busy>
       {[0, 1, 2].map((i) => (
@@ -320,6 +334,13 @@ export function CleanupBranchesDialog({
   const checkingMerged =
     (Boolean(defaultBranch) && divergence.isLoading) ||
     prCheckState === "pending";
+  // Which of the status region's lines are DRAWN — it announces more than it
+  // shows: the check line stays sr-only on the empty first paint (the skeleton
+  // is the visual signal there) and on a parked re-check of an answered list,
+  // whose visible staleness caveat is a surface this change doesn't own.
+  const showCheckLine =
+    checkingMerged && (prCheckPaused || candidates.length > 0);
+  const showPrFailedLine = prCheckState === "failed" && candidates.length > 0;
 
   const selectedCount = candidateNames.filter((n) => selected.has(n)).length;
   const allChecked =
@@ -534,73 +555,116 @@ export function CleanupBranchesDialog({
             </button>
           )}
 
-          {/* List / skeleton / empty */}
-          {checkingMerged && candidates.length === 0 ? (
-            <CheckingMergedPlaceholder paused={prCheckPaused} />
-          ) : candidates.length === 0 ? (
-            <p className="py-6 text-center text-xs text-muted-foreground">
-              No stale branches — nothing is merged into{" "}
-              <span className="font-mono">
-                {defaultBranch ?? "the default branch"}
-              </span>
-              {EMPTY_MERGED_CLAUSE[prCheckState]}
-              {windowDays} days. Try a shorter window.
-              {prCheckState === "failed"
-                ? " Pull requests couldn't be checked, so a branch merged through one may be missing here."
-                : null}
-            </p>
-          ) : (
+          {/* Merged-detection status + the list it describes. `gap` (not
+              `space-y`) spaces the two, so the status region contributes none
+              while it is sr-only and therefore out of flow. */}
+          <div className="flex flex-col gap-0.5">
+            {/* Mounted unconditionally: a live region created together with its
+                text announces unreliably, so the region pre-exists and only its
+                CONTENT changes. `sr-only` keeps the silent states out of layout.
+                No aria-busy — on a live region it tells a screen reader to hold
+                announcements back; it belongs on the skeleton, which sits
+                outside this region. */}
             <div
-              className="-mx-1 max-h-[45vh] space-y-0.5 overflow-x-hidden overflow-y-auto px-1"
-              onKeyDown={onKeyDown}
+              role="status"
+              className={cn(
+                "flex flex-col gap-0.5",
+                !showCheckLine && !showPrFailedLine && "sr-only",
+              )}
             >
-              {checkingMerged && <MergedCheckLine paused={prCheckPaused} />}
-              {prCheckState === "failed" && (
-                <p className="px-1 py-1 text-[11px] text-muted-foreground">
+              {/* A parked pull-request read is still waiting, so it keeps the
+                  waiting line; the resting line reports the count and claims
+                  nothing about the check, which is what a `role="status"`
+                  region can honestly repeat on every mode and window change. */}
+              {checkingMerged || prCheckPaused ? (
+                <MergedCheckLine
+                  paused={prCheckPaused}
+                  srOnly={!checkingMerged}
+                />
+              ) : (
+                <p className="sr-only">
+                  {candidates.length === 0
+                    ? "No stale branches."
+                    : `${pluralBranches(candidates.length)} to review.`}
+                </p>
+              )}
+              {/* Announced even where the empty state carries it in prose: only
+                  the region's copy reaches a screen reader as it happens. */}
+              {prCheckState === "failed" ? (
+                <p
+                  className={
+                    showPrFailedLine
+                      ? "px-1 py-1 text-[11px] text-muted-foreground"
+                      : "sr-only"
+                  }
+                >
                   Pull requests couldn't be checked — a branch merged through
                   one may be missing.
                 </p>
-              )}
-              {candidates.map((c, idx) => {
-                const name = c.branch.name;
-                const checked = selected.has(name);
-                const err = failed.get(name);
-                const rovingTab =
-                  idx === (activeIndex === -1 ? 0 : activeIndex) ? 0 : -1;
-                return (
-                  <label
-                    key={name}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2 rounded-none px-1.5 py-1.5 text-xs transition-colors hover:bg-accent",
-                      activeName === name && "bg-accent",
-                    )}
-                  >
-                    <Checkbox
-                      data-row={name}
-                      tabIndex={rovingTab}
-                      checked={checked}
-                      disabled={running}
-                      onCheckedChange={() => toggle(name)}
-                      onFocus={() => setActiveName(name)}
-                    />
-                    <span className="min-w-0 flex-1 truncate font-mono">
-                      {name}
-                    </span>
-                    <span className="flex shrink-0 items-center gap-2">
-                      <RowBadge
-                        error={err}
-                        merged={c.merged}
-                        prMerged={c.prMerged}
-                      />
-                      <span className="tabular-nums text-muted-foreground">
-                        <RelativeTime date={c.branch.lastCommitDate} />
-                      </span>
-                    </span>
-                  </label>
-                );
-              })}
+              ) : null}
             </div>
-          )}
+
+            {/* List / skeleton / empty */}
+            {checkingMerged && candidates.length === 0 ? (
+              <CheckingMergedPlaceholder paused={prCheckPaused} />
+            ) : candidates.length === 0 ? (
+              <p className="py-6 text-center text-xs text-muted-foreground">
+                No stale branches — nothing is merged into{" "}
+                <span className="font-mono">
+                  {defaultBranch ?? "the default branch"}
+                </span>
+                {EMPTY_MERGED_CLAUSE[prCheckState]}
+                {windowDays} days. Try a shorter window.
+                {prCheckState === "failed"
+                  ? " Pull requests couldn't be checked, so a branch merged through one may be missing here."
+                  : null}
+              </p>
+            ) : (
+              <div
+                className="-mx-1 max-h-[45vh] space-y-0.5 overflow-x-hidden overflow-y-auto px-1"
+                onKeyDown={onKeyDown}
+              >
+                {candidates.map((c, idx) => {
+                  const name = c.branch.name;
+                  const checked = selected.has(name);
+                  const err = failed.get(name);
+                  const rovingTab =
+                    idx === (activeIndex === -1 ? 0 : activeIndex) ? 0 : -1;
+                  return (
+                    <label
+                      key={name}
+                      className={cn(
+                        "flex cursor-pointer items-center gap-2 rounded-none px-1.5 py-1.5 text-xs transition-colors hover:bg-accent",
+                        activeName === name && "bg-accent",
+                      )}
+                    >
+                      <Checkbox
+                        data-row={name}
+                        tabIndex={rovingTab}
+                        checked={checked}
+                        disabled={running}
+                        onCheckedChange={() => toggle(name)}
+                        onFocus={() => setActiveName(name)}
+                      />
+                      <span className="min-w-0 flex-1 truncate font-mono">
+                        {name}
+                      </span>
+                      <span className="flex shrink-0 items-center gap-2">
+                        <RowBadge
+                          error={err}
+                          merged={c.merged}
+                          prMerged={c.prMerged}
+                        />
+                        <span className="tabular-nums text-muted-foreground">
+                          <RelativeTime date={c.branch.lastCommitDate} />
+                        </span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
 
           <DialogFooter>
             <Button

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -116,7 +116,7 @@ function MergedCheckLine({
       }
     >
       {paused
-        ? "Waiting for a connection to check which branches a pull request merged…"
+        ? "Waiting for a connection to check which branches were merged through a pull request…"
         : "Checking which branches are merged…"}
     </p>
   );

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -17,6 +17,7 @@ export interface ErrorPresentation {
 /** Human labels for every AppError kind (mirrors the union in tauri/invoke.ts). */
 const KIND_LABELS: Record<AppError["kind"], string> = {
   git: "Git error",
+  conflict: "Merge conflict",
   notARepo: "Not a Git repository",
   gitNotFound: "Git not found",
   ghNotFound: "GitHub CLI not found",
@@ -61,7 +62,9 @@ function firstMeaningfulLine(message: string): string {
   return stripToolPrefix(nonEmpty ?? message).trim() || message.trim();
 }
 
-/** Conflict-family markers: anchored to git's own diagnostic line shapes and
+/** Conflict-family markers — the FALLBACK classifier, for `git`-kind errors from
+ *  a producer that doesn't carry the structured `conflict` variant. Anchored to
+ *  git's own diagnostic line shapes and
  *  matched case-sensitively against the raw text, because git echoes commit
  *  subjects and file paths into the same blob, so an unanchored match would
  *  collapse ANY failure into the conflict summary — a commit titled "resolve
@@ -136,6 +139,12 @@ const DIRTY_TREE_MARKERS = [
   "cannot rebase: your index contains uncommitted changes",
 ];
 
+/** The `git` kind is the only one carrying a stderr blob distinct from its
+ *  message; every other kind folds its detail into `message` itself. */
+function gitStderr(e: AppError): string {
+  return e.kind === "git" ? (e.stderr?.trim() ?? "") : "";
+}
+
 /**
  * Whether a thrown value is git refusing an operation because it would
  * overwrite uncommitted work — the pull / merge / rebase / switch dirty-tree
@@ -144,7 +153,7 @@ const DIRTY_TREE_MARKERS = [
  */
 export function isDirtyTreeRefusal(e: unknown): boolean {
   const text = isAppError(e)
-    ? `${e.message ?? ""}\n${e.stderr ?? ""}`
+    ? `${e.message ?? ""}\n${gitStderr(e)}`
     : e instanceof Error
       ? e.message
       : String(e);
@@ -206,6 +215,30 @@ function conflictSummary(text: string): string {
   return paused("Operation", "continue");
 }
 
+/** What a paused operation is called and how the user finishes it, keyed by the
+ *  `op` a structured conflict names. Same grammar as `conflictSummary` above,
+ *  which has to read the name out of git's own advice instead. The stash trio
+ *  has no `--continue` to point at, so each says where its changes ended up:
+ *  pop and apply keep the entry (measured, git 2.51.1), while `stash-restore`
+ *  recovers a DANGLING stash that is already off the list — promising a kept
+ *  entry there would send the user looking for one that isn't coming back. */
+const CONFLICT_SUMMARIES: Record<string, string> = {
+  merge: "Merge paused — resolve the conflicts, then commit.",
+  rebase: "Rebase paused — resolve the conflicts, then continue.",
+  "cherry-pick": "Cherry-pick paused — resolve the conflicts, then continue.",
+  revert: "Revert paused — resolve the conflicts, then continue.",
+  "stash-pop": "Stash pop hit conflicts — resolve them; your stash was kept.",
+  "stash-apply":
+    "Stash apply hit conflicts — resolve them; your stash was kept.",
+  "stash-restore":
+    "Restore hit conflicts — resolve them; the recovered changes are in your working tree.",
+};
+
+/** Mirrors `conflictSummary`'s own unknown-operation line, so an `op` the Rust
+ *  layer adds ahead of a table entry still reads as a paused operation. */
+const UNKNOWN_CONFLICT_SUMMARY =
+  "Operation paused — resolve the conflicts, then continue.";
+
 /** Count of non-empty lines in a string. */
 function nonEmptyLineCount(text: string): number {
   return text.split("\n").filter((l) => l.trim() !== "").length;
@@ -215,12 +248,32 @@ function nonEmptyLineCount(text: string): number {
  * Humanize any thrown value into a toast-friendly summary plus the raw full
  * text. AppErrors get a kind label; plain Error/string values get label null and
  * their first line as the summary. Conflict-family errors collapse to one calm
- * "<Op> paused" line while preserving the raw dump in `fullText`.
+ * "<Op> paused" line while preserving the raw dump in `fullText` — from the
+ * structured `conflict` variant where the producer carries it, from the anchored
+ * prose markers otherwise.
  */
 export function presentError(e: unknown): ErrorPresentation {
   if (isAppError(e)) {
+    const label = KIND_LABELS[e.kind];
+    // The structured variant first: the Rust layer already named the paused
+    // operation, so nothing is inferred from prose. The markers below stay for
+    // `git`-kind errors — every producer not carrying the structured variant.
+    if (e.kind === "conflict") {
+      // The Rust layer substitutes a one-line stand-in into `message` when git
+      // wrote to neither stream, so falling back to it keeps Details populated
+      // in the one case `report` cannot fill — and `long` follows the report,
+      // since that stand-in says no more than the summary already does.
+      const report = (e.report ?? "").trim();
+      return {
+        label,
+        summary: CONFLICT_SUMMARIES[e.op] ?? UNKNOWN_CONFLICT_SUMMARY,
+        fullText: report || (e.message ?? ""),
+        long: report !== "",
+      };
+    }
+
     const message = e.message ?? "";
-    const stderr = e.stderr?.trim() ?? "";
+    const stderr = gitStderr(e);
     // Append stderr only when it adds something the message doesn't already carry.
     const fullText =
       stderr && !message.includes(stderr) ? `${message}\n\n${stderr}` : message;
@@ -235,7 +288,6 @@ export function presentError(e: unknown): ErrorPresentation {
       ROLLBACK_VERDICTS.some((v) => verdictLine.includes(v));
     const isConflict =
       !rolledBack && CONFLICT_MARKERS.some((m) => m.test(combined));
-    const label = KIND_LABELS[e.kind];
     const summary = isConflict
       ? conflictSummary(combined)
       : firstMeaningfulLine(message) || label;

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -3085,8 +3085,9 @@ export const ghRulesetGet = (repoPath: string, id: number) =>
   invoke<RulesetFull>("gh_ruleset_get", { repoPath, id });
 
 /** The status-check contexts a branch's active rules require. Empty for a readable
- *  branch under no rules; a branch this token can't read rejects, which a caller
- *  showing a fallback may treat as empty. GitHub only. */
+ *  branch under no rules; a branch this token can't read — or a name the backend's
+ *  ref gate refuses — rejects, which a caller showing a fallback may treat as
+ *  empty. GitHub only. */
 export const ghBranchRequiredChecks = (
   repoPath: string,
   branch: string,

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -3084,6 +3084,15 @@ export const ghRulesetsList = (repoPath: string) =>
 export const ghRulesetGet = (repoPath: string, id: number) =>
   invoke<RulesetFull>("gh_ruleset_get", { repoPath, id });
 
+/** The status-check contexts a branch's active rules require. Empty for a readable
+ *  branch under no rules; a branch this token can't read rejects, which a caller
+ *  showing a fallback may treat as empty. GitHub only. */
+export const ghBranchRequiredChecks = (
+  repoPath: string,
+  branch: string,
+  lens: RemoteLens,
+) => invoke<string[]>("gh_branch_required_checks", { repoPath, branch, lens });
+
 export const ghRulesetCreate = (
   repoPath: string,
   body: Record<string, unknown>,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4045,6 +4045,10 @@ export function useBranchDivergence(
     queryKey: ["repo", repo, "divergence", base] as const,
     queryFn: () => api.gitBranchDivergence(repo, base ?? ""),
     enabled: enabled && Boolean(base),
+    // Local rev-list reads only. react-query's default "online" mode parks the
+    // fetch whenever the OS reports no connection, and a parked query is neither
+    // loading nor errored — consumers would silently render without divergence.
+    networkMode: "always",
   });
 }
 

--- a/src/lib/tauri/invoke.ts
+++ b/src/lib/tauri/invoke.ts
@@ -1,27 +1,39 @@
 import { getTransport } from "@/lib/transport";
 
-export interface AppError {
-  kind:
-    | "git"
-    | "notARepo"
-    | "gitNotFound"
-    | "ghNotFound"
-    | "gh"
-    | "issuesDisabled"
-    | "glabNotFound"
-    | "glab"
-    | "bitbucketNotConfigured"
-    | "bitbucket"
-    | "jira"
-    | "keyring"
-    | "invalidArgument"
-    | "command"
-    | "io"
-    | "timeout";
-  message: string;
-  code?: number;
-  stderr?: string;
-}
+/** The kinds whose wire shape is kind + message alone (Rust `AppError`
+ *  serializes a payload only for the two members below). */
+type PlainErrorKind =
+  | "notARepo"
+  | "gitNotFound"
+  | "ghNotFound"
+  | "gh"
+  | "issuesDisabled"
+  | "glabNotFound"
+  | "glab"
+  | "bitbucketNotConfigured"
+  | "bitbucket"
+  | "jira"
+  | "keyring"
+  | "invalidArgument"
+  | "command"
+  | "io"
+  | "timeout";
+
+/** Mirrors Rust's `AppError` — a union on `kind`, so a payload is only in reach
+ *  once the kind that carries it has been narrowed. */
+export type AppError =
+  | { kind: "git"; message: string; code?: number; stderr?: string }
+  /** A git operation stopped on conflicts and left the repo mid-op: `op` names
+   *  what the user now has to finish, `paths` the conflicted files, `report`
+   *  git's own output across both streams. */
+  | {
+      kind: "conflict";
+      message: string;
+      op: string;
+      paths: string[];
+      report: string;
+    }
+  | { kind: PlainErrorKind; message: string };
 
 export function isAppError(e: unknown): e is AppError {
   return (


### PR DESCRIPTION
Failures that pause a git operation reported themselves as the bare "git exited with code 1", because a conflicted merge, stash pop or refused commit writes its whole report to stdout with stderr empty. A GitHub pull request refused by branch protection said nothing about what it was waiting on. This change carries git's full report through a structured conflict error, names the unmet requirements on a blocked merge, and fixes GitLab host detection against hand-edited `glab` configs.

### Conflict errors carry git's report

- Adds `AppError::Conflict { op, paths, report }` in `src-tauri/src/error.rs`, serialized under the `"conflict"` kind with `op`/`paths`/`report` keys; `conflict_message` supplies the `Display` text for non-presenting readers, and new unit tests pin the wire shape for `Conflict`, `Git`, and a payload-free variant.
- Routes failures through `classify_failure` / `unmerged_paths` in `src-tauri/src/git/ops.rs`: `op_continue`, `git_revert_core`, `git_cherry_pick_core`, `git_stash_pop_core`, `git_stash_apply_core`, and a new `git_restore_orphaned_core` (under its own `stash-restore` op, since there is no stash entry left to return to).
- Splits `git_update_branch_from` into a testable `update_branch_from` core in `src-tauri/src/git/branches.rs`; the in-place "update from main" merge now runs raw and classifies, with a real-repo tokio test for the paused merge.
- `git_pull_core` in `src-tauri/src/git/remote.rs` relabels the runner's error by the mode it ran (`merge` vs `rebase`), covered by a new `diverged_clone` fixture and two tests.
- `src-tauri/src/git/commit.rs` and `src-tauri/src/git/worktree.rs` shape a refusing `commit` with `GitOutput::full_failure_text()` instead of stderr alone (`worktree_commit_all`, `git_worktree_squash`).
- Frontend presentation follows in `src/lib/error-summary.ts` and `src/lib/tauri/invoke.ts`; the autostash tests in `src-tauri/src/git/autostash.rs` are updated to the new variant and to describe the prose-marker path as the fallback arm.

### Blocked by branch protection (GitHub)

- Adds the `gh_branch_required_checks` command in `src-tauri/src/github/rulesets.rs`, backed by a pure `required_check_contexts` over `/rules/branches/{branch}` with tests for a verbatim live response, non-status rule types, cross-ruleset dedupe, and shapes the endpoint never promised; registered in `src-tauri/src/lib.rs` and exposed as `ghBranchRequiredChecks` in `src/lib/git/api.ts`.
- New `src/features/pulls/useBranchRequiredChecks.ts`: a non-polling query plus `unmetRequiredChecks`, which joins rule contexts to check names and counts one as outstanding only when it has failed, is running, or never reported.
- `src/features/pulls/PrMergeabilityBanner.tsx` gains the `blocked` arm and the shared `blockedMergeLine` (four names, then *and N more*, with a generic fallback), keeps the arm informational rather than a warning, and re-admits the existing Update branch controls when the head is also behind.
- `src/features/pulls/RemotePrView.tsx` derives `blockedByRules` from a `mergeable` server state with a `BLOCKED` detail, places the arm above `behind` on the ladder, guards the read behind `blockedDetailsReady` and the `repoTab` `<Activity>` term, preserves `canUpdateBranch`, and repeats the same line beside the forge's own message when a merge is refused.
- `checkPresentation` is exported from `src/features/pulls/ChecksRollup.tsx` so the join reuses the rollup's own bucketing.

### GitLab host detection

- Rewrites `hosts_from_config` in `src-tauri/src/forge/glab.rs` around `is_hosts_header`, `strip_scheme`, and `host_from_key_line`, so YAML anchors, aliases, inline comments, quoted host keys, and a flow-form `hosts:` value no longer drop a host; the merge key `<<` and any key carrying whitespace or a comma are refused, and values are still never inspected.
- Sets `GLAB_CHECK_UPDATE=false` in `run_glab_raw`, `run_glab_ex`, and the reconnect child in `src-tauri/src/forge/session.rs`, since glab's switch is inverted from gh's and `ParseBool`'d, and the notice it suppresses lands on the stderr those paths read.

### Clean up branches, offline

- `useBranchDivergence` in `src/lib/git/queries.ts` takes `networkMode: "always"`, so the local `rev-list` read is no longer parked (neither loading nor errored) when the OS reports no connection.
- `src/features/repository/CleanupBranchesDialog.tsx` shows which branches are merged from local history without a connection and announces its progress line to screen readers.

### Guardrail

- Adds invariant D to `scripts/check-rust-invariants.mjs`: `checkStderrOnlyGitError` flags an `AppError::Git` whose `stderr:` field is built from stderr alone, reading the verdict from the field value as an expression (chasing a named binding to its initializer, failing closed on an unresolvable one, telling `failure_text()` from `full_failure_text()`, skipping `#[cfg(test)]` modules), with a rationale-carrying allowlist.
- `scripts/checks.test.mjs` covers each of those arms, including the comment that must not disarm the check.

### Documentation

- README gains a *Blocked by branch protection* bullet; `site/src/data/capabilities.ts` gains the matching capability under *Pull requests & review*.
- `src/features/help/content.ts` adds a *Blocked by branch protection* section and updates the update-branch and conflicts copy that it interacts with.
- Changelog fragments: `changed-merge-blocked-names-rules.md`, `fixed-conflict-error-details.md`, `fixed-glab-config-hosts.md`, `fixed-pr-finish-continue-report.md`, `fixed-cleanup-offline-divergence.md`, plus a wording fix in `fixed-cleanup-offline-waiting.md`.

Relates to #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub pull requests now show unmet branch-protection checks when merges are blocked.
  * Users who can bypass protection can still access the Merge action.
  * Conflict errors identify affected files, preserve Git’s full report in Details, and indicate when a conflicted stash is kept.
  * Branch cleanup works offline where possible, waits for connection when needed, and announces progress accessibly.
  * GitLab sign-in recognizes more self-managed host configurations.

* **Bug Fixes**
  * Commit refusals now display Git’s complete report.
  * GitLab errors and sign-in screens no longer show `glab` update notices.

* **Documentation**
  * Updated guidance and changelog entries for these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->