### PR TITLE
fix(branches,sync,pulls,hotkeys): offer a reset after a remote rebase

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -165,9 +165,12 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
 - **Large ints over IPC:** snowflake/`u64` ids lose precision as JS numbers —
   serialize as strings end-to-end.
 - **Advisory probes fail SAFE toward inaction:** a probe whose verdict can
-  unlock a destructive offer (`BranchRewriteStatus` is the model) returns
-  "unknown" on ANY failed sub-probe — never a defaulted count — and callers
-  render exactly what they render without the data. The unlock condition
+  unlock a destructive offer (`BranchRewriteStatus` is the model) keeps its
+  VERDICT "unknown" on any failed sub-probe — and never ships a defaulted
+  count PRESENTED AS MEASURED: the pre-verdict shape zeroes the counts, and
+  the null verdict is what makes them unreadable (every consumer gates on
+  the verdict first). Callers render exactly what they render without the
+  data. The unlock condition
   must rest on measured evidence (e.g. rewrite = reflog miss AND
   patch-twins present — strong evidence, not proof; the failure direction
   stays inaction), and the destructive action targets the measured sha,

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -96,6 +96,15 @@ dialog.
   chips, the discussion upvote chip) take the SAME contract from the shared
   `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
   (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
+- The AI-generate chord in a dialog goes through `useGenerateChord`
+  (`src/lib/hotkeys/useGenerateChord.ts`) — never a hand-rolled handler. Its
+  invariants: effective-binding read (null = fully inert), `eventToBinding`
+  match, `preventDefault` before `enabled` on any surface WITH a generator,
+  run only under the visible button's gate, swallow-don't-cancel while
+  generating, handler mounted on `DialogContent` (the X close is a form
+  sibling). The hook returns the `hint` string so buttons can't forget it.
+  Recorded exception: surfaces with several per-row generators and no
+  focused-row concept (Edit history's reword buttons) carry no chord.
 - Worktree actions gate on in-flight removal/promote state: menu items disable
   with the parenthetical reason riding the label (a disabled menu item can't
   carry a tooltip), and mutation choke points re-check at fire time —
@@ -155,6 +164,14 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
 
 - **Large ints over IPC:** snowflake/`u64` ids lose precision as JS numbers —
   serialize as strings end-to-end.
+- **Advisory probes fail SAFE toward inaction:** a probe whose verdict can
+  unlock a destructive offer (`BranchRewriteStatus` is the model) returns
+  "unknown" on ANY failed sub-probe — never a defaulted count — and callers
+  render exactly what they render without the data. The unlock condition
+  must rest on measured evidence (e.g. rewrite = reflog miss AND
+  patch-twins present — strong evidence, not proof; the failure direction
+  stays inaction), and the destructive action targets the measured sha,
+  never a re-resolved ref.
 - **GraphQL nullability:** fields without `!` deserialize into `Option<T>`;
   never `unwrap_or_default()` a `from_value`; confirm a field exists before
   querying it.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -166,15 +166,14 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
   serialize as strings end-to-end.
 - **Advisory probes fail SAFE toward inaction:** a probe whose verdict can
   unlock a destructive offer (`BranchRewriteStatus` is the model) keeps its
-  VERDICT "unknown" on any failed sub-probe — and never ships a defaulted
-  count PRESENTED AS MEASURED: the pre-verdict shape zeroes the counts, and
+  VERDICT "unknown" on any failed sub-probe, and never ships a defaulted
+  count PRESENTED AS MEASURED — the pre-verdict shape zeroes the counts, and
   the null verdict is what makes them unreadable (every consumer gates on
   the verdict first). Callers render exactly what they render without the
   data. The unlock condition must rest on measured evidence (e.g. rewrite =
-  reflog miss AND
-  patch-twins present — strong evidence, not proof; the failure direction
-  stays inaction), and the destructive action targets the measured sha,
-  never a re-resolved ref.
+  reflog miss AND patch-twins present — strong evidence, not proof; the
+  failure direction stays inaction), and the destructive action targets the
+  measured sha, never a re-resolved ref.
 - **GraphQL nullability:** fields without `!` deserialize into `Option<T>`;
   never `unwrap_or_default()` a `from_value`; confirm a field exists before
   querying it.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -170,8 +170,8 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
   count PRESENTED AS MEASURED: the pre-verdict shape zeroes the counts, and
   the null verdict is what makes them unreadable (every consumer gates on
   the verdict first). Callers render exactly what they render without the
-  data. The unlock condition
-  must rest on measured evidence (e.g. rewrite = reflog miss AND
+  data. The unlock condition must rest on measured evidence (e.g. rewrite =
+  reflog miss AND
   patch-twins present — strong evidence, not proof; the failure direction
   stays inaction), and the destructive action targets the measured sha,
   never a re-resolved ref.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ Fetch, pull, and push, with the ahead/behind counts shown right on the Push
 and Pull buttons. Pull is `--ff-only`, and divergence routes to a guarded
 force push with `--force-with-lease --force-if-includes` (lease-only on
 Git releases older than 2.30, or when the branch has no reflog for the
-check to read). When a repo has an `upstream` remote, the Pull menu adds
+check to read). When the *remote* itself was rewritten (a server-side
+rebase) and every local commit already landed there under new ids, the
+Pull menu offers a confirmed **Reset to _origin/…_** that lines the two
+up instead. When a repo has an `upstream` remote, the Pull menu adds
 **Update from upstream**: one click fetches upstream and brings your
 branch up to date (fast-forward when it can, a merge commit when cleanly
 diverged, the conflict editor otherwise), for keeping a fork current.

--- a/changelog.d/changed-generate-chord-coverage.md
+++ b/changelog.d/changed-generate-chord-coverage.md
@@ -1,0 +1,6 @@
+- The AI-generate shortcut now works in the dialogs that carry a **Generate**
+  button (branches, issue drafts, release notes, squash messages, scripts,
+  publish, and repo settings, alongside the commit box and PR dialogs it
+  already served), and those buttons' tooltips show the current binding. Edit
+  history's per-commit reword buttons are the exception. The shortcut's label
+  in **Settings → Keyboard** is now *Generate with AI*.

--- a/changelog.d/changed-generate-chord-coverage.md
+++ b/changelog.d/changed-generate-chord-coverage.md
@@ -3,4 +3,7 @@
   publish, and repo settings, alongside the commit box and PR dialogs it
   already served), and those buttons' tooltips show the current binding. Edit
   history's per-commit reword buttons are the exception. The shortcut's label
-  in **Settings → Keyboard** is now *Generate with AI*.
+  in **Settings → Keyboard** is now *Generate with AI*. Alongside: the commit
+  box's **Commit** tooltip shows your actual binding rather than a hardcoded
+  one, and Enter in the task dialog's description no longer fires a generation
+  with nothing to go on.

--- a/changelog.d/changed-queued-merge-chip.md
+++ b/changelog.d/changed-queued-merge-chip.md
@@ -1,0 +1,4 @@
+- Merging a stacked pull request into a base that uses GitHub's **merge queue**
+  now leaves a **Queued to merge** chip on the pull request beside the toast, so
+  the waiting state stays visible until the queue lands it or the pull request
+  closes. The chip lasts for the app session.

--- a/changelog.d/fixed-hide-ai-generate-buttons.md
+++ b/changelog.d/fixed-hide-ai-generate-buttons.md
@@ -1,0 +1,2 @@
+- With **Hide AI features** on, the squash dialog and Edit history's reword
+  rows no longer show their **Generate** buttons.

--- a/changelog.d/fixed-notification-landing.md
+++ b/changelog.d/fixed-notification-landing.md
@@ -1,0 +1,5 @@
+- A notification now lands exactly where its event happened: clicking a
+  pull-request entry applies the fork/upstream view the event belongs to
+  before opening the PR, and a review entry scrolls the conversation to the
+  review itself once the data is in (GitHub). Older entries keep working as
+  before.

--- a/changelog.d/fixed-promotion-pr-behind-honesty.md
+++ b/changelog.d/fixed-promotion-pr-behind-honesty.md
@@ -1,0 +1,5 @@
+- Promotion pull requests (ones whose head is the repository's default branch,
+  like `main` → `staging`) no longer offer **Update branch**, which would merge
+  the base back into the default branch. The strip explains that the gap is
+  expected and needs no closing, and the Update button now names the operation
+  it performs (**Merges base into head**).

--- a/changelog.d/fixed-remote-rebase-divergence.md
+++ b/changelog.d/fixed-remote-rebase-divergence.md
@@ -6,4 +6,7 @@
   force-push confirmation warns that pushing would put the old history back.
   With commits of your own on top, the confirmation counts what's at stake and
   points at **Pull with rebase**, and the merge routes that would duplicate the
-  rewritten history stand down with the reason.
+  rewritten history stand down with the reason. When Git can't confirm the
+  rewrite (no reflog to read, say), the usual divergence controls stay exactly
+  as they are and no reset is offered. And once GitHub finishes an **Update
+  branch**, a background fetch brings the header's counts current.

--- a/changelog.d/fixed-remote-rebase-divergence.md
+++ b/changelog.d/fixed-remote-rebase-divergence.md
@@ -1,0 +1,9 @@
+- **A remote-rebased branch gets the right remedy.** When the remote rewrote
+  your branch (a server-side rebase or force-push, like GitHub's *Update branch
+  → rebase*) and every commit here already landed upstream under new ids, the
+  Pull menu and the branch's context menu offer a confirmed **Reset to
+  _origin/…_** that lines the two up without losing anything, and the
+  force-push confirmation warns that pushing would put the old history back.
+  With commits of your own on top, the confirmation counts what's at stake and
+  points at **Pull with rebase**, and the merge routes that would duplicate the
+  rewritten history stand down with the reason.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -363,6 +363,11 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
+    label:
+      "Rewrite-aware divergence — a server-rebased branch gets a confirmed Reset to origin/…",
+  },
+  {
+    group: "Repository & workspace",
     label: "Auto-fetch — quiet background sync, never auto-pulls",
     highlight: true,
   },

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -854,6 +854,7 @@ fn from_bb_poll_pr(p: BbPollPr, viewer_uuid: &str, viewer_login: &str) -> PrPoll
         last_comment_author: String::new(),
         review_count: 0,
         last_review_author: String::new(),
+        last_review_id: String::new(),
         review_requests: Vec::new(),
         head_ref_name,
         base_ref_name,

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -746,6 +746,7 @@ fn from_glab_poll_mr(m: GlabPollMr) -> PrPollInfo {
         last_comment_author: String::new(),
         review_count: 0,
         last_review_author: String::new(),
+        last_review_id: String::new(),
         review_requests: Vec::new(),
         head_ref_name: m.source_branch,
         base_ref_name: m.target_branch,

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -277,9 +277,18 @@ pub(crate) async fn git_rename_branch_core(
 /// Best-effort: a `worktree list` failure yields `None` and lets git's own error
 /// speak. The `repo_path` checkout is excluded so deleting its *current* branch
 /// isn't misreported here (that path pre-switches, and git errors clearly if not).
+///
+/// The self-exclusion compares CANONICALIZED spellings (the #152 helper, same as
+/// `ops::path_is_under`): git's porcelain prints the resolved path, so a caller
+/// holding macOS's `/var/…` symlink or a Windows 8.3 short name (`RUNNER~1`)
+/// would otherwise fail to recognize its OWN checkout and report the branch as
+/// held by a "linked" worktree that is really this one — sending the caller to
+/// the wrong remedy. A path that no longer resolves falls back to the raw
+/// spelling, so the normalize-only compare stays as a second chance; either
+/// match excludes, which can only ever remove a false positive.
 async fn worktree_holding_branch(repo_path: &str, name: &str) -> Option<String> {
     use crate::git::ops::{parse_worktree_branches, parse_worktree_paths};
-    use crate::git::worktree::normalize_wt_path;
+    use crate::git::worktree::{canonical_wt_path, normalize_wt_path};
     let listed = run_git(
         Some(repo_path),
         &["worktree", "list", "--porcelain"],
@@ -289,12 +298,15 @@ async fn worktree_holding_branch(repo_path: &str, name: &str) -> Option<String> 
     .ok()?;
     let porcelain = listed.stdout_lossy();
     let self_norm = normalize_wt_path(repo_path);
+    let self_canon = canonical_wt_path(repo_path);
+    let is_self =
+        |p: &str| normalize_wt_path(p) == self_norm || canonical_wt_path(p) == self_canon;
     // Both parsers emit one entry per `worktree …` stanza in the same list order,
     // so the zip is length-safe and pairs each worktree's path with its branch.
     parse_worktree_paths(&porcelain)
         .into_iter()
         .zip(parse_worktree_branches(&porcelain))
-        .find(|(path, branch)| branch == name && normalize_wt_path(path) != self_norm)
+        .find(|(path, branch)| branch == name && !is_self(path))
         .map(|(path, _)| path)
 }
 
@@ -704,11 +716,13 @@ pub async fn git_branch_divergence(
 /// lacks a patch-twin upstream) does it describe the shape a rewrite produces,
 /// and only that pair may drive a reset-to-upstream offer.
 ///
-/// `None` means nothing was provable — no upstream, no reflog, or any failed
-/// probe — and callers MUST then render exactly what they render without this
-/// data. The inverse of [`branch_has_reflog`](crate::git::remote)'s fail-safe on
-/// purpose: there, an unrunnable probe must not unlock a degraded push; here, it
-/// must not unlock a destructive offer.
+/// `None` means nothing was provable — no upstream, no reflog, any failed probe,
+/// or a divergence too large to walk (a probe that SUCCEEDED but whose answer is
+/// out of the range these surfaces serve) — and callers MUST then render exactly
+/// what they render without this data. The inverse of
+/// [`branch_has_reflog`](crate::git::remote)'s fail-safe on purpose: there, an
+/// unrunnable probe must not unlock a degraded push; here, it must not unlock a
+/// destructive offer.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchRewriteStatus {
@@ -732,7 +746,12 @@ pub struct BranchRewriteStatus {
 }
 
 impl BranchRewriteStatus {
-    /// The "nothing provable" answer — every arm that can't complete a probe.
+    /// The zeroed, verdict-less shape. It is what the PRE-VERDICT arms return —
+    /// the ones that bail before any count exists (no upstream, unresolvable tip,
+    /// unreadable or oversized counts). A sub-probe that fails AFTER the counts
+    /// land does NOT come here: the reflog arm keeps its real counts and only
+    /// leaves `remote_rewritten: None` (pinned by
+    /// `rewrite_status_without_a_reflog_refuses_to_guess`).
     fn unknown() -> Self {
         Self {
             remote_rewritten: None,
@@ -797,6 +816,37 @@ pub(crate) async fn branch_rewrite_status(
         return Ok(BranchRewriteStatus::unknown());
     }
 
+    let range = format!("{branch}...{upstream_rev}");
+
+    // Cheap size gate BEFORE the patch-id walk: `--cherry-mark` computes a patch id
+    // for every commit on both sides, which means diffing each one, where a plain
+    // left/right count only walks the graph.
+    //
+    // The two bounds are ASYMMETRIC because they answer different questions, and a
+    // single sum-based bound gets the motivating case wrong: "Update branch →
+    // rebase" on a branch forked far back leaves a handful of local commits against
+    // a huge remote side (3 local vs ~253 remote is the reported shape), which a
+    // combined 200 would refuse — disabling the feature exactly where it exists to
+    // help. So the LOCAL side alone carries the copy bound, since it is the N in
+    // "all N commits are already upstream", and the remote side is allowed to be
+    // enormous.
+    let sizes = run_git_raw(
+        Some(repo_path),
+        &["rev-list", "--left-right", "--count", &range],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if sizes.code != 0 {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+    if divergence_out_of_range(
+        &sizes.stdout_lossy(),
+        MAX_LOCAL_COMMITS_FOR_COPY,
+        MAX_CHERRY_MARK_TOTAL,
+    ) {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+
     // Symmetric difference with patch-id matching: left = branch-only, right =
     // upstream-only, third = the patch-equal commits `--cherry-mark` paired off.
     let counts = run_git_raw(
@@ -806,7 +856,7 @@ pub(crate) async fn branch_rewrite_status(
             "--left-right",
             "--cherry-mark",
             "--count",
-            &format!("{branch}...{upstream_rev}"),
+            &range,
         ],
         DEFAULT_TIMEOUT,
     )
@@ -859,6 +909,36 @@ pub(crate) async fn branch_rewrite_status(
         upstream: Some(upstream),
         upstream_tip: Some(tip),
     })
+}
+
+/// Commits on the LOCAL side past which this probe stops being useful. Purely a
+/// UI bound: it is the N in the confirm's "all N commits are already upstream",
+/// and a branch carrying that many unique commits wants a rebase, not a one-click
+/// reset. The REMOTE side is deliberately unbounded here — a branch forked far
+/// back sits hundreds of commits behind by construction, which says nothing about
+/// whether its own handful of commits were replayed.
+const MAX_LOCAL_COMMITS_FOR_COPY: u32 = 200;
+
+/// Total two-sided divergence past which the patch-id walk is refused on COST
+/// alone — nothing to do with the copy. `--cherry-mark` diffs every commit on both
+/// sides; this caps that work for a pathological range while staying far above any
+/// shape the feature actually serves.
+const MAX_CHERRY_MARK_TOTAL: u32 = 1000;
+
+/// Whether a plain `rev-list --left-right --count` reply is outside the range this
+/// probe will walk: more than `max_local` commits on the LOCAL side (a copy bound)
+/// or more than `max_total` across both (a cost bound). An unreadable reply answers
+/// `true` — the caller turns that into the no-verdict shape, the same "never guess"
+/// direction that governs [`parse_cherry_counts`].
+fn divergence_out_of_range(text: &str, max_local: u32, max_total: u32) -> bool {
+    let mut nums = text.split_whitespace();
+    let mut next = || nums.next()?.parse::<u32>().ok();
+    match (next(), next()) {
+        (Some(left), Some(right)) => {
+            left > max_local || left.saturating_add(right) > max_total
+        }
+        _ => true,
+    }
 }
 
 /// Parses `rev-list --left-right --cherry-mark --count`'s reply into
@@ -1170,10 +1250,10 @@ fn unique_suffix() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args, git_branches,
-        git_create_branch_core, git_default_branch, git_rename_branch_core, parse_cherry_counts,
-        parse_upstream_track, update_branch_from, validate_branch_name, validate_ref_name,
-        BranchRewriteStatus,
+        branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args,
+        divergence_out_of_range, git_branches, git_create_branch_core, git_default_branch,
+        git_rename_branch_core, parse_cherry_counts, parse_upstream_track, update_branch_from,
+        validate_branch_name, validate_ref_name, BranchRewriteStatus,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -1996,10 +2076,27 @@ mod tests {
         };
         // The PATH, not the word "worktree": the message has to be actionable, and
         // asserting the noun would pass on a message that never says where.
+        //
+        // Compared against the path GIT reports, not the fixture's own spelling of
+        // it: a Windows runner hands out 8.3 temp paths (`RUNNER~1`) and macOS
+        // tempdirs sit behind the `/var` → `/private/var` symlink, so the two are
+        // routinely different spellings of one directory. The message quotes git's
+        // spelling, so that is what an exact containment check has to use — and the
+        // canonical compare below proves it IS this fixture's worktree.
+        let porcelain = run(&local_s, &["worktree", "list", "--porcelain"]).await;
+        let reported = crate::git::ops::parse_worktree_paths(&porcelain)
+            .into_iter()
+            .zip(crate::git::ops::parse_worktree_branches(&porcelain))
+            .find(|(_, b)| b == "feature")
+            .map(|(p, _)| p)
+            .expect("git lists a worktree holding feature");
+        assert_eq!(
+            crate::git::worktree::canonical_wt_path(&reported),
+            crate::git::worktree::canonical_wt_path(&wt_s),
+            "fixture sanity: git's worktree IS the one this test created"
+        );
         assert!(
-            msg.contains("feature")
-                && crate::git::worktree::normalize_wt_path(msg)
-                    .contains(&crate::git::worktree::normalize_wt_path(&wt_s)),
+            msg.contains("feature") && msg.contains(&reported),
             "the refusal must name the branch and the holding worktree's path: {msg}"
         );
         assert_eq!(
@@ -2058,6 +2155,44 @@ mod tests {
         );
     }
 
+    /// REGRESSION GUARD for the CI-only failure: the caller's spelling of the repo
+    /// path and git's differ, so a normalize-only self-exclusion doesn't recognize
+    /// this checkout and reports the branch as held by a "linked" worktree that is
+    /// really this one — the wrong remedy.
+    ///
+    /// The divergence comes from passing the CANONICALIZED path while git reports
+    /// its own spelling. That discriminates on Windows, where `canonicalize` adds
+    /// the `\\?\` verbatim prefix and `normalize_wt_path` leaves it in place
+    /// (locally verified: reverting the self-exclusion to normalize-only fails this
+    /// test right here). On macOS and Linux it does NOT discriminate — canonical is
+    /// the same side git already resolves to, so both spellings agree and this
+    /// degrades to a duplicate of the test above. Inconclusive-by-platform, so the
+    /// assertion is on the ARM rather than on any path string.
+    #[tokio::test]
+    async fn reset_to_upstream_recognizes_its_own_checkout_under_another_spelling() {
+        let (_base, base) = temp_base("reset-upstream-spelling");
+        let local_s = server_rebase_fixture(&base).await;
+        let target = run(&local_s, &["rev-parse", "origin/feature"])
+            .await
+            .trim()
+            .to_string();
+        // The same directory, spelled the way the OS resolves it.
+        let resolved = std::fs::canonicalize(&local_s).expect("repo resolves");
+        let resolved_s = resolved.to_string_lossy().into_owned();
+
+        let state = AppState::default();
+        let err = branch_reset_to_upstream(&state, &resolved_s, "feature", &target)
+            .await
+            .expect_err("feature is checked out in this very repo");
+        let AppError::Command(msg) = &err else {
+            panic!("expected an actionable Command error, got {err:?}");
+        };
+        assert!(
+            msg.contains("sync controls"),
+            "must take the checked-out-HERE arm, not the linked-worktree one: {msg}"
+        );
+    }
+
     /// The self-checkout arm of the same guard: `branch -f` can't touch the branch
     /// you are ON, and the refusal has to point at the surface that CAN.
     #[tokio::test]
@@ -2112,6 +2247,51 @@ mod tests {
                 parse_cherry_counts(bad),
                 None,
                 "{bad:?} must not yield counts"
+            );
+        }
+    }
+
+    /// The size gate in front of the patch-id walk, both arms. Building a real
+    /// fixture at these scales costs far more than the seam is worth, so the
+    /// thresholds are pinned on the parse that reads them; the spawn feeding it is
+    /// a plain `rev-list --left-right --count`, whose two-integer shape this
+    /// mirrors. An unreadable reply must gate OUT, matching the "never guess"
+    /// direction the counts parse takes.
+    ///
+    /// The asymmetry is the point: a big REMOTE side must stay admissible, because
+    /// that is the motivating shape (a branch forked far back, rebased by the
+    /// remote) — a combined bound would refuse exactly the case the feature exists
+    /// for.
+    #[test]
+    fn divergence_gate_bounds_the_local_side_for_copy_and_the_sum_for_cost() {
+        // The reported scenario: 3 local commits, ~253 remote. Must be ADMITTED.
+        assert!(
+            !divergence_out_of_range("3\t253", 200, 1000),
+            "a far-forked branch the remote rebased is the motivating case, not an \
+             excluded one"
+        );
+        assert!(!divergence_out_of_range("200\t800", 200, 1000), "both at the limits runs");
+        assert!(!divergence_out_of_range("0\t0", 200, 1000), "in sync runs");
+
+        // Copy bound: the LOCAL side is the N in "all N commits are already upstream".
+        assert!(
+            divergence_out_of_range("201\t0", 200, 1000),
+            "one local commit past the copy bound gates out"
+        );
+        // Cost bound: the sum alone, regardless of how one-sided it is.
+        assert!(
+            divergence_out_of_range("1\t1000", 200, 1000),
+            "one commit past the total cost bound gates out"
+        );
+        assert!(
+            !divergence_out_of_range("1\t999", 200, 1000),
+            "and just inside it still runs"
+        );
+
+        for bad in ["", "x\t1", "12", "not a count"] {
+            assert!(
+                divergence_out_of_range(bad, 200, 1000),
+                "{bad:?} is unreadable and must gate out"
             );
         }
     }

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -686,6 +686,282 @@ pub async fn git_branch_divergence(
     Ok(result)
 }
 
+/// Evidence for telling a server-side REWRITE of a branch's upstream (GitHub's
+/// "Update branch → rebase", any remote rebase or force-push) apart from ordinary
+/// two-sided divergence — the two need OPPOSITE remedies, so the app must not
+/// guess.
+///
+/// `remote_rewritten` answers one narrow question: is the upstream tip absent
+/// from this branch's own reflog, i.e. has the branch ever literally been AT it.
+/// That is a membership test over the same reflog `--force-if-includes` walks,
+/// but a weaker question than the flag's — the flag asks whether the remote tip
+/// is REACHABLE from some reflog entry, so a branch that saw the tip and then
+/// merged or rebased past it satisfies the flag and fails this test. Those
+/// shapes land on the ordinary-divergence arms, which is the safe direction.
+///
+/// It is NOT proof of a rewrite on its own either — ordinary divergence looks
+/// identical (measured). Only paired with `local_only == 0` (no local commit
+/// lacks a patch-twin upstream) does it describe the shape a rewrite produces,
+/// and only that pair may drive a reset-to-upstream offer.
+///
+/// `None` means nothing was provable — no upstream, no reflog, or any failed
+/// probe — and callers MUST then render exactly what they render without this
+/// data. The inverse of [`branch_has_reflog`](crate::git::remote)'s fail-safe on
+/// purpose: there, an unrunnable probe must not unlock a degraded push; here, it
+/// must not unlock a destructive offer.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BranchRewriteStatus {
+    /// `Some(true)` = the upstream tip is not in the branch's reflog.
+    pub remote_rewritten: Option<bool>,
+    /// Commits on the branch with NO patch-equivalent upstream — exactly the work
+    /// a reset to the upstream would destroy.
+    pub local_only: u32,
+    /// Commits on the upstream with no patch-equivalent locally.
+    pub remote_only: u32,
+    /// Commits `--cherry-mark` matched by patch id. It counts BOTH sides' members
+    /// of each pair (measured, git 2.51.1), so a clean N-commit rebase reports
+    /// `2 * N` — user-facing copy must not present it as a commit count.
+    pub patch_equal: u32,
+    /// The upstream's short name (e.g. `origin/feature`).
+    pub upstream: Option<String>,
+    /// The upstream tip's sha. A confirmed reset targets THIS commit rather than
+    /// re-resolving the ref, so it can only ever land on the state the user was
+    /// shown — and it keeps `git_reset`'s hex-only validator intact.
+    pub upstream_tip: Option<String>,
+}
+
+impl BranchRewriteStatus {
+    /// The "nothing provable" answer — every arm that can't complete a probe.
+    fn unknown() -> Self {
+        Self {
+            remote_rewritten: None,
+            local_only: 0,
+            remote_only: 0,
+            patch_equal: 0,
+            upstream: None,
+            upstream_tip: None,
+        }
+    }
+}
+
+/// Classifies a diverged branch against its upstream. Read-only: every spawn is
+/// a `rev-parse`/`rev-list`, so this is safe to call from a menu-open path.
+#[tauri::command]
+pub async fn git_branch_rewrite_status(
+    repo_path: String,
+    branch: String,
+) -> AppResult<BranchRewriteStatus> {
+    branch_rewrite_status(&repo_path, &branch).await
+}
+
+pub(crate) async fn branch_rewrite_status(
+    repo_path: &str,
+    branch: &str,
+) -> AppResult<BranchRewriteStatus> {
+    validate_branch_name(branch)?;
+    let upstream_rev = format!("{branch}@{{upstream}}");
+
+    // No upstream at all → nothing to compare against. `rev-parse` exits non-zero
+    // and writes its own diagnostic; that is a normal answer here, not a failure.
+    let short = run_git_raw(
+        Some(repo_path),
+        &["rev-parse", "--abbrev-ref", &upstream_rev],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if short.code != 0 {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+    let upstream = short.stdout_lossy().trim().to_string();
+    if upstream.is_empty() {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+
+    let tip_out = run_git_raw(
+        Some(repo_path),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{upstream_rev}^{{commit}}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if tip_out.code != 0 {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+    let tip = tip_out.stdout_lossy().trim().to_string();
+    if tip.is_empty() {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+
+    // Symmetric difference with patch-id matching: left = branch-only, right =
+    // upstream-only, third = the patch-equal commits `--cherry-mark` paired off.
+    let counts = run_git_raw(
+        Some(repo_path),
+        &[
+            "rev-list",
+            "--left-right",
+            "--cherry-mark",
+            "--count",
+            &format!("{branch}...{upstream_rev}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if counts.code != 0 {
+        return Ok(BranchRewriteStatus::unknown());
+    }
+    let Some((local_only, remote_only, patch_equal)) =
+        parse_cherry_counts(&counts.stdout_lossy())
+    else {
+        return Ok(BranchRewriteStatus::unknown());
+    };
+
+    // `--walk-reflogs` lists the commit each of the branch's reflog entries names.
+    // A branch with no reflog (core.logAllRefUpdates=false, or an expired one)
+    // yields nothing to walk, which cannot distinguish anything — verdict stays
+    // `None` rather than reading absence as a rewrite.
+    let reflog = run_git_raw(
+        Some(repo_path),
+        &["rev-list", "--walk-reflogs", branch],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    let reflog_text = reflog.stdout_lossy();
+    let mut entries = reflog_text.lines().map(str::trim).filter(|l| !l.is_empty());
+    let remote_rewritten = if reflog.code != 0 {
+        None
+    } else {
+        let mut seen = false;
+        let contains = entries.any(|l| {
+            seen = true;
+            l == tip
+        });
+        // `any` short-circuits, so a hit leaves `seen` true; a miss walked the
+        // whole list and `seen` distinguishes "no entries" from "not found".
+        if contains {
+            Some(false)
+        } else if seen {
+            Some(true)
+        } else {
+            None
+        }
+    };
+
+    Ok(BranchRewriteStatus {
+        remote_rewritten,
+        local_only,
+        remote_only,
+        patch_equal,
+        upstream: Some(upstream),
+        upstream_tip: Some(tip),
+    })
+}
+
+/// Parses `rev-list --left-right --cherry-mark --count`'s reply into
+/// `(local_only, remote_only, patch_equal)`.
+///
+/// ALL THREE or nothing. A per-field default would fabricate `local_only == 0`,
+/// which is half of the pair that unlocks the destructive reset offer — the one
+/// value this must never invent, so an unreadable line answers `None` and the
+/// whole status degrades to "nothing provable".
+fn parse_cherry_counts(text: &str) -> Option<(u32, u32, u32)> {
+    let mut nums = text.split_whitespace();
+    let mut next = || nums.next()?.parse::<u32>().ok();
+    Some((next()?, next()?, next()?))
+}
+
+/// Points a branch at its upstream's tip (`git branch -f`), the remedy when the
+/// remote rewrote it and nothing local is unique. Never touches a working tree,
+/// so it is the NON-current-branch half of the reset story; the current branch
+/// goes through `git_reset` in `--hard` mode, which moves the tree too.
+///
+/// Refused with the holding worktree named when the branch is checked out
+/// ANYWHERE — a linked worktree or this checkout itself: git refuses both, but
+/// only after the caller has already framed the action as available.
+///
+/// `expected_tip` is the sha the caller measured and showed the user. The
+/// upstream is re-resolved here and must still be at it, so a background fetch
+/// that moved the ref while the confirmation sat open turns into a refusal
+/// rather than a silent reset onto a state nobody approved.
+#[tauri::command]
+pub async fn git_branch_reset_to_upstream(
+    state: State<'_, AppState>,
+    repo_path: String,
+    branch: String,
+    expected_tip: String,
+) -> AppResult<()> {
+    branch_reset_to_upstream(&state, &repo_path, &branch, &expected_tip).await
+}
+
+pub(crate) async fn branch_reset_to_upstream(
+    state: &AppState,
+    repo_path: &str,
+    branch: &str,
+    expected_tip: &str,
+) -> AppResult<()> {
+    validate_branch_name(branch)?;
+    crate::git::history::validate_hash(expected_tip)?;
+    let upstream_rev = format!("{branch}@{{upstream}}");
+    let tip_out = run_git_raw(
+        Some(repo_path),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{upstream_rev}^{{commit}}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if tip_out.code != 0 {
+        return Err(AppError::InvalidArgument(format!(
+            "{branch} has no upstream branch to reset to."
+        )));
+    }
+    let tip = tip_out.stdout_lossy().trim().to_string();
+    if tip != expected_tip {
+        return Err(AppError::InvalidArgument(format!(
+            "{branch}'s upstream moved since this was measured — reopen the branch \
+             menu to see where it stands now."
+        )));
+    }
+
+    // Pre-mutation guards: git refuses both of these itself, but only after the
+    // user has confirmed a destructive action, and its wording names neither
+    // remedy. The linked-worktree probe excludes THIS checkout, so the current
+    // branch takes its own arm.
+    if let Some(path) = worktree_holding_branch(repo_path, branch).await {
+        return Err(AppError::Command(format!(
+            "{branch} is checked out in the worktree at {path} — switch that worktree \
+             to another branch (or remove it) before resetting {branch}."
+        )));
+    }
+    let current = run_git_raw(
+        Some(repo_path),
+        &["symbolic-ref", "--short", "-q", "HEAD"],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if current.code == 0 && current.stdout_lossy().trim() == branch {
+        return Err(AppError::Command(format!(
+            "{branch} is checked out here — use Reset to {branch}'s upstream from the \
+             sync controls, which moves your working tree with it."
+        )));
+    }
+    run_git_mutating(
+        state,
+        repo_path,
+        &["branch", "-f", "--", branch, &tip],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    Ok(())
+}
+
 /// Updates `branch` with the latest commits from `base` WITHOUT switching to it, so
 /// the user's working tree — and any watchers (vite, `tsc --watch`) — never change.
 ///
@@ -894,9 +1170,10 @@ fn unique_suffix() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_create_branch_args, git_branches, git_create_branch_core, git_default_branch,
-        git_rename_branch_core, parse_upstream_track, update_branch_from, validate_branch_name,
-        validate_ref_name,
+        branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args, git_branches,
+        git_create_branch_core, git_default_branch, git_rename_branch_core, parse_cherry_counts,
+        parse_upstream_track, update_branch_from, validate_branch_name, validate_ref_name,
+        BranchRewriteStatus,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -1395,5 +1672,447 @@ mod tests {
             None,
             "and is gone under the old one"
         );
+    }
+
+    // --- Rewrite-aware divergence (`git_branch_rewrite_status`). ---
+
+    /// Builds the shape a server-side rebase leaves behind and returns the local
+    /// clone's path: a bare `remote`, a `server` clone that rebases `feature` onto
+    /// an advanced `main` and force-pushes it, and a `local` clone that has the
+    /// PRE-rebase commits on `feature` plus a fetched view of the rewritten
+    /// upstream. `local/feature` ends up 2 ahead / 3 behind `origin/feature`, with
+    /// both of its commits patch-equal to the rewritten pair.
+    async fn server_rebase_fixture(base: &std::path::Path) -> String {
+        let remote_s = base.join("remote").to_string_lossy().into_owned();
+        run_git(
+            None,
+            &["init", "-q", "--bare", "-b", "main", &remote_s],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .expect("init bare remote");
+
+        let server = base.join("server");
+        let server_s = server.to_string_lossy().into_owned();
+        run_git(None, &["clone", "-q", &remote_s, &server_s], DEFAULT_TIMEOUT)
+            .await
+            .expect("clone server");
+        run(&server_s, &["config", "user.email", "t@t.local"]).await;
+        run(&server_s, &["config", "user.name", "T"]).await;
+        std::fs::write(server.join("seed.txt"), "seed\n").unwrap();
+        run(&server_s, &["add", "-A"]).await;
+        run(&server_s, &["commit", "-qm", "seed"]).await;
+        run(&server_s, &["push", "-q", "origin", "main"]).await;
+
+        let local = base.join("local");
+        let local_s = local.to_string_lossy().into_owned();
+        run(&remote_s, &["symbolic-ref", "HEAD", "refs/heads/main"]).await;
+        run_git(None, &["clone", "-q", &remote_s, &local_s], DEFAULT_TIMEOUT)
+            .await
+            .expect("clone local");
+        run(&local_s, &["config", "user.email", "t@t.local"]).await;
+        run(&local_s, &["config", "user.name", "T"]).await;
+        run(&local_s, &["switch", "-qc", "feature"]).await;
+        for n in ["one", "two"] {
+            std::fs::write(local.join(format!("{n}.txt")), format!("{n}\n")).unwrap();
+            run(&local_s, &["add", "-A"]).await;
+            run(&local_s, &["commit", "-qm", &format!("feat {n}")]).await;
+        }
+        run(&local_s, &["push", "-q", "-u", "origin", "feature"]).await;
+
+        // The server advances main, rebases feature onto it, and force-pushes —
+        // GitHub's "Update branch → rebase" in miniature.
+        run(&server_s, &["fetch", "-q", "origin"]).await;
+        std::fs::write(server.join("main.txt"), "main moved\n").unwrap();
+        run(&server_s, &["add", "-A"]).await;
+        run(&server_s, &["commit", "-qm", "main moves"]).await;
+        run(&server_s, &["push", "-q", "origin", "main"]).await;
+        run(&server_s, &["switch", "-qc", "feature", "origin/feature"]).await;
+        run(&server_s, &["rebase", "-q", "main"]).await;
+        run(&server_s, &["push", "-q", "--force", "origin", "feature"]).await;
+
+        run(&local_s, &["fetch", "-q", "origin"]).await;
+        local_s
+    }
+
+    /// The motivating case: the remote rebased this branch. Nothing local is
+    /// unique (both commits have patch-twins upstream) and the rewritten upstream
+    /// tip was never in the branch's reflog, so the verdict is a rewrite and a
+    /// reset-to-upstream is safe to offer.
+    #[tokio::test]
+    async fn rewrite_status_detects_a_server_side_rebase() {
+        let (_base, base) = temp_base("rewrite-server-rebase");
+        let local_s = server_rebase_fixture(&base).await;
+
+        let st = branch_rewrite_status(&local_s, "feature")
+            .await
+            .expect("status resolves");
+        assert_eq!(
+            st.remote_rewritten,
+            Some(true),
+            "the rewritten upstream tip is absent from the branch's reflog"
+        );
+        assert_eq!(
+            st.local_only, 0,
+            "every local commit has a patch-equivalent upstream — nothing unique to lose"
+        );
+        assert_eq!(
+            st.remote_only, 1,
+            "only the commit the server added to main is genuinely remote-only"
+        );
+        // `--cherry-mark` counts BOTH members of each matched pair.
+        assert_eq!(st.patch_equal, 4, "two commits matched on two sides");
+        assert_eq!(st.upstream.as_deref(), Some("origin/feature"));
+        assert_eq!(
+            st.upstream_tip.as_deref(),
+            Some(run(&local_s, &["rev-parse", "origin/feature"]).await.trim()),
+            "the tip a confirmed reset would land on"
+        );
+    }
+
+    /// NEGATIVE CONTROL for the reflog containment probe. The rewrite verdict must
+    /// come from the reflog walk and nothing else: with the branch's reflog removed,
+    /// the same fixture — identical counts — must stop claiming a rewrite rather
+    /// than fall back to inferring one from `local_only == 0`.
+    #[tokio::test]
+    async fn rewrite_status_without_a_reflog_refuses_to_guess() {
+        let (_base, base) = temp_base("rewrite-no-reflog");
+        let local_s = server_rebase_fixture(&base).await;
+        std::fs::remove_file(
+            std::path::Path::new(&local_s)
+                .join(".git")
+                .join("logs")
+                .join("refs")
+                .join("heads")
+                .join("feature"),
+        )
+        .expect("drop the branch reflog");
+
+        let st = branch_rewrite_status(&local_s, "feature")
+            .await
+            .expect("status resolves");
+        assert_eq!(
+            st.remote_rewritten, None,
+            "no reflog to walk proves nothing — the UI must stay ordinary"
+        );
+        assert_eq!(
+            (st.local_only, st.remote_only),
+            (0, 1),
+            "the counts are unchanged, so only the reflog can be driving the verdict"
+        );
+    }
+
+    /// A commit made locally AFTER the rewrite lands is unique work: `local_only`
+    /// must rise above zero so the UI withholds the reset offer.
+    #[tokio::test]
+    async fn rewrite_status_counts_genuinely_local_commits() {
+        let (_base, base) = temp_base("rewrite-local-work");
+        let local_s = server_rebase_fixture(&base).await;
+        std::fs::write(
+            std::path::Path::new(&local_s).join("mine.txt"),
+            "unique\n",
+        )
+        .unwrap();
+        run(&local_s, &["add", "-A"]).await;
+        run(&local_s, &["commit", "-qm", "my own work"]).await;
+
+        let st = branch_rewrite_status(&local_s, "feature")
+            .await
+            .expect("status resolves");
+        assert_eq!(
+            st.local_only, 1,
+            "the new commit has no patch-twin upstream — resetting would destroy it"
+        );
+        assert_eq!(st.remote_rewritten, Some(true));
+    }
+
+    /// The discriminating positive case: a branch whose reflog DOES hold the
+    /// upstream tip (it was created there and only moved forward). Without this,
+    /// a probe that answered "rewritten" for every branch with a reflog would go
+    /// unnoticed — the rewrite tests alone can't tell the two apart.
+    #[tokio::test]
+    async fn rewrite_status_clears_a_branch_that_has_seen_its_upstream() {
+        let (_base, base) = temp_base("rewrite-seen-upstream");
+        let local_s = server_rebase_fixture(&base).await;
+        // Adopt the rewritten upstream, then commit on top: the branch is now
+        // plainly ahead, and its reflog holds the current upstream tip.
+        run(&local_s, &["reset", "-q", "--hard", "origin/feature"]).await;
+        std::fs::write(
+            std::path::Path::new(&local_s).join("after.txt"),
+            "after\n",
+        )
+        .unwrap();
+        run(&local_s, &["add", "-A"]).await;
+        run(&local_s, &["commit", "-qm", "after the rebase"]).await;
+
+        let st = branch_rewrite_status(&local_s, "feature")
+            .await
+            .expect("status resolves");
+        assert_eq!(
+            st.remote_rewritten,
+            Some(false),
+            "the upstream tip is in this branch's reflog — nothing was rewritten under it"
+        );
+        assert_eq!((st.local_only, st.remote_only), (1, 0));
+    }
+
+    /// ORDINARY divergence — a teammate pushed while you committed, no rewrite
+    /// anywhere. The reflog verdict reads `Some(true)` here too (you have never
+    /// been at that remote tip), which is exactly why no surface may treat the
+    /// verdict alone as a rewrite: what separates the two is `patchEqual`, zero
+    /// here and non-zero whenever commits were actually replayed.
+    #[tokio::test]
+    async fn rewrite_status_says_true_for_ordinary_divergence_with_no_twins() {
+        let (_base, base) = temp_base("rewrite-ordinary");
+        let local_s = server_rebase_fixture(&base).await;
+        // Start from a synced state, then diverge for real: one commit each side
+        // of `feature`, touching different files so nothing is patch-equal.
+        run(&local_s, &["reset", "-q", "--hard", "origin/feature"]).await;
+        let server_s = base.join("server").to_string_lossy().into_owned();
+        std::fs::write(base.join("server").join("theirs.txt"), "theirs\n").unwrap();
+        run(&server_s, &["add", "-A"]).await;
+        run(&server_s, &["commit", "-qm", "their work"]).await;
+        run(&server_s, &["push", "-q", "origin", "feature"]).await;
+        std::fs::write(
+            std::path::Path::new(&local_s).join("mine.txt"),
+            "mine\n",
+        )
+        .unwrap();
+        run(&local_s, &["add", "-A"]).await;
+        run(&local_s, &["commit", "-qm", "my work"]).await;
+        run(&local_s, &["fetch", "-q", "origin"]).await;
+
+        let st = branch_rewrite_status(&local_s, "feature")
+            .await
+            .expect("status resolves");
+        assert_eq!(
+            st.remote_rewritten,
+            Some(true),
+            "an unseen remote tip reads the same whether or not anything was rewritten"
+        );
+        assert_eq!((st.local_only, st.remote_only), (1, 1));
+        assert_eq!(
+            st.patch_equal, 0,
+            "no patch twins — the discriminator between this and a rewrite"
+        );
+    }
+
+    /// A branch with no upstream has nothing to be rewritten against, and the
+    /// answer must be the same "nothing provable" shape as a failed probe.
+    #[tokio::test]
+    async fn rewrite_status_without_an_upstream_is_unknown() {
+        let (_base, base) = temp_base("rewrite-no-upstream");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "r.txt").await;
+        run(&repo_s, &["switch", "-qc", "solo"]).await;
+
+        let st = branch_rewrite_status(&repo_s, "solo")
+            .await
+            .expect("status resolves");
+        assert_eq!(st.remote_rewritten, None);
+        assert_eq!(st.upstream, None);
+        assert_eq!(st.upstream_tip, None);
+    }
+
+    /// The wire names the TS `BranchRewriteStatus` mirror reads. `rename_all` does
+    /// NOT cover a struct's fields by inheritance from anywhere else, so the
+    /// camelCase keys are pinned here or the frontend reads `undefined` silently.
+    #[test]
+    fn rewrite_status_serializes_to_the_camel_case_wire_shape() {
+        let json = serde_json::to_string(&BranchRewriteStatus {
+            remote_rewritten: Some(true),
+            local_only: 0,
+            remote_only: 1,
+            patch_equal: 4,
+            upstream: Some("origin/feature".into()),
+            upstream_tip: Some("abc123".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"remoteRewritten":true,"localOnly":0,"remoteOnly":1,"patchEqual":4,"upstream":"origin/feature","upstreamTip":"abc123"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&BranchRewriteStatus::unknown()).unwrap(),
+            r#"{"remoteRewritten":null,"localOnly":0,"remoteOnly":0,"patchEqual":0,"upstream":null,"upstreamTip":null}"#
+        );
+    }
+
+    /// The non-current-branch remedy moves the ref and leaves the working tree —
+    /// and the branch you are actually on — untouched.
+    #[tokio::test]
+    async fn reset_to_upstream_moves_an_idle_branch() {
+        let (_base, base) = temp_base("reset-upstream-idle");
+        let local_s = server_rebase_fixture(&base).await;
+        // Step off `feature` so it is idle; `main` tracks origin/main already.
+        run(&local_s, &["switch", "-q", "main"]).await;
+        let target = run(&local_s, &["rev-parse", "origin/feature"])
+            .await
+            .trim()
+            .to_string();
+        let head_before = run(&local_s, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        let state = AppState::default();
+        branch_reset_to_upstream(&state, &local_s, "feature", &target)
+            .await
+            .expect("reset succeeds");
+
+        assert_eq!(
+            run(&local_s, &["rev-parse", "feature"]).await.trim(),
+            target,
+            "the branch now points at the upstream tip"
+        );
+        assert_eq!(
+            run(&local_s, &["rev-parse", "HEAD"]).await.trim(),
+            head_before,
+            "the checked-out branch never moved"
+        );
+    }
+
+    /// The pre-mutation guard: a branch checked out in ANOTHER worktree can't be
+    /// force-updated, and the refusal has to name the worktree holding it.
+    #[tokio::test]
+    async fn reset_to_upstream_refuses_and_names_the_holding_worktree() {
+        let (_base, base) = temp_base("reset-upstream-worktree");
+        let local_s = server_rebase_fixture(&base).await;
+        run(&local_s, &["switch", "-q", "main"]).await;
+        let wt = base.join("wt");
+        let wt_s = wt.to_string_lossy().into_owned();
+        run(&local_s, &["worktree", "add", "--quiet", &wt_s, "feature"]).await;
+        let before = run(&local_s, &["rev-parse", "feature"]).await.trim().to_string();
+        let target = run(&local_s, &["rev-parse", "origin/feature"])
+            .await
+            .trim()
+            .to_string();
+
+        let state = AppState::default();
+        let err = branch_reset_to_upstream(&state, &local_s, "feature", &target)
+            .await
+            .expect_err("a branch held by a worktree can't be reset");
+        let AppError::Command(msg) = &err else {
+            panic!("expected an actionable Command error, got {err:?}");
+        };
+        // The PATH, not the word "worktree": the message has to be actionable, and
+        // asserting the noun would pass on a message that never says where.
+        assert!(
+            msg.contains("feature")
+                && crate::git::worktree::normalize_wt_path(msg)
+                    .contains(&crate::git::worktree::normalize_wt_path(&wt_s)),
+            "the refusal must name the branch and the holding worktree's path: {msg}"
+        );
+        assert_eq!(
+            run(&local_s, &["rev-parse", "feature"]).await.trim(),
+            before,
+            "and the branch must not have moved"
+        );
+
+        let _ = run_git(
+            Some(&local_s),
+            &["worktree", "remove", "--force", &wt_s],
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+    }
+
+    /// The stale-evidence guard. A background fetch can move the upstream while
+    /// the confirmation sits open, and `branch -f` would then land somewhere the
+    /// user never saw — so the measured sha has to survive a re-resolve.
+    #[tokio::test]
+    async fn reset_to_upstream_refuses_a_tip_that_moved_since_it_was_measured() {
+        let (_base, base) = temp_base("reset-upstream-moved");
+        let local_s = server_rebase_fixture(&base).await;
+        run(&local_s, &["switch", "-q", "main"]).await;
+        let measured = run(&local_s, &["rev-parse", "origin/feature"])
+            .await
+            .trim()
+            .to_string();
+        let before = run(&local_s, &["rev-parse", "feature"]).await.trim().to_string();
+
+        // The server pushes again; a background fetch picks it up mid-dialog.
+        let server_s = base.join("server").to_string_lossy().into_owned();
+        std::fs::write(base.join("server").join("later.txt"), "later\n").unwrap();
+        run(&server_s, &["add", "-A"]).await;
+        run(&server_s, &["commit", "-qm", "later work"]).await;
+        run(&server_s, &["push", "-q", "origin", "feature"]).await;
+        run(&local_s, &["fetch", "-q", "origin"]).await;
+        assert_ne!(
+            run(&local_s, &["rev-parse", "origin/feature"]).await.trim(),
+            measured,
+            "fixture must actually move the upstream for this to discriminate"
+        );
+
+        let state = AppState::default();
+        let err = branch_reset_to_upstream(&state, &local_s, "feature", &measured)
+            .await
+            .expect_err("a moved upstream must refuse");
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("moved")),
+            "the refusal must say the upstream moved, got {err:?}"
+        );
+        assert_eq!(
+            run(&local_s, &["rev-parse", "feature"]).await.trim(),
+            before,
+            "and the branch must not have moved"
+        );
+    }
+
+    /// The self-checkout arm of the same guard: `branch -f` can't touch the branch
+    /// you are ON, and the refusal has to point at the surface that CAN.
+    #[tokio::test]
+    async fn reset_to_upstream_refuses_the_branch_checked_out_here() {
+        let (_base, base) = temp_base("reset-upstream-current");
+        let local_s = server_rebase_fixture(&base).await;
+        // `feature` is the checked-out branch of this very repo path.
+        let target = run(&local_s, &["rev-parse", "origin/feature"])
+            .await
+            .trim()
+            .to_string();
+        let before = run(&local_s, &["rev-parse", "feature"]).await.trim().to_string();
+
+        let state = AppState::default();
+        let err = branch_reset_to_upstream(&state, &local_s, "feature", &target)
+            .await
+            .expect_err("the current branch can't take a ref-only reset");
+        let AppError::Command(msg) = &err else {
+            panic!("expected an actionable Command error, got {err:?}");
+        };
+        assert!(
+            msg.contains("feature") && msg.contains("sync controls"),
+            "the refusal must name the branch and the surface that handles it: {msg}"
+        );
+        assert_eq!(
+            run(&local_s, &["rev-parse", "feature"]).await.trim(),
+            before,
+            "and the branch must not have moved"
+        );
+    }
+
+    /// A malformed (but exit-0) counts line must NOT default to zeros: `local_only
+    /// == 0` is half the pair that unlocks the destructive reset offer, so a
+    /// fabricated one is the worst answer this type can give. Every shape that
+    /// isn't three integers has to answer `None`, which the caller turns into the
+    /// whole "nothing provable" status.
+    #[test]
+    fn cherry_counts_parse_is_all_three_or_nothing() {
+        assert_eq!(parse_cherry_counts("0\t3\t4\n"), Some((0, 3, 4)));
+        assert_eq!(parse_cherry_counts(" 1 2 3 "), Some((1, 2, 3)));
+        // A trailing field is ignored — git prints exactly three.
+        assert_eq!(parse_cherry_counts("1\t2\t3\t9"), Some((1, 2, 3)));
+        for bad in [
+            "",                 // empty (a silenced failure)
+            "0\t3",             // truncated — the fabrication risk
+            "not-a-number",     // wrong shape entirely
+            "0\tx\t4",          // one unreadable field
+            "-1\t2\t3",         // negative can't be a u32 count
+            "0\t3\t",           // trailing separator, third field missing
+        ] {
+            assert_eq!(
+                parse_cherry_counts(bad),
+                None,
+                "{bad:?} must not yield counts"
+            );
+        }
     }
 }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -404,6 +404,18 @@ fn remove_lines(content: &str, drop: &std::collections::HashSet<u32>) -> String 
 /// the dirty check alone would let a reset strand those markers and leave the
 /// repo claiming an operation whose commits have moved out from under it.
 ///
