### PR TITLE
fix(pulls,oplog,activity,sessions): explain blocked merges, lock stores

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -167,6 +167,13 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
   per-toggle auto-save; a single discrete select may apply-on-change.
 - Repo-content config features (FUNDING.yml, CODEOWNERS, …) scaffold the
   local file for the user to commit — never write repo content via an API.
+- A mutation whose host can unmount mid-flight (a dialog closable by Esc / ✕ /
+  backdrop, a keyed remount) rides `await mutateAsync` continuations, never
+  `.mutate(vars, { onSuccess, onError })` — react-query drops per-call
+  callbacks when the observer unmounts, so the toast, navigation, or cleanup
+  that lived in them silently never runs. The house idiom is `form.ts`'s
+  awaited-submit convention (`SquashDialog` in
+  `src/features/history/RewriteDialogs.tsx` is the reference).
 
 ## Rust / Tauri conventions
 
@@ -205,11 +212,17 @@ clickables add `cursor-pointer` at the call site (vendored Button sets none).
   (`oplog.rs` `GD_OPLOG_DIR`, `review_notes.rs` `GD_REVIEW_NOTES_DIR`:
   env override outranks the `cfg!(test)` temp arm; both ship in release) —
   a new store module mirrors one of these, never resolves app-data bare.
-  Concurrency: `oplog.rs` holds a process-LOCAL mutex per store mutation,
-  `review_notes.rs` relies on atomic whole-file replace — NEITHER serializes
-  across processes, and the MCP server writes both stores, so every write
-  stays best-effort/last-writer-wins; a new store module picks its shape
-  deliberately, never assuming a lock covers the other process.
+  Concurrency: the MCP server is a second writing process, so both stores'
+  read→modify→writes take the cross-process file lock in `store_lock.rs` (a
+  `create_new` lock file beside the store, stale-evicted, fail-open) on top of
+  their own in-process guards — `oplog.rs` its `OPLOG_LOCK` mutex,
+  `review_notes.rs` its `notes_lock()` mutex — with the atomic whole-file
+  replace underneath both (torn-file safety, not lost-update safety). The GUI's
+  review-notes writes route through the locked `review_notes_set_branch` /
+  `review_notes_delete_branch` Tauri commands rather than the plugin store
+  (cold-start test mode is the one exception: it aliases the store file and
+  has no second writer). A NEW store module with more than one process
+  writing adopts `store_lock` — don't assume last-writer-wins is acceptable.
 - **Forge gating:** per-action `Implemented` flags. Shared-with-GitHub
   controls gate on `canWrite || forgeFeatureReady` (GitHub must be zero-diff);
   provider-only controls gate on `forgeFeatureReady` alone with the flag

--- a/README.md
+++ b/README.md
@@ -285,11 +285,14 @@ PR (comments and all) in one click.
   worktree and nothing else, and an unfinished resolution is offered back as
   **Continue resolving**. Fork PRs are excluded, since their head lives in
   another repository.
-- **Blocked by branch protection** (GitHub): a PR that merges cleanly but
-  whose base branch rules aren't satisfied gets its own strip line, naming
-  the required checks still outstanding (four, then *and N more*).
-  **Merge** stays available (whoever holds bypass permission can merge anyway),
-  and a refused merge repeats the same line beside the forge's own message.
+- **Blocked by branch protection**: a PR that merges cleanly but whose rules
+  refuse it gets its own strip line naming the reason. On **GitHub** that's
+  the required checks still outstanding (four, then *and N more*) plus the
+  approving-review count the rules demand; on **GitLab** it's the blocking
+  reason itself — approval, pipeline, unresolved discussions, and the rest of
+  its detailed merge statuses. **Merge** stays available (whoever holds bypass
+  permission can merge anyway), and a refused merge repeats the same line
+  beside the forge's own message.
 - **Local PR merges**: a merge **pre-shows conflicts** and lets you resolve
   them in the in-app editor, in an isolated worktree that never touches your
   working tree, then **Finish** or **Abort**.
@@ -919,8 +922,10 @@ review via its subscription login. The full list is under
     picked.
 - **Keys**: kept in the OS keychain (Windows Credential Manager, macOS
   Keychain, libsecret). **Hide AI** (Settings → General) hides the AI
-  surfaces and pauses your automations while keeping your config; rules
-  start firing again when you turn AI features back on.
+  surfaces (finished AI activity in the dock and notification inbox
+  included), mutes AI desktop notifications, and pauses your automations
+  while keeping your config; rules start firing again when you turn AI
+  features back on.
 
 ## Updates
 

--- a/changelog.d/changed-gitlab-blocked-banner.md
+++ b/changelog.d/changed-gitlab-blocked-banner.md
@@ -1,0 +1,2 @@
+- GitLab merge requests blocked on approvals, pipelines, discussions, or other
+  rules show the reason in the mergeability banner before you try to merge.

--- a/changelog.d/changed-scope-hints-reconnect.md
+++ b/changelog.d/changed-scope-hints-reconnect.md
@@ -1,0 +1,2 @@
+- Permission-scope hints in repository settings open the in-app reconnect flow
+  with the scope they need, alongside the copyable `gh auth refresh` command.

--- a/changelog.d/changed-session-model-picker.md
+++ b/changelog.d/changed-session-model-picker.md
@@ -1,0 +1,3 @@
+- The session, plan, and research model pickers search their suggestions as you
+  type and take any model id you enter, so a custom provider's model reaches the
+  agent CLI exactly as typed.

--- a/changelog.d/fixed-cross-process-store-writes.md
+++ b/changelog.d/fixed-cross-process-store-writes.md
@@ -1,0 +1,2 @@
+- Review notes and operation-journal records survive concurrent writes from the
+  app and its MCP server.

--- a/changelog.d/fixed-dialog-dismissed-outcomes.md
+++ b/changelog.d/fixed-dialog-dismissed-outcomes.md
@@ -1,0 +1,4 @@
+- Worktree rename, lock, unlock, repair and create, stash apply, drop and
+  restore, and history edits report their result even when their dialog closes
+  while the operation is still running; a paused rebase still lands you on the
+  Changes tab.

--- a/changelog.d/fixed-glab-quoted-host-keys.md
+++ b/changelog.d/fixed-glab-quoted-host-keys.md
@@ -1,0 +1,2 @@
+- Self-managed GitLab hosts are detected from quoted config keys, including
+  quoted `host:port` and `https://host` forms.

--- a/changelog.d/fixed-hide-ai-activity-rows.md
+++ b/changelog.d/fixed-hide-ai-activity-rows.md
@@ -1,0 +1,3 @@
+- Hiding AI features hides finished AI activity (reviews, agent runs, plans, and
+  research) from the activity dock and inbox, and mutes AI-event desktop
+  notifications; runs already in flight stay visible until they finish.

--- a/changelog.d/fixed-merge-refusal-reasons.md
+++ b/changelog.d/fixed-merge-refusal-reasons.md
@@ -1,0 +1,2 @@
+- Refused merges show the blocking reason in the app's own words, on GitHub and
+  GitLab.

