### PR TITLE
docs(blog): add post on safe force pushing with --force-if-includes

### DIFF
--- a/site/src/content/blog/force-push-without-overwriting-work.md
+++ b/site/src/content/blog/force-push-without-overwriting-work.md
@@ -31,17 +31,18 @@ hint: use 'git pull' before pushing again.
 hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 ```
 
-Git says you're behind. You're not: the amend replaced 289a64d with
-002ba27, so the commit the remote is standing on no longer appears in
-your history, and no fast-forward can get there from here. The hint's
-advice would bring your own replaced commit back. What you want
-is for the remote to take the new version, and that means some
-kind of force.
+Git says you're behind. Only by the numbers: the one commit you're
+missing is 289a64d, the commit the amend replaced with 002ba27. That
+commit no longer appears in your history, so no fast-forward can get
+there from here. The hint's advice would bring your own replaced
+commit back. What you want is for the remote to take the new version,
+and that means some kind of force.
 
 ## What `--force` costs
 
 The branch is shared, though, and shared branches have a meanwhile.
-While you were amending, your teammate pushed tests. In their clone:
+While you were staring at that rejection, your teammate pushed
+tests. In their clone:
 
 ```sh
 $ git commit -m "Add limiter tests"
@@ -62,9 +63,11 @@ To …/origin.git
  + ee31f16...002ba27 feature -> feature (forced update)
 ```
 
-The `+` is Git's only acknowledgment that this push replaced history
-instead of adding to it. The tests commit, ee31f16, is no longer on
-the branch. On your teammate's side, the disappearance looks like one
+The `(forced update)` tag, the leading `+`, the three-dot range
+where a fast-forward prints two — that one line is all the
+acknowledgment Git gives that this push replaced history instead
+of adding to it. The tests commit, ee31f16, is no longer on the
+branch. On your teammate's side, the disappearance looks like one
 marker in their next fetch:
 
 ```sh
@@ -196,14 +199,15 @@ not a lookalike.
 The flag is easy to make permanent:
 
 ```sh
-$ git config push.useForceIfIncludes true
+git config push.useForceIfIncludes true
 ```
 
 After that, every `--force-with-lease` carries the check by itself.
-Two caveats: the flag needs Git 2.30 (December 2020) or newer, and
-the exact form `--force-with-lease=feature:<sha>` turns the check
-off — name a precise expectation and Git assumes you know
-something it doesn't.
+Three caveats: the flag needs Git 2.30 (December 2020) or newer; the
+check reads your branch's reflog, so with none to read it refuses
+every force push, integrated or not; and the exact form
+`--force-with-lease=feature:<sha>` turns the check off — name a
+precise expectation and Git assumes you know something it doesn't.
 
 ## When it refuses
 
@@ -258,9 +262,11 @@ more than a bare lease can enforce.
 
 So the fix adds `--force-if-includes` to every force-push path in
 the app, its assistant's included; on a Git too old to know the
-flag, the push retries without it instead of failing. The confirm
-dialog's wording changed to match what Git actually enforces: a
-force push will not overwrite work your branch doesn't include.
+flag, or a branch with no reflog for the check to read, the push
+retries with the lease alone instead of failing. The confirm
+dialog's wording changed to match what Git actually enforces:
+where the check runs, a force push will not overwrite work your
+branch doesn't include.
 
 A force push promises that nobody built on what it deletes. Make Git
 check the promise.

