### PR TITLE
fix(git,mcp): add --force-if-includes to guarded force pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,12 @@ save, so apps updating from that release show the notes you just wrote.
 
 Fetch, pull, and push, with the ahead/behind counts shown right on the Push
 and Pull buttons. Pull is `--ff-only`, and divergence routes to a guarded
-force push with `--force-with-lease --force-if-includes`. When a repo has
-an `upstream` remote, the Pull menu adds **Update from upstream**: one
-click fetches upstream and brings your branch up to date (fast-forward when
-it can, a merge commit when cleanly diverged, the conflict editor
-otherwise), for keeping a fork current.
+force push with `--force-with-lease --force-if-includes` (lease-only on
+Git releases older than 2.30). When a repo has an `upstream` remote, the
+Pull menu adds **Update from upstream**: one click fetches upstream and
+brings your branch up to date (fast-forward when it can, a merge commit
+when cleanly diverged, the conflict editor otherwise), for keeping a fork
+current.
 **Auto-fetch** (on by default) quietly runs a background `git fetch` on an
 interval while the window is focused, so the behind-count and incoming
 commits stay current without pressing Fetch; it never pulls or merges, and

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ save, so apps updating from that release show the notes you just wrote.
 Fetch, pull, and push, with the ahead/behind counts shown right on the Push
 and Pull buttons. Pull is `--ff-only`, and divergence routes to a guarded
 force push with `--force-with-lease --force-if-includes` (lease-only on
-Git releases older than 2.30). When a repo has an `upstream` remote, the
-Pull menu adds **Update from upstream**: one click fetches upstream and
-brings your branch up to date (fast-forward when it can, a merge commit
-when cleanly diverged, the conflict editor otherwise), for keeping a fork
-current.
+Git releases older than 2.30, or when the branch has no reflog for the
+check to read). When a repo has an `upstream` remote, the Pull menu adds
+**Update from upstream**: one click fetches upstream and brings your
+branch up to date (fast-forward when it can, a merge commit when cleanly
+diverged, the conflict editor otherwise), for keeping a fork current.
 **Auto-fetch** (on by default) quietly runs a background `git fetch` on an
 interval while the window is focused, so the behind-count and incoming
 commits stay current without pressing Fetch; it never pulls or merges, and

--- a/README.md
+++ b/README.md
@@ -211,10 +211,11 @@ save, so apps updating from that release show the notes you just wrote.
 
 Fetch, pull, and push, with the ahead/behind counts shown right on the Push
 and Pull buttons. Pull is `--ff-only`, and divergence routes to a guarded
-force push with `--force-with-lease`. When a repo has an `upstream` remote,
-the Pull menu adds **Update from upstream**: one click fetches upstream and
-brings your branch up to date (fast-forward when it can, a merge commit when
-cleanly diverged, the conflict editor otherwise), for keeping a fork current.
+force push with `--force-with-lease --force-if-includes`. When a repo has
+an `upstream` remote, the Pull menu adds **Update from upstream**: one
+click fetches upstream and brings your branch up to date (fast-forward when
+it can, a merge commit when cleanly diverged, the conflict editor
+otherwise), for keeping a fork current.
 **Auto-fetch** (on by default) quietly runs a background `git fetch` on an
 interval while the window is focused, so the behind-count and incoming
 commits stay current without pressing Fetch; it never pulls or merges, and

--- a/changelog.d/fixed-force-push-lease-gap.md
+++ b/changelog.d/fixed-force-push-lease-gap.md
@@ -1,0 +1,1 @@
+- Force pushes now pass `--force-if-includes` alongside `--force-with-lease`: the push refuses to overwrite work you haven't incorporated, even when a background fetch has already brought it into your remote-tracking refs (which is enough to satisfy the lease alone). On Git releases without the flag (pre-2.30), the push retries without it.

--- a/changelog.d/fixed-force-push-lease-gap.md
+++ b/changelog.d/fixed-force-push-lease-gap.md
@@ -1,5 +1,6 @@
 - Force pushes now pass `--force-if-includes` alongside `--force-with-lease`:
   the push refuses to overwrite work you haven't incorporated, even when a
   background fetch has already brought it into your remote-tracking refs
-  (which is enough to satisfy the lease alone). On Git releases without the
-  flag (pre-2.30), the push retries without it.
+  (which is enough to satisfy the lease alone). On a Git older than 2.30,
+  or a branch without a reflog for the check to read, pushes keep the
+  previous lease-only guard.

