### PR TITLE
fix(push,oplog,worktrees,branches): explain blocked pushes and pause stopped cherry-picks

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -96,6 +96,13 @@ dialog.
   chips, the discussion upvote chip) take the SAME contract from the shared
   `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
   (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
+- Worktree actions gate on in-flight removal/promote state: menu items disable
+  with the parenthetical reason riding the label (a disabled menu item can't
+  carry a tooltip), and mutation choke points re-check at fire time —
+  `useIsRemovingWorktree`/`useWorktreeRemovals` for render,
+  `refuseWhileLeaving` (WorktreesDialog.tsx) plus `isWorktreePromoting`
+  (worktree-removal store; fire-time only, deliberately non-reactive) for the
+  refusal toast.
 - Per-variant copy/labels/glyphs are `Record` lookups, never ternary chains:
   an exact union discriminant gets a total `Record` (compiler
   exhaustiveness); a wide wire string gets `Partial<Record>` + explicit
@@ -166,7 +173,11 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
   pushes via `build_push_args` (git/remote.rs) — never construct an inline
   refspec or re-derive the validation.
 - **Rust tests never read the real settings store** — use the
-  `TEST_STORE_DIR` seam in `app_store.rs` (arm 0 of `store_path`).
+  `TEST_STORE_DIR` seam in `app_store.rs` (arm 0 of `store_path`). The other
+  app-data modules carry their own seams with the opposite arm order
+  (`oplog.rs` `GD_OPLOG_DIR`, `review_notes.rs` `GD_REVIEW_NOTES_DIR`:
+  env override outranks the `cfg!(test)` temp arm; both ship in release) —
+  a new store module mirrors one of these, never resolves app-data bare.
 - **Forge gating:** per-action `Implemented` flags. Shared-with-GitHub
   controls gate on `canWrite || forgeFeatureReady` (GitHub must be zero-diff);
   provider-only controls gate on `forgeFeatureReady` alone with the flag

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -178,6 +178,11 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
   (`oplog.rs` `GD_OPLOG_DIR`, `review_notes.rs` `GD_REVIEW_NOTES_DIR`:
   env override outranks the `cfg!(test)` temp arm; both ship in release) —
   a new store module mirrors one of these, never resolves app-data bare.
+  Concurrency: `oplog.rs` holds a process-LOCAL mutex per store mutation,
+  `review_notes.rs` relies on atomic whole-file replace — NEITHER serializes
+  across processes, and the MCP server writes both stores, so every write
+  stays best-effort/last-writer-wins; a new store module picks its shape
+  deliberately, never assuming a lock covers the other process.
 - **Forge gating:** per-action `Implemented` flags. Shared-with-GitHub
   controls gate on `canWrite || forgeFeatureReady` (GitHub must be zero-diff);
   provider-only controls gate on `forgeFeatureReady` alone with the flag

--- a/changelog.d/changed-cherry-pick-onto-conflict.md
+++ b/changelog.d/changed-cherry-pick-onto-conflict.md
@@ -1,6 +1,7 @@
 - **Cherry-pick to branch** with a single commit now pauses on the destination
   branch when it conflicts, so you resolve it in the app and continue like any
   other conflict — and a resolution that keeps the destination's own version
-  finishes from the banner too. Picking several commits at once still rolls the
+  finishes from the banner too. **Operation history** shows the pick as
+  *Paused* until you finish or abort it. Picking several commits at once still rolls the
   whole batch back, and the dialog now refuses to start while another merge,
   rebase, cherry-pick or revert is in progress.

--- a/changelog.d/fixed-force-push-lease-gap.md
+++ b/changelog.d/fixed-force-push-lease-gap.md
@@ -3,4 +3,4 @@
   background fetch has already brought it into your remote-tracking refs
   (which is enough to satisfy the lease alone). On a Git older than 2.30,
   or a branch without a reflog for the check to read, pushes keep the
-  previous lease-only guard, and the confirmation toast says so.
+  lease-only guard, and the success toast says so.

--- a/changelog.d/fixed-force-push-lease-gap.md
+++ b/changelog.d/fixed-force-push-lease-gap.md
@@ -3,4 +3,4 @@
   background fetch has already brought it into your remote-tracking refs
   (which is enough to satisfy the lease alone). On a Git older than 2.30,
   or a branch without a reflog for the check to read, pushes keep the
-  previous lease-only guard.
+  previous lease-only guard, and the confirmation toast says so.

--- a/changelog.d/fixed-force-push-rejection-copy.md
+++ b/changelog.d/fixed-force-push-rejection-copy.md
@@ -1,0 +1,4 @@
+- A force push that Git blocks now explains what happened (the remote moved
+  since your last fetch, or it holds commits your branch hasn't incorporated)
+  instead of showing raw Git output; the full text is still one click away under
+  Details.

--- a/changelog.d/fixed-review-notes-branch-rename.md
+++ b/changelog.d/fixed-review-notes-branch-rename.md
@@ -1,0 +1,2 @@
+- Notes for reviewers follow a branch through a rename, so the Create-PR dialog
+  still seeds them under the branch's new name.

--- a/changelog.d/fixed-worktree-actions-during-removal.md
+++ b/changelog.d/fixed-worktree-actions-during-removal.md
@@ -1,0 +1,3 @@
+- While a worktree removal runs in the background, the branch menu's worktree
+  actions now stand down with the reason on the label (matching the Worktrees
+  manager) instead of failing against a half-deleted folder.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -257,6 +257,17 @@ pub(crate) async fn git_rename_branch_core(
         DEFAULT_TIMEOUT,
     )
     .await?;
+    // Carry the branch's reviewer note over to the new name, keyed by the same identity
+    // the MCP deposit path uses. Strictly after the `?` and best-effort: the rename has
+    // already happened, so a store failure must never be reported as a failed rename.
+    // This is the one seam both in-app renames share (the GUI command and the MCP
+    // `rename_branch` tool); a terminal `git branch -m` has no hook, the same accepted
+    // gap as the commit-draft migration. Cold-start test mode is out of reach too — the
+    // GUI aliases its store file there (`storeName` in src/lib/test-mode.ts).
+    let identity = crate::git::repo::repo_identity(&repo_path).await;
+    if let Err(e) = crate::review_notes::rename_branch(&identity, &old_name, &new_name) {
+        eprintln!("gitdesktop: reviewer-note rename failed (branch renamed anyway): {e}");
+    }
     Ok(())
 }
 
@@ -884,7 +895,8 @@ fn unique_suffix() -> String {
 mod tests {
     use super::{
         build_create_branch_args, git_branches, git_create_branch_core, git_default_branch,
-        parse_upstream_track, update_branch_from, validate_branch_name, validate_ref_name,
+        git_rename_branch_core, parse_upstream_track, update_branch_from, validate_branch_name,
+        validate_ref_name,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -1341,6 +1353,47 @@ mod tests {
         assert!(
             crate::git::ops::op_state(&repo_s).await.unwrap().merging,
             "the merge is left in progress for the conflict banner to finish"
+        );
+    }
+
+    /// End-to-end: a real `branch -m` through the core carries the branch's reviewer
+    /// note to the new name. Both the deposit and the assertion go through
+    /// `review_notes::store_path`, whose cfg(test) arm keeps them off the developer's
+    /// real store; the identity key is this fixture's own git dir, so the shared test
+    /// store file can't collide with another test's entries.
+    #[tokio::test]
+    async fn rename_carries_the_reviewer_note_to_the_new_branch() {
+        let (_base, base) = temp_base("rename-review-note");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "r.txt").await;
+        run(&repo_s, &["branch", "feature"]).await;
+
+        let identity = crate::git::repo::repo_identity(&repo_s).await;
+        crate::review_notes::set(&identity, "feature", "look at the migration")
+            .expect("deposit the note");
+
+        let state = AppState::default();
+        git_rename_branch_core(&state, repo_s.clone(), "feature".into(), "renamed".into())
+            .await
+            .expect("rename succeeds");
+
+        assert!(
+            run(&repo_s, &["branch", "--list", "renamed"])
+                .await
+                .contains("renamed"),
+            "the branch itself was renamed"
+        );
+        assert_eq!(
+            crate::review_notes::note_body(&identity, "renamed").as_deref(),
+            Some("look at the migration"),
+            "the note reads back under the new name"
+        );
+        assert_eq!(
+            crate::review_notes::note_body(&identity, "feature"),
+            None,
+            "and is gone under the old one"
         );
     }
 }

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -219,6 +219,12 @@ pub(crate) async fn git_commit_core(
     body: Option<String>,
     amend: bool,
 ) -> AppResult<CommitResult> {
+    // git's own conflict advice offers `git commit` as the way to conclude a
+    // cherry-pick, and the commit box has no mid-op gate, so this route ends picks
+    // that never reach `op_continue`. The probe is stat-level because every commit
+    // pays it, and the journal read below runs only when a pick really was stopped.
+    let was_cherry_picking = crate::git::ops::cherry_pick_marker_present(&repo_path);
+
     let mut args = vec!["commit"];
     if amend {
         args.push("--amend");
@@ -237,6 +243,14 @@ pub(crate) async fn git_commit_core(
             code: commit.code,
             stderr: commit.full_failure_text(),
         });
+    }
+    // The widest of the close routes, and the loosest: this is also the MCP commit
+    // tool's choke point, and ANY commit that clears a `CHERRY_PICK_HEAD` fires it —
+    // so a plain unjournaled `cherry-pick` resolved here closes whatever paused
+    // record the repo still holds, which is only the right one while no stale record
+    // predates it.
+    if was_cherry_picking && !crate::git::ops::cherry_pick_marker_present(&repo_path) {
+        crate::oplog::close_paused_pick(&repo_path, crate::oplog::PausedOutcome::Continued).await;
     }
     let out = run_git(Some(&repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT).await?;
     Ok(CommitResult {

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -86,6 +86,37 @@ async fn absolute_git_dir(repo: &str) -> Option<std::path::PathBuf> {
     (!dir.is_empty()).then(|| std::path::PathBuf::from(dir))
 }
 
+/// Whether `CHERRY_PICK_HEAD` is present, resolved without spawning git — for the
+/// commit path, which pays this on EVERY commit and must not grow a `rev-parse`
+/// child for it. Anything unreadable answers "no pick", never an error.
+///
+/// A linked worktree or submodule replaces `.git` with a one-line `gitdir:` pointer
+/// to the dir holding ITS markers, and that path may be relative to the tree holding
+/// the `.git` file — always for a submodule (`gitdir: ../.git/modules/<name>`), and
+/// for a worktree under `worktree.useRelativePaths` / `--relative-paths`
+/// (`gitdir: ../<main>/.git/worktrees/<name>`); measured, git 2.51.1. Joining on the
+/// repo path resolves those and leaves an absolute pointer untouched.
+///
+/// Narrower than [`op_state`] on purpose: it answers only "is a single-commit pick
+/// stopped here", the state `cherry-pick <hash>` leaves and `git commit` clears. The
+/// sequencer-only pick (`cherry-pick -n`, no marker) is deliberately outside it.
+pub(crate) fn cherry_pick_marker_present(repo: &str) -> bool {
+    let repo_root = Path::new(repo);
+    let dot_git = repo_root.join(".git");
+    let git_dir = match std::fs::metadata(&dot_git) {
+        Ok(meta) if meta.is_dir() => dot_git,
+        Ok(_) => match std::fs::read_to_string(&dot_git) {
+            Ok(text) => match text.trim().strip_prefix("gitdir:") {
+                Some(dir) => repo_root.join(dir.trim()),
+                None => return false,
+            },
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+    git_dir.join("CHERRY_PICK_HEAD").exists()
+}
+
 /// True when an interactive rebase is paused at an `edit` instruction (the last
 /// executed todo line is `edit`/`e`), as opposed to a conflict.
 fn rebase_stopped_for_edit(git_dir: &Path) -> bool {
@@ -224,19 +255,27 @@ pub async fn git_op_abort(
     repo_path: String,
     op: String,
 ) -> AppResult<()> {
-    validate_op(&op)?;
-    let out = run_git_mutating_raw(
-        &state,
-        &repo_path,
-        &[op.as_str(), "--abort"],
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
+    op_abort(&state, &repo_path, &op).await
+}
+
+/// Testable core of [`git_op_abort`] — takes a plain `&AppState` so real-repo tokio
+/// tests can drive it.
+pub(crate) async fn op_abort(state: &AppState, repo_path: &str, op: &str) -> AppResult<()> {
+    validate_op(op)?;
+    let out = run_git_mutating_raw(state, repo_path, &[op, "--abort"], DEFAULT_TIMEOUT).await?;
     if out.code != 0 {
         return Err(AppError::Git {
             code: out.code,
             stderr: out.full_failure_text(),
         });
+    }
+    // Closes the stop arm's paused record as the user's own abandonment. The verdict
+    // is only right for the record this abort actually ended: a pick concluded
+    // outside the app leaves a stale paused record that this call would close as
+    // "aborted by user" instead — the accepted cost of keying on the newest paused
+    // record rather than an op id.
+    if op == "cherry-pick" {
+        crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Aborted).await;
     }
     Ok(())
 }
@@ -291,6 +330,10 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
             )
             .await?;
             if skip.code == 0 {
+                // The skip ended the pick just as a commit would, so the journal's
+                // paused record closes here too.
+                crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Continued)
+                    .await;
                 return Ok(false);
             }
             return Err(
@@ -301,6 +344,14 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
         // the paths the operation the CALLER named is already paused on, so they
         // are attributable by construction rather than by having just appeared.
         return Err(classify_failure(repo_path, op, &[], out.code, out.full_failure_text()).await);
+    }
+    // A cherry-pick that reaches here is over, so a `cherry_pick_onto` record the
+    // stop arm left "paused" is closed as done. This is one of the two in-app routes
+    // that end a pick — the commit box is the other, and closes it too. A pick
+    // concluded from a terminal leaves its record paused until a later in-app
+    // continue or abort of any pick closes it.
+    if op == "cherry-pick" {
+        crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Continued).await;
     }
     Ok(true)
 }
@@ -799,12 +850,20 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
     // journal's app-data I/O so it doesn't extend the hold.
     drop(guard);
 
-    crate::oplog::finish(
-        repo_path,
-        &op_id,
-        result.as_ref().err().map(|e| e.to_string()),
-    )
-    .await;
+    // The stop arm handed the pick to the user rather than ending it, so its record
+    // is "paused", not "failed". `AppError::Conflict` leaves this funnel only from
+    // that arm (every other class routes through the rollback below it), so matching
+    // on the variant needs no `hashes.len()` gate.
+    if matches!(result, Err(AppError::Conflict { .. })) {
+        crate::oplog::pause(repo_path, &op_id).await;
+    } else {
+        crate::oplog::finish(
+            repo_path,
+            &op_id,
+            result.as_ref().err().map(|e| e.to_string()),
+        )
+        .await;
+    }
     result
 }
 
@@ -5129,8 +5188,9 @@ mod tests {
         );
         assert_eq!(rev(&repo, "target").await, target_tip);
         assert_eq!(rev(&repo, "feature").await, feature_tip);
-        // A paused op is a finished journal record, not an interrupted one — the
-        // recovery banner must not offer to undo a pick the user is still resolving.
+        // A paused op is never a PENDING journal record, so reconcile can't read it
+        // as interrupted — the recovery banner must not offer to undo a pick the
+        // user is still resolving.
         assert!(
             crate::oplog::git_oplog_check(repo.clone())
                 .await
@@ -5138,6 +5198,53 @@ mod tests {
                 .is_empty(),
             "a paused pick must leave no pending journal entry"
         );
+        // The history dialog must not call it "Failed": the deliberate handoff is a
+        // pause, and the op has not ended, so it carries no finish time.
+        let record = pick_record(&repo).await;
+        assert_eq!(record.status, "paused");
+        assert!(
+            record.finished_at.is_none(),
+            "a paused op has not finished: {:?}",
+            record.finished_at
+        );
+    }
+
+    /// The repo's newest journaled `cherry_pick_onto` entry.
+    async fn pick_record(repo: &str) -> crate::oplog::OpLogEntry {
+        crate::oplog::git_oplog_list(repo.to_string())
+            .await
+            .expect("the journal must be readable")
+            .into_iter()
+            .find(|e| e.op == "cherry_pick_onto")
+            .expect("the pick must be journaled")
+    }
+
+    /// Pause a single-commit pick of `feature`'s edit onto `target`, both diverged on
+    /// `a.txt`, and hand back the repo dir plus the target's tip. The shared fixture
+    /// behind every paused-record test.
+    async fn setup_paused_pick(marker: &str) -> (tempfile::TempDir, String, String) {
+        let (dir, repo) = setup_repo(marker).await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        git(&repo, &["checkout", "target"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        let target_tip = rev(&repo, "HEAD").await;
+
+        let state = AppState::default();
+        assert!(
+            cherry_pick_onto(&state, &repo, &[c1], "target")
+                .await
+                .is_err(),
+            "the fixture's pick must conflict"
+        );
+        assert_eq!(
+            pick_record(&repo).await.status,
+            "paused",
+            "the fixture must start from a paused journal record"
+        );
+        (dir, repo, target_tip)
     }
 
     /// A pick paused with its conflicts staged has a CLEAN tree, so `ensure_clean_tree`
@@ -5235,22 +5342,11 @@ mod tests {
     /// routine dead-ends in the UI.
     #[tokio::test]
     async fn op_continue_finishes_a_cherry_pick_emptied_by_its_resolution() {
-        let (dir, repo) = setup_repo("continue-empty-pick").await;
-        git(&repo, &["branch", "target"]).await;
-        git(&repo, &["checkout", "-b", "feature"]).await;
-        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
-        let c1 = rev(&repo, "HEAD").await;
-        git(&repo, &["checkout", "target"]).await;
-        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
-        let target_tip = rev(&repo, "HEAD").await;
-
-        let state = AppState::default();
-        assert!(cherry_pick_onto(&state, &repo, &[c1], "target")
-            .await
-            .is_err());
+        let (_dir, repo, target_tip) = setup_paused_pick("continue-empty-pick").await;
         git(&repo, &["checkout", "--ours", "a.txt"]).await;
         git(&repo, &["add", "a.txt"]).await;
 
+        let state = AppState::default();
         let recorded = op_continue(&state, &repo, "cherry-pick")
             .await
             .expect("continue must finish a pick emptied by its own resolution");
@@ -5266,28 +5362,39 @@ mod tests {
         assert_eq!(rev(&repo, "HEAD").await, target_tip);
         let status = git(&repo, &["status", "--porcelain"]).await;
         assert!(status.trim().is_empty(), "tree should be clean: {status}");
+        // The skip ended the op, so its paused journal record closes too.
+        assert_eq!(pick_record(&repo).await.status, "done");
+    }
+
+    /// Aborting a paused pick closes its record as the user's own abandonment, in the
+    /// same words the local-PR merge abort uses.
+    #[tokio::test]
+    async fn op_abort_closes_the_paused_pick_record_as_aborted() {
+        let (_dir, repo, target_tip) = setup_paused_pick("abort-closes-record").await;
+
+        let state = AppState::default();
+        op_abort(&state, &repo, "cherry-pick")
+            .await
+            .expect("aborting a paused pick must succeed");
+        assert!(!op_state(&repo).await.unwrap().cherry_picking);
+        assert_eq!(rev(&repo, "HEAD").await, target_tip);
+
+        let record = pick_record(&repo).await;
+        assert_eq!(record.status, "failed");
+        assert_eq!(record.error.as_deref(), Some("aborted by user"));
+        assert!(record.finished_at.is_some());
     }
 
     /// The sibling arm: a resolution that keeps content of its own DOES commit, so
-    /// the same call answers true and the banner says the pick continued.
+    /// the same call answers true and the banner says the pick continued — and the
+    /// paused journal record closes with it.
     #[tokio::test]
     async fn op_continue_reports_a_recorded_commit_for_a_resolved_cherry_pick() {
-        let (dir, repo) = setup_repo("continue-resolved-pick").await;
-        git(&repo, &["branch", "target"]).await;
-        git(&repo, &["checkout", "-b", "feature"]).await;
-        commit_file(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
-        let c1 = rev(&repo, "HEAD").await;
-        git(&repo, &["checkout", "target"]).await;
-        commit_file(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
-        let target_tip = rev(&repo, "HEAD").await;
-
-        let state = AppState::default();
-        assert!(cherry_pick_onto(&state, &repo, &[c1], "target")
-            .await
-            .is_err());
+        let (dir, repo, target_tip) = setup_paused_pick("continue-resolved-pick").await;
         std::fs::write(dir.path().join("a.txt"), "merged\n").unwrap();
         git(&repo, &["add", "a.txt"]).await;
 
+        let state = AppState::default();
         let recorded = op_continue(&state, &repo, "cherry-pick")
             .await
             .expect("a resolved pick must continue");
@@ -5298,6 +5405,46 @@ mod tests {
             target_tip,
             "the resolution must have landed as a commit"
         );
+        let record = pick_record(&repo).await;
+        assert_eq!(record.status, "done");
+        assert!(
+            record.finished_at.is_some(),
+            "a closed record must carry its finish time"
+        );
+        assert_eq!(record.error, None, "a continued pick is not a failure");
+    }
+
+    /// git's own conflict advice offers `git commit`, and the commit box has no
+    /// mid-op gate, so a paused pick can be concluded without `--continue` ever
+    /// running. The journal must close its record on that route too, or the next
+    /// in-app abort of any pick reads the stale record as "aborted by user".
+    /// (Exercises `git::commit::git_commit_core`; the fixture lives here.)
+    #[tokio::test]
+    async fn a_commit_closes_the_paused_cherry_pick_record() {
+        let (dir, repo, target_tip) = setup_paused_pick("commit-closes-record").await;
+        std::fs::write(dir.path().join("a.txt"), "merged\n").unwrap();
+        git(&repo, &["add", "a.txt"]).await;
+
+        let state = AppState::default();
+        crate::git::commit::git_commit_core(
+            &state,
+            repo.clone(),
+            "resolve the pick".to_string(),
+            None,
+            false,
+        )
+        .await
+        .expect("the commit box must be able to conclude a resolved pick");
+        assert!(
+            !op_state(&repo).await.unwrap().cherry_picking,
+            "the commit must have concluded the pick"
+        );
+        assert_ne!(rev(&repo, "HEAD").await, target_tip);
+
+        let record = pick_record(&repo).await;
+        assert_eq!(record.status, "done");
+        assert!(record.finished_at.is_some());
+        assert_eq!(record.error, None);
     }
 
     /// Only a CONFLICT stops on the target; every other failure class still rolls
@@ -5662,6 +5809,79 @@ mod tests {
         );
 
         git(&repo, &["worktree", "remove", "--force", &link]).await;
+    }
+
+    /// The commit path's spawn-free probe has to follow the one-line `gitdir:`
+    /// pointer a linked worktree leaves in place of `.git`, or a pick paused in a
+    /// worktree would close no journal record when the commit box concludes it.
+    #[tokio::test]
+    async fn cherry_pick_marker_probe_follows_a_worktrees_gitdir_pointer() {
+        let (dir, repo) = setup_repo("worktree-pick-marker").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        let c1 = rev(&repo, "HEAD").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        let tip = rev(&repo, "HEAD").await;
+
+        let link_dir = tempfile::Builder::new()
+            .prefix("gd-rewrite-worktree-pick-")
+            .tempdir()
+            .expect("create temp dir");
+        let link = link_dir.path().join("linked").to_string_lossy().into_owned();
+        git(&repo, &["worktree", "add", "--detach", &link, &tip]).await;
+        assert!(
+            !cherry_pick_marker_present(&link),
+            "nothing is picking in the fresh worktree"
+        );
+
+        let pick = run_git_raw(Some(&link), &["cherry-pick", &c1], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(pick.code, 0, "the pick inside the worktree should conflict");
+        assert!(
+            cherry_pick_marker_present(&link),
+            "the worktree's own CHERRY_PICK_HEAD must be found through its gitdir pointer"
+        );
+        assert!(
+            !cherry_pick_marker_present(&repo),
+            "and the main checkout has no pick of its own"
+        );
+
+        git(&repo, &["worktree", "remove", "--force", &link]).await;
+    }
+
+    /// The same probe against a RELATIVE `gitdir:` pointer, which a submodule always
+    /// writes (`gitdir: ../.git/modules/<name>`) and a worktree writes under
+    /// `worktree.useRelativePaths` (`gitdir: ../<main>/.git/worktrees/<name>`) — both
+    /// shapes measured, git 2.51.1. Resolving one against the process CWD instead of
+    /// the tree holding the `.git` file would answer "no pick" and silently skip the
+    /// close. The pointer is written by hand: a live submodule needs a second repo
+    /// plus `protocol.file.allow`, and `--relative-paths` needs git >= 2.48, which
+    /// the CI matrix's runners don't all carry.
+    #[test]
+    fn cherry_pick_marker_probe_resolves_a_relative_gitdir_pointer() {
+        let tmp = tempfile::Builder::new()
+            .prefix("gd-relative-gitdir-")
+            .tempdir()
+            .expect("create temp dir");
+        let tree = tmp.path().join("tree");
+        let real_git_dir = tmp.path().join("real/.git/modules/mod");
+        std::fs::create_dir_all(&tree).unwrap();
+        std::fs::create_dir_all(&real_git_dir).unwrap();
+        std::fs::write(tree.join(".git"), "gitdir: ../real/.git/modules/mod\n").unwrap();
+        let repo = tree.to_string_lossy().into_owned();
+
+        assert!(
+            !cherry_pick_marker_present(&repo),
+            "no marker file, no pick — the pointer alone proves nothing"
+        );
+        std::fs::write(real_git_dir.join("CHERRY_PICK_HEAD"), "deadbeef\n").unwrap();
+        assert!(
+            cherry_pick_marker_present(&repo),
+            "a relative pointer resolves against the tree holding the .git file"
+        );
     }
 
     /// Conflicted revert / cherry-pick / rebase all split ONE report across both

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -5447,6 +5447,45 @@ mod tests {
         assert_eq!(record.error, None);
     }
 
+    /// The commit route's gate, from the other side: a pick concluded OUTSIDE the app
+    /// leaves its record paused by design, and every ordinary commit afterwards must
+    /// leave it alone. Without the was-picking gate the widest close route would flip
+    /// whatever stale record the repo still holds on the user's next unrelated commit.
+    #[tokio::test]
+    async fn an_ordinary_commit_leaves_a_stale_paused_record_alone() {
+        let (dir, repo, _target_tip) = setup_paused_pick("commit-leaves-stale-record").await;
+        git(&repo, &["cherry-pick", "--abort"]).await;
+        assert!(
+            !op_state(&repo).await.unwrap().cherry_picking,
+            "the out-of-app abort must have ended the pick"
+        );
+        assert_eq!(
+            pick_record(&repo).await.status,
+            "paused",
+            "nothing in-app closed it, so the record is the stale one this pins"
+        );
+
+        std::fs::write(dir.path().join("unrelated.txt"), "unrelated\n").unwrap();
+        git(&repo, &["add", "unrelated.txt"]).await;
+        let state = AppState::default();
+        crate::git::commit::git_commit_core(
+            &state,
+            repo.clone(),
+            "an unrelated change".to_string(),
+            None,
+            false,
+        )
+        .await
+        .expect("an ordinary commit must succeed");
+
+        let record = pick_record(&repo).await;
+        assert_eq!(
+            record.status, "paused",
+            "no pick was in progress, so this commit concluded nothing"
+        );
+        assert!(record.finished_at.is_none());
+    }
+
     /// Only a CONFLICT stops on the target; every other failure class still rolls
     /// back, single commit included — a killed pick otherwise leaves HEAD on the
     /// target with nothing for the user to resolve.

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -505,7 +505,7 @@ pub async fn git_push(
     branch: Option<String>,
     remote: Option<String>,
     remote_branch: Option<String>,
-) -> AppResult<()> {
+) -> AppResult<PushGuard> {
     git_push_core(
         &state,
         repo_path,
@@ -516,14 +516,18 @@ pub async fn git_push(
         remote_branch,
     )
     .await
-    // The guard is an in-process detail; the IPC contract stays `void`.
-    .map(|_| ())
 }
 
 /// Which guarantee a completed push actually ran under. Only meaningful for a
 /// FORCE push: a non-force push has no lease to degrade, and reports
 /// [`PushGuard::LeaseAndIncludes`] as the neutral value.
-#[derive(Debug, PartialEq)]
+///
+/// Crosses the IPC boundary as `git_push`'s return value, so the caller's
+/// success toast can name a degraded guarantee instead of overclaiming. The
+/// camelCase wire strings mirror the `PushGuard` union in `src/lib/git/api.ts`
+/// and are pinned by `push_guard_serializes_to_the_camel_case_wire_values`.
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 #[allow(clippy::enum_variant_names)] // the shared `Lease` prefix IS the shared guarantee
 pub(crate) enum PushGuard {
     /// `--force-with-lease --force-if-includes`, the intended pair.
@@ -877,7 +881,7 @@ mod tests {
         build_push_args, cache_get, cache_invalidate, cache_put, git_pull_core, git_push_core,
         git_remote_remove_core, is_auth_class_failure, is_unknown_push_option,
         parse_upstream_tracking, publish_refspec, resolve_push_target, run_git_mutating_with_creds,
-        without_force_if_includes, PushGuard,
+        without_force_if_includes, IF_INCLUDES_REJECTION, PushGuard,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -1392,6 +1396,93 @@ mod tests {
         (guard, base, origin.to_string_lossy().into_owned(), url)
     }
 
+    /// git's per-ref reason when `--force-with-lease` finds the remote-tracking ref
+    /// behind the real remote — verbatim from `! [rejected] … (…)`. The prod-side
+    /// twin is [`IF_INCLUDES_REJECTION`]; this one only ever appears in git's report.
+    const STALE_LEASE_REJECTION: &str = "stale info";
+
+    /// Assert git's failure report still carries a `! [rejected] … (<reason>)` line
+    /// — the exact shape `PUSH_REJECTION_SUMMARIES` (src/lib/error-summary.ts)
+    /// anchors on to turn a blocked force push into one human line. Keep the two
+    /// lists in step: a reason git renames goes back to raw stderr in the toast.
+    fn assert_rejection_reason(report: &str, reason: &str) {
+        let marked = format!("({reason})");
+        assert!(
+            report
+                .lines()
+                .any(|l| l.trim_start().starts_with("! [rejected]") && l.contains(&marked)),
+            "git no longer emits `! [rejected] … {marked}` — the frontend summary is now blind \
+             to this rejection. Actual report:\n{report}"
+        );
+    }
+
+    /// The bare lease's own refusal, driven end to end: with the remote moved and
+    /// never fetched, the remote-tracking ref is stale and git rejects before
+    /// `--force-if-includes` has anything to say. Canary for the frontend's
+    /// `(stale info)` marker — the counterpart of
+    /// `refusal_stderr_still_matches_the_frontend_markers` (autostash.rs).
+    #[tokio::test]
+    async fn force_push_rejection_stderr_still_matches_the_frontend_markers() {
+        let (_guard, base, origin_s, url) = seeded_origin("stale-info").await;
+        let base_s = base.to_string_lossy().into_owned();
+
+        for name in ["clone1", "clone2"] {
+            run(&base_s, &["-c", "core.autocrlf=false", "clone", "-q", &url, name]).await;
+            let c = base.join(name).to_string_lossy().into_owned();
+            run(&c, &["config", "core.autocrlf", "false"]).await;
+            run(&c, &["config", "user.email", "t@t.local"]).await;
+            run(&c, &["config", "user.name", "T"]).await;
+        }
+        let clone1 = base.join("clone1");
+        let clone2 = base.join("clone2");
+        let clone1_s = clone1.to_string_lossy().into_owned();
+        let clone2_s = clone2.to_string_lossy().into_owned();
+
+        // clone2 moves the shared branch; clone1 never learns of it, so its
+        // remote-tracking ref — the lease's expectation — is stale.
+        std::fs::write(clone2.join("b.txt"), "theirs\n").unwrap();
+        run(&clone2_s, &["add", "-A"]).await;
+        run(&clone2_s, &["commit", "-qm", "from clone2"]).await;
+        run(&clone2_s, &["push", "-q"]).await;
+        let theirs = run(&clone2_s, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        std::fs::write(clone1.join("c.txt"), "mine\n").unwrap();
+        run(&clone1_s, &["add", "-A"]).await;
+        run(&clone1_s, &["commit", "-q", "--amend", "-m", "amended seed"]).await;
+
+        let state = AppState::default();
+        let err = git_push_core(&state, clone1_s.clone(), false, true, None, None, None)
+            .await
+            .expect_err("a stale lease must not clobber the remote");
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a git error, got {err:?}")
+        };
+        assert_rejection_reason(stderr, STALE_LEASE_REJECTION);
+        assert_eq!(
+            run(&origin_s, &["rev-parse", "refs/heads/main"]).await.trim(),
+            theirs,
+            "clone2's commit is still origin's tip"
+        );
+    }
+
+    /// The wire values the TS `PushGuard` union (src/lib/git/api.ts) mirrors: the
+    /// success toast keys on these exact strings, so a variant rename that skips
+    /// the mirror would silently stop reporting a degraded force push.
+    #[test]
+    fn push_guard_serializes_to_the_camel_case_wire_values() {
+        for (guard, wire) in [
+            (PushGuard::LeaseAndIncludes, "leaseAndIncludes"),
+            (PushGuard::LeaseOnlyOldGit, "leaseOnlyOldGit"),
+            (PushGuard::LeaseOnlyNoReflog, "leaseOnlyNoReflog"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(&guard).unwrap(),
+                serde_json::Value::String(wire.to_string()),
+                "{guard:?} must stay on the wire as {wire:?}"
+            );
+        }
+    }
+
     /// The gap `--force-if-includes` closes, driven end to end: a plain `fetch`
     /// alone satisfies the bare lease, so with the lease only, clone1's amend would
     /// clobber a commit clone2 pushed and clone1 never integrated. Integrating it
@@ -1431,7 +1522,10 @@ mod tests {
         let err = git_push_core(&state, clone1_s.clone(), false, true, None, None, None)
             .await
             .expect_err("a merely-fetched remote commit must not be clobbered");
-        assert!(matches!(err, AppError::Git { .. }), "expected a git error, got {err:?}");
+        let AppError::Git { stderr, .. } = &err else {
+            panic!("expected a git error, got {err:?}")
+        };
+        assert_rejection_reason(stderr, IF_INCLUDES_REJECTION);
         assert_eq!(
             run(&origin_s, &["rev-parse", "refs/heads/main"]).await.trim(),
             theirs,

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -44,7 +44,8 @@ use crate::error::{AppError, AppResult};
 const APP_IDENTIFIER: &str = "com.thebguy.gitdesktop";
 /// The store filename.
 const STORE_FILE: &str = "opslog.json";
-/// Keep at most this many entries per repo (never evicting a `"pending"` one).
+/// Keep at most this many entries per repo (never evicting a `"pending"` or
+/// `"paused"` one).
 const HISTORY_CAP: usize = 50;
 
 /// A single journaled operation. `#[serde(rename_all = "camelCase")]` freezes the