--- a/site/src/content/blog/force-push-without-overwriting-work.md
+++ b/site/src/content/blog/force-push-without-overwriting-work.md
@@ -166,7 +166,7 @@ To …/origin.git
 ```
 
 Forced update. The push that was just refused would now go through,
-taking cab8c4e, the tests, with it (the range's other commit,
+taking cab8c4e, the tests, with it (the fetch line's other end,
 9f74736, is your own pushed commit, the one the amend replaced).
 What changed sides was a fetch you may not even have run yourself.
 VS Code fetches on a timer if you let it. So does my own Git client.
@@ -253,10 +253,10 @@ prove you don't mean it by accident.
 ## Or don't do any of this
 
 The demo above doubled as a bug report against my own client.
-[GitDesktop](/features/) force pushes with `--force-with-lease`, and
-it also auto-fetches every ten minutes by default so your
+[GitDesktop](/features/) force pushed with `--force-with-lease`
+alone, and it auto-fetches every ten minutes by default so your
 behind-counts stay current without pressing Fetch. That combination
-is the fetch that breaks it, running on a schedule: the app was
+was the fetch that breaks it, running on a schedule: the app was
 refreshing its own lease on a timer, and its confirm dialog promised
 more than a bare lease can enforce.
 

--- a/site/src/content/blog/force-push-without-overwriting-work.md
+++ b/site/src/content/blog/force-push-without-overwriting-work.md
@@ -193,8 +193,8 @@ fetch answers it for you. `--force-if-includes` asks whether the
 remote's tip is part of the history you're pushing — a question about
 the work, and only integrating that commit answers it. A fetch can't
 fake the answer. Neither can a cherry-picked copy of the commit:
-the check wants the remote tip itself reachable in your branch,
-not a lookalike.
+the check walks your branch's reflog looking for the remote tip
+itself, not a lookalike.
 
 The flag is easy to make permanent:
 

--- a/site/src/content/blog/force-push-without-overwriting-work.md
+++ b/site/src/content/blog/force-push-without-overwriting-work.md
@@ -189,11 +189,11 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 
 The two checks differ in kind. The lease asks whether the remote is
 where you last saw it — a question about your bookkeeping, and any
-fetch answers it for you. `--force-if-includes` asks whether the
-remote's tip is part of the history you're pushing — a question
-about the work, one a fetch can't answer for you. Neither can a
-cherry-picked copy of the commit: the check walks your branch's
-reflog looking for the remote tip itself, not a lookalike.
+fetch answers it for you. `--force-if-includes` asks whether your
+branch has ever contained the remote's tip — a question about the
+work, one a fetch can't answer for you. Neither can a cherry-picked
+copy of the commit: the check walks your branch's reflog looking
+for the remote tip itself, not a lookalike.
 
 The flag is easy to make permanent for a repository:
 

--- a/site/src/content/blog/force-push-without-overwriting-work.md
+++ b/site/src/content/blog/force-push-without-overwriting-work.md
@@ -1,0 +1,266 @@
+---
+title: "Force push without overwriting your teammate's work"
+description: "git push --force-with-lease protects you only until something fetches. The gap, demonstrated live, and the flag that closes it: --force-if-includes."
+pubDate: 2026-08-26
+author: theBGuy
+pillar: git-safety
+tags: ["git", "force-push", "workflow"]
+---
+
+You pushed a commit, then spotted what it was missing: the config file
+that makes the feature work. The repair is muscle memory. Add the file,
+amend, push again:
+
+```sh
+$ git log --oneline -2
+289a64d Add burst allowance
+8a66181 Add rate limiter
+$ git add limiter.config.json
+$ git commit --amend --no-edit
+[feature 002ba27] Add burst allowance
+ Date: Tue Aug 18 01:53:39 2026 -0400
+ 2 files changed, 2 insertions(+)
+ create mode 100644 limiter.config.json
+$ git push
+To …/origin.git
+ ! [rejected]        feature -> feature (non-fast-forward)
+error: failed to push some refs to '…/origin.git'
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. If you want to integrate the remote changes,
+hint: use 'git pull' before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+```
+
+Git says you're behind. You're not: the amend replaced 289a64d with
+002ba27, so the commit the remote is standing on no longer appears in
+your history, and no fast-forward can get there from here. The hint's
+advice would bring your own replaced commit back. What you want
+is for the remote to take the new version, and that means some
+kind of force.
+
+## What `--force` costs
+
+The branch is shared, though, and shared branches have a meanwhile.
+While you were amending, your teammate pushed tests. In their clone:
+
+```sh
+$ git commit -m "Add limiter tests"
+[feature ee31f16] Add limiter tests
+ 1 file changed, 1 insertion(+)
+ create mode 100644 limiter.test.js
+$ git push
+To …/origin.git
+   289a64d..ee31f16  feature -> feature
+```
+
+You don't know that. Nothing has told you the remote moved, and
+`--force` doesn't ask:
+
+```sh
+$ git push --force
+To …/origin.git
+ + ee31f16...002ba27 feature -> feature (forced update)
+```
+
+The `+` is Git's only acknowledgment that this push replaced history
+instead of adding to it. The tests commit, ee31f16, is no longer on
+the branch. On your teammate's side, the disappearance looks like one
+marker in their next fetch:
+
+```sh
+$ git fetch
+From …/origin
+ + ee31f16...002ba27 feature    -> origin/feature  (forced update)
+$ git status -sb
+## feature...origin/feature [ahead 2, behind 1]
+```
+
+And their reflex from here makes it worse. "Diverged from the remote"
+has a standard answer, and the standard answer eats their commit:
+
+```sh
+$ git pull --rebase
+Successfully rebased and updated refs/heads/feature.
+$ git log --oneline -3
+002ba27 Add burst allowance
+8a66181 Add rate limiter
+```
+
+Their tests are gone from their own branch now. The rebase saw a
+rewritten upstream and treated every commit the old upstream contained,
+theirs included, as rewritten away on purpose. What's left of the work
+lives in their reflog and nowhere else:
+
+```sh
+$ git reflog -4
+002ba27 HEAD@{0}: pull --rebase (finish): returning to refs/heads/feature
+002ba27 HEAD@{1}: pull --rebase (start): checkout 002ba27923d9a9a79c3dc2437adefeb1a6a754a7
+ee31f16 HEAD@{2}: commit: Add limiter tests
+289a64d HEAD@{3}: clone: from …/origin.git
+```
+
+One cherry-pick in their clone puts it back, and an ordinary push
+publishes it again:
+
+```sh
+$ git cherry-pick ee31f16
+[feature aa305f5] Add limiter tests
+ Date: Tue Aug 18 01:53:48 2026 -0400
+ 1 file changed, 1 insertion(+)
+ create mode 100644 limiter.test.js
+$ git push
+To …/origin.git
+   002ba27..aa305f5  feature -> feature
+```
+
+Two people's time, one commit that briefly existed only in a reflog.
+That is the price of `--force` on a shared branch, in the *good*
+case, the one where somebody noticed.
+
+## The lease
+
+`--force-with-lease` is force with a condition. Your repository keeps
+a remote-tracking ref for the branch — `origin/feature`, its snapshot
+of where the remote stood the last time you looked, the same
+bookkeeping that [updating a branch without checking it
+out](/blog/update-a-branch-without-checking-it-out/) leaned on. The
+lease: replace the remote only if it still matches that snapshot. If
+anyone pushed since, it won't match.
+
+A week later the story repeats. A pushed commit, a forgotten file, an
+amend, and a teammate's new test commit already on the remote,
+unfetched. This time you force carefully:
+
+```sh
+$ git log --oneline -2
+b798839 Add retry budget
+aa305f5 Add limiter tests
+$ git push --force-with-lease
+To …/origin.git
+ ! [rejected]        feature -> feature (stale info)
+error: failed to push some refs to '…/origin.git'
+```
+
+"Stale info" is all it says (there is no hint block), but it did the
+thing `--force` wouldn't: it noticed the remote had moved past your
+snapshot and kept your push away from work you haven't seen.
+
+## The fetch that breaks it
+
+The lease guards a comparison, and both sides of the comparison are
+yours. Anything that runs `git fetch` refreshes `origin/feature`: a
+habitual fetch you ran without reading the result, an editor's Git
+integration, a Git client's auto-fetch timer. None of those integrate
+your teammate's commit. They only update the snapshot:
+
+```sh
+$ git fetch origin
+From …/origin
+   9f74736..cab8c4e  feature    -> origin/feature
+$ git push --force-with-lease --dry-run
+To …/origin.git
+ + cab8c4e...b798839 feature -> feature (forced update)
+```
+
+Forced update. The push that was just refused would now go through,
+taking cab8c4e, the tests, with it (the range's other commit,
+9f74736, is your own pushed commit, the one the amend replaced).
+What changed sides was a fetch you may not even have run yourself.
+VS Code fetches on a timer if you let it. So does my own Git client.
+More on that at the end.
+
+## Close the gap with `--force-if-includes`
+
+One more flag adds the question the lease never asks:
+
+```sh
+$ git push --force-with-lease --force-if-includes
+To …/origin.git
+ ! [rejected]        feature -> feature (remote ref updated since checkout)
+error: failed to push some refs to '…/origin.git'
+hint: Updates were rejected because the tip of the remote-tracking branch has
+hint: been updated since the last checkout. If you want to integrate the
+hint: remote changes, use 'git pull' before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+```
+
+The two checks differ in kind. The lease asks whether the remote is
+where you last saw it — a question about your bookkeeping, and any
+fetch answers it for you. `--force-if-includes` asks whether the
+remote's tip is part of the history you're pushing — a question about
+the work, and only integrating that commit answers it. A fetch can't
+fake the answer. Neither can a cherry-picked copy of the commit:
+the check wants the remote tip itself reachable in your branch,
+not a lookalike.
+
+The flag is easy to make permanent:
+
+```sh
+$ git config push.useForceIfIncludes true
+```
+
+After that, every `--force-with-lease` carries the check by itself.
+Two caveats: the flag needs Git 2.30 (December 2020) or newer, and
+the exact form `--force-with-lease=feature:<sha>` turns the check
+off — name a precise expectation and Git assumes you know
+something it doesn't.
+
+## When it refuses
+
+A refusal from `--force-if-includes` is information: someone built on
+the commit you rewrote. Look at the remote before touching the
+force flags again:
+
+```sh
+$ git log --oneline -1 origin/feature
+cab8c4e Test retry budget
+$ git rebase origin/feature
+Successfully rebased and updated refs/heads/feature.
+$ git log --oneline -3
+b5b3d0e Add retry budget
+cab8c4e Test retry budget
+9f74736 Add retry budget
+```
+
+The rebase settles the competition. Your amend can't stay a rewrite
+(replacing 9f74736 now would pull the foundation out from under
+cab8c4e), so its content gets replayed *on top*, as a commit of its
+own. The replay kept the amended message, which no longer fits a
+commit whose only content is the forgotten file. Nothing here has
+been pushed yet, so rewording is free — and then the push needs no
+force at all:
+
+```sh
+$ git commit --amend -m "Note that retries back off"
+[feature c5124e3] Note that retries back off
+ Date: Tue Aug 18 01:54:26 2026 -0400
+ 1 file changed, 1 insertion(+)
+ create mode 100644 RETRY.md
+$ git push
+To …/origin.git
+   cab8c4e..c5124e3  feature -> feature
+```
+
+A fast-forward. Your fix is on the branch, their tests are on the
+branch, and the remote never lost a commit. The force flags exist for
+the times you do mean to replace history; the refusals exist to
+prove you don't mean it by accident.
+
+## Or don't do any of this
+
+The demo above doubled as a bug report against my own client.
+[GitDesktop](/features/) force pushes with `--force-with-lease`, and
+it also auto-fetches every ten minutes by default so your
+behind-counts stay current without pressing Fetch. That combination
+is the fetch that breaks it, running on a schedule: the app was
+refreshing its own lease on a timer, and its confirm dialog promised
+more than a bare lease can enforce.
+
+So the fix adds `--force-if-includes` to every force-push path in
+the app, its assistant's included; on a Git too old to know the
+flag, the push retries without it instead of failing. The confirm
+dialog's wording changed to match what Git actually enforces: a
+force push will not overwrite work your branch doesn't include.
+
+A force push promises that nobody built on what it deletes. Make Git
+check the promise.

--- a/site/src/content/blog/force-push-without-overwriting-work.md
+++ b/site/src/content/blog/force-push-without-overwriting-work.md
@@ -91,8 +91,8 @@ $ git log --oneline -3
 
 Their tests are gone from their own branch now. The rebase saw a
 rewritten upstream and treated every commit the old upstream contained,
-theirs included, as rewritten away on purpose. What's left of the work
-lives in their reflog and nowhere else:
+theirs included, as rewritten away on purpose. What's left of the
+work is no longer on any branch; only their reflog still names it:
 
 ```sh
 $ git reflog -4
