### PR TITLE
fix(git,conflicts,branches,commit): pause cherry-picks on conflicts

### DIFF
--- a/changelog.d/changed-cherry-pick-onto-conflict.md
+++ b/changelog.d/changed-cherry-pick-onto-conflict.md
@@ -1,0 +1,6 @@
+- **Cherry-pick to branch** with a single commit now pauses on the destination
+  branch when it conflicts, so you resolve it in the app and continue like any
+  other conflict — and a resolution that keeps the destination's own version
+  finishes from the banner too. Picking several commits at once still rolls the
+  whole batch back, and the dialog now refuses to start while another merge,
+  rebase, cherry-pick or revert is in progress.

--- a/changelog.d/fixed-accept-deleted-side.md
+++ b/changelog.d/fixed-accept-deleted-side.md
@@ -1,0 +1,3 @@
+- **Accept all current** / **Accept all incoming** now resolve a conflict where
+  that side deleted the file — taking the side takes the deletion. The conflict
+  view names which side removed it, so the choice is clear before you make it.

--- a/changelog.d/fixed-archived-branch-handling.md
+++ b/changelog.d/fixed-archived-branch-handling.md
@@ -1,0 +1,3 @@
+- Archived branches stay archived: **Cherry-pick to branch…** lists (and
+  pre-selects) only active branches, **Unarchive** is available on the branch
+  you're checked out on, and the default branch can no longer be archived.