@@ -58,7 +59,9 @@ pub struct OpLogEntry {
     pub op: String,
     /// Human summary, e.g. `"Squash-merge feature → main"`.
     pub label: String,
-    /// `"pending"` | `"done"` | `"failed"` | `"dismissed"`.
+    /// `"pending"` | `"done"` | `"failed"` | `"dismissed"` | `"paused"`.
+    /// `"paused"` = handed to the user mid-op (a stopped cherry-pick), so it is
+    /// neither in-flight nor finished until they continue or abort it.
     pub status: String,
     /// `now_iso()` captured at [`begin`].
     pub started_at: String,
@@ -220,20 +223,22 @@ fn insert_pending(repo: &str, entry: &OpLogEntry) -> AppResult<()> {
     write_store(&path, &store)
 }
 
-/// Drop oldest non-`"pending"` entries until `list.len() <= HISTORY_CAP`. A
-/// `"pending"` entry (possibly an in-flight op) is never evicted, so the cap is a
-/// soft ceiling that a burst of concurrent pending ops can legitimately exceed.
+/// Drop oldest evictable entries until `list.len() <= HISTORY_CAP`. An unfinished
+/// entry is never evicted — `"pending"` may be an in-flight op, and `"paused"` is a
+/// live handle [`close_paused_pick`] still needs — so the cap is a soft ceiling that
+/// a burst of concurrent unfinished ops can legitimately exceed.
 fn cap_history(list: &mut Vec<Value>) {
     if list.len() <= HISTORY_CAP {
         return;
     }
-    // Iterate oldest-first (end of the newest-first vec) and remove non-pending
+    // Iterate oldest-first (end of the newest-first vec) and remove finished entries
     // until at or under the cap.
     let mut i = list.len();
     while list.len() > HISTORY_CAP && i > 0 {
         i -= 1;
-        let is_pending = list[i].get("status").and_then(Value::as_str) == Some("pending");
-        if !is_pending {
+        let status = list[i].get("status").and_then(Value::as_str);
+        let unfinished = matches!(status, Some("pending") | Some("paused"));
+        if !unfinished {
             list.remove(i);
         }
     }
@@ -265,6 +270,52 @@ where
     };
     mutate(obj);
     write_store(&path, &store)
+}
+
+/// How a paused op ended, once the user acted on it — see [`close_paused_pick`].
+pub(crate) enum PausedOutcome {
+    /// Continued to completion in-app.
+    Continued,
+    /// Abandoned in-app.
+    Aborted,
+}
+
+/// Mark an entry as handed to the user: no `finishedAt` (the op hasn't ended) and no
+/// `error` (the conflict lives in the banner, and the history dialog's error line
+/// gates on `"failed"`). Both are written explicitly so the shape holds whatever the
+/// record carried before.
+fn apply_pause(obj: &mut Map<String, Value>) {
+    obj.insert("status".to_string(), Value::String("paused".to_string()));
+    obj.insert("finishedAt".to_string(), Value::Null);
+    obj.insert("error".to_string(), Value::Null);
+}
+
+/// Close a paused entry at its terminal disposition. An abort is journaled `"failed"`
+/// with the same wording [`crate::git::ops::git_abort_local_pr_merge`] uses, so the
+/// history dialog reads one sentence for a user-abandoned op.
+fn apply_close(obj: &mut Map<String, Value>, outcome: &PausedOutcome, now: String) {
+    let (status, error) = match outcome {
+        PausedOutcome::Continued => ("done", Value::Null),
+        PausedOutcome::Aborted => ("failed", Value::String("aborted by user".to_string())),
+    };
+    obj.insert("status".to_string(), Value::String(status.to_string()));
+    obj.insert("finishedAt".to_string(), Value::String(now));
+    obj.insert("error".to_string(), error);
+}
+
+/// The id of the NEWEST `"paused"` cherry-pick entry in `entries`, if any. Sorts in
+/// place (the caller owns a store copy), so callers may pass unsorted store order.
+fn newest_paused_pick(entries: &mut [Value]) -> Option<String> {
+    sort_newest_first(entries);
+    entries
+        .iter()
+        .find(|e| {
+            e.get("op").and_then(Value::as_str) == Some("cherry_pick_onto")
+                && e.get("status").and_then(Value::as_str) == Some("paused")
+        })
+        .and_then(|e| e.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// The newest pending op is genuinely interrupted UNLESS the repo is back in a
@@ -313,7 +364,9 @@ fn reconcile(
         return Ok(Vec::new());
     };
 
-    // Indices of pending entries, newest-first by startedAt.
+    // Indices of pending entries, newest-first by startedAt. Strictly `"pending"`:
+    // a `"paused"` op was handed to the user and is owned by the conflict banner,
+    // never a recovery candidate.
     let mut pending_idx: Vec<usize> = list
         .iter()
         .enumerate()
@@ -426,6 +479,49 @@ pub async fn finish(repo: &str, id: &Option<String>, error: Option<String>) {
     });
     if let Err(e) = result {
         eprintln!("gitdesktop: opslog finish failed (op unaffected): {e}");
+    }
+}
+
+/// Best-effort: if `id` is `Some`, flip that entry to `"paused"` — the op did not
+/// end, it was handed to the user to resolve, so it is neither a failure nor a
+/// recovery candidate until [`close_paused_pick`] closes it. Swallow+log like
+/// [`finish`].
+pub(crate) async fn pause(repo: &str, id: &Option<String>) {
+    let Some(id) = id else {
+        return;
+    };
+    if let Err(e) = mutate_entry(repo, id, apply_pause) {
+        eprintln!("gitdesktop: opslog pause failed (op unaffected): {e}");
+    }
+}
+
+/// Best-effort: close `repo`'s newest `"paused"` cherry-pick entry now that the user
+/// has ended the pick in-app. No paused entry → no-op.
+///
+/// The handle is the newest paused record, not the specific pick: a pick ended
+/// outside the app (a terminal `git cherry-pick --abort`) leaves its record
+/// `"paused"`, and a later in-app continue or abort of any cherry-pick is what will
+/// close it — the same best-effort posture the journal takes for out-of-app work.
+pub(crate) async fn close_paused_pick(repo: &str, outcome: PausedOutcome) {
+    let now = now_iso();
+    let found = store_path().and_then(|path| {
+        let mut entries = {
+            let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+            let store = read_store(&path)?;
+            repo_entries(&store, repo)
+        };
+        Ok(newest_paused_pick(&mut entries))
+    });
+    let id = match found {
+        Ok(Some(id)) => id,
+        Ok(None) => return,
+        Err(e) => {
+            eprintln!("gitdesktop: opslog paused lookup failed (op unaffected): {e}");
+            return;
+        }
+    };
+    if let Err(e) = mutate_entry(repo, &id, |obj| apply_close(obj, &outcome, now)) {
+        eprintln!("gitdesktop: opslog close failed (op unaffected): {e}");
     }
 }
 
@@ -741,9 +837,9 @@ mod tests {
     }
 
     #[test]
-    fn cap_never_evicts_a_pending_entry() {
-        // A newest-first list: 1 old pending at the very end, then 60 done entries.
-        // Capping to 50 must drop oldest done entries but keep the pending one.
+    fn cap_never_evicts_an_unfinished_entry() {
+        // A newest-first list: 60 done entries, then the two oldest unfinished ones.
+        // Capping to 50 must drop oldest done entries but keep both of those.
         let mut list: Vec<Value> = Vec::new();
         for i in 0..60 {
             list.push(json!({
@@ -752,10 +848,16 @@ mod tests {
                 "startedAt": format!("2026-02-{:02}T00:00:00.000Z", i + 1),
             }));
         }
-        // The oldest entry (last in newest-first order) is pending.
+        // The oldest entries (last in newest-first order) are still open.
         list.push(json!({
             "id": "old-pending",
             "status": "pending",
+            "startedAt": "2026-01-02T00:00:00.000Z",
+        }));
+        list.push(json!({
+            "id": "old-paused",
+            "op": "cherry_pick_onto",
+            "status": "paused",
             "startedAt": "2026-01-01T00:00:00.000Z",
         }));
         cap_history(&mut list);
@@ -765,6 +867,136 @@ mod tests {
             list.iter().any(|e| e["id"] == "old-pending"),
             "the pending entry must never be evicted by the cap"
         );
+        assert!(
+            list.iter().any(|e| e["id"] == "old-paused"),
+            "evicting a paused entry would lose the handle the close helper needs"
+        );
+    }
+
+    /// Build a wire record for a `cherry_pick_onto` entry at `status`.
+    fn pick_record(id: &str, started_at: &str, status: &str) -> Value {
+        json!({
+            "id": id,
+            "op": "cherry_pick_onto",
+            "label": "Cherry-pick abc1234 → target",
+            "status": status,
+            "startedAt": started_at,
+            "finishedAt": null,
+            "originalRef": "feature",
+            "originalSha": "abc123",
+            "preOpTip": "def456",
+            "error": null,
+        })
+    }
+
+    #[test]
+    fn pause_marks_the_entry_without_finishing_it() {
+        let (_tmp, path) = tmp_store();
+        let repo = r"C:\repo\one";
+        let mut rec = pick_record("pick-1", "2026-01-01T00:00:00.000Z", "pending");
+        // Seed the fields pause must clear, so the assertions below can't pass by
+        // the record having arrived clean.
+        let obj = rec.as_object_mut().unwrap();
+        obj.insert("finishedAt".into(), json!("2026-01-02T00:00:00.000Z"));
+        obj.insert("error".into(), json!("stale"));
+        let mut store = Map::new();
+        store.insert(repo.to_string(), Value::Array(vec![rec]));
+        write_store(&path, &store).unwrap();
+
+        let mut s = read_store(&path).unwrap();
+        apply_pause(s[repo].as_array_mut().unwrap()[0].as_object_mut().unwrap());
+        write_store(&path, &s).unwrap();
+
+        let back = read_store(&path).unwrap();
+        let entry = &back[repo][0];
+        assert_eq!(entry["status"], "paused");
+        assert_eq!(
+            entry["finishedAt"],
+            Value::Null,
+            "a paused op has not ended, so it has no finish time"
+        );
+        assert_eq!(entry["error"], Value::Null);
+        // And it still parses, or the history dialog's from_value filter drops it.
+        let parsed: OpLogEntry = serde_json::from_value(entry.clone()).unwrap();
+        assert_eq!(parsed.status, "paused");
+        assert!(parsed.finished_at.is_none());
+    }
+
+    #[test]
+    fn close_targets_the_newest_paused_pick() {
+        let (_tmp, path) = tmp_store();
+        let repo = r"C:\repo\one";
+        let mut store = Map::new();
+        store.insert(
+            repo.to_string(),
+            Value::Array(vec![
+                pick_record("old-paused", "2026-01-01T00:00:00.000Z", "paused"),
+                pick_record("new-paused", "2026-01-03T00:00:00.000Z", "paused"),
+                pick_record("later-done", "2026-01-04T00:00:00.000Z", "done"),
+            ]),
+        );
+        write_store(&path, &store).unwrap();
+
+        let mut entries = repo_entries(&read_store(&path).unwrap(), repo);
+        let id = newest_paused_pick(&mut entries).expect("the paused pick must be found");
+        assert_eq!(id, "new-paused", "a newer finished entry is not the handle");
+
+        let mut s = read_store(&path).unwrap();
+        {
+            let list = s.get_mut(repo).unwrap().as_array_mut().unwrap();
+            let obj = list
+                .iter_mut()
+                .find(|e| e["id"] == id)
+                .unwrap()
+                .as_object_mut()
+                .unwrap();
+            apply_close(
+                obj,
+                &PausedOutcome::Aborted,
+                "2026-01-05T00:00:00.000Z".to_string(),
+            );
+        }
+        write_store(&path, &s).unwrap();
+
+        let back = read_store(&path).unwrap();
+        let list = back[repo].as_array().unwrap();
+        let closed = list.iter().find(|e| e["id"] == "new-paused").unwrap();
+        assert_eq!(closed["status"], "failed");
+        assert_eq!(closed["error"], "aborted by user");
+        assert_eq!(closed["finishedAt"], "2026-01-05T00:00:00.000Z");
+        // Only the newest is closed: an older paused record is not this op's.
+        let untouched = list.iter().find(|e| e["id"] == "old-paused").unwrap();
+        assert_eq!(untouched["status"], "paused");
+    }
+
+    #[test]
+    fn close_continued_marks_done_without_an_error() {
+        let mut rec = pick_record("pick-1", "2026-01-01T00:00:00.000Z", "paused");
+        apply_close(
+            rec.as_object_mut().unwrap(),
+            &PausedOutcome::Continued,
+            "2026-01-02T00:00:00.000Z".to_string(),
+        );
+        assert_eq!(rec["status"], "done");
+        assert_eq!(rec["finishedAt"], "2026-01-02T00:00:00.000Z");
+        assert_eq!(rec["error"], Value::Null);
+    }
+
+    #[test]
+    fn close_is_a_no_op_without_a_paused_pick() {
+        // A finished pick and another op's paused entry: neither is a pick handle,
+        // so the close helper must find nothing to flip.
+        let mut entries = vec![
+            pick_record("done-pick", "2026-01-02T00:00:00.000Z", "done"),
+            json!({
+                "id": "paused-merge",
+                "op": "merge_local_pr",
+                "status": "paused",
+                "startedAt": "2026-01-03T00:00:00.000Z",
+            }),
+        ];
+        assert!(newest_paused_pick(&mut entries).is_none());
+        assert!(newest_paused_pick(&mut Vec::new()).is_none());
     }
 
     #[test]

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -23,7 +23,8 @@
 //!
 //! We resolve it here with the SAME `dirs::data_dir()` the Tauri path layer uses, joined with
 //! the identifier (reusing [`crate::local_prs::APP_IDENTIFIER`]) — so the two processes always
-//! agree on the file.
+//! agree on the file. A `GD_REVIEW_NOTES_DIR` override and a `cfg(test)` temp dir precede that
+//! resolution; see [`resolve_store_base`].
 //!
 //! ## Shape
 //!
@@ -58,13 +59,50 @@ use crate::local_prs::APP_IDENTIFIER;
 /// The store filename the GUI's reviewer-notes store writes.
 const STORE_FILE: &str = "review-notes.json";
 
-/// Resolve the absolute path of the `review-notes.json` the frontend store writes.
-/// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
-/// (`dirs::data_dir()/<identifier>`) — see the module contract and [`crate::local_prs`].
+/// Pure resolution of the store's base directory, in precedence order (mirroring
+/// [`crate::oplog::resolve_store_base`]):
+/// 1. a non-empty `GD_REVIEW_NOTES_DIR` override — the escape hatch for headless/test
+///    callers;
+/// 2. under `cfg!(test)`, a temp subdir, so no in-crate test can write the user's real
+///    store (the rename migration runs for real under `cargo test`);
+/// 3. otherwise the real app-data dir (`dirs::data_dir()/<identifier>`), mirroring
+///    `tauri-plugin-store` v2's `BaseDirectory::AppData` — see the module contract.
+///
+/// No filesystem side effects — `atomic_write` creates the parent at write time.
+fn resolve_store_base(gd_review_notes_dir: Option<&str>, is_test: bool) -> AppResult<PathBuf> {
+    match gd_review_notes_dir {
+        Some(dir) if !dir.is_empty() => Ok(PathBuf::from(dir)),
+        _ if is_test => Ok(std::env::temp_dir().join("gd-review-notes-test")),
+        _ => {
+            let data = dirs::data_dir().ok_or_else(|| {
+                AppError::Command("could not resolve the app-data directory".to_string())
+            })?;
+            Ok(data.join(APP_IDENTIFIER))
+        }
+    }
+}
+
+/// Absolute path of the `review-notes.json` the frontend store writes —
+/// `<store base>/review-notes.json`; see [`resolve_store_base`] for how the base is chosen.
 pub(crate) fn store_path() -> AppResult<PathBuf> {
-    let data = dirs::data_dir()
-        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
-    Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
+    let base = resolve_store_base(
+        std::env::var("GD_REVIEW_NOTES_DIR").ok().as_deref(),
+        cfg!(test),
+    )?;
+    Ok(base.join(STORE_FILE))
+}
+
+/// The note stored for `repo`'s `branch`, read through [`store_path`] — the seam-aware
+/// reader an end-to-end test asserts on. Test-only; production readers are the GUI's.
+#[cfg(test)]
+pub(crate) fn note_body(repo: &str, branch: &str) -> Option<String> {
+    let store = read_store(&store_path().ok()?).ok()?;
+    store
+        .get(repo)?
+        .get(branch)?
+        .get("body")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// Read the whole store file as a JSON object. A missing file is an empty object;
@@ -151,6 +189,56 @@ fn upsert_branch(store: &mut Map<String, Value>, repo: &str, branch: &str, body:
     }
 }
 
+/// Carry `from`'s reviewer note over to `to` under `repo`, so a renamed branch keeps its
+/// deposit. `repo` is the worktree-stable identity key ([`crate::git::repo::repo_identity`]).
+///
+/// The note record moves verbatim (unknown fields included) and its `savedAt` is left alone —
+/// a rename is not a re-save. Nothing is written when there is nothing to migrate.
+pub(crate) fn rename_branch(repo: &str, from: &str, to: &str) -> AppResult<()> {
+    let path = store_path()?;
+    rename_at(&path, repo, from, to)
+}
+
+/// The pure store logic behind [`rename_branch`], taking an explicit path so tests can drive
+/// it against a temp file without touching the real app-data store.
+fn rename_at(path: &Path, repo: &str, from: &str, to: &str) -> AppResult<()> {
+    // A same-name rename has nothing to migrate, so skip the redundant rewrite of the file.
+    if from == to {
+        return Ok(());
+    }
+    let mut store = read_store(path)?;
+    if !move_branch(&mut store, repo, from, to) {
+        // Nothing to migrate: leave the file (which may not even exist) untouched.
+        return Ok(());
+    }
+    write_store(path, &store)
+}
+
+/// Move `from`'s note onto `to` within `repo`'s map, dropping the repo key if that empties it.
+/// Returns whether anything changed, so the caller can skip the write entirely.
+fn move_branch(store: &mut Map<String, Value>, repo: &str, from: &str, to: &str) -> bool {
+    let Some(entry) = store.get_mut(repo) else {
+        return false;
+    };
+    let Some(branches) = entry.as_object_mut() else {
+        return false;
+    };
+    let changed = match branches.remove(from) {
+        Some(note) => {
+            branches.insert(to.to_string(), note);
+            true
+        }
+        // Nothing carried over, so a note already under the new name is stale: `git branch -m`
+        // refuses an existing target, so that note belongs to a branch that no longer answers
+        // to the name (the commit-draft rule, `migrateCommitDraft` in src/lib/stores/ui.ts).
+        None => branches.remove(to).is_some(),
+    };
+    if changed && branches.is_empty() {
+        store.remove(repo);
+    }
+    changed
+}
+
 /// Remove `branch` from `repo`'s map, and drop the repo key entirely if that leaves it empty.
 fn clear_branch(store: &mut Map<String, Value>, repo: &str, branch: &str) {
     let Some(entry) = store.get_mut(repo) else {
@@ -184,15 +272,57 @@ mod tests {
     }
 
     #[test]
-    fn store_path_is_under_identifier_and_named() {
+    fn store_path_avoids_the_real_store_under_test() {
+        // This runs in a cfg(test) build, so `store_path` takes arm 2 (temp subdir)
+        // UNLESS a GD_REVIEW_NOTES_DIR override is present in the environment. Branch on
+        // the var rather than mutating process env (which would race parallel tests).
         let path = store_path().unwrap();
-        // …/com.thebguy.gitdesktop/review-notes.json
         assert!(path.ends_with(STORE_FILE), "path: {}", path.display());
-        assert!(
-            path.to_string_lossy().contains(APP_IDENTIFIER),
-            "path: {}",
-            path.display()
+        match std::env::var("GD_REVIEW_NOTES_DIR").ok().filter(|d| !d.is_empty()) {
+            Some(dir) => {
+                // Override wins even under test: path is under the override dir.
+                assert!(
+                    path.starts_with(&dir),
+                    "override path {path:?} should be under {dir}"
+                );
+            }
+            None => {
+                // The real store must NOT be reachable from an in-crate test.
+                assert!(
+                    path.starts_with(std::env::temp_dir()),
+                    "test store {path:?} should be under the temp dir"
+                );
+                assert!(
+                    !path.components().any(|c| c.as_os_str() == APP_IDENTIFIER),
+                    "test store {path:?} must not contain the real app-data segment {APP_IDENTIFIER}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn store_path_honors_gd_review_notes_dir_override() {
+        // Drive the pure resolver directly — deterministic + parallel-safe (no
+        // process-env mutation).
+        // 1. An explicit override wins regardless of the test flag.
+        let over = resolve_store_base(Some("C:/tmp/x"), true).unwrap();
+        assert_eq!(over, PathBuf::from("C:/tmp/x"));
+        let over_nontest = resolve_store_base(Some("C:/tmp/x"), false).unwrap();
+        assert_eq!(over_nontest, PathBuf::from("C:/tmp/x"));
+        // An empty override is ignored (falls through to the next arm).
+        assert_eq!(
+            resolve_store_base(Some(""), true).unwrap(),
+            std::env::temp_dir().join("gd-review-notes-test")
         );
+        // 2. No override + test → the temp subdir.
+        assert_eq!(
+            resolve_store_base(None, true).unwrap(),
+            std::env::temp_dir().join("gd-review-notes-test")
+        );
+        // 3. No override + non-test → the real app-data dir, so the production path
+        //    stays …/com.thebguy.gitdesktop/review-notes.json, unchanged by the seam.
+        let real = resolve_store_base(None, false).unwrap();
+        assert_eq!(real, dirs::data_dir().unwrap().join(APP_IDENTIFIER));
     }
 
     #[test]
@@ -312,6 +442,120 @@ mod tests {
         // Our repo now has both the sibling branch and the new one.
         assert_eq!(back[repo]["sibling"]["body"], "sib");
         assert_eq!(back[repo]["feature"]["body"], "new note");
+    }
+
+    #[test]
+    fn rename_moves_the_note_to_the_new_branch() {
+        let (_tmp, path) = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "feature", "look at the migration").unwrap();
+        set_at(&path, repo, "other", "note B").unwrap();
+
+        rename_at(&path, repo, "feature", "feature-renamed").unwrap();
+
+        let back = read_store(&path).unwrap();
+        assert!(back[repo].get("feature").is_none(), "{back:?}");
+        assert_eq!(back[repo]["feature-renamed"]["body"], "look at the migration");
+        // The sibling branch is untouched.
+        assert_eq!(back[repo]["other"]["body"], "note B");
+    }
+
+    #[test]
+    fn rename_overwrites_a_note_sitting_under_the_new_name() {
+        let (_tmp, path) = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "feature", "carried over").unwrap();
+        set_at(&path, repo, "taken", "stale").unwrap();
+
+        rename_at(&path, repo, "feature", "taken").unwrap();
+
+        let back = read_store(&path).unwrap();
+        assert_eq!(back[repo]["taken"]["body"], "carried over");
+        assert_eq!(back[repo].as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn rename_without_a_source_note_drops_a_stale_target_note() {
+        let (_tmp, path) = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "taken", "stale").unwrap();
+        set_at(&path, repo, "other", "note B").unwrap();
+
+        // "feature" never had a note, so the one under the claimed name is stale.
+        rename_at(&path, repo, "feature", "taken").unwrap();
+
+        let back = read_store(&path).unwrap();
+        assert!(back[repo].get("taken").is_none(), "{back:?}");
+        assert_eq!(back[repo]["other"]["body"], "note B");
+    }
+
+    #[test]
+    fn stale_target_delete_that_empties_the_map_drops_the_repo_key() {
+        let (_tmp, path) = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "taken", "stale").unwrap();
+
+        rename_at(&path, repo, "feature", "taken").unwrap();
+
+        let back = read_store(&path).unwrap();
+        assert!(back.get(repo).is_none(), "repo key should be gone: {back:?}");
+        assert!(back.is_empty());
+    }
+
+    #[test]
+    fn rename_with_nothing_to_migrate_writes_nothing() {
+        let (_tmp, path) = tmp_store();
+        let repo = "C:/repo/one/.git";
+        // No store file at all: an unnoted branch's rename must not create one.
+        rename_at(&path, repo, "feature", "feature-renamed").unwrap();
+        assert!(!path.exists(), "no store file should have been created");
+
+        // A store holding only other repos/branches is left byte-identical.
+        set_at(&path, "C:/repo/other/.git", "main", "keep me").unwrap();
+        let before = std::fs::read(&path).unwrap();
+        rename_at(&path, repo, "feature", "feature-renamed").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn a_same_name_rename_leaves_the_note_alone() {
+        let (_tmp, path) = tmp_store();
+        let repo = "C:/repo/one/.git";
+        set_at(&path, repo, "feature", "keep me").unwrap();
+
+        rename_at(&path, repo, "feature", "feature").unwrap();
+
+        let back = read_store(&path).unwrap();
+        assert_eq!(back[repo]["feature"]["body"], "keep me");
+    }
+
+    #[test]
+    fn rename_preserves_unknown_fields_on_the_moved_and_sibling_notes() {
+        let (_tmp, path) = tmp_store();
+        let other_repo = "C:/repo/other/.git";
+        let repo = "C:/repo/one/.git";
+        let mut store = Map::new();
+        store.insert(
+            other_repo.to_string(),
+            json!({ "main": { "body": "keep me", "savedAt": "2026-01-01T00:00:00.000Z", "futureField": 7 } }),
+        );
+        store.insert(
+            repo.to_string(),
+            json!({ "feature": { "body": "moved", "savedAt": "2026-01-02T00:00:00.000Z", "futureField": 9 } }),
+        );
+        write_store(&path, &store).unwrap();
+
+        rename_at(&path, repo, "feature", "feature-renamed").unwrap();
+
+        let back = read_store(&path).unwrap();
+        // The record moves verbatim — unknown field and original savedAt included.
+        assert_eq!(back[repo]["feature-renamed"]["futureField"], 9);
+        assert_eq!(
+            back[repo]["feature-renamed"]["savedAt"],
+            "2026-01-02T00:00:00.000Z"
+        );
+        // The other repo's note (and its unknown field) is untouched.
+        assert_eq!(back[other_repo]["main"]["futureField"], 7);
     }
 
     #[test]

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -62,7 +62,8 @@ const STORE_FILE: &str = "review-notes.json";
 /// Pure resolution of the store's base directory, in precedence order (mirroring
 /// [`crate::oplog::resolve_store_base`]):
 /// 1. a non-empty `GD_REVIEW_NOTES_DIR` override — the escape hatch for headless/test
-///    callers;
+///    callers. Unlike the oplog (Rust-only), this store has a GUI reader that does NOT
+///    honor the override, so an override splits Rust writer from GUI reader;
 /// 2. under `cfg!(test)`, a temp subdir, so no in-crate test can write the user's real
 ///    store (the rename migration runs for real under `cargo test`);
 /// 3. otherwise the real app-data dir (`dirs::data_dir()/<identifier>`), mirroring

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -62,8 +62,9 @@ const STORE_FILE: &str = "review-notes.json";
 /// Pure resolution of the store's base directory, in precedence order (mirroring
 /// [`crate::oplog::resolve_store_base`]):
 /// 1. a non-empty `GD_REVIEW_NOTES_DIR` override — the escape hatch for headless/test
-///    callers. Unlike the oplog (Rust-only), this store has a GUI reader that does NOT
-///    honor the override, so an override splits Rust writer from GUI reader;
+///    callers. Unlike the oplog (Rust-only), this store has a GUI reader/writer that
+///    does NOT honor the override, so an override splits the Rust side from the GUI's
+///    copy entirely;
 /// 2. under `cfg!(test)`, a temp subdir, so no in-crate test can write the user's real
 ///    store (the rename migration runs for real under `cargo test`);
 /// 3. otherwise the real app-data dir (`dirs::data_dir()/<identifier>`), mirroring

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -524,13 +524,13 @@ can safely preview and recover work you thought was gone.
 **Operation history** (in the branch ⋮ menu, or the command palette) opens a
 journal of the *risky* operations GitDesktop runs — local PR merges, cherry-picks, history
 edits, and interactive rebases — each recorded with the exact branch and commit it started
-from, and whether it finished, failed, or is still pending. If one of these operations is
-interrupted (a crash or a restart mid-op), a calm recovery line appears above the **Changes**
-list naming what was interrupted and the state it started from. That notice only informs — it
-never resets or continues anything on its own (the git-native **Continue**/**Abort** for an
-in-progress merge, rebase, cherry-pick, or revert live in the conflict bar right above it);
-from it you can open this history, jump to **Recover lost work** to rescue any orphaned
-changes, or dismiss the notice.
+from, and whether it finished, failed, is paused on conflicts, or is still pending. If one
+of these operations is interrupted (a crash or a restart mid-op), a calm recovery line
+appears above the **Changes** list naming what was interrupted and the state it started
+from. That notice only informs — it never resets or continues anything on its own (the
+git-native **Continue**/**Abort** for an in-progress merge, rebase, cherry-pick, or revert
+live in the conflict bar right above it); from it you can open this history, jump to
+**Recover lost work** to rescue any orphaned changes, or dismiss the notice.
 
 ## Compare
 
@@ -595,8 +595,8 @@ lands *there* (not the main workspace) and offers a one-click **Open main worksp
 checked-out branch. Each of those rows carries the worktree management actions on its
 context menu — **Open worktree**, **Copy path**, **Rename…**, **Lock…**/**Unlock**,
 **Promote to main workspace…**, **Delete worktree…** — with the ones a row doesn't support
-(the main workspace, a detached checkout, a locked worktree) hidden or disabled with the
-reason in the label. **Open main workspace** and
+(the main workspace, a detached checkout, a locked worktree, one being removed) hidden or
+disabled with the reason in the label. **Open main workspace** and
 **Promote this worktree to main workspace** are in the command palette too.
 
 A repository's local pull requests, issues, review history, and per-repo settings are shared
@@ -664,7 +664,9 @@ already pushed), GitDesktop detects the divergence and turns Push into a **confi
 force push using \`--force-with-lease --force-if-includes\`** — which refuses to overwrite
 work someone else pushed unless your branch already includes it, even when auto-fetch has
 already updated your view of the remote. On a Git older than 2.30, or a branch with no
-reflog for the check to read, the push falls back to \`--force-with-lease\` alone.
+reflog for the check to read, the push falls back to \`--force-with-lease\` alone, and the
+confirmation toast says so. When the remote has moved since your last look, the blocked
+push explains it in plain words, with Git's full output one click away under **Details**.
 
 ## Resolving conflicts
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -588,9 +588,10 @@ already in use. The **branch switcher** knows this too: a branch that's checked 
 another worktree is badged, and choosing it offers to open that worktree instead of failing
 with a checkout error. You can also **Delete worktree…** straight from that badged branch's
 context menu (disabled when the badge points at the main workspace, which can't be
-removed) — the branch stays, and its **Delete…** item un-disables once the worktree
-is gone. When you're in a linked worktree the switcher reminds you that a branch checkout
-lands *there* (not the main workspace) and offers a one-click **Open main workspace**, and its
+removed, and while that worktree's removal is already running) — the branch stays, and
+its **Delete…** item un-disables once the worktree is gone. When you're in a linked
+worktree the switcher reminds you that a branch checkout lands *there* (not the
+main workspace) and offers a one-click **Open main workspace**, and its
 **Worktrees** section jumps you straight to any other worktree — no detour through a
 checked-out branch. Each of those rows carries the worktree management actions on its
 context menu — **Open worktree**, **Copy path**, **Rename…**, **Lock…**/**Unlock**,
@@ -665,7 +666,7 @@ force push using \`--force-with-lease --force-if-includes\`** — which refuses 
 work someone else pushed unless your branch already includes it, even when auto-fetch has
 already updated your view of the remote. On a Git older than 2.30, or a branch with no
 reflog for the check to read, the push falls back to \`--force-with-lease\` alone, and the
-confirmation toast says so. When the remote has moved since your last look, the blocked
+success toast says so. When the remote has moved since your last look, the blocked
 push explains it in plain words, with Git's full output one click away under **Details**.
 
 ## Resolving conflicts

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -85,6 +85,10 @@ import {
   useSettings,
 } from "@/lib/settings/queries";
 import { type SelectedPr, useUiStore } from "@/lib/stores/ui";
+import {
+  isWorktreePromoting,
+  useWorktreeRemovals,
+} from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
@@ -111,7 +115,12 @@ import {
   reportAutostashOutcome,
   useStashReapplyRecovery,
 } from "./useStashReapplyRecovery";
-import { LockWorktreeDialog, RenameWorktreeDialog } from "./WorktreesDialog";
+import {
+  LockWorktreeDialog,
+  RenameWorktreeDialog,
+  refuseWhileLeaving,
+  worktreeItemLabel,
+} from "./WorktreesDialog";
 
 /** Last path segment (folder name), tolerating either separator. */
 const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
@@ -428,6 +437,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     (w) => normPath(w.path) !== activeNorm,
   );
   const inLinkedWorktree = Boolean(currentWorktree && !currentWorktree.isMain);
+  // A worktree whose folder is being removed still lists (the removal outlives
+  // the dialog that started it), but nothing may act on it until it settles.
+  // Raw paths on both sides: these and the removals' come from listUserWorktrees.
+  const removals = useWorktreeRemovals(repoPath);
+  const removingPaths = new Set(removals.map((r) => r.path));
   const currentWorktreeName = currentWorktree
     ? baseName(currentWorktree.path)
     : "";
@@ -643,6 +657,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // (git forbids it); offer to open that worktree instead of erroring.
     const wtPath = worktreeByBranch.get(name);
     if (wtPath) {
+      // Its folder is on its way out — offering to open it would land the app
+      // in a directory mid-deletion.
+      if (refuseWhileLeaving(wtPath, removingPaths.has(wtPath))) return;
       setWorktreeSwitchTarget({ name, path: wtPath });
       return;
     }
@@ -1208,6 +1225,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         toast.info("This worktree is locked — unlock it before promoting.");
         return;
       }
+      // Only a promote can have claimed the worktree you're standing in: no
+      // surface offers to delete the active checkout, and a promote marks its
+      // removal under the main workspace's key, never this one's.
+      if (isWorktreePromoting(here.path)) {
+        toast.info("This worktree is being promoted.");
+        return;
+      }
       setPromoteTarget(here);
     } catch (e) {
       toastError(e);
@@ -1238,6 +1262,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       (w) => w.path === worktreeByBranch.get(branch.name),
     );
     const inWorktree = rowWorktree !== undefined;
+    const rowWorktreeRemoving = Boolean(
+      rowWorktree && removingPaths.has(rowWorktree.path),
+    );
     // Outbound sync gating. `pushable` = tracked on a KNOWN remote and ahead →
     // offer a plain push to that remote (disabled with "(diverged)" when also
     // behind); the backend resolves to the branch's own upstream remote.
@@ -1568,16 +1595,18 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           <ContextMenuSeparator />
           {inWorktree && (
             <ContextMenuItem
-              disabled={rowWorktree?.isMain}
+              disabled={rowWorktree?.isMain || rowWorktreeRemoving}
               onClick={() => {
                 if (!rowWorktree) return;
                 setOpen(false);
                 setRemoveWorktreeTarget(rowWorktree);
               }}
             >
-              {rowWorktree?.isMain
-                ? "Delete worktree… (main workspace)"
-                : "Delete worktree…"}
+              {worktreeItemLabel(
+                "Delete worktree…",
+                rowWorktreeRemoving,
+                rowWorktree?.isMain ? "main workspace" : undefined,
+              )}
             </ContextMenuItem>
           )}
           <ContextMenuItem
@@ -1823,131 +1852,161 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   {/* No isCurrent gating on these menus: otherWorktrees excludes
                       the active checkout, by the same normalized-path comparison
                       the whole section keys on. */}
-                  {otherWorktrees.map((w) => (
-                    <ContextMenu key={w.path}>
-                      <ContextMenuTrigger
-                        render={
-                          <button
-                            type="button"
-                            data-row={w.path}
-                            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
+                  {otherWorktrees.map((w) => {
+                    const isRemoving = removingPaths.has(w.path);
+                    const itemLabel = (label: string, otherReason?: string) =>
+                      worktreeItemLabel(label, isRemoving, otherReason);
+                    const renameBlockedReason = (() => {
+                      if (w.isMain) return "main workspace";
+                      if (w.isLocked) return "locked";
+                      return undefined;
+                    })();
+                    return (
+                      <ContextMenu key={w.path}>
+                        <ContextMenuTrigger
+                          render={
+                            <button
+                              type="button"
+                              data-row={w.path}
+                              // Not `disabled`: the row must stay focusable so
+                              // arrow-key nav can move through it.
+                              aria-disabled={isRemoving || undefined}
+                              title={
+                                isRemoving ? "Removal in progress" : undefined
+                              }
+                              className={cn(
+                                "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none",
+                                isRemoving && "cursor-default",
+                              )}
+                              onClick={() => {
+                                if (isRemoving) return;
+                                setOpen(false);
+                                openWorktree(w.path);
+                              }}
+                            >
+                              <TreeStructureIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                              <span className="min-w-0 flex-1 truncate">
+                                {w.isDetached
+                                  ? "detached HEAD"
+                                  : w.branch || "—"}
+                              </span>
+                              {w.isMain && (
+                                <Badge variant="secondary" className="shrink-0">
+                                  Main
+                                </Badge>
+                              )}
+                              <span
+                                className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground"
+                                onMouseEnter={(e) => {
+                                  const el = e.currentTarget;
+                                  // Full path is the useful tooltip (the row already
+                                  // shows the folder name). removeAttribute, not
+                                  // title="", so an unclipped row leaves no empty tooltip.
+                                  if (el.scrollWidth > el.clientWidth)
+                                    el.title = w.path;
+                                  else el.removeAttribute("title");
+                                }}
+                              >
+                                {baseName(w.path)}
+                              </span>
+                            </button>
+                          }
+                        />
+                        <ContextMenuContent className="min-w-48">
+                          <ContextMenuItem
+                            disabled={isRemoving}
                             onClick={() => {
                               setOpen(false);
                               openWorktree(w.path);
                             }}
                           >
-                            <TreeStructureIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                            <span className="min-w-0 flex-1 truncate">
-                              {w.isDetached ? "detached HEAD" : w.branch || "—"}
-                            </span>
-                            {w.isMain && (
-                              <Badge variant="secondary" className="shrink-0">
-                                Main
-                              </Badge>
-                            )}
-                            <span
-                              className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground"
-                              onMouseEnter={(e) => {
-                                const el = e.currentTarget;
-                                // Full path is the useful tooltip (the row already
-                                // shows the folder name). removeAttribute, not
-                                // title="", so an unclipped row leaves no empty tooltip.
-                                if (el.scrollWidth > el.clientWidth)
-                                  el.title = w.path;
-                                else el.removeAttribute("title");
-                              }}
-                            >
-                              {baseName(w.path)}
-                            </span>
-                          </button>
-                        }
-                      />
-                      <ContextMenuContent className="min-w-48">
-                        <ContextMenuItem
-                          onClick={() => {
-                            setOpen(false);
-                            openWorktree(w.path);
-                          }}
-                        >
-                          Open worktree
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onClick={() => copyText(w.path, "Path copied")}
-                        >
-                          Copy path
-                        </ContextMenuItem>
-                        <ContextMenuSeparator />
-                        <ContextMenuItem
-                          // git worktree move refuses the main worktree and a
-                          // locked one.
-                          disabled={w.isMain || w.isLocked}
-                          onClick={() => {
-                            setOpen(false);
-                            setRenameWorktreeTarget(w);
-                          }}
-                        >
-                          {w.isMain
-                            ? "Rename… (main workspace)"
-                            : w.isLocked
-                              ? "Rename… (locked)"
-                              : "Rename…"}
-                        </ContextMenuItem>
-                        {!w.isMain &&
-                          (w.isLocked ? (
-                            <ContextMenuItem
-                              // In-place state change: the list refreshes via the
-                              // mutation's invalidation, so the popover stays open.
-                              onClick={() =>
-                                unlockWorktree.mutate(w.path, {
-                                  onSuccess: () =>
-                                    toast.success("Worktree unlocked"),
-                                  onError,
-                                })
-                              }
-                            >
-                              Unlock
-                            </ContextMenuItem>
-                          ) : (
-                            <ContextMenuItem
-                              onClick={() => {
-                                setOpen(false);
-                                setLockWorktreeTarget(w);
-                              }}
-                            >
-                              Lock…
-                            </ContextMenuItem>
-                          ))}
-                        {/* Promote moves this worktree's branch into the main
-                            workspace, so it needs a linked worktree with a
-                            branch. */}
-                        {!w.isMain && !w.isDetached && (
+                            {itemLabel("Open worktree")}
+                          </ContextMenuItem>
+                          {/* Copying a path acts on nothing, so a removal doesn't
+                            block it. */}
                           <ContextMenuItem
-                            disabled={w.isLocked}
+                            onClick={() => copyText(w.path, "Path copied")}
+                          >
+                            Copy path
+                          </ContextMenuItem>
+                          <ContextMenuSeparator />
+                          <ContextMenuItem
+                            // git worktree move refuses the main worktree and a
+                            // locked one.
+                            disabled={w.isMain || w.isLocked || isRemoving}
                             onClick={() => {
                               setOpen(false);
-                              setPromoteTarget(w);
+                              setRenameWorktreeTarget(w);
                             }}
                           >
-                            {w.isLocked
-                              ? "Promote to main workspace… (locked)"
-                              : "Promote to main workspace…"}
+                            {itemLabel("Rename…", renameBlockedReason)}
                           </ContextMenuItem>
-                        )}
-                        <ContextMenuSeparator />
-                        <ContextMenuItem
-                          disabled={w.isMain}
-                          onClick={() => {
-                            setOpen(false);
-                            setRemoveWorktreeTarget(w);
-                          }}
-                        >
-                          {w.isMain
-                            ? "Delete worktree… (main workspace)"
-                            : "Delete worktree…"}
-                        </ContextMenuItem>
-                      </ContextMenuContent>
-                    </ContextMenu>
-                  ))}
+                          {!w.isMain &&
+                            (w.isLocked ? (
+                              <ContextMenuItem
+                                // In-place state change: the list refreshes via the
+                                // mutation's invalidation, so the popover stays open.
+                                disabled={isRemoving}
+                                onClick={() => {
+                                  // The menu can outlive the state that disabled
+                                  // this item, and a promote's claim never
+                                  // re-renders it.
+                                  if (refuseWhileLeaving(w.path, isRemoving))
+                                    return;
+                                  unlockWorktree.mutate(w.path, {
+                                    onSuccess: () =>
+                                      toast.success("Worktree unlocked"),
+                                    onError,
+                                  });
+                                }}
+                              >
+                                {itemLabel("Unlock")}
+                              </ContextMenuItem>
+                            ) : (
+                              <ContextMenuItem
+                                disabled={isRemoving}
+                                onClick={() => {
+                                  setOpen(false);
+                                  setLockWorktreeTarget(w);
+                                }}
+                              >
+                                {itemLabel("Lock…")}
+                              </ContextMenuItem>
+                            ))}
+                          {/* Promote moves this worktree's branch into the main
+                            workspace, so it needs a linked worktree with a
+                            branch. */}
+                          {!w.isMain && !w.isDetached && (
+                            <ContextMenuItem
+                              disabled={w.isLocked || isRemoving}
+                              onClick={() => {
+                                setOpen(false);
+                                setPromoteTarget(w);
+                              }}
+                            >
+                              {itemLabel(
+                                "Promote to main workspace…",
+                                w.isLocked ? "locked" : undefined,
+                              )}
+                            </ContextMenuItem>
+                          )}
+                          <ContextMenuSeparator />
+                          <ContextMenuItem
+                            disabled={w.isMain || isRemoving}
+                            onClick={() => {
+                              setOpen(false);
+                              setRemoveWorktreeTarget(w);
+                            }}
+                          >
+                            {itemLabel(
+                              "Delete worktree…",
+                              w.isMain ? "main workspace" : undefined,
+                            )}
+                          </ContextMenuItem>
+                        </ContextMenuContent>
+                      </ContextMenu>
+                    );
+                  })}
                 </div>
               )}
               <div className="border-t py-1">
@@ -2240,7 +2299,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         onConfirm={() => {
           const target = worktreeSwitchTarget;
           setWorktreeSwitchTarget(null);
-          if (target) openWorktree(target.path);
+          if (!target) return;
+          // This dialog can outlive the state that would have refused it.
+          if (refuseWhileLeaving(target.path, removingPaths.has(target.path)))
+            return;
+          openWorktree(target.path);
         }}
       />
 

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1879,7 +1879,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                                 isRemoving && "cursor-default",
                               )}
                               onClick={() => {
-                                if (isRemoving) return;
+                                if (refuseWhileLeaving(w.path, isRemoving))
+                                  return;
                                 setOpen(false);
                                 openWorktree(w.path);
                               }}
@@ -1916,6 +1917,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                           <ContextMenuItem
                             disabled={isRemoving}
                             onClick={() => {
+                              if (refuseWhileLeaving(w.path, isRemoving))
+                                return;
                               setOpen(false);
                               openWorktree(w.path);
                             }}

--- a/src/features/repository/OperationHistoryDialog.tsx
+++ b/src/features/repository/OperationHistoryDialog.tsx
@@ -4,6 +4,7 @@ import {
   GitBranchIcon,
   GitCommitIcon,
   GitMergeIcon,
+  PauseCircleIcon,
   PencilSimpleIcon,
   ProhibitIcon,
   WarningCircleIcon,
@@ -43,6 +44,7 @@ const STATUS_META: Record<
   { label: string; Icon: IconType; tone: string }
 > = {
   pending: { label: "Pending", Icon: ClockIcon, tone: "text-warning" },
+  paused: { label: "Paused", Icon: PauseCircleIcon, tone: "text-warning" },
   done: { label: "Done", Icon: CheckCircleIcon, tone: "text-success" },
   failed: {
     label: "Failed",

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -27,7 +27,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
-import { forgeDetectForkPrForBranch, type PullMode } from "@/lib/git/api";
+import {
+  forgeDetectForkPrForBranch,
+  type PullMode,
+  type PushGuard,
+} from "@/lib/git/api";
 import {
   useAutoFetch,
   useFetchStatusStore,
@@ -53,6 +57,21 @@ import { toastError } from "@/lib/toast";
 import { ForkPrPublishGuard } from "./ForkPrPublishGuard";
 import { PublishRepoControl, usePublishProviders } from "./PublishRepoControl";
 import { useStashReapplyRecovery } from "./useStashReapplyRecovery";
+
+/** What a force push fell back to, for the guarantees weaker than the intended
+ *  `--force-with-lease --force-if-includes` pair. TOTAL on purpose: a new
+ *  `PushGuard` variant has to fail the typecheck here rather than ship the bare
+ *  "Force pushed" this table exists to stop overclaiming. Same two reasons the
+ *  MCP `force_push` tool reports (mcp_server/write_git.rs) — keep the wording in
+ *  step. */
+const FORCE_PUSH_DEGRADED: Record<PushGuard, string | undefined> = {
+  // The intended pair is what the plain confirmation already means.
+  leaseAndIncludes: undefined,
+  leaseOnlyOldGit:
+    "Protected by the lease alone: this Git predates --force-if-includes.",
+  leaseOnlyNoReflog:
+    "Protected by the lease alone: the branch has no reflog for --force-if-includes to check.",
+};
 
 export function SyncControls({ repoPath }: { repoPath: string }) {
   const status = useRepoStatus(repoPath);
@@ -294,8 +313,13 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
     push.mutate(
       { setUpstream: !hasUpstream, force },
       {
-        onSuccess: () => {
-          if (force) toast.success("Force pushed");
+        onSuccess: (guard) => {
+          // Only a force push has a guarantee to report, and only the two
+          // degraded values say more than the plain confirmation does.
+          if (force)
+            toast.success("Force pushed", {
+              description: FORCE_PUSH_DEGRADED[guard],
+            });
           setForceConfirmOpen(false);
         },
         onError: (e) => {

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -341,8 +341,8 @@ function WorktreeRow({
         role="option"
         aria-selected={highlighted}
         // Not `disabled`: the current row must stay focusable so arrow-key nav
-        // can move through it. onOpen already no-ops on the current worktree
-        // and on one being removed.
+        // can move through it. onOpen already no-ops on the current worktree,
+        // and refuses one that's being removed or promoted.
         aria-disabled={isCurrent || isRemoving || undefined}
         data-wt-path={path}
         onFocus={onFocus}

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -56,7 +56,11 @@ import {
 import type { UserWorktree } from "@/lib/git/worktree";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
-import { useWorktreeRemovals } from "@/lib/stores/worktree-removal";
+import {
+  isWorktreePromoting,
+  useIsRemovingWorktree,
+  useWorktreeRemovals,
+} from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
@@ -314,13 +318,8 @@ function WorktreeRow({
 }) {
   const { path, branch, isMain, isDetached, isLocked, lockReason } = worktree;
 
-  // A disabled menu item can't carry a tooltip, so its blocking reason rides the
-  // label. A removal in progress outranks the other reasons — the worktree is on
-  // its way out, whatever else is true of it.
-  const itemLabel = (label: string, otherReason?: string) => {
-    if (isRemoving) return `${label} (removal in progress)`;
-    return otherReason ? `${label} (${otherReason})` : label;
-  };
+  const itemLabel = (label: string, otherReason?: string) =>
+    worktreeItemLabel(label, isRemoving, otherReason);
   const openTitle = isCurrent ? "Current worktree" : "Open this worktree";
 
   return (
@@ -517,6 +516,36 @@ function RowTags({
 
 // --------------------------------------------------------------- rename worktree
 
+/** A disabled menu item can't carry a tooltip, so its blocking reason rides the
+ *  label. A removal in progress outranks the other reasons — the worktree is on
+ *  its way out, whatever else is true of it. */
+export function worktreeItemLabel(
+  label: string,
+  isRemoving: boolean,
+  otherReason?: string,
+): string {
+  if (isRemoving) return `${label} (removal in progress)`;
+  return otherReason ? `${label} (${otherReason})` : label;
+}
+
+/** Refuses an action on a worktree that's on its way out, at the moment it would
+ *  fire: the menu that opened the dialog can outlive the state that disabled it,
+ *  and a promote's claim never re-renders anything. Returns true when the caller
+ *  must not start its mutation. These callers never asked for the removal, so the
+ *  wording states the state rather than the store's "already" (a duplicate
+ *  attempt, correct only where the store refuses one). */
+export function refuseWhileLeaving(path: string, removing: boolean): boolean {
+  if (removing) {
+    toast.info("This worktree is being removed.");
+    return true;
+  }
+  if (isWorktreePromoting(path)) {
+    toast.info("This worktree is being promoted.");
+    return true;
+  }
+  return false;
+}
+
 export function RenameWorktreeDialog({
   repoPath,
   worktree,
@@ -527,6 +556,7 @@ export function RenameWorktreeDialog({
   onClose: () => void;
 }) {
   const move = useMoveUserWorktree(repoPath);
+  const removing = useIsRemovingWorktree(repoPath, worktree?.path);
   const { parent, name: currentName } = splitPath(worktree?.path ?? "");
   const [name, setName] = useState(currentName);
 
@@ -539,6 +569,7 @@ export function RenameWorktreeDialog({
 
   function handleRename() {
     if (!worktree || !trimmed || unchanged || invalid) return;
+    if (refuseWhileLeaving(worktree.path, removing)) return;
     move.mutate(
       { from: worktree.path, to: newPath },
       {
@@ -587,12 +618,23 @@ export function RenameWorktreeDialog({
           </span>
         </form>
 
+        {/* A disabled button can't carry a tooltip; the reason goes on screen. */}
+        {removing && (
+          <p className="text-xs text-muted-foreground">
+            This worktree is being removed, so it can't be renamed.
+          </p>
+        )}
+
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={move.isPending}>
-            Cancel
+            {/* Nothing here can call the removal off, so "Cancel" would promise
+                more than closing this dialog does. */}
+            {removing ? "Close" : "Cancel"}
           </Button>
           <Button
-            disabled={!trimmed || unchanged || invalid || move.isPending}
+            disabled={
+              !trimmed || unchanged || invalid || move.isPending || removing
+            }
             onClick={handleRename}
           >
             {move.isPending && <Spinner data-icon="inline-start" />}
@@ -616,10 +658,12 @@ export function LockWorktreeDialog({
   onClose: () => void;
 }) {
   const lock = useLockUserWorktree(repoPath);
+  const removing = useIsRemovingWorktree(repoPath, worktree?.path);
   const [reason, setReason] = useState("");
 
   function handleLock() {
     if (!worktree) return;
+    if (refuseWhileLeaving(worktree.path, removing)) return;
     lock.mutate(
       { path: worktree.path, reason: reason.trim() || undefined },
       {
@@ -665,11 +709,20 @@ export function LockWorktreeDialog({
           />
         </form>
 
+        {/* A disabled button can't carry a tooltip; the reason goes on screen. */}
+        {removing && (
+          <p className="text-xs text-muted-foreground">
+            This worktree is being removed, so it can't be locked.
+          </p>
+        )}
+
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={lock.isPending}>
-            Cancel
+            {/* Nothing here can call the removal off, so "Cancel" would promise
+                more than closing this dialog does. */}
+            {removing ? "Close" : "Cancel"}
           </Button>
-          <Button onClick={handleLock} disabled={lock.isPending}>
+          <Button onClick={handleLock} disabled={lock.isPending || removing}>
             {lock.isPending && <Spinner data-icon="inline-start" />}
             Lock
           </Button>

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -121,8 +121,7 @@ export function WorktreesDialog({
   );
 }
 
-// ----------------------------------------------------------------- list mode
-
+/** List mode: every worktree as a row, its actions on a removal-gated menu. */
 function WorktreeList({
   repoPath,
   open,
@@ -164,7 +163,10 @@ function WorktreeList({
 
   async function handleOpen(w: UserWorktree) {
     if (normPath(w.path) === activeNorm) return; // already here
-    if (removingPaths.has(w.path)) return; // its folder is going away
+    // Its folder is on its way out. Not just the removal entry: a promote gaps
+    // it on both ends — the claim lands before markRemoval, and the tail runs
+    // on past the delete with nothing left in `removingPaths`.
+    if (refuseWhileLeaving(w.path, removingPaths.has(w.path))) return;
     await openWorktree(w.path);
     onClose();
   }
@@ -514,11 +516,10 @@ function RowTags({
   );
 }
 
-// --------------------------------------------------------------- rename worktree
-
 /** A disabled menu item can't carry a tooltip, so its blocking reason rides the
  *  label. A removal in progress outranks the other reasons — the worktree is on
- *  its way out, whatever else is true of it. */
+ *  its way out, whatever else is true of it. Shared with the branch switcher's
+ *  worktree rows and its badged-branch Delete item, not just this manager. */
 export function worktreeItemLabel(
   label: string,
   isRemoving: boolean,
@@ -529,11 +530,12 @@ export function worktreeItemLabel(
 }
 
 /** Refuses an action on a worktree that's on its way out, at the moment it would
- *  fire: the menu that opened the dialog can outlive the state that disabled it,
+ *  fire: the UI that offered the action can outlive the state that disabled it,
  *  and a promote's claim never re-renders anything. Returns true when the caller
- *  must not start its mutation. These callers never asked for the removal, so the
- *  wording states the state rather than the store's "already" (a duplicate
- *  attempt, correct only where the store refuses one). */
+ *  must not proceed — mutations and open/switch navigations alike. These callers
+ *  never asked for the removal, so the wording states the state rather than the
+ *  store's "already" (a duplicate attempt, correct only where the store refuses
+ *  one). */
 export function refuseWhileLeaving(path: string, removing: boolean): boolean {
   if (removing) {
     toast.info("This worktree is being removed.");
@@ -546,6 +548,8 @@ export function refuseWhileLeaving(path: string, removing: boolean): boolean {
   return false;
 }
 
+/** Renames (moves) a worktree's folder. Shared by the manager and the branch
+ *  switcher; refuses at submit while the worktree is being removed or promoted. */
 export function RenameWorktreeDialog({
   repoPath,
   worktree,
@@ -646,8 +650,8 @@ export function RenameWorktreeDialog({
   );
 }
 
-// ----------------------------------------------------------------- lock worktree
-
+/** Locks a worktree (with an optional reason). Shared by the manager and the
+ *  branch switcher; refuses at submit while it's being removed or promoted. */
 export function LockWorktreeDialog({
   repoPath,
   worktree,
@@ -732,8 +736,7 @@ export function LockWorktreeDialog({
   );
 }
 
-// ---------------------------------------------------------------- create mode
-
+/** Create mode: the add-a-worktree form this dialog swaps to. */
 function CreateWorktree({
   repoPath,
   onCancel,

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -139,6 +139,47 @@ const DIRTY_TREE_MARKERS = [
   "cannot rebase: your index contains uncommitted changes",
 ];
 
+/** Force-push rejections whose reason git prints ONLY inside its per-ref
+ *  `! [rejected]        main -> main (<reason>)` line — everything above and
+ *  below that line is the remote URL and a generic "failed to push some refs",
+ *  which is what a raw summary would otherwise show. Anchored to that line
+ *  shape and matched case-sensitively, since the same blob echoes branch names
+ *  and URLs. The leading space is optional: the Rust layer trims the whole
+ *  report, so the line loses its indent whenever nothing precedes it.
+ *
+ *  Only the two guarded-force reasons are mapped. A plain non-fast-forward
+ *  rejection (`(non-fast-forward)`, `(fetch first)`) means the branch is simply
+ *  behind — different advice, and git's own hint already reads plainly — so it
+ *  keeps its raw presentation.
+ *
+ *  Paired with the Rust canaries
+ *  `force_push_rejection_stderr_still_matches_the_frontend_markers` and
+ *  `force_push_refuses_fetched_but_unintegrated_remote_work` (git/remote.rs),
+ *  which re-run real rejections and assert these reasons still hold — keep the
+ *  two lists in step. */
+const PUSH_REJECTION_SUMMARIES: readonly (readonly [RegExp, string])[] = [
+  // The bare lease refused: the remote-tracking ref no longer describes the
+  // remote, so git can't tell what the push would destroy. The advice has to
+  // reach past a bare fetch — that satisfies the lease but leaves
+  // `--force-if-includes` to reject the retry with the reason below.
+  [
+    /^[ \t]*! \[rejected\][^\n]*\(stale info\)/m,
+    "Force push blocked — the remote moved since your last fetch. Fetch and review the new commits, then bring them into your branch before pushing.",
+  ],
+  // `--force-if-includes` refused: the remote tip was fetched but never merged
+  // or rebased into this branch, so pushing would drop it.
+  [
+    /^[ \t]*! \[rejected\][^\n]*\(remote ref updated since checkout\)/m,
+    "Force push blocked — the remote has commits your branch hasn't incorporated. Pull them in, then push again.",
+  ],
+];
+
+/** The humanized line for a blocked force push, or null when the text carries
+ *  no mapped rejection reason. */
+function pushRejectionSummary(text: string): string | null {
+  return PUSH_REJECTION_SUMMARIES.find(([m]) => m.test(text))?.[1] ?? null;
+}
+
 /** The `git` kind is the only one carrying a stderr blob distinct from its
  *  message; every other kind folds its detail into `message` itself. */
 function gitStderr(e: AppError): string {
@@ -288,9 +329,12 @@ export function presentError(e: unknown): ErrorPresentation {
       ROLLBACK_VERDICTS.some((v) => verdictLine.includes(v));
     const isConflict =
       !rolledBack && CONFLICT_MARKERS.some((m) => m.test(combined));
+    // A rejection reason is read from the COMBINED text: it rides the `stderr`
+    // blob, which the fall-through below deliberately never reads.
     const summary = isConflict
       ? conflictSummary(combined)
-      : firstMeaningfulLine(message) || label;
+      : (pushRejectionSummary(combined) ??
+        (firstMeaningfulLine(message) || label));
 
     const distinctStderr = stderr !== "" && !message.includes(stderr);
     const long =

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -791,6 +791,17 @@ export const gitSwitchAutostash = (
     reapply,
   });
 
+/** Which guarantee a completed push actually ran under (mirrors the Rust
+ *  `PushGuard` in git/remote.rs). Only meaningful when `force` is set: a
+ *  non-force push has no lease to degrade and reports the neutral
+ *  `"leaseAndIncludes"`. The two `leaseOnly*` values mean the push landed with
+ *  `--force-with-lease` alone, so a caller announcing it must not claim the
+ *  stronger `--force-if-includes` protection. */
+export type PushGuard =
+  | "leaseAndIncludes"
+  | "leaseOnlyOldGit"
+  | "leaseOnlyNoReflog";
+
 /** `remoteBranch` names the DESTINATION branch when it differs from the local
  *  one (pushing back to a fork PR's head); it requires both `branch` and
  *  `remote`, and never sets upstream. */
@@ -802,7 +813,7 @@ export const gitPush = (
   remote?: string,
   remoteBranch?: string,
 ) =>
-  invoke<void>("git_push", {
+  invoke<PushGuard>("git_push", {
     repoPath,
     setUpstream,
     force,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
+import { reloadReviewNotes } from "@/lib/review-notes/store";
 import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
 import { COLD_START_NO_GH, COLD_START_NO_GIT } from "@/lib/test-mode";
@@ -3821,19 +3822,32 @@ export function useStashCount(repo: string) {
 }
 
 export function useRenameBranch(repo: string) {
+  const queryClient = useQueryClient();
   return useRepoMutation(
     repo,
     (args: { oldName: string; newName: string }) =>
       api.gitRenameBranch(repo, args.oldName, args.newName),
     {
-      // Re-key the branch's commit draft before the status refetch reports the new
-      // name, so the draft (and any generation streaming into it) survives.
-      // Renames from outside the app (MCP, a terminal `git branch -m`) have no such
-      // hook and still lose the draft when the ambient poll flips the key.
-      onSuccess: (_data, args) =>
+      onSuccess: (_data, args) => {
+        // Re-key the branch's commit draft before the status refetch reports the new
+        // name, so the draft (and any generation streaming into it) survives.
+        // Renames from outside the app (MCP, a terminal `git branch -m`) have no such
+        // hook and still lose the draft when the ambient poll flips the key.
         useUiStore
           .getState()
-          .migrateCommitDraft(repo, args.oldName, args.newName),
+          .migrateCommitDraft(repo, args.oldName, args.newName);
+        // The backend moved the branch's reviewer note on disk as part of the rename;
+        // reload the in-memory store BEFORE invalidating (the focus bridge's pattern in
+        // App.tsx) so the Create-PR dialog reads the note under the new name without
+        // waiting for a focus cycle. Fire-and-forget — this callback must stay sync.
+        void reloadReviewNotes()
+          .then(() =>
+            queryClient.invalidateQueries({ queryKey: ["review-notes"] }),
+          )
+          .catch(() => {
+            // Best-effort: a failed reload just leaves the last known state.
+          });
+      },
     },
   );
 }

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -405,7 +405,8 @@ export interface OpLogEntry {
   op: "merge_local_pr" | "cherry_pick_onto" | "rewrite_commits" | "rebase_edit";
   /** Human label, e.g. "Squash-merge feature → main". */
   label: string;
-  status: "pending" | "done" | "failed" | "dismissed";
+  /** "paused" = handed to you mid-op (a stopped cherry-pick), neither in-flight nor finished. */
+  status: "pending" | "done" | "failed" | "dismissed" | "paused";
   /** ISO timestamp the op started. */
   startedAt: string;
   /** ISO timestamp the op finished, or null while still open. */

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -127,6 +127,14 @@ const promotingMains = new Set<string>();
  *  screen that never started. */
 const promotingWorktrees = new Set<string>();
 
+/** True while a promote has claimed this worktree. A FIRE-TIME check only:
+ *  {@link promotingWorktrees} is deliberately not store state, so nothing
+ *  re-renders when it changes — call this where a mutation would start, never
+ *  to decide what a component paints. */
+export function isWorktreePromoting(path: string): boolean {
+  return promotingWorktrees.has(normPath(path));
+}
+
 // `_set` unused: every write goes through the module-level helpers below, so a
 // runner that outlives its dialog reaches state the same way the starters do.
 export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(


### PR DESCRIPTION
Four fixes that stop the app from claiming more (or less) than what actually happened: a force push now names the guarantee it ran under and explains a rejection in plain words, a cherry-pick that stops on conflicts is journaled as paused rather than finished, worktree actions stand down while a removal is in flight, and a branch's reviewer note follows it through a rename.

### Force-push honesty

- `git_push` in `src-tauri/src/git/remote.rs` now returns `PushGuard` across IPC instead of `()`; the enum gains `serde::Serialize` with `rename_all = "camelCase"`, mirrored by the new `PushGuard` union in `src/lib/git/api.ts`.
- `src/features/repository/SyncControls.tsx` keys the success toast's description off a total `FORCE_PUSH_DEGRADED` record, so a push that fell back to `--force-with-lease` alone (old Git, or a branch with no reflog) says so instead of a bare "Force pushed".
- `src/lib/error-summary.ts` adds `PUSH_REJECTION_SUMMARIES` and `pushRejectionSummary`, anchored on git's per-ref `! [rejected] … (stale info)` / `(remote ref updated since checkout)` lines, turning a blocked force push into one human sentence with the raw output still available under Details.
- New Rust canaries in `remote.rs` (`force_push_rejection_stderr_still_matches_the_frontend_markers`, `push_guard_serializes_to_the_camel_case_wire_values`, plus the `assert_rejection_reason` helper) drive a real rejection end to end and pin the wire strings the frontend matches on.
- Fragments: `changelog.d/fixed-force-push-rejection-copy.md`, plus an extended `changelog.d/fixed-force-push-lease-gap.md`.

### Paused cherry-picks in the operation journal

- `src-tauri/src/oplog.rs` gains a `"paused"` status with `pause`, `close_paused_pick`, `PausedOutcome`, `apply_pause`/`apply_close` and `newest_paused_pick`. `cap_history` no longer evicts an unfinished entry, and `reconcile` stays strictly on `"pending"` so a paused op is never offered as a recovery candidate.
- `cherry_pick_onto_with_timeouts` in `src-tauri/src/git/ops.rs` records a pause instead of a finish when the pick stops on `AppError::Conflict`; `op_continue` and the extracted, testable `op_abort` core close that record as `Continued` or `Aborted`.
- `git_commit_core` in `src-tauri/src/git/commit.rs` closes a pick concluded through the commit box, using the new stat-level `cherry_pick_marker_present` helper in `ops.rs` (it resolves a `gitdir:` pointer so linked worktrees and submodules answer correctly).
- Frontend: `"paused"` joins the status union in `src/lib/git/types.ts` and gets a `PauseCircleIcon` entry in `STATUS_META` in `src/features/repository/OperationHistoryDialog.tsx`.

### Worktree actions during a removal

- `src/features/repository/WorktreesDialog.tsx` exports `worktreeItemLabel` (lifted out of `WorktreeRow`) and a new `refuseWhileLeaving` guard; the Rename and Lock dialogs now disable their action, print the reason on screen, and relabel Cancel to Close while a removal runs.
- `src/features/repository/BranchSwitcher.tsx` subscribes to `useWorktreeRemovals` and applies the same gating to the branch menu's worktree rows and its Delete worktree item, declines to offer opening a worktree mid-deletion, and refuses to promote one that a promote already claimed.
- `src/lib/stores/worktree-removal.ts` exports `isWorktreePromoting`, a deliberately non-reactive fire-time check for those mutation choke points.
- Fragment: `changelog.d/fixed-worktree-actions-during-removal.md`.

### Reviewer notes survive a branch rename

- `src-tauri/src/review_notes.rs` adds `rename_branch` / `rename_at` / `move_branch` (the note record moves verbatim, `savedAt` untouched, and a stale note already sitting under the target name is dropped) plus a `resolve_store_base` seam with a `GD_REVIEW_NOTES_DIR` override and a `cfg(test)` temp dir, so no in-crate test writes the real store.
- `git_rename_branch_core` in `src-tauri/src/git/branches.rs` calls it best-effort after the rename lands, so a store failure can never surface as a failed rename; `rename_carries_the_reviewer_note_to_the_new_branch` covers it against a real repo.
- `useRenameBranch` in `src/lib/git/queries.ts` now reloads the in-memory note store and invalidates `["review-notes"]` alongside the existing commit-draft migration, so the Create-PR dialog seeds under the new name without waiting for a focus cycle.
- Fragment: `changelog.d/fixed-review-notes-branch-rename.md`.

### Documentation

- `src/features/help/content.ts`: the operation-history section now lists "paused on conflicts" as a state, the worktree row actions mention "one being removed" among the disabled reasons, and the force-push section covers both the degraded-guarantee confirmation and the plain-words rejection.
- `.claude/skills/gd-conventions/SKILL.md`: records the worktree action-gating contract (`useIsRemovingWorktree` / `refuseWhileLeaving` / `isWorktreePromoting`) and the per-module app-data store seams (`GD_OPLOG_DIR`, `GD_REVIEW_NOTES_DIR`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reviewer notes now follow branches after renaming.
  * Interrupted cherry-pick operations appear as paused and resume with clearer history.
  * Force-push results explain the protection used, including fallback conditions.
* **Bug Fixes**
  * Improved messages for rejected force pushes, with detailed Git output available when needed.
  * Prevented worktree actions while removal or promotion is in progress.
  * Improved handling of cherry-pick conflicts, aborts, continuations, empty picks, and destination-version resolutions.
* **Documentation**
  * Updated help content for paused operations, worktree removal status, and force-push behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->