### PR TITLE
feat(branch-rules,history,issues): add promotion branches and destructive confirms

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -72,7 +72,9 @@ the same change (`listKeyboardNav` in `src/lib/list-keyboard-nav.ts`) — an
 invariant, not polish. Destructive paths stay behind confirmation via the
 shared `useConfirm`/`ConfirmDialogHost` primitive (`src/lib/stores/confirm.ts`,
 host in `src/components/confirm-dialog-host.tsx`) — never a bespoke confirm
-dialog.
+dialog. Commit-level destructive prompts (checkout, revert, cherry-pick, undo)
+share their wording through `src/features/history/commit-confirms.ts`: a new
+route to one of those ops imports the existing prompt, never re-spells it.
 
 **Command palette.** Any new tab/surface/action needs an ACTIONS entry in
 `src/lib/hotkeys/registry.ts` + `useHotkeyAction` wiring in the same change
@@ -96,6 +98,9 @@ dialog.
   chips, the discussion upvote chip) take the SAME contract from the shared
   `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
   (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
+- A conversation surface's own actions sit before the submit button via
+  `CommentComposer`'s `leadingActions` slot (`actions` renders after submit) —
+  the caller owns the row layout up to that boundary, spacers included.
 - The AI-generate chord in a dialog goes through `useGenerateChord`
   (`src/lib/hotkeys/useGenerateChord.ts`) — never a hand-rolled handler. Its
   invariants: effective-binding read (null = fully inert), `eventToBinding`

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -99,8 +99,11 @@ route to one of those ops imports the existing prompt, never re-spells it.
   `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
   (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
 - A conversation surface's own actions sit before the submit button via
-  `CommentComposer`'s `leadingActions` slot (`actions` renders after submit) —
-  the caller owns the row layout up to that boundary, spacers included.
+  `CommentComposer`'s `leadingActions` slot when submit is the row's last
+  action (the issue views); a surface whose right-slot action is itself a
+  primary (Approve / Review… on the PR views) keeps it in `actions`, which
+  renders after submit — the caller owns the row layout up to that boundary,
+  spacers included.
 - The AI-generate chord in a dialog goes through `useGenerateChord`
   (`src/lib/hotkeys/useGenerateChord.ts`) — never a hand-rolled handler. Its
   invariants: effective-binding read (null = fully inert), `eventToBinding`

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ PR badge.
   merge/rebase, and jump-to-PR.
 - **Local branch-protection rules**: naming, merge methods, require-PR, and
   force-push rules, shareable via a committed file or importable from
-  GitHub.
+  GitHub. A promotion-branches list marks pull requests from those branches
+  as promotions, so GitDesktop stops offering to update them from their
+  base.
 
 ### History
 
@@ -855,8 +857,10 @@ review via its subscription login. The full list is under
   app/OS/Tauri versions and the status of every CLI GitDesktop uses (git,
   the GitHub & GitLab CLIs, Claude Code, Codex): installed?, version,
   resolved path, and sign-in state, with an Install link for anything
-  that's missing. It also shows a live readout of the window's current
-  position, size, and display (with copy-coords).
+  that's missing. A CLI that's installed but too old for a feature that
+  needs it (git, or the GitHub CLI) gets a warning naming the feature and
+  the version it wants, with an Update link. It also shows a live readout
+  of the window's current position, size, and display (with copy-coords).
 - **Window memory**: GitDesktop reopens at the size and position you left
   it, and maximized if it was, validated against your current monitors so
   an unplugged display can't strand it off-screen. Your layout is saved as

--- a/README.md
+++ b/README.md
@@ -662,7 +662,9 @@ priority, labels, and original/remaining estimates.
 
 Reconnect **GitHub** (`gh`'s device-code flow) and **GitLab**
 (`glab --web`) right from the not-signed-in panels, Settings → Accounts, or
-the palette; no dropping to a terminal (though it stays a fallback).
+the palette; no dropping to a terminal for github.com and gitlab.com (a
+self-managed GitLab host needs `glab auth login --hostname …` once, in a
+terminal).
 GitDesktop tells an **expired-or-revoked session** apart from
 never-signed-in and network blips, badges the affected account with
 one-click **Reconnect**, and **warns before a token lapses**: GitLab and

--- a/changelog.d/added-promotion-branches-setting.md
+++ b/changelog.d/added-promotion-branches-setting.md
@@ -1,0 +1,6 @@
+- **Branch rules** gains a **Promotion branches** list — name the branches whose
+  pull requests carry work onward, like `staging`, and GitDesktop stops offering
+  to update those pull requests from their base. It covers the
+  `staging` → `production` flows and upstream-lens pull requests the
+  default-branch detection can't see, and the strip names the head as a promotion
+  branch for this repository.

--- a/changelog.d/changed-cli-version-floor.md
+++ b/changelog.d/changed-cli-version-floor.md
@@ -1,0 +1,3 @@
+- **Settings → About** now flags a Git or GitHub CLI that's older than a feature
+  needs, naming what breaks and offering the download link; opening an issue with
+  an outdated GitHub CLI explains that too, instead of failing with raw CLI output.

--- a/changelog.d/changed-cli-version-floor.md
+++ b/changelog.d/changed-cli-version-floor.md
@@ -1,3 +1,3 @@
 - **Settings → About** now flags a Git or GitHub CLI that's older than a feature
   needs, naming what breaks and offering the download link; opening an issue with
-  an outdated GitHub CLI explains that too, instead of failing with raw CLI output.
+  an outdated GitHub CLI now says which version it needs.

--- a/changelog.d/changed-destructive-confirms.md
+++ b/changelog.d/changed-destructive-confirms.md
@@ -1,0 +1,6 @@
+- Reverting, cherry-picking, checking out a commit or a tag, taking a whole side
+  of a conflicted file, and applying or popping a stash from the **Stashes**
+  dialog now confirm first, each naming exactly what changes and what stays
+  safe. Undoing a branch's first commit confirms too, since that one deletes the
+  branch's ref instead of moving it back. The **Change base of…** and rebase
+  dialogs now say up front that the commits they replay get new ids.

--- a/changelog.d/changed-issue-composer-layout.md
+++ b/changelog.d/changed-issue-composer-layout.md
@@ -1,7 +1,7 @@
 - The issue view's comment box now spans the full width beneath the sidebar,
   matching pull requests and discussions, and **Comment** sits at the
   bottom-right where a form's submit is looked for, with close and reopen to its
-  left. The same widening applies to Jira issues, and a new palette action,
-  **Focus the comment box**, jumps straight to it. Closing an issue, pull
-  request, or discussion on your forge now asks first, since watchers are
-  notified and reopening can't unsend that.
+  left. The same widening applies to Jira issues. A new palette action, **Focus
+  the comment box**, jumps to the comment box on any conversation view. Closing
+  an issue, pull request, or discussion on your forge now asks first, since
+  watchers are notified and reopening can't unsend that.

--- a/changelog.d/changed-issue-composer-layout.md
+++ b/changelog.d/changed-issue-composer-layout.md
@@ -1,0 +1,7 @@
+- The issue view's comment box now spans the full width beneath the sidebar,
+  matching pull requests and discussions, and **Comment** sits at the
+  bottom-right where a form's submit is looked for, with close and reopen to its
+  left. The same widening applies to Jira issues, and a new palette action,
+  **Focus the comment box**, jumps straight to it. Closing an issue, pull
+  request, or discussion on your forge now asks first, since watchers are
+  notified and reopening can't unsend that.

--- a/changelog.d/fixed-explore-fork-gh-flag.md
+++ b/changelog.d/fixed-explore-fork-gh-flag.md
@@ -1,0 +1,3 @@
+- Forking a repository from the Explore tab works on GitHub again. Newer
+  GitHub CLI releases (2.88 and up) reject a flag the app passed, so forking
+  by name failed immediately.

--- a/changelog.d/fixed-explore-fork-gh-flag.md
+++ b/changelog.d/fixed-explore-fork-gh-flag.md
@@ -1,3 +1,2 @@
-- Forking a repository from the Explore tab works on GitHub again. Newer
-  GitHub CLI releases (2.88 and up) reject a flag the app passed, so forking
-  by name failed immediately.
+- Forking a repository from the Explore tab works with GitHub CLI 2.88 and
+  newer.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -238,6 +238,10 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Forges & trackers",
+    label: "Self-managed GitLab — any host glab is signed in to",
+  },
+  {
+    group: "Forges & trackers",
     label: "Multiple accounts, switch the active one per host",
   },
   {
@@ -420,6 +424,10 @@ export const capabilities: Capability[] = [
     label: "Edit the Sponsor button (.github/FUNDING.yml)",
   },
   { group: "Admin & settings", label: "Branch-protection rules, locally" },
+  {
+    group: "Admin & settings",
+    label: "Promotion branches — no Update-branch on staging→production PRs",
+  },
   {
     group: "Admin & settings",
     label: "Git hooks manager — husky / pre-commit / lefthook aware",

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -971,9 +971,17 @@ pub async fn search_repos(query: &str, sort: &str, page: u32) -> AppResult<Forge
     })
 }
 
+/// Argv for forking `source` (an `owner/name` nwo) without touching the caller's
+/// working copy. `--clone=false` skips the non-TTY clone prompt; no `--remote` flag
+/// may ever join it — gh 2.88+ rejects `--remote`/`--remote-name` alongside a
+/// repository argument at parse time, before any network call (cli/cli#12375).
+fn fork_args(source: &str) -> Vec<&str> {
+    vec!["repo", "fork", source, "--clone=false"]
+}
+
 /// Fork a GitHub repo by `owner/name` into the caller's account. Idempotent: an
 /// existing fork makes `gh repo fork` exit 0 with an "already exists" note, which we
-/// treat as success. `--clone=false --remote=false` skips the non-TTY clone prompt.
+/// treat as success.
 /// Resolves the real fork nwo with PARENT VERIFICATION (GitHub renames on a
 /// name-collision — `login/name` may be an unrelated pre-existing repo, and the real
 /// fork is `login/name-1`), then polls the fork's commits until it's cloneable