--- a/changelog.d/fixed-rename-keeps-commit-draft.md
+++ b/changelog.d/fixed-rename-keeps-commit-draft.md
@@ -1,0 +1,2 @@
+- Renaming the branch you're on carries your commit draft over to the new name,
+  and a commit message being generated at the time keeps streaming into it.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -206,6 +206,11 @@ pub async fn git_set_branch_archived(
     archived: bool,
 ) -> AppResult<()> {
     validate_ref_name(&name)?;
+    // No current/default-branch refusal here by design: the frontend owns the
+    // guard (the current-branch arm is total; the default arm is best-effort,
+    // dropping out while defaultName resolves), no MCP tool mutates the flag,
+    // and it is fully reversible — a backend default-branch check would also
+    // ride the multi-spawn, fallible remote-HEAD resolution per call.
     let key = format!("branch.{name}.gitdesktopArchived");
     if archived {
         run_git(Some(&repo_path), &["config", &key, "true"], DEFAULT_TIMEOUT).await?;

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -66,6 +66,30 @@ async fn stage_blob(repo: &str, stage: u8, path: &str) -> AppResult<Option<Strin
     Ok((out.code == 0).then(|| out.stdout_lossy()))
 }
 
+/// The unmerged index stages present for `spec` (1 = base, 2 = ours, 3 = theirs).
+/// Empty when the path isn't conflicted at all.
+///
+/// One `ls-files -u` spawn answers for every stage and returns only mode/sha/stage
+/// metadata; `stage_blob` costs the same spawn but materializes the whole blob
+/// (up to the 256 KB cap, binary bytes included) just to test for presence.
+async fn unmerged_stages(repo: &str, spec: &str) -> AppResult<Vec<u8>> {
+    let out = run_git(Some(repo), &["ls-files", "-u", "--", spec], DEFAULT_TIMEOUT).await?;
+    Ok(out
+        .stdout_lossy()
+        .lines()
+        // `<mode> <sha> <stage>\t<path>` — read the stage from the metadata half
+        // only, so a path containing whitespace can't shift the field index.
+        .filter_map(|line| {
+            line.split('\t')
+                .next()?
+                .split_whitespace()
+                .nth(2)?
+                .parse()
+                .ok()
+        })
+        .collect())
+}
+
 /// Whether the path matches any of the user's AI-ignore `exclude` patterns —
 /// the gate that decides whether a conflicted file's contents go to a model.
 ///
@@ -151,8 +175,9 @@ pub async fn git_resolve_conflict(
 /// Resolves a whole conflicted file by taking one side outright: `side` is
 /// "ours" (current branch / HEAD) or "theirs" (incoming). `git checkout
 /// --ours/--theirs` writes that side's version to the working tree, then `git
-/// add` stages it (marks resolved). Works for binary conflicts too, where a
-/// text merge is impossible.
+/// add` stages it (marks resolved). When the chosen side has no version at this
+/// path — it deleted or renamed the file away — `git rm` takes that removal
+/// instead. Works for binary conflicts too, where a text merge is impossible.
 #[tauri::command]
 pub async fn git_checkout_conflict_side(
     state: State<'_, AppState>,
@@ -170,26 +195,52 @@ pub(crate) async fn git_checkout_conflict_side_core(
     side: String,
 ) -> AppResult<()> {
     validate_rel_path(&path)?;
-    let flag = match side.as_str() {
-        "ours" => "--ours",
-        "theirs" => "--theirs",
+    let (flag, stage) = match side.as_str() {
+        "ours" => ("--ours", 2u8),
+        "theirs" => ("--theirs", 3u8),
         _ => {
             return Err(AppError::InvalidArgument(format!(
                 "invalid conflict side: {side}"
             )))
         }
     };
-    // Literal pathspec on both steps: a `[slug]`-style path would otherwise take
+    // Literal pathspec on every step: a `[slug]`-style path would otherwise take
     // this side for its glob-siblings too, silently resolving conflicts the user
     // never opened.
     let spec = crate::git::pathspec::literal(&path);
 
-    // One hold across checkout→add: between the two a concurrent stage or discard can
-    // rewrite the working-tree file, and the `add` would then stage THAT content as
-    // the user's chosen side. Lock-free runners only while held (see
-    // `run_git_mutating`).
+    // One hold across the stage read and checkout→add: between them a concurrent
+    // stage or discard can rewrite the working-tree file, and the `add` would then
+    // stage THAT content as the user's chosen side. Lock-free runners only while
+    // held (see `run_git_mutating`).
     let lock = state.repo_lock(&repo_path).await;
     let _guard = lock.lock().await;
+
+    // A side that removed the file (deleted it, or renamed it away) has no stage
+    // entry, and `checkout --ours|--theirs` then exits 1 ("does not have our
+    // version"), so taking that side means `git rm` — which needs no `-f` on an
+    // unmerged path, whatever the working copy holds (measured, git 2.51.1).
+    // Gated on the path being unmerged RIGHT NOW: on an already-resolved path
+    // `git rm` exits 0 and deletes the file, turning a stale second click into
+    // data loss.
+    let stages = unmerged_stages(&repo_path, &spec).await?;
+    if !stages.is_empty() && !stages.contains(&stage) {
+        run_git(Some(&repo_path), &["rm", "--", &spec], DEFAULT_TIMEOUT).await?;
+        return Ok(());
+    }
+    // Nothing unmerged and nothing on disk: an accept landing after this path was
+    // already resolved AS A REMOVAL. `checkout` would exit 1 on the missing
+    // pathspec and put raw git text in a toast, so settle for the state the user
+    // asked for. Positive knowledge of absence only — a resolved path whose file
+    // still exists keeps today's harmless checkout no-op.
+    if stages.is_empty()
+        && matches!(
+            tokio::fs::try_exists(Path::new(&repo_path).join(&path)).await,
+            Ok(false)
+        )
+    {
+        return Ok(());
+    }
 
     run_git(
         Some(&repo_path),
@@ -426,6 +477,200 @@ mod tests {
             !staged.contains("src/app/s/page.tsx"),
             "the glob-sibling was staged: {staged}"
         );
+    }
+
+    async fn git_ok(repo: &str, args: &[&str]) {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT).await.unwrap();
+    }
+
+    async fn stdout_of(repo: &str, args: &[&str]) -> String {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+    }
+
+    /// Builds a real modify/delete conflict on `path`: one side deletes the file
+    /// while the other modifies it, so the deleting side has NO index stage.
+    /// `deleted_by` is "ours" (the current branch) or "theirs" (the merged one).
+    async fn modify_delete_repo(
+        tag: &str,
+        path: &str,
+        deleted_by: &str,
+    ) -> (tempfile::TempDir, String) {
+        let (dir, repo) = temp_repo(tag);
+        git_ok(&repo, &["init"]).await;
+        git_ok(&repo, &["config", "user.email", "t@t"]).await;
+        git_ok(&repo, &["config", "user.name", "t"]).await;
+        let file = Path::new(&repo).join(path);
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "base\n").unwrap();
+        // A file neither branch touches, so the deleting side still commits a
+        // non-empty tree.
+        std::fs::write(Path::new(&repo).join("keep.txt"), "keep\n").unwrap();
+        git_ok(&repo, &["add", "."]).await;
+        git_ok(&repo, &["commit", "-m", "base"]).await;
+
+        git_ok(&repo, &["checkout", "-b", "feature"]).await;
+        if deleted_by == "theirs" {
+            git_ok(&repo, &["rm", "-q", "--", path]).await;
+        } else {
+            std::fs::write(&file, "theirs\n").unwrap();
+            git_ok(&repo, &["add", "--", path]).await;
+        }
+        git_ok(&repo, &["commit", "-m", "feature"]).await;
+
+        git_ok(&repo, &["checkout", "-"]).await;
+        if deleted_by == "ours" {
+            git_ok(&repo, &["rm", "-q", "--", path]).await;
+        } else {
+            std::fs::write(&file, "ours\n").unwrap();
+            git_ok(&repo, &["add", "--", path]).await;
+        }
+        git_ok(&repo, &["commit", "-m", "ours"]).await;
+
+        // The merge is expected to conflict (non-zero exit), so run it raw.
+        run_git_raw(Some(&repo), &["merge", "feature"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        (dir, repo)
+    }
+
+    /// Asserts the fixture really is a modify/delete: `present` survives as an
+    /// index stage and `missing` does not.
+    async fn assert_modify_delete(repo: &str, path: &str, present: u8, missing: u8) {
+        let stages = stdout_of(repo, &["ls-files", "-u"]).await;
+        assert!(
+            stages.contains(&format!(" {present}\t{path}")),
+            "stage {present} should survive: {stages}"
+        );
+        assert!(
+            !stages.contains(&format!(" {missing}\t{path}")),
+            "stage {missing} should be absent: {stages}"
+        );
+    }
+
+    /// Asserts the path is fully resolved AND gone — no unmerged stages, no index
+    /// entry, no working file.
+    async fn assert_deleted_and_resolved(repo: &str, path: &str) {
+        let unmerged = stdout_of(repo, &["ls-files", "-u"]).await;
+        assert!(
+            unmerged.trim().is_empty(),
+            "conflict left behind: {unmerged}"
+        );
+        let tracked = stdout_of(repo, &["ls-files", "--", path]).await;
+        assert!(tracked.trim().is_empty(), "still in the index: {tracked}");
+        assert!(
+            !Path::new(repo).join(path).exists(),
+            "the working file survived the deletion"
+        );
+    }
+
+    /// Accept-all-current when OUR side deleted the file: `checkout --ours` can't
+    /// serve a side with no stage, so taking it has to mean taking the deletion.
+    /// Reverting the deletion arm turns this red — the core call errors instead.
+    #[tokio::test]
+    async fn accept_current_takes_the_deletion_when_our_side_deleted() {
+        let (_dir, repo) = modify_delete_repo("md-ours", "file.txt", "ours").await;
+        assert_modify_delete(&repo, "file.txt", 3, 2).await;
+
+        let state = AppState::default();
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "ours".into())
+            .await
+            .unwrap();
+
+        assert_deleted_and_resolved(&repo, "file.txt").await;
+    }
+
+    /// The mirror: accept-all-incoming when THEIR side deleted the file. Here the
+    /// deletion is also a staged change, since HEAD still carries the file.
+    #[tokio::test]
+    async fn accept_incoming_takes_the_deletion_when_their_side_deleted() {
+        let (_dir, repo) = modify_delete_repo("md-theirs", "file.txt", "theirs").await;
+        assert_modify_delete(&repo, "file.txt", 2, 3).await;
+
+        let state = AppState::default();
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "theirs".into())
+            .await
+            .unwrap();
+
+        assert_deleted_and_resolved(&repo, "file.txt").await;
+        let staged = stdout_of(&repo, &["diff", "--cached", "--name-status"]).await;
+        assert!(staged.contains("D\tfile.txt"), "deletion staged: {staged}");
+    }
+
+    /// The other half of a modify/delete: taking the side that KEPT the file still
+    /// goes through checkout, so the deletion arm must not swallow it.
+    #[tokio::test]
+    async fn modify_delete_keeps_the_file_when_the_surviving_side_is_taken() {
+        let (_dir, repo) = modify_delete_repo("md-keep", "file.txt", "ours").await;
+        // Pins the fixture: a typo in `deleted_by` would silently build the mirror
+        // and leave this test asserting the wrong direction.
+        assert_modify_delete(&repo, "file.txt", 3, 2).await;
+
+        let state = AppState::default();
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "theirs".into())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(Path::new(&repo).join("file.txt"))
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "theirs\n"
+        );
+        let unmerged = stdout_of(&repo, &["ls-files", "-u"]).await;
+        assert!(
+            unmerged.trim().is_empty(),
+            "conflict left behind: {unmerged}"
+        );
+    }
+
+    /// The guard on the deletion arm: `git rm` exits 0 and DELETES an
+    /// already-resolved path (measured, git 2.51.1), so a second accept on a file
+    /// whose conflict is gone must stay the harmless no-op it is today.
+    #[tokio::test]
+    async fn a_resolved_path_is_never_removed_by_a_second_accept() {
+        let (_dir, repo) = conflicted_repo("md-double-fire", "file.txt", &[]).await;
+        let state = AppState::default();
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "ours".into())
+            .await
+            .unwrap();
+
+        // The stale second click: same side, conflict already gone.
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "ours".into())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(Path::new(&repo).join("file.txt"))
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "ours\n",
+            "the resolved file survives a repeat accept"
+        );
+    }
+
+    /// The aftermath of a taken removal: no stages left AND no file, so the
+    /// checkout path would exit 1 on a pathspec matching nothing and hand the user
+    /// raw git text. A repeat accept has to settle instead.
+    #[tokio::test]
+    async fn a_second_accept_after_a_taken_removal_is_a_no_op() {
+        let (_dir, repo) = modify_delete_repo("md-repeat", "file.txt", "ours").await;
+        let state = AppState::default();
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "ours".into())
+            .await
+            .unwrap();
+        assert_deleted_and_resolved(&repo, "file.txt").await;
+
+        // Both sides, since either button is reachable in the header.
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "ours".into())
+            .await
+            .unwrap();
+        git_checkout_conflict_side_core(&state, repo.clone(), "file.txt".into(), "theirs".into())
+            .await
+            .unwrap();
+        assert_deleted_and_resolved(&repo, "file.txt").await;
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -26,7 +26,9 @@ const RESOLVE_MAX_BYTES: usize = 256_000;
 #[serde(rename_all = "camelCase")]
 pub struct ConflictSides {
     /// The working-tree file, conflict markers and all — the primary input, since
-    /// its `<<<<<<<`/`>>>>>>>` markers label each side in place.
+    /// its `<<<<<<<`/`>>>>>>>` markers label each side in place. Not every
+    /// conflict carries markers — a modify/delete file, for one, is just the
+    /// surviving side's content.
     pub working: String,
     /// Common-ancestor version (index stage 1). `None` for add/add conflicts,
     /// which have no shared base.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -246,7 +246,7 @@ pub async fn git_op_abort(
 /// with `core.editor=true` so git never tries to open an editor.
 ///
 /// `false` means the pending cherry-pick was dropped as empty instead of
-/// committed (its changes are already on this branch); `true` that the operation
+/// committed (the resolution left nothing to commit); `true` that the operation
 /// completed normally. Callers must say which happened — the frontend's
 /// "continued" copy would otherwise promise a commit that was never made.
 #[tauri::command]

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -269,6 +269,29 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
     // stderr-only error renders as "git exited with code 1".
     let out = run_git_mutating_raw(state, repo_path, &args, DEFAULT_TIMEOUT).await?;
     if out.code != 0 {
+        // A resolution that keeps the target's side leaves the pick with nothing to
+        // commit: `--continue` then exits 1 asking for `--skip`, on stderr, with
+        // CHERRY_PICK_HEAD still in place (measured, git 2.51.1). Taking that escape
+        // is what lets Continue finish an all-ours resolution. Cherry-pick only —
+        // `revert --continue` writes no such advice for the same resolution
+        // (measured), so there is nothing to match on there.
+        if op == "cherry-pick"
+            && (out.stderr.contains("is now empty") || out.stderr.contains("--allow-empty"))
+        {
+            let skip = run_git_mutating_raw(
+                state,
+                repo_path,
+                &["cherry-pick", "--skip"],
+                DEFAULT_TIMEOUT,
+            )
+            .await?;
+            if skip.code == 0 {
+                return Ok(());
+            }
+            return Err(
+                classify_failure(repo_path, op, &[], skip.code, skip.full_failure_text()).await,
+            );
+        }
         // Empty baseline, unlike every other site: a refused `--continue` reports
         // the paths the operation the CALLER named is already paused on, so they
         // are attributable by construction rather than by having just appeared.
@@ -443,10 +466,12 @@ pub struct CherryPickRangeResult {
 
 /// Copies the given commits (oldest-first) onto `target_branch`, then leaves
 /// you on that branch. Commits whose changes already exist there are skipped
-/// rather than erroring. If any pick fails — conflict, timeout, unreadable
-/// repo — the batch is rolled back: the target branch is reset to its prior tip
-/// and you return to where you started. Each rollback step is best-effort; when
-/// one fails the returned error names what was left behind and how to recover.
+/// rather than erroring. A single commit that conflicts stops on `target_branch`
+/// with the pick in progress, for the conflict banner to continue or abort.
+/// Every other failure (and any failure in a multi-commit batch) is rolled back:
+/// the target branch is reset to its prior tip and you return to where you
+/// started. Each rollback step is best-effort; when one fails the returned error
+/// names what was left behind and how to recover.
 #[tauri::command]
 pub async fn git_cherry_pick_onto(
     state: State<'_, AppState>,
@@ -507,6 +532,16 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
     // runners only while held (see `run_git_mutating`).
     let lock = state.repo_lock(repo_path).await;
     let guard = lock.lock().await;
+
+    // Ahead of the tree check because it can't stand in for this one: a pick paused
+    // with its conflicts staged has a CLEAN tree, so the only refusal left would be
+    // git's own raw "cannot switch branch while cherry-picking" (measured, git
+    // 2.51.1). Shares `op_state`'s detection, like the rebase-edit guard.
+    if op_in_progress(repo_path).await {
+        return Err(AppError::InvalidArgument(
+            "a rebase, merge, cherry-pick or revert is already in progress — finish or abort it from the banner first".into(),
+        ));
+    }
 
     // The failure path hard-resets `target` to its prior tip, which would discard
     // uncommitted work when target is the current branch — refuse first.
@@ -591,9 +626,14 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
 
         let mut applied = 0usize;
         let mut skipped = 0usize;
-        // Every pick failure class — conflict, timeout, IO — leaves through the one
-        // rollback funnel below, so none of them exits with HEAD on `target` unless
-        // the rollback itself fails, which the error then says.
+        // The pre-op unmerged set for `classify_failure` below. `ensure_clean_tree`
+        // already refused a dirty tree, so this reads empty — kept real for the same
+        // reason `git_cherry_pick_core` reads it: a baseline is never assumed.
+        let already_unmerged = unmerged_paths(repo_path).await;
+        // Every failure class that reaches this leaves through the one rollback funnel
+        // below, so none of them exits with HEAD on `target` unless the rollback itself
+        // fails, which the error then says. The exception returns before it: a
+        // single-commit conflict, which stops for the user instead.
         let mut failure: Option<(String, AppError)> = None;
         'picks: for hash in hashes {
             // Raw plus an explicit code check, never a mutating runner: this loop
@@ -625,13 +665,31 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
                 skipped += 1;
                 continue;
             }
-            failure = Some((
-                hash.clone(),
+            // A lone commit that conflicts stops here instead of rolling back:
+            // CHERRY_PICK_HEAD survives for the conflict banner's Continue/Abort, and
+            // resolving on `target` is where the user wants to end up anyway — the same
+            // place a manual checkout-and-pick would have left them. A batch keeps the
+            // rollback (git's sequencer resume is not wired up), and so does a
+            // single-commit failure that added no conflict.
+            let err = if hashes.len() == 1 {
+                classify_failure(
+                    repo_path,
+                    "cherry-pick",
+                    &already_unmerged,
+                    out.code,
+                    out.full_failure_text(),
+                )
+                .await
+            } else {
                 AppError::Git {
                     code: out.code,
                     stderr: out.full_failure_text(),
-                },
-            ));
+                }
+            };
+            if matches!(err, AppError::Conflict { .. }) {
+                return Err(err);
+            }
+            failure = Some((hash.clone(), err));
             break 'picks;
         }
 
@@ -694,17 +752,28 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
                     "The cherry-pick failed and its automatic rollback also failed.\n{target_branch} may still carry the commits applied so far; its tip before this run was {target_tip}.\nRun git cherry-pick --abort if a pick is still in progress, or git reset --hard {target_tip} on {target_branch} to restore it."
                 )
             };