@@ -116,9 +116,9 @@ To …/origin.git
    002ba27..aa305f5  feature -> feature
 ```
 
-Two people's time, one commit that briefly existed only in a reflog.
-That is the price of `--force` on a shared branch, in the *good*
-case, the one where somebody noticed.
+Two people's time, one commit that briefly had no name left but a
+reflog entry. That is the price of `--force` on a shared branch, in
+the *good* case, the one where somebody noticed.
 
 ## The lease
 
@@ -190,30 +190,30 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 The two checks differ in kind. The lease asks whether the remote is
 where you last saw it — a question about your bookkeeping, and any
 fetch answers it for you. `--force-if-includes` asks whether the
-remote's tip is part of the history you're pushing — a question about
-the work, and only integrating that commit answers it. A fetch can't
-fake the answer. Neither can a cherry-picked copy of the commit:
-the check walks your branch's reflog looking for the remote tip
-itself, not a lookalike.
+remote's tip is part of the history you're pushing — a question
+about the work, one a fetch can't answer for you. Neither can a
+cherry-picked copy of the commit: the check walks your branch's
+reflog looking for the remote tip itself, not a lookalike.
 
-The flag is easy to make permanent:
+The flag is easy to make permanent for a repository:
 
 ```sh
 git config push.useForceIfIncludes true
 ```
 
-After that, every `--force-with-lease` carries the check by itself.
-Three caveats: the flag needs Git 2.30 (December 2020) or newer; the
-check reads your branch's reflog, so with none to read it refuses
-every force push, integrated or not; and the exact form
-`--force-with-lease=feature:<sha>` turns the check off — name a
-precise expectation and Git assumes you know something it doesn't.
+After that, every `--force-with-lease` there carries the check by
+itself, and `--global` widens it to every repository. Three caveats:
+`--force-if-includes` needs Git 2.30 (December 2020) or newer; with
+no reflog to walk, the check refuses every force push, integrated
+or not; and the exact form `--force-with-lease=feature:<sha>` turns
+the check off — name a precise expectation and Git assumes you know
+something it doesn't.
 
 ## When it refuses
 
-A refusal from `--force-if-includes` is information: someone built on
-the commit you rewrote. Look at the remote before touching the
-force flags again:
+A refusal from `--force-if-includes` almost always means one
+thing: someone built on the commit you rewrote. Look at the remote
+before touching the force flags again:
 
 ```sh
 $ git log --oneline -1 origin/feature