--- a/changelog.d/fixed-force-push-lease-gap.md
+++ b/changelog.d/fixed-force-push-lease-gap.md
@@ -1,1 +1,5 @@
-- Force pushes now pass `--force-if-includes` alongside `--force-with-lease`: the push refuses to overwrite work you haven't incorporated, even when a background fetch has already brought it into your remote-tracking refs (which is enough to satisfy the lease alone). On Git releases without the flag (pre-2.30), the push retries without it.
+- Force pushes now pass `--force-if-includes` alongside `--force-with-lease`:
+  the push refuses to overwrite work you haven't incorporated, even when a
+  background fetch has already brought it into your remote-tracking refs
+  (which is enough to satisfy the lease alone). On Git releases without the
+  flag (pre-2.30), the push retries without it.

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -52,12 +52,6 @@ const REFSPEC_ALLOWLIST = [
       "Bitbucket REST path, not a git refspec — every segment is encode_query_value'd",
   },
   {
-    file: "git/remote.rs",
-    fn: "branch_has_reflog",
-    rationale:
-      "read-only `reflog exists` probe (never a refspec); the name is either git_push_core's branch, validated with validate_ref_name at the arm entry, or `symbolic-ref --short` output — git's own ref name",
-  },
-  {
     file: "git/branches.rs",
     fn: "git_default_branch",
     rationale: "interpolates only the fixed literals main/master",
@@ -117,6 +111,12 @@ const REFSPEC_ALLOWLIST = [
     file: "git/remote.rs",
     fn: "publish_refspec",
     rationale: "the publish-refspec chokepoint; callers validate the branch",
+  },
+  {
+    file: "git/remote.rs",
+    fn: "branch_has_reflog",
+    rationale:
+      "read-only `reflog exists` probe (never a refspec); the name is either git_push_core's branch, validated with validate_ref_name at the arm entry, or `symbolic-ref --short` output — git's own ref name",
   },
   {
     file: "git/remote.rs",

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -52,6 +52,12 @@ const REFSPEC_ALLOWLIST = [
       "Bitbucket REST path, not a git refspec — every segment is encode_query_value'd",
   },
   {
+    file: "git/remote.rs",
+    fn: "branch_has_reflog",
+    rationale:
+      "read-only `reflog exists` probe (never a refspec); the name is either git_push_core's branch, validated with validate_ref_name at the arm entry, or `symbolic-ref --short` output — git's own ref name",
+  },
+  {
     file: "git/branches.rs",
     fn: "git_default_branch",
     rationale: "interpolates only the fixed literals main/master",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -357,7 +357,7 @@ export const capabilities: Capability[] = [
     highlight: true,
   },
   { group: "Repository & workspace", label: "Manage tracked & ignored files" },
-  { group: "Repository & workspace", label: "--force-with-lease by default" },
+  { group: "Repository & workspace", label: "--force-with-lease --force-if-includes by default" },
   {
     group: "Repository & workspace",
     label: "Auto-fetch — quiet background sync, never auto-pulls",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -357,7 +357,10 @@ export const capabilities: Capability[] = [
     highlight: true,
   },
   { group: "Repository & workspace", label: "Manage tracked & ignored files" },
-  { group: "Repository & workspace", label: "--force-with-lease --force-if-includes by default" },
+  {
+    group: "Repository & workspace",
+    label: "--force-with-lease --force-if-includes by default",
+  },
   {
     group: "Repository & workspace",
     label: "Auto-fetch — quiet background sync, never auto-pulls",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -359,7 +359,7 @@ export const capabilities: Capability[] = [
   { group: "Repository & workspace", label: "Manage tracked & ignored files" },
   {
     group: "Repository & workspace",
-    label: "--force-with-lease --force-if-includes by default",
+    label: "--force-with-lease + --force-if-includes (Git 2.30+) by default",
   },
   {
     group: "Repository & workspace",

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -162,7 +162,7 @@ const groups: Group[] = [
         them: { state: "partial", note: "plain force push" },
         gd: {
           state: "yes",
-          note: "--force-with-lease only, behind divergence detection",
+          note: "--force-with-lease --force-if-includes only, behind divergence detection",
         },
       },
       {

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -162,7 +162,7 @@ const groups: Group[] = [
         them: { state: "partial", note: "plain force push" },
         gd: {
           state: "yes",
-          note: "--force-with-lease --force-if-includes only, behind divergence detection",
+          note: "--force-with-lease + --force-if-includes (Git 2.30+), behind divergence detection, never plain --force",
         },
       },
       {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -677,8 +677,8 @@ const forges = [
         <div class="min-w-0">
           <h3 class="text-ink"><code class="text-ink">--force-with-lease</code> by default.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
-            Divergence routes to a guarded force push that won't clobber a teammate's
-            work; pull is <code class="text-ink">--ff-only</code>.
+            Divergence routes to a guarded force push, never a plain
+            <code class="text-ink">--force</code>; pull is <code class="text-ink">--ff-only</code>.
           </p>
         </div>
         <div class="min-w-0">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -677,7 +677,7 @@ const forges = [
         <div class="min-w-0">
           <h3 class="text-ink"><code class="text-ink">--force-with-lease</code> by default.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
-            Divergence routes to a guarded force push that can't clobber a teammate's
+            Divergence routes to a guarded force push that won't clobber a teammate's
             work; pull is <code class="text-ink">--ff-only</code>.
           </p>
         </div>

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -552,8 +552,11 @@ pub(crate) async fn git_push_core(
             }
             let mut a = vec!["push".to_string()];
             if force {
-                // refuses to clobber remote work that arrived after our last fetch
+                // The pair refuses to clobber remote work this branch hasn't
+                // integrated: a bare lease is satisfied by ANY fetch, and the app
+                // auto-fetches in the background.
                 a.push("--force-with-lease".to_string());
+                a.push(FORCE_IF_INCLUDES.to_string());
             }
             if set_upstream {
                 a.extend(["-u", "origin", "HEAD"].map(str::to_string));
@@ -625,15 +628,46 @@ pub(crate) async fn git_push_core(
         }
     };
     let cred = crate::forge::credential_config_for_remote(&repo_path, &cred_remote).await?;
-    run_git_mutating_with_creds(
-        state,
-        &repo_path,
-        &cred,
-        &args.iter().map(String::as_str).collect::<Vec<_>>(),
-        NETWORK_TIMEOUT,
-    )
-    .await?;
-    Ok(())
+    let argv: Vec<&str> = args.iter().map(String::as_str).collect();
+    match run_git_mutating_with_creds(state, &repo_path, &cred, &argv, NETWORK_TIMEOUT).await {
+        Ok(_) => Ok(()),
+        Err(AppError::Git { stderr, .. })
+            if argv.contains(&FORCE_IF_INCLUDES) && is_unknown_push_option(&stderr) =>
+        {
+            // git < 2.30 doesn't know `--force-if-includes`. Unknown options are
+            // rejected while parsing argv, before any network I/O, so this retry
+            // can't push twice; it degrades to the lease alone.
+            let retry = without_force_if_includes(&argv);
+            run_git_mutating_with_creds(state, &repo_path, &cred, &retry, NETWORK_TIMEOUT).await?;
+            Ok(())
+        }
+        Err(other) => Err(other),
+    }
+}
+
+/// Companion to `--force-with-lease`: git refuses the push unless the remote tip
+/// is already incorporated into the local branch, so a background fetch can't
+/// satisfy the lease on a teammate's unseen work. Git 2.30+.
+const FORCE_IF_INCLUDES: &str = "--force-if-includes";
+
+/// Whether git's stderr says it rejected an unknown command-line option — for a
+/// push, the signal that this git predates `--force-if-includes` (2.30). Matched
+/// case-insensitively on git's phrasings plus the `usage: git push` banner it
+/// prints on an option error; a real rejection reads "failed to push some refs"
+/// and never matches.
+fn is_unknown_push_option(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("unknown switch")
+        || lower.contains("unknown option")
+        || lower.contains("usage: git push")
+}
+
+/// The push argv minus `--force-if-includes`, everything else kept in order.
+fn without_force_if_includes<'a>(argv: &[&'a str]) -> Vec<&'a str> {
+    argv.iter()
+        .copied()
+        .filter(|a| *a != FORCE_IF_INCLUDES)
+        .collect()
 }
 
 /// Parse one `for-each-ref … --format=%(refname)%00%(upstream:short)%00%(upstream:remotename)%00%(upstream:track)`
@@ -705,7 +739,8 @@ fn resolve_push_target<'a>(
 ///
 /// Refspecs are fully qualified so a branch named `+x`/`-x` can't be read as a
 /// force/delete indicator; the remote is only ever the bare `push <remote>` arg.
-/// `force` prepends `--force-with-lease` before the refspec in every arm.
+/// `force` prepends `--force-with-lease --force-if-includes` before the refspec in
+/// every arm.
 #[allow(clippy::too_many_arguments)] // one flat arg per decision-table input
 fn build_push_args(
     branch: &str,
@@ -721,6 +756,7 @@ fn build_push_args(
     let mut args = vec!["push".to_string()];
     if force {
         args.push("--force-with-lease".to_string());
+        args.push(FORCE_IF_INCLUDES.to_string());
     }
     if let Some(rb) = remote_branch {
         // Destination named outright: never `-u` and never the tracking-derived
@@ -764,8 +800,9 @@ pub(crate) fn publish_refspec(branch: &str) -> String {
 mod tests {
     use super::{
         build_push_args, cache_get, cache_invalidate, cache_put, git_pull_core, git_push_core,
-        git_remote_remove_core, is_auth_class_failure, parse_upstream_tracking, publish_refspec,
-        resolve_push_target, run_git_mutating_with_creds,
+        git_remote_remove_core, is_auth_class_failure, is_unknown_push_option,
+        parse_upstream_tracking, publish_refspec, resolve_push_target, run_git_mutating_with_creds,
+        without_force_if_includes,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -1180,12 +1217,13 @@ mod tests {
 
     #[test]
     fn push_force_flag_precedes_refspec_args() {
-        // --force-with-lease sits right after `push`, before the refspec.
+        // The force pair sits right after `push`, before the refspec.
         assert_eq!(
             build_push_args("feature", "origin/feat", "origin", false, false, true, None, None),
             vec![
                 "push",
                 "--force-with-lease",
+                "--force-if-includes",
                 "origin",
                 "refs/heads/feature:refs/heads/feat"
             ]
@@ -1195,6 +1233,7 @@ mod tests {
             vec![
                 "push",
                 "--force-with-lease",
+                "--force-if-includes",
                 "-u",
                 "origin",
                 "refs/heads/feature:refs/heads/feature"
@@ -1204,16 +1243,58 @@ mod tests {
 
     #[test]
     fn push_force_flag_precedes_refspec_on_requested_remote() {
-        // Force + a requested non-tracked remote: `--force-with-lease` still sits
-        // right after `push`, then the bare remote, then the fully-qualified refspec.
+        // Force + a requested non-tracked remote: the force pair still sits right
+        // after `push`, then the bare remote, then the fully-qualified refspec.
         assert_eq!(
             build_push_args("feature", "origin/feat", "origin", false, false, true, Some("upstream"), None),
             vec![
                 "push",
                 "--force-with-lease",
+                "--force-if-includes",
                 "upstream",
                 "refs/heads/feature:refs/heads/feature"
             ]
+        );
+    }
+
+    #[test]
+    fn unknown_push_option_matches_gits_phrasings_only() {
+        assert!(is_unknown_push_option("error: unknown option `force-if-includes'"));
+        assert!(is_unknown_push_option(
+            "fatal: unknown switch `force-if-includes'"
+        ));
+        assert!(is_unknown_push_option(
+            "usage: git push [<options>] [<repository> [<refspec>...]]"
+        ));
+        // A real rejection must NOT trigger the pre-2.30 retry.
+        assert!(!is_unknown_push_option(
+            " ! [rejected]        feature -> feature (stale info)\nerror: failed to push some refs to 'C:/temp/remote.git'"
+        ));
+    }
+
+    #[test]
+    fn strip_removes_only_the_if_includes_flag() {
+        assert_eq!(
+            without_force_if_includes(&[
+                "push",
+                "--force-with-lease",
+                "--force-if-includes",
+                "-u",
+                "origin",
+                "refs/heads/feature:refs/heads/feature",
+            ]),
+            vec![
+                "push",
+                "--force-with-lease",
+                "-u",
+                "origin",
+                "refs/heads/feature:refs/heads/feature"
+            ]
+        );
+        // Nothing to strip: the argv survives untouched.
+        assert_eq!(
+            without_force_if_includes(&["push", "-u", "origin", "HEAD"]),
+            vec!["push", "-u", "origin", "HEAD"]
         );
     }
 
@@ -1276,7 +1357,13 @@ mod tests {
         // `force` keeps its position ahead of the target, as in every other arm.
         assert_eq!(
             build_push_args("local", "", "", false, false, true, Some("fork"), Some("contrib")),
-            vec!["push", "--force-with-lease", "fork", "refs/heads/local:refs/heads/contrib"]
+            vec![
+                "push",
+                "--force-with-lease",
+                "--force-if-includes",
+                "fork",
+                "refs/heads/local:refs/heads/contrib"
+            ]
         );
     }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -516,6 +516,23 @@ pub async fn git_push(
         remote_branch,
     )
     .await
+    // The guard is an in-process detail; the IPC contract stays `void`.
+    .map(|_| ())
+}
+
+/// Which guarantee a completed push actually ran under. Only meaningful for a
+/// FORCE push: a non-force push has no lease to degrade, and reports
+/// [`PushGuard::LeaseAndIncludes`] as the neutral value.
+#[derive(Debug, PartialEq)]
+#[allow(clippy::enum_variant_names)] // the shared `Lease` prefix IS the shared guarantee
+pub(crate) enum PushGuard {
+    /// `--force-with-lease --force-if-includes`, the intended pair.
+    LeaseAndIncludes,
+    /// This git predates `--force-if-includes` (2.30) — the lease alone.
+    LeaseOnlyOldGit,
+    /// The branch has no reflog for `--force-if-includes` to walk, so the check
+    /// could never pass — the lease alone.
+    LeaseOnlyNoReflog,
 }
 
 /// `remote_branch` names the DESTINATION branch when it differs from the local one
@@ -530,7 +547,7 @@ pub(crate) async fn git_push_core(
     branch: Option<String>,
     remote: Option<String>,
     remote_branch: Option<String>,
-) -> AppResult<()> {
+) -> AppResult<PushGuard> {
     if remote_branch.is_some() && (branch.is_none() || remote.is_none()) {
         return Err(AppError::InvalidArgument(
             "remote branch requires an explicit branch and remote".to_string(),
@@ -630,7 +647,7 @@ pub(crate) async fn git_push_core(
     let cred = crate::forge::credential_config_for_remote(&repo_path, &cred_remote).await?;
     let argv: Vec<&str> = args.iter().map(String::as_str).collect();
     match run_git_mutating_with_creds(state, &repo_path, &cred, &argv, NETWORK_TIMEOUT).await {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(PushGuard::LeaseAndIncludes),
         Err(AppError::Git { stderr, .. })
             if argv.contains(&FORCE_IF_INCLUDES) && is_unknown_push_option(&stderr) =>
         {
@@ -639,7 +656,28 @@ pub(crate) async fn git_push_core(
             // can't push twice; it degrades to the lease alone.
             let retry = without_force_if_includes(&argv);
             run_git_mutating_with_creds(state, &repo_path, &cred, &retry, NETWORK_TIMEOUT).await?;
-            Ok(())
+            Ok(PushGuard::LeaseOnlyOldGit)
+        }
+        Err(AppError::Git { code, stderr })
+            if argv.contains(&FORCE_IF_INCLUDES) && stderr.contains(IF_INCLUDES_REJECTION) =>
+        {
+            // The flag proves inclusion by walking the local branch's reflog, so
+            // with no reflog it can never pass: an amend with the remote left
+            // untouched is rejected (measured) under core.logAllRefUpdates=false.
+            // The lease still guards the retry — at worst, pre-change behavior.
+            // Left standing on purpose: a PRESENT reflog with expired entries
+            // (gc.reflogExpire), and a cross-name push colliding with a stale
+            // local branch named like the destination (git walks THAT branch's
+            // reflog — measured); neither can prove inclusion, so both reject.
+            let Some(b) = pushed_branch(&repo_path, branch.as_deref()).await else {
+                return Err(AppError::Git { code, stderr });
+            };
+            if branch_has_reflog(&repo_path, &b).await {
+                return Err(AppError::Git { code, stderr });
+            }
+            let retry = without_force_if_includes(&argv);
+            run_git_mutating_with_creds(state, &repo_path, &cred, &retry, NETWORK_TIMEOUT).await?;
+            Ok(PushGuard::LeaseOnlyNoReflog)
         }
         Err(other) => Err(other),
     }
@@ -650,11 +688,48 @@ pub(crate) async fn git_push_core(
 /// satisfy the lease on a teammate's unseen work. Git 2.30+.
 const FORCE_IF_INCLUDES: &str = "--force-if-includes";
 
-/// Whether git's stderr says it rejected an unknown command-line option — for a
-/// push, the signal that this git predates `--force-if-includes` (2.30). Matched
-/// case-insensitively on git's phrasings plus the `usage: git push` banner it
-/// prints on an option error; a real rejection reads "failed to push some refs"
-/// and never matches.
+/// git's per-ref reason when `--force-if-includes` finds the remote tip missing
+/// from the local branch's reflog — verbatim from `! [rejected] … (…)`.
+const IF_INCLUDES_REJECTION: &str = "remote ref updated since checkout";
+
+/// The local branch a push targeted: the caller's explicit name, else HEAD's own
+/// branch. `None` on a detached HEAD (and on a spawn failure) — no branch means
+/// no reflog to reason about, so callers must not retry. Git itself walks the
+/// local ref named after the DESTINATION when one exists (measured); the source
+/// name probed here covers the app's same-name default — see the arm's comment.
+async fn pushed_branch(repo_path: &str, branch: Option<&str>) -> Option<String> {
+    if let Some(b) = branch {
+        return Some(b.to_string());
+    }
+    let out = run_git_raw(
+        Some(repo_path),
+        &["symbolic-ref", "--short", "-q", "HEAD"],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .ok()?;
+    (out.code == 0)
+        .then(|| out.stdout_lossy().trim().to_string())
+        .filter(|b| !b.is_empty())
+}
+
+/// Whether `refs/heads/<branch>` has a reflog (`git reflog exists`, exit 0/1). An
+/// unrunnable probe counts as "has one": the degrading retry only fires on
+/// positive proof that `--force-if-includes` had nothing to walk.
+async fn branch_has_reflog(repo_path: &str, branch: &str) -> bool {
+    run_git_raw(
+        Some(repo_path),
+        &["reflog", "exists", &format!("refs/heads/{branch}")],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .map_or(true, |out| out.code == 0)
+}
+
+/// Whether git rejected an unknown command-line option — for a push, the signal
+/// that this git predates `--force-if-includes` (2.30). The matched text is the
+/// runner's `full_failure_text`, which can carry remote-relayed lines, so a
+/// server-echoed phrase triggers the retry too; that only degrades to the lease.
 fn is_unknown_push_option(stderr: &str) -> bool {
     let lower = stderr.to_ascii_lowercase();
     lower.contains("unknown switch")
@@ -802,7 +877,7 @@ mod tests {
         build_push_args, cache_get, cache_invalidate, cache_put, git_pull_core, git_push_core,
         git_remote_remove_core, is_auth_class_failure, is_unknown_push_option,
         parse_upstream_tracking, publish_refspec, resolve_push_target, run_git_mutating_with_creds,
-        without_force_if_includes,
+        without_force_if_includes, PushGuard,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -1295,6 +1370,151 @@ mod tests {
         assert_eq!(
             without_force_if_includes(&["push", "-u", "origin", "HEAD"]),
             vec!["push", "-u", "origin", "HEAD"]
+        );
+    }
+
+    /// Set up a bare origin seeded with one commit on `main`, and return the temp
+    /// guard, the base dir, and the origin's path plus its `file://` URL.
+    async fn seeded_origin(tag: &str) -> (tempfile::TempDir, std::path::PathBuf, String, String) {
+        let (guard, base) = temp_base(tag);
+        let origin = base.join("origin.git");
+        let work = base.join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        let base_s = base.to_string_lossy().into_owned();
+        let work_s = work.to_string_lossy().into_owned();
+        let url = format!("file://{}", origin.to_string_lossy().replace('\\', "/"));
+
+        run(&base_s, &["init", "-q", "--bare", "-b", "main", "origin.git"]).await;
+        init_repo(&work_s, "a.txt").await;
+        run(&work_s, &["branch", "-M", "main"]).await;
+        run(&work_s, &["remote", "add", "origin", &url]).await;
+        run(&work_s, &["push", "-q", "-u", "origin", "main"]).await;
+        (guard, base, origin.to_string_lossy().into_owned(), url)
+    }
+
+    /// The gap `--force-if-includes` closes, driven end to end: a plain `fetch`
+    /// alone satisfies the bare lease, so with the lease only, clone1's amend would
+    /// clobber a commit clone2 pushed and clone1 never integrated. Integrating it
+    /// (`pull --rebase`) is what lets the same force push land.
+    #[tokio::test]
+    async fn force_push_refuses_fetched_but_unintegrated_remote_work() {
+        let (_guard, base, origin_s, url) = seeded_origin("if-includes").await;
+        let base_s = base.to_string_lossy().into_owned();
+
+        for name in ["clone1", "clone2"] {
+            run(&base_s, &["-c", "core.autocrlf=false", "clone", "-q", &url, name]).await;
+            let c = base.join(name).to_string_lossy().into_owned();
+            run(&c, &["config", "core.autocrlf", "false"]).await;
+            run(&c, &["config", "user.email", "t@t.local"]).await;
+            run(&c, &["config", "user.name", "T"]).await;
+        }
+        let clone1 = base.join("clone1");
+        let clone2 = base.join("clone2");
+        let clone1_s = clone1.to_string_lossy().into_owned();
+        let clone2_s = clone2.to_string_lossy().into_owned();
+
+        // clone2 lands a commit of its own on the shared branch.
+        std::fs::write(clone2.join("b.txt"), "theirs\n").unwrap();
+        run(&clone2_s, &["add", "-A"]).await;
+        run(&clone2_s, &["commit", "-qm", "from clone2"]).await;
+        run(&clone2_s, &["push", "-q"]).await;
+        let theirs = run(&clone2_s, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        // clone1 only FETCHES it — the whole point: that alone used to satisfy the
+        // lease. Its amend adds a NEW file so the later replay stays conflict-free.
+        run(&clone1_s, &["fetch", "-q"]).await;
+        std::fs::write(clone1.join("c.txt"), "mine\n").unwrap();
+        run(&clone1_s, &["add", "-A"]).await;
+        run(&clone1_s, &["commit", "-q", "--amend", "-m", "amended seed"]).await;
+
+        let state = AppState::default();
+        let err = git_push_core(&state, clone1_s.clone(), false, true, None, None, None)
+            .await
+            .expect_err("a merely-fetched remote commit must not be clobbered");
+        assert!(matches!(err, AppError::Git { .. }), "expected a git error, got {err:?}");
+        assert_eq!(
+            run(&origin_s, &["rev-parse", "refs/heads/main"]).await.trim(),
+            theirs,
+            "clone2's commit is still origin's tip"
+        );
+
+        // Integrating the remote work unblocks the very same push.
+        run(&clone1_s, &["pull", "--rebase", "-q"]).await;
+        assert_eq!(
+            git_push_core(&state, clone1_s.clone(), false, true, None, None, None)
+                .await
+                .expect("an integrated branch force-pushes"),
+            PushGuard::LeaseAndIncludes
+        );
+        let landed = run(&origin_s, &["ls-tree", "--name-only", "refs/heads/main"]).await;
+        assert!(
+            landed.contains("b.txt") && landed.contains("c.txt"),
+            "both sides' work is on the new tip: {landed}"
+        );
+    }
+
+    /// `--force-if-includes` walks the local branch's REFLOG, so a repo with
+    /// reflogs off rejects every force push — even with the remote untouched and
+    /// nothing to clobber. The push must still land, degraded to the lease alone
+    /// and reported as such.
+    #[tokio::test]
+    async fn force_push_falls_back_to_the_lease_when_the_branch_has_no_reflog() {
+        let (_guard, base, origin_s, url) = seeded_origin("no-reflog").await;
+        let base_s = base.to_string_lossy().into_owned();
+
+        // Reflogs off at CLONE time: set afterwards, `.git/logs/` already exists and
+        // the check would pass. This is `git clone`'s OWN `-c`, which writes the key
+        // into the new repo's config — git's one-shot `-c` (before the subcommand)
+        // would not persist, and the first ref update would re-enable reflogs.
+        run(
+            &base_s,
+            &[
+                "-c",
+                "core.autocrlf=false",
+                "clone",
+                "-q",
+                "-c",
+                "core.logAllRefUpdates=false",
+                &url,
+                "nolog",
+            ],
+        )
+        .await;
+        let clone = base.join("nolog");
+        let clone_s = clone.to_string_lossy().into_owned();
+        run(&clone_s, &["config", "core.autocrlf", "false"]).await;
+        run(&clone_s, &["config", "user.email", "t@t.local"]).await;
+        run(&clone_s, &["config", "user.name", "T"]).await;
+
+        // Rewrite the tip; the remote is untouched, so the lease has no complaint.
+        std::fs::write(clone.join("c.txt"), "mine\n").unwrap();
+        run(&clone_s, &["add", "-A"]).await;
+        run(&clone_s, &["commit", "-q", "--amend", "-m", "amended seed"]).await;
+        let amended = run(&clone_s, &["rev-parse", "HEAD"]).await.trim().to_string();
+        // The discriminating state, in the retry gate's own terms — asserted AFTER
+        // the amend, since a ref update would otherwise create the reflog.
+        assert!(
+            run_git(
+                Some(&clone_s),
+                &["reflog", "exists", "refs/heads/main"],
+                DEFAULT_TIMEOUT
+            )
+            .await
+            .is_err(),
+            "the fixture's branch must have no reflog for the flag to walk"
+        );
+
+        let state = AppState::default();
+        assert_eq!(
+            git_push_core(&state, clone_s.clone(), false, true, None, None, None)
+                .await
+                .expect("a no-reflog rejection is spurious; the push must still land"),
+            PushGuard::LeaseOnlyNoReflog
+        );
+        assert_eq!(
+            run(&origin_s, &["rev-parse", "refs/heads/main"]).await.trim(),
+            amended,
+            "the amended commit is origin's tip"
         );
     }
 

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -26,6 +26,7 @@ use rmcp::model::{CallToolResult, ContentBlock};
 use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
 
 use super::{app_err, ensure_not_flag, json_result, GitDesktopMcp, SESSION_BRANCH_PREFIX};
+use crate::git::remote::PushGuard;
 
 /// Refuses a branch name that names a GitDesktop agent-session branch, with an
 /// actionable error. Pure string logic (no repo access) so it's unit-testable.
@@ -836,13 +837,15 @@ impl GitDesktopMcp {
         description = "Force-push the current branch to its remote in the bound repository, using \
                        --force-with-lease --force-if-includes (refuses to overwrite remote work \
                        that isn't already incorporated into your local branch, even when a \
-                       background fetch has updated the remote-tracking ref). Rewrites the remote \
-                       branch. Requires --allow-git-write AND --allow-destructive.",
+                       background fetch has updated the remote-tracking ref; on a Git older than \
+                       2.30, or a branch with no reflog for the check to read, the push falls back \
+                       to the lease alone). Rewrites the remote branch. Requires --allow-git-write \
+                       AND --allow-destructive.",
         annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn force_push(&self) -> Result<CallToolResult, McpError> {
         self.ensure_destructive()?;
-        crate::git::remote::git_push_core(
+        let guard = crate::git::remote::git_push_core(
             &self.state,
             self.repo.clone(),
             false,
@@ -853,7 +856,18 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
-        ok_text("force-pushed (with lease + if-includes)")
+        // The tool's result text names the guarantee the push ACTUALLY ran under —
+        // a static "with lease + if-includes" overclaims on either fallback.
+        ok_text(match guard {
+            PushGuard::LeaseAndIncludes => "force-pushed (with lease + if-includes)",
+            PushGuard::LeaseOnlyOldGit => {
+                "force-pushed (with lease; this Git predates --force-if-includes)"
+            }
+            PushGuard::LeaseOnlyNoReflog => {
+                "force-pushed (with lease; the branch has no reflog for --force-if-includes to \
+                 check)"
+            }
+        })
     }
 
     #[tool(

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -834,9 +834,10 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Force-push the current branch to its remote in the bound repository, using \
-                       --force-with-lease (refuses to clobber remote work that arrived after your \
-                       last fetch). Rewrites the remote branch. Requires --allow-git-write AND \
-                       --allow-destructive.",
+                       --force-with-lease --force-if-includes (refuses to overwrite remote work \
+                       that isn't already incorporated into your local branch, even when a \
+                       background fetch has updated the remote-tracking ref). Rewrites the remote \
+                       branch. Requires --allow-git-write AND --allow-destructive.",
         annotations(read_only_hint = false, destructive_hint = true)
     )]
     async fn force_push(&self) -> Result<CallToolResult, McpError> {
@@ -852,7 +853,7 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
-        ok_text("force-pushed (with lease)")
+        ok_text("force-pushed (with lease + if-includes)")
     }
 
     #[tool(

--- a/src/features/commit/AmendForcePushDialog.tsx
+++ b/src/features/commit/AmendForcePushDialog.tsx
@@ -57,8 +57,9 @@ export function AmendForcePushDialog({
             This commit is already on {upstream ?? "the remote"}. Amending
             rewrites it, so your branch and the remote will diverge and you'll
             need to force push to update it. GitDesktop force pushes with
-            --force-with-lease (it won't overwrite work others pushed since),
-            but it still rewrites the branch's history.
+            --force-with-lease and --force-if-includes (it won't overwrite
+            others' work your branch doesn't include), but it still rewrites the
+            branch's history.
           </DialogDescription>
         </DialogHeader>
         <label className="flex cursor-pointer items-center gap-2 text-xs">

--- a/src/features/commit/AmendForcePushDialog.tsx
+++ b/src/features/commit/AmendForcePushDialog.tsx
@@ -57,9 +57,9 @@ export function AmendForcePushDialog({
             This commit is already on {upstream ?? "the remote"}. Amending
             rewrites it, so your branch and the remote will diverge and you'll
             need to force push to update it. GitDesktop force pushes with
-            --force-with-lease and --force-if-includes (it won't overwrite
-            others' work your branch doesn't include), but it still rewrites the
-            branch's history.
+            --force-with-lease and, where your Git can check it,
+            --force-if-includes (the pair won't overwrite others' work your
+            branch doesn't include), but it still rewrites the branch's history.
           </DialogDescription>
         </DialogHeader>
         <label className="flex cursor-pointer items-center gap-2 text-xs">

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -414,7 +414,8 @@ The **Blame file…** command (from the command palette) opens a fuzzy picker of
 tracked file and blames the one you choose as it is now.
 
 > History-rewriting actions (reset, Edit history, squash) only ever touch **unpushed**
-> commits, and a push of rewritten history becomes a safe **force-with-lease** push (see
+> commits, and a push of rewritten history becomes a safe
+> **force-with-lease --force-if-includes** push (see
 > *Syncing & conflicts*).`,
   },
   {
@@ -655,8 +656,9 @@ when the repo was last fetched. Turn it off, or change the interval, under
 
 If your local history was rewritten (for example, after amending a commit that was
 already pushed), GitDesktop detects the divergence and turns Push into a **confirmed
-force push using \`--force-with-lease\`** — which refuses to clobber work someone else
-pushed in the meantime.
+force push using \`--force-with-lease --force-if-includes\`** — which refuses to overwrite
+work someone else pushed unless your branch already includes it, even when auto-fetch has
+already updated your view of the remote.
 
 ## Resolving conflicts
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -415,7 +415,7 @@ tracked file and blames the one you choose as it is now.
 
 > History-rewriting actions (reset, Edit history, squash) only ever touch **unpushed**
 > commits, and a push of rewritten history becomes a safe
-> **force-with-lease --force-if-includes** push (see
+> **force-with-lease --force-if-includes** push (the second flag needs Git 2.30+ — see
 > *Syncing & conflicts*).`,
   },
   {
@@ -658,7 +658,8 @@ If your local history was rewritten (for example, after amending a commit that w
 already pushed), GitDesktop detects the divergence and turns Push into a **confirmed
 force push using \`--force-with-lease --force-if-includes\`** — which refuses to overwrite
 work someone else pushed unless your branch already includes it, even when auto-fetch has
-already updated your view of the remote.
+already updated your view of the remote. On a Git older than 2.30, or a branch with no
+reflog for the check to read, the push falls back to \`--force-with-lease\` alone.
 
 ## Resolving conflicts
 

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -513,9 +513,10 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             <DialogDescription>
               Your branch and {head?.upstream} have diverged (usually after
               amending or resetting a pushed commit). Force pushing rewrites the
-              remote branch to match your local one. Uses --force-with-lease with
-              --force-if-includes, so it aborts if the remote has work your branch
-              doesn't include — even work a background fetch has already seen.
+              remote branch to match your local one. Uses --force-with-lease
+              with --force-if-includes, so it aborts if the remote has work your
+              branch doesn't include — even work a background fetch has already
+              seen.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -513,8 +513,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             <DialogDescription>
               Your branch and {head?.upstream} have diverged (usually after
               amending or resetting a pushed commit). Force pushing rewrites the
-              remote branch to match your local one. Uses --force-with-lease, so
-              it aborts if someone else pushed new work in the meantime.
+              remote branch to match your local one. Uses --force-with-lease with
+              --force-if-includes, so it aborts if the remote has work your branch
+              doesn't include — even work a background fetch has already seen.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -514,9 +514,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
               Your branch and {head?.upstream} have diverged (usually after
               amending or resetting a pushed commit). Force pushing rewrites the
               remote branch to match your local one. Uses --force-with-lease
-              with --force-if-includes, so it aborts if the remote has work your
-              branch doesn't include — even work a background fetch has already
-              seen.
+              and, where your Git can check it, --force-if-includes — the pair
+              aborts rather than overwrite work your branch doesn't include,
+              even work a background fetch has already seen.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>


### PR DESCRIPTION
Guarded force pushes relied on `--force-with-lease` alone, which is satisfied by *any* fetch of the remote ref. Since the app runs a background auto-fetch on an interval, a teammate's push could land in the remote-tracking ref and let the lease pass over work the local branch never incorporated. Every force push now also passes `--force-if-includes`, so git additionally requires the remote tip to be part of the local history, with a fallback for Git releases that predate the flag.

### Push argv and compatibility fallback

- Adds the `FORCE_IF_INCLUDES` constant in `src-tauri/src/git/remote.rs` and appends it after `--force-with-lease` in both argv builders: the inline force arm inside `git_push_core` and `build_push_args`.
- Wraps the `run_git_mutating_with_creds` call in `git_push_core` in a match that retries once without the flag when git rejects it as unknown, using the new `is_unknown_push_option` (matching `unknown switch`, `unknown option`, and the `usage: git push` banner case-insensitively) and `without_force_if_includes` helpers. The retry is scoped to option-parsing failures, which git reports before any network I/O, so a genuine `stale info` rejection still surfaces as an error.
- Updates the `build_push_args` doc comment and the force-arm comment to describe the pair rather than the lease alone.

### Tests

- Extends the existing expectations in `push_force_flag_precedes_refspec_args`, `push_force_flag_precedes_refspec_on_requested_remote`, and the explicit-remote-and-branch case to include `--force-if-includes` in position.
- Adds `unknown_push_option_matches_gits_phrasings_only`, which pins the pre-2.30 detector against git's phrasings and asserts a real `! [rejected] … (stale info)` failure does not trigger the retry.
- Adds `strip_removes_only_the_if_includes_flag`, covering both the strip and the no-op case.

### MCP tool surface

- Rewrites the `force_push` tool description in `src-tauri/src/mcp_server/write_git.rs` to state the new guarantee, and changes the success text to `force-pushed (with lease + if-includes)`.

### User-facing copy and docs

- Updates the divergence dialog in `src/features/repository/SyncControls.tsx` and the amend warning in `src/features/commit/AmendForcePushDialog.tsx`, both of which previously claimed the push would not overwrite work "others pushed since".
- Updates the two matching claims in `src/features/help/content.ts`: the history-rewriting blockquote and the force-push paragraph under *Syncing & conflicts*.
- Updates the sync paragraph in `README.md`.
- Adds `changelog.d/fixed-force-push-lease-gap.md` describing the behavior change and the pre-2.30 retry.

### Site copy (second commit)

- Updates the two site surfaces that state the force-push mechanism precisely: the capability catalog entry in `site/src/data/capabilities.ts` and the force-push cell on the GitHub Desktop comparison page. The home-page hero and about-page mentions keep `--force-with-lease` alone deliberately — subset claims that stay true, with the precision surfaces carrying the pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Force pushes now use both `--force-with-lease` and `--force-if-includes` to better protect remote work.
  - Operations abort when remote changes are missing locally, including changes detected by background syncing.
  - Older Git versions and branches without readable reflogs fall back to lease-only protection.

- **Documentation**
  - Updated help content, warnings, comparisons, and syncing documentation to explain the safer force-push behavior and compatibility fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->