+            // Only a good reset retires git's hints: it cleared the pick state, so
+            // the report's `--continue` / `--abort` advice is stale. A FAILED reset
+            // leaves a pick that may still be in progress, which is why the recovery
+            // line above points the user at `--abort` on purpose.
+            let stale_hints = if reset_ok {
+                "\nThe rollback has already run, so git's continue/abort hints above no longer apply."
+            } else {
+                ""
+            };
             let short = &hash[..hash.len().min(7)];
             return Err(match err {
                 AppError::Git { code, stderr } if rolled_back => AppError::Git {
                     code,
                     stderr: format!(
-                        "The cherry-pick was rolled back — {target_branch} is unchanged.\nPick {short} failed, usually a conflict; nothing from this batch was kept.\n{stderr}"
+                        "The cherry-pick was rolled back — {target_branch} is unchanged.\nPick {short} failed, usually a conflict; nothing from this batch was kept.\n{stderr}{stale_hints}"
                     ),
                 },
                 AppError::Git { code, stderr } => AppError::Git {
                     code,
-                    stderr: format!("{recovery}\nThe failing pick was {short}.\n{stderr}"),
+                    stderr: format!(
+                        "{recovery}\nThe failing pick was {short}.\n{stderr}{stale_hints}"
+                    ),
                 },
                 other if rolled_back => other,
                 // Timeout carries only a u64 and GitNotFound carries nothing, so a
@@ -4952,14 +5021,19 @@ mod tests {
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
     }
 
+    /// A BATCH keeps the rollback — git's sequencer resume isn't wired up, so the
+    /// half-applied batch has nowhere to go but back.
     #[tokio::test]
-    async fn cherry_pick_onto_conflict_rolls_back_and_returns_home() {
+    async fn cherry_pick_onto_batch_conflict_rolls_back_and_returns_home() {
         let (dir, repo) = setup_repo("pick-onto-conflict").await;
         git(&repo, &["branch", "target"]).await;
         git(&repo, &["checkout", "-b", "feature"]).await;
-        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        // The first pick applies cleanly; the second touches the file target
+        // diverged on, so the batch fails partway through.
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
         let c1 = rev(&repo, "HEAD").await;
-        // Diverge target on the same file so the pick can't apply.
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c2 = rev(&repo, "HEAD").await;
         git(&repo, &["checkout", "target"]).await;
         commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
         let target_tip = rev(&repo, "HEAD").await;
@@ -4967,7 +5041,7 @@ mod tests {
         let feature_tip = rev(&repo, "HEAD").await;
 
         let state = AppState::default();
-        match cherry_pick_onto(&state, &repo, &[c1], "target").await {
+        match cherry_pick_onto(&state, &repo, &[c1, c2], "target").await {
             Err(AppError::Git { stderr, .. }) => {
                 assert_verdict_shape(&stderr, "was rolled back");
                 assert!(
@@ -4981,6 +5055,14 @@ mod tests {
                         && stderr.contains("CONFLICT (content): Merge conflict in a.txt"),
                     "the verdict must carry git's diagnostic AND its file list: {stderr}"
                 );
+                // git's report ends in --continue/--abort hints that the rollback has
+                // already invalidated, so the message must retire them last.
+                assert!(
+                    stderr
+                        .trim_end()
+                        .ends_with("git's continue/abort hints above no longer apply."),
+                    "the rolled-back verdict must retire git's own hints: {stderr}"
+                );
             }
             Ok(_) => panic!("the conflicting pick must fail"),
             Err(e) => panic!("expected a Git error, got {e}"),
@@ -4993,12 +5075,193 @@ mod tests {
             git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).await.trim(),
             "feature"
         );
+        assert!(!op_state(&repo).await.unwrap().cherry_picking);
         let status = git(&repo, &["status", "--porcelain"]).await;
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
     }
 
-    /// The rollback must run for every failure class, not just a conflict — a
-    /// killed pick otherwise leaves HEAD on the target mid-cherry-pick.
+    /// One commit that conflicts STOPS on the target instead of rolling back: the
+    /// dialog is the app's only route to "send this commit to another branch", so a
+    /// rollback would dead-end the user in a terminal.
+    #[tokio::test]
+    async fn cherry_pick_onto_single_conflict_pauses_on_the_target() {
+        let (dir, repo) = setup_repo("pick-onto-single-conflict").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        // Diverge target on the same file so the pick can't apply.
+        git(&repo, &["checkout", "target"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        let target_tip = rev(&repo, "HEAD").await;
+        git(&repo, &["checkout", "feature"]).await;
+        let feature_tip = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        match cherry_pick_onto(&state, &repo, &[c1], "target").await {
+            Err(AppError::Conflict { op, paths, report }) => {
+                assert_eq!(op, "cherry-pick", "the banner's copy table keys on this");
+                assert_eq!(paths, vec!["a.txt".to_string()]);
+                assert!(
+                    report.contains("could not apply")
+                        && report.contains("CONFLICT (content): Merge conflict in a.txt"),
+                    "the report must carry git's diagnostic AND its file list: {report}"
+                );
+            }
+            Ok(_) => panic!("the conflicting pick must fail"),
+            Err(e) => panic!("expected the structured conflict, got {e:?}"),
+        }
+        // No rollback ran: the pick is still in progress, on the target branch, with
+        // the target's own tip intact and the source branch untouched.
+        assert!(
+            op_state(&repo).await.unwrap().cherry_picking,
+            "the paused pick must be visible to the conflict banner"
+        );
+        assert_eq!(
+            git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).await.trim(),
+            "target",
+            "resolving happens where the commit is going"
+        );
+        assert_eq!(rev(&repo, "target").await, target_tip);
+        assert_eq!(rev(&repo, "feature").await, feature_tip);
+        // A paused op is a finished journal record, not an interrupted one — the
+        // recovery banner must not offer to undo a pick the user is still resolving.
+        assert!(
+            crate::oplog::git_oplog_check(repo.clone())
+                .await
+                .unwrap()
+                .is_empty(),
+            "a paused pick must leave no pending journal entry"
+        );
+    }
+
+    /// A pick paused with its conflicts staged has a CLEAN tree, so `ensure_clean_tree`
+    /// waves a second run through: without the in-progress guard the user meets git's
+    /// raw "cannot switch branch while cherry-picking" instead of the app's own
+    /// refusal, and the resolution they staged is one `cherry-pick <hash>` away from
+    /// being replaced by fresh conflict stages (measured, git 2.51.1).
+    #[tokio::test]
+    async fn cherry_pick_onto_refuses_while_a_pick_is_in_progress() {
+        let (dir, repo) = setup_repo("pick-onto-reentry").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        git(&repo, &["checkout", "target"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        let target_tip = rev(&repo, "HEAD").await;
+
+        // Pause a pick on target and resolve it all-ours, which stages a resolution
+        // AND leaves the tree clean.
+        let state = AppState::default();
+        assert!(cherry_pick_onto(&state, &repo, std::slice::from_ref(&c1), "target")
+            .await
+            .is_err());
+        git(&repo, &["checkout", "--ours", "a.txt"]).await;
+        git(&repo, &["add", "a.txt"]).await;
+        let staged = git(&repo, &["ls-files", "--unmerged"]).await;
+        assert!(
+            staged.trim().is_empty(),
+            "the fixture must start from a RESOLVED index: {staged}"
+        );
+        let tracked = git(&repo, &["status", "--porcelain", "--untracked-files=no"]).await;
+        assert!(
+            tracked.trim().is_empty(),
+            "and from a clean tree, or the guard under test isn't the one refusing: {tracked}"
+        );
+
+        match cherry_pick_onto(&state, &repo, &[c1], "target").await {
+            Err(AppError::InvalidArgument(msg)) => {
+                assert!(
+                    msg.contains("already in progress"),
+                    "the refusal must name the in-flight op: {msg}"
+                );
+            }
+            Ok(_) => panic!("a second pick must be refused while one is in progress"),
+            Err(e) => panic!("expected the app's own refusal, got {e:?}"),
+        }
+        // The staged resolution and the paused pick both survive untouched.
+        assert!(
+            git(&repo, &["ls-files", "--unmerged"]).await.trim().is_empty(),
+            "the refusal must not re-conflict the resolved index"
+        );
+        assert!(op_state(&repo).await.unwrap().cherry_picking);
+        assert_eq!(rev(&repo, "target").await, target_tip);
+    }
+
+    /// `classify_failure`'s pass-through arm: a pick that fails WITHOUT adding a
+    /// conflict is still a plain `AppError::Git`, so a single commit takes the
+    /// rollback exactly as it did before the stop arm existed. A merge commit
+    /// without `-m` is the cheapest such failure.
+    #[tokio::test]
+    async fn cherry_pick_onto_rolls_back_a_single_non_conflict_failure() {
+        let (dir, repo) = setup_repo("pick-onto-merge-commit").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "b.txt", "b\n", "one").await;
+        git(&repo, &["checkout", "-b", "side"]).await;
+        commit_file(&repo, dir.path(), "c.txt", "c\n", "two").await;
+        git(&repo, &["checkout", "feature"]).await;
+        git(&repo, &["merge", "--no-ff", "-m", "merge side", "side"]).await;
+        let merge_commit = rev(&repo, "HEAD").await;
+        let feature_tip = merge_commit.clone();
+        let target_tip = rev(&repo, "target").await;
+
+        let state = AppState::default();
+        match cherry_pick_onto(&state, &repo, &[merge_commit], "target").await {
+            Err(AppError::Git { stderr, .. }) => {
+                assert_verdict_shape(&stderr, "was rolled back");
+                assert!(
+                    stderr.contains("is a merge but no -m option was given"),
+                    "git's own reason must survive the pass-through: {stderr}"
+                );
+            }
+            Ok(_) => panic!("cherry-picking a merge commit without -m must fail"),
+            Err(e) => panic!("expected the pass-through Git error, got {e:?}"),
+        }
+        assert_eq!(rev(&repo, "target").await, target_tip);
+        assert_eq!(rev(&repo, "HEAD").await, feature_tip);
+        assert!(!op_state(&repo).await.unwrap().cherry_picking);
+    }
+
+    /// Continue on an all-ours resolution: the pick has nothing left to commit, so
+    /// git refuses `--continue` and asks for `--skip` (measured, git 2.51.1). The
+    /// banner's Continue has to take that escape, or the state P1's pause makes
+    /// routine dead-ends in the UI.
+    #[tokio::test]
+    async fn op_continue_finishes_a_cherry_pick_emptied_by_its_resolution() {
+        let (dir, repo) = setup_repo("continue-empty-pick").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        git(&repo, &["checkout", "target"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        let target_tip = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        assert!(cherry_pick_onto(&state, &repo, &[c1], "target")
+            .await
+            .is_err());
+        git(&repo, &["checkout", "--ours", "a.txt"]).await;
+        git(&repo, &["add", "a.txt"]).await;
+
+        op_continue(&state, &repo, "cherry-pick")
+            .await
+            .expect("continue must finish a pick emptied by its own resolution");
+        assert!(
+            !op_state(&repo).await.unwrap().cherry_picking,
+            "the escape must leave nothing in progress"
+        );
+        // Nothing was committed: the resolution kept the target's own content.
+        assert_eq!(rev(&repo, "HEAD").await, target_tip);
+        let status = git(&repo, &["status", "--porcelain"]).await;
+        assert!(status.trim().is_empty(), "tree should be clean: {status}");
+    }
+
+    /// Only a CONFLICT stops on the target; every other failure class still rolls
+    /// back, single commit included — a killed pick otherwise leaves HEAD on the
+    /// target with nothing for the user to resolve.
     #[tokio::test]
     async fn cherry_pick_onto_rolls_back_when_a_pick_fails_non_git() {
         let (dir, repo) = setup_repo("pick-onto-nongit").await;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -244,18 +244,23 @@ pub async fn git_op_abort(
 /// Finishes an in-progress operation once every conflict is resolved and
 /// staged. A merge concludes with its commit; rebase/cherry-pick/revert continue
 /// with `core.editor=true` so git never tries to open an editor.
+///
+/// `false` means the pending cherry-pick was dropped as empty instead of
+/// committed (its changes are already on this branch); `true` that the operation
+/// completed normally. Callers must say which happened — the frontend's
+/// "continued" copy would otherwise promise a commit that was never made.
 #[tauri::command]
 pub async fn git_op_continue(
     state: State<'_, AppState>,
     repo_path: String,
     op: String,
-) -> AppResult<()> {
+) -> AppResult<bool> {
     op_continue(&state, &repo_path, &op).await
 }
 
 /// Testable core of [`git_op_continue`] — takes a plain `&AppState` so real-repo
-/// tokio tests can drive it.
-pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> AppResult<()> {
+/// tokio tests can drive it. Same `bool` contract.
+pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> AppResult<bool> {
     validate_op(op)?;
     let args: Vec<&str> = match op {
         // `--cleanup=strip` is load-bearing: with no editor run, cleanup defaults
@@ -286,7 +291,7 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
             )
             .await?;
             if skip.code == 0 {
-                return Ok(());
+                return Ok(false);
             }
             return Err(
                 classify_failure(repo_path, op, &[], skip.code, skip.full_failure_text()).await,
@@ -297,7 +302,7 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
         // are attributable by construction rather than by having just appeared.
         return Err(classify_failure(repo_path, op, &[], out.code, out.full_failure_text()).await);
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Discards selected 1-based lines from an untracked (new) file by deleting them
@@ -539,7 +544,7 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
     // 2.51.1). Shares `op_state`'s detection, like the rebase-edit guard.
     if op_in_progress(repo_path).await {
         return Err(AppError::InvalidArgument(
-            "a rebase, merge, cherry-pick or revert is already in progress — finish or abort it from the banner first".into(),
+            "Can't cherry-pick while a merge, rebase, cherry-pick or revert is in progress — finish or abort it from the banner first.".into(),
         ));
     }
 
@@ -4029,7 +4034,7 @@ pub async fn git_rebase_edit(
     // hand-rolled copy this replaces missed the sequencer-only and revert windows.
     if op_in_progress(&repo_path).await {
         return Err(AppError::InvalidArgument(
-            "a rebase, merge, cherry-pick or revert is already in progress — finish or abort it from the banner first".into(),
+            "Can't edit history while a merge, rebase, cherry-pick or revert is in progress — finish or abort it from the banner first.".into(),
         ));
     }
     // git rebase refuses a dirty tree too, but a clear message here is nicer.
@@ -5173,8 +5178,8 @@ mod tests {
         match cherry_pick_onto(&state, &repo, &[c1], "target").await {
             Err(AppError::InvalidArgument(msg)) => {
                 assert!(
-                    msg.contains("already in progress"),
-                    "the refusal must name the in-flight op: {msg}"
+                    msg.starts_with("Can't cherry-pick while") && msg.contains("in progress"),
+                    "the refusal is the toast summary verbatim, so it reads as a sentence: {msg}"
                 );
             }
             Ok(_) => panic!("a second pick must be refused while one is in progress"),
@@ -5246,9 +5251,13 @@ mod tests {
         git(&repo, &["checkout", "--ours", "a.txt"]).await;
         git(&repo, &["add", "a.txt"]).await;
 
-        op_continue(&state, &repo, "cherry-pick")
+        let recorded = op_continue(&state, &repo, "cherry-pick")
             .await
             .expect("continue must finish a pick emptied by its own resolution");
+        assert!(
+            !recorded,
+            "the skipped pick recorded no commit, and the banner's copy keys on that"
+        );
         assert!(
             !op_state(&repo).await.unwrap().cherry_picking,
             "the escape must leave nothing in progress"
@@ -5257,6 +5266,38 @@ mod tests {
         assert_eq!(rev(&repo, "HEAD").await, target_tip);
         let status = git(&repo, &["status", "--porcelain"]).await;
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
+    }
+
+    /// The sibling arm: a resolution that keeps content of its own DOES commit, so
+    /// the same call answers true and the banner says the pick continued.
+    #[tokio::test]
+    async fn op_continue_reports_a_recorded_commit_for_a_resolved_cherry_pick() {
+        let (dir, repo) = setup_repo("continue-resolved-pick").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        git(&repo, &["checkout", "target"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        let target_tip = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        assert!(cherry_pick_onto(&state, &repo, &[c1], "target")
+            .await
+            .is_err());
+        std::fs::write(dir.path().join("a.txt"), "merged\n").unwrap();
+        git(&repo, &["add", "a.txt"]).await;
+
+        let recorded = op_continue(&state, &repo, "cherry-pick")
+            .await
+            .expect("a resolved pick must continue");
+        assert!(recorded, "a pick that commits must answer true");
+        assert!(!op_state(&repo).await.unwrap().cherry_picking);
+        assert_ne!(
+            rev(&repo, "HEAD").await,
+            target_tip,
+            "the resolution must have landed as a commit"
+        );
     }
 
     /// Only a CONFLICT stops on the target; every other failure class still rolls
@@ -5483,7 +5524,7 @@ mod tests {
             panic!("edit-rebase must refuse over sequencer state, got {refused:?}");
         };
         assert!(
-            msg.contains("already in progress"),
+            msg.starts_with("Can't edit history while"),
             "the mid-op guard must be the one that refuses: {msg}"
         );
     }

--- a/src/features/commit/useGenerateCommitMessage.ts
+++ b/src/features/commit/useGenerateCommitMessage.ts
@@ -8,7 +8,7 @@ import {
   gitStagedDiff,
   readRepoInstructions,
 } from "@/lib/git/api";
-import { useUiStore } from "@/lib/stores/ui";
+import { resolveDraftKey, useUiStore } from "@/lib/stores/ui";
 
 /** Raw diff bytes requested from the backend; prompt budgeting trims further. */
 const RAW_DIFF_MAX_BYTES = 200_000;
@@ -31,7 +31,12 @@ export function useGenerateCommitMessage(repoPath: string) {
     // A null startKey (pre-branch-resolution) treats any later key as a move.
     // On a move, cancel() always aborts THIS run: a second generation can't
     // start while `generating` is set (CommitBox gates the button and hotkey).
-    const keyMoved = () => useUiStore.getState().activeDraftKey !== startKey;
+    // The test is draft identity, not key equality: a branch rename re-keys the
+    // same draft, so resolve the captured key through the store's rename remaps.
+    const keyMoved = () => {
+      const s = useUiStore.getState();
+      return resolveDraftKey(s.draftKeyRemaps, startKey) !== s.activeDraftKey;
+    };
     setGenerating(true);
     const buffer = await run(
       async (settings) => {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -376,7 +376,7 @@ selection to compare a range.
 - **Amend** the most recent commit (reword, or fold in staged changes).
 - **Revert** — create a new commit that undoes a commit's changes.
 - **Cherry-pick** a commit onto the current branch, or **Cherry-pick to branch…** to copy
-  it (or a multi-selection) onto another branch without switching. A single commit that
+  it (or a multi-selection) onto another branch and switch to it. A single commit that
   conflicts pauses on the destination branch so you can resolve it and continue; a
   multi-commit batch rolls back automatically on any failure.
 - **Reset** the current branch to a commit — a **mixed reset**, so the changes from later
@@ -435,11 +435,11 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   and labeled with the default branch's name.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
-  it, collapsing it into an "Archived" section. The default branch can't be archived, and
-  **Unarchive** works even on the branch you're checked out on. When creating, the
-  **Base it on** picker is
-  a searchable list grouped into **Local** and **Remote** branches, so you can start from
-  *any* branch — not just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`)
+  it, collapsing it into an "Archived" section. The branch you're on and the default
+  branch can't be archived; **Unarchive** has no such limit — it works even on the
+  branch you're checked out on. When creating, the **Base it on** picker is a
+  searchable list grouped into **Local** and **Remote** branches, so you can start
+  from *any* branch — not just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`)
   starts from the remote tip and leaves the new branch with **no upstream**, so its first
   push publishes it under its own name — pairs with pushing a branch without switching to it
   (below).

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -375,7 +375,10 @@ selection to compare a range.
 
 - **Amend** the most recent commit (reword, or fold in staged changes).
 - **Revert** — create a new commit that undoes a commit's changes.
-- **Cherry-pick** a commit onto the current branch.
+- **Cherry-pick** a commit onto the current branch, or **Cherry-pick to branch…** to copy
+  it (or a multi-selection) onto another branch without switching. A single commit that
+  conflicts pauses on the destination branch so you can resolve it and continue; a
+  multi-commit batch rolls back automatically on any failure.
 - **Reset** the current branch to a commit — a **mixed reset**, so the changes from later
   commits return to your working tree as uncommitted changes.
 - **Edit history** — open the interactive-rebase editor over your unpushed commits, where
@@ -432,7 +435,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   and labeled with the default branch's name.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
-  it, collapsing it into an "Archived" section. When creating, the **Base it on** picker is
+  it, collapsing it into an "Archived" section. The default branch can't be archived, and
+  **Unarchive** works even on the branch you're checked out on. When creating, the
+  **Base it on** picker is
   a searchable list grouped into **Local** and **Remote** branches, so you can start from
   *any* branch — not just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`)
   starts from the remote tip and leaves the new branch with **no upstream**, so its first
@@ -668,7 +673,9 @@ editor**: each conflict region shows **Current (ours)** over **Incoming (theirs)
 **Accept current**, **Accept incoming**, or **Accept both**, and the header adds whole-file
 **Accept all current** / **Accept all incoming** and **Open in editor**. Files mark
 themselves resolved as you go — the \`!\` badge clears — and the finish control stays
-disabled, saying so, until every conflict is resolved.
+disabled, saying so, until every conflict is resolved. When one side of a conflict removed
+a file, the editor names the removal instead of showing regions, and the same whole-file
+accept actions choose between keeping the file and taking the deletion.
 
 {{ai}}## Resolve conflicts with AI
 

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -27,7 +27,8 @@ import {
   useResetToCommit,
 } from "@/lib/git/queries";
 import { refNameWarning } from "@/lib/git/ref-name";
-import { toastError } from "@/lib/toast";
+import { isAppError } from "@/lib/tauri/invoke";
+import { toastError, toastErrorWithNote } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
 
 const onError = (e: unknown) => toastError(e);
@@ -189,6 +190,7 @@ export function CherryPickOntoDialog({
   const cherryPickOnto = useCherryPickOnto(repoPath);
   const destId = useId();
   const shownHashes = useRetained(hashes);
+  const count = shownHashes?.length ?? 0;
   function run() {
     if (!hashes || !branch) return;
     const target = branch;
@@ -210,7 +212,17 @@ export function CherryPickOntoDialog({
           onDone();
         },
         onError: (e) => {
-          onError(e);
+          // A paused pick leaves you on the destination branch and closes this
+          // dialog, so the toast is the only place left that can say where you
+          // are; the generic summary names the operation, never the branch.
+          if (isAppError(e) && e.kind === "conflict") {
+            toastErrorWithNote(
+              e,
+              `You're now on ${target} — resolve the conflicts there, then continue the cherry-pick.`,
+            );
+          } else {
+            onError(e);
+          }
           onClose();
         },
       },
@@ -227,11 +239,14 @@ export function CherryPickOntoDialog({
         <DialogHeader>
           <DialogTitle>Cherry-pick to branch</DialogTitle>
           <DialogDescription>
-            {shownHashes && shownHashes.length > 1
-              ? `Copies these ${shownHashes.length} commits onto the chosen branch and switches to it. `
+            {count > 1
+              ? `Copies these ${count} commits onto the chosen branch and switches to it. `
               : "Copies this commit onto the chosen branch and switches to it. "}
             They stay on {currentBranch ?? "this branch"} too. Commits already
-            present are skipped; any failure rolls the batch back automatically.
+            present are skipped;{" "}
+            {count > 1
+              ? "any failure rolls the whole batch back automatically."
+              : "the cherry-pick pauses on the destination branch, where you can resolve the conflict and continue; any other failure rolls it back automatically."}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -239,14 +239,22 @@ export function CherryPickOntoDialog({
         <DialogHeader>
           <DialogTitle>Cherry-pick to branch</DialogTitle>
           <DialogDescription>
-            {count > 1
-              ? `Copies these ${count} commits onto the chosen branch and switches to it. `
-              : "Copies this commit onto the chosen branch and switches to it. "}
-            They stay on {currentBranch ?? "this branch"} too. Commits already
-            present are skipped;{" "}
-            {count > 1
-              ? "any failure rolls the whole batch back automatically."
-              : "the cherry-pick pauses on the destination branch, where you can resolve the conflict and continue; any other failure rolls it back automatically."}
+            {count > 1 ? (
+              <>
+                Copies these {count} commits onto the chosen branch and switches
+                to it. They stay on {currentBranch ?? "this branch"} too.
+                Commits already present are skipped; any failure rolls the whole
+                batch back automatically.
+              </>
+            ) : (
+              <>
+                Copies this commit onto the chosen branch and switches to it. It
+                stays on {currentBranch ?? "this branch"} too. If the
+                destination already has it, it's skipped; a conflict pauses the
+                cherry-pick on the destination branch, where you can resolve it
+                and continue; any other failure rolls it back automatically.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -147,10 +147,20 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
   const currentBranch = status.data?.branch?.name ?? null;
   // Agent-session branches (`gd/session/*`) are app-internal — never offer them
   // as a cherry-pick target (it would switch to and cherry-pick onto one), like
-  // ComparePanel / BranchSwitcher.
-  const targetBranches = (branches.data ?? []).filter(
+  // ComparePanel / BranchSwitcher. Archived branches are hidden here for the same
+  // reason they are hidden elsewhere: they were archived to get them out of the way.
+  const pickOntoCandidates = (branches.data ?? []).filter(
     (b) => !b.isCurrent && !b.name.startsWith("gd/session/"),
   );
+  const targetBranches = pickOntoCandidates.filter((b) => !b.archived);
+  const noPickOntoTargets = targetBranches.length === 0;
+  // Why cherry-pick-to-branch is unavailable — in particular the case a repo full of
+  // (archived) branches makes look like a bug: every candidate is archived, and the
+  // remedy lives in the branch switcher rather than here.
+  const pickOntoDisabledHint =
+    pickOntoCandidates.length > 0
+      ? " (all other branches are archived — unarchive one first)"
+      : " (no other branches)";
 
   const branchForm = useAppForm({
     ...createRefFromCommitFormOpts,
@@ -549,10 +559,11 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
       return (
         <>
           <ContextMenuItem
-            disabled={targetBranches.length === 0}
+            disabled={noPickOntoTargets}
             onClick={() => openCherryPickOnto(commit.hash)}
           >
             Cherry-pick {selected.size} commits to branch…
+            {noPickOntoTargets && pickOntoDisabledHint}
           </ContextMenuItem>
           <ContextMenuItem disabled={!canSquash} onClick={openSquash}>
             Squash {selected.size} commits…
@@ -645,10 +656,11 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
           Cherry-pick commit
         </ContextMenuItem>
         <ContextMenuItem
-          disabled={targetBranches.length === 0}
+          disabled={noPickOntoTargets}
           onClick={() => openCherryPickOnto(commit.hash)}
         >
           Cherry-pick to branch…
+          {noPickOntoTargets && pickOntoDisabledHint}
         </ContextMenuItem>
         <ContextMenuItem
           disabled={!canEditHistory}

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -153,14 +153,6 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     (b) => !b.isCurrent && !b.name.startsWith("gd/session/"),
   );
   const targetBranches = pickOntoCandidates.filter((b) => !b.archived);
-  const noPickOntoTargets = targetBranches.length === 0;
-  // Why cherry-pick-to-branch is unavailable — in particular the case a repo full of
-  // (archived) branches makes look like a bug: every candidate is archived, and the
-  // remedy lives in the branch switcher rather than here.
-  const pickOntoDisabledHint =
-    pickOntoCandidates.length > 0
-      ? " (all other branches are archived — unarchive one first)"
-      : " (no other branches)";
 
   const branchForm = useAppForm({
     ...createRefFromCommitFormOpts,
@@ -469,6 +461,17 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
   const editHistoryHint = opInProgress
     ? " (finish the operation in Changes first)"
     : "";
+  // Why cherry-picking onto a branch is unavailable, in precedence order: an
+  // in-flight operation (the pick's own conflict path pauses one), then a repo
+  // whose every other branch is archived — offerable-looking, but not offered.
+  const pickOntoDisabledHint = (() => {
+    if (opInProgress) return " (finish the operation in Changes first)";
+    if (targetBranches.length > 0) return "";
+    if (pickOntoCandidates.length > 0)
+      return " (all other branches are archived — unarchive one first)";
+    return " (no other branches)";
+  })();
+  const canPickOnto = pickOntoDisabledHint === "";
   const editCommits = commits.slice(0, Math.max(editLen, 0));
   const editBase = commits[Math.max(editLen, 0)]?.hash ?? "";
 
@@ -559,11 +562,11 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
       return (
         <>
           <ContextMenuItem
-            disabled={noPickOntoTargets}
+            disabled={!canPickOnto}
             onClick={() => openCherryPickOnto(commit.hash)}
           >
             Cherry-pick {selected.size} commits to branch…
-            {noPickOntoTargets && pickOntoDisabledHint}
+            {pickOntoDisabledHint}
           </ContextMenuItem>
           <ContextMenuItem disabled={!canSquash} onClick={openSquash}>
             Squash {selected.size} commits…
@@ -656,11 +659,11 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
           Cherry-pick commit
         </ContextMenuItem>
         <ContextMenuItem
-          disabled={noPickOntoTargets}
+          disabled={!canPickOnto}
           onClick={() => openCherryPickOnto(commit.hash)}
         >
           Cherry-pick to branch…
-          {noPickOntoTargets && pickOntoDisabledHint}
+          {pickOntoDisabledHint}
         </ContextMenuItem>
         <ContextMenuItem
           disabled={!canEditHistory}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1219,6 +1219,18 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const div = divByName.get(branch.name);
     const canUpdate = Boolean(defaultName) && branch.name !== defaultName;
     const deletionBlocked = isDeletionBlocked(rulesConfig, branch.name);
+    // Archiving hides a branch from the branch surfaces, so it's refused for the
+    // branch you're on and for the default branch. Unarchiving is never refused —
+    // an archived branch can be checked out, and this is its only way back.
+    const archiveLabel = branch.archived ? "Unarchive" : "Archive";
+    // Best-effort by design: a null `defaultName` (still loading, or unresolvable)
+    // drops the default-branch guard rather than disabling Archive everywhere.
+    const archiveBlockedReason = (() => {
+      if (branch.archived) return null;
+      if (branch.isCurrent) return "current branch";
+      if (branch.name === defaultName) return "default branch";
+      return null;
+    })();
     // The worktree (other than the active checkout) this branch occupies, when
     // any — the Delete worktree… item gates on it (git refuses to remove the
     // main working tree).
@@ -1546,10 +1558,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             Copy branch name
           </ContextMenuItem>
           <ContextMenuItem
-            disabled={branch.isCurrent}
+            disabled={archiveBlockedReason !== null}
             onClick={() => setArchived(branch.name, !branch.archived)}
           >
-            {branch.archived ? "Unarchive" : "Archive"}
+            {archiveBlockedReason === null
+              ? archiveLabel
+              : `${archiveLabel} (${archiveBlockedReason})`}
           </ContextMenuItem>
           <ContextMenuSeparator />
           {inWorktree && (

--- a/src/features/repository/ConflictBanner.tsx
+++ b/src/features/repository/ConflictBanner.tsx
@@ -164,18 +164,21 @@ export function ConflictBanner({
               onClick={() =>
                 continueOp.mutate(op, {
                   onSuccess: (recorded) => {
-                    // The flag is per-commit: the conflicted pick was dropped as
-                    // empty, while a multi-commit sequencer may still have applied
-                    // the rest — so this names the skipped commit, never the whole
-                    // operation's outcome.
+                    // Only a resolution that emptied the pick reaches this: a commit
+                    // whose changes the destination already had never conflicts, so
+                    // it is skipped inside the pick itself and never pauses here.
+                    // The flag speaks for that one pick — a longer sequence may
+                    // still have applied its remaining commits.
                     if (!recorded) {
-                      toast.success(
-                        "Commit skipped — the destination already had its changes.",
+                      toast.info(
+                        "Commit skipped — your resolution left nothing to commit.",
                       );
                       return;
                     }
                     toast.success(
-                      op === "merge" ? "Merge completed" : `${opVerb} continued`,
+                      op === "merge"
+                        ? "Merge completed"
+                        : `${opVerb} continued`,
                     );
                   },
                   onError,

--- a/src/features/repository/ConflictBanner.tsx
+++ b/src/features/repository/ConflictBanner.tsx
@@ -163,12 +163,21 @@ export function ConflictBanner({
               }
               onClick={() =>
                 continueOp.mutate(op, {
-                  onSuccess: () =>
+                  onSuccess: (recorded) => {
+                    // The flag is per-commit: the conflicted pick was dropped as
+                    // empty, while a multi-commit sequencer may still have applied
+                    // the rest — so this names the skipped commit, never the whole
+                    // operation's outcome.
+                    if (!recorded) {
+                      toast.success(
+                        "Commit skipped — the destination already had its changes.",
+                      );
+                      return;
+                    }
                     toast.success(
-                      op === "merge"
-                        ? "Merge completed"
-                        : `${opVerb} continued`,
-                    ),
+                      op === "merge" ? "Merge completed" : `${opVerb} continued`,
+                    );
+                  },
                   onError,
                 })
               }

--- a/src/features/repository/ConflictBanner.tsx
+++ b/src/features/repository/ConflictBanner.tsx
@@ -41,6 +41,20 @@ const OP_LABELS: Record<
   },
 };
 
+/** What Abort undoes, per op. A cherry-pick can be reached from "Cherry-pick to
+ *  branch…", which switched branches to get here and whose abort does NOT switch
+ *  back — so its copy promises this branch back, never the whole repository. */
+const ABORT_DESCRIPTIONS: Record<RepoOp, string> = {
+  merge:
+    "Abandons the in-progress merge and restores the repository to the state before it started. Any conflict resolutions you've made will be lost.",
+  rebase:
+    "Abandons the in-progress rebase and restores the repository to the state before it started. Any conflict resolutions you've made will be lost.",
+  "cherry-pick":
+    "Abandons the in-progress cherry-pick and restores this branch to the state before the pick started. You stay on this branch, and any conflict resolutions you've made will be lost.",
+  revert:
+    "Abandons the in-progress revert and restores the repository to the state before it started. Any conflict resolutions you've made will be lost.",
+};
+
 /** The `RepoOpState` flags that name an operation. Derived, so a renamed field
  *  breaks here; `editPaused` is excluded because it modifies `rebasing` rather
  *  than naming an op of its own. */
@@ -172,7 +186,7 @@ export function ConflictBanner({
                   <DialogDescription>
                     {editPaused
                       ? "Abandons the rebase and restores your branch to its original history. Any changes you've amended into this commit are lost."
-                      : `Abandons the in-progress ${op} and restores the repository to the state before it started. Any conflict resolutions you've made will be lost.`}
+                      : ABORT_DESCRIPTIONS[op]}
                   </DialogDescription>
                 </DialogHeader>
                 <DialogFooter>

--- a/src/features/repository/ConflictFileView.tsx
+++ b/src/features/repository/ConflictFileView.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { HighlightedCode } from "@/features/diff/HighlightedCode";
 import { hasConflictMarkers } from "@/lib/ai/conflict-prompt";
 import { openWithDefault, openWithProgram } from "@/lib/git/api";
+import type { ConflictSides } from "@/lib/git/conflict";
 import {
   type ConflictChoice,
   parseConflictSegments,
@@ -26,6 +27,87 @@ import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { toastError } from "@/lib/toast";
 
 const baseName = (path: string) => path.split("/").pop() || path;
+
+/** Which side has no version at this path, when exactly one of them does — the
+ *  modify/delete shape. `null` for a content conflict (both sides present) and
+ *  when both are absent, neither of which is about a removal to accept. */
+function deletedSide(sides: ConflictSides): "ours" | "theirs" | null {
+  const ourGone = sides.ours == null;
+  if (ourGone === (sides.theirs == null)) return null;
+  return ourGone ? "ours" : "theirs";
+}
+
+/** The notice per removing side. "Removed" rather than "deleted": a side that
+ *  renamed the file away also has no version at this path. */
+const DELETION_COPY = {
+  ours: {
+    lead: "The current branch removed this file; the incoming change edited it (below).",
+    takesDeletion: "Accept all current",
+    keepsFile: "Accept all incoming",
+  },
+  theirs: {
+    lead: "The incoming change removed this file; the current branch edited it (below).",
+    takesDeletion: "Accept all incoming",
+    keepsFile: "Accept all current",
+  },
+} as const;
+
+/**
+ * What a conflicted file shows when the parser found no regions to resolve: a
+ * side with no version at this path, an empty file, or markers it can't trust.
+ * Each keeps the header's whole-file actions as the way through.
+ */
+function ConflictFallback({
+  path,
+  sides,
+}: {
+  path: string;
+  sides: ConflictSides;
+}) {
+  // The index stages decide first: a modify/delete leaves the SURVIVING side's
+  // content in the tree, marker-free, so the parser's null here means a removal
+  // to accept rather than markers it failed on. Ordered ahead of the empty-file
+  // check, which is a heuristic and would swallow a surviving side that is empty.
+  const deleted = deletedSide(sides);
+  if (deleted !== null) {
+    const copy = DELETION_COPY[deleted];
+    return (
+      <>
+        <p className="border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+          {copy.lead} <span className="font-medium">{copy.takesDeletion}</span>{" "}
+          takes the deletion,{" "}
+          <span className="font-medium">{copy.keepsFile}</span> keeps the file.
+        </p>
+        <HighlightedCode path={path} content={sides.working || " "} />
+      </>
+    );
+  }
+
+  if (sides.working.trim() === "") {
+    // A both-deleted (or empty) conflict — nothing to merge as text.
+    return (
+      <p className="p-4 text-xs text-muted-foreground">
+        This file was deleted on one or both sides — there's nothing to merge.
+        Take a side with <span className="font-medium">Accept all current</span>{" "}
+        / <span className="font-medium">incoming</span>, or open it in your
+        editor.
+      </p>
+    );
+  }
+
+  // Couldn't parse the markers cleanly (malformed or ambiguous, e.g. a bare
+  // 7-char marker inside the content) — show the raw file so nothing is hidden,
+  // and keep the whole-file actions in the header.
+  return (
+    <>
+      <p className="border-b bg-warning/10 px-3 py-1.5 text-[11px] text-warning">
+        Couldn't cleanly parse the conflict markers in this file. Resolve it
+        with the header actions or in your editor.
+      </p>
+      <HighlightedCode path={path} content={sides.working} />
+    </>
+  );
+}
 
 /**
  * The conflicted-file editor: renders the file with git's conflict markers
@@ -172,27 +254,7 @@ export function ConflictFileView({
             editor.
           </p>
         ) : segments === null ? (
-          file.data.working.trim() === "" ? (
-            // A both-deleted (or empty) conflict — nothing to merge as text.
-            <p className="p-4 text-xs text-muted-foreground">
-              This file was deleted on one or both sides — there's nothing to
-              merge. Take a side with{" "}
-              <span className="font-medium">Accept all current</span> /{" "}
-              <span className="font-medium">incoming</span>, or open it in your
-              editor.
-            </p>
-          ) : (
-            // Couldn't parse the markers cleanly (malformed or ambiguous, e.g. a
-            // bare 7-char marker inside the content) — show the raw file so
-            // nothing is hidden, and keep the whole-file actions in the header.
-            <>
-              <p className="border-b bg-warning/10 px-3 py-1.5 text-[11px] text-warning">
-                Couldn't cleanly parse the conflict markers in this file.
-                Resolve it with the header actions or in your editor.
-              </p>
-              <HighlightedCode path={path} content={file.data.working} />
-            </>
-          )
+          <ConflictFallback path={path} sides={file.data} />
         ) : (
           segments.map((seg, idx) => {
             if (seg.kind === "context") {

--- a/src/lib/ai/conflict-prompt.ts
+++ b/src/lib/ai/conflict-prompt.ts
@@ -1,13 +1,14 @@
 import type { ConflictSides } from "@/lib/git/conflict";
 import { safeSlice } from "./truncate";
 
-const CONFLICT_SYSTEM = `You resolve a single git merge conflict. You are given the conflicted file WITH its conflict markers, plus — when available — the clean BASE (common ancestor), OURS (current branch / HEAD side), and THEIRS (incoming side) versions of the whole file.
+const CONFLICT_SYSTEM = `You resolve a single git merge conflict. You are given the conflicted file as it stands in the working tree. It usually carries its conflict markers, but a modify/delete conflict leaves only the surviving side's content, with no markers at all. You also get, when available, the clean BASE (common ancestor), OURS (current branch / HEAD side), and THEIRS (incoming side) versions of the whole file; a section stating that a side REMOVED the file has no version to show.
 
 Produce the correct merged file:
 - Integrate the INTENT of both sides. Keep every non-conflicting change from each. Do not discard one side wholesale unless that side made no meaningful change relative to the base.
 - Remove ALL conflict markers (\`<<<<<<<\`, \`|||||||\`, \`=======\`, \`>>>>>>>\`). The output must be a clean, valid file with no markers left.
 - Preserve the file's existing language, formatting, indentation style, and trailing newline. Do not reformat or "improve" code outside the conflicting regions.
 - When the two sides genuinely contradict (not just additive), prefer the combination that keeps the code correct and compiling; if you truly cannot tell, favor OURS but keep THEIRS's additions that don't conflict.
+- When one side REMOVED the file, build on the surviving side's content. Never answer with a deletion or an empty file — the user takes a removal with the whole-file accept actions instead.
 
 Output ONLY the complete resolved file contents inside a single fenced code block (\`\`\`). Output the ENTIRE file, not just the changed region. Put nothing before or after the block — no explanation, no commentary, no summary of what you changed.`;
 
@@ -22,13 +23,25 @@ export interface ConflictPromptInput {
  *  The backend already refuses files over 256 KB; this trims each rendered side. */
 const SECTION_MAX = 80_000;
 
-function section(title: string, body: string | null): string | null {
-  if (body == null) return null;
+function section(title: string, body: string): string {
   const clipped =
     body.length > SECTION_MAX
       ? `${safeSlice(body, SECTION_MAX)}\n[…truncated for length…]`
       : body;
   return `## ${title}\n\`\`\`\n${clipped}\n\`\`\``;
+}
+
+/** A side that has no index stage, rendered as `absent` prose rather than
+ *  dropped: a silently missing OURS/THEIRS reads to the model as a one-sided
+ *  conflict, so it merges the surviving side against nothing and never learns
+ *  the other side has no version here. */
+function sideSection(
+  title: string,
+  body: string | null,
+  absent: string,
+): string {
+  if (body == null) return `## ${title}\n${absent}`;
+  return section(title, body);
 }
 
 export function buildConflictPrompt(input: ConflictPromptInput): {
@@ -44,16 +57,34 @@ export function buildConflictPrompt(input: ConflictPromptInput): {
   }
 
   const { sides } = input;
+  // The working file is the primary input — on a content conflict its markers
+  // label each side in place, and on a modify/delete it is the surviving side
+  // alone. The clean sides below are supplementary context.
+  //
+  // The model is never asked to PROPOSE a deletion: the accept path writes file
+  // contents by contract (`ConflictResolveView`), so that stays deferred.
   const promptParts = [
     `Resolve the merge conflict in \`${input.path}\`.`,
-    // The marked working file is the primary input — its markers label each side
-    // in place. The clean sides below are supplementary context.
-    section("Conflicted file (with markers)", sides.working),
-    section("OURS — current branch / HEAD side", sides.ours),
-    section("THEIRS — incoming side", sides.theirs),
-    section("BASE — common ancestor", sides.base),
+    section("Conflicted file (working tree)", sides.working),
+    sideSection(
+      "OURS — current branch / HEAD side",
+      sides.ours,
+      "The current branch REMOVED this file (deleted or renamed away).",
+    ),
+    sideSection(
+      "THEIRS — incoming side",
+      sides.theirs,
+      "The incoming side REMOVED this file (deleted or renamed away).",
+    ),
+    // Observation, not diagnosis: stage 1 is missing for add/add, but also for
+    // other shapes, so this never asserts a cause the index can't confirm.
+    sideSection(
+      "BASE — common ancestor",
+      sides.base,
+      "No common-ancestor version for this path.",
+    ),
     "Output the fully merged file contents in a single fenced code block.",
-  ].filter((p): p is string => Boolean(p));
+  ];
 
   return {
     system: systemParts.join("\n\n"),

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -440,9 +440,11 @@ export interface CherryPickRangeResult {
 }
 
 /** Copies `hashes` (oldest-first) onto `targetBranch` and leaves you there.
- *  A failed pick rolls `targetBranch` back to its prior tip and returns you
- *  to your starting branch; the error says when either rollback step failed
- *  and how to recover. */
+ *  A single commit that conflicts stops on `targetBranch` with the pick in
+ *  progress, for the conflict banner to continue or abort. Every other failure
+ *  (and any failure in a multi-commit batch) rolls `targetBranch` back to its
+ *  prior tip and returns you to your starting branch; the error says when
+ *  either rollback step failed and how to recover. */
 export const gitCherryPickOnto = (
   repoPath: string,
   hashes: string[],

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -307,9 +307,10 @@ export const gitOpAbort = (repoPath: string, op: RepoOp) =>
   invoke<void>("git_op_abort", { repoPath, op });
 
 /** Resolves true when the operation completed normally, false when the pending
- *  cherry-pick was skipped as empty (its changes were already on this branch).
- *  Per-commit: a skip can still let the rest of a multi-commit sequence apply,
- *  so false never means the whole operation committed nothing. */
+ *  cherry-pick was skipped because the resolution left nothing to commit. The
+ *  flag speaks for that pick alone: it fully describes a single-commit
+ *  cherry-pick, while a longer sequence may still have applied its remaining
+ *  picks. */
 export const gitOpContinue = (repoPath: string, op: RepoOp) =>
   invoke<boolean>("git_op_continue", { repoPath, op });
 

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -306,8 +306,12 @@ export const gitOpState = (repoPath: string) =>
 export const gitOpAbort = (repoPath: string, op: RepoOp) =>
   invoke<void>("git_op_abort", { repoPath, op });
 
+/** Resolves true when the operation completed normally, false when the pending
+ *  cherry-pick was skipped as empty (its changes were already on this branch).
+ *  Per-commit: a skip can still let the rest of a multi-commit sequence apply,
+ *  so false never means the whole operation committed nothing. */
 export const gitOpContinue = (repoPath: string, op: RepoOp) =>
-  invoke<void>("git_op_continue", { repoPath, op });
+  invoke<boolean>("git_op_continue", { repoPath, op });
 
 /** Base64 file content at a rev (null rev = working tree; null result = absent). */
 export const gitFileBase64 = (

--- a/src/lib/git/conflict.ts
+++ b/src/lib/git/conflict.ts
@@ -2,7 +2,8 @@ import { invoke } from "@/lib/tauri/invoke";
 
 /** The clean and marked versions of one conflicted file, for AI resolution. */
 export interface ConflictSides {
-  /** The working-tree file with conflict markers — the primary input. */
+  /** The working-tree file with conflict markers — the primary input. Not every
+   *  conflict has markers; a modify/delete file is the surviving side's content. */
   working: string;
   /** Common-ancestor version (stage 1); null for add/add conflicts. */
   base: string | null;

--- a/src/lib/git/conflict.ts
+++ b/src/lib/git/conflict.ts
@@ -35,7 +35,8 @@ export const resolveConflict = (
 ) => invoke<void>("git_resolve_conflict", { repoPath, path, content, stage });
 
 /** Resolves a whole conflicted file by taking one side: "ours" (current/HEAD)
- *  or "theirs" (incoming). Writes that side + stages it. Works for binary too. */
+ *  or "theirs" (incoming). Writes that side + stages it, or removes the file when
+ *  that side has no version at this path. Works for binary too. */
 export const checkoutConflictSide = (
   repoPath: string,
   path: string,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3119,8 +3119,9 @@ function useRepoMutation<TArgs, TData>(
     refetchBeforeSuccess?: boolean;
     /** Runs on success before any invalidation fires (react-query awaits
      *  `onSuccess` ahead of `onSettled`), so store state can be fixed up while the
-     *  cache still describes the pre-mutation world. Must not throw: under
-     *  `refetchBeforeSuccess` a throw would skip the invalidation entirely. */
+     *  cache still describes the pre-mutation world. Must be synchronous — an
+     *  async callback's rejection escapes the containment; a synchronous throw
+     *  is contained and logged, and the invalidation still runs. */
     onSuccess?: (data: TData, variables: TArgs) => void;
   } = {},
 ) {
@@ -3137,18 +3138,27 @@ function useRepoMutation<TArgs, TData>(
         queryClient.invalidateQueries({ queryKey }),
       ),
     );
+  // A caller's hook must not take the mutation down with it: a throw here would
+  // otherwise skip the invalidation, or report a succeeded mutation as failed.
+  const notifySuccess = (data: TData, variables: TArgs) => {
+    try {
+      opts.onSuccess?.(data, variables);
+    } catch (e) {
+      console.error("[queries] mutation onSuccess failed", e);
+    }
+  };
   return useMutation({
     mutationFn,
     ...(opts.refetchBeforeSuccess
       ? {
           onSuccess: async (data: TData, variables: TArgs) => {
-            opts.onSuccess?.(data, variables);
+            notifySuccess(data, variables);
             await invalidate();
             void invalidateAfter();
           },
         }
       : {
-          onSuccess: opts.onSuccess,
+          onSuccess: notifySuccess,
           onSettled: () => {
             void invalidate();
             void invalidateAfter();

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
+import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
 import { COLD_START_NO_GH, COLD_START_NO_GIT } from "@/lib/test-mode";
 import { toastError } from "@/lib/toast";
@@ -3116,6 +3117,11 @@ function useRepoMutation<TArgs, TData>(
      *  commit uses this so the emptied list, cleared draft, and toast appear
      *  together. (As a result it does NOT invalidate on error.) */
     refetchBeforeSuccess?: boolean;
+    /** Runs on success before any invalidation fires (react-query awaits
+     *  `onSuccess` ahead of `onSettled`), so store state can be fixed up while the
+     *  cache still describes the pre-mutation world. Must not throw: under
+     *  `refetchBeforeSuccess` a throw would skip the invalidation entirely. */
+    onSuccess?: (data: TData, variables: TArgs) => void;
   } = {},
 ) {
   const queryClient = useQueryClient();
@@ -3135,12 +3141,14 @@ function useRepoMutation<TArgs, TData>(
     mutationFn,
     ...(opts.refetchBeforeSuccess
       ? {
-          onSuccess: async () => {
+          onSuccess: async (data: TData, variables: TArgs) => {
+            opts.onSuccess?.(data, variables);
             await invalidate();
             void invalidateAfter();
           },
         }
       : {
+          onSuccess: opts.onSuccess,
           onSettled: () => {
             void invalidate();
             void invalidateAfter();
@@ -3803,8 +3811,20 @@ export function useStashCount(repo: string) {
 }
 
 export function useRenameBranch(repo: string) {
-  return useRepoMutation(repo, (args: { oldName: string; newName: string }) =>
-    api.gitRenameBranch(repo, args.oldName, args.newName),
+  return useRepoMutation(
+    repo,
+    (args: { oldName: string; newName: string }) =>
+      api.gitRenameBranch(repo, args.oldName, args.newName),
+    {
+      // Re-key the branch's commit draft before the status refetch reports the new
+      // name, so the draft (and any generation streaming into it) survives.
+      // Renames from outside the app (MCP, a terminal `git branch -m`) have no such
+      // hook and still lose the draft when the ambient poll flips the key.
+      onSuccess: (_data, args) =>
+        useUiStore
+          .getState()
+          .migrateCommitDraft(repo, args.oldName, args.newName),
+    },
   );
 }
 

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -389,8 +389,11 @@ interface UiState {
    *  switch). The previous draft is already mirrored in `commitDrafts`. */
   loadCommitDraft: (key: string) => void;
   /** Carry a commit draft across a branch rename: moves its `commitDrafts` entry
-   *  and, when the renamed branch owns the live fields, retargets `activeDraftKey`
-   *  so nothing in flight is orphaned by the new name. */
+   *  and, when the renamed branch owns the live fields, retargets `activeDraftKey`.
+   *  Always records the old -> new remap so consumers holding the old key (the
+   *  generation guard, a `restoreCommitDraft` deferred behind a commit) resolve
+   *  to the renamed draft — key identity, not stream survival: a poll that flips
+   *  the key first has already cancelled an in-flight generation's next chunk. */
   migrateCommitDraft: (
     repoPath: string,
     fromBranch: string,
@@ -722,17 +725,22 @@ export const useUiStore = create<UiState>()((set, get) => {
           else delete drafts[newKey];
           result.commitDrafts = drafts;
         }
+        // Recorded for every rename, not just the retargeting one: the status
+        // poll can flip the key first, and a generation or a deferred restore
+        // still holds the old key. Collapse existing entries onto the new key so
+        // a chain of renames stays one lookup deep, dropping any identities.
+        const remaps: Record<string, string> = {};
+        for (const [from, to] of Object.entries(s.draftKeyRemaps)) {
+          const next = to === oldKey ? newKey : to;
+          if (next !== from) remaps[from] = next;
+        }
+        remaps[oldKey] = newKey;
+        // A freshly claimed name has no live owner elsewhere, so any surviving
+        // mapping AWAY from it is dead — left in place it would hijack the key.
+        delete remaps[newKey];
+        result.draftKeyRemaps = remaps;
         if (retargeting) {
           result.activeDraftKey = newKey;
-          // Collapse existing remaps onto the new key so a chain of renames stays
-          // one lookup deep, and drop any that become identities.
-          const remaps: Record<string, string> = {};
-          for (const [from, to] of Object.entries(s.draftKeyRemaps)) {
-            const next = to === oldKey ? newKey : to;
-            if (next !== from) remaps[from] = next;
-          }
-          remaps[oldKey] = newKey;
-          result.draftKeyRemaps = remaps;
         } else if (s.activeDraftKey === newKey && moved) {
           // The status poll can flip the key to the new name before this runs,
           // which blanks the live fields; put the carried-over draft back into

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -162,12 +162,22 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   commitAiGenerated: false,
   amendingHash: null,
   activeDraftKey: null,
+  draftKeyRemaps: {},
 };
 
 /** Key a commit draft so each repo + branch keeps its own message. A git branch
  *  name can't contain a colon, so the key stays unambiguous. */
 export function commitDraftKey(repoPath: string, branch: string): string {
   return `${repoPath}:${branch}`;
+}
+
+/** Where the draft captured under `key` lives now, following branch renames.
+ *  Remaps are collapsed on write, so one lookup covers a chain of renames. */
+export function resolveDraftKey(
+  remaps: Record<string, string>,
+  key: string | null,
+): string | null {
+  return key === null ? null : (remaps[key] ?? key);
 }
 
 function isEmptyDraft(d: CommitDraft): boolean {
@@ -276,6 +286,10 @@ interface UiState {
    *  The live commit fields above mirror the entry for `activeDraftKey`. */
   commitDrafts: Record<string, CommitDraft>;
   activeDraftKey: string | null;
+  /** Draft keys a branch rename moved: captured key -> where that draft lives now.
+   *  Lets a generation started before the rename recognise its own draft after it;
+   *  a genuine branch switch or a repo switch clears the whole record. */
+  draftKeyRemaps: Record<string, string>;
 
   openRepo: (info: RepoInfo) => void;
   closeRepo: () => void;
@@ -374,6 +388,14 @@ interface UiState {
   /** Point the live commit fields at `key`'s saved draft (load on repo/branch
    *  switch). The previous draft is already mirrored in `commitDrafts`. */
   loadCommitDraft: (key: string) => void;
+  /** Carry a commit draft across a branch rename: moves its `commitDrafts` entry
+   *  and, when the renamed branch owns the live fields, retargets `activeDraftKey`
+   *  so nothing in flight is orphaned by the new name. */
+  migrateCommitDraft: (
+    repoPath: string,
+    fromBranch: string,
+    toBranch: string,
+  ) => void;
 }
 
 export const useUiStore = create<UiState>()((set, get) => {
@@ -451,6 +473,7 @@ export const useUiStore = create<UiState>()((set, get) => {
     amendingHash: null,
     commitDrafts: {},
     activeDraftKey: null,
+    draftKeyRemaps: {},
 
     openRepo: (info) =>
       startViewTransition(() =>
@@ -634,18 +657,22 @@ export const useUiStore = create<UiState>()((set, get) => {
       }),
     restoreCommitDraft: (draft, key) =>
       set((s) => {
+        // `key` is captured before the commit is awaited, so a rename landing in
+        // between must restore where that draft lives now — the same identity
+        // seam the generation guard resolves through.
+        const target = resolveDraftKey(s.draftKeyRemaps, key);
         const result: Partial<UiState> = {};
         // Put the message back into the draft it belonged to.
-        if (key) {
+        if (target) {
           const drafts = { ...s.commitDrafts };
-          if (isEmptyDraft(draft)) delete drafts[key];
-          else drafts[key] = draft;
+          if (isEmptyDraft(draft)) delete drafts[target];
+          else drafts[target] = draft;
           result.commitDrafts = drafts;
         }
         // Only touch the live fields if that draft is still the active one —
         // if the user switched branches mid-commit, leave their current draft
         // alone (the restored message reappears when they switch back).
-        if (s.activeDraftKey === key) {
+        if (s.activeDraftKey === target) {
           result.commitTitle = draft.title;
           result.commitBody = draft.body;
           result.commitCoAuthors = draft.coAuthors;
@@ -666,12 +693,57 @@ export const useUiStore = create<UiState>()((set, get) => {
         const d = s.commitDrafts[key] ?? EMPTY_COMMIT_DRAFT;
         return {
           activeDraftKey: key,
+          // A real switch retires the rename record: anything it was keeping
+          // alive is bound to the key we're leaving, so it can't apply here.
+          draftKeyRemaps: {},
           commitTitle: d.title,
           commitBody: d.body,
           commitCoAuthors: d.coAuthors,
           commitAiGenerated: d.aiGenerated,
           amendingHash: d.amendingHash,
         };
+      }),
+    migrateCommitDraft: (repoPath, fromBranch, toBranch) =>
+      set((s) => {
+        const oldKey = commitDraftKey(repoPath, fromBranch);
+        const newKey = commitDraftKey(repoPath, toBranch);
+        if (oldKey === newKey) return {};
+        const result: Partial<UiState> = {};
+        const moved = s.commitDrafts[oldKey];
+        const retargeting = s.activeDraftKey === oldKey;
+        // A draft already sitting under the new name belongs to a branch that no
+        // longer answers to it, so the state carried across the rename wins —
+        // including an empty one, which must leave no entry for the live fields
+        // (about to point here) to contradict.
+        if (moved || (retargeting && s.commitDrafts[newKey])) {
+          const drafts = { ...s.commitDrafts };
+          delete drafts[oldKey];
+          if (moved) drafts[newKey] = moved;
+          else delete drafts[newKey];
+          result.commitDrafts = drafts;
+        }
+        if (retargeting) {
+          result.activeDraftKey = newKey;
+          // Collapse existing remaps onto the new key so a chain of renames stays
+          // one lookup deep, and drop any that become identities.
+          const remaps: Record<string, string> = {};
+          for (const [from, to] of Object.entries(s.draftKeyRemaps)) {
+            const next = to === oldKey ? newKey : to;
+            if (next !== from) remaps[from] = next;
+          }
+          remaps[oldKey] = newKey;
+          result.draftKeyRemaps = remaps;
+        } else if (s.activeDraftKey === newKey && moved) {
+          // The status poll can flip the key to the new name before this runs,
+          // which blanks the live fields; put the carried-over draft back into
+          // them so the rename never costs the user their message.
+          result.commitTitle = moved.title;
+          result.commitBody = moved.body;
+          result.commitCoAuthors = moved.coAuthors;
+          result.commitAiGenerated = moved.aiGenerated;
+          result.amendingHash = moved.amendingHash;
+        }
+        return result;
       }),
   };
 });


### PR DESCRIPTION
"Cherry-pick to branch…" is the app's only route for sending a commit to another branch, but any conflict rolled the whole thing back and left the user with no way forward inside the app. A single-commit pick now stops on the destination branch with the pick in progress, so the existing conflict banner can resolve and continue it. Alongside that, this batch fixes three adjacent gaps that showed up while exercising the flow: whole-file accepts on a modify/delete conflict, archived branches leaking into cherry-pick targets, and commit drafts lost to a branch rename.

### Cherry-pick pauses instead of rolling back

- `cherry_pick_onto_with_timeouts` in `src-tauri/src/git/ops.rs` routes a single-commit failure through `classify_failure` and returns the structured `AppError::Conflict` without rolling back, leaving `CHERRY_PICK_HEAD` and HEAD on the target branch. Multi-commit batches, and single-commit failures that add no conflict (a merge commit without `-m`), keep the existing rollback funnel.
- Adds an `op_in_progress` guard ahead of `ensure_clean_tree` in the same function: a paused pick with its resolutions staged has a clean tree, so the tree check alone would wave a second run through into git's raw "cannot switch branch while cherry-picking".
- `op_continue` takes the `cherry-pick --skip` escape when git refuses `--continue` with "is now empty" / "--allow-empty", so a resolution that keeps the destination's own version can still finish from the banner. Scoped to `cherry-pick`, since `revert --continue` writes no matching advice.
- The rolled-back verdict now appends a line retiring git's own continue/abort hints, but only when the reset actually succeeded.
- `CherryPickOntoDialog` in `src/features/history/HistoryDialogs.tsx` reports a conflict with `toastErrorWithNote`, naming the branch you were switched to, and its description text now differs for a single commit versus a batch.
- `ABORT_DESCRIPTIONS` in `src/features/repository/ConflictBanner.tsx` replaces the generic per-op sentence; the cherry-pick entry promises this branch back rather than the whole repository, since Abort does not switch you back.
- Updates the contract docs on `gitCherryPickOnto` (`src/lib/git/api.ts`) and `git_cherry_pick_onto`, and adds tests covering the pause, the re-entry refusal, the non-conflict rollback, and the emptied-pick continue (`cherry_pick_onto_single_conflict_pauses_on_the_target` and siblings).

### Modify/delete conflicts

- `git_checkout_conflict_side_core` in `src-tauri/src/git/conflict.rs` reads the unmerged stages via a new `unmerged_stages` helper and, when the chosen side has no stage at that path, takes the removal with `git rm` instead of a `checkout --ours/--theirs` that would exit 1. The `rm` is gated on the path being unmerged right now, so a stale second accept on an already-resolved path can't delete the file; an accept arriving after the removal already landed settles as a no-op.
- `ConflictFileView.tsx` gains a `ConflictFallback` component with `deletedSide` and `DELETION_COPY`: it names which side removed the file and which accept action takes the deletion versus keeps the file, ahead of the pre-existing empty-file and unparseable-markers fallbacks, which move into the same component.
- `src/lib/ai/conflict-prompt.ts` renders an absent OURS/THEIRS/BASE as explicit prose through a new `sideSection` rather than dropping the section, so the model doesn't read a modify/delete as a one-sided conflict; the system prompt describes the marker-free working file and forbids answering with a deletion.
- New Rust tests build a real modify/delete fixture (`modify_delete_repo`) and cover both deleting sides, the surviving side, and the two repeat-accept guards.

### Archived branches

- `HistoryPanel.tsx` splits `pickOntoCandidates` from `targetBranches` so archived branches are no longer offered as cherry-pick destinations, and adds `pickOntoDisabledHint` to say why the menu item is disabled when every other branch is archived.
- `BranchSwitcher.tsx` derives `archiveBlockedReason`: Archive is refused on the current branch and on the default branch with the reason in the label, while Unarchive stays available on any branch, including the one you're checked out on.

### Commit drafts across a branch rename

- `src/lib/stores/ui.ts` adds `draftKeyRemaps`, `resolveDraftKey`, and `migrateCommitDraft`, which moves the draft to the new key and retargets `activeDraftKey`. `loadCommitDraft` clears the remaps on a genuine branch switch, `restoreCommitDraft` resolves through them, and `CROSS_REPO_RESET` covers the new field.
- `useRepoMutation` in `src/lib/git/queries.ts` gains an `onSuccess` option that runs before invalidation, and `useRenameBranch` uses it to migrate the draft ahead of the status refetch reporting the new name.
- `useGenerateCommitMessage.ts` resolves its captured `startKey` through the remaps in `keyMoved`, so a rename mid-generation no longer looks like a branch move and cancels the run.

### Documentation

- Four `changelog.d/` fragments: `changed-cherry-pick-onto-conflict.md`, `fixed-accept-deleted-side.md`, `fixed-archived-branch-handling.md`, `fixed-rename-keeps-commit-draft.md`.
- `src/features/help/content.ts` updates the history section (cherry-pick to branch, pause versus batch rollback), the branch section (default branch can't be archived, Unarchive on the current branch), and the conflict section (removal notice and what the whole-file accepts do).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cherry-picking between branches with clearer single-commit conflict resolution and multi-commit rollback behavior.
  * Added safer handling for file-deletion conflicts, including accurate conflict labels and resolution guidance.
  * Added branch archiving safeguards, including active-branch filtering and protection for the current and default branches.
  * Preserved commit drafts when renaming branches, including in-progress generated messages.
  * Added clearer operation-specific abort messages and conflict-resolution guidance.

* **Documentation**
  * Updated help content and in-app guidance for cherry-picking, conflicts, and branch archiving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->