@@ -261,7 +261,7 @@ refreshing its own lease on a timer, and its confirm dialog promised
 more than a bare lease can enforce.
 
 So the fix adds `--force-if-includes` to every force-push path in
-the app, its assistant's included; on a Git too old to know the
+the app, including the assistant's; on a Git too old to know the
 flag, or a branch with no reflog for the check to read, the push
 retries with the lease alone instead of failing. The confirm
 dialog's wording changed to match what Git actually enforces:

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -42,7 +42,7 @@ const principles: { term: string; note: string; ai?: boolean }[] = [
   },
   {
     term: "Careful with your work",
-    note: "Signed releases and auto-updates; discards are recoverable and pushes use --force-with-lease with --force-if-includes where your Git supports it.",
+    note: "Signed releases and auto-updates; discards are recoverable and pushes use --force-with-lease with --force-if-includes where your Git can check it.",
   },
 ];
 

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -42,7 +42,7 @@ const principles: { term: string; note: string; ai?: boolean }[] = [
   },
   {
     term: "Careful with your work",
-    note: "Signed releases and auto-updates; discards are recoverable and pushes use --force-with-lease.",
+    note: "Signed releases and auto-updates; discards are recoverable and pushes use --force-with-lease with --force-if-includes where your Git supports it.",
   },
 ];
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -678,8 +678,9 @@ const forges = [
           <h3 class="text-ink"><code class="text-ink">--force-with-lease --force-if-includes</code> by default.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
             Divergence routes to a guarded force push, never a plain
-            <code class="text-ink">--force</code> — on Git 2.30+ the pair refuses to overwrite
-            work your branch doesn't include; pull is <code class="text-ink">--ff-only</code>.
+            <code class="text-ink">--force</code> — where your Git can check it, the pair refuses
+            to overwrite work your branch doesn't include; pull is
+            <code class="text-ink">--ff-only</code>.
           </p>
         </div>
         <div class="min-w-0">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -675,10 +675,11 @@ const forges = [
           </p>
         </div>
         <div class="min-w-0">
-          <h3 class="text-ink"><code class="text-ink">--force-with-lease</code> by default.</h3>
+          <h3 class="text-ink"><code class="text-ink">--force-with-lease --force-if-includes</code> by default.</h3>
           <p class="mt-2 max-w-[48ch] text-sm leading-relaxed text-muted">
             Divergence routes to a guarded force push, never a plain
-            <code class="text-ink">--force</code>; pull is <code class="text-ink">--ff-only</code>.
+            <code class="text-ink">--force</code> — on Git 2.30+ the pair refuses to overwrite
+            work your branch doesn't include; pull is <code class="text-ink">--ff-only</code>.
           </p>
         </div>
         <div class="min-w-0">
@@ -820,7 +821,7 @@ const forges = [
       <p data-reveal style="transition-delay:80ms" class="mx-auto mt-6 max-w-[48ch] leading-relaxed text-body">
         Free, open source, and local. Fast enough to live in, careful enough to trust
         with your work: discards are recoverable and pushes use
-        <code class="text-ink">--force-with-lease</code>.
+        <code class="text-ink">--force-with-lease --force-if-includes</code> by default.
       </p>
       <div
         data-reveal


### PR DESCRIPTION
Adds a marketing-site blog post explaining why `git push --force-with-lease` stops protecting a shared branch the moment anything runs a fetch, and how pairing it with `--force-if-includes` closes that gap. The post is built entirely from shell transcripts so the failure mode is demonstrated rather than asserted, and its closer ties the gap back to GitDesktop's own auto-fetch timer.

- Adds `site/src/content/blog/force-push-without-overwriting-work.md`, a transcript-driven walkthrough: an amend that gets rejected as non-fast-forward, a plain `--force` that silently drops a teammate's commit, the teammate's `git pull --rebase` reflex that erases it from their own branch too, and the reflog/cherry-pick recovery.
- Structures the argument across `## What --force costs`, `## The lease`, `## The fetch that breaks it`, `## Close the gap with --force-if-includes`, and `## When it refuses`, ending with the series' `## Or don't do any of this` heading. The `--force-if-includes` section contrasts the two checks: the lease compares against your remote-tracking snapshot (any fetch answers it), while `--force-if-includes` requires the remote tip to be reachable in the history you're pushing.
- Documents the practical caveats alongside the flag: `git config push.useForceIfIncludes true` to make it permanent, Git 2.30 as the minimum version, and the fact that the explicit `--force-with-lease=feature:<sha>` form turns the check off.
- Sets frontmatter `pubDate: 2026-08-26` (a bare future date), so the post behaves as a draft — visible in dev and Pages previews only — until the `site-scheduled-publish` cron rebuilds the site on or after that day. Also sets `author: theBGuy`, `pillar: git-safety`, and tags `git` / `force-push` / `workflow`.
- Cross-links the earlier `/blog/update-a-branch-without-checking-it-out/` post where remote-tracking refs first came up, and `/features/` in the closing section.
- The closing section describes GitDesktop's force-push behavior for readers: `--force-with-lease` plus `--force-if-includes` on every force-push path (including the assistant's), a retry without the flag on a Git too old to know it, and confirm-dialog wording matched to what Git enforces.
- Site-only content, so per `changelog.d/README.md` this carries no changelog fragment, and it adds no capability line, README bullet, or in-app guide section — it documents existing behavior rather than shipping a new surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide explaining the risks of force-pushing to shared branches.
  * Described safer alternatives, including `--force-with-lease` and `--force-if-includes`.
  * Added recovery steps for overwritten commits and guidance on auto-fetch behavior.
  * Documented compatibility considerations and updated force-push confirmation behavior.
  * Updated the homepage and about page to reflect improved push safety protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->