@@ -982,12 +990,7 @@ pub async fn fork_repo(owner: &str, name: &str) -> AppResult<ForgeForkResult> {
     validate_owner(owner)?;
     validate_repo_name(name)?;
     let source = format!("{owner}/{name}");
-    run_gh(
-        None,
-        &["repo", "fork", &source, "--clone=false", "--remote=false"],
-        GH_NETWORK_TIMEOUT,
-    )
-    .await?;
+    run_gh(None, &fork_args(&source), GH_NETWORK_TIMEOUT).await?;
     // The fork owner is the signed-in user.
     let login = run_gh(None, &["api", "user", "-q", ".login"], GH_TIMEOUT)
         .await?
@@ -1208,6 +1211,14 @@ mod tests {
         assert!(!gh_stderr_is_404("HTTP 401: Bad credentials"));
         assert!(!gh_stderr_is_404("HTTP 500: Internal Server Error"));
         assert!(!gh_stderr_is_404(""));
+    }
+
+    #[test]
+    fn fork_args_pin_the_argv_without_any_remote_flag() {
+        assert_eq!(fork_args("o/r"), vec!["repo", "fork", "o/r", "--clone=false"]);
+        // gh 2.88+ makes --remote/--remote-name a parse error next to a repo
+        // argument, so no --remote flag may ever join this argv.
+        assert!(!fork_args("o/r").iter().any(|a| a.starts_with("--remote")));
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -31,8 +31,8 @@ use crate::github::pr::{
 use crate::github::release::{ReleaseAsset, ReleaseDetails, ReleaseInfo};
 use crate::state::AppState;
 
-/// GitLab via the `glab` CLI. Carries the repo's host (gitlab.com today; a
-/// self-managed host list arrives with the Settings → Accounts work).
+/// GitLab via the `glab` CLI. Carries the repo's resolved host — gitlab.com or any
+/// self-managed host glab is signed in to (detected via `forge::glab::known_hosts`).
 pub struct GitLabForge {
     host: String,
 }

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -8,7 +8,7 @@
 
 use tauri::State;
 
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::git::branches::validate_ref_name;
 use crate::git::remote::run_git_with_creds_once;
 use crate::git::runner::{run_git, run_git_raw, GitOutput, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
@@ -63,41 +63,47 @@ async fn autostash_pop(repo: &str) -> AppResult<GitOutput> {
     run_git_raw(Some(repo), &["stash", "pop"], DEFAULT_TIMEOUT).await
 }
 
-/// Shapes a non-zero raw result for the no-stash arm, which reports the plain
-/// command's own failures — so the shaping has to match what those cores now do.
-/// Merge and pull both carry their stdout report into the error (`git_merge_core`,
-/// `run_git_mutating_with_creds`), and the parity tests below pin that. Switch is
-/// the exception in the other direction: a FAILING `git switch` emits no stdout at
-/// all (measured across its refusal modes — stdout there is success-path chatter),
-/// so the combined shaping is identical to stderr alone for it.
-fn git_error(out: GitOutput) -> AppError {
-    AppError::Git {
-        code: out.code,
-        stderr: out.full_failure_text(),
-    }
-}
-
 /// Turns the inner op's result into an outcome, unwinding the autostash when it can
 /// be unwound safely. Never errors on a failed pop — the retained stash is the
 /// user's safety net, and reporting it is the whole point of the outcome enum.
+///
+/// `op_name` is the paused operation the no-stash arm reports — `classify_failure`'s
+/// closed set, spelled as the matching plain core spells it.
 async fn settle(
     repo: &str,
+    op_name: &str,
     stashed: bool,
     reapply: bool,
     op: AppResult<GitOutput>,
 ) -> AppResult<AutostashOutcome> {
-    // Nothing was stashed, so there is nothing to unwind: behave like the plain command.
+    // Nothing was stashed, so there is nothing to unwind: behave like the plain
+    // command, structured error included — the same failure must not report as a
+    // conflict through one entry point and as prose through the other.
     if !stashed {
         let out = op?;
         if out.code != 0 {
-            return Err(git_error(out));
+            // The baseline is empty because every compound refuses mid-op BEFORE
+            // stashing, so nothing was unmerged when the op started (`op_continue`
+            // passes an empty one for its own reason). `full_failure_text` because
+            // merge and pull both carry half their report on stdout, which the
+            // parity tests below pin; switch is the exception in the other direction
+            // — a FAILING `git switch` emits no stdout at all (measured across its
+            // refusal modes), so the combined text is identical to stderr alone.
+            return Err(crate::git::ops::classify_failure(
+                repo,
+                op_name,
+                &[],
+                out.code,
+                out.full_failure_text(),
+            )
+            .await);
         }
         return Ok(AutostashOutcome::NothingStashed);
     }
 
     let failure = match &op {
         Ok(out) if out.code == 0 => None,
-        // Combined, matching the no-stash arm's `git_error` and the plain cores:
+        // Combined, matching the no-stash arm and the plain cores:
         // a substitution reports a conflicted pull's fetch summary alone and says
         // nothing about the conflict, so the stashed and unstashed paths would
         // disagree on the same failure.
@@ -169,6 +175,10 @@ pub(crate) async fn git_pull_autostash_core(
         "merge" => "--no-rebase",
         _ => "--ff-only",
     };
+    // Same label as `git_pull_core`: the operation a conflicted pull pauses is the
+    // mode it RAN. A refused `--ff-only` leaves nothing unmerged, so its label
+    // never surfaces.
+    let paused = if mode == "rebase" { "rebase" } else { "merge" };
     // A read that shells out to git itself — resolve it BEFORE taking the lock.
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
 
@@ -178,7 +188,7 @@ pub(crate) async fn git_pull_autostash_core(
 
     let stashed = autostash_push(&repo_path).await?;
     let op = run_git_with_creds_once(&repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await;
-    settle(&repo_path, stashed, true, op).await
+    settle(&repo_path, paused, stashed, true, op).await
 }
 
 /// Merge `branch` into the current one with the uncommitted changes stashed across
@@ -210,7 +220,7 @@ pub(crate) async fn git_merge_autostash_core(
         DEFAULT_TIMEOUT,
     )
     .await;
-    settle(&repo_path, stashed, true, op).await
+    settle(&repo_path, "merge", stashed, true, op).await
 }
 
 /// Rebase the current branch onto `branch` with the uncommitted changes stashed
@@ -247,7 +257,7 @@ pub(crate) async fn git_rebase_autostash_core(
         DEFAULT_TIMEOUT,
     )
     .await;
-    settle(&repo_path, stashed, true, op).await
+    settle(&repo_path, "rebase", stashed, true, op).await
 }
 
 /// `git rebase --onto <new_base> <old_base>` — replaying only `old_base..HEAD`
@@ -290,7 +300,7 @@ pub(crate) async fn git_rebase_onto_autostash_core(
         DEFAULT_TIMEOUT,
     )
     .await;
-    settle(&repo_path, stashed, true, op).await
+    settle(&repo_path, "rebase", stashed, true, op).await
 }
 
 /// Switch branches with the uncommitted changes stashed across the switch, and
@@ -330,12 +340,18 @@ pub(crate) async fn git_switch_autostash_core(
         None => vec!["switch", &name],
     };
     let op = run_git_raw(Some(&repo_path), &args, DEFAULT_TIMEOUT).await;
-    settle(&repo_path, stashed, reapply, op).await
+    // Unreachable as a label: a refused `git switch` leaves nothing unmerged, so
+    // `classify_failure` always answers with a plain git error here. "merge" is the
+    // closed set's spelling for the only way a checkout could ever pause one.
+    settle(&repo_path, "merge", stashed, reapply, op).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Test-only import: the module's own code shapes every failure through
+    // `classify_failure`, so only the error assertions name the enum.
+    use crate::error::AppError;
 
     async fn git(repo: &str, args: &[&str]) -> String {
         run_git(Some(repo), args, DEFAULT_TIMEOUT)
@@ -1417,7 +1433,7 @@ mod tests {
         )
         .await;
 
-        let outcome = settle(&repo, true, true, op).await.unwrap();
+        let outcome = settle(&repo, "merge", true, true, op).await.unwrap();
         assert!(
             matches!(
                 outcome,
@@ -1443,7 +1459,7 @@ mod tests {
         write(dir.path(), "u.txt", "other\n");
         let op = run_git_raw(Some(&repo), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT).await;
 
-        let outcome = settle(&repo, true, true, op).await.unwrap();
+        let outcome = settle(&repo, "merge", true, true, op).await.unwrap();
         assert!(
             matches!(
                 outcome,
@@ -1503,10 +1519,9 @@ mod tests {
     /// Pull has its own arm below (a different stream split); switch never will,
     /// since a failing `git switch` writes no stdout to lose.
     ///
-    /// The parity is over git's TEXT, not the variant: the plain core names the
-    /// paused operation structurally while this compound reports its own outcome
-    /// enum and shapes the no-stash arm as a plain git error, which the frontend's
-    /// prose markers still classify identically.
+    /// The parity covers the VARIANT as well as git's text: both sides name the
+    /// paused operation structurally, so the frontend cannot tell which entry
+    /// point produced the error.
     #[tokio::test]
     async fn a_conflict_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, repo) = setup_with_feat("plain-parity-conflict").await;
@@ -1535,18 +1550,24 @@ mod tests {
 
         match (&compound, &plain) {
             (
-                AppError::Git { stderr: a_err, .. },
                 AppError::Conflict {
-                    op,
-                    paths,
+                    op: a_op,
+                    paths: a_paths,
+                    report: a_err,
+                },
+                AppError::Conflict {
+                    op: b_op,
+                    paths: b_paths,
                     report: b_err,
                 },
             ) => {
                 assert_eq!(a_err, b_err);
-                assert_eq!(op, "merge");
-                assert_eq!(paths, &vec!["a.txt".to_string()]);
+                assert_eq!(a_op, b_op);
+                assert_eq!(a_op, "merge");
+                assert_eq!(a_paths, b_paths);
+                assert_eq!(a_paths, &vec!["a.txt".to_string()]);
                 // Mirrors the frontend's anchored CONFLICT_MARKERS: without the
-                // stdout backfill both sides carry an empty stderr instead, which
+                // stdout backfill both sides carry an empty report instead, which
                 // renders as "git exited with code 1".
                 assert!(
                     a_err.lines().any(|l| l.starts_with("CONFLICT (")),
@@ -1557,15 +1578,15 @@ mod tests {
                     "and the verdict line that names it a merge: {a_err}"
                 );
             }
-            other => panic!("expected a git error and a conflict, got {other:?}"),
+            other => panic!("expected two conflicts, got {other:?}"),
         }
     }
 
     /// Pull's version of the same parity, on the split that hides the loss: the
     /// fetch summary fills stderr while the merge verdict rides stdout, so an
     /// error carrying stderr alone looks populated and still says nothing about
-    /// the conflict. Both sides must carry the whole report, identically — the
-    /// plain core additionally naming the operation it paused.
+    /// the conflict. Both sides must carry the whole report, identically, and both
+    /// must name the operation they paused.
     #[tokio::test]
     async fn a_conflicted_pull_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, work, clone) = setup_clone("pull-parity-conflict").await;
@@ -1609,16 +1630,22 @@ mod tests {
 
         match (&compound, &plain) {
             (
-                AppError::Git { stderr: a_err, .. },
                 AppError::Conflict {
-                    op,
-                    paths,
+                    op: a_op,
+                    paths: a_paths,
+                    report: a_err,
+                },
+                AppError::Conflict {
+                    op: b_op,
+                    paths: b_paths,
                     report: b_err,
                 },
             ) => {
                 assert_eq!(a_err, b_err);
-                assert_eq!(op, "merge", "a merge-mode pull pauses a merge");
-                assert_eq!(paths, &vec!["a.txt".to_string()]);
+                assert_eq!(a_op, b_op);
+                assert_eq!(a_op, "merge", "a merge-mode pull pauses a merge");
+                assert_eq!(a_paths, b_paths);
+                assert_eq!(a_paths, &vec!["a.txt".to_string()]);
                 assert!(
                     a_err.lines().any(|l| l.starts_with("CONFLICT (")),
                     "the conflict line must reach the frontend: {a_err}"
@@ -1628,7 +1655,7 @@ mod tests {
                     "and the verdict line that names it a merge: {a_err}"
                 );
             }
-            other => panic!("expected a git error and a conflict, got {other:?}"),
+            other => panic!("expected two conflicts, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -32,6 +32,28 @@ fn map_issues_disabled(err: AppError) -> AppError {
     }
 }
 
+/// Whether a gh failure is the "this gh doesn't know that `--json` field" error.
+/// gh validates the field list against its own build before calling the API and
+/// prints `Unknown JSON field: "issueType"` (measured on gh 2.94.0); match the
+/// stable substring case-insensitively like the disabled-issues signature.
+fn is_unknown_json_field(stderr: &str) -> bool {
+    stderr.to_ascii_lowercase().contains("unknown json field")
+}
+
+/// Remaps that failure to the version floor it really means, leaving every other
+/// error untouched: [`ISSUE_VIEW_FIELDS`] asks for `issueType`, which gh's field
+/// list gained at v2.94.0, so an older gh rejects the whole read with a dump.
+fn map_gh_too_old(err: AppError) -> AppError {
+    match &err {
+        AppError::Gh(msg) if is_unknown_json_field(msg) => AppError::Gh(
+            "Opening issues needs GitHub CLI 2.94 or newer — this gh doesn't know the fields \
+             GitDesktop requests. Update gh, then retry."
+                .into(),
+        ),
+        _ => err,
+    }
+}
+
 /// An org-defined issue type (Bug/Feature/Task/…). `color` is a GitHub color
 /// NAME (GRAY/BLUE/GREEN/…), mapped to a swatch on the frontend.
 #[derive(Serialize, Deserialize, Clone)]
@@ -286,8 +308,9 @@ pub async fn gh_issue_view(
         run_gh(Some(&repo_path), &view_args, GH_TIMEOUT),
         run_gh(Some(&repo_path), &lock_args, GH_TIMEOUT),
     );
-    // Same disabled-issues remap as `gh_issue_list`.
-    let out = view_res.map_err(map_issues_disabled)?;
+    // Same disabled-issues remap as `gh_issue_list`, plus the version-floor remap:
+    // this read requests fields older gh builds don't have.
+    let out = view_res.map_err(map_issues_disabled).map_err(map_gh_too_old)?;
     let raw: RawIssue = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh issue view: {e}")))?;
     // Best-effort: a failed lock lookup just leaves the issue shown as unlocked.
@@ -1343,7 +1366,8 @@ pub fn read_issue_templates(repo_path: String) -> AppResult<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_issues_disabled;
+    use super::{is_issues_disabled, map_gh_too_old};
+    use crate::error::AppError;
 
     #[test]
     fn detects_the_disabled_issues_signature() {
@@ -1363,6 +1387,41 @@ mod tests {
         ));
         assert!(!is_issues_disabled(
             "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable"
+        ));
+    }
+
+    #[test]
+    fn maps_an_unknown_field_failure_to_the_gh_version_floor() {
+        // gh's own output shape: the rejected field, then its known field list.
+        let err = map_gh_too_old(AppError::Gh(
+            "Unknown JSON field: \"issueType\"\nAvailable fields:\n  assignees\n  author".into(),
+        ));
+        let AppError::Gh(msg) = err else {
+            panic!("expected the Gh variant");
+        };
+        assert_eq!(
+            msg,
+            "Opening issues needs GitHub CLI 2.94 or newer — this gh doesn't know the fields \
+             GitDesktop requests. Update gh, then retry."
+        );
+    }
+
+    #[test]
+    fn leaves_unrelated_view_failures_unchanged() {
+        let err = map_gh_too_old(AppError::Gh(
+            "GraphQL: Could not resolve to an Issue with the number 999.".into(),
+        ));
+        let AppError::Gh(msg) = err else {
+            panic!("expected the Gh variant");
+        };
+        assert_eq!(
+            msg,
+            "GraphQL: Could not resolve to an Issue with the number 999."
+        );
+        // Errors already classified upstream pass through untouched.
+        assert!(matches!(
+            map_gh_too_old(AppError::IssuesDisabled),
+            AppError::IssuesDisabled
         ));
     }
 }

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -43,6 +43,9 @@ fn is_unknown_json_field(stderr: &str) -> bool {
 /// Remaps that failure to the version floor it really means, leaving every other
 /// error untouched: [`ISSUE_VIEW_FIELDS`] asks for `issueType`, which gh's field
 /// list gained at v2.94.0, so an older gh rejects the whole read with a dump.
+/// The matcher fires on ANY unknown `--json` field while the message names the
+/// 2.94 floor — the same floor `CLI_FLOORS` spells in src/lib/system/health.ts;
+/// a bump moves both strings.
 fn map_gh_too_old(err: AppError) -> AppError {
     match &err {
         AppError::Gh(msg) if is_unknown_json_field(msg) => AppError::Gh(

--- a/src/features/branch-rules/BranchRulesDialog.tsx
+++ b/src/features/branch-rules/BranchRulesDialog.tsx
@@ -63,6 +63,10 @@ export function BranchRulesDialog({
   const patternInputId = useId();
   const hintInputId = useId();
   const testNameInputId = useId();
+  // Keyed by row position, like the list itself — Add and Remove hand focus to a
+  // neighbour rather than dropping it to the body.
+  const promotionRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const addPromotionRef = useRef<HTMLButtonElement>(null);
 
   const active = scope === "shared" ? shared : personal;
   const saving = scope === "shared" ? saveShared : savePersonal;
@@ -141,6 +145,43 @@ export function BranchRulesDialog({
     }));
   }
 
+  // Promotion branches are bare patterns with no per-entry settings, so they're
+  // edited by position rather than by an id the way protections are. Focus follows
+  // the edit — deferred to after the re-render, since the row being focused doesn't
+  // exist (or has shifted) until then.
+  function addPromotionBranch() {
+    const next = draft.promotionBranches.length;
+    setDraft((d) => ({
+      ...d,
+      promotionBranches: [...d.promotionBranches, ""],
+    }));
+    requestAnimationFrame(() => promotionRefs.current[next]?.focus());
+  }
+
+  function updatePromotionBranch(index: number, pattern: string) {
+    setDraft((d) => ({
+      ...d,
+      promotionBranches: d.promotionBranches.map((p, i) =>
+        i === index ? pattern : p,
+      ),
+    }));
+  }
+
+  function removePromotionBranch(index: number) {
+    const emptied = draft.promotionBranches.length === 1;
+    setDraft((d) => ({
+      ...d,
+      promotionBranches: d.promotionBranches.filter((_, i) => i !== index),
+    }));
+    // The survivors shift down one, so index-1 IS the row above — and index 0 lands
+    // on whichever row took its place. With none left, Add is the nearest control
+    // that outlives the removal.
+    requestAnimationFrame(() => {
+      if (emptied) addPromotionRef.current?.focus();
+      else promotionRefs.current[Math.max(0, index - 1)]?.focus();
+    });
+  }
+
   // Pulls GitHub's branch protection rules into the draft (deduped by pattern),
   // for the user to review and save. Read-only against GitHub.
   async function importFromGitHub() {
@@ -184,6 +225,7 @@ export function BranchRulesDialog({
     });
   }
 
+  const promotionBranches = draft.promotionBranches;
   const namePattern = draft.naming.pattern.trim();
   const testMatches = namePattern !== "" && matchesGlob(namePattern, testName);
 
@@ -418,6 +460,61 @@ export function BranchRulesDialog({
                             ))}
                           </div>
                         </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              <section className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-xs font-medium">Promotion branches</h3>
+                  <Button
+                    ref={addPromotionRef}
+                    variant="outline"
+                    size="xs"
+                    onClick={addPromotionBranch}
+                  >
+                    <PlusIcon data-icon="inline-start" />
+                    Add
+                  </Button>
+                </div>
+                {promotionBranches.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No promotion branches. Add a pattern (e.g.{" "}
+                    <span className="font-mono">staging</span> or{" "}
+                    <span className="font-mono">release/*</span>) to mark pull
+                    requests from that branch as promotions — GitDesktop won't
+                    offer to update them from their base.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {promotionBranches.map((pattern, i) => (
+                      // Position IS the identity here: the entries are bare
+                      // strings, so two blank rows would share any value-derived
+                      // key. The inputs stay controlled from the array, so a
+                      // removal re-renders the survivors correctly.
+                      <div key={i} className="flex items-center gap-2">
+                        <Input
+                          ref={(el) => {
+                            promotionRefs.current[i] = el;
+                          }}
+                          value={pattern}
+                          onChange={(e) =>
+                            updatePromotionBranch(i, e.target.value)
+                          }
+                          placeholder="staging"
+                          className="font-mono"
+                          aria-label={`Promotion branch pattern ${i + 1}`}
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          aria-label={`Remove promotion branch ${pattern || i + 1}`}
+                          onClick={() => removePromotionBranch(i)}
+                        >
+                          <TrashIcon />
+                        </Button>
                       </div>
                     ))}
                   </div>

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -10,8 +10,8 @@ import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
  * The bottom "leave a comment" bar every conversation surface ends with. Fully
  * controlled: the draft lives in CALLER state, keyed there per entity so a
  * switch retains it, which a composer-owned draft could not do. Per-surface
- * extras (Approve, Close, Review…) ride the `actions` slot rather than growing
- * the prop list.
+ * extras (Approve, Close, Review…) ride the `actions`/`leadingActions` slots
+ * rather than growing the prop list.
  */
 export function CommentComposer({
   ref,
@@ -26,6 +26,7 @@ export function CommentComposer({
   reason,
   disabled,
   actions,
+  leadingActions,
 }: {
   /** The editor handle, so a caller can focus/fill the box from elsewhere
    *  (quote reply). */
@@ -48,6 +49,10 @@ export function CommentComposer({
   disabled?: boolean;
   /** Extra buttons rendered after submit, before Clear. */
   actions?: ReactNode;
+  /** Extra buttons rendered before submit — for a surface whose submit is not
+   *  the row's first action. Everything up to that boundary is the caller's to
+   *  lay out, spacers included. */
+  leadingActions?: ReactNode;
 }) {
   const hasDraft = value.trim().length > 0;
   // Only the `busy` hold gets words: an empty draft explains itself, and a reason
@@ -75,6 +80,7 @@ export function CommentComposer({
         textareaClassName="max-h-32 min-h-12 resize-y"
       />
       <div className="flex items-center gap-2">
+        {leadingActions}
         <DisabledReasonButton
           variant="outline"
           size="sm"

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -258,7 +258,10 @@ export function DiscussionView({
   useHotkeyAction(
     "focus-comment",
     () => composerRef.current?.focus(),
-    selectedDiscussion?.number === number && !!d && !details.isError,
+    selectedDiscussion?.number === number &&
+      !!d &&
+      !details.isPlaceholderData &&
+      !details.isError,
   );
 
   if (details.isPending) {

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/lib/git/queries";
 import type { PrThreadOut } from "@/lib/git/types";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError, toastErrorWithNote } from "@/lib/toast";
@@ -456,6 +457,16 @@ export function DiscussionView({
     // Captured before the await: posting clears the draft, and the error arm
     // below has to know a comment already went out.
     const withComment = draftRidesStateChange;
+    // Ahead of the riding draft: a cancelled confirm must leave the comment
+    // unposted.
+    const ok = await useConfirm.getState().ask({
+      title: `Close discussion #${d.number}?`,
+      body: `Everyone watching is notified and the discussion leaves the open list. Reopening puts it back, but the notification can't be unsent.${
+        withComment ? " Your draft posts as a comment first." : ""
+      }`,
+      confirmLabel: withComment ? "Close with comment" : "Close discussion",
+    });
+    if (!ok) return;
     if (!(await postRidingDraft(d.id))) return;
     closeDiscussion.mutate(
       { discussionId: d.id, reason },

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/lib/git/queries";
 import type { PrThreadOut } from "@/lib/git/types";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
@@ -220,6 +221,7 @@ export function DiscussionView({
   const setRepoTab = useUiStore((s) => s.setRepoTab);
   const setPendingIssueDraft = useUiStore((s) => s.setPendingIssueDraft);
   const selectDiscussion = useUiStore((s) => s.selectDiscussion);
+  const selectedDiscussion = useUiStore((s) => s.selectedDiscussion);
 
   const composerRef = useRef<MarkdownEditorHandle>(null);
   const [deletingCommentId, setDeletingCommentId] = useState<string | null>(
@@ -249,6 +251,15 @@ export function DiscussionView({
 
   const onError = (e: unknown) => toastError(e);
   const d = details.data;
+
+  // The palette's route to the comment box, so reaching it never depends on
+  // tabbing the whole thread. Only the view that owns the selection answers —
+  // the mounted one lags it through a switch.
+  useHotkeyAction(
+    "focus-comment",
+    () => composerRef.current?.focus(),
+    selectedDiscussion?.number === number && !!d && !details.isError,
+  );
 
   if (details.isPending) {
     return (

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -557,8 +557,10 @@ deletion, allowed merge methods, require-PR, and force-push blocking. They're en
 inside the app, can be shared with your team via a committed file, and can be imported
 from a repo's GitHub branch-protection rules. The same dialog keeps a **Promotion
 branches** list: a pull request from a branch you name there carries work onward rather
-than catching up, so GitDesktop stops offering to update it from its base. (For
-server-side enforcement, use **Rules** in *Repository settings*.)
+than catching up, so GitDesktop stops offering to update it from its base. That applies
+to the repository's own pull requests — one from a fork keeps the update offer even if
+its branch shares the name. (For server-side enforcement, use **Rules** in *Repository
+settings*.)
 
 ## Worktrees
 
@@ -868,11 +870,12 @@ a mergeability answer the app couldn't read. **Update pull request branch** is i
 command palette ({{kbd:command-palette}}) too — no default shortcut, so give it one in
 **Settings → Keyboard**.
 
-One exception: on a **promotion** pull request (one whose head is the repository's
-default branch, like \`main\` → \`staging\`, or a branch you've listed under
-**Promotion branches** in *Branch rules*, like \`staging\` → \`production\`) the gap
-is expected and doesn't need closing, so the strip says so and **Update branch** is
-withheld — it would merge the base back into the head.
+One exception: on a **promotion** pull request from this repository's own branches
+(one whose head is the repository's default branch on the origin view, like
+\`main\` → \`staging\`, or a branch you've listed under **Promotion branches** in
+*Branch rules*, like \`staging\` → \`production\`) the gap is expected and doesn't
+need closing, so the strip says so and **Update branch** is withheld — it would
+merge the base back into the head.
 
 ## Blocked by branch protection
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -759,7 +759,8 @@ excludes the PR author, whom GitHub won't let you request), flip a PR between
 **Convert to draft** pair, also reachable from the command palette),
 **merge** (merge commit, squash, or rebase, with optional branch deletion), and **close**.
 Closing asks first: everyone watching is notified, and reopening puts the pull request
-back but can't unsend that.
+back but can't unsend that. The command palette's **Focus the comment box** jumps
+straight to the composer here too.
 Reviewers who've already reviewed show as read-only chips carrying their verdict — a check
 for **approved**, an X for **requested changes**, a speech bubble for **commented** (icon
 shape plus the word, never color alone) — so a finished review (including Copilot's) stays
@@ -1430,7 +1431,7 @@ part in GitHub Discussions for the repo. (Discussions must be enabled on the rep
   **reopen**, **lock**, and **delete**. Closing or reopening posts your drafted comment
   alongside, and the menu item says so while a draft is waiting. Closing asks first:
   everyone watching is notified, and reopening puts the discussion back but can't
-  unsend that.
+  unsend that. The command palette's **Focus the comment box** works here too.
 - **Create a discussion**, or **create an issue from a discussion** when a thread turns
   into actionable work (the new issue links back to it).`,
   },

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -354,7 +354,8 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
 {{ai}}- **Generate with AI** ({{kbd:generate-commit-message}}) — write the summary and
   description from your staged diff (see *AI & automations*).
 {{/ai}}- After committing, **Undo** ({{kbd:undo-commit}}) reverses the last commit and
-  returns your message to the box.
+  returns your message to the box. Undoing a branch's *first* commit asks first —
+  it has no parent to fall back to, so the branch ref goes with it.
 
 > Discarding an **untracked** file moves it to the recycle bin, so it's recoverable —
 > it isn't deleted outright.`,
@@ -374,8 +375,10 @@ selection to compare a range.
 {{Secondaryclick}} a commit (or use the commit detail view) for:
 
 - **Amend** the most recent commit (reword, or fold in staged changes).
-- **Revert** — create a new commit that undoes a commit's changes.
-- **Cherry-pick** a commit onto the current branch, or **Cherry-pick to branch…** to copy
+- **Revert** — create a new commit that undoes a commit's changes. It asks first, and
+  says that history keeps both commits.
+- **Cherry-pick** a commit onto the current branch (it asks first, and says where the
+  copy lands), or **Cherry-pick to branch…** to copy
   it (or a multi-selection) onto another branch and switch to it. A single commit that
   conflicts pauses on the destination branch so you can resolve it and continue; a
   multi-commit batch rolls back automatically on any failure.
@@ -391,7 +394,8 @@ selection to compare a range.
   amend it in the **Changes** tab (stage and commit/amend as usual), then **Continue** from the
   banner there. A quick **Squash N commits…** is also on the context menu when you select
   adjacent commits.
-- **Create a branch** or **create a tag** at a commit, **check out** a commit, or copy
+- **Create a branch** or **create a tag** at a commit, **check out** a commit (it asks
+  first and explains the detached HEAD you land in), or copy
   its SHA.
 
 ## Commit comments
@@ -512,9 +516,10 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 ## Stash
 
 **Stash all changes** ({{kbd:stash-all}}) sets your working changes aside; **View
-stashes** lists them to apply, pop, or drop, and **Pop latest stash** restores the most
-recent. Setting changes aside is refused while conflicts are still unresolved, or while a
-merge, rebase, cherry-pick or revert is in progress — finish or abort it first, so a
+stashes** lists them to apply, pop, or drop (each asks first, and the apply and pop
+prompts say whether the stash stays in the list afterwards), and **Pop latest stash**
+restores the most recent. Setting changes aside is refused while conflicts are still
+unresolved, or while a merge, rebase, cherry-pick or revert is in progress — finish or abort it first, so a
 resolution you've already staged can't be swept out of the operation.
 
 **Recover lost work** (in the branch ⋮ menu, or the command palette) opens the
@@ -550,8 +555,10 @@ straight to opening a pull request.
 **Branch rules…** (in the ⋮ menu) sets local protections — naming patterns, blocked
 deletion, allowed merge methods, require-PR, and force-push blocking. They're enforced
 inside the app, can be shared with your team via a committed file, and can be imported
-from a repo's GitHub branch-protection rules. (For server-side enforcement, use **Rules**
-in *Repository settings*.)
+from a repo's GitHub branch-protection rules. The same dialog keeps a **Promotion
+branches** list: a pull request from a branch you name there carries work onward rather
+than catching up, so GitDesktop stops offering to update it from its base. (For
+server-side enforcement, use **Rules** in *Repository settings*.)
 
 ## Worktrees
 
@@ -686,7 +693,9 @@ that names it too (**Finish merge**, **Continue rebase**, **Continue cherry-pick
 **Continue revert**). Select a conflicted file (the \`!\` badge) to open the **conflict
 editor**: each conflict region shows **Current (ours)** over **Incoming (theirs)** with
 **Accept current**, **Accept incoming**, or **Accept both**, and the header adds whole-file
-**Accept all current** / **Accept all incoming** and **Open in editor**. Files mark
+**Accept all current** / **Accept all incoming** and **Open in editor**. Those whole-file
+accepts ask first, since taking a side replaces the file wholesale, conflict regions you
+already settled by hand included. Files mark
 themselves resolved as you go — the \`!\` badge clears — and the finish control stays
 disabled, saying so, until every conflict is resolved. When one side of a conflict removed
 a file, the editor names the removal instead of showing regions, and the same whole-file
@@ -749,6 +758,8 @@ excludes the PR author, whom GitHub won't let you request), flip a PR between
 **draft** and **ready for review** in either direction (a footer **Ready for review** /
 **Convert to draft** pair, also reachable from the command palette),
 **merge** (merge commit, squash, or rebase, with optional branch deletion), and **close**.
+Closing asks first: everyone watching is notified, and reopening puts the pull request
+back but can't unsend that.
 Reviewers who've already reviewed show as read-only chips carrying their verdict — a check
 for **approved**, an X for **requested changes**, a speech bubble for **commented** (icon
 shape plus the word, never color alone) — so a finished review (including Copilot's) stays
@@ -857,9 +868,10 @@ command palette ({{kbd:command-palette}}) too — no default shortcut, so give i
 **Settings → Keyboard**.
 
 One exception: on a **promotion** pull request (one whose head is the repository's
-default branch, like \`main\` → \`staging\`) the gap is expected and doesn't need
-closing, so the strip says so and **Update branch** is withheld — it would merge
-the base back into your default branch.
+default branch, like \`main\` → \`staging\`, or a branch you've listed under
+**Promotion branches** in *Branch rules*, like \`staging\` → \`production\`) the gap
+is expected and doesn't need closing, so the strip says so and **Update branch** is
+withheld — it would merge the base back into the head.
 
 ## Blocked by branch protection
 
@@ -1030,7 +1042,8 @@ Point the app at a **GitLab** repo and the same tab lists its **merge requests**
 closed/merged) next to any local PRs. Open one for the description, comments, commits, and a
 highlighted **diff** (with an **Open on GitLab** link) — and the GitLab MR writes:
 **comment** on it (and **edit** or **delete** your own comments), **close / reopen** it
-(posting your drafted comment alongside, as **request changes** does),
+(closing asks first; either way your drafted comment posts alongside, as
+**request changes** does),
 **edit** its title and description (and **retarget** its target branch),
 **approve / unapprove** it (a reviewer action,
 with the approval count shown inline), **request changes** (the blocking reviewer state —
@@ -1065,8 +1078,8 @@ Compare tab points you at an **existing open MR** from your branch instead of cr
 duplicate. GitLab uses the GitLab
 CLI (\`glab\`) — sign in once from **Settings → Accounts** (or the Pull Requests tab's
 sign-in button), or with \`glab auth login\` in a terminal; no tokens stored. **Self-managed
-GitLab works too**: sign \`glab\` in to your instance (from Accounts, or
-\`glab auth login --hostname …\`) and the app recognizes repositories on that host
+GitLab works too**: sign \`glab\` in to your instance (with \`glab auth login --hostname …\`
+in a terminal) and the app recognizes repositories on that host
 automatically. Its issues, CI pipelines, and
 releases work too (see their sections below).
 
@@ -1268,8 +1281,11 @@ GitLab actions are available.)
 Browse, filter, and open issues in a full view: body, comments, labels, assignees,
 milestone, and reactions. The **funnel** filter is the same searchable author/label
 popup as the PR list. **Create** an issue, comment with the Markdown editor, edit,
-add labels, **close / reopen** (posting your drafted comment alongside), **lock**, and
-**transfer** an issue to another repo.
+add labels, **close / reopen** (closing asks first; either way your drafted comment posts
+alongside), **lock**, and **transfer** an issue to another repo.
+The comment box sits at the bottom of the issue,
+past the side rail, and the command palette's **Focus the comment box** jumps straight
+to it — no default shortcut, so give it one in **Settings → Keyboard**.
 
 - **Sub-issues** — break an issue into a parent/child checklist with completion tracking.
 - **Dependencies** — link issues as blocked-by / blocking.
@@ -1302,7 +1318,8 @@ reads **Create in \<parent\>**.
 Point the app at a **GitLab** repo and the same tab lists its **issues** (open and closed)
 next to any local issues. Open one to read the description and comments — and the GitLab
 issue **writes**: **comment** on the issue (and **edit** or **delete** your own comments),
-**close / reopen** it (posting your drafted comment alongside), **edit** its title and
+**close / reopen** it (closing asks first; either way your drafted comment posts
+alongside), **edit** its title and
 description, **react** with emoji on the description and comments (GitLab's award emoji),
 and set its **assignees**, **labels**, and **milestone** right in the side
 rail. The rail also carries GitLab-unique fields: a **due date** (type a date and
@@ -1332,7 +1349,8 @@ ones. The open / closed / all filter maps to Jira's status **categories** — "T
 "In Progress" issues count as open, and anything in the **Done** category counts as closed
 — while each row still shows its real status name (e.g. *Selected for Development*,
 *In Review*, *Done*). Open an issue to read its **status**, **type**, **priority**,
-**assignee**, and **labels**, plus the Markdown **description** and **comments**. Every
+**assignee**, and **labels**, plus the Markdown **description** and **comments** — the
+command palette's **Focus the comment box** jumps to the composer here too. Every
 issue links out with **View in Jira**.
 
 When the project uses them, issues also show their **agile fields** — **story points** (both
@@ -1410,7 +1428,9 @@ part in GitHub Discussions for the repo. (Discussions must be enabled on the rep
   waiting on.
 - Manage a discussion's lifecycle: **close** (as resolved / outdated / duplicate),
   **reopen**, **lock**, and **delete**. Closing or reopening posts your drafted comment
-  alongside, and the menu item says so while a draft is waiting.
+  alongside, and the menu item says so while a draft is waiting. Closing asks first:
+  everyone watching is notified, and reopening puts the discussion back but can't
+  unsend that.
 - **Create a discussion**, or **create an issue from a discussion** when a thread turns
   into actionable work (the new issue links back to it).`,
   },
@@ -2265,7 +2285,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   terminal the detection doesn't know). These power the "Open in…" actions throughout the app.
 - **About** — app, OS, and component versions, a **health check** for your installed tools
   (Git, the GitHub / GitLab CLIs{{ai}}, and the Claude Code / Codex / Copilot / opencode
-  agents{{/ai}}), and the current window position.
+  agents{{/ai}}) that flags anything missing, or installed but older than a feature needs,
+  with a download link either way, and the current window position.
 
 ## Staying up to date
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2285,8 +2285,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   terminal the detection doesn't know). These power the "Open in…" actions throughout the app.
 - **About** — app, OS, and component versions, a **health check** for your installed tools
   (Git, the GitHub / GitLab CLIs{{ai}}, and the Claude Code / Codex / Copilot / opencode
-  agents{{/ai}}) that flags anything missing, or installed but older than a feature needs,
-  with a download link either way, and the current window position.
+  agents{{/ai}}) that flags anything missing (and warns when Git or the GitHub CLI is
+  older than a feature needs), with a download link either way, and the current window
+  position.
 
 ## Staying up to date
 

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -44,8 +44,14 @@ import {
 } from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { useConfirm } from "@/lib/stores/confirm";
 import { toastError } from "@/lib/toast";
 import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
+import {
+  checkoutCommitConfirm,
+  cherryPickCommitConfirm,
+  revertCommitConfirm,
+} from "./commit-confirms";
 import { FileRowActions } from "./FileRowActions";
 import { useAmendWithConfirm } from "./useAmendCommit";
 
@@ -231,6 +237,39 @@ export function CommitDetailView({
     }
   }
 
+  // Each of these asks before it runs, in the same words as the History list's
+  // menu. All three act on the `hash` PROP for the same reason `copyHash` does.
+  async function doCheckoutCommit() {
+    if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
+    checkoutCommit.mutate(hash, { onError });
+  }
+
+  async function doRevertCommit() {
+    if (!(await useConfirm.getState().ask(revertCommitConfirm(hash)))) return;
+    revertCommit.mutate(hash, { onError });
+  }
+
+  // No branch name: this view doesn't subscribe to repo status, and doing so for
+  // one prompt's wording would re-render the diff pane on every status poll.
+  async function doCherryPick() {
+    const ok = await useConfirm
+      .getState()
+      .ask(cherryPickCommitConfirm(hash, null));
+    if (!ok) return;
+    cherryPick.mutate(hash, {
+      onSuccess: (applied) => {
+        if (applied) {
+          toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
+        } else {
+          toast.info(
+            "Nothing to cherry-pick — these changes are already on this branch.",
+          );
+        }
+      },
+      onError,
+    });
+  }
+
   const fileList = files.data;
   // The comments pane's file jumps carry a FORGE-derived path (GitHub's patch),
   // but the sidebar + effectivePath guard come from LOCAL `useCommitFiles`. On a
@@ -328,32 +367,13 @@ export function CommitDetailView({
               >
                 Amend commit…
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => checkoutCommit.mutate(hash, { onError })}
-              >
+              <DropdownMenuItem onClick={doCheckoutCommit}>
                 Checkout commit
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => revertCommit.mutate(hash, { onError })}
-              >
+              <DropdownMenuItem onClick={doRevertCommit}>
                 Revert changes in commit
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() =>
-                  cherryPick.mutate(hash, {
-                    onSuccess: (applied) => {
-                      if (applied) {
-                        toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
-                      } else {
-                        toast.info(
-                          "Nothing to cherry-pick — these changes are already on this branch.",
-                        );
-                      }
-                    },
-                    onError,
-                  })
-                }
-              >
+              <DropdownMenuItem onClick={doCherryPick}>
                 Cherry-pick commit
               </DropdownMenuItem>
               <DropdownMenuSeparator />

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -32,7 +32,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
 import { copyText } from "@/lib/clipboard";
 import { useAppForm } from "@/lib/form";
-import { gitCommitDetails } from "@/lib/git/api";
+import { gitCommitDetails, gitRecentCommits } from "@/lib/git/api";
 import {
   useBranches,
   useCheckoutCommit,
@@ -55,10 +55,17 @@ import { sanitizeRefName } from "@/lib/git/ref-name";
 import type { CommitSummary, RewriteStep } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
+import {
+  checkoutCommitConfirm,
+  cherryPickCommitConfirm,
+  revertCommitConfirm,
+  UNDO_ROOT_COMMIT_CONFIRM,
+} from "./commit-confirms";
 import { EditHistoryDialog } from "./EditHistoryDialog";
 import {
   CherryPickOntoDialog,
@@ -199,10 +206,31 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
       head &&
       (head.upstream === null || head.upstreamGone || head.ahead > 0),
   );
+  // Whether HEAD is a root commit, which sends undo down git's ref-deleting
+  // path. The log walks HEAD's ancestry and only stops paging once a page comes
+  // up short, so a lone loaded commit with no next page means HEAD has no parent.
+  const headIsRoot = log.data?.pages[0]?.length === 1 && !log.hasNextPage;
 
   async function undoLast() {
     if (!lastCommit) return;
+    // Only the root case is lossy enough to ask about: an ordinary undo is gated
+    // to unpushed commits and leaves everything staged.
+    if (
+      headIsRoot &&
+      !(await useConfirm.getState().ask(UNDO_ROOT_COMMIT_CONFIRM))
+    ) {
+      return;
+    }
     try {
+      // The undo names no commit — it always unwinds whatever HEAD is at the
+      // moment it runs — so re-read HEAD across the prompt's await. A commit
+      // landing out of band (another window, a terminal) would otherwise be the
+      // one undone, under a confirmation that described a different commit.
+      const [headNow] = await gitRecentCommits(repoPath, 1);
+      if (headNow?.hash !== lastCommit.hash) {
+        toast.info("The latest commit changed — nothing was undone.");
+        return;
+      }
       const details = await gitCommitDetails(repoPath, lastCommit.hash);
       undoCommit.mutate(undefined, {
         onSuccess: () => {
@@ -217,6 +245,36 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     } catch (e) {
       onError(e);
     }
+  }
+
+  // The confirm sits here rather than on the menu items, so the search menu and
+  // the single-commit menu can't diverge on whether they ask.
+  async function doCheckoutCommit(hash: string) {
+    if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
+    checkoutCommit.mutate(hash, { onError });
+  }
+
+  async function doRevertCommit(hash: string) {
+    if (!(await useConfirm.getState().ask(revertCommitConfirm(hash)))) return;
+    revertCommit.mutate(hash, { onError });
+  }
+
+  // `alreadyApplied` is the one thing the two menus word differently.
+  async function doCherryPick(hash: string, alreadyApplied: string) {
+    const ok = await useConfirm
+      .getState()
+      .ask(cherryPickCommitConfirm(hash, currentBranch));
+    if (!ok) return;
+    cherryPick.mutate(hash, {
+      onSuccess: (applied) => {
+        if (applied) {
+          toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
+        } else {
+          toast.info(alreadyApplied);
+        }
+      },
+      onError,
+    });
   }
 
   useHotkeyAction("undo-commit", undoLast, canUndo && !undoCommit.isPending);
@@ -507,27 +565,18 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
       // amend/reset/squash/reorder, which assume contiguous recent history).
       return (
         <>
-          <ContextMenuItem
-            onClick={() => checkoutCommit.mutate(commit.hash, { onError })}
-          >
+          <ContextMenuItem onClick={() => doCheckoutCommit(commit.hash)}>
             Checkout commit
           </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() => revertCommit.mutate(commit.hash, { onError })}
-          >
+          <ContextMenuItem onClick={() => doRevertCommit(commit.hash)}>
             Revert changes in commit
           </ContextMenuItem>
           <ContextMenuItem
             onClick={() =>
-              cherryPick.mutate(commit.hash, {
-                onSuccess: (applied) =>
-                  applied
-                    ? toast.success(`Cherry-picked ${commit.hash.slice(0, 7)}`)
-                    : toast.info(
-                        "Nothing to cherry-pick — already on this branch.",
-                      ),
-                onError,
-              })
+              doCherryPick(
+                commit.hash,
+                "Nothing to cherry-pick — already on this branch.",
+              )
             }
           >
             Cherry-pick commit
@@ -613,14 +662,10 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
         >
           Reset to commit…
         </ContextMenuItem>
-        <ContextMenuItem
-          onClick={() => checkoutCommit.mutate(commit.hash, { onError })}
-        >
+        <ContextMenuItem onClick={() => doCheckoutCommit(commit.hash)}>
           Checkout commit
         </ContextMenuItem>
-        <ContextMenuItem
-          onClick={() => revertCommit.mutate(commit.hash, { onError })}
-        >
+        <ContextMenuItem onClick={() => doRevertCommit(commit.hash)}>
           Revert changes in commit
         </ContextMenuItem>
         <ContextMenuSeparator />
@@ -642,18 +687,10 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
         </ContextMenuItem>
         <ContextMenuItem
           onClick={() =>
-            cherryPick.mutate(commit.hash, {
-              onSuccess: (applied) => {
-                if (applied) {
-                  toast.success(`Cherry-picked ${commit.hash.slice(0, 7)}`);
-                } else {
-                  toast.info(
-                    "Nothing to cherry-pick — these changes are already on this branch.",
-                  );
-                }
-              },
-              onError,
-            })
+            doCherryPick(
+              commit.hash,
+              "Nothing to cherry-pick — these changes are already on this branch.",
+            )
           }
         >
           Cherry-pick commit

--- a/src/features/history/commit-confirms.ts
+++ b/src/features/history/commit-confirms.ts
@@ -1,0 +1,50 @@
+/**
+ * The one wording for each commit-level action that changes the working tree or
+ * writes history. The History list, the commit detail view's ⋯ menu, and a tag's
+ * Checkout all ask through these, so no route can pose a different question than
+ * its twin. Prompts go through `useConfirm.getState().ask(...)`.
+ */
+
+const short = (hash: string) => hash.slice(0, 7);
+
+/** Checking out a commit and checking out a tag land in the same detached HEAD,
+ *  so both name their entity and share the explanation. */
+export function checkoutDetachedConfirm(kind: "commit" | "tag", name: string) {
+  return {
+    title: `Check out ${kind} ${name}?`,
+    body: `Your files move to that ${kind} and HEAD detaches, so you won't be on a branch. Switching back to a branch returns everything to normal, and commits you make while detached need a new branch to keep them.`,
+    confirmLabel: `Check out ${kind}`,
+  };
+}
+
+export const checkoutCommitConfirm = (hash: string) =>
+  checkoutDetachedConfirm("commit", short(hash));
+
+export const revertCommitConfirm = (hash: string) => ({
+  title: `Revert commit ${short(hash)}?`,
+  body: `Creates a new commit that undoes what ${short(hash)} changed, so history keeps both and nothing already recorded is rewritten. If it conflicts, the revert pauses in Changes for you to resolve.`,
+  confirmLabel: "Revert commit",
+});
+
+/** `branch` names the destination when the caller already holds repo status;
+ *  without it the copy says "the current branch" rather than subscribing a view
+ *  to status for a string only this prompt reads. */
+export const cherryPickCommitConfirm = (
+  hash: string,
+  branch: string | null,
+) => ({
+  title: `Cherry-pick commit ${short(hash)}?`,
+  body: `Copies ${short(hash)} onto ${branch ?? "the current branch"} as a new commit and leaves the original where it is. If it conflicts, the pick pauses in Changes for you to resolve.`,
+  confirmLabel: "Cherry-pick commit",
+});
+
+/** A parentless commit has nothing to soft-reset to, so undo deletes the branch
+ *  ref instead — the one undo that doesn't just re-stage in place. Scoped to the
+ *  branch, never the repository: an orphan branch's first commit takes this path
+ *  while the repository's history carries on elsewhere. */
+export const UNDO_ROOT_COMMIT_CONFIRM = {
+  title: "Undo this branch's first commit?",
+  body: "This is the first commit on this branch, so undoing it deletes the branch's ref instead of moving it back. Your changes stay staged.",
+  confirmLabel: "Undo first commit",
+  confirmVariant: "destructive",
+} as const;

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -48,6 +48,7 @@ import { CommentEditor } from "@/features/conversations/CommentEditor";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { JiraIssueSidebar } from "@/features/issues/JiraIssueSidebar";
 import type { ForgeUserRef } from "@/lib/git/types";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { formatHmDelta, isValidJiraDuration } from "@/lib/jira/duration";
 import {
   useJiraAssign,
@@ -1488,6 +1489,7 @@ export function JiraIssueView({
 }) {
   const link = useJiraLink(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
+  const selectedIssue = useUiStore((s) => s.selectedIssue);
   const details = useJiraIssue(repoPath, link.data, issueKey);
   // Per-project write permissions gate every affordance below: permitted →
   // rendered, not-permitted (or a failed probe → every flag `?? false`) →
@@ -1517,6 +1519,19 @@ export function JiraIssueView({
   // remounting its own per-issue drafts.
   const issueIdentity = `${repoPath}#${issueKey}`;
   const compose = useKeyedEntityState(issueIdentity, "");
+  // The composer sits below the thread AND the sidebar, so reaching it by Tab
+  // means crossing the whole rail — this is the keyboard route past it. Enabled
+  // only while the box is actually on screen, and only for the view that owns
+  // the selection (the mounted one lags it through a switch).
+  useHotkeyAction(
+    "focus-comment",
+    () => composerRef.current?.focus(),
+    selectedIssue?.kind === "jira" &&
+      selectedIssue.id === issueKey &&
+      canComment &&
+      !!details.data &&
+      !details.isError,
+  );
 
   // The link resolved to nothing (unlinked, or unlinked while this view was
   // open): the issue query is disabled, so it would otherwise sit on a pending
@@ -1747,24 +1762,6 @@ export function JiraIssueView({
               )}
             </div>
           </ScrollArea>
-
-          {canComment && (
-            <CommentComposer
-              ref={composerRef}
-              ariaLabel="Leave a comment"
-              placeholder="Leave a comment…"
-              value={compose.value}
-              onChange={compose.set}
-              onSubmit={submitComment}
-              onClear={() => compose.set("")}
-              submitLabel="Comment"
-              // A placeholder issue is the previously selected one, so submitting
-              // would comment on it; typing stays live through the window.
-              busy={comment.isPending || detailsStale}
-              reason={composerReason}
-              disabled={comment.isPending}
-            />
-          )}
         </div>
 
         <JiraIssueSidebar
@@ -1789,6 +1786,26 @@ export function JiraIssueView({
           stale={detailsStale}
         />
       </div>
+
+      {/* Below the thread AND the rail: the conversation is the widest thing on
+          this surface, so the box you write in spans the same width. */}
+      {canComment && (
+        <CommentComposer
+          ref={composerRef}
+          ariaLabel="Leave a comment"
+          placeholder="Leave a comment…"
+          value={compose.value}
+          onChange={compose.set}
+          onSubmit={submitComment}
+          onClear={() => compose.set("")}
+          submitLabel="Comment"
+          // A placeholder issue is the previously selected one, so submitting
+          // would comment on it; typing stays live through the window.
+          busy={comment.isPending || detailsStale}
+          reason={composerReason}
+          disabled={comment.isPending}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1530,6 +1530,7 @@ export function JiraIssueView({
       selectedIssue.id === issueKey &&
       canComment &&
       !!details.data &&
+      !details.isPlaceholderData &&
       !details.isError,
   );
 

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -45,6 +45,7 @@ import { useLocalConversation } from "@/features/conversations/useLocalConversat
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { copyText } from "@/lib/clipboard";
 import { forgeFeatureReady, useForgeStatus } from "@/lib/git/queries";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import {
   useDeleteLocalIssue,
   useLocalIssues,
@@ -69,6 +70,7 @@ export function LocalIssueView({
   const update = useUpdateLocalIssue(repoPath);
   const del = useDeleteLocalIssue(repoPath);
   const selectIssue = useUiStore((s) => s.selectIssue);
+  const selectedIssue = useUiStore((s) => s.selectedIssue);
   const ghStatus = useForgeStatus(repoPath);
   // Two independent publish gates: the forge's static issue-create capability
   // and a live per-user Jira permission probe. The Publish affordance shows when
@@ -118,6 +120,14 @@ export function LocalIssueView({
     setPromoteOpen(false);
     edit.setOpen(false);
   }
+
+  // The palette's route to the comment box. Only the view that owns the
+  // selection answers — the mounted one lags it through a switch.
+  useHotkeyAction(
+    "focus-comment",
+    () => composerRef.current?.focus(),
+    selectedIssue?.kind === "local" && selectedIssue.id === id && !!issue,
+  );
 
   if (!issue) {
     return <DiffPlaceholder message="This local issue no longer exists" />;

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -273,7 +273,11 @@ export function RemoteIssueView({
   useHotkeyAction(
     "focus-comment",
     () => composerRef.current?.focus(),
-    isSelectedIssue && canComment && !!issue && !details.isError,
+    isSelectedIssue &&
+      canComment &&
+      !!issue &&
+      !details.isPlaceholderData &&
+      !details.isError,
   );
 
   if (details.isPending) {

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -558,8 +558,8 @@ export function RemoteIssueView({
   // The close/reopen arm LEADS the bottom bar in both permission states — inside
   // the composer's action row (Comment is the primary and stays last), or alone
   // in the bar when the provider permits state changes but not comments, so
-  // Close keeps the same corner either way. Both call sites supply their own
-  // spacer, so this fragment carries none.
+  // Close keeps the same corner either way. The composer call site supplies its
+  // own spacer; the state-only bar left-aligns, so this fragment carries none.
   const stateActions = (
     <>
       {canChangeState &&

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -71,7 +71,9 @@ import {
   writeAccessReason,
 } from "@/lib/git/queries";
 import { providerLabel } from "@/lib/git/types";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useRepoLens } from "@/lib/repo-lens/queries";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
 import { toastError, toastErrorWithNote } from "@/lib/toast";
@@ -93,6 +95,13 @@ const LOCK_REASONS: [string, LockReason | null][] = [
   ["Spam", "spam"],
   ["Too heated", "too_heated"],
 ];
+
+/** What the close prompt's title adds per route: GitHub's "not planned" close is
+ *  a different act from a plain one, and only the title says so. */
+const CLOSE_TITLE_QUALIFIER = {
+  completed: "",
+  not_planned: " as not planned",
+} as const;
 
 /**
  * Full read+write view for a GitHub issue: header, description, threaded
@@ -192,7 +201,12 @@ export function RemoteIssueView({
   const transferIssue = useTransferIssue(repoPath, lens);
   const deleteIssue = useDeleteIssue(repoPath, lens);
   const selectIssue = useUiStore((s) => s.selectIssue);
+  const selectedIssue = useUiStore((s) => s.selectedIssue);
   const setPendingIssueDraft = useUiStore((s) => s.setPendingIssueDraft);
+  // Whether this view owns the current selection: the mounted view lags the
+  // selection through a switch, and only the selected one may answer the palette.
+  const isSelectedIssue =
+    selectedIssue?.kind === "remote" && selectedIssue.id === String(number);
   // Reactions are a shared control (GitLab awards emoji); the fetch is gated so
   // it never fires for a provider whose reactions aren't wired (Bitbucket).
   const canReact = canWrite || forgeFeatureReady(forge.data, "issueReactions");
@@ -252,6 +266,15 @@ export function RemoteIssueView({
   const onError = (e: unknown) => toastError(e);
 
   const issue = details.data;
+
+  // The composer sits below the thread AND the sidebar, so reaching it by Tab
+  // means crossing the whole rail — this is the keyboard route past it. Enabled
+  // only while the box is actually on screen.
+  useHotkeyAction(
+    "focus-comment",
+    () => composerRef.current?.focus(),
+    isSelectedIssue && canComment && !!issue && !details.isError,
+  );
 
   if (details.isPending) {
     return (
@@ -383,6 +406,16 @@ export function RemoteIssueView({
     // Captured before the await: posting clears the draft, and the error arm
     // below has to know a comment already went out.
     const withComment = draftRidesStateChange;
+    // Ahead of the riding draft: a cancelled confirm must leave the comment
+    // unposted.
+    const ok = await useConfirm.getState().ask({
+      title: `Close issue #${number}${CLOSE_TITLE_QUALIFIER[reason]}?`,
+      body: `Everyone watching is notified and the issue leaves the open list. Reopening puts it back, but the notification can't be unsent.${
+        withComment ? " Your draft posts as a comment first." : ""
+      }`,
+      confirmLabel: withComment ? "Close with comment" : "Close issue",
+    });
+    if (!ok) return;
     if (!(await postRidingDraft())) return;
     closeIssue.mutate(
       { number, reason },
@@ -522,12 +555,13 @@ export function RemoteIssueView({
     .filter((n) => !repoQuery || n.toLowerCase().includes(repoQuery))
     .slice(0, 6);
 
-  // The close/reopen arm ends the bottom bar behind a spacer — inside the
-  // composer's action row when commenting is allowed, alone in the bar when the
-  // provider permits state changes but not comments.
+  // The close/reopen arm LEADS the bottom bar in both permission states — inside
+  // the composer's action row (Comment is the primary and stays last), or alone
+  // in the bar when the provider permits state changes but not comments, so
+  // Close keeps the same corner either way. Both call sites supply their own
+  // spacer, so this fragment carries none.
   const stateActions = (
     <>
-      <span className="flex-1" />
       {canChangeState &&
         (isOpen ? (
           <>
@@ -994,46 +1028,6 @@ export function RemoteIssueView({
               )}
             </div>
           </ScrollArea>
-          {/* Comment is allowed after the issue closes too, matching GitHub. On
-              GitLab the composer + close/reopen show, but the GitHub-only
-              close-reason dropdown stays hidden (GitLab has no reasons);
-              Bitbucket has neither, so the whole bar hides. */}
-          {canComment ? (
-            <CommentComposer
-              ref={composerRef}
-              ariaLabel="Leave a comment"
-              placeholder="Leave a comment…"
-              value={compose.value}
-              onChange={compose.set}
-              onSubmit={submitComment}
-              submitLabel="Comment"
-              busy={busy}
-              reason={composerReason}
-              // Clear is site-rendered rather than the shared `onClear` one: the
-              // close/reopen arm follows it, and the shared Clear is `ml-auto`.
-              actions={
-                <>
-                  {compose.value.trim() && (
-                    <DisabledReasonButton
-                      variant="ghost"
-                      size="sm"
-                      disabled={busy}
-                      reason={composerReason}
-                      onClick={() => compose.set("")}
-                      title="Discard this draft (e.g. a quote reply)"
-                    >
-                      Clear
-                    </DisabledReasonButton>
-                  )}
-                  {stateActions}
-                </>
-              }
-            />
-          ) : canChangeState ? (
-            <div className="space-y-2 border-t p-3">
-              <div className="flex items-center gap-2">{stateActions}</div>
-            </div>
-          ) : null}
         </div>
         <IssueSidebar
           // Remounts the rail per issue so its sections' drafts (the uncontrolled
@@ -1059,6 +1053,52 @@ export function RemoteIssueView({
           writeItemReason={writeItemReason}
         />
       </div>
+      {/* Below the thread AND the rail: the conversation is the widest thing on
+          this surface, so the box you write in spans the same width the other
+          conversation surfaces (which have no rail) already get.
+          Comment is allowed after the issue closes too, matching GitHub. On
+          GitLab the composer + close/reopen show, but the GitHub-only
+          close-reason dropdown stays hidden (GitLab has no reasons);
+          Bitbucket has neither, so the whole bar hides. */}
+      {canComment ? (
+        <CommentComposer
+          ref={composerRef}
+          ariaLabel="Leave a comment"
+          placeholder="Leave a comment…"
+          value={compose.value}
+          onChange={compose.set}
+          onSubmit={submitComment}
+          submitLabel="Comment"
+          busy={busy}
+          reason={composerReason}
+          // Close/reopen lead, Comment ends the row where a form's submit is
+          // looked for. Clear is site-rendered rather than the shared `onClear`
+          // one so it sits just left of Comment: the shared Clear is `ml-auto`,
+          // which would put it past the submit button.
+          leadingActions={
+            <>
+              {stateActions}
+              <span className="flex-1" />
+              {compose.value.trim() && (
+                <DisabledReasonButton
+                  variant="ghost"
+                  size="sm"
+                  disabled={busy}
+                  reason={composerReason}
+                  onClick={() => compose.set("")}
+                  title="Discard this draft (e.g. a quote reply)"
+                >
+                  Clear
+                </DisabledReasonButton>
+              )}
+            </>
+          }
+        />
+      ) : canChangeState ? (
+        <div className="space-y-2 border-t p-3">
+          <div className="flex items-center gap-2">{stateActions}</div>
+        </div>
+      ) : null}
 
       <EditTitleBodyDialog
         form={edit.form}

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -67,6 +67,7 @@ import {
   useRepoStatus,
   useUpdateBranchFrom,
 } from "@/lib/git/queries";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import { useLocalPrs, useUpdateLocalPr } from "@/lib/pulls/queries";
@@ -292,6 +293,19 @@ export function LocalPrView({
     pr?.status === "open",
   );
   const defaultBranch = useDefaultBranch(repoPath);
+
+  // The palette's route to the comment box. Every term the composer itself is
+  // gated on rides here too: a paused merge takes the whole view over, and the
+  // other sub-tabs have no composer.
+  useHotkeyAction(
+    "focus-comment",
+    () => composerRef.current?.focus(),
+    selectedPr?.kind === "local" &&
+      selectedPr.id === id &&
+      section === "conversation" &&
+      !!pr &&
+      !pr.pendingMerge?.worktreePath,
+  );
 
   if (!pr) {
     return (

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -46,8 +46,14 @@ import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { CommitDetailView } from "@/features/history/CommitDetailView";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
 import { useStashReapplyRecovery } from "@/features/repository/useStashReapplyRecovery";
-import { isMergeMethodAllowed } from "@/lib/branch-rules/match";
-import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import {
+  isMergeMethodAllowed,
+  isPromotionBranch,
+} from "@/lib/branch-rules/match";
+import {
+  useEffectiveBranchRules,
+  useEffectiveBranchRulesSettling,
+} from "@/lib/branch-rules/queries";
 import { copyText } from "@/lib/clipboard";
 import { gitBranchDiff, type MergeStrategy } from "@/lib/git/api";
 import {
@@ -70,6 +76,7 @@ import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { LocalPrLifecycleRow } from "./LocalPrTimeline";
+import { PROMOTION_REASON, type PromotionKind } from "./PrMergeabilityBanner";
 import { PromoteLocalPrDialog } from "./PromoteLocalPrDialog";
 import { PrReviewPanel } from "./PrReviewPanel";
 import {
@@ -174,6 +181,7 @@ export function LocalPrView({
     if (!availableSections.includes(section)) setSection("conversation");
   }, [availableSections, section]);
   const rulesConfig = useEffectiveBranchRules(repoPath);
+  const rulesSettling = useEffectiveBranchRulesSettling(repoPath);
   const {
     comment,
     setComment,
@@ -295,14 +303,24 @@ export function LocalPrView({
   // Commits on `base` that `head` lacks — i.e. how far the PR's head branch has
   // fallen behind base. Non-empty ⇒ offer GitHub's "Update branch".
   const behind = comparison.data?.behind ?? [];
-  // A promotion pull request (main → staging): the HEAD is this repository's
-  // default branch, so it stays permanently behind its base and "Update branch"
-  // would merge the base back INTO the default branch, inverting the flow. The
-  // head-is-default shape is the whole test — a topology probe false-positives on
-  // stacked pull requests. staging → production has the same inversion and is not
-  // covered.
-  const promotionLike =
-    Boolean(defaultBranch.data) && pr.head === defaultBranch.data;
+  // A promotion pull request (main → staging): the head carries work onward, so it
+  // stays permanently behind its base and "Update branch" would merge the base back
+  // INTO it, inverting the flow. Either the head IS this repository's default branch
+  // — a topology probe would false-positive on stacked pull requests, so that name
+  // comparison is the whole test — or the repo's rules name it a promotion branch,
+  // which is what covers staging → production. Which kind it is decides only the
+  // words the note uses; a configured head is no claim about the default branch.
+  const promotionKind: PromotionKind = (() => {
+    switch (true) {
+      case !!defaultBranch.data && pr.head === defaultBranch.data:
+        return "default";
+      case isPromotionBranch(rulesConfig, pr.head):
+        return "configured";
+      default:
+        return null;
+    }
+  })();
+  const promotionLike = promotionKind !== null;
 
   // AI title+description generation — shared by the Edit dialog's Generate button
   // and its mod+g chord. Verbatim the button's prior onClick body. `pr` is aliased
@@ -516,16 +534,16 @@ export function LocalPrView({
     // catch-up goes away. The gap does NOT close on merge — merging the head into
     // the base ADDS a commit the head lacks — so the copy says it needs no closing.
     const promotion =
-      promotionLike && behind.length > 0 ? (
+      promotionKind !== null && behind.length > 0 ? (
         <div className="flex items-start gap-1.5 text-muted-foreground">
           <InfoIcon className="mt-px size-3.5 shrink-0" />
           <span className="min-w-0">
             <span className="font-mono">{pr.base}</span> has {behind.length}{" "}
             commit{behind.length === 1 ? "" : "s"}{" "}
             <span className="font-mono">{pr.head}</span> doesn't.{" "}
-            <span className="font-mono">{pr.head}</span> is the repository's
-            default branch, so this gap is expected and doesn't need closing.
-            Updating the branch would merge{" "}
+            <span className="font-mono">{pr.head}</span>
+            {PROMOTION_REASON[promotionKind]}, so this gap is expected and
+            doesn't need closing. Updating the branch would merge{" "}
             <span className="font-mono">{pr.base}</span> back into{" "}
             <span className="font-mono">{pr.head}</span>.
           </span>
@@ -1034,20 +1052,27 @@ export function LocalPrView({
               <DisabledReasonButton
                 variant="outline"
                 size="sm"
-                // `promotionLike` reads false until `useDefaultBranch` resolves, so
-                // the button holds rather than deciding early. PENDING only (the
-                // query is never disabled): a FAILED read falls open to the ordinary
+                // `promotionLike` reads false until BOTH its inputs land — the
+                // default branch and the repo's promotion-branch rules — so the
+                // button holds rather than deciding early. PENDING only (neither
+                // query is ever disabled): a FAILED read falls open to the ordinary
                 // button instead of disabling forever behind a stale "checking…".
                 disabled={
                   updateBranchFrom.isPending ||
                   recovery.pending ||
-                  defaultBranch.isPending
+                  defaultBranch.isPending ||
+                  rulesSettling
                 }
-                reason={
-                  defaultBranch.isPending
-                    ? "Checking which branch is the default…"
-                    : undefined
-                }
+                reason={(() => {
+                  switch (true) {
+                    case defaultBranch.isPending:
+                      return "Checking which branch is the default…";
+                    case rulesSettling:
+                      return "Checking this repository's promotion branches…";
+                    default:
+                      return undefined;
+                  }
+                })()}
                 title={`Merge ${pr.base} into ${pr.head} to catch it up`}
                 onClick={() =>
                   updateBranchFrom.mutate(

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -66,6 +66,19 @@ export type PrMergeabilityArm =
   | "blocked"
   | null;
 
+/** What makes a pull request a promotion — its head is this repository's default
+ *  branch, or a branch the repo's rules name as a promotion branch. `null` for an
+ *  ordinary pull request. */
+export type PromotionKind = "default" | "configured" | null;
+
+/** The clause naming why the head is a promotion — the only words that differ
+ *  between the two kinds, so the rest of the sentence can't drift apart. Shared
+ *  with LocalPrView's inline note for the same reason. */
+export const PROMOTION_REASON: Record<Exclude<PromotionKind, null>, string> = {
+  default: " is the repository's default branch",
+  configured: " is a promotion branch for this repository",
+};
+
 /** Words carry the meaning; the icon and tone only reinforce it. */
 const ARM_ICON: Record<
   Exclude<PrMergeabilityArm, null>,
@@ -95,7 +108,7 @@ const ARM_MESSAGE: Record<
     predictedClean: boolean;
     forgeUnreachable: boolean;
     blockedRequirements: string[];
-    promotionLike: boolean;
+    promotionKind: PromotionKind;
   }) => ReactNode
 > = {
   conflicting: ({ base, provider }) => (
@@ -149,13 +162,13 @@ const ARM_MESSAGE: Record<
   // The behind clause rides along in the `behind` arm's own words, because the update
   // controls come with it — a bare refusal beside an Update branch button would leave
   // the button unexplained.
-  blocked: ({ base, behindBy, blockedRequirements, promotionLike }) => (
+  blocked: ({ base, behindBy, blockedRequirements, promotionKind }) => (
     <>
       {blockedMergeLine(blockedRequirements)}
       {/* The behind clause exists to explain the Update controls beside it, so it
           goes wherever they go: on a promotion pull request they'd invert the
           flow, and a count with no route out would read as a demand. */}
-      {behindBy > 0 && !promotionLike ? (
+      {behindBy > 0 && promotionKind === null ? (
         <>
           {` It is also ${behindBy} commit${behindBy === 1 ? "" : "s"} behind `}
           <span className="font-mono">{base}</span>
@@ -165,20 +178,22 @@ const ARM_MESSAGE: Record<
     </>
   ),
   // A promotion pull request (main → staging) is permanently behind its base by
-  // design, and "update the branch" would merge the base back into the default
-  // branch. Say which direction the work is going instead of implying a catch-up.
-  // The gap does NOT close on merge — merging the head into the base ADDS a
-  // commit the head lacks — so the copy says it needs no closing.
-  behind: ({ base, head, behindBy, promotionLike }) =>
-    promotionLike ? (
+  // design, and "update the branch" would merge the base back into the head. Say
+  // which direction the work is going instead of implying a catch-up. The gap does
+  // NOT close on merge — merging the head into the base ADDS a commit the head
+  // lacks — so the copy says it needs no closing. Only the reason clause differs
+  // between the two kinds; a configured head is no claim about the default branch.
+  behind: ({ base, head, behindBy, promotionKind }) =>
+    promotionKind !== null ? (
       <>
         <span className="font-mono">{base}</span>
         {` has ${behindBy} commit${behindBy === 1 ? "" : "s"} that `}
         <span className="font-mono">{head}</span>
         {" doesn't. "}
         <span className="font-mono">{head}</span>
+        {PROMOTION_REASON[promotionKind]}
         {
-          " is the repository's default branch, so this gap is expected and doesn't need closing. Updating the branch would merge "
+          ", so this gap is expected and doesn't need closing. Updating the branch would merge "
         }
         <span className="font-mono">{base}</span>
         {" back into "}
@@ -204,7 +219,7 @@ export function PrMergeabilityBanner({
   arm,
   base,
   head,
-  promotionLike,
+  promotionKind,
   provider,
   forkBlocked,
   hasResolveWorktree,
@@ -217,6 +232,7 @@ export function PrMergeabilityBanner({
   updateBlockedReason,
   updateBusy,
   updateAwaitingDefault,
+  updateAwaitingRules,
   updateSubmitting,
   onResolve,
   onResolveWithAi,
@@ -229,11 +245,12 @@ export function PrMergeabilityBanner({
   arm: PrMergeabilityArm;
   base: string;
   head: string;
-  /** The head IS this repository's default branch, so the pull request promotes
-   *  it somewhere (main → staging). Updating such a branch would merge the base
-   *  back into the default branch, inverting the flow — so the behind arm keeps
-   *  its true count and drops the action. */
-  promotionLike: boolean;
+  /** The pull request promotes its head onward (main → staging), because the head
+   *  IS this repository's default branch or the repo's rules name it a promotion
+   *  branch. Updating such a branch would merge the base back into it, inverting
+   *  the flow — so the behind arm keeps its true count and drops the action. The
+   *  two kinds only differ in the words that name the reason. */
+  promotionKind: PromotionKind;
   provider: ForgeProvider | null | undefined;
   /** The head branch lives in another repository, so there's nowhere to push. */
   forkBlocked: boolean;
@@ -261,6 +278,9 @@ export function PrMergeabilityBanner({
    *  promotion demotion depends on — it gets its own wording, since the generic
    *  busy line would claim the pull request is still loading. */
   updateAwaitingDefault: boolean;
+  /** The same wait for the other half of the demotion: the repo's branch rules,
+   *  which name the promotion branches. */
+  updateAwaitingRules: boolean;
   /** The update call itself is in flight — the slice of `updateBusy` before the forge
    *  has even accepted the job. */
   updateSubmitting: boolean;
@@ -308,9 +328,8 @@ export function PrMergeabilityBanner({
   const updateDisabled = updateBusy || updateBlockedReason !== undefined;
   // The busy hold now spans the forge's whole queued update, so a silent disabled
   // control would leave the user waiting on nothing they can read. Each cause gets its
-  // own words: the queued job, the call that hasn't been accepted yet, the
-  // default-branch read this action's promotion check depends on, and the
-  // PR-switch window are four different waits.
+  // own words: the queued job, the call that hasn't been accepted yet, the two reads
+  // this action's promotion check depends on, and the PR-switch window.
   const updateBusyReason = (() => {
     switch (true) {
       case arm === "updating":
@@ -319,6 +338,8 @@ export function PrMergeabilityBanner({
         return "Submitting the update…";
       case updateAwaitingDefault:
         return "Checking which branch is the default…";
+      case updateAwaitingRules:
+        return "Checking this repository's promotion branches…";
       default:
         return PR_SWITCH_LOADING_REASON;
     }
@@ -352,7 +373,7 @@ export function PrMergeabilityBanner({
             predictedClean,
             forgeUnreachable,
             blockedRequirements,
-            promotionLike,
+            promotionKind,
           })}
         </span>
       </span>
@@ -415,7 +436,7 @@ export function PrMergeabilityBanner({
       {(arm === "behind" ||
         arm === "updating" ||
         (arm === "blocked" && behindBy > 0)) &&
-        !promotionLike && (
+        promotionKind === null && (
           <div className="flex items-center gap-1.5">
             <DisabledReasonButton
               variant="ghost"

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1884,6 +1884,21 @@ export function RemotePrView({
     if (revealReviewId !== null) setRevealReviewId(null);
   }, [revealReviewId]);
 
+  // The palette's route to the comment box. Every term the composer itself is
+  // gated on rides here too, so the action is offered only where there is a box
+  // to focus: a resolve takes the whole view over, and the other sub-tabs have
+  // no composer.
+  useHotkeyAction(
+    "focus-comment",
+    () => composerRef.current?.focus(),
+    isSelectedPr &&
+      canComment &&
+      section === "conversation" &&
+      !resolve &&
+      !!pr &&
+      !details.isError,
+  );
+
   if (details.isPending) {
     return (
       <div className="space-y-3 p-4">

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -1896,6 +1896,7 @@ export function RemotePrView({
       section === "conversation" &&
       !resolve &&
       !!pr &&
+      !details.isPlaceholderData &&
       !details.isError,
   );
 

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -66,8 +66,12 @@ import { prOpenEligible } from "@/lib/automations/sync";
 import {
   isDeletionBlocked,
   isMergeMethodAllowed,
+  isPromotionBranch,
 } from "@/lib/branch-rules/match";
-import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import {
+  useEffectiveBranchRules,
+  useEffectiveBranchRulesSettling,
+} from "@/lib/branch-rules/queries";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
 import {
@@ -178,6 +182,7 @@ import {
   PR_SWITCH_LOADING_REASON,
   type PrMergeabilityArm,
   PrMergeabilityBanner,
+  type PromotionKind,
 } from "./PrMergeabilityBanner";
 import { PrReviewPanel } from "./PrReviewPanel";
 import { PrTasksChip, PrTasksSection } from "./PrTasksSection";
@@ -591,6 +596,7 @@ export function RemotePrView({
     if (!availableSections.includes(section)) setSection("conversation");
   }, [availableSections, section, capabilitiesSettled]);
   const rulesConfig = useEffectiveBranchRules(repoPath);
+  const rulesSettling = useEffectiveBranchRulesSettling(repoPath);
   const defaultBranch = useDefaultBranch(repoPath);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   // Commits-tab drill-in: the selected commit's oid, or null for the list. Reset
@@ -1001,43 +1007,41 @@ export function RemotePrView({
       ? "The contributor hasn't allowed edits from maintainers."
       : undefined);
 
-  // A promotion pull request: the HEAD is this repository's default branch, so the
-  // work flows main → staging and the head is permanently behind its base by
-  // design. "Update branch" there merges the base back INTO the default branch,
-  // inverting the flow — so every route to it is demoted below, and the behind
-  // copy names the direction instead of asking for a catch-up.
+  // A promotion pull request: the head carries work onward (main → staging), so it is
+  // permanently behind its base by design and "Update branch" would merge the base
+  // back INTO it, inverting the flow. Either the head IS this repository's default
+  // branch — a topology probe false-positives on stacked pull requests and
+  // `allowUpdateBranch` is absent for non-push viewers, so that name comparison is the
+  // whole test — or the repo's rules name it a promotion branch, which covers
+  // staging → production and the upstream lens.
   //
-  // Head-is-default is the whole test on purpose: a topology probe false-positives
-  // on stacked pull requests, which this app first-classes, and `allowUpdateBranch`
-  // is absent for non-push viewers (serde-defaulting to false), so gating on it
-  // would delete the behind banner for every read-only viewer. This shape is the
-  // reported one and both inputs are already held. A staging → production pull
-  // request has the same inversion and is NOT covered.
-  //
-  // `crossRepository` is what keeps the name comparison honest: `headRefName` is
-  // UNQUALIFIED, so a contribution from someone's fork whose head is THEIR `main`
-  // matches our default branch by name alone — an ordinary pull request that would
-  // otherwise lose Update branch and gain copy about a promotion that isn't one.
-  //
-  // `lens === "origin"` for the same reason from the other side: `useDefaultBranch`
-  // reads ORIGIN's default with no lens parameter, while `details` follows the
-  // lens, so on the upstream lens the two names describe different repositories.
-  // An upstream-lens promotion pull request therefore keeps today's behavior —
-  // a recorded limitation, like staging → production.
-  const promotionLike =
-    !!details.data?.headRefName &&
-    !!defaultBranch.data &&
-    details.data.headRefName === defaultBranch.data &&
-    !details.data.crossRepository &&
-    lens === "origin";
+  // `crossRepository` guards both arms: `headRefName` is UNQUALIFIED, so a fork's own
+  // `main` (or its `staging`) matches by name alone. `lens === "origin"` guards only
+  // the default arm, since `useDefaultBranch` reads ORIGIN's default while `details`
+  // follows the lens; a configured pattern is the user's assertion about the branch
+  // NAMES of this repo's fork family, so it applies on either lens by design.
+  // Default wins the tie, and the kind decides only the words the copy uses.
+  const promotionKind: PromotionKind = (() => {
+    const head = details.data?.headRefName;
+    if (!head || details.data?.crossRepository) return null;
+    switch (true) {
+      case lens === "origin" && head === defaultBranch.data:
+        return "default";
+      case isPromotionBranch(rulesConfig, head):
+        return "configured";
+      default:
+        return null;
+    }
+  })();
+  const promotionLike = promotionKind !== null;
 
-  // `promotionLike` is hard-false until the default branch resolves, so an update
-  // started in that window races the demotion. Every entry point holds on this —
-  // the banner via `updateBusy`, the hotkey via `canUpdateBranch`, and
-  // `runUpdateBranch` itself — but ONLY on the origin lens, where the comparison
-  // could change the answer; elsewhere `promotionLike` is false by design and a
-  // hold would buy nothing. A FAILED read is deliberately not held: it falls open,
-  // matching LocalPrView's twin.
+  // Neither arm can fire until its input lands, so an update started in that window
+  // races the demotion and inverts the flow this feature exists to protect. Every
+  // entry point holds on both — the banner via `updateBusy`, the hotkey via
+  // `canUpdateBranch`, and `runUpdateBranch` itself. The default-branch hold is
+  // origin-only, where the comparison could change the answer; elsewhere that arm is
+  // false by design. A FAILED read is deliberately not held on either: it falls open,
+  // matching LocalPrView's twin, since nothing would arrive to lift the hold.
   const defaultBranchSettling = lens === "origin" && defaultBranch.isPending;
 
   // The banner's arm: server truth, then the local prediction where the forge has
@@ -1116,6 +1120,7 @@ export function RemotePrView({
     !detailsStale &&
     !promotionLike &&
     !defaultBranchSettling &&
+    !rulesSettling &&
     updateBlockedReason === undefined &&
     !updateBranch.isPending;
 
@@ -1203,13 +1208,14 @@ export function RemotePrView({
       updateBlockedReason !== undefined ||
       updateBranch.isPending ||
       updatingBranch ||
-      // A promotion pull request would merge the base back INTO the default
-      // branch. The demotion has to live here too, or it is only as good as the
-      // surfaces that happen to read `canUpdateBranch` — and it has to include
-      // the window where the demotion hasn't been decided yet, or a fast hotkey
-      // slips through with `promotionLike` still false.
+      // A promotion pull request would merge the base back INTO the head. The
+      // demotion has to live here too, or it is only as good as the surfaces that
+      // happen to read `canUpdateBranch` — and it has to include both windows
+      // where the demotion hasn't been decided yet, or a fast hotkey slips
+      // through with `promotionLike` still false.
       promotionLike ||
-      defaultBranchSettling
+      defaultBranchSettling ||
+      rulesSettling
     )
       return;
     if (rebase) {
@@ -1529,6 +1535,16 @@ export function RemotePrView({
     // Captured before the await: posting clears the draft, and the error arm
     // below has to know a comment already went out.
     const withComment = draftRidesStateChange;
+    // Ahead of the riding draft: a cancelled confirm must leave the comment
+    // unposted.
+    const ok = await useConfirm.getState().ask({
+      title: `Close ${prNoun} #${number}?`,
+      body: `Everyone watching is notified and the ${prNoun} leaves the open list. Reopening puts it back, but the notification can't be unsent.${
+        withComment ? " Your draft posts as a comment first." : ""
+      }`,
+      confirmLabel: withComment ? "Close with comment" : `Close ${prNoun}`,
+    });
+    if (!ok) return;
     if (!(await postRidingDraft())) return;
     closePr.mutate(number, {
       // The riding comment posts through `mutateAsync`, which skips the
@@ -2522,7 +2538,7 @@ export function RemotePrView({
         arm={bannerArm}
         base={pr.baseRefName}
         head={pr.headRefName}
-        promotionLike={promotionLike}
+        promotionKind={promotionKind}
         provider={provider}
         forkBlocked={!!pr.crossRepository}
         hasResolveWorktree={resolveWorktree !== null}
@@ -2543,11 +2559,13 @@ export function RemotePrView({
           updateBranch.isPending ||
           updatingBranch ||
           detailsStale ||
-          defaultBranchSettling
+          defaultBranchSettling ||
+          rulesSettling
         }
-        // The one wait the generic busy wording would misdescribe, so it gets its
+        // The two waits the generic busy wording would misdescribe, so each gets its
         // own arm rather than claiming the pull request is still loading.
         updateAwaitingDefault={defaultBranchSettling}
+        updateAwaitingRules={rulesSettling}
         updateSubmitting={updateBranch.isPending}
         onResolve={() => runResolve(false)}
         onResolveWithAi={() => runResolve(true)}

--- a/src/features/repository/BranchMergePickerDialog.tsx
+++ b/src/features/repository/BranchMergePickerDialog.tsx
@@ -55,7 +55,7 @@ const PICKER_COPY: Record<
   rebase: {
     title: (c) => `Rebase ${c} onto`,
     description:
-      "Replays your branch's commits on top of the selected branch. Aborted automatically on conflicts.",
+      "Replays your branch's commits on top of the selected branch, each rewritten with a new commit id. Aborted automatically on conflicts.",
     action: "Rebase",
   },
 };

--- a/src/features/repository/ConflictFileView.tsx
+++ b/src/features/repository/ConflictFileView.tsx
@@ -23,10 +23,36 @@ import {
   useReviewConfigured,
   useSettings,
 } from "@/lib/settings/queries";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { toastError } from "@/lib/toast";
 
 const baseName = (path: string) => path.split("/").pop() || path;
+
+/** The whole-file sides, worded as the header buttons word them. */
+const ACCEPT_ALL_COPY = {
+  ours: { side: "current", other: "incoming" },
+  theirs: { side: "incoming", other: "current" },
+} as const;
+
+/** What taking a whole side actually does, given which side (if either) has no
+ *  version at this path. */
+type AcceptAllArm = "content" | "takesDeletion" | "keepsFile";
+
+/** One body per outcome: a modify/delete conflict doesn't "replace" anything —
+ *  the backend runs `git rm` for a removing side and re-checks the file out
+ *  whole for a surviving one. */
+const ACCEPT_ALL_BODY: Record<
+  AcceptAllArm,
+  (name: string, side: string, other: string) => string
+> = {
+  content: (name, side, other) =>
+    `Replaces ${name} with the whole ${side} version, including any conflict regions you already resolved by hand. The ${other} changes to this file are discarded.`,
+  takesDeletion: (name, side, other) =>
+    `The ${side} side removed ${name}, so this deletes the file from your working tree and index. The ${other} side's changes to it are discarded.`,
+  keepsFile: (name, side, other) =>
+    `Keeps ${name} whole as the ${side} side left it, replacing what's in your working tree now. The ${other} side removed the file, and that removal is discarded.`,
+};
 
 /** Which side has no version at this path, when exactly one of them does — the
  *  modify/delete shape. `null` for a content conflict (both sides present) and
@@ -174,7 +200,31 @@ export function ConflictFileView({
     );
   }
 
-  function acceptAll(side: "ours" | "theirs") {
+  async function acceptAll(side: "ours" | "theirs") {
+    // Nothing records which regions were resolved by hand, so every arm warns
+    // unconditionally: taking a side re-checks the file out from the index and
+    // any manual work in it goes with the other side. An unreadable file
+    // (binary, oversized) has no sides to classify and takes the content arm.
+    const copy = ACCEPT_ALL_COPY[side];
+    const name = baseName(path);
+    const deleted = file.data ? deletedSide(file.data) : null;
+    const arm: AcceptAllArm = (() => {
+      switch (true) {
+        case deleted === null:
+          return "content";
+        case deleted === side:
+          return "takesDeletion";
+        default:
+          return "keepsFile";
+      }
+    })();
+    const ok = await useConfirm.getState().ask({
+      title: `Accept all ${copy.side} in ${name}?`,
+      body: ACCEPT_ALL_BODY[arm](name, copy.side, copy.other),
+      confirmLabel: `Accept all ${copy.side}`,
+      confirmVariant: "destructive",
+    });
+    if (!ok) return;
     checkoutSide.mutate(
       { path, side },
       {

--- a/src/features/repository/RebaseOntoDialog.tsx
+++ b/src/features/repository/RebaseOntoDialog.tsx
@@ -154,7 +154,8 @@ export function RebaseOntoDialog({
           <DialogTitle>Change base of {currentLabel}</DialogTitle>
           <DialogDescription>
             Replay only {currentLabel}'s own commits onto a different branch —
-            for when it was branched off the wrong one. Conflicts appear in the
+            for when it was branched off the wrong one. Each one is rewritten
+            with a new commit id as it replays, and conflicts appear in the
             changes list.
           </DialogDescription>
         </DialogHeader>

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -44,7 +44,8 @@ type FileSource =
   | { kind: "orphaned"; sha: string };
 
 /** Apply and pop differ only in what becomes of the stash afterward. The pop
- *  wording matches the branch menu's "Pop latest stash" so the two can't drift. */
+ *  wording is kept in step BY HAND with the branch menu's "Pop latest stash"
+ *  prompt (BranchSwitcher) — edit both or hoist a shared prompt. */
 const STASH_APPLY_COPY = {
   apply: {
     verb: "Apply",

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -43,6 +43,40 @@ type FileSource =
   | { kind: "stash"; index: number }
   | { kind: "orphaned"; sha: string };
 
+/** Apply and pop differ only in what becomes of the stash afterward. The pop
+ *  wording matches the branch menu's "Pop latest stash" so the two can't drift. */
+const STASH_APPLY_COPY = {
+  apply: {
+    verb: "Apply",
+    fate: "leaves it in the stash list, so you can apply it again.",
+    confirmLabel: "Apply stash",
+  },
+  pop: {
+    verb: "Pop",
+    fate: "removes it from the stash list. If applying conflicts, the stash is kept.",
+    confirmLabel: "Pop stash",
+  },
+} as const;
+
+/** A pending apply/pop, plus the stash's identity as it was when the prompt
+ *  opened — `stash@{n}` is a SLOT, not an identity. */
+interface PendingApply {
+  index: number;
+  pop: boolean;
+  message: string;
+  date: string;
+}
+
+const stashApplyPrompt = ({ index, pop }: PendingApply) => {
+  const slot = `stash@{${index}}`;
+  const copy = STASH_APPLY_COPY[pop ? "pop" : "apply"];
+  return {
+    title: `${copy.verb} ${slot}?`,
+    body: `Applies ${slot} to your working tree and ${copy.fate}`,
+    confirmLabel: copy.confirmLabel,
+  };
+};
+
 /**
  * Browse the stash stack: pick a stash, see the files it holds, inspect each
  * one's diff, then apply, pop, or drop it. A "Recoverable" view surfaces
@@ -65,6 +99,12 @@ export function StashesDialog({
   const drop = useStashDrop(repoPath);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [confirmDrop, setConfirmDrop] = useState<number | null>(null);
+  // Apply/pop confirm as a NESTED dialog, like the drop confirm below. The
+  // app-root confirm host is a SIBLING dialog, and Base UI only suppresses a
+  // parent's Escape for dialogs nested in its React tree — Esc over a sibling
+  // would close this dialog underneath it too.
+  const [confirmApply, setConfirmApply] = useState<PendingApply | null>(null);
+  const shownApply = useRetained(confirmApply);
   // The hook's nullish retain condition is load-bearing here rather than a
   // truthiness one: stash@{0} is a valid index.
   const shownDrop = useRetained(confirmDrop);
@@ -86,7 +126,26 @@ export function StashesDialog({
   const busy = apply.isPending || drop.isPending;
   const onError = (e: unknown) => toastError(e);
 
-  function applyStash(index: number, pop: boolean) {
+  function askApply(index: number, pop: boolean) {
+    const stash = list.find((s) => s.index === index);
+    if (!stash) return;
+    setConfirmApply({ index, pop, message: stash.message, date: stash.date });
+  }
+
+  function runApply() {
+    if (!confirmApply) return;
+    const { index, pop, message, date } = confirmApply;
+    setConfirmApply(null);
+    // The list can refetch (or another surface push or drop a stash) while the
+    // prompt is open, sliding a different stash into the confirmed slot. Apply
+    // only the one the prompt described. message + date is the strongest key
+    // StashEntry exposes — two same-second stashes off one HEAD tie, so a sha
+    // on the entry is the real identity if this guard ever needs tightening.
+    const current = list.find((s) => s.index === index);
+    if (!current || current.message !== message || current.date !== date) {
+      toast.info("The stash list changed — nothing was applied.");
+      return;
+    }
     apply.mutate(
       { index, pop },
       {
@@ -96,6 +155,8 @@ export function StashesDialog({
       },
     );
   }
+
+  const applyPrompt = shownApply ? stashApplyPrompt(shownApply) : null;
 
   // Arrow keys walk the stash list, mirroring the app's other lists.
   const onStashesKeyDown = listKeyboardNav({
@@ -198,14 +259,14 @@ export function StashesDialog({
                     variant="outline"
                     size="xs"
                     disabled={busy}
-                    onClick={() => applyStash(effectiveIndex, false)}
+                    onClick={() => askApply(effectiveIndex, false)}
                   >
                     Apply
                   </Button>
                   <Button
                     size="xs"
                     disabled={busy}
-                    onClick={() => applyStash(effectiveIndex, true)}
+                    onClick={() => askApply(effectiveIndex, true)}
                   >
                     Pop
                   </Button>
@@ -220,6 +281,17 @@ export function StashesDialog({
               />
             ) : null}
           </div>
+        )}
+
+        {applyPrompt && (
+          <ConfirmDialog
+            open={confirmApply !== null}
+            onCancel={() => setConfirmApply(null)}
+            title={applyPrompt.title}
+            body={applyPrompt.body}
+            confirmLabel={applyPrompt.confirmLabel}
+            onConfirm={runApply}
+          />
         )}
 
         <Dialog

--- a/src/features/settings/AboutSection.tsx
+++ b/src/features/settings/AboutSection.tsx
@@ -19,7 +19,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import type { AuthStatus } from "@/lib/ai/agent";
 import { copyText } from "@/lib/clipboard";
-import { type ToolStatus, useSystemHealth } from "@/lib/system/health";
+import {
+  cliFloorWarning,
+  type ToolStatus,
+  useSystemHealth,
+} from "@/lib/system/health";
 
 /** Per-tool display metadata. `auth` marks tools that have a login concept;
  *  git (always local) doesn't. */
@@ -96,6 +100,11 @@ function AuthState({ authed }: { authed: AuthStatus }) {
 function ToolRow({ tool }: { tool: ToolStatus }) {
   const meta = TOOL_META[tool.id];
   if (!meta) return null;
+  // An installed-but-too-old tool gets the same install link as a missing one,
+  // since the fix is the same download.
+  const floorWarning = tool.found
+    ? cliFloorWarning(tool.id, tool.version)
+    : null;
   return (
     <li className="flex items-start justify-between gap-3 py-2">
       <div className="min-w-0 space-y-0.5">
@@ -132,18 +141,21 @@ function ToolRow({ tool }: { tool: ToolStatus }) {
             meta.role
           )}
         </p>
+        {floorWarning ? (
+          <p className="text-[11px] text-warning">{floorWarning}</p>
+        ) : null}
       </div>
-      {!tool.found && (
+      {!tool.found || floorWarning ? (
         <Button
           variant="outline"
           size="xs"
           className="shrink-0 cursor-pointer"
           onClick={() => openUrl(meta.install)}
         >
-          Install
+          {tool.found ? "Update" : "Install"}
           <ArrowSquareOutIcon data-icon="inline-end" />
         </Button>
-      )}
+      ) : null}
     </li>
   );
 }
@@ -213,8 +225,8 @@ function useWindowGeometry(): WindowGeo | null {
 
 /**
  * Settings → About: app/OS info plus the status of every external CLI
- * GitDesktop relies on (installed?, version, path, sign-in), with an Install
- * link for any that are missing.
+ * GitDesktop relies on (installed?, version, path, sign-in), with a download
+ * link for any that are missing or too old for a feature that needs them.
  */
 export function AboutSection() {
   const health = useSystemHealth();
@@ -236,7 +248,7 @@ export function AboutSection() {
         <h2 className="text-sm font-semibold">About</h2>
         <p className="mt-1 text-xs text-muted-foreground">
           Your environment and the tools GitDesktop depends on. Several features
-          quietly degrade when a CLI is missing or signed out.
+          quietly degrade when a CLI is missing, outdated, or signed out.
         </p>
       </div>
 

--- a/src/features/settings/AccountsSection.tsx
+++ b/src/features/settings/AccountsSection.tsx
@@ -510,7 +510,10 @@ function GitLabAccount() {
         <p className="text-xs text-muted-foreground">
           GitDesktop acts as whichever account is signed in to the GitLab CLI
           (glab) — merge requests, issues, and pushes all use it. Works with
-          gitlab.com and self-managed GitLab hosts alike.
+          gitlab.com and self-managed GitLab hosts alike; signing in from here
+          covers gitlab.com, so for your own instance run{" "}
+          <span className="font-mono">glab auth login --hostname …</span> in a
+          terminal and it appears below.
         </p>
       </div>
 

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -28,6 +28,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { checkoutDetachedConfirm } from "@/features/history/commit-confirms";
 import { formatBytes } from "@/features/repository/insights/primitives";
 import { presentError } from "@/lib/error-summary";
 import { UPDATER_MANIFEST_NAME } from "@/lib/git/api";
@@ -197,6 +198,23 @@ export function TagDetailView({
       { tag, assetName },
       { onSuccess: () => toast.success("Asset deleted"), onError },
     );
+  }
+
+  // Checking out a tag detaches HEAD exactly as checking out its commit does, so
+  // it asks the History surface's question with the tag's name in it. The target
+  // sha is read before the prompt, so a tag list refetched under the open dialog
+  // can't redirect the checkout the user confirmed.
+  async function onCheckout() {
+    const target = tagInfo?.target;
+    if (!target) return;
+    const ok = await useConfirm
+      .getState()
+      .ask(checkoutDetachedConfirm("tag", tag));
+    if (!ok) return;
+    checkout.mutate(target, {
+      onSuccess: () => toast.success(`Checked out ${tag}`),
+      onError,
+    });
   }
 
   // ── Release view ───────────────────────────────────────────────────────────
@@ -736,13 +754,7 @@ export function TagDetailView({
           variant="outline"
           size="sm"
           disabled={!tagInfo?.target || checkout.isPending}
-          onClick={() =>
-            tagInfo?.target &&
-            checkout.mutate(tagInfo.target, {
-              onSuccess: () => toast.success(`Checked out ${tag}`),
-              onError,
-            })
-          }
+          onClick={onCheckout}
         >
           Checkout
         </Button>

--- a/src/lib/branch-rules/match.ts
+++ b/src/lib/branch-rules/match.ts
@@ -7,9 +7,9 @@ import {
 
 /**
  * Combines the repo's shared rules with the user's personal rules into the
- * single config that's actually enforced. Protections are the union of both;
- * the shared team naming policy wins when present, else the personal one
- * applies.
+ * single config that's actually enforced. Protections and promotion branches
+ * are the union of both; the shared team naming policy wins when present, else
+ * the personal one applies.
  */
 export function mergeBranchRules(
   shared: BranchRulesConfig,
@@ -18,6 +18,10 @@ export function mergeBranchRules(
   return {
     naming: shared.naming.enabled ? shared.naming : personal.naming,
     protections: [...shared.protections, ...personal.protections],
+    promotionBranches: [
+      ...shared.promotionBranches,
+      ...personal.promotionBranches,
+    ],
   };
 }
 
@@ -78,6 +82,21 @@ export function protectionsFor(
 ): BranchProtection[] {
   return config.protections.filter(
     (p) => p.pattern.trim() !== "" && matchesGlob(p.pattern.trim(), branch),
+  );
+}
+
+/**
+ * Whether `branch` is configured as a promotion branch — a pull request FROM it
+ * carries work onward rather than catching up, so the update-from-base offer is
+ * withheld. The user's own assertion about this repository, so it needs no
+ * topology check to back it up.
+ */
+export function isPromotionBranch(
+  config: BranchRulesConfig,
+  branch: string,
+): boolean {
+  return config.promotionBranches.some(
+    (p) => p.trim() !== "" && matchesGlob(p.trim(), branch),
   );
 }
 

--- a/src/lib/branch-rules/queries.ts
+++ b/src/lib/branch-rules/queries.ts
@@ -64,3 +64,15 @@ export function useEffectiveBranchRules(repo: string): BranchRulesConfig {
     personal.data ?? EMPTY_BRANCH_RULES,
   );
 }
+
+/**
+ * Whether either scope is still on its FIRST read, so the effective rules stand
+ * in as empty. An action a rule would have refused must hold on this rather than
+ * act on the stand-in. A read that FAILED is not pending: it falls open, since
+ * nothing would ever arrive to lift the hold.
+ */
+export function useEffectiveBranchRulesSettling(repo: string): boolean {
+  const personal = useBranchRules(repo);
+  const shared = useSharedBranchRules(repo);
+  return personal.isPending || shared.isPending;
+}

--- a/src/lib/branch-rules/store.ts
+++ b/src/lib/branch-rules/store.ts
@@ -20,6 +20,7 @@ export function normalizeBranchRules(saved: unknown): BranchRulesConfig {
   const obj = (saved ?? {}) as {
     naming?: Partial<NamingPolicy>;
     protections?: Partial<BranchProtection>[];
+    promotionBranches?: unknown;
   };
   return {
     naming: { ...EMPTY_BRANCH_RULES.naming, ...obj.naming },
@@ -31,6 +32,12 @@ export function normalizeBranchRules(saved: unknown): BranchRulesConfig {
       requirePr: p.requirePr ?? false,
       allowedMergeMethods: p.allowedMergeMethods ?? [...ALL_MERGE_METHODS],
     })),
+    // Typed loosely because the shared file is hand-editable: anything but an
+    // array of strings yields no promotion branches rather than throwing away
+    // the rest of the config.
+    promotionBranches: Array.isArray(obj.promotionBranches)
+      ? obj.promotionBranches.filter((p): p is string => typeof p === "string")
+      : [],
   };
 }
 

--- a/src/lib/branch-rules/types.ts
+++ b/src/lib/branch-rules/types.ts
@@ -48,9 +48,14 @@ export interface NamingPolicy {
 export interface BranchRulesConfig {
   naming: NamingPolicy;
   protections: BranchProtection[];
+  /** fnmatch-style globs for branches whose pull requests PROMOTE work onward
+   *  (a `staging` → `production` PR, say). Their head is behind its base by
+   *  design, so GitDesktop never offers to update them from it. */
+  promotionBranches: string[];
 }
 
 export const EMPTY_BRANCH_RULES: BranchRulesConfig = {
   naming: { enabled: false, pattern: "", hint: "" },
   protections: [],
+  promotionBranches: [],
 };

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -191,6 +191,14 @@ export const ACTIONS = [
     category: "Navigation",
     defaultBinding: "mod+f",
   },
+  {
+    id: "focus-comment",
+    label: "Focus the comment box",
+    category: "Navigation",
+    // Palette-only by default: it applies on the conversation surfaces alone, so
+    // it ships without spending a chord. Users can bind a key.
+    defaultBinding: null,
+  },
 
   // Repository
   {

--- a/src/lib/system/health.ts
+++ b/src/lib/system/health.ts
@@ -24,6 +24,84 @@ export interface SystemHealth {
   tools: ToolStatus[];
 }
 
+/** The first dotted numeric run in a `--version` line — "2.45.1" out of
+ *  "git version 2.45.1.windows.1". Distros and vendors wrap the number in their
+ *  own prose and suffixes, so it's matched anywhere rather than anchored. */
+const VERSION_TOKEN = /\d+(?:\.\d+)+/;
+
+/** A CLI's version: the numbers that get compared, plus the token as printed. */
+export interface CliVersion {
+  major: number;
+  minor: number;
+  /** The matched token ("2.45.1"), shown back to the user verbatim. */
+  token: string;
+}
+
+/** Reads a CLI's `--version` line. Shapes it must keep parsing:
+ *  "git version 2.45.1.windows.1", "git version 2.39.5 (Apple Git-154)",
+ *  "gh version 2.94.0 (2026-06-10)", "2.43.0-1ubuntu1.12". A line carrying no
+ *  dotted number is null — "unknown", never "too old", so callers fail open. */
+export function parseCliVersion(line: string | null): CliVersion | null {
+  const token = line?.match(VERSION_TOKEN)?.[0];
+  if (!token) return null;
+  const [major = 0, minor = 0] = token.split(".").map(Number);
+  return { major, minor, token };
+}
+
+/** Whether a parsed version is at least `major.minor`. */
+function atLeast(version: CliVersion, major: number, minor: number): boolean {
+  return (
+    version.major > major || (version.major === major && version.minor >= minor)
+  );
+}
+
+/** The oldest version of one CLI that still supports the features GitDesktop
+ *  drives through it, with the sentence shown when it falls short. */
+interface CliFloor {
+  major: number;
+  minor: number;
+  warning: (version: CliVersion) => string;
+}
+
+/** Floors for the CLIs whose shortfall breaks a user-visible feature; every
+ *  other tool id has none. gh's `--json` field list (api/query_builder.go)
+ *  gains `issueType` at v2.94.0 and lacks it through v2.93.0 (cli/cli tags);
+ *  git gained `merge-tree --write-tree` in 2.38 and the `rev-parse
+ *  --path-format` behind the worktree-stable repo identity in 2.31 (git
+ *  release notes). */
+const CLI_FLOORS: Record<string, CliFloor> = {
+  gh: {
+    major: 2,
+    minor: 94,
+    warning: (version) =>
+      `Opening issues needs GitHub CLI 2.94 or newer (you have ${version.token}).`,
+  },
+  git: {
+    major: 2,
+    minor: 38,
+    // The worktree-split clause reaches only the versions it applies to:
+    // 2.31–2.37 lose the merge preview alone.
+    warning: (version) =>
+      atLeast(version, 2, 31)
+        ? `Merge previews need Git 2.38 or newer (you have ${version.token}).`
+        : `Merge previews need Git 2.38 or newer — and below 2.31, per-repo data can split across worktrees (you have ${version.token}).`,
+  },
+};
+
+/** The warning for a tool older than a feature needs, or null when it's at or
+ *  above its floor, has no floor, or reports a version we can't parse. */
+export function cliFloorWarning(
+  id: string,
+  version: string | null,
+): string | null {
+  const floor = CLI_FLOORS[id];
+  const parsed = parseCliVersion(version);
+  if (!floor || !parsed) return null;
+  return atLeast(parsed, floor.major, floor.minor)
+    ? null
+    : floor.warning(parsed);
+}
+
 /** OS/app diagnostics + the status of the CLIs GitDesktop shells out to, for
  *  the Settings → About screen. Detection runs concurrently in Rust. */
 export function useSystemHealth() {

--- a/src/lib/system/health.ts
+++ b/src/lib/system/health.ts
@@ -30,7 +30,7 @@ export interface SystemHealth {
 const VERSION_TOKEN = /\d+(?:\.\d+)+/;
 
 /** A CLI's version: the numbers that get compared, plus the token as printed. */
-export interface CliVersion {
+interface CliVersion {
   major: number;
   minor: number;
   /** The matched token ("2.45.1"), shown back to the user verbatim. */
@@ -41,7 +41,7 @@ export interface CliVersion {
  *  "git version 2.45.1.windows.1", "git version 2.39.5 (Apple Git-154)",
  *  "gh version 2.94.0 (2026-06-10)", "2.43.0-1ubuntu1.12". A line carrying no
  *  dotted number is null — "unknown", never "too old", so callers fail open. */
-export function parseCliVersion(line: string | null): CliVersion | null {
+function parseCliVersion(line: string | null): CliVersion | null {
   const token = line?.match(VERSION_TOKEN)?.[0];
   if (!token) return null;
   const [major = 0, minor = 0] = token.split(".").map(Number);
@@ -68,7 +68,8 @@ interface CliFloor {
  *  gains `issueType` at v2.94.0 and lacks it through v2.93.0 (cli/cli tags);
  *  git gained `merge-tree --write-tree` in 2.38 and the `rev-parse
  *  --path-format` behind the worktree-stable repo identity in 2.31 (git
- *  release notes). */
+ *  release notes). The gh floor is spelled again in `map_gh_too_old`'s message
+ *  (src-tauri/src/github/issue.rs) — a bump moves both strings. */
 const CLI_FLOORS: Record<string, CliFloor> = {
   gh: {
     major: 2,


### PR DESCRIPTION
Pull requests that carry work onward (`staging` → `production`, or an upstream-lens PR the default-branch check can't see) were still offered an "Update branch" that would merge the base back into the head and invert the flow. This adds a per-repo **Promotion branches** list to branch rules that suppresses those offers, puts confirmation prompts on the commit-, conflict-, stash-, and forge-level actions that still ran on a single click, and widens the issue comment composer to match pull requests and discussions.

### Promotion branches

- Adds `promotionBranches` to the branch-rules config (`src/lib/branch-rules/types.ts`, `store.ts`), an `isPromotionBranch` matcher (`src/lib/branch-rules/match.ts`), and a `useEffectiveBranchRulesSettling` hook (`src/lib/branch-rules/queries.ts`) so update controls hold rather than decide early.
- Adds a **Promotion branches** section to `src/features/branch-rules/BranchRulesDialog.tsx` — bare patterns edited by position, with Add/Remove handing focus to a neighbouring row instead of dropping it to the body, and an empty-state explaining what naming a branch there does.
- Replaces the boolean `promotionLike` with a `PromotionKind` (`"default" | "configured" | null`) plus shared `PROMOTION_REASON` copy in `src/features/pulls/PrMergeabilityBanner.tsx`, so both kinds share one sentence and only the reason clause differs. The banner gains an `updateAwaitingRules` prop for the second input's load window.
- Wires the new kind through `src/features/pulls/RemotePrView.tsx` and `LocalPrView.tsx`: `crossRepository` guards both arms, the default-branch arm stays origin-lens-only, and the configured arm applies on either lens (covering the upstream-lens case), with every update entry point holding until both inputs land.

### Destructive-action confirmations

- Adds `src/features/history/commit-confirms.ts` as the single wording for checkout / revert / cherry-pick / undo prompts, consumed by both `HistoryPanel.tsx` and `CommitDetailView.tsx` so the two menus can't diverge, and by `src/features/tags/TagDetailView.tsx` for a tag's detached checkout.
- Gates undo of a branch's *first* commit behind `UNDO_ROOT_COMMIT_CONFIRM` in `HistoryPanel.tsx` (that path deletes the branch ref rather than moving it back), and re-reads HEAD via `gitRecentCommits` across the prompt's await, bailing with a toast if a commit landed out of band.
- Confirms whole-file side accepts in `src/features/repository/ConflictFileView.tsx`, with one body per outcome (content conflict, taking a deletion, keeping a file the other side removed).
- Confirms apply / pop / drop in `src/features/repository/StashesDialog.tsx`, and states up front that replayed commits get new ids in `BranchMergePickerDialog.tsx` and `RebaseOntoDialog.tsx`.
- Confirms closing on the forge for issues (`src/features/issues/RemoteIssueView.tsx`, including a "as not planned" title qualifier), discussions (`src/features/discussions/DiscussionView.tsx`), and pull requests (`src/features/pulls/RemotePrView.tsx`) — asked ahead of any riding draft, so a cancelled prompt leaves the comment unposted.

### Issue composer layout

- Adds a `leadingActions` slot to `src/features/conversations/CommentComposer.tsx` for surfaces whose submit isn't the row's first action; callers now own their own spacers.
- Moves the composer below the sidebar in `RemoteIssueView.tsx` and `JiraIssueView.tsx` so it spans the full width, with close/reopen leading the row and **Comment** last.
- Registers a `focus-comment` action in `src/lib/hotkeys/registry.ts`, wired in both issue views and enabled only for the view that owns the current selection.

### CLI version floors and forge fixes

- Adds version-floor checks in `src/lib/system/health.ts` surfaced by `src/features/settings/AboutSection.tsx`: a git or GitHub CLI that's installed but too old for a feature gets a warning naming the feature, the wanted version, and an Update link.
- Maps gh's `Unknown JSON field` failure to the real cause in `src-tauri/src/github/issue.rs` (`is_unknown_json_field` / `map_gh_too_old`), so opening an issue on a pre-2.94 gh explains the floor instead of dumping CLI output; covered by two new unit tests.
- Fixes Explore-tab forking by dropping `--remote=false` from the fork argv in `src-tauri/src/forge/github.rs` — gh 2.88+ rejects it beside a repository argument at parse time. The argv moves into a `fork_args` helper pinned by a test that also asserts no `--remote*` flag can rejoin it.
- Routes the no-stash failure arm of `settle` in `src-tauri/src/git/autostash.rs` through `classify_failure` with the paused operation's name, so the same conflict no longer reports as structured state through one entry point and prose through the other.
- Updates the `GitLabForge` doc comment in `src-tauri/src/forge/gitlab.rs` to describe the resolved-host behavior that shipped.

### Documentation

- `README.md`: extends the branch-rules bullet with promotion branches and the About bullet with the outdated-CLI warning.
- `site/src/data/capabilities.ts`: adds the promotion-branches and self-managed-GitLab capability lines.
- `src/features/help/content.ts`: covers the new confirmations (undo first commit, revert, cherry-pick, commit checkout, stash apply/pop, whole-file accepts, closing a PR), the promotion-branches list, and the promotion strip's two wordings.
- Adds five `changelog.d/` fragments (promotion branches, destructive confirms, issue composer layout, CLI version floor, fork fix).
- `.claude/skills/gd-conventions/SKILL.md`: records the `commit-confirms.ts` shared-wording rule and the `leadingActions` composer contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable promotion branches for staging-to-production workflows.
  * Added self-managed GitLab host support and clearer authentication guidance.
  * Added a command-palette action to focus comment boxes.
  * Comment boxes now span the full content area with improved action placement.

* **Bug Fixes**
  * Restored repository forking from GitHub Explore.
  * Improved compatibility messaging for outdated Git and GitHub CLI versions.
  * Improved conflict reporting and promotion-branch update detection.

* **Safety Improvements**
  * Added confirmations for destructive history, stash, conflict-resolution, and hosted-item actions.
  * Clarified that rebased commits receive new IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->