+/// Both `--hard` guards and the reset itself run under ONE `repo_lock` hold, so
+/// no OTHER CALLER IN THIS PROCESS can dirty the tree or start a merge between the
+/// checks and a rewrite that has no stash and no reflog to recover from. That is
+/// the whole reach of the guarantee: a separate MCP-server process holds its own
+/// lock, and no lock constrains a terminal git or an editor writing files. That
+/// means the
+/// lock-free `run_git` for the reset — `run_git_mutating` re-acquires the same
+/// non-reentrant mutex and deadlocks — trading away its one-shot index.lock retry,
+/// the same bargain `git_stash_all_core` and the cherry-pick compound make. The
+/// `--mixed` arm keeps `run_git_mutating`: it has no guards to protect, so there
+/// is no check-then-act window and the retry is worth more than a hold.
+///
 /// Worktree-correct without extra work: every spawn runs with `repo_path` as its
 /// cwd, so a linked worktree resets ITS own HEAD and ITS own tree.
 #[tauri::command]
@@ -432,17 +444,32 @@ pub(crate) async fn git_reset_core(
             )))
         }
     };
-    if hard {
-        ensure_clean_tree(&repo_path).await?;
-        if op_state(&repo_path).await?.mid_op() {
-            return Err(AppError::InvalidArgument(
-                "an operation is still in progress — finish or abort it before resetting"
-                    .into(),
-            ));
-        }
+    if !hard {
+        run_git_mutating(
+            state,
+            &repo_path,
+            &["reset", "--mixed", &hash],
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+        return Ok(());
     }
-    let flag = if hard { "--hard" } else { "--mixed" };
-    run_git_mutating(state, &repo_path, &["reset", flag, &hash], DEFAULT_TIMEOUT).await?;
+    // One hold across both guards and the rewrite — see this function's doc for
+    // why the runner inside it must be the lock-free one.
+    let lock = state.repo_lock(&repo_path).await;
+    let _guard = lock.lock().await;
+    ensure_clean_tree(&repo_path).await?;
+    if op_state(&repo_path).await?.mid_op() {
+        return Err(AppError::InvalidArgument(
+            "an operation is still in progress — finish or abort it before resetting".into(),
+        ));
+    }
+    run_git(
+        Some(&repo_path),
+        &["reset", "--hard", &hash],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -394,23 +394,55 @@ fn remove_lines(content: &str, drop: &std::collections::HashSet<u32>) -> String 
         .collect()
 }
 
-/// Mixed reset: moves the branch pointer, keeps the working tree.
+/// Moves the branch pointer to `hash`. `mode` is `"mixed"` (the default — the
+/// working tree keeps every change) or `"hard"`, which rewrites the working tree
+/// too and is therefore refused while tracked changes are outstanding: `--hard`
+/// discards them with no stash and no reflog entry to recover from.
+///
+/// `--hard` also refuses mid-operation. A paused merge/rebase/pick/revert can sit
+/// on a CLEAN tree (the sequencer's own state lives in `.git`, not the tree), so
+/// the dirty check alone would let a reset strand those markers and leave the
+/// repo claiming an operation whose commits have moved out from under it.
+///
+/// Worktree-correct without extra work: every spawn runs with `repo_path` as its
+/// cwd, so a linked worktree resets ITS own HEAD and ITS own tree.
 #[tauri::command]
 pub async fn git_reset(
     state: State<'_, AppState>,
     repo_path: String,
     hash: String,
+    mode: Option<String>,
 ) -> AppResult<()> {
-    git_reset_core(&state, repo_path, hash).await
+    git_reset_core(&state, repo_path, hash, mode).await
 }
 
 pub(crate) async fn git_reset_core(
     state: &AppState,
     repo_path: String,
     hash: String,
+    mode: Option<String>,
 ) -> AppResult<()> {
     validate_hash(&hash)?;
-    run_git_mutating(state, &repo_path, &["reset", "--mixed", &hash], DEFAULT_TIMEOUT).await?;
+    let hard = match mode.as_deref() {
+        None | Some("mixed") => false,
+        Some("hard") => true,
+        Some(other) => {
+            return Err(AppError::InvalidArgument(format!(
+                "unknown reset mode: {other}"
+            )))
+        }
+    };
+    if hard {
+        ensure_clean_tree(&repo_path).await?;
+        if op_state(&repo_path).await?.mid_op() {
+            return Err(AppError::InvalidArgument(
+                "an operation is still in progress — finish or abort it before resetting"
+                    .into(),
+            ));
+        }
+    }
+    let flag = if hard { "--hard" } else { "--mixed" };
+    run_git_mutating(state, &repo_path, &["reset", flag, &hash], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -4610,6 +4642,150 @@ mod tests {
         git(&repo, &["add", "a.txt"]).await;
         assert!(ensure_clean_tree(&repo).await.is_err());
 
+    }
+
+    /// Working-tree content with line endings normalized: an ambient
+    /// `core.autocrlf=true` (the Windows default) materializes committed `\n` as
+    /// `\r\n`, which would false-fail every content assertion below.
+    fn tree_text(dir: &std::path::Path, file: &str) -> String {
+        std::fs::read_to_string(dir.join(file))
+            .unwrap()
+            .replace("\r\n", "\n")
+    }
+
+    /// `--hard` mode moves HEAD *and* rewrites the working tree; `--mixed` (the
+    /// default every existing caller gets) moves the pointer alone.
+    #[tokio::test]
+    async fn reset_hard_moves_the_tree_and_mixed_leaves_it() {
+        let (dir, repo) = setup_repo("reset-hard").await;
+        let base = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "second").await;
+        let tip = rev(&repo, "HEAD").await;
+        let state = AppState::default();
+
+        // Default mode: the pointer rewinds, the file keeps the newer content.
+        git_reset_core(&state, repo.clone(), base.clone(), None)
+            .await
+            .expect("mixed reset succeeds");
+        assert_eq!(rev(&repo, "HEAD").await, base);
+        assert_eq!(
+            tree_text(dir.path(), "a.txt"),
+            "v1\n",
+            "a mixed reset must not touch the working tree"
+        );
+
+        // Hard mode from a clean tree: both move.
+        git(&repo, &["reset", "--hard", &tip]).await;
+        git_reset_core(&state, repo.clone(), base.clone(), Some("hard".into()))
+            .await
+            .expect("hard reset succeeds");
+        assert_eq!(rev(&repo, "HEAD").await, base);
+        assert_eq!(
+            tree_text(dir.path(), "a.txt"),
+            "v0\n",
+            "a hard reset rewrites the working tree to the target commit"
+        );
+    }
+
+    /// The guard that makes `--hard` safe to offer: uncommitted tracked work is a
+    /// typed refusal, not a discarded file. The second half is the destruction
+    /// control — the same `reset --hard` run WITHOUT the guard eats the edit, so
+    /// the refusal is provably what saved it.
+    #[tokio::test]
+    async fn reset_hard_refuses_a_dirty_tree_and_leaves_it_untouched() {
+        let (dir, repo) = setup_repo("reset-hard-dirty").await;
+        let base = rev(&repo, "HEAD").await;
+        commit_file(&repo, dir.path(), "a.txt", "v1\n", "second").await;
+        let tip = rev(&repo, "HEAD").await;
+        std::fs::write(dir.path().join("a.txt"), "uncommitted work\n").unwrap();
+        let state = AppState::default();
+
+        let err = git_reset_core(&state, repo.clone(), base.clone(), Some("hard".into()))
+            .await
+            .expect_err("a dirty tree must refuse a hard reset");
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("uncommitted changes")),
+            "the refusal must name the remedy, got {err:?}"
+        );
+        assert_eq!(
+            tree_text(dir.path(), "a.txt"),
+            "uncommitted work\n",
+            "the edit survives"
+        );
+        assert_eq!(rev(&repo, "HEAD").await, tip, "and HEAD never moved");
+
+        // Destruction control: git itself has no such scruples.
+        git(&repo, &["reset", "--hard", &base]).await;
+        assert_eq!(
+            tree_text(dir.path(), "a.txt"),
+            "v0\n",
+            "an unguarded hard reset destroys exactly what the refusal protects"
+        );
+    }
+
+    /// A paused sequencer sits on a CLEAN tree, so the dirty check alone lets a
+    /// hard reset through and strands the operation's markers. The op-state guard
+    /// is what refuses it.
+    #[tokio::test]
+    async fn reset_hard_refuses_while_an_operation_is_in_progress() {
+        let (dir, repo) = setup_repo("reset-hard-midop").await;
+        let base = rev(&repo, "HEAD").await;
+        let start = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        git(&repo, &["switch", &start]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        // A conflicting merge leaves MERGE_HEAD standing.
+        let _ = run_git_raw(
+            Some(&repo),
+            &["merge", "--no-edit", "feature"],
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+        assert!(
+            op_state(&repo).await.unwrap().merging,
+            "fixture must leave a merge in progress"
+        );
+        // Resolve back to HEAD's own content so the index matches it and the tree
+        // reads CLEAN — this is the whole point: only the operation marker is left
+        // to refuse, so a pass here can't be the dirty check doing the work.
+        git(&repo, &["checkout", "--ours", "--", "a.txt"]).await;
+        git(&repo, &["add", "a.txt"]).await;
+        assert!(
+            ensure_clean_tree(&repo).await.is_ok(),
+            "fixture must leave a CLEAN tree, or this test proves nothing new"
+        );
+
+        let state = AppState::default();
+        let tip = rev(&repo, "HEAD").await;
+        let err = git_reset_core(&state, repo.clone(), base.clone(), Some("hard".into()))
+            .await
+            .expect_err("a mid-operation hard reset must refuse");
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("in progress")),
+            "got {err:?}"
+        );
+        assert_eq!(rev(&repo, "HEAD").await, tip, "HEAD never moved");
+        assert!(
+            op_state(&repo).await.unwrap().merging,
+            "and the operation's markers are still there to finish or abort"
+        );
+    }
+
+    /// An unrecognized mode is rejected before any git runs, so a typo can never
+    /// silently degrade to the destructive arm — or to the harmless one.
+    #[tokio::test]
+    async fn reset_rejects_an_unknown_mode() {
+        let (_dir, repo) = setup_repo("reset-mode").await;
+        let base = rev(&repo, "HEAD").await;
+        let state = AppState::default();
+        let err = git_reset_core(&state, repo, base, Some("keep".into()))
+            .await
+            .expect_err("unknown modes are refused");
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("keep")),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -406,10 +406,10 @@ fn remove_lines(content: &str, drop: &std::collections::HashSet<u32>) -> String 
 ///
 /// Both `--hard` guards and the reset itself run under ONE `repo_lock` hold, so
 /// no other caller in THIS PROCESS can dirty the tree or start a merge between the
-/// checks and a rewrite that has no stash and no reflog to recover from. That
-/// means the lock-free `run_git` for the reset — `run_git_mutating` re-acquires
-/// the same non-reentrant mutex and deadlocks — trading away its one-shot
-/// index.lock retry, the same bargain `git_stash_all_core` and the cherry-pick
+/// checks and a rewrite that has no stash and no reflog to recover from. The hold
+/// is why the reset runs on the lock-free `run_git`: `run_git_mutating` re-acquires
+/// the same non-reentrant mutex and deadlocks, so this trades away its one-shot
+/// index.lock retry — the same bargain `git_stash_all_core` and the cherry-pick
 /// compound make. The `--mixed` arm keeps `run_git_mutating`: it has no guards to
 /// protect, so there is no check-then-act window and the retry is worth more than
 /// a hold.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -405,16 +405,18 @@ fn remove_lines(content: &str, drop: &std::collections::HashSet<u32>) -> String 
 /// repo claiming an operation whose commits have moved out from under it.
 ///
 /// Both `--hard` guards and the reset itself run under ONE `repo_lock` hold, so
-/// no OTHER CALLER IN THIS PROCESS can dirty the tree or start a merge between the
-/// checks and a rewrite that has no stash and no reflog to recover from. That is
-/// the whole reach of the guarantee: a separate MCP-server process holds its own
-/// lock, and no lock constrains a terminal git or an editor writing files. That
-/// means the
-/// lock-free `run_git` for the reset — `run_git_mutating` re-acquires the same
-/// non-reentrant mutex and deadlocks — trading away its one-shot index.lock retry,
-/// the same bargain `git_stash_all_core` and the cherry-pick compound make. The
-/// `--mixed` arm keeps `run_git_mutating`: it has no guards to protect, so there
-/// is no check-then-act window and the retry is worth more than a hold.
+/// no other caller in THIS PROCESS can dirty the tree or start a merge between the
+/// checks and a rewrite that has no stash and no reflog to recover from. That
+/// means the lock-free `run_git` for the reset — `run_git_mutating` re-acquires
+/// the same non-reentrant mutex and deadlocks — trading away its one-shot
+/// index.lock retry, the same bargain `git_stash_all_core` and the cherry-pick
+/// compound make. The `--mixed` arm keeps `run_git_mutating`: it has no guards to
+/// protect, so there is no check-then-act window and the retry is worth more than
+/// a hold.
+///
+/// The hold's reach ends at this process, as `run_git_mutating`'s own doc says: a
+/// separate MCP-server process holds its own lock, and no lock constrains a
+/// terminal git or an editor writing files.
 ///
 /// Worktree-correct without extra work: every spawn runs with `repo_path` as its
 /// cwd, so a linked worktree resets ITS own HEAD and ITS own tree.

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2496,6 +2496,10 @@ pub struct PrPollInfo {
     /// Login of the most recent review's author — same self-suppression as
     /// `last_comment_author`. GitHub only; "" elsewhere.
     pub last_review_author: String,
+    /// Node id of the most recent review — the SAME `PRR_` id the detail view's
+    /// review rows carry, so a review notification can land on that row. GitHub
+    /// only; "" elsewhere.
+    pub last_review_id: String,
     /// Logins currently requested to review this PR — the poller notifies you
     /// when you newly appear here. GitHub only; empty for GitLab/Bitbucket.
     pub review_requests: Vec<String>,
@@ -2512,6 +2516,16 @@ pub struct PrPollInfo {
     pub created_at: String,
 }
 
+/// The poller's projection. Separate from its caller so a test can assert what
+/// it asks for: every `PrPollInfo` field the frontend keys a notification on has
+/// to be selected here, and a silently dropped selection reads as "no event".
+/// Both embeds are validated by the caller before they reach this.
+fn pr_poll_query(owner: &str, name: &str) -> String {
+    format!(
+        r#"query{{ repository(owner:"{owner}", name:"{name}"){{ pullRequests(first:30, states:[OPEN, CLOSED, MERGED], orderBy:{{field:UPDATED_AT, direction:DESC}}){{ nodes{{ number title url state isDraft createdAt headRefName baseRefName author{{login}} reviewDecision comments(last:1){{ totalCount nodes{{ author{{ login }} }} }} reviews(last:1){{ totalCount nodes{{ id author{{ login }} }} }} reviewRequests(first:20){{ nodes{{ requestedReviewer{{ ... on User{{ login }} }} }} }} commits(last:1){{ nodes{{ commit{{ oid statusCheckRollup{{ state }} }} }} }} }} }} }} }}"#
+    )
+}
+
 /// Lightweight snapshot of the repo's recently-updated PRs for the
 /// notification poller — one GraphQL round trip including the check rollup
 /// (reliable on old gh, unlike `pr list --json statusCheckRollup`).
@@ -2526,9 +2540,7 @@ pub async fn gh_pr_poll(repo_path: String) -> AppResult<Vec<PrPollInfo>> {
     validate_graphql_embed(owner, "repository owner")?;
     validate_graphql_embed(name, "repository name")?;
 
-    let query = format!(
-        r#"query{{ repository(owner:"{owner}", name:"{name}"){{ pullRequests(first:30, states:[OPEN, CLOSED, MERGED], orderBy:{{field:UPDATED_AT, direction:DESC}}){{ nodes{{ number title url state isDraft createdAt headRefName baseRefName author{{login}} reviewDecision comments(last:1){{ totalCount nodes{{ author{{ login }} }} }} reviews(last:1){{ totalCount nodes{{ author{{ login }} }} }} reviewRequests(first:20){{ nodes{{ requestedReviewer{{ ... on User{{ login }} }} }} }} commits(last:1){{ nodes{{ commit{{ oid statusCheckRollup{{ state }} }} }} }} }} }} }} }}"#
-    );
+    let query = pr_poll_query(owner, name);
     let out = run_gh(
         Some(&repo_path),
         &["api", "graphql", "-f", &format!("query={query}")],
@@ -2570,6 +2582,7 @@ pub async fn gh_pr_poll(repo_path: String) -> AppResult<Vec<PrPollInfo>> {
                 .and_then(|x| x.as_u64())
                 .unwrap_or(0),
             last_review_author: str_at(n, "/reviews/nodes/0/author/login"),
+            last_review_id: str_at(n, "/reviews/nodes/0/id"),
             review_requests: n
                 .pointer("/reviewRequests/nodes")
                 .and_then(|x| x.as_array())
@@ -5593,7 +5606,8 @@ mod tests {
         apply_stack_join, classify_merge_async, external_items_from_thread_nodes,
         flatten_slurped_pages, fork_head_identity, gh_api_error_message, host_from_url,
         is_diff_too_large, is_object_id, map_timeline_node, parse_actions_run_job,
-        parse_auth_accounts, parse_pr_url_repo, pr_edit_args, pull_stack_ref, real_check_time,
+        parse_auth_accounts, parse_pr_url_repo, pr_edit_args, pr_poll_query, pull_stack_ref,
+        real_check_time,
         real_time_or_empty, reconstruct_pr_diff, reject_upstream_create_metadata,
         rest_comment_to_out, rest_commit_to_out, rest_pull_to_pr_info, rest_review_to_out,
         rollup_state_to_ci, scrape_pr_ref, split_commit_message, stack_members_from,
@@ -5602,7 +5616,8 @@ mod tests {
         GhPrRestComment,
         GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner, GhPrRestPull, GhPrRestReview,
         GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails, PrInfo, PrMergeOutcome,
-        GhMergeabilityRow, PrMergeability, PrStackInfo, PrStackMember, PrTimelineEventOut,
+        GhMergeabilityRow, PrMergeability, PrPollInfo, PrStackInfo, PrStackMember,
+        PrTimelineEventOut,
         batch_check_present, oid_outside_origin_graph, select_fork_pr_match, validate_branch,
         ForkPrMatch, RawForkPr, RawLogin, RawPr,
     };
@@ -6431,6 +6446,75 @@ mod tests {
             !list.contains(&"mergeable") && !list.contains(&"mergeStateStatus"),
             "got: {PR_LIST_FIELDS}"
         );
+    }
+
+    /// A review notification carries the review's node id so the click-through
+    /// lands on that review's card, and the id can only come from the poll's own
+    /// `reviews(last:1)` slice — dropping it degrades silently to a PR-level jump.
+    #[test]
+    fn poll_query_requests_the_latest_review_id() {
+        let q = pr_poll_query("owner", "repo");
+        let after = q
+            .split_once("reviews(last:1)")
+            .expect("the poll must select the latest review")
+            .1;
+        // Up to the next sibling selection, so the assertion can't be satisfied
+        // by an `id` somewhere else in the query.
+        let selection = after
+            .split_once("reviewRequests")
+            .expect("reviewRequests follows the reviews selection")
+            .0;
+        assert!(
+            selection.contains(" id "),
+            "reviews nodes must select `id`, got: {selection}"
+        );
+    }
+
+    /// The poll payload is read field-by-field in TypeScript, where a renamed or
+    /// dropped key reads as `undefined` and silently disables a notification
+    /// branch. Pin the wire names the frontend keys on; the struct literal makes a
+    /// future field a compile error here rather than a silent omission.
+    #[test]
+    fn poll_info_serializes_camel_case_wire_names() {
+        let info = PrPollInfo {
+            number: 7,
+            title: "t".into(),
+            url: "u".into(),
+            state: "OPEN".into(),
+            is_draft: false,
+            author: "a".into(),
+            review_decision: "APPROVED".into(),
+            checks_state: "SUCCESS".into(),
+            head_sha: "deadbeef".into(),
+            comment_count: 1,
+            last_comment_author: "c".into(),
+            review_count: 2,
+            last_review_author: "r".into(),
+            last_review_id: "PRR_kwDO".into(),
+            review_requests: vec!["v".into()],
+            head_ref_name: "topic".into(),
+            base_ref_name: "main".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+        };
+        let v = serde_json::to_value(info).expect("PrPollInfo serializes");
+        for key in [
+            "isDraft",
+            "reviewDecision",
+            "checksState",
+            "headSha",
+            "commentCount",
+            "lastCommentAuthor",
+            "reviewCount",
+            "lastReviewAuthor",
+            "lastReviewId",
+            "reviewRequests",
+            "headRefName",
+            "baseRefName",
+            "createdAt",
+        ] {
+            assert!(v.get(key).is_some(), "{key} missing from: {v}");
+        }
+        assert_eq!(v.get("lastReviewId").and_then(|x| x.as_str()), Some("PRR_kwDO"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -135,6 +135,8 @@ pub fn run() {
             git::branches::git_default_branch,
             git::branches::git_branch_divergence,
             git::branches::git_branch_merge_states,
+            git::branches::git_branch_rewrite_status,
+            git::branches::git_branch_reset_to_upstream,
             git::branches::git_set_branch_archived,
             git::branches::git_update_branch_from,
             git::branches::commit_on_remote,

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -827,7 +827,7 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_destructive()?;
         ensure_not_flag(&args.sha, "sha")?;
-        crate::git::ops::git_reset_core(&self.state, self.repo.clone(), args.sha.clone())
+        crate::git::ops::git_reset_core(&self.state, self.repo.clone(), args.sha.clone(), None)
             .await
             .map_err(app_err)?;
         ok_text(format!("reset to {}", args.sha))

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -14,6 +14,7 @@ import {
   XCircleIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { ElapsedTime } from "@/components/elapsed-time";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
@@ -26,8 +27,10 @@ import {
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { displayLogin } from "@/lib/git/bot-login";
+import type { RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { PrSection } from "@/lib/pulls/pr-section";
+import { applyRepoLens } from "@/lib/repo-lens/queries";
 import {
   type AppNotification,
   clearAllNotifications,
@@ -165,6 +168,7 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   const tasks = useReviewTasks();
   const notifs = useNotifications();
   const repoPath = useUiStore((s) => s.repoPath);
+  const queryClient = useQueryClient();
   const openPr = useUiStore((s) => s.openPr);
   const openRun = useUiStore((s) => s.openRun);
   const openAgentTab = useUiStore((s) => s.openAgentTab);
@@ -186,12 +190,38 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
     markNotificationRead(n.id);
     const t = n.target;
     if (t?.type === "pr") {
+      // Land under the lens the event happened under — a fork's two lenses
+      // surface different pull requests at the same ref. Session-only
+      // (`persist: false`): a click is navigation, not a choice of lens, so the
+      // switcher's stored preference is what later sessions still open on.
+      // Only for REMOTE rows — a local PR is lens-independent, so applying one
+      // there would be a side effect its navigation never implied. Hydrated
+      // rows are untrusted, so narrow the stored value the way the lens reader
+      // does; a row from before the field existed carries none and keeps
+      // today's behavior (whichever lens the repo already sits on). No
+      // selection clears — the same call selects this PR.
+      let applyLens: (() => void) | undefined;
+      if (t.kind === "remote" && t.lens !== undefined) {
+        const lens: RemoteLens = t.lens === "upstream" ? "upstream" : "origin";
+        applyLens = () =>
+          applyRepoLens(queryClient, n.repoPath, lens, {
+            clearSelections: false,
+            persist: false,
+          });
+      }
       openPr({
         kind: t.kind,
         repoPath: n.repoPath,
         repoName: n.repoName,
         ref: t.ref,
         section: KIND_SECTION[n.kind as NotificationKind] ?? null,
+        // Hydrated rows are untrusted here too — a non-string can't address a
+        // review card, so it reads as "no reveal" rather than travelling on.
+        reviewId: typeof t.reviewId === "string" ? t.reviewId : null,
+        // Run inside openPr's view-transition callback, so the lens and the
+        // selection reach the same commit; applied here it would land a render
+        // early and fetch the new lens against the OLD number.
+        beforeSelect: applyLens,
       });
     } else if (t?.type === "run") {
       openRun({ repoPath: n.repoPath, repoName: n.repoName, runId: t.runId });

--- a/src/features/commit/CommitBox.tsx
+++ b/src/features/commit/CommitBox.tsx
@@ -14,7 +14,8 @@ import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
 import { coAuthorTrailers } from "@/lib/git/co-authors";
 import { useCommit, useRepoStatus } from "@/lib/git/queries";
 import { formatBinding } from "@/lib/hotkeys/binding";
-import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
 import { quickTransition } from "@/lib/motion";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { commitDraftKey, useUiStore } from "@/lib/stores/ui";
@@ -75,6 +76,11 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
     generate,
     aiEnabled && aiConfigured && stagedCount > 0 && !generating,
   );
+  // Both button hints read the effective bindings rather than the defaults, so
+  // a Settings → Keyboard rebind shows up here; null = the user unbound it and
+  // there is no shortcut to name.
+  const commitBinding = useEffectiveBindings().get("commit") ?? null;
+  const generateHint = useGenerateChordHint();
 
   function doCommit() {
     const commitTitle = title.trim();
@@ -229,7 +235,7 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
                     size="sm"
                     disabled={stagedCount === 0}
                     reason="Stage changes to generate a commit message"
-                    title="Generate commit message with AI"
+                    title={`Generate commit message with AI${generateHint}`}
                     onClick={generate}
                   >
                     <SparkleIcon data-icon="inline-start" />
@@ -266,7 +272,7 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
                   ? "Stage changes to commit"
                   : null
           }
-          title={formatBinding("mod+enter")}
+          title={commitBinding ? formatBinding(commitBinding) : undefined}
           onClick={doCommit}
         >
           {commit.isPending && <Spinner data-icon="inline-start" />}

--- a/src/features/commit/CommitBox.tsx
+++ b/src/features/commit/CommitBox.tsx
@@ -235,7 +235,13 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
                     size="sm"
                     disabled={stagedCount === 0}
                     reason="Stage changes to generate a commit message"
-                    title={`Generate commit message with AI${generateHint}`}
+                    // The chord is only offered while it would do something — a
+                    // disabled Generate's shortcut is dead too.
+                    title={
+                      stagedCount > 0
+                        ? `Generate commit message with AI${generateHint}`
+                        : "Generate commit message with AI"
+                    }
                     onClick={generate}
                   >
                     <SparkleIcon data-icon="inline-start" />

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -11,8 +11,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { required, useAppForm, withForm } from "@/lib/form";
-import { eventToBinding, SUBMIT_HINT } from "@/lib/hotkeys/binding";
-import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { toastError } from "@/lib/toast";
 
 /** Shared form shape so the hook's `useAppForm` and the `withForm` dialog agree. */
@@ -118,11 +118,14 @@ export const EditTitleBodyDialog = withForm({
     generateDisabled,
     belowBody,
   }) {
-    // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
-    // default) while this dialog is open — never a hardcoded chord, so a
-    // Settings → Keyboard rebinding drives it. null = explicitly unbound.
-    const generateBinding =
-      useEffectiveBindings().get("generate-commit-message") ?? null;
+    // Context-sensitive reuse of the `generate-commit-message` binding while
+    // this dialog is open. This dialog is shared with the ISSUE views, which
+    // pass no `onGenerate` (they have no Generate) — the chord then falls
+    // through untouched instead of being swallowed for nothing.
+    const generateChord = useGenerateChord({
+      enabled: !generating && !generateDisabled,
+      run: onGenerate,
+    });
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent
@@ -135,11 +138,13 @@ export const EditTitleBodyDialog = withForm({
           // handler misses a chord pressed with focus on the X, which would then
           // leak to the global commit / generate-commit-message actions behind the
           // dialog. Capturing on the Popup covers the X and every field, so the
-          // UNCONDITIONAL preventDefault is what actually contains each chord.
-          //
-          // This dialog is shared with the ISSUE views, which pass no `onGenerate`
-          // (they have no Generate) — so the generate chord only arms when a
-          // consumer opts in, and otherwise falls through untouched.
+          // preventDefault here is what actually contains each chord: mod+enter
+          // unconditionally, and the generate chord on every match for as long as
+          // the consumer HAS a Generate. A consumer that passes no `onGenerate`
+          // (the issue views) lets it fall through untouched, which is safe:
+          // the only global handler is CommitBox's, and it runs nothing unless
+          // it is both mounted (Changes tab only) and enabled (never under
+          // Hide-AI) — the listener runs the newest ENABLED handler or none.
           onKeyDown={(e) => {
             if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
               e.preventDefault();
@@ -148,20 +153,7 @@ export const EditTitleBodyDialog = withForm({
               if (!generating) form.handleSubmit();
               return;
             }
-            // Run this consumer's Generate only when it has a Generate surface and
-            // the chord is bound. ALWAYS swallow it then: without this the chord
-            // would fire the global generate-commit-message action behind the
-            // dialog. Run Generate only when its button would be enabled; while
-            // generating we swallow but DON'T cancel (an accidental repeat must not
-            // abort a running generation).
-            if (
-              onGenerate &&
-              generateBinding !== null &&
-              eventToBinding(e) === generateBinding
-            ) {
-              e.preventDefault();
-              if (!generating && !generateDisabled) onGenerate();
-            }
+            generateChord.onKeyDown(e);
           }}
         >
           {/* min-w-0: DialogContent is a grid; without this the form's content

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -477,7 +477,11 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   Run it with uncommitted changes and it offers to stash them, rebase, and put them back
   (see *Stash and reapply*).
 - **Update a branch from its own upstream** without switching to it: when a branch is
-  behind the remote it tracks, its context menu offers **Update from _origin/…_**. This
+  behind the remote it tracks, its context menu offers **Update from _origin/…_**. If the
+  remote was rewritten (a rebase or force-push) and every commit here already landed
+  upstream under new ids, the item becomes a confirmed **Reset to _origin/…_** instead —
+  and when you still have commits of your own on top of a proven rewrite, the update is
+  disabled with the reason, since a merge would duplicate the rewritten history. This
   is the "just merged a PR — bring the default branch current before I switch back" flow;
   every branch's row shows its own push/pull state (↑/↓ vs. its upstream) after a fetch, so
   the branches with commits to pull are visible at a glance, and *Update default branch from
@@ -668,6 +672,11 @@ already updated your view of the remote. On a Git older than 2.30, or a branch w
 reflog for the check to read, the push falls back to \`--force-with-lease\` alone, and the
 success toast says so. When the remote has moved since your last look, the blocked
 push explains it in plain words, with Git's full output one click away under **Details**.
+And when it's the **remote** that was rewritten (a server-side rebase, like GitHub's
+*Update branch → rebase*) and every commit of yours already landed upstream under new
+ids, the force-push confirmation warns that pushing would put the old history back,
+and the Pull menu offers a confirmed **Reset to _origin/…_** that lines the two up
+instead.
 
 ## Resolving conflicts
 
@@ -828,7 +837,11 @@ too — no default shortcut, so give it one in **Settings → Keyboard**.
 
 When an open pull request merges cleanly but its base has moved on since, that same
 strip reads **This branch is N commits behind \`main\`**, and **Update branch** brings
-the head up to date on the forge — a merge of the base into it. GitHub runs that update
+the head up to date on the forge — a merge of the base into it. One exception: on a
+**promotion** pull request (one whose head is the repository's default branch, like
+\`main\` → \`staging\`) that gap is expected and doesn't need closing, so the strip says
+so and **Update branch** is withheld, since it would merge the base back into your
+default branch. GitHub runs that update
 as a background job, so the strip switches to **GitHub is updating this branch from
 \`main\`…** — controls disabled, the reason on hover — and holds there until a fresh
 comparison shows the head caught up, which is when the confirmation arrives. If GitHub
@@ -860,7 +873,8 @@ base branch's protection rules.**
 
 Where the head is also behind its base, the refusal says so in the same breath and
 **Update branch** stays on the strip, so a blocked pull request never loses the route
-to updating it.
+to updating it — except on a promotion pull request, where the update stays withheld
+for the same reason as above.
 
 **Merge** stays available throughout. Whoever holds bypass permission on those rules
 can merge anyway, and nothing GitDesktop can read from here says whether you're one of
@@ -1004,8 +1018,10 @@ deliberate, documented decision isn't re-flagged. Notes present here also ground
 select, so you can **retarget** a pull request at a different branch without recreating it —
 on GitHub, GitLab, and Bitbucket alike. On a **stacked GitHub** pull request that select is
 disabled, since the stack decides what each member targets: dissolve the stack first (see
-*Stacked pull requests* below) and the base is yours to change again.{{ai}} While a PR dialog
-is open, {{kbd:generate-commit-message}} runs its **Generate** for you.{{/ai}}
+*Stacked pull requests* below) and the base is yours to change again.{{ai}} While a
+dialog with a single **Generate** button is open (pull request, branch, issue draft,
+release notes, squash message, script, publish, or repo settings),
+{{kbd:generate-commit-message}} runs that dialog's own Generate for you.{{/ai}}
 
 ## GitLab merge requests
 
@@ -1095,8 +1111,9 @@ default shortcut, so give them one in **Settings → Keyboard** if you want them
 On **GitHub**, merging is **stack-aware**: merging a stacked pull request merges it *and*
 every still-open pull request below it, bottom-up, as a single operation, so the stack
 lands in dependency order without you walking it by hand — or, when the base branch uses a
-**merge queue**, is handed to the queue and lands when it clears, the head branch left in
-place for it. Before you confirm, the merge dialog **spells out the full scope of the
+**merge queue**, is handed to the queue and lands when it clears, the head branch left
+in place for it — a **Queued to merge** chip stays on the pull request until it lands,
+for the rest of the session. Before you confirm, the merge dialog **spells out the full scope of the
 merge** — naming each pull request it will merge, in the order they'll go in, whenever it
 has the list.
 
@@ -2160,7 +2177,8 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
   {{kbd:delete-branch}} delete · {{kbd:update-from-default}} update from default ·
   {{kbd:stash-all}} stash all.
 - **Changes:** {{kbd:commit}} commit{{ai}} · {{kbd:generate-commit-message}} generate
-  commit message{{/ai}} · {{kbd:undo-commit}} undo last commit.
+  with AI (the open dialog's Generate when one is up){{/ai}} · {{kbd:undo-commit}} undo
+  last commit.
 - **Pull requests:** {{kbd:create-pr}} create pull request.
 {{ai}}- **Agent:** {{kbd:agent-toggle-terminal}} toggle the session terminal.
 {{/ai}}
@@ -2205,8 +2223,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump
   to it, arrow-key through the list, and clear items or mark all read. A
-  pull-request entry opens that PR on the tab its event happened on, so a new
-  comment or approval lands on **Conversation**.{{ai}} A review still running shows
+  pull-request entry opens that PR on the tab its event happened on, under the
+  fork/upstream view it belongs to, so a new comment or approval lands on
+  **Conversation** — and a review entry scrolls to the review itself.{{ai}} A review still running shows
   a live **elapsed timer** so you can see how long it's taken. When an
   **automated** review or security audit is cancelled or fails, it stays in the popover
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -837,12 +837,8 @@ too — no default shortcut, so give it one in **Settings → Keyboard**.
 
 When an open pull request merges cleanly but its base has moved on since, that same
 strip reads **This branch is N commits behind \`main\`**, and **Update branch** brings
-the head up to date on the forge — a merge of the base into it. One exception: on a
-**promotion** pull request (one whose head is the repository's default branch, like
-\`main\` → \`staging\`) that gap is expected and doesn't need closing, so the strip says
-so and **Update branch** is withheld, since it would merge the base back into your
-default branch. GitHub runs that update
-as a background job, so the strip switches to **GitHub is updating this branch from
+the head up to date on the forge — a merge of the base into it. GitHub runs that
+update as a background job, so the strip switches to **GitHub is updating this branch from
 \`main\`…** — controls disabled, the reason on hover — and holds there until a fresh
 comparison shows the head caught up, which is when the confirmation arrives. If GitHub
 is still working by the time GitDesktop stops watching, a notice says so and the strip
@@ -859,6 +855,11 @@ conflict, an unfinished resolution, a merge the base branch's rules are blocking
 a mergeability answer the app couldn't read. **Update pull request branch** is in the
 command palette ({{kbd:command-palette}}) too — no default shortcut, so give it one in
 **Settings → Keyboard**.
+
+One exception: on a **promotion** pull request (one whose head is the repository's
+default branch, like \`main\` → \`staging\`) the gap is expected and doesn't need
+closing, so the strip says so and **Update branch** is withheld — it would merge
+the base back into your default branch.
 
 ## Blocked by branch protection
 
@@ -1113,9 +1114,9 @@ every still-open pull request below it, bottom-up, as a single operation, so the
 lands in dependency order without you walking it by hand — or, when the base branch uses a
 **merge queue**, is handed to the queue and lands when it clears, the head branch left
 in place for it — a **Queued to merge** chip stays on the pull request until it lands,
-for the rest of the session. Before you confirm, the merge dialog **spells out the full scope of the
-merge** — naming each pull request it will merge, in the order they'll go in, whenever it
-has the list.
+for the rest of the session. Before you confirm, the merge dialog **spells out
+the full scope of the merge** — naming each pull request it will merge, in the
+order they'll go in, whenever it has the list.
 
 ## Bitbucket PRs
 

--- a/src/features/history/EditHistoryDialog.tsx
+++ b/src/features/history/EditHistoryDialog.tsx
@@ -31,6 +31,7 @@ import {
   useUnpushedMessages,
 } from "@/lib/git/queries";
 import type { CommitSummary } from "@/lib/git/types";
+import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useLatestRef } from "@/lib/use-latest-ref";
@@ -120,6 +121,7 @@ export function EditHistoryDialog({
   // mirrors it for the async completion callback (which fires after streaming).
   const [genHash, setGenHash] = useState<string | null>(null);
   const genHashRef = useLatestRef(genHash);
+  const aiEnabled = useAiEnabled();
   const ai = useGenerateSquashMessage(repoPath, (message) => {
     const h = genHashRef.current;
     if (h) setOverrides((o) => ({ ...o, [h]: message }));
@@ -319,7 +321,8 @@ export function EditHistoryDialog({
                         }))
                       }
                     />
-                    {row.action === "reword" &&
+                    {aiEnabled &&
+                      row.action === "reword" &&
                       (ai.generating && genHash === row.hash ? (
                         <Button
                           type="button"

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -211,7 +211,13 @@ export function SquashDialog({
                   size="sm"
                   wrapperClassName="mr-auto"
                   disabled={!runHead}
-                  title={`Generate the commit message with AI${generateChord.hint}`}
+                  // The chord is only offered while it would do something — a
+                  // disabled Generate's shortcut is dead too.
+                  title={
+                    runHead
+                      ? `Generate the commit message with AI${generateChord.hint}`
+                      : "Generate the commit message with AI"
+                  }
                   reason="Nothing to generate from — this squash has no run of commits to combine"
                   onClick={() => runHead && ai.generate(base, runHead)}
                 >

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -22,7 +22,9 @@ import {
 } from "@/lib/git/api";
 import { useRewriteCommits } from "@/lib/git/queries";
 import type { RewriteStep } from "@/lib/git/types";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { loadSettings } from "@/lib/settings/api";
+import { useAiEnabled } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 
 /**
@@ -120,12 +122,24 @@ export function SquashDialog({
   onDone: () => void;
 }) {
   const rewrite = useRewriteCommits(repoPath);
+  const aiEnabled = useAiEnabled();
   const ai = useGenerateSquashMessage(repoPath, (message) =>
     form.setFieldValue("message", message),
   );
   // The squash step is oldest-first, so its last hash is the run's tip;
   // diffing base..tip yields exactly the changes the new commit will hold.
   const runHead = steps.find((s) => s.hashes.length > 1)?.hashes.at(-1);
+  // The generate chord writes the squashed message while this dialog is open.
+  // Mounted on DialogContent so it also covers the X close button (a form
+  // SIBLING inside the Popup); the swallow is unconditional so it can't reach
+  // the global generate-commit-message action behind the dialog, and while
+  // generating it swallows but DOESN'T cancel.
+  const generateChord = useGenerateChord({
+    enabled: aiEnabled && !ai.generating && Boolean(runHead),
+    run: () => {
+      if (runHead) ai.generate(base, runHead);
+    },
+  });
 
   const form = useAppForm({
     defaultValues: { message: defaultMessage },
@@ -148,7 +162,7 @@ export function SquashDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent onKeyDown={generateChord.onKeyDown}>
         <form
           className="space-y-4"
           onSubmit={(e) => {
@@ -176,34 +190,35 @@ export function SquashDialog({
             )}
           </form.AppField>
           <DialogFooter className="sm:items-center">
-            {ai.generating ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="mr-auto"
-                onClick={ai.cancel}
-              >
-                <XIcon data-icon="inline-start" />
-                Cancel
-              </Button>
-            ) : (
-              // `runHead` is the collapsing step's tip, so without it there's no
-              // range to diff.
-              <DisabledReasonButton
-                type="button"
-                variant="outline"
-                size="sm"
-                wrapperClassName="mr-auto"
-                disabled={!runHead}
-                title="Generate the commit message with AI"
-                reason="Nothing to generate from — this squash has no run of commits to combine"
-                onClick={() => runHead && ai.generate(base, runHead)}
-              >
-                <SparkleIcon data-icon="inline-start" />
-                Generate
-              </DisabledReasonButton>
-            )}
+            {aiEnabled &&
+              (ai.generating ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mr-auto"
+                  onClick={ai.cancel}
+                >
+                  <XIcon data-icon="inline-start" />
+                  Cancel
+                </Button>
+              ) : (
+                // `runHead` is the collapsing step's tip, so without it there's no
+                // range to diff.
+                <DisabledReasonButton
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  wrapperClassName="mr-auto"
+                  disabled={!runHead}
+                  title={`Generate the commit message with AI${generateChord.hint}`}
+                  reason="Nothing to generate from — this squash has no run of commits to combine"
+                  onClick={() => runHead && ai.generate(base, runHead)}
+                >
+                  <SparkleIcon data-icon="inline-start" />
+                  Generate
+                </DisabledReasonButton>
+              ))}
             <Button
               type="button"
               variant="outline"

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -269,7 +269,13 @@ export function CreateIssueDialog({
                         size="xs"
                         disabled={!notes.trim()}
                         onClick={runGenerate}
-                        title={`Expand your notes into a structured issue with AI${generateChord.hint}`}
+                        // The chord is only offered while it would do something —
+                        // a disabled Generate's shortcut is dead too.
+                        title={
+                          notes.trim()
+                            ? `Expand your notes into a structured issue with AI${generateChord.hint}`
+                            : "Expand your notes into a structured issue with AI"
+                        }
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Draft with AI

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -23,6 +23,7 @@ import {
   useRepoLabels,
 } from "@/lib/git/queries";
 import type { ForgeUserRef, IssueType, RemoteLens } from "@/lib/git/types";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useRemoteSlug } from "@/lib/repo-lens/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -172,9 +173,34 @@ export function CreateIssueDialog({
     labels.has(l.name),
   );
 
+  // Shared by the Draft-with-AI button and the generate chord below.
+  function runGenerate() {
+    generate({
+      notes,
+      repoName,
+      onResult: (d) => {
+        if (d.title) form.setFieldValue("title", d.title);
+        form.setFieldValue("body", d.body);
+      },
+    });
+  }
+  // The generate chord drafts this issue while the dialog is open. It's mounted
+  // on DialogContent, not the <form>: the X close button is a form SIBLING
+  // inside the Popup, so a form-level handler would miss a chord pressed with
+  // focus on X. The swallow is unconditional so it can't reach the global
+  // generate-commit-message action behind the dialog; while generating it
+  // swallows but DOESN'T cancel.
+  const generateChord = useGenerateChord({
+    enabled: aiEnabled && !generating && notes.trim() !== "",
+    run: runGenerate,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <form
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
@@ -242,17 +268,8 @@ export function CreateIssueDialog({
                         variant="outline"
                         size="xs"
                         disabled={!notes.trim()}
-                        onClick={() =>
-                          generate({
-                            notes,
-                            repoName,
-                            onResult: (d) => {
-                              if (d.title) form.setFieldValue("title", d.title);
-                              form.setFieldValue("body", d.body);
-                            },
-                          })
-                        }
-                        title="Expand your notes into a structured issue with AI"
+                        onClick={runGenerate}
+                        title={`Expand your notes into a structured issue with AI${generateChord.hint}`}
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Draft with AI

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -265,7 +265,13 @@ export function CreateJiraIssueDialog({
                         size="xs"
                         disabled={!notes.trim()}
                         onClick={runGenerate}
-                        title={`Expand your notes into a structured issue with AI${generateChord.hint}`}
+                        // The chord is only offered while it would do something —
+                        // a disabled Generate's shortcut is dead too.
+                        title={
+                          notes.trim()
+                            ? `Expand your notes into a structured issue with AI${generateChord.hint}`
+                            : "Expand your notes into a structured issue with AI"
+                        }
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Draft with AI

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { required, useAppForm } from "@/lib/form";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useJiraCreateIssue, useJiraIssueTypes } from "@/lib/jira/queries";
 import type { JiraLink } from "@/lib/jira/store";
 import { useAiEnabled } from "@/lib/settings/queries";
@@ -130,9 +131,34 @@ export function CreateJiraIssueDialog({
       ? "Select an issue type to create the issue"
       : null;
 
+  // Shared by the Draft-with-AI button and the generate chord below.
+  function runGenerate() {
+    generate({
+      notes,
+      repoName,
+      onResult: (d) => {
+        if (d.title) form.setFieldValue("summary", d.title);
+        form.setFieldValue("body", d.body);
+      },
+    });
+  }
+  // The generate chord drafts this issue while the dialog is open. It's mounted
+  // on DialogContent, not the <form>: the X close button is a form SIBLING
+  // inside the Popup, so a form-level handler would miss a chord pressed with
+  // focus on X. The swallow is unconditional so it can't reach the global
+  // generate-commit-message action behind the dialog; while generating it
+  // swallows but DOESN'T cancel.
+  const generateChord = useGenerateChord({
+    enabled: aiEnabled && !generating && notes.trim() !== "",
+    run: runGenerate,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <form
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
@@ -238,18 +264,8 @@ export function CreateJiraIssueDialog({
                         variant="outline"
                         size="xs"
                         disabled={!notes.trim()}
-                        onClick={() =>
-                          generate({
-                            notes,
-                            repoName,
-                            onResult: (d) => {
-                              if (d.title)
-                                form.setFieldValue("summary", d.title);
-                              form.setFieldValue("body", d.body);
-                            },
-                          })
-                        }
-                        title="Expand your notes into a structured issue with AI"
+                        onClick={runGenerate}
+                        title={`Expand your notes into a structured issue with AI${generateChord.hint}`}
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Draft with AI

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -152,7 +152,13 @@ export function CreateLocalIssueDialog({
                         size="xs"
                         disabled={!notes.trim()}
                         onClick={runGenerate}
-                        title={`Expand your notes into a structured issue with AI${generateChord.hint}`}
+                        // The chord is only offered while it would do something —
+                        // a disabled Generate's shortcut is dead too.
+                        title={
+                          notes.trim()
+                            ? `Expand your notes into a structured issue with AI${generateChord.hint}`
+                            : "Expand your notes into a structured issue with AI"
+                        }
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Draft with AI

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { required, useAppForm } from "@/lib/form";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useCreateLocalIssue } from "@/lib/issues/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -70,9 +71,34 @@ export function CreateLocalIssueDialog({
     if (open) seedOnOpen();
   }, [open]);
 
+  // Shared by the Draft-with-AI button and the generate chord below.
+  function runGenerate() {
+    generate({
+      notes,
+      repoName,
+      onResult: (d) => {
+        if (d.title) form.setFieldValue("title", d.title);
+        form.setFieldValue("body", d.body);
+      },
+    });
+  }
+  // The generate chord drafts this issue while the dialog is open. It's mounted
+  // on DialogContent, not the <form>: the X close button is a form SIBLING
+  // inside the Popup, so a form-level handler would miss a chord pressed with
+  // focus on X. The swallow is unconditional so it can't reach the global
+  // generate-commit-message action behind the dialog; while generating it
+  // swallows but DOESN'T cancel.
+  const generateChord = useGenerateChord({
+    enabled: aiEnabled && !generating && notes.trim() !== "",
+    run: runGenerate,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <form
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
@@ -125,17 +151,8 @@ export function CreateLocalIssueDialog({
                         variant="outline"
                         size="xs"
                         disabled={!notes.trim()}
-                        onClick={() =>
-                          generate({
-                            notes,
-                            repoName,
-                            onResult: (d) => {
-                              if (d.title) form.setFieldValue("title", d.title);
-                              form.setFieldValue("body", d.body);
-                            },
-                          })
-                        }
-                        title="Expand your notes into a structured issue with AI"
+                        onClick={runGenerate}
+                        title={`Expand your notes into a structured issue with AI${generateChord.hint}`}
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Draft with AI

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -22,12 +22,8 @@ import {
   useForgeStatus,
   useRepoStatus,
 } from "@/lib/git/queries";
-import {
-  eventToBinding,
-  formatBinding,
-  SUBMIT_HINT,
-} from "@/lib/hotkeys/binding";
-import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { updateLocalPr } from "@/lib/pulls/local";
 import { useCreateLocalPr } from "@/lib/pulls/queries";
 import { deleteReviewNote } from "@/lib/review-notes/store";
@@ -258,14 +254,14 @@ export function CreateLocalPrDialog({
       buildIssueCandidates(),
     );
   }
-  // Context-sensitive reuse of the `generate-commit-message` binding (mod+g by
-  // default) while this dialog is open — never a hardcoded chord, so a
-  // Settings → Keyboard rebinding drives it. null = explicitly unbound.
-  const generateBinding =
-    useEffectiveBindings().get("generate-commit-message") ?? null;
-  const generateHint = generateBinding
-    ? ` (${formatBinding(generateBinding)})`
-    : "";
+  // Context-sensitive reuse of the `generate-commit-message` binding while this
+  // dialog is open. `run` is undefined with AI off — no Generate surface, so
+  // the chord falls through instead of being swallowed for nothing.
+  const generateChord = useGenerateChord({
+    enabled: !generating && !(sameBranch || ahead.length === 0),
+    run: aiEnabled ? runGenerate : undefined,
+  });
+  const generateHint = generateChord.hint;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -287,24 +283,15 @@ export function CreateLocalPrDialog({
             if (!generating) form.handleSubmit();
             return;
           }
-          // The generate-commit-message chord (mod+g by default) runs this
-          // dialog's own Generate while it's open. Only when AI is on (no
-          // Generate surface otherwise) and the chord is bound. ALWAYS swallow
-          // it: this dialog is hoisted over the Changes tab, where the global
-          // generate-commit-message action has a live handler — without this the
-          // chord would generate a COMMIT MESSAGE behind the dialog. Run Generate
-          // only when its button would be enabled; while generating we swallow
-          // but DON'T cancel (an accidental repeat must not abort a running one).
-          if (
-            aiEnabled &&
-            generateBinding !== null &&
-            eventToBinding(e) === generateBinding
-          ) {
-            e.preventDefault();
-            if (!generating && !(sameBranch || ahead.length === 0)) {
-              runGenerate();
-            }
-          }
+          // The generate chord runs this dialog's own Generate while it's open.
+          // This dialog is hoisted over the Changes tab, where the global
+          // generate-commit-message action has a live handler — so while that
+          // Generate exists the chord is swallowed on every match, enabled or
+          // not. With Hide-AI on there's no Generate here at all and the chord
+          // falls through instead, which is still safe: the same flag leaves
+          // CommitBox's handler DISABLED and the listener only ever runs an
+          // enabled one, and off the Changes tab CommitBox registers nothing.
+          generateChord.onKeyDown(e);
         }}
       >
         <form

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -393,7 +393,13 @@ export function CreateLocalPrDialog({
                         size="xs"
                         disabled={sameBranch || ahead.length === 0}
                         onClick={runGenerate}
-                        title={`Generate the title and description with AI${generateHint}`}
+                        // The chord is only offered while it would do something —
+                        // a disabled Generate's shortcut is dead too.
+                        title={
+                          !(sameBranch || ahead.length === 0)
+                            ? `Generate the title and description with AI${generateHint}`
+                            : "Generate the title and description with AI"
+                        }
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Generate

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -945,7 +945,13 @@ export function CreatePrDialog({
                         size="xs"
                         disabled={nothingToMerge}
                         onClick={runGenerate}
-                        title={`Generate the title and description with AI${generateHint}`}
+                        // The chord is only offered while it would do something —
+                        // a disabled Generate's shortcut is dead too.
+                        title={
+                          !nothingToMerge
+                            ? `Generate the title and description with AI${generateHint}`
+                            : "Generate the title and description with AI"
+                        }
                       >
                         <SparkleIcon data-icon="inline-start" />
                         Generate

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -44,12 +44,8 @@ import {
   providerLabel,
   type RemoteLens,
 } from "@/lib/git/types";
-import {
-  eventToBinding,
-  formatBinding,
-  SUBMIT_HINT,
-} from "@/lib/hotkeys/binding";
-import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useJiraLink } from "@/lib/jira/queries";
 import {
   useLensGate,
@@ -600,12 +596,13 @@ export function CreatePrDialog({
     );
   }
   // Context-sensitive reuse of the `generate-commit-message` binding while this
-  // dialog is open — never a hardcoded chord. null = explicitly unbound.
-  const generateBinding =
-    useEffectiveBindings().get("generate-commit-message") ?? null;
-  const generateHint = generateBinding
-    ? ` (${formatBinding(generateBinding)})`
-    : "";
+  // dialog is open. `run` is undefined with AI off — no Generate surface, so
+  // the chord falls through instead of being swallowed for nothing.
+  const generateChord = useGenerateChord({
+    enabled: !generating && !nothingToMerge,
+    run: aiEnabled ? runGenerate : undefined,
+  });
+  const generateHint = generateChord.hint;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -632,20 +629,15 @@ export function CreatePrDialog({
             }
             return;
           }
-          // The generate-commit-message chord runs this dialog's own Generate while
-          // it's open — only when AI is on and the chord is bound. ALWAYS swallow it
-          // so it can't reach the global listener and generate a commit message
-          // behind the dialog; run Generate only when its button would be enabled.
-          // While generating we swallow but DON'T cancel — an accidental repeat must
-          // never abort an in-flight generation.
-          if (
-            aiEnabled &&
-            generateBinding !== null &&
-            eventToBinding(e) === generateBinding
-          ) {
-            e.preventDefault();
-            if (!generating && !nothingToMerge) runGenerate();
-          }
+          // The generate chord runs this dialog's own Generate while it's open.
+          // While that Generate exists it swallows the chord on every match,
+          // enabled or not, so it can't reach the global listener and generate a
+          // commit message behind the dialog. With Hide-AI on there's no
+          // Generate here at all and the chord falls through instead — harmless,
+          // because the same flag leaves CommitBox's global handler DISABLED
+          // (the listener only ever runs an enabled one), and off the Changes
+          // tab CommitBox is unmounted and registers nothing.
+          generateChord.onKeyDown(e);
         }}
       >
         <form

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -55,13 +55,13 @@ import {
   useBranchDiffFiles,
   useCompareBranches,
   useConflictPreview,
+  useDefaultBranch,
   useForgeStatus,
   useMergeLocalPr,
   useRepoStatus,
   useUpdateBranchFrom,
 } from "@/lib/git/queries";
-import { formatBinding } from "@/lib/hotkeys/binding";
-import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import { useLocalPrs, useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
@@ -228,13 +228,9 @@ export function LocalPrView({
   // The edit dialog's in-flight generation belongs to the PR it was started on; the
   // cancel is imperative, so it rides an effect rather than the block above.
   useCancelOnIdentityChange(id, prGen.cancel);
-  // Context-sensitive reuse of the generate-commit-message binding (mod+g by
-  // default) for the Edit dialog's chord + button hint — a rebinding drives both.
-  const generateBinding =
-    useEffectiveBindings().get("generate-commit-message") ?? null;
-  const generateHint = generateBinding
-    ? ` (${formatBinding(generateBinding)})`
-    : "";
+  // The generate-commit-message binding's title suffix. The chord itself lives in
+  // EditTitleBodyDialog; this is only the label, so a rebinding drives both.
+  const generateHint = useGenerateChordHint();
 
   const comparison = useCompareBranches(
     repoPath,
@@ -287,6 +283,7 @@ export function LocalPrView({
     pr?.head ?? "",
     pr?.status === "open",
   );
+  const defaultBranch = useDefaultBranch(repoPath);
 
   if (!pr) {
     return (
@@ -298,6 +295,14 @@ export function LocalPrView({
   // Commits on `base` that `head` lacks — i.e. how far the PR's head branch has
   // fallen behind base. Non-empty ⇒ offer GitHub's "Update branch".
   const behind = comparison.data?.behind ?? [];
+  // A promotion pull request (main → staging): the HEAD is this repository's
+  // default branch, so it stays permanently behind its base and "Update branch"
+  // would merge the base back INTO the default branch, inverting the flow. The
+  // head-is-default shape is the whole test — a topology probe false-positives on
+  // stacked pull requests. staging → production has the same inversion and is not
+  // covered.
+  const promotionLike =
+    Boolean(defaultBranch.data) && pr.head === defaultBranch.data;
 
   // AI title+description generation — shared by the Edit dialog's Generate button
   // and its mod+g chord. Verbatim the button's prior onClick body. `pr` is aliased
@@ -452,9 +457,10 @@ export function LocalPrView({
     );
   }
 
-  // A calm status block above the Merge button: up to two INDEPENDENT lines —
-  // the in-memory conflict prediction, and (when merging is currently blocked)
-  // the visible reason it's disabled. The reason is shown here because a
+  // A calm status block above the Merge button: up to three INDEPENDENT lines —
+  // the in-memory conflict prediction, the promotion note that stands in for the
+  // Update branch button this shape hides, and (when merging is currently
+  // blocked) the visible reason it's disabled. The reason is shown here because a
   // disabled <Button>'s `title` never surfaces a tooltip (the repo's
   // explain-disabled-actions gotcha).
   function renderMergeStatus() {
@@ -505,10 +511,32 @@ export function LocalPrView({
       </div>
     ) : null;
 
-    if (!prediction && !reason) return null;
+    // Names the direction the work travels, in place of the Update branch button
+    // this arm hides. The count is true and stays visible; only the implied
+    // catch-up goes away. The gap does NOT close on merge — merging the head into
+    // the base ADDS a commit the head lacks — so the copy says it needs no closing.
+    const promotion =
+      promotionLike && behind.length > 0 ? (
+        <div className="flex items-start gap-1.5 text-muted-foreground">
+          <InfoIcon className="mt-px size-3.5 shrink-0" />
+          <span className="min-w-0">
+            <span className="font-mono">{pr.base}</span> has {behind.length}{" "}
+            commit{behind.length === 1 ? "" : "s"}{" "}
+            <span className="font-mono">{pr.head}</span> doesn't.{" "}
+            <span className="font-mono">{pr.head}</span> is the repository's
+            default branch, so this gap is expected and doesn't need closing.
+            Updating the branch would merge{" "}
+            <span className="font-mono">{pr.base}</span> back into{" "}
+            <span className="font-mono">{pr.head}</span>.
+          </span>
+        </div>
+      ) : null;
+
+    if (!prediction && !reason && !promotion) return null;
     return (
       <div className="space-y-1 border-t px-3 py-1.5 text-xs">
         {prediction}
+        {promotion}
         {reason}
       </div>
     );
@@ -1002,7 +1030,7 @@ export function LocalPrView({
                 branch) so the branch catches up; the repo-scoped invalidation
                 then refreshes the comparison (behind → 0, this button hides)
                 and the conflict preview. */}
-            {behind.length > 0 && (
+            {behind.length > 0 && !promotionLike && (
               <Button
                 variant="outline"
                 size="sm"

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -1031,10 +1031,31 @@ export function LocalPrView({
                 then refreshes the comparison (behind → 0, this button hides)
                 and the conflict preview. */}
             {behind.length > 0 && !promotionLike && (
-              <Button
+              <DisabledReasonButton
                 variant="outline"
                 size="sm"
-                disabled={updateBranchFrom.isPending || recovery.pending}
+                // `promotionLike` reads false while `useDefaultBranch` is still
+                // resolving, so an enabled button there is a demotion that hasn't
+                // decided yet. Held, not hidden: a control that vanishes and
+                // reappears is worse than one that says what it's waiting on.
+                //
+                // PENDING only, never `!isSuccess`: a FAILED read would otherwise
+                // disable the button forever behind a "checking…" that is no longer
+                // true. An error falls open to the ordinary button instead — the
+                // same direction the rest of this feature takes, where an
+                // unprovable answer means today's behavior rather than a
+                // withheld one. (The query is never `enabled: false`, so `isPending`
+                // here can only mean in-flight.)
+                disabled={
+                  updateBranchFrom.isPending ||
+                  recovery.pending ||
+                  defaultBranch.isPending
+                }
+                reason={
+                  defaultBranch.isPending
+                    ? "Checking which branch is the default…"
+                    : undefined
+                }
                 title={`Merge ${pr.base} into ${pr.head} to catch it up`}
                 onClick={() =>
                   updateBranchFrom.mutate(
@@ -1066,7 +1087,7 @@ export function LocalPrView({
               >
                 <ArrowClockwiseIcon data-icon="inline-start" />
                 Update branch
-              </Button>
+              </DisabledReasonButton>
             )}
             <DropdownMenu>
               {/* A natively-disabled Button swallows `title`, so the refusal
@@ -1193,7 +1214,13 @@ export function LocalPrView({
               size="xs"
               disabled={ahead.length === 0}
               onClick={runGenerate}
-              title={`Generate the title and description with AI${generateHint}`}
+              // The chord is only offered while it would do something — a
+              // disabled Generate's shortcut is dead too.
+              title={
+                ahead.length > 0
+                  ? `Generate the title and description with AI${generateHint}`
+                  : "Generate the title and description with AI"
+              }
             >
               <SparkleIcon data-icon="inline-start" />
               Generate

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -1034,18 +1034,10 @@ export function LocalPrView({
               <DisabledReasonButton
                 variant="outline"
                 size="sm"
-                // `promotionLike` reads false while `useDefaultBranch` is still
-                // resolving, so an enabled button there is a demotion that hasn't
-                // decided yet. Held, not hidden: a control that vanishes and
-                // reappears is worse than one that says what it's waiting on.
-                //
-                // PENDING only, never `!isSuccess`: a FAILED read would otherwise
-                // disable the button forever behind a "checking…" that is no longer
-                // true. An error falls open to the ordinary button instead — the
-                // same direction the rest of this feature takes, where an
-                // unprovable answer means today's behavior rather than a
-                // withheld one. (The query is never `enabled: false`, so `isPending`
-                // here can only mean in-flight.)
+                // `promotionLike` reads false until `useDefaultBranch` resolves, so
+                // the button holds rather than deciding early. PENDING only (the
+                // query is never disabled): a FAILED read falls open to the ordinary
+                // button instead of disabling forever behind a stale "checking…".
                 disabled={
                   updateBranchFrom.isPending ||
                   recovery.pending ||

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -121,19 +121,18 @@ export function usePrThreadClaims(
 }
 
 /**
- * A feed row carrying its review's id. `data-review-id` is a DOM contract the
- * reveal seam reads; the row also scrolls ITSELF via a layout effect on its own
- * ref, so a row that only just mounted still lands — no frame racing — and then
- * clears the request through `onRevealed`.
+ * A review row that scrolls ITSELF into view when it's the target of a pending
+ * reveal, via a layout effect on its own ref — so a row that only just mounted
+ * still lands, with no frame racing — and then clears the request through
+ * `onRevealed`. The caller decides which row is the target; nothing queries the
+ * DOM for it.
  */
 function ReviewAnchor({
-  reviewId,
   revealTarget,
   onRevealed,
   className,
   children,
 }: {
-  reviewId: string;
   revealTarget: boolean;
   onRevealed?: () => void;
   className?: string;
@@ -148,7 +147,7 @@ function ReviewAnchor({
     onRevealed?.();
   }, [revealTarget, onRevealed]);
   return (
-    <div ref={rootRef} data-review-id={reviewId} className={className}>
+    <div ref={rootRef} className={className}>
       {children}
     </div>
   );
@@ -302,7 +301,6 @@ export function PrActivityFeed({
         node: (
           <ReviewAnchor
             key={`reply-wrap-${r.id || `${r.author}-${r.date}`}`}
-            reviewId={r.id}
             revealTarget={revealTarget}
             onRevealed={onReviewRevealed}
             className="flex items-start gap-2 text-xs"
@@ -365,7 +363,6 @@ export function PrActivityFeed({
       node: (
         <ReviewAnchor
           key={`review-${r.id || `${r.author}-${r.date}`}`}
-          reviewId={r.id}
           revealTarget={revealTarget}
           onRevealed={onReviewRevealed}
         >

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { type ReactNode, useLayoutEffect, useMemo, useRef } from "react";
 import { RelativeTime } from "@/components/relative-time";
 import {
   AuthorAvatar,
@@ -121,6 +121,40 @@ export function usePrThreadClaims(
 }
 
 /**
+ * A feed row carrying its review's id. `data-review-id` is a DOM contract the
+ * reveal seam reads; the row also scrolls ITSELF via a layout effect on its own
+ * ref, so a row that only just mounted still lands — no frame racing — and then
+ * clears the request through `onRevealed`.
+ */
+function ReviewAnchor({
+  reviewId,
+  revealTarget,
+  onRevealed,
+  className,
+  children,
+}: {
+  reviewId: string;
+  revealTarget: boolean;
+  onRevealed?: () => void;
+  className?: string;
+  children: ReactNode;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (!revealTarget) return;
+    const node = rootRef.current;
+    if (!node) return;
+    node.scrollIntoView({ block: "nearest", behavior: "auto" });
+    onRevealed?.();
+  }, [revealTarget, onRevealed]);
+  return (
+    <div ref={rootRef} data-review-id={reviewId} className={className}>
+      {children}
+    </div>
+  );
+}
+
+/**
  * The remote PR's merged activity feed: reviews + comments + commits + timeline
  * events, date-sorted oldest→newest. Each source maps to a {date, sortKey, node}
  * entry so the sort is provider-neutral; adjacent commit entries coalesce into
@@ -144,6 +178,8 @@ export function PrActivityFeed({
   disabledReason,
   revealThreadId,
   setRevealThreadId,
+  revealReviewId,
+  onReviewRevealed,
   setSection,
   onSelectCommit,
   canWrite,
@@ -177,6 +213,11 @@ export function PrActivityFeed({
   disabledReason: string | undefined;
   revealThreadId: string | null;
   setRevealThreadId: (threadId: string | null) => void;
+  /** The review a notification's click-through asked to land on; that row scrolls
+   *  itself. Null (and always so off GitHub, which mints no review ids). */
+  revealReviewId?: string | null;
+  /** Cleared by the row once it has scrolled itself into view for a reveal. */
+  onReviewRevealed?: () => void;
   /** Bring the Conversation tab forward — see the "View thread" handler. */
   setSection: (section: "conversation") => void;
   /** Drill into a commit from a grouped push row. */
@@ -244,6 +285,10 @@ export function PrActivityFeed({
   // A stale APPROVED/CHANGES_REQUESTED review (dated before the newest
   // commit) gets a warning marker after its card.
   for (const r of renderedReviews) {
+    // GitLab/Bitbucket reviews carry an EMPTY id, so equality alone would let a
+    // blank request claim every one of them at once; a reveal request is always
+    // a real GitHub node id.
+    const revealTarget = !!revealReviewId && revealReviewId === r.id;
     // A wrapper review renders as a compact row instead of an empty
     // "commented" card, with a jump link when its thread was fetched.
     if (wrapperReviewIds.has(r.id)) {
@@ -255,8 +300,11 @@ export function PrActivityFeed({
         date: r.date,
         sortKey: 1,
         node: (
-          <div
+          <ReviewAnchor
             key={`reply-wrap-${r.id || `${r.author}-${r.date}`}`}
+            reviewId={r.id}
+            revealTarget={revealTarget}
+            onRevealed={onReviewRevealed}
             className="flex items-start gap-2 text-xs"
           >
             <AuthorAvatar login={r.author} avatarUrl={r.authorAvatarUrl} />
@@ -289,7 +337,7 @@ export function PrActivityFeed({
                 </span>
               )}
             </div>
-          </div>
+          </ReviewAnchor>
         ),
       });
       continue;
@@ -315,7 +363,12 @@ export function PrActivityFeed({
       date: r.date,
       sortKey: 1,
       node: (
-        <div key={`review-${r.id || `${r.author}-${r.date}`}`}>
+        <ReviewAnchor
+          key={`review-${r.id || `${r.author}-${r.date}`}`}
+          reviewId={r.id}
+          revealTarget={revealTarget}
+          onRevealed={onReviewRevealed}
+        >
           <Thread
             thread={r}
             onQuote={
@@ -352,7 +405,7 @@ export function PrActivityFeed({
               />
             </div>
           )}
-        </div>
+        </ReviewAnchor>
       ),
     });
   }

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -216,6 +216,7 @@ export function PrMergeabilityBanner({
   blockedRequirements,
   updateBlockedReason,
   updateBusy,
+  updateAwaitingDefault,
   updateSubmitting,
   onResolve,
   onResolveWithAi,
@@ -256,6 +257,10 @@ export function PrMergeabilityBanner({
   /** Why updating the branch is refused, if it is; undefined = allowed. */
   updateBlockedReason: string | undefined;
   updateBusy: boolean;
+  /** The slice of `updateBusy` spent waiting on the default-branch read the
+   *  promotion demotion depends on — it gets its own wording, since the generic
+   *  busy line would claim the pull request is still loading. */
+  updateAwaitingDefault: boolean;
   /** The update call itself is in flight — the slice of `updateBusy` before the forge
    *  has even accepted the job. */
   updateSubmitting: boolean;
@@ -303,14 +308,17 @@ export function PrMergeabilityBanner({
   const updateDisabled = updateBusy || updateBlockedReason !== undefined;
   // The busy hold now spans the forge's whole queued update, so a silent disabled
   // control would leave the user waiting on nothing they can read. Each cause gets its
-  // own words: the queued job, the call that hasn't been accepted yet, and the
-  // PR-switch window are three different waits.
+  // own words: the queued job, the call that hasn't been accepted yet, the
+  // default-branch read this action's promotion check depends on, and the
+  // PR-switch window are four different waits.
   const updateBusyReason = (() => {
     switch (true) {
       case arm === "updating":
         return `${providerLabel(provider)} is still updating this branch.`;
       case updateSubmitting:
         return "Submitting the update…";
+      case updateAwaitingDefault:
+        return "Checking which branch is the default…";
       default:
         return PR_SWITCH_LOADING_REASON;
     }

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -89,11 +89,13 @@ const ARM_MESSAGE: Record<
   Exclude<PrMergeabilityArm, null>,
   (ctx: {
     base: string;
+    head: string;
     provider: ForgeProvider | null | undefined;
     behindBy: number;
     predictedClean: boolean;
     forgeUnreachable: boolean;
     blockedRequirements: string[];
+    promotionLike: boolean;
   }) => ReactNode
 > = {
   conflicting: ({ base, provider }) => (
@@ -147,10 +149,13 @@ const ARM_MESSAGE: Record<
   // The behind clause rides along in the `behind` arm's own words, because the update
   // controls come with it — a bare refusal beside an Update branch button would leave
   // the button unexplained.
-  blocked: ({ base, behindBy, blockedRequirements }) => (
+  blocked: ({ base, behindBy, blockedRequirements, promotionLike }) => (
     <>
       {blockedMergeLine(blockedRequirements)}
-      {behindBy > 0 ? (
+      {/* The behind clause exists to explain the Update controls beside it, so it
+          goes wherever they go: on a promotion pull request they'd invert the
+          flow, and a count with no route out would read as a demand. */}
+      {behindBy > 0 && !promotionLike ? (
         <>
           {` It is also ${behindBy} commit${behindBy === 1 ? "" : "s"} behind `}
           <span className="font-mono">{base}</span>
@@ -159,13 +164,34 @@ const ARM_MESSAGE: Record<
       ) : null}
     </>
   ),
-  behind: ({ base, behindBy }) => (
-    <>
-      {`This branch is ${behindBy} commit${behindBy === 1 ? "" : "s"} behind `}
-      <span className="font-mono">{base}</span>
-      {"."}
-    </>
-  ),
+  // A promotion pull request (main → staging) is permanently behind its base by
+  // design, and "update the branch" would merge the base back into the default
+  // branch. Say which direction the work is going instead of implying a catch-up.
+  // The gap does NOT close on merge — merging the head into the base ADDS a
+  // commit the head lacks — so the copy says it needs no closing.
+  behind: ({ base, head, behindBy, promotionLike }) =>
+    promotionLike ? (
+      <>
+        <span className="font-mono">{base}</span>
+        {` has ${behindBy} commit${behindBy === 1 ? "" : "s"} that `}
+        <span className="font-mono">{head}</span>
+        {" doesn't. "}
+        <span className="font-mono">{head}</span>
+        {
+          " is the repository's default branch, so this gap is expected and doesn't need closing. Updating the branch would merge "
+        }
+        <span className="font-mono">{base}</span>
+        {" back into "}
+        <span className="font-mono">{head}</span>
+        {"."}
+      </>
+    ) : (
+      <>
+        {`This branch is ${behindBy} commit${behindBy === 1 ? "" : "s"} behind `}
+        <span className="font-mono">{base}</span>
+        {"."}
+      </>
+    ),
 };
 
 /**
@@ -177,6 +203,8 @@ const ARM_MESSAGE: Record<
 export function PrMergeabilityBanner({
   arm,
   base,
+  head,
+  promotionLike,
   provider,
   forkBlocked,
   hasResolveWorktree,
@@ -199,6 +227,12 @@ export function PrMergeabilityBanner({
 }: {
   arm: PrMergeabilityArm;
   base: string;
+  head: string;
+  /** The head IS this repository's default branch, so the pull request promotes
+   *  it somewhere (main → staging). Updating such a branch would merge the base
+   *  back into the default branch, inverting the flow — so the behind arm keeps
+   *  its true count and drops the action. */
+  promotionLike: boolean;
   provider: ForgeProvider | null | undefined;
   /** The head branch lives in another repository, so there's nowhere to push. */
   forkBlocked: boolean;
@@ -283,6 +317,12 @@ export function PrMergeabilityBanner({
   })();
   const updateDisabledReason =
     updateBlockedReason ?? (updateBusy ? updateBusyReason : undefined);
+  // "Update branch" doesn't say which way the commits travel; the tooltip does.
+  // The caret gets its own wording rather than this one — its menu holds the
+  // REBASE variant, which rewrites rather than merges (and names that in its own
+  // confirm), so borrowing the button's label there would misdescribe it.
+  const updateOperation = `Merges ${base} into ${head}`;
+  const updateOptionsLabel = "Other ways to update this branch";
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b px-3 py-1.5 text-xs">
@@ -298,11 +338,13 @@ export function PrMergeabilityBanner({
         <span className="min-w-0">
           {ARM_MESSAGE[arm]({
             base,
+            head,
             provider,
             behindBy,
             predictedClean,
             forgeUnreachable,
             blockedRequirements,
+            promotionLike,
           })}
         </span>
       </span>
@@ -364,61 +406,64 @@ export function PrMergeabilityBanner({
           route to the update along with it would be a refusal the app never intended. */}
       {(arm === "behind" ||
         arm === "updating" ||
-        (arm === "blocked" && behindBy > 0)) && (
-        <div className="flex items-center gap-1.5">
-          <DisabledReasonButton
-            variant="ghost"
-            size="xs"
-            disabled={updateDisabled}
-            reason={updateDisabledReason}
-            onClick={onUpdateBranch}
-          >
-            {/* The `updating` arm already spins in the sentence — one progress mark
+        (arm === "blocked" && behindBy > 0)) &&
+        !promotionLike && (
+          <div className="flex items-center gap-1.5">
+            <DisabledReasonButton
+              variant="ghost"
+              size="xs"
+              disabled={updateDisabled}
+              reason={updateDisabledReason}
+              title={updateOperation}
+              onClick={onUpdateBranch}
+            >
+              {/* The `updating` arm already spins in the sentence — one progress mark
                 per strip, so the button only carries the momentary holds. */}
-            {updateBusy && arm !== "updating" && (
-              <Spinner data-icon="inline-start" />
-            )}
-            Update branch
-          </DisabledReasonButton>
-          {/* A span-wrapped `render` would swallow the caret's disabled state — the
+              {updateBusy && arm !== "updating" && (
+                <Spinner data-icon="inline-start" />
+              )}
+              Update branch
+            </DisabledReasonButton>
+            {/* A span-wrapped `render` would swallow the caret's disabled state — the
               vendored Button's `pointer-events-none` routes the click to the span,
               which IS the trigger — so a refused update renders no trigger at all. */}
-          {updateDisabled ? (
-            <span className="inline-flex" title={updateDisabledReason}>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Update branch options"
-                disabled
-              >
-                <CaretDownIcon />
-              </Button>
-            </span>
-          ) : (
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Update branch options"
-                  />
-                }
-              >
-                <CaretDownIcon />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-48">
-                <DropdownMenuItem
-                  disabled={updateDisabled}
-                  onClick={onUpdateWithRebase}
+            {updateDisabled ? (
+              <span className="inline-flex" title={updateDisabledReason}>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Update branch options"
+                  disabled
                 >
-                  Update with rebase…
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
-      )}
+                  <CaretDownIcon />
+                </Button>
+              </span>
+            ) : (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label="Update branch options"
+                      title={updateOptionsLabel}
+                    />
+                  }
+                >
+                  <CaretDownIcon />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-48">
+                  <DropdownMenuItem
+                    disabled={updateDisabled}
+                    onClick={onUpdateWithRebase}
+                  >
+                    Update with rebase…
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        )}
 
       {(arm === "unknown" || arm === "unreachable") && (
         <div className="flex items-center gap-1.5">

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -352,6 +352,11 @@ export function RemotePrView({
     canSubmitReview,
   } = usePrCapabilities(forge.data, provider, writeAccess.data);
   const details = usePrDetails(repoPath, number, lens);
+  // Every handler that refuses while the rendered PR is the previous one reads
+  // this, so each of their entry points can hold too rather than sit enabled and
+  // do nothing. Declared up here beside `details` because the gates that need it
+  // (the update-branch derivation among them) run well before the strip does.
+  const detailsStale = details.isPlaceholderData;
   const prDiff = usePrDiff(repoPath, number, lens);
   const setAssignees = useSetPrAssignees(repoPath, lens);
   const setReviewers = useSetPrReviewers(repoPath, lens);
@@ -1010,11 +1015,18 @@ export function RemotePrView({
   // UNQUALIFIED, so a contribution from someone's fork whose head is THEIR `main`
   // matches our default branch by name alone — an ordinary pull request that would
   // otherwise lose Update branch and gain copy about a promotion that isn't one.
+  //
+  // `lens === "origin"` for the same reason from the other side: `useDefaultBranch`
+  // reads ORIGIN's default with no lens parameter, while `details` follows the
+  // lens, so on the upstream lens the two names describe different repositories.
+  // An upstream-lens promotion pull request therefore keeps today's behavior —
+  // a recorded limitation, like staging → production.
   const promotionLike =
     !!details.data?.headRefName &&
     !!defaultBranch.data &&
     details.data.headRefName === defaultBranch.data &&
-    !details.data.crossRepository;
+    !details.data.crossRepository &&
+    lens === "origin";
 
   // The banner's arm: server truth, then the local prediction where the forge has
   // none, then the resume offer — the resolve worktree is only worth its own line
@@ -1083,8 +1095,19 @@ export function RemotePrView({
   // block it: the strip's sentence changes, the affordance does not. Neither arm
   // needs an `updating` term — both sit below it. The submitting window precedes
   // the latch.
+  // `!detailsStale` is REDUNDANT today and kept deliberately. Every route is
+  // already covered: the hotkey below ANDs its own `!details.isPlaceholderData`,
+  // the banner's controls ride `updateBusy` (which includes `detailsStale`), and
+  // `runUpdateBranch` early-returns on placeholder data. It sits here because this
+  // is the named "can update" predicate, and the term it guards is a real one —
+  // `promotionLike` reads `details`, which serves the PREVIOUS pull request
+  // through a switch, while `behindBy` comes from the divergence query, which has
+  // no placeholder and caches per number. A consumer added later without its own
+  // staleness gate would otherwise inherit exactly that window on exactly the pull
+  // requests the demotion exists to protect.
   const canUpdateBranch =
     (bannerArm === "behind" || (bannerArm === "blocked" && behindBy > 0)) &&
+    !detailsStale &&
     !promotionLike &&
     updateBlockedReason === undefined &&
     !updateBranch.isPending;
@@ -1757,10 +1780,6 @@ export function RemotePrView({
         ? `${approval.approvedBy.length} of ${approval.approvalsRequired} approvals`
         : `${approval.approvedBy.length} approval${approval.approvedBy.length === 1 ? "" : "s"}`
       : null;
-  // Every handler that refuses while the rendered PR is the previous one reads
-  // this, so each of their entry points can hold too rather than sit enabled and
-  // do nothing.
-  const detailsStale = details.isPlaceholderData;
   // What a control that holds through the switch says, in one wording. It ranks
   // BELOW any permission or read-error reason wherever both hold: those never
   // lift on their own and are the ones still true once the switch lands.

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -519,13 +519,16 @@ export function RemotePrView({
   // Merge-queue record for THIS pull request. The forge reports the queue once,
   // in the merge outcome, and nothing fetchable carries it afterwards, so the
   // store is the only source and the PR leaving OPEN is the only retraction.
-  const queuedKey = queuedMergeKey(repoPath, number);
+  // Keyed on the same repo+number+LENS identity `divergenceIdentity` uses: the
+  // lens flips while this view stays mounted, and origin and upstream can both
+  // have a pull request numbered 7.
+  const queuedKey = queuedMergeKey(repoPath, number, lens);
   const mergeQueued = useUiStore((s) => Boolean(s.queuedMerges[queuedKey]));
   const markMergeQueued = useUiStore((s) => s.markMergeQueued);
   const clearMergeQueued = useUiStore((s) => s.clearMergeQueued);
   // Details are authoritative once they land: a merged or closed pull request is
   // out of the queue however it got there. The placeholder gate is what makes the
-  // retraction safe — `queuedKey` follows the `number` prop immediately while
+  // retraction safe — `queuedKey` follows the number and lens immediately while
   // `details` still serves the PREVIOUS pull request, so switching away to a
   // merged one and back would otherwise read ITS state against THIS key and drop
   // the record for good. Same gate on the chip below, so both read one truth.
@@ -1095,16 +1098,10 @@ export function RemotePrView({
   // block it: the strip's sentence changes, the affordance does not. Neither arm
   // needs an `updating` term — both sit below it. The submitting window precedes
   // the latch.
-  // `!detailsStale` is REDUNDANT today and kept deliberately. Every route is
-  // already covered: the hotkey below ANDs its own `!details.isPlaceholderData`,
-  // the banner's controls ride `updateBusy` (which includes `detailsStale`), and
-  // `runUpdateBranch` early-returns on placeholder data. It sits here because this
-  // is the named "can update" predicate, and the term it guards is a real one —
-  // `promotionLike` reads `details`, which serves the PREVIOUS pull request
-  // through a switch, while `behindBy` comes from the divergence query, which has
-  // no placeholder and caches per number. A consumer added later without its own
-  // staleness gate would otherwise inherit exactly that window on exactly the pull
-  // requests the demotion exists to protect.
+  // `promotionLike` reads placeholder-served `details` while `behindBy` comes from
+  // the per-number divergence cache, so a stale render can show the old PR's
+  // verdict. Redundant today (every route gates staleness itself) — kept so this
+  // named predicate stays self-sufficient for the next consumer.
   const canUpdateBranch =
     (bannerArm === "behind" || (bannerArm === "blocked" && behindBy > 0)) &&
     !detailsStale &&
@@ -2529,7 +2526,15 @@ export function RemotePrView({
         updateBlockedReason={updateBlockedReason}
         // Busy-shaped, not a reason — the banner supplies its own words for the wait,
         // which now spans GitHub's whole queued update rather than one CLI call.
-        updateBusy={updateBranch.isPending || updatingBranch || detailsStale}
+        // `defaultBranch.isPending` rides along because `promotionLike` reads false
+        // until it resolves: holding is the only way the demotion can't be raced.
+        // A FAILED read is deliberately not held (see LocalPrView's twin).
+        updateBusy={
+          updateBranch.isPending ||
+          updatingBranch ||
+          detailsStale ||
+          defaultBranch.isPending
+        }
         updateSubmitting={updateBranch.isPending}
         onResolve={() => runResolve(false)}
         onResolveWithAi={() => runResolve(true)}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -70,10 +70,11 @@ import {
 import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
-import type {
-  MergeStrategy,
-  MinimizeReason,
-  RemotePrResolveHandle,
+import {
+  gitFetch,
+  type MergeStrategy,
+  type MinimizeReason,
+  type RemotePrResolveHandle,
 } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
 import { splitUnifiedDiff } from "@/lib/git/diff-split";
@@ -83,6 +84,7 @@ import {
   PIPELINE_IN_FLIGHT,
   prDiffOptions,
   prUpdateBranchKeys,
+  repoKeys,
   TRIAGE_ACCESS_ITEM_REASON,
   triageAccessReason,
   useAbortRemotePrResolve,
@@ -149,8 +151,8 @@ import {
   providerLabel,
   type RemoteLens,
 } from "@/lib/git/types";
-import { formatBinding } from "@/lib/hotkeys/binding";
-import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
 import { useJiraLink } from "@/lib/jira/queries";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import {
@@ -161,7 +163,7 @@ import { useRepoLens } from "@/lib/repo-lens/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useConfirm } from "@/lib/stores/confirm";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
-import { useUiStore } from "@/lib/stores/ui";
+import { queuedMergeKey, useUiStore } from "@/lib/stores/ui";
 import { toastError, toastErrorWithNote } from "@/lib/toast";
 import { useKeyedEntityState } from "@/lib/use-keyed-entity-state";
 import { useRetained } from "@/lib/use-retained";
@@ -488,6 +490,10 @@ export function RemotePrView({
   // whichever ReviewThreadList owns it; that list reveals the (possibly
   // resolved/collapsed) thread and clears this via onRevealed.
   const [revealThreadId, setRevealThreadId] = useState<string | null>(null);
+  // The review card a notification asked to land on. Deliberately its OWN state
+  // rather than a read of the store hint: the hint is handed over only once this
+  // view's details are real (below), long after the sub-tab hint has settled.
+  const [revealReviewId, setRevealReviewId] = useState<string | null>(null);
   // Activity-timeline events (force-pushes, labels, state changes, review requests,
   // approvals) interleaved into the Conversation feed; provider-neutral via the
   // backend's `forge_pr_timeline`. Fetch only while Conversation is showing AND a
@@ -501,8 +507,30 @@ export function RemotePrView({
   );
   const pendingPrSection = useUiStore((s) => s.pendingPrSection);
   const setPendingPrSection = useUiStore((s) => s.setPendingPrSection);
+  const pendingReviewId = useUiStore((s) => s.pendingReviewId);
+  const setPendingReviewId = useUiStore((s) => s.setPendingReviewId);
   const selectedPr = useUiStore((s) => s.selectedPr);
   const selectPr = useUiStore((s) => s.selectPr);
+  // Merge-queue record for THIS pull request. The forge reports the queue once,
+  // in the merge outcome, and nothing fetchable carries it afterwards, so the
+  // store is the only source and the PR leaving OPEN is the only retraction.
+  const queuedKey = queuedMergeKey(repoPath, number);
+  const mergeQueued = useUiStore((s) => Boolean(s.queuedMerges[queuedKey]));
+  const markMergeQueued = useUiStore((s) => s.markMergeQueued);
+  const clearMergeQueued = useUiStore((s) => s.clearMergeQueued);
+  // Details are authoritative once they land: a merged or closed pull request is
+  // out of the queue however it got there. The placeholder gate is what makes the
+  // retraction safe — `queuedKey` follows the `number` prop immediately while
+  // `details` still serves the PREVIOUS pull request, so switching away to a
+  // merged one and back would otherwise read ITS state against THIS key and drop
+  // the record for good. Same gate on the chip below, so both read one truth.
+  const queuedDetailsReady = !details.isPlaceholderData;
+  const prState = details.data?.state;
+  useEffect(() => {
+    if (!queuedDetailsReady) return;
+    if (mergeQueued && prState !== undefined && prState !== "OPEN")
+      clearMergeQueued(queuedKey);
+  }, [queuedDetailsReady, mergeQueued, prState, queuedKey, clearMergeQueued]);
   // Whether this view owns the current selection. Several hint/palette paths
   // gate on it so a still-mounted lagging view (deferredPr) can't answer first.
   const isSelectedPr =
@@ -928,6 +956,15 @@ export function RemotePrView({
       // reports throughout, so the refetch above would land on a gave-up arm. The head
       // just moved: the question is new again, and the ladder has to start over with it.
       mergeability.retry();
+      // The remote head moved, so the local repo's tracking refs and ahead/behind
+      // counts are stale — the same background catch-up the merge path runs. Not
+      // awaited and silent: the update already landed, and a fetch failure toast
+      // would misreport it (the header's Fetch stays the manual fallback).
+      void gitFetch(repoPath)
+        .then(() =>
+          queryClient.invalidateQueries({ queryKey: repoKeys.all(repoPath) }),
+        )
+        .catch(() => undefined);
       toast.success(`Branch updated from ${awaited.base}.`);
       return;
     }
@@ -955,6 +992,29 @@ export function RemotePrView({
     (details.data?.crossRepository && details.data.maintainerCanModify === false
       ? "The contributor hasn't allowed edits from maintainers."
       : undefined);
+
+  // A promotion pull request: the HEAD is this repository's default branch, so the
+  // work flows main → staging and the head is permanently behind its base by
+  // design. "Update branch" there merges the base back INTO the default branch,
+  // inverting the flow — so every route to it is demoted below, and the behind
+  // copy names the direction instead of asking for a catch-up.
+  //
+  // Head-is-default is the whole test on purpose: a topology probe false-positives
+  // on stacked pull requests, which this app first-classes, and `allowUpdateBranch`
+  // is absent for non-push viewers (serde-defaulting to false), so gating on it
+  // would delete the behind banner for every read-only viewer. This shape is the
+  // reported one and both inputs are already held. A staging → production pull
+  // request has the same inversion and is NOT covered.
+  //
+  // `crossRepository` is what keeps the name comparison honest: `headRefName` is
+  // UNQUALIFIED, so a contribution from someone's fork whose head is THEIR `main`
+  // matches our default branch by name alone — an ordinary pull request that would
+  // otherwise lose Update branch and gain copy about a promotion that isn't one.
+  const promotionLike =
+    !!details.data?.headRefName &&
+    !!defaultBranch.data &&
+    details.data.headRefName === defaultBranch.data &&
+    !details.data.crossRepository;
 
   // The banner's arm: server truth, then the local prediction where the forge has
   // none, then the resume offer — the resolve worktree is only worth its own line
@@ -1025,6 +1085,7 @@ export function RemotePrView({
   // the latch.
   const canUpdateBranch =
     (bannerArm === "behind" || (bannerArm === "blocked" && behindBy > 0)) &&
+    !promotionLike &&
     updateBlockedReason === undefined &&
     !updateBranch.isPending;
 
@@ -1111,7 +1172,11 @@ export function RemotePrView({
     if (
       updateBlockedReason !== undefined ||
       updateBranch.isPending ||
-      updatingBranch
+      updatingBranch ||
+      // A promotion pull request would merge the base back INTO the default
+      // branch. The demotion has to live here too, or it is only as good as the
+      // surfaces that happen to read `canUpdateBranch`.
+      promotionLike
     )
       return;
     if (rebase) {
@@ -1155,6 +1220,14 @@ export function RemotePrView({
     string | null
   >(null);
   const [mergeOpen, setMergeOpen] = useState(false);
+  // The cleanup note a queued merge came back with (a head-branch deletion that
+  // failed), carried on the chip's tooltip. Keyed so it can never paint onto
+  // another pull request; the queue record itself lives in the store, which is
+  // why the chip survives a switch away and back while this detail doesn't.
+  const [queuedWarning, setQueuedWarning] = useState<{
+    key: string;
+    text: string;
+  } | null>(null);
   const [mergeStrategy, setMergeStrategy] = useState<MergeStrategy>("merge");
   const [deleteBranch, setDeleteBranch] = useState(false);
   // Whether the open merge dialog is arming auto-merge (vs merging now) — set by
@@ -1245,13 +1318,9 @@ export function RemotePrView({
   });
   const prGen = useGeneratePrDescription(repoPath);
   const composerRef = useRef<MarkdownEditorHandle>(null);
-  // Context-sensitive reuse of the generate-commit-message binding (mod+g by
-  // default) for the Edit dialog's chord + button hint — a rebinding drives both.
-  const generateBinding =
-    useEffectiveBindings().get("generate-commit-message") ?? null;
-  const generateHint = generateBinding
-    ? ` (${formatBinding(generateBinding)})`
-    : "";
+  // The generate-commit-message binding's title suffix. The chord itself lives in
+  // EditTitleBodyDialog; this is only the label, so a rebinding drives both.
+  const generateHint = useGenerateChordHint();
 
   const onError = (e: unknown) => toastError(e);
 
@@ -1511,6 +1580,15 @@ export function RemotePrView({
             toast.success(
               outcome.cleanupWarning ?? `Merge queued for #${number}`,
             );
+            // The toast is gone in seconds and nothing fetchable carries queue
+            // state, so record it: the chip below is the only lasting sign the
+            // merge is waiting rather than done.
+            markMergeQueued(queuedKey);
+            setQueuedWarning(
+              outcome.cleanupWarning
+                ? { key: queuedKey, text: outcome.cleanupWarning }
+                : null,
+            );
           } else {
             toast.success(`Merged #${number}`);
             // Merged for real; a cleanupWarning here means only the post-merge
@@ -1572,7 +1650,9 @@ export function RemotePrView({
   // and a local branch RULE can block deleting the head (so it's disabled with a
   // reason, mirroring the switcher's Delete menu item). Name-keyed against this
   // repo's default — the common same-repo case; a fork PR whose head is
-  // coincidentally named like our default is an accepted v1 over-hide.
+  // coincidentally named like our default is an accepted v1 over-hide — which is
+  // why this stays the bare comparison and NOT `promotionLike`, whose same-repo
+  // term exists to refuse exactly that match.
   const headIsDefault =
     pr != null &&
     defaultBranch.data != null &&
@@ -1721,6 +1801,43 @@ export function RemotePrView({
   // close, so one opened mid-switch would write the previous PR's members under
   // the new number. Their triggers disable on a reason, so this rides that seam.
   const pickerReason = triageReason ?? staleReason;
+  // A review notification's click-through, taken over from the store only once
+  // the rendered details are THIS pull request's: a scroll fired against
+  // placeholder rows lands on another PR's cards. The Conversation feed owns the
+  // anchors, so the handoff waits for that sub-tab too — the hinted tab arrives
+  // through `pendingPrSection` in its own commit.
+  //
+  // Details alone aren't enough: threads decide which reviews claim inline
+  // blocks and the timeline interleaves rows ABOVE the target, so either landing
+  // afterwards would push a scrolled-to card back off screen. Waiting for all
+  // three to settle (an ERROR settles too — the feed renders what it has) keeps
+  // this to one attempt against the finished layout. A DISABLED timeline (no
+  // provider resolved yet) is neither, so the reveal waits and fires once the
+  // probe answers; if it never does, the request simply lapses.
+  const revealInputsSettled =
+    details.isSuccess &&
+    !detailsStale &&
+    (reviewThreads.isSuccess || reviewThreads.isError) &&
+    (timeline.isSuccess || timeline.isError);
+  useEffect(() => {
+    if (pendingReviewId === null || !isSelectedPr) return;
+    if (!revealInputsSettled || section !== "conversation") return;
+    setRevealReviewId(pendingReviewId);
+    setPendingReviewId(null);
+  }, [
+    pendingReviewId,
+    setPendingReviewId,
+    isSelectedPr,
+    revealInputsSettled,
+    section,
+  ]);
+  // Exactly one attempt. Child layout effects run before this one, so the target
+  // row has already scrolled itself if it rendered; a review with no visible body
+  // and no state renders no row at all, and dropping the request is the fail-soft
+  // there — never a retry loop or a jump to the top of the feed.
+  useLayoutEffect(() => {
+    if (revealReviewId !== null) setRevealReviewId(null);
+  }, [revealReviewId]);
 
   if (details.isPending) {
     return (
@@ -2375,6 +2492,8 @@ export function RemotePrView({
       <PrMergeabilityBanner
         arm={bannerArm}
         base={pr.baseRefName}
+        head={pr.headRefName}
+        promotionLike={promotionLike}
         provider={provider}
         forkBlocked={!!pr.crossRepository}
         hasResolveWorktree={resolveWorktree !== null}
@@ -2558,6 +2677,8 @@ export function RemotePrView({
                 disabledReason={triageItemReason ?? staleReason}
                 revealThreadId={revealThreadId}
                 setRevealThreadId={setRevealThreadId}
+                revealReviewId={revealReviewId}
+                onReviewRevealed={() => setRevealReviewId(null)}
                 setSection={setSection}
                 // Drill into the commit via the Commits-tab machinery
                 // (selectedCommitOid → PrCommitDetail).
@@ -2934,6 +3055,24 @@ export function RemotePrView({
             >
               Convert to draft
             </DisabledReasonButton>
+          )}
+          {/* The merge is in the forge's queue, not landed. Same icon + words
+              shape as the auto-merge chip below (not color-alone), and it stands
+              until the pull request itself leaves OPEN — read behind the same
+              placeholder gate as the retraction, so a lagging `details` can't
+              blank the chip during a PR switch. */}
+          {mergeQueued && isOpenPr && queuedDetailsReady && (
+            <span
+              className="flex items-center gap-1 text-xs text-info"
+              title={
+                queuedWarning?.key === queuedKey
+                  ? queuedWarning.text
+                  : "Merges when the queue reaches it"
+              }
+            >
+              <ClockCountdownIcon className="size-3.5 shrink-0" />
+              Queued to merge
+            </span>
           )}
           {/* Auto-merge armed indicator + cancel (GitLab-only) — sits on the left,
               opposite Close/Merge. Not color-alone: icon + words. */}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1031,6 +1031,15 @@ export function RemotePrView({
     !details.data.crossRepository &&
     lens === "origin";
 
+  // `promotionLike` is hard-false until the default branch resolves, so an update
+  // started in that window races the demotion. Every entry point holds on this —
+  // the banner via `updateBusy`, the hotkey via `canUpdateBranch`, and
+  // `runUpdateBranch` itself — but ONLY on the origin lens, where the comparison
+  // could change the answer; elsewhere `promotionLike` is false by design and a
+  // hold would buy nothing. A FAILED read is deliberately not held: it falls open,
+  // matching LocalPrView's twin.
+  const defaultBranchSettling = lens === "origin" && defaultBranch.isPending;
+
   // The banner's arm: server truth, then the local prediction where the forge has
   // none, then the resume offer — the resolve worktree is only worth its own line
   // when there's nothing more urgent to say about the merge. `updating` outranks
@@ -1106,6 +1115,7 @@ export function RemotePrView({
     (bannerArm === "behind" || (bannerArm === "blocked" && behindBy > 0)) &&
     !detailsStale &&
     !promotionLike &&
+    !defaultBranchSettling &&
     updateBlockedReason === undefined &&
     !updateBranch.isPending;
 
@@ -1195,8 +1205,11 @@ export function RemotePrView({
       updatingBranch ||
       // A promotion pull request would merge the base back INTO the default
       // branch. The demotion has to live here too, or it is only as good as the
-      // surfaces that happen to read `canUpdateBranch`.
-      promotionLike
+      // surfaces that happen to read `canUpdateBranch` — and it has to include
+      // the window where the demotion hasn't been decided yet, or a fast hotkey
+      // slips through with `promotionLike` still false.
+      promotionLike ||
+      defaultBranchSettling
     )
       return;
     if (rebase) {
@@ -2526,15 +2539,15 @@ export function RemotePrView({
         updateBlockedReason={updateBlockedReason}
         // Busy-shaped, not a reason — the banner supplies its own words for the wait,
         // which now spans GitHub's whole queued update rather than one CLI call.
-        // `defaultBranch.isPending` rides along because `promotionLike` reads false
-        // until it resolves: holding is the only way the demotion can't be raced.
-        // A FAILED read is deliberately not held (see LocalPrView's twin).
         updateBusy={
           updateBranch.isPending ||
           updatingBranch ||
           detailsStale ||
-          defaultBranch.isPending
+          defaultBranchSettling
         }
+        // The one wait the generic busy wording would misdescribe, so it gets its
+        // own arm rather than claiming the pull request is still loading.
+        updateAwaitingDefault={defaultBranchSettling}
         updateSubmitting={updateBranch.isPending}
         onResolve={() => runResolve(false)}
         onResolveWithAi={() => runResolve(true)}

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -23,6 +23,7 @@ import type {
   BitbucketRepoSettingsInput,
   Branch,
 } from "@/lib/git/types";
+import { usePublishGenerateAction } from "@/lib/hotkeys/useGenerateChord";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
@@ -123,6 +124,22 @@ function BitbucketGeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
+  // Shared by the Generate button and the settings dialog's generate chord,
+  // which this publishes to — the shell owns the chord because it owns the
+  // DialogContent every section renders inside.
+  function runGenerate() {
+    descGen.generate({
+      repoName,
+      onResult: ({ description }) => {
+        if (description) set("description", description);
+      },
+    });
+  }
+  const { hint: generateHint } = usePublishGenerateAction(
+    aiEnabled && aiConfigured && !descGen.generating,
+    runGenerate,
+  );
+
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
 
   // Keep the current default selectable even if that branch isn't local; drop
@@ -171,14 +188,8 @@ function BitbucketGeneralForm({
               type="button"
               variant="ghost"
               size="xs"
-              onClick={() =>
-                descGen.generate({
-                  repoName,
-                  onResult: ({ description }) => {
-                    if (description) set("description", description);
-                  },
-                })
-              }
+              title={`Suggest a description from the README with AI${generateHint}`}
+              onClick={runGenerate}
             >
               <SparkleIcon data-icon="inline-start" />
               Generate

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -44,6 +44,7 @@ import {
   useTransferRepo,
 } from "@/lib/git/queries";
 import { type ForgeProvider, providerLabel } from "@/lib/git/types";
+import { clearRepoLensCache } from "@/lib/repo-lens/queries";
 import { deleteRepoLens } from "@/lib/repo-lens/store";
 import { settingsKeys, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -415,6 +416,7 @@ function ArchiveAction({
  *  never fakes the persisted `isFork` provenance (that reflects GitHub-side
  *  truth and only changes via re-probe). */
 function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
+  const queryClient = useQueryClient();
   const remotes = useRemotes(repoPath);
   const removeRemote = useRemoveRemote(repoPath);
   const [confirming, setConfirming] = useState(false);
@@ -441,8 +443,12 @@ function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
                     onSuccess: () => {
                       // Hygiene: the persisted "upstream" lens no longer applies.
                       // Fire-and-forget — the lens read safe-defaults to origin,
-                      // so a failure here is harmless.
+                      // so a failure here is harmless. The CACHED lens drops with
+                      // it: its key sits outside the repo subtree this mutation
+                      // invalidates, so re-adding upstream in the same session
+                      // would otherwise resurrect the preference just deleted.
                       deleteRepoLens(repoPath).catch(() => undefined);
+                      clearRepoLensCache(queryClient, repoPath);
                       // Removing upstream collapses the lens to origin, so a still-
                       // selected remote number would resolve against the other repo.
                       // Same clears `useSetRepoLens` does on an explicit lens flip.

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -24,6 +24,7 @@ import {
   useUpdateRepoSettings,
 } from "@/lib/git/queries";
 import type { Branch, RepoSettings, RepoSettingsInput } from "@/lib/git/types";
+import { usePublishGenerateAction } from "@/lib/hotkeys/useGenerateChord";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
@@ -232,6 +233,23 @@ function GeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
+  // Shared by the Generate button and the settings dialog's generate chord,
+  // which this publishes to — the shell owns the chord because it owns the
+  // DialogContent every section renders inside.
+  function runGenerate() {
+    descGen.generate({
+      repoName,
+      onResult: ({ description, topics }) => {
+        if (description) set("description", description);
+        if (topics.length) set("topics", normalizeTopics(topics));
+      },
+    });
+  }
+  const { hint: generateHint } = usePublishGenerateAction(
+    aiEnabled && aiConfigured && !descGen.generating,
+    runGenerate,
+  );
+
   const mergeValid =
     form.allowSquashMerge || form.allowMergeCommit || form.allowRebaseMerge;
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
@@ -281,15 +299,8 @@ function GeneralForm({
               type="button"
               variant="ghost"
               size="xs"
-              onClick={() =>
-                descGen.generate({
-                  repoName,
-                  onResult: ({ description, topics }) => {
-                    if (description) set("description", description);
-                    if (topics.length) set("topics", normalizeTopics(topics));
-                  },
-                })
-              }
+              title={`Suggest a description + topics from the README with AI${generateHint}`}
+              onClick={runGenerate}
             >
               <SparkleIcon data-icon="inline-start" />
               Generate

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -23,6 +23,7 @@ import type {
   GitLabRepoSettings,
   GitLabRepoSettingsInput,
 } from "@/lib/git/types";
+import { usePublishGenerateAction } from "@/lib/hotkeys/useGenerateChord";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
@@ -177,6 +178,23 @@ function GitLabGeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
+  // Shared by the Generate button and the settings dialog's generate chord,
+  // which this publishes to — the shell owns the chord because it owns the
+  // DialogContent every section renders inside.
+  function runGenerate() {
+    descGen.generate({
+      repoName,
+      onResult: ({ description, topics }) => {
+        if (description) set("description", description);
+        if (topics.length) set("topics", normalizeGlTopics(topics));
+      },
+    });
+  }
+  const { hint: generateHint } = usePublishGenerateAction(
+    aiEnabled && aiConfigured && !descGen.generating,
+    runGenerate,
+  );
+
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
 
   // Keep the current default selectable even if that branch isn't local; drop
@@ -225,15 +243,8 @@ function GitLabGeneralForm({
               type="button"
               variant="ghost"
               size="xs"
-              onClick={() =>
-                descGen.generate({
-                  repoName,
-                  onResult: ({ description, topics }) => {
-                    if (description) set("description", description);
-                    if (topics.length) set("topics", normalizeGlTopics(topics));
-                  },
-                })
-              }
+              title={`Suggest a description + topics from the README with AI${generateHint}`}
+              onClick={runGenerate}
             >
               <SparkleIcon data-icon="inline-start" />
               Generate

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -55,6 +55,11 @@ import {
   type Webhook,
   type WebhookInput,
 } from "@/lib/git/types";
+import {
+  GenerateActionContext,
+  useGenerateActionSink,
+  useGenerateChord,
+} from "@/lib/hotkeys/useGenerateChord";
 import { quickTransition } from "@/lib/motion";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
@@ -336,12 +341,30 @@ export function RepoSettingsDialog({
       ? undefined
       : SECTION_BODIES[activeSection][provider];
 
+  // The generate chord belongs to whichever section is showing a Generate
+  // affordance — only the General sections have one, and they publish it here,
+  // keyed by the section they mounted under so the crossfade's outgoing section
+  // can't answer the chord (see `useGenerateActionSink`).
+  // The swallow below is unconditional whatever the active section: this dialog
+  // opens over any tab, including Changes where the global
+  // generate-commit-message action is live, so a chord that leaked would write
+  // a commit message behind the dialog. `enabled: true` is that swallow; the
+  // published action's own gate decides whether anything actually runs.
+  const generate = useGenerateActionSink(activeSection);
+  const generateChord = useGenerateChord({
+    enabled: true,
+    run: generate.runPublished,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Fixed, calm height so switching sections never resizes the dialog; the
           body column scrolls (overflow-y-auto) so a long form / many webhooks
           stay contained while the rail stays put. Caps to 85vh on short screens. */}
-      <DialogContent className="flex h-150 max-h-[85vh] flex-col sm:max-w-3xl">
+      <DialogContent
+        className="flex h-150 max-h-[85vh] flex-col sm:max-w-3xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>Repository settings</DialogTitle>
           <DialogDescription>
@@ -374,7 +397,9 @@ export function RepoSettingsDialog({
                 exit={{ opacity: 0 }}
                 transition={reduceMotion ? { duration: 0 } : quickTransition}
               >
-                {Body && <Body repoPath={repoPath} open={open} />}
+                <GenerateActionContext value={generate.sink}>
+                  {Body && <Body repoPath={repoPath} open={open} />}
+                </GenerateActionContext>
                 {activeSection === "danger" && (
                   <DangerZone
                     repoPath={repoPath}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -12,7 +12,7 @@ import {
   TreeStructureIcon,
 } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { RelativeTime } from "@/components/relative-time";
@@ -141,6 +141,12 @@ const secondaryClickCapitalized =
  *  dialog's merged badge. The open list keeps the default so it goes on sharing a
  *  cache entry with the session PR audit. */
 const CLOSED_PR_SCAN_LIMIT = 100;
+
+/** How many diverged rows get their rewrite status warmed when the popover opens.
+ *  The prefetch exists to keep a right-click from painting a slot whose identity
+ *  is still in flight; each entry costs several rev-list spawns, so it is capped
+ *  rather than run per branch. Rows past the cap fall back to the waiting slot. */
+const MAX_REWRITE_PREFETCH = 4;
 
 interface BranchPr {
   state: PrAuditState;
@@ -290,6 +296,16 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   const head = status.data?.branch;
   const currentName = head?.name ?? null;
+  // The live branch name, readable AFTER an await. A handler's closure still holds
+  // the `currentName` of the render that created it, and `status.data` read inside
+  // one is that same render's snapshot — neither can tell whether HEAD moved
+  // during a confirmation the user left open. Same ref pattern SyncControls uses
+  // to guard its reset. Load-bearing for `git reset --hard`, which carries no
+  // branch identity: it rewrites whatever HEAD points at now.
+  const currentNameRef = useRef(currentName);
+  useEffect(() => {
+    currentNameRef.current = currentName;
+  }, [currentName]);
   const currentLabel = head?.detached
     ? `detached @ ${head.oid?.slice(0, 7) ?? "?"}`
     : (currentName ?? "…");
@@ -349,8 +365,15 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // on every branches refetch, and this must re-run when the diverged SET
   // changes, not when its container does. Git forbids control characters in a
   // ref name, so `\n` can't appear inside one.
+  //
+  // Capped: each entry is several rev-list spawns, and a repo where many branches
+  // are BOTH ahead and behind would otherwise fan out one probe per branch on
+  // every popover open. The rows past the cap keep the waiting slot, which is
+  // exactly what it is for. Four covers the ordinary 0-2 and leaves headroom
+  // without turning an open into a burst.
   const divergedSignature = allBranches
     .filter((b) => b.upstreamAhead > 0 && b.upstreamBehind > 0)
+    .slice(0, MAX_REWRITE_PREFETCH)
     .map((b) => b.name)
     .join("\n");
   useEffect(() => {
@@ -1049,8 +1072,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       onSuccess: () => toast.success(`Reset ${branch.name} to ${base}`),
       onError,
     };
-    if (branch.isCurrent) hardReset.mutate(tip, done);
-    else
+    if (branch.isCurrent) {
+      // The confirmation above spans an await, and HEAD can move under it — an
+      // out-of-app `git switch`, or the app's own checkout. `reset --hard` names
+      // no branch, so a moved HEAD would rewrite whatever is checked out NOW to a
+      // tip measured for a branch the user is no longer on. The ref reads live;
+      // the captured name is the only branch the confirmation described. Says so
+      // rather than returning quietly: the user just confirmed a destructive
+      // action, and silence there reads as "it worked". Wording kept in step with
+      // the sync controls' twin.
+      if (currentNameRef.current !== branch.name) {
+        toast.info("HEAD moved while the dialog was open — nothing was reset.");
+        return;
+      }
+      hardReset.mutate(tip, done);
+    } else
       resetToUpstream.mutate({ branch: branch.name, expectedTip: tip }, done);
   }
 

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -11,7 +11,8 @@ import {
   GitPullRequestIcon,
   TreeStructureIcon,
 } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { RelativeTime } from "@/components/relative-time";
@@ -36,9 +37,12 @@ import { isDirtyTreeRefusal } from "@/lib/error-summary";
 import { forgeDetectForkPrForBranch } from "@/lib/git/api";
 import { normPath } from "@/lib/git/path";
 import {
+  branchRewriteStatusOptions,
   forgeFeatureReady,
   useBranchDivergence,
   useBranches,
+  useBranchResetToUpstream,
+  useBranchRewriteStatus,
   useCheckoutBranch,
   useCheckoutRemoteBranch,
   useCompareBranches,
@@ -47,6 +51,7 @@ import {
   useDeleteRemoteBranch,
   useDiscardAll,
   useForgeStatus,
+  useHardResetToCommit,
   useMergeBranch,
   usePrList,
   usePush,
@@ -84,6 +89,7 @@ import {
   useSaveSettings,
   useSettings,
 } from "@/lib/settings/queries";
+import { useConfirm } from "@/lib/stores/confirm";
 import { type SelectedPr, useUiStore } from "@/lib/stores/ui";
 import {
   isWorktreePromoting,
@@ -193,6 +199,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   const rebaseBranch = useRebaseBranch(repoPath);
   const rebaseOnto = useRebaseOnto(repoPath);
   const updateBranchFrom = useUpdateBranchFrom(repoPath);
+  const resetToUpstream = useBranchResetToUpstream(repoPath);
+  const hardReset = useHardResetToCommit(repoPath);
   const push = usePush(repoPath);
   const remotes = useRemotes(repoPath);
   const setBranchArchived = useSetBranchArchived(repoPath);
@@ -319,6 +327,42 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     () => new Map((divergence.data ?? []).map((d) => [d.name, d] as const)),
     [divergence.data],
   );
+
+  // The row whose context menu is open, when that row is DIVERGED from its own
+  // upstream — the only case worth several rev-list spawns. One slot is enough:
+  // a context menu is singular, so the probe follows whichever row was opened
+  // last and every other row renders as it always has.
+  const [rewriteProbe, setRewriteProbe] = useState<string | null>(null);
+  const rewrite = useBranchRewriteStatus(repoPath, rewriteProbe, {
+    enabled: rewriteProbe !== null,
+  });
+  const queryClient = useQueryClient();
+
+  // Warm those probes when the POPOVER opens, so a right-click a moment later
+  // paints its final identity instead of the disabled waiting slot swapping
+  // under the pointer. The probe is fast enough locally that the swap lands
+  // AFTER the menu paints, which reads as a flash; the only way to remove it is
+  // to have the answer before the menu exists. The waiting slot stays as the
+  // fallback for a genuinely slow probe.
+  //
+  // A newline-joined signature, not the array: `allBranches` gets a new identity
+  // on every branches refetch, and this must re-run when the diverged SET
+  // changes, not when its container does. Git forbids control characters in a
+  // ref name, so `\n` can't appear inside one.
+  const divergedSignature = allBranches
+    .filter((b) => b.upstreamAhead > 0 && b.upstreamBehind > 0)
+    .map((b) => b.name)
+    .join("\n");
+  useEffect(() => {
+    if (!open || divergedSignature === "") return;
+    for (const name of divergedSignature.split("\n")) {
+      // `prefetchQuery` honors the options' staleTime, so a still-fresh entry
+      // costs nothing and a reopen inside 30s spawns no git at all.
+      void queryClient.prefetchQuery(
+        branchRewriteStatusOptions(repoPath, name),
+      );
+    }
+  }, [open, divergedSignature, repoPath, queryClient]);
 
   // Per-branch PR badge: remote PRs (open + closed, the latter carrying merged)
   // fetched while the menu OR the cleanup dialog is open AND the repo's forge
@@ -976,6 +1020,40 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     );
   }
 
+  // The remedy for a branch whose upstream already carries its changes under
+  // other ids: point the branch back at that upstream instead of merging it in,
+  // which would duplicate them. `tip` is the sha the status was measured against,
+  // so a confirmed reset can only land where the copy said it would. The current
+  // branch takes the hard reset (its working tree moves too); every other branch
+  // is a ref move, which is why it works even from another checkout.
+  async function doResetToUpstream(branch: Branch, tip: string) {
+    const base = branch.upstream;
+    if (!base) return;
+    setOpen(false);
+    const treeNote = branch.isCurrent
+      ? ` Your files are rewritten to match, so commit or stash any uncommitted changes first.`
+      : "";
+    const n = branch.upstreamAhead;
+    const alreadyThere =
+      n === 1
+        ? `The only commit on ${branch.name} is already on ${base} under a different id`
+        : `All ${n} commits on ${branch.name} are already on ${base} under different ids`;
+    const ok = await useConfirm.getState().ask({
+      title: `Reset ${branch.name} to ${base}?`,
+      body: `${alreadyThere}, so no unique work is lost. ${branch.name} moves to ${base}'s tip.${treeNote}`,
+      confirmLabel: `Reset to ${base}`,
+      confirmVariant: "destructive",
+    });
+    if (!ok) return;
+    const done = {
+      onSuccess: () => toast.success(`Reset ${branch.name} to ${base}`),
+      onError,
+    };
+    if (branch.isCurrent) hardReset.mutate(tip, done);
+    else
+      resetToUpstream.mutate({ branch: branch.name, expectedTip: tip }, done);
+  }
+
   // Push a branch's ref without checking it out — the outbound counterpart of
   // doUpdateFromUpstream. Whether this publishes (-u) or plain pushes is decided
   // backend-side from the branch's tracking state. The publish arms pass an
@@ -1026,6 +1104,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     rebaseOnto.isPending ||
     push.isPending ||
     updateBranchFrom.isPending ||
+    resetToUpstream.isPending ||
+    hardReset.isPending ||
     switchAutostash.isPending ||
     recovery.pending;
 
@@ -1138,12 +1218,42 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     Boolean(defaultName && defaultName !== currentName && !busy),
   );
   const defaultBranchRow = allBranches.find((b) => b.name === defaultName);
+  // The palette's own route to the same merge the row menu offers — so it needs
+  // the same refusal. There is no row rendered here to hang the probe's hook on,
+  // so it runs ON INVOCATION against the hook's own cached options: a diverged
+  // default pays one probe (usually a cache hit), and every other default spawns
+  // nothing at all.
+  async function updateDefaultFromUpstream() {
+    const row = defaultBranchRow;
+    if (!row?.upstream || row.upstreamGone) return;
+    if (row.upstreamAhead > 0 && row.upstreamBehind > 0) {
+      const status = await queryClient
+        .fetchQuery(branchRewriteStatusOptions(repoPath, row.name))
+        .catch(() => null);
+      // `patchEqual > 0` is strong evidence, not proof — two sides can apply the
+      // same patch independently. It only WITHHOLDS the merge, so a false read
+      // costs an explained no-op, never a duplicated history.
+      if (status?.remoteRewritten === true && status.patchEqual > 0) {
+        // The remedy has to match what the row actually offers: only the
+        // nothing-unique case gets a reset item there. With local-only commits
+        // the row shows a disabled update and no reset, so point at the pull that
+        // keeps them.
+        const remedy =
+          status.localOnly === 0
+            ? `Open the branch menu and use the ${row.name} row's reset instead.`
+            : `Switch to ${row.name} and use Pull with rebase — it keeps the ${status.localOnly} commit${status.localOnly === 1 ? "" : "s"} only ${row.name} has.`;
+        toast.warning(
+          `${row.upstream} already carries ${row.name}'s changes under different ids — merging it in would duplicate them.`,
+          { description: remedy, duration: 10000 },
+        );
+        return;
+      }
+    }
+    doUpdateFromUpstream(row.name, row.upstream);
+  }
   useHotkeyAction(
     "update-default-from-upstream",
-    () =>
-      defaultBranchRow?.upstream &&
-      !defaultBranchRow.upstreamGone &&
-      doUpdateFromUpstream(defaultBranchRow.name, defaultBranchRow.upstream),
+    () => void updateDefaultFromUpstream(),
     Boolean(defaultBranchRow?.upstream) &&
       !defaultBranchRow?.upstreamGone &&
       !busy,
@@ -1287,8 +1397,57 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           a === "origin" ? -1 : b === "origin" ? 1 : a.localeCompare(b),
         )
       : [];
+    // Upstream classification, for this row only while ITS menu is open. An
+    // upstream that already carries this branch's changes under other ids makes
+    // "Update from <upstream>" harmful: merging it back in duplicates them, and
+    // in a throwaway worktree it can't even run against a branch checked out
+    // elsewhere.
+    const rowDiverged = branch.upstreamAhead > 0 && branch.upstreamBehind > 0;
+    const rowProbeOpen = rowDiverged && rewriteProbe === branch.name;
+    // `isFetching` matters as much as the name match: a repo-wide invalidation
+    // leaves the previous answer served while the refetch is in flight, and that
+    // answer is the evidence a destructive confirm would quote.
+    const rowRewrite =
+      rowProbeOpen && !rewrite.isFetching ? rewrite.data : undefined;
+    // The verdict for the OPEN menu hasn't landed. This slot must never hold an
+    // ENABLED item that changes meaning underneath a pointer already aimed at it:
+    // the probe resolves a beat after the menu paints, and a merge silently
+    // becoming a destructive reset at the same coordinates is the context-menu
+    // TOCTOU class. So the slot waits, disabled, and only ever becomes enabled
+    // wearing its FINAL identity. An ERRORED probe is not pending — it falls
+    // through to the ordinary item, the same fail-safe an unprovable status takes.
+    const rowProbePending =
+      rowProbeOpen &&
+      !rewrite.isError &&
+      (rewrite.isFetching || rewrite.data === undefined);
+    // The pair, never the reflog verdict alone: offering a reset while unique
+    // local work exists would destroy it.
+    const resetTip =
+      rowRewrite?.remoteRewritten === true && rowRewrite.localOnly === 0
+        ? rowRewrite.upstreamTip
+        : null;
+    // Patch twins upstream AND commits without one: a reset would destroy the
+    // latter, and a merge would bring the twinned changes back in beside the
+    // copies already there. `patchEqual > 0` is strong evidence, not proof — two
+    // sides can apply the same patch independently, or cherry-pick both ways,
+    // with no rewrite involved. That is why this arm only WITHHOLDS an action:
+    // its failure direction is inaction, which the row's other items cover.
+    const rowMixedRewrite =
+      rowRewrite?.remoteRewritten === true &&
+      rowRewrite.localOnly > 0 &&
+      rowRewrite.patchEqual > 0;
     return (
-      <ContextMenu key={branch.name}>
+      <ContextMenu
+        key={branch.name}
+        onOpenChange={(menuOpen) => {
+          if (menuOpen) setRewriteProbe(rowDiverged ? branch.name : null);
+          // Functional, not a captured read: right-clicking a second row closes
+          // this menu in the SAME tick the other one opens, and a batched
+          // comparison against the pre-update value would clear the new row's
+          // probe on the way out.
+          else setRewriteProbe((cur) => (cur === branch.name ? null : cur));
+        }}
+      >
         <ContextMenuTrigger
           render={
             <button
@@ -1521,18 +1680,53 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 </ContextMenuItem>
               )}
               {/* Pull the branch's own upstream in without switching — the star
-                  use case is the default branch after a PR merged upstream. */}
-              {branch.upstream && branch.upstreamBehind > 0 && (
-                <ContextMenuItem
-                  disabled={busy}
-                  onClick={() =>
-                    branch.upstream &&
-                    doUpdateFromUpstream(branch.name, branch.upstream)
+                  use case is the default branch after a PR merged upstream. An
+                  upstream that already carries this branch's changes under other
+                  ids replaces it: merging there duplicates them rather than
+                  syncing. The waiting arm comes FIRST so the slot can never be
+                  enabled while its identity is still in flight. */}
+              {branch.upstream &&
+                branch.upstreamBehind > 0 &&
+                (() => {
+                  const base = branch.upstream;
+                  // No onClick at all, not merely `disabled`: a pointer already
+                  // aimed here when the menu painted must be a hard no-op.
+                  if (rowProbePending) {
+                    return (
+                      <ContextMenuItem disabled>
+                        Update from {base} (checking the remote…)
+                      </ContextMenuItem>
+                    );
                   }
-                >
-                  Update from {branch.upstream}
-                </ContextMenuItem>
-              )}
+                  if (resetTip) {
+                    const holder = worktreeByBranch.get(branch.name);
+                    return (
+                      <ContextMenuItem
+                        disabled={busy || inWorktree}
+                        onClick={() => void doResetToUpstream(branch, resetTip)}
+                      >
+                        Reset to {base}…
+                        {inWorktree && ` (checked out in ${holder})`}
+                      </ContextMenuItem>
+                    );
+                  }
+                  if (rowMixedRewrite) {
+                    return (
+                      <ContextMenuItem disabled>
+                        Update from {base} ({base} already carries these changes
+                        under different ids — a merge would duplicate them)
+                      </ContextMenuItem>
+                    );
+                  }
+                  return (
+                    <ContextMenuItem
+                      disabled={busy}
+                      onClick={() => doUpdateFromUpstream(branch.name, base)}
+                    >
+                      Update from {base}
+                    </ContextMenuItem>
+                  );
+                })()}
               {/* Sync-out below sync-in. Push a branch's ref to origin without
                   checking it out — works even when the branch is checked out in
                   another worktree, since a push touches refs, never a working

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -16,13 +16,17 @@ import { required, useAppForm } from "@/lib/form";
 import { useCreateBranch } from "@/lib/git/queries";
 import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { toastError } from "@/lib/toast";
 import {
   BaseBranchCombobox,
   useHasBaseOptions,
   useSeedBase,
 } from "./BaseBranchCombobox";
-import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
+import {
+  GenerateBranchNameButton,
+  useBranchNameGenerateAction,
+} from "./GenerateBranchNameButton";
 import {
   type CommittedNameSource,
   useGenerateBranchName,
@@ -148,6 +152,28 @@ export function CreateBranchDialog({
     if (open) seedOnOpen();
   }, [open]);
 
+  // One generate pair for the button and the chord — see
+  // `useBranchNameGenerateAction`.
+  const generateAction = useBranchNameGenerateAction({
+    gen: branchNameGen,
+    aiEnabled,
+    aiConfigured,
+    hasChanges,
+    headExists,
+    entries,
+    recentBranches: allBranchNames,
+    nameTarget: "new-branch",
+    committedFallback: baseIsHead ? committedFallback : null,
+    onName: (name) => createForm.setFieldValue("name", name),
+  });
+  // This dialog opens from the header over any tab, including Changes where the
+  // global generate-commit-message action is live — so the chord is swallowed
+  // here whether or not it can generate, and never reaches the commit box.
+  const generateChord = useGenerateChord({
+    enabled: generateAction.enabled,
+    run: generateAction.run,
+  });
+
   return (
     <Dialog
       open={open}
@@ -156,7 +182,7 @@ export function CreateBranchDialog({
         else closeDialog();
       }}
     >
-      <DialogContent>
+      <DialogContent onKeyDown={generateChord.onKeyDown}>
         <form
           // min-w-0: DialogContent is display:grid, so this grid item must be
           // allowed to shrink below its content — otherwise a long base branch
@@ -205,19 +231,18 @@ export function CreateBranchDialog({
           </createForm.AppField>
           <GenerateBranchNameButton
             gen={branchNameGen}
+            action={generateAction}
+            hint={generateChord.hint}
             aiEnabled={aiEnabled}
             aiConfigured={aiConfigured}
             hasChanges={hasChanges}
             headExists={headExists}
-            entries={entries}
-            recentBranches={allBranchNames}
             nameTarget="new-branch"
             committedFallback={baseIsHead ? committedFallback : null}
             // Resolved by definition when the fallback can't apply — the button
             // explains the picked base instead of waiting on a lookup it won't use.
             committedStatus={baseIsHead ? committedStatus : "ready"}
             basedElsewhere={baseIsHead ? null : createBase}
-            onName={(name) => createForm.setFieldValue("name", name)}
             onSetupAi={() => {
               closeDialog();
               onOpenSettings("ai");

--- a/src/features/repository/GenerateBranchNameButton.tsx
+++ b/src/features/repository/GenerateBranchNameButton.tsx
@@ -21,17 +21,29 @@ export type BranchNameTarget =
    *  commits describe it — the working tree belongs to someone else. */
   | "other-branch";
 
+/** The working tree belongs to the checked-out branch, so it can only name a
+ *  new branch or that branch itself. */
+function usesWorkingTree(nameTarget: BranchNameTarget): boolean {
+  return nameTarget !== "other-branch";
+}
+
+/** The one generate pair the button and the host dialog's generate chord both
+ *  consume — see {@link useBranchNameGenerateAction}. */
+export interface BranchNameGenerateAction {
+  /** Starts the generation with the sources `nameTarget` says apply. */
+  run: () => void;
+  /** Whether generating is possible right now — the button's enabled state, and
+   *  the only gate the chord may run under. */
+  enabled: boolean;
+}
+
 /**
- * The "✧ Generate from changes" affordance shared by the create- and
- * rename-branch dialogs: suggests a branch name from the working-tree changes
- * (when they describe the branch being named) — or, failing that, from that
- * branch's committed work (`committedFallback`) — or points the user at AI
- * setup when no provider is connected. Renders nothing when AI is disabled.
- * The host dialog owns the generation stream (`gen`) so it can block its own
- * submit while a name is still being generated; the button decides only which
- * name sources apply (`nameTarget`) and where the name lands (`onName`).
+ * Derives the branch-name generation — its prompt sources and its enabled
+ * gate — once per host dialog, so the Generate button and the dialog's generate
+ * chord can't drift apart on either. The dialog owns the stream (`gen`) so it
+ * can block its own submit while a name is still generating.
  */
-export function GenerateBranchNameButton({
+export function useBranchNameGenerateAction({
   gen,
   aiEnabled,
   aiConfigured,
@@ -41,12 +53,8 @@ export function GenerateBranchNameButton({
   recentBranches,
   nameTarget,
   committedFallback,
-  committedStatus,
-  basedElsewhere,
   onName,
-  onSetupAi,
 }: {
-  /** Owned by the host dialog — see {@link BranchNameGenerator}. */
   gen: BranchNameGenerator;
   aiEnabled: boolean;
   aiConfigured: boolean;
@@ -55,6 +63,70 @@ export function GenerateBranchNameButton({
   entries: FileEntry[];
   /** Existing branch names, used as a naming-convention reference (capped). */
   recentBranches: string[];
+  nameTarget: BranchNameTarget;
+  committedFallback: CommittedNameSource | null;
+  onName: (name: string) => void;
+}): BranchNameGenerateAction {
+  const useWorkingTree = usesWorkingTree(nameTarget);
+  return {
+    enabled:
+      aiEnabled &&
+      aiConfigured &&
+      !gen.generating &&
+      headExists &&
+      ((useWorkingTree && hasChanges) || committedFallback !== null),
+    run: () =>
+      gen.generate({
+        entries,
+        recentBranches: recentBranches.slice(0, 20),
+        useWorkingTree,
+        // Only when naming the very branch those commits sit on.
+        workingTreeSubjects:
+          nameTarget === "checked-out-branch"
+            ? (committedFallback?.subjects ?? [])
+            : [],
+        committedFallback,
+        onName,
+      }),
+  };
+}
+
+/**
+ * The "✧ Generate from changes" affordance shared by the create- and
+ * rename-branch dialogs: suggests a branch name from the working-tree changes
+ * (when they describe the branch being named) — or, failing that, from that
+ * branch's committed work (`committedFallback`) — or points the user at AI
+ * setup when no provider is connected. Renders nothing when AI is disabled.
+ * The host dialog owns the generation stream (`gen`) so it can block its own
+ * submit while a name is still being generated, and hands down the `action` it
+ * shares with its generate chord; the button adds only the explanatory copy for
+ * why generating is (or isn't) available.
+ */
+export function GenerateBranchNameButton({
+  gen,
+  action,
+  hint,
+  aiEnabled,
+  aiConfigured,
+  hasChanges,
+  headExists,
+  nameTarget,
+  committedFallback,
+  committedStatus,
+  basedElsewhere,
+  onSetupAi,
+}: {
+  /** Owned by the host dialog — see {@link BranchNameGenerator}. */
+  gen: BranchNameGenerator;
+  /** Shared with the host dialog's generate chord — see
+   *  {@link useBranchNameGenerateAction}. */
+  action: BranchNameGenerateAction;
+  /** The generate chord's " (Ctrl+G)" hint; "" when it's unbound. */
+  hint: string;
+  aiEnabled: boolean;
+  aiConfigured: boolean;
+  hasChanges: boolean;
+  headExists: boolean;
   /** What the name must describe — see {@link BranchNameTarget}. */
   nameTarget: BranchNameTarget;
   /** The committed work of the branch being named, vs the default branch. Null
@@ -70,17 +142,12 @@ export function GenerateBranchNameButton({
    *  none of that work), and the disabled state must say THAT rather than
    *  claim there's no committed work. Null whenever the fallback does apply. */
   basedElsewhere: string | null;
-  onName: (name: string) => void;
   /** Close the host dialog and open AI settings. */
   onSetupAi: () => void;
 }) {
   if (!aiEnabled) return null;
-  // The working tree belongs to the checked-out branch, so it can only name a
-  // new branch or that branch itself.
-  const useWorkingTree = nameTarget !== "other-branch";
+  const useWorkingTree = usesWorkingTree(nameTarget);
   const fromWorkingTree = useWorkingTree && hasChanges;
-  const canGenerate =
-    headExists && (fromWorkingTree || committedFallback !== null);
   const reason = !headExists
     ? "Make your first commit before branching from changes"
     : fromWorkingTree
@@ -127,24 +194,13 @@ export function GenerateBranchNameButton({
           variant="ghost"
           size="xs"
           className="text-muted-foreground"
-          disabled={!canGenerate}
-          // `reason` doubles as the enabled-state hint ("Suggest a name from…").
-          reason={canGenerate ? null : reason}
-          title={reason}
-          onClick={() =>
-            gen.generate({
-              entries,
-              recentBranches: recentBranches.slice(0, 20),
-              useWorkingTree,
-              // Only when naming the very branch those commits sit on.
-              workingTreeSubjects:
-                nameTarget === "checked-out-branch"
-                  ? (committedFallback?.subjects ?? [])
-                  : [],
-              committedFallback,
-              onName,
-            })
-          }
+          disabled={!action.enabled}
+          // `reason` doubles as the enabled-state hint ("Suggest a name from…"),
+          // which is where the chord belongs — a disabled button's shortcut does
+          // nothing, so it isn't offered.
+          reason={action.enabled ? null : reason}
+          title={action.enabled ? `${reason}${hint}` : reason}
+          onClick={action.run}
         >
           <SparkleIcon data-icon="inline-start" />
           Generate from changes

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { required, useAppForm } from "@/lib/form";
 import { useBbWorkspaces, usePublishRepo } from "@/lib/git/queries";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
 import { useGenerateRepoDescription } from "../repo-settings/useGenerateRepoDescription";
@@ -147,9 +148,36 @@ export function PublishDialog({
     if (open && isBitbucket) seedWorkspace(defaultWorkspace);
   }, [open, isBitbucket, defaultWorkspace]);
 
+  // Shared by the Generate button and the generate chord below.
+  function runGenerate() {
+    descGen.generate({
+      repoName: nameVal.trim() || defaultName,
+      onResult: ({ description, topics }) => {
+        if (description) {
+          form.setFieldValue("description", description);
+        }
+        // Bitbucket has no topics field — drop that arm.
+        if (!isBitbucket && topics.length) {
+          form.setFieldValue("topics", topics.join(" "));
+        }
+      },
+    });
+  }
+  // This dialog opens from the header over any tab, including Changes where the
+  // global generate-commit-message action is live — so the chord is swallowed
+  // here whether or not it can generate. Mounted on DialogContent, not the
+  // <form>: the X close button is a form SIBLING inside the Popup.
+  const generateChord = useGenerateChord({
+    enabled: aiEnabled && !descGen.generating,
+    run: runGenerate,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <form
           className="flex min-h-0 flex-col gap-4"
           onSubmit={(e) => {
@@ -236,24 +264,11 @@ export function PublishDialog({
                     type="button"
                     variant="ghost"
                     size="xs"
-                    onClick={() =>
-                      descGen.generate({
-                        repoName: nameVal.trim() || defaultName,
-                        onResult: ({ description, topics }) => {
-                          if (description) {
-                            form.setFieldValue("description", description);
-                          }
-                          // Bitbucket has no topics field — drop that arm.
-                          if (!isBitbucket && topics.length) {
-                            form.setFieldValue("topics", topics.join(" "));
-                          }
-                        },
-                      })
-                    }
+                    onClick={runGenerate}
                     title={
                       isBitbucket
-                        ? "Suggest a description from the README with AI"
-                        : "Suggest a description + topics from the README with AI"
+                        ? `Suggest a description from the README with AI${generateChord.hint}`
+                        : `Suggest a description + topics from the README with AI${generateChord.hint}`
                     }
                   >
                     <SparkleIcon data-icon="inline-start" />

--- a/src/features/repository/RenameBranchDialog.tsx
+++ b/src/features/repository/RenameBranchDialog.tsx
@@ -13,9 +13,13 @@ import { required, useAppForm } from "@/lib/form";
 import { useRenameBranch } from "@/lib/git/queries";
 import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
-import { GenerateBranchNameButton } from "./GenerateBranchNameButton";
+import {
+  GenerateBranchNameButton,
+  useBranchNameGenerateAction,
+} from "./GenerateBranchNameButton";
 import {
   type BranchNameGenerator,
   type CommittedNameSource,
@@ -134,6 +138,29 @@ export function RenameBranchDialog({
     return () => cancelGenerate();
   }, [target, cancelGenerate]);
 
+  // One generate pair for the button and the chord — see
+  // `useBranchNameGenerateAction`. It rides `guardedGen`, so a chord pressed
+  // during the close fade can't start an uncancellable generation either.
+  const generateAction = useBranchNameGenerateAction({
+    gen: guardedGen,
+    aiEnabled,
+    aiConfigured,
+    hasChanges,
+    headExists,
+    entries,
+    recentBranches: allBranchNames,
+    nameTarget: targetIsCurrent ? "checked-out-branch" : "other-branch",
+    committedFallback: shownCommittedFallback,
+    onName: (name) => renameForm.setFieldValue("name", name),
+  });
+  // This dialog opens from any branch row over any tab, including Changes where
+  // the global generate-commit-message action is live — so the chord is
+  // swallowed here whether or not it can generate.
+  const generateChord = useGenerateChord({
+    enabled: generateAction.enabled,
+    run: generateAction.run,
+  });
+
   return (
     <Dialog
       open={target !== null}
@@ -141,7 +168,7 @@ export function RenameBranchDialog({
         if (!o) closeDialog();
       }}
     >
-      <DialogContent>
+      <DialogContent onKeyDown={generateChord.onKeyDown}>
         <form
           // min-w-0: DialogContent is display:grid, so this grid item must be
           // allowed to shrink below its content — otherwise a long branch name
@@ -176,18 +203,17 @@ export function RenameBranchDialog({
           </renameForm.AppField>
           <GenerateBranchNameButton
             gen={guardedGen}
+            action={generateAction}
+            hint={generateChord.hint}
             aiEnabled={aiEnabled}
             aiConfigured={aiConfigured}
             hasChanges={hasChanges}
             headExists={headExists}
-            entries={entries}
-            recentBranches={allBranchNames}
             nameTarget={targetIsCurrent ? "checked-out-branch" : "other-branch"}
             committedFallback={shownCommittedFallback}
             committedStatus={shownCommittedStatus}
             // Renaming never picks a base — the fallback always applies here.
             basedElsewhere={null}
-            onName={(name) => renameForm.setFieldValue("name", name)}
             onSetupAi={() => {
               closeDialog();
               onOpenSettings("ai");

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -390,8 +390,13 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
     });
     if (!ok) return;
     // HEAD can move while the dialog sits open; the captured branch is the only
-    // one the confirmation described.
-    if (headNameRef.current !== branch) return;
+    // one the confirmation described. Says so rather than returning quietly: the
+    // user just confirmed a destructive action, and silence reads as "it worked".
+    // Wording kept in step with the branch menu's twin.
+    if (headNameRef.current !== branch) {
+      toast.info("HEAD moved while the dialog was open — nothing was reset.");
+      return;
+    }
     hardReset.mutate(tip, {
       onSuccess: () => toast.success(`Reset ${branch} to ${upstream}`),
       onError,

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -38,7 +38,9 @@ import {
   useLastFetchedAt,
 } from "@/lib/git/auto-fetch";
 import {
+  useBranchRewriteStatus,
   useFetchRemote,
+  useHardResetToCommit,
   usePull,
   usePush,
   useRemotes,
@@ -52,6 +54,7 @@ import {
 } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useSettings } from "@/lib/settings/queries";
+import { useConfirm } from "@/lib/stores/confirm";
 import { formatRelativeTime } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { ForkPrPublishGuard } from "./ForkPrPublishGuard";
@@ -127,11 +130,47 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // The BranchSwitcher alongside already surfaces the detached state.
   const detached = Boolean(head?.detached);
   const canUpdateUpstream = hasUpstreamRemote && !detached;
+  // Only a diverged branch has anything to classify, so the probe (several
+  // rev-list spawns) never runs on the ordinary in-sync path.
+  const rewrite = useBranchRewriteStatus(repoPath, head?.name ?? null, {
+    enabled: diverged && !detached,
+  });
+  // `isFetching` matters as much as `diverged`: a repo-wide invalidation keeps
+  // serving the previous answer while the refetch is in flight, and that answer
+  // is the evidence a destructive confirm would quote.
+  const rewriteData =
+    diverged && !rewrite.isFetching ? rewrite.data : undefined;
+  // The reflog verdict ALONE matches ordinary divergence too; only paired with
+  // "no local commit lacks a patch-twin upstream" does it describe an upstream
+  // that already carries this branch's work — and offering a reset while unique
+  // work exists would destroy it.
+  const remoteRebased =
+    rewriteData?.remoteRewritten === true &&
+    rewriteData.localOnly === 0 &&
+    Boolean(rewriteData.upstreamTip);
+  // Patch twins upstream AND commits without one: a reset would destroy the
+  // latter, a merge would re-import the former beside the copies already there.
+  // `patchEqual > 0` is strong evidence, not proof — two sides can apply the same
+  // patch independently, or cherry-pick both ways, with no rewrite involved. This
+  // arm only WITHHOLDS the merge, so its failure direction is inaction.
+  const mixedRewrite =
+    rewriteData?.remoteRewritten === true &&
+    rewriteData.localOnly > 0 &&
+    rewriteData.patchEqual > 0;
+  // Commits a force push would keep and a reset would drop. This is NOT
+  // rewrite-proof on its own — it counts the same under ordinary divergence,
+  // where the advice it carries is equally correct.
+  const localAtRisk =
+    rewriteData?.remoteRewritten === true ? rewriteData.localOnly : 0;
+  // True only where the status actually measured commits on the other side.
+  const remoteAhead = rewriteData?.remoteOnly ?? 0;
+  const hardReset = useHardResetToCommit(repoPath);
   const busy =
     fetchRemote.isPending ||
     pull.isPending ||
     push.isPending ||
     updateUpstream.isPending ||
+    hardReset.isPending ||
     detecting ||
     recovery.pending;
   const onError = (e: unknown) => toastError(e);
@@ -201,11 +240,29 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
     behindCount > 0
       ? `Pull — ${behindCount} commit${behindCount === 1 ? "" : "s"} to pull from ${head?.upstream}`
       : undefined;
+  // The two diverged arms are computed up front rather than folded in as extra
+  // ternary levels: an upstream that already HOLDS these commits under other ids
+  // makes the standing "rebase or merge" advice duplicate them.
+  const attachedPushDescription = remoteRebased
+    ? `${pushLabel} — ${head?.upstream} already has your commits under different ids; force pushing would replace them with your copies`
+    : aheadLabel;
+  const divergedPullDescription = (() => {
+    if (remoteRebased)
+      return `Pull — ${head?.upstream} already has your commits under different ids; use "Reset to ${head?.upstream}" from the Pull menu`;
+    // A merge here re-imports the twinned changes beside the copies already
+    // upstream, so the menu's merge item is disabled and the advice narrows.
+    if (mixedRewrite)
+      return `Pull — ${head?.upstream} already has some of your commits under different ids and you have ${localAtRisk} it doesn't; use Pull with rebase from the menu`;
+    return `Pull — branch has diverged (${behindCount} commit${behindCount === 1 ? "" : "s"} behind ${head?.upstream}); use Pull with rebase or merge from the menu`;
+  })();
+  // One wording for the refusal, shared by the disabled menu item and the tooltip
+  // the branch menu shows for the same shape.
+  const mergeDuplicatesReason = `${head?.upstream} already carries these changes under different ids — a merge would duplicate them. Use Pull with rebase.`;
   const pushDescription = detached
     ? `${pushLabel} — you're on a detached HEAD; check out a branch to push`
-    : aheadLabel;
+    : attachedPushDescription;
   const pullDescription = diverged
-    ? `Pull — branch has diverged (${behindCount} commit${behindCount === 1 ? "" : "s"} behind ${head?.upstream}); use Pull with rebase or merge from the menu`
+    ? divergedPullDescription
     : detached
       ? "Pull — you're on a detached HEAD; check out a branch to pull"
       : head?.upstreamGone
@@ -305,6 +362,38 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           toast.success(`Merged ${ref} into your branch.`);
         }
       },
+      onError,
+    });
+  }
+
+  // The remedy when the upstream already carries this branch's commits under
+  // other ids and nothing local is unique: move the branch (and the working tree)
+  // onto the upstream tip the status was measured against, so the two match again
+  // with every commit intact.
+  async function doResetToUpstream() {
+    const branch = head?.name;
+    const upstream = head?.upstream;
+    const tip = rewriteData?.upstreamTip;
+    if (!branch || !upstream || !tip) return;
+    // The count is `ahead` rather than the status's patchEqual, which tallies
+    // both sides of every matched pair; localOnly === 0 is what shows all of them
+    // landed upstream.
+    const alreadyThere =
+      aheadCount === 1
+        ? `The only commit on ${branch} is already on ${upstream} under a different id`
+        : `All ${aheadCount} commits on ${branch} are already on ${upstream} under different ids`;
+    const ok = await useConfirm.getState().ask({
+      title: `Reset ${branch} to ${upstream}?`,
+      body: `${alreadyThere}. Resetting moves ${branch} to ${upstream}'s tip and rewrites your files to match, so no unique work is lost. Uncommitted changes block the reset — commit or stash them first.`,
+      confirmLabel: `Reset to ${upstream}`,
+      confirmVariant: "destructive",
+    });
+    if (!ok) return;
+    // HEAD can move while the dialog sits open; the captured branch is the only
+    // one the confirmation described.
+    if (headNameRef.current !== branch) return;
+    hardReset.mutate(tip, {
+      onSuccess: () => toast.success(`Reset ${branch} to ${upstream}`),
       onError,
     });
   }
@@ -478,9 +567,27 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
                   <DropdownMenuItem onClick={() => doPull("rebase")}>
                     Pull with rebase
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => doPull("merge")}>
-                    Pull with merge
+                  {/* Disabled with the reason IN the label: a disabled menu item
+                      surfaces no tooltip, and the branch menu states the same
+                      refusal the same way. */}
+                  <DropdownMenuItem
+                    disabled={mixedRewrite}
+                    title={mixedRewrite ? mergeDuplicatesReason : undefined}
+                    onClick={() => doPull("merge")}
+                  >
+                    {mixedRewrite
+                      ? `Pull with merge (${head?.upstream} already carries these changes under different ids)`
+                      : "Pull with merge"}
                   </DropdownMenuItem>
+                  {/* Offered only once the probe has measured an upstream that
+                      carries every one of these commits, with no unique local
+                      work; every other divergence keeps the two pull items
+                      alone. */}
+                  {remoteRebased && (
+                    <DropdownMenuItem onClick={() => void doResetToUpstream()}>
+                      Reset to {head?.upstream}…
+                    </DropdownMenuItem>
+                  )}
                 </>
               )}
               {canUpdateUpstream && (
@@ -543,6 +650,34 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
               even work a background fetch has already seen.
             </DialogDescription>
           </DialogHeader>
+          {/* The measured arms — both state what the counts SHOW, never how the
+              upstream came to look that way (a rebase, a force push and a
+              cherry-pick all leave patch twins). `localAtRisk` counts the work
+              only this branch has, for which a rebasing pull (not a force push)
+              is the remedy — equally true under ordinary divergence. Neither arm
+              renders while the probe is unresolved. */}
+          {remoteRebased && (
+            <p className="text-muted-foreground text-sm">
+              {head?.upstream} already carries every commit on your branch under
+              different ids. Force pushing would replace them with your copies;
+              "Reset to {head?.upstream}" in the Pull menu keeps the same work
+              and matches the remote instead.
+            </p>
+          )}
+          {localAtRisk > 0 && (
+            <p className="text-muted-foreground text-sm">
+              {localAtRisk} commit{localAtRisk === 1 ? "" : "s"} exist
+              {localAtRisk === 1 ? "s" : ""} only on your branch
+              {/* Only asserted where the counts actually found commits on the
+                  other side — an amended tip plus one new local commit leaves
+                  `remoteOnly` at zero, and the clause would be false. */}
+              {remoteAhead > 0
+                ? `, and ${head?.upstream} has ${remoteAhead} commit${remoteAhead === 1 ? "" : "s"} yours doesn't`
+                : ""}
+              . Pull with rebase keeps yours and replays them on top of{" "}
+              {head?.upstream}.
+            </p>
+          )}
           <DialogFooter>
             <Button
               variant="outline"

--- a/src/features/repository/usePrNotifications.ts
+++ b/src/features/repository/usePrNotifications.ts
@@ -161,11 +161,17 @@ export function usePrNotifications(repoPath: string) {
       title: string,
       pr: PrPollInfo,
       dedupeKey: string,
-      // Only events that know an author pass one (pr-opened). No avatar URL in the
-      // poll payload — the row derives it from the login + `ghHost` (bot handles via
-      // the bot-avatar API; initials off GitHub / on failure).
-      authorLogin?: string,
+      opts?: {
+        /** Only events that know an author pass one (pr-opened). No avatar URL in the
+         *  poll payload — the row derives it from the login + `ghHost` (bot handles via
+         *  the bot-avatar API; initials off GitHub / on failure). */
+        authorLogin?: string;
+        /** The review a review-flavored event is about, so the click-through can
+         *  scroll to it. Empty (GitLab/Bitbucket, or an unfetched id) is dropped. */
+        reviewId?: string;
+      },
     ) => {
+      const authorLogin = opts?.authorLogin;
       pushNotification({
         kind,
         tone,
@@ -175,7 +181,15 @@ export function usePrNotifications(repoPath: string) {
         repoName,
         authorLogin,
         authorGhHost: authorLogin ? (ghHost ?? undefined) : undefined,
-        target: { type: "pr", kind: "remote", ref: String(pr.number) },
+        target: {
+          type: "pr",
+          kind: "remote",
+          ref: String(pr.number),
+          // The poll pins the ORIGIN slug (see `gh_pr_poll`), so every event it
+          // reports happened on the fork's own pull requests.
+          lens: "origin",
+          reviewId: opts?.reviewId || undefined,
+        },
         dedupeKey,
       });
       void notifyIfUnfocused(title, pr.title);
@@ -213,7 +227,7 @@ export function usePrNotifications(repoPath: string) {
             `New pull request #${pr.number}`,
             pr,
             `opened:${pr.number}`,
-            pr.author,
+            { authorLogin: pr.author },
           );
         }
         if (old && old.state === "OPEN" && pr.state !== "OPEN") {
@@ -243,6 +257,9 @@ export function usePrNotifications(repoPath: string) {
               : `Changes requested on #${pr.number}`,
             pr,
             `decision:${pr.number}:${pr.reviewDecision}`,
+            // A verdict IS a review — same `reviews(last:1)` source as the plain
+            // "commented" case below, so it lands on the review card too.
+            { reviewId: pr.lastReviewId },
           );
         } else if (
           // A plain "commented" review: count rose, decision unchanged. Skip your
@@ -256,6 +273,7 @@ export function usePrNotifications(repoPath: string) {
             `New review on #${pr.number}`,
             pr,
             `review:${pr.number}:${pr.reviewCount}`,
+            { reviewId: pr.lastReviewId },
           );
         }
         // A SEPARATE event from the review decision above — an independent `if`, not

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -24,6 +24,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { clipTitle } from "@/lib/clip-title";
 import { isMac, isWindows } from "@/lib/hotkeys/binding";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import {
   useDetectedInterpreters,
   useResolvedInterpreter,
@@ -207,6 +208,31 @@ export function TaskDialog({
     if (guess) setInterpreter(guess);
   }
 
+  // Shared by the Generate button, the describe field's Enter key, and the
+  // generate chord.
+  function runGenerate() {
+    scriptGen.generate({
+      description: describe,
+      interpreter,
+      onBody: setBody,
+    });
+  }
+  // The generate chord drives Generate — never Analyze, which documents an
+  // existing script rather than writing one. Mounted on DialogContent so it also
+  // covers the X close button (a SIBLING of the fields inside the Popup); the
+  // swallow is unconditional, including the file-source case where there's no
+  // Generate at all, so it can't reach the global generate-commit-message action
+  // behind the dialog.
+  const generateChord = useGenerateChord({
+    enabled:
+      sourceKind === "inline" &&
+      aiEnabled &&
+      aiConfigured &&
+      describe.trim() !== "" &&
+      !scriptGen.generating,
+    run: runGenerate,
+  });
+
   function runAnalyze() {
     scriptAnalyze.analyze({
       interpreter,
@@ -252,7 +278,10 @@ export function TaskDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent
+        className="max-h-[85vh] overflow-y-auto sm:max-w-2xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>{shownEditing ? "Edit task" : "New task"}</DialogTitle>
           <DialogDescription>
@@ -491,13 +520,11 @@ export function TaskDialog({
                   value={describe}
                   onChange={(e) => setDescribe(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                    // Same gate as the Generate button and the chord — Enter on
+                    // an empty description would otherwise generate from nothing.
+                    if (e.key === "Enter" && describe.trim() !== "") {
                       e.preventDefault();
-                      scriptGen.generate({
-                        description: describe,
-                        interpreter,
-                        onBody: setBody,
-                      });
+                      runGenerate();
                     }
                   }}
                   placeholder="Describe what the script should do…"
@@ -507,13 +534,8 @@ export function TaskDialog({
                   type="button"
                   variant="outline"
                   disabled={describe.trim() === ""}
-                  onClick={() =>
-                    scriptGen.generate({
-                      description: describe,
-                      interpreter,
-                      onBody: setBody,
-                    })
-                  }
+                  title={`Write the script with AI${generateChord.hint}`}
+                  onClick={runGenerate}
                 >
                   <SparkleIcon data-icon="inline-start" />
                   Generate

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -534,7 +534,13 @@ export function TaskDialog({
                   type="button"
                   variant="outline"
                   disabled={describe.trim() === ""}
-                  title={`Write the script with AI${generateChord.hint}`}
+                  // The chord is only offered while it would do something — a
+                  // disabled Generate's shortcut is dead too.
+                  title={
+                    describe.trim() !== ""
+                      ? `Write the script with AI${generateChord.hint}`
+                      : "Write the script with AI"
+                  }
                   onClick={runGenerate}
                 >
                   <SparkleIcon data-icon="inline-start" />

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -58,6 +58,7 @@ import {
   useTagList,
 } from "@/lib/git/queries";
 import type { CommitSummary } from "@/lib/git/types";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -246,11 +247,32 @@ export function CreateReleaseDialog({
     });
   }
 
+  // The generate chord drives the AI item only — never the From-GitHub one, and
+  // it never opens the dropdown. Mounted on DialogContent, not the <form>: the X
+  // close button is a form SIBLING inside the Popup. The swallow is
+  // unconditional so the chord can't reach the global generate-commit-message
+  // action behind the dialog; while generating it swallows but DOESN'T cancel.
+  const generateChord = useGenerateChord({
+    enabled: aiEnabled && Boolean(tagTrimmed) && !busyGenerating,
+    run: generateWithAi,
+  });
+  // The chord's shortcut belongs on the item it drives; with AI off that item is
+  // disabled and says why instead.
+  const aiNotesHintTitle = generateChord.hint
+    ? `Summarize with AI${generateChord.hint}`
+    : undefined;
+  const aiNotesTitle = aiEnabled
+    ? aiNotesHintTitle
+    : "Enable AI in Settings first.";
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* A fixed height (not a cap): release bodies routinely run thousands of
           lines, so the notes editor claims the dialog's whole spare height. */}
-      <DialogContent className="flex h-[85vh] flex-col sm:max-w-2xl">
+      <DialogContent
+        className="flex h-[85vh] flex-col sm:max-w-2xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <form
           className="flex min-h-0 flex-1 flex-col gap-4"
           onSubmit={(e) => {
@@ -445,11 +467,7 @@ export function CreateReleaseDialog({
                         )}
                         <DropdownMenuItem
                           disabled={!aiEnabled}
-                          title={
-                            aiEnabled
-                              ? undefined
-                              : "Enable AI in Settings first."
-                          }
+                          title={aiNotesTitle}
                           onClick={generateWithAi}
                         >
                           Summarize with AI

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -632,6 +632,10 @@ async function run(
                   type: "pr",
                   kind: event.target.type,
                   ref: targetRef(event),
+                  // Automations run against the fork's own PRs: the poll that
+                  // feeds them pins the origin slug deliberately, so the
+                  // click-through lands there too.
+                  lens: "origin",
                 },
               }),
           // This run's stopped dock row; passing a dismissed key is safe (resetReview

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -24,6 +24,7 @@ import type {
   Branch,
   BranchComparison,
   BranchDivergence,
+  BranchRewriteStatus,
   BranchStats,
   CodeFreqPoint,
   Collaborator,
@@ -425,8 +426,14 @@ export const gitDiscardUntrackedLines = (
   lines: number[],
 ) => invoke<void>("git_discard_untracked_lines", { repoPath, path, lines });
 
-export const gitReset = (repoPath: string, hash: string) =>
-  invoke<void>("git_reset", { repoPath, hash });
+/** Moves the branch pointer to `hash`. `"mixed"` (the default) keeps every
+ *  working-tree change; `"hard"` rewrites the working tree too and is refused
+ *  outright while tracked changes are outstanding. */
+export const gitReset = (
+  repoPath: string,
+  hash: string,
+  mode?: "mixed" | "hard",
+) => invoke<void>("git_reset", { repoPath, hash, mode: mode ?? null });
 
 export const gitCheckoutCommit = (repoPath: string, hash: string) =>
   invoke<void>("git_checkout_commit", { repoPath, hash });
@@ -926,6 +933,33 @@ export const gitRebaseOnto = (
 
 export const gitBranchDivergence = (repoPath: string, base: string) =>
   invoke<BranchDivergence[]>("git_branch_divergence", { repoPath, base });
+
+/** Whether `branch`'s upstream was rewritten under it, and what a reset to that
+ *  upstream would cost. Read-only (rev-parse / rev-list only). */
+export const gitBranchRewriteStatus = (repoPath: string, branch: string) =>
+  invoke<BranchRewriteStatus>("git_branch_rewrite_status", {
+    repoPath,
+    branch,
+  });
+
+/** Points `branch` at its upstream's tip without checking it out. Refuses when
+ *  the branch is checked out anywhere (naming the worktree, or pointing at the
+ *  sync controls for the current branch — that arm takes {@link gitReset} in
+ *  `"hard"` mode, which moves the working tree too).
+ *
+ *  `expectedTip` is the sha the caller measured and showed the user: the backend
+ *  re-resolves the upstream and refuses if it has moved since, so a background
+ *  fetch during the confirmation can't redirect the reset. */
+export const gitBranchResetToUpstream = (
+  repoPath: string,
+  branch: string,
+  expectedTip: string,
+) =>
+  invoke<void>("git_branch_reset_to_upstream", {
+    repoPath,
+    branch,
+    expectedTip,
+  });
 
 export interface MergePair {
   base: string;

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1057,7 +1057,11 @@ export function usePrDetails(
   return useQuery({
     ...prDetailsOptions(repo, number ?? 0, lens),
     enabled: number !== null,
-    placeholderData: keepPreviousDataForRepo(repo),
+    // The lens segment is an IDENTITY axis: a fork's two lenses surface different
+    // pull requests at the same number, so a cross-lens placeholder paints the
+    // wrong PR. A number change deliberately KEEPS the previous PR's data — the
+    // dimmed switch beat that RemotePrView's detailsStale gates compensate for.
+    placeholderData: keepPreviousDataForKeyAxes(repo, [[3, lens]]),
   });
 }
 
@@ -1270,7 +1274,9 @@ export function usePrDiff(
   return useQuery({
     ...prDiffOptions(repo, number ?? 0, lens),
     enabled: number !== null,
-    placeholderData: keepPreviousDataForRepo(repo),
+    // Lens axis mirrors usePrDetails; the number axis stays placeholder-served so
+    // RemotePrView's diffStale keeps gating the Files tab during a PR switch.
+    placeholderData: keepPreviousDataForKeyAxes(repo, [[3, lens]]),
   });
 }
 
@@ -3445,6 +3451,15 @@ export function useResetToCommit(repo: string) {
   return useRepoMutation(repo, (hash: string) => api.gitReset(repo, hash));
 }
 
+/** Moves the CURRENT branch and the working tree to `hash`. The backend refuses
+ *  outright while tracked changes are outstanding, so the caller's confirm can
+ *  promise a clean tree is required rather than pre-flighting one. */
+export function useHardResetToCommit(repo: string) {
+  return useRepoMutation(repo, (hash: string) =>
+    api.gitReset(repo, hash, "hard"),
+  );
+}
+
 export function useCheckoutCommit(repo: string) {
   return useRepoMutation(repo, (hash: string) =>
     api.gitCheckoutCommit(repo, hash),
@@ -4099,6 +4114,53 @@ export function useBranchDivergence(
 export function useUpdateBranchFrom(repo: string) {
   return useRepoMutation(repo, (args: { branch: string; base: string }) =>
     api.gitUpdateBranchFrom(repo, args.branch, args.base),
+  );
+}
+
+/**
+ * Whether a diverged branch's upstream was rewritten under it (a remote rebase
+ * or force-push), and what a reset to that upstream would cost.
+ *
+ * LAZY on purpose: `enabled` must stay false unless a surface is actually facing
+ * a diverged branch, so the ordinary in-sync path spawns no git. Keyed under the
+ * repo, so the whole-subtree invalidation every fetch/pull/push mutation already
+ * runs refreshes it. Local rev-list reads only — `networkMode: "always"` keeps
+ * an offline OS from parking the query into a permanent pending state, matching
+ * {@link useBranchDivergence}.
+ */
+export function useBranchRewriteStatus(
+  repo: string,
+  branch: string | null,
+  opts: { enabled: boolean },
+) {
+  return useQuery({
+    ...branchRewriteStatusOptions(repo, branch ?? ""),
+    enabled: opts.enabled && Boolean(branch),
+  });
+}
+
+/** The one options object behind {@link useBranchRewriteStatus}. Exported so an
+ *  IMPERATIVE probe — a palette action that has to decide before it acts, with no
+ *  render to hang a hook on — reads and caches exactly what the hook would, rather
+ *  than a second spelling that can drift from it. */
+export function branchRewriteStatusOptions(repo: string, branch: string) {
+  return {
+    queryKey: ["repo", repo, "rewrite-status", branch] as const,
+    queryFn: () => api.gitBranchRewriteStatus(repo, branch),
+    staleTime: 30_000,
+    networkMode: "always" as const,
+  };
+}
+
+/** Points a NON-current branch at its upstream's tip, refusing if that upstream
+ *  moved away from `expectedTip` since the caller measured it. The current branch
+ *  takes {@link useHardResetToCommit} instead — only that moves the working tree
+ *  with it. */
+export function useBranchResetToUpstream(repo: string) {
+  return useRepoMutation(
+    repo,
+    (args: { branch: string; expectedTip: string }) =>
+      api.gitBranchResetToUpstream(repo, args.branch, args.expectedTip),
   );
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1772,7 +1772,11 @@ export function useIssueDetails(
   return useQuery({
     ...issueDetailsOptions(repo, number ?? 0, lens),
     enabled: number !== null,
-    placeholderData: keepPreviousDataForRepo(repo),
+    // Lens is an IDENTITY axis, like the PR details twin: a fork's two lenses
+    // number their issues independently, so matching on repo alone would serve
+    // the other lens's issue under this one's number. The number axis stays out
+    // — a switch between issues keeps the previous one painted by design.
+    placeholderData: keepPreviousDataForKeyAxes(repo, [[3, lens]]),
   });
 }
 

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -78,6 +78,36 @@ export interface RemoteBranch {
   lastCommitDate: string;
 }
 
+/**
+ * Evidence for telling a server-side REWRITE of a branch's upstream (a remote
+ * rebase or force-push — GitHub's "Update branch → rebase") apart from ordinary
+ * two-sided divergence. The two want opposite remedies, so the app measures
+ * rather than guesses.
+ *
+ * `remoteRewritten` answers one narrow question: is the upstream tip absent from
+ * this branch's own reflog. That is NOT proof of a rewrite on its own — ordinary
+ * divergence looks identical — so only the pair `remoteRewritten === true &&
+ * localOnly === 0` (nothing local lacks a patch-twin upstream) may unlock a
+ * reset-to-upstream offer. `null` means nothing was provable and every surface
+ * must render exactly what it renders without this data.
+ */
+export interface BranchRewriteStatus {
+  remoteRewritten: boolean | null;
+  /** Commits on the branch with no patch-equivalent upstream — exactly the work
+   *  a reset to the upstream would destroy. */
+  localOnly: number;
+  /** Commits on the upstream with no patch-equivalent locally. */
+  remoteOnly: number;
+  /** Commits matched by patch id. Counts BOTH sides of each pair, so a clean
+   *  N-commit rebase reports `2 * N` — never render it as a commit count. */
+  patchEqual: number;
+  /** The upstream's short name (e.g. `origin/feature`). */
+  upstream: string | null;
+  /** The upstream tip's sha — a confirmed reset targets this commit, so it can
+   *  only land on the state the user was shown. */
+  upstreamTip: string | null;
+}
+
 /** A local branch's ahead/behind counts vs. the default branch. */
 export interface BranchDivergence {
   name: string;
@@ -452,6 +482,10 @@ export interface PrPollInfo {
   /** Login of the latest review's author — used to suppress a "new review"
    *  notification for your own review. GitHub only ("" elsewhere in v1). */
   lastReviewAuthor: string;
+  /** Node id of the latest review — the same id its card carries in the detail
+   *  view, so a review notification can land on that card. GitHub only ("" for
+   *  GitLab/Bitbucket in v1). */
+  lastReviewId: string;
   /** Logins currently requested to review — you newly appearing here fires a
    *  "review requested" notification. GitHub only (empty elsewhere in v1). */
   reviewRequests: string[];

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -550,7 +550,9 @@ export const ACTIONS = [
   },
   {
     id: "generate-commit-message",
-    label: "Generate commit message (AI)",
+    // The id is persisted in user rebindings, so it keeps its commit-box origin;
+    // the chord now drives whatever Generate surface is on screen.
+    label: "Generate with AI",
     category: "Changes",
     defaultBinding: "mod+g",
   },

--- a/src/lib/hotkeys/useGenerateChord.ts
+++ b/src/lib/hotkeys/useGenerateChord.ts
@@ -1,0 +1,164 @@
+import { createContext, useContext, useEffect, useMemo, useRef } from "react";
+import { eventToBinding, formatBinding } from "./binding";
+import { useEffectiveBindings } from "./hotkeys";
+
+/** What a surface does when the generate chord fires there. */
+export interface GenerateAction {
+  /** Mirrors the visible Generate button's enabled state — including "not
+   *  already generating", since a repeat must never abort a running stream. */
+  enabled: boolean;
+  run: () => void;
+}
+
+/**
+ * The `generate-commit-message` chord, reused by whichever AI-generate surface
+ * is on screen. Mount the returned `onKeyDown` on the dialog's DialogContent —
+ * NOT the `<form>`: the X close button renders as a form SIBLING inside the
+ * Popup, so a form-level handler misses a chord pressed with focus on X.
+ *
+ * The binding comes from the user's effective bindings (never a literal chord),
+ * so a Settings → Keyboard rebind drives every surface at once; null = the user
+ * cleared it, and the chord stays fully inert.
+ *
+ * Swallowing follows the generator, not its enabled state: while this surface
+ * HAS a generator the chord is swallowed on every match, before `enabled` is
+ * consulted, so a disabled Generate can't let the chord reach the global
+ * listener. `run` undefined means the surface has no generator at all — Hide-AI
+ * removed it, or a shared dialog's host passes none — and the chord falls
+ * through untouched instead. Nothing generates behind a dialog in that arm
+ * either, because the only global handler is the commit box's: Hide-AI leaves
+ * it registered but DISABLED, and the listener runs the newest ENABLED handler
+ * or none; and off the Changes tab the commit box is unmounted, so it isn't
+ * registered at all.
+ *
+ * Auto-repeat is dropped without swallowing, matching that global listener —
+ * holding the chord must not re-fire before the generating flag lands.
+ */
+export function useGenerateChord({
+  enabled,
+  run,
+}: {
+  enabled: boolean;
+  run?: () => void;
+}): {
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  /** " (Ctrl+G)" — append to a Generate button's `title`; "" when unbound. */
+  hint: string;
+  binding: string | null;
+} {
+  const binding = useEffectiveBindings().get("generate-commit-message") ?? null;
+  return {
+    onKeyDown: (e) => {
+      if (binding === null || run === undefined || e.repeat) return;
+      if (eventToBinding(e) !== binding) return;
+      e.preventDefault();
+      if (enabled) run();
+    },
+    hint: bindingHint(binding),
+    binding,
+  };
+}
+
+/** The chord's title suffix on its own, for a Generate button whose chord is
+ *  owned by an ancestor (see {@link GenerateActionContext}). */
+export function useGenerateChordHint(): string {
+  return bindingHint(
+    useEffectiveBindings().get("generate-commit-message") ?? null,
+  );
+}
+
+function bindingHint(binding: string | null): string {
+  return binding === null ? "" : ` (${formatBinding(binding)})`;
+}
+
+/** A published action plus the shell key (section id) that owns it. */
+interface PublishedGenerateAction extends GenerateAction {
+  key: string;
+}
+
+/** Where a nested surface hands its generate action to the ancestor that owns
+ *  the chord. */
+interface GenerateActionSink {
+  /** The shell key the subtree currently being rendered belongs to. */
+  activeKey: string;
+  publish: (action: PublishedGenerateAction) => void;
+  /** Identity-paired with `publish`, so a retraction can only clear its own. */
+  retract: (action: PublishedGenerateAction) => void;
+}
+
+export const GenerateActionContext = createContext<GenerateActionSink | null>(
+  null,
+);
+
+/**
+ * Shell side of {@link GenerateActionContext}, for a container that owns the
+ * chord but not the generator — a settings dialog whose sections come and go.
+ * Provide `sink` on the context and call `runPublished` from the chord handler;
+ * the swallow stays unconditional, so the chord can never leak out of the
+ * shell, and a section without a generator makes it a no-op.
+ *
+ * `activeKey` is what makes the published action safe to run. Under an
+ * `AnimatePresence mode="wait"` crossfade the OUTGOING section stays mounted —
+ * and published — for the whole fade, and its successor mounts only once that
+ * finishes: the successor can never clobber, but the section the user just left
+ * would otherwise answer the chord, starting a stream into a form that is
+ * unmounting and whose Cancel affordance is already gone. So a published action
+ * runs only while its key is still the shell's active one.
+ */
+export function useGenerateActionSink(activeKey: string): {
+  sink: GenerateActionSink;
+  runPublished: () => void;
+} {
+  // A ref, not state: the value is only ever read at keydown time, and a
+  // re-render per publish would fight the section crossfade.
+  const current = useRef<PublishedGenerateAction | null>(null);
+  const fns = useMemo(
+    () => ({
+      publish: (action: PublishedGenerateAction) => {
+        current.current = action;
+      },
+      retract: (action: PublishedGenerateAction) => {
+        if (current.current === action) current.current = null;
+      },
+    }),
+    [],
+  );
+  const sink = useMemo<GenerateActionSink>(
+    () => ({ activeKey, ...fns }),
+    [activeKey, fns],
+  );
+  return {
+    sink,
+    runPublished: () => {
+      const action = current.current;
+      if (action?.key === activeKey && action.enabled) action.run();
+    },
+  };
+}
+
+/** Section side of {@link GenerateActionContext}: publishes this surface's
+ *  generate action while it's mounted, and returns the chord hint for its
+ *  Generate button. No provider ⇒ inert, so a section still renders standalone. */
+export function usePublishGenerateAction(
+  enabled: boolean,
+  run: () => void,
+): { hint: string } {
+  const sink = useContext(GenerateActionContext);
+  const hint = useGenerateChordHint();
+  // The key this section mounted under. Two host constraints keep it honest:
+  // the shell's crossfade retains the EXITING subtree's element — provider
+  // included — so an outgoing section keeps reading the sink it rendered with,
+  // never its successor's; and that subtree is keyed by section, so it remounts
+  // per section rather than carrying a stale snapshot across a switch.
+  const keyRef = useRef(sink?.activeKey ?? null);
+  // No dep array: `run` is a fresh closure on most renders and republishing is
+  // a single ref write, so re-running every render is cheaper than comparing.
+  useEffect(() => {
+    const key = keyRef.current;
+    if (!sink || key === null) return;
+    const action: PublishedGenerateAction = { key, enabled, run };
+    sink.publish(action);
+    return () => sink.retract(action);
+  });
+  return { hint };
+}

--- a/src/lib/repo-lens/queries.ts
+++ b/src/lib/repo-lens/queries.ts
@@ -49,11 +49,11 @@ export function useRepoLens(repo: string): RemoteLens {
 }
 
 /**
- * Point a repo at `lens`: write the query cache synchronously (so the UI flips
- * instantly), optionally persist to disk (fire-and-forget with an error toast),
+ * Point a repo at `lens`: persist it to disk when asked (fire-and-forget with an
+ * error toast), write the query cache synchronously so the UI flips instantly,
  * and — when asked — clear any REMOTE PR/issue selection so a selected number
- * can't silently point at a different repo's item. No-op when the lens is
- * unchanged.
+ * can't silently point at a different repo's item. A lens the cache already
+ * holds is a UI no-op; the disk write is decided separately, below.
  *
  * Synchronous by contract, so a caller can apply the lens and navigate in the
  * same turn. That means the gate ({@link useLensGate}, an async pair of reads)
@@ -61,24 +61,31 @@ export function useRepoLens(repo: string): RemoteLens {
  * construction — {@link useRepoLens} re-gates on every read, so a repo that
  * isn't a fork keeps resolving to "origin" whatever is stored.
  *
- * A cache MISS is unknown, never "origin". The cache is cold for any repo the
- * window hasn't opened this session (and after gc), while disk may hold
- * "upstream" — so defaulting the read would let a target of "origin"
- * short-circuit as a no-op and leave the stored value to win once it loads,
- * opening the wrong pull request. Only a HOT cache that already matches skips
- * the write; a cold write is cache-only when `persist` is false, which still
- * settles the session without touching disk — {@link lensKey} sits outside the
- * ["repo", …] subtree, so no repo mutation's invalidation can refetch it back
- * to the stored value.
- *
  * `persist` separates the two callers. The switcher is the user CHOOSING a
  * lens, so it writes disk. A navigation only needs the view to land on the
  * right pull request — rewriting the stored preference from a notification
  * click would outlive the visit and change what every later session opens on.
  *
+ * INVARIANT from that split: cache and disk DIVERGE by design once a navigation
+ * applies a session-only lens, so persistence must never key off cache
+ * equality. A switcher choice matching the cached value is exactly the case
+ * where disk still holds the other one — hence the unconditional write, which
+ * is safe because `saveRepoLens` is idempotent.
+ *
+ * The cache write keeps its own short-circuit, and a cache MISS is unknown
+ * there, never "origin": the cache is cold for any repo the window hasn't
+ * opened this session (and after gc), while disk may hold "upstream" — so
+ * defaulting the read would let a target of "origin" skip the write and leave
+ * the stored value to win once it loads, opening the wrong pull request. A
+ * cache-only write still settles the session — {@link lensKey} sits outside the
+ * ["repo", …] subtree, so no repo mutation's invalidation can refetch it back
+ * to the stored value.
+ *
  * `clearSelections` is false for a navigation that selects its own PR right
  * after (clearing would fight it) and true for the switcher, whose whole point
- * is to drop a selection minted under the old lens.
+ * is to drop a selection minted under the old lens. It rides the cache
+ * short-circuit: a re-select of the lens already showing must not drop the
+ * user's selection.
  */
 export function applyRepoLens(
   queryClient: QueryClient,
@@ -86,14 +93,16 @@ export function applyRepoLens(
   lens: RemoteLens,
   { clearSelections, persist }: { clearSelections: boolean; persist: boolean },
 ): void {
-  const current = queryClient.getQueryData<RemoteLens>(lensKey(repo));
-  if (current !== undefined && current === lens) return;
-  queryClient.setQueryData(lensKey(repo), lens);
+  // Ahead of the cache short-circuit, never behind it: an explicit choice has to
+  // reach disk even when the cache already shows that lens.
   if (persist) {
     void saveRepoLens(repo, lens).catch(() => {
       toast.error("Couldn't save the fork/upstream view preference.");
     });
   }
+  const current = queryClient.getQueryData<RemoteLens>(lensKey(repo));
+  if (current !== undefined && current === lens) return;
+  queryClient.setQueryData(lensKey(repo), lens);
   if (!clearSelections) return;
   // A remote number selected under the old lens would resolve against the
   // wrong repo — drop it. Local + Jira selections are lens-independent.
@@ -115,6 +124,18 @@ export function useSetRepoLens(repo: string) {
     },
     [queryClient, repo],
   );
+}
+
+/** Drop a repo's CACHED lens back to "origin" — the companion to the store's
+ *  `deleteRepoLens` for the detach path. Because {@link lensKey} sits outside
+ *  the ["repo", …] subtree, no mutation's invalidation reconciles the cache with
+ *  the deleted disk entry: without this, re-adding the upstream remote in the
+ *  same session would resurrect the preference the delete dropped. */
+export function clearRepoLensCache(
+  queryClient: QueryClient,
+  repo: string,
+): void {
+  queryClient.setQueryData<RemoteLens>(lensKey(repo), "origin");
 }
 
 /** Parse "owner/repo" from a remote's URL (both `https://host/owner/repo(.git)`

--- a/src/lib/repo-lens/queries.ts
+++ b/src/lib/repo-lens/queries.ts
@@ -10,7 +10,12 @@ import type { RemoteLens } from "@/lib/git/types";
 import { useUiStore } from "@/lib/stores/ui";
 import { loadRepoLens, saveRepoLens } from "./store";
 
-const lensKey = (repo: string) => ["repo", repo, "lens"] as const;
+// Deliberately OUTSIDE the ["repo", …] subtree (like `useRepoIdentity`'s key):
+// every repo mutation invalidates that whole prefix, and an invalidation
+// refetches an active query whatever its staleTime — which would re-read disk
+// and overwrite a session-only lens applied by a navigation, repainting the
+// other lens's pull request under the selected number.
+const lensKey = (repo: string) => ["repo-lens", repo] as const;
 
 /** The raw persisted lens for a repo, unfiltered by the gate. Prefer
  *  {@link useRepoLens} in surfaces — this exists so the setter and the switcher
@@ -62,7 +67,9 @@ export function useRepoLens(repo: string): RemoteLens {
  * short-circuit as a no-op and leave the stored value to win once it loads,
  * opening the wrong pull request. Only a HOT cache that already matches skips
  * the write; a cold write is cache-only when `persist` is false, which still
- * settles the session (`lensKey` never goes stale) without touching disk.
+ * settles the session without touching disk — {@link lensKey} sits outside the
+ * ["repo", …] subtree, so no repo mutation's invalidation can refetch it back
+ * to the stored value.
  *
  * `persist` separates the two callers. The switcher is the user CHOOSING a
  * lens, so it writes disk. A navigation only needs the view to land on the

--- a/src/lib/repo-lens/queries.ts
+++ b/src/lib/repo-lens/queries.ts
@@ -1,4 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useForgeStatus, useRemotes, useRemoteUrl } from "@/lib/git/queries";
@@ -39,26 +43,68 @@ export function useRepoLens(repo: string): RemoteLens {
   return gate && raw === "upstream" ? "upstream" : "origin";
 }
 
-/** A setter for the persisted lens. It writes the query cache synchronously (so
- *  the UI flips instantly), persists to disk (fire-and-forget with an error
- *  toast), and clears any REMOTE PR/issue selection so a selected number can't
- *  silently point at a different repo's item. No-op when the lens is unchanged. */
+/**
+ * Point a repo at `lens`: write the query cache synchronously (so the UI flips
+ * instantly), optionally persist to disk (fire-and-forget with an error toast),
+ * and — when asked — clear any REMOTE PR/issue selection so a selected number
+ * can't silently point at a different repo's item. No-op when the lens is
+ * unchanged.
+ *
+ * Synchronous by contract, so a caller can apply the lens and navigate in the
+ * same turn. That means the gate ({@link useLensGate}, an async pair of reads)
+ * isn't consulted: the raw preference is written fail-open. Safe by
+ * construction — {@link useRepoLens} re-gates on every read, so a repo that
+ * isn't a fork keeps resolving to "origin" whatever is stored.
+ *
+ * A cache MISS is unknown, never "origin". The cache is cold for any repo the
+ * window hasn't opened this session (and after gc), while disk may hold
+ * "upstream" — so defaulting the read would let a target of "origin"
+ * short-circuit as a no-op and leave the stored value to win once it loads,
+ * opening the wrong pull request. Only a HOT cache that already matches skips
+ * the write; a cold write is cache-only when `persist` is false, which still
+ * settles the session (`lensKey` never goes stale) without touching disk.
+ *
+ * `persist` separates the two callers. The switcher is the user CHOOSING a
+ * lens, so it writes disk. A navigation only needs the view to land on the
+ * right pull request — rewriting the stored preference from a notification
+ * click would outlive the visit and change what every later session opens on.
+ *
+ * `clearSelections` is false for a navigation that selects its own PR right
+ * after (clearing would fight it) and true for the switcher, whose whole point
+ * is to drop a selection minted under the old lens.
+ */
+export function applyRepoLens(
+  queryClient: QueryClient,
+  repo: string,
+  lens: RemoteLens,
+  { clearSelections, persist }: { clearSelections: boolean; persist: boolean },
+): void {
+  const current = queryClient.getQueryData<RemoteLens>(lensKey(repo));
+  if (current !== undefined && current === lens) return;
+  queryClient.setQueryData(lensKey(repo), lens);
+  if (persist) {
+    void saveRepoLens(repo, lens).catch(() => {
+      toast.error("Couldn't save the fork/upstream view preference.");
+    });
+  }
+  if (!clearSelections) return;
+  // A remote number selected under the old lens would resolve against the
+  // wrong repo — drop it. Local + Jira selections are lens-independent.
+  const ui = useUiStore.getState();
+  if (ui.selectedPr?.kind === "remote") ui.selectPr(null);
+  if (ui.selectedIssue?.kind === "remote") ui.selectIssue(null);
+}
+
+/** The switcher's setter — {@link applyRepoLens} with the selection clears and
+ *  the disk write on, since this path is the user choosing the lens. */
 export function useSetRepoLens(repo: string) {
   const queryClient = useQueryClient();
   return useCallback(
     (lens: RemoteLens) => {
-      const current =
-        queryClient.getQueryData<RemoteLens>(lensKey(repo)) ?? "origin";
-      if (current === lens) return;
-      queryClient.setQueryData(lensKey(repo), lens);
-      void saveRepoLens(repo, lens).catch(() => {
-        toast.error("Couldn't save the fork/upstream view preference.");
+      applyRepoLens(queryClient, repo, lens, {
+        clearSelections: true,
+        persist: true,
       });
-      // A remote number selected under the old lens would resolve against the
-      // wrong repo — drop it. Local + Jira selections are lens-independent.
-      const ui = useUiStore.getState();
-      if (ui.selectedPr?.kind === "remote") ui.selectPr(null);
-      if (ui.selectedIssue?.kind === "remote") ui.selectIssue(null);
     },
     [queryClient, repo],
   );

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -1,5 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { create } from "zustand";
+import type { RemoteLens } from "@/lib/git/types";
 import { storeName } from "@/lib/test-mode";
 
 /** Semantic tone for a notification's glyph — paired with an icon + word in the
@@ -37,7 +38,21 @@ export type NotificationKind =
 /** How clicking a notification routes. Data only — the surface maps it to the UI
  *  store's atomic navigation actions, so this module stays free of view logic. */
 export type NotificationTarget =
-  | { type: "pr"; kind: "remote" | "local"; ref: string }
+  | {
+      type: "pr";
+      kind: "remote" | "local";
+      ref: string;
+      /** The origin|upstream lens the event happened under — a fork's two lenses
+       *  surface DIFFERENT pull requests at the same `ref`, so without it the
+       *  click-through lands on whichever lens the repo currently sits on.
+       *  Absent on rows persisted before this field existed; a consumer narrows
+       *  the hydrated value rather than trusting it. */
+      lens?: RemoteLens;
+      /** The review the event is about (a GitHub `PRR_` node id), so the landing
+       *  view can scroll to that review's card. Absent for non-review events and
+       *  off GitHub. */
+      reviewId?: string;
+    }
   | { type: "run"; runId: number }
   | { type: "agent" }
   | { type: "repo" };

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -377,11 +377,15 @@ async function notifyReviewDone(
       subtitle,
       repoPath: target.repoPath,
       repoName: target.repoName,
-      target: { type: "pr", kind: target.kind, ref: target.ref },
+      target: {
+        type: "pr",
+        kind: target.kind,
+        ref: target.ref,
+        lens: target.lens,
+      },
       // The lens is in the dedupe key because a fork's origin and upstream PRs share
       // a number: without it, two reviews settling in the same window collapse into
-      // one notification. (The `target` above carries no lens, so the click-through
-      // still lands on whichever lens the repo is currently set to.)
+      // one notification.
       dedupeKey: `review:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
     });
     void notifyIfUnfocused(headline, subtitle);

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -143,7 +143,11 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   compareBranch: null,
   localPrCreate: null,
   selectedPr: null,
+  // queuedMerges deliberately survives this reset: its keys embed the repoPath,
+  // so entries can't leak across repos, and clearing here would kill the
+  // queued-merge chip's promised session persistence on any repo round-trip.
   pendingPrSection: null,
+  pendingReviewId: null,
   selectedIssue: null,
   selectedDiscussion: null,
   pendingIssueDraft: null,
@@ -164,6 +168,13 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   activeDraftKey: null,
   draftKeyRemaps: {},
 };
+
+/** Key a queued merge per repo + pull request. Opaque (never parsed back), and
+ *  collision-free because the suffix is always digits: a path that itself ends
+ *  in `#<digits>` still can't produce another pair's key. */
+export function queuedMergeKey(repoPath: string, number: number): string {
+  return `${repoPath}#${number}`;
+}
 
 /** Key a commit draft so each repo + branch keeps its own message. A git branch
  *  name can't contain a colon, so the key stays unambiguous. */
@@ -213,6 +224,13 @@ interface UiState {
    *  `${provider}|${host}|${expiresAt}`. In-memory only (never persisted), so a
    *  dismissed notice returns next launch until the token is actually renewed. */
   dismissedExpiryNotices: Set<string>;
+  /** Pull requests whose merge the forge accepted into a MERGE QUEUE rather than
+   *  landing, keyed by {@link queuedMergeKey}. Nothing the app can fetch carries
+   *  that state (no mergeStateStatus member reports it), so the accepted outcome
+   *  is the only evidence there is — recorded here so the chip survives a switch
+   *  away and back. In-memory only: a relaunch forgets, and the PR's own state
+   *  takes over once it lands. */
+  queuedMerges: Record<string, true>;
   repoPath: string | null;
   repoName: string | null;
   repoTab: RepoTab;
@@ -224,6 +242,11 @@ interface UiState {
    *  notification row's click-through so the event's own tab opens; null asks
    *  for no switch. Consumed and cleared by the PR detail views. */
   pendingPrSection: PrSection | null;
+  /** Review the Pulls view should scroll to once the opened PR's details land —
+   *  set from a review notification's click-through, null when the event names no
+   *  review. Consumed by the PR detail view, which hands it to its own reveal
+   *  state rather than reading it per render. */
+  pendingReviewId: string | null;
   /** Selected issue on the Issues tab. */
   selectedIssue: SelectedIssue | null;
   /** Selected discussion (by number) on the Discussions tab. */
@@ -303,6 +326,14 @@ interface UiState {
     repoName: string;
     ref: string;
     section: PrSection | null;
+    /** Review to scroll to once the PR's details land; omitted/null = none. */
+    reviewId?: string | null;
+    /** Store-external state this navigation depends on (the caller's repo-lens
+     *  write), run inside the SAME view-transition callback as the selection.
+     *  Written outside it, it would land a render early — the transition callback
+     *  is deferred on Chromium — pairing the new lens with the old PR number and
+     *  fetching a pair the user never selected. */
+    beforeSelect?: () => void;
   }) => void;
   /** Open a repo (if not already) and land on a workflow run in the Actions tab —
    *  used by a notification's click-through. Atomic, like openPr. */
@@ -330,6 +361,9 @@ interface UiState {
   closeReconnect: () => void;
   /** Dismiss the token-expiry notice for `key` (session-scoped, not persisted). */
   dismissExpiryNotice: (key: string) => void;
+  /** Record / forget that a PR's merge went into the forge's merge queue. */
+  markMergeQueued: (key: string) => void;
+  clearMergeQueued: (key: string) => void;
   closeSettings: () => void;
   openHelp: () => void;
   closeHelp: () => void;
@@ -339,6 +373,7 @@ interface UiState {
   setCompareBranch: (branch: string | null) => void;
   selectPr: (pr: SelectedPr | null) => void;
   setPendingPrSection: (section: PrSection | null) => void;
+  setPendingReviewId: (reviewId: string | null) => void;
   selectIssue: (issue: SelectedIssue | null) => void;
   selectDiscussion: (discussion: { number: number } | null) => void;
   setPendingIssueDraft: (
@@ -448,12 +483,14 @@ export const useUiStore = create<UiState>()((set, get) => {
     activityOpen: false,
     reconnectTarget: null,
     dismissedExpiryNotices: new Set<string>(),
+    queuedMerges: {},
     repoPath: null,
     repoName: null,
     repoTab: "changes",
     compareBranch: null,
     selectedPr: null,
     pendingPrSection: null,
+    pendingReviewId: null,
     selectedIssue: null,
     selectedDiscussion: null,
     pendingIssueDraft: null,
@@ -505,6 +542,10 @@ export const useUiStore = create<UiState>()((set, get) => {
       ),
     openPr: (target) =>
       startViewTransition(() => {
+        // Before the set, inside this callback: react-query updates an
+        // observer's result synchronously, so the flush below renders the
+        // caller's write and this selection in one pass.
+        target.beforeSelect?.();
         const switchingRepo = get().repoPath !== target.repoPath;
         set({
           view: "repo",
@@ -518,6 +559,10 @@ export const useUiStore = create<UiState>()((set, get) => {
           ...(switchingRepo ? CROSS_REPO_RESET : {}),
           selectedPr: { kind: target.kind, id: target.ref },
           pendingPrSection: target.section,
+          // In THIS set, not a follow-up one: a second set() would be clobbered
+          // (see openCommit's note), and the reveal target must land with the
+          // selection it belongs to.
+          pendingReviewId: target.reviewId ?? null,
         });
       }),
     openRun: (target) =>
@@ -553,6 +598,7 @@ export const useUiStore = create<UiState>()((set, get) => {
       set({ compareBranch: branch, compareCommitHash: null }),
     selectPr: (pr) => set({ selectedPr: pr }),
     setPendingPrSection: (section) => set({ pendingPrSection: section }),
+    setPendingReviewId: (reviewId) => set({ pendingReviewId: reviewId }),
     selectIssue: (issue) => set({ selectedIssue: issue }),
     selectDiscussion: (discussion) => set({ selectedDiscussion: discussion }),
     setPendingIssueDraft: (draft) => set({ pendingIssueDraft: draft }),
@@ -608,6 +654,14 @@ export const useUiStore = create<UiState>()((set, get) => {
       set((s) => ({
         dismissedExpiryNotices: new Set(s.dismissedExpiryNotices).add(key),
       })),
+    markMergeQueued: (key) =>
+      set((s) => ({ queuedMerges: { ...s.queuedMerges, [key]: true } })),
+    clearMergeQueued: (key) =>
+      set((s) => {
+        if (!s.queuedMerges[key]) return {};
+        const { [key]: _gone, ...rest } = s.queuedMerges;
+        return { queuedMerges: rest };
+      }),
     closeSettings: () =>
       startViewTransition(() => set({ view: get().previousView })),
     openHelp: () =>

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -140,12 +140,12 @@ const EMPTY_COMMIT_DRAFT: CommitDraft = {
  *  same set openRepo / openPr reset, hoisted so the run/agent navigations
  *  stay in lockstep. Staying in the same repo keeps the user's other selections. */
 const CROSS_REPO_RESET: Partial<UiState> = {
+  // Absent on purpose: `queuedMerges` keys embed the repoPath (and lens), so
+  // entries can't leak across repos, and clearing here would kill the queued-merge
+  // chip's promised session persistence on any repo round-trip.
   compareBranch: null,
   localPrCreate: null,
   selectedPr: null,
-  // queuedMerges deliberately survives this reset: its keys embed the repoPath
-  // (and lens), so entries can't leak across repos, and clearing here would kill
-  // the queued-merge chip's promised session persistence on any repo round-trip.
   pendingPrSection: null,
   pendingReviewId: null,
   selectedIssue: null,
@@ -606,7 +606,10 @@ export const useUiStore = create<UiState>()((set, get) => {
     // Atomic (a follow-up set() would be clobbered); rationale in the compareCommitHash doc.
     setCompareBranch: (branch) =>
       set({ compareBranch: branch, compareCommitHash: null }),
-    selectPr: (pr) => set({ selectedPr: pr }),
+    // Clears any armed reveal in the SAME set (openPr's atomicity): a review
+    // request belongs to the PR the notification opened, and picking another
+    // from the list would leave it armed to fire on a later return to that one.
+    selectPr: (pr) => set({ selectedPr: pr, pendingReviewId: null }),
     setPendingPrSection: (section) => set({ pendingPrSection: section }),
     setPendingReviewId: (reviewId) => set({ pendingReviewId: reviewId }),
     selectIssue: (issue) => set({ selectedIssue: issue }),

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { CommitAuthor, RepoInfo } from "@/lib/git/types";
+import type { CommitAuthor, RemoteLens, RepoInfo } from "@/lib/git/types";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import { startViewTransition } from "@/lib/view-transition";
 
@@ -143,9 +143,9 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   compareBranch: null,
   localPrCreate: null,
   selectedPr: null,
-  // queuedMerges deliberately survives this reset: its keys embed the repoPath,
-  // so entries can't leak across repos, and clearing here would kill the
-  // queued-merge chip's promised session persistence on any repo round-trip.
+  // queuedMerges deliberately survives this reset: its keys embed the repoPath
+  // (and lens), so entries can't leak across repos, and clearing here would kill
+  // the queued-merge chip's promised session persistence on any repo round-trip.
   pendingPrSection: null,
   pendingReviewId: null,
   selectedIssue: null,
@@ -169,11 +169,21 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   draftKeyRemaps: {},
 };
 
-/** Key a queued merge per repo + pull request. Opaque (never parsed back), and
- *  collision-free because the suffix is always digits: a path that itself ends
- *  in `#<digits>` still can't produce another pair's key. */
-export function queuedMergeKey(repoPath: string, number: number): string {
-  return `${repoPath}#${number}`;
+/** Key a queued merge by the SAME identity the PR view uses — repo + number +
+ *  lens. The lens is part of it because a fork's origin and upstream can both
+ *  carry a pull request numbered 7, and the view flips lens while staying
+ *  mounted: without it, one lens's chip shows on the other, and the
+ *  clear-on-non-OPEN effect deletes the other's record.
+ *
+ *  Opaque (never parsed back) and collision-free read from the RIGHT: the lens is
+ *  a fixed two-value enum and the number is digits, so neither trailing segment
+ *  can contain `#` however exotic the path in front of them is. */
+export function queuedMergeKey(
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+): string {
+  return `${repoPath}#${number}#${lens}`;
 }
 
 /** Key a commit draft so each repo + branch keeps its own message. A git branch


### PR DESCRIPTION
When the *remote* rewrites a branch (a server-side rebase or force-push, such as GitHub's *Update branch → rebase*), plain ahead/behind divergence routes you to a force push that puts the dead history back, or a merge that duplicates it. This batch teaches the app to tell that shape apart from ordinary two-sided divergence and offer the remedy it actually needs — a confirmed reset onto the upstream — and carries four smaller fixes that rode the same branch: notification landing, generate-shortcut coverage, promotion-PR honesty, and a queued-merge chip.

### Remote-rebase divergence

- Adds `BranchRewriteStatus` and the `git_branch_rewrite_status` command in `src-tauri/src/git/branches.rs`: a reflog membership probe (`rev-list --walk-reflogs`) paired with `rev-list --left-right --cherry-mark --count` for patch-twin counts. Any failed sub-probe returns the "unknown" answer rather than a defaulted count, so a probe that can't run never unlocks the destructive offer.
- Adds `git_branch_reset_to_upstream` (same file), registered alongside the status command in `src-tauri/src/lib.rs`. The reset targets the measured upstream sha carried on the status rather than re-resolving the ref.
- Extends `git_reset` in `src-tauri/src/git/ops.rs` with a `mode` argument (`mixed` stays the default; `hard` is new). `--hard` refuses a dirty tree and refuses mid-operation, since a paused sequencer sits on a clean tree; the MCP caller in `src-tauri/src/mcp_server/write_git.rs` passes `None`. Covered by tests including a destruction control that shows an unguarded `reset --hard` eats exactly what the guard protects.
- Surfaces the offer in `src/features/repository/SyncControls.tsx` (Pull menu **Reset to _origin/…_**, plus force-push confirmation copy that warns pushing would restore the old history and points at **Pull with rebase** when local commits sit on top) and in `src/features/repository/BranchSwitcher.tsx` (the branch context menu's **Update from _origin/…_** becomes the reset, or disables with the reason when a merge would duplicate rewritten history).
- Frontend plumbing in `src/lib/git/api.ts`, `src/lib/git/queries.ts`, and `src/lib/git/types.ts`.

### Generate shortcut coverage

- New `src/lib/hotkeys/useGenerateChord.ts` centralizes the AI-generate chord: effective-binding read (null = inert), `eventToBinding` match, `preventDefault` before `enabled`, swallow-don't-cancel while generating, and a returned `hint` string so buttons can't forget to name the binding. Also exports `useGenerateChordHint` and `usePublishGenerateAction` for surfaces whose chord is owned by an outer dialog shell.
- Converts the existing hand-rolled handlers (`src/features/commit/CommitBox.tsx`, `src/features/pulls/CreatePrDialog.tsx`, `src/features/pulls/CreateLocalPrDialog.tsx`, `src/features/conversations/EditTitleBodyDialog.tsx`, `src/features/pulls/LocalPrView.tsx`) and extends the chord to the dialogs that previously had only a button: branches (`CreateBranchDialog.tsx`, `RenameBranchDialog.tsx`, `GenerateBranchNameButton.tsx`), issues (`CreateIssueDialog.tsx`, `CreateJiraIssueDialog.tsx`, `CreateLocalIssueDialog.tsx`), `RewriteDialogs.tsx`, `PublishDialog.tsx`, `TaskDialog.tsx`, `CreateReleaseDialog.tsx`, and the repo-settings sections plus their shell (`RepoSettingsDialog.tsx`, `GeneralSettingsSection.tsx`, `GitLabGeneralSection.tsx`, `BitbucketGeneralSection.tsx`).
- Renames the action's label to *Generate with AI* in `src/lib/hotkeys/registry.ts`, and gates the remaining Generate surfaces on the Hide-AI flag in `src/features/history/EditHistoryDialog.tsx` and `src/features/history/RewriteDialogs.tsx`.

### Notification landing

- Adds `last_review_id` to `PrPollInfo` in `src-tauri/src/github/pr.rs`, extracting the poll's GraphQL projection into `pr_poll_query` so tests can assert the `reviews(last:1)` selection carries `id` (a dropped selection would degrade silently to a PR-level jump). Neutral-shape construction updated in `src-tauri/src/forge/gitlab.rs` and `src-tauri/src/forge/bitbucket.rs`.
- Carries the originating lens and review id on notification targets (`src/lib/stores/notifications.ts`, `src/features/repository/usePrNotifications.ts`), and applies them on click in `src/features/activity/ActivityDock.tsx` — the lens goes through `applyRepoLens` (`src/lib/repo-lens/queries.ts`, which gains `clearSelections` / `persist` options so navigation doesn't rewrite the stored preference) inside the new `beforeSelect` hook on `openPr` (`src/lib/stores/ui.ts`).
- Adds a `ReviewAnchor` row to `src/features/pulls/PrActivityFeed.tsx` that scrolls itself via a layout effect on mount and clears the request, with the `revealReviewId` / `onReviewRevealed` wiring in `src/features/pulls/RemotePrView.tsx`.

### Promotion pull requests

- Detects the promotion shape (head is the repository's default branch, e.g. `main` → `staging`) in `src/features/pulls/LocalPrView.tsx` via `useDefaultBranch`, withholds **Update branch** there, and replaces it with a status line explaining the gap is expected and won't close on merge.
- Same withholding and explanation on remote pull requests in `src/features/pulls/PrMergeabilityBanner.tsx` and `src/features/pulls/RemotePrView.tsx`, where the Update button now names the operation it performs (**Merges base into head**).

### Queued merge chip

- Keeps session-scoped queued state (`src/lib/stores/reviews.ts`) so a stacked merge handed to GitHub's merge queue leaves a **Queued to merge** chip on the pull request (`src/features/pulls/RemotePrView.tsx`, `src/features/pulls/PrMergeabilityBanner.tsx`) instead of only a toast.

### Documentation

- `README.md`: the Pull-menu paragraph now covers the rewrite-aware reset.
- `site/src/data/capabilities.ts`: adds the rewrite-aware divergence capability.
- `src/features/help/content.ts`: updates the branch-switcher, push/pull, pull-request, merge-queue, and shortcut-cheat-sheet sections.
- `changelog.d/`: five fragments — `fixed-remote-rebase-divergence.md`, `changed-generate-chord-coverage.md`, `fixed-notification-landing.md`, `fixed-promotion-pr-behind-honesty.md`, `changed-queued-merge-chip.md`.
- `.claude/skills/gd-conventions/SKILL.md`: records the `useGenerateChord` contract (with the Edit-history exception) and the "advisory probes fail safe toward inaction" rule the rewrite status models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI generation shortcuts and contextual hints across dialogs, drafts, commits, branch names, publishing, and settings.
  * Added persistent “Queued to merge” status for merge-queue pull requests.
  * Added detection and guided reset recovery for remotely rewritten branch history.
  * Improved notification navigation with repository context and direct review targeting.
* **Bug Fixes**
  * Improved promotion pull-request messaging and removed invalid update actions.
  * Added safer reset, merge, pull, and force-push protections.
  * Prevented empty task descriptions from triggering generation.
  * Hide AI features now removes related Generate controls.
* **Documentation**
  * Updated help and README guidance for these workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->