--- a/changelog.d/fixed-oplog-stale-paused.md
+++ b/changelog.d/fixed-oplog-stale-paused.md
@@ -1,0 +1,3 @@
+- Operation history marks a cherry-pick that was finished or aborted outside the
+  app as "Ended outside the app", and those records age out of the history cap
+  normally.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -166,7 +166,7 @@ export const capabilities: Capability[] = [
   {
     group: "Pull requests & review",
     label:
-      "A merge blocked by branch protection names the required checks still unmet (GitHub)",
+      "A blocked merge names why — unmet checks & required approvals (GitHub), the blocking reason (GitLab)",
   },
   {
     group: "Pull requests & review",
@@ -581,7 +581,8 @@ export const capabilities: Capability[] = [
   {
     group: "AI · agents & sessions",
     ai: true,
-    label: "Delegate a task to a Claude, Codex, Copilot or opencode agent",
+    label:
+      "Delegate a task to a Claude, Codex, Copilot or opencode agent — searchable model picker, any typed id accepted",
     highlight: true,
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -247,7 +247,7 @@ export const capabilities: Capability[] = [
   {
     group: "Forges & trackers",
     label:
-      "Sign in & reconnect in-app — session-expired detection & token-expiry warnings",
+      "Sign in & reconnect in-app — session-expired detection & token-expiry warnings, plus scope hints that reconnect with the needed scope",
   },
   {
     group: "Forges & trackers",

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -2555,6 +2555,47 @@ pub async fn merge_mr(
     merge_mr_inner(repo_path, number, strategy, delete_branch, sha, false).await
 }
 
+/// The HTTP status behind a failed `glab api` call. glab writes either
+/// `glab: <message> (HTTP <code>)` when the error body carried a `message`, or a bare
+/// `glab: HTTP <code>` when it didn't (`internal/commands/api/api.go`). Read from the
+/// LAST `HTTP ` in the text: GitLab's own message often opens with the code too, and
+/// only the trailing one is glab's.
+fn glab_http_status(stderr: &str) -> Option<u16> {
+    const MARK: &str = "HTTP ";
+    let idx = stderr.rfind(MARK)?;
+    stderr[idx + MARK.len()..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .ok()
+}
+
+/// A refused merge PUT, in the app's own words — `None` for anything else, so an
+/// unrecognized failure still surfaces glab's raw text. Only two of the statuses the
+/// merge endpoint documents are reworded: `405 Method Not Allowed` ("The merge request
+/// cannot merge") and `409` ("SHA does not match HEAD of source branch") — GitLab's
+/// `doc/api/merge_requests.md`, "Merge a merge request".
+///
+/// `arming_auto_merge` holds the 405 arm back as the conservative choice, NOT a
+/// documented distinction: arming rides the same endpoint and the same status table,
+/// and whether a finished head pipeline answers 405 there is unverified. Falling open
+/// to glab's own text on that path risks a worse message, never a wrong claim.
+///
+/// The 405 message deliberately doesn't name WHICH requirement is unmet: the
+/// mergeability read owns that wording, and the refusal toast carries its line as a
+/// note — one place for the reasons, not two that can drift.
+fn classify_gl_merge_refusal(stderr: &str, arming_auto_merge: bool) -> Option<String> {
+    match glab_http_status(stderr)? {
+        405 if !arming_auto_merge => Some(
+            "GitLab is blocking this merge — the merge request isn't in a mergeable state yet."
+                .to_string(),
+        ),
+        409 => Some("The merge request changed while merging — refresh and retry.".to_string()),
+        _ => None,
+    }
+}
+
 /// The shared body behind `merge_mr` and `auto_merge_mr` — same endpoint, same
 /// strategy validation, same `sha` guard. The only difference is the extra
 /// `merge_when_pipeline_succeeds` flag, so both wrappers can't drift apart.
@@ -2628,7 +2669,25 @@ async fn merge_mr_inner(
         args.push("-f");
         args.push("merge_when_pipeline_succeeds=true");
     }
-    run_glab(Some(repo_path), &args, GLAB_NETWORK_TIMEOUT).await?;
+    let out = run_glab_raw(Some(repo_path), &args, GLAB_NETWORK_TIMEOUT).await?;
+    if out.code != 0 {
+        // Raw rather than `run_glab` only so a documented refusal can be reworded;
+        // everything else keeps `run_glab`'s exact fallback.
+        let raw = out.stderr.trim();
+        return Err(AppError::Glab(
+            match classify_gl_merge_refusal(&out.stderr, when_pipeline_succeeds) {
+                Some(message) => message,
+                None if raw.is_empty() => format!("glab exited with code {}", out.code),
+                None => raw.to_string(),
+            },
+        ));
+    }
+    // GitLab can also refuse in a body with a ZERO exit — the shape that makes a cancel
+    // look successful, and nothing about it is specific to that endpoint. A body without
+    // the error marker is success, whatever else it holds.
+    if let Some(message) = service_error_message(&out.stdout_lossy()) {
+        return Err(AppError::Glab(message));
+    }
     Ok(())
 }
 
@@ -9106,6 +9165,91 @@ mod tests {
         // A plain success-ish body and empty input are NOT errors.
         assert_eq!(service_error_message(r#"{"iid": 6}"#), None);
         assert_eq!(service_error_message(""), None);
+    }
+
+    /// The merge PUT gets the same envelope treatment as the cancel: a refusal can
+    /// ride a zero exit, and the success body is the MR object, which carries no
+    /// marker and must stay success. The message/status pair is the one GitLab
+    /// documents for a failed merge (`422 Branch cannot be merged`).
+    #[test]
+    fn a_merge_put_that_exits_zero_still_reports_an_error_envelope() {
+        assert_eq!(
+            service_error_message(
+                r#"{"message":"Branch cannot be merged","status":"error","http_status":422}"#
+            )
+            .as_deref(),
+            Some("Branch cannot be merged")
+        );
+        assert_eq!(
+            service_error_message(
+                r#"{"iid":7,"state":"merged","detailed_merge_status":"mergeable","merge_commit_sha":"abc"}"#
+            ),
+            None
+        );
+    }
+
+    /// glab's two stderr forms for an API failure, pinned as fixtures: with a server
+    /// `message` it writes `glab: <message> (HTTP <code>)`, without one a bare
+    /// `glab: HTTP <code>` (`internal/commands/api/api.go`).
+    #[test]
+    fn reads_the_status_glab_reports_for_a_failed_call() {
+        assert_eq!(
+            glab_http_status("glab: 405 Method Not Allowed (HTTP 405)\n"),
+            Some(405)
+        );
+        assert_eq!(glab_http_status("glab: HTTP 409\n"), Some(409));
+        // The trailing occurrence is glab's; a code inside the server message is not.
+        assert_eq!(
+            glab_http_status("glab: 404 Project Not Found (HTTP 403)\n"),
+            Some(403)
+        );
+        assert_eq!(glab_http_status("could not resolve host\n"), None);
+        assert_eq!(glab_http_status(""), None);
+    }
+
+    /// Only the two statuses GitLab documents for the merge endpoint are reworded —
+    /// 405 for an MR that can't be merged, 409 for a `sha` that no longer matches the
+    /// source head. Everything else falls open to glab's own text.
+    #[test]
+    fn classifies_the_documented_merge_refusals() {
+        assert_eq!(
+            classify_gl_merge_refusal("glab: 405 Method Not Allowed (HTTP 405)\n", false)
+                .as_deref(),
+            Some(
+                "GitLab is blocking this merge — the merge request isn't in a mergeable state yet."
+            )
+        );
+        assert_eq!(
+            classify_gl_merge_refusal(
+                "glab: SHA does not match HEAD of source branch (HTTP 409)\n",
+                false
+            )
+            .as_deref(),
+            Some("The merge request changed while merging — refresh and retry.")
+        );
+        // Arming rides the same endpoint and status table, so a 405 there may mean a
+        // race rather than a blocked merge. Unverified either way — that arm keeps
+        // glab's own wording rather than risking a wrong claim.
+        assert_eq!(
+            classify_gl_merge_refusal("glab: 405 Method Not Allowed (HTTP 405)\n", true),
+            None
+        );
+        // The stale-sha guard means the same thing whichever wrapper armed it.
+        assert!(classify_gl_merge_refusal("glab: HTTP 409\n", true).is_some());
+    }
+
+    /// Fail-open control: an unrecognized failure classifies to nothing, so the caller
+    /// surfaces glab's raw stderr rather than an invented reason.
+    #[test]
+    fn leaves_an_unrecognized_merge_failure_alone() {
+        for raw in [
+            "",
+            "glab: 401 Unauthorized (HTTP 401)\n",
+            "glab: HTTP 500\n",
+            "could not resolve host gitlab.example.com\n",
+        ] {
+            assert_eq!(classify_gl_merge_refusal(raw, false), None, "raw: {raw:?}");
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -224,14 +224,39 @@ fn flow_depth_after(depth: usize, text: &str) -> usize {
     })
 }
 
+/// The key and value of a `key: value` line. A QUOTED key is unquoted here,
+/// before any colon is looked for: YAML puts a colon inside the quotes (a port,
+/// a scheme), where splitting at the first colon cuts the key in half and bakes a
+/// quote into the hostname. An unbalanced quote yields None — the module's bias is
+/// never to drop a host, but a line whose quoting is broken has no readable key,
+/// and a corrupted entry (a junk account row Settings then probes) is worse than
+/// one dropped hand-mangled line. Both readers of a key line share this split, so
+/// a well-formed key ends in the same place for host extraction and for flow-depth
+/// tracking. None means BOTH stand down: an unbalanced-quote line that also opens a
+/// flow map has its depth left untracked, so its wrapped continuation can still be
+/// scanned as a key — accepted, since only triple-mangled input reaches it.
+///
+/// Quote handling is YAML-spec-grounded (a reader unquotes keys) rather than
+/// glab-source-verified: glab's own writer never emits a quoted key, so only a
+/// hand-edited config reaches this branch.
+fn split_key_value(trimmed: &str) -> Option<(&str, &str)> {
+    if let Some(quote) = trimmed.chars().next().filter(|c| matches!(c, '\'' | '"')) {
+        let rest = &trimmed[quote.len_utf8()..];
+        let end = rest.find(quote)?;
+        let after = rest[end + quote.len_utf8()..].trim_start();
+        return Some((&rest[..end], after.strip_prefix(':')?));
+    }
+    // Unquoted: the FIRST colon, scheme term included — without it a
+    // `https://host: {…}` line splits at the scheme and its flow map goes unseen,
+    // so the wrapped continuation is read back as a host key.
+    strip_scheme(trimmed).split_once(':')
+}
+
 /// The flow-collection depth a key line OPENS. Zero unless its value BEGINS with
 /// `{`/`[` — that is the only place YAML starts a flow collection, so a bracket
 /// inside a plain scalar (`token: abc[def`) must not latch the scanner shut.
 fn flow_open_depth(trimmed: &str) -> usize {
-    // The same key/value split `host_from_key_line` uses, scheme term included:
-    // without it a `https://host: {…}` line splits at the scheme and its flow map
-    // goes unseen, so the wrapped continuation is read back as a host key.
-    let Some((_, value)) = strip_scheme(trimmed).split_once(':') else {
+    let Some((_, value)) = split_key_value(trimmed) else {
         return 0;
     };
     let value = value.trim_start();
@@ -249,16 +274,13 @@ fn flow_open_depth(trimmed: &str) -> usize {
 /// comma is never a hostname and is refused: that is the one shape a stray value
 /// fragment (a mis-indented flow continuation) could otherwise arrive in.
 fn host_from_key_line(trimmed: &str) -> Option<String> {
-    let key = strip_scheme(trimmed).split_once(':')?.0.trim();
+    let key = split_key_value(trimmed)?.0.trim();
     if key == "<<" || key.contains(char::is_whitespace) || key.contains(',') {
         return None;
     }
-    // Quotes around a key are YAML syntax; left on they bake into the hostname.
-    let unquoted = ['\'', '"']
-        .iter()
-        .find_map(|q| key.strip_prefix(*q)?.strip_suffix(*q))
-        .unwrap_or(key);
-    normalize_host(unquoted)
+    // A quoted key arrives already unquoted; `normalize_host` strips whatever
+    // scheme, port, or path the quotes were protecting.
+    normalize_host(key)
 }
 
 /// The host keys of the `hosts:` section of a glab config.yml. A minimal line
@@ -649,6 +671,31 @@ hosts:
             (
                 "quoted keys",
                 "hosts:\n  \"gitlab.example.com\":\n  'other.example.com':\n",
+                &["gitlab.example.com", "other.example.com"],
+            ),
+            (
+                "a port inside the quotes — the colon is the key's, not a separator",
+                "hosts:\n  \"gitlab.example.com:8443\":\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "a scheme inside the quotes",
+                "hosts:\n  \"https://gitlab.example.com\":\n    token: secret\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "single quotes carry a port too",
+                "hosts:\n  'gitlab.example.com:443':\n",
+                &["gitlab.example.com"],
+            ),
+            (
+                "an unbalanced quote has no readable key — skip the line",
+                "hosts:\n  \"gitlab.example.com:\n  other.example.com:\n",
+                &["other.example.com"],
+            ),
+            (
+                "a quoted key opening a wrapped flow map",
+                "hosts:\n  \"gitlab.example.com:8443\": {token: secret,\n  api_host: x}\n  other.example.com:\n",
                 &["gitlab.example.com", "other.example.com"],
             ),
         ]);

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -770,33 +770,123 @@ impl Drop for ReconnectGuard {
     }
 }
 
+/// A reconnect host must be a bare hostname: no port, no scheme, no path. Narrow
+/// on purpose — the value becomes a `--hostname` argument, and the CLIs key their
+/// stored credentials by exactly this spelling.
+fn valid_reconnect_host(host: &str) -> bool {
+    !host.is_empty()
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+}
+
+/// The most extra scopes one reconnect may request — a scope hint asks for one, and
+/// a caller sending a long list is malformed rather than ambitious.
+const MAX_RECONNECT_SCOPES: usize = 4;
+
+/// The argv for a reconnect child, pure so the flag spelling and the scope rules are
+/// pinned by tests rather than by a live CLI. `scopes` ride a GitHub *refresh* only:
+/// that is the one gh flow that widens an existing token's grants (`gh auth refresh
+/// -s <scope>`), while `auth login` re-runs the whole OAuth flow and glab has no
+/// equivalent — so a scope arriving on any other arm is refused, never dropped
+/// silently, since dropping it would hand back a session still missing the scope.
+fn reconnect_args(
+    provider: &str,
+    mode: &str,
+    host: &str,
+    scopes: &[String],
+) -> AppResult<Vec<String>> {
+    if !scopes.is_empty() {
+        if provider != "github" || mode != "refresh" {
+            return Err(AppError::InvalidArgument(
+                "scopes apply only to a GitHub refresh".into(),
+            ));
+        }
+        if scopes.len() > MAX_RECONNECT_SCOPES {
+            return Err(AppError::InvalidArgument(format!(
+                "too many scopes: {}",
+                scopes.len()
+            )));
+        }
+        // `[a-z0-9_:]+` — the whole shape of an OAuth scope (`repo`,
+        // `admin:repo_hook`, `delete_repo`); anything else can't be one.
+        if let Some(bad) = scopes.iter().find(|s| {
+            s.is_empty()
+                || !s
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == ':')
+        }) {
+            return Err(AppError::InvalidArgument(format!("invalid scope: {bad}")));
+        }
+    }
+    let mut args: Vec<String> = match (provider, mode) {
+        ("github", "refresh") => vec!["auth", "refresh", "--hostname", host],
+        ("github", _) => vec![
+            "auth",
+            "login",
+            "--hostname",
+            host,
+            "--web",
+            "--skip-ssh-key",
+            "--git-protocol",
+            "https",
+        ],
+        // glab has no `refresh` subcommand — login re-runs OAuth in both modes.
+        ("gitlab", _) => vec!["auth", "login", "--hostname", host, "--web"],
+        ("bitbucket", _) => {
+            return Err(AppError::InvalidArgument(
+                "Reconnect Bitbucket in Settings → Accounts.".into(),
+            ))
+        }
+        (other, _) => {
+            return Err(AppError::InvalidArgument(format!(
+                "unknown provider: {other}"
+            )))
+        }
+    }
+    .into_iter()
+    .map(String::from)
+    .collect();
+    for scope in scopes {
+        args.push("-s".to_string());
+        args.push(scope.clone());
+    }
+    Ok(args)
+}
+
 /// A cancellable `gh`/`glab` re-auth driver. Spawns the device-flow login/refresh
 /// child, streams its stdout+stderr as sanitized `ReconnectEvent`s, and resolves when
 /// the child exits or is cancelled. `session_id` is a frontend uuid; `mode` is
 /// `"login"` | `"refresh"`; `provider` is `github` | `gitlab` (Bitbucket has no CLI
-/// reconnect — it errors).
+/// reconnect — it errors). `scopes` widen a GitHub refresh (see `reconnect_args`).
+///
+/// gh refreshes the host's ACTIVE account: on a multi-account host the granted scopes
+/// land on whichever account `gh auth switch` last selected, not necessarily the one
+/// whose missing scope prompted the call.
 #[tauri::command]
 pub async fn forge_reconnect(
     session_id: String,
     provider: String,
     host: String,
     mode: String,
+    scopes: Option<Vec<String>>,
     on_event: Channel<ReconnectEvent>,
 ) -> AppResult<()> {
     // ── Validate every input before spawning anything ──
     if !valid_session_id(&session_id) {
         return Err(AppError::InvalidArgument("invalid session id".into()));
     }
-    if host.is_empty()
-        || !host
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
-    {
+    if !valid_reconnect_host(&host) {
         return Err(AppError::InvalidArgument(format!("invalid host: {host}")));
     }
     if !matches!(mode.as_str(), "login" | "refresh") {
         return Err(AppError::InvalidArgument(format!("invalid mode: {mode}")));
     }
+    // Built before registering: a rejected provider/scope must not seed a registry
+    // entry, and the build is sync — nothing can race in ahead of the registration.
+    let args = reconnect_args(&provider, &mode, &host, scopes.as_deref().unwrap_or(&[]))?;
+    let is_github = provider == "github";
+    let bin_names: &[&str] = if is_github { &["gh"] } else { &["glab"] };
 
     // Register BEFORE the async resolve+spawn so a cancel racing ahead of them is
     // captured (see `register_reconnect`). The guard unregisters on every exit path
@@ -805,52 +895,6 @@ pub async fn forge_reconnect(
         session_id: session_id.clone(),
         notify: register_reconnect(&session_id),
     };
-
-    let (bin_names, args): (&[&str], Vec<String>) = match provider.as_str() {
-        "github" => {
-            let args = match mode.as_str() {
-                "refresh" => vec![
-                    "auth".to_string(),
-                    "refresh".to_string(),
-                    "--hostname".to_string(),
-                    host.clone(),
-                ],
-                // login
-                _ => vec![
-                    "auth".to_string(),
-                    "login".to_string(),
-                    "--hostname".to_string(),
-                    host.clone(),
-                    "--web".to_string(),
-                    "--skip-ssh-key".to_string(),
-                    "--git-protocol".to_string(),
-                    "https".to_string(),
-                ],
-            };
-            (&["gh"], args)
-        }
-        "gitlab" => (
-            &["glab"],
-            vec![
-                "auth".to_string(),
-                "login".to_string(),
-                "--hostname".to_string(),
-                host.clone(),
-                "--web".to_string(),
-            ],
-        ),
-        "bitbucket" => {
-            return Err(AppError::InvalidArgument(
-                "Reconnect Bitbucket in Settings → Accounts.".into(),
-            ))
-        }
-        other => {
-            return Err(AppError::InvalidArgument(format!(
-                "unknown provider: {other}"
-            )))
-        }
-    };
-    let is_github = provider == "github";
 
     let Some(binary) = crate::agent::resolve_named(bin_names, None).await else {
         return Err(if is_github {
@@ -1694,5 +1738,107 @@ mod tests {
         assert!(!valid_session_id("short")); // < 8
         assert!(!valid_session_id("has space in it here")); // space
         assert!(!valid_session_id(&"a".repeat(65))); // > 64
+    }
+
+    // ── reconnect argv seam ──
+    fn args_of(provider: &str, mode: &str, scopes: &[&str]) -> Vec<String> {
+        let scopes: Vec<String> = scopes.iter().map(|s| (*s).to_string()).collect();
+        reconnect_args(provider, mode, "github.com", &scopes).unwrap()
+    }
+
+    #[test]
+    fn reconnect_args_per_provider_and_mode() {
+        assert_eq!(
+            args_of("github", "refresh", &[]),
+            ["auth", "refresh", "--hostname", "github.com"]
+        );
+        assert_eq!(
+            args_of("github", "login", &[]),
+            [
+                "auth",
+                "login",
+                "--hostname",
+                "github.com",
+                "--web",
+                "--skip-ssh-key",
+                "--git-protocol",
+                "https"
+            ]
+        );
+        // glab has no refresh — both modes are the same `--web` login.
+        for mode in ["login", "refresh"] {
+            assert_eq!(
+                args_of("gitlab", mode, &[]),
+                ["auth", "login", "--hostname", "github.com", "--web"]
+            );
+        }
+    }
+
+    #[test]
+    fn reconnect_args_emit_repeated_scope_flags() {
+        assert_eq!(
+            args_of("github", "refresh", &["admin:repo_hook", "delete_repo"]),
+            [
+                "auth",
+                "refresh",
+                "--hostname",
+                "github.com",
+                "-s",
+                "admin:repo_hook",
+                "-s",
+                "delete_repo"
+            ]
+        );
+    }
+
+    #[test]
+    fn reconnect_args_reject_scopes_off_the_github_refresh_arm() {
+        let scopes = vec!["repo".to_string()];
+        // Refused, never silently dropped — a dropped scope hands back a session
+        // still missing it.
+        assert!(reconnect_args("github", "login", "github.com", &scopes).is_err());
+        assert!(reconnect_args("gitlab", "login", "gitlab.com", &scopes).is_err());
+        assert!(reconnect_args("gitlab", "refresh", "gitlab.com", &scopes).is_err());
+    }
+
+    #[test]
+    fn reconnect_args_reject_malformed_scopes() {
+        let bad = [
+            "Repo",           // uppercase
+            "read-org",       // dash
+            "repo workflow",  // space
+            "",               // empty
+            "repo;rm -rf /",  // shell-ish
+            "--reset-scopes", // a flag posing as a scope
+        ];
+        for scope in bad {
+            assert!(
+                reconnect_args("github", "refresh", "github.com", &[scope.to_string()]).is_err(),
+                "scope should be refused: {scope:?}"
+            );
+        }
+        let too_many: Vec<String> = (0..MAX_RECONNECT_SCOPES + 1)
+            .map(|i| format!("scope{i}"))
+            .collect();
+        assert!(reconnect_args("github", "refresh", "github.com", &too_many).is_err());
+        let at_cap = &too_many[..MAX_RECONNECT_SCOPES];
+        assert!(reconnect_args("github", "refresh", "github.com", at_cap).is_ok());
+    }
+
+    #[test]
+    fn reconnect_args_reject_unsupported_providers() {
+        assert!(reconnect_args("bitbucket", "login", "bitbucket.org", &[]).is_err());
+        assert!(reconnect_args("codeberg", "login", "codeberg.org", &[]).is_err());
+    }
+
+    #[test]
+    fn reconnect_host_grammar_stays_bare() {
+        assert!(valid_reconnect_host("github.com"));
+        assert!(valid_reconnect_host("gitlab.example-corp.com"));
+        assert!(!valid_reconnect_host("")); // empty
+        assert!(!valid_reconnect_host("gitlab.example.com:8443")); // port
+        assert!(!valid_reconnect_host("https://gitlab.example.com")); // scheme
+        assert!(!valid_reconnect_host("gitlab.example.com/path")); // path
+        assert!(!valid_reconnect_host("host --flag")); // argv injection
     }
 }

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -247,8 +247,8 @@ pub(crate) async fn git_commit_core(
     // The widest of the close routes, and the loosest: this is also the MCP commit
     // tool's choke point, and ANY commit that clears a `CHERRY_PICK_HEAD` fires it —
     // so a plain unjournaled `cherry-pick` resolved here closes whatever paused
-    // record the repo still holds, which is only the right one while no stale record
-    // predates it.
+    // record the repo still holds. Wrong only when a stale record predates it, and
+    // only until a `git_oplog_check` that finds no pick in progress retires it.
     if was_cherry_picking && !crate::git::ops::cherry_pick_marker_present(&repo_path) {
         crate::oplog::close_paused_pick(&repo_path, crate::oplog::PausedOutcome::Continued).await;
     }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -271,9 +271,10 @@ pub(crate) async fn op_abort(state: &AppState, repo_path: &str, op: &str) -> App
     }
     // Closes the stop arm's paused record as the user's own abandonment. The verdict
     // is only right for the record this abort actually ended: a pick concluded
-    // outside the app leaves a stale paused record that this call would close as
-    // "aborted by user" instead — the accepted cost of keying on the newest paused
-    // record rather than an op id.
+    // outside the app leaves a stale paused record until the next `git_oplog_check`
+    // that finds no pick in progress retires it via `conclude_stale_pauses` — until
+    // then, this call would close it as "aborted by user" (the accepted cost of
+    // keying on the newest paused record rather than an op id).
     if op == "cherry-pick" {
         crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Aborted).await;
     }
@@ -348,8 +349,8 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
     // A cherry-pick that reaches here is over, so a `cherry_pick_onto` record the
     // stop arm left "paused" is closed as done. This is one of the two in-app routes
     // that end a pick — the commit box is the other, and closes it too. A pick
-    // concluded from a terminal leaves its record paused until a later in-app
-    // continue or abort of any pick closes it.
+    // concluded from a terminal keeps its record paused until the next
+    // `git_oplog_check` that finds no pick in progress retires it.
     if op == "cherry-pick" {
         crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Continued).await;
     }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -619,6 +619,78 @@ pub struct PrMergeOutcome {
     pub queued: bool,
 }
 
+/// Drops the trailing ` (<path>)` go-gh appends to a GraphQL error message — the
+/// mutation path is GitHub's plumbing, not something a reader acts on.
+///
+/// A GraphQL path is one token (`mergePullRequest`, `a.b.0`), so a parenthetical
+/// holding a SPACE is the author's own aside and survives. And go-gh joins several
+/// errors into one line (`m1 (p1), m2 (p2)`), where dropping only the last would leave
+/// the first inline and read as mangled — so a message carrying more than one
+/// path-shaped parenthetical rides through whole.
+fn strip_graphql_path(msg: &str) -> &str {
+    let msg = msg.trim();
+    let mut found: Option<(usize, usize)> = None;
+    let mut count = 0usize;
+    let mut cursor = 0usize;
+    while let Some(rel) = msg[cursor..].find(" (") {
+        let open = cursor + rel;
+        let inner = open + " (".len();
+        let Some(rel_close) = msg[inner..].find(')') else {
+            break;
+        };
+        let close = inner + rel_close;
+        if !msg[inner..close].is_empty() && !msg[inner..close].contains(' ') {
+            count += 1;
+            found = Some((open, close));
+        }
+        cursor = close + 1;
+    }
+    match found {
+        Some((open, close)) if count == 1 && close + 1 == msg.len() => msg[..open].trim_end(),
+        _ => msg,
+    }
+}
+
+/// A refused `gh pr merge`, in the app's own words — `None` for any stderr that isn't
+/// one of the shapes below, so an unrecognized failure still surfaces gh's raw text.
+///
+/// Matching is per LINE, which is what drops gh's advice lines (`--auto`, `--admin`,
+/// `gh pr checkout …` — flags and a flow this app doesn't offer) instead of showing
+/// them. Within a line the reason is matched as a substring: cli/cli writes it as
+/// `<FailureIcon> Pull request <owner>/<repo>#<n> is not mergeable: <reason>.`
+/// (`pkg/cmd/pr/merge/merge.go`, `canMerge` + `blockedReason`), so the anchor sits
+/// after a prefix that carries the repo slug and the PR number. A GraphQL refusal is
+/// GitHub's own sentence, which go-gh formats as `GraphQL: <message> (<path>)`.
+fn classify_gh_merge_refusal(stderr: &str) -> Option<String> {
+    const GRAPHQL: &str = "GraphQL: ";
+    for line in stderr.lines() {
+        let line = line.trim();
+        if line.contains("is not mergeable: the base branch policy prohibits the merge") {
+            return Some(
+                "GitHub is blocking this merge — branch protections aren't satisfied yet."
+                    .to_string(),
+            );
+        }
+        if line.contains("is not mergeable: the head branch is not up to date") {
+            return Some(
+                "The branch is behind its base — update the branch, then merge.".to_string(),
+            );
+        }
+        if line.contains("is not mergeable: the merge commit cannot be cleanly created") {
+            return Some(
+                "The branch has conflicts with its base — resolve them, then merge.".to_string(),
+            );
+        }
+        if let Some(idx) = line.find(GRAPHQL) {
+            let msg = strip_graphql_path(&line[idx + GRAPHQL.len()..]);
+            if !msg.is_empty() {
+                return Some(msg.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Merges the PR with the given strategy ("merge"/"squash"/"rebase"). With
 /// `delete_branch`, only the *remote* head branch is removed — local branch and
 /// HEAD are untouched.
@@ -659,12 +731,23 @@ pub async fn gh_pr_merge(
     let queued = if gh_pr_is_stacked(&repo_path, &slug, number).await {
         gh_pr_merge_async(&repo_path, &slug, number, &strategy).await? == StackedMergeResult::Queued
     } else {
-        run_gh(
+        let out = run_gh_raw(
             Some(&repo_path),
             &["pr", "merge", &n, method, "--repo", &slug],
             GH_NETWORK_TIMEOUT,
         )
         .await?;
+        if out.code != 0 {
+            // Raw rather than `run_gh` only so the refusal can be reworded: gh's own
+            // blob advises `--auto`/`--admin`/`gh pr checkout`, none of which this app
+            // offers. Every unrecognized failure keeps `run_gh`'s exact fallback.
+            let raw = out.stderr.trim();
+            return Err(AppError::Gh(match classify_gh_merge_refusal(&out.stderr) {
+                Some(message) => message,
+                None if raw.is_empty() => format!("gh exited with code {}", out.code),
+                None => raw.to_string(),
+            }));
+        }
         false
     };
     // Merge accepted: from here a cleanup failure is a warning on success, never an error.
@@ -5603,7 +5686,8 @@ fn scrape_pr_ref(stdout: &str) -> (u64, String) {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_stack_join, classify_merge_async, external_items_from_thread_nodes,
+        apply_stack_join, classify_gh_merge_refusal, classify_merge_async,
+        external_items_from_thread_nodes,
         flatten_slurped_pages, fork_head_identity, gh_api_error_message, host_from_url,
         is_diff_too_large, is_object_id, map_timeline_node, parse_actions_run_job,
         parse_auth_accounts, parse_pr_url_repo, pr_edit_args, pr_poll_query, pull_stack_ref,
@@ -5623,6 +5707,97 @@ mod tests {
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
+
+    /// The three blobs `gh pr merge` writes to stderr when it refuses, assembled from
+    /// cli/cli `pkg/cmd/pr/merge/merge.go` — `canMerge` writes the `is not mergeable`
+    /// line plus the advice lines, `blockedReason` supplies the reason text. Fixtures
+    /// rather than a live gh: reproducing them needs a protected repo, a stale branch
+    /// and a conflicted one. The failure icon is a plain `X` under `NO_COLOR`
+    /// (`iostreams::ColorScheme::FailureIcon`), which the runner sets.
+    #[test]
+    fn classifies_the_merge_refusals_gh_writes() {
+        let blocked = "X Pull request theBGuy/GitDesktop#12 is not mergeable: the base branch policy prohibits the merge.\nTo have the pull request merged after all the requirements have been met, add the `--auto` flag.\nTo use administrator privileges to immediately merge the pull request, add the `--admin` flag.\n";
+        assert_eq!(
+            classify_gh_merge_refusal(blocked).as_deref(),
+            Some("GitHub is blocking this merge — branch protections aren't satisfied yet.")
+        );
+
+        let behind = "X Pull request theBGuy/GitDesktop#12 is not mergeable: the head branch is not up to date with the base branch.\nTo have the pull request merged after all the requirements have been met, add the `--auto` flag.\nTo use administrator privileges to immediately merge the pull request, add the `--admin` flag.\n";
+        assert_eq!(
+            classify_gh_merge_refusal(behind).as_deref(),
+            Some("The branch is behind its base — update the branch, then merge.")
+        );
+
+        let dirty = "X Pull request theBGuy/GitDesktop#12 is not mergeable: the merge commit cannot be cleanly created.\nTo have the pull request merged after all the requirements have been met, add the `--auto` flag.\nRun the following to resolve the merge conflicts locally:\n  gh pr checkout 12 && git fetch origin master && git merge origin/master\n";
+        assert_eq!(
+            classify_gh_merge_refusal(dirty).as_deref(),
+            Some("The branch has conflicts with its base — resolve them, then merge.")
+        );
+
+        // The advice never survives into the rewritten message — it names flags and a
+        // checkout flow the app doesn't offer.
+        for raw in [blocked, behind, dirty] {
+            let message = classify_gh_merge_refusal(raw).expect("classified");
+            assert!(!message.contains("--auto"), "{message}");
+            assert!(!message.contains("--admin"), "{message}");
+            assert!(!message.contains("gh pr checkout"), "{message}");
+        }
+    }
+
+    /// go-gh formats a GraphQL refusal as `GraphQL: <message> (<path>)`
+    /// (`pkg/api/errors.go`). GitHub's own sentence is the useful part; the mutation
+    /// path is plumbing.
+    #[test]
+    fn passes_a_graphql_refusal_through_without_its_plumbing() {
+        assert_eq!(
+            classify_gh_merge_refusal(
+                "GraphQL: Pull Request is not mergeable (mergePullRequest)\n"
+            )
+            .as_deref(),
+            Some("Pull Request is not mergeable")
+        );
+        // No path element — nothing to strip.
+        assert_eq!(
+            classify_gh_merge_refusal("GraphQL: Base branch was modified\n").as_deref(),
+            Some("Base branch was modified")
+        );
+        // go-gh joins multiple errors with ", " and gives each its own path. Stripping
+        // only the trailing one would leave `m1 (p1)` inline beside a bare `m2`, so the
+        // whole line rides through as GitHub composed it.
+        assert_eq!(
+            classify_gh_merge_refusal(
+                "GraphQL: Pull Request is not mergeable (mergePullRequest), Base branch was modified (mergePullRequest)\n"
+            )
+            .as_deref(),
+            Some(
+                "Pull Request is not mergeable (mergePullRequest), Base branch was modified (mergePullRequest)"
+            )
+        );
+        // A parenthetical with a space in it is prose, not a path — a GraphQL path is
+        // always one token, so the aside is kept.
+        assert_eq!(
+            classify_gh_merge_refusal(
+                "GraphQL: Base branch was modified (review and try the merge again)\n"
+            )
+            .as_deref(),
+            Some("Base branch was modified (review and try the merge again)")
+        );
+    }
+
+    /// Fail-open control: an unrecognized failure must classify to nothing, so the
+    /// caller surfaces gh's raw stderr rather than an invented reason.
+    #[test]
+    fn leaves_an_unrecognized_merge_failure_alone() {
+        for raw in [
+            "",
+            "   \n\n",
+            "gh: Not Found (HTTP 404)\n",
+            "X Cannot use `-d` or `--delete-branch` when merge queue enabled\n",
+            "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com\n",
+        ] {
+            assert_eq!(classify_gh_merge_refusal(raw), None, "raw: {raw:?}");
+        }
+    }
 
     /// Both PR branches ride a push refspec, so every character that could
     /// reshape one is refused before any remote work: `:` would retarget the

--- a/src-tauri/src/github/rulesets.rs
+++ b/src-tauri/src/github/rulesets.rs
@@ -148,6 +148,36 @@ fn required_check_contexts(rules: &Value) -> Vec<String> {
     out
 }
 
+/// The approving reviews the branch's `pull_request` rules demand, or `None` when no
+/// such rule names a count. The MAXIMUM across rules: several rulesets may each set a
+/// count and GitHub enforces the strictest. A count of zero is "no approvals required"
+/// — the same thing as an absent rule to a reader, so it reads as `None` rather than
+/// "0 approving reviews".
+fn required_approving_reviews(rules: &Value) -> Option<u32> {
+    rules
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|rule| rule.get("type").and_then(Value::as_str) == Some("pull_request"))
+        .filter_map(|rule| {
+            rule.pointer("/parameters/required_approving_review_count")
+                .and_then(Value::as_u64)
+        })
+        .max()
+        .filter(|n| *n > 0)
+        .map(|n| n as u32)
+}
+
+/// What the base branch's active rules demand of a pull request, for the blocked-merge
+/// line. Approvals ride alongside the check contexts because the PR's own check rollup
+/// can never name them — nothing in it corresponds to a review requirement.
+#[derive(Serialize, Default, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BranchRequiredRules {
+    pub contexts: Vec<String>,
+    pub required_approving_review_count: Option<u32>,
+}
+
 /// A branch name made safe for the `rules/branches/{branch}` path. gh parses the URL
 /// with Go's `url.Parse`, where a raw `#` opens a FRAGMENT — `master#x` reads
 /// `master`'s rules, naming another branch's checks — and a bare `%` fails the parse.
@@ -159,17 +189,18 @@ fn escape_branch_path(branch: &str) -> String {
     branch.replace('%', "%25").replace('#', "%23")
 }
 
-/// The status-check contexts the branch's active rules require, for the pull-request
-/// view's blocked-merge line. `/rules/branches` aggregates every ruleset that applies
-/// and answers `[]` for a readable branch under no rules. A branch the token can't
-/// read — or a name the ref gate refuses — is an Err, like every other `run_gh`
-/// non-zero exit; the caller may treat that as empty, but it is not reported as empty.
+/// What the branch's active rules require, for the pull-request view's blocked-merge
+/// line. `/rules/branches` aggregates every ruleset that applies and answers `[]` for a
+/// readable branch under no rules. A branch the token can't read — or a name the ref
+/// gate refuses — is an Err, like every other `run_gh` non-zero exit; the caller may
+/// treat that as empty, but it is not reported as empty. One response feeds both the
+/// contexts and the approvals count — the approvals rule rides the same payload.
 #[tauri::command]
 pub async fn gh_branch_required_checks(
     repo_path: String,
     branch: String,
     lens: Option<String>,
-) -> AppResult<Vec<String>> {
+) -> AppResult<BranchRequiredRules> {
     // Both guards are needed: the ref gate rejects refspec metacharacters but permits
     // `#`/`%`, which are legal in a git ref and special in a URL.
     crate::git::branches::validate_branch_name(&branch)?;
@@ -190,7 +221,10 @@ pub async fn gh_branch_required_checks(
     .await?;
     let rules: Value = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse the branch rules: {e}")))?;
-    Ok(required_check_contexts(&rules))
+    Ok(BranchRequiredRules {
+        contexts: required_check_contexts(&rules),
+        required_approving_review_count: required_approving_reviews(&rules),
+    })
 }
 
 /// Flips only `enforcement` (the reversible soft-off). PUT is a full replace, so
@@ -229,6 +263,63 @@ mod tests {
 
     fn contexts(raw: &str) -> Vec<String> {
         required_check_contexts(&serde_json::from_str::<Value>(raw).expect("valid JSON"))
+    }
+
+    fn approvals(raw: &str) -> Option<u32> {
+        required_approving_reviews(&serde_json::from_str::<Value>(raw).expect("valid JSON"))
+    }
+
+    #[test]
+    fn reads_the_approvals_count_the_same_payload_already_carries() {
+        // The `pull_request` rule rides the very response the contexts come from, so
+        // naming approvals costs no second call.
+        let raw = r#"[
+            {"type":"pull_request","parameters":{"required_approving_review_count":2,"dismiss_stale_reviews_on_push":true}},
+            {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"build"}]}}
+        ]"#;
+        assert_eq!(approvals(raw), Some(2));
+        assert_eq!(contexts(raw), vec!["build"]);
+    }
+
+    #[test]
+    fn the_strictest_rule_wins_and_no_requirement_reads_as_none() {
+        assert_eq!(
+            approvals(
+                r#"[
+                    {"type":"pull_request","parameters":{"required_approving_review_count":1}},
+                    {"type":"pull_request","parameters":{"required_approving_review_count":3}}
+                ]"#
+            ),
+            Some(3)
+        );
+        // Absent rule, absent field, a zero count, and shapes the endpoint never
+        // promised all mean "no approvals to name" — never a fabricated 0.
+        for raw in [
+            "[]",
+            r#"[{"type":"required_status_checks","parameters":{"required_status_checks":[]}}]"#,
+            r#"[{"type":"pull_request"}]"#,
+            r#"[{"type":"pull_request","parameters":{}}]"#,
+            r#"[{"type":"pull_request","parameters":{"required_approving_review_count":0}}]"#,
+            r#"[{"type":"pull_request","parameters":{"required_approving_review_count":"two"}}]"#,
+            r#"{"message":"Not Found"}"#,
+        ] {
+            assert_eq!(approvals(raw), None, "raw: {raw}");
+        }
+    }
+
+    #[test]
+    fn the_rules_shape_serializes_camel_case() {
+        // The frontend reads `requiredApprovingReviewCount`; an absent count must
+        // travel as an explicit null rather than vanishing from the object.
+        let json = serde_json::to_string(&BranchRequiredRules {
+            contexts: vec!["build".into()],
+            required_approving_review_count: None,
+        })
+        .expect("serializes");
+        assert_eq!(
+            json,
+            r#"{"contexts":["build"],"requiredApprovingReviewCount":null}"#
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/rulesets.rs
+++ b/src-tauri/src/github/rulesets.rs
@@ -162,10 +162,12 @@ fn required_approving_reviews(rules: &Value) -> Option<u32> {
         .filter_map(|rule| {
             rule.pointer("/parameters/required_approving_review_count")
                 .and_then(Value::as_u64)
+                // Out-of-u32-range counts DROP rather than truncate — `as u32` would
+                // turn a nonsense 2^32+1 into a fabricated "1 approving review".
+                .and_then(|n| u32::try_from(n).ok())
         })
-        .max()
         .filter(|n| *n > 0)
-        .map(|n| n as u32)
+        .max()
 }
 
 /// What the base branch's active rules demand of a pull request, for the blocked-merge
@@ -292,6 +294,17 @@ mod tests {
             ),
             Some(3)
         );
+        // The u32 conversion runs per-value, BEFORE the max: an out-of-range nonsense
+        // count drops while its in-range sibling still names the requirement.
+        assert_eq!(
+            approvals(
+                r#"[
+                    {"type":"pull_request","parameters":{"required_approving_review_count":4294967297}},
+                    {"type":"pull_request","parameters":{"required_approving_review_count":3}}
+                ]"#
+            ),
+            Some(3)
+        );
         // Absent rule, absent field, a zero count, and shapes the endpoint never
         // promised all mean "no approvals to name" — never a fabricated 0.
         for raw in [
@@ -301,6 +314,8 @@ mod tests {
             r#"[{"type":"pull_request","parameters":{}}]"#,
             r#"[{"type":"pull_request","parameters":{"required_approving_review_count":0}}]"#,
             r#"[{"type":"pull_request","parameters":{"required_approving_review_count":"two"}}]"#,
+            // Past u32: dropped, never truncated (`as` would fabricate "1" from 2^32+1).
+            r#"[{"type":"pull_request","parameters":{"required_approving_review_count":4294967297}}]"#,
             r#"{"message":"Not Found"}"#,
         ] {
             assert_eq!(approvals(raw), None, "raw: {raw}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ mod review_notes;
 mod secrets;
 mod sessions;
 mod state;
+mod store_lock;
 mod tray;
 
 use state::AppState;
@@ -242,6 +243,8 @@ pub fn run() {
             oplog::git_oplog_list,
             oplog::git_oplog_check,
             oplog::git_oplog_dismiss,
+            review_notes::review_notes_set_branch,
+            review_notes::review_notes_delete_branch,
             automation_claims::claim_automation_run,
             automation_claims::release_automation_claim,
             automation_claims::touch_automation_claim,

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -31,6 +31,11 @@
 //! helper guarded by [`OPLOG_LOCK`] held across read→mutate→write: `atomic_write`
 //! gives torn-file safety, the lock gives lost-update safety — both are needed. The
 //! lock is never held across an `.await`.
+//!
+//! The mutex only covers THIS process, and `gitdesktop mcp` runs the same binary as a
+//! second writer, so each guarded helper also takes the cross-process
+//! [`crate::store_lock`] inside the mutex — cheap intra-process serialization first,
+//! then the OS-level file lock (which fails open, as this journal must).
 
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -59,9 +64,11 @@ pub struct OpLogEntry {
     pub op: String,
     /// Human summary, e.g. `"Squash-merge feature → main"`.
     pub label: String,
-    /// `"pending"` | `"done"` | `"failed"` | `"dismissed"` | `"paused"`.
+    /// `"pending"` | `"done"` | `"failed"` | `"dismissed"` | `"paused"` | `"concluded"`.
     /// `"paused"` = handed to the user mid-op (a stopped cherry-pick), so it is
-    /// neither in-flight nor finished until they continue or abort it.
+    /// neither in-flight nor finished until they continue or abort it;
+    /// `"concluded"` = that pick ended outside the app, so the journal knows only
+    /// that it is over (see [`conclude_stale_pauses`]).
     pub status: String,
     /// `now_iso()` captured at [`begin`].
     pub started_at: String,
@@ -210,6 +217,7 @@ fn insert_pending(repo: &str, entry: &OpLogEntry) -> AppResult<()> {
         .map_err(|e| AppError::Command(format!("serialize opslog entry: {e}")))?;
     let path = store_path()?;
     let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
 
     let key = existing_key(&store, repo).unwrap_or_else(|| repo.to_string());
@@ -226,7 +234,9 @@ fn insert_pending(repo: &str, entry: &OpLogEntry) -> AppResult<()> {
 /// Drop oldest evictable entries until `list.len() <= HISTORY_CAP`. An unfinished
 /// entry is never evicted — `"pending"` may be an in-flight op, and `"paused"` is a
 /// live handle [`close_paused_pick`] still needs — so the cap is a soft ceiling that
-/// a burst of concurrent unfinished ops can legitimately exceed.
+/// a burst of concurrent unfinished ops can legitimately exceed. `"concluded"` is
+/// deliberately OUTSIDE that set: a pick that ended outside the app is over, so its
+/// record ages out like any other finished one.
 fn cap_history(list: &mut Vec<Value>) {
     if list.len() <= HISTORY_CAP {
         return;
@@ -252,6 +262,7 @@ where
 {
     let path = store_path()?;
     let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     let Some(key) = existing_key(&store, repo) else {
         return Ok(());
@@ -341,21 +352,87 @@ fn is_interrupted(
     mid_op || tree_dirty || !on_home
 }
 
-/// Reconcile `repo`'s pending entries against real git state, persist, and return
-/// the still-`"pending"` entries newest-first (0 or 1). `mid_op` = a merge,
-/// cherry-pick, rebase or revert is currently in progress ([`RepoOpState::mid_op`]);
+/// Conclude every STALE `"paused"` cherry-pick record in `list` — one whose pick was
+/// finished or abandoned OUTSIDE the app (a terminal `git cherry-pick
+/// --continue`/`--abort`), which otherwise leaves the record paused forever: immortal
+/// under [`cap_history`], a live handle [`close_paused_pick`] misattributes to the
+/// next in-app pick, and a permanent lie in Operation history.
+///
+/// The verdict is deliberately narrower than `mid_op`: a concurrent merge or rebase
+/// says nothing about a pick. It comes from TWO reads, and either one saying "a pick
+/// is live" spares the records. `cherry_picking` is the caller's earlier op-state
+/// read, which by the time we hold the lock is two git subprocesses old — a pick that
+/// paused in that window would have its brand-new record concluded permanently, and
+/// the user's later Continue/Abort would then find no handle to close. So
+/// `pick_in_progress` re-probes under the lock and is authoritative for that
+/// direction; it must answer whether `CHERRY_PICK_HEAD` exists for THIS repo, which
+/// is exactly the marker a paused (single-hash) pick leaves.
+///
+/// Residual, accepted: git can finish an in-app continue between that probe and
+/// [`close_paused_pick`]'s own locked RMW, so a check landing in those few
+/// milliseconds concludes the record first and the close then no-ops. Both run
+/// in-process and the window is order-of-ms; the cost is one history row reading
+/// "Ended outside the app" for a pick that ended inside it.
+///
+/// ALL stale records are concluded, not just the pre-newest ones — leaving any behind
+/// keeps the close-handle misattribution alive.
+///
+/// Status-write ONLY: the journal never mutates git to "recover" (module contract), and
+/// `finishedAt` stays null because a reconcile observes THAT the op ended, never when.
+/// Answers whether anything changed, so a no-op check doesn't rewrite the file.
+fn conclude_stale_pauses(
+    list: &mut [Value],
+    cherry_picking: bool,
+    pick_in_progress: impl Fn() -> bool,
+) -> bool {
+    fn is_paused_pick(entry: &Value) -> bool {
+        entry.get("status").and_then(Value::as_str) == Some("paused")
+            // Every paused record is a cherry-pick today; asserting the op keeps the
+            // verdict honest if another op ever learns to pause.
+            && entry.get("op").and_then(Value::as_str) == Some("cherry_pick_onto")
+    }
+
+    // Probe only when there is something to conclude — the common check touches no
+    // filesystem beyond the store it already read.
+    if !list.iter().any(is_paused_pick) {
+        return false;
+    }
+    if cherry_picking || pick_in_progress() {
+        return false;
+    }
+    let mut changed = false;
+    for entry in list.iter_mut() {
+        if !is_paused_pick(entry) {
+            continue;
+        }
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert("status".to_string(), Value::String("concluded".to_string()));
+            changed = true;
+        }
+    }
+    changed
+}
+
+/// Reconcile `repo`'s entries against real git state, persist, and return the
+/// still-`"pending"` entries newest-first (0 or 1). `mid_op` = a merge, cherry-pick,
+/// rebase or revert is currently in progress ([`RepoOpState::mid_op`]);
 /// `tree_dirty` = tracked changes are present (catches a mid-squash interrupt
-/// git_op_state can't see); `current_branch` = the branch HEAD is on now. Guarded
-/// by [`OPLOG_LOCK`].
+/// git_op_state can't see); `current_branch` = the branch HEAD is on now;
+/// `cherry_picking` and the `pick_in_progress` re-probe gate the stale-pause arm
+/// alone, and the probe runs INSIDE the lock (see [`conclude_stale_pauses`]).
+/// Guarded by [`OPLOG_LOCK`] plus the cross-process store lock.
 fn reconcile(
     repo: &str,
     mid_op: bool,
     tree_dirty: bool,
     current_branch: &str,
+    cherry_picking: bool,
+    pick_in_progress: impl Fn() -> bool,
 ) -> AppResult<Vec<OpLogEntry>> {
     let path = store_path()?;
     let now = now_iso();
     let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     let Some(key) = existing_key(&store, repo) else {
         return Ok(Vec::new());
@@ -364,9 +441,13 @@ fn reconcile(
         return Ok(Vec::new());
     };
 
+    let mut changed = conclude_stale_pauses(list, cherry_picking, pick_in_progress);
+
     // Indices of pending entries, newest-first by startedAt. Strictly `"pending"`:
-    // a `"paused"` op was handed to the user and is owned by the conflict banner,
-    // never a recovery candidate.
+    // a live `"paused"` op was handed to the user and is owned by the conflict
+    // banner, never a recovery candidate — and a concluded one is over, so neither
+    // may reach this function's RETURN value (the recovery banner renders every
+    // returned entry as "Interrupted").
     let mut pending_idx: Vec<usize> = list
         .iter()
         .enumerate()
@@ -385,39 +466,41 @@ fn reconcile(
         sb.cmp(sa)
     });
 
-    if pending_idx.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // The genuinely-interrupted op, if any: the NEWEST pending, but only when the
-    // repo isn't back in a clean, on-home state (see `is_interrupted`). git permits
-    // only one such op at a time, so at most one entry is genuinely interrupted;
-    // every other pending must have completed (a newer op started, or the repo is
-    // clean) — `finish` just never wrote "done".
-    let keep_pending = pending_idx.first().copied().filter(|&i| {
-        is_interrupted(
-            mid_op,
-            tree_dirty,
-            current_branch,
-            list[i].get("originalRef").and_then(Value::as_str),
-        )
-    });
-    for &idx in &pending_idx {
-        if Some(idx) == keep_pending {
-            continue;
+    let results: Vec<OpLogEntry> = if pending_idx.is_empty() {
+        Vec::new()
+    } else {
+        changed = true;
+        // The genuinely-interrupted op, if any: the NEWEST pending, but only when the
+        // repo isn't back in a clean, on-home state (see `is_interrupted`). git permits
+        // only one such op at a time, so at most one entry is genuinely interrupted;
+        // every other pending must have completed (a newer op started, or the repo is
+        // clean) — `finish` just never wrote "done".
+        let keep_pending = pending_idx.first().copied().filter(|&i| {
+            is_interrupted(
+                mid_op,
+                tree_dirty,
+                current_branch,
+                list[i].get("originalRef").and_then(Value::as_str),
+            )
+        });
+        for &idx in &pending_idx {
+            if Some(idx) == keep_pending {
+                continue;
+            }
+            if let Some(obj) = list[idx].as_object_mut() {
+                obj.insert("status".to_string(), Value::String("done".to_string()));
+                obj.insert("finishedAt".to_string(), Value::String(now.clone()));
+            }
         }
-        if let Some(obj) = list[idx].as_object_mut() {
-            obj.insert("status".to_string(), Value::String("done".to_string()));
-            obj.insert("finishedAt".to_string(), Value::String(now.clone()));
-        }
+        keep_pending
+            .and_then(|idx| serde_json::from_value(list[idx].clone()).ok())
+            .into_iter()
+            .collect()
+    };
+
+    if changed {
+        write_store(&path, &store)?;
     }
-
-    let results: Vec<OpLogEntry> = keep_pending
-        .and_then(|idx| serde_json::from_value(list[idx].clone()).ok())
-        .into_iter()
-        .collect();
-
-    write_store(&path, &store)?;
     Ok(results)
 }
 
@@ -498,31 +581,45 @@ pub(crate) async fn pause(repo: &str, id: &Option<String>) {
 /// Best-effort: close `repo`'s newest `"paused"` cherry-pick entry now that the user
 /// has ended the pick in-app. No paused entry → no-op.
 ///
-/// The handle is the newest paused record, not the specific pick: a pick ended
-/// outside the app (a terminal `git cherry-pick --abort`) leaves its record
-/// `"paused"`, and a later in-app continue or abort of any cherry-pick is what will
-/// close it — the same best-effort posture the journal takes for out-of-app work.
+/// The handle is the newest paused record, not the specific pick, so it can only be
+/// as accurate as the store is current: [`conclude_stale_pauses`] retires the records
+/// of picks ended outside the app on the next [`git_oplog_check`], which is what keeps
+/// one of those from standing in as this op's handle.
 pub(crate) async fn close_paused_pick(repo: &str, outcome: PausedOutcome) {
-    let now = now_iso();
-    let found = store_path().and_then(|path| {
-        let mut entries = {
-            let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
-            let store = read_store(&path)?;
-            repo_entries(&store, repo)
-        };
-        Ok(newest_paused_pick(&mut entries))
-    });
-    let id = match found {
-        Ok(Some(id)) => id,
-        Ok(None) => return,
-        Err(e) => {
-            eprintln!("gitdesktop: opslog paused lookup failed (op unaffected): {e}");
-            return;
-        }
-    };
-    if let Err(e) = mutate_entry(repo, &id, |obj| apply_close(obj, &outcome, now)) {
+    if let Err(e) = close_newest_paused_pick(repo, &outcome, now_iso()) {
         eprintln!("gitdesktop: opslog close failed (op unaffected): {e}");
     }
+}
+
+/// The lookup AND the status write under ONE acquisition of both locks. Splitting
+/// them (find the handle, release, re-take to mutate) lets two concurrent closes
+/// resolve the same newest-paused id and both write it — the second overwriting the
+/// first's disposition.
+fn close_newest_paused_pick(repo: &str, outcome: &PausedOutcome, now: String) -> AppResult<()> {
+    let path = store_path()?;
+    let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
+    let mut store = read_store(&path)?;
+    let Some(key) = existing_key(&store, repo) else {
+        return Ok(());
+    };
+    let Some(list) = store.get_mut(&key).and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    // Resolve the handle on a copy: `newest_paused_pick` sorts what it is given, and
+    // the stored order is the file's own (readers sort for themselves).
+    let Some(id) = newest_paused_pick(&mut list.clone()) else {
+        return Ok(());
+    };
+    let Some(obj) = list
+        .iter_mut()
+        .find(|e| e.get("id").and_then(Value::as_str) == Some(id.as_str()))
+        .and_then(Value::as_object_mut)
+    else {
+        return Ok(());
+    };
+    apply_close(obj, outcome, now);
+    write_store(&path, &store)
 }
 
 /// The `preOpTip` a [`begin`] recorded for `id` — the ref position the operation
@@ -575,6 +672,11 @@ pub async fn git_oplog_check(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
     // `op_in_progress`, whose Err arm answers `true` — that would manufacture an
     // interrupt from a failed read, which the two probes below refuse to do.
     let mid_op = state.mid_op();
+    // The stale-pause verdict keys on the pick flag ALONE, not `mid_op` — see
+    // `conclude_stale_pauses`. This read goes stale across the two git subprocesses
+    // below, so `reconcile` re-probes the marker under the lock; this one only
+    // short-circuits.
+    let cherry_picking = state.cherry_picking;
     // A squash-merge leaves none of those markers, so git_op_state alone misses a
     // mid-squash interrupt. Corroborate with a *tracked*-dirty check (untracked is
     // allowed — mirrors ensure_clean_tree) + the current branch.
@@ -594,7 +696,15 @@ pub async fn git_oplog_check(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
     .await
     .map(|o| o.stdout_lossy().trim().to_string())
     .unwrap_or_default();
-    reconcile(&repo_path, mid_op, tree_dirty, &current_branch)
+    reconcile(
+        &repo_path,
+        mid_op,
+        tree_dirty,
+        &current_branch,
+        cherry_picking,
+        // FS-only (no subprocess), so it is cheap to run while holding the store lock.
+        || crate::git::ops::cherry_pick_marker_present(&repo_path),
+    )
 }
 
 /// Set the entry with `id` under `repo` to `status = "dismissed"` and persist.
@@ -1034,5 +1144,250 @@ mod tests {
         let store = read_store(&path).unwrap();
         let entries = repo_entries(&store, r"C:\nope");
         assert!(entries.is_empty());
+    }
+
+    // ── Stale-pause reconcile ────────────────────────────────────────────────
+    //
+    // These drive `reconcile`/`git_oplog_check` for real, so they go through
+    // `store_path()` — the cfg(test) arm, a temp file no in-crate test may leave the
+    // developer's real store for. The file is shared with every other test in the
+    // binary, so each seeds a repo key of its own and mutates under the same locks
+    // production takes.
+
+    /// Replace `repo`'s entries in the seam-resolved store, as one locked RMW.
+    fn seed_entries(repo: &str, entries: Vec<Value>) {
+        let path = store_path().unwrap();
+        let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _store_lock = crate::store_lock::lock_store(&path);
+        let mut store = read_store(&path).unwrap();
+        store.insert(repo.to_string(), Value::Array(entries));
+        write_store(&path, &store).unwrap();
+    }
+
+    /// `repo`'s record `id`, straight off disk — under both locks, so the read can't
+    /// land inside another test's (or process's) atomic rename over the file.
+    fn stored_entry(repo: &str, id: &str) -> Value {
+        let path = store_path().unwrap();
+        let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _store_lock = crate::store_lock::lock_store(&path);
+        let store = read_store(&path).unwrap();
+        repo_entries(&store, repo)
+            .into_iter()
+            .find(|e| e.get("id").and_then(Value::as_str) == Some(id))
+            .unwrap_or_else(|| panic!("record {id} must still be in the store"))
+    }
+
+    async fn git(repo: &str, args: &[&str]) -> String {
+        crate::git::runner::run_git(Some(repo), args, crate::git::runner::DEFAULT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| panic!("git {args:?} failed: {e}"))
+            .stdout_lossy()
+    }
+
+    async fn commit(repo: &str, dir: &Path, file: &str, content: &str, msg: &str) {
+        std::fs::write(dir.join(file), content).unwrap();
+        git(repo, &["add", "."]).await;
+        git(repo, &["commit", "-m", msg]).await;
+    }
+
+    /// A repo left mid-cherry-pick on a content conflict: `target` and `feature` both
+    /// edited `a.txt`, so picking feature's commit onto target stops for the user.
+    async fn setup_conflicting_pick(marker: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-oplog-{marker}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        git(&repo, &["init"]).await;
+        git(&repo, &["config", "user.email", "t@t"]).await;
+        git(&repo, &["config", "user.name", "t"]).await;
+        commit(&repo, dir.path(), "a.txt", "base\n", "base").await;
+        git(&repo, &["branch", "target"]).await;
+        git(&repo, &["checkout", "-b", "feature"]).await;
+        commit(&repo, dir.path(), "a.txt", "feature\n", "feature edit").await;
+        let pick = git(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
+        git(&repo, &["checkout", "target"]).await;
+        commit(&repo, dir.path(), "a.txt", "target\n", "target edit").await;
+        // Conflicts by construction, so git exits nonzero and leaves the pick open.
+        let _ = crate::git::runner::run_git(
+            Some(&repo),
+            &["cherry-pick", &pick],
+            crate::git::runner::DEFAULT_TIMEOUT,
+        )
+        .await;
+        assert!(
+            crate::git::ops::git_op_state(repo.clone())
+                .await
+                .unwrap()
+                .cherry_picking,
+            "the fixture must leave a pick in progress"
+        );
+        (dir, repo)
+    }
+
+    /// A pick concluded OUTSIDE the app leaves its record `"paused"` — nothing in-app
+    /// ever closes it, so it was cap-immortal, a handle the next in-app close would
+    /// misattribute, and a permanent lie in the history dialog. The next check must
+    /// retire it, WITHOUT leaking it into the return value (the recovery banner
+    /// renders every returned entry as "Interrupted").
+    #[tokio::test]
+    async fn a_stale_paused_pick_is_concluded_by_the_next_check() {
+        let (_dir, repo) = setup_conflicting_pick("stale-pause").await;
+        seed_entries(
+            &repo,
+            vec![pick_record(
+                "stale-pick",
+                "2026-01-01T00:00:00.000Z",
+                "paused",
+            )],
+        );
+        // The terminal route the app has no hook for.
+        git(&repo, &["cherry-pick", "--abort"]).await;
+
+        let returned = git_oplog_check(repo.clone()).await.unwrap();
+        assert!(
+            returned.is_empty(),
+            "a concluded record must never reach the recovery banner: {returned:?}"
+        );
+        let entry = stored_entry(&repo, "stale-pick");
+        assert_eq!(entry["status"], "concluded");
+        assert_eq!(
+            entry["finishedAt"],
+            Value::Null,
+            "a reconcile observes THAT the op ended, never when"
+        );
+    }
+
+    /// NEGATIVE CONTROL for the arm above: a pick the user is still resolving reads
+    /// `cherry_picking == true`, and its record is the live handle `close_paused_pick`
+    /// needs — concluding it would break every in-app continue/abort.
+    #[tokio::test]
+    async fn a_live_paused_pick_is_never_concluded() {
+        let (_dir, repo) = setup_conflicting_pick("live-pause").await;
+        seed_entries(
+            &repo,
+            vec![pick_record(
+                "live-pick",
+                "2026-01-01T00:00:00.000Z",
+                "paused",
+            )],
+        );
+
+        let returned = git_oplog_check(repo.clone()).await.unwrap();
+        assert!(returned.is_empty(), "a pause is not an interrupt");
+        assert_eq!(
+            stored_entry(&repo, "live-pick")["status"],
+            "paused",
+            "a pick still in progress keeps its record"
+        );
+    }
+
+    /// The check's `git_op_state` read is two git subprocesses old by the time
+    /// `reconcile` holds the lock, so a pick that pauses in that window arrives with
+    /// the flag reading FALSE. Concluding then would retire a record the user's
+    /// Continue/Abort still needs — the marker re-probe, taken under the lock, is what
+    /// overrules the stale flag.
+    #[tokio::test]
+    async fn a_pick_that_started_after_the_state_read_is_not_concluded() {
+        let (_dir, repo) = setup_conflicting_pick("post-read-pause").await;
+        seed_entries(
+            &repo,
+            vec![pick_record(
+                "raced-pick",
+                "2026-01-01T00:00:00.000Z",
+                "paused",
+            )],
+        );
+
+        // `cherry_picking: false` is the stale pre-race read; the pick is live NOW.
+        let returned = reconcile(&repo, false, false, "target", false, || {
+            crate::git::ops::cherry_pick_marker_present(&repo)
+        })
+        .unwrap();
+
+        assert!(returned.is_empty());
+        assert_eq!(
+            stored_entry(&repo, "raced-pick")["status"],
+            "paused",
+            "the locked re-probe must overrule the stale op-state read"
+        );
+    }
+
+    #[test]
+    fn every_stale_paused_pick_is_concluded_in_one_pass() {
+        let repo = r"C:\oplog\two-stale-pauses";
+        seed_entries(
+            repo,
+            vec![
+                pick_record("older-paused", "2026-01-01T00:00:00.000Z", "paused"),
+                pick_record("newer-paused", "2026-01-02T00:00:00.000Z", "paused"),
+                // Not a pick: the op guard must leave it alone.
+                json!({
+                    "id": "paused-merge",
+                    "op": "merge_local_pr",
+                    "status": "paused",
+                    "startedAt": "2026-01-03T00:00:00.000Z",
+                }),
+            ],
+        );
+
+        let returned = reconcile(repo, false, false, "main", false, || false).unwrap();
+        assert!(returned.is_empty());
+        // Sparing the newest would leave `close_paused_pick` a stale handle to
+        // misattribute the user's next in-app pick to.
+        for id in ["older-paused", "newer-paused"] {
+            assert_eq!(stored_entry(repo, id)["status"], "concluded", "{id}");
+        }
+        assert_eq!(stored_entry(repo, "paused-merge")["status"], "paused");
+    }
+
+    #[test]
+    fn the_pending_arm_is_untouched_by_the_paused_one() {
+        let repo = r"C:\oplog\pending-beside-a-stale-pause";
+        seed_entries(
+            repo,
+            vec![
+                pending_record("interrupted-merge", "2026-01-03T00:00:00.000Z"),
+                pick_record("stale-pick", "2026-01-01T00:00:00.000Z", "paused"),
+            ],
+        );
+
+        // A merge is mid-flight — which is why the pause verdict reads
+        // `cherry_picking` and not repo-wide `mid_op`: this merge says nothing about
+        // whether a cherry-pick ended.
+        let returned = reconcile(repo, true, false, "feature", false, || false).unwrap();
+        assert_eq!(returned.len(), 1, "{returned:?}");
+        assert_eq!(returned[0].id, "interrupted-merge");
+        assert_eq!(returned[0].status, "pending");
+        assert_eq!(stored_entry(repo, "stale-pick")["status"], "concluded");
+    }
+
+    #[test]
+    fn cap_evicts_a_concluded_entry() {
+        // The flip of `cap_never_evicts_an_unfinished_entry`: a pick that ended
+        // outside the app is over, so its record ages out like any finished one —
+        // which is what stops a stale pause from starving the cap forever.
+        let mut list: Vec<Value> = (0..60)
+            .map(|i| {
+                json!({
+                    "id": format!("done-{i}"),
+                    "status": "done",
+                    "startedAt": format!("2026-02-{:02}T00:00:00.000Z", i + 1),
+                })
+            })
+            .collect();
+        list.push(json!({
+            "id": "old-concluded",
+            "op": "cherry_pick_onto",
+            "status": "concluded",
+            "startedAt": "2026-01-01T00:00:00.000Z",
+        }));
+        cap_history(&mut list);
+
+        assert!(list.len() <= HISTORY_CAP);
+        assert!(
+            !list.iter().any(|e| e["id"] == "old-concluded"),
+            "a concluded record is finished, so the cap must be able to evict it"
+        );
     }
 }

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -469,7 +469,6 @@ fn reconcile(
     let results: Vec<OpLogEntry> = if pending_idx.is_empty() {
         Vec::new()
     } else {
-        changed = true;
         // The genuinely-interrupted op, if any: the NEWEST pending, but only when the
         // repo isn't back in a clean, on-home state (see `is_interrupted`). git permits
         // only one such op at a time, so at most one entry is genuinely interrupted;
@@ -490,6 +489,7 @@ fn reconcile(
             if let Some(obj) = list[idx].as_object_mut() {
                 obj.insert("status".to_string(), Value::String("done".to_string()));
                 obj.insert("finishedAt".to_string(), Value::String(now.clone()));
+                changed = true;
             }
         }
         keep_pending
@@ -583,8 +583,8 @@ pub(crate) async fn pause(repo: &str, id: &Option<String>) {
 ///
 /// The handle is the newest paused record, not the specific pick, so it can only be
 /// as accurate as the store is current: [`conclude_stale_pauses`] retires the records
-/// of picks ended outside the app on the next [`git_oplog_check`], which is what keeps
-/// one of those from standing in as this op's handle.
+/// of picks ended outside the app on the next [`git_oplog_check`] that finds no pick
+/// in progress, which is what keeps one from standing in as this op's handle.
 pub(crate) async fn close_paused_pick(repo: &str, outcome: PausedOutcome) {
     if let Err(e) = close_newest_paused_pick(repo, &outcome, now_iso()) {
         eprintln!("gitdesktop: opslog close failed (op unaffected): {e}");

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -3,9 +3,12 @@
 //! **Reviewer notes are GitDesktop's own app-data deposits** — no forge or remote writes
 //! are involved. An agent session deposits a per-branch note ("Notes for reviewers") keyed
 //! by repo + branch; the GUI later seeds its Create-PR dialog's "Notes for reviewers" field
-//! from this store. The GUI persists them via the Tauri Store plugin (`src/lib/…`); this
-//! module is the headless mirror the MCP server (which has NO `AppHandle`) uses to write the
-//! SAME file. It is a leaner parallel of [`crate::local_issues`] / [`crate::local_prs`] — see
+//! from this store. This module owns every WRITE to that file: the MCP server (which has NO
+//! `AppHandle`) calls [`set`] directly, and the GUI routes through
+//! [`review_notes_set_branch`]/[`review_notes_delete_branch`] so both processes mutate under
+//! one [`crate::store_lock`]. The GUI still READS through the Tauri Store plugin
+//! (`src/lib/review-notes/store.ts`), reloading after each write.
+//! It is a leaner parallel of [`crate::local_issues`] / [`crate::local_prs`] — see
 //! either for the full storage-dir / Value-round-trip / statelessness contract, which applies
 //! identically here (only the store filename and the record shape differ).
 //!
@@ -50,6 +53,7 @@
 //! read → modify → atomic write. We never cache across calls.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use serde_json::{Map, Value};
 
@@ -58,6 +62,17 @@ use crate::local_prs::APP_IDENTIFIER;
 
 /// The store filename the GUI's reviewer-notes store writes.
 const STORE_FILE: &str = "review-notes.json";
+
+/// Guards the whole read-modify-write of the shared store file within THIS process
+/// (mirroring [`crate::oplog`]'s `OPLOG_LOCK`). It sits OUTSIDE the cross-process
+/// file lock deliberately: same-process serialization is exact and free, where the
+/// file lock fails open after its retry budget — so two concurrent handlers in one
+/// process must not be relying on it. Never held across an `.await`: every fn it
+/// wraps is synchronous.
+fn notes_lock() -> &'static Mutex<()> {
+    static NOTES_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    NOTES_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// Pure resolution of the store's base directory, in precedence order (mirroring
 /// [`crate::oplog::resolve_store_base`]):
@@ -154,7 +169,38 @@ fn now_iso() -> String {
 /// when the empty-body rule cleared the deposit.
 pub fn set(repo: &str, branch: &str, body: &str) -> AppResult<bool> {
     let path = store_path()?;
+    // Hold both locks across the whole read→modify→write: the GUI and the
+    // `gitdesktop mcp` server both write this file, and an unlocked RMW drops whichever
+    // note lost the race (see [`crate::store_lock`]; acquisition fails open, which is
+    // why the exact in-process mutex goes outside it).
+    let _guard = notes_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _lock = crate::store_lock::lock_store(&path);
     set_at(&path, repo, branch, body)
+}
+
+/// Save (or clear) the GUI's reviewer note for `branch`, taking the same
+/// cross-process lock the MCP writer takes. The GUI's plugin-store writer keeps a
+/// per-process cache the MCP server's writes are invisible to, so its whole
+/// read→modify→write runs here instead. An empty or whitespace-only `body` clears
+/// the deposit; the answer is whether a note was saved (see [`set`]).
+#[tauri::command]
+pub async fn review_notes_set_branch(
+    repo_path: String,
+    branch: String,
+    body: String,
+) -> AppResult<bool> {
+    let identity = crate::git::repo::repo_identity(&repo_path).await;
+    set(&identity, &branch, &body)
+}
+
+/// Remove the GUI's reviewer note for `branch` — the consume-on-open path behind the
+/// Create-PR dialogs — through [`set`]'s empty-body clear, so both write routes share
+/// one locked implementation. A branch with no note is a harmless no-op.
+#[tauri::command]
+pub async fn review_notes_delete_branch(repo_path: String, branch: String) -> AppResult<()> {
+    let identity = crate::git::repo::repo_identity(&repo_path).await;
+    set(&identity, &branch, "")?;
+    Ok(())
 }
 
 /// The pure store logic behind [`set`], taking an explicit path so tests can drive it against
@@ -198,6 +244,10 @@ fn upsert_branch(store: &mut Map<String, Value>, repo: &str, branch: &str, body:
 /// a rename is not a re-save. Nothing is written when there is nothing to migrate.
 pub(crate) fn rename_branch(repo: &str, from: &str, to: &str) -> AppResult<()> {
     let path = store_path()?;
+    // Same lock pair as [`set`]: the read→move→write must not interleave with a
+    // concurrent deposit, which would resurrect the old branch name's note.
+    let _guard = notes_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _lock = crate::store_lock::lock_store(&path);
     rename_at(&path, repo, from, to)
 }
 

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -1,0 +1,382 @@
+//! Cross-process advisory lock for GitDesktop's shared app-data JSON stores.
+//!
+//! `opslog.json` and `review-notes.json` are whole-file read→modify→write stores with
+//! TWO writing processes: the GUI and the `gitdesktop mcp` server — the SAME binary
+//! under a different subcommand, so both link this module and share its protocol. An
+//! in-process mutex cannot serialize across that boundary, so a concurrent write
+//! silently drops the loser's records.
+//!
+//! Exclusion is taken at the OS level with `OpenOptions::create_new` on a
+//! `<store>.lock` file beside the store — the atomic exclusive-create
+//! [`crate::automation_claims`] already relies on, and no new dependency (the
+//! lockfile carries zero file-locking crates; keep it that way). The lock path is
+//! derived from the store's own RESOLVED path, so the `GD_OPLOG_DIR` /
+//! `GD_REVIEW_NOTES_DIR` / `cfg!(test)` seams stay coherent on both sides by
+//! construction. Nothing here involves the single-instance plugin: that lock is
+//! release-only and keyed on the bundle identifier, and the MCP server is a
+//! deliberately co-running second process.
+//!
+//! ## Fail-open, always
+//!
+//! Both stores are best-effort by contract — a journal write must never fail or alter
+//! a git op ([`crate::oplog`]'s module docs) — so every failure to acquire (a poisoned
+//! directory, a holder that outlasts the retry budget) runs the caller's mutation
+//! ANYWAY. Worst case of fail-open is the pre-existing lost update; worst case of
+//! fail-closed is a git operation reporting failure because a journal file was busy.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Retry budget for a held lock: 20 × 25ms ≈ 500ms of blocking. An RMW on these
+/// stores is ms-scale, so a holder still present after half a second is either wedged
+/// or dead, and the caller is better served by proceeding than by waiting.
+const MAX_ATTEMPTS: u32 = 20;
+const RETRY_DELAY: Duration = Duration::from_millis(25);
+
+/// A lock file whose mtime is older than this is abandoned (a process killed between
+/// create and release) and is evicted by the next caller. The mtime is never
+/// refreshed — an RMW is ms-scale, so 10s is orders of magnitude of headroom, and a
+/// heartbeat would need a write handle on Windows for no gain.
+const STALE_LOCK_AGE: Duration = Duration::from_secs(10);
+
+/// RAII holder of a store lock: dropping it releases (best-effort `remove_file`) on
+/// every path, success or panic. A guard that FAILED to acquire owns nothing and
+/// releases nothing — deleting a live holder's file would break the exclusion it is
+/// currently providing to someone else.
+pub(crate) struct StoreLock {
+    owned: Option<PathBuf>,
+}
+
+impl Drop for StoreLock {
+    fn drop(&mut self) {
+        if let Some(path) = &self.owned {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// Take the cross-process lock for `store_file` and hold it until the returned guard
+/// drops. ALWAYS returns a guard: an un-acquired one lets the caller proceed
+/// unlocked, per the module's fail-open contract. Blocks the calling thread for at
+/// most [`MAX_ATTEMPTS`] × [`RETRY_DELAY`]; callers are synchronous store helpers.
+pub(crate) fn lock_store(store_file: &Path) -> StoreLock {
+    lock_at(
+        &lock_path(store_file),
+        MAX_ATTEMPTS,
+        RETRY_DELAY,
+        STALE_LOCK_AGE,
+    )
+}
+
+/// `<store_file>.lock`, beside the store — same directory, same resolution seam, so
+/// two processes that agree on the store file agree on the lock file.
+fn lock_path(store_file: &Path) -> PathBuf {
+    let mut name = store_file.as_os_str().to_os_string();
+    name.push(".lock");
+    PathBuf::from(name)
+}
+
+/// [`lock_store`] with the budget and staleness window injected, so tests drive the
+/// contention and eviction arms without sleeping for real.
+fn lock_at(lock_file: &Path, max_attempts: u32, delay: Duration, stale_age: Duration) -> StoreLock {
+    StoreLock {
+        owned: acquire(lock_file, max_attempts, delay, stale_age),
+    }
+}
+
+/// Atomically create `path`. `Ok(true)` = created by us, `Ok(false)` = someone else
+/// holds it. `create_new` is the atomic exclusive-create: exactly one of two racing
+/// callers gets `Ok(File)`, the other gets `AlreadyExists`. The file stays empty —
+/// only its existence and its mtime carry meaning.
+fn create_new_lock(path: &Path) -> std::io::Result<bool> {
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+fn mtime(path: &Path) -> Option<SystemTime> {
+    path.metadata().and_then(|m| m.modified()).ok()
+}
+
+/// `path`'s mtime WHEN it is at least `stale_age` old, else `None`. Unreadable
+/// metadata, or a future mtime (clock skew, which yields `Err`), both answer `None` —
+/// a lock we cannot age is never evicted. The mtime comes back because the eviction
+/// has to prove it removed the very file it aged.
+fn stale_mtime(path: &Path, stale_age: Duration) -> Option<SystemTime> {
+    let modified = mtime(path)?;
+    let age = SystemTime::now().duration_since(modified).ok()?;
+    (age >= stale_age).then_some(modified)
+}
+
+/// Evict the abandoned lock at `path`, whose mtime was observed as `observed`, and
+/// take it. The eviction is claimed by RENAME rather than unlink, because the aside
+/// copy proves WHICH file we removed: a plain `remove_file` + `create_new` lets a
+/// second contender — still carrying its own older staleness verdict — unlink the
+/// lock the first has already re-created and then claim it too, leaving two holders
+/// inside the critical section.
+///
+/// So if what we renamed away is not the file we aged, someone re-created it in that
+/// window: put it back and fail open rather than hold a lock we broke.
+fn evict_stale(path: &Path, observed: SystemTime) -> Option<PathBuf> {
+    let name = path.file_name()?.to_string_lossy().into_owned();
+    let aside = path.with_file_name(format!(
+        "{name}.evict.{}.{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    // A failed rename means the lock is gone or another contender is already evicting
+    // it — either way it is not ours to take.
+    if std::fs::rename(path, &aside).is_err() {
+        return None;
+    }
+    if mtime(&aside) != Some(observed) {
+        // A live lock, not the abandoned one. Restore it; if the restore loses to a
+        // third contender that has already taken the empty slot, drop the aside copy
+        // rather than leak it beside the store.
+        if std::fs::rename(&aside, path).is_err() {
+            let _ = std::fs::remove_file(&aside);
+        }
+        return None;
+    }
+    let _ = std::fs::remove_file(&aside);
+    won(path)
+}
+
+/// Acquire the lock at `path`, answering the owned path or `None` to fail open.
+fn acquire(
+    path: &Path,
+    max_attempts: u32,
+    delay: Duration,
+    stale_age: Duration,
+) -> Option<PathBuf> {
+    for attempt in 0..max_attempts {
+        match create_new_lock(path) {
+            Ok(true) => return Some(path.to_path_buf()),
+            Ok(false) => {}
+            // The store's directory doesn't exist yet — nothing has been written
+            // there. `atomic_write` creates it at write time, so create it here too
+            // rather than leaving the first-ever write of a fresh install unlocked.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let ready = path
+                    .parent()
+                    .is_some_and(|dir| std::fs::create_dir_all(dir).is_ok());
+                return if ready { won(path) } else { None };
+            }
+            // Anything else (permissions, full disk) fails open — see the module docs.
+            Err(_) => return None,
+        }
+        // Held by someone. Only an ABANDONED lock is evictable, and the eviction is
+        // itself claimed atomically ([`evict_stale`]); anything short of winning it
+        // outright yields rather than looping (mirrors `automation_claims`).
+        if let Some(observed) = stale_mtime(path, stale_age) {
+            return evict_stale(path, observed);
+        }
+        if attempt + 1 < max_attempts {
+            std::thread::sleep(delay);
+        }
+    }
+    None
+}
+
+/// One exclusive-create attempt as an ownership answer: `Some(path)` only when this
+/// caller created the file.
+fn won(path: &Path) -> Option<PathBuf> {
+    match create_new_lock(path) {
+        Ok(true) => Some(path.to_path_buf()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A temp dir plus a store path inside it. The dir is the RAII guard — hold it.
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-store-lock-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let store = dir.path().join("store.json");
+        (dir, store)
+    }
+
+    /// Age `path`'s mtime by `age`. The write handle is required: on Windows
+    /// `set_modified` fails with PermissionDenied on a read-only one.
+    fn backdate(path: &Path, age: Duration) {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(SystemTime::now() - age)
+            .unwrap();
+    }
+
+    #[test]
+    fn the_lock_file_sits_beside_the_store() {
+        assert_eq!(
+            lock_path(Path::new("C:/data/opslog.json")),
+            PathBuf::from("C:/data/opslog.json.lock")
+        );
+        // Both processes derive it from the SAME resolved store path, so a seam
+        // (GD_OPLOG_DIR, cfg(test)) moves the lock with the store it guards.
+        assert_eq!(
+            lock_path(Path::new("/tmp/gd-oplog-test/opslog.json")),
+            PathBuf::from("/tmp/gd-oplog-test/opslog.json.lock")
+        );
+    }
+
+    #[test]
+    fn a_second_caller_loses_the_exclusive_create_and_fails_open() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+
+        let held = lock_at(&path, 3, Duration::from_millis(1), STALE_LOCK_AGE);
+        assert!(held.owned.is_some(), "the first caller must win");
+        assert!(path.exists());
+
+        // The holder is FRESH, so the loser burns its budget and proceeds unlocked
+        // rather than failing the caller's write.
+        let loser = lock_at(&path, 3, Duration::from_millis(1), STALE_LOCK_AGE);
+        assert!(loser.owned.is_none(), "a fresh lock must keep excluding");
+
+        // A fail-open guard owns nothing, so its drop must not release the winner's
+        // lock out from under it.
+        drop(loser);
+        assert!(path.exists(), "the loser must not delete the holder's lock");
+        drop(held);
+        assert!(!path.exists(), "the holder's drop releases the lock");
+    }
+
+    #[test]
+    fn a_stale_lock_is_evicted_by_the_next_caller() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+
+        // A process took the lock and died without releasing it.
+        assert!(create_new_lock(&path).unwrap());
+        backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
+
+        let taken = lock_at(&path, 1, Duration::from_millis(1), STALE_LOCK_AGE);
+        assert!(
+            taken.owned.is_some(),
+            "an abandoned lock must not starve the next writer"
+        );
+        assert!(path.exists(), "the evictor now holds its own lock file");
+        drop(taken);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn eviction_takes_the_lock_it_aged_and_leaves_no_scratch() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        assert!(create_new_lock(&path).unwrap());
+        backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
+        let observed = mtime(&path).unwrap();
+
+        let owned = evict_stale(&path, observed).expect("an abandoned lock is evictable");
+        assert_eq!(owned, path);
+        assert_ne!(
+            mtime(&path),
+            Some(observed),
+            "the evictor holds its own fresh file, not the corpse"
+        );
+        let strays: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".evict."))
+            .collect();
+        assert!(strays.is_empty(), "the aside copy must not be left behind");
+    }
+
+    #[test]
+    fn eviction_that_finds_a_re_created_lock_restores_it_and_stands_down() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        assert!(create_new_lock(&path).unwrap());
+        backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
+        let observed = mtime(&path).unwrap();
+
+        // Another contender got there first: it evicted the abandoned lock and took
+        // its own, so the file on disk is no longer the one we aged. Under a plain
+        // remove + create_new this caller would unlink that live lock and claim the
+        // slot too — two holders inside the critical section.
+        std::fs::remove_file(&path).unwrap();
+        assert!(create_new_lock(&path).unwrap());
+        let theirs = mtime(&path).unwrap();
+        assert_ne!(theirs, observed);
+
+        assert!(
+            evict_stale(&path, observed).is_none(),
+            "a lock we did not age is not ours to evict"
+        );
+        assert_eq!(
+            mtime(&path),
+            Some(theirs),
+            "the live lock must be put back, not consumed"
+        );
+    }
+
+    #[test]
+    fn a_lock_younger_than_the_window_is_never_evicted() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        assert!(create_new_lock(&path).unwrap());
+        // Just inside the window: a live holder mid-RMW must keep excluding, or the
+        // eviction path reintroduces the lost update it exists to prevent.
+        backdate(&path, STALE_LOCK_AGE - Duration::from_secs(2));
+
+        let denied = lock_at(&path, 1, Duration::from_millis(1), STALE_LOCK_AGE);
+        assert!(denied.owned.is_none());
+    }
+
+    #[test]
+    fn a_poisoned_store_directory_fails_open() {
+        let (tmp, _store) = tmp_store();
+        // A regular file where the store's directory should be: every create attempt
+        // errors, and the parent-create recovery can't help either.
+        let blocker = tmp.path().join("not-a-directory");
+        std::fs::write(&blocker, b"x").unwrap();
+        let store = blocker.join("store.json");
+
+        let guard = lock_store(&store);
+        assert!(
+            guard.owned.is_none(),
+            "an unusable lock path must let the caller write anyway"
+        );
+    }
+
+    #[test]
+    fn a_missing_store_directory_is_created_and_locked() {
+        let (tmp, _store) = tmp_store();
+        // A fresh install: nothing has written the app-data dir yet.
+        let store = tmp.path().join("fresh").join("opslog.json");
+        let guard = lock_store(&store);
+        assert!(
+            guard.owned.is_some(),
+            "the first write must still be locked"
+        );
+        assert!(lock_path(&store).exists());
+    }
+
+    #[test]
+    fn the_lock_is_reusable_after_release() {
+        let (_tmp, store) = tmp_store();
+        let first = lock_store(&store);
+        assert!(first.owned.is_some());
+        drop(first);
+
+        let second = lock_store(&store);
+        assert!(
+            second.owned.is_some(),
+            "a released lock must be immediately re-acquirable"
+        );
+    }
+}

--- a/src/features/accounts/ReconnectDialog.tsx
+++ b/src/features/accounts/ReconnectDialog.tsx
@@ -58,10 +58,11 @@ export function ReconnectDialog() {
           for each open — and unmounts (cancelling its live session) on close. */}
       {target && (
         <ReconnectFlow
-          key={`${target.provider}|${target.host}|${target.mode}`}
+          key={`${target.provider}|${target.host}|${target.mode}|${(target.scopes ?? []).join(",")}`}
           provider={target.provider}
           host={target.host}
           mode={target.mode}
+          scopes={target.scopes}
           onClose={closeReconnect}
         />
       )}
@@ -73,11 +74,13 @@ function ReconnectFlow({
   provider,
   host,
   mode,
+  scopes,
   onClose,
 }: {
   provider: "github" | "gitlab";
   host: string;
   mode: "login" | "refresh";
+  scopes?: string[];
   onClose: () => void;
 }) {
   const label = providerLabel(provider);
@@ -94,13 +97,15 @@ function ReconnectFlow({
   const primaryRef = useRef<HTMLButtonElement>(null);
   const autoCloseRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // The copy-paste fallback must match the flow the dialog was driving: a GitHub
-  // "refresh" maps to `gh auth refresh` (preserves granted scopes), everything else to
-  // `auth login --web` (glab has no `refresh` subcommand — login re-runs OAuth for it in
-  // both modes).
+  // The copy-paste fallback must match the flow the dialog was driving, argv spelling
+  // included: a GitHub "refresh" maps to `gh auth refresh` (preserves granted scopes,
+  // plus one `-s` per requested scope), everything else to `auth login --web` (glab has
+  // no `refresh` subcommand — login re-runs OAuth for it in both modes).
+  // gh refreshes the host's ACTIVE account, so on a multi-account host the scopes land
+  // wherever `gh auth switch` last pointed.
   const fallbackCommand =
     isGitHub && mode === "refresh"
-      ? `gh auth refresh --hostname ${host}`
+      ? `gh auth refresh --hostname ${host}${(scopes ?? []).map((s) => ` -s ${s}`).join("")}`
       : `${isGitHub ? "gh" : "glab"} auth login --hostname ${host} --web`;
 
   // Handle streamed events without re-subscribing the channel on every render:
@@ -146,7 +151,14 @@ function ReconnectFlow({
     const sessionId = crypto.randomUUID();
     sessionIdRef.current = sessionId;
     setPhase({ kind: "starting" });
-    forgeReconnect({ sessionId, provider, host, mode, onEvent }).catch((e) => {
+    forgeReconnect({
+      sessionId,
+      provider,
+      host,
+      mode,
+      scopes,
+      onEvent,
+    }).catch((e) => {
       // A hard launch failure (CLI missing, spawn error) surfaces as a failed
       // finish so the fallbacks (terminal / copy command) are offered.
       if (sessionIdRef.current === sessionId) {

--- a/src/features/accounts/ReconnectDialog.tsx
+++ b/src/features/accounts/ReconnectDialog.tsx
@@ -16,6 +16,7 @@ import {
   forgeReconnectCancel,
   openInTerminal,
 } from "@/lib/git/api";
+import { isReconnectHostSafe } from "@/lib/git/host";
 import { useInvalidateAfterReconnect } from "@/lib/git/queries";
 import { providerLabel, type ReconnectEvent } from "@/lib/git/types";
 import { useSettings } from "@/lib/settings/queries";
@@ -103,8 +104,11 @@ function ReconnectFlow({
   // no `refresh` subcommand — login re-runs OAuth for it in both modes).
   // gh refreshes the host's ACTIVE account, so on a multi-account host the scopes land
   // wherever `gh auth switch` last pointed.
-  const fallbackCommand =
-    isGitHub && mode === "refresh"
+  // Null when the host fails the reconnect grammar, so a crafted remote host can't
+  // put shell syntax into the copyable command (the in-app flow re-validates anyway).
+  const fallbackCommand = !isReconnectHostSafe(host)
+    ? null
+    : isGitHub && mode === "refresh"
       ? `gh auth refresh --hostname ${host}${(scopes ?? []).map((s) => ` -s ${s}`).join("")}`
       : `${isGitHub ? "gh" : "glab"} auth login --hostname ${host} --web`;
 
@@ -299,18 +303,20 @@ function ReconnectFlow({
               </Button>
             )}
           </div>
-          <p className="text-muted-foreground">
-            Or run{" "}
-            <button
-              type="button"
-              className="cursor-pointer font-mono underline underline-offset-2"
-              onClick={() => copyText(fallbackCommand, "Command copied")}
-              title="Copy command"
-            >
-              {fallbackCommand}
-            </button>{" "}
-            in a terminal.
-          </p>
+          {fallbackCommand && (
+            <p className="text-muted-foreground">
+              Or run{" "}
+              <button
+                type="button"
+                className="cursor-pointer font-mono underline underline-offset-2"
+                onClick={() => copyText(fallbackCommand, "Command copied")}
+                title="Copy command"
+              >
+                {fallbackCommand}
+              </button>{" "}
+              in a terminal.
+            </p>
+          )}
         </div>
       )}
     </DialogContent>

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -31,16 +31,19 @@ import type { RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import { applyRepoLens } from "@/lib/repo-lens/queries";
+import { useAiEnabled } from "@/lib/settings/queries";
 import {
+  AI_NOTIFICATION_KINDS,
   type AppNotification,
   clearAllNotifications,
   clearNotification,
+  clearNotifications,
   markAllNotificationsRead,
   markNotificationRead,
+  markNotificationsRead,
   type NotificationKind,
   type NotificationTone,
   useNotifications,
-  useUnreadCount,
 } from "@/lib/stores/notifications";
 import {
   cancelReview,
@@ -76,17 +79,19 @@ export function ActivityStrip() {
   const activityOpen = useUiStore((s) => s.activityOpen);
   const tasks = useReviewTasks();
   const notifs = useNotifications();
+  const aiEnabled = useAiEnabled();
   // The header dock already covers the repo view; the strip only fills in for
   // the header-less screens — when there's something to reach, OR when the
   // palette / hotkey opened the popover (so the bell + its empty state are
   // reachable even with an empty inbox on the welcome/settings/help screens).
   if (view === "repo") return null;
   const live = liveTasks(tasks);
-  const stopped = stoppedTasks(tasks);
+  const stopped = stoppedTasks(tasks, aiEnabled);
+  const visible = visibleNotifications(notifs, aiEnabled);
   if (
     live.length === 0 &&
     stopped.length === 0 &&
-    notifs.length === 0 &&
+    visible.length === 0 &&
     !activityOpen
   ) {
     return null;
@@ -107,22 +112,46 @@ function liveTasks(tasks: ReviewTask[]): ReviewTask[] {
 
 /** Stopped automation runs — cancelled or failed rows that carry a `rerun`. The
  *  `rerun` presence is the discriminator: a manual panel run also reaches
- *  "cancelled"/"error" but never carries one, so it's kept out of the dock. */
-function stoppedTasks(tasks: ReviewTask[]): ReviewTask[] {
+ *  "cancelled"/"error" but never carries one, so it's kept out of the dock.
+ *
+ *  Every row here is an AI automation review by construction, so hiding AI
+ *  features empties the zone outright. Live rows are NOT filtered — they hold the
+ *  only Cancel an in-flight automation run has, so they stay until they settle. */
+function stoppedTasks(tasks: ReviewTask[], aiEnabled: boolean): ReviewTask[] {
+  if (!aiEnabled) return [];
   return tasks.filter(
     (t) => (t.phase === "cancelled" || t.phase === "error") && t.rerun,
   );
 }
 
+/** The inbox rows this dock shows. Hiding AI features drops AI-minted kinds from
+ *  the render only — the records keep accruing, so the history is intact when AI
+ *  is shown again. A kind the set doesn't name renders (hydrated rows from an
+ *  older build are untrusted, and a forge event must never be mistaken for AI). */
+function visibleNotifications(
+  notifs: AppNotification[],
+  aiEnabled: boolean,
+): AppNotification[] {
+  if (aiEnabled) return notifs;
+  return notifs.filter((n) => !AI_NOTIFICATION_KINDS.has(n.kind));
+}
+
 function ActivityBell({ variant }: { variant: "header" | "strip" }) {
   const tasks = useReviewTasks();
-  const unread = useUnreadCount();
+  const notifs = useNotifications();
+  const aiEnabled = useAiEnabled();
   // Open state lives in the UI store so the command palette / a hotkey can
   // toggle it (only one mount — header or strip — is on screen at a time).
   const open = useUiStore((s) => s.activityOpen);
   const setOpen = useUiStore((s) => s.setActivityOpen);
+  // The badge counts what the panel will actually show: a hidden AI row must not
+  // send the user to an inbox where the unread it promised isn't there.
+  const unread = visibleNotifications(notifs, aiEnabled).reduce(
+    (n, i) => (i.read ? n : n + 1),
+    0,
+  );
   const live = liveTasks(tasks).length;
-  const stopped = stoppedTasks(tasks).length;
+  const stopped = stoppedTasks(tasks, aiEnabled).length;
 
   const label = `Activity & notifications${
     unread > 0 ? ` · ${unread} unread` : ""
@@ -172,11 +201,13 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   const openPr = useUiStore((s) => s.openPr);
   const openRun = useUiStore((s) => s.openRun);
   const openAgentTab = useUiStore((s) => s.openAgentTab);
+  const aiEnabled = useAiEnabled();
   const [focusedId, setFocusedId] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   const live = liveTasks(tasks);
-  const stopped = stoppedTasks(tasks);
+  const stopped = stoppedTasks(tasks, aiEnabled);
+  const visible = visibleNotifications(notifs, aiEnabled);
   // Queue position per lane (local + cloud run independently), FIFO by seq.
   const queuePos = new Map<string, number>();
   for (const isLocal of [true, false]) {
@@ -234,8 +265,8 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   // Keyboard delete: focus the neighbour that takes this row's place (next, else
   // previous) so arrow-key flow survives a delete instead of dropping to <body>.
   const handleDelete = (id: string) => {
-    const idx = notifs.findIndex((n) => n.id === id);
-    const nextId = notifs[idx + 1]?.id ?? notifs[idx - 1]?.id ?? null;
+    const idx = visible.findIndex((n) => n.id === id);
+    const nextId = visible[idx + 1]?.id ?? visible[idx - 1]?.id ?? null;
     clearNotification(id);
     setFocusedId(nextId);
     if (nextId) {
@@ -248,11 +279,24 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   };
 
   const onListKeyDown = listKeyboardNav({
-    items: notifs,
-    activeIndex: focusedId ? notifs.findIndex((n) => n.id === focusedId) : -1,
+    items: visible,
+    activeIndex: focusedId ? visible.findIndex((n) => n.id === focusedId) : -1,
     onActivate: (n) => setFocusedId(n.id),
     rowKey: (n) => n.id,
   });
+
+  // Bulk actions reach only what's on screen: while AI rows are hidden they run
+  // id-scoped, so pressing Clear all can't wipe history the user can't see. With
+  // nothing filtered out the blanket store actions stay, which also catch a row
+  // that arrived between this render and the click.
+  const markAllVisibleRead = () => {
+    if (aiEnabled) markAllNotificationsRead();
+    else markNotificationsRead(visible.map((n) => n.id));
+  };
+  const clearAllVisible = () => {
+    if (aiEnabled) clearAllNotifications();
+    else clearNotifications(visible.map((n) => n.id));
+  };
 
   return (
     <>
@@ -301,32 +345,25 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
 
       <div className="flex items-center justify-between px-3 py-2">
         <span className="text-xs font-medium">Notifications</span>
-        {notifs.length > 0 && (
+        {visible.length > 0 && (
           <div className="-mr-1 flex items-center gap-0.5">
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => markAllNotificationsRead()}
-            >
+            <Button variant="ghost" size="xs" onClick={markAllVisibleRead}>
               Mark all read
             </Button>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => clearAllNotifications()}
-            >
+            <Button variant="ghost" size="xs" onClick={clearAllVisible}>
               Clear all
             </Button>
           </div>
         )}
       </div>
 
-      {notifs.length === 0 ? (
+      {visible.length === 0 ? (
         <div className="px-3 pt-1 pb-6 text-center">
           <p className="text-xs font-medium">You're all caught up</p>
           <p className="mt-1 text-[11px] text-muted-foreground">
-            Finished reviews, PR activity, checks, and completed runs show up
-            here so you never miss one.
+            {aiEnabled
+              ? "Finished reviews, PR activity, checks, and completed runs show up here so you never miss one."
+              : "PR activity, checks, and completed runs show up here so you never miss one."}
           </p>
         </div>
       ) : (
@@ -335,7 +372,7 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
           className="max-h-80 overflow-y-auto outline-none"
           onKeyDown={onListKeyDown}
         >
-          {notifs.map((n) => (
+          {visible.map((n) => (
             <NotificationRow
               key={n.id}
               n={n}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -891,7 +891,8 @@ request, counting one as outstanding when it has failed, is still running, or ha
 never reported. Four are named, then *and N more*. Where the rules also require
 approving reviews, the count rides along: **The rules also require 2 approving
 reviews.** Wherever the specific requirements can't be named, the line falls back to
-**Merge is blocked by the base branch's protection rules.**
+**Merge is blocked by the base branch's protection rules.** When only the approval
+count is known it reads **…protection rules, which require 2 approving reviews.**
 
 On **GitLab** the project's own answer supplies the reason, in the app's words:
 **Merge is blocked — needs approval before it can merge**, **the pipeline must pass

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -533,8 +533,10 @@ can safely preview and recover work you thought was gone.
 **Operation history** (in the branch ⋮ menu, or the command palette) opens a
 journal of the *risky* operations GitDesktop runs — local PR merges, cherry-picks, history
 edits, and interactive rebases — each recorded with the exact branch and commit it started
-from, and whether it finished, failed, is paused on conflicts, or is still pending. If one
-of these operations is interrupted (a crash or a restart mid-op), a calm recovery line
+from, and whether it finished, failed, is paused on conflicts, is still pending, or
+**ended outside the app** (a cherry-pick you continued or aborted in a terminal, which the
+journal only knows is over). If one of these operations is interrupted (a crash or a
+restart mid-op), a calm recovery line
 appears above the **Changes** list naming what was interrupted and the state it started
 from. That notice only informs — it never resets or continues anything on its own (the
 git-native **Continue**/**Abort** for an in-progress merge, rebase, cherry-pick, or revert
@@ -879,25 +881,38 @@ merge the base back into the head.
 
 ## Blocked by branch protection
 
-A pull request can merge cleanly and still be refused. **GitHub** reports one as
-blocked while the base branch's rules go unmet, and the strip says so, naming what is
-outstanding: **Merge is blocked — waiting on: build, fragment.** GitDesktop asks
-GitHub what that branch requires and matches it against the checks on this pull
-request, counting one as outstanding when it has failed, is still running, or has
-never reported. Four are named, then *and N more*. Wherever the specific
-requirements can't be named, the line falls back to **Merge is blocked by the
-base branch's protection rules.**
+A pull request can merge cleanly and still be refused, and the strip names the reason
+on both **GitHub** and **GitLab**.
 
-Where the head is also behind its base, the refusal says so in the same breath and
-**Update branch** stays on the strip, so a blocked pull request never loses the route
-to updating it — except on a promotion pull request, where the update stays withheld
-for the same reason as above.
+On **GitHub** the refusal is the base branch's rules going unmet, and the line names
+what is outstanding: **Merge is blocked — waiting on: build, fragment.** GitDesktop
+asks GitHub what that branch requires and matches it against the checks on this pull
+request, counting one as outstanding when it has failed, is still running, or has
+never reported. Four are named, then *and N more*. Where the rules also require
+approving reviews, the count rides along: **The rules also require 2 approving
+reviews.** Wherever the specific requirements can't be named, the line falls back to
+**Merge is blocked by the base branch's protection rules.**
+
+On **GitLab** the project's own answer supplies the reason, in the app's words:
+**Merge is blocked — needs approval before it can merge**, **the pipeline must pass
+first**, **the pipeline is still running**, **all discussions must be resolved
+first**, **a reviewer requested changes**, **it needs a rebase first**, or the rest of
+GitLab's detailed merge statuses (external status checks, security policies, locked
+paths and LFS files, a required Jira reference, a title pattern, a scheduled merge
+time, another merge request blocking this one). A reason GitLab words itself is shown
+as GitLab wrote it, and one this app hasn't learned yet is spelled out rather than
+shown as a raw token.
+
+On **GitHub**, where the behind count is read, a head that is also behind its base
+gets that in the same breath and **Update branch** stays on the strip, so a blocked
+pull request never loses the route to updating it — except on a promotion pull
+request, where the update stays withheld for the same reason as above.
 
 **Merge** stays available throughout. Whoever holds bypass permission on those rules
 can merge anyway, and nothing GitDesktop can read from here says whether you're one of
 them — so the button stays live and the call stays yours. If the forge does refuse the
-merge, the notice carries that same line beside the forge's own words. This reads
-GitHub's rules, so it's **GitHub** only.
+merge, the notice carries that same line beside the forge's own words. **Bitbucket**
+publishes no mergeability of its own, so no blocked line arms there.
 
 ## Maintaining a pull request from a fork
 
@@ -1793,7 +1808,10 @@ to an implementing session**.
 
 **Delegate** starts a write-capable session. Describe the task, pick the **agent** (it
 opens on your **Settings → AI** default agent), **model**, and **reasoning effort**
-(Low / Medium / High / Max), and send. The agent works in an **isolated git worktree**
+(Low / Medium / High / Max), and send. The model box (the same one on research and plan
+runs) filters its suggestions as you type and takes any model id you type, so a custom
+provider's models work without being on the list; leave it empty for your account's
+default. The agent works in an **isolated git worktree**
 — a throwaway branch (\`gd/session/…\`) that never touches your working tree — and
 commits a **checkpoint** each turn. It works in the open: the conversation shows a
 **step-by-step transcript** of each file it reads, edits, searches, and command it
@@ -2070,9 +2088,10 @@ notes**, and **repository descriptions**.
   (the file, its folder, or its file type — or a multi-selection) appends to
   \`.gitdesktop/aiignore\`, creating it if needed — an anchored line (\`/src/config.ts\`,
   \`/vendor/\`) for exactly the file or folder you picked.
-- **Hide AI** (Settings → General) hides the AI surfaces and pauses your automations —
-  nothing new runs or posts while it's on. Your configuration and rules are kept, and
-  automations start again when you turn AI features back on.
+- **Hide AI** (Settings → General) hides the AI surfaces (finished AI activity in the
+  activity dock and notification inbox included), mutes AI desktop notifications, and
+  pauses your automations — nothing new runs or posts while it's on. Your configuration
+  and rules are kept, and automations start again when you turn AI features back on.
 
 ## Automations
 
@@ -2220,9 +2239,10 @@ there's an equivalent.`,
 
 Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 
-- **General** — hide AI features (which also pauses your automations until you show them
-  again — your rules are kept), keep running in the **system tray** on close (so
-  background work continues; launching the app again while it's running —
+- **General** — hide AI features (which also hides finished AI activity in the activity
+  dock and notification inbox, mutes AI desktop notifications, and pauses your automations
+  until you show them again — your rules are kept), keep running in the **system tray** on
+  close (so background work continues; launching the app again while it's running —
   tray-hidden or not — focuses the existing window), **automatically fetch from your
   remotes** (a background fetch on an interval you pick — it never pulls, merges, or
   changes your files), **automatically stash and reapply on pull, merge, rebase, and branch

--- a/src/features/history/EditHistoryDialog.tsx
+++ b/src/features/history/EditHistoryDialog.tsx
@@ -165,40 +165,37 @@ export function EditHistoryDialog({
   }
 
   const busy = rewrite.isPending || rebaseEdit.isPending;
-  function apply() {
+  // Awaited rather than per-call mutation callbacks: this dialog is mounted
+  // conditionally, so closing it mid-rewrite would drop the outcome — including
+  // the hand-off to the Changes tab that the paused rebase depends on.
+  async function apply() {
     if (plan.error || !plan.changed) return;
     if (plan.hasEdit) {
       // Resumable path: starts a real rebase that pauses at the first Edit —
       // the conflict/op banner in Changes takes it from there.
-      rebaseEdit.mutate(
-        { base, steps: plan.steps },
-        {
-          onSuccess: () => {
-            toast.success("Rebase started — paused to edit a commit");
-            onOpenChange(false);
-            setRepoTab("changes");
-            onDone();
-          },
-          onError: (e) => toastError(e),
-        },
-      );
+      try {
+        await rebaseEdit.mutateAsync({ base, steps: plan.steps });
+        toast.success("Rebase started — paused to edit a commit");
+        onOpenChange(false);
+        setRepoTab("changes");
+        onDone();
+      } catch (e) {
+        toastError(e);
+      }
       return;
     }
-    rewrite.mutate(
-      { base, steps: plan.steps },
-      {
-        onSuccess: () => {
-          toast.success(
-            plan.resultCount === 1
-              ? "History rewritten into one commit"
-              : `History rewritten — ${plan.resultCount} commits`,
-          );
-          onOpenChange(false);
-          onDone();
-        },
-        onError: (e) => toastError(e),
-      },
-    );
+    try {
+      await rewrite.mutateAsync({ base, steps: plan.steps });
+      toast.success(
+        plan.resultCount === 1
+          ? "History rewritten into one commit"
+          : `History rewritten — ${plan.resultCount} commits`,
+      );
+      onOpenChange(false);
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/plan/ImplementPlanButton.tsx
+++ b/src/features/plan/ImplementPlanButton.tsx
@@ -6,20 +6,13 @@ import {
   AgentPicker,
   EffortPicker,
   ModelPicker,
+  modelsForAgent,
 } from "@/features/sessions/AgentPickers";
 import { clearAgentSelection } from "@/features/sessions/agentSelect";
 import { useSessionsStore } from "@/features/sessions/store";
 import { type AgentKind, extractContextPack } from "@/lib/ai/agent";
 import { buildImplementPrompt } from "@/lib/ai/prompt";
-import { MODEL_SUGGESTIONS } from "@/lib/ai/providers";
 import { type PlanRun, usePlanStore } from "./store";
-
-const MODELS: Record<AgentKind, string[]> = {
-  claude: MODEL_SUGGESTIONS["claude-cli"],
-  codex: MODEL_SUGGESTIONS["codex-cli"],
-  copilot: MODEL_SUGGESTIONS["copilot-cli"],
-  opencode: MODEL_SUGGESTIONS["opencode-cli"],
-};
 
 /**
  * The plan's primary action: start a write-capable agent session that implements
@@ -83,7 +76,7 @@ export function ImplementPlanButton({ run }: { run: PlanRun }) {
               <ModelPicker
                 value={model}
                 onChange={setModel}
-                models={MODELS[agent]}
+                models={modelsForAgent(agent)}
               />
               <EffortPicker value={effort} onChange={setEffort} />
             </div>

--- a/src/features/plan/PlanView.tsx
+++ b/src/features/plan/PlanView.tsx
@@ -13,6 +13,7 @@ import {
   AgentPicker,
   ComposerOptions,
   ModelPicker,
+  modelsForAgent,
 } from "@/features/sessions/AgentPickers";
 import { AgentTranscript } from "@/features/sessions/AgentTranscript";
 import { selectSession } from "@/features/sessions/agentSelect";
@@ -20,7 +21,6 @@ import { useSessionsStore } from "@/features/sessions/store";
 import { type AgentKind, defaultAgentKind } from "@/lib/ai/agent";
 import { formatUsd } from "@/lib/ai/cost";
 import { extractPlanQuestions } from "@/lib/ai/prompt";
-import { MODEL_SUGGESTIONS } from "@/lib/ai/providers";
 import { forgeFeatureReady, useForgeStatus } from "@/lib/git/queries";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useSettings } from "@/lib/settings/queries";
@@ -34,13 +34,6 @@ import {
   useActivePlanRun,
   usePlanStore,
 } from "./store";
-
-const MODELS: Record<AgentKind, string[]> = {
-  claude: MODEL_SUGGESTIONS["claude-cli"],
-  codex: MODEL_SUGGESTIONS["codex-cli"],
-  copilot: MODEL_SUGGESTIONS["copilot-cli"],
-  opencode: MODEL_SUGGESTIONS["opencode-cli"],
-};
 
 /**
  * The read-only planning canvas — peer of the session canvas in the agent
@@ -121,10 +114,13 @@ export function PlanComposer({
   const [agentPick, setAgentPick] = useState<AgentKind | null>(null);
   const agent: AgentKind = agentPick ?? defaultAgentKind(settings.data);
   const [model, setModel] = useState("");
+  // The agent `model` was chosen for; null = nothing chosen yet. Any model id is
+  // accepted, so list membership can't decide whether one still fits the agent.
+  const [modelAgent, setModelAgent] = useState<AgentKind | null>(null);
   const [effort, setEffort] = useState("");
-  // A model picked for one agent isn't in another's list; "" = the account
-  // default. Derived, so a default-agent change drops a model it can't run.
-  const modelForAgent = MODELS[agent].includes(model) ? model : "";
+  // A model belongs to the agent it was chosen for; "" = the account default.
+  // Derived, so a default-agent change drops a model that agent wasn't given.
+  const modelForAgent = modelAgent === agent ? model : "";
 
   const planningIssue = Boolean(seed?.issueTitle || seed?.issueBody);
   const canPlan = goal.trim().length > 0 || planningIssue;
@@ -195,12 +191,16 @@ export function PlanComposer({
               onChange={(a) => {
                 setAgentPick(a);
                 setModel("");
+                setModelAgent(null);
               }}
             />
             <ModelPicker
               value={modelForAgent}
-              onChange={setModel}
-              models={MODELS[agent]}
+              onChange={(m) => {
+                setModel(m);
+                setModelAgent(agent);
+              }}
+              models={modelsForAgent(agent)}
             />
             <ComposerOptions effort={effort} onEffort={setEffort} />
             <div className="ml-auto flex items-center gap-2">

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -228,7 +228,14 @@ export const usePlanStore = create<PlanState>((set, get) => {
         : hasQuestions
           ? "Plan ready — answer its questions"
           : "Plan ready";
-      void notify(headline, label);
+      // Hiding AI features mutes the OS ping — a hidden feature must not tap you
+      // on the shoulder. The inbox row below still lands (the dock filters it at
+      // render time), and a settings read that fails falls through to notifying.
+      void loadSettings()
+        .catch(() => null)
+        .then((s) => {
+          if (!s?.hideAi) void notify(headline, label);
+        });
       pushNotification({
         kind: "plan-done",
         tone: failed ? "danger" : hasQuestions ? "warning" : "success",

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -34,15 +34,96 @@ const MAX_REQUIREMENT_NAMES = 4;
 /** The one wording for a merge the base branch's rules are refusing — the strip says
  *  it, and so does the note on a refused merge, so the two can't drift apart. With
  *  nothing named (the rules read failed, or named nothing the app could join) it
- *  still states where things stand rather than going quiet. */
-export function blockedMergeLine(requirements: string[]): string {
+ *  still states where things stand rather than going quiet.
+ *
+ *  `requiredApprovals` gets its own clause rather than joining the waiting-on list:
+ *  that list is what the checks join found UNMET, and the rules payload only says how
+ *  many approvals are required, never how many the pull request has. */
+export function blockedMergeLine(
+  requirements: string[],
+  requiredApprovals?: number | null,
+): string {
+  const approvals =
+    requiredApprovals && requiredApprovals > 0
+      ? `${requiredApprovals} approving review${requiredApprovals === 1 ? "" : "s"}`
+      : null;
   if (requirements.length === 0)
-    return "Merge is blocked by the base branch's protection rules.";
+    return approvals
+      ? `Merge is blocked by the base branch's protection rules, which require ${approvals}.`
+      : "Merge is blocked by the base branch's protection rules.";
   const shown = requirements.slice(0, MAX_REQUIREMENT_NAMES);
   const extra = requirements.length - shown.length;
   const names =
     extra > 0 ? `${shown.join(", ")} and ${extra} more` : shown.join(", ");
-  return `Merge is blocked — waiting on: ${names}.`;
+  const line = `Merge is blocked — waiting on: ${names}.`;
+  return approvals ? `${line} The rules also require ${approvals}.` : line;
+}
+
+/** GitLab's `detailed_merge_status` values that name a rule refusing the merge, said
+ *  in the app's own words. Each maps to the clause after "Merge is blocked — ". The
+ *  values are GitLab's documented enum (18.3); anything absent here either already
+ *  rides the mergeability `state` or is deliberately unarmed (see
+ *  `GITLAB_UNARMED_MERGE_STATUSES`). */
+const GITLAB_BLOCKED_REASONS: Record<string, string> = {
+  not_approved: "needs approval before it can merge",
+  ci_must_pass: "the pipeline must pass first",
+  ci_still_running: "the pipeline is still running",
+  discussions_not_resolved: "all discussions must be resolved first",
+  merge_request_blocked: "it's blocked by another merge request",
+  status_checks_must_pass: "external status checks must pass first",
+  requested_changes: "a reviewer requested changes",
+  need_rebase: "it needs a rebase first",
+  merge_time: "it can't merge before its scheduled time",
+  jira_association_missing: "its title or description must reference a Jira issue",
+  security_policy_violations: "security policies must be satisfied first",
+  locked_paths: "paths locked by other users must be unlocked first",
+  locked_lfs_files: "locked LFS files must be unlocked first",
+  title_regex: "its title doesn't match the project's required pattern",
+};
+
+/** `detailed_merge_status` values that deliberately arm NOTHING — each is either
+ *  already carried by the mergeability state (`mergeable`, the checking family,
+ *  `conflict`, `not_open`), owned by another surface (`draft_status` is the merge
+ *  control's own refusal), or still being computed (`approvals_syncing`,
+ *  `commits_status`). Membership here is the only route to silence: an enum value in
+ *  neither table still renders, humanized (`some_status` → "some status"), and
+ *  free-form `merge_error` prose renders verbatim. */
+const GITLAB_UNARMED_MERGE_STATUSES: ReadonlySet<string> = new Set([
+  "mergeable",
+  "checking",
+  "unchecked",
+  "preparing",
+  "broken_status",
+  "conflict",
+  "draft_status",
+  "not_open",
+  "approvals_syncing",
+  "commits_status",
+]);
+
+/** Ends a line the app didn't write like a sentence. GitLab's prose sometimes carries
+ *  its own terminator and sometimes doesn't, and the blocked arm can append a clause
+ *  straight after this line. */
+function terminated(line: string): string {
+  return /[.!?]$/.test(line) ? line : `${line}.`;
+}
+
+/** The banner's line for a GitLab merge request the project's rules are refusing, or
+ *  `null` when the detail names nothing worth a line.
+ *
+ *  `detail` carries GitLab's `merge_error` when there is one and the
+ *  `detailed_merge_status` enum otherwise, and the backend keeps both raw — so the
+ *  enum lookup is gated on the enum's own shape and free-form prose is shown exactly
+ *  as GitLab wrote it. An enum value this app hasn't learned yet is humanized rather
+ *  than shown as a token: GitLab's word beats silence about a merge that will refuse. */
+export function gitlabBlockedLine(detail: string): string | null {
+  const raw = detail.trim();
+  if (raw === "") return null;
+  if (!/^[a-z_]+$/.test(raw)) return terminated(`Merge is blocked — ${raw}`);
+  if (GITLAB_UNARMED_MERGE_STATUSES.has(raw)) return null;
+  const reason = GITLAB_BLOCKED_REASONS[raw];
+  if (reason) return `Merge is blocked — ${reason}.`;
+  return `Merge is blocked — ${raw.replace(/_/g, " ")}.`;
 }
 
 /** What a control held open through the PR-switch window says. Shared with the view's
@@ -108,6 +189,8 @@ const ARM_MESSAGE: Record<
     predictedClean: boolean;
     forgeUnreachable: boolean;
     blockedRequirements: string[];
+    blockedApprovals: number | null;
+    blockedReason: string | null;
     promotionKind: PromotionKind;
   }) => ReactNode
 > = {
@@ -162,9 +245,18 @@ const ARM_MESSAGE: Record<
   // The behind clause rides along in the `behind` arm's own words, because the update
   // controls come with it — a bare refusal beside an Update branch button would leave
   // the button unexplained.
-  blocked: ({ base, behindBy, blockedRequirements, promotionKind }) => (
+  blocked: ({
+    base,
+    behindBy,
+    blockedRequirements,
+    blockedApprovals,
+    blockedReason,
+    promotionKind,
+  }) => (
     <>
-      {blockedMergeLine(blockedRequirements)}
+      {/* GitLab names its own reason and gets no requirements join — rules and
+          branch protections are a GitHub read, and there is nothing to join it to. */}
+      {blockedReason ?? blockedMergeLine(blockedRequirements, blockedApprovals)}
       {/* The behind clause exists to explain the Update controls beside it, so it
           goes wherever they go: on a promotion pull request they'd invert the
           flow, and a count with no route out would read as a demand. */}
@@ -229,6 +321,8 @@ export function PrMergeabilityBanner({
   forgeUnreachable,
   behindBy,
   blockedRequirements,
+  blockedApprovals,
+  blockedReason,
   updateBlockedReason,
   updateBusy,
   updateAwaitingDefault,
@@ -271,6 +365,13 @@ export function PrMergeabilityBanner({
    *  arm, where an empty list means the app couldn't name any and the line stays
    *  generic. */
   blockedRequirements: string[];
+  /** Approving reviews the base branch's rules require; `null` when the rules name
+   *  no count or the read didn't land. GitHub only, like `blockedRequirements`. */
+  blockedApprovals: number | null;
+  /** The whole blocked sentence, where the provider supplies the reason itself
+   *  (GitLab). Non-null replaces the rules-derived line — the two describe different
+   *  refusals and only one provider can be answering. */
+  blockedReason: string | null;
   /** Why updating the branch is refused, if it is; undefined = allowed. */
   updateBlockedReason: string | undefined;
   updateBusy: boolean;
@@ -373,6 +474,8 @@ export function PrMergeabilityBanner({
             predictedClean,
             forgeUnreachable,
             blockedRequirements,
+            blockedApprovals,
+            blockedReason,
             promotionKind,
           })}
         </span>

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -74,7 +74,8 @@ const GITLAB_BLOCKED_REASONS: Record<string, string> = {
   requested_changes: "a reviewer requested changes",
   need_rebase: "it needs a rebase first",
   merge_time: "it can't merge before its scheduled time",
-  jira_association_missing: "its title or description must reference a Jira issue",
+  jira_association_missing:
+    "its title or description must reference a Jira issue",
   security_policy_violations: "security policies must be satisfied first",
   locked_paths: "paths locked by other users must be unlocked first",
   locked_lfs_files: "locked LFS files must be unlocked first",

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -396,11 +396,10 @@ export function PrReviewPanel({
             items={models}
             inputValue={reviewAi?.model ?? ""}
             onInputValueChange={(v) => updateReview({ model: v })}
-            value={
-              reviewAi && models.includes(reviewAi.model)
-                ? reviewAi.model
-                : null
-            }
+            // UNCLAMPED on purpose: Base UI syncs the input to the selected
+            // item's label as the popup finishes closing, and a null selection
+            // syncs it to "" — clamping to the catalog would wipe a typed id.
+            value={reviewAi?.model || null}
             onValueChange={(v) => v && updateReview({ model: v })}
             openOnInputClick
           >

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -179,6 +179,7 @@ import { PrActivityFeed, usePrThreadClaims } from "./PrActivityFeed";
 import { PrCommitDetail } from "./PrCommitDetail";
 import {
   blockedMergeLine,
+  gitlabBlockedLine,
   PR_SWITCH_LOADING_REASON,
   type PrMergeabilityArm,
   PrMergeabilityBanner,
@@ -936,11 +937,18 @@ export function RemotePrView({
     previewEnabled && conflictPreview.data?.status === "clean";
   // GitHub reports a PR the base branch's rules are refusing as MERGEABLE with a
   // BLOCKED merge-state — the merge itself is clean, the rules are the refusal.
-  // GitLab/Bitbucket `detail` values are not interpreted here.
   const blockedByRules =
     provider === "github" &&
     serverState === "mergeable" &&
     mergeability.data?.detail === "BLOCKED";
+  // GitLab's twin: the merge is clean and `detailed_merge_status` (or the free-form
+  // `merge_error` that outranks it) names the rule refusing it. Null whenever the
+  // detail names nothing worth a line, which is what keeps the arm off. Bitbucket has
+  // no mergeability to interpret and is deliberately absent from both.
+  const gitlabBlockedNote =
+    provider === "gitlab" && serverState === "mergeable"
+      ? gitlabBlockedLine(mergeability.data?.detail ?? "")
+      : null;
   const behindBy = divergenceEnabled ? (divergence.data?.behindBy ?? 0) : 0;
   // Same gate as `behindBy` — a disabled divergence query keeps serving its last value,
   // and a latch left armed on one PR must never paint onto the next.
@@ -1073,7 +1081,7 @@ export function RemotePrView({
       // rides a settled "mergeable" answer, which neither `checking` nor
       // `unreachable` can be true of. It does outrank `behind` — rules the base is
       // enforcing are more pressing than a base that has merely moved on.
-      case blockedByRules:
+      case blockedByRules || gitlabBlockedNote !== null:
         return "blocked";
       case behindBy > 0:
         return "behind";
@@ -1086,8 +1094,10 @@ export function RemotePrView({
   // synchronously, so the arm can be "blocked" while the base ref and checks belong to
   // the last one. Naming that PR's checks, or reading rules for its base, would both
   // be wrong.
+  // `blockedByRules` and not merely the arm: the rules read below is a GitHub command,
+  // and the arm now also fires for GitLab, which names its own reason.
   const blockedDetailsReady =
-    bannerArm === "blocked" && !details.isPlaceholderData;
+    bannerArm === "blocked" && blockedByRules && !details.isPlaceholderData;
   // The base branch's required checks, read only for the arm that names them. The
   // repoTab term is the <Activity> gate every sibling read here carries: a hidden
   // subtree still refetches, and this one would respawn `gh` on every focus regain.
@@ -1101,11 +1111,16 @@ export function RemotePrView({
   // banner never waits on the join to say that the merge is blocked.
   const blockedRequirements = blockedDetailsReady
     ? unmetRequiredChecks(
-        requiredChecks.data ?? [],
+        requiredChecks.data?.contexts ?? [],
         details.data?.checks ?? [],
         providerKey,
       )
     : [];
+  // Approvals ride the same read; nothing in the PR's checks could name them, so they
+  // are reported as a requirement rather than joined into the unmet list.
+  const blockedApprovals = blockedDetailsReady
+    ? (requiredChecks.data?.requiredApprovingReviewCount ?? null)
+    : null;
   // `blocked` outranks `behind` on the ladder, so a PR that is both would otherwise
   // lose every route to the update (button, caret, hotkey, palette) while the rules
   // block it: the strip's sentence changes, the affordance does not. Neither arm
@@ -1650,11 +1665,16 @@ export function RemotePrView({
           setMergeOpen(false);
         },
         onError: (e) => {
-          // The forge's own refusal text advises flags this app doesn't offer, so
-          // where the rules are the known reason, say which requirement is unmet
-          // alongside it — the same line the strip is already showing.
+          // Where the rules are the known reason, say which requirement is unmet
+          // alongside the refusal — the same line the strip is already showing, and
+          // on GitLab the only place the reason is worded at all (the backend's
+          // message deliberately doesn't duplicate this table).
           if (bannerArm === "blocked")
-            toastErrorWithNote(e, blockedMergeLine(blockedRequirements));
+            toastErrorWithNote(
+              e,
+              gitlabBlockedNote ??
+                blockedMergeLine(blockedRequirements, blockedApprovals),
+            );
           else onError(e);
           setMergeOpen(false);
         },
@@ -2568,6 +2588,8 @@ export function RemotePrView({
         forgeUnreachable={forgeUnreachable}
         behindBy={behindBy}
         blockedRequirements={blockedRequirements}
+        blockedApprovals={blockedApprovals}
+        blockedReason={gitlabBlockedNote}
         updateBlockedReason={updateBlockedReason}
         // Busy-shaped, not a reason — the banner supplies its own words for the wait,
         // which now spans GitHub's whole queued update rather than one CLI call.

--- a/src/features/pulls/useBranchRequiredChecks.ts
+++ b/src/features/pulls/useBranchRequiredChecks.ts
@@ -4,12 +4,13 @@ import type { ForgeProvider, PrCheckOut, RemoteLens } from "@/lib/git/types";
 import { checkPresentation } from "./check-presentation";
 
 /**
- * The status-check contexts a pull request's BASE branch requires, read from
- * GitHub's active rules for that branch. Never polls, and it is enabled only where
- * the answer is about to be shown — the read exists to name what a blocked merge is
- * waiting on. It can still refetch on the usual triggers (focus, reconnect, remount)
- * once stale, so the caller's gate carries the <Activity> term too. An empty answer
- * is the honest one for a branch with no rules this viewer can see.
+ * What a pull request's BASE branch requires — status-check contexts and any
+ * approving-review count — read from GitHub's active rules for that branch. Never
+ * polls, and it is enabled only where the answer is about to be shown: the read
+ * exists to name what a blocked merge is waiting on. It can still refetch on the
+ * usual triggers (focus, reconnect, remount) once stale, so the caller's gate
+ * carries the <Activity> term too. An empty answer is the honest one for a branch
+ * with no rules this viewer can see.
  */
 export function useBranchRequiredChecks(
   repo: string,

--- a/src/features/repo-settings/ScopeRefreshHint.tsx
+++ b/src/features/repo-settings/ScopeRefreshHint.tsx
@@ -1,7 +1,7 @@
 import { CopyIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { copyText } from "@/lib/clipboard";
-import { useActiveGhHost } from "@/lib/git/host";
+import { isReconnectHostSafe, useActiveGhHost } from "@/lib/git/host";
 import { useGhScopes } from "@/lib/git/queries";
 import { useUiStore } from "@/lib/stores/ui";
 
@@ -23,6 +23,11 @@ export function ScopeRefreshHint({
   const scopes = useGhScopes(host);
   const openReconnect = useUiStore((s) => s.openReconnect);
   if (!scopes.data?.classic || scopes.data.scopes.includes(scope)) return null;
+  // A host outside the reconnect grammar never reaches a copyable command string
+  // (shell-syntax injection via a crafted remote) — only the command block is
+  // suppressed: the explanation and the button stay, and the button's flow
+  // re-validates the host backend-side, failing loudly rather than silently.
+  const hostSafe = isReconnectHostSafe(host);
   // Spelled as the reconnect flow spawns it (`--hostname`, one `-s` per scope), so
   // the copied command and the button do the same thing.
   const cmd = `gh auth refresh --hostname ${host} -s ${scope}`;
@@ -48,20 +53,26 @@ export function ScopeRefreshHint({
           Reconnect GitHub…
         </Button>
       </div>
-      <p className="mt-2 text-muted-foreground">Or run this, then reopen:</p>
-      <div className="mt-1.5 flex items-center gap-2">
-        <code className="min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-1 font-mono">
-          {cmd}
-        </code>
-        <button
-          type="button"
-          className="shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
-          title="Copy command"
-          onClick={() => copyText(cmd, "Command copied")}
-        >
-          <CopyIcon className="size-3.5" />
-        </button>
-      </div>
+      {hostSafe && (
+        <>
+          <p className="mt-2 text-muted-foreground">
+            Or run this, then reopen:
+          </p>
+          <div className="mt-1.5 flex items-center gap-2">
+            <code className="min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-1 font-mono">
+              {cmd}
+            </code>
+            <button
+              type="button"
+              className="shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
+              title="Copy command"
+              onClick={() => copyText(cmd, "Command copied")}
+            >
+              <CopyIcon className="size-3.5" />
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/features/repo-settings/ScopeRefreshHint.tsx
+++ b/src/features/repo-settings/ScopeRefreshHint.tsx
@@ -1,13 +1,16 @@
 import { CopyIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
 import { copyText } from "@/lib/clipboard";
 import { useActiveGhHost } from "@/lib/git/host";
 import { useGhScopes } from "@/lib/git/queries";
+import { useUiStore } from "@/lib/stores/ui";
 
 /**
- * Shows a copyable `gh auth refresh -s <scope>` when the active gh token is a
- * classic OAuth/PAT token missing `scope`. Renders nothing when the scope is
- * present, or for a fine-grained/App token (those have no readable scopes and
- * can't be refreshed this way) — so it never nags about a non-problem.
+ * Offers the in-app reconnect (and a copyable `gh auth refresh -s <scope>`) when
+ * the active gh token is a classic OAuth/PAT token missing `scope`. Renders
+ * nothing when the scope is present, or for a fine-grained/App token (those have
+ * no readable scopes and can't be refreshed this way) — so it never nags about a
+ * non-problem.
  */
 export function ScopeRefreshHint({
   scope,
@@ -18,14 +21,34 @@ export function ScopeRefreshHint({
 }) {
   const host = useActiveGhHost();
   const scopes = useGhScopes(host);
+  const openReconnect = useUiStore((s) => s.openReconnect);
   if (!scopes.data?.classic || scopes.data.scopes.includes(scope)) return null;
-  const cmd = `gh auth refresh -h ${host} -s ${scope}`;
+  // Spelled as the reconnect flow spawns it (`--hostname`, one `-s` per scope), so
+  // the copied command and the button do the same thing.
+  const cmd = `gh auth refresh --hostname ${host} -s ${scope}`;
   return (
     <div className="rounded-md border border-warning/40 bg-warning/10 p-2.5 text-[11px]">
       <p className="text-muted-foreground">
         {action} needs the <span className="font-mono">{scope}</span> scope,
-        which your GitHub sign-in is missing. Run this, then reopen:
+        which your GitHub sign-in is missing.
       </p>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={() =>
+            openReconnect({
+              provider: "github",
+              host,
+              mode: "refresh",
+              scopes: [scope],
+            })
+          }
+        >
+          Reconnect GitHub…
+        </Button>
+      </div>
+      <p className="mt-2 text-muted-foreground">Or run this, then reopen:</p>
       <div className="mt-1.5 flex items-center gap-2">
         <code className="min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-1 font-mono">
           {cmd}

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -6,6 +6,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { highlightJson } from "@/features/diff/shiki-highlighter";
 import { copyText } from "@/lib/clipboard";
 import { useActiveGhHost } from "@/lib/git/host";
+import { useGhScopes } from "@/lib/git/queries";
+import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 
 /**
@@ -35,13 +37,12 @@ export function AsyncListBody({
   /** Skeleton size, sized to roughly match each section's row height. */
   skeletonClassName?: string;
   errorTitle?: string;
-  /** Renders the standard "needs a broader scope — run `gh auth refresh -s <scope>`"
-   *  note in the error card. */
+  /** Renders the standard "needs a broader scope" note in the error card — with a
+   *  reconnect button when the sign-in is a refreshable classic token. */
   errorScope?: string;
   /** A custom hint node in the error card, for sections without a single scope. */
   errorHint?: ReactNode;
 }) {
-  const host = useActiveGhHost();
   if (loading) {
     return (
       <div className="space-y-2">
@@ -57,16 +58,7 @@ export function AsyncListBody({
         {error instanceof Error && (
           <p className="mt-1 text-muted-foreground">{error.message}</p>
         )}
-        {errorScope && (
-          <p className="mt-2 text-muted-foreground">
-            If this is a permissions error, your GitHub sign-in may need a
-            broader scope — run{" "}
-            <span className="font-mono">
-              gh auth refresh -h {host} -s {errorScope}
-            </span>{" "}
-            and reopen this dialog.
-          </p>
-        )}
+        {errorScope && <ScopeErrorHint scope={errorScope} />}
         {errorHint && (
           <div className="mt-2 text-muted-foreground">{errorHint}</div>
         )}
@@ -81,6 +73,59 @@ export function AsyncListBody({
     );
   }
   return <div className="space-y-2">{children}</div>;
+}
+
+/**
+ * The scope note inside an async list's error card, in `ScopeRefreshHint`'s
+ * grammar. The reconnect button only appears for a classic OAuth/PAT sign-in
+ * actually missing `scope` (the same gate that hint applies): this card also
+ * renders for "not signed in" and for failures that aren't about permissions at
+ * all, where a refresh is the wrong move — those keep the command text alone.
+ * The lead names the scope because one open dialog can show several of these
+ * cards, each wanting a different one. Lives in its own component so the
+ * token-scopes probe runs on the error path only, not from every healthy list.
+ */
+function ScopeErrorHint({ scope }: { scope: string }) {
+  const host = useActiveGhHost();
+  const scopes = useGhScopes(host);
+  const openReconnect = useUiStore((s) => s.openReconnect);
+  const canRefresh =
+    scopes.data?.classic === true && !scopes.data.scopes.includes(scope);
+  return (
+    <div className="mt-2 text-muted-foreground">
+      <p>
+        If this is a permissions error, your GitHub sign-in may be missing the{" "}
+        <span className="font-mono">{scope}</span> scope.
+      </p>
+      {canRefresh && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() =>
+              openReconnect({
+                provider: "github",
+                host,
+                mode: "refresh",
+                scopes: [scope],
+              })
+            }
+          >
+            Reconnect GitHub…
+          </Button>
+        </div>
+      )}
+      {/* The reopen only applies to the copied command: the button's flow
+          invalidates this list itself, so its card refetches in place. */}
+      <p className="mt-2">
+        {canRefresh ? "Or run" : "Run"}{" "}
+        <span className="font-mono">
+          gh auth refresh --hostname {host} -s {scope}
+        </span>{" "}
+        in a terminal, then reopen this dialog.
+      </p>
+    </div>
+  );
 }
 
 /**

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { highlightJson } from "@/features/diff/shiki-highlighter";
 import { copyText } from "@/lib/clipboard";
-import { useActiveGhHost } from "@/lib/git/host";
+import { isReconnectHostSafe, useActiveGhHost } from "@/lib/git/host";
 import { useGhScopes } from "@/lib/git/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
@@ -91,6 +91,9 @@ function ScopeErrorHint({ scope }: { scope: string }) {
   const openReconnect = useUiStore((s) => s.openReconnect);
   const canRefresh =
     scopes.data?.classic === true && !scopes.data.scopes.includes(scope);
+  // A host outside the reconnect grammar never reaches a copyable command string
+  // (shell-syntax injection via a crafted remote) — the generic error card stands.
+  if (!isReconnectHostSafe(host)) return null;
   return (
     <div className="mt-2 text-muted-foreground">
       <p>

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -92,8 +92,10 @@ function ScopeErrorHint({ scope }: { scope: string }) {
   const canRefresh =
     scopes.data?.classic === true && !scopes.data.scopes.includes(scope);
   // A host outside the reconnect grammar never reaches a copyable command string
-  // (shell-syntax injection via a crafted remote) — the generic error card stands.
-  if (!isReconnectHostSafe(host)) return null;
+  // (shell-syntax injection via a crafted remote) — only the command sentence is
+  // suppressed, matching ScopeRefreshHint: the explanation and button stay, and
+  // the button's flow re-validates the host backend-side, failing loudly.
+  const hostSafe = isReconnectHostSafe(host);
   return (
     <div className="mt-2 text-muted-foreground">
       <p>
@@ -120,13 +122,15 @@ function ScopeErrorHint({ scope }: { scope: string }) {
       )}
       {/* The reopen only applies to the copied command: the button's flow
           invalidates this list itself, so its card refetches in place. */}
-      <p className="mt-2">
-        {canRefresh ? "Or run" : "Run"}{" "}
-        <span className="font-mono">
-          gh auth refresh --hostname {host} -s {scope}
-        </span>{" "}
-        in a terminal, then reopen this dialog.
-      </p>
+      {hostSafe && (
+        <p className="mt-2">
+          {canRefresh ? "Or run" : "Run"}{" "}
+          <span className="font-mono">
+            gh auth refresh --hostname {host} -s {scope}
+          </span>{" "}
+          in a terminal, then reopen this dialog.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/features/repository/OperationHistoryDialog.tsx
+++ b/src/features/repository/OperationHistoryDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowSquareOutIcon,
   CheckCircleIcon,
   ClockIcon,
   GitBranchIcon,
@@ -54,6 +55,13 @@ const STATUS_META: Record<
   dismissed: {
     label: "Dismissed",
     Icon: ProhibitIcon,
+    tone: "text-muted-foreground",
+  },
+  // A cherry-pick finished or abandoned in a terminal: over, but the journal never
+  // saw how it ended, so it reads as neither Done nor Failed.
+  concluded: {
+    label: "Ended outside the app",
+    Icon: ArrowSquareOutIcon,
     tone: "text-muted-foreground",
   },
 };

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -133,7 +133,7 @@ export function StashesDialog({
     setConfirmApply({ index, pop, message: stash.message, date: stash.date });
   }
 
-  function runApply() {
+  async function runApply() {
     if (!confirmApply) return;
     const { index, pop, message, date } = confirmApply;
     setConfirmApply(null);
@@ -147,14 +147,12 @@ export function StashesDialog({
       toast.info("The stash list changed — nothing was applied.");
       return;
     }
-    apply.mutate(
-      { index, pop },
-      {
-        onSuccess: () =>
-          toast.success(pop ? "Stash applied and dropped" : "Stash applied"),
-        onError,
-      },
-    );
+    try {
+      await apply.mutateAsync({ index, pop });
+      toast.success(pop ? "Stash applied and dropped" : "Stash applied");
+    } catch (e) {
+      onError(e);
+    }
   }
 
   const applyPrompt = shownApply ? stashApplyPrompt(shownApply) : null;
@@ -317,18 +315,16 @@ export function StashesDialog({
               <Button
                 variant="destructive"
                 disabled={drop.isPending}
-                onClick={() => {
+                onClick={async () => {
                   if (confirmDrop === null) return;
-                  drop.mutate(confirmDrop, {
-                    onSuccess: () => {
-                      setConfirmDrop(null);
-                      toast.success("Stash dropped");
-                    },
-                    onError: (e) => {
-                      setConfirmDrop(null);
-                      onError(e);
-                    },
-                  });
+                  try {
+                    await drop.mutateAsync(confirmDrop);
+                    setConfirmDrop(null);
+                    toast.success("Stash dropped");
+                  } catch (e) {
+                    setConfirmDrop(null);
+                    onError(e);
+                  }
                 }}
               >
                 {drop.isPending && <Spinner data-icon="inline-start" />}
@@ -370,18 +366,22 @@ function RecoverableView({
   // loaded, assume dirty so the confirm is never skipped by a first-paint race.
   const dirty = status.data ? status.data.entries.length > 0 : true;
 
-  function restoreSha(sha: string) {
-    restore.mutate(sha, {
-      onSuccess: () => toast.success("Restored to working tree"),
-      onError,
-    });
+  // Awaited: a view swap or a dialog close unmounts this mid-restore, and
+  // per-call mutation callbacks don't survive that — the outcome would be lost.
+  async function restoreSha(sha: string) {
+    try {
+      await restore.mutateAsync(sha);
+      toast.success("Restored to working tree");
+    } catch (e) {
+      onError(e);
+    }
   }
 
   function onRestoreClick(sha: string) {
     if (dirty) {
       setConfirmRestore(sha);
     } else {
-      restoreSha(sha);
+      void restoreSha(sha);
     }
   }
 
@@ -476,7 +476,7 @@ function RecoverableView({
           if (confirmRestore === null) return;
           const sha = confirmRestore;
           setConfirmRestore(null);
-          restoreSha(sha);
+          void restoreSha(sha);
         }}
       />
     </div>

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -171,11 +171,24 @@ function WorktreeList({
     onClose();
   }
 
-  function handleUnlock(w: UserWorktree) {
-    unlock.mutate(w.path, {
-      onSuccess: () => toast.success("Worktree unlocked"),
-      onError: toastError,
-    });
+  // Awaited, not per-call callbacks: react-query drops those when the dialog
+  // unmounts mid-flight, so the outcome would never reach the user.
+  async function handleUnlock(w: UserWorktree) {
+    try {
+      await unlock.mutateAsync(w.path);
+      toast.success("Worktree unlocked");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRepair() {
+    try {
+      await repair.mutateAsync(undefined);
+      toast.success("Worktree links repaired");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -237,12 +250,7 @@ function WorktreeList({
             className="text-muted-foreground sm:mr-auto"
             disabled={repair.isPending}
             title="Re-link worktrees after moving or renaming the repository folder"
-            onClick={() =>
-              repair.mutate(undefined, {
-                onSuccess: () => toast.success("Worktree links repaired"),
-                onError: toastError,
-              })
-            }
+            onClick={handleRepair}
           >
             {repair.isPending ? (
               <Spinner data-icon="inline-start" />
@@ -571,19 +579,18 @@ export function RenameWorktreeDialog({
   // move into another folder) — keep this a simple in-place rename.
   const invalid = /[\\/]/.test(trimmed);
 
-  function handleRename() {
+  // Awaited: this dialog is remounted by a `key` flip and unmounts on close, and
+  // per-call mutation callbacks don't survive that — the outcome would be lost.
+  async function handleRename() {
     if (!worktree || !trimmed || unchanged || invalid) return;
     if (refuseWhileLeaving(worktree.path, removing)) return;
-    move.mutate(
-      { from: worktree.path, to: newPath },
-      {
-        onSuccess: () => {
-          toast.success(`Renamed to ${trimmed}`);
-          onClose();
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await move.mutateAsync({ from: worktree.path, to: newPath });
+      toast.success(`Renamed to ${trimmed}`);
+      onClose();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -601,7 +608,7 @@ export function RenameWorktreeDialog({
           className="grid grid-cols-[auto_1fr] items-center gap-x-3 text-xs"
           onSubmit={(e) => {
             e.preventDefault();
-            handleRename();
+            void handleRename();
           }}
         >
           <label htmlFor="wt-rename" className="text-muted-foreground">
@@ -665,19 +672,19 @@ export function LockWorktreeDialog({
   const removing = useIsRemovingWorktree(repoPath, worktree?.path);
   const [reason, setReason] = useState("");
 
-  function handleLock() {
+  async function handleLock() {
     if (!worktree) return;
     if (refuseWhileLeaving(worktree.path, removing)) return;
-    lock.mutate(
-      { path: worktree.path, reason: reason.trim() || undefined },
-      {
-        onSuccess: () => {
-          toast.success("Worktree locked");
-          onClose();
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await lock.mutateAsync({
+        path: worktree.path,
+        reason: reason.trim() || undefined,
+      });
+      toast.success("Worktree locked");
+      onClose();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -696,7 +703,7 @@ export function LockWorktreeDialog({
           className="grid grid-cols-[auto_1fr] items-center gap-x-3 text-xs"
           onSubmit={(e) => {
             e.preventDefault();
-            handleLock();
+            void handleLock();
           }}
         >
           <label htmlFor="wt-lock-reason" className="text-muted-foreground">
@@ -786,22 +793,19 @@ function CreateWorktree({
         : "Pick a branch and folder to continue."
       : "";
 
-  function handleCreate() {
-    add.mutate(
-      {
+  async function handleCreate() {
+    try {
+      await add.mutateAsync({
         path: effectivePath,
         branch,
         newBranch: source === "new",
         baseRef: source === "new" ? base : undefined,
-      },
-      {
-        onSuccess: () => {
-          toast.success(`Worktree created on ${branch}`);
-          onCreated();
-        },
-        onError: toastError,
-      },
-    );
+      });
+      toast.success(`Worktree created on ${branch}`);
+      onCreated();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -225,10 +225,13 @@ export function ResearchComposer({
   const [agentPick, setAgentPick] = useState<AgentKind | null>(null);
   const agent: AgentKind = agentPick ?? defaultAgentKind(settings.data);
   const [model, setModel] = useState("");
+  // The agent `model` was chosen for; null = nothing chosen yet. Any model id is
+  // accepted, so list membership can't decide whether one still fits the agent.
+  const [modelAgent, setModelAgent] = useState<AgentKind | null>(null);
   const [effort, setEffort] = useState("");
-  // A model picked for one agent isn't in another's list; "" = the account
-  // default. Derived, so a default-agent change drops a model it can't run.
-  const modelForAgent = modelsForAgent(agent).includes(model) ? model : "";
+  // A model belongs to the agent it was chosen for; "" = the account default.
+  // Derived, so a default-agent change drops a model that agent wasn't given.
+  const modelForAgent = modelAgent === agent ? model : "";
 
   const canRun = topic.trim().length > 0;
   const copy = INTENT_COPY[depth];
@@ -280,11 +283,15 @@ export function ResearchComposer({
               onChange={(a) => {
                 setAgentPick(a);
                 setModel(""); // model lists differ between agents
+                setModelAgent(null);
               }}
             />
             <ModelPicker
               value={modelForAgent}
-              onChange={setModel}
+              onChange={(m) => {
+                setModel(m);
+                setModelAgent(agent);
+              }}
               models={modelsForAgent(agent)}
             />
             <ComposerOptions effort={effort} onEffort={setEffort} />

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -305,7 +305,14 @@ export const useResearchStore = create<ResearchState>((set, get) => {
         return;
       const label = run.origin?.topic?.trim() || "Research";
       const headline = failed ? "Research failed" : "Research ready";
-      void notify(headline, label);
+      // Hiding AI features mutes the OS ping — a hidden feature must not tap you
+      // on the shoulder. The inbox row below still lands (the dock filters it at
+      // render time), and a settings read that fails falls through to notifying.
+      void loadSettings()
+        .catch(() => null)
+        .then((s) => {
+          if (!s?.hideAi) void notify(headline, label);
+        });
       pushNotification({
         kind: "research-done",
         tone: failed ? "danger" : "success",

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -6,9 +6,17 @@ import {
   UsersThreeIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
-import { type ReactNode, useId, useMemo, useRef } from "react";
+import { type ReactNode, useId, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
 import {
   Popover,
   PopoverContent,
@@ -59,9 +67,9 @@ export function modelsForAgent(agent: AgentKind): string[] {
   }
 }
 
-// "" (account default) maps to a non-empty sentinel for the Select value.
-const DEFAULT_MODEL = "default";
-
+/** The model for a run: the agent's suggestions are searchable, and any other id
+ *  typed here reaches the CLI verbatim (custom providers publish ids no static
+ *  list can carry). `""` is the account default and shows the placeholder. */
 export function ModelPicker({
   value,
   onChange,
@@ -71,41 +79,48 @@ export function ModelPicker({
   onChange: (m: string) => void;
   models: string[];
 }) {
-  // Base UI renders the raw value in the trigger unless the labels are passed as
-  // `items`. Derived per render because the model set varies by agent, and the
-  // popup below renders from it too so the two can never drift.
-  const items = useMemo(
-    () => ({
-      [DEFAULT_MODEL]: "Default model",
-      ...Object.fromEntries(models.map((m) => [m, m])),
-    }),
-    [models],
-  );
-
   return (
-    <Select
-      items={items}
-      value={value || DEFAULT_MODEL}
-      onValueChange={(v) => onChange(v === DEFAULT_MODEL ? "" : String(v))}
+    <Combobox
+      items={models}
+      // The input text is the source of truth — a typed id needs no match.
+      inputValue={value}
+      onInputValueChange={(model) => onChange(model)}
+      // UNCLAMPED on purpose: Base UI syncs the input to the selected item's
+      // label as the popup finishes closing, and a null selection syncs it to
+      // "" — clamping to the suggestion list would wipe a typed id on close.
+      value={value || null}
+      onValueChange={(model) => {
+        if (model) onChange(model);
+      }}
+      openOnInputClick
     >
-      <SelectTrigger
-        size="sm"
+      {/* Composer-toolbar weight: quiet until focus, matching the sibling
+          Select-based pickers on the same row. */}
+      <ComboboxInput
         aria-label="Agent model"
-        className="w-auto border-0 text-muted-foreground shadow-none hover:bg-muted dark:bg-transparent"
-      >
-        <SelectValue />
-      </SelectTrigger>
-      {/* Models come from a narrow (w-auto) trigger, so the default
-          `w-(--anchor-width)` popup clips long ids (e.g. `opencode/…`). Let it
-          size to its content instead, capped so it can't run off-screen. */}
-      <SelectContent className="w-fit max-w-sm">
-        {Object.entries(items).map(([model, label]) => (
-          <SelectItem key={model} value={model}>
-            {label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+        placeholder="Default model"
+        // Long ids outrun the capped width with the caret hiding the tail, and
+        // an input has no truncation tooltip of its own.
+        title={value || undefined}
+        className="h-7 w-auto max-w-44 min-w-28 border-transparent text-muted-foreground hover:bg-muted dark:bg-transparent"
+      />
+      {/* The input is narrow, so the default `w-(--anchor-width)` popup clips
+          long ids (e.g. `opencode/…`). Size to content, capped on-screen. */}
+      <ComboboxContent className="w-fit max-w-sm">
+        <ComboboxEmpty>
+          No matching models — the typed id is used as-is
+        </ComboboxEmpty>
+        {/* Render FUNCTION, not static rows: only this form maps the store's
+            filtered items, so static children would never narrow as you type. */}
+        <ComboboxList>
+          {(model: string) => (
+            <ComboboxItem key={model} value={model}>
+              <span className="truncate font-mono">{model}</span>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
   );
 }
 

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -199,6 +199,12 @@ export function SessionComposer({
   const settings = useSettings();
   const [draft, setDraft] = useState("");
   const [startModel, setStartModel] = useState("");
+  // The agent `startModel` was chosen for; null = nothing chosen yet. Any model
+  // id is accepted (custom providers publish ids no suggestion list carries), so
+  // list membership can't decide whether a model still fits the agent.
+  const [startModelAgent, setStartModelAgent] = useState<AgentKind | null>(
+    null,
+  );
   const [startEffort, setStartEffort] = useState("");
   // An explicit pick for a NEW session; null = follow the Settings default.
   // Derived during render — no effect — so settings arriving late can't clobber
@@ -206,12 +212,10 @@ export function SessionComposer({
   const [startAgentPick, setStartAgentPick] = useState<AgentKind | null>(null);
   const startAgent: AgentKind =
     startAgentPick ?? defaultAgentKind(settings.data);
-  // A model picked for one agent isn't in another's list; "" = the account default.
+  // A model belongs to the agent it was chosen for; "" = the account default.
   // Derived, so every path that can move the agent — the picker, a stash restore,
-  // settings landing — drops a model the new agent can't run.
-  const startModelForAgent = modelsForAgent(startAgent).includes(startModel)
-    ? startModel
-    : "";
+  // settings landing — drops a model that agent wasn't given.
+  const startModelForAgent = startModelAgent === startAgent ? startModel : "";
   // MCP servers opted into for a NEW session. null = "use the default" (every
   // enabled registry server); a concrete array once the user picks. Frozen at
   // turn 1, so it only matters before a session exists.
@@ -256,7 +260,10 @@ export function SessionComposer({
   const models = modelsForAgent(agent);
   const onModel = session
     ? (m: string) => setModel(session.id, m)
-    : setStartModel;
+    : (m: string) => {
+        setStartModel(m);
+        setStartModelAgent(startAgent);
+      };
   // Effort is changeable mid-session (like model). Mapped per-CLI in Rust (Codex
   // config, Copilot/opencode flags, Claude thinking keyword).
   const effort = session ? session.effort : startEffort;
@@ -317,7 +324,13 @@ export function SessionComposer({
     if (pendingTask.isolation !== undefined)
       setStartIsolation(pendingTask.isolation);
     if (pendingTask.agent !== undefined) setStartAgentPick(pendingTask.agent);
-    if (pendingTask.model !== undefined) setStartModel(pendingTask.model);
+    if (pendingTask.model !== undefined) {
+      setStartModel(pendingTask.model);
+      // `modelAgent` is the record's own answer; `agent` is the fallback for a
+      // handoff that set a model without one. Absent from both = nothing pins the
+      // model, so it's released rather than re-aimed at whatever agent now applies.
+      setStartModelAgent(pendingTask.modelAgent ?? pendingTask.agent ?? null);
+    }
     if (pendingTask.effort !== undefined) setStartEffort(pendingTask.effort);
     if (pendingTask.mode !== undefined) setMode(pendingTask.mode);
     if (pendingTask.mcpServers !== undefined)
@@ -479,6 +492,9 @@ export function SessionComposer({
       isolation: startIsolation ?? undefined,
       agent: startAgentPick ?? undefined,
       model: startModel,
+      // Pinned even when the agent isn't: the model has to come back knowing
+      // which agent it was for, or the restore can't tell it still fits.
+      modelAgent: startModelAgent ?? undefined,
       effort: startEffort,
       mode,
       // Verbatim: null here MEANS "follow the default set", so it must survive.
@@ -951,6 +967,7 @@ export function SessionComposer({
                   onChange={(a) => {
                     setStartAgentPick(a);
                     setStartModel(""); // model lists differ between agents
+                    setStartModelAgent(null);
                     setStartMcp(null); // re-derive the new agent's default servers
                   }}
                 />

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -142,6 +142,11 @@ export interface PendingTask {
   agent?: "claude" | "codex" | "copilot" | "opencode";
   /** "" = the account default model. */
   model?: string;
+  /** The agent `model` was chosen for. Recorded separately because `agent` is
+   *  absent when unpicked (so a Default-agent change during the round trip is
+   *  followed), which would otherwise leave the restore unable to tell a model
+   *  that still fits from one aimed at the agent the user just moved away from. */
+  modelAgent?: "claude" | "codex" | "copilot" | "opencode";
   /** "" = Auto. */
   effort?: string;
   mode?: "single" | "ensemble";
@@ -364,7 +369,14 @@ async function runTurn(
       "Agent session";
     const failed = t.status === "error";
     const headline = failed ? "Agent failed" : "Agent finished";
-    void notify(headline, label);
+    // Hiding AI features mutes the OS ping — a hidden feature must not tap you
+    // on the shoulder. The inbox row below still lands (the dock filters it at
+    // render time), and a settings read that fails falls through to notifying.
+    void loadSettings()
+      .catch(() => null)
+      .then((s) => {
+        if (!s?.hideAi) void notify(headline, label);
+      });
     pushNotification({
       kind: "agent-done",
       tone: failed ? "danger" : "success",

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -186,7 +186,10 @@ function ModelPicker({
           items={models}
           inputValue={value.model}
           onInputValueChange={(model) => onChange({ ...value, model })}
-          value={models.includes(value.model) ? value.model : null}
+          // UNCLAMPED on purpose: Base UI syncs the input to the selected item's
+          // label as the popup finishes closing, and a null selection syncs it
+          // to "" — clamping to the catalog would wipe a typed id on close.
+          value={value.model || null}
           onValueChange={(model) => {
             if (model) onChange({ ...value, model });
           }}

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -50,8 +50,8 @@ export const GeneralSection = withForm({
             Hides the AI commit-message and pull-request helpers, the AI review
             panel, the AI-related settings sections, and finished AI activity in
             the dock and notification inbox, mutes AI desktop notifications, and
-            pauses your automations. Your provider, API keys, and rules are
-            kept — automations run again once you turn AI features back on.
+            pauses your automations. Your provider, API keys, and rules are kept
+            — automations run again once you turn AI features back on.
           </p>
           {automationsPaused && (
             <p

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -48,9 +48,10 @@ export const GeneralSection = withForm({
           </form.AppField>
           <p className="text-xs text-muted-foreground">
             Hides the AI commit-message and pull-request helpers, the AI review
-            panel, and the AI-related settings sections, and pauses your
-            automations. Your provider, API keys, and rules are kept —
-            automations run again once you turn AI features back on.
+            panel, the AI-related settings sections, and finished AI activity in
+            the dock and notification inbox, mutes AI desktop notifications, and
+            pauses your automations. Your provider, API keys, and rules are
+            kept — automations run again once you turn AI features back on.
           </p>
           {automationsPaused && (
             <p

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -648,7 +648,12 @@ async function run(
             event.kind === "commit" ? event.hash : targetRef(event)
           }:${action}`,
         });
-        void notifyIfUnfocused(`AI ${label} failed`, subtitle);
+        // Re-read rather than trust the run-start snapshot: hiding AI mid-run
+        // mutes the OS ping, while the inbox row above still records the failure
+        // (the dock filters that at render time, so no history is lost).
+        if (!(await loadSettings().catch(() => null))?.hideAi) {
+          void notifyIfUnfocused(`AI ${label} failed`, subtitle);
+        }
       }
       // Persist a "Failed" stopped row (keeping its Re-run) instead of removing it.
       handle.fail(message);
@@ -1021,6 +1026,11 @@ async function deliver(
   notify: boolean,
 ): Promise<void> {
   const label = modeLabel(mode);
+  // Whether this delivery may ping the OS. Read fresh, not from the run-start
+  // snapshot: hiding AI while a run is in flight mutes its ping, and the in-app
+  // toast + inbox row below still land (the dock filters those at render time).
+  // A settings-read failure counts as shown — delivery must never fail on it.
+  const osPing = notify && !(await loadSettings().catch(() => null))?.hideAi;
 
   if (event.kind === "commit") {
     // Commits have no comment surface — keep the result in-session and let
@@ -1041,7 +1051,7 @@ async function deliver(
         onClick: () => useAutomationResults.getState().setOpen(result.id),
       },
     });
-    if (notify) {
+    if (osPing) {
       void notifyIfUnfocused(
         `AI ${label} ready`,
         `${event.hash.slice(0, 7)} — ${event.title}`,
@@ -1067,7 +1077,7 @@ async function deliver(
       queryKey: ["repo", event.repoPath, "pr", "origin", event.target.number],
     });
     toast.success(`AI ${label} posted on #${event.target.number}`);
-    if (notify) {
+    if (osPing) {
       void notifyIfUnfocused(
         `AI ${label} posted on #${event.target.number}`,
         event.title,
@@ -1100,7 +1110,7 @@ async function deliver(
     queryKey: ["local-prs", event.repoPath],
   });
   toast.success(`AI ${label} added to "${pr.title}"`);
-  if (notify) {
+  if (osPing) {
     void notifyIfUnfocused(`AI ${label} finished`, `Local PR "${pr.title}"`);
   }
 }

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -24,6 +24,7 @@ import type {
   Branch,
   BranchComparison,
   BranchDivergence,
+  BranchRequiredRules,
   BranchRewriteStatus,
   BranchStats,
   CodeFreqPoint,
@@ -1408,6 +1409,9 @@ export const forgeReconnect = (args: {
   provider: "github" | "gitlab";
   host: string;
   mode: "login" | "refresh";
+  /** Extra OAuth scopes (`gh auth refresh -s …`) — GitHub `refresh` only; the
+   *  backend rejects them elsewhere rather than dropping them. */
+  scopes?: string[];
   onEvent: (event: ReconnectEvent) => void;
 }): Promise<void> => {
   const channel = new Channel<ReconnectEvent>();
@@ -1417,6 +1421,7 @@ export const forgeReconnect = (args: {
     provider: args.provider,
     host: args.host,
     mode: args.mode,
+    scopes: args.scopes ?? null,
     onEvent: channel,
   });
 };
@@ -3136,15 +3141,20 @@ export const ghRulesetsList = (repoPath: string) =>
 export const ghRulesetGet = (repoPath: string, id: number) =>
   invoke<RulesetFull>("gh_ruleset_get", { repoPath, id });
 
-/** The status-check contexts a branch's active rules require. Empty for a readable
- *  branch under no rules; a branch this token can't read — or a name the backend's
- *  ref gate refuses — rejects, which a caller showing a fallback may treat as
- *  empty. GitHub only. */
+/** What a branch's active rules require — check contexts and any approving-review
+ *  count. Empty for a readable branch under no rules; a branch this token can't read —
+ *  or a name the backend's ref gate refuses — rejects, which a caller showing a
+ *  fallback may treat as empty. GitHub only. */
 export const ghBranchRequiredChecks = (
   repoPath: string,
   branch: string,
   lens: RemoteLens,
-) => invoke<string[]>("gh_branch_required_checks", { repoPath, branch, lens });
+) =>
+  invoke<BranchRequiredRules>("gh_branch_required_checks", {
+    repoPath,
+    branch,
+    lens,
+  });
 
 export const ghRulesetCreate = (
   repoPath: string,

--- a/src/lib/git/host.ts
+++ b/src/lib/git/host.ts
@@ -2,6 +2,17 @@ import { useUiStore } from "@/lib/stores/ui";
 import { useForgeStatus } from "./queries";
 
 /**
+ * Whether a host is safe to interpolate into a copyable `gh`/`glab auth …` command —
+ * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`).
+ * `remote_host` only splits a remote URL on `/` and `:`, so a crafted remote can carry
+ * `;`, `$`, or a space into the host; the executed reconnect flow re-validates, but the
+ * copy-paste command string is guarded here so it can never hand the user shell syntax.
+ */
+export function isReconnectHostSafe(host: string): boolean {
+  return /^[a-zA-Z0-9.-]+$/.test(host);
+}
+
+/**
  * The hosting host of the open repo — "github.com" or an Enterprise server like
  * "github.acme.com" — defaulting to github.com until it's known. Lets avatar
  * URLs, profile links, and gh-command hints resolve on the right host without

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2744,9 +2744,11 @@ export function useAccountsHealth() {
 
 /** Refresh everything a successful reconnect can change: the accounts-health list,
  *  every repo's forge-status (a dead session flips a repo back to ready) and
- *  forge-session-health, the gh-accounts list (which account is active), and the
- *  gh token scopes (a reconnect can grant new ones). Call from a reconnect's
- *  `finished: ok` handler. */
+ *  forge-session-health, the gh-accounts list (which account is active), the gh
+ *  token scopes (a reconnect can grant new ones), and the repo-settings lists a
+ *  scope hint sends users here from — secrets, variables and webhooks all fail
+ *  closed on a missing scope, so their error cards must retry the call themselves.
+ *  Call from a reconnect's `finished: ok` handler. */
 export function useInvalidateAfterReconnect() {
   const queryClient = useQueryClient();
   return useCallback(() => {
@@ -2755,10 +2757,14 @@ export function useInvalidateAfterReconnect() {
     // Partial key: covers every host variant of useGhScopes' key.
     queryClient.invalidateQueries({ queryKey: ["gh", "token-scopes"] });
     queryClient.invalidateQueries({
+      // Partial keys with a repo path in slot 1, so match on the axis instead.
       predicate: (q) =>
         q.queryKey[0] === "repo" &&
         (q.queryKey[2] === "forge-status" ||
-          q.queryKey[2] === "forge-session-health"),
+          q.queryKey[2] === "forge-session-health" ||
+          q.queryKey[2] === "secrets" ||
+          q.queryKey[2] === "variables" ||
+          q.queryKey[2] === "webhooks"),
     });
   }, [queryClient]);
 }

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -435,8 +435,10 @@ export interface OpLogEntry {
   op: "merge_local_pr" | "cherry_pick_onto" | "rewrite_commits" | "rebase_edit";
   /** Human label, e.g. "Squash-merge feature → main". */
   label: string;
-  /** "paused" = handed to you mid-op (a stopped cherry-pick), neither in-flight nor finished. */
-  status: "pending" | "done" | "failed" | "dismissed" | "paused";
+  /** "paused" = handed to you mid-op (a stopped cherry-pick), neither in-flight nor
+   *  finished. "concluded" = that pick ended outside the app, so the journal knows
+   *  only that it is over (no finish time). */
+  status: "pending" | "done" | "failed" | "dismissed" | "paused" | "concluded";
   /** ISO timestamp the op started. */
   startedAt: string;
   /** ISO timestamp the op finished, or null while still open. */
@@ -1410,6 +1412,16 @@ export interface RulesetFull {
   conditions?: { ref_name?: { include?: string[]; exclude?: string[] } };
   bypass_actors?: unknown[];
   rules?: { type: string; parameters?: Record<string, unknown> }[];
+}
+
+/** What a branch's active rules demand of a pull request, aggregated across every
+ *  ruleset that applies. GitHub only. */
+export interface BranchRequiredRules {
+  /** Required status-check contexts, in GitHub's own order and deduplicated. */
+  contexts: string[];
+  /** Approving reviews the rules require; `null` when no rule names a count. The
+   *  PR's check rollup can never carry this — nothing in it names reviews. */
+  requiredApprovingReviewCount: number | null;
 }
 
 /** A "Code security and analysis" toggle. */

--- a/src/lib/review-notes/store.ts
+++ b/src/lib/review-notes/store.ts
@@ -1,6 +1,7 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { repoIdentity } from "@/lib/git/repo-identity";
-import { storeName } from "@/lib/test-mode";
+import { invoke } from "@/lib/tauri/invoke";
+import { COLD_START, storeName } from "@/lib/test-mode";
 
 /** A per-branch "Notes for reviewers" deposit, keyed by the repo's
  *  worktree-stable identity then the branch name. Written (out-of-process) by
@@ -33,8 +34,8 @@ function getStore(): Promise<Store> {
 // reload the SAME pre-flush disk snapshot — autoSave persists on a ~100ms
 // debounce, so the first write isn't on disk yet — and the later write drops
 // the earlier one's change (a lost update; the settings-store write-race rule).
-// Running them one at a time, plus the force-save in writeBranch, guarantees
-// each reload sees a current snapshot.
+// Running them one at a time, plus the force-save in `writeBranchToStore`,
+// guarantees each reload sees a current snapshot.
 let opChain: Promise<unknown> = Promise.resolve();
 function serialize<T>(op: () => Promise<T>): Promise<T> {
   const run = opChain.then(op, op);
@@ -76,7 +77,44 @@ async function keyFor(repo: string): Promise<string> {
   return repoIdentity(repo);
 }
 
+/** Write `branch`'s note (or clear it with `note === null`) for `repo`. The write
+ *  runs in Rust, under the cross-process lock the MCP server's writer also takes —
+ *  the plugin store's cache is per-process, so a GUI write through it can drop a
+ *  concurrent MCP deposit. Reads stay on the plugin store, so pull the file back in
+ *  afterwards. */
 async function writeBranch(
+  repo: string,
+  branch: string,
+  note: ReviewNote | null,
+): Promise<void> {
+  // Cold-start test mode aliases the GUI's store FILE (`coldstart-review-notes.json`,
+  // `storeName`) while the Rust command always writes the real one, so routing there
+  // would leak throwaway onboarding state into the user's own notes. That mode has no
+  // second writer to race, so it keeps the plugin-store path.
+  if (COLD_START) {
+    return writeBranchToStore(await keyFor(repo), branch, note);
+  }
+  if (note === null) {
+    await invoke<void>("review_notes_delete_branch", {
+      repoPath: repo,
+      branch,
+    });
+  } else {
+    // The Rust writer stamps its own savedAt — a save is a save, whatever the
+    // caller's record said.
+    await invoke<boolean>("review_notes_set_branch", {
+      repoPath: repo,
+      branch,
+      body: note.body,
+    });
+  }
+  // `reloadRaw`, not the serialized `reloadReviewNotes`: we are already inside a
+  // serialized op, and queueing behind it would wait on ourselves.
+  await reloadRaw();
+}
+
+/** The legacy plugin-store write, still the cold-start path (see [`writeBranch`]). */
+async function writeBranchToStore(
   key: string,
   branch: string,
   note: ReviewNote | null,
@@ -118,9 +156,10 @@ export async function deleteReviewNote(
   branch: string,
 ): Promise<void> {
   return serialize(async () => {
-    // Fresh disk state first, so we don't drop a concurrent external MCP write.
+    // Fresh disk state first. Only the cold-start plugin-store path needs it — its
+    // in-memory copy would otherwise clobber an external write. The Rust route reads
+    // the file itself, under the lock.
     await reloadRaw();
-    const key = await keyFor(repo);
-    await writeBranch(key, branch, null);
+    await writeBranch(repo, branch, null);
   });
 }

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -35,6 +35,20 @@ export type NotificationKind =
   | "research-done"
   | "plan-done";
 
+/** The kinds minted by AI producers. The activity dock's render filter and the
+ *  OS-ping gates both read this set, so a new AI producer can't drift out of the
+ *  Hide-AI story. `review-requested` is deliberately absent — it is a forge event
+ *  (a human asked you to review), not AI output. Widened to `string` on read
+ *  because {@link AppNotification.kind} is untrusted: an unlisted kind shows. */
+export const AI_NOTIFICATION_KINDS: ReadonlySet<string> =
+  new Set<NotificationKind>([
+    "review-ready",
+    "review-failed",
+    "agent-done",
+    "research-done",
+    "plan-done",
+  ]);
+
 /** How clicking a notification routes. Data only — the surface maps it to the UI
  *  store's atomic navigation actions, so this module stays free of view logic. */
 export type NotificationTarget =
@@ -175,7 +189,9 @@ interface NotifState {
   push: (n: AppNotification) => void;
   markRead: (id: string) => void;
   markAllRead: () => void;
+  markManyRead: (ids: string[]) => void;
   remove: (id: string) => void;
+  removeMany: (ids: string[]) => void;
   clearAll: () => void;
 }
 
@@ -201,7 +217,27 @@ const useNotifStore = create<NotifState>()((set) => ({
         ? { items: s.items.map((i) => (i.read ? i : { ...i, read: true })) }
         : {},
     ),
+  // Both `*Many` variants keep `markAllRead`'s no-op-when-nothing-changes shape:
+  // returning the same array skips the persist subscription's disk write.
+  markManyRead: (ids) =>
+    set((s) => {
+      const wanted = new Set(ids);
+      return s.items.some((i) => !i.read && wanted.has(i.id))
+        ? {
+            items: s.items.map((i) =>
+              i.read || !wanted.has(i.id) ? i : { ...i, read: true },
+            ),
+          }
+        : {};
+    }),
   remove: (id) => set((s) => ({ items: s.items.filter((i) => i.id !== id) })),
+  removeMany: (ids) =>
+    set((s) => {
+      const wanted = new Set(ids);
+      return s.items.some((i) => wanted.has(i.id))
+        ? { items: s.items.filter((i) => !wanted.has(i.id)) }
+        : {};
+    }),
   clearAll: () => set((s) => (s.items.length > 0 ? { items: [] } : {})),
 }));
 
@@ -292,13 +328,6 @@ export function useNotifications(): AppNotification[] {
   return useNotifStore((s) => s.items);
 }
 
-/** Unread count for the anchor badge. */
-export function useUnreadCount(): number {
-  return useNotifStore((s) =>
-    s.items.reduce((n, i) => (i.read ? n : n + 1), 0),
-  );
-}
-
 /** Repo display name from its path (the folder basename). The detector sites
  *  have the path but not always the canonical name; the basename matches how
  *  `RepoInfo.name` is derived and is enough for the row label + navigation. */
@@ -315,3 +344,10 @@ export const clearNotification = (id: string): void =>
   useNotifStore.getState().remove(id);
 export const clearAllNotifications = (): void =>
   useNotifStore.getState().clearAll();
+/** Id-scoped twins of the two "all" actions, for a surface that renders a SUBSET
+ *  of the inbox (the dock while AI rows are hidden): a bulk action there must
+ *  reach only what the user can see, leaving the rest of the history intact. */
+export const markNotificationsRead = (ids: string[]): void =>
+  useNotifStore.getState().markManyRead(ids);
+export const clearNotifications = (ids: string[]): void =>
+  useNotifStore.getState().removeMany(ids);

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -361,7 +361,7 @@ async function notifyReviewDone(
   error?: string,
 ): Promise<void> {
   try {
-    const { notifications } = await loadSettings();
+    const { notifications, hideAi } = await loadSettings();
     if (!notifications.reviews) return;
     const label = mode === "security" ? "security audit" : "review";
     const headline = ok ? `AI ${label} ready` : `AI ${label} failed`;
@@ -388,7 +388,10 @@ async function notifyReviewDone(
       // one notification.
       dedupeKey: `review:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
     });
-    void notifyIfUnfocused(headline, subtitle);
+    // Hiding AI features mutes the OS ping (a hidden feature must not tap you on
+    // the shoulder) but never the inbox record above — the dock filters that at
+    // render time, so the history is whole again when AI is shown.
+    if (!hideAi) void notifyIfUnfocused(headline, subtitle);
   } catch {
     // best-effort — a missed notification must never affect the review
   }

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -117,6 +117,9 @@ export interface ReconnectTarget {
   provider: "github" | "gitlab";
   host: string;
   mode: "login" | "refresh";
+  /** Extra OAuth scopes to request alongside the ones already granted. GitHub
+   *  `refresh` only — the backend refuses them on any other arm. */
+  scopes?: string[];
 }
 
 /** An in-progress commit message, persisted per repo + branch. */


### PR DESCRIPTION
Silent operations were the theme of this batch: merges refused without a reason, dialogs that swallowed their own outcome when closed mid-flight, journal records stuck "paused" forever, and two processes writing the same JSON stores with no exclusion between them. This PR closes those gaps across the pull-request, operation-history, activity, sessions and account-reconnect surfaces, and adds a cross-process store lock so records stop disappearing.

### Blocked & refused merges

- Adds `classify_gh_merge_refusal` and `strip_graphql_path` in `src-tauri/src/github/pr.rs`, switching `gh_pr_merge` to `run_gh_raw` so a documented refusal (base-branch policy, behind head, unclean merge commit) is reworded in the app's own words while every unrecognized failure keeps gh's raw text.
- Adds the GitLab twin in `src-tauri/src/forge/gitlab.rs`: `glab_http_status` reads the status from glab's two stderr forms, `classify_gl_merge_refusal` rewords the documented 405/409 arms, and `merge_mr_inner` now also catches an error envelope arriving on a *zero* exit via `service_error_message`.
- Extends `src-tauri/src/github/rulesets.rs` with `required_approving_reviews` and a new `BranchRequiredRules` shape (`contexts` + `requiredApprovingReviewCount`), so `gh_branch_required_checks` names the required approval count from the payload it already fetched.
- Rewires the banner in `src/features/pulls/PrMergeabilityBanner.tsx`, plus `RemotePrView.tsx`, `PrReviewPanel.tsx`, `useBranchRequiredChecks.ts` and the types in `src/lib/git/types.ts`, to render the GitLab blocking reason and the GitHub approvals line.

### Cross-process store safety

- New `src-tauri/src/store_lock.rs`: an advisory `<store>.lock` taken with `create_new`, with a bounded retry budget, stale-lock eviction by rename, RAII release, and a deliberate fail-open contract so a busy journal never fails a git operation. Registered in `src-tauri/src/lib.rs`.
- `src-tauri/src/oplog.rs` and `src-tauri/src/review_notes.rs` now take that lock inside their existing in-process mutexes across each read→modify→write.
- Routes the GUI's reviewer-note writes through new `review_notes_set_branch` / `review_notes_delete_branch` Tauri commands (`review_notes.rs`, `src/lib/review-notes/store.ts`) so the plugin store's per-process cache can no longer clobber the MCP server's writes.

### Operation history

- Adds `conclude_stale_pauses` and a `"concluded"` status to `src-tauri/src/oplog.rs`: a cherry-pick finished or aborted outside the app is marked "Ended outside the app" instead of staying paused forever, and — unlike `"paused"` — those records are evictable by `cap_history`. The verdict re-probes `CHERRY_PICK_HEAD` under the lock so a freshly paused pick is never concluded.
- Surfaces the new status in `src/features/repository/OperationHistoryDialog.tsx`.

### Dialog outcomes that survive an unmount

- Converts per-call mutation callbacks to awaited `mutateAsync` in `src/features/history/EditHistoryDialog.tsx`, `src/features/repository/WorktreesDialog.tsx` and `StashesDialog.tsx`, so rename/lock/unlock/repair/create, stash apply/drop/restore and history edits report their result even when the dialog closes mid-flight — including the hand-off to the Changes tab a paused rebase depends on.
- Codifies the rule in `.claude/skills/gd-conventions/SKILL.md` alongside the updated store-concurrency section.

### Hide AI coverage

- `src/features/activity/ActivityDock.tsx` gains `visibleNotifications` and an AI-aware `stoppedTasks`, filtering finished AI rows from the dock, the inbox and the unread badge while leaving in-flight runs (and their Cancel) visible; `src/lib/stores/notifications.ts` exports `AI_NOTIFICATION_KINDS` plus batch `clearNotifications` / `markNotificationsRead`.
- Gates AI desktop notifications on `hideAi` in `src/features/plan/store.ts`, `src/features/research/store.ts`, `src/features/sessions/store.ts` and `src/lib/stores/reviews.ts`.

### Model pickers & reconnect scopes

- Introduces `modelsForAgent` in `src/features/sessions/AgentPickers.tsx` and makes the picker a searchable combobox that accepts any typed model id; `PlanView.tsx`, `ImplementPlanButton.tsx`, `ResearchView.tsx` and `SessionComposer.tsx` drop their duplicated `MODELS` maps, with `PlanView` tracking which agent a model was chosen for instead of testing list membership.
- Adds scope-aware reconnect: `reconnect_args` + `valid_reconnect_host` in `src-tauri/src/forge/session.rs` build and validate the argv (scopes only ride a GitHub `auth refresh`, capped and charset-checked), threaded through `src/features/accounts/ReconnectDialog.tsx`, `src/lib/git/api.ts` and `src/lib/stores/ui.ts`.
- `src/features/repo-settings/ScopeRefreshHint.tsx` and `parts.tsx` now open the in-app reconnect flow with the needed scope beside the copyable `gh auth refresh` command.

### glab config parsing

- Adds `split_key_value` in `src-tauri/src/forge/glab.rs`, unquoting a quoted host key *before* splitting on the colon, so `"host:port"` and `"https://host"` forms are detected instead of being cut in half; an unbalanced quote drops the line rather than minting a corrupted account entry. Table-driven cases cover both quote styles, ports, schemes and a quoted key opening a wrapped flow map.

### Docs

- README: rewrites the blocked-by-branch-protection bullet for both forges and extends the Hide AI bullet.
- `site/src/data/capabilities.ts`: updates the blocked-merge and agent-delegation capability lines.
- `src/features/help/content.ts`: rewrites the "Blocked by branch protection" section for GitHub *and* GitLab, documents the "ended outside the app" journal status, the searchable model box, and the widened Hide AI behavior.
- Nine `changelog.d/` fragments, one per user-facing change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable model pickers accept custom model IDs for sessions, plans, research, and AI providers.
  * Reconnect prompts can request missing GitHub permissions and provide safe, copyable commands.
  * Merge-blocking banners show clearer GitHub approval/check requirements and GitLab blocking reasons.
* **Bug Fixes**
  * Hidden AI features suppress completed activity and desktop notifications while preserving in-progress work and inbox records.
  * Concurrent review notes and operation history updates persist reliably.
  * Operations completed outside the app are clearly labeled and handled correctly.
  * Dialog actions retain success and error outcomes when closed during execution.
  * GitLab hosts with quoted configuration keys are